### PR TITLE
Don't clear session twice

### DIFF
--- a/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
@@ -50,7 +50,6 @@ defmodule FzHttpWeb.AuthController do
 
   def delete(conn, _params) do
     conn
-    |> configure_session(drop: true)
     |> Authentication.sign_out()
     |> put_flash(:info, "You are now signed out.")
     |> redirect(to: Routes.root_path(conn, :index))


### PR DESCRIPTION
Fixes an issue where clearing the session twice could result in inconsistent cookie behavior or prevent the session from sticking.