### PR TITLE
Add debugging statements to OpenID Connect failures

### DIFF
--- a/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
@@ -92,7 +92,9 @@ defmodule FzHttpWeb.AuthController do
         |> put_flash(:error, msg)
         |> request(%{})
 
-      _ ->
+      # Error verifying claims or fetching tokens
+      {:error, action, reason} ->
+        Logger.warn("OpenIDConnect Error during #{action}: #{reason}")
         send_resp(conn, 401, "")
     end
   end


### PR DESCRIPTION
Log cases where OpenIDConnect can't fetch tokens or verify claims.

Refs #734 #731 