### PR TITLE
Remove nodejs from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,6 @@ jobs:
             net-tools \
             wireguard
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '25'


### PR DESCRIPTION
Cleans up the `test` workflow to not depend on nodejs.