### PR TITLE
Add user id to rules

### DIFF
--- a/apps/fz_http/lib/fz_http/devices.ex
+++ b/apps/fz_http/lib/fz_http/devices.ex
@@ -23,6 +23,10 @@ defmodule FzHttp.Devices do
 
   def get_device!(id), do: Repo.get!(Device, id)
 
+  def get_device(public_key) when is_binary(public_key) do
+    Repo.one(from d in Device, where: d.public_key == ^public_key)
+  end
+
   def create_device(attrs \\ %{}) do
     # XXX: insert sometimes fails with deadlock errors, probably because
     # of the giant SELECT in queries/inet.ex. Find a way to do this more gracefully.

--- a/apps/fz_http/lib/fz_http/devices.ex
+++ b/apps/fz_http/lib/fz_http/devices.ex
@@ -23,7 +23,7 @@ defmodule FzHttp.Devices do
 
   def get_device!(id), do: Repo.get!(Device, id)
 
-  def get_device(public_key) when is_binary(public_key) do
+  def get_device({:public_key, public_key}) do
     Repo.one(from d in Device, where: d.public_key == ^public_key)
   end
 

--- a/apps/fz_http/lib/fz_http/devices.ex
+++ b/apps/fz_http/lib/fz_http/devices.ex
@@ -23,10 +23,6 @@ defmodule FzHttp.Devices do
 
   def get_device!(id), do: Repo.get!(Device, id)
 
-  def get_device({:public_key, public_key}) do
-    Repo.one(from d in Device, where: d.public_key == ^public_key)
-  end
-
   def create_device(attrs \\ %{}) do
     # XXX: insert sometimes fails with deadlock errors, probably because
     # of the giant SELECT in queries/inet.ex. Find a way to do this more gracefully.

--- a/apps/fz_http/lib/fz_http/events.ex
+++ b/apps/fz_http/lib/fz_http/events.ex
@@ -13,9 +13,9 @@ defmodule FzHttp.Events do
   end
 
   def delete_device(public_key) when is_binary(public_key) do
-    # XXX: Handle nil case
-    device = Devices.get_device(public_key)
-    delete_device(device)
+    if device = Devices.get_device({:public_key, public_key}) do
+      delete_device(device)
+    end
   end
 
   def delete_device(device) when is_struct(device) do

--- a/apps/fz_http/lib/fz_http/events.ex
+++ b/apps/fz_http/lib/fz_http/events.ex
@@ -8,8 +8,8 @@ defmodule FzHttp.Events do
   # set_config is used because devices need to be re-evaluated in case a
   # device is added to a User that's not active.
   def update_device(device) do
-    GenServer.call(vpn_pid(), {:set_config, Devices.to_peer_list()})
     GenServer.call(wall_pid(), {:add_rules, Rules.nftables_device_spec(device)})
+    GenServer.call(vpn_pid(), {:set_config, Devices.to_peer_list()})
   end
 
   def delete_device(public_key) when is_binary(public_key) do

--- a/apps/fz_http/lib/fz_http/events.ex
+++ b/apps/fz_http/lib/fz_http/events.ex
@@ -17,6 +17,7 @@ defmodule FzHttp.Events do
 
   def delete_device(device) when is_struct(device) do
     GenServer.call(vpn_pid(), {:remove_peer, device.public_key})
+    GenServer.call(wall_pid(), {:delete_device_rules, {device.ipv4, device.ipv6}})
   end
 
   def add_rule(rule) do

--- a/apps/fz_http/lib/fz_http/events.ex
+++ b/apps/fz_http/lib/fz_http/events.ex
@@ -12,13 +12,7 @@ defmodule FzHttp.Events do
     GenServer.call(vpn_pid(), {:set_config, Devices.to_peer_list()})
   end
 
-  def delete_device(public_key) when is_binary(public_key) do
-    if device = Devices.get_device({:public_key, public_key}) do
-      delete_device(device)
-    end
-  end
-
-  def delete_device(device) when is_struct(device) do
+  def delete_device(device) do
     GenServer.call(
       wall_pid(),
       {:delete_device_rules, {Rules.decode(device.ipv4), Rules.decode(device.ipv6)}}

--- a/apps/fz_http/lib/fz_http/rules.ex
+++ b/apps/fz_http/lib/fz_http/rules.ex
@@ -8,6 +8,15 @@ defmodule FzHttp.Rules do
 
   alias FzHttp.{Repo, Rules.Rule, Telemetry}
 
+  def list_rules, do: Repo.all(Rule)
+
+  def list_rules(user_id) do
+    Repo.all(
+      from r in Rule,
+        where: r.user_id == ^user_id
+    )
+  end
+
   def get_rule!(id), do: Repo.get!(Rule, id)
 
   def new_rule(attrs \\ %{}) do

--- a/apps/fz_http/lib/fz_http/rules.ex
+++ b/apps/fz_http/lib/fz_http/rules.ex
@@ -61,7 +61,26 @@ defmodule FzHttp.Rules do
   end
 
   def nftables_spec(rule) do
-    {decode(rule.destination), rule.action}
+    {get_user_ips(rule.user_id, FzCommon.FzNet.ip_type("#{rule.destination}")),
+     decode(rule.destination), rule.action}
+  end
+
+  defp get_user_ips(nil, _), do: nil
+
+  defp get_user_ips(user_id, "IPv4") do
+    Enum.map(FzHttp.Devices.list_devices(user_id), fn device ->
+      "#{device.ipv4}"
+    end)
+  end
+
+  defp get_user_ips(user_id, "IPv6") do
+    Enum.map(FzHttp.Devices.list_devices(user_id), fn device ->
+      "#{device.ipv6}"
+    end)
+  end
+
+  defp get_user_ips(_, "unknown") do
+    raise "Unknown protoocl."
   end
 
   def to_nftables do

--- a/apps/fz_http/lib/fz_http/rules.ex
+++ b/apps/fz_http/lib/fz_http/rules.ex
@@ -111,10 +111,9 @@ defmodule FzHttp.Rules do
   end
 
   def to_nftables do
-    Enum.map(nftables_query(), fn rule ->
+    Enum.flat_map(nftables_query(), fn rule ->
       nftables_spec(rule)
     end)
-    |> List.flatten()
   end
 
   defp nftables_query do

--- a/apps/fz_http/lib/fz_http/rules.ex
+++ b/apps/fz_http/lib/fz_http/rules.ex
@@ -7,7 +7,7 @@ defmodule FzHttp.Rules do
   import FzCommon.FzNet
   alias EctoNetwork.INET
 
-  alias FzHttp.{Repo, Rules.Rule, Telemetry}
+  alias FzHttp.{Devices.Device, Repo, Rules.Rule, Telemetry}
 
   def list_rules, do: Repo.all(Rule)
 
@@ -79,47 +79,52 @@ defmodule FzHttp.Rules do
   end
 
   defp nftables_spec(rule, nil) do
-    [{decode(rule.destination), rule.action}]
+    [spec_tuple(rule, nil)]
   end
 
   defp nftables_spec(rule, user_id) do
-    get_user_ips(user_id, ip_type("#{rule.destination}"))
+    FzHttp.Devices.list_devices(user_id)
+    |> Enum.map(fn device -> spec_tuple(rule, device) end)
     # XXX: This should only be needed if a destination can be ipv4/v6 while ipv4/v6
     # is disabled in firezone
     |> Enum.reject(fn ip -> is_nil(ip) end)
-    |> Enum.map(fn source -> {decode(source), decode(rule.destination), rule.action} end)
+  end
+
+  defp spec_tuple({rule, device}) do
+    spec_tuple(rule, device)
+  end
+
+  defp spec_tuple(rule, nil) do
+    {decode(rule.destination), rule.action}
+  end
+
+  defp spec_tuple(rule, device) do
+    case get_device_ip(device, ip_type("#{rule.destination}")) do
+      nil -> nil
+      ip -> {decode(ip), decode(rule.destination), rule.action}
+    end
   end
 
   defp get_device_ip(device, "IPv4"), do: device.ipv4
   defp get_device_ip(device, "IPv6"), do: device.ipv6
   defp get_device_ip(_, "unknown"), do: raise("Unknown protocol")
 
-  defp get_user_ips(user_id, "IPv4") do
-    Enum.map(FzHttp.Devices.list_devices(user_id), fn device ->
-      device.ipv4
-    end)
-  end
-
-  defp get_user_ips(user_id, "IPv6") do
-    Enum.map(FzHttp.Devices.list_devices(user_id), fn device ->
-      device.ipv6
-    end)
-  end
-
-  defp get_user_ips(_, "unknown") do
-    raise "Unknown protocol."
-  end
-
   def to_nftables do
-    Enum.flat_map(nftables_query(), fn rule ->
-      nftables_spec(rule)
+    Enum.map(nftables_query(), fn spec ->
+      spec_tuple(spec)
     end)
+    |> Enum.reject(fn spec -> is_nil(spec) end)
   end
 
   defp nftables_query do
     query =
       from r in Rule,
-        order_by: r.action
+        left_join: d in Device,
+        on: d.user_id == r.user_id,
+        select: {r, d},
+        order_by: r.action,
+        where: is_nil(r.user_id),
+        or_where: not is_nil(d)
 
     Repo.all(query)
   end

--- a/apps/fz_http/lib/fz_http/rules/rule.ex
+++ b/apps/fz_http/lib/fz_http/rules/rule.ex
@@ -6,7 +6,7 @@ defmodule FzHttp.Rules.Rule do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @rule_dupe_msg "A rule with that IP/CIDR address already exists."
+  @rule_dupe_msg "A rule with that IP/CIDR address already exists and for the same user (or no user)."
 
   schema "rules" do
     field :uuid, Ecto.UUID, autogenerate: true
@@ -25,6 +25,6 @@ defmodule FzHttp.Rules.Rule do
       :destination
     ])
     |> validate_required([:action, :destination])
-    |> unique_constraint([:destination, :action], message: @rule_dupe_msg)
+    |> unique_constraint([:user_id, :destination, :action], message: @rule_dupe_msg)
   end
 end

--- a/apps/fz_http/lib/fz_http/rules/rule.ex
+++ b/apps/fz_http/lib/fz_http/rules/rule.ex
@@ -6,7 +6,7 @@ defmodule FzHttp.Rules.Rule do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @rule_dupe_msg "A rule with that IP/CIDR address already exists and for the same user (or no user)."
+  @rule_dupe_msg "A rule with that specification already exists."
 
   schema "rules" do
     field :uuid, Ecto.UUID, autogenerate: true

--- a/apps/fz_http/lib/fz_http/rules/rule.ex
+++ b/apps/fz_http/lib/fz_http/rules/rule.ex
@@ -12,6 +12,7 @@ defmodule FzHttp.Rules.Rule do
     field :uuid, Ecto.UUID, autogenerate: true
     field :destination, EctoNetwork.INET, read_after_writes: true
     field :action, Ecto.Enum, values: [:drop, :accept], default: :drop
+    belongs_to :user, FzHttp.Users.User
 
     timestamps(type: :utc_datetime_usec)
   end
@@ -19,6 +20,7 @@ defmodule FzHttp.Rules.Rule do
   def changeset(rule, attrs) do
     rule
     |> cast(attrs, [
+      :user_id,
       :action,
       :destination
     ])

--- a/apps/fz_http/lib/fz_http_web/live/device_live/admin/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/admin/show_live.ex
@@ -32,7 +32,7 @@ defmodule FzHttpWeb.DeviceLive.Admin.Show do
 
     case Devices.delete_device(device) do
       {:ok, _deleted_device} ->
-        {:ok, _deleted_pubkey} = @events_module.delete_device(device.public_key)
+        {:ok, _deleted_pubkey} = @events_module.delete_device(device)
 
         {:noreply,
          socket

--- a/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/show_live.ex
@@ -25,7 +25,7 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.Show do
 
     case delete_device(device, socket) do
       {:ok, _deleted_device} ->
-        {:ok, _deleted_pubkey} = @events_module.delete_device(device.public_key)
+        {:ok, _deleted_pubkey} = @events_module.delete_device(device)
 
         {:noreply,
          socket

--- a/apps/fz_http/lib/fz_http_web/mock_events.ex
+++ b/apps/fz_http/lib/fz_http_web/mock_events.ex
@@ -7,8 +7,8 @@ defmodule FzHttpWeb.MockEvents do
   inside FzHttp and use that for the tests.
   """
 
-  def delete_device(public_key) do
-    {:ok, public_key}
+  def delete_device(device) do
+    {:ok, device}
   end
 
   def update_device(_device) do

--- a/apps/fz_http/priv/repo/migrations/20220614192937_add_user_id_to_rules.exs
+++ b/apps/fz_http/priv/repo/migrations/20220614192937_add_user_id_to_rules.exs
@@ -1,0 +1,9 @@
+defmodule FzHttp.Repo.Migrations.AddUserIdToRules do
+  use Ecto.Migration
+
+  def change do
+    alter table(:rules) do
+      add :user_id, references(:users, on_delete: :delete_all), default: nil
+    end
+  end
+end

--- a/apps/fz_http/priv/repo/migrations/20220614192937_add_user_id_to_rules.exs
+++ b/apps/fz_http/priv/repo/migrations/20220614192937_add_user_id_to_rules.exs
@@ -2,8 +2,12 @@ defmodule FzHttp.Repo.Migrations.AddUserIdToRules do
   use Ecto.Migration
 
   def change do
+    drop unique_index(:rules, [:destination, :action])
+
     alter table(:rules) do
       add :user_id, references(:users, on_delete: :delete_all), default: nil
     end
+
+    create unique_index(:rules, [:user_id, :destination, :action])
   end
 end

--- a/apps/fz_http/test/fz_http/events_test.exs
+++ b/apps/fz_http/test/fz_http/events_test.exs
@@ -95,8 +95,7 @@ defmodule FzHttp.EventsTest do
                ])
              )
 
-      pubkey = device.public_key
-      assert {:ok, ^pubkey} = Events.delete_device(pubkey)
+      assert {:ok, _} = Events.delete_device(device)
 
       assert :sys.get_state(Events.vpn_pid()) == %{
                "4" => %{

--- a/apps/fz_http/test/fz_http/rules_test.exs
+++ b/apps/fz_http/test/fz_http/rules_test.exs
@@ -17,6 +17,12 @@ defmodule FzHttp.RulesTest do
     test "list Rules scoped by user", %{user: user, rule: rule} do
       assert Rules.list_rules(user.id) == [rule]
     end
+
+    test "Deleting user deletes rule", %{user: user, rule: rule} do
+      assert rule in Rules.list_rules()
+      FzHttp.Users.delete_user(user)
+      assert rule not in Rules.list_rules()
+    end
   end
 
   describe "get_rule!/1" do
@@ -44,6 +50,7 @@ defmodule FzHttp.RulesTest do
       {:ok, rule} = Rules.create_rule(%{destination: "::1"})
       assert !is_nil(rule.id)
       assert rule.action == :drop
+      assert rule.user_id == nil
     end
 
     test "prevents invalid CIDRs" do
@@ -74,7 +81,10 @@ defmodule FzHttp.RulesTest do
       {"2.2.2.0/24", :drop},
       {"3.3.3.0/24", :drop},
       {"4.4.4.0/24", :drop},
-      {"5.5.5.0/24", :drop}
+      {"5.5.5.0/24", :drop},
+      {"10.3.2.4", "4.4.4.0/24", :drop},
+      {"10.3.2.5", "5.5.5.0/24", :drop},
+      {"10.3.2.6", "6.6.6.0/24", :drop}
     ]
 
     test "prints all rules to nftables format", %{rules: _rules} do
@@ -101,20 +111,69 @@ defmodule FzHttp.RulesTest do
   describe "nftables_spec/1 IPv4" do
     setup [:create_rule4]
 
-    @ipv4tables_spec {nil, "10.10.10.0/24", :drop}
+    @ipv4tables_spec [{"10.10.10.0/24", :drop}]
 
     test "returns IPv4 tuple", %{rule4: rule} do
       assert @ipv4tables_spec = Rules.nftables_spec(rule)
     end
   end
 
-  describe "nftables_spec/1 IPv6" do
-    setup [:create_rule6]
+  describe "nftables_spec/1 with user IPv4" do
+    setup [:create_rule4_with_user]
 
-    @ipv6tables_spec {nil, "::/0", :drop}
+    @ipv4tables_spec [
+      {"10.3.2.2", "10.10.10.0/24", :drop},
+      {"10.3.2.3", "10.10.10.0/24", :drop},
+      {"10.3.2.4", "10.10.10.0/24", :drop},
+      {"10.3.2.5", "10.10.10.0/24", :drop}
+    ]
+
+    test "returns IPv4 tuple", %{rule4: rule} do
+      assert @ipv4tables_spec = Rules.nftables_spec(rule)
+    end
+  end
+
+  describe "nftables_spec/1 with user IPv6" do
+    setup [:create_rule6_with_user]
+
+    @ipv6tables_spec [
+      {"fd00::3:2:2", "::/0", :drop},
+      {"fd00::3:2:3", "::/0", :drop},
+      {"fd00::3:2:4", "::/0", :drop},
+      {"fd00::3:2:5", "::/0", :drop}
+    ]
 
     test "returns IPv6 tuple", %{rule6: rule} do
       assert @ipv6tables_spec = Rules.nftables_spec(rule)
+    end
+  end
+
+  describe "nftables_spec/1 with user no devices" do
+    setup [:create_rule_with_user]
+
+    @iptables_spec []
+
+    test "returns Empty", %{rule: rule} do
+      assert @iptables_spec = Rules.nftables_spec(rule)
+    end
+  end
+
+  describe "nftables_device_spec/1" do
+    setup [:create_device_with_rules]
+
+    @ipv4tables_spec [
+      {"10.3.2.2", "1.1.1.0/24", :drop},
+      {"10.3.2.2", "2.2.2.0/24", :drop},
+      {"10.3.2.2", "3.3.3.0/24", :drop},
+      {"10.3.2.2", "4.4.4.0/24", :drop},
+      {"fd00::3:2:2", "1::/112", :drop},
+      {"fd00::3:2:2", "2::/112", :drop},
+      {"fd00::3:2:2", "3::/112", :drop},
+      {"fd00::3:2:2", "4::/112", :drop}
+    ]
+
+    test "returns IPv4 tuple", %{device: device} do
+      assert @ipv4tables_spec = Rules.nftables_device_spec(device)
     end
   end
 end

--- a/apps/fz_http/test/fz_http/rules_test.exs
+++ b/apps/fz_http/test/fz_http/rules_test.exs
@@ -3,6 +3,22 @@ defmodule FzHttp.RulesTest do
 
   alias FzHttp.Rules
 
+  describe "list_rules/0" do
+    setup [:create_rules]
+
+    test "lists all Rules", %{rules: rules} do
+      assert length(rules) == length(Rules.list_rules())
+    end
+  end
+
+  describe "list_rules/1" do
+    setup [:create_rule_with_user]
+
+    test "list Rules scoped by user", %{user: user, rule: rule} do
+      assert Rules.list_rules(user.id) == [rule]
+    end
+  end
+
   describe "get_rule!/1" do
     setup [:create_rule]
 

--- a/apps/fz_http/test/fz_http/rules_test.exs
+++ b/apps/fz_http/test/fz_http/rules_test.exs
@@ -101,7 +101,7 @@ defmodule FzHttp.RulesTest do
   describe "nftables_spec/1 IPv4" do
     setup [:create_rule4]
 
-    @ipv4tables_spec {"10.10.10.0/24", :drop}
+    @ipv4tables_spec {nil, "10.10.10.0/24", :drop}
 
     test "returns IPv4 tuple", %{rule4: rule} do
       assert @ipv4tables_spec = Rules.nftables_spec(rule)
@@ -111,7 +111,7 @@ defmodule FzHttp.RulesTest do
   describe "nftables_spec/1 IPv6" do
     setup [:create_rule6]
 
-    @ipv6tables_spec {"::/0", :drop}
+    @ipv6tables_spec {nil, "::/0", :drop}
 
     test "returns IPv6 tuple", %{rule6: rule} do
       assert @ipv6tables_spec = Rules.nftables_spec(rule)

--- a/apps/fz_http/test/fz_http/rules_test.exs
+++ b/apps/fz_http/test/fz_http/rules_test.exs
@@ -88,7 +88,7 @@ defmodule FzHttp.RulesTest do
     ]
 
     test "prints all rules to nftables format", %{rules: _rules} do
-      assert @nftables_rules == Rules.to_nftables()
+      assert MapSet.equal?(MapSet.new(@nftables_rules), MapSet.new(Rules.to_nftables()))
     end
   end
 

--- a/apps/fz_http/test/support/test_helpers.ex
+++ b/apps/fz_http/test/support/test_helpers.ex
@@ -112,8 +112,42 @@ defmodule FzHttp.TestHelpers do
     {:ok, rule6: rule}
   end
 
+  def create_rule6_with_user(_) do
+    user = UsersFixtures.user()
+
+    2..5
+    |> Enum.each(fn num ->
+      DevicesFixtures.device(%{
+        name: "device #{num}",
+        public_key: "#{num}",
+        user_id: user.id,
+        ipv6: "fd00::3:2:#{num}"
+      })
+    end)
+
+    rule = RulesFixtures.rule6(%{user_id: user.id})
+    {:ok, rule6: rule}
+  end
+
   def create_rule4(_) do
     rule = RulesFixtures.rule4(%{})
+    {:ok, rule4: rule}
+  end
+
+  def create_rule4_with_user(_) do
+    user = UsersFixtures.user()
+
+    2..5
+    |> Enum.each(fn num ->
+      DevicesFixtures.device(%{
+        name: "device #{num}",
+        public_key: "#{num}",
+        user_id: user.id,
+        ipv4: "10.3.2.#{num}"
+      })
+    end)
+
+    rule = RulesFixtures.rule4(%{user_id: user.id})
     {:ok, rule4: rule}
   end
 
@@ -128,7 +162,54 @@ defmodule FzHttp.TestHelpers do
         RulesFixtures.rule(%{destination: destination})
       end)
 
-    {:ok, rules: rules}
+    rules_with_user =
+      4..6
+      |> Enum.map(fn num ->
+        destination = "#{num}.#{num}.#{num}.0/24"
+        user = UsersFixtures.user()
+
+        DevicesFixtures.device(%{
+          name: "device #{num}",
+          public_key: "#{num}",
+          user_id: user.id,
+          ipv4: "10.3.2.#{num}",
+          ipv6: "fd00::3:2:#{num}"
+        })
+
+        RulesFixtures.rule(%{destination: destination, user_id: user.id})
+      end)
+
+    destination = "7.7.7.0/24"
+    user = UsersFixtures.user()
+    rule_without_device = RulesFixtures.rule(%{destination: destination, user_id: user.id})
+    {:ok, rules: rules ++ rules_with_user ++ [rule_without_device]}
+  end
+
+  def create_device_with_rules(_) do
+    user = UsersFixtures.user()
+
+    1..4
+    |> Enum.each(fn num ->
+      destination = "#{num}.#{num}.#{num}.0/24"
+      RulesFixtures.rule(%{destination: destination, user_id: user.id})
+    end)
+
+    1..4
+    |> Enum.each(fn num ->
+      destination = "#{num}::/112"
+      RulesFixtures.rule(%{destination: destination, user_id: user.id})
+    end)
+
+    device =
+      DevicesFixtures.device(%{
+        name: "device",
+        public_key: "1",
+        user_id: user.id,
+        ipv4: "10.3.2.2",
+        ipv6: "fd00::3:2:2"
+      })
+
+    {:ok, device: device}
   end
 
   def create_rule_with_user(_) do

--- a/apps/fz_http/test/support/test_helpers.ex
+++ b/apps/fz_http/test/support/test_helpers.ex
@@ -131,6 +131,13 @@ defmodule FzHttp.TestHelpers do
     {:ok, rules: rules}
   end
 
+  def create_rule_with_user(_) do
+    user = UsersFixtures.user()
+    rule = RulesFixtures.rule(%{user_id: user.id})
+
+    {:ok, rule: rule, user: user}
+  end
+
   def create_user_with_valid_sign_in_token(_) do
     {:ok, user: %User{} = UsersFixtures.user(Users.sign_in_keys())}
   end

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -83,18 +83,10 @@ defmodule FzWall.CLI.Live do
   defp delete_rule_matching(rule_str) do
     rules = exec!("#{nft()} -a list table inet #{@table_name}")
 
-    case rule_handle_regex(~r/#{rule_str}.*# handle (?<num>\d+)/, rules) do
-      nil ->
-        {:error, "rule not found"}
-
-      handles ->
-        Enum.each(
-          handles,
-          fn handle ->
-            exec!("#{nft()} delete rule inet #{@table_name} forward handle #{handle}")
-          end
-        )
-    end
+    rule_handle_regex(~r/#{rule_str}.*# handle (?<num>\d+)/, rules)
+    |> Enum.flat_map(fn handle ->
+      exec!("#{nft()} delete rule inet #{@table_name} forward handle #{handle}")
+    end)
   end
 
   @doc """
@@ -129,7 +121,7 @@ defmodule FzWall.CLI.Live do
   end
 
   defp rule_handle_regex(regex, rules) do
-    Regex.run(regex, rules, capture: :all_names)
+    Regex.scan(regex, rules, capture: :all_names)
   end
 
   defp egress_interface do

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -75,7 +75,7 @@ defmodule FzWall.CLI.Live do
     |> delete_rule_matching()
   end
 
-  def delete_rules({source}) do
+  def delete_rules(source) do
     source_match_str(source)
     |> delete_rule_matching()
   end

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -85,7 +85,7 @@ defmodule FzWall.CLI.Live do
 
     # When a rule is deleted the others might change handle so we need to
     # re-scan each time.
-    case rule_handle_regex(~r/^#{rule_str}.*# handle (?<num>\d+)/m, rules) do
+    case rule_handle_regex(~r/^\s*#{rule_str}.*# handle (?<num>\d+)/m, rules) do
       nil ->
         :no_rule
 

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -85,7 +85,7 @@ defmodule FzWall.CLI.Live do
 
     # When a rule is deleted the others might change handle so we need to
     # re-scan each time.
-    case rule_handle_regex(~r/#{rule_str}.*# handle (?<num>\d+)/, rules) do
+    case rule_handle_regex(~r/^#{rule_str}.*# handle (?<num>\d+)/m, rules) do
       nil ->
         :no_rule
 

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -85,15 +85,7 @@ defmodule FzWall.CLI.Live do
 
     case rule_handle_regex(~r/#{rule_str}.*# handle (?<num>\d+)/, rules) do
       nil ->
-        raise("""
-          ######################################################
-          Could not get handle to delete rule!
-          Rule spec: #{rule_str}
-
-          Current rules:
-          #{rules}
-          ######################################################
-        """)
+        {:error, "rule not found"}
 
       handles ->
         Enum.each(

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -80,16 +80,6 @@ defmodule FzWall.CLI.Live do
     |> delete_rule_matching()
   end
 
-  def delete_rules({[source | sources], dest}) do
-    rule_match_str(source, dest)
-    |> delete_rule_matching()
-
-    delete_rules({sources, dest})
-  end
-
-  def delete_rules({[], _}) do
-  end
-
   defp delete_rule_matching(rule_str) do
     rules = exec!("#{nft()} -a list table inet #{@table_name}")
 

--- a/apps/fz_wall/lib/fz_wall/cli/sandbox.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/sandbox.ex
@@ -10,6 +10,7 @@ defmodule FzWall.CLI.Sandbox do
   def teardown_table, do: @default_returned
   def add_rule(_rule_spec), do: @default_returned
   def delete_rule(_rule_spec), do: @default_returned
+  def delete_rules(_rules_spec), do: @default_returned
   def restore(_fz_http_rules), do: @default_returned
   def egress_address, do: "10.0.0.1"
 end

--- a/apps/fz_wall/lib/fz_wall/server.ex
+++ b/apps/fz_wall/lib/fz_wall/server.ex
@@ -73,9 +73,10 @@ defmodule FzWall.Server do
   end
 
   defp delete_device_rules(source, rules) do
+    # We ignore the errors here so that we can keep deleting rules
     cli().delete_rules(source)
-    # XXX: Consider using MapSet here
 
+    # XXX: Consider using MapSet here
     new_rules =
       Enum.reject(rules, fn rule ->
         case rule do
@@ -91,6 +92,7 @@ defmodule FzWall.Server do
   # instead of multiple callings to delete_rule
   defp delete_rules(rules_spec, rules) do
     Enum.reduce(rules_spec, MapSet.new(rules), fn rule_spec, rules_acc ->
+      # We ignore errors here just to keep deleting the other rules
       cli().delete_rule(rule_spec)
       MapSet.delete(rules_acc, rule_spec)
     end)

--- a/apps/fz_wall/lib/fz_wall/server.ex
+++ b/apps/fz_wall/lib/fz_wall/server.ex
@@ -23,68 +23,31 @@ defmodule FzWall.Server do
     {:ok, existing_rules}
   end
 
-  defp get_rule_list({nil, dest, action}), do: [{dest, action}]
-
-  defp get_rule_list({[source | sources], dest, action}) do
-    [{source, dest, action}] ++ get_rule_list({sources, dest, action})
-  end
-
-  defp get_rule_list({source, dest, action}) do
-    [{source, dest, action}]
-  end
-
-  defp add_device_rules([rule_spec | rules_spec], rules) do
-    new_rules = add_rules(rule_spec, rules)
-    add_device_rules(rules_spec, new_rules)
-  end
-
-  defp add_device_rules([], _) do
-  end
-
   @impl GenServer
-  def handle_call({:add_device_rules, rules_spec}, _from, rules) do
-    new_rules = add_device_rules(rules_spec, rules)
-    {:reply, :ok, new_rules}
-  end
-
-  @impl GenServer
-  def handle_call({:add_rule, rule_spec}, _from, rules) do
+  def handle_call({:add_rules, rule_spec}, _from, rules) do
     new_rules = add_rules(rule_spec, rules)
 
     {:reply, :ok, new_rules}
   end
 
-  # XXX: For multiple rules it'd be better to have something like [ src1 | src2 | src3 | ...]
-  # instead of multiple callings to delete_rule
   @impl GenServer
-  def handle_call({:delete_rule, rule_spec}, _from, rules) do
-    new_rules =
-      get_rule_list(rule_spec)
-      |> List.foldl(rules, fn rule_spec, rules_acc ->
-        cli().delete_rule(rule_spec)
-        # XXX: Consider using MapSet here
-        if rule_spec in rules_acc do
-          List.delete(rules_acc, rule_spec)
-        else
-          rules_acc
-        end
-      end)
-
+  def handle_call({:delete_rule, rules_spec}, _from, rules) do
+    new_rules = delete_rules(rules_spec, rules)
     {:reply, :ok, new_rules}
   end
 
   @impl GenServer
   def handle_call({:delete_device_rules, {ipv4, nil}}, _from, rules),
-    do: delete_rules(ipv4, rules)
+    do: delete_device_rules(ipv4, rules)
 
   @impl GenServer
   def handle_call({:delete_device_rules, {nil, ipv6}}, _from, rules),
-    do: delete_rules(ipv6, rules)
+    do: delete_device_rules(ipv6, rules)
 
   @impl GenServer
   def handle_call({:delete_device_rules, {ipv4, ipv6}}, _from, rules) do
-    {:reply, :ok, new_rules} = delete_rules(ipv4, rules)
-    delete_rules(ipv6, new_rules)
+    {:reply, :ok, new_rules} = delete_device_rules(ipv4, rules)
+    delete_device_rules(ipv6, new_rules)
   end
 
   @impl GenServer
@@ -109,7 +72,7 @@ defmodule FzWall.Server do
     :global.whereis_name(:fz_http_server)
   end
 
-  defp delete_rules(source, rules) do
+  defp delete_device_rules(source, rules) do
     cli().delete_rules({source})
     # XXX: Consider using MapSet here
 
@@ -124,9 +87,22 @@ defmodule FzWall.Server do
     {:reply, :ok, new_rules}
   end
 
-  defp add_rules(rule_spec, rules) do
-    get_rule_list(rule_spec)
-    |> List.foldl(rules, fn rule_spec, rules_acc ->
+  # XXX: For multiple rules it'd be better to have something like [ src1 | src2 | src3 | ...]
+  # instead of multiple callings to delete_rule
+  defp delete_rules(rules_spec, rules) do
+    List.foldl(rules_spec, rules, fn rule_spec, rules_acc ->
+      cli().delete_rule(rule_spec)
+      # XXX: Consider using MapSet here
+      if rule_spec in rules_acc do
+        List.delete(rules_acc, rule_spec)
+      else
+        rules_acc
+      end
+    end)
+  end
+
+  defp add_rules(rules_spec, rules) do
+    List.foldl(rules_spec, rules, fn rule_spec, rules_acc ->
       cli().add_rule(rule_spec)
 
       if rule_spec in rules_acc do

--- a/apps/fz_wall/lib/fz_wall/server.ex
+++ b/apps/fz_wall/lib/fz_wall/server.ex
@@ -73,7 +73,7 @@ defmodule FzWall.Server do
   end
 
   defp delete_device_rules(source, rules) do
-    cli().delete_rules({source})
+    cli().delete_rules(source)
     # XXX: Consider using MapSet here
 
     new_rules =
@@ -90,26 +90,18 @@ defmodule FzWall.Server do
   # XXX: For multiple rules it'd be better to have something like [ src1 | src2 | src3 | ...]
   # instead of multiple callings to delete_rule
   defp delete_rules(rules_spec, rules) do
-    List.foldl(rules_spec, rules, fn rule_spec, rules_acc ->
+    Enum.reduce(rules_spec, MapSet.new(rules), fn rule_spec, rules_acc ->
       cli().delete_rule(rule_spec)
-      # XXX: Consider using MapSet here
-      if rule_spec in rules_acc do
-        List.delete(rules_acc, rule_spec)
-      else
-        rules_acc
-      end
+      MapSet.delete(rules_acc, rule_spec)
     end)
+    |> Enum.to_list()
   end
 
   defp add_rules(rules_spec, rules) do
-    List.foldl(rules_spec, rules, fn rule_spec, rules_acc ->
+    Enum.reduce(rules_spec, MapSet.new(rules), fn rule_spec, rules_acc ->
       cli().add_rule(rule_spec)
-
-      if rule_spec in rules_acc do
-        rules_acc
-      else
-        rules_acc ++ [rule_spec]
-      end
+      MapSet.put(rules_acc, rule_spec)
     end)
+    |> Enum.to_list()
   end
 end


### PR DESCRIPTION
Addressing firezone/product#392

* Add user_id to rules
* Update events to keep track of rules<-->device relations
* Update fz_wall to handle adding multiple rules at once since now a rule can correspond to multiple devices and adding a device might mean adding all the device's user's rules
* Update tests accordingly

Opening for now as a draft since I haven't done manual testing yet but I'm not planning on more changes