### PR TITLE
Fix kernelCheck order

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -179,8 +179,8 @@ firezoneSetup() {
 
 main() {
   adminUser=''
-  wireguardCheck
   kernelCheck
+  wireguardCheck
   promptEmail "Enter the administrator email you'd like to use for logging into this Firezone instance:"
   promptContact
   releaseUrl=''


### PR DESCRIPTION
Makes more sense to check for a kernel too low because upgrading it will likely mean the user doesn't need to install WireGuard.