### PR TITLE
Allow btree_gist extension to preexist

### DIFF
--- a/apps/fz_http/priv/repo/migrations/20220614192937_add_user_id_to_rules.exs
+++ b/apps/fz_http/priv/repo/migrations/20220614192937_add_user_id_to_rules.exs
@@ -26,7 +26,7 @@ defmodule FzHttp.Repo.Migrations.AddUserIdToRules do
     ")
 
     execute(
-      "CREATE EXTENSION btree_gist",
+      "CREATE EXTENSION IF NOT EXISTS btree_gist",
       "DROP EXTENSION btree_gist"
     )
 


### PR DESCRIPTION
This commit has the exact same rationale as cc280dae, just for a different extension that I unfortunately missed the first time around.

This time I searched the repo for occurrences of `CREATE EXTENSION` instead of the name of the extension causing the error, so hopefully I did not miss anything else.