### PR TITLE
Execute migrations on the correct database

### DIFF
--- a/omnibus/cookbooks/firezone/recipes/database.rb
+++ b/omnibus/cookbooks/firezone/recipes/database.rb
@@ -29,6 +29,7 @@ ENV['PGHOST'] = node['firezone']['database']['host']
 ENV['PGPORT'] = node['firezone']['database']['port'].to_s
 ENV['PGUSER'] = node['firezone']['database']['user']
 ENV['PGPASSWORD'] = node['firezone']['database']['password']
+ENV['PGDATABASE'] = node['firezone']['database']['name']
 
 unless node['firezone']['database']['create_user'] == false
   enterprise_pg_user node['firezone']['database']['user'] do


### PR DESCRIPTION
Otherwise it tries to execute migrations on the user's login database
```
================================================================================                  
Error executing action `run` on resource 'execute[create postgresql pg_trgm extension]'
================================================================================                                                                                                                            

Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '2'                                                  
---- Begin output of echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql ----                        
STDOUT:                                                                                               
STDERR: psql: error: FATAL:  database "root" does not exist                                           
---- End output of echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql ----                          
Ran echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql returned 2                                                                                                                                         Resource Declaration:                                                                                 
---------------------                                                                                 
# In /var/opt/firezone/cache/cache/cookbooks/firezone/recipes/database.rb
52:   execute "create postgresql #{ext} extension" do                                                 
53:     user node['firezone']['database']['user']                                                     
54:     command "echo 'CREATE EXTENSION IF NOT EXISTS #{ext}' | psql"
55:     not_if "echo '\\dx' | psql #{node['firezone']['database']['name']} | grep #{ext}"
56:   end                                                                                             57: end                                                                                                                                                                                                    Compiled Resource:                                                                                    
------------------                                                                                    
# Declared in /var/opt/firezone/cache/cache/cookbooks/firezone/recipes/database.rb:52:in `block in from_file'                                                                                                                                                                                                     execute("create postgresql pg_trgm extension") do                                                       
  action [:run]                                                                                        
  default_guard_interpreter :execute                                                                   
  command "echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql"                                        
  declared_type :execute                                                                                
  cookbook_name "firezone"                                                                              
  recipe_name "database"                                                                                
  domain nil                                                                                            
  user "root"                                                                                           
  not_if "echo '\dx' | psql firezone | grep pg_trgm"                                                  
end                                                                                                                                                                                                         System Info:                                                                                          
------------                                                                                          
chef_version=16.17.51                                                                                 
platform=ubuntu                                                                                       
platform_version=20.04                                                                                
ruby=ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [x86_64-linux]                                   program_name=/opt/firezone/embedded/bin/chef-client
    executable=/opt/firezone/embedded/bin/chef-client

Running handlers:
[2022-06-11T18:43:47+00:00] ERROR: Running exception handlers
Running handlers complete
[2022-06-11T18:43:47+00:00] ERROR: Exception handlers complete
Chef Infra Client failed. 5 resources updated in 03 seconds
[2022-06-11T18:43:48+00:00] FATAL: Stacktrace dumped to /var/opt/firezone/cache/cache/chef-stacktrace.out
[2022-06-11T18:43:48+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2022-06-11T18:43:48+00:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: execute[create postgresql pg_trgm extension] (firezone::database line 52) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '2'
---- Begin output of echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql ----
STDOUT:
STDERR: psql: error: FATAL:  database "root" does not exist
---- End output of echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql ----
Ran echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql returned 2
```