### PR TITLE
Clarify when UI config is overriding ENV config

### DIFF
--- a/apps/fz_http/lib/fz_http_web/live/setting_live/security.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/security.html.heex
@@ -29,8 +29,7 @@
     </.form>
   </div>
 
-  <div class="block"
-       title={if(!is_nil(Conf.get(:local_auth_enabled)), do: @override_title)}>
+  <div class="block" title={@field_titles.local_auth_enabled}>
 
     <strong>Local Auth</strong>
 
@@ -50,8 +49,7 @@
     </div>
   </div>
 
-  <div class="block"
-       title={if(!is_nil(Conf.get(:allow_unprivileged_device_management)), do: @override_title)}>
+  <div class="block" title={@field_titles.allow_unprivileged_device_management}>
 
     <strong>Allow unprivileged device management</strong>
 
@@ -82,8 +80,7 @@
     </p>
   </div>
 
-  <div class="block"
-       title={if(!is_nil(Conf.get(:disable_vpn_on_oidc_error)), do: @override_title)}>
+  <div class="block" title={@field_titles.disable_vpn_on_oidc_error}>
     <strong>Auto disable VPN</strong>
 
     <div class="level">
@@ -102,8 +99,7 @@
     </div>
   </div>
 
-  <div class="block"
-       title={if(!is_nil(Conf.get(:auto_create_oidc_users)), do: @override_title)}>
+  <div class="block" title={@field_titles.auto_create_oidc_users}>
     <strong>Auto create OIDC users</strong>
 
     <div class="level">
@@ -122,8 +118,7 @@
     </div>
   </div>
 
-  <div class="block"
-       title={if(!is_nil(Conf.get(:openid_connect_providers)), do: @override_title)}>
+  <div class="block" title={@field_titles.openid_connect_providers}>
     <.form let={f} for={@config_changeset} id="oidc-config-form" phx-submit="save_oidc_config">
       <div class="field">
         <%= label f, :openid_connect_providers, "OpenID Connect providers configuration",

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/security.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/security.html.heex
@@ -29,7 +29,9 @@
     </.form>
   </div>
 
-  <div class="block">
+  <div class="block"
+       title={if(!is_nil(Conf.get(:local_auth_enabled)), do: @override_title)}>
+
     <strong>Local Auth</strong>
 
     <div class="level">
@@ -38,7 +40,8 @@
       </div>
       <div class="level-right">
         <label class="switch is-medium">
-          <input type="checkbox" phx-click="toggle" phx-value-config="local_auth_enabled"
+          <input type="checkbox" phx-click="toggle"
+              phx-value-config="local_auth_enabled"
               checked={Conf.get(:local_auth_enabled)}
               value={if(!Conf.get(:local_auth_enabled), do: "on")} />
           <span class="check"></span>
@@ -47,7 +50,9 @@
     </div>
   </div>
 
-  <div class="block">
+  <div class="block"
+       title={if(!is_nil(Conf.get(:allow_unprivileged_device_management)), do: @override_title)}>
+
     <strong>Allow unprivileged device management</strong>
 
     <div class="level">
@@ -77,7 +82,8 @@
     </p>
   </div>
 
-  <div class="block">
+  <div class="block"
+       title={if(!is_nil(Conf.get(:disable_vpn_on_oidc_error)), do: @override_title)}>
     <strong>Auto disable VPN</strong>
 
     <div class="level">
@@ -96,7 +102,8 @@
     </div>
   </div>
 
-  <div class="block">
+  <div class="block"
+       title={if(!is_nil(Conf.get(:auto_create_oidc_users)), do: @override_title)}>
     <strong>Auto create OIDC users</strong>
 
     <div class="level">
@@ -115,16 +122,25 @@
     </div>
   </div>
 
-  <div class="block">
+  <div class="block"
+       title={if(!is_nil(Conf.get(:openid_connect_providers)), do: @override_title)}>
     <.form let={f} for={@config_changeset} id="oidc-config-form" phx-submit="save_oidc_config">
       <div class="field">
         <%= label f, :openid_connect_providers, "OpenID Connect providers configuration",
             class: "label" %>
+        <p>
+          Enter a valid JSON string representing the OIDC configuration to apply.
+          Read more about the format of this field in
+          <a href="https://docs.firezone.dev/authenticate">
+            our documentation
+          </a>.
+        </p>
 
         <div class="control">
           <%= textarea f,
               :openid_connect_providers,
-              placeholder: ~s|{"google": {...}, "okta": {...}}|,
+              rows: 10,
+              placeholder: @oidc_placeholder,
               class: "textarea #{input_error_class(@config_changeset, :openid_connect_providers)}" %>
         </div>
 
@@ -133,7 +149,7 @@
         </p>
       </div>
 
-      <%= Phoenix.View.render(FzHttpWeb.SharedView, "submit_button.html", []) %>
+      <%= Phoenix.View.render(FzHttpWeb.SharedView, "submit_button.html", button_text: "Save Providers") %>
     </.form>
   </div>
 </section>

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/security_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/security_live.ex
@@ -10,7 +10,6 @@ defmodule FzHttpWeb.SettingLive.Security do
 
   @page_title "Security Settings"
   @page_subtitle "Configure security-related settings."
-  @override_title "This value is overridding the configuration file value."
   @oidc_placeholder """
   {
     "google": {
@@ -35,7 +34,7 @@ defmodule FzHttpWeb.SettingLive.Security do
      |> assign(:session_duration_options, session_duration_options())
      |> assign(:site_changeset, site_changeset())
      |> assign(:config_changeset, config_changeset)
-     |> assign(:override_title, @override_title)
+     |> assign(:field_titles, field_titles(config_changeset))
      |> assign(:oidc_placeholder, @oidc_placeholder)
      |> assign(:page_subtitle, @page_subtitle)
      |> assign(:page_title, @page_title)}
@@ -122,5 +121,26 @@ defmodule FzHttpWeb.SettingLive.Security do
   defp site_changeset do
     Sites.get_site!()
     |> Sites.change_site()
+  end
+
+  @fields ~w(
+    local_auth_enabled
+    disable_vpn_on_oidc_error
+    allow_unprivileged_device_management
+    auto_create_oidc_users
+    openid_connect_providers
+  )a
+  @override_title """
+  This value is currently overriding the value set in your configuration file.
+  """
+  defp field_titles(changeset) do
+    @fields
+    |> Map.new(fn key ->
+      if is_nil(get_field(changeset, key)) do
+        {key, ""}
+      else
+        {key, @override_title}
+      end
+    end)
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/security_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/security_live.ex
@@ -10,6 +10,20 @@ defmodule FzHttpWeb.SettingLive.Security do
 
   @page_title "Security Settings"
   @page_subtitle "Configure security-related settings."
+  @override_title "This value is overridding the configuration file value."
+  @oidc_placeholder """
+  {
+    "google": {
+      "discovery_document_uri": "https://accounts.google.com/.well-known/openid-configuration",
+      "client_id": "CLIENT_ID",
+      "client_secret": "CLIENT_SECRET",
+      "redirect_uri": "https://firezone.example.com/auth/oidc/google/callback/",
+      "response_type": "code",
+      "scope:" "openid email profile",
+      "label": "Google"
+    }
+  }
+  """
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -21,6 +35,8 @@ defmodule FzHttpWeb.SettingLive.Security do
      |> assign(:session_duration_options, session_duration_options())
      |> assign(:site_changeset, site_changeset())
      |> assign(:config_changeset, config_changeset)
+     |> assign(:override_title, @override_title)
+     |> assign(:oidc_placeholder, @oidc_placeholder)
      |> assign(:page_subtitle, @page_subtitle)
      |> assign(:page_title, @page_title)}
   end


### PR DESCRIPTION
~~Fixes a UX issue where users are now confused which applies first: the UI setting or the config file setting.~~

~~Config file / ENV var settings should take precedence -- will allow a local admin to override configs when starting Firezone from the CLI.~~

EDIT: Holding after discussing with @princemaple 