### PR TITLE
Favor live redirects over patches

### DIFF
--- a/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/index.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/index.html.heex
@@ -42,10 +42,9 @@
         <%= for device <- @devices do %>
           <tr>
             <td>
-              <%= live_patch(
-                  device.name,
-                  to: Routes.device_unprivileged_show_path(@socket, :show, device),
-                  replace: true) %>
+              <.link navigate={Routes.device_unprivileged_show_path(@socket, :show, device)}>
+                <%= device.name %>
+              </.link>
             </td>
             <td class="code">
               <span><%= device.ipv4 %></span>
@@ -66,12 +65,9 @@
 
   <%= if FzHttpWeb.DeviceView.can_manage_devices?(@current_user) do %>
     <div class="block">
-      <%= live_patch(
-          to: Routes.device_unprivileged_index_path(@socket, :new),
-          replace: true,
-          class: "button") do %>
+      <.link navigate={Routes.device_unprivileged_index_path(@socket, :new)} class="button">
         Add Device
-      <% end %>
+      </.link>
     </div>
   <% end %>
 
@@ -109,11 +105,9 @@
           Signed in as <%= @current_user.email %>.
         </p>
         <p>
-          <%= live_patch(
-              to: Routes.setting_unprivileged_account_path(@socket, :show),
-              replace: true) do %>
+          <.link navigate={Routes.setting_unprivileged_account_path(@socket, :show)}>
             My Account
-          <% end %>
+          </.link>
           /
           <%= link(to: Routes.auth_path(@socket, :delete), method: :delete) do %>
             Sign out

--- a/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/show.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/show.html.heex
@@ -1,7 +1,6 @@
 <div class="block">
-  <%= live_patch(
-      "<- Back to devices",
-      to: Routes.device_unprivileged_index_path(@socket, :index),
-      replace: true) %>
+  <.link navigate={Routes.device_unprivileged_index_path(@socket, :index)}>
+    &lt;- Back to devices
+  </.link>
 </div>
 <%= render FzHttpWeb.SharedView, "show_device.html", assigns %>

--- a/apps/fz_http/lib/fz_http_web/live/mfa_live/auth_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/mfa_live/auth_live.ex
@@ -42,7 +42,9 @@ defmodule FzHttpWeb.MFALive.Auth do
     <hr>
 
     <div class="block has-text-right">
-      <%= live_patch("Other authenticators ->", to: Routes.mfa_auth_path(@socket, :types), replace: true) %>
+      <.link navigate={Routes.mfa_auth_path(@socket, :types)}>
+        Other authenticators -&gt;
+      </.link>
     </div>
 
     <div class="block">
@@ -94,9 +96,9 @@ defmodule FzHttpWeb.MFALive.Auth do
       <ul>
         <%= for method <- @methods do %>
         <li>
-          <%= live_patch("[#{method.type}] #{method.name} ->",
-              to: Routes.mfa_auth_path(@socket, :auth, method.id),
-              replace: true) %>
+          <.link navigate={Routes.mfa_auth_path(@socket, :auth, method.id)}>
+            <%= "[#{method.type}] #{method.name} ->" %>
+          </.link>
         </li>
         <% end %>
       </ul>

--- a/apps/fz_http/lib/fz_http_web/live/modal_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/modal_component.ex
@@ -43,7 +43,7 @@ defmodule FzHttpWeb.ModalComponent do
 
   @impl Phoenix.LiveComponent
   def handle_event("close", _, socket) do
-    {:noreply, push_patch(socket, to: socket.assigns.return_to)}
+    {:noreply, push_redirect(socket, to: socket.assigns.return_to)}
   end
 
   @impl Phoenix.LiveComponent

--- a/apps/fz_http/lib/fz_http_web/live/oidc_live/connections_table_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/oidc_live/connections_table_component.ex
@@ -16,7 +16,7 @@ defmodule FzHttpWeb.OIDCLive.ConnectionsTableComponent do
     {:noreply,
      socket
      |> put_flash(:info, "A refresh is underway, please check back in a minute.")
-     |> push_patch(to: Routes.user_show_path(socket, :show, socket.assigns.user.id))}
+     |> push_redirect(to: Routes.user_show_path(socket, :show, socket.assigns.user.id))}
   end
 
   def handle_event("delete", %{"id" => id}, socket) do

--- a/apps/fz_http/lib/fz_http_web/live/rule_live/rule_list_component.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/rule_live/rule_list_component.html.heex
@@ -28,7 +28,7 @@
           <%= select f,
               :user_id,
               user_options(@users),
-              prompt: "Optional user scope" %>
+              prompt: "All users" %>
         </div>
       </div>
 
@@ -38,7 +38,7 @@
           <%= select f,
               :port_type,
               port_type_options(),
-              prompt: "Optional port type",
+              prompt: "All protocols",
               title: if(!@port_rules_supported, do: "Kernel 5.6.9 required for port-based rules."),
               disabled: !@port_rules_supported %>
         </div>

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/account.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/account.html.heex
@@ -29,12 +29,12 @@
     </div>
 
     <div class="level-right">
-      <%= live_patch(to: Routes.setting_account_path(@socket, :edit), class: "button") do %>
+      <.link navigate={Routes.setting_account_path(@socket, :edit)} class="button">
         <span class="icon is-small">
           <i class="mdi mdi-pencil"></i>
         </span>
         <span>Change Email or Password</span>
-      <% end %>
+      </.link>
     </div>
   </div>
 
@@ -98,12 +98,13 @@
     <% end %>
   </div>
 
-  <%= live_patch(to: Routes.setting_account_path(@socket, :register_mfa), class: "button") do %>
+
+  <.link navigate={Routes.setting_account_path(@socket, :register_mfa)} class="button">
     <span class="icon is-small">
       <i class="mdi mdi-plus"></i>
     </span>
     <span>Add MFA Method</span>
-  <% end %>
+  </.link>
 </section>
 
 <section class="section is-main-section">

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/unprivileged/account.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/unprivileged/account.html.heex
@@ -15,10 +15,9 @@
       return_to={Routes.setting_unprivileged_account_path(@socket, :show)} />
 <% end %>
 
-<%= live_patch(
-    "<- Back to devices",
-    to: Routes.device_unprivileged_index_path(@socket, :index),
-    replace: true) %>
+<.link navigate={Routes.device_unprivileged_index_path(@socket, :index)}>
+  &lt;- Back to devices
+</.link>
 
 <%= render FzHttpWeb.SharedView, "heading.html", page_title: @page_title %>
 
@@ -36,12 +35,12 @@
 
     <div class="level-right">
       <%= if @local_auth_enabled do %>
-        <%= live_patch(to: Routes.setting_unprivileged_account_path(@socket, :change_password), class: "button") do %>
+        <.link navigate={Routes.setting_unprivileged_account_path(@socket, :change_password)} class="button">
           <span class="icon is-small">
             <i class="mdi mdi-pencil"></i>
           </span>
           <span>Change Password</span>
-        <% end %>
+        </.link>
       <% end %>
     </div>
   </div>
@@ -106,10 +105,10 @@
     <% end %>
   </div>
 
-  <%= live_patch(to: Routes.setting_unprivileged_account_path(@socket, :register_mfa), class: "button") do %>
+  <.link navigate={Routes.setting_unprivileged_account_path(@socket, :register_mfa)} class="button">
     <span class="icon is-small">
       <i class="mdi mdi-plus"></i>
     </span>
     <span>Add MFA Method</span>
-  <% end %>
+  </.link>
 </section>

--- a/apps/fz_http/lib/fz_http_web/live/user_live/index.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/index.html.heex
@@ -32,10 +32,9 @@
       <%= for user <- @users do %>
         <tr>
           <td>
-            <%= live_patch(
-                user.email,
-                to: Routes.user_show_path(@socket, :show, user),
-                replace: true) %>
+            <.link navigate={Routes.user_show_path(@socket, :show, user)}>
+              <%= user.email %>
+            </.link>
           </td>
           <td id={"user-#{user.id}-device-count"}><%= user.device_count %></td>
           <td id={"user-#{user.id}-vpn-status"} class="has-text-centered">
@@ -66,7 +65,7 @@
     </table>
   </div>
 
-  <%= live_patch(to: Routes.user_index_path(@socket, :new), replace: true, class: "button") do %>
+  <.link navigate={Routes.user_index_path(@socket, :new)} class="button">
     Add User
-  <% end %>
+  </.link>
 </section>

--- a/apps/fz_http/lib/fz_http_web/live/user_live/show.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/show.html.heex
@@ -31,15 +31,12 @@
       <h4 class="title is-4">Details</h4>
     </div>
     <div class="level-right">
-      <%= live_patch(
-          to: Routes.user_show_path(@socket, :edit, @user),
-          replace: true,
-          class: "button") do %>
+      <.link navigate={Routes.user_show_path(@socket, :edit, @user)} class="button">
         <span class="icon is-small">
           <i class="mdi mdi-pencil"></i>
         </span>
         <span>Change Email or Password</span>
-      <% end %>
+      </.link>
     </div>
   </div>
 
@@ -65,12 +62,12 @@
     <% end %>
   </div>
 
-  <%= live_patch(
-      "Add Device",
-      to: Routes.user_show_path(@socket, :new_device, @user),
-      id: "add-device-button",
-      replace: true,
-      class: "button") %>
+  <.link
+       navigate={Routes.user_show_path(@socket, :new_device, @user)}
+       id="add-device-button"
+       class="button">
+    Add Device
+  </.link>
 </section>
 
 <section class="section is-main-section">

--- a/apps/fz_http/lib/fz_http_web/templates/shared/devices_table.html.heex
+++ b/apps/fz_http/lib/fz_http_web/templates/shared/devices_table.html.heex
@@ -16,10 +16,9 @@
   <%= for device <- @devices do %>
     <tr>
       <td>
-        <%= live_patch(
-            device.name,
-            to: Routes.device_admin_show_path(@socket, :show, device),
-            replace: true) %>
+        <.link navigate={Routes.device_admin_show_path(@socket, :show, device)}>
+          <%= device.name %>
+        </.link>
       </td>
       <%= if @show_user do %>
         <td>

--- a/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
@@ -136,8 +136,6 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
         |> render_click()
 
       assert_redirected(view, Routes.device_unprivileged_index_path(conn, :new))
-      assert new_view =~ "Add Device"
-      assert new_view =~ ~s|<form id="create-device"|
     end
 
     test "creates device", %{unprivileged_conn: conn} do

--- a/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
@@ -135,7 +135,7 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
         |> element("a", "Add Device")
         |> render_click()
 
-      assert_patched(view, Routes.device_unprivileged_index_path(conn, :new))
+      assert_redirected(view, Routes.device_unprivileged_index_path(conn, :new))
       assert new_view =~ "Add Device"
       assert new_view =~ ~s|<form id="create-device"|
     end

--- a/apps/fz_http/test/fz_http_web/live/mfa_live/auth_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/mfa_live/auth_test.exs
@@ -54,7 +54,7 @@ defmodule FzHttpWeb.MFALive.AuthTest do
       |> element("a[href=\"/mfa/types\"]")
       |> render_click()
 
-      assert_patched(view, "/mfa/types")
+      assert_redirected(view, "/mfa/types")
     end
   end
 
@@ -85,7 +85,7 @@ defmodule FzHttpWeb.MFALive.AuthTest do
       |> element("a", "Test 2")
       |> render_click()
 
-      assert_patched(view, "/mfa/auth/#{method.id}")
+      assert_redirected(view, "/mfa/auth/#{method.id}")
     end
   end
 end

--- a/apps/fz_http/test/fz_http_web/live/setting_live/account_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/setting_live/account_test.exs
@@ -85,10 +85,7 @@ defmodule FzHttpWeb.SettingLive.AccountTest do
       |> element("button.delete")
       |> render_click()
 
-      # Sometimes assert_patched fails without this :-(
-      Process.sleep(1000)
-
-      assert_patched(view, Routes.setting_account_path(conn, :show))
+      assert_redirected(view, Routes.setting_account_path(conn, :show))
     end
   end
 end

--- a/apps/fz_http/test/fz_http_web/live/setting_live/unprivileged/account_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/setting_live/unprivileged/account_test.exs
@@ -71,10 +71,7 @@ defmodule FzHttpWeb.SettingLive.Unprivileged.AccountTest do
       |> element("button.delete")
       |> render_click()
 
-      # Sometimes we have to wait a little
-      Process.sleep(10)
-
-      assert_patched(view, Routes.setting_unprivileged_account_path(conn, :show))
+      assert_redirected(view, Routes.setting_unprivileged_account_path(conn, :show))
     end
   end
 end

--- a/apps/fz_http/test/fz_http_web/live/user_live/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/index_test.exs
@@ -109,12 +109,11 @@ defmodule FzHttpWeb.UserLive.IndexTest do
       path = Routes.user_index_path(conn, :index)
       {:ok, view, _html} = live(conn, path)
 
-      modal =
-        view
-        |> element("a", "Add User")
-        |> render_click()
+      view
+      |> element("a", "Add User")
+      |> render_click()
 
-      assert modal =~ "<p class=\"modal-card-title\">Add User</p>"
+      assert_redirected(view, Routes.user_index_path(conn, :new))
     end
   end
 end

--- a/apps/fz_http/test/fz_http_web/live/user_live/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/index_test.exs
@@ -41,7 +41,7 @@ defmodule FzHttpWeb.UserLive.IndexTest do
       |> element("a", user.email)
       |> render_click()
 
-      assert_patched(view, Routes.user_show_path(conn, :show, user))
+      assert_redirected(view, Routes.user_show_path(conn, :show, user))
     end
   end
 

--- a/apps/fz_http/test/fz_http_web/live/user_live/show_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/show_test.exs
@@ -436,7 +436,7 @@ defmodule FzHttpWeb.UserLive.ShowTest do
       |> element("button", "Delete Device #{device.name}")
       |> render_click()
 
-      _flash = assert_redirected(view, Routes.device_admin_index_path(conn, :index))
+      assert_redirected(view, Routes.device_admin_index_path(conn, :index))
     end
   end
 

--- a/apps/fz_http/test/fz_http_web/live/user_live/show_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/show_test.exs
@@ -159,7 +159,7 @@ defmodule FzHttpWeb.UserLive.ShowTest do
       |> element("#add-device-button")
       |> render_click()
 
-      assert_patched(view, Routes.user_show_path(conn, :new_device, user.id))
+      assert_redirected(view, Routes.user_show_path(conn, :new_device, user.id))
     end
 
     test "allows name changes", %{admin_conn: conn, admin_user: user} do


### PR DESCRIPTION
live_patch seemed to have issues updating the URL in the address even with [`replace: true`](https://hexdocs.pm/phoenix_live_view/live-navigation.html#replace-page-address).

Fixes #979 