### PR TITLE
Use release drafter resolved version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,11 @@ jobs:
           sudo rm -rf /tmp/firezone*
           rm -rf omnibus/pkg/*
 
+  # Publish packages to the drafted release on merges to master so we can
+  # manually test them if needed. Then we can just publish the drafted release
+  # and we're good to go.
   publish:
+    if: startsWith(github.ref, 'refs/heads/master')
     needs: build-package-test
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Build
         env:
           GIT_SHA: ${{ github.sha }}
-          VERSION: ${{ needs.draft_release.outputs.tag_name }}
+          VERSION: ${{ needs.draft-release.outputs.tag_name }}
         run: |
           echo "removing lock file in case last run sucked"
           sudo rm -f /opt/runner/omnibus-local/cache/git_cache/opt/firezone/index.lock
@@ -255,12 +255,12 @@ jobs:
           path: ./
       - name: Rename artifact file to tag
         run: |
-          mv ./firezone*.rpm firezone_${{ needs.draft_release.outputs.tag_name }}-${{ matrix.platform }}.rpm || true
-          mv ./firezone*.deb firezone_${{ needs.draft_release.outputs.tag_name }}-${{ matrix.platform }}.deb || true
+          mv ./firezone*.rpm firezone_${{ needs.draft-release.outputs.tag_name }}-${{ matrix.platform }}.rpm || true
+          mv ./firezone*.deb firezone_${{ needs.draft-release.outputs.tag_name }}-${{ matrix.platform }}.deb || true
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ needs.draft_release.outputs.tag_name }}
+          tag_name: ${{ needs.draft-release.outputs.tag_name }}
           draft: true
           files: |
             ./firezone*.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ concurrency: ci
 
 name: CI
 on:
-  workflow_dispatch:
   push:
   pull_request:
 defaults:
@@ -126,9 +125,23 @@ jobs:
           # coveralls fails
           mix coveralls.github --umbrella || mix test
 
+  draft-release:
+    runs-on: ubuntu-20.04
+    needs:
+      - static-analysis
+      - unit-test
+      - lint-docs
+    outputs:
+      tag_name: ${{ steps.release_drafter.outputs.tag_name }}
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        id: release_drafter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-package-test:
     # Doesn't really need, but don't run this stage when iterating over docs
-    needs: lint-docs
+    needs: draft-release
     env:
       TELEMETRY_ENABLED: "false"
     runs-on: ${{ matrix.platform }}
@@ -168,6 +181,7 @@ jobs:
       - name: Build
         env:
           GIT_SHA: ${{ github.sha }}
+          VERSION: ${{ needs.draft_release.outputs.tag_name }}
         run: |
           echo "removing lock file in case last run sucked"
           sudo rm -f /opt/runner/omnibus-local/cache/git_cache/opt/firezone/index.lock
@@ -200,25 +214,8 @@ jobs:
           sudo rm -rf /tmp/firezone*
           rm -rf omnibus/pkg/*
 
-  draft_release:
-    runs-on: ubuntu-latest
-    needs:
-      - static-analysis
-      - unit-test
-      - lint-docs
-      - build-package-test
-    # Draft releases on merges to master
-    if: startsWith(github.ref, 'refs/heads/master')
-    outputs:
-      tag_name: ${{ steps.release_drafter.outputs.tag_name }}
-    steps:
-      - uses: release-drafter/release-drafter@v5
-        id: release_drafter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish:
-    needs: draft_release
+    needs: build-package-test
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ concurrency: ci
 name: CI
 on:
   push:
-  pull_request:
+
 defaults:
   run:
     shell: bash

--- a/omnibus/config/projects/firezone.rb
+++ b/omnibus/config/projects/firezone.rb
@@ -33,7 +33,8 @@ install_dir "#{default_root}/#{name}"
 stage_path = '/opt/runner/omnibus-local/stage'
 ENV['CI'] && Dir.exist?(stage_path) && staging_dir(stage_path)
 
-build_version Omnibus::BuildVersion.semver
+# Use Release Drafter's resolved version
+build_version ENV.fetch('VERSION', Omnibus::BuildVersion.semver)
 build_iteration 1
 
 # firezone build dependencies/components


### PR DESCRIPTION
Wrapping up a couple oversights:

* Building packages now uses Release Drafter's `resolved_version` which essentially guess the next tag and is used for the Omnibus build.
* Run Release Drafter on every PR / push, but publish to the drafted release on merges to `master`, allowing us to test packages leading up to the release.

Fixes #629 