### PR TITLE
Fix peer connection flapping

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,9 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+        description: Forces to replace line ending by the UNIX 'lf' character.
       - id: check-yaml
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/apps/fz_http/lib/fz_http/devices.ex
+++ b/apps/fz_http/lib/fz_http/devices.ex
@@ -105,7 +105,7 @@ defmodule FzHttp.Devices do
     |> Enum.map(fn device ->
       %{
         public_key: device.public_key,
-        allowed_ips: "#{ipv4_address(device)}/32,#{ipv6_address(device)}/128"
+        inet: "#{ipv4_address(device)},#{ipv6_address(device)}"
       }
     end)
   end
@@ -163,7 +163,7 @@ defmodule FzHttp.Devices do
     """
     [Interface]
     PrivateKey = #{device.private_key}
-    Address = #{ipv4_address(device)}/32, #{ipv6_address(device)}/128
+    Address = #{ipv4_address(device)}, #{ipv6_address(device)}
     #{dns_servers_config(device)}
 
     [Peer]

--- a/apps/fz_http/lib/fz_http_web/events.ex
+++ b/apps/fz_http/lib/fz_http_web/events.ex
@@ -9,20 +9,12 @@ defmodule FzHttpWeb.Events do
     GenServer.call(vpn_pid(), :create_device)
   end
 
-  def device_created(_device) do
-    GenServer.call(vpn_pid(), {:set_config, Devices.to_peer_list()})
-  end
-
-  def device_updated(_device) do
-    # XXX: Come up with a better way to do this
-    GenServer.call(vpn_pid(), {:set_config, Devices.to_peer_list()})
-
-    # This gets out of sync
-    # GenServer.cast(vpn_pid(), {
-    #   :device_updated,
-    #   device.public_key,
-    #   "#{Devices.ipv4_address(device)},#{Devices.ipv6_address(device)}"
-    # })
+  def update_device(device) do
+    GenServer.call(vpn_pid(), {
+      :update_device,
+      device.public_key,
+      "#{Devices.ipv4_address(device)},#{Devices.ipv6_address(device)}"
+    })
   end
 
   def delete_device(device_pubkey) when is_binary(device_pubkey) do

--- a/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/create_form_component.ex
@@ -18,7 +18,7 @@ defmodule FzHttpWeb.DeviceLive.CreateFormComponent do
   def handle_event("save", %{"device" => %{"user_id" => user_id}}, socket) do
     case Devices.auto_create_device(%{user_id: user_id}) do
       {:ok, device} ->
-        @events_module.device_created(device)
+        @events_module.update_device(device)
 
         {:noreply,
          socket

--- a/apps/fz_http/lib/fz_http_web/live/device_live/form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/form_component.ex
@@ -39,7 +39,7 @@ defmodule FzHttpWeb.DeviceLive.FormComponent do
 
     case Devices.update_device(device, device_params) do
       {:ok, device} ->
-        @events_module.device_updated(device)
+        @events_module.update_device(device)
 
         {:noreply,
          socket

--- a/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/index_live.ex
@@ -22,7 +22,7 @@ defmodule FzHttpWeb.DeviceLive.Index do
       # Must be the admin user
       case Devices.auto_create_device(%{user_id: Users.admin().id}) do
         {:ok, device} ->
-          @events_module.device_created(device)
+          @events_module.update_device(device)
 
           {:noreply,
            socket

--- a/apps/fz_http/lib/fz_http_web/live/user_live/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/show_live.ex
@@ -64,7 +64,7 @@ defmodule FzHttpWeb.UserLive.Show do
 
     case Devices.create_device(attributes) do
       {:ok, device} ->
-        @events_module.device_created(device)
+        @events_module.update_device(device)
 
         {:noreply,
          socket

--- a/apps/fz_http/lib/fz_http_web/mock_events.ex
+++ b/apps/fz_http/lib/fz_http_web/mock_events.ex
@@ -15,11 +15,7 @@ defmodule FzHttpWeb.MockEvents do
     {:ok, pubkey}
   end
 
-  def device_created(_device) do
-    :ok
-  end
-
-  def device_updated(_device) do
+  def update_device(_device) do
     :ok
   end
 

--- a/apps/fz_http/test/fz_http/devices_test.exs
+++ b/apps/fz_http/test/fz_http/devices_test.exs
@@ -266,8 +266,7 @@ defmodule FzHttp.DevicesTest do
     test "renders all peers", %{device: device} do
       assert Devices.to_peer_list() |> List.first() == %{
                public_key: device.public_key,
-               allowed_ips:
-                 "#{Devices.ipv4_address(device)}/32,#{Devices.ipv6_address(device)}/128"
+               inet: "#{Devices.ipv4_address(device)},#{Devices.ipv6_address(device)}"
              }
     end
   end

--- a/apps/fz_http/test/fz_http_web/events_test.exs
+++ b/apps/fz_http/test/fz_http_web/events_test.exs
@@ -21,15 +21,15 @@ defmodule FzHttpWeb.EventsTest do
     end
   end
 
-  describe "device_created/1" do
+  describe "update_device/1" do
     setup [:create_device]
 
     test "adds device to peer config", %{device: device} do
-      assert :ok == Events.device_created(device)
+      assert :ok == Events.update_device(device)
 
       assert :sys.get_state(Events.vpn_pid()) == %{
                device.public_key =>
-                 "#{Devices.ipv4_address(device)}/32,#{Devices.ipv6_address(device)}/128"
+                 "#{Devices.ipv4_address(device)},#{Devices.ipv6_address(device)}"
              }
     end
   end
@@ -38,11 +38,11 @@ defmodule FzHttpWeb.EventsTest do
     setup [:create_device]
 
     test "updates peer config", %{device: device} do
-      assert :ok = Events.device_updated(device)
+      assert :ok = Events.update_device(device)
 
       assert :sys.get_state(Events.vpn_pid()) == %{
                device.public_key =>
-                 "#{Devices.ipv4_address(device)}/32,#{Devices.ipv6_address(device)}/128"
+                 "#{Devices.ipv4_address(device)},#{Devices.ipv6_address(device)}"
              }
     end
   end
@@ -77,7 +77,7 @@ defmodule FzHttpWeb.EventsTest do
       :ok = Events.set_config()
 
       assert :sys.get_state(Events.vpn_pid()) ==
-               Map.new(Devices.to_peer_list(), fn peer -> {peer.public_key, peer.allowed_ips} end)
+               Map.new(Devices.to_peer_list(), fn peer -> {peer.public_key, peer.inet} end)
     end
   end
 

--- a/apps/fz_vpn/lib/fz_vpn/cli/live.ex
+++ b/apps/fz_vpn/lib/fz_vpn/cli/live.ex
@@ -33,22 +33,8 @@ defmodule FzVpn.CLI.Live do
     {privkey, pubkey(privkey)}
   end
 
-  def set_peer(pubkey, allowed_ips) do
-    set("peer #{pubkey} allowed-ips #{allowed_ips}")
-  end
-
-  def delete_peers do
-    exec!("#{wg()} show")
-    |> String.split("\n")
-    |> Enum.filter(fn line ->
-      String.contains?(line, "peer")
-    end)
-    |> Enum.map(fn line ->
-      String.replace_leading(line, "peer: ", "")
-    end)
-    |> Enum.each(fn pubkey ->
-      delete_peer(pubkey)
-    end)
+  def set_peer(pubkey, inet) do
+    set("peer #{pubkey} allowed-ips #{inet}")
   end
 
   def delete_peer(pubkey) do

--- a/apps/fz_vpn/lib/fz_vpn/cli/sandbox.ex
+++ b/apps/fz_vpn/lib/fz_vpn/cli/sandbox.ex
@@ -13,7 +13,7 @@ defmodule FzVpn.CLI.Sandbox do
 
   peer: 1RSUaL+er3+HJM7JW2u5uZDIFNNJkw2nV7dnZyOAK2k=
     endpoint: 73.136.58.38:55433
-    allowed ips: 10.3.2.2/32, fd00:3:2::2/128
+    allowed ips: 10.3.2.2, fd00:3:2::2
     latest handshake: 56 minutes, 14 seconds ago
     transfer: 1.21 MiB received, 39.30 MiB sent
   """

--- a/apps/fz_vpn/lib/fz_vpn/server.ex
+++ b/apps/fz_vpn/lib/fz_vpn/server.ex
@@ -37,7 +37,7 @@ defmodule FzVpn.Server do
     cli().setup()
     {:ok, peers} = GenServer.call(http_pid(), :load_peers, @init_timeout)
     config = peers_to_config(peers)
-    apply_config(config)
+    apply_config_diff(config)
   end
 
   @impl GenServer
@@ -49,39 +49,44 @@ defmodule FzVpn.Server do
 
   @impl GenServer
   def handle_call({:delete_device, pubkey}, _from, config) do
-    new_config = Map.delete(config, pubkey)
     cli().delete_peer(pubkey)
-    apply_config(new_config)
-
+    new_config = Map.delete(config, pubkey)
     {:reply, {:ok, pubkey}, new_config}
   end
 
   @impl GenServer
-  def handle_call({:set_config, peers}, _from, _config) do
+  def handle_call({:set_config, peers}, _from, config) do
     new_config = peers_to_config(peers)
-    apply_config(new_config)
+    apply_config_diff(config, new_config)
     {:reply, :ok, new_config}
   end
 
   @impl GenServer
-  def handle_cast({:device_created, pubkey, inet}, config) do
+  def handle_call({:update_device, pubkey, inet}, _from, config) do
     cli().set_peer(pubkey, inet)
-    {:noreply, Map.put(config, pubkey, inet)}
-  end
-
-  @impl GenServer
-  def handle_cast({:device_updated, pubkey, inet}, config) do
-    cli().set_peer(pubkey, inet)
-    {:noreply, Map.put(config, pubkey, inet)}
+    {:reply, :ok, Map.put(config, pubkey, inet)}
   end
 
   @doc """
-  Apply configuration to interface.
+  Determines which peers to remove, add, and change and sets them on the WireGuard interface.
   """
-  def apply_config(config) do
-    cli().delete_peers()
-    cli().set(Config.render(config))
-    {:ok, config}
+  def apply_config_diff(old_config \\ %{}, new_config) do
+    delete_old_peers(old_config, new_config)
+    update_changed_peers(old_config, new_config)
+    {:ok, new_config}
+  end
+
+  defp delete_old_peers(old_config, new_config) do
+    for pubkey <- Map.keys(old_config) -- Map.keys(new_config) do
+      cli().delete_peer(pubkey)
+    end
+  end
+
+  defp update_changed_peers(old_config, new_config) do
+    new_config
+    |> Enum.filter(fn {pubkey, inet} -> Map.get(old_config, pubkey) != inet end)
+    |> Config.render()
+    |> cli().set()
   end
 
   def http_pid do
@@ -89,6 +94,6 @@ defmodule FzVpn.Server do
   end
 
   defp peers_to_config(peers) do
-    Map.new(peers, fn peer -> {peer.public_key, peer.allowed_ips} end)
+    Map.new(peers, fn peer -> {peer.public_key, peer.inet} end)
   end
 end

--- a/apps/fz_vpn/test/fz_vpn/config_test.exs
+++ b/apps/fz_vpn/test/fz_vpn/config_test.exs
@@ -2,7 +2,7 @@ defmodule FzVpn.ConfigTest do
   use ExUnit.Case, async: true
   alias FzVpn.Config
 
-  @populated_config "peer test-pubkey allowed-ips test-ipv4/32,test-ipv6/128"
+  @populated_config "peer test-pubkey allowed-ips test-ipv4,test-ipv6"
 
   describe "render" do
     test "renders default config" do
@@ -12,7 +12,7 @@ defmodule FzVpn.ConfigTest do
     end
 
     test "renders populated config" do
-      config = %{"test-pubkey" => "test-ipv4/32,test-ipv6/128"}
+      config = %{"test-pubkey" => "test-ipv4,test-ipv6"}
 
       assert Config.render(config) == @populated_config
     end

--- a/apps/fz_vpn/test/fz_vpn/server_test.exs
+++ b/apps/fz_vpn/test/fz_vpn/server_test.exs
@@ -4,7 +4,13 @@ defmodule FzVpn.ServerTest do
 
   @empty []
   @single_peer [
-    %{public_key: "test-pubkey", allowed_ips: "127.0.0.1/32,::1/128"}
+    %{public_key: "test-pubkey", inet: "127.0.0.1,::1"}
+  ]
+  @many_peers [
+    %{public_key: "key1", inet: "0.0.0.0,::1"},
+    %{public_key: "key2", inet: "127.0.0.1,::1"},
+    %{public_key: "key3", inet: "127.0.0.1,::1"},
+    %{public_key: "key4", inet: "127.0.0.1,::1"}
   ]
 
   describe "state" do
@@ -30,6 +36,21 @@ defmodule FzVpn.ServerTest do
       GenServer.call(test_pid, {:delete_device, "test-pubkey"})
 
       assert :sys.get_state(test_pid) == %{}
+    end
+
+    @tag stubbed_config: @many_peers
+    test "calcs diff and sets only the diff", %{test_pid: test_pid} do
+      new_peers = [%{public_key: "key5", inet: "1.1.1.1,::2"}]
+
+      assert :sys.get_state(test_pid) == %{
+               "key1" => "0.0.0.0,::1",
+               "key2" => "127.0.0.1,::1",
+               "key3" => "127.0.0.1,::1",
+               "key4" => "127.0.0.1,::1"
+             }
+
+      GenServer.call(test_pid, {:set_config, new_peers})
+      assert :sys.get_state(test_pid) == %{"key5" => "1.1.1.1,::2"}
     end
   end
 end


### PR DESCRIPTION
Intelligently compute diff of peers before adding / removing from the WireGuard interface.

Fixes #372 