### PR TITLE
Add wireguard service

### DIFF
--- a/omnibus/cookbooks/firezone/attributes/default.rb
+++ b/omnibus/cookbooks/firezone/attributes/default.rb
@@ -199,12 +199,22 @@ default['firezone']['phoenix']['log_rotation']['num_to_keep'] = 10
 
 # ## WireGuard
 #
-# ### The WireGuard interface settings
+# ### Interface Management
+# Enable management of the WireGuard interface itself. Set this to false if you
+# want to manually create your WireGuard interface and manage its interface properties.
+default['firezone']['wireguard']['enable'] = true
+default['firezone']['wireguard']['log_directory'] = "#{node['firezone']['log_directory']}/wireguard"
+default['firezone']['wireguard']['log_rotation']['file_maxbytes'] = 104857600
+default['firezone']['wireguard']['log_rotation']['num_to_keep'] = 10
+
+# The WireGuard interface name Firezone will apply configuration settings to.
 default['firezone']['wireguard']['interface_name'] = 'wg-firezone'
-
-# ### WireGuard listen port
+# WireGuard listen port
 default['firezone']['wireguard']['port'] = 51820
+# WireGuard interface MTU
+default['firezone']['wireguard']['mtu'] = 1420
 
+# ### WireGuard endpoint
 # IPv4, IPv6, or hostname that device configs will use to connect to this server.
 # If left blank, this will be set to the IPv4 address of the default egress interface.
 # Override this to your publicly routable IP if you're behind a NAT and need to

--- a/omnibus/cookbooks/firezone/recipes/network.rb
+++ b/omnibus/cookbooks/firezone/recipes/network.rb
@@ -16,15 +16,10 @@ include_recipe 'line::default'
 
 require 'mixlib/shellout'
 
-wg_path = "#{node['firezone']['install_directory']}/embedded/bin/wg"
-awk_path = "#{node['firezone']['install_directory']}/embedded/bin/awk"
-wg_interface = node['firezone']['wireguard']['interface_name']
-private_key_path = "#{node['firezone']['var_directory']}/cache/wg_private_key"
-
 # Use ip route for finding default egress interface
+awk_path = "#{node['firezone']['install_directory']}/embedded/bin/awk"
 egress_int_cmd = Mixlib::ShellOut.new("ip route show default 0.0.0.0/0 | grep -oP '(?<=dev ).*' | cut -f1 -d' '")
 egress_interface = egress_int_cmd.run_command.stdout.chomp
-
 # Set default endpoint ip to default egress ip
 egress_addr_cmd = "ip address show dev #{egress_interface} | grep 'inet ' | #{awk_path} '{print $2}'"
 egress_ip = Mixlib::ShellOut.new(egress_addr_cmd)
@@ -32,47 +27,6 @@ egress_ip.run_command
 
 node.default['firezone']['wireguard']['endpoint'] ||= egress_ip.stdout.chomp.gsub(%r{/.*}, '')
 node.default['firezone']['egress_interface'] = egress_interface
-
-# Create wireguard interface if missing
-wg_exists = Mixlib::ShellOut.new("ip link show dev #{wg_interface}")
-wg_exists.run_command
-if wg_exists.status.exitstatus == 1
-  execute 'create_wireguard_interface' do
-    command "ip link add #{wg_interface} type wireguard"
-  end
-end
-
-execute 'wireguard_ipv4' do
-  addr = '10.3.2.1/24'
-  command "ip address replace #{addr} dev #{wg_interface}"
-end
-
-execute 'wireguard_ipv6' do
-  addr = 'fd00:3:2::1/120'
-  command "ip -6 address replace #{addr} dev #{wg_interface}"
-end
-
-execute 'set_mtu' do
-  command "ip link set mtu 1420 up dev #{wg_interface}"
-end
-
-execute 'set_wireguard_interface_private_key' do
-  command "#{wg_path} set #{wg_interface} private-key #{private_key_path}"
-end
-
-execute 'set_listen_port' do
-  listen_port = node['firezone']['wireguard']['port']
-  command "#{wg_path} set #{wg_interface} listen-port #{listen_port}"
-end
-
-route '10.3.2.0/24' do
-  # XXX: Make this configurable
-  device wg_interface
-end
-
-route 'fd00:3:2::0/120' do
-  device wg_interface
-end
 
 replace_or_add "IPv4 packet forwarding" do
   path "/etc/sysctl.conf"

--- a/omnibus/cookbooks/firezone/recipes/phoenix.rb
+++ b/omnibus/cookbooks/firezone/recipes/phoenix.rb
@@ -23,6 +23,7 @@
 
 include_recipe 'firezone::config'
 include_recipe 'firezone::nginx'
+include_recipe 'firezone::wireguard'
 
 [node['firezone']['phoenix']['log_directory'],
  "#{node['firezone']['var_directory']}/phoenix/run"].each do |dir|

--- a/omnibus/cookbooks/firezone/recipes/wireguard.rb
+++ b/omnibus/cookbooks/firezone/recipes/wireguard.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Cookbook:: firezone
+# Recipe:: wireguard
+#
+# Copyright:: 2021, Firezone, All Rights Reserved.
+
+# Sets up service to manage WireGuard interface
+
+include_recipe 'firezone::config'
+
+directory node['firezone']['wireguard']['log_directory'] do
+  owner node['firezone']['user']
+  group node['firezone']['group']
+  mode '0700'
+  recursive true
+end
+
+if node['firezone']['wireguard']['enable']
+  component_runit_service 'wireguard' do
+    package 'firezone'
+    action :enable
+    subscribes :restart, 'template[sv-wireguard-run]'
+  end
+else
+  runit_service 'wireguard' do
+    action :disable
+  end
+end

--- a/omnibus/cookbooks/firezone/templates/sv-wireguard-log-run.erb
+++ b/omnibus/cookbooks/firezone/templates/sv-wireguard-log-run.erb
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec <%= node['runit']['svlogd_bin'] %> \
+       -tt <%= node['firezone']['wireguard']['log_directory'] %>

--- a/omnibus/cookbooks/firezone/templates/sv-wireguard-run.erb
+++ b/omnibus/cookbooks/firezone/templates/sv-wireguard-run.erb
@@ -1,0 +1,15 @@
+#!/bin/sh
+exec 2>&1
+<%= "export OPENSSL_FIPS=1" if node['firezone']['fips_enabled'] == true %>
+
+export WIREGUARD_INTERFACE_NAME=<%= node['firezone']['wireguard']['interface_name'] %>
+export WG_PATH=<%= node['firezone']['install_directory'] %>/embedded/bin/wg
+export WIREGUARD_PRIVATE_KEY_PATH=<%= node['firezone']['var_directory'] %>/cache/wg_private_key
+export WIREGUARD_IPV4=10.3.2.1/24
+export WIREGUARD_IPV6=fd00:3:2::1/120
+export WIREGUARD_INTERFACE_MTU=<%= node['firezone']['wireguard']['mtu'] %>
+export WIREGUARD_LISTEN_PORT=<%= node['firezone']['wireguard']['port'] %>
+
+exec <%= node['runit']['chpst_bin'] %> \
+     -P \
+     <%= node['firezone']['install_directory'] %>/bin/wireguard

--- a/omnibus/cookbooks/firezone/templates/sv-wireguard-run.erb
+++ b/omnibus/cookbooks/firezone/templates/sv-wireguard-run.erb
@@ -12,4 +12,4 @@ export WIREGUARD_LISTEN_PORT=<%= node['firezone']['wireguard']['port'] %>
 
 exec <%= node['runit']['chpst_bin'] %> \
      -P \
-     <%= node['firezone']['install_directory'] %>/bin/wireguard
+     <%= node['firezone']['install_directory'] %>/embedded/bin/wireguard

--- a/omnibus/files/firezone-scripts/wireguard
+++ b/omnibus/files/firezone-scripts/wireguard
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Sets up the wireguard interface and begins logging
+
+error_exit()
+{
+  echo "${1:-"Unknown Error"}" 1>&2
+  exit 1
+}
+
+setup_interface()
+{
+  ip link show dev ${WIREGUARD_INTERFACE_NAME}
+  if [ $? -ne 0 ]; then
+    ip link add ${WIREGUARD_INTERFACE_NAME} type wireguard
+  fi
+
+  ip address replace ${WIREGUARD_IPV4} dev ${WIREGUARD_INTERFACE_NAME}
+  ip -6 address replace ${WIREGUARD_IPV6} dev ${WIREGUARD_INTERFACE_NAME}
+  ip link set mtu ${WIREGUARD_INTERFACE_MTU} up dev ${WIREGUARD_INTERFACE_NAME}
+  ${WG_PATH} set ${WIREGUARD_INTERFACE_NAME} private-key ${WIREGUARD_PRIVATE_KEY_PATH}
+  ${WG_PATH} set ${WIREGUARD_INTERFACE_NAME} listen-port ${WIREGUARD_LISTEN_PORT}
+}
+
+add_routes()
+{
+  ip route add 10.3.2.0/24 dev ${WIREGUARD_INTERFACE_NAME}
+  ip -6 route add fd00:3:2::0/120 dev ${WIREGUARD_INTERFACE_NAME}
+}
+
+main()
+{
+  echo 'Enabling WireGuard debugging support...'
+  echo module wireguard +p > /sys/kernel/debug/dynamic_debug/control
+  if [ $? -eq 0 ]; then
+    echo 'WireGuard debugging enabled. Starting dmesg...'
+    dmesg -wT | grep "wireguard: ${WIREGUARD_INTERFACE_NAME}:"
+  else
+    echo 'There was an issue enabling WireGuard debugging. Twiddling my thumbs...'
+    tail -f /dev/null
+  fi
+}
+
+setup_interface
+add_routes
+main


### PR DESCRIPTION
Adds a new Firezone-managed service called `wireguard` that maintains logs for the wireguard kernel module. This also allows runsvdir to monitor the service and start the wireguard interface on boot.

Fixes #298