### PR TITLE
Split setcap calls

### DIFF
--- a/omnibus/cookbooks/firezone/recipes/app.rb
+++ b/omnibus/cookbooks/firezone/recipes/app.rb
@@ -28,6 +28,11 @@ execute 'fix app permissions' do
   command "chown -R #{user}:#{group} #{app_dir} && chmod -R o-rwx #{app_dir} && chmod -R g-rwx #{app_dir}"
 end
 
+beam_path = `ls -1 #{node['firezone']['install_directory']}/embedded/service/firezone/erts-*/bin/beam.smp`
+execute 'setcap_beam' do
+  command "setcap 'cap_net_admin+eip' #{beam_path}"
+end
+
 file 'environment-variables' do
   path "#{node['firezone']['var_directory']}/etc/env"
 

--- a/omnibus/cookbooks/firezone/recipes/default.rb
+++ b/omnibus/cookbooks/firezone/recipes/default.rb
@@ -12,8 +12,8 @@ include_recipe 'firezone::network'
 include_recipe 'firezone::postgresql'
 include_recipe 'firezone::nginx'
 include_recipe 'firezone::database'
-include_recipe 'firezone::app'
 include_recipe 'firezone::setcap'
+include_recipe 'firezone::app'
 include_recipe 'firezone::telemetry'
 
 # Write out a firezone-running.json at the end of the run

--- a/omnibus/cookbooks/firezone/recipes/setcap.rb
+++ b/omnibus/cookbooks/firezone/recipes/setcap.rb
@@ -12,7 +12,6 @@ include_recipe 'firezone::config'
 
 nft_path = "#{node['firezone']['install_directory']}/embedded/sbin/nft"
 wg_path = "#{node['firezone']['install_directory']}/embedded/bin/wg"
-beam_path = `ls -1 #{node['firezone']['install_directory']}/embedded/service/firezone/erts-*/bin/beam.smp`
 
 file nft_path do
   # Ensure phoenix app can control nftables
@@ -38,8 +37,4 @@ end
 
 execute 'setcap_wg' do
   command "setcap 'cap_net_admin,cap_net_raw,cap_dac_read_search+eip' #{wg_path}"
-end
-
-execute 'setcap_beam' do
-  command "setcap 'cap_net_admin+eip' #{beam_path}"
 end


### PR DESCRIPTION
Fixes issue where the `nft` executable wasn't setcap'd before the
database migration, causing it to fail (app is loaded and firewall
rules loaded)

<img width="1072" alt="Screen Shot 2022-06-19 at 4 32 20 PM" src="https://user-images.githubusercontent.com/167144/174499331-eed44f48-5cf4-48d4-94ee-096b1faaf8b4.png">

Not sure why it didn't fail the CI pipeline...

