### PR TITLE
Use application_version() to link back to repo

### DIFF
--- a/apps/fz_http/lib/fz_http_web/templates/layout/admin.html.heex
+++ b/apps/fz_http/lib/fz_http_web/templates/layout/admin.html.heex
@@ -107,7 +107,7 @@
             </div>
             <div class="level-right">
               <div class="level-item">
-                <a href={"https://github.com/firezone/firezone/tree/#{git_sha()}"}>
+                <a href={"https://github.com/firezone/firezone/tree/refs/tags/#{application_version()}"}>
                   Version <%= application_version() %>
                 </a>
               </div>

--- a/apps/fz_http/lib/fz_http_web/views/layout_view.ex
+++ b/apps/fz_http/lib/fz_http_web/views/layout_view.ex
@@ -14,12 +14,4 @@ defmodule FzHttpWeb.LayoutView do
   def application_version do
     Application.spec(:fz_http, :vsn)
   end
-
-  @doc """
-  The current github sha, used to link to our Github repo.
-  This is set during application compile time.
-  """
-  def git_sha do
-    Application.fetch_env!(:fz_http, :git_sha)
-  end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,21 +26,6 @@ require Logger
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-git_sha =
-  case System.get_env("GIT_SHA") do
-    nil ->
-      case System.cmd("git", ["rev-parse", "--short", "HEAD"], stderr_to_stdout: true) do
-        {output, 0} ->
-          String.trim(output)
-
-        {_error, _code} ->
-          "deadbeef"
-      end
-
-    str ->
-      str
-  end
-
 # Public API key for telemetry
 config :posthog,
   api_url: "https://telemetry.firez.one",
@@ -78,7 +63,6 @@ config :fz_http,
   connectivity_checks_enabled: true,
   connectivity_checks_interval: 3_600,
   connectivity_checks_url: "https://ping-dev.firez.one/",
-  git_sha: git_sha,
   cookie_secure: true,
   cookie_signing_salt: "Z9eq8iof",
   cookie_encryption_salt: "3A33Dz4C2k",


### PR DESCRIPTION
`git_sha()` is not necessary -- it's entirely possible to link back to Github using the application version.

Fixes #1173 