### PR TITLE
Prevent navigating to `/user_devices/new` when management is disabled

### DIFF
--- a/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/index_live.ex
@@ -23,8 +23,7 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.Index do
   end
 
   @doc """
-  This is called when modal is closed. Conveniently, allows us to reload
-  devices table.
+  This is called when modal is closed. Conveniently, allows us to reload devices table.
   """
   @impl Phoenix.LiveView
   def handle_params(_params, _url, socket) do

--- a/apps/fz_http/lib/fz_http_web/live/hooks/live_auth.ex
+++ b/apps/fz_http/lib/fz_http_web/live/hooks/live_auth.ex
@@ -10,15 +10,30 @@ defmodule FzHttpWeb.LiveAuth do
   require Logger
 
   def on_mount(role, _params, session, socket) do
-    user = Authentication.get_current_user(session)
+    do_on_mount(role, Authentication.get_current_user(session), socket)
+  end
 
-    if user do
-      socket
-      |> assign_new(:current_user, fn -> user end)
-      |> authorize_role(role)
+  defp do_on_mount(_role, nil, socket) do
+    Logger.warn("Could not get_current_user from session in LiveAuth.on_mount/4.")
+    {:halt, not_authorized(socket)}
+  end
+
+  # XXX: A hack for now, will be going away with client apps
+  defp do_on_mount(
+         :unprivileged,
+         %{role: :unprivileged} = user,
+         %{assigns: %{live_action: :new}, view: FzHttpWeb.DeviceLive.Unprivileged.Index} = socket
+       ) do
+    if Application.fetch_env!(:fz_http, :allow_unprivileged_device_management) do
+      {:cont, assign_new(socket, :current_user, fn -> user end)}
     else
-      Logger.warn("Could not get_current_user from session in LiveAuth.on_mount/4.")
       {:halt, not_authorized(socket)}
     end
+  end
+
+  defp do_on_mount(role, user, socket) do
+    socket
+    |> assign_new(:current_user, fn -> user end)
+    |> authorize_role(role)
   end
 end

--- a/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
@@ -31,23 +31,18 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
       restore_env(:allow_unprivileged_device_management, false, &on_exit/1)
     end
 
+    test "prevents navigating to /user_devices/new", %{unprivileged_conn: conn} do
+      path = ~p"/user_devices/new"
+      expected_path = ~p"/"
+
+      assert {:error, {:redirect, %{to: ^expected_path}}} = live(conn, path)
+    end
+
     test "omits Add Device button", %{unprivileged_conn: conn} do
       path = ~p"/user_devices"
       {:ok, _view, html} = live(conn, path)
 
       refute html =~ "Add Device"
-    end
-
-    test "prevents creating a device", %{unprivileged_conn: conn} do
-      path = ~p"/user_devices/new"
-      {:ok, view, _html} = live(conn, path)
-
-      view
-      |> element("#create-device")
-      |> render_submit(%{"device" => %{"public_key" => "test-pubkey", "name" => "test-tunnel"}})
-
-      flash = assert_redirect(view, "/")
-      assert flash["error"] == "Not authorized."
     end
   end
 


### PR DESCRIPTION
As the title suggests.

Fixes #1017 