### PR TITLE
Disable form autocomplete in some cases

### DIFF
--- a/apps/fz_http/lib/fz_http_web/live/setting_live/account_form_component.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/account_form_component.html.heex
@@ -1,5 +1,5 @@
 <div>
-  <.form let={f} for={@changeset} id="account-edit" phx-target={@myself} phx-submit="save">
+  <.form let={f} for={@changeset} autocomplete="off" id="account-edit" phx-target={@myself} phx-submit="save">
     <div class="block">
       <p>Change email or enter new password below.</p>
     </div>

--- a/apps/fz_http/lib/fz_http_web/live/user_live/form_component.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/form_component.html.heex
@@ -1,5 +1,5 @@
 <div>
-  <.form let={f} for={@changeset} id="user-form" phx-target={@myself} phx-submit="save">
+  <.form let={f} for={@changeset} autocomplete="off" id="user-form" phx-target={@myself} phx-submit="save">
     <%= if @action == :edit do %>
       <div class="block">
         <p>Change user email or enter new password below.</p>


### PR DESCRIPTION
Fixes an issue raised by a user where added a new user auto-fills in your current user's details