### PR TITLE
Don't run connectivity checks in CI

### DIFF
--- a/apps/fz_http/lib/fz_http/connectivity_check_service.ex
+++ b/apps/fz_http/lib/fz_http/connectivity_check_service.ex
@@ -73,6 +73,7 @@ defmodule FzHttp.ConnectivityCheckService do
   end
 
   defp enabled? do
-    Application.fetch_env!(:fz_http, :connectivity_checks_enabled)
+    Application.fetch_env!(:fz_http, :connectivity_checks_enabled) &&
+      System.get_env("CI") != "true"
   end
 end


### PR DESCRIPTION
Prevents connectivity checks from running in CI environments.