### PR TITLE
Implement PKCE

### DIFF
--- a/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
@@ -98,7 +98,7 @@ defmodule FzHttpWeb.AuthController do
     |> fetch_cookies(signed: [@oidc_state_key])
     |> then(fn
       %{cookies: %{@oidc_state_key => ^state}} ->
-        {:ok, []}
+        {:ok, state}
 
       _ ->
         {:error, "Cannot verify state"}

--- a/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
@@ -138,7 +138,7 @@ defmodule FzHttpWeb.AuthController do
       access_type: "offline"
     }
 
-    uri = openid_connect.authorization_uri(String.to_atom(provider), params)
+    uri = openid_connect.authorization_uri(String.to_existing_atom(provider), params)
 
     conn
     |> redirect(external: uri)

--- a/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
@@ -159,7 +159,7 @@ defmodule FzHttpWeb.AuthController do
       max_age: @oidc_state_valid_duration,
       sign: true,
       same_site: "Lax",
-      secure: true
+      secure: Application.fetch_env!(:fz_http, :cookie_secure)
     )
     |> redirect(external: uri)
   end

--- a/apps/fz_http/test/fz_http_web/controllers/auth_controller_test.exs
+++ b/apps/fz_http/test/fz_http_web/controllers/auth_controller_test.exs
@@ -87,7 +87,29 @@ defmodule FzHttpWeb.AuthControllerTest do
   end
 
   describe "creating session from OpenID Connect" do
-    setup [:create_user]
+    setup :create_user
+
+    @key "fz_oidc_state"
+    @state "test"
+
+    @params %{
+      "code" => "MyFaketoken",
+      "provider" => "google",
+      "state" => @state
+    }
+
+    setup %{unauthed_conn: conn} = context do
+      signed_state =
+        Plug.Crypto.sign(
+          Application.fetch_env!(:fz_http, FzHttpWeb.Endpoint)[:secret_key_base],
+          @key <> "_cookie",
+          @state,
+          key: Plug.Keys,
+          max_age: context[:max_age] || 300
+        )
+
+      {:ok, unauthed_conn: put_req_cookie(conn, "fz_oidc_state", signed_state)}
+    end
 
     test "when a user returns with a valid claim", %{unauthed_conn: conn, user: user} do
       expect(OpenIDConnect.Mock, :fetch_tokens, fn _, _ -> {:ok, %{"id_token" => "abc"}} end)
@@ -96,17 +118,12 @@ defmodule FzHttpWeb.AuthControllerTest do
         {:ok, %{"email" => user.email, "sub" => "12345"}}
       end)
 
-      params = %{
-        "code" => "MyFaketoken",
-        "provider" => "google"
-      }
-
-      test_conn = get(conn, Routes.auth_oidc_path(conn, :callback, "google"), params)
-
+      test_conn = get(conn, Routes.auth_oidc_path(conn, :callback, "google"), @params)
       assert redirected_to(test_conn) == Routes.user_index_path(test_conn, :index)
     end
 
     @moduletag :capture_log
+
     test "when a user returns with an invalid claim", %{unauthed_conn: conn} do
       expect(OpenIDConnect.Mock, :fetch_tokens, fn _, _ -> {:ok, %{}} end)
 
@@ -114,13 +131,25 @@ defmodule FzHttpWeb.AuthControllerTest do
         {:error, "Invalid token for user!"}
       end)
 
-      params = %{
-        "code" => "MyFaketoken",
-        "provider" => "google"
-      }
-
-      test_conn = get(conn, Routes.auth_oidc_path(conn, :callback, "google"), params)
+      test_conn = get(conn, Routes.auth_oidc_path(conn, :callback, "google"), @params)
       assert get_flash(test_conn, :error) == "OpenIDConnect Error: Invalid token for user!"
+    end
+
+    test "when a user returns with an invalid state", %{unauthed_conn: conn} do
+      test_conn =
+        get(conn, Routes.auth_oidc_path(conn, :callback, "google"), %{
+          @params
+          | "state" => "not_valid"
+        })
+
+      assert get_flash(test_conn, :error) == "OpenIDConnect Error: Cannot verify state"
+    end
+
+    @tag max_age: 0
+    test "when a user returns with an expired state", %{unauthed_conn: conn} do
+      test_conn = get(conn, Routes.auth_oidc_path(conn, :callback, "google"), @params)
+
+      assert get_flash(test_conn, :error) == "OpenIDConnect Error: Cannot verify state"
     end
   end
 


### PR DESCRIPTION
close https://github.com/firezone/firezone/issues/788

It's suggested that the state should be tied to a session. I thought cookie fits every requirement in this case.

Tested with manually modifying state in the oauth url (invalid state) and using a very short duration (expired state).

![image](https://user-images.githubusercontent.com/1329716/177889093-8511d9f3-d591-461a-a828-d7e5170e4c32.png)
