### PR TITLE
Docs seo fix (duplicate title and description tags)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -66,7 +66,6 @@ aux_links:
 # Plugins
 plugins:
   - jekyll-sitemap
-  - jekyll-seo-tag
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -66,6 +66,7 @@ aux_links:
 # Plugins
 plugins:
   - jekyll-sitemap
+  - jekyll-seo-tag
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -4,10 +4,6 @@
 
   {% unless site.plugins contains "jekyll-seo-tag" %}
     <title>{{ page.title }} - {{ site.title }}</title>
-
-    {% if page.description %}
-      <meta name="Description" content="{{ page.description }}">
-    {% endif %}
   {% endunless %}
 
   <link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -4,6 +4,10 @@
 
   {% unless site.plugins contains "jekyll-seo-tag" %}
     <title>{{ page.title }} - {{ site.title }}</title>
+
+    {% if page.description %}
+      <meta name="Description" content="{{ page.description }}">
+    {% endif %}
   {% endunless %}
 
   <link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -2,14 +2,6 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-  {% unless site.plugins contains "jekyll-seo-tag" %}
-    <title>{{ page.title }} - {{ site.title }}</title>
-
-    {% if page.description %}
-      <meta name="Description" content="{{ page.description }}">
-    {% endif %}
-  {% endunless %}
-
   <link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
 
   <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,7 @@ layout: default
 title: Overview
 nav_order: 1
 description: >
-  Firezone is a self-managed WireGuard-based VPN server and Linux firewall
-  designed for simplicity and security.
+  Firezone is a self-managed WireGuard-based VPN server and Linux firewall designed for simplicity and security.
 ---
 ---
 


### PR DESCRIPTION
adds `jekyll-seo-tag` to the plugin section of the `docs/_config.yml` file. 

The theme we are using (just the docs) comes bundled with this plugin, but not putting the redundant line in the config file results in the duplicate title and description tags in the header (bad for SEO):
![image](https://user-images.githubusercontent.com/52545545/154555324-4ee59968-75b9-4b4f-a302-a0218c5b3037.png)

This is caused by some code in the header file that checks for whether the plugin is present in `docs/_config.yml`. 
https://github.com/firezone/firezone/blob/65ac01fa94128ddf51e4d8daa543b251f8bf3a80/docs/_includes/head.html#L5-L11

The other option is removing the code in `docs/_config.yml`.