### PR TITLE
Allow RELEASE_NAME to be overridden in environment

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -15,7 +15,10 @@
 # the one below (my_app@127.0.0.1), you need to also uncomment the
 # RELEASE_DISTRIBUTION variable below. Must be "sname", "name" or "none".
 export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=<%= @release.name %>@127.0.0.1
+# RELEASE_NAME is guaranteed to be set by the start script and defaults to 'firezone'
+# set RELEASE_NAME in the environment to a unique value when running multiple instances
+# in the same network namespace (i.e. with host networking in Podman)
+export RELEASE_NODE=$RELEASE_NAME@127.0.0.1
 
 # Choices here are 'interactive' and 'embedded'. 'interactive' boots faster which
 # prevents some runit process management edge cases at the expense of the application


### PR DESCRIPTION
RELEASE_NAME was locked to a static value which prevented multiple instances of Firezone from running in the same network namespace (i.e. using net=host in a container). This change uses the value of the RELEASE_NAME environment variable and defaults to the current static value if not set.

The use case for this change is running two or more instances of Firezone on a single machine in the same network namespace, such as with host networking. Use of the host networking allows simplified routing when not masquerading for client IPs. For example, Firezone instance A is used for a home VPN whose clients are placed on the subnet 172.18.250.128/26 and Firezone instance B is used for a lab VPN whose clients are placed on the subnet 172.18.250.192/26. In this setup, an upstream firewall applies different access to clients in each subnet and must be able to determine the clients' VPN addresses.