### PR TITLE
Fix runtime.exs when DNS is nil

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -42,7 +42,7 @@ if config_env() == :prod do
   egress_interface = System.fetch_env!("EGRESS_INTERFACE")
   wireguard_public_key = System.fetch_env!("WIREGUARD_PUBLIC_KEY")
   wireguard_psk_dir = System.fetch_env!("WIREGUARD_PSK_DIR")
-  wireguard_dns = System.fetch_env!("WIREGUARD_DNS")
+  wireguard_dns = System.get_env("WIREGUARD_DNS")
   wireguard_allowed_ips = System.fetch_env!("WIREGUARD_ALLOWED_IPS")
   wireguard_persistent_keepalive = System.fetch_env!("WIREGUARD_PERSISTENT_KEEPALIVE")
   wireguard_ipv4_enabled = FzString.to_boolean(System.fetch_env!("WIREGUARD_IPV4_ENABLED"))


### PR DESCRIPTION
By using `get_env` instead of `fetch_env` when setting `wireguard_dns` if WIREGUARD_DNS is not set we will get nil instead of an error.

Using this, instead of the server erroring when setting:
```rb
default['firezone']['wireguard']['dns'] = nil
```
in `/etc/firezone/firezone.rb`.

The server keeps working and when creating a device now we see: 

![image](https://user-images.githubusercontent.com/3310803/171874459-57fa7578-63ff-4eac-a9ee-a1df96154e31.png)

And the generated config is:

 ```
[Interface]
PrivateKey = dM/Ypyj/tGe6wgMFcqz/x/gFCQbRw7EljRIH+DEpJSU=
Address = 10.3.2.3/32,fd00::3:2:3/128
MTU = 1420


[Peer]
PresharedKey = Ex8+nbN/7sfYvvBMNg0hQVTNyVYkZsUfYGSIl7T1O18=
PublicKey = aTiAuuEeHlQzMle1pdrYBlXnFO2nBpFe+mko0YUbIhw=
AllowedIPs = 0.0.0.0/0, ::/0
Endpoint = 190.19.29.102:51820
PersistentKeepalive = 0
```

Note that no dns is added to the config.

This fix was tested on Ubuntu 20.04 in a production enviroment.

Fixes #670