### PR TITLE
Dont error for failed capture calls

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,8 @@ capture () {
             \"email\": \"$2\"
           }
         }" \
-        https://telemetry.firez.one/capture/ > /dev/null
+        https://telemetry.firez.one/capture/ > /dev/null \
+        || true
     fi
   fi
 }


### PR DESCRIPTION
Fixes issues where install script doesn't work when telemetry.firez.one is blackholed.

Refs #658 