### PR TITLE
allow dns hosts; fix notifications concurrency issues

### DIFF
--- a/apps/fz_http/lib/fz_http/application.ex
+++ b/apps/fz_http/lib/fz_http/application.ex
@@ -35,7 +35,7 @@ defmodule FzHttp.Application do
       FzHttp.Configurations.Cache,
       FzHttpWeb.Endpoint,
       {Phoenix.PubSub, name: FzHttp.PubSub},
-      FzHttp.Notifications,
+      {FzHttp.Notifications, [name: FzHttp.Notifications]},
       FzHttpWeb.Presence,
       FzHttp.ConnectivityCheckService,
       FzHttp.TelemetryPingService,
@@ -57,7 +57,7 @@ defmodule FzHttp.Application do
       FzHttpWeb.Endpoint,
       {FzHttp.OIDC.StartProxy, :test},
       {Phoenix.PubSub, name: FzHttp.PubSub},
-      FzHttp.Notifications,
+      {FzHttp.Notifications, [name: FzHttp.Notifications]},
       FzHttpWeb.Presence,
       FzHttp.SAML.StartProxy
     ]

--- a/apps/fz_http/lib/fz_http/application.ex
+++ b/apps/fz_http/lib/fz_http/application.ex
@@ -35,7 +35,7 @@ defmodule FzHttp.Application do
       FzHttp.Configurations.Cache,
       FzHttpWeb.Endpoint,
       {Phoenix.PubSub, name: FzHttp.PubSub},
-      {FzHttp.Notifications, [name: FzHttp.Notifications]},
+      {FzHttp.Notifications, name: FzHttp.Notifications},
       FzHttpWeb.Presence,
       FzHttp.ConnectivityCheckService,
       FzHttp.TelemetryPingService,
@@ -57,7 +57,7 @@ defmodule FzHttp.Application do
       FzHttpWeb.Endpoint,
       {FzHttp.OIDC.StartProxy, :test},
       {Phoenix.PubSub, name: FzHttp.PubSub},
-      {FzHttp.Notifications, [name: FzHttp.Notifications]},
+      {FzHttp.Notifications, name: FzHttp.Notifications},
       FzHttpWeb.Presence,
       FzHttp.SAML.StartProxy
     ]

--- a/apps/fz_http/lib/fz_http/devices/device.ex
+++ b/apps/fz_http/lib/fz_http/devices/device.ex
@@ -12,7 +12,6 @@ defmodule FzHttp.Devices.Device do
       trim: 2,
       validate_fqdn_or_ip: 2,
       validate_omitted: 2,
-      validate_list_of_ips: 2,
       validate_no_duplicates: 2,
       validate_list_of_ips_or_cidrs: 2
     ]
@@ -137,7 +136,6 @@ defmodule FzHttp.Devices.Device do
       :mtu
     ])
     |> validate_list_of_ips_or_cidrs(:allowed_ips)
-    |> validate_list_of_ips(:dns)
     |> validate_no_duplicates(:dns)
     |> validate_fqdn_or_ip(:endpoint)
     |> validate_number(:persistent_keepalive,

--- a/apps/fz_http/lib/fz_http/notifications.ex
+++ b/apps/fz_http/lib/fz_http/notifications.ex
@@ -4,8 +4,8 @@ defmodule FzHttp.Notifications do
   """
   use GenServer
 
+  @topic "notifications_live"
   alias Phoenix.PubSub
-  import FzHttpWeb.NotificationsLive.Index, only: [topic: 0]
 
   def start_link(opts \\ []) do
     if opts[:name] do
@@ -18,32 +18,42 @@ defmodule FzHttp.Notifications do
   @doc """
   Gets a list of current notifications.
   """
-  def current(pid \\ __MODULE__), do: GenServer.call(pid, :current)
+  def current, do: current(__MODULE__)
+  def current(nil), do: current()
+  def current(pid), do: GenServer.call(pid, :current)
 
   @doc """
   Add a notification.
   """
-  def add(pid \\ __MODULE__, notification), do: GenServer.call(pid, {:add, notification})
+  def add(notification), do: add(__MODULE__, notification)
+  def add(nil, notification), do: add(notification)
+  def add(pid, notification), do: GenServer.call(pid, {:add, notification})
 
   @doc """
   Clear all notifications.
   """
-  def clear_all(pid \\ __MODULE__), do: GenServer.call(pid, :clear_all)
+  def clear_all, do: clear_all(__MODULE__)
+  def clear_all(nil), do: clear_all()
+  def clear_all(pid), do: GenServer.call(pid, :clear_all)
 
   @doc """
   Clear the given notification.
   """
-  def clear(pid \\ __MODULE__, notification), do: GenServer.call(pid, {:clear, notification})
+  def clear(notification), do: clear(__MODULE__, notification)
+  def clear(nil, notification), do: clear(notification)
+  def clear(pid, notification), do: GenServer.call(pid, {:clear, notification})
 
   @doc """
   Clear a notification at the given index.
   """
-  def clear_at(pid \\ __MODULE__, index), do: GenServer.call(pid, {:clear_at, index})
+  def clear_at(index), do: clear_at(__MODULE__, index)
+  def clear_at(nil, index), do: clear_at(index)
+  def clear_at(pid, index), do: GenServer.call(pid, {:clear_at, index})
 
   defp broadcast(notifications) do
     PubSub.broadcast(
       FzHttp.PubSub,
-      topic(),
+      @topic,
       {:notifications, notifications}
     )
   end

--- a/apps/fz_http/lib/fz_http/notifications.ex
+++ b/apps/fz_http/lib/fz_http/notifications.ex
@@ -1,44 +1,49 @@
 defmodule FzHttp.Notifications do
   @moduledoc """
-  Notification state for notifications live view.
+  Notification notifications for notifications live view.
   """
   use GenServer
 
   alias Phoenix.PubSub
+  import FzHttpWeb.NotificationsLive.Index, only: [topic: 0]
 
-  alias FzHttpWeb.NotificationsLive
-
-  def start_link(_), do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts \\ []) do
+    if opts[:name] do
+      GenServer.start_link(__MODULE__, [], name: opts[:name])
+    else
+      GenServer.start_link(__MODULE__, [])
+    end
+  end
 
   @doc """
   Gets a list of current notifications.
   """
-  def current, do: GenServer.call(__MODULE__, :current)
+  def current(pid \\ __MODULE__), do: GenServer.call(pid, :current)
 
   @doc """
   Add a notification.
   """
-  def add(notification), do: GenServer.call(__MODULE__, {:add, notification})
+  def add(pid \\ __MODULE__, notification), do: GenServer.call(pid, {:add, notification})
 
   @doc """
   Clear all notifications.
   """
-  def clear, do: GenServer.call(__MODULE__, :clear_all)
+  def clear_all(pid \\ __MODULE__), do: GenServer.call(pid, :clear_all)
 
   @doc """
   Clear the given notification.
   """
-  def clear(notification), do: GenServer.call(__MODULE__, {:clear, notification})
+  def clear(pid \\ __MODULE__, notification), do: GenServer.call(pid, {:clear, notification})
 
   @doc """
   Clear a notification at the given index.
   """
-  def clear_at(index), do: GenServer.call(__MODULE__, {:clear_at, index})
+  def clear_at(pid \\ __MODULE__, index), do: GenServer.call(pid, {:clear_at, index})
 
   defp broadcast(notifications) do
     PubSub.broadcast(
       FzHttp.PubSub,
-      NotificationsLive.Index.topic(),
+      topic(),
       {:notifications, notifications}
     )
   end

--- a/apps/fz_http/lib/fz_http/sites/site.ex
+++ b/apps/fz_http/lib/fz_http/sites/site.ex
@@ -10,7 +10,6 @@ defmodule FzHttp.Sites.Site do
     only: [
       trim: 2,
       validate_fqdn_or_ip: 2,
-      validate_list_of_ips: 2,
       validate_list_of_ips_or_cidrs: 2,
       validate_no_duplicates: 2
     ]
@@ -56,7 +55,6 @@ defmodule FzHttp.Sites.Site do
     ])
     |> trim(@whitespace_trimmed_fields)
     |> validate_required(:name)
-    |> validate_list_of_ips(:dns)
     |> validate_no_duplicates(:dns)
     |> validate_list_of_ips_or_cidrs(:allowed_ips)
     |> validate_no_duplicates(:allowed_ips)

--- a/apps/fz_http/lib/fz_http_web/live/notifications_live/badge.ex
+++ b/apps/fz_http/lib/fz_http_web/live/notifications_live/badge.ex
@@ -8,15 +8,17 @@ defmodule FzHttpWeb.NotificationsLive.Badge do
   alias FzHttp.Notifications
   alias Phoenix.PubSub
 
-  import FzHttpWeb.NotificationsLive.Index, only: [topic: 0]
+  @topic "notifications_live"
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
-    PubSub.subscribe(FzHttp.PubSub, topic())
+  def mount(_params, session, socket) do
+    PubSub.subscribe(FzHttp.PubSub, @topic)
+    pid = session["notifications_pid"]
 
     {:ok,
      socket
-     |> assign(assigns(Notifications.current()))}
+     |> assign(:notifications_pid, pid)
+     |> assign(assigns(Notifications.current(pid)))}
   end
 
   @impl Phoenix.LiveView

--- a/apps/fz_http/lib/fz_http_web/live/notifications_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/notifications_live/index_live.ex
@@ -13,15 +13,15 @@ defmodule FzHttpWeb.NotificationsLive.Index do
   @page_title "Notifications"
   @page_subtitle "Persisted notifications will appear below."
 
-  def topic, do: @topic
-
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
-    PubSub.subscribe(FzHttp.PubSub, topic())
+  def mount(_params, session, socket) do
+    PubSub.subscribe(FzHttp.PubSub, @topic)
+    pid = session["notifications_pid"]
 
     {:ok,
      socket
-     |> assign(:notifications, Notifications.current())
+     |> assign(:notifications_pid, pid)
+     |> assign(:notifications, Notifications.current(pid))
      |> assign(:page_subtitle, @page_subtitle)
      |> assign(:page_title, @page_title)}
   end
@@ -35,7 +35,7 @@ defmodule FzHttpWeb.NotificationsLive.Index do
 
   @impl Phoenix.LiveView
   def handle_event("clear_notification", %{"index" => index}, socket) do
-    Notifications.clear_at(String.to_integer(index))
+    Notifications.clear_at(socket.assigns.notifications_pid, String.to_integer(index))
     {:noreply, socket}
   end
 

--- a/apps/fz_http/test/fz_http/devices_test.exs
+++ b/apps/fz_http/test/fz_http/devices_test.exs
@@ -195,10 +195,6 @@ defmodule FzHttp.DevicesTest do
       dns: "1.1.1.1, 1.0.0.1, 2606:4700:4700::1111, 2606:4700:4700::1001"
     }
 
-    @invalid_dns_attrs %{
-      dns: "8.8.8.8, 1.1.1, 1.0.0, 1.1.1."
-    }
-
     @duplicate_dns_attrs %{
       dns: "8.8.8.8, 1.1.1.1, 1.1.1.1, ::1, ::1, ::1, ::1, ::1, 8.8.8.8"
     }
@@ -305,6 +301,11 @@ defmodule FzHttp.DevicesTest do
       end
     end
 
+    @tag attrs: %{use_site_dns: false, dns: "foobar.com"}
+    test "allows hosts for DNS", %{attrs: attrs, device: device} do
+      assert {:ok, _device} = Devices.update_device(device, attrs)
+    end
+
     test "prevents updating device with invalid ipv6 endpoint", %{device: device} do
       {:error, changeset} = Devices.update_device(device, @invalid_endpoint_ipv6_attrs)
 
@@ -329,15 +330,6 @@ defmodule FzHttp.DevicesTest do
       assert changeset.errors[:endpoint] == {
                "can't be blank",
                [{:validation, :required}]
-             }
-    end
-
-    test "prevents updating device with invalid dns", %{device: device} do
-      {:error, changeset} = Devices.update_device(device, @invalid_dns_attrs)
-
-      assert changeset.errors[:dns] == {
-               "is invalid: 1.1.1 is not a valid IPv4 / IPv6 address",
-               []
              }
     end
 

--- a/apps/fz_http/test/fz_http/notifications_test.exs
+++ b/apps/fz_http/test/fz_http/notifications_test.exs
@@ -3,51 +3,51 @@ defmodule FzHttp.NotificationsTest do
   alias FzHttp.Notifications
 
   setup do
-    on_exit(fn -> Notifications.clear() end)
+    {:ok, test_pid: start_supervised!(Notifications)}
   end
 
   setup [:create_notification, :create_notifications]
 
-  test "add notification", %{notification: notification} do
-    Notifications.add(notification)
+  test "add notification", %{test_pid: pid, notification: notification} do
+    Notifications.add(pid, notification)
 
-    assert [notification] == Notifications.current()
+    assert [notification] == Notifications.current(pid)
   end
 
-  test "clear notification", %{notification: notification} do
-    Notifications.add(notification)
-    Notifications.clear(notification)
+  test "clear notification", %{test_pid: pid, notification: notification} do
+    Notifications.add(pid, notification)
+    Notifications.clear(pid, notification)
 
-    assert [] == Notifications.current()
+    assert [] == Notifications.current(pid)
   end
 
-  test "add multiple notifications", %{notifications: notifications} do
+  test "add multiple notifications", %{test_pid: pid, notifications: notifications} do
     for notification <- notifications do
-      Notifications.add(notification)
+      Notifications.add(pid, notification)
     end
 
-    assert Enum.reverse(notifications) == Notifications.current()
+    assert Enum.reverse(notifications) == Notifications.current(pid)
   end
 
-  test "clear all notifications", %{notifications: notifications} do
+  test "clear all notifications", %{test_pid: pid, notifications: notifications} do
     for notification <- notifications do
-      Notifications.add(notification)
+      Notifications.add(pid, notification)
     end
 
-    Notifications.clear()
+    Notifications.clear_all(pid)
 
-    assert [] == Notifications.current()
+    assert [] == Notifications.current(pid)
   end
 
-  test "clear notification at index", %{notifications: notifications} do
+  test "clear notification at index", %{test_pid: pid, notifications: notifications} do
     for notification <- notifications do
-      Notifications.add(notification)
+      Notifications.add(pid, notification)
     end
 
-    Notifications.clear_at(2)
+    Notifications.clear_at(pid, 2)
 
     {_, expected_notifications} = List.pop_at(notifications, 2)
 
-    assert Enum.reverse(expected_notifications) == Notifications.current()
+    assert Enum.reverse(expected_notifications) == Notifications.current(pid)
   end
 end

--- a/apps/fz_http/test/fz_http/sites_test.exs
+++ b/apps/fz_http/test/fz_http/sites_test.exs
@@ -1,7 +1,9 @@
 defmodule FzHttp.SitesTest do
   use FzHttp.DataCase
 
+  alias FzHttp.Sites.Site
   alias FzHttp.Sites
+  import FzHttp.SitesFixtures
 
   describe "trimmed fields" do
     test "trims expected fields" do
@@ -24,11 +26,23 @@ defmodule FzHttp.SitesTest do
     end
   end
 
+  describe "update_site/2 with name-based dns" do
+    setup do
+      {:ok, site: site_fixture()}
+    end
+
+    @tag attrs: %{dns: "foobar.com"}
+    test "update_site/2 allows hosts for DNS", %{site: site, attrs: attrs} do
+      assert {:ok, _site} = Sites.update_site(site, attrs)
+    end
+
+    @tag attrs: %{dns: "foobar.com, google.com"}
+    test "update_site/2 allows list hosts for DNS", %{site: site, attrs: attrs} do
+      assert {:ok, _site} = Sites.update_site(site, attrs)
+    end
+  end
+
   describe "sites" do
-    alias FzHttp.Sites.Site
-
-    import FzHttp.SitesFixtures
-
     @valid_sites [
       %{
         "dns" => "8.8.8.8",

--- a/apps/fz_http/test/fz_http_web/live/notifications_live/badge_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/notifications_live/badge_test.exs
@@ -6,8 +6,11 @@ defmodule FzHttpWeb.NotificationsLive.BadgeTest do
   use FzHttpWeb.ConnCase, async: false
   alias FzHttp.Notifications
 
-  setup do
-    {:ok, test_pid: start_supervised!(Notifications)}
+  setup tags do
+    # Pass the pid to the Notifications views
+    pid = start_supervised!(Notifications)
+    conn = put_session(tags[:admin_conn], :notifications_pid, pid)
+    {:ok, test_pid: pid, admin_conn: conn}
   end
 
   setup [:create_notifications]

--- a/apps/fz_http/test/fz_http_web/live/notifications_live/badge_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/notifications_live/badge_test.exs
@@ -2,11 +2,12 @@ defmodule FzHttpWeb.NotificationsLive.BadgeTest do
   @moduledoc """
   Test notifications badge.
   """
-  use FzHttpWeb.ConnCase, async: true
+  # async: true causes intermittent failures...
+  use FzHttpWeb.ConnCase, async: false
   alias FzHttp.Notifications
 
   setup do
-    on_exit(fn -> Notifications.clear() end)
+    {:ok, test_pid: start_supervised!(Notifications)}
   end
 
   setup [:create_notifications]
@@ -20,10 +21,11 @@ defmodule FzHttpWeb.NotificationsLive.BadgeTest do
 
   test "badge has 5 notifications after adding 5", %{
     admin_conn: conn,
+    test_pid: pid,
     notifications: notifications
   } do
     for notification <- notifications do
-      Notifications.add(notification)
+      Notifications.add(pid, notification)
     end
 
     {:ok, _view, html} = live_isolated(conn, FzHttpWeb.NotificationsLive.Badge)
@@ -33,14 +35,15 @@ defmodule FzHttpWeb.NotificationsLive.BadgeTest do
 
   test "badge has 3 notifications after adding 5 and clearing 2", %{
     admin_conn: conn,
+    test_pid: pid,
     notifications: notifications
   } do
     for notification <- notifications do
-      Notifications.add(notification)
+      Notifications.add(pid, notification)
     end
 
-    Notifications.clear_at(0)
-    Notifications.clear_at(1)
+    Notifications.clear_at(pid, 0)
+    Notifications.clear_at(pid, 1)
 
     {:ok, _view, html} = live_isolated(conn, FzHttpWeb.NotificationsLive.Badge)
 
@@ -49,13 +52,14 @@ defmodule FzHttpWeb.NotificationsLive.BadgeTest do
 
   test "badge has 0 notifications after clearing all", %{
     admin_conn: conn,
+    test_pid: pid,
     notifications: notifications
   } do
     for notification <- notifications do
-      Notifications.add(notification)
+      Notifications.add(pid, notification)
     end
 
-    Notifications.clear()
+    Notifications.clear_all(pid)
 
     {:ok, _view, html} = live_isolated(conn, FzHttpWeb.NotificationsLive.Badge)
 

--- a/apps/fz_http/test/fz_http_web/live/notifications_live/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/notifications_live/index_test.exs
@@ -5,8 +5,11 @@ defmodule FzHttpWeb.NotificationsLive.IndexTest do
   use FzHttpWeb.ConnCase, async: false
   alias FzHttp.Notifications
 
-  setup do
-    {:ok, test_pid: start_supervised!(Notifications)}
+  setup tags do
+    # Pass the pid to the Notifications views
+    pid = start_supervised!(Notifications)
+    conn = put_session(tags[:admin_conn], :notifications_pid, pid)
+    {:ok, test_pid: pid, admin_conn: conn}
   end
 
   setup [:create_notification, :create_notifications]
@@ -17,10 +20,9 @@ defmodule FzHttpWeb.NotificationsLive.IndexTest do
     notification: notification
   } do
     path = Routes.notifications_index_path(conn, :index)
+    Notifications.add(pid, notification)
 
     {:ok, _view, html} = live(conn, path)
-
-    Notifications.add(pid, notification)
 
     assert html =~ notification.user
   end

--- a/apps/fz_http/test/fz_http_web/live/setting_live/account_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/setting_live/account_test.exs
@@ -82,11 +82,12 @@ defmodule FzHttpWeb.SettingLive.AccountTest do
       {:ok, view, _html} = live(conn, path)
 
       view
-      |> element("button.delete")
+      |> element("button[aria-label=close]")
       |> render_click()
 
-      # Intermittent failure unless we wait a bit
-      Process.sleep(10)
+      # Ensure view's messages are flushed... prevents intermittent failures
+      # See https://elixirforum.com/t/testing-liveviews-that-rely-on-pubsub-for-updates/40938/5
+      _ = :sys.get_state(view.pid)
 
       assert_patched(view, Routes.setting_account_path(conn, :show))
     end

--- a/apps/fz_http/test/fz_http_web/live/setting_live/site_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/setting_live/site_test.exs
@@ -23,9 +23,6 @@ defmodule FzHttpWeb.SettingLive.SiteTest do
     @invalid_allowed_ips %{
       "site" => %{"allowed_ips" => "foobar"}
     }
-    @invalid_dns %{
-      "site" => %{"dns" => "foobar"}
-    }
     @invalid_endpoint %{
       "site" => %{"endpoint" => "-foobar"}
     }
@@ -137,19 +134,6 @@ defmodule FzHttpWeb.SettingLive.SiteTest do
       assert test_view =~ """
              <textarea class="textarea is-danger" id="site_form_component_allowed_ips" name="site[allowed_ips]" placeholder="0.0.0.0/0, ::/0">
              foobar</textarea>\
-             """
-    end
-
-    test "prevents invalid dns", %{view: view} do
-      test_view =
-        view
-        |> element("#site_form_component")
-        |> render_submit(@invalid_dns)
-
-      assert test_view =~ "is invalid"
-
-      assert test_view =~ """
-             <input class="input is-danger" id="site_form_component_dns" name="site[dns]" placeholder="1.1.1.1, 1.0.0.1" type="text" value="foobar"/>\
              """
     end
 

--- a/apps/fz_http/test/fz_http_web/user_from_auth_test.exs
+++ b/apps/fz_http/test/fz_http_web/user_from_auth_test.exs
@@ -1,7 +1,6 @@
 defmodule FzHttpWeb.UserFromAuthTest do
   use FzHttp.DataCase, async: true
 
-  alias FzHttp.Configurations, as: Conf
   alias FzHttp.Users
   alias FzHttpWeb.UserFromAuth
   alias Ueberauth.Auth


### PR DESCRIPTION
- Fix intermittent Notifications test by isolating its GenServer state and Phoenix.PubSub topic.
- Allow hosts to be entered for the `DNS` field.

Fixes #978 