### PR TITLE
Fix crash from empty address

### DIFF
--- a/apps/fz_http/lib/fz_http/devices.ex
+++ b/apps/fz_http/lib/fz_http/devices.ex
@@ -24,13 +24,13 @@ defmodule FzHttp.Devices do
 
   def create_device(attrs \\ %{}) do
     %Device{}
-    |> Device.changeset(attrs)
+    |> Device.create_changeset(attrs)
     |> Repo.insert()
   end
 
   def update_device(%Device{} = device, attrs) do
     device
-    |> Device.changeset(attrs)
+    |> Device.update_changeset(attrs)
     |> Repo.update()
   end
 
@@ -39,7 +39,7 @@ defmodule FzHttp.Devices do
   end
 
   def change_device(%Device{} = device) do
-    Device.changeset(device, %{})
+    Device.update_changeset(device, %{})
   end
 
   def rand_name do

--- a/apps/fz_http/lib/fz_http/devices/device.ex
+++ b/apps/fz_http/lib/fz_http/devices/device.ex
@@ -30,7 +30,7 @@ defmodule FzHttp.Devices.Device do
     timestamps(type: :utc_datetime_usec)
   end
 
-  def changeset(device, attrs) do
+  def create_changeset(device, attrs) do
     device
     |> cast(attrs, [
       :allowed_ips,
@@ -43,6 +43,28 @@ defmodule FzHttp.Devices.Device do
       :name,
       :public_key
     ])
+    |> shared_changeset()
+  end
+
+  def update_changeset(device, attrs) do
+    device
+    |> cast(attrs, [
+      :allowed_ips,
+      :dns_servers,
+      :remote_ip,
+      :address,
+      :server_public_key,
+      :private_key,
+      :user_id,
+      :name,
+      :public_key
+    ])
+    |> shared_changeset()
+    |> validate_required(:address)
+  end
+
+  defp shared_changeset(changeset) do
+    changeset
     |> validate_required([
       :user_id,
       :name,

--- a/apps/fz_http/test/fz_http/devices_test.exs
+++ b/apps/fz_http/test/fz_http/devices_test.exs
@@ -71,6 +71,18 @@ defmodule FzHttp.DevicesTest do
       allowed_ips: "1.1.1.1, 11, foobar"
     }
 
+    @empty_address %{
+      address: ""
+    }
+
+    @low_address %{
+      address: "1"
+    }
+
+    @high_address %{
+      address: "255"
+    }
+
     test "updates device", %{device: device} do
       {:ok, test_device} = Devices.update_device(device, @attrs)
       assert @attrs = test_device
@@ -88,6 +100,28 @@ defmodule FzHttp.DevicesTest do
                "is invalid: 1.1.1 is not a valid IPv4 / IPv6 address",
                []
              }
+    end
+
+    test "prevents updating device with empty address", %{device: device} do
+      {:error, changeset} = Devices.update_device(device, @empty_address)
+
+      assert changeset.errors[:address] == {"can't be blank", [{:validation, :required}]}
+    end
+
+    test "prevents updating device with address too low", %{device: device} do
+      {:error, changeset} = Devices.update_device(device, @low_address)
+
+      assert changeset.errors[:address] ==
+               {"must be greater than or equal to %{number}",
+                [{:validation, :number}, {:kind, :greater_than_or_equal_to}, {:number, 2}]}
+    end
+
+    test "prevents updating device with address too high", %{device: device} do
+      {:error, changeset} = Devices.update_device(device, @high_address)
+
+      assert changeset.errors[:address] ==
+               {"must be less than or equal to %{number}",
+                [{:validation, :number}, {:kind, :less_than_or_equal_to}, {:number, 254}]}
     end
 
     test "updates device with valid allowed_ips", %{device: device} do


### PR DESCRIPTION
Fix an issue where setting an empty device `address` octet caused the http process to crash and restart.