### PR TITLE
Fix typo "MacOS" in user documentation

### DIFF
--- a/docs/docs/user-guides/client-instructions.mdx
+++ b/docs/docs/user-guides/client-instructions.mdx
@@ -12,7 +12,7 @@ through the WireGuard native client.
 
 Firezone is compatible with the official WireGuard clients found here:
 
-* [MacOS](https://itunes.apple.com/us/app/wireguard/id1451685025)
+* [macOS](https://itunes.apple.com/us/app/wireguard/id1451685025)
 * [Windows](https://download.wireguard.com/windows-client/wireguard-installer.exe)
 * [iOS](https://itunes.apple.com/us/app/wireguard/id1441195209)
 * [Android](https://play.google.com/store/apps/details?id=com.wireguard.android)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


**What is the current behavior?** (You can also link to an open issue here)
Typo "MacOS" on https://docs.firezone.dev/user-guides/client-instructions/#step-1---install-the-native-wireguard-client.


**What is the new behavior (if this is a feature change)?**
Typo fixed to "macOS"


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Other occurrences of macOS are correct: https://github.com/search?q=repo%3Afirezone%2Ffirezone%20macos&type=code