### PR TITLE
Fix handling invalid client reason

### DIFF
--- a/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
@@ -83,7 +83,10 @@ defmodule FzHttpWeb.AuthController do
       # Error verifying claims or fetching tokens
       {:error, action, reason} ->
         Logger.warn("OpenIDConnect Error during #{action}: #{inspect(reason)}")
-        send_resp(conn, 401, "")
+
+        conn
+        |> put_flash(:error, "Failed when performing this action: #{action}")
+        |> redirect(to: Routes.root_path(conn, :index))
     end
   end
 

--- a/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
@@ -82,7 +82,7 @@ defmodule FzHttpWeb.AuthController do
 
       # Error verifying claims or fetching tokens
       {:error, action, reason} ->
-        Logger.warn("OpenIDConnect Error during #{action}: #{reason}")
+        Logger.warn("OpenIDConnect Error during #{action}: #{inspect(reason)}")
         send_resp(conn, 401, "")
     end
   end


### PR DESCRIPTION
Fix a bug @gongjason encountered when testing `onelogin`

```
==> /var/log/firezone/phoenix/current <==
2022-07-20_23:27:48.69174 23:27:48.691 request_id=FwOtVRIu4CsQCZcAAANR [info] GET /auth/oidc/onelogin/callback/
2022-07-20_23:27:48.86157 23:27:48.861 request_id=FwOtVRIu4CsQCZcAAANR [info] Sent 500 in 169ms

==> /var/log/firezone/nginx/access.log <==
104.171.53.75 - - [2022-07-20T23:27:48+00:00]  "GET /auth/oidc/onelogin/callback/?code=_aFgsYoc3BRg5v40bZH0202HWhv&state=lXqO3_5spqnbUIwc HTTP/1.1" 500 1010 "0.171" 21 "https://firezonedemo-dev.onelogin.com/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"

==> /var/log/firezone/phoenix/current <==
2022-07-20_23:27:48.89047 23:27:48.868 [error] #PID<0.540.0> running FzHttpWeb.Endpoint (connection #PID<0.539.0>, stream id 1) terminated
2022-07-20_23:27:48.89064 Server: awsdemo.firezone.dev:80 (http)
2022-07-20_23:27:48.89072 Request: GET /auth/oidc/onelogin/callback/?code=_aFgsYoc3BRg5v40bZH0202HWhv&state=lXqO3_5spqnbUIwc
2022-07-20_23:27:48.89079 ** (exit) an exception was raised:
2022-07-20_23:27:48.89086     ** (Protocol.UndefinedError) protocol String.Chars not implemented for %HTTPoison.Response{body: "{\"error\":\"invalid_client\",\"error_description\":\"client authentication failed\"}", headers: [{"cache-control", "no-cache, no-store"}, {"content-length", "77"}, {"content-type", "application/json; charset=utf-8"}, {"date", "Wed, 20 Jul 2022 23:27:48 GMT"}, {"pragma", "no-cache"}, {"vary", "Origin"}, {"strict-transport-security", "max-age=63072000; includeSubDomains;"}, {"x-content-type-options", "nosniff"}, {"set-cookie", "ol_oidc_canary_113=false; path=/; domain=.onelogin.com; HttpOnly; Secure"}], request: %HTTPoison.Request{body: {:form, [{:client_id, "634919f0-cbb9-013a-5101-02834cac517f210911"}, {:client_secret, "4aa0dfed1b5e6abcefd20a4dd04bd100e16735e8e41f9c12dc0dd214707d57af"}, {:grant_type, "authorization_code"}, {:redirect_uri, "https://awsdemo.firezone.dev/auth/oidc/onelogin/callback/"}, {"code", "_aFgsYoc3BRg5v40bZH0202HWhv"}, {"provider", "onelogin"}, {"state", "lXqO3_5spqnbUIwc"}]}, headers: [{"Content-Type", "application/x-www-form-urlencoded"}], method: :post, options: [], params: %{}, url: "https://firezonedemo-dev.onelogin.com/oidc/2/token"}, request_url: "https://firezonedemo-dev.onelogin.com/oidc/2/token", status_code: 401} of type HTTPoison.Response (a struct). This protocol is implemented for the following type(s): Atom, BitString, CIDR, Date, DateTime, Decimal, FileSize.Bit, FileSize.Byte, Float, Integer, List, NaiveDateTime, Phoenix.LiveComponent.CID, Postgrex.Copy, Postgrex.INET, Postgrex.MACADDR, Postgrex.Query, Time, URI, Version, Version.Requirement
2022-07-20_23:27:48.89111         (elixir 1.13.4) lib/string/chars.ex:3: String.Chars.impl_for!/1
2022-07-20_23:27:48.89118         (elixir 1.13.4) lib/string/chars.ex:22: String.Chars.to_string/1
2022-07-20_23:27:48.89123         (fz_http 0.4.5) lib/fz_http_web/controllers/auth_controller.ex:89: FzHttpWeb.AuthController.callback/2
2022-07-20_23:27:48.89128         (fz_http 0.4.5) lib/fz_http_web/controllers/auth_controller.ex:1: FzHttpWeb.AuthController.action/2
2022-07-20_23:27:48.89132         (fz_http 0.4.5) lib/fz_http_web/controllers/auth_controller.ex:1: FzHttpWeb.AuthController.phoenix_controller_pipeline/2
2022-07-20_23:27:48.89136         (phoenix 1.6.10) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
2022-07-20_23:27:48.89140         (fz_http 0.4.5) lib/fz_http_web/endpoint.ex:1: FzHttpWeb.Endpoint.plug_builder_call/2
2022-07-20_23:27:48.89144         (fz_http 0.4.5) lib/fz_http_web/endpoint.ex:1: FzHttpWeb.Endpoint.call/2
```