### PR TITLE
soft-require EXTERNAL_URL to be set

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,7 +3,7 @@ MIX_ENV=dev
 # rename to `.env`
 
 # Set the EXTERNAL_URL if it's not localhost:4000
-# EXTERNAL_URL=https:///local.dev
+EXTERNAL_URL=http://localhost:4000
 
 LOCAL_AUTH_ENABLED=true
 

--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@ MIX_ENV=dev
 # This is a sample .env file. Update and add variables in here as needed, and
 # rename to `.env`
 
-# Set the EXTERNAL_URL if it's not localhost:4000
+# Set the EXTERNAL_URL
 EXTERNAL_URL=http://localhost:4000
 
 LOCAL_AUTH_ENABLED=true

--- a/config/config.exs
+++ b/config/config.exs
@@ -99,13 +99,7 @@ config :fz_vpn,
   cli: FzVpn.CLI.Sandbox,
   server_process_opts: [name: {:global, :fz_vpn_server}]
 
-# Configures the endpoint
-# These will be overridden at runtime in production by config/releases.exs
-external_url = "http://localhost:4000"
-%{host: host, scheme: scheme, port: port, path: path} = URI.parse(external_url)
-
 config :fz_http, FzHttpWeb.Endpoint,
-  url: [host: host, port: port, scheme: scheme, path: path],
   render_errors: [view: FzHttpWeb.ErrorView, accepts: ~w(html json)],
   pubsub_server: FzHttp.PubSub,
   proxy_forwarded: false

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,36 +7,20 @@ import Config
 
 alias FzCommon.{CLI, FzInteger, FzString}
 
+# external is important
+external_url = System.get_env("EXTERNAL_URL", "http://localhost:4000")
+
 # Optional config across all envs
-
-# Defaults to what's set upstream
-external_url = System.get_env("EXTERNAL_URL")
-
-if config_env() == :prod do
-  # Errors if not set in production
-  System.fetch_env!("EXTERNAL_URL")
-end
 
 # Enable Forwarded headers, e.g 'X-FORWARDED-HOST'
 proxy_forwarded = FzString.to_boolean(System.get_env("PROXY_FORWARDED") || "false")
 
-endpoint_opts =
-  if external_url do
-    %{host: host, path: path, port: port, scheme: scheme} = URI.parse(external_url)
+%{host: host, path: path, port: port, scheme: scheme} = URI.parse(external_url)
 
-    [
-      url: [host: host, scheme: scheme, port: port, path: path],
-      check_origin: ["//127.0.0.1", "//localhost", "//#{host}"],
-      proxy_forwarded: proxy_forwarded
-    ]
-  else
-    [
-      check_origin: ["//127.0.0.1", "//localhost"],
-      proxy_forwarded: proxy_forwarded
-    ]
-  end
-
-config :fz_http, FzHttpWeb.Endpoint, endpoint_opts
+config :fz_http, FzHttpWeb.Endpoint,
+  url: [host: host, scheme: scheme, port: port, path: path],
+  check_origin: ["//127.0.0.1", "//localhost", "//#{host}"],
+  proxy_forwarded: proxy_forwarded
 
 # Formerly releases.exs - Only evaluated in production
 if config_env() == :prod do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,10 +7,8 @@ import Config
 
 alias FzCommon.{CLI, FzInteger, FzString}
 
-# external is important
+# external_url is important
 external_url = System.get_env("EXTERNAL_URL", "http://localhost:4000")
-
-# Optional config across all envs
 
 # Enable Forwarded headers, e.g 'X-FORWARDED-HOST'
 proxy_forwarded = FzString.to_boolean(System.get_env("PROXY_FORWARDED") || "false")


### PR DESCRIPTION
Fixes an issue where a blank `external_url` broke OIDC auth in development.