### PR TITLE
Fix config ui out of sync

### DIFF
--- a/apps/fz_http/lib/fz_http_web/live/setting_live/security.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/security.html.heex
@@ -43,8 +43,8 @@
       <div class="level-right">
         <label class="switch is-medium">
           <input type="checkbox" phx-click="toggle" phx-value-config="local_auth_enabled"
-              checked={@configs.local_auth_enabled}
-              value={if(!@configs.local_auth_enabled, do: "on")} />
+              checked={Conf.get(:local_auth_enabled)}
+              value={if(!Conf.get(:local_auth_enabled), do: "on")} />
           <span class="check"></span>
         </label>
       </div>
@@ -62,8 +62,8 @@
         <label class="switch is-medium">
           <input type="checkbox" phx-click="toggle"
               phx-value-config="allow_unprivileged_device_management"
-              checked={@configs.allow_unprivileged_device_management}
-              value={if(!@configs.allow_unprivileged_device_management, do: "on")} />
+              checked={Conf.get(:allow_unprivileged_device_management)}
+              value={if(!Conf.get(:allow_unprivileged_device_management), do: "on")} />
           <span class="check"></span>
         </label>
       </div>
@@ -92,8 +92,8 @@
         <label class="switch is-medium">
           <input type="checkbox" phx-click="toggle"
               phx-value-config="disable_vpn_on_oidc_error"
-              checked={@configs.disable_vpn_on_oidc_error}
-              value={if(!@configs.disable_vpn_on_oidc_error, do: "on")} />
+              checked={Conf.get(:disable_vpn_on_oidc_error)}
+              value={if(!Conf.get(:disable_vpn_on_oidc_error), do: "on")} />
           <span class="check"></span>
         </label>
       </div>
@@ -111,8 +111,8 @@
         <label class="switch is-medium">
           <input type="checkbox" phx-click="toggle"
               phx-value-config="auto_create_oidc_users"
-              checked={@configs.auto_create_oidc_users}
-              value={if(!@configs.auto_create_oidc_users, do: "on")} />
+              checked={Conf.get(:auto_create_oidc_users)}
+              value={if(!Conf.get(:auto_create_oidc_users), do: "on")} />
           <span class="check"></span>
         </label>
       </div>

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/security_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/security_live.ex
@@ -18,7 +18,6 @@ defmodule FzHttpWeb.SettingLive.Security do
      |> assign(:session_duration_options, session_duration_options())
      |> assign(:site_changeset, site_changeset())
      |> assign(:config_changeset, config_changeset)
-     |> assign(:configs, config_changeset.data)
      |> assign(:page_title, "Security Settings")}
   end
 
@@ -54,8 +53,8 @@ defmodule FzHttpWeb.SettingLive.Security do
   @impl Phoenix.LiveView
   def handle_event("toggle", %{"config" => config} = params, socket) do
     toggle_value = !!params["value"]
-    {:ok, conf} = Conf.update_configuration(%{config => toggle_value})
-    {:noreply, assign(socket, :configs, conf)}
+    {:ok, _conf} = Conf.update_configuration(%{config => toggle_value})
+    {:noreply, socket}
   end
 
   @impl Phoenix.LiveView

--- a/apps/fz_http/test/fz_http_web/live/setting_live/security_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/setting_live/security_test.exs
@@ -49,63 +49,27 @@ defmodule FzHttpWeb.SettingLive.SecurityTest do
     end
   end
 
-  describe "toggles with db nil value" do
-    setup %{admin_conn: conn} do
-      Conf.update_configuration(%{
-        local_auth_enabled: nil,
-        allow_unprivileged_device_management: nil,
-        disable_vpn_on_oidc_error: nil,
-        auto_create_oidc_users: nil
-      })
+  describe "toggles" do
+    setup %{admin_conn: conn, config: config, config_val: config_val} do
+      Conf.update_configuration(%{config => config_val})
 
       FzHttp.Conf.Cache.init([])
 
       {:ok, path: Routes.setting_security_path(conn, :show)}
     end
 
-    for t <- [
-          :local_auth_enabled,
-          :allow_unprivileged_device_management,
-          :disable_vpn_on_oidc_error,
-          :auto_create_oidc_users
+    for {t, val} <- [
+          {:local_auth_enabled, true},
+          {:allow_unprivileged_device_management, true},
+          {:disable_vpn_on_oidc_error, true},
+          {:auto_create_oidc_users, true},
+          {:local_auth_enabled, nil},
+          {:allow_unprivileged_device_management, nil},
+          {:disable_vpn_on_oidc_error, nil},
+          {:auto_create_oidc_users, nil}
         ] do
-      test "toggle #{t}", %{admin_conn: conn, path: path} do
-        {:ok, view, _html} = live(conn, path)
-        html = view |> element("input[phx-value-config=#{unquote(t)}]") |> render()
-        assert html =~ "checked"
-
-        view |> element("input[phx-value-config=#{unquote(t)}]") |> render_click()
-        assert Conf.get(unquote(t)) == false
-
-        {:ok, view, _html} = live(conn, path)
-        html = view |> element("input[phx-value-config=#{unquote(t)}]") |> render()
-        refute html =~ "checked"
-
-        view |> element("input[phx-value-config=#{unquote(t)}]") |> render_click()
-        assert Conf.get(unquote(t)) == true
-      end
-    end
-  end
-
-  describe "toggles with db existing value" do
-    setup %{admin_conn: conn} do
-      Conf.update_configuration(%{
-        local_auth_enabled: true,
-        allow_unprivileged_device_management: true,
-        disable_vpn_on_oidc_error: true,
-        auto_create_oidc_users: true
-      })
-
-      {:ok, path: Routes.setting_security_path(conn, :show)}
-    end
-
-    for t <- [
-          :local_auth_enabled,
-          :allow_unprivileged_device_management,
-          :disable_vpn_on_oidc_error,
-          :auto_create_oidc_users
-        ] do
-      test "toggle #{t}", %{admin_conn: conn, path: path} do
+      @tag [config: t, config_val: val]
+      test "toggle #{t} when value in db is #{val}", %{admin_conn: conn, path: path} do
         {:ok, view, _html} = live(conn, path)
         html = view |> element("input[phx-value-config=#{unquote(t)}]") |> render()
         assert html =~ "checked"

--- a/apps/fz_http/test/fz_http_web/live/setting_live/security_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/setting_live/security_test.exs
@@ -49,18 +49,18 @@ defmodule FzHttpWeb.SettingLive.SecurityTest do
     end
   end
 
-  describe "toggles" do
+  describe "toggles with db nil value" do
     setup %{admin_conn: conn} do
       Conf.update_configuration(%{
-        local_auth_enabled: true,
-        allow_unprivileged_device_management: true,
-        disable_vpn_on_oidc_error: true,
-        auto_create_oidc_users: true
+        local_auth_enabled: nil,
+        allow_unprivileged_device_management: nil,
+        disable_vpn_on_oidc_error: nil,
+        auto_create_oidc_users: nil
       })
 
-      path = Routes.setting_security_path(conn, :show)
-      {:ok, view, _html} = live(conn, path)
-      [view: view]
+      FzHttp.Conf.Cache.init([])
+
+      {:ok, path: Routes.setting_security_path(conn, :show)}
     end
 
     for t <- [
@@ -69,13 +69,51 @@ defmodule FzHttpWeb.SettingLive.SecurityTest do
           :disable_vpn_on_oidc_error,
           :auto_create_oidc_users
         ] do
-      test "toggle #{t}", %{view: view} do
+      test "toggle #{t}", %{admin_conn: conn, path: path} do
+        {:ok, view, _html} = live(conn, path)
         html = view |> element("input[phx-value-config=#{unquote(t)}]") |> render()
         assert html =~ "checked"
 
         view |> element("input[phx-value-config=#{unquote(t)}]") |> render_click()
         assert Conf.get(unquote(t)) == false
 
+        {:ok, view, _html} = live(conn, path)
+        html = view |> element("input[phx-value-config=#{unquote(t)}]") |> render()
+        refute html =~ "checked"
+
+        view |> element("input[phx-value-config=#{unquote(t)}]") |> render_click()
+        assert Conf.get(unquote(t)) == true
+      end
+    end
+  end
+
+  describe "toggles with db existing value" do
+    setup %{admin_conn: conn} do
+      Conf.update_configuration(%{
+        local_auth_enabled: true,
+        allow_unprivileged_device_management: true,
+        disable_vpn_on_oidc_error: true,
+        auto_create_oidc_users: true
+      })
+
+      {:ok, path: Routes.setting_security_path(conn, :show)}
+    end
+
+    for t <- [
+          :local_auth_enabled,
+          :allow_unprivileged_device_management,
+          :disable_vpn_on_oidc_error,
+          :auto_create_oidc_users
+        ] do
+      test "toggle #{t}", %{admin_conn: conn, path: path} do
+        {:ok, view, _html} = live(conn, path)
+        html = view |> element("input[phx-value-config=#{unquote(t)}]") |> render()
+        assert html =~ "checked"
+
+        view |> element("input[phx-value-config=#{unquote(t)}]") |> render_click()
+        assert Conf.get(unquote(t)) == false
+
+        {:ok, view, _html} = live(conn, path)
         html = view |> element("input[phx-value-config=#{unquote(t)}]") |> render()
         refute html =~ "checked"
 


### PR DESCRIPTION
My bad.

I did this "refactor fix" to cope with something else, at the end of that PR, forgetting that this actually missed a designed behaviour. My db was already populated with value and I failed to realize that it's no longer handling the empty db config case.