### PR TITLE
Migrate allowed ips on devices to text

### DIFF
--- a/apps/fz_http/priv/repo/migrations/20220516063916_change_allowed_ips_to_text.exs
+++ b/apps/fz_http/priv/repo/migrations/20220516063916_change_allowed_ips_to_text.exs
@@ -1,0 +1,9 @@
+defmodule FzHttp.Repo.Migrations.ChangeAllowedIpsToText do
+  use Ecto.Migration
+
+  def change do
+    alter table("devices") do
+      modify :allowed_ips, :text, default: nil
+    end
+  end
+end

--- a/apps/fz_http/priv/repo/migrations/20220516063916_change_allowed_ips_to_text.exs
+++ b/apps/fz_http/priv/repo/migrations/20220516063916_change_allowed_ips_to_text.exs
@@ -1,9 +1,23 @@
 defmodule FzHttp.Repo.Migrations.ChangeAllowedIpsToText do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table("devices") do
       modify :allowed_ips, :text, default: nil
+    end
+
+    alter table("sites") do
+      modify :allowed_ips, :text, default: nil
+    end
+  end
+
+  def down do
+    alter table("devices") do
+      modify :allowed_ips, :string, default: nil
+    end
+
+    alter table("sites") do
+      modify :allowed_ips, :string, default: nil
     end
   end
 end


### PR DESCRIPTION
close #599 

- Migrate both devices and sites
- Split into up and down because modify field cannot rollback automatically, just in case.
  - once a field is filled with more than 255 chars, the rollback will error. it's there for dev only.