### PR TITLE
detect force_ssl config and error out

### DIFF
--- a/omnibus/package-scripts/firezone/preinst
+++ b/omnibus/package-scripts/firezone/preinst
@@ -39,7 +39,7 @@ configCheck() {
 
   if test -f $config_file && grep -q "^\s*default\['firezone'\]\['nginx'\]\['force_ssl'\]\s*=\s*false" $config_file ; then
     echo "${error}ERROR: Firezone 0.5+ removes support for disabling SSL redirect!${normal}"
-    echo "To deploy your own proxy instead see our new docs on how to do it: https://docs.firezone.dev/deploy/reverse-proxies"
+    echo "Instead, disable Nginx and point your SSL-terminating proxy directly to the phoenix app on port 13000. See the docs for more information: https://docs.firezone.dev/deploy/reverse-proxies"
     exit 1
   fi
 }

--- a/omnibus/package-scripts/firezone/preinst
+++ b/omnibus/package-scripts/firezone/preinst
@@ -36,6 +36,12 @@ configCheck() {
     echo "Please see our transition guide to move to a generic OIDC config: https://docs.firezone.dev/administer/upgrade#upgrading-from--050-to--050"
     exit 1
   fi
+
+  if test -f $config_file && grep -q "^\s*default\['firezone'\]\['nginx'\]\['force_ssl'\]\s*=\s*false" $config_file ; then
+    echo "${error}ERROR: Firezone 0.5+ removes support for disabling SSL redirect!${normal}"
+    echo "To deploy your own proxy instead see our new docs on how to do it: https://docs.firezone.dev/deploy/reverse-proxies"
+    exit 1
+  fi
 }
 
 capture () {


### PR DESCRIPTION
Based on firezone/product#425 detect when `force_ssl` is `false` and redirect to the proxy config docs to prevent confusion if someone deployed their own proy before `0.5.0`.

Will create a separate PR to remove further options for http-related nginx config.