### PR TITLE
Remove no longer needed compilers declaration

### DIFF
--- a/apps/fz_http/mix.exs
+++ b/apps/fz_http/mix.exs
@@ -16,7 +16,7 @@ defmodule FzHttp.MixProject do
       lockfile: "../../mix.lock",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:phoenix, :gettext] ++ Mix.compilers(),
+      compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [


### PR DESCRIPTION
Not related to fixing the build, but 🤷 

:phoenix no longer needed in Phoenix 1.6+ with Elixir 1.11+
:gettext no longer needed in Gettext 0.20.0 (which we just upgraded to)