### PR TITLE
remove `ct != established` from rules

### DIFF
--- a/apps/fz_wall/lib/fz_wall/cli/helpers/nft.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/helpers/nft.ex
@@ -227,7 +227,7 @@ defmodule FzWall.CLI.Helpers.Nft do
   defp dev_set_type(ip_type), do: filter_set_type(ip_type, false)
 
   defp additional_matches do
-    "ct state != established meta iifname #{wireguard_interface_name()}"
+    "meta iifname #{wireguard_interface_name()}"
   end
 
   defp rule_filter_match_str(type, dest_set, action, false) do


### PR DESCRIPTION
Refs firezone/product#476

Since we have `iifname wg-firezone` for all rules, rules no longer apply to returning packets so we can remove `ct != established`