### PR TITLE
Fix redirect always happening when issuing cert

### DIFF
--- a/omnibus/cookbooks/firezone/recipes/force_renewal.rb
+++ b/omnibus/cookbooks/firezone/recipes/force_renewal.rb
@@ -17,7 +17,7 @@ bin_path = "#{node['firezone']['install_directory']}/embedded/bin"
 acme_home = "#{node['firezone']['var_directory']}/#{server}/#{keylength}/acme"
 
 # Remove cronjob (if cronjob doesn't exist no harm is done)
-execute 'ACME remove cronjob' do
+execute 'ACME force cronjob' do
   command <<~ACME
     #{bin_path}/acme.sh --cron \
     --force \

--- a/omnibus/cookbooks/firezone/templates/redirect.conf.erb
+++ b/omnibus/cookbooks/firezone/templates/redirect.conf.erb
@@ -6,11 +6,13 @@ server {
   <% end -%>
   server_name <%= @server_name %>;
 
-  return 301 https://<%= @server_name %>$request_uri;
-
   # Needed for ACME requests
   location /.well-known/acme-challenge/ {
     alias <%= @acme_www_root %>/.well-known/acme-challenge/;
+  }
+
+  location ^~ ^/.well-known/acme-challenge/ {
+    return 301 https://<%= @server_name %>$request_uri;
   }
 }
 <% end -%>


### PR DESCRIPTION
Fixes an issue with the upgraded Nginx from 0.5.8 where the `redirect` call always executed when trying to issue ACME certs.