### PR TITLE
Fix nil device error for stats push service and use live WireGuard adapter in dev.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,6 @@ PROXY_FORWARDED=true
 # export AUTH_OIDC="{\"google\":{\"discovery_document_uri\":\"https://accounts.google.com/.well-known/openid-configuration\",\"client_id\":\"1032390727302-u0lg90d3i1ive15lv7qgtbkka0hnsmgr.apps.googleusercontent.com\",\"client_secret\":\"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\",\"redirect_uri\":\"https://example.com/session\",\"response_type\":\"code\",\"scope\":\"openid email profile\",\"label\":\"Google\"},\"okta\":{\"discovery_document_uri\":\"https://accounts.google.com/.well-known/openid-configuration\",\"client_id\":\"CLIENT_ID\",\"client_secret\":\"CLIENT_SECRET\",\"redirect_uri\":\"https://example.com/session\",\"response_type\":\"code\",\"scope\":\"openid email profile\",\"label\":\"Okta\"}}"
 
 # Convenient overrides for live testing Firezone in dev
-# FZ_VPN_WGADAPTER_MODULE=FzVpn.Interface.WGAdapter.Live
 # NFT_PATH=/path/to/nft
 # EGRESS_INTERFACE=eth0
 # FZ_WALL_CLI_MODULE=FzWall.CLI.Live

--- a/apps/fz_vpn/lib/fz_vpn/application.ex
+++ b/apps/fz_vpn/lib/fz_vpn/application.ex
@@ -5,15 +5,29 @@ defmodule FzVpn.Application do
 
   use Application
 
+  alias FzVpn.Interface.WGAdapter
+
   def start(_type, _args) do
-    children = [
-      FzVpn.Server,
-      FzVpn.StatsPushService
-    ]
+    children = sandbox_children() ++ common_children()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: FzVpn.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp common_children do
+    [
+      FzVpn.Server,
+      FzVpn.StatsPushService
+    ]
+  end
+
+  defp sandbox_children do
+    if WGAdapter.wg_adapter() == WGAdapter.Sandbox do
+      [WGAdapter.Sandbox]
+    else
+      []
+    end
   end
 end

--- a/apps/fz_vpn/lib/fz_vpn/application.ex
+++ b/apps/fz_vpn/lib/fz_vpn/application.ex
@@ -5,29 +5,14 @@ defmodule FzVpn.Application do
 
   use Application
 
-  alias FzVpn.Interface.WGAdapter
-
   def start(_type, _args) do
-    children = sandbox_children() ++ common_children()
-
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: FzVpn.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link(children(), opts)
   end
 
-  defp common_children do
-    [
-      FzVpn.Server,
-      FzVpn.StatsPushService
-    ]
-  end
-
-  defp sandbox_children do
-    if WGAdapter.wg_adapter() == WGAdapter.Sandbox do
-      [WGAdapter.Sandbox]
-    else
-      []
-    end
+  defp children do
+    Application.fetch_env!(:fz_vpn, :supervised_children)
   end
 end

--- a/apps/fz_vpn/lib/fz_vpn/interface/wg_adapter/sandbox.ex
+++ b/apps/fz_vpn/lib/fz_vpn/interface/wg_adapter/sandbox.ex
@@ -5,38 +5,28 @@ defmodule FzVpn.Interface.WGAdapter.Sandbox do
 
   use GenServer
 
-  @adapter_pid :sandbox_adapter_pid
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
 
   def get_device(name) do
-    GenServer.call(sandbox_pid(), {:get_device, name})
+    GenServer.call(__MODULE__, {:get_device, name})
   end
 
   def list_devices do
-    GenServer.call(sandbox_pid(), {:list_devices})
+    GenServer.call(__MODULE__, {:list_devices})
   end
 
   def set_device(config, name) do
-    GenServer.call(sandbox_pid(), {:set_device, config, name})
+    GenServer.call(__MODULE__, {:set_device, config, name})
   end
 
   def delete_device(name) do
-    GenServer.call(sandbox_pid(), {:delete_device, name})
+    GenServer.call(__MODULE__, {:delete_device, name})
   end
 
   def remove_peer(name, public_key) do
-    GenServer.call(sandbox_pid(), {:remove_peer, name, public_key})
-  end
-
-  defp sandbox_pid do
-    case Process.get(@adapter_pid) do
-      nil ->
-        {:ok, pid} = GenServer.start_link(__MODULE__, %{})
-        Process.put(@adapter_pid, pid)
-        pid
-
-      pid ->
-        pid
-    end
+    GenServer.call(__MODULE__, {:remove_peer, name, public_key})
   end
 
   @impl GenServer

--- a/apps/fz_vpn/lib/fz_vpn/stats_push_service.ex
+++ b/apps/fz_vpn/lib/fz_vpn/stats_push_service.ex
@@ -16,10 +16,7 @@ defmodule FzVpn.StatsPushService do
 
   @impl GenServer
   def init(state) do
-    if enabled?() do
-      :timer.send_interval(@interval, :perform)
-    end
-
+    :timer.send_interval(@interval, :perform)
     {:ok, state}
   end
 
@@ -30,9 +27,5 @@ defmodule FzVpn.StatsPushService do
 
   def push_stats do
     GenServer.call(Server.http_pid(), {:update_device_stats, Interface.dump(Server.iface_name())})
-  end
-
-  defp enabled? do
-    Application.fetch_env!(:fz_vpn, :stats_push_service_enabled)
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -106,8 +106,9 @@ config :fz_vpn,
   wireguard_interface_name: "wg-firezone",
   wireguard_port: 51_820,
   wireguard_endpoint: "127.0.0.1",
-  wg_adapter: FzVpn.Interface.WGAdapter.Sandbox,
-  server_process_opts: [name: {:global, :fz_vpn_server}]
+  wg_adapter: FzVpn.Interface.WGAdapter.Live,
+  server_process_opts: [name: {:global, :fz_vpn_server}],
+  supervised_children: [FzVpn.Server, FzVpn.StatsPushService]
 
 config :fz_http, FzHttpWeb.Endpoint,
   render_errors: [view: FzHttpWeb.ErrorView, accepts: ~w(html json)],

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -40,17 +40,13 @@ egress_interface = System.get_env("EGRESS_INTERFACE") || get_egress_interface.()
 {fz_wall_cli_module, _} =
   Code.eval_string(System.get_env("FZ_WALL_CLI_MODULE", "FzWall.CLI.Sandbox"))
 
-{fz_vpn_wgadapter_module, _} =
-  Code.eval_string(System.get_env("FZ_VPN_WGADAPTER_MODULE", "FzVpn.Interface.WGAdapter.Sandbox"))
-
 config :fz_wall,
   nft_path: System.get_env("NFT_PATH", "nft"),
   egress_interface: egress_interface,
   cli: fz_wall_cli_module
 
 config :fz_vpn,
-  wireguard_private_key_path: "priv/wg_dev_private_key",
-  wg_adapter: fz_vpn_wgadapter_module
+  wireguard_private_key_path: "priv/wg_dev_private_key"
 
 # Auth
 local_auth_enabled = System.get_env("LOCAL_AUTH_ENABLED") == "true"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,9 +10,6 @@ import Config
 # which you should run after static files are built and
 # before starting your production server.
 
-config :fz_vpn,
-  wg_adapter: FzVpn.Interface.WGAdapter.Live
-
 config :fz_wall,
   nft_path: "nft",
   cli: FzWall.CLI.Sandbox

--- a/config/test.exs
+++ b/config/test.exs
@@ -82,5 +82,6 @@ config :fz_http, :openid_connect, OpenIDConnect.Mock
 config :fz_http, FzHttp.Mailer, adapter: Swoosh.Adapters.Test, from_email: "test@firez.one"
 
 config :fz_vpn,
-  # XXX: Bump test coverage by replacing this with a stubbed out module
-  stats_push_service_enabled: false
+  # XXX: Bump test coverage by adding a stubbed out module for FzVpn.StatsPushService
+  supervised_children: [FzVpn.Interface.WGAdapter.Sandbox, FzVpn.Server],
+  wg_adapter: FzVpn.Interface.WGAdapter.Sandbox


### PR DESCRIPTION
I noticed this error when running with the sandbox adapter:
```
[error] GenServer #PID<0.947.0> terminating
** (UndefinedFunctionError) function nil.peers/0 is undefined
    nil.peers()
    (fz_vpn 0.0.0+git.0.deadbeef) lib/fz_vpn/interface.ex:141: FzVpn.Interface.dump/1
    (fz_vpn 0.0.0+git.0.deadbeef) lib/fz_vpn/stats_push_service.ex:32: FzVpn.StatsPushService.push_stats/0
    (fz_vpn 0.0.0+git.0.deadbeef) lib/fz_vpn/stats_push_service.ex:28: FzVpn.StatsPushService.handle_info/2
    (stdlib 4.0.1) gen_server.erl:1120: :gen_server.try_dispatch/4
    (stdlib 4.0.1) gen_server.erl:1197: :gen_server.handle_msg/6
    (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: :perform
State: %{}
```
The cause of the error was that the server & stats push service modules had their own process dictionaries, so two sandbox adapters were started, one with the `wg-firezone` device set and the other without causing the nil error.

~So I moved the sandbox to being started conditionally with fz_vpn's application supervisor instead.~