### PR TITLE
Modal bug workaround; Add persistent keepalives

### DIFF
--- a/apps/fz_http/lib/fz_http/devices/device.ex
+++ b/apps/fz_http/lib/fz_http/devices/device.ex
@@ -23,7 +23,9 @@ defmodule FzHttp.Devices.Device do
     field :use_default_allowed_ips, :boolean, read_after_writes: true, default: true
     field :use_default_dns_servers, :boolean, read_after_writes: true, default: true
     field :use_default_endpoint, :boolean, read_after_writes: true, default: true
+    field :use_default_persistent_keepalives, :boolean, read_after_writes: true, default: true
     field :endpoint, :string
+    field :persistent_keepalives, :integer
     field :allowed_ips, :string
     field :dns_servers, :string
     field :private_key, FzHttp.Encrypted.Binary
@@ -62,9 +64,11 @@ defmodule FzHttp.Devices.Device do
       :use_default_allowed_ips,
       :use_default_dns_servers,
       :use_default_endpoint,
+      :use_default_persistent_keepalives,
       :allowed_ips,
       :dns_servers,
       :endpoint,
+      :persistent_keepalives,
       :remote_ip,
       :address,
       :server_public_key,
@@ -86,12 +90,21 @@ defmodule FzHttp.Devices.Device do
       :server_public_key,
       :private_key
     ])
-    |> validate_required_unless_default([:allowed_ips, :dns_servers, :endpoint])
-    |> validate_omitted_if_default([:allowed_ips, :dns_servers, :endpoint])
+    |> validate_required_unless_default([
+      :allowed_ips,
+      :dns_servers,
+      :endpoint,
+      :persistent_keepalives
+    ])
+    |> validate_omitted_if_default([:allowed_ips, :dns_servers, :endpoint, :persistent_keepalives])
     |> validate_list_of_ips_or_cidrs(:allowed_ips)
     |> validate_list_of_ips(:dns_servers)
     |> validate_no_duplicates(:dns_servers)
     |> validate_ip(:endpoint)
+    |> validate_number(:persistent_keepalives,
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: 120
+    )
     |> unique_constraint(:address)
     |> validate_number(:address, greater_than_or_equal_to: 2, less_than_or_equal_to: 254)
     |> unique_constraint(:public_key)

--- a/apps/fz_http/lib/fz_http/macros.ex
+++ b/apps/fz_http/lib/fz_http/macros.ex
@@ -3,6 +3,9 @@ defmodule FzHttp.Macros do
   Metaprogramming macros
   """
 
+  @doc """
+  Defines getters for all Setting keys as functions on the Settings module.
+  """
   defmacro def_settings(keys) do
     quote bind_quoted: [keys: keys] do
       Enum.each(keys, fn key ->

--- a/apps/fz_http/lib/fz_http/settings.ex
+++ b/apps/fz_http/lib/fz_http/settings.ex
@@ -13,6 +13,7 @@ defmodule FzHttp.Settings do
     default.device.allowed_ips
     default.device.dns_servers
     default.device.endpoint
+    default.device.persistent_keepalives
   ))
 
   @doc """

--- a/apps/fz_http/lib/fz_http/settings/setting.ex
+++ b/apps/fz_http/lib/fz_http/settings/setting.ex
@@ -15,6 +15,7 @@ defmodule FzHttp.Settings.Setting do
 
   import FzHttp.SharedValidators,
     only: [
+      validate_ip: 2,
       validate_list_of_ips: 2,
       validate_list_of_ips_or_cidrs: 2,
       validate_no_duplicates: 2
@@ -57,8 +58,12 @@ defmodule FzHttp.Settings.Setting do
 
   defp validate_kv_pair(changeset, "default.device.endpoint") do
     changeset
-    |> validate_list_of_ips_or_cidrs(:value)
-    |> validate_no_duplicates(:value)
+    |> validate_ip(:value)
+  end
+
+  defp validate_kv_pair(changeset, "default.device.persistent_keepalives") do
+    changeset
+    |> validate_number(:value, greater_than_or_equal_to: 0, less_than_or_equal_to: 120)
   end
 
   defp validate_kv_pair(changeset, unknown_key) do

--- a/apps/fz_http/lib/fz_http_web/live/device_live/form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/form_component.ex
@@ -18,6 +18,10 @@ defmodule FzHttpWeb.DeviceLive.FormComponent do
      |> assign(:default_device_allowed_ips, Settings.default_device_allowed_ips())
      |> assign(:default_device_dns_servers, Settings.default_device_dns_servers())
      |> assign(:default_device_endpoint, default_device_endpoint)
+     |> assign(
+       :default_device_persistent_keepalives,
+       Settings.default_device_persistent_keepalives()
+     )
      |> assign(:changeset, changeset)}
   end
 

--- a/apps/fz_http/lib/fz_http_web/live/device_live/form_component.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/form_component.html.heex
@@ -93,6 +93,39 @@
     </div>
 
     <div class="field">
+      <%= label f, :use_default_persistent_keepalives, "Use Default Persistent Keepalives", class: "label" %>
+      <div class="control">
+        <label class="radio">
+          <%= radio_button f, :use_default_persistent_keepalives, true %>
+          Yes
+        </label>
+        <label class="radio">
+          <%= radio_button f, :use_default_persistent_keepalives, false %>
+          No
+        </label>
+      </div>
+      <p class="help">
+        Default: <%= @default_device_persistent_keepalives %>
+      </p>
+    </div>
+
+    <div class="field">
+      <%= label f, :persistent_keepalives, "Persistent Keepalives", class: "label" %>
+      <p>
+        Interval for WireGuard
+        <a href="https://www.wireguard.com/quickstart/#nat-and-firewall-traversal-persistence">
+          persistent keepalives</a>. A value of 0 disables this. Leave this disabled
+          unless you're experiencing NAT or firewall traversal problems.
+      </p>
+      <div class="control">
+        <%= text_input f, :persistent_keepalives, class: "input", disabled: @use_default_persistent_keepalives %>
+      </div>
+      <p class="help is-danger">
+        <%= error_tag f, :persistent_keepalives %>
+      </p>
+    </div>
+
+    <div class="field">
       <%= label f, :address, "Interface Address (last octet only)", class: "label" %>
 
       <div class="control">

--- a/apps/fz_http/lib/fz_http_web/live/device_live/show.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/show.html.heex
@@ -63,6 +63,17 @@
       </tr>
 
       <tr>
+        <td><strong>Persistent Keepalives</strong></td>
+        <td>
+          <%= if @persistent_keepalives == 0 do %>
+            Every <%= @persistent_keepalives %> seconds
+          <% else %>
+            Disabled
+          <% end %>
+        </td>
+      </tr>
+
+      <tr>
         <td><strong>Public key</strong></td>
         <td class="code"><%= @device.public_key %></td>
       </tr>
@@ -87,8 +98,13 @@
     </div>
     <div class="level-right">
       <div class="field has-addons">
-        <div class={@dropdown_active_class <> " control dropdown is-right"}
-          phx-click-away="hide_config_token">
+        <div
+          id="shareable-link-trigger"
+          class={@dropdown_active_class <> " control dropdown is-right"}
+          phx-capture-click="close_dropdown"
+          phx-key="escape"
+          phx-click-away="close_dropdown"
+          phx-window-keydown="close_dropdown">
           <div class="dropdown-trigger">
             <button
               id="get-shareable-link"

--- a/apps/fz_http/lib/fz_http_web/live/device_live/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/show_live.ex
@@ -42,7 +42,7 @@ defmodule FzHttpWeb.DeviceLive.Show do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("hide_config_token", _params, socket) do
+  def handle_event("close_dropdown", _params, socket) do
     {:noreply,
      socket
      |> assign(:dropdown_active_class, "")}
@@ -84,6 +84,7 @@ defmodule FzHttpWeb.DeviceLive.Show do
         allowed_ips: Devices.allowed_ips(device),
         dns_servers: Devices.dns_servers(device),
         endpoint: Devices.endpoint(device),
+        persistent_keepalives: Devices.persistent_keepalives(device),
         config: Devices.as_config(device)
       )
     else

--- a/apps/fz_http/lib/fz_http_web/live/modal_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/modal_component.ex
@@ -4,11 +4,11 @@ defmodule FzHttpWeb.ModalComponent do
   """
   use FzHttpWeb, :live_component
 
-  @impl true
+  @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
     <div
-      id={@myself}
+      id={"modal-#{@myself}"}
       class="modal is-active"
       phx-capture-click="close"
       phx-window-keydown="close"
@@ -33,8 +33,18 @@ defmodule FzHttpWeb.ModalComponent do
     """
   end
 
-  @impl true
+  @impl Phoenix.LiveComponent
   def handle_event("close", _, socket) do
     {:noreply, push_patch(socket, to: socket.assigns.return_to)}
+  end
+
+  @impl Phoenix.LiveComponent
+  @doc """
+  XXX: This is needed due to a bug on pages with dropdowns.
+  Basically this modal receives the phx-click-away event and the
+  server crashes if this is not implemented.
+  """
+  def handle_event("close_dropdown", _params, socket) do
+    {:noreply, socket}
   end
 end

--- a/apps/fz_http/priv/repo/migrations/20211217003247_add_persistent_keepalives.exs
+++ b/apps/fz_http/priv/repo/migrations/20211217003247_add_persistent_keepalives.exs
@@ -1,0 +1,17 @@
+defmodule FzHttp.Repo.Migrations.AddPersistentKeepalives do
+  use Ecto.Migration
+
+  def change do
+    alter table(:devices) do
+      add :persistent_keepalives, :integer
+      add :use_default_persistent_keepalives, :boolean, null: false, default: true
+    end
+
+    now = DateTime.utc_now()
+
+    execute """
+    INSERT INTO settings (key, value, inserted_at, updated_at) VALUES \
+    ('default.device.persistent_keepalives', 0, '#{now}', '#{now}')
+    """
+  end
+end


### PR DESCRIPTION
Exposes WireGuard PersistentKeepalives config option for device configs.

Fixes firezone/backlog#129