### PR TITLE
Force kill phoenix for restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,30 +231,6 @@ For any problems that arise, a good first bet is to check the Firezone logs.
 
 To view Firezone logs, run `sudo firezone-ctl tail`.
 
-### Phoenix restart times out
-
-Occasionally, during a `sudo firezone-ctl reconfigure`, the `phoenix` service
-will fail to start with a `TIMEOUT` error like below:
-
-```
-================================================================================
-Error executing action `restart` on resource 'runit_service[phoenix]'
-================================================================================
-
-Mixlib::ShellOut::ShellCommandFailed
-------------------------------------
-Expected process to exit with [0], but received '1'
----- Begin output of /opt/firezone/embedded/bin/sv restart /opt/firezone/service/phoenix ----
-STDOUT: timeout: run: /opt/firezone/service/phoenix: (pid 3091432) 34s, got TERM
-STDERR:
----- End output of /opt/firezone/embedded/bin/sv restart /opt/firezone/service/phoenix ----
-Ran /opt/firezone/embedded/bin/sv restart /opt/firezone/service/phoenix returned 1
-```
-
-This happens because of the way phoenix handles input before fully starting up.
-To workaround, simply run `sudo firezone-ctl reconfigure` once more and everything
-should start fine.
-
 ## Uninstalling
 
 To completely remove Firezone and its configuration files, run the [uninstall.sh

--- a/omnibus/cookbooks/firezone/files/default/ctl-commands/teardown.rb
+++ b/omnibus/cookbooks/firezone/files/default/ctl-commands/teardown.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'mixlib/shellout'
+
+add_command_under_category 'teardown-network', 'general', 'Removes WireGuard interface and firezone nftables table', 2 do
+  command = %W(
+    chef-client
+    -z
+    -l info
+    -c #{base_path}/embedded/cookbooks/solo.rb
+    -o recipe[firezone::teardown]
+  )
+
+  result = run_command(command.join(" "))
+  remove_old_node_state
+  Kernel.exit 1 unless result.success?
+end

--- a/omnibus/cookbooks/firezone/recipes/default.rb
+++ b/omnibus/cookbooks/firezone/recipes/default.rb
@@ -22,3 +22,10 @@ file "#{node['firezone']['config_directory']}/firezone-running.json" do
   group node['firezone']['group']
   mode '0600'
 end
+
+file "#{node['firezone']['var_directory']}/.license.accepted" do
+  content ""
+  owner node['firezone']['user']
+  group node['firezone']['group']
+  mode '0600'
+end

--- a/omnibus/cookbooks/firezone/recipes/phoenix.rb
+++ b/omnibus/cookbooks/firezone/recipes/phoenix.rb
@@ -51,6 +51,7 @@ end
 if node['firezone']['phoenix']['enable']
   component_runit_service 'phoenix' do
     package 'firezone'
+    control ['t']
     action :enable
     subscribes :restart, 'file[environment-variables]'
   end

--- a/omnibus/cookbooks/firezone/templates/sv-phoenix-t.erb
+++ b/omnibus/cookbooks/firezone/templates/sv-phoenix-t.erb
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "received TERM from runit, forcing quit"
+<%= node['runit']['sv_bin'] %> kill phoenix

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo 'Removing Firezone network settings...'
-firezone-ctl teardown
+firezone-ctl teardown-network
 
 echo 'Removing all Firezone directories...'
 firezone-ctl cleanse yes


### PR DESCRIPTION
Unfortunately, the beam process doesn't respond to user requests until a few seconds after launched. This causes start-stop sequences to fail if executed in quick succession.

This is a workaround by force killing the beam.