### PR TITLE
Fix migrations and expand CONTRIBUTING.md docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,11 @@ Firezone development requires access to a Postgresql instance. Versions 9.6 or
 higher should work fine. Access can be configured using the [
 .env](#the-env-file) described below.
 
+**Note:** To use the default configuration without specifying the database URL in the `.env` file, you need to configure the `postgres` user with the password `postgres` to do so use the following command:
+```sql
+ALTER USER postgres WITH PASSWORD 'postgres';
+```
+
 ### Pre-commit
 
 We use [pre-commit](https://pre-commit.com) to catch any static analysis issues

--- a/apps/fz_http/priv/repo/migrations/20220124162404_add_uuids.exs
+++ b/apps/fz_http/priv/repo/migrations/20220124162404_add_uuids.exs
@@ -3,6 +3,11 @@ defmodule FzHttp.Repo.Migrations.AddUuids do
 
   def change do
     execute(
+      "CREATE EXTENSION pgcrypto",
+      "DROP EXTENSION pgcrypto"
+    )
+
+    execute(
       "ALTER TABLE rules ADD COLUMN uuid uuid DEFAULT gen_random_uuid() NOT NULL",
       "ALTER TABLE rules DROP COLUMN uuid"
     )


### PR DESCRIPTION
When following the [Bootstrap section of CONTRIBUTING.md](https://github.com/conectado/firezone/blob/e9478cff2d7247bc55e76f07dd9aacd28b59687e/CONTRIBUTING.md#bootstrapping) while doing `MIX_ENV=test mix do ecto.remigrate` I was getting this error:

```
17:12:12.444 [info]  execute "ALTER TABLE rules ADD COLUMN uuid uuid DEFAULT gen_random_uuid() NOT NULL"
** (Postgrex.Error) ERROR 42883 (undefined_function) function gen_random_uuid() does not exist

    hint: No function matches the given name and argument types. You might need to add explicit type casts.
    (ecto_sql 3.8.2) lib/ecto/adapters/sql.ex:932: Ecto.Adapters.SQL.raise_sql_call_error/1
    (elixir 1.13.4) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
    (ecto_sql 3.8.2) lib/ecto/adapters/sql.ex:1024: Ecto.Adapters.SQL.execute_ddl/4
    (ecto_sql 3.8.2) lib/ecto/migration/runner.ex:352: Ecto.Migration.Runner.log_and_execute_ddl/3
    (ecto_sql 3.8.2) lib/ecto/migration/runner.ex:117: anonymous fn/6 in Ecto.Migration.Runner.flush/0
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto_sql 3.8.2) lib/ecto/migration/runner.ex:116: Ecto.Migration.Runner.flush/0
    (ecto_sql 3.8.2) lib/ecto/migration/runner.ex:289: Ecto.Migration.Runner.perform_operation/3
```

This was due to a missing extension in the `add_uuids` this PR fixes this.

Furthermore, while setting up firezone I didn't realize I needed to add the password to the postgres user so I added a line about that to CONTRIBUTE.md.

In case it's useful my postgres version is:

```
psql (PostgreSQL) 12.11 (Ubuntu 12.11-0ubuntu0.20.04.1)
```