### PR TITLE
Add onelogin to authentication docs

### DIFF
--- a/docs/docs/authenticate/README.md
+++ b/docs/docs/authenticate/README.md
@@ -56,6 +56,8 @@ default['firezone']['authentication']['oidc'] = {
 }
 ```
 
+The following config settings are required for the integration:
+
 1. `discovery_document_uri`: This URL returns a JSON with information to
 construct a request to the OpenID server.
 1. `client_id`: The client ID of the application.

--- a/docs/docs/authenticate/README.md
+++ b/docs/docs/authenticate/README.md
@@ -22,7 +22,7 @@ through an OIDC provider. The configuration file can be found at
 `/etc/firezone/firezone.rb`. To pick up changes, run `firezone-ctl reconfigure`
 and `firezone-ctl restart` to update the application.
 
-```shell
+```ruby
 # This is an example using Google and Okta as an SSO identity provider.
 # Multiple OIDC configs can be added to the same Firezone instance.
 

--- a/docs/docs/authenticate/README.md
+++ b/docs/docs/authenticate/README.md
@@ -22,7 +22,7 @@ through an OIDC provider. The configuration file can be found at
 `/etc/firezone/firezone.rb`. To pick up changes, run `firezone-ctl reconfigure`
 and `firezone-ctl restart` to update the application.
 
-```ruby
+```shell
 # This is an example using Google and Okta as an SSO identity provider.
 # Multiple OIDC configs can be added to the same Firezone instance.
 

--- a/docs/docs/authenticate/README.md
+++ b/docs/docs/authenticate/README.md
@@ -96,9 +96,12 @@ If your identity provider is not listed above, but has a generic OIDC
 connector, please consult their documentation to find instructions on obtaining
 the config settings required.
 
-Join our [Slack](https://www.firezone.dev/slack) to request additional help or
-open a [Github Issue](https://github.com/firezone/firezone/issues) to request
-additional documentation for your provider.
+Open a [Github Issue](https://github.com/firezone/firezone/issues)
+to request documentation
+or submit a [pull request](https://github.com/firezone/firezone/tree/master/docs/docs/authenticate/index.md)
+to add documentation for your provider.
+If you require assistance in setting up your OIDC provider, please
+join the [Firezone Slack group](https://www.firezone.dev/slack).
 
 ## Enforce Periodic Re-authentication
 

--- a/docs/docs/authenticate/README.md
+++ b/docs/docs/authenticate/README.md
@@ -58,8 +58,10 @@ default['firezone']['authentication']['oidc'] = {
 
 The following config settings are required for the integration:
 
-1. `discovery_document_uri`: This URL returns a JSON with information to
-construct a request to the OpenID server.
+1. `discovery_document_uri`: The
+[OpenID Connect provider configuration URI](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
+which returns a JSON document used to construct subsequent requests to this
+OIDC provider.
 1. `client_id`: The client ID of the application.
 1. `client_secret`: The client secret of the application.
 1. `redirect_uri`: Instructs OIDC provider where to redirect after authentication.

--- a/docs/docs/authenticate/azuread.md
+++ b/docs/docs/authenticate/azuread.md
@@ -64,7 +64,7 @@ click `Add a permission`, and select `Microsoft Graph`. Add `email`, `openid`,
 
 Edit `/etc/firezone/firezone.rb` to include the options below.
 
-```shell
+```ruby
 # Using Azure Active Directory as the SSO identity provider
 default['firezone']['authentication']['oidc'] = {
   azure: {

--- a/docs/docs/authenticate/azuread.md
+++ b/docs/docs/authenticate/azuread.md
@@ -62,7 +62,7 @@ click `Add a permission`, and select `Microsoft Graph`. Add `email`, `openid`,
 
 Edit `/etc/firezone/firezone.rb` to include the options below.
 
-```ruby
+```shell
 # Using Azure Active Directory as the SSO identity provider
 default['firezone']['authentication']['oidc'] = {
   azure: {

--- a/docs/docs/authenticate/azuread.md
+++ b/docs/docs/authenticate/azuread.md
@@ -7,8 +7,10 @@ Firezone supports Single Sign-On (SSO) using Azure Active Directory through the 
 OIDC connector. This guide will walk you through how to obtain the following
 config settings required for the integration:
 
-1. `discovery_document_uri`: This URL returns a JSON with information to
-construct a request to the OpenID server.
+1. `discovery_document_uri`: The
+[OpenID Connect provider configuration URI](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
+which returns a JSON document used to construct subsequent requests to this
+OIDC provider.
 1. `client_id`: The client ID of the application.
 1. `client_secret`: The client secret of the application.
 1. `redirect_uri`: Instructs OIDC provider where to redirect after authentication.

--- a/docs/docs/authenticate/google.md
+++ b/docs/docs/authenticate/google.md
@@ -7,8 +7,10 @@ Firezone supports Single Sign-On (SSO) using Google Workspace and Cloud Identity
 through the generic OIDC connector. This guide will walk you through how to
 obtain the following config settings required for the integration:
 
-1. `discovery_document_uri`: This URL returns a JSON with information to
-construct a request to the OpenID server.
+1. `discovery_document_uri`: The
+[OpenID Connect provider configuration URI](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
+which returns a JSON document used to construct subsequent requests to this
+OIDC provider.
 1. `client_id`: The client ID of the application.
 1. `client_secret`: The client secret of the application.
 1. `redirect_uri`: Instructs OIDC provider where to redirect after authentication.

--- a/docs/docs/authenticate/google.md
+++ b/docs/docs/authenticate/google.md
@@ -79,7 +79,7 @@ These will be used together with the redirect URI in the next step.
 
 Edit `/etc/firezone/firezone.rb` to include the options below.
 
-```ruby
+```shell
 # Using Google as the SSO identity provider
 default['firezone']['authentication']['oidc'] = {
   google: {

--- a/docs/docs/authenticate/google.md
+++ b/docs/docs/authenticate/google.md
@@ -81,7 +81,7 @@ These will be used together with the redirect URI in the next step.
 
 Edit `/etc/firezone/firezone.rb` to include the options below.
 
-```shell
+```ruby
 # Using Google as the SSO identity provider
 default['firezone']['authentication']['oidc'] = {
   google: {

--- a/docs/docs/authenticate/local-auth.md
+++ b/docs/docs/authenticate/local-auth.md
@@ -1,6 +1,6 @@
 ---
 title: Local Authentication
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 By default, Firezone will use local email / password for authenticating users to

--- a/docs/docs/authenticate/okta.md
+++ b/docs/docs/authenticate/okta.md
@@ -7,8 +7,10 @@ Firezone supports Single Sign-On (SSO) using Okta
 through the generic OIDC connector. This guide will walk you through how to
 obtain the following config settings required for the integration:
 
-1. `discovery_document_uri`: This URL returns a JSON with information to
-construct a request to the OpenID server.
+1. `discovery_document_uri`: The
+[OpenID Connect provider configuration URI](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
+which returns a JSON document used to construct subsequent requests to this
+OIDC provider.
 1. `client_id`: The client ID of the application.
 1. `client_secret`: The client secret of the application.
 1. `redirect_uri`: Instructs OIDC provider where to redirect after authentication.

--- a/docs/docs/authenticate/okta.md
+++ b/docs/docs/authenticate/okta.md
@@ -59,7 +59,7 @@ and **Okta Domain**. These 3 values will be used in Step 2 to configure Firezone
 Edit `/etc/firezone/firezone.rb` to include the options below. Your `discovery_document_url`
 will be `/.well-known/openid-configuration` appended to the end of your `okta_domain`.
 
-```ruby
+```shell
 # Using Okta as the SSO identity provider
 default['firezone']['authentication']['oidc'] = {
   okta: {

--- a/docs/docs/authenticate/okta.md
+++ b/docs/docs/authenticate/okta.md
@@ -61,7 +61,7 @@ and **Okta Domain**. These 3 values will be used in Step 2 to configure Firezone
 Edit `/etc/firezone/firezone.rb` to include the options below. Your `discovery_document_url`
 will be `/.well-known/openid-configuration` appended to the end of your `okta_domain`.
 
-```shell
+```ruby
 # Using Okta as the SSO identity provider
 default['firezone']['authentication']['oidc'] = {
   okta: {

--- a/docs/docs/authenticate/onelogin.md
+++ b/docs/docs/authenticate/onelogin.md
@@ -1,6 +1,6 @@
 ---
 title: Onelogin
-sidebar_position: 4
+sidebar_position: 3
 ---
 
 Firezone supports Single Sign-On (SSO) using OneLogin

--- a/docs/docs/authenticate/onelogin.md
+++ b/docs/docs/authenticate/onelogin.md
@@ -1,0 +1,68 @@
+---
+title: Onelogin
+sidebar_position: 4
+---
+
+Firezone supports Single Sign-On (SSO) using OneLogin
+through the generic OIDC connector. This guide will walk you through how to
+obtain the following config settings required for the integration:
+
+1. `discovery_document_uri`: This URL returns a JSON with information to
+construct a request to the OpenID server.
+1. `client_id`: The client ID of the application.
+1. `client_secret`: The client secret of the application.
+1. `redirect_uri`: Instructs OIDC provider where to redirect after authentication.
+This should be your Firezone `EXTERNAL_URL + /auth/oidc/<provider_key>/callback/`
+(e.g. `https://firezone.example.com/auth/oidc/onelogin/callback/`).
+1. `response_type`: Set to `code`.
+1. `scope`: [OIDC scopes](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes)
+to obtain from your OIDC provider. This should be set to `openid email profile`
+to provide Firezone with the user's email in the returned claims.
+1. `label`: The button label text that shows up on your Firezone login screen.
+
+## Obtain Config Settings
+
+### Step 1 - Configure Custom Connector
+
+Create a new OIDC connector by visiting **Appliances > Custom Connectors**.
+
+1. **App name**: `Firezone`
+1. **Icon**: [Firezone logo](https://user-images.githubusercontent.com/52545545/156854754-da66a9e1-33d5-47f5-877f-eff8b330ab2b.png)
+or
+[Firezone icon](https://user-images.githubusercontent.com/52545545/156854754-da66a9e1-33d5-47f5-877f-eff8b330ab2b.png)
+(save link as).
+1. **Sign on method**: select **OpenID Connect**
+1. **Redirect URI**: Add your Firezone `<EXTERNAL_URL> + /auth/oidc/onelogin/callback/`
+(e.g. `https://firezone.example.com/auth/oidc/onelogin/callback/`).
+
+![Onelogin Configuration](https://user-images.githubusercontent.com/52545545/173190108-569e5cb5-e66b-4505-a4c5-fedd22872a04.png)
+
+### Step 2 - Configure the OIDC Application
+
+Next, click **Add App to Connector** to create an OIDC application. You will
+find the values for the config settings required by Firezone
+under the **SSO** sub-menu.
+
+![Onelogin Config Parameters](https://user-images.githubusercontent.com/52545545/173190389-d8cf7382-b415-413f-b16c-4196ccee6726.png)
+
+## Integrate With Firezone
+
+Edit `/etc/firezone/firezone.rb` to include the options below.
+
+```shell
+# Using Google as the SSO identity provider
+default['firezone']['authentication']['oidc'] = {
+  onelogin: {
+    discovery_document_uri: "https://<ONELOGIN_URL>/oidc/2/.well-known/openid-configuration",
+    client_id: "<CLIENT_ID>",
+    client_secret: "<CLIENT_SECRET>",
+    redirect_uri: "https://firezone.example.com/auth/oidc/onelogin/callback",
+    response_type: "code",
+    scope: "openid email profile",
+    label: "OneLogin"
+  }
+}
+```
+
+Run `firezone-ctl reconfigure`and `firezone-ctl restart` to update the application.
+You should now see a `Sign in with OneLogin` button at the root Firezone URL.

--- a/docs/docs/authenticate/onelogin.md
+++ b/docs/docs/authenticate/onelogin.md
@@ -7,8 +7,10 @@ Firezone supports Single Sign-On (SSO) using OneLogin
 through the generic OIDC connector. This guide will walk you through how to
 obtain the following config settings required for the integration:
 
-1. `discovery_document_uri`: This URL returns a JSON with information to
-construct a request to the OpenID server.
+1. `discovery_document_uri`: The
+[OpenID Connect provider configuration URI](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
+which returns a JSON document used to construct subsequent requests to this
+OIDC provider.
 1. `client_id`: The client ID of the application.
 1. `client_secret`: The client secret of the application.
 1. `redirect_uri`: Instructs OIDC provider where to redirect after authentication.
@@ -67,5 +69,5 @@ default['firezone']['authentication']['oidc'] = {
 }
 ```
 
-Run `firezone-ctl reconfigure`and `firezone-ctl restart` to update the application.
+Run `firezone-ctl reconfigure` to update the application.
 You should now see a `Sign in with OneLogin` button at the root Firezone URL.

--- a/docs/docs/authenticate/onelogin.md
+++ b/docs/docs/authenticate/onelogin.md
@@ -54,7 +54,7 @@ on this page as well.
 
 Edit `/etc/firezone/firezone.rb` to include the options below.
 
-```shell
+```ruby
 # Using Google as the SSO identity provider
 default['firezone']['authentication']['oidc'] = {
   onelogin: {

--- a/docs/docs/authenticate/onelogin.md
+++ b/docs/docs/authenticate/onelogin.md
@@ -39,11 +39,14 @@ or
 
 ### Step 2 - Configure the OIDC Application
 
-Next, click **Add App to Connector** to create an OIDC application. You will
-find the values for the config settings required by Firezone
-under the **SSO** sub-menu.
+Next, click **Add App to Connector** to create an OIDC application.
+Visit the **SSO** tab, then change the token endpoint authentication method
+to **POST**.
 
-![Onelogin Config Parameters](https://user-images.githubusercontent.com/52545545/173190389-d8cf7382-b415-413f-b16c-4196ccee6726.png)
+You will find the values for the config settings required by Firezone
+on this page as well.
+
+![Onelogin Config Parameters](https://user-images.githubusercontent.com/52545545/180120191-dfeab4ef-d7f5-4c04-a7b2-7d9338af34e6.png)
 
 ## Integrate With Firezone
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -62,14 +62,14 @@ const config = {
             "aria-label": "Old Documentation",
           },
           {
-            href: "https://github.com/facebook/docusaurus",
+            href: "https://discourse.firez.one/",
             label: "Ask a Question",
             position: "right",
             "aria-label": "GitHub repository",
           },
           {
-            href: "https://github.com/facebook/docusaurus",
-            label: "Join the Business Beta",
+            href: "https://www.firezone.dev/pricing",
+            label: "Join the Beta",
             position: "right",
             "aria-label": "GitHub repository",
           },
@@ -114,7 +114,7 @@ const config = {
               },
               {
                 label: "Slack",
-                href: "https://join.slack.com/t/firezone-users/shared_invite/zt-19jd956j4-rWcCqiKMh~ikPGsUFbvZiA",
+                href: "https://www.firezone.dev/slack",
               },
               {
                 label: "Github",


### PR DESCRIPTION
It was easier to create a new PR than to rebase https://github.com/firezone/firezone/pull/699 for the move to Docusaurus. 

This includes a small change required to get the OIDC refresh token. Similar to Google, Onelogin does not need the `offline_access` scope. Just needed to change the token endpoint authentication method to **POST**.

Thanks @princemaple for the help!