### PR TITLE
switch back to libclang-dev for ubuntu/debian

### DIFF
--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -56,4 +56,4 @@ jobs:
           startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -yq llvm clang
+          sudo apt-get install -yq llvm libclang-dev


### PR DESCRIPTION
My bad, it was working I should've just left it. I switched back to libclang-dev. Find/replaced them all to clang 🤦 