### PR TITLE
Basic RBAC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
   unit-test:
     runs-on: ubuntu-18.04
     env:
+      ADMIN_EMAIL: firezone@localhost
       MIX_ENV: test
       POSTGRES_HOST: localhost
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
   unit-test:
     runs-on: ubuntu-18.04
     env:
-      ADMIN_EMAIL: firezone@localhost
       MIX_ENV: test
       POSTGRES_HOST: localhost
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/fz_common/lib/fz_map.ex
+++ b/apps/fz_common/lib/fz_map.ex
@@ -19,7 +19,13 @@ defmodule FzCommon.FzMap do
   """
   def stringify_keys(map) when is_map(map) do
     map
-    |> Enum.map(fn {k, v} -> {Atom.to_string(k), v} end)
+    |> Enum.map(fn {k, v} ->
+      if is_atom(k) do
+        {Atom.to_string(k), v}
+      else
+        {k, v}
+      end
+    end)
     |> Enum.into(%{})
   end
 end

--- a/apps/fz_http/lib/fz_http/release.ex
+++ b/apps/fz_http/lib/fz_http/release.ex
@@ -33,7 +33,7 @@ defmodule FzHttp.Release do
     if Repo.exists?(from u in User, where: u.email == ^email()) do
       change_password(email(), default_password())
     else
-      Users.create_user(
+      Users.create_admin_user(
         email: email(),
         password: default_password(),
         password_confirmation: default_password()

--- a/apps/fz_http/lib/fz_http/users.ex
+++ b/apps/fz_http/lib/fz_http/users.ex
@@ -12,6 +12,10 @@ defmodule FzHttp.Users do
   # one hour
   @sign_in_token_validity_secs 3600
 
+  def count do
+    Repo.one(from u in User, select: count(u.id))
+  end
+
   def consume_sign_in_token(token) when is_binary(token) do
     case find_token_transaction(token) do
       {:ok, {:ok, user}} -> {:ok, user}
@@ -93,6 +97,13 @@ defmodule FzHttp.Users do
     Repo.all(User)
   end
 
+  @doc """
+  Fetches all users and groups into an Enumerable that can be used for an HTML form input.
+  """
+  def as_options_for_select do
+    Repo.all(from u in User, select: {u.email, u.id})
+  end
+
   def list_users(:with_device_counts) do
     query =
       from(
@@ -106,7 +117,7 @@ defmodule FzHttp.Users do
     Repo.all(query)
   end
 
-  # Assume only one admin
+  # XXX: Assume only one admin
   def admin do
     Repo.one(
       from u in User,

--- a/apps/fz_http/lib/fz_http/users/session.ex
+++ b/apps/fz_http/lib/fz_http/users/session.ex
@@ -8,6 +8,7 @@ defmodule FzHttp.Users.Session do
   alias FzHttp.{Users, Users.User}
 
   schema "users" do
+    field :role, Ecto.Enum, values: [:unprivileged, :admin], default: :unprivileged
     field :email, :string
     field :password, :string, virtual: true
     field :last_signed_in_at, :utc_datetime_usec

--- a/apps/fz_http/lib/fz_http/users/user.ex
+++ b/apps/fz_http/lib/fz_http/users/user.ex
@@ -34,6 +34,7 @@ defmodule FzHttp.Users.User do
   def create_changeset(user, attrs \\ %{}) do
     user
     |> cast(attrs, [
+      :role,
       :sign_in_token,
       :sign_in_token_created_at,
       :email,
@@ -98,7 +99,7 @@ defmodule FzHttp.Users.User do
         } = attrs
       ) do
     user
-    |> cast(attrs, [:email, :password, :password_confirmation, :current_password])
+    |> cast(attrs, [:role, :email, :password, :password_confirmation, :current_password])
     |> validate_required([:email, :password, :password_confirmation, :current_password])
     |> validate_format(:email, ~r/@/)
     |> verify_current_password(user)

--- a/apps/fz_http/lib/fz_http/users/user.ex
+++ b/apps/fz_http/lib/fz_http/users/user.ex
@@ -13,6 +13,7 @@ defmodule FzHttp.Users.User do
   alias FzHttp.Devices.Device
 
   schema "users" do
+    field :role, Ecto.Enum, values: [:unprivileged, :admin], default: :unprivileged
     field :email, :string
     field :last_signed_in_at, :utc_datetime_usec
     field :password_hash, :string

--- a/apps/fz_http/lib/fz_http_web/controller_helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/controller_helpers.ex
@@ -16,6 +16,7 @@ defmodule FzHttpWeb.ControllerHelpers do
       redirect: 2
     ]
 
+  alias FzHttp.Users
   alias FzHttpWeb.Router.Helpers, as: Routes
 
   def redirect_unauthenticated(conn, _options) do
@@ -27,6 +28,21 @@ defmodule FzHttpWeb.ControllerHelpers do
 
       _ ->
         conn
+    end
+  end
+
+  def root_path_for_role(conn) do
+    user = Users.get_user!(get_session(conn, :user_id))
+
+    case user.role do
+      :unprivileged ->
+        Routes.user_path(conn, :show)
+
+      :admin ->
+        Routes.device_path(conn, :index)
+
+      _ ->
+        Routes.session_path(conn, :new)
     end
   end
 

--- a/apps/fz_http/lib/fz_http_web/controller_helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/controller_helpers.ex
@@ -47,21 +47,37 @@ defmodule FzHttpWeb.ControllerHelpers do
     end
   end
 
-  def root_path_for_role(conn) do
-    user = Users.get_user!(get_session(conn, :user_id))
-    root_path_for_role(conn, user)
+  def root_path_for_role(%Plug.Conn{} = conn) do
+    user_id = get_session(conn, :user_id)
+
+    if is_nil(user_id) do
+      Routes.session_path(conn, :new)
+    else
+      user = Users.get_user!(user_id)
+      root_path_for_role(conn, user)
+    end
   end
 
-  def root_path_for_role(conn, user) do
+  def root_path_for_role(socket) do
+    user = Map.get(socket.assigns, :current_user)
+
+    if is_nil(user) do
+      Routes.session_path(socket, :new)
+    else
+      root_path_for_role(socket, user)
+    end
+  end
+
+  def root_path_for_role(conn_or_sock, user) do
     case user.role do
       :unprivileged ->
-        Routes.user_path(conn, :show)
+        Routes.user_path(conn_or_sock, :show)
 
       :admin ->
-        Routes.device_index_path(conn, :index)
+        Routes.device_index_path(conn_or_sock, :index)
 
       _ ->
-        Routes.session_path(conn, :new)
+        Routes.session_path(conn_or_sock, :new)
     end
   end
 

--- a/apps/fz_http/lib/fz_http_web/controllers/device_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/device_controller.ex
@@ -8,11 +8,7 @@ defmodule FzHttpWeb.DeviceController do
   alias FzHttp.Devices
 
   plug :redirect_unauthenticated, except: [:config]
-
-  def index(conn, _params) do
-    conn
-    |> redirect(to: Routes.device_index_path(conn, :index))
-  end
+  plug :authorize_authenticated, except: [:config]
 
   def download_config(conn, %{"id" => device_id}) do
     device = Devices.get_device!(device_id)

--- a/apps/fz_http/lib/fz_http_web/controllers/root_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/root_controller.ex
@@ -1,0 +1,13 @@
+defmodule FzHttpWeb.RootController do
+  @moduledoc """
+  Handles redirecting from /
+  """
+  use FzHttpWeb, :controller
+
+  plug :redirect_unauthenticated
+
+  def index(conn, _params) do
+    conn
+    |> redirect(to: root_path_for_role(conn))
+  end
+end

--- a/apps/fz_http/lib/fz_http_web/controllers/session_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/session_controller.ex
@@ -3,7 +3,7 @@ defmodule FzHttpWeb.SessionController do
   Implements the CRUD for a Session
   """
 
-  alias FzHttp.{Sessions, Users, Users.Session}
+  alias FzHttp.{Sessions, Users}
   use FzHttpWeb, :controller
 
   plug :put_root_layout, "auth.html"
@@ -31,22 +31,14 @@ defmodule FzHttpWeb.SessionController do
 
       record ->
         case Sessions.create_session(record, %{email: email, password: password}) do
-          {:ok, %Session{role: :unprivileged} = session} ->
-            conn
-            |> clear_session()
-            |> assign(:current_session, session)
-            |> activate_vpn()
-            |> put_session(:user_id, session.id)
-            |> redirect(to: Routes.user_path(conn, :show))
-
-          {:ok, %Session{role: :admin} = session} ->
+          {:ok, session} ->
             conn
             |> clear_session()
             |> assign(:current_session, session)
             |> activate_vpn()
             |> put_session(:user_id, session.id)
             |> put_session(:live_socket_id, "users_socket:#{session.id}")
-            |> redirect(to: Routes.device_path(conn, :index))
+            |> redirect(to: Routes.root_path(conn, :index))
 
           {:error, _changeset} ->
             conn
@@ -65,7 +57,7 @@ defmodule FzHttpWeb.SessionController do
         |> clear_session()
         |> put_session(:user_id, user.id)
         |> put_session(:live_socket_id, "users_socket:#{user.id}")
-        |> redirect(to: Routes.device_path(conn, :index))
+        |> redirect(to: Routes.device_index_path(conn, :index))
 
       {:error, error_msg} ->
         conn

--- a/apps/fz_http/lib/fz_http_web/controllers/user_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/user_controller.ex
@@ -14,6 +14,16 @@ defmodule FzHttpWeb.UserController do
     |> redirect(to: Routes.user_index_path(conn, :index))
   end
 
+  def show(conn, _params) do
+    user_id = get_session(conn, :user_id)
+    user = Users.get_user!(user_id)
+
+    conn
+    |> put_root_layout({FzHttpWeb.LayoutView, "auth.html"})
+    |> put_layout({FzHttpWeb.LayoutView, "app.html"})
+    |> render("show.html", user: user)
+  end
+
   def delete(conn, _params) do
     user_id = get_session(conn, :user_id)
     user = Users.get_user!(user_id)

--- a/apps/fz_http/lib/fz_http_web/live/account_live/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/account_live/show_live.ex
@@ -20,7 +20,13 @@ defmodule FzHttpWeb.AccountLive.Show do
   end
 
   defp load_data(_params, socket) do
-    socket
-    |> assign(:changeset, Users.change_user(socket.assigns.current_user))
+    user = socket.assigns.current_user
+
+    if user.role == :admin do
+      socket
+      |> assign(:changeset, Users.change_user(socket.assigns.current_user))
+    else
+      not_authorized(socket)
+    end
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/connectivity_check_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/connectivity_check_live/index_live.ex
@@ -15,6 +15,13 @@ defmodule FzHttpWeb.ConnectivityCheckLive.Index do
   end
 
   defp load_data(_params, socket) do
-    assign(socket, :connectivity_checks, ConnectivityChecks.list_connectivity_checks(limit: 20))
+    user = socket.assigns.current_user
+
+    if user.role == :admin do
+      socket
+      |> assign(:connectivity_checks, ConnectivityChecks.list_connectivity_checks(limit: 20))
+    else
+      not_authorized(socket)
+    end
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.ex
@@ -6,6 +6,7 @@ defmodule FzHttpWeb.DeviceLive.CreateFormComponent do
 
   alias FzHttp.{Devices, Users}
 
+  @impl Phoenix.LiveComponent
   def update(assigns, socket) do
     {:ok,
      socket
@@ -13,6 +14,7 @@ defmodule FzHttpWeb.DeviceLive.CreateFormComponent do
      |> assign(assigns)}
   end
 
+  @impl Phoenix.LiveComponent
   def handle_event("save", %{"device" => %{"user_id" => user_id}}, socket) do
     case Devices.auto_create_device(%{user_id: user_id}) do
       {:ok, device} ->
@@ -20,7 +22,7 @@ defmodule FzHttpWeb.DeviceLive.CreateFormComponent do
 
         {:noreply,
          socket
-         |> redirect(to: Routes.device_show_path(socket, :show, device))}
+         |> push_redirect(to: Routes.device_show_path(socket, :show, device))}
 
       {:error, changeset} ->
         {:noreply,

--- a/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.ex
@@ -1,0 +1,31 @@
+defmodule FzHttpWeb.DeviceLive.CreateFormComponent do
+  @moduledoc """
+  Handles create device form.
+  """
+  use FzHttpWeb, :live_component
+
+  alias FzHttp.{Devices, Users}
+
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(:options_for_select, Users.as_options_for_select())
+     |> assign(assigns)}
+  end
+
+  def handle_event("save", %{"device" => %{"user_id" => user_id}}, socket) do
+    case Devices.auto_create_device(%{user_id: user_id}) do
+      {:ok, device} ->
+        @events_module.device_created(device)
+
+        {:noreply,
+         socket
+         |> redirect(to: Routes.device_show_path(socket, :show, device))}
+
+      {:error, changeset} ->
+        {:noreply,
+         socket
+         |> assign(:changeset, changeset)}
+    end
+  end
+end

--- a/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.html.heex
@@ -1,0 +1,27 @@
+<div>
+  <.form let={f} for={@changeset} id="add-device" phx-target={@myself} phx-submit="save">
+    <div class="field">
+      <%= label f, :user_id, "User", class: "label" %>
+      <div class="select">
+        <%= select f, :user_id, @options_for_select, class: "input" %>
+      </div>
+      <p class="help is-danger">
+        <%= error_tag f, :user_id %>
+      </p>
+      <p class="help">
+        Select a user to add the device for.
+      </p>
+    </div>
+
+    <div class="field">
+      <div class="control">
+        <div class="level">
+          <div class="level-left"></div>
+          <div class="level-right">
+            <%= submit "Save", phx_disable_with: "Saving...", class: "button is-primary" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </.form>
+</div>

--- a/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.html.heex
@@ -9,7 +9,7 @@
         <%= error_tag f, :user_id %>
       </p>
       <p class="help">
-        Select a user to add the device for.
+        Select the user who this device should belong to.
       </p>
     </div>
 

--- a/apps/fz_http/lib/fz_http_web/live/device_live/index.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/index.html.heex
@@ -1,3 +1,12 @@
+<%= if @live_action == :new do %>
+  <%= live_modal(
+        FzHttpWeb.DeviceLive.CreateFormComponent,
+        return_to: Routes.device_index_path(@socket, :index),
+        title: "Add Device",
+        changeset: @changeset,
+        id: "add-device-modal") %>
+<% end %>
+
 <%= render FzHttpWeb.SharedView, "heading.html", page_title: @page_title %>
 
 <section class="section is-main-section">

--- a/apps/fz_http/lib/fz_http_web/live/device_live/index.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/index.html.heex
@@ -4,7 +4,8 @@
         return_to: Routes.device_index_path(@socket, :index),
         title: "Add Device",
         changeset: @changeset,
-        id: "add-device-modal") %>
+        id: "add-device-modal",
+        action: @live_action) %>
 <% end %>
 
 <%= render FzHttpWeb.SharedView, "heading.html", page_title: @page_title %>

--- a/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
@@ -7,6 +7,7 @@ defmodule FzHttpWeb.DeviceLive.Index do
   alias FzHttp.{Devices, Users}
   alias FzHttpWeb.ErrorHelpers
 
+  @impl Phoenix.LiveView
   def mount(params, session, socket) do
     {:ok,
      socket
@@ -15,6 +16,7 @@ defmodule FzHttpWeb.DeviceLive.Index do
      |> assign(:page_title, "Devices")}
   end
 
+  @impl Phoenix.LiveView
   def handle_event("create_device", _params, socket) do
     if Users.count() == 1 do
       # Must be the admin user
@@ -37,8 +39,16 @@ defmodule FzHttpWeb.DeviceLive.Index do
     else
       {:noreply,
        socket
-       |> push_redirect(to: Routes.device_index_path(socket, :new))}
+       |> push_patch(to: Routes.device_index_path(socket, :new))}
     end
+  end
+
+  @doc """
+  Needed because this view will receive handle_params when modal is closed.
+  """
+  @impl Phoenix.LiveView
+  def handle_params(_params, _url, socket) do
+    {:noreply, socket}
   end
 
   defp load_data(_params, socket) do

--- a/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
@@ -42,6 +42,13 @@ defmodule FzHttpWeb.DeviceLive.Index do
   end
 
   defp load_data(_params, socket) do
-    assign(socket, :devices, Devices.list_devices())
+    # XXX: Update this to use new LiveView session auth
+    user = socket.assigns.current_user
+
+    if user.role == :admin do
+      assign(socket, :devices, Devices.list_devices())
+    else
+      not_authorized(socket)
+    end
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
@@ -4,42 +4,40 @@ defmodule FzHttpWeb.DeviceLive.Index do
   """
   use FzHttpWeb, :live_view
 
-  alias FzHttp.Devices
+  alias FzHttp.{Devices, Users}
   alias FzHttpWeb.ErrorHelpers
 
   def mount(params, session, socket) do
     {:ok,
      socket
      |> assign_defaults(params, session, &load_data/2)
+     |> assign(:changeset, Devices.new_device())
      |> assign(:page_title, "Devices")}
   end
 
   def handle_event("create_device", _params, socket) do
-    {:ok, privkey, pubkey, server_pubkey} = @events_module.create_device()
+    if Users.count() == 1 do
+      # Must be the admin user
+      case Devices.auto_create_device(%{user_id: Users.admin().id}) do
+        {:ok, device} ->
+          @events_module.device_created(device)
 
-    attributes = %{
-      private_key: privkey,
-      public_key: pubkey,
-      server_public_key: server_pubkey,
-      user_id: socket.assigns.current_user.id,
-      name: Devices.rand_name()
-    }
+          {:noreply,
+           socket
+           |> push_redirect(to: Routes.device_show_path(socket, :show, device))}
 
-    case Devices.create_device(attributes) do
-      {:ok, device} ->
-        @events_module.device_created(device)
-
-        {:noreply,
-         socket
-         |> redirect(to: Routes.device_show_path(socket, :show, device))}
-
-      {:error, changeset} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           "Error creating device: #{ErrorHelpers.aggregated_errors(changeset)}"
-         )}
+        {:error, changeset} ->
+          {:noreply,
+           socket
+           |> put_flash(
+             :error,
+             "Error creating device: #{ErrorHelpers.aggregated_errors(changeset)}"
+           )}
+      end
+    else
+      {:noreply,
+       socket
+       |> push_redirect(to: Routes.device_index_path(socket, :new))}
     end
   end
 

--- a/apps/fz_http/lib/fz_http_web/live/device_live/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/show_live.ex
@@ -14,6 +14,9 @@ defmodule FzHttpWeb.DeviceLive.Show do
      |> assign_defaults(params, session, &load_data/2)}
   end
 
+  @doc """
+  Needed because this view will receive handle_params when modal is closed.
+  """
   @impl Phoenix.LiveView
   def handle_params(_params, _url, socket) do
     {:noreply, socket}

--- a/apps/fz_http/lib/fz_http_web/live/device_live/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/show_live.ex
@@ -23,7 +23,7 @@ defmodule FzHttpWeb.DeviceLive.Show do
   def handle_event("create_config_token", _params, socket) do
     device = socket.assigns.device
 
-    if device.user_id == socket.assigns.current_user.id do
+    if authorized?(socket.assigns.current_user, device) do
       case Devices.create_config_token(device) do
         {:ok, device} ->
           {:noreply,
@@ -52,7 +52,7 @@ defmodule FzHttpWeb.DeviceLive.Show do
   def handle_event("delete_device", _params, socket) do
     device = socket.assigns.device
 
-    if device.user_id == socket.assigns.current_user.id do
+    if authorized?(socket.assigns.current_user, device) do
       case Devices.delete_device(device) do
         {:ok, _deleted_device} ->
           {:ok, _deleted_pubkey} = @events_module.delete_device(device.public_key)
@@ -75,7 +75,7 @@ defmodule FzHttpWeb.DeviceLive.Show do
   defp load_data(%{"id" => id}, socket) do
     device = Devices.get_device!(id)
 
-    if device.user_id == socket.assigns.current_user.id do
+    if authorized?(socket.assigns.current_user, device) do
       socket
       |> assign(
         device: device,
@@ -90,5 +90,9 @@ defmodule FzHttpWeb.DeviceLive.Show do
     else
       not_authorized(socket)
     end
+  end
+
+  defp authorized?(user, device) do
+    device.user_id == user.id || user.role == :admin
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/modal_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/modal_component.ex
@@ -8,7 +8,7 @@ defmodule FzHttpWeb.ModalComponent do
   def render(assigns) do
     ~H"""
     <div
-      id={"modal-#{@myself}"}
+      id={@myself}
       class="modal is-active"
       phx-capture-click="close"
       phx-window-keydown="close"

--- a/apps/fz_http/lib/fz_http_web/live/rule_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/rule_live/index_live.ex
@@ -7,7 +7,17 @@ defmodule FzHttpWeb.RuleLive.Index do
   def mount(params, session, socket) do
     {:ok,
      socket
-     |> assign_defaults(params, session)
-     |> assign(:page_title, "Egress Rules")}
+     |> assign_defaults(params, session, &load_data/2)}
+  end
+
+  defp load_data(_params, socket) do
+    user = socket.assigns.current_user
+
+    if user.role == :admin do
+      socket
+      |> assign(:page_title, "Egress Rules")
+    else
+      not_authorized(socket)
+    end
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/default_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/default_live.ex
@@ -28,11 +28,7 @@ defmodule FzHttpWeb.SettingLive.Default do
   def mount(params, session, socket) do
     {:ok,
      socket
-     |> assign_defaults(params, session)
-     |> assign(:help_texts, @help_texts)
-     |> assign(:changesets, load_changesets())
-     |> assign(:endpoint_placeholder, endpoint_placeholder())
-     |> assign(:page_title, "Default Settings")}
+     |> assign_defaults(params, session, &load_data/2)}
   end
 
   defp endpoint_placeholder do
@@ -42,5 +38,19 @@ defmodule FzHttpWeb.SettingLive.Default do
   defp load_changesets do
     Settings.to_list("default.")
     |> Map.new(fn setting -> {setting.key, Settings.change_setting(setting)} end)
+  end
+
+  defp load_data(_params, socket) do
+    user = socket.assigns.current_user
+
+    if user.role == :admin do
+      socket
+      |> assign(:changesets, load_changesets())
+      |> assign(:help_texts, @help_texts)
+      |> assign(:endpoint_placeholder, endpoint_placeholder())
+      |> assign(:page_title, "Default Settings")
+    else
+      not_authorized(socket)
+    end
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/user_live/form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/form_component.ex
@@ -28,7 +28,7 @@ defmodule FzHttpWeb.UserLive.FormComponent do
 
   @impl Phoenix.LiveComponent
   def handle_event("save", %{"user" => user_params}, %{assigns: %{action: :new}} = socket) do
-    case Users.create_user(user_params) do
+    case Users.create_unprivileged_user(user_params) do
       {:ok, user} ->
         {:noreply,
          socket

--- a/apps/fz_http/lib/fz_http_web/live/user_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/index_live.ex
@@ -21,10 +21,16 @@ defmodule FzHttpWeb.UserLive.Index do
   end
 
   defp load_data(_params, socket) do
-    assign(
-      socket,
-      :users,
-      Users.list_users(:with_device_counts)
-    )
+    user = socket.assigns.current_user
+
+    if user.role == :admin do
+      assign(
+        socket,
+        :users,
+        Users.list_users(:with_device_counts)
+      )
+    else
+      not_authorized(socket)
+    end
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/user_live/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/show_live.ex
@@ -15,14 +15,6 @@ defmodule FzHttpWeb.UserLive.Show do
      |> assign_defaults(params, session, &load_data/2)}
   end
 
-  defp load_data(params, socket) do
-    user = Users.get_user!(params["id"])
-
-    socket
-    |> assign(:devices, Devices.list_devices(user))
-    |> assign(:user, user)
-  end
-
   @impl Phoenix.LiveView
   def handle_params(_params, _url, socket) do
     {:noreply, socket}
@@ -86,6 +78,18 @@ defmodule FzHttpWeb.UserLive.Show do
            :error,
            "Error creating device: #{ErrorHelpers.aggregated_errors(changeset)}"
          )}
+    end
+  end
+
+  defp load_data(params, socket) do
+    user = Users.get_user!(params["id"])
+
+    if socket.assigns.current_user.role == :admin do
+      socket
+      |> assign(:devices, Devices.list_devices(user))
+      |> assign(:user, user)
+    else
+      not_authorized(socket)
     end
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live_helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/live_helpers.ex
@@ -8,7 +8,7 @@ defmodule FzHttpWeb.LiveHelpers do
   import Phoenix.LiveView.Helpers
   alias FzHttp.Users
 
-  import FzHttpWeb.ControllerHelpers, only: [root_path_for_role: 2]
+  import FzHttpWeb.ControllerHelpers, only: [root_path_for_role: 1]
 
   @doc """
   Load user into socket assigns and call the callback function if provided.
@@ -36,12 +36,9 @@ defmodule FzHttpWeb.LiveHelpers do
   end
 
   def not_authorized(socket) do
-    # XXX: Update this to use new LiveView session auth
-    user = socket.assigns.current_user
-
     socket
     |> put_flash(:error, "Not authorized.")
-    |> redirect(to: root_path_for_role(socket, user))
+    |> redirect(to: root_path_for_role(socket))
   end
 
   def live_modal(component, opts) do

--- a/apps/fz_http/lib/fz_http_web/live_helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/live_helpers.ex
@@ -7,7 +7,8 @@ defmodule FzHttpWeb.LiveHelpers do
   import Phoenix.LiveView
   import Phoenix.LiveView.Helpers
   alias FzHttp.Users
-  alias FzHttpWeb.Router.Helpers, as: Routes
+
+  import FzHttpWeb.ControllerHelpers, only: [root_path_for_role: 2]
 
   @doc """
   Load user into socket assigns and call the callback function if provided.
@@ -35,9 +36,12 @@ defmodule FzHttpWeb.LiveHelpers do
   end
 
   def not_authorized(socket) do
+    # XXX: Update this to use new LiveView session auth
+    user = socket.assigns.current_user
+
     socket
     |> put_flash(:error, "Not authorized.")
-    |> redirect(to: Routes.session_path(socket, :new))
+    |> redirect(to: root_path_for_role(socket, user))
   end
 
   def live_modal(component, opts) do

--- a/apps/fz_http/lib/fz_http_web/router.ex
+++ b/apps/fz_http/lib/fz_http_web/router.ex
@@ -31,6 +31,7 @@ defmodule FzHttpWeb.Router do
     live "/rules", RuleLive.Index, :index
 
     live "/devices", DeviceLive.Index, :index
+    live "/devices/new", DeviceLive.Index, :new
     live "/devices/:id", DeviceLive.Show, :show
     live "/devices/:id/edit", DeviceLive.Show, :edit
     get "/devices/:id/dl", DeviceController, :download_config
@@ -49,5 +50,6 @@ defmodule FzHttpWeb.Router do
 
     get "/sign_in/:token", SessionController, :create
     delete "/user", UserController, :delete
+    get "/user", UserController, :show
   end
 end

--- a/apps/fz_http/lib/fz_http_web/router.ex
+++ b/apps/fz_http/lib/fz_http_web/router.ex
@@ -35,7 +35,6 @@ defmodule FzHttpWeb.Router do
     live "/devices/:id", DeviceLive.Show, :show
     live "/devices/:id/edit", DeviceLive.Show, :edit
     get "/devices/:id/dl", DeviceController, :download_config
-    get "/", DeviceController, :index
     get "/device_config/:config_token", DeviceController, :config
     get "/device_config/:config_token/dl", DeviceController, :download_shared_config
 
@@ -51,5 +50,7 @@ defmodule FzHttpWeb.Router do
     get "/sign_in/:token", SessionController, :create
     delete "/user", UserController, :delete
     get "/user", UserController, :show
+
+    get "/", RootController, :index
   end
 end

--- a/apps/fz_http/lib/fz_http_web/templates/shared/user_details.html.heex
+++ b/apps/fz_http/lib/fz_http_web/templates/shared/user_details.html.heex
@@ -6,6 +6,11 @@
     </tr>
 
     <tr>
+      <td><strong>Role</strong></td>
+      <td><%= @user.role %></td>
+    </tr>
+
+    <tr>
       <td><strong>Last Signed In</strong></td>
       <td
         id="last-signed-in-at"

--- a/apps/fz_http/lib/fz_http_web/templates/user/show.html.heex
+++ b/apps/fz_http/lib/fz_http_web/templates/user/show.html.heex
@@ -1,0 +1,13 @@
+<p>
+  Your VPN session is active!
+</p>
+
+<p>
+  User: <%= @user.email %>
+</p>
+
+<p>
+  <%= link(to: Routes.session_path(@conn, :delete), method: :delete) do %>
+    Sign out and end your session.
+  <% end %>
+</p>

--- a/apps/fz_http/lib/fz_http_web/views/user_view.ex
+++ b/apps/fz_http/lib/fz_http_web/views/user_view.ex
@@ -1,0 +1,3 @@
+defmodule FzHttpWeb.UserView do
+  use FzHttpWeb, :view
+end

--- a/apps/fz_http/priv/repo/migrations/20211221183311_add_role_to_users.exs
+++ b/apps/fz_http/priv/repo/migrations/20211221183311_add_role_to_users.exs
@@ -14,14 +14,7 @@ defmodule FzHttp.Repo.Migrations.AddRoleToUsers do
     # Make existing admin the admin if exists. Admin is most likely the first created user.
     flush()
 
-    execute """
-    UPDATE users SET role = 'admin' WHERE id IN (
-        SELECT id FROM (
-            SELECT id FROM users
-            ORDER BY inserted_at ASC
-            LIMIT 1
-        ) tmp
-    )
-    """
+    admin_email = System.get_env!("ADMIN_EMAIL")
+    execute "UPDATE users SET role = 'admin' WHERE email = '#{admin_email}'"
   end
 end

--- a/apps/fz_http/priv/repo/migrations/20211221183311_add_role_to_users.exs
+++ b/apps/fz_http/priv/repo/migrations/20211221183311_add_role_to_users.exs
@@ -14,7 +14,7 @@ defmodule FzHttp.Repo.Migrations.AddRoleToUsers do
     # Make existing admin the admin if exists. Admin is most likely the first created user.
     flush()
 
-    admin_email = System.get_env!("ADMIN_EMAIL")
+    admin_email = System.fetch_env!("ADMIN_EMAIL")
     execute "UPDATE users SET role = 'admin' WHERE email = '#{admin_email}'"
   end
 end

--- a/apps/fz_http/priv/repo/migrations/20211221183311_add_role_to_users.exs
+++ b/apps/fz_http/priv/repo/migrations/20211221183311_add_role_to_users.exs
@@ -1,0 +1,27 @@
+defmodule FzHttp.Repo.Migrations.AddRoleToUsers do
+  use Ecto.Migration
+
+  @create_query "CREATE TYPE role_enum AS ENUM ('unprivileged', 'admin')"
+  @drop_query "DROP TYPE role_enum"
+
+  def change do
+    execute(@create_query, @drop_query)
+
+    alter table(:users) do
+      add :role, :role_enum, default: "unprivileged", null: false
+    end
+
+    # Make existing admin the admin if exists. Admin is most likely the first created user.
+    flush()
+
+    execute """
+    UPDATE users SET role = 'admin' WHERE id IN (
+        SELECT id FROM (
+            SELECT id FROM users
+            ORDER BY inserted_at ASC
+            LIMIT 1
+        ) tmp
+    )
+    """
+  end
+end

--- a/apps/fz_http/priv/repo/migrations/20211221183311_add_role_to_users.exs
+++ b/apps/fz_http/priv/repo/migrations/20211221183311_add_role_to_users.exs
@@ -14,7 +14,10 @@ defmodule FzHttp.Repo.Migrations.AddRoleToUsers do
     # Make existing admin the admin if exists. Admin is most likely the first created user.
     flush()
 
-    admin_email = System.fetch_env!("ADMIN_EMAIL")
-    execute "UPDATE users SET role = 'admin' WHERE email = '#{admin_email}'"
+    admin_email = System.get_env("ADMIN_EMAIL")
+
+    if admin_email do
+      execute "UPDATE users SET role = 'admin' WHERE email = '#{admin_email}'"
+    end
   end
 end

--- a/apps/fz_http/priv/repo/seeds.exs
+++ b/apps/fz_http/priv/repo/seeds.exs
@@ -13,7 +13,7 @@
 alias FzHttp.{Devices, ConnectivityChecks, Rules, Users}
 
 {:ok, user} =
-  Users.create_user(%{
+  Users.create_admin_user(%{
     email: "firezone@localhost",
     password: "firezone",
     password_confirmation: "firezone"

--- a/apps/fz_http/test/fz_http/users_test.exs
+++ b/apps/fz_http/test/fz_http/users_test.exs
@@ -91,7 +91,7 @@ defmodule FzHttp.UsersTest do
     ]
 
     test "doesn't create user with password too short" do
-      assert {:error, changeset} = Users.create_user(@too_short_password)
+      assert {:error, changeset} = Users.create_admin_user(@too_short_password)
 
       assert changeset.errors[:password] == {
                "should be at least %{count} character(s)",
@@ -100,7 +100,7 @@ defmodule FzHttp.UsersTest do
     end
 
     test "doesn't create user with password too long" do
-      assert {:error, changeset} = Users.create_user(@too_long_password)
+      assert {:error, changeset} = Users.create_admin_user(@too_long_password)
 
       assert changeset.errors[:password] == {
                "should be at most %{count} character(s)",
@@ -109,19 +109,19 @@ defmodule FzHttp.UsersTest do
     end
 
     test "creates user with valid map of attributes" do
-      assert {:ok, _user} = Users.create_user(@valid_attrs_map)
+      assert {:ok, _user} = Users.create_admin_user(@valid_attrs_map)
     end
 
     test "creates user with valid list of attributes" do
-      assert {:ok, _user} = Users.create_user(@valid_attrs_list)
+      assert {:ok, _user} = Users.create_admin_user(@valid_attrs_list)
     end
 
     test "doesn't create user with invalid map of attributes" do
-      assert {:error, _changeset} = Users.create_user(@invalid_attrs_map)
+      assert {:error, _changeset} = Users.create_admin_user(@invalid_attrs_map)
     end
 
     test "doesn't create user with invalid list of attributes" do
-      assert {:error, _changeset} = Users.create_user(@invalid_attrs_list)
+      assert {:error, _changeset} = Users.create_admin_user(@invalid_attrs_list)
     end
   end
 

--- a/apps/fz_http/test/fz_http_web/controllers/device_controller_test.exs
+++ b/apps/fz_http/test/fz_http_web/controllers/device_controller_test.exs
@@ -5,13 +5,13 @@ defmodule FzHttpWeb.DeviceControllerTest do
     setup [:create_user]
 
     test "authenticated loads device live view", %{authed_conn: conn, user: _user} do
-      test_conn = get(conn, Routes.device_path(conn, :index))
+      test_conn = get(conn, Routes.root_path(conn, :index))
 
       assert redirected_to(test_conn) == Routes.device_index_path(test_conn, :index)
     end
 
     test "unauthenticated redirects to sign in", %{unauthed_conn: conn, user: _user} do
-      test_conn = get(conn, Routes.device_path(conn, :index))
+      test_conn = get(conn, Routes.root_path(conn, :index))
 
       assert redirected_to(test_conn) == Routes.session_path(conn, :new)
     end

--- a/apps/fz_http/test/fz_http_web/controllers/session_controller_test.exs
+++ b/apps/fz_http/test/fz_http_web/controllers/session_controller_test.exs
@@ -13,7 +13,7 @@ defmodule FzHttpWeb.SessionControllerTest do
     test "authed: redirects to devices page", %{authed_conn: conn, user: _user} do
       test_conn = get(conn, Routes.session_path(conn, :new))
 
-      assert redirected_to(test_conn) == Routes.device_path(test_conn, :index)
+      assert redirected_to(test_conn) == Routes.device_index_path(test_conn, :index)
     end
   end
 
@@ -60,7 +60,7 @@ defmodule FzHttpWeb.SessionControllerTest do
 
       test_conn = post(conn, Routes.session_path(conn, :create), params)
 
-      assert redirected_to(test_conn) == Routes.device_path(test_conn, :index)
+      assert redirected_to(test_conn) == Routes.root_path(test_conn, :index)
       assert get_session(test_conn, :user_id) == user.id
     end
 
@@ -74,7 +74,7 @@ defmodule FzHttpWeb.SessionControllerTest do
     test "token valid; sets session", %{unauthed_conn: conn, user: user} do
       test_conn = get(conn, Routes.session_path(conn, :create, user.sign_in_token))
 
-      assert redirected_to(test_conn) == Routes.device_path(test_conn, :index)
+      assert redirected_to(test_conn) == Routes.device_index_path(test_conn, :index)
       assert get_session(test_conn, :user_id) == user.id
     end
   end

--- a/apps/fz_http/test/fz_http_web/live/device_live/show_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/device_live/show_test.exs
@@ -295,17 +295,18 @@ defmodule FzHttpWeb.DeviceLive.ShowTest do
     end
   end
 
-  describe "authenticated as other user" do
-    setup [:create_device, :create_other_user_device]
-
-    test "mount redirects to session path", %{
-      authed_conn: conn,
-      device: _device,
-      other_device: other_device
-    } do
-      path = Routes.device_show_path(conn, :show, other_device)
-      expected_path = Routes.session_path(conn, :new)
-      assert {:error, {:redirect, %{to: ^expected_path}}} = live(conn, path)
-    end
-  end
+  # XXX: Revisit this when RBAC is more fleshed out. Admins can now view other admins' devices.
+  # describe "authenticated as other user" do
+  #   setup [:create_device, :create_other_user_device]
+  #
+  #   test "mount redirects to session path", %{
+  #     authed_conn: conn,
+  #     device: _device,
+  #     other_device: other_device
+  #   } do
+  #     path = Routes.device_show_path(conn, :show, other_device)
+  #     expected_path = Routes.session_path(conn, :new)
+  #     assert {:error, {:redirect, %{to: ^expected_path}}} = live(conn, path)
+  #   end
+  # end
 end

--- a/apps/fz_http/test/support/fixtures/users_fixtures.ex
+++ b/apps/fz_http/test/support/fixtures/users_fixtures.ex
@@ -17,7 +17,7 @@ defmodule FzHttp.UsersFixtures do
         {:ok, user} =
           %{email: email, password: "testtest", password_confirmation: "testtest"}
           |> Map.merge(attrs)
-          |> Users.create_user()
+          |> Users.create_admin_user()
 
         user
 

--- a/apps/fz_http/test/support/test_helpers.ex
+++ b/apps/fz_http/test/support/test_helpers.ex
@@ -30,7 +30,7 @@ defmodule FzHttp.TestHelpers do
   end
 
   def create_other_user_device(_) do
-    user_id = UsersFixtures.user(%{email: "other_user@test"}).id
+    user_id = UsersFixtures.user(%{role: :unprivileged, email: "other_user@test"}).id
 
     device =
       DevicesFixtures.device(%{


### PR DESCRIPTION
* Creates `:admin, :unprivileged` role types
* Allows `:unprivileged` users to log in (currently starts a dummy VPN session -- will be implemented in firezone/backlog#)
* Allows `:admins` to manage all users' devices
* Prompts admin to select the user to create the device under if there are multiple users in the system

Fixes firezone/backlog#3
Fixes firezone/backlog#158
Fixes firezone/backlog#159

@gongjason You'll need to add `ADMIN_EMAIL=firezone@localhost` to your `.env` in the repository root after this gets merged (this file is gitignored).

<img width="690" alt="Screen Shot 2021-12-22 at 4 57 58 PM" src="https://user-images.githubusercontent.com/167144/147164313-61c40a28-4f98-4af7-a370-dcde1137966e.png">


