### PR TITLE
Bump OTP to 25.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: '3.9'
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: '24'
+          otp-version: '25'
           elixir-version: '1.13.4'
       - uses: actions/cache@v2
         name: Setup Elixir cache
@@ -48,9 +48,9 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-otp-24-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-otp-24-
+            ${{ runner.os }}-mix-otp-25-
       - uses: actions/cache@v2
         name: Setup ruby cache
         with:
@@ -126,16 +126,16 @@ jobs:
           node-version: '14.19.3'
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: '24'
+          otp-version: '25'
           elixir-version: '1.13.4'
       - uses: actions/cache@v2
         with:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-otp-24-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-otp-24
+            ${{ runner.os }}-mix-otp-25
       - name: Install Dependencies
         run: mix deps.get --only test
       - name: Setup Database

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,10 +1,8 @@
 # These are used for the dev environment.
 # This should match the versions used in the built product.
 nodejs 14.19.3
-elixir 1.13.4-otp-24
-erlang 24.3.4
-# HTTPoison times out to some SSL connections with OTP 25
-# erlang 25.0
+elixir 1.13.4-otp-25
+erlang 25.0.1
 
 # Used for static analysis
 ruby 2.7.5

--- a/omnibus/config/software/erlang.rb
+++ b/omnibus/config/software/erlang.rb
@@ -20,7 +20,7 @@
 name 'erlang'
 
 # Erlang 25 has SSL issues -- HTTPoison times out to some servers, e.g. Azure https://login.microsoftonline.com
-default_version '24.3.4'
+default_version '25.0.1'
 
 license 'Apache-2.0'
 license_file 'LICENSE.txt'
@@ -39,6 +39,7 @@ source url: "https://github.com/erlang/otp/archive/OTP-#{version}.tar.gz"
 relative_path "otp-OTP-#{version}"
 
 # versions_list: https://github.com/erlang/otp/tags filter=*.tar.gz
+version('25.0.1')    { source sha256: '4426bdf717c9f359f592fceb5dc29b9cab152010cd258475730de4582de42bff' }
 version('25.0')      { source sha256: '5988e3bca208486494446e885ca2149fe487ee115cbc3770535fd22a795af5d2' }
 version('24.3.4')    { source sha256: 'e59bedbb871af52244ca5284fd0a572d52128abd4decf4347fe2aef047b65c58' }
 version('24.2.1')    { source sha256: '2854318d12d727fc508e8fd5fe6921c0cbc7727d1183ad8f6f808585496e42d6' }


### PR DESCRIPTION
Looks like 25.0.1 [fixes the SSL issue](https://github.com/erlang/otp/issues/6065). Refs #642 