### PR TITLE
Detect kernel module on install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,8 +41,13 @@ promptContact() {
 
 wireguardCheck() {
   if ! test -f /sys/module/wireguard/version; then
-    echo "Error! WireGuard not detected. Please upgrade your kernel to at least 5.6 or install the WireGuard kernel module."
-    echo "See more at https://www.wireguard.com/install/"
+    if test -f `find /lib/modules/$(uname -r) -type f -name 'wireguard.ko'`; then
+      echo "Wireguard kernel module found, but not loaded."
+      echo "Load it with 'sudo modprobe wireguard' and run this install script again"
+    else
+      echo "Error! WireGuard not detected. Please upgrade your kernel to at least 5.6 or install the WireGuard kernel module."
+      echo "See more at https://www.wireguard.com/install/"
+    fi
     exit
   fi
 }


### PR DESCRIPTION
If you go to install this on a new Ubuntu 20.04 instance you start in a state where the wireguard kernel module is available but not loaded. The instructions point you to the Wireguard install page, which tell you to install Wireguard with 'apt install wireguard'.

This installs the 'wireguard' and 'wireguard-tools' package, but the module still isn't loaded until you actually use something like wg-quick, so the install script still fails even after following the install instructions.

Instead you can detect if wireguard.ko is available and instruct the user to load it with modprobe.