### PR TITLE
Allow pgcrypto extension to preexist

### DIFF
--- a/apps/fz_http/priv/repo/migrations/20220124162404_add_uuids.exs
+++ b/apps/fz_http/priv/repo/migrations/20220124162404_add_uuids.exs
@@ -3,7 +3,7 @@ defmodule FzHttp.Repo.Migrations.AddUuids do
 
   def change do
     execute(
-      "CREATE EXTENSION pgcrypto",
+      "CREATE EXTENSION IF NOT EXISTS pgcrypto",
       "DROP EXTENSION pgcrypto"
     )
 


### PR DESCRIPTION
The `CREATE EXTENSION` query requires superuser privileges, which means that the Firezone container may not be allowed to execute it when accessing an externally hosted database, resulting in the database failing to initialise properly.

One potential workaround to this problem is to have the database admin ascertain that the pgcrypto extension is already present and ready for use, prior to starting the Firezone container for the first time.

Unfortunately, however, this currently fails in the following manner:

```
14:42:44.731 [info] execute "CREATE EXTENSION pgcrypto"
** (Postgrex.Error) ERROR 42710 (duplicate_object) extension "pgcrypto" already exists
```

Adding the `IF NOT EXISTS` condition to the `CREATE EXTENSION` query should allow it to succeed.