### PR TITLE
use x-forwarded-for in addition to x-real-ip

### DIFF
--- a/apps/fz_http/lib/fz_http_web/channels/user_socket.ex
+++ b/apps/fz_http/lib/fz_http_web/channels/user_socket.ex
@@ -49,7 +49,9 @@ defmodule FzHttpWeb.UserSocket do
   def id(socket), do: "user_socket:#{socket.assigns.current_user.id}"
 
   defp get_ip_address(%{x_headers: headers_list}) when length(headers_list) > 0 do
-    header = Enum.find(headers_list, fn {key, _val} -> key == "x-real-ip" end)
+    header =
+      Enum.find(headers_list, fn {key, _val} -> key == "x-real-ip" end) ||
+        Enum.find(headers_list, fn {key, _val} -> key == "x-forwarded-for" end)
 
     case header do
       {_key, value} -> value


### PR DESCRIPTION
Ref https://github.com/firezone/firezone/issues/480

I'm not sure if I'm missing something...

Is this fix sufficient?

![image](https://user-images.githubusercontent.com/1329716/177662790-4e97611f-3277-4450-aa2e-f9d3ab635e58.png)

I was working off the docker branch. The caddy ip is static on `172.28.0.99`. Any incoming request (into docker world) is from `172.28.0.1`.

```elixir
# connect_info
%{
  peer_data: %{address: {172, 28, 0, 99}, port: 45152, ssl_cert: nil},
  uri: %URI{
    authority: "localhost",
    fragment: nil,
    host: "localhost",
    path: "/socket/websocket",
    port: 80,
    query: "token=SFMyNTY.g2gDYQFuBgB9RPbVgQFiAAFRgA.A7_s9jhQROdRw4fYgN3hJRTDE0rEHkpo8aO3Oe33_xU&vsn=2.0.0",
    scheme: "http",
    userinfo: nil
  },
  x_headers: [
    {"x-forwarded-for", "172.28.0.1"},
    {"x-forwarded-host", "localhost"},
    {"x-forwarded-proto", "https"}
  ]
}
```