### PR TITLE
Add websocket path to nginx conf

### DIFF
--- a/omnibus/cookbooks/firezone/templates/phoenix.nginx.conf.erb
+++ b/omnibus/cookbooks/firezone/templates/phoenix.nginx.conf.erb
@@ -108,6 +108,14 @@ server {
     proxy_set_header Connection "upgrade";
   }
 
+  location ~ ^/socket {
+    proxy_pass http://phoenix;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+
   location / {
     proxy_set_header HOST $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Adds a Websocket upgrade handler to the new `/socket` endpoint.