### PR TITLE
Add cloudsmith publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     # Doesn't really need, but don't run this stage when iterating over docs
     needs: draft-release
     env:
-      TELEMETRY_ENABLED: "false"
+      TELEMETRY_ENABLED: 'false'
     runs-on: ${{ matrix.platform }}
     strategy:
       # Failing fast breaks the Omnibus build cache because the job is
@@ -58,7 +58,7 @@ jobs:
           - opensuse15-x64
     steps:
       - run: cat /sys/module/wireguard/version
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         env:
           GIT_SHA: ${{ github.sha }}
@@ -86,7 +86,7 @@ jobs:
       - name: Functional Test
         run: |
           .ci/functional_test.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: firezone-${{ matrix.platform }}
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,12 @@
 name: Publish to Cloudsmith
 
 on:
-  push:
-    tags:
-      - '*'
-  workflow_dispatch:
-    inputs:
-      tag:
-        type: text
-        required: true
+  release:
+    types: [published]
 
 jobs:
   publish:
     runs-on: ubuntu-20.04
-
-    env:
-      tag: ${{ github.event.inputs.tag || github.ref_name }}
 
     strategy:
       matrix:
@@ -148,20 +139,20 @@ jobs:
 
       - name: Rename artifact file to tag
         run: |
-          mv ./firezone*.rpm firezone_${{ env.tag }}-${{ matrix.platform }}.rpm || true
-          mv ./firezone*.deb firezone_${{ env.tag }}-${{ matrix.platform }}.deb || true
+          mv ./firezone*.rpm firezone_${{ github.ref_name }}-${{ matrix.platform }}.rpm || true
+          mv ./firezone*.deb firezone_${{ github.ref_name }}-${{ matrix.platform }}.deb || true
 
       - name: Check DEB
         uses: andstor/file-existence-action@v1
         id: check_deb
         with:
-          files: firezone_${{ env.tag }}-${{ matrix.platform }}.deb
+          files: firezone_${{ github.ref_name }}-${{ matrix.platform }}.deb
 
       - name: Check RPM
         uses: andstor/file-existence-action@v1
         id: check_rpm
         with:
-          files: firezone_${{ env.tag }}-${{ matrix.platform }}.rpm
+          files: firezone_${{ github.ref_name }}-${{ matrix.platform }}.rpm
 
       - name: Pubslih RPM
         uses: cloudsmith-io/action@master
@@ -175,7 +166,7 @@ jobs:
           distro: ${{ matrix.distro }}
           release: ${{ matrix.release }}
           republish: 'true'
-          file: firezone_${{ env.tag }}-${{ matrix.platform }}.rpm
+          file: firezone_${{ github.ref_name }}-${{ matrix.platform }}.rpm
 
       - name: Pubslih DEB
         uses: cloudsmith-io/action@master
@@ -189,4 +180,4 @@ jobs:
           distro: ${{ matrix.distro }}
           release: ${{ matrix.release }}
           republish: 'true'
-          file: firezone_${{ env.tag }}-${{ matrix.platform }}.deb
+          file: firezone_${{ github.ref_name }}-${{ matrix.platform }}.deb

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish to Cloudsmith
 
 on:
   push:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,12 @@ jobs:
           - platform: debian11-arm64
             distro: debian
             release: bullseye
+          - platform: debian10-arm64
+            distro: raspbian
+            release: buster
+          - platform: debian11-arm64
+            distro: raspbian
+            release: bullseye
           - platform: fedora33-arm64
             distro: fedora
             release: '33'
@@ -30,12 +36,21 @@ jobs:
           - platform: fedora35-arm64
             distro: fedora
             release: '35'
+          - platform: fedora35-arm64
+            distro: fedora
+            release: '36'
           - platform: ubuntu1804-arm64
             distro: ubuntu
             release: bionic
           - platform: ubuntu2004-arm64
             distro: ubuntu
             release: focal
+          - platform: ubuntu2004-arm64
+            distro: ubuntu
+            release: hirsute
+          - platform: ubuntu2004-arm64
+            distro: ubuntu
+            release: jammy
 
           # x64-based
           - platform: amazonlinux2-x64
@@ -50,6 +65,27 @@ jobs:
           - platform: centos9-x64
             distro: el
             release: '9'
+          - platform: centos8-x64
+            distro: rocky
+            release: '8.3'
+          - platform: centos8-x64
+            distro: rocky
+            release: '8.4'
+          - platform: centos8-x64
+            distro: rocky
+            release: '8.5'
+          - platform: centos8-x64
+            distro: rocky
+            release: '8.6'
+          - platform: centos8-x64
+            distro: almalinux
+            release: '8.3'
+          - platform: centos8-x64
+            distro: almalinux
+            release: '8.4'
+          - platform: centos8-x64
+            distro: almalinux
+            release: '8.5'
           - platform: debian10-x64
             distro: debian
             release: buster
@@ -65,6 +101,9 @@ jobs:
           - platform: fedora35-x64
             distro: fedora
             release: '35'
+          - platform: fedora35-x64
+            distro: fedora
+            release: '36'
           - platform: ubuntu1804-x64
             distro: ubuntu
             release: bionic
@@ -77,6 +116,12 @@ jobs:
           - platform: ubuntu2004-x64
             distro: ubuntu
             release: jammy
+          - platform: opensuse15-x64
+            distro: opensuse
+            release: '15.1'
+          - platform: opensuse15-x64
+            distro: opensuse
+            release: '15.2'
           - platform: opensuse15-x64
             distro: opensuse
             release: '15.3'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,10 +1,22 @@
 name: Publish
 
-on: push
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: text
+        required: true
 
 jobs:
   publish:
     runs-on: ubuntu-20.04
+
+    env:
+      tag: ${{ github.event.inputs.tag || github.ref_name }}
+
     strategy:
       matrix:
         include:
@@ -126,34 +138,30 @@ jobs:
             distro: opensuse
             release: '15.3'
     steps:
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: firezone-${{ matrix.platform }}
-      #     path: ./
-
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         with:
+          commit: ${{ github.sha }}
           workflow: build.yml
           workflow_conclusion: success
           name: firezone-${{ matrix.platform }}
 
       - name: Rename artifact file to tag
         run: |
-          mv ./firezone*.rpm firezone_0.4.6-${{ matrix.platform }}.rpm || true
-          mv ./firezone*.deb firezone_0.4.6-${{ matrix.platform }}.deb || true
+          mv ./firezone*.rpm firezone_${{ env.tag }}-${{ matrix.platform }}.rpm || true
+          mv ./firezone*.deb firezone_${{ env.tag }}-${{ matrix.platform }}.deb || true
 
       - name: Check DEB
         uses: andstor/file-existence-action@v1
         id: check_deb
         with:
-          files: firezone_0.4.6-${{ matrix.platform }}.deb
+          files: firezone_${{ env.tag }}-${{ matrix.platform }}.deb
 
       - name: Check RPM
         uses: andstor/file-existence-action@v1
         id: check_rpm
         with:
-          files: firezone_0.4.6-${{ matrix.platform }}.rpm
+          files: firezone_${{ env.tag }}-${{ matrix.platform }}.rpm
 
       - name: Pubslih RPM
         uses: cloudsmith-io/action@master
@@ -167,7 +175,7 @@ jobs:
           distro: ${{ matrix.distro }}
           release: ${{ matrix.release }}
           republish: 'true'
-          file: firezone_0.4.6-${{ matrix.platform }}.rpm
+          file: firezone_${{ env.tag }}-${{ matrix.platform }}.rpm
 
       - name: Pubslih DEB
         uses: cloudsmith-io/action@master
@@ -181,4 +189,4 @@ jobs:
           distro: ${{ matrix.distro }}
           release: ${{ matrix.release }}
           republish: 'true'
-          file: firezone_0.4.6-${{ matrix.platform }}.deb
+          file: firezone_${{ env.tag }}-${{ matrix.platform }}.deb

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,139 @@
+name: Publish
+
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          # ARM-based
+          - platform: amazonlinux2-arm64
+            distro: amzn
+            release: '2'
+          - platform: centos9-arm64
+            distro: el
+            release: '9'
+          - platform: debian10-arm64
+            distro: debian
+            release: buster
+          - platform: debian11-arm64
+            distro: debian
+            release: bullseye
+          - platform: fedora33-arm64
+            distro: fedora
+            release: '33'
+          - platform: fedora34-arm64
+            distro: fedora
+            release: '34'
+          - platform: fedora35-arm64
+            distro: fedora
+            release: '35'
+          - platform: ubuntu1804-arm64
+            distro: ubuntu
+            release: bionic
+          - platform: ubuntu2004-arm64
+            distro: ubuntu
+            release: focal
+
+          # x64-based
+          - platform: amazonlinux2-x64
+            distro: amzn
+            release: '2'
+          - platform: centos7-x64
+            distro: el
+            release: '7'
+          - platform: centos8-x64
+            distro: el
+            release: '8'
+          - platform: centos9-x64
+            distro: el
+            release: '9'
+          - platform: debian10-x64
+            distro: debian
+            release: buster
+          - platform: debian11-x64
+            distro: debian
+            release: bullseye
+          - platform: fedora33-x64
+            distro: fedora
+            release: '33'
+          - platform: fedora34-x64
+            distro: fedora
+            release: '34'
+          - platform: fedora35-x64
+            distro: fedora
+            release: '35'
+          - platform: ubuntu1804-x64
+            distro: ubuntu
+            release: bionic
+          - platform: ubuntu2004-x64
+            distro: ubuntu
+            release: focal
+          - platform: ubuntu2004-x64
+            distro: ubuntu
+            release: hirsute
+          - platform: ubuntu2004-x64
+            distro: ubuntu
+            release: jammy
+          - platform: opensuse15-x64
+            distro: opensuse
+            release: '15.3'
+    steps:
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: firezone-${{ matrix.platform }}
+      #     path: ./
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build.yml
+          workflow_conclusion: success
+          name: firezone-${{ matrix.platform }}
+
+      - name: Rename artifact file to tag
+        run: |
+          mv ./firezone*.rpm firezone_0.4.6-${{ matrix.platform }}.rpm || true
+          mv ./firezone*.deb firezone_0.4.6-${{ matrix.platform }}.deb || true
+
+      - name: Check DEB
+        uses: andstor/file-existence-action@v1
+        id: check_deb
+        with:
+          files: firezone_0.4.6-${{ matrix.platform }}.deb
+
+      - name: Check RPM
+        uses: andstor/file-existence-action@v1
+        id: check_rpm
+        with:
+          files: firezone_0.4.6-${{ matrix.platform }}.rpm
+
+      - name: Pubslih RPM
+        uses: cloudsmith-io/action@master
+        if: steps.check_rpm.outputs.files_exists == 'true'
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: 'push'
+          format: 'rpm'
+          owner: 'firezone'
+          repo: 'firezone'
+          distro: ${{ matrix.distro }}
+          release: ${{ matrix.release }}
+          republish: 'true'
+          file: firezone_0.4.6-${{ matrix.platform }}.rpm
+
+      - name: Pubslih DEB
+        uses: cloudsmith-io/action@master
+        if: steps.check_deb.outputs.files_exists == 'true'
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: 'push'
+          format: 'deb'
+          owner: 'firezone'
+          repo: 'firezone'
+          distro: ${{ matrix.distro }}
+          release: ${{ matrix.release }}
+          republish: 'true'
+          file: firezone_0.4.6-${{ matrix.platform }}.deb

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
   </a>
   <img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/firezone/firezone"/>
   <img alt="GitHub closed issues" src="https://img.shields.io/github/issues-closed/firezone/firezone"/>
+  <a href="https://cloudsmith.com">
+    <img src="https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith" alt="Cloudsmith">
+  </a>
   <a href="https://twitter.com/intent/follow?screen_name=firezonehq">
     <img src="https://img.shields.io/twitter/follow/firezonehq?style=social&logo=twitter" alt="follow on Twitter">
   </a>
@@ -73,6 +76,17 @@ help:
 * [Discussion Forums](https://discourse.firez.one/): ask questions, report bugs, and suggest features
 * [Community Slack](https://www.firezone.dev/slack): join discussions, meet other users, and meet the contributors
 * [Email Us](mailto:team@firezone.dev): we're always happy to chat
+
+
+## Package Repository
+
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=for-the-badge)](https://cloudsmith.com)
+
+Package repository hosting is graciously provided by  [Cloudsmith](https://cloudsmith.com).
+Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
+enables your organization to create, store and share packages in any format, to any place, with total
+confidence.
+
 
 ## Developing and Contributing
 


### PR DESCRIPTION
Ref https://github.com/firezone/firezone/issues/668

When a release is published, it downloads the artifacts built for the tagged commit, does the same handling as when publishing to the release, and pushes the packages to Cloudsmith.

Hence, publishing a new release needs to wait for the latest build of the commit that's included in the release to finish first. This seems to be what we normally do - so shouldn't be a problem.