### PR TITLE
Update more dev configs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -107,4 +107,6 @@ RUN pip install pre-commit
 
 ENV PATH=${HOME}/.local/bin:/opt/asdf-data/shims:/opt/asdf/bin:${PATH}
 
+RUN git config --global --add safe.directory /workspace
+
 CMD ["/bin/bash"]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 # These are used for the dev environment.
 # This should match the versions used in the built product.
 nodejs 14.18.3
-elixir ref:v1.13.4
-erlang 25.0-rc3
+elixir 1.13.4-otp-24
+erlang 24.3.4
 ruby 2.7.5


### PR DESCRIPTION
- Aligning the Elixir OTP version and the Erlang version eliminates the re-compilation of BEAM files. Elixir compiles precompiled.
  - It saves a lot of time
  - and gets around a possible compilation blocker with the not yet released OTP 25 version... I've been failing to compile it.
- Newer git version has an ownership check, which errors when using docker. Not sure if it's Windows only, though. [1](https://stackoverflow.com/questions/71849415/i-cannot-add-the-parent-directory-to-safe-directory-in-git) [2](https://github.blog/2022-04-12-git-security-vulnerability-announced/)