### PR TITLE
Replaces nftables rule management to use sets

### DIFF
--- a/apps/fz_http/lib/fz_http/events.ex
+++ b/apps/fz_http/lib/fz_http/events.ex
@@ -3,22 +3,22 @@ defmodule FzHttp.Events do
   Handles interfacing with other processes in the system.
   """
 
-  alias FzHttp.{Devices, Rules}
+  alias FzHttp.{Devices, Rules, Users}
 
   # set_config is used because devices need to be re-evaluated in case a
   # device is added to a User that's not active.
   def update_device(device) do
-    GenServer.call(wall_pid(), {:add_device, Rules.device_projection(device)})
+    GenServer.call(wall_pid(), {:add_device, Devices.setting_projection(device)})
     GenServer.call(vpn_pid(), {:set_config, Devices.to_peer_list()})
   end
 
   def delete_device(device) do
-    GenServer.call(wall_pid(), {:delete_device, Rules.device_projection(device)})
+    GenServer.call(wall_pid(), {:delete_device, Devices.setting_projection(device)})
     GenServer.call(vpn_pid(), {:remove_peer, device.public_key})
   end
 
   def delete_user(user) do
-    GenServer.call(wall_pid(), {:delete_user, Rules.user_projection(user)})
+    GenServer.call(wall_pid(), {:delete_user, Users.setting_projection(user)})
   end
 
   def create_user(user) do
@@ -26,15 +26,15 @@ defmodule FzHttp.Events do
     # otherwise, nft could have succeeded in adding the user's set but not the rules
     # this means that in `update_device` add_device can succeed adding the device to the user's set
     # but any rule for the user won't take effect since the user rule doesn't exists.
-    GenServer.call(wall_pid(), {:add_user, Rules.user_projection(user)})
+    GenServer.call(wall_pid(), {:add_user, Users.setting_projection(user)})
   end
 
   def add_rule(rule) do
-    GenServer.call(wall_pid(), {:add_rule, Rules.rule_projection(rule)})
+    GenServer.call(wall_pid(), {:add_rule, Rules.setting_projection(rule)})
   end
 
   def delete_rule(rule) do
-    GenServer.call(wall_pid(), {:delete_rule, Rules.rule_projection(rule)})
+    GenServer.call(wall_pid(), {:delete_rule, Rules.setting_projection(rule)})
   end
 
   def set_config do
@@ -42,7 +42,15 @@ defmodule FzHttp.Events do
   end
 
   def set_rules do
-    GenServer.call(wall_pid(), {:set_rules, Rules.to_settings()})
+    GenServer.call(
+      wall_pid(),
+      {:set_rules,
+       {
+         Users.as_settings(),
+         Devices.as_settings(),
+         Rules.as_settings()
+       }}
+    )
   end
 
   def vpn_pid do

--- a/apps/fz_http/lib/fz_http/events.ex
+++ b/apps/fz_http/lib/fz_http/events.ex
@@ -8,25 +8,33 @@ defmodule FzHttp.Events do
   # set_config is used because devices need to be re-evaluated in case a
   # device is added to a User that's not active.
   def update_device(device) do
-    GenServer.call(wall_pid(), {:add_rules, Rules.nftables_device_spec(device)})
+    GenServer.call(wall_pid(), {:add_device, Rules.device_projection(device)})
     GenServer.call(vpn_pid(), {:set_config, Devices.to_peer_list()})
   end
 
   def delete_device(device) do
-    GenServer.call(
-      wall_pid(),
-      {:delete_device_rules, {Rules.decode(device.ipv4), Rules.decode(device.ipv6)}}
-    )
-
+    GenServer.call(wall_pid(), {:delete_device, Rules.device_projection(device)})
     GenServer.call(vpn_pid(), {:remove_peer, device.public_key})
   end
 
+  def delete_user(user) do
+    GenServer.call(wall_pid(), {:delete_user, Rules.user_projection(user)})
+  end
+
+  def create_user(user) do
+    # Security note: It's important to let an exception here crash this service
+    # otherwise, nft could have succeeded in adding the user's set but not the rules
+    # this means that in `update_device` add_device can succeed adding the device to the user's set
+    # but any rule for the user won't take effect since the user rule doesn't exists.
+    GenServer.call(wall_pid(), {:add_user, Rules.user_projection(user)})
+  end
+
   def add_rule(rule) do
-    GenServer.call(wall_pid(), {:add_rules, Rules.nftables_spec(rule)})
+    GenServer.call(wall_pid(), {:add_rule, Rules.rule_projection(rule)})
   end
 
   def delete_rule(rule) do
-    GenServer.call(wall_pid(), {:delete_rule, Rules.nftables_spec(rule)})
+    GenServer.call(wall_pid(), {:delete_rule, Rules.rule_projection(rule)})
   end
 
   def set_config do
@@ -34,7 +42,7 @@ defmodule FzHttp.Events do
   end
 
   def set_rules do
-    GenServer.call(wall_pid(), {:set_rules, Rules.to_nftables()})
+    GenServer.call(wall_pid(), {:set_rules, Rules.to_settings()})
   end
 
   def vpn_pid do

--- a/apps/fz_http/lib/fz_http/events.ex
+++ b/apps/fz_http/lib/fz_http/events.ex
@@ -45,10 +45,10 @@ defmodule FzHttp.Events do
     GenServer.call(
       wall_pid(),
       {:set_rules,
-       {
-         Users.as_settings(),
-         Devices.as_settings(),
-         Rules.as_settings()
+       %{
+         users: Users.as_settings(),
+         devices: Devices.as_settings(),
+         rules: Rules.as_settings()
        }}
     )
   end

--- a/apps/fz_http/lib/fz_http/server.ex
+++ b/apps/fz_http/lib/fz_http/server.ex
@@ -29,10 +29,10 @@ defmodule FzHttp.Server do
   def handle_call(:load_settings, _from, state) do
     reply =
       {:ok,
-       {
-         Users.as_settings(),
-         Devices.as_settings(),
-         Rules.as_settings()
+       %{
+         users: Users.as_settings(),
+         devices: Devices.as_settings(),
+         rules: Rules.as_settings()
        }}
 
     {:reply, reply, state}

--- a/apps/fz_http/lib/fz_http/server.ex
+++ b/apps/fz_http/lib/fz_http/server.ex
@@ -26,8 +26,8 @@ defmodule FzHttp.Server do
   end
 
   @impl GenServer
-  def handle_call(:load_rules, _from, state) do
-    reply = {:ok, Rules.to_nftables()}
+  def handle_call(:load_settings, _from, state) do
+    reply = {:ok, Rules.to_settings()}
     {:reply, reply, state}
   end
 

--- a/apps/fz_http/lib/fz_http/server.ex
+++ b/apps/fz_http/lib/fz_http/server.ex
@@ -5,7 +5,7 @@ defmodule FzHttp.Server do
 
   use GenServer
 
-  alias FzHttp.{Devices, Devices.StatsUpdater, Rules}
+  alias FzHttp.{Devices, Devices.StatsUpdater, Rules, Users}
 
   @process_opts Application.compile_env(:fz_http, :server_process_opts, [])
 
@@ -27,7 +27,14 @@ defmodule FzHttp.Server do
 
   @impl GenServer
   def handle_call(:load_settings, _from, state) do
-    reply = {:ok, Rules.to_settings()}
+    reply =
+      {:ok,
+       {
+         Users.as_settings(),
+         Devices.as_settings(),
+         Rules.as_settings()
+       }}
+
     {:reply, reply, state}
   end
 

--- a/apps/fz_http/lib/fz_http/users.ex
+++ b/apps/fz_http/lib/fz_http/users.ex
@@ -113,6 +113,16 @@ defmodule FzHttp.Users do
     Repo.all(User)
   end
 
+  def as_settings do
+    Repo.all(from u in User, select: %{id: u.id})
+    |> Enum.map(&setting_projection/1)
+    |> MapSet.new()
+  end
+
+  def setting_projection(user) do
+    user.id
+  end
+
   @doc """
   Fetches all users and groups into an Enumerable that can be used for an HTML form input.
   """

--- a/apps/fz_http/lib/fz_http/users.ex
+++ b/apps/fz_http/lib/fz_http/users.ex
@@ -8,6 +8,8 @@ defmodule FzHttp.Users do
 
   alias FzHttp.{Devices.Device, Mailer, Repo, Sites.Site, Telemetry, Users.User}
 
+  @events_module Application.compile_env!(:fz_http, :events_module)
+
   require Logger
 
   # one hour
@@ -70,8 +72,12 @@ defmodule FzHttp.Users do
       |> Repo.insert()
 
     case result do
-      {:ok, _user} -> Telemetry.add_user()
-      _ -> nil
+      {:ok, user} ->
+        @events_module.create_user(user)
+        Telemetry.add_user()
+
+      _ ->
+        nil
     end
 
     result

--- a/apps/fz_http/lib/fz_http_web/live/user_live/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/show_live.ex
@@ -9,6 +9,7 @@ defmodule FzHttpWeb.UserLive.Show do
   alias FzHttpWeb.ErrorHelpers
 
   @impl Phoenix.LiveView
+
   def mount(%{"id" => user_id} = _params, _session, socket) do
     user = Users.get_user!(user_id)
     devices = Devices.list_devices(user)
@@ -48,6 +49,7 @@ defmodule FzHttpWeb.UserLive.Show do
       case Users.delete_user(user) do
         {:ok, _} ->
           for device <- user.devices, do: @events_module.delete_device(device)
+          @events_module.delete_user(user)
           FzHttpWeb.Endpoint.broadcast("users_socket:#{user.id}", "disconnect", %{})
 
           {:noreply,

--- a/apps/fz_http/lib/fz_http_web/mock_events.ex
+++ b/apps/fz_http/lib/fz_http_web/mock_events.ex
@@ -11,6 +11,14 @@ defmodule FzHttpWeb.MockEvents do
     {:ok, device}
   end
 
+  def create_user(_user) do
+    :ok
+  end
+
+  def delete_user(_user) do
+    :ok
+  end
+
   def update_device(_device) do
     :ok
   end

--- a/apps/fz_http/test/fz_http/devices_test.exs
+++ b/apps/fz_http/test/fz_http/devices_test.exs
@@ -401,4 +401,25 @@ defmodule FzHttp.DevicesTest do
       assert Devices.Device.new_name("1234567890ABCDEF") == "1234567890A4772"
     end
   end
+
+  describe "setting_projection/1" do
+    setup [:create_rule_with_user_and_device]
+
+    test "projects expected fields", %{device: device, user: user} do
+      user_id = user.id
+
+      assert %{ip: "10.3.2.2", ip6: "fd00::3:2:2", user_id: ^user_id} =
+               Devices.setting_projection(device)
+    end
+  end
+
+  describe "as_settings/0" do
+    setup [:create_rules]
+
+    test "Maps rules to projections", %{devices: devices} do
+      expected_devices = Enum.map(devices, &Devices.setting_projection/1) |> MapSet.new()
+
+      assert Devices.as_settings() == expected_devices
+    end
+  end
 end

--- a/apps/fz_http/test/fz_http/events_test.exs
+++ b/apps/fz_http/test/fz_http/events_test.exs
@@ -12,7 +12,7 @@ defmodule FzHttp.EventsTest do
       :sys.replace_state(Events.vpn_pid(), fn _state -> %{} end)
 
       :sys.replace_state(Events.wall_pid(), fn _state ->
-        {MapSet.new(), MapSet.new(), MapSet.new()}
+        %{users: MapSet.new(), devices: MapSet.new(), rules: MapSet.new()}
       end)
     end)
   end
@@ -24,9 +24,11 @@ defmodule FzHttp.EventsTest do
       :ok = Events.update_device(device)
 
       assert :sys.get_state(Events.wall_pid()) ==
-               {MapSet.new(),
-                MapSet.new([%{ip: "10.3.2.2", ip6: "fd00::3:2:2", user_id: user.id}]),
-                MapSet.new()}
+               %{
+                 users: MapSet.new(),
+                 devices: MapSet.new([%{ip: "10.3.2.2", ip6: "fd00::3:2:2", user_id: user.id}]),
+                 rules: MapSet.new()
+               }
 
       assert :sys.get_state(Events.vpn_pid()) == %{
                "1" => %{
@@ -48,7 +50,7 @@ defmodule FzHttp.EventsTest do
       assert :sys.get_state(Events.vpn_pid()) == %{}
 
       assert :sys.get_state(Events.wall_pid()) ==
-               {MapSet.new(), MapSet.new(), MapSet.new()}
+               %{users: MapSet.new(), devices: MapSet.new(), rules: MapSet.new()}
     end
   end
 
@@ -59,7 +61,7 @@ defmodule FzHttp.EventsTest do
       :ok = Events.create_user(user)
 
       assert :sys.get_state(Events.wall_pid()) ==
-               {MapSet.new([user.id]), MapSet.new(), MapSet.new()}
+               %{users: MapSet.new([user.id]), devices: MapSet.new(), rules: MapSet.new()}
     end
   end
 
@@ -71,7 +73,7 @@ defmodule FzHttp.EventsTest do
       :ok = Events.delete_user(user)
 
       assert :sys.get_state(Events.wall_pid()) ==
-               {MapSet.new(), MapSet.new(), MapSet.new()}
+               %{users: MapSet.new(), devices: MapSet.new(), rules: MapSet.new()}
     end
   end
 
@@ -82,8 +84,11 @@ defmodule FzHttp.EventsTest do
       :ok = Events.add_rule(rule)
 
       assert :sys.get_state(Events.wall_pid()) ==
-               {MapSet.new(), MapSet.new(),
-                MapSet.new([%{destination: "10.10.10.0/24", user_id: nil, action: :drop}])}
+               %{
+                 users: MapSet.new(),
+                 devices: MapSet.new(),
+                 rules: MapSet.new([%{destination: "10.10.10.0/24", user_id: nil, action: :drop}])
+               }
     end
   end
 
@@ -94,8 +99,12 @@ defmodule FzHttp.EventsTest do
       :ok = Events.add_rule(rule)
 
       assert :sys.get_state(Events.wall_pid()) ==
-               {MapSet.new(), MapSet.new(),
-                MapSet.new([%{destination: "10.10.10.0/24", user_id: nil, action: :accept}])}
+               %{
+                 users: MapSet.new(),
+                 devices: MapSet.new(),
+                 rules:
+                   MapSet.new([%{destination: "10.10.10.0/24", user_id: nil, action: :accept}])
+               }
     end
   end
 
@@ -106,7 +115,11 @@ defmodule FzHttp.EventsTest do
       :ok = Events.add_rule(rule)
       :ok = Events.delete_rule(rule)
 
-      assert :sys.get_state(Events.wall_pid()) == {MapSet.new(), MapSet.new(), MapSet.new()}
+      assert :sys.get_state(Events.wall_pid()) == %{
+               users: MapSet.new(),
+               rules: MapSet.new(),
+               devices: MapSet.new()
+             }
     end
   end
 
@@ -159,8 +172,8 @@ defmodule FzHttp.EventsTest do
           end)
         )
 
-      assert {^expected_user_ids, ^expected_devices, ^expected_rules} =
-               :sys.get_state(Events.wall_pid())
+      assert :sys.get_state(Events.wall_pid()) ==
+               %{users: expected_user_ids, devices: expected_devices, rules: expected_rules}
     end
   end
 

--- a/apps/fz_http/test/fz_http/rules_test.exs
+++ b/apps/fz_http/test/fz_http/rules_test.exs
@@ -73,47 +73,6 @@ defmodule FzHttp.RulesTest do
     end
   end
 
-  describe "to_settings/0" do
-    setup [:create_rules]
-
-    test "prints all rules to nftables format", %{
-      rules: expected_rules,
-      users: expected_users,
-      devices: expected_devices
-    } do
-      {users, devices, rules} = Rules.to_settings()
-      expected_user_ids = MapSet.new(Enum.map(expected_users, fn user -> user.id end))
-
-      expected_devices =
-        MapSet.new(
-          Enum.map(expected_devices, fn device ->
-            %{
-              # XXX: Ideally we could hardcode the expected ips here as not to depend on the `decode` implementation
-              # However, we can't know user_id in advance, perhaps we can test the user_id part and ip parts separately
-              user_id: device.user_id,
-              ip: Rules.decode(device.ipv4),
-              ip6: Rules.decode(device.ipv6)
-            }
-          end)
-        )
-
-      expected_rules =
-        MapSet.new(
-          Enum.map(expected_rules, fn rule ->
-            %{
-              user_id: rule.user_id,
-              destination: Rules.decode(rule.destination),
-              action: rule.action
-            }
-          end)
-        )
-
-      assert ^expected_user_ids = users
-      assert ^expected_devices = devices
-      assert ^expected_rules = rules
-    end
-  end
-
   describe "allowlist/0" do
     setup [:create_accept_rule]
 
@@ -130,16 +89,22 @@ defmodule FzHttp.RulesTest do
     end
   end
 
-  describe "projections" do
+  describe "setting_projection/1" do
     setup [:create_rule_with_user_and_device]
 
-    test "returns IPv4 tuple", %{device: device, user: user, rule: rule} do
+    test "projects expected fields", %{rule: rule, user: user} do
       user_id = user.id
-      assert ^user_id = Rules.user_projection(user)
-      assert %{destination: "10.20.30.0/24", user_id: ^user_id} = Rules.rule_projection(rule)
+      assert %{destination: "10.20.30.0/24", user_id: ^user_id} = Rules.setting_projection(rule)
+    end
+  end
 
-      assert %{user_id: ^user_id, ip: "10.3.2.2", ip6: "fd00::3:2:2"} =
-               Rules.device_projection(device)
+  describe "as_settings/0" do
+    setup [:create_rules]
+
+    test "Maps rules to projections", %{rules: rules} do
+      expected_rules = Enum.map(rules, &Rules.setting_projection/1) |> MapSet.new()
+
+      assert Rules.as_settings() == expected_rules
     end
   end
 end

--- a/apps/fz_http/test/fz_http/rules_test.exs
+++ b/apps/fz_http/test/fz_http/rules_test.exs
@@ -12,7 +12,7 @@ defmodule FzHttp.RulesTest do
   end
 
   describe "list_rules/1" do
-    setup [:create_rule_with_user]
+    setup [:create_rule_with_user_and_device]
 
     test "list Rules scoped by user", %{user: user, rule: rule} do
       assert Rules.list_rules(user.id) == [rule]
@@ -73,22 +73,44 @@ defmodule FzHttp.RulesTest do
     end
   end
 
-  describe "to_nftables/0" do
+  describe "to_settings/0" do
     setup [:create_rules]
 
-    @nftables_rules [
-      {"1.1.1.0/24", :drop},
-      {"2.2.2.0/24", :drop},
-      {"3.3.3.0/24", :drop},
-      {"4.4.4.0/24", :drop},
-      {"5.5.5.0/24", :drop},
-      {"10.3.2.4", "4.4.4.0/24", :drop},
-      {"10.3.2.5", "5.5.5.0/24", :drop},
-      {"10.3.2.6", "6.6.6.0/24", :drop}
-    ]
+    test "prints all rules to nftables format", %{
+      rules: expected_rules,
+      users: expected_users,
+      devices: expected_devices
+    } do
+      {users, devices, rules} = Rules.to_settings()
+      expected_user_ids = MapSet.new(Enum.map(expected_users, fn user -> user.id end))
 
-    test "prints all rules to nftables format", %{rules: _rules} do
-      assert MapSet.equal?(MapSet.new(@nftables_rules), MapSet.new(Rules.to_nftables()))
+      expected_devices =
+        MapSet.new(
+          Enum.map(expected_devices, fn device ->
+            %{
+              # XXX: Ideally we could hardcode the expected ips here as not to depend on the `decode` implementation
+              # However, we can't know user_id in advance, perhaps we can test the user_id part and ip parts separately
+              user_id: device.user_id,
+              ip: Rules.decode(device.ipv4),
+              ip6: Rules.decode(device.ipv6)
+            }
+          end)
+        )
+
+      expected_rules =
+        MapSet.new(
+          Enum.map(expected_rules, fn rule ->
+            %{
+              user_id: rule.user_id,
+              destination: Rules.decode(rule.destination),
+              action: rule.action
+            }
+          end)
+        )
+
+      assert ^expected_user_ids = users
+      assert ^expected_devices = devices
+      assert ^expected_rules = rules
     end
   end
 
@@ -108,72 +130,16 @@ defmodule FzHttp.RulesTest do
     end
   end
 
-  describe "nftables_spec/1 IPv4" do
-    setup [:create_rule4]
+  describe "projections" do
+    setup [:create_rule_with_user_and_device]
 
-    @ipv4tables_spec [{"10.10.10.0/24", :drop}]
+    test "returns IPv4 tuple", %{device: device, user: user, rule: rule} do
+      user_id = user.id
+      assert ^user_id = Rules.user_projection(user)
+      assert %{destination: "10.20.30.0/24", user_id: ^user_id} = Rules.rule_projection(rule)
 
-    test "returns IPv4 tuple", %{rule4: rule} do
-      assert @ipv4tables_spec = Rules.nftables_spec(rule)
-    end
-  end
-
-  describe "nftables_spec/1 with user IPv4" do
-    setup [:create_rule4_with_user]
-
-    @ipv4tables_spec [
-      {"10.3.2.2", "10.10.10.0/24", :drop},
-      {"10.3.2.3", "10.10.10.0/24", :drop},
-      {"10.3.2.4", "10.10.10.0/24", :drop},
-      {"10.3.2.5", "10.10.10.0/24", :drop}
-    ]
-
-    test "returns IPv4 tuple", %{rule4: rule} do
-      assert @ipv4tables_spec = Rules.nftables_spec(rule)
-    end
-  end
-
-  describe "nftables_spec/1 with user IPv6" do
-    setup [:create_rule6_with_user]
-
-    @ipv6tables_spec [
-      {"fd00::3:2:2", "::/0", :drop},
-      {"fd00::3:2:3", "::/0", :drop},
-      {"fd00::3:2:4", "::/0", :drop},
-      {"fd00::3:2:5", "::/0", :drop}
-    ]
-
-    test "returns IPv6 tuple", %{rule6: rule} do
-      assert @ipv6tables_spec = Rules.nftables_spec(rule)
-    end
-  end
-
-  describe "nftables_spec/1 with user no devices" do
-    setup [:create_rule_with_user]
-
-    @iptables_spec []
-
-    test "returns Empty", %{rule: rule} do
-      assert @iptables_spec = Rules.nftables_spec(rule)
-    end
-  end
-
-  describe "nftables_device_spec/1" do
-    setup [:create_device_with_rules]
-
-    @ipv4tables_spec [
-      {"10.3.2.2", "1.1.1.0/24", :drop},
-      {"10.3.2.2", "2.2.2.0/24", :drop},
-      {"10.3.2.2", "3.3.3.0/24", :drop},
-      {"10.3.2.2", "4.4.4.0/24", :drop},
-      {"fd00::3:2:2", "1::/112", :drop},
-      {"fd00::3:2:2", "2::/112", :drop},
-      {"fd00::3:2:2", "3::/112", :drop},
-      {"fd00::3:2:2", "4::/112", :drop}
-    ]
-
-    test "returns IPv4 tuple", %{device: device} do
-      assert @ipv4tables_spec = Rules.nftables_device_spec(device)
+      assert %{user_id: ^user_id, ip: "10.3.2.2", ip6: "fd00::3:2:2"} =
+               Rules.device_projection(device)
     end
   end
 end

--- a/apps/fz_http/test/fz_http/users_test.exs
+++ b/apps/fz_http/test/fz_http/users_test.exs
@@ -275,4 +275,22 @@ defmodule FzHttp.UsersTest do
       assert user.disabled_at
     end
   end
+
+  describe "setting_projection/1" do
+    setup [:create_rule_with_user_and_device]
+
+    test "projects expected fields", %{user: user} do
+      assert user.id == Users.setting_projection(user)
+    end
+  end
+
+  describe "as_settings/0" do
+    setup [:create_rules]
+
+    test "Maps rules to projections", %{users: users} do
+      expected_users = Enum.map(users, &Users.setting_projection/1) |> MapSet.new()
+
+      assert Users.as_settings() == expected_users
+    end
+  end
 end

--- a/apps/fz_http/test/support/test_helpers.ex
+++ b/apps/fz_http/test/support/test_helpers.ex
@@ -107,48 +107,9 @@ defmodule FzHttp.TestHelpers do
     {:ok, rule: rule}
   end
 
-  def create_rule6(_) do
-    rule = RulesFixtures.rule6(%{})
-    {:ok, rule6: rule}
-  end
-
-  def create_rule6_with_user(_) do
-    user = UsersFixtures.user()
-
-    2..5
-    |> Enum.each(fn num ->
-      DevicesFixtures.device(%{
-        name: "device #{num}",
-        public_key: "#{num}",
-        user_id: user.id,
-        ipv6: "fd00::3:2:#{num}"
-      })
-    end)
-
-    rule = RulesFixtures.rule6(%{user_id: user.id})
-    {:ok, rule6: rule}
-  end
-
-  def create_rule4(_) do
-    rule = RulesFixtures.rule4(%{})
-    {:ok, rule4: rule}
-  end
-
-  def create_rule4_with_user(_) do
-    user = UsersFixtures.user()
-
-    2..5
-    |> Enum.each(fn num ->
-      DevicesFixtures.device(%{
-        name: "device #{num}",
-        public_key: "#{num}",
-        user_id: user.id,
-        ipv4: "10.3.2.#{num}"
-      })
-    end)
-
-    rule = RulesFixtures.rule4(%{user_id: user.id})
-    {:ok, rule4: rule}
+  def create_rule_accept(_) do
+    rule = RulesFixtures.rule(%{action: :accept})
+    {:ok, rule: rule}
   end
 
   @doc """
@@ -162,43 +123,41 @@ defmodule FzHttp.TestHelpers do
         RulesFixtures.rule(%{destination: destination})
       end)
 
-    rules_with_user =
+    {rules_with_users, users_and_devices} =
       4..6
       |> Enum.map(fn num ->
-        destination = "#{num}.#{num}.#{num}.0/24"
         user = UsersFixtures.user()
+        destination = "#{num}.#{num}.#{num}.0/24"
 
-        DevicesFixtures.device(%{
-          name: "device #{num}",
-          public_key: "#{num}",
-          user_id: user.id,
-          ipv4: "10.3.2.#{num}",
-          ipv6: "fd00::3:2:#{num}"
-        })
+        device =
+          DevicesFixtures.device(%{
+            name: "device #{num}",
+            public_key: "#{num}",
+            user_id: user.id,
+            ipv4: "10.3.2.#{num}",
+            ipv6: "fd00::3:2:#{num}"
+          })
 
-        RulesFixtures.rule(%{destination: destination, user_id: user.id})
+        rule = RulesFixtures.rule(%{destination: destination, user_id: user.id})
+        {rule, {user, device}}
       end)
+      |> Enum.unzip()
+
+    {users, devices} = Enum.unzip(users_and_devices)
 
     destination = "7.7.7.0/24"
     user = UsersFixtures.user()
     rule_without_device = RulesFixtures.rule(%{destination: destination, user_id: user.id})
-    {:ok, rules: rules ++ rules_with_user ++ [rule_without_device]}
+
+    rules = rules ++ [rule_without_device | rules_with_users]
+    users = [user | users]
+
+    {:ok, %{rules: rules, users: users, devices: devices}}
   end
 
-  def create_device_with_rules(_) do
+  def create_rule_with_user_and_device(_) do
     user = UsersFixtures.user()
-
-    1..4
-    |> Enum.each(fn num ->
-      destination = "#{num}.#{num}.#{num}.0/24"
-      RulesFixtures.rule(%{destination: destination, user_id: user.id})
-    end)
-
-    1..4
-    |> Enum.each(fn num ->
-      destination = "#{num}::/112"
-      RulesFixtures.rule(%{destination: destination, user_id: user.id})
-    end)
+    rule = RulesFixtures.rule(%{user_id: user.id, destination: "10.20.30.0/24"})
 
     device =
       DevicesFixtures.device(%{
@@ -209,14 +168,7 @@ defmodule FzHttp.TestHelpers do
         ipv6: "fd00::3:2:2"
       })
 
-    {:ok, device: device}
-  end
-
-  def create_rule_with_user(_) do
-    user = UsersFixtures.user()
-    rule = RulesFixtures.rule(%{user_id: user.id})
-
-    {:ok, rule: rule, user: user}
+    {:ok, rule: rule, user: user, device: device}
   end
 
   def create_user_with_valid_sign_in_token(_) do

--- a/apps/fz_wall/lib/fz_wall/cli/helpers/nft.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/helpers/nft.ex
@@ -113,7 +113,7 @@ defmodule FzWall.CLI.Helpers.Nft do
         true
 
       {error, _exit_code} ->
-        if String.contains?(error, "Error: No such file or directory") do
+        if error =~ ~r/No such file or directory|does not exist/ do
           false
         else
           raise """

--- a/apps/fz_wall/lib/fz_wall/cli/helpers/nft.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/helpers/nft.ex
@@ -1,0 +1,161 @@
+defmodule FzWall.CLI.Helpers.Nft do
+  @moduledoc """
+  Helper module concering nft commands
+  """
+  import FzCommon.CLI
+  import FzCommon.FzNet, only: [standardized_inet: 1]
+  require Logger
+  @table_name "firezone"
+
+  @doc """
+  Creates a nft rule
+  """
+  def create_rule(type, source_set, dest_set, action) do
+    exec!("""
+      #{nft()} 'add rule inet #{@table_name} forward #{rule_match_str(type, source_set, dest_set, action)}'
+    """)
+  end
+
+  @doc """
+  Removes a nft rule
+  """
+  def remove_rule(type, source_set, dest_set, action) do
+    delete_rule_matching(rule_match_str(type, source_set, dest_set, action))
+  end
+
+  @doc """
+  Adds an element from a nft set
+  """
+  def add_elem(set, ip) do
+    exec!("""
+      #{nft()} 'add element inet #{@table_name} #{set} { #{standardized_inet(ip)} }'
+    """)
+  end
+
+  @doc """
+  Deletes an element from a nft set
+  """
+  def delete_elem(set, ip) do
+    exec!("""
+      #{nft()} 'delete element inet #{@table_name} #{set} { #{standardized_inet(ip)} }'
+    """)
+  end
+
+  @doc """
+  Adds a nft set
+  """
+  def add_set(set_spec) do
+    exec!("""
+      #{nft()} 'add set inet #{@table_name} #{set_spec.name} { type #{set_type(set_spec.type)} ; flags interval ; }'
+    """)
+  end
+
+  @doc """
+  Deletes a nft set
+  """
+  def delete_set(set_spec) do
+    exec!("""
+      #{nft()} 'delete set inet #{@table_name} #{set_spec.name}'
+    """)
+  end
+
+  @doc """
+  Sets up firezone table.
+  """
+  def setup_table do
+    exec!("#{nft()} create table inet #{@table_name}")
+  end
+
+  @doc """
+  Sets up firezone chains.
+  """
+  def setup_chains do
+    exec!(
+      "#{nft()} 'add chain inet #{@table_name} forward " <>
+        "{ type filter hook forward priority 0 ; policy accept ; }'"
+    )
+
+    exec!(
+      "#{nft()} 'add chain inet #{@table_name} postrouting " <>
+        "{ type nat hook postrouting priority 100 ; }'"
+    )
+
+    # XXX: Do more testing with this method of creating masquerade rules
+    for int <- File.ls!("/sys/class/net/") do
+      # Masquerade all interfaces except loopback and our own wireguard interface
+      if int not in ["lo", wireguard_interface_name()] do
+        exec!(
+          "#{nft()} 'add rule inet #{@table_name} postrouting oifname " <>
+            "#{int} masquerade persistent'"
+        )
+      end
+    end
+  end
+
+  @doc """
+  Deletes nft tables (This will remove)
+  """
+  def teardown_table do
+    if table_exists?() do
+      exec!("#{nft()} delete table inet #{@table_name}")
+    end
+  end
+
+  defp nft do
+    Application.fetch_env!(:fz_wall, :nft_path)
+  end
+
+  defp table_exists? do
+    cmd = "#{nft()} list table inet #{@table_name}"
+
+    case bash(cmd) do
+      {_result, 0} ->
+        true
+
+      {error, _exit_code} ->
+        if String.contains?(error, "Error: No such file or directory") do
+          false
+        else
+          raise """
+            Unknown Error from command #{cmd}. Error:
+            #{error}
+          """
+        end
+    end
+  end
+
+  defp delete_rule_matching(rule_str) do
+    rules = exec!("#{nft()} -a list table inet #{@table_name}")
+
+    # When a rule is deleted the others might change handle so we need to
+    # re-scan each time.
+    case rule_handle_regex(~r/^\s*#{rule_str}.*# handle (?<num>\d+)/m, rules) do
+      nil ->
+        Logger.warning(
+          "Tried to delete a rule with string: #{rule_str} but it wasn't found, might have been removed manually"
+        )
+
+      handle ->
+        exec!("#{nft()} delete rule inet #{@table_name} forward handle #{handle}")
+    end
+  end
+
+  defp wireguard_interface_name do
+    Application.fetch_env!(:fz_wall, :wireguard_interface_name)
+  end
+
+  defp rule_handle_regex(regex, rules) do
+    Regex.run(regex, rules, capture: :all_names)
+  end
+
+  defp set_type(:ip), do: "ipv4_addr"
+  defp set_type(:ip6), do: "ipv6_addr"
+
+  defp rule_match_str(type, nil, dest_set, action) do
+    "#{type} daddr @#{dest_set} #{action}"
+  end
+
+  defp rule_match_str(type, source_set, dest_set, action) do
+    "#{type} saddr @#{source_set} #{rule_match_str(type, nil, dest_set, action)}"
+  end
+end

--- a/apps/fz_wall/lib/fz_wall/cli/helpers/sets.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/helpers/sets.ex
@@ -17,7 +17,7 @@ defmodule FzWall.CLI.Helpers.Sets do
 
   def list_sets(user_id) do
     list_dest_sets(user_id) ++
-      (@types |> Enum.map(fn type -> %{name: get_device_set_name(user_id, type), type: type} end))
+      Enum.map(@types, fn type -> %{name: get_device_set_name(user_id, type), type: type} end)
   end
 
   def get_types do

--- a/apps/fz_wall/lib/fz_wall/cli/helpers/sets.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/helpers/sets.ex
@@ -1,0 +1,42 @@
+defmodule FzWall.CLI.Helpers.Sets do
+  @moduledoc """
+  Helper module concering nft's named sets
+  """
+
+  @actions [:drop, :accept]
+  @types [:ip, :ip6]
+
+  def list_dest_sets(user_id) do
+    cross(@types, @actions)
+    |> Enum.map(fn {type, action} ->
+      %{name: get_dest_set_name(user_id, type, action), type: type}
+    end)
+  end
+
+  def list_sets(nil), do: list_dest_sets(nil)
+
+  def list_sets(user_id) do
+    list_dest_sets(user_id) ++
+      (@types |> Enum.map(fn type -> %{name: get_device_set_name(user_id, type), type: type} end))
+  end
+
+  def get_types do
+    @types
+  end
+
+  def get_actions do
+    @actions
+  end
+
+  def get_dest_set_name(nil, type, action), do: "#{type}_#{action}"
+  def get_dest_set_name(user_id, type, action), do: "user_#{user_id}_#{type}_#{action}"
+  def get_device_set_name(nil, _type), do: nil
+  def get_device_set_name(user_id, type), do: "user_#{user_id}_#{type}_devices"
+
+  def cross([x | a], [y | b]) do
+    [{x, y}] ++ cross([x], b) ++ cross(a, [y | b])
+  end
+
+  def cross([], _b), do: []
+  def cross(_a, []), do: []
+end

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -102,12 +102,12 @@ defmodule FzWall.CLI.Live do
 
   defp add_sets(user_id) do
     list_sets(user_id)
-    |> Enum.each(fn set -> add_set(set) end)
+    |> Enum.each(&add_set/1)
   end
 
   defp delete_sets(user_id) do
     list_sets(user_id)
-    |> Enum.each(fn set -> delete_set(set) end)
+    |> Enum.each(&delete_set/1)
   end
 
   defp add_rules(user_id) do
@@ -136,9 +136,9 @@ defmodule FzWall.CLI.Live do
 
   # xxx: here we could add multiple devices/rules in a single nft call
   def restore({users, devices, rules}) do
-    users |> Enum.each(fn user -> add_user(user) end)
-    devices |> Enum.each(fn device -> add_device(device) end)
-    rules |> Enum.each(fn rule -> add_rule(rule) end)
+    Enum.each(users, &add_user/1)
+    Enum.each(devices, &add_device/1)
+    Enum.each(rules, &add_rule/1)
   end
 
   def egress_address do

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -135,7 +135,7 @@ defmodule FzWall.CLI.Live do
   end
 
   # xxx: here we could add multiple devices/rules in a single nft call
-  def restore({users, devices, rules}) do
+  def restore(%{users: users, devices: devices, rules: rules}) do
     Enum.each(users, &add_user/1)
     Enum.each(devices, &add_device/1)
     Enum.each(rules, &add_rule/1)

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -13,6 +13,16 @@ defmodule FzWall.CLI.Live do
   require Logger
 
   @doc """
+  Setup
+  """
+  def setup_firewall do
+    teardown_table()
+    setup_table()
+    setup_chains()
+    setup_rules()
+  end
+
+  @doc """
   Adds user sets and rules.
   """
   def add_user(user_id) do

--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -6,104 +6,129 @@ defmodule FzWall.CLI.Live do
   specified IP addresses, ports, and protocols from Firezone device IPs.
   """
 
+  import FzWall.CLI.Helpers.Sets
+  import FzWall.CLI.Helpers.Nft
   import FzCommon.CLI
-  import FzCommon.FzNet, only: [ip_type: 1, standardized_inet: 1]
+  import FzCommon.FzNet, only: [ip_type: 1]
   require Logger
 
-  @table_name "firezone"
-
   @doc """
-  Adds nftables rule.
+  Adds user sets and rules.
   """
-  def add_rule(params) do
-    exec!("""
-      #{nft()} 'add rule inet #{@table_name} forward #{rule_str(params)}'
-    """)
+  def add_user(user_id) do
+    add_sets(user_id)
+    add_rules(user_id)
   end
 
   @doc """
-  Sets up firezone table.
+  Remove user sets and rules.
   """
-  def setup_table do
-    exec!("#{nft()} create table inet #{@table_name}")
+  def delete_user(user_id) do
+    delete_rules(user_id)
+    delete_sets(user_id)
   end
 
   @doc """
-  Sets up firezone chains.
+  Adds general sets and rules.
   """
-  def setup_chains do
-    exec!(
-      "#{nft()} 'add chain inet #{@table_name} forward " <>
-        "{ type filter hook forward priority 0 ; policy accept ; }'"
-    )
-
-    exec!(
-      "#{nft()} 'add chain inet #{@table_name} postrouting " <>
-        "{ type nat hook postrouting priority 100 ; }'"
-    )
-
-    # XXX: Do more testing with this method of creating masquerade rules
-    for int <- File.ls!("/sys/class/net/") do
-      # Masquerade all interfaces except loopback and our own wireguard interface
-      if int not in ["lo", wireguard_interface_name()] do
-        exec!(
-          "#{nft()} 'add rule inet #{@table_name} postrouting oifname " <>
-            "#{int} masquerade persistent'"
-        )
-      end
-    end
-  end
-
-  def teardown_table do
-    if table_exists?() do
-      exec!("#{nft()} delete table inet #{@table_name}")
-    end
+  def setup_rules do
+    add_sets(nil)
+    add_rules(nil)
   end
 
   @doc """
-  List currently loaded rules.
+  Adds device ip to the user's sets.
   """
-  def list_rules do
-    exec!("#{nft()} -a list table inet #{@table_name}")
+  def add_device(device) do
+    get_types()
+    |> Enum.each(fn type -> add_to_set(device.user_id, device[type], type) end)
   end
 
   @doc """
-  Deletes nftables rule.
+  Adds rule ip to its corresponding sets.
   """
-  def delete_rule(params) do
-    rule_str(params)
-    |> delete_rule_matching()
-  end
-
-  def delete_rules(source) do
-    source_match_str(source)
-    |> delete_rule_matching()
-  end
-
-  defp delete_rule_matching(rule_str) do
-    rules = exec!("#{nft()} -a list table inet #{@table_name}")
-
-    # When a rule is deleted the others might change handle so we need to
-    # re-scan each time.
-    case rule_handle_regex(~r/^\s*#{rule_str}.*# handle (?<num>\d+)/m, rules) do
-      nil ->
-        :no_rule
-
-      [handle] ->
-        exec!("#{nft()} delete rule inet #{@table_name} forward handle #{handle}")
-        # There might still be matching rules so re-run it
-        delete_rule_matching(rule_str)
-    end
+  def add_rule(rule) do
+    add_to_set(rule.user_id, rule.destination, proto(rule.destination), rule.action)
   end
 
   @doc """
-  Restores rules.
+  Delete rule destination ip from its corresponding sets.
   """
-  def restore(rules) do
-    # XXX: Priority?
-    for rule_spec <- rules do
-      add_rule(rule_spec)
-    end
+  def delete_rule(rule) do
+    remove_from_set(rule.user_id, rule.destination, proto(rule.destination), rule.action)
+  end
+
+  @doc """
+  Eliminates device rules from its corresponding sets.
+  """
+  def delete_device(device) do
+    get_types()
+    |> Enum.each(fn type -> remove_from_set(device.user_id, device[type], type) end)
+  end
+
+  defp remove_from_set(_user_id, nil, _type), do: :no_ip
+
+  defp remove_from_set(user_id, ip, type) do
+    get_device_set_name(user_id, type)
+    |> delete_elem(ip)
+  end
+
+  defp remove_from_set(user_id, ip, type, action) do
+    get_dest_set_name(user_id, type, action)
+    |> delete_elem(ip)
+  end
+
+  defp add_to_set(_user_id, nil, _type), do: :no_ip
+
+  defp add_to_set(user_id, ip, type) do
+    get_device_set_name(user_id, type)
+    |> add_elem(ip)
+  end
+
+  defp add_to_set(user_id, ip, type, action) do
+    get_dest_set_name(user_id, type, action)
+    |> add_elem(ip)
+  end
+
+  defp add_sets(user_id) do
+    list_sets(user_id)
+    |> Enum.each(fn set -> add_set(set) end)
+  end
+
+  defp delete_sets(user_id) do
+    list_sets(user_id)
+    |> Enum.each(fn set -> delete_set(set) end)
+  end
+
+  defp add_rules(user_id) do
+    cross(get_types(), get_actions())
+    |> Enum.each(fn {type, action} ->
+      create_rule(
+        type,
+        get_device_set_name(user_id, type),
+        get_dest_set_name(user_id, type, action),
+        action
+      )
+    end)
+  end
+
+  defp delete_rules(user_id) do
+    cross(get_types(), get_actions())
+    |> Enum.each(fn {type, action} ->
+      remove_rule(
+        type,
+        get_device_set_name(user_id, type),
+        get_dest_set_name(user_id, type, action),
+        action
+      )
+    end)
+  end
+
+  # xxx: here we could add multiple devices/rules in a single nft call
+  def restore({users, devices, rules}) do
+    users |> Enum.each(fn user -> add_user(user) end)
+    devices |> Enum.each(fn device -> add_device(device) end)
+    rules |> Enum.each(fn rule -> add_rule(rule) end)
   end
 
   def egress_address do
@@ -127,54 +152,15 @@ defmodule FzWall.CLI.Live do
     end
   end
 
-  defp rule_handle_regex(regex, rules) do
-    Regex.run(regex, rules, capture: :all_names)
-  end
-
   defp egress_interface do
     Application.fetch_env!(:fz_wall, :egress_interface)
   end
 
-  defp nft do
-    Application.fetch_env!(:fz_wall, :nft_path)
-  end
-
-  defp table_exists? do
-    cmd = "#{nft()} list table inet #{@table_name}"
-
-    case bash(cmd) do
-      {_result, 0} ->
-        true
-
-      {error, _exit_code} ->
-        if String.contains?(error, "Error: No such file or directory") do
-          false
-        else
-          raise """
-            Unknown Error from command #{cmd}. Error:
-            #{error}
-          """
-        end
-    end
-  end
-
-  defp wireguard_interface_name do
-    Application.fetch_env!(:fz_wall, :wireguard_interface_name)
-  end
-
-  defp proto(dest) do
-    case ip_type("#{dest}") do
+  defp proto(ip) do
+    case ip_type("#{ip}") do
       "IPv4" -> "ip"
       "IPv6" -> "ip6"
       "unknown" -> raise "Unknown protocol."
     end
   end
-
-  defp rule_str({dest, action}), do: "#{rule_match_str(dest)} #{action}"
-  defp rule_str({source, dest, action}), do: "#{rule_match_str(source, dest)} #{action}"
-
-  defp rule_match_str(dest), do: "#{proto(dest)} daddr #{standardized_inet(dest)}"
-  defp rule_match_str(source, dest), do: "#{source_match_str(source)} #{rule_match_str(dest)}"
-
-  defp source_match_str(source), do: "#{proto(source)} saddr #{standardized_inet(source)}"
 end

--- a/apps/fz_wall/lib/fz_wall/cli/sandbox.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/sandbox.ex
@@ -5,10 +5,7 @@ defmodule FzWall.CLI.Sandbox do
 
   @default_returned ""
 
-  def setup_rules, do: @default_returned
-  def setup_table, do: @default_returned
-  def setup_chains, do: @default_returned
-  def teardown_table, do: @default_returned
+  def setup_firewall, do: @default_returned
   def add_rule(_rule_spec), do: @default_returned
   def delete_rule(_rule_spec), do: @default_returned
   def restore(_fz_http_rules), do: @default_returned

--- a/apps/fz_wall/lib/fz_wall/cli/sandbox.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/sandbox.ex
@@ -5,12 +5,16 @@ defmodule FzWall.CLI.Sandbox do
 
   @default_returned ""
 
+  def setup_rules, do: @default_returned
   def setup_table, do: @default_returned
   def setup_chains, do: @default_returned
   def teardown_table, do: @default_returned
   def add_rule(_rule_spec), do: @default_returned
   def delete_rule(_rule_spec), do: @default_returned
-  def delete_rules(_rules_spec), do: @default_returned
   def restore(_fz_http_rules), do: @default_returned
+  def add_device(_device), do: @default_returned
+  def delete_device(_device), do: @default_returned
+  def add_user(_user), do: @default_returned
+  def delete_user(_user), do: @default_returned
   def egress_address, do: "10.0.0.1"
 end

--- a/apps/fz_wall/lib/fz_wall/server.ex
+++ b/apps/fz_wall/lib/fz_wall/server.ex
@@ -89,42 +89,36 @@ defmodule FzWall.Server do
   defp add_rule(rule, existing_rules) do
     cli().add_rule(rule)
 
-    existing_rules
-    |> MapSet.put(rule)
+    MapSet.put(existing_rules, rule)
   end
 
   defp delete_rule(rule, existing_rules) do
     cli().delete_rule(rule)
 
-    existing_rules
-    |> MapSet.delete(rule)
+    MapSet.delete(existing_rules, rule)
   end
 
   defp add_user(user_id, existing_users) do
     cli().add_user(user_id)
 
-    existing_users
-    |> MapSet.put(user_id)
+    MapSet.put(existing_users, user_id)
   end
 
   defp delete_user(user_id, existing_users) do
     cli().delete_user(user_id)
 
-    existing_users
-    |> MapSet.delete(user_id)
+    MapSet.delete(existing_users, user_id)
   end
 
   defp add_device(device, existing_devices) do
     cli().add_device(device)
 
-    existing_devices
-    |> MapSet.put(device)
+    MapSet.put(existing_devices, device)
   end
 
   defp delete_device(device, existing_devices) do
     cli().delete_device(device)
 
-    existing_devices
-    |> MapSet.delete(device)
+    MapSet.delete(existing_devices, device)
   end
 end

--- a/apps/fz_wall/lib/fz_wall/server.ex
+++ b/apps/fz_wall/lib/fz_wall/server.ex
@@ -15,10 +15,7 @@ defmodule FzWall.Server do
 
   @impl GenServer
   def init(_rules) do
-    cli().teardown_table()
-    cli().setup_table()
-    cli().setup_chains()
-    cli().setup_rules()
+    cli().setup_firewall()
     {:ok, settings} = GenServer.call(http_pid(), :load_settings, @init_timeout)
     cli().restore(settings)
     {:ok, settings}

--- a/apps/fz_wall/lib/fz_wall/server.ex
+++ b/apps/fz_wall/lib/fz_wall/server.ex
@@ -22,39 +22,31 @@ defmodule FzWall.Server do
   end
 
   @impl GenServer
-  def handle_call({:add_rule, rule}, _from, {existing_users, existing_devices, existing_rules}) do
+  def handle_call({:add_rule, rule}, _from, %{rules: existing_rules} = state) do
     new_rules = add_rule(rule, existing_rules)
 
-    {:reply, :ok, {existing_users, existing_devices, new_rules}}
+    {:reply, :ok, %{state | rules: new_rules}}
   end
 
   @impl GenServer
-  def handle_call({:delete_rule, rule}, _from, {existing_users, existing_devices, existing_rules}) do
+  def handle_call({:delete_rule, rule}, _from, %{rules: existing_rules} = state) do
     new_rules = delete_rule(rule, existing_rules)
 
-    {:reply, :ok, {existing_users, existing_devices, new_rules}}
+    {:reply, :ok, %{state | rules: new_rules}}
   end
 
   @impl GenServer
-  def handle_call(
-        {:add_device, device},
-        _from,
-        {existing_users, existing_devices, existing_rules}
-      ) do
+  def handle_call({:add_device, device}, _from, %{devices: existing_devices} = state) do
     new_devices = add_device(device, existing_devices)
 
-    {:reply, :ok, {existing_users, new_devices, existing_rules}}
+    {:reply, :ok, %{state | devices: new_devices}}
   end
 
   @impl GenServer
-  def handle_call(
-        {:delete_device, device},
-        _from,
-        {existing_users, existing_devices, existing_rules}
-      ) do
+  def handle_call({:delete_device, device}, _from, %{devices: existing_devices} = state) do
     new_devices = delete_device(device, existing_devices)
 
-    {:reply, :ok, {existing_users, new_devices, existing_rules}}
+    {:reply, :ok, %{state | devices: new_devices}}
   end
 
   @impl GenServer
@@ -65,21 +57,17 @@ defmodule FzWall.Server do
   end
 
   @impl GenServer
-  def handle_call({:add_user, user_id}, _from, {existing_users, existing_devices, existing_rules}) do
+  def handle_call({:add_user, user_id}, _from, %{users: existing_users} = state) do
     new_users = add_user(user_id, existing_users)
 
-    {:reply, :ok, {new_users, existing_devices, existing_rules}}
+    {:reply, :ok, %{state | users: new_users}}
   end
 
   @impl GenServer
-  def handle_call(
-        {:delete_user, user_id},
-        _from,
-        {existing_users, existing_devices, existing_rules}
-      ) do
+  def handle_call({:delete_user, user_id}, _from, %{users: existing_users} = state) do
     new_users = delete_user(user_id, existing_users)
 
-    {:reply, :ok, {new_users, existing_devices, existing_rules}}
+    {:reply, :ok, %{state | users: new_users}}
   end
 
   def http_pid do

--- a/apps/fz_wall/lib/fz_wall/server.ex
+++ b/apps/fz_wall/lib/fz_wall/server.ex
@@ -18,92 +18,116 @@ defmodule FzWall.Server do
     cli().teardown_table()
     cli().setup_table()
     cli().setup_chains()
-    {:ok, existing_rules} = GenServer.call(http_pid(), :load_rules, @init_timeout)
-    cli().restore(existing_rules)
-    {:ok, existing_rules}
+    cli().setup_rules()
+    {:ok, settings} = GenServer.call(http_pid(), :load_settings, @init_timeout)
+    cli().restore(settings)
+    {:ok, settings}
   end
 
   @impl GenServer
-  def handle_call({:add_rules, rule_spec}, _from, rules) do
-    new_rules = add_rules(rule_spec, rules)
+  def handle_call({:add_rule, rule}, _from, {existing_users, existing_devices, existing_rules}) do
+    new_rules = add_rule(rule, existing_rules)
 
-    {:reply, :ok, new_rules}
+    {:reply, :ok, {existing_users, existing_devices, new_rules}}
   end
 
   @impl GenServer
-  def handle_call({:delete_rule, rules_spec}, _from, rules) do
-    new_rules = delete_rules(rules_spec, rules)
-    {:reply, :ok, new_rules}
+  def handle_call({:delete_rule, rule}, _from, {existing_users, existing_devices, existing_rules}) do
+    new_rules = delete_rule(rule, existing_rules)
+
+    {:reply, :ok, {existing_users, existing_devices, new_rules}}
   end
 
   @impl GenServer
-  def handle_call({:delete_device_rules, {ipv4, nil}}, _from, rules),
-    do: delete_device_rules(ipv4, rules)
+  def handle_call(
+        {:add_device, device},
+        _from,
+        {existing_users, existing_devices, existing_rules}
+      ) do
+    new_devices = add_device(device, existing_devices)
 
-  @impl GenServer
-  def handle_call({:delete_device_rules, {nil, ipv6}}, _from, rules),
-    do: delete_device_rules(ipv6, rules)
-
-  @impl GenServer
-  def handle_call({:delete_device_rules, {ipv4, ipv6}}, _from, rules) do
-    {:reply, :ok, new_rules} = delete_device_rules(ipv4, rules)
-    delete_device_rules(ipv6, new_rules)
+    {:reply, :ok, {existing_users, new_devices, existing_rules}}
   end
 
   @impl GenServer
-  def handle_call({:set_rules, fz_http_rules}, _from, _rules) do
-    cli().restore(fz_http_rules)
-    {:reply, :ok, fz_http_rules}
+  def handle_call(
+        {:delete_device, device},
+        _from,
+        {existing_users, existing_devices, existing_rules}
+      ) do
+    new_devices = delete_device(device, existing_devices)
+
+    {:reply, :ok, {existing_users, new_devices, existing_rules}}
   end
 
-  # XXX: Set up NAT and Masquerade and load existing rules with nftables here
   @impl GenServer
-  def handle_call(:setup, _from, rules) do
-    {:reply, :ok, rules}
+  def handle_call({:set_rules, settings}, _from, _settings) do
+    cli().restore(settings)
+
+    {:reply, :ok, settings}
   end
 
-  # XXX: Tear down NAT and Masquerade and drop rules here
   @impl GenServer
-  def handle_call(:teardown, _from, rules) do
-    {:reply, :ok, rules}
+  def handle_call({:add_user, user_id}, _from, {existing_users, existing_devices, existing_rules}) do
+    new_users = add_user(user_id, existing_users)
+
+    {:reply, :ok, {new_users, existing_devices, existing_rules}}
+  end
+
+  @impl GenServer
+  def handle_call(
+        {:delete_user, user_id},
+        _from,
+        {existing_users, existing_devices, existing_rules}
+      ) do
+    new_users = delete_user(user_id, existing_users)
+
+    {:reply, :ok, {new_users, existing_devices, existing_rules}}
   end
 
   def http_pid do
     :global.whereis_name(:fz_http_server)
   end
 
-  defp delete_device_rules(source, rules) do
-    # We ignore the errors here so that we can keep deleting rules
-    cli().delete_rules(source)
+  defp add_rule(rule, existing_rules) do
+    cli().add_rule(rule)
 
-    # XXX: Consider using MapSet here
-    new_rules =
-      Enum.reject(rules, fn rule ->
-        case rule do
-          {src, _, _} -> src == source
-          _ -> false
-        end
-      end)
-
-    {:reply, :ok, new_rules}
+    existing_rules
+    |> MapSet.put(rule)
   end
 
-  # XXX: For multiple rules it'd be better to have something like [ src1 | src2 | src3 | ...]
-  # instead of multiple callings to delete_rule
-  defp delete_rules(rules_spec, rules) do
-    Enum.reduce(rules_spec, MapSet.new(rules), fn rule_spec, rules_acc ->
-      # We ignore errors here just to keep deleting the other rules
-      cli().delete_rule(rule_spec)
-      MapSet.delete(rules_acc, rule_spec)
-    end)
-    |> Enum.to_list()
+  defp delete_rule(rule, existing_rules) do
+    cli().delete_rule(rule)
+
+    existing_rules
+    |> MapSet.delete(rule)
   end
 
-  defp add_rules(rules_spec, rules) do
-    Enum.reduce(rules_spec, MapSet.new(rules), fn rule_spec, rules_acc ->
-      cli().add_rule(rule_spec)
-      MapSet.put(rules_acc, rule_spec)
-    end)
-    |> Enum.to_list()
+  defp add_user(user_id, existing_users) do
+    cli().add_user(user_id)
+
+    existing_users
+    |> MapSet.put(user_id)
+  end
+
+  defp delete_user(user_id, existing_users) do
+    cli().delete_user(user_id)
+
+    existing_users
+    |> MapSet.delete(user_id)
+  end
+
+  defp add_device(device, existing_devices) do
+    cli().add_device(device)
+
+    existing_devices
+    |> MapSet.put(device)
+  end
+
+  defp delete_device(device, existing_devices) do
+    cli().delete_device(device)
+
+    existing_devices
+    |> MapSet.delete(device)
   end
 end


### PR DESCRIPTION
Fixes firezone/product#398

Use sets instead of individual rules to manage devices/general rules(See related issue for a detailed explanation). Plus some refactoring around `fz_wall`.