### PR TITLE
Don't fail fast for publishing to Cloudsmith

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
-
     strategy:
+      fail-fast: false
       matrix:
         include:
           # ARM-based


### PR DESCRIPTION
Getting intermittent failures publishing to Cloudsmith. This should at least allow the successful packages to finish syncing.