### PR TITLE
Fix phoenix intermittent restart timeout

### DIFF
--- a/.ci/functional_test.sh
+++ b/.ci/functional_test.sh
@@ -12,13 +12,8 @@ fi
 
 sudo firezone-ctl reconfigure
 
-# Usually fails the first time
-sudo firezone-ctl restart
-
-# Wait for phoenix app to boot
-sleep 30
-
-sudo find /var/log/firezone/phoenix/ -type f | sudo xargs cat
+# Wait for app to fully boot
+sleep 10
 
 echo "Trying to load homepage"
 page=$(curl -L -i -vvv -k https://$(hostname))

--- a/omnibus/cookbooks/firezone/recipes/phoenix.rb
+++ b/omnibus/cookbooks/firezone/recipes/phoenix.rb
@@ -51,7 +51,6 @@ end
 if node['firezone']['phoenix']['enable']
   component_runit_service 'phoenix' do
     package 'firezone'
-    control ['t']
     action :enable
     subscribes :restart, 'file[environment-variables]'
   end

--- a/omnibus/cookbooks/firezone/templates/sv-phoenix-run.erb
+++ b/omnibus/cookbooks/firezone/templates/sv-phoenix-run.erb
@@ -1,18 +1,18 @@
 #!/bin/sh
 exec 2>&1
 
+<%= Firezone::Config.environment_variables_from(Firezone::Config.app_env(node['firezone'])) %>
+<%= Firezone::Config.locale_variables %>
 export PATH=<%= node['firezone']['install_directory'] %>/embedded/bin:$PATH
 export LD_LIBRARY_PATH=<%= node['firezone']['install_directory'] %>/embedded/lib
 export DIR=<%= node['firezone']['app_directory'] %>
 export HOME=$DIR
 <%= "export OPENSSL_FIPS=1" if node['firezone']['fips_enabled'] == true %>
-<%= Firezone::Config.environment_variables_from(Firezone::Config.app_env(node['firezone'])) %>
-<%= Firezone::Config.locale_variables %>
 
 cd $DIR
 
 exec <%= node['runit']['chpst_bin'] %> \
-      -P \
-      -U <%= node['firezone']['user'] %>:<%= node['firezone']['group'] %> \
-      -u <%= node['firezone']['user'] %>:<%= node['firezone']['group'] %> \
-      bin/firezone start
+  -P \
+  -U <%= node['firezone']['user'] %>:<%= node['firezone']['group'] %> \
+  -u <%= node['firezone']['user'] %>:<%= node['firezone']['group'] %> \
+  bin/firezone start

--- a/omnibus/cookbooks/firezone/templates/sv-phoenix-t.erb
+++ b/omnibus/cookbooks/firezone/templates/sv-phoenix-t.erb
@@ -1,4 +1,0 @@
-#!/bin/sh
-echo "received TERM from runit, sending to process group (-PID)"
-pid=$(<%= node['firezone']['app_directory'] %>/bin/firezone pid)
-kill -- -$pid

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -16,3 +16,8 @@
 # RELEASE_DISTRIBUTION variable below. Must be "sname", "name" or "none".
 export RELEASE_DISTRIBUTION=name
 export RELEASE_NODE=<%= @release.name %>@127.0.0.1
+
+# Choices here are 'interactive' and 'embedded'. 'interactive' boots faster which
+# prevents some runit process management edge cases at the expense of the application
+# not technically being ready to serve requests "right away". This is a useful tradeoff.
+export RELEASE_MODE=interactive


### PR DESCRIPTION
mix releases seem to ignore `TERM` signals until the apps are preloaded and the app is fully booted. This sets the `RELEASE_MODE` env var to `interactive` to speed up app booting and shorten the window of time the phoenix process is unresponsive.