### PR TITLE
Clarify whitelisting doc

### DIFF
--- a/docs/docs/user-guides/whitelist-vpn.md
+++ b/docs/docs/user-guides/whitelist-vpn.md
@@ -22,15 +22,19 @@ list grows.
 
 ## AWS Example
 
-In this example, a Firezone instance has already been set up on
-a `tc2.micro` EC2 instance.
-See the
+Our goal is to configure VPN traffic to the restricted resource to be routed
+through a Firezone server on an EC2 instance.
+
+### Step 1 - Deploy Firezone server
+
+In this example, a Firezone instance has been set up on a `tc2.micro`
+EC2 instance. See the
 [Deployment Guide]({% link docs/deploy/index.md %})
-for details on deploying Firezone.
+for details on deploying Firezone. Specific to AWS, ensure:
 
-### Step 1 - Set a static IP for the Firezone instance
-
-Create and associate an Elastic IP with the Firezone instance. In this case the
+1. The security group of the Firezone EC2 instance allows outbound traffic to the
+IP of the protected resource.
+1. An Elastic IP is associated with the Firezone instance. In this case the
 IP is `52.202.88.54`.
 
 ![Allocate Elastic IP](https://user-images.githubusercontent.com/52545545/154821256-9335703b-a120-4a9d-b9f5-bbca673cef63.png){:width="600"}

--- a/docs/docs/user-guides/whitelist-vpn.md
+++ b/docs/docs/user-guides/whitelist-vpn.md
@@ -34,8 +34,9 @@ for details on deploying Firezone. Specific to AWS, ensure:
 
 1. The security group of the Firezone EC2 instance allows outbound traffic to the
 IP of the protected resource.
-1. An Elastic IP is associated with the Firezone instance. In this case the
-IP is `52.202.88.54`.
+1. An Elastic IP is associated with the Firezone instance. This will be the
+source IP address of traffic routed through the Firezone instance to external destinations.
+In this case the IP is `52.202.88.54`.
 
 ![Allocate Elastic IP](https://user-images.githubusercontent.com/52545545/154821256-9335703b-a120-4a9d-b9f5-bbca673cef63.png){:width="600"}
 

--- a/docs/docs/user-guides/whitelist-vpn.md
+++ b/docs/docs/user-guides/whitelist-vpn.md
@@ -23,7 +23,9 @@ list grows.
 ## AWS Example
 
 Our goal is to configure VPN traffic to the restricted resource to be routed
-through a Firezone server on an EC2 instance.
+through a Firezone server on an EC2 instance. In this case Firezone is acting as
+a network proxy or NAT gateway to provide a single public egress IP for all the
+devices connected to it.
 
 ### Step 1 - Deploy Firezone server
 


### PR DESCRIPTION
To properly set up Firezone on AWS you already need to set up an Elastic IP address. I clarified the docs to be less redundant and also to mention you need to allow outbound traffic to the destination IP of the protected resource.