### PR TITLE
Add telemetry data to the ping event

### DIFF
--- a/apps/fz_http/lib/fz_http/devices.ex
+++ b/apps/fz_http/lib/fz_http/devices.ex
@@ -15,6 +15,16 @@ defmodule FzHttp.Devices do
     Repo.one(from d in Device, select: count(d.id))
   end
 
+  def max_count_by_user_id do
+    Repo.one(
+      from d in Device,
+        select: fragment("count(*) AS user_count"),
+        group_by: d.user_id,
+        order_by: fragment("user_count DESC"),
+        limit: 1
+    )
+  end
+
   def list_devices do
     Repo.all(Device)
   end

--- a/apps/fz_http/lib/fz_http/mfa.ex
+++ b/apps/fz_http/lib/fz_http/mfa.ex
@@ -11,6 +11,10 @@ defmodule FzHttp.MFA do
     Repo.one(from m in Method, select: count(m.user_id, :distinct))
   end
 
+  def count_distinct_totp_by_user_id do
+    Repo.one(from m in Method, select: count(m.user_id, :distinct), where: [type: :totp])
+  end
+
   def exists?(%User{id: id}) do
     Repo.exists?(from Method, where: [user_id: ^id])
   end

--- a/apps/fz_http/test/fz_http/telemetry_test.exs
+++ b/apps/fz_http/test/fz_http/telemetry_test.exs
@@ -1,0 +1,85 @@
+defmodule FzHttp.TelemetryTest do
+  use FzHttp.DataCase, async: true
+
+  alias FzHttp.Telemetry
+
+  describe "user" do
+    setup :create_user
+
+    test "count" do
+      ping_data = Telemetry.ping_data()
+
+      assert ping_data[:user_count] == 1
+    end
+
+    test "count mfa", %{user: user} do
+      {:ok, [user: other_user]} = create_user(%{})
+      {:ok, _method} = create_method(user, type: :totp)
+      {:ok, _method} = create_method(other_user, type: :portable)
+      ping_data = Telemetry.ping_data()
+
+      assert ping_data[:users_with_mfa] == 2
+      assert ping_data[:users_with_mfa_totp] == 1
+    end
+  end
+
+  describe "device" do
+    setup [:create_devices, :create_other_user_device]
+
+    test "count" do
+      ping_data = Telemetry.ping_data()
+
+      assert ping_data[:device_count] == 6
+    end
+
+    test "max count for users" do
+      ping_data = Telemetry.ping_data()
+
+      assert ping_data[:max_devices_for_users] == 5
+    end
+  end
+
+  describe "auth" do
+    test "count openid providers" do
+      ping_data = Telemetry.ping_data()
+
+      assert ping_data[:openid_providers] == 2
+    end
+
+    test "auto create oidc users" do
+      ping_data = Telemetry.ping_data()
+
+      assert ping_data[:auto_create_oidc_users]
+    end
+
+    test "disable vpn on oidc error" do
+      ping_data = Telemetry.ping_data()
+
+      assert ping_data[:disable_vpn_on_oidc_error]
+    end
+
+    test "local authentication" do
+      ping_data = Telemetry.ping_data()
+
+      assert ping_data[:local_authentication]
+    end
+
+    test "unprivileged device management" do
+      ping_data = Telemetry.ping_data()
+
+      assert ping_data[:unprivileged_device_management]
+    end
+  end
+
+  test "external database" do
+    ping_data = Telemetry.ping_data()
+
+    assert !ping_data[:external_database]
+  end
+
+  test "outbound email" do
+    ping_data = Telemetry.ping_data()
+
+    assert ping_data[:outbound_email]
+  end
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -56,7 +56,7 @@ config :ueberauth, Ueberauth,
   ]
 
 # OIDC auth for testing
-config :fz_http, :openid_connect_providers, %{
+config :fz_http, :openid_connect_providers,
   google: [
     discovery_document_uri: "https://accounts.google.com/.well-known/openid-configuration",
     client_id: "CLIENT_ID",
@@ -65,8 +65,16 @@ config :fz_http, :openid_connect_providers, %{
     response_type: "code",
     scope: "openid email profile",
     label: "OIDC Google"
+  ],
+  okta: [
+    discovery_document_uri: "https://<OKTA_DOMAIN>/.well-known/openid-configuration",
+    client_id: "CLIENT_ID",
+    client_secret: "CLIENT_SECRET",
+    redirect_uri: "https://firezone.example.com/auth/oidc/okta/callback/",
+    response_type: "code",
+    scope: "openid email profile offline_access",
+    label: "OIDC Okta"
   ]
-}
 
 # Provide mock for HTTPClient
 config :fz_http, :openid_connect, OpenIDConnect.Mock


### PR DESCRIPTION
Fixes firezone/product#410

### Summary

This PR adds the following telemetry data to the ping event:
- `max_devices_for_users` The largest number of devices created for users.
- `users_with_mfa_totp` The number of users that have TOTP MFA set.
- `openid_providers` The number of configured OIDC providers.
- `auto_create_oidc_users` If auto creation of OIDC users is enabled.
- `unprivileged_device_management` If non admin users can manage their devices.
- `local_authentication` If local auth is enabled.
- `disable_vpn_on_oidc_error` If a user's vpn connection is disabled on an OIDC refresh failure.
- `outbound_email` If an outbound email was set
- `external_database` If an external database is being used instead of the default local db.