### PR TITLE
Updated upgrade.mdx "docker-compose" to "docker compose"

### DIFF
--- a/docs/docs/administer/upgrade.mdx
+++ b/docs/docs/administer/upgrade.mdx
@@ -17,13 +17,13 @@ To upgrade Firezone, follow these steps:
 <Tabs>
 <TabItem label="Docker" value="docker" default>
 
-1. Update docker-compose images:
+1. Update docker compose images:
 ```
-docker-compose pull
+docker compose pull
 ```
 2. Re-up the services (**warning: this will restart updated services**):
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 </TabItem>


### PR DESCRIPTION
as docker compose v2 is now required for the install script, it makes sense to use the same in the docs...

Signed-off-by: thermionic <thermionic@lovius.net>