### PR TITLE
Prevent autocompleting passwords in FF

### DIFF
--- a/apps/fz_http/lib/fz_http_web/live/setting_live/account_form_component.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/account_form_component.html.heex
@@ -19,12 +19,14 @@
         "password_field.html",
         context: f,
         field: :password,
+        autocomplete: "new-password",
         label: "Password" %>
 
     <%= render FzHttpWeb.SharedView,
         "password_field.html",
         context: f,
         field: :password_confirmation,
+        autocomplete: "new-password",
         label: "Password Confirmation" %>
 
     <hr>

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/unprivileged/account_form_component.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/unprivileged/account_form_component.html.heex
@@ -8,12 +8,14 @@
         "password_field.html",
         context: f,
         field: :password,
+        autocomplete: "new-password",
         label: "Password" %>
 
     <%= render FzHttpWeb.SharedView,
         "password_field.html",
         context: f,
         field: :password_confirmation,
+        autocomplete: "new-password",
         label: "Password Confirmation" %>
 
   </.form>

--- a/apps/fz_http/lib/fz_http_web/live/user_live/form_component.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/form_component.html.heex
@@ -23,12 +23,14 @@
         "password_field.html",
         context: f,
         field: :password,
+        autocomplete: "new-password",
         label: "New Password" %>
 
     <%= render FzHttpWeb.SharedView,
         "password_field.html",
         context: f,
         field: :password_confirmation,
+        autocomplete: "new-password",
         label: "New Password Confirmation" %>
   </.form>
 </div>

--- a/apps/fz_http/lib/fz_http_web/templates/shared/password_field.html.heex
+++ b/apps/fz_http/lib/fz_http_web/templates/shared/password_field.html.heex
@@ -6,7 +6,7 @@
         @field,
         class: "input password",
         id: "#{@field}-field",
-        autocomplete: :off,
+        autocomplete: "new-password",
         data_target: "#{@field}-progress",
         phx_hook: "PasswordStrength" %>
   </div>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#preventing_autofilling_with_autocompletenew-password


# Before

<img width="1552" alt="Screen Shot 2022-08-29 at 10 26 03 PM" src="https://user-images.githubusercontent.com/167144/187357402-9424dae3-ae74-4a74-81e9-4e64c9b4806b.png">

# After

<img width="1552" alt="Screen Shot 2022-08-29 at 10 30 17 PM" src="https://user-images.githubusercontent.com/167144/187357418-41167f9a-9dd9-4739-b399-7d470ec6cf7e.png">

# After (Chrome)

<img width="1552" alt="Screen Shot 2022-08-29 at 10 30 44 PM" src="https://user-images.githubusercontent.com/167144/187357431-4a733c19-a732-4703-bf7b-f41d4f1b4109.png">
