### PR TITLE
Improve user vpn connection status ui

### DIFF
--- a/apps/fz_http/lib/fz_http_web/live/user_live/index.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/index.html.heex
@@ -35,11 +35,10 @@
             <%= live_patch(user.email, to: Routes.user_show_path(@socket, :show, user)) %>
           </td>
           <td id={"user-#{user.id}-device-count"}><%= user.device_count %></td>
-          <td class="has-text-centered">
-            <.live_component id={"vpn-status-#{user.id}"}
-              module={FzHttpWeb.UserLive.VPNStatusComponent}
+          <td id={"user-#{user.id}-vpn-status"} class="has-text-centered">
+            <FzHttpWeb.UserLive.VPNStatusComponent.status
               user={user}
-              vpn_expired={vpn_expired?(user)}
+              expired={vpn_expired?(user)}
             />
           </td>
           <td id={"user-#{user.id}-timestamp"}

--- a/apps/fz_http/lib/fz_http_web/live/user_live/index.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/index.html.heex
@@ -35,10 +35,12 @@
             <%= live_patch(user.email, to: Routes.user_show_path(@socket, :show, user)) %>
           </td>
           <td id={"user-#{user.id}-device-count"}><%= user.device_count %></td>
-          <td>
-            <.live_component id={"allowed-to-connect-#{user.id}"}
-              module={FzHttpWeb.UserLive.VPNConnectionComponent }
-              user={user} disabled={true} />
+          <td class="has-text-centered">
+            <.live_component id={"vpn-status-#{user.id}"}
+              module={FzHttpWeb.UserLive.VPNStatusComponent}
+              user={user}
+              vpn_expired={vpn_expired?(user)}
+            />
           </td>
           <td id={"user-#{user.id}-timestamp"}
               data-timestamp={user.last_signed_in_at}

--- a/apps/fz_http/lib/fz_http_web/live/user_live/vpn_status_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/vpn_status_component.ex
@@ -8,17 +8,41 @@ defmodule FzHttpWeb.UserLive.VPNStatusComponent do
   def render(assigns) do
     ~H"""
     <div>
-    <%= cond do %>
-      <% @user.disabled_at -> %>
-      <span class="tag is-danger is-medium" title="This user's VPN connect is disabled by an administrator or OIDC refresh failure">DISABLED</span>
-      <% @vpn_expired && @user.last_signed_in_at -> %>
-      <span class="tag is-warning is-medium" title="This user's VPN connection is disabled due to authentication expiration">EXPIRED</span>
-      <% @vpn_expired && !@user.last_signed_in_at -> %>
-      <span class="tag is-warning is-medium" title="User must sign in to activate">EXPIRED</span>
-      <% !@vpn_expired -> %>
-      <span class="tag is-success is-medium" title="This user's VPN connection is enabled">ENABLED</span>
-    <% end %>
+      <%= tag_for_vpn_status(@user, @vpn_expired, assigns) %>
     </div>
+    """
+  end
+
+  defp tag_for_vpn_status(user, expired, assigns) do
+    cond do
+      user.disabled_at -> disabled_tag(assigns)
+      expired && user.last_signed_in_at -> expired_tag_sign_in(assigns)
+      expired && is_nil(user.last_signed_in_at) -> expired_tag_auth(assigns)
+      !expired -> enabled_tag(assigns)
+    end
+  end
+
+  defp disabled_tag(assigns) do
+    ~H"""
+    <span class="tag is-danger is-medium" title="This user's VPN connect is disabled by an administrator or OIDC refresh failure">DISABLED</span>
+    """
+  end
+
+  defp enabled_tag(assigns) do
+    ~H"""
+    <span class="tag is-success is-medium" title="This user's VPN connection is enabled">ENABLED</span>
+    """
+  end
+
+  defp expired_tag_sign_in(assigns) do
+    ~H"""
+    <span class="tag is-warning is-medium" title="This user's VPN connection is disabled due to authentication expiration">EXPIRED</span>
+    """
+  end
+
+  defp expired_tag_auth(assigns) do
+    ~H"""
+    <span class="tag is-warning is-medium" title="User must sign in to activate">EXPIRED</span>
     """
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/user_live/vpn_status_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/vpn_status_component.ex
@@ -2,18 +2,12 @@ defmodule FzHttpWeb.UserLive.VPNStatusComponent do
   @moduledoc """
   Handles VPN status tag.
   """
-  use FzHttpWeb, :live_component
+  use Phoenix.Component
 
-  @impl Phoenix.LiveComponent
-  def render(assigns) do
-    ~H"""
-    <div>
-      <%= tag_for_vpn_status(@user, @vpn_expired, assigns) %>
-    </div>
-    """
-  end
+  def status(assigns) do
+    user = assigns.user
+    expired = assigns.expired
 
-  defp tag_for_vpn_status(user, expired, assigns) do
     cond do
       user.disabled_at -> disabled_tag(assigns)
       expired && user.last_signed_in_at -> expired_tag_sign_in(assigns)

--- a/apps/fz_http/lib/fz_http_web/live/user_live/vpn_status_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/vpn_status_component.ex
@@ -1,0 +1,24 @@
+defmodule FzHttpWeb.UserLive.VPNStatusComponent do
+  @moduledoc """
+  Handles VPN status tag.
+  """
+  use FzHttpWeb, :live_component
+
+  @impl Phoenix.LiveComponent
+  def render(assigns) do
+    ~H"""
+    <label>
+    <%= cond do %>
+      <% @user.disabled_at -> %>
+      <span class="tag is-danger is-medium" title="This user's VPN connect is disabled by an administrator or OIDC refresh error">DISABLED</span>
+      <% @vpn_expired && @user.last_signed_in_at -> %>
+      <span class="tag is-warning is-medium" title="This user's VPN connection is disabled due to authentication expiration">EXPIRED</span>
+      <% @vpn_expired && !@user.last_signed_in_at -> %>
+      <span class="tag is-warning is-medium" title="User must sign in to activate">EXPIRED</span>
+      <% !@vpn_expired -> %>
+      <span class="tag is-success is-medium" title="This user's VPN connection is enabled">ENABLED</span>
+    <% end %>
+    </label>
+    """
+  end
+end

--- a/apps/fz_http/lib/fz_http_web/live/user_live/vpn_status_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/vpn_status_component.ex
@@ -7,10 +7,10 @@ defmodule FzHttpWeb.UserLive.VPNStatusComponent do
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
-    <label>
+    <div>
     <%= cond do %>
       <% @user.disabled_at -> %>
-      <span class="tag is-danger is-medium" title="This user's VPN connect is disabled by an administrator or OIDC refresh error">DISABLED</span>
+      <span class="tag is-danger is-medium" title="This user's VPN connect is disabled by an administrator or OIDC refresh failure">DISABLED</span>
       <% @vpn_expired && @user.last_signed_in_at -> %>
       <span class="tag is-warning is-medium" title="This user's VPN connection is disabled due to authentication expiration">EXPIRED</span>
       <% @vpn_expired && !@user.last_signed_in_at -> %>
@@ -18,7 +18,7 @@ defmodule FzHttpWeb.UserLive.VPNStatusComponent do
       <% !@vpn_expired -> %>
       <span class="tag is-success is-medium" title="This user's VPN connection is enabled">ENABLED</span>
     <% end %>
-    </label>
+    </div>
     """
   end
 end

--- a/apps/fz_http/test/fz_http/events_test.exs
+++ b/apps/fz_http/test/fz_http/events_test.exs
@@ -44,7 +44,7 @@ defmodule FzHttp.EventsTest do
 
     test "removes device from vpn and wall state", %{device: device} do
       :ok = Events.update_device(device)
-      pubkey = device.public_key
+
       assert :ok = Events.delete_device(device)
 
       assert :sys.get_state(Events.vpn_pid()) == %{}

--- a/apps/fz_http/test/fz_http_web/live/user_live/vpn_status_component_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/vpn_status_component_test.exs
@@ -37,7 +37,9 @@ defmodule FzHttpWeb.UserLive.VPNStatusComponentTest do
         })
 
       assert test_component =~ ~r"\bEXPIRED\b"
-      assert test_component =~ ~r"\bThis user's VPN connection is disabled due to authentication expiration\b"
+
+      assert test_component =~
+               ~r"\bThis user's VPN connection is disabled due to authentication expiration\b"
     end
 
     test "expired tag user signed out", %{user: user} do

--- a/apps/fz_http/test/fz_http_web/live/user_live/vpn_status_component_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/vpn_status_component_test.exs
@@ -8,10 +8,9 @@ defmodule FzHttpWeb.UserLive.VPNStatusComponentTest do
 
     test "enabled tag", %{user: user} do
       test_component =
-        render_component(VPNStatusComponent, %{
-          id: "1",
+        render_component(&VPNStatusComponent.status/1, %{
           user: user,
-          vpn_expired: false
+          expired: false
         })
 
       assert test_component =~ ~r"\bENABLED\b"
@@ -19,10 +18,9 @@ defmodule FzHttpWeb.UserLive.VPNStatusComponentTest do
 
     test "disabled tag", %{user: user} do
       test_component =
-        render_component(VPNStatusComponent, %{
-          id: "1",
+        render_component(&VPNStatusComponent.status/1, %{
           user: Map.put(user, :disabled_at, DateTime.utc_now()),
-          vpn_expired: false
+          expired: false
         })
 
       assert test_component =~ ~r"\bDISABLED\b"
@@ -30,10 +28,9 @@ defmodule FzHttpWeb.UserLive.VPNStatusComponentTest do
 
     test "expired tag user signed in", %{user: user} do
       test_component =
-        render_component(VPNStatusComponent, %{
-          id: "1",
+        render_component(&VPNStatusComponent.status/1, %{
           user: Map.put(user, :last_signed_in_at, DateTime.utc_now()),
-          vpn_expired: true
+          expired: true
         })
 
       assert test_component =~ ~r"\bEXPIRED\b"
@@ -44,10 +41,9 @@ defmodule FzHttpWeb.UserLive.VPNStatusComponentTest do
 
     test "expired tag user signed out", %{user: user} do
       test_component =
-        render_component(VPNStatusComponent, %{
-          id: "1",
+        render_component(&VPNStatusComponent.status/1, %{
           user: user,
-          vpn_expired: true
+          expired: true
         })
 
       assert test_component =~ ~r"\bEXPIRED\b"

--- a/apps/fz_http/test/fz_http_web/live/user_live/vpn_status_component_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/vpn_status_component_test.exs
@@ -1,0 +1,55 @@
+defmodule FzHttpWeb.UserLive.VPNStatusComponentTest do
+  use FzHttpWeb.ConnCase, async: true
+
+  alias FzHttpWeb.UserLive.VPNStatusComponent
+
+  describe "admin" do
+    setup :create_user
+
+    test "enabled tag", %{user: user} do
+      test_component =
+        render_component(VPNStatusComponent, %{
+          id: "1",
+          user: user,
+          vpn_expired: false
+        })
+
+      assert test_component =~ ~r"\bENABLED\b"
+    end
+
+    test "disabled tag", %{user: user} do
+      test_component =
+        render_component(VPNStatusComponent, %{
+          id: "1",
+          user: Map.put(user, :disabled_at, DateTime.utc_now()),
+          vpn_expired: false
+        })
+
+      assert test_component =~ ~r"\bDISABLED\b"
+    end
+
+    test "expired tag user signed in", %{user: user} do
+      test_component =
+        render_component(VPNStatusComponent, %{
+          id: "1",
+          user: Map.put(user, :last_signed_in_at, DateTime.utc_now()),
+          vpn_expired: true
+        })
+
+      assert test_component =~ ~r"\bEXPIRED\b"
+      assert test_component =~ ~r"\bThis user's VPN connection is disabled due to authentication expiration\b"
+    end
+
+    test "expired tag user signed out", %{user: user} do
+      test_component =
+        render_component(VPNStatusComponent, %{
+          id: "1",
+          user: user,
+          vpn_expired: true
+        })
+
+      assert test_component =~ ~r"\bEXPIRED\b"
+      assert test_component =~ ~r"\bUser must sign in to activate\b"
+    end
+  end
+end

--- a/docs/docs/authenticate/README.md
+++ b/docs/docs/authenticate/README.md
@@ -108,6 +108,19 @@ You can set the session length to a minimum of 1 hour and maximum of 90 days.
 Setting this to Never disables this setting, allowing VPN sessions indefinitely.
 This is the default.
 
+#### VPN Connection Status
+
+A user's connection status is shown on the Users page under the table column
+`VPN Connection`. The connection statuses are:
+
+* ENABLED - The connection is enabled.
+* DISABLED - The connection is disabled by an administrator or OIDC refresh error.
+* EXPIRED - The connection is disabled due to authentication expiration or a user
+    has not signed in for the first time.
+
+
+### Re-authentication
+
 To re-authenticate an expired VPN session, a user will need to turn off their
 VPN session and sign in to the Firezone portal (URL specified during
 [deployment](../deploy/prerequisites)

--- a/docs/docs/authenticate/README.md
+++ b/docs/docs/authenticate/README.md
@@ -108,7 +108,7 @@ You can set the session length to a minimum of 1 hour and maximum of 90 days.
 Setting this to Never disables this setting, allowing VPN sessions indefinitely.
 This is the default.
 
-#### VPN Connection Status
+**VPN Connection Status**
 
 A user's connection status is shown on the Users page under the table column
 `VPN Connection`. The connection statuses are:

--- a/docs/docs/authenticate/README.md
+++ b/docs/docs/authenticate/README.md
@@ -124,6 +124,6 @@ A user's connection status is shown on the Users page under the table column
 `VPN Connection`. The connection statuses are:
 
 * ENABLED - The connection is enabled.
-* DISABLED - The connection is disabled by an administrator or OIDC refresh error.
+* DISABLED - The connection is disabled by an administrator or OIDC refresh failure.
 * EXPIRED - The connection is disabled due to authentication expiration or a user
     has not signed in for the first time.

--- a/docs/docs/authenticate/README.md
+++ b/docs/docs/authenticate/README.md
@@ -108,17 +108,6 @@ You can set the session length to a minimum of 1 hour and maximum of 90 days.
 Setting this to Never disables this setting, allowing VPN sessions indefinitely.
 This is the default.
 
-**VPN Connection Status**
-
-A user's connection status is shown on the Users page under the table column
-`VPN Connection`. The connection statuses are:
-
-* ENABLED - The connection is enabled.
-* DISABLED - The connection is disabled by an administrator or OIDC refresh error.
-* EXPIRED - The connection is disabled due to authentication expiration or a user
-    has not signed in for the first time.
-
-
 ### Re-authentication
 
 To re-authenticate an expired VPN session, a user will need to turn off their
@@ -128,3 +117,13 @@ VPN session and sign in to the Firezone portal (URL specified during
 
 See detailed Client Instructions on how to re-authenticate your session
 [here](../user-guides/client-instructions).
+
+#### VPN Connection Status
+
+A user's connection status is shown on the Users page under the table column
+`VPN Connection`. The connection statuses are:
+
+* ENABLED - The connection is enabled.
+* DISABLED - The connection is disabled by an administrator or OIDC refresh error.
+* EXPIRED - The connection is disabled due to authentication expiration or a user
+    has not signed in for the first time.


### PR DESCRIPTION
This PR adds a status tag to the `VPN Connection` column to the table on the Users page.
The three tags are:

* ENABLED - User's vpn connection is enabled.
* DISABLED - Users' vpn connection is disabled by an admin or OIDC refresh error.
* EXPIRED - User's vpn connection is disabled due to auth expiration or not having logged in for the first time.

The docs have also been updated with a similar description of these tags under the Authenticate section.

Fixes #765 