### PR TITLE
Enable IPv6 support for WireGuard tunnels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,8 @@
+# We're running on a self-hosted runner, so only allow one workflow to run at a
+# time.
+# XXX: Remove this when self-hosted ephemeral runners are implmented.
+concurrency: ci
+
 name: CI
 on:
   - push

--- a/apps/fz_http/lib/fz_http/devices.ex
+++ b/apps/fz_http/lib/fz_http/devices.ex
@@ -8,6 +8,7 @@ defmodule FzHttp.Devices do
   alias FzHttp.{Devices.Device, Repo, Users.User}
 
   @ipv4_prefix "10.3.2."
+  @ipv6_prefix "fd00:3:2::"
 
   def list_devices do
     Repo.all(Device)
@@ -49,11 +50,15 @@ defmodule FzHttp.Devices do
     @ipv4_prefix <> Integer.to_string(device.address)
   end
 
+  def ipv6_address(%Device{} = device) do
+    @ipv6_prefix <> Integer.to_string(device.address)
+  end
+
   def to_peer_list do
     for device <- Repo.all(Device) do
       %{
         public_key: device.public_key,
-        allowed_ips: ipv4_address(device)
+        allowed_ips: "#{ipv4_address(device)}/32, #{ipv6_address(device)}/128"
       }
     end
   end

--- a/apps/fz_http/lib/fz_http_web/live/device_live/index.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/index.html.heex
@@ -20,7 +20,7 @@
           <td>
             <%= live_patch(device.name, to: Routes.device_show_path(@socket, :show, device)) %>
           </td>
-          <td class="code"><%= FzHttp.Devices.ipv4_address(device) %></td>
+          <td class="code"><%= FzHttp.Devices.ipv4_address(device) %>, <%= FzHttp.Devices.ipv6_address(device) %></td>
           <td class="code"><%= device.public_key %></td>
         </tr>
       <% end %>

--- a/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
@@ -37,7 +37,7 @@ defmodule FzHttpWeb.DeviceLive.Index do
       {:ok, device} ->
         @events_module.device_created(
           device.public_key,
-          Devices.ipv4_address(device)
+          {Devices.ipv4_address(device), Devices.ipv6_address(device)}
         )
 
         {:noreply,

--- a/apps/fz_http/lib/fz_http_web/live/device_live/show.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/show.html.heex
@@ -33,7 +33,7 @@
           <dt>
             <strong>Interface IP:</strong>
           </dt>
-          <dd><%= FzHttp.Devices.ipv4_address(@device) %></dd>
+          <dd><%= FzHttp.Devices.ipv4_address(@device) %>, <%= FzHttp.Devices.ipv6_address(@device) %></dd>
 
           <dt>
             <strong>Public key:</strong>
@@ -72,7 +72,7 @@
         <pre><code id="wg-conf">
 [Interface]
 PrivateKey = <%= @device.private_key %>
-Address = <%= FzHttp.Devices.ipv4_address(@device) %>
+Address = <%= FzHttp.Devices.ipv4_address(@device) %>/32, <%= FzHttp.Devices.ipv6_address(@device) %>/128
 DNS = 1.1.1.1, 1.0.0.1
 
 [Peer]

--- a/apps/fz_http/test/fz_http/devices_test.exs
+++ b/apps/fz_http/test/fz_http/devices_test.exs
@@ -85,7 +85,7 @@ defmodule FzHttp.DevicesTest do
     test "renders all peers", %{device: device} do
       assert Devices.to_peer_list() |> List.first() == %{
                public_key: device.public_key,
-               allowed_ips: Devices.ipv4_address(device)
+               allowed_ips: "#{Devices.ipv4_address(device)}/32, #{Devices.ipv6_address(device)}/128"
              }
     end
   end

--- a/apps/fz_vpn/lib/fz_vpn/cli/live.ex
+++ b/apps/fz_vpn/lib/fz_vpn/cli/live.ex
@@ -33,8 +33,8 @@ defmodule FzVpn.CLI.Live do
     {privkey, pubkey(privkey)}
   end
 
-  def add_peer(pubkey, ip) do
-    set("peer #{pubkey} allowed-ips #{ip}")
+  def add_peer(pubkey, {ipv4, ipv6}) do
+    set("peer #{pubkey} allowed-ips #{ipv4}/32,#{ipv6}/128")
   end
 
   def delete_peer(pubkey) do

--- a/omnibus/cookbooks/firezone/recipes/network.rb
+++ b/omnibus/cookbooks/firezone/recipes/network.rb
@@ -44,15 +44,18 @@ if wg_exists.status.exitstatus == 1
   end
 end
 
-execute 'setup_wireguard_ipv4' do
-  # XXX: Make this configurable
-  if_addr = '10.3.2.1/24'
-  command "ip address replace #{if_addr} dev #{wg_interface}"
+ifconfig '10.3.2.1' do
+  family 'inet'
+  device wg_interface
+  netmask '255.255.255.0'
+  mtu '1420'
 end
 
-execute 'setup_wireguard_ipv6' do
-  if_addr = 'fd00:3:2::1/48'
-  command "ip address replace #{if_addr} dev #{wg_interface}"
+  # XXX: Make this configurable
+ifconfig 'fd00:3:2::1' do
+  family 'inet6'
+  device wg_interface
+  mtu '1420'
 end
 
 execute 'set_wireguard_interface_private_key' do
@@ -62,10 +65,6 @@ end
 execute 'set_listen_port' do
   listen_port = node['firezone']['wireguard']['port']
   command "#{wg_path} set #{wg_interface} listen-port #{listen_port}"
-end
-
-execute 'set_mtu' do
-  command "ip link set mtu 1420 up dev #{wg_interface}"
 end
 
 route '10.3.2.0/24' do

--- a/omnibus/cookbooks/firezone/recipes/network.rb
+++ b/omnibus/cookbooks/firezone/recipes/network.rb
@@ -44,9 +44,14 @@ if wg_exists.status.exitstatus == 1
   end
 end
 
-execute 'setup_wireguard_ip' do
+execute 'setup_wireguard_ipv4' do
   # XXX: Make this configurable
   if_addr = '10.3.2.1/24'
+  command "ip address replace #{if_addr} dev #{wg_interface}"
+end
+
+execute 'setup_wireguard_ipv6' do
+  if_addr = 'fd00:3:2:1/48'
   command "ip address replace #{if_addr} dev #{wg_interface}"
 end
 
@@ -65,6 +70,10 @@ end
 
 route '10.3.2.0/24' do
   # XXX: Make this configurable
+  device wg_interface
+end
+
+route 'fd00:3:2::/48' do
   device wg_interface
 end
 

--- a/omnibus/cookbooks/firezone/recipes/network.rb
+++ b/omnibus/cookbooks/firezone/recipes/network.rb
@@ -44,17 +44,14 @@ if wg_exists.status.exitstatus == 1
   end
 end
 
-ifconfig '10.3.2.1/24' do
-  family 'inet'
-  device wg_interface
-  mtu '1420'
+execute 'wireguard_ipv4' do
+  addr = '10.3.2.1/24'
+  command "ip address replace #{addr} dev #{wg_interface}"
 end
 
-  # XXX: Make this configurable
-ifconfig 'fd00:3:2::1/120' do
-  family 'inet6'
-  device wg_interface
-  mtu '1420'
+execute 'wireguard_ipv6' do
+  addr = 'fd00:3:2::1/120'
+  command "ip -6 address replace #{addr} dev #{wg_interface}"
 end
 
 execute 'set_wireguard_interface_private_key' do
@@ -73,6 +70,10 @@ end
 
 route 'fd00:3:2::0/120' do
   device wg_interface
+end
+
+execute 'set_mtu' do
+  command "ip link set mtu 1420 up dev #{wg_interface}"
 end
 
 replace_or_add "IPv4 packet forwarding" do

--- a/omnibus/cookbooks/firezone/recipes/network.rb
+++ b/omnibus/cookbooks/firezone/recipes/network.rb
@@ -44,15 +44,14 @@ if wg_exists.status.exitstatus == 1
   end
 end
 
-ifconfig '10.3.2.1' do
+ifconfig '10.3.2.1/24' do
   family 'inet'
   device wg_interface
-  netmask '255.255.255.0'
   mtu '1420'
 end
 
   # XXX: Make this configurable
-ifconfig 'fd00:3:2::1' do
+ifconfig 'fd00:3:2::1/120' do
   family 'inet6'
   device wg_interface
   mtu '1420'
@@ -72,7 +71,7 @@ route '10.3.2.0/24' do
   device wg_interface
 end
 
-route 'fd00:3:2::/48' do
+route 'fd00:3:2::0/120' do
   device wg_interface
 end
 

--- a/omnibus/cookbooks/firezone/recipes/network.rb
+++ b/omnibus/cookbooks/firezone/recipes/network.rb
@@ -51,7 +51,7 @@ execute 'setup_wireguard_ipv4' do
 end
 
 execute 'setup_wireguard_ipv6' do
-  if_addr = 'fd00:3:2:1/48'
+  if_addr = 'fd00:3:2::1/48'
   command "ip address replace #{if_addr} dev #{wg_interface}"
 end
 


### PR DESCRIPTION
Adds the IPv6 prefix `fd00:3:2::/120` for ipv6 support.