### PR TITLE
Don't set default url opts in runtime

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -100,7 +100,7 @@ config :fz_vpn,
 
 # Configures the endpoint
 # These will be overridden at runtime in production by config/releases.exs
-external_url = "http://localhost:4000"
+external_url = "http://127.0.0.1:4000"
 %{host: host, scheme: scheme, port: port, path: path} = URI.parse(external_url)
 
 config :fz_http, FzHttpWeb.Endpoint,

--- a/config/config.exs
+++ b/config/config.exs
@@ -100,7 +100,7 @@ config :fz_vpn,
 
 # Configures the endpoint
 # These will be overridden at runtime in production by config/releases.exs
-external_url = "http://127.0.0.1:4000"
+external_url = "http://localhost:4000"
 %{host: host, scheme: scheme, port: port, path: path} = URI.parse(external_url)
 
 config :fz_http, FzHttpWeb.Endpoint,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -9,8 +9,8 @@ alias FzCommon.{CLI, FzInteger, FzString}
 
 # Optional config across all envs
 
-# Defaults to localhost:4000.
-external_url = System.get_env("EXTERNAL_URL") || "http://localhost:4000"
+# Defaults to what's set upstream
+external_url = System.get_env("EXTERNAL_URL")
 
 if config_env() == :prod do
   # Errors if not set in production
@@ -20,12 +20,23 @@ end
 # Enable Forwarded headers, e.g 'X-FORWARDED-HOST'
 proxy_forwarded = FzString.to_boolean(System.get_env("PROXY_FORWARDED") || "false")
 
-%{host: host, path: path, port: port, scheme: scheme} = URI.parse(external_url)
+endpoint_opts =
+  if external_url do
+    %{host: host, path: path, port: port, scheme: scheme} = URI.parse(external_url)
 
-config :fz_http, FzHttpWeb.Endpoint,
-  url: [host: host, scheme: scheme, port: port, path: path],
-  check_origin: ["//127.0.0.1", "//localhost", "//#{host}"],
-  proxy_forwarded: proxy_forwarded
+    [
+      url: [host: host, scheme: scheme, port: port, path: path],
+      check_origin: ["//127.0.0.1", "//localhost", "//#{host}"],
+      proxy_forwarded: proxy_forwarded
+    ]
+  else
+    [
+      check_origin: ["//127.0.0.1", "//localhost"],
+      proxy_forwarded: proxy_forwarded
+    ]
+  end
+
+config :fz_http, FzHttpWeb.Endpoint, endpoint_opts
 
 # Formerly releases.exs - Only evaluated in production
 if config_env() == :prod do


### PR DESCRIPTION
Allows for upstream config to take effect.