### PR TITLE
Telemetry ping service

### DIFF
--- a/apps/fz_http/lib/fz_http/application.ex
+++ b/apps/fz_http/lib/fz_http/application.ex
@@ -36,6 +36,7 @@ defmodule FzHttp.Application do
       {Phoenix.PubSub, name: FzHttp.PubSub},
       FzHttpWeb.Presence,
       FzHttp.ConnectivityCheckService,
+      FzHttp.TelemetryPingService,
       FzHttp.VpnSessionScheduler,
       {OpenIDConnect.Worker, openid_connect_providers},
       {DynamicSupervisor, name: FzHttp.RefresherSupervisor, strategy: :one_for_one},

--- a/apps/fz_http/lib/fz_http/connectivity_check_service.ex
+++ b/apps/fz_http/lib/fz_http/connectivity_check_service.ex
@@ -7,7 +7,7 @@ defmodule FzHttp.ConnectivityCheckService do
 
   require Logger
 
-  alias FzHttp.{ConnectivityChecks, Telemetry}
+  alias FzHttp.ConnectivityChecks
 
   def start_link(_) do
     http_client().start()
@@ -26,7 +26,6 @@ defmodule FzHttp.ConnectivityCheckService do
   # XXX: Consider passing state here to implement exponential backoff in case of errors.
   @impl GenServer
   def handle_info(:perform, _state) do
-    Telemetry.ping()
     {:noreply, post_request()}
   end
 

--- a/apps/fz_http/lib/fz_http/telemetry_ping_service.ex
+++ b/apps/fz_http/lib/fz_http/telemetry_ping_service.ex
@@ -1,0 +1,27 @@
+defmodule FzHttp.TelemetryPingService do
+  @moduledoc """
+  Periodic service for sending `ping` telemetry
+  events.
+  """
+  use GenServer
+  alias FzHttp.Telemetry
+
+  @interval 3_600
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{})
+  end
+
+  @impl GenServer
+  def init(state) do
+    # Send ping every hour
+    :timer.send_interval(@interval * 1000, :perform)
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_info(:perform, state) do
+    Telemetry.ping()
+    {:noreply, state}
+  end
+end


### PR DESCRIPTION
Moves the telemetry ping to a dedicated timer module which initializes a timer on application boot which then calls itself every hour to perform the Telemetry.ping() event.