### PR TITLE
Relax websocket check_origin in favor of using CSRF tokens

### DIFF
--- a/apps/fz_http/lib/fz_http_web/endpoint.ex
+++ b/apps/fz_http/lib/fz_http_web/endpoint.ex
@@ -7,14 +7,18 @@ defmodule FzHttpWeb.Endpoint do
   end
 
   socket "/socket", FzHttpWeb.UserSocket,
-    websocket: [connect_info: [:peer_data, :x_headers]],
+    websocket: [
+      connect_info: [:peer_data, :x_headers],
+      check_origin: :conn
+    ],
     longpoll: false
 
   socket "/live", Phoenix.LiveView.Socket,
     websocket: [
       connect_info: [
         session: {Session, :options, []}
-      ]
+      ],
+      check_origin: :conn
     ]
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/apps/fz_http/lib/fz_http_web/endpoint.ex
+++ b/apps/fz_http/lib/fz_http_web/endpoint.ex
@@ -9,7 +9,8 @@ defmodule FzHttpWeb.Endpoint do
   socket "/socket", FzHttpWeb.UserSocket,
     websocket: [
       connect_info: [:peer_data, :x_headers],
-      check_origin: :conn
+      # XXX: channel token should prevent CSWH but double check
+      check_origin: false
     ],
     longpoll: false
 
@@ -18,7 +19,8 @@ defmodule FzHttpWeb.Endpoint do
       connect_info: [
         session: {Session, :options, []}
       ],
-      check_origin: :conn
+      # XXX: csrf token should prevent CSWH but double check
+      check_origin: false
     ]
 
   # Serve at "/" the static files from "priv/static" directory.


### PR DESCRIPTION
Fixes firezone/backlog#172

