### PR TITLE
Database backup instructions (pg_dump)

### DIFF
--- a/docs/docs/administer/running-sql-queries.md
+++ b/docs/docs/administer/running-sql-queries.md
@@ -20,6 +20,19 @@ used from the local shell like so:
   -c "SQL_STATEMENT"
 ```
 
+In addition, the `pg_dump` utility is also bundled; this can be used to take
+consistent backups of the database. To dump a copy of the database in the
+standard SQL query format execute it like this (replace `/path/to/backup.sql`
+with the location to create the SQL file):
+
+```shell
+/opt/firezone/embedded/bin/pg_dump \
+  -U firezone \
+  -d firezone \
+  -h localhost \
+  -p 15432 > /path/to/backup.sql
+```
+
 This can be useful for debugging or troubleshooting purposes. It can also be
 used to modify Firezone configuration data, but **this can have unintended
 consequences**. We recommend using the UI (or upcoming API) <!-- XXX: Remove


### PR DESCRIPTION
This pull request adds instructions for dumping the database with `pg_dump` to a SQL file for consistent backups while the service is running.