### PR TITLE
Use dummy ACME cert initially; Reload nginx immediately before ACME issuance

### DIFF
--- a/docs/docs/administer/security-considerations.md
+++ b/docs/docs/administer/security-considerations.md
@@ -16,7 +16,8 @@ Shown below is a table of ports used by Firezone services.
 
 | Service | Default port | Listen address | Description |
 | ------ | --------- | ------- | --------- |
-| Nginx | `80` `443` | `all` | Public HTTP(S) port for administering Firezone and facilitating authentication. |
+| Nginx | `443` | `all` | Public HTTPS port for administering Firezone and facilitating authentication. |
+| Nginx | `80` | `all` | Public HTTP port used for ACME. Disabled when ACME is disabled. |
 | WireGuard | `51820` | `all` | Public WireGuard port used for VPN sessions. |
 | Postgresql | `15432` | `127.0.0.1` | Local-only port used for bundled Postgresql server. |
 | Phoenix | `13000` | `127.0.0.1` | Local-only port used by upstream elixir app server. |

--- a/omnibus/cookbooks/firezone/recipes/acme.rb
+++ b/omnibus/cookbooks/firezone/recipes/acme.rb
@@ -66,6 +66,9 @@ if node['firezone']['ssl']['acme']['enabled'] && !node['firezone']['ssl']['certi
   end
 
   execute 'ACME issue' do
+    # Pick up any nginx conf changes that may have happened during this Chef run
+    notifies :reload, 'component_runit_service[nginx]', :immediately
+
     # Command returns 0: Cert was issued
     # Command returns 2: Skipping because renewal isn't needed
     returns [0, 2]

--- a/omnibus/cookbooks/firezone/recipes/acme.rb
+++ b/omnibus/cookbooks/firezone/recipes/acme.rb
@@ -65,10 +65,13 @@ if node['firezone']['ssl']['acme']['enabled'] && !node['firezone']['ssl']['certi
     ACME
   end
 
-  execute 'ACME issue' do
-    # Pick up any nginx conf changes that may have happened during this Chef run
+  # Pick up any nginx conf changes that may have happened during this Chef run
+  execute 'Reload Nginx' do
     notifies :reload, 'component_runit_service[nginx]', :immediately
+    command 'echo "reloading nginx..."'
+  end
 
+  execute 'ACME issue' do
     # Command returns 0: Cert was issued
     # Command returns 2: Skipping because renewal isn't needed
     returns [0, 2]

--- a/omnibus/cookbooks/firezone/recipes/nginx.rb
+++ b/omnibus/cookbooks/firezone/recipes/nginx.rb
@@ -64,7 +64,8 @@ template 'redirect.conf' do
     server_name: URI.parse(node['firezone']['external_url']).host,
     acme_www_root: "#{node['firezone']['var_directory']}/nginx/acme_root",
     rate_limiting_zone_name: node['firezone']['nginx']['rate_limiting_zone_name'],
-    ipv6: node['firezone']['nginx']['ipv6']
+    ipv6: node['firezone']['nginx']['ipv6'],
+    acme: { 'enabled' => node['firezone']['ssl']['acme']['enabled'] }
   )
 end
 
@@ -74,6 +75,7 @@ if node['firezone']['nginx']['enabled']
     action :enable
     subscribes :restart, 'template[nginx.conf]'
     subscribes :restart, 'template[phoenix.nginx.conf]'
+    subscribes :restart, 'template[redirect.conf]'
     subscribes :restart, 'template[acme.conf]'
   end
 else

--- a/omnibus/cookbooks/firezone/recipes/nginx.rb
+++ b/omnibus/cookbooks/firezone/recipes/nginx.rb
@@ -65,7 +65,7 @@ template 'redirect.conf' do
     acme_www_root: "#{node['firezone']['var_directory']}/nginx/acme_root",
     rate_limiting_zone_name: node['firezone']['nginx']['rate_limiting_zone_name'],
     ipv6: node['firezone']['nginx']['ipv6'],
-    acme: { 'enabled' => node['firezone']['ssl']['acme']['enabled'] }
+    acme: node['firezone']['ssl']['acme']
   )
 end
 

--- a/omnibus/cookbooks/firezone/recipes/phoenix.rb
+++ b/omnibus/cookbooks/firezone/recipes/phoenix.rb
@@ -42,7 +42,7 @@ acme_key = "#{node['firezone']['var_directory']}/ssl/acme/#{fqdn}.key"
 end
 
 if node['firezone']['ssl']['acme']['enabled']
-  # Generate a temporary cert until ACME issues one
+  # Generate a temporary cert until ACME issues one so that nginx can be restarted
   openssl_x509_certificate acme_cert do
     common_name fqdn
     org node['firezone']['ssl']['company_name']

--- a/omnibus/cookbooks/firezone/templates/phoenix.nginx.conf.erb
+++ b/omnibus/cookbooks/firezone/templates/phoenix.nginx.conf.erb
@@ -21,7 +21,8 @@ server {
 
   server_name <%= @fqdn %>;
 
-  <% if @acme['enabled'] && !@ssl['certificate'] -%>
+  <% if @acme['enabled'] && !@ssl['certificate'] && \
+      File.exist?(@acme['certificate']) && File.exist?(@acme['certificate_key']) -%>
   ssl_certificate <%= @acme['certificate'] %>;
   ssl_certificate_key <%= @acme['certificate_key'] %>;
   <% else -%>

--- a/omnibus/cookbooks/firezone/templates/phoenix.nginx.conf.erb
+++ b/omnibus/cookbooks/firezone/templates/phoenix.nginx.conf.erb
@@ -21,8 +21,7 @@ server {
 
   server_name <%= @fqdn %>;
 
-  <% if @acme['enabled'] && !@ssl['certificate'] && \
-      File.exist?(@acme['certificate']) && File.exist?(@acme['certificate_key']) -%>
+  <% if @acme['enabled'] && !@ssl['certificate'] -%>
   ssl_certificate <%= @acme['certificate'] %>;
   ssl_certificate_key <%= @acme['certificate_key'] %>;
   <% else -%>

--- a/omnibus/cookbooks/firezone/templates/redirect.conf.erb
+++ b/omnibus/cookbooks/firezone/templates/redirect.conf.erb
@@ -1,3 +1,4 @@
+<% if @acme['enabled'] -%>
 server {
   listen 80 default_server;
   <% if @ipv6 -%>
@@ -10,3 +11,4 @@ server {
     alias <%= @acme_www_root %>/.well-known/acme-challenge/;
   }
 }
+<% end -%>


### PR DESCRIPTION
* Reload nginx config just before ACME issuance to ensure it's listening on port 80
* Use dummy ACME cert when writing `phoenix.nginx.conf` so that nginx starts without erroring

Fixes #931 