### PR TITLE
Fix fz_vpn server test

### DIFF
--- a/apps/fz_vpn/test/fz_vpn/interface_test.exs
+++ b/apps/fz_vpn/test/fz_vpn/interface_test.exs
@@ -12,12 +12,12 @@ defmodule FzVpn.InterfaceTest do
   end
 
   test "list interface names" do
-    expected_names = [Server.iface_name(), "wg0-list", "wg1-list"]
-    Enum.each(expected_names, fn name -> Interface.set(name, %{}) end)
+    additional_names = ["wg0-list", "wg1-list"]
+    Enum.each(additional_names, fn name -> Interface.set(name, %{}) end)
     {:ok, names} = Interface.list_names()
-    Enum.each(expected_names, fn name -> :ok = Interface.delete(name) end)
+    Enum.each(additional_names, fn name -> :ok = Interface.delete(name) end)
 
-    assert names == expected_names
+    assert names == [Server.iface_name()] ++ additional_names
   end
 
   test "remove peer from interface" do


### PR DESCRIPTION
Removing the `wg-firezone` interface test from the sandbox wg adapter will break server tests intermittently. Instead, just add it to the list of tested names. 

Long term, I can refactor these tests to run in isolation. I mostly had it there while working in between other things, but this is a quicker fix for now.