### PR TITLE
Minor MFA fixes

### DIFF
--- a/apps/fz_http/assets/js/root.js
+++ b/apps/fz_http/assets/js/root.js
@@ -8,7 +8,7 @@ import "@fontsource/fira-mono"
 
 import "phoenix_html"
 import Hooks from "./hooks.js"
-import {Socket, Presence} from "phoenix"
+import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import "./event_listeners.js"
 

--- a/apps/fz_http/assets/js/root.js
+++ b/apps/fz_http/assets/js/root.js
@@ -7,5 +7,26 @@ import "@fontsource/open-sans"
 import "@fontsource/fira-mono"
 
 import "phoenix_html"
+import Hooks from "./hooks.js"
+import {Socket, Presence} from "phoenix"
+import {LiveSocket} from "phoenix_live_view"
 import "./event_listeners.js"
-import { FormatTimestamp } from './util.js'
+
+
+// Basic LiveView setup
+const csrfToken = document
+  .querySelector("meta[name='csrf-token']")
+  .getAttribute("content")
+const liveSocket = new LiveSocket(
+  "/live",
+  Socket,
+  {
+    hooks: Hooks,
+    params: {
+      _csrf_token: csrfToken
+    }
+  }
+)
+
+liveSocket.connect()
+window.liveSocket = liveSocket

--- a/apps/fz_http/lib/fz_http_web/live/mfa_live/auth_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/mfa_live/auth_live.ex
@@ -9,7 +9,7 @@ defmodule FzHttpWeb.MFALive.Auth do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, socket |> assign(:page_title, "MFA")}
+    {:ok, socket |> assign(:page_title, "Multi-factor Authentication")}
   end
 
   @impl Phoenix.LiveView
@@ -31,25 +31,28 @@ defmodule FzHttpWeb.MFALive.Auth do
   @impl Phoenix.LiveView
   def render(%{live_action: :auth} = assigns) do
     ~H"""
-    <section class="section is-main-section">
-      <%= render FzHttpWeb.SharedView, "flash.html", assigns %>
-      <h4 class="title is-4"><%= @page_title %></h4>
+    <h3 class="is-3 title"><%= @page_title %></h3>
 
-      <form id="mfa-method-form" phx-submit="verify">
-        <h4>Verify Code</h4>
-        <hr>
+    <p>
+      Authenticate with your configured MFA method.
+    </p>
 
-        <div class="field is-horizontal">
-          <div class="field-label is-normal">
-            <label class="label">Code</label>
-          </div>
-          <div class="field-body">
-            <div class="field">
-              <p class="control">
-                <input class={"input #{input_error_class(@changeset, :code)}"}
-                    type="text" name="code" placeholder="123456" required />
-              </p>
-            </div>
+    <hr>
+
+    <div class="block has-text-right">
+      <%= live_patch "Other authenticators ->", to: Routes.mfa_auth_path(@socket, :types) %>
+    </div>
+
+    <div class="block">
+      <.form let={f} for={@changeset} id="mfa-method-form" phx-submit="verify">
+
+        <div class="field">
+          <%= label f, :code, class: "label" %>
+          <div class="control">
+            <%= text_input f, :code, name: "code", placeholder: "123456", required: true, class: "input #{input_error_class(@changeset, :code)}" %>
+            <p class="help is-danger">
+              <%= error_tag f, :code %>
+            </p>
           </div>
         </div>
 
@@ -59,18 +62,18 @@ defmodule FzHttpWeb.MFALive.Auth do
               <div class="level-left">
                 <%= submit "Verify",
                     phx_disable_with: "verifying...",
-                    form: assigns[:form],
-                    class: "button is-primary" %>
+                    class: "button" %>
               </div>
               <div class="level-right">
-                <%= live_patch "Other authenticators ->",
-                    to: Routes.mfa_auth_path(@socket, :types) %>
+                <%= link(to: Routes.auth_path(@socket, :delete), method: :delete) do %>
+                  Sign out
+                <% end %>
               </div>
             </div>
           </div>
         </div>
-      </form>
-    </section>
+      </.form>
+    </div>
     """
   end
 
@@ -79,10 +82,13 @@ defmodule FzHttpWeb.MFALive.Auth do
     assigns = Map.put(assigns, :methods, MFA.list_methods(assigns.current_user))
 
     ~H"""
-    <section class="section is-main-section">
-      <%= render FzHttpWeb.SharedView, "flash.html", assigns %>
-      <h4 class="title is-4"><%= @page_title %></h4>
+    <h3 class="is-3 title"><%= @page_title %></h3>
 
+    <p class="block">
+      Select your MFA method:
+    </p>
+
+    <div class="block">
       <ul>
         <%= for method <- @methods do %>
         <li>
@@ -91,7 +97,7 @@ defmodule FzHttpWeb.MFALive.Auth do
         </li>
         <% end %>
       </ul>
-    </section>
+    </div>
     """
   end
 

--- a/apps/fz_http/lib/fz_http_web/router.ex
+++ b/apps/fz_http/lib/fz_http_web/router.ex
@@ -83,7 +83,7 @@ defmodule FzHttpWeb.Router do
     live_session(
       :authenticated,
       on_mount: [{FzHttpWeb.LiveAuth, :any}, {FzHttpWeb.LiveNav, nil}],
-      root_layout: {FzHttpWeb.LayoutView, :unprivileged}
+      root_layout: {FzHttpWeb.LayoutView, :root}
     ) do
       live "/auth", MFALive.Auth, :auth
       live "/auth/:id", MFALive.Auth, :auth

--- a/apps/fz_http/lib/fz_http_web/templates/layout/root.html.heex
+++ b/apps/fz_http/lib/fz_http_web/templates/layout/root.html.heex
@@ -17,6 +17,8 @@
     <meta name="msapplication-config" content="/browserconfig.xml" />
     <meta name="msapplication-TileColor" content="331700">
     <meta name="theme-color" content="331700">
+    <!-- CSRF -->
+    <%= csrf_meta_tag() %>
   </head>
 <body>
 <section class="section hero is-fullheight is-error-section">

--- a/apps/fz_http/test/fz_http_web/live/mfa_live/auth_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/mfa_live/auth_test.exs
@@ -51,7 +51,7 @@ defmodule FzHttpWeb.MFALive.AuthTest do
       {:ok, view, _html} = live(conn, path)
 
       view
-      |> element("a")
+      |> element("a[href=\"/mfa/types\"]")
       |> render_click()
 
       assert_patched(view, "/mfa/types")


### PR DESCRIPTION
Fixes a bug on Firefox where the code wasn't being accepted -- the `handle_event` function wasn't being called when the form was submitted for some reason.

* Add liveview on the main `root` layout.
* Use root layout for MFA
* Add `error_tag` to display TOTP code errors.
* Add sign_out link so users can sign out (cookie is set after the email/pass step so need some way to clear it)