### PR TITLE
Fix error message matching

### DIFF
--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -142,7 +142,7 @@ defmodule FzWall.CLI.Live do
         true
 
       {error, _exit_code} ->
-        if error =~ ~r"No such file or directory|does not exist") do
+        if error =~ ~r"No such file or directory|does not exist" do
           false
         else
           raise """

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -142,7 +142,7 @@ defmodule FzWall.CLI.Live do
         true
 
       {error, _exit_code} ->
-        if error =~ ~r"No such file or directory|does not exist" do
+        if error =~ ~r/No such file or directory|does not exist/ do
           false
         else
           raise """

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -142,7 +142,7 @@ defmodule FzWall.CLI.Live do
         true
 
       {error, _exit_code} ->
-        if String.contains?(error, "Error: No such file or directory") do
+        if error =~ ~r"No such file or directory|does not exist") do
           false
         else
           raise """


### PR DESCRIPTION
On bionic `nftables` is limited to `0.8.2`.

When executing this command `nft list table inet firezone` and the table does not exist, the error message is:

```
Error: Could not process rule: Table 'firezone' does not exist
```

On later versions, e.g. jammy, with `nftables` at `1.0+` (I didn't test 0.9.x on focal), the error message is:

```
Error: No such file or directory
```

-----

Not sure if we should "fix" this or drop `bionic` from support list.

Bionic also gives me this error that Jammy doesn't:
```
** (RuntimeError)   Error executing command nft 'add rule inet firezone postrouting oifname eth0 masquerade persistent'.
  Exit code: 1
  Error message:
  Error: NAT is only supported for IPv4/IPv6
```