### PR TITLE
Fix intermittent assert_{patched,redirected} failures

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,81 @@
+name: Static Analysis
+on: [pull_request]
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: dev
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '25'
+          elixir-version: '1.14'
+      - uses: actions/cache@v3.0.11
+        name: Setup Elixir cache
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
+            ${{ runner.os }}-mix-otp-25-
+      - uses: actions/cache@v3.0.11
+        name: Setup ruby cache
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - uses: actions/cache@v3.0.11
+        name: Setup Python cache
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install Elixir Dependencies
+        run: mix deps.get --only $MIX_ENV
+      - name: Install Ruby Dependencies
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Install Python Dependencies
+        run: |
+          pip install -r requirements.txt
+      # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
+      # Cache key based on Elixir & Erlang version (also usefull when running in matrix)
+      - name: Restore PLT cache
+        uses: actions/cache@v3.0.11
+        id: plt_cache
+        with:
+          key: |
+            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
+          path: |
+            priv/plts
+      # Create PLTs if no cache was found
+      - name: Create PLTs
+        if: steps.plt_cache.outputs.cache-hit != 'true'
+        run: mix dialyzer --plt
+      - name: Install node modules
+        run: npm ci --prefix docs/
+      - name: Run pre-commit
+        run: |
+          pre-commit install
+          SKIP=no-commit-to-branch pre-commit run --all-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,84 +1,7 @@
 name: Test
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
-  static-analysis:
-    runs-on: ubuntu-latest
-    env:
-      MIX_ENV: dev
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: '25'
-          elixir-version: '1.14'
-      - uses: actions/cache@v3.0.11
-        name: Setup Elixir cache
-        with:
-          path: |
-            deps
-            _build
-          key: ${{ runner.os }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-otp-25-
-      - uses: actions/cache@v3.0.11
-        name: Setup ruby cache
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - uses: actions/cache@v3.0.11
-        name: Setup Python cache
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install Elixir Dependencies
-        run: mix deps.get --only dev
-      - name: Install Ruby Dependencies
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-      - name: Install Python Dependencies
-        run: |
-          pip install -r requirements.txt
-      # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
-      # Cache key based on Elixir & Erlang version (also usefull when running in matrix)
-      - name: Restore PLT cache
-        uses: actions/cache@v3.0.11
-        id: plt_cache
-        with:
-          key: |
-            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
-          path: |
-            priv/plts
-      # Create PLTs if no cache was found
-      - name: Create PLTs
-        if: steps.plt_cache.outputs.cache-hit != 'true'
-        run: mix dialyzer --plt
-      - name: Install node modules
-        run: npm ci --prefix docs/
-      - name: Run pre-commit
-        run: |
-          pre-commit install
-          SKIP=no-commit-to-branch pre-commit run --all-files
-
   unit-test:
     runs-on: ubuntu-latest
     env:
@@ -87,7 +10,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     services:
       postgres:
-        image: postgres:13
+        image: postgres:15
         ports:
           - 5432:5432
         env:
@@ -121,9 +44,10 @@ jobs:
             _build
           key: ${{ runner.os }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-otp-25
+            ${{ runner.os }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
+            ${{ runner.os }}-mix-otp-25-
       - name: Install Dependencies
-        run: mix deps.get --only test
+        run: mix deps.get --only $MIX_ENV
       - name: Setup Database
         run: |
           mix ecto.create

--- a/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
@@ -46,7 +46,7 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
       |> element("#create-device")
       |> render_submit(%{"device" => %{"public_key" => "test-pubkey", "name" => "test-tunnel"}})
 
-      flash = assert_redirected(view, "/")
+      flash = assert_redirect(view, "/")
       assert flash["error"] == "Not authorized."
     end
   end
@@ -134,7 +134,7 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
       |> element("a", "Add Device")
       |> render_click()
 
-      assert_patched(view, ~p"/user_devices/new")
+      assert_patch(view, ~p"/user_devices/new")
     end
 
     test "creates device", %{unprivileged_conn: conn} do

--- a/apps/fz_http/test/fz_http_web/live/mfa_live/auth_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/mfa_live/auth_test.exs
@@ -54,7 +54,7 @@ defmodule FzHttpWeb.MFALive.AuthTest do
       |> element("a[href=\"/mfa/types\"]")
       |> render_click()
 
-      assert_redirected(view, "/mfa/types")
+      assert_redirect(view, "/mfa/types")
     end
   end
 
@@ -85,7 +85,7 @@ defmodule FzHttpWeb.MFALive.AuthTest do
       |> element("a", "Test 2")
       |> render_click()
 
-      assert_redirected(view, "/mfa/auth/#{method.id}")
+      assert_redirect(view, "/mfa/auth/#{method.id}")
     end
   end
 end

--- a/apps/fz_http/test/fz_http_web/live/setting_live/account_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/setting_live/account_test.exs
@@ -41,7 +41,7 @@ defmodule FzHttpWeb.SettingLive.AccountTest do
       |> element("#account-edit")
       |> render_submit(@valid_params)
 
-      flash = assert_redirected(view, ~p"/settings/account")
+      flash = assert_redirect(view, ~p"/settings/account")
       assert flash["info"] == "Account updated successfully."
     end
 
@@ -85,11 +85,7 @@ defmodule FzHttpWeb.SettingLive.AccountTest do
       |> element("button[aria-label=close]")
       |> render_click()
 
-      # Ensure view's messages are flushed... prevents intermittent failures
-      # See https://elixirforum.com/t/testing-liveviews-that-rely-on-pubsub-for-updates/40938/5
-      _ = :sys.get_state(view.pid)
-
-      assert_patched(view, ~p"/settings/account")
+      assert_patch(view, ~p"/settings/account")
     end
   end
 end

--- a/apps/fz_http/test/fz_http_web/live/setting_live/unprivileged/account_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/setting_live/unprivileged/account_test.exs
@@ -46,7 +46,7 @@ defmodule FzHttpWeb.SettingLive.Unprivileged.AccountTest do
       |> element("#account-edit")
       |> render_submit(@valid_params)
 
-      flash = assert_redirected(view, ~p"/user_account")
+      flash = assert_redirect(view, ~p"/user_account")
       assert flash["info"] == "Password updated successfully."
     end
 
@@ -73,7 +73,7 @@ defmodule FzHttpWeb.SettingLive.Unprivileged.AccountTest do
 
       Process.sleep(10)
 
-      assert_patched(view, ~p"/user_account")
+      assert_patch(view, ~p"/user_account")
     end
   end
 end

--- a/apps/fz_http/test/fz_http_web/live/user_live/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/index_test.exs
@@ -41,7 +41,7 @@ defmodule FzHttpWeb.UserLive.IndexTest do
       |> element("a", user.email)
       |> render_click()
 
-      assert_redirected(view, ~p"/users/#{user}")
+      assert_redirect(view, ~p"/users/#{user}")
     end
   end
 
@@ -113,7 +113,7 @@ defmodule FzHttpWeb.UserLive.IndexTest do
       |> element("a", "Add User")
       |> render_click()
 
-      assert_patched(view, ~p"/users/new")
+      assert_patch(view, ~p"/users/new")
     end
   end
 end

--- a/apps/fz_http/test/fz_http_web/live/user_live/show_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/show_test.exs
@@ -159,7 +159,7 @@ defmodule FzHttpWeb.UserLive.ShowTest do
       |> element("#add-device-button")
       |> render_click()
 
-      assert_patched(view, ~p"/users/#{user.id}/new_device")
+      assert_patch(view, ~p"/users/#{user.id}/new_device")
     end
 
     test "allows name changes", %{admin_conn: conn, admin_user: user} do
@@ -436,7 +436,7 @@ defmodule FzHttpWeb.UserLive.ShowTest do
       |> element("button", "Delete Device #{device.name}")
       |> render_click()
 
-      assert_redirected(view, ~p"/devices")
+      assert_redirect(view, ~p"/devices")
     end
   end
 


### PR DESCRIPTION
Uses the [`assert_{patch,redirect}`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveViewTest.html#assert_patch/3) (with `ed`) variants to benefit from the default timeout of 100. I guess there's no getting around timeouts/sleep 🤠 

Fixes https://github.com/firezone/product/issues/510