### PR TITLE
Fix #761 - Deprecated nginx SSL directive

### DIFF
--- a/omnibus/cookbooks/firezone/templates/phoenix.nginx.conf.erb
+++ b/omnibus/cookbooks/firezone/templates/phoenix.nginx.conf.erb
@@ -32,14 +32,21 @@ server {
 }
 
 server {
+<% if @ssl['enabled'] -%>
+  listen <%= @nginx['ssl_port'] %> default_server ssl;
+  <% if @nginx['ipv6'] -%>
+    listen [::]:<%= @nginx['ssl_port'] %> default_server ssl;
+  <% end -%>
+<% else -%>
   listen <%= @nginx['ssl_port'] %> default_server;
-<% if @nginx['ipv6'] -%>
-  listen [::]:<%= @nginx['ssl_port'] %> default_server;
+  <% if @nginx['ipv6'] -%>
+    listen [::]:<%= @nginx['ssl_port'] %> default_server;
+  <% end -%>
 <% end -%>
+
   server_name <%= @fqdn %>;
 
 <%   if @ssl['enabled'] -%>
-  ssl on;
   ssl_certificate <%= @ssl['certificate'] %>;
   ssl_certificate_key <%= @ssl['certificate_key'] %>;
   ssl_dhparam <%= @ssl['ssl_dhparam'] %>;


### PR DESCRIPTION
This pull request removes `ssl on;` in the phoenix vhost and instead adds the `ssl` directive to the listen statement.

This change resolves #761 