### PR TITLE
Refactor all tests to minimize global state

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = ./erl_crash.dump,./cover,./vendor,./omnibus,*.json,yarn.lock,seeds.exs,./docs/node_modules,./deps,./priv/static,./priv/plts,./**/priv/static,./.git,./docs/build,./_build
+skip = ./erl_crash.dump,./apps/fz_http/erl_crash.dump,./cover,./vendor,./omnibus,*.json,yarn.lock,seeds.exs,./docs/node_modules,./deps,./priv/static,./priv/plts,./**/priv/static,./.git,./docs/build,./_build
 ignore-words-list = keypair,keypairs,iif,statics,wee

--- a/apps/fz_http/lib/actual/app.ex
+++ b/apps/fz_http/lib/actual/app.ex
@@ -1,0 +1,9 @@
+defmodule Actual.Application do
+  @moduledoc """
+  The opposite of Wrapped.Application: Calls the actual Application modules.
+  """
+
+  def app do
+    Application
+  end
+end

--- a/apps/fz_http/lib/actual/cache.ex
+++ b/apps/fz_http/lib/actual/cache.ex
@@ -1,0 +1,10 @@
+defmodule Actual.Cache do
+  @moduledoc """
+  The opposite of Wrapped.Cache -- allows us to use the same
+  cache() helper in bootup before Mox has stubbed anything.
+  """
+
+  def cache do
+    FzHttp.Configurations.Cache
+  end
+end

--- a/apps/fz_http/lib/fz_http/application.ex
+++ b/apps/fz_http/lib/fz_http/application.ex
@@ -6,6 +6,7 @@ defmodule FzHttp.Application do
   use Application
 
   alias FzHttp.Telemetry
+  import Actual.Application
 
   def start(_type, _args) do
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -22,12 +23,11 @@ defmodule FzHttp.Application do
     :ok
   end
 
-  defp children, do: children(Application.fetch_env!(:fz_http, :supervision_tree_mode))
+  defp children, do: children(app().fetch_env!(:fz_http, :supervision_tree_mode))
 
   defp children(:full) do
     [
       {Cachex, name: :conf},
-      {Cachex, name: :revoked_api_tokens},
       FzHttp.Server,
       FzHttp.Repo,
       {Postgrex.Notifications, [name: FzHttp.Repo.Notifications] ++ FzHttp.Repo.config()},

--- a/apps/fz_http/lib/fz_http/conf/cache.ex
+++ b/apps/fz_http/lib/fz_http/conf/cache.ex
@@ -5,7 +5,8 @@ defmodule FzHttp.Configurations.Cache do
 
   use GenServer, restart: :transient
 
-  alias FzHttp.Configurations, as: Conf
+  alias FzHttp.Configurations
+  import Actual.Application
 
   @name :conf
 
@@ -34,7 +35,7 @@ defmodule FzHttp.Configurations.Cache do
   @impl true
   def init(_) do
     configurations =
-      Conf.get_configuration!()
+      Configurations.get_configuration!()
       |> Map.from_struct()
       |> Map.delete(:id)
 
@@ -42,7 +43,7 @@ defmodule FzHttp.Configurations.Cache do
       # XXX: Remove fallbacks before 1.0?
       v =
         with nil <- v, true <- k not in @no_fallback do
-          Application.fetch_env!(:fz_http, k)
+          app().fetch_env!(:fz_http, k)
         else
           _ -> v
         end

--- a/apps/fz_http/lib/fz_http/configurations.ex
+++ b/apps/fz_http/lib/fz_http/configurations.ex
@@ -5,17 +5,15 @@ defmodule FzHttp.Configurations do
 
   import Ecto.Query, warn: false
   import Ecto.Changeset
-  alias FzHttp.{Repo, Configurations.Configuration, Configurations.Cache}
-
-  defdelegate get(key), to: FzHttp.Configurations.Cache
-  defdelegate get!(key), to: FzHttp.Configurations.Cache
+  import Wrapped.Cache
+  alias FzHttp.{Repo, Configurations.Configuration}
 
   def get_configuration! do
     Repo.one!(Configuration)
   end
 
   def auto_create_users?(field, provider) do
-    get!(field)
+    cache().get!(field)
     |> Map.get(provider)
     |> Map.get("auto_create_users")
   end
@@ -33,10 +31,10 @@ defmodule FzHttp.Configurations do
       for {k, v} <- changeset.changes do
         case v do
           %Ecto.Changeset{} ->
-            Cache.put!(k, v.changes)
+            cache().put!(k, v.changes)
 
           _ ->
-            Cache.put!(k, v)
+            cache().put!(k, v)
         end
       end
 

--- a/apps/fz_http/lib/fz_http/connectivity_check_service.ex
+++ b/apps/fz_http/lib/fz_http/connectivity_check_service.ex
@@ -7,6 +7,8 @@ defmodule FzHttp.ConnectivityCheckService do
 
   require Logger
 
+  import Actual.Application
+
   alias FzHttp.ConnectivityChecks
 
   def start_link(_) do
@@ -61,11 +63,11 @@ defmodule FzHttp.ConnectivityCheckService do
   end
 
   defp url do
-    Application.fetch_env!(:fz_http, :connectivity_checks_url) <> version()
+    app().fetch_env!(:fz_http, :connectivity_checks_url) <> version()
   end
 
   defp http_client do
-    Application.fetch_env!(:fz_http, :http_client)
+    app().fetch_env!(:fz_http, :http_client)
   end
 
   defp version do
@@ -73,10 +75,10 @@ defmodule FzHttp.ConnectivityCheckService do
   end
 
   defp interval do
-    Application.fetch_env!(:fz_http, :connectivity_checks_interval) * 1_000
+    app().fetch_env!(:fz_http, :connectivity_checks_interval) * 1_000
   end
 
   defp enabled? do
-    Application.fetch_env!(:fz_http, :connectivity_checks_enabled)
+    app().fetch_env!(:fz_http, :connectivity_checks_enabled)
   end
 end

--- a/apps/fz_http/lib/fz_http/devices.ex
+++ b/apps/fz_http/lib/fz_http/devices.ex
@@ -5,6 +5,7 @@ defmodule FzHttp.Devices do
 
   import Ecto.Changeset
   import Ecto.Query, warn: false
+  import Wrapped.Application
 
   alias EctoNetwork.INET
   alias FzHttp.{Devices.Device, Devices.DeviceSetting, Repo, Sites, Telemetry, Users, Users.User}
@@ -172,7 +173,7 @@ defmodule FzHttp.Devices do
   def as_encoded_config(device), do: Base.encode64(as_config(device))
 
   def as_config(device) do
-    wireguard_port = Application.fetch_env!(:fz_vpn, :wireguard_port)
+    wireguard_port = app().fetch_env!(:fz_vpn, :wireguard_port)
     server_public_key = Application.get_env(:fz_vpn, :wireguard_public_key)
 
     if is_nil(server_public_key) do
@@ -264,10 +265,10 @@ defmodule FzHttp.Devices do
   defp field_empty?(_), do: false
 
   defp ipv4? do
-    Application.fetch_env!(:fz_http, :wireguard_ipv4_enabled)
+    app().fetch_env!(:fz_http, :wireguard_ipv4_enabled)
   end
 
   defp ipv6? do
-    Application.fetch_env!(:fz_http, :wireguard_ipv6_enabled)
+    app().fetch_env!(:fz_http, :wireguard_ipv6_enabled)
   end
 end

--- a/apps/fz_http/lib/fz_http/devices/device.ex
+++ b/apps/fz_http/lib/fz_http/devices/device.ex
@@ -5,6 +5,7 @@ defmodule FzHttp.Devices.Device do
 
   use Ecto.Schema
   import Ecto.Changeset
+  import Wrapped.Application
   require Logger
 
   import FzHttp.Validators.Common,
@@ -164,9 +165,11 @@ defmodule FzHttp.Devices.Device do
   end
 
   defp validate_max_devices(changeset) do
-    user_id = changeset.changes.user_id || changeset.data.user_id
-    count = Devices.count(user_id)
-    max_devices = Application.fetch_env!(:fz_http, :max_devices_per_user)
+    count =
+      get_field(changeset, :user_id)
+      |> Devices.count()
+
+    max_devices = app().fetch_env!(:fz_http, :max_devices_per_user)
 
     if count >= max_devices do
       add_error(
@@ -200,7 +203,7 @@ defmodule FzHttp.Devices.Device do
   end
 
   defp validate_ipv4_required(changeset) do
-    if Application.fetch_env!(:fz_http, :wireguard_ipv4_enabled) do
+    if app().fetch_env!(:fz_http, :wireguard_ipv4_enabled) do
       validate_required(changeset, :ipv4)
     else
       changeset
@@ -208,7 +211,7 @@ defmodule FzHttp.Devices.Device do
   end
 
   defp validate_ipv6_required(changeset) do
-    if Application.fetch_env!(:fz_http, :wireguard_ipv6_enabled) do
+    if app().fetch_env!(:fz_http, :wireguard_ipv6_enabled) do
       validate_required(changeset, :ipv6)
     else
       changeset
@@ -216,14 +219,14 @@ defmodule FzHttp.Devices.Device do
   end
 
   defp validate_in_network(%Ecto.Changeset{changes: %{ipv4: ip}} = changeset, :ipv4) do
-    net = Application.fetch_env!(:fz_http, :wireguard_ipv4_network)
+    net = app().fetch_env!(:fz_http, :wireguard_ipv4_network)
     add_net_error_if_outside_bounds(changeset, net, ip, :ipv4)
   end
 
   defp validate_in_network(changeset, :ipv4), do: changeset
 
   defp validate_in_network(%Ecto.Changeset{changes: %{ipv6: ip}} = changeset, :ipv6) do
-    net = Application.fetch_env!(:fz_http, :wireguard_ipv6_network)
+    net = app().fetch_env!(:fz_http, :wireguard_ipv6_network)
     add_net_error_if_outside_bounds(changeset, net, ip, :ipv6)
   end
 
@@ -261,7 +264,7 @@ defmodule FzHttp.Devices.Device do
 
   defp ipv4_address do
     {:ok, inet} =
-      Application.fetch_env!(:fz_http, :wireguard_ipv4_address)
+      app().fetch_env!(:fz_http, :wireguard_ipv4_address)
       |> EctoNetwork.INET.cast()
 
     inet
@@ -269,7 +272,7 @@ defmodule FzHttp.Devices.Device do
 
   defp ipv6_address do
     {:ok, inet} =
-      Application.fetch_env!(:fz_http, :wireguard_ipv6_address)
+      app().fetch_env!(:fz_http, :wireguard_ipv6_address)
       |> EctoNetwork.INET.cast()
 
     inet

--- a/apps/fz_http/lib/fz_http/devices/stats_updater.ex
+++ b/apps/fz_http/lib/fz_http/devices/stats_updater.ex
@@ -4,6 +4,7 @@ defmodule FzHttp.Devices.StatsUpdater do
   """
 
   import Ecto.Query, warn: false
+  import Wrapped.Application
   alias FzHttp.{Devices.Device, Repo}
 
   def update(stats) do
@@ -32,7 +33,7 @@ defmodule FzHttp.Devices.StatsUpdater do
 
   # XXX: Come up with a better way to update devices in Sandbox mode
   defp device_to_update(public_key) do
-    if Application.fetch_env!(:fz_http, :sandbox) do
+    if app().fetch_env!(:fz_http, :sandbox) do
       Repo.one(
         from Device,
           order_by: fragment("RANDOM()"),

--- a/apps/fz_http/lib/fz_http/mailer.ex
+++ b/apps/fz_http/lib/fz_http/mailer.ex
@@ -4,6 +4,7 @@ defmodule FzHttpWeb.Mailer do
   """
 
   use Swoosh.Mailer, otp_app: :fz_http
+  import Actual.Application
 
   alias Swoosh.{Adapters, Email}
 
@@ -18,7 +19,7 @@ defmodule FzHttpWeb.Mailer do
 
   def default_email do
     Email.new()
-    |> Email.from(Application.fetch_env!(:fz_http, FzHttpWeb.Mailer)[:from_email])
+    |> Email.from(app().fetch_env!(:fz_http, FzHttpWeb.Mailer)[:from_email])
   end
 
   def configs_for(provider) do

--- a/apps/fz_http/lib/fz_http/oidc/refresher.ex
+++ b/apps/fz_http/lib/fz_http/oidc/refresher.ex
@@ -6,7 +6,7 @@ defmodule FzHttp.OIDC.Refresher do
 
   import Ecto.{Changeset, Query}
   import FzHttpWeb.OIDC.Helpers
-  alias FzHttp.Configurations, as: Conf
+  import Wrapped.Cache
   alias FzHttp.{OIDC, OIDC.Connection, Repo, Users}
   require Logger
 
@@ -79,6 +79,6 @@ defmodule FzHttp.OIDC.Refresher do
   end
 
   defp enabled? do
-    Conf.get!(:disable_vpn_on_oidc_error)
+    cache().get!(:disable_vpn_on_oidc_error)
   end
 end

--- a/apps/fz_http/lib/fz_http/oidc/start_proxy.ex
+++ b/apps/fz_http/lib/fz_http/oidc/start_proxy.ex
@@ -4,25 +4,25 @@ defmodule FzHttp.OIDC.StartProxy do
   (after `FzHttp.Configurations.Cache` has started) and pass to `OpenIDConnect.Worker`
   """
 
-  alias FzHttp.Configurations, as: Conf
-
   require Logger
+  import Actual.Application
+  import Actual.Cache
 
   def child_spec(arg) do
     %{id: __MODULE__, start: {__MODULE__, :start_link, [arg]}}
   end
 
   def start_link(:test) do
-    auth_oidc_env = Conf.get!(:openid_connect_providers)
-    Conf.Cache.put!(:parsed_openid_connect_providers, parse(auth_oidc_env))
+    auth_oidc_env = cache().get!(:openid_connect_providers)
+    cache().put!(:parsed_openid_connect_providers, parse(auth_oidc_env))
     :ignore
   end
 
   def start_link(_) do
-    auth_oidc_env = Conf.get!(:openid_connect_providers)
+    auth_oidc_env = cache().get!(:openid_connect_providers)
 
     if parsed = auth_oidc_env && parse(auth_oidc_env) do
-      Conf.Cache.put!(:parsed_openid_connect_providers, parsed)
+      cache().put!(:parsed_openid_connect_providers, parsed)
       OpenIDConnect.Worker.start_link(parsed)
     else
       :ignore
@@ -34,7 +34,7 @@ defmodule FzHttp.OIDC.StartProxy do
   end
 
   defp parse(auth_oidc_config) when is_map(auth_oidc_config) do
-    external_url = Application.fetch_env!(:fz_http, :external_url)
+    external_url = app().fetch_env!(:fz_http, :external_url)
 
     # Convert Map to something openid_connect expects, atomic keyed configs
     # eg. [provider: [client_id: "CLIENT_ID" ...]]

--- a/apps/fz_http/lib/fz_http/queries/inet.ex
+++ b/apps/fz_http/lib/fz_http/queries/inet.ex
@@ -1,4 +1,6 @@
 defmodule FzHttp.Queries.INET do
+  import Wrapped.Application
+
   @moduledoc """
   Raw SQL INET queries
   """
@@ -60,13 +62,13 @@ defmodule FzHttp.Queries.INET do
 
   defp wireguard_network(type) do
     network_key = "wireguard_#{type}_network" |> String.to_existing_atom()
-    {:ok, network} = EctoNetwork.INET.cast(Application.fetch_env!(:fz_http, network_key))
+    {:ok, network} = EctoNetwork.INET.cast(app().fetch_env!(:fz_http, network_key))
     network
   end
 
   defp wireguard_address(type) do
     address_key = "wireguard_#{type}_address" |> String.to_existing_atom()
-    {:ok, address} = EctoNetwork.INET.cast(Application.fetch_env!(:fz_http, address_key))
+    {:ok, address} = EctoNetwork.INET.cast(app().fetch_env!(:fz_http, address_key))
     address
   end
 

--- a/apps/fz_http/lib/fz_http/release.ex
+++ b/apps/fz_http/lib/fz_http/release.ex
@@ -4,6 +4,7 @@ defmodule FzHttp.Release do
   """
 
   alias FzHttp.{Repo, Users, Users.User}
+  import Wrapped.Application
   import Ecto.Query, only: [from: 2]
   require Logger
 
@@ -55,11 +56,11 @@ defmodule FzHttp.Release do
   end
 
   def repos do
-    Application.fetch_env!(@app, :ecto_repos)
+    app().fetch_env!(@app, :ecto_repos)
   end
 
   defp email do
-    Application.fetch_env!(@app, :admin_email)
+    app().fetch_env!(@app, :admin_email)
   end
 
   defp load_app do
@@ -71,6 +72,6 @@ defmodule FzHttp.Release do
   end
 
   defp default_password do
-    Application.fetch_env!(@app, :default_admin_password)
+    app().fetch_env!(@app, :default_admin_password)
   end
 end

--- a/apps/fz_http/lib/fz_http/rules.ex
+++ b/apps/fz_http/lib/fz_http/rules.ex
@@ -5,9 +5,10 @@ defmodule FzHttp.Rules do
 
   import Ecto.Query, warn: false
   import Ecto.Changeset
+  import Actual.Application
   alias FzHttp.{Repo, Rules.Rule, Rules.RuleSetting, Telemetry}
 
-  def port_rules_supported?, do: Application.fetch_env!(:fz_wall, :port_based_rules_supported)
+  def port_rules_supported?, do: app().fetch_env!(:fz_wall, :port_based_rules_supported)
 
   defp scope(port_based_rules) when port_based_rules == true do
     Rule

--- a/apps/fz_http/lib/fz_http/sites.ex
+++ b/apps/fz_http/lib/fz_http/sites.ex
@@ -4,6 +4,7 @@ defmodule FzHttp.Sites do
   """
 
   import Ecto.Query, warn: false
+  import Wrapped.Application
   alias FzHttp.{ConnectivityChecks, Repo, Sites.Site}
 
   @wg_settings [:allowed_ips, :dns, :endpoint, :persistent_keepalive, :mtu]
@@ -63,14 +64,10 @@ defmodule FzHttp.Sites do
   end
 
   def default(:endpoint) do
-    app_env(:wireguard_endpoint) || ConnectivityChecks.endpoint()
+    app().fetch_env!(:fz_http, :wireguard_endpoint) || ConnectivityChecks.endpoint()
   end
 
   def default(key) do
-    app_env(String.to_atom("wireguard_#{key}"))
-  end
-
-  defp app_env(key) do
-    Application.fetch_env!(:fz_http, key)
+    app().fetch_env!(:fz_http, String.to_existing_atom("wireguard_#{key}"))
   end
 end

--- a/apps/fz_http/lib/fz_http_web.ex
+++ b/apps/fz_http/lib/fz_http_web.ex
@@ -25,7 +25,7 @@ defmodule FzHttpWeb do
       import FzHttpWeb.Gettext
       import Phoenix.LiveView.Controller
       import FzHttpWeb.ControllerHelpers
-      alias FzHttp.Configurations, as: Conf
+      import Wrapped.Cache
 
       unquote(verified_routes())
     end
@@ -59,7 +59,7 @@ defmodule FzHttpWeb do
     quote do
       use Phoenix.LiveView, layout: {FzHttpWeb.LayoutView, :live}
       import FzHttpWeb.LiveHelpers
-      alias FzHttp.Configurations, as: Conf
+      import Wrapped.Cache
       alias Phoenix.LiveView.JS
 
       unquote(view_helpers())
@@ -70,7 +70,7 @@ defmodule FzHttpWeb do
     quote do
       use Phoenix.LiveView, layout: nil
       import FzHttpWeb.LiveHelpers
-      alias FzHttp.Configurations, as: Conf
+      import Wrapped.Cache
       alias Phoenix.LiveView.JS
 
       unquote(view_helpers())
@@ -83,7 +83,7 @@ defmodule FzHttpWeb do
       use Phoenix.LiveComponent
       use Phoenix.Component, global_prefixes: ~w(x-)
       import FzHttpWeb.LiveHelpers
-      alias FzHttp.Configurations, as: Conf
+      import Wrapped.Cache
 
       unquote(view_helpers())
     end

--- a/apps/fz_http/lib/fz_http_web/auth/html/authentication.ex
+++ b/apps/fz_http/lib/fz_http_web/auth/html/authentication.ex
@@ -5,7 +5,7 @@ defmodule FzHttpWeb.Auth.HTML.Authentication do
   use Guardian, otp_app: :fz_http
   use FzHttpWeb, :controller
 
-  alias FzHttp.Configurations, as: Conf
+  import Wrapped.Cache
   alias FzHttp.Telemetry
   alias FzHttp.Users
   alias FzHttp.Users.User
@@ -76,7 +76,7 @@ defmodule FzHttpWeb.Auth.HTML.Authentication do
     with {:ok, provider_key} <- parse_provider(Plug.Conn.get_session(conn, "login_method")),
          {:ok, provider} <- atomize_provider(provider_key),
          {:ok, client_id} <-
-           parse_client_id(Conf.get!(:parsed_openid_connect_providers)[provider]),
+           parse_client_id(cache().get!(:parsed_openid_connect_providers)[provider]),
          {:ok, token} <- parse_token(Plug.Conn.get_session(conn, "id_token")),
          {:ok, end_session_uri} <-
            parse_end_session_uri(

--- a/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
@@ -13,6 +13,8 @@ defmodule FzHttpWeb.AuthController do
   alias FzHttpWeb.OIDC.State
   alias FzHttpWeb.UserFromAuth
 
+  import Wrapped.Cache
+
   import FzHttpWeb.OIDC.Helpers
 
   # Uncomment when Helpers.callback_url/1 is fixed
@@ -167,7 +169,7 @@ defmodule FzHttpWeb.AuthController do
 
   defp maybe_sign_in(conn, user, %{provider: provider} = auth)
        when provider in @local_auth_providers do
-    if Conf.get!(:local_auth_enabled) do
+    if cache().get!(:local_auth_enabled) do
       do_sign_in(conn, user, auth)
     else
       conn

--- a/apps/fz_http/lib/fz_http_web/controllers/json/configuration_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/json/configuration_controller.ex
@@ -1,21 +1,20 @@
 defmodule FzHttpWeb.JSON.ConfigurationController do
   use FzHttpWeb, :controller
 
-  alias FzHttp.Configurations, as: Conf
-  alias FzHttp.Configurations.Configuration
+  alias FzHttp.{Configurations.Configuration, Configurations}
 
   action_fallback FzHttpWeb.JSON.FallbackController
 
   def show(conn, _params) do
-    configuration = Conf.get_configuration!()
+    configuration = Configurations.get_configuration!()
     render(conn, "show.json", configuration: configuration)
   end
 
   def update(conn, %{"configuration" => params}) do
-    configuration = Conf.get_configuration!()
+    configuration = Configurations.get_configuration!()
 
     with {:ok, %Configuration{} = configuration} <-
-           Conf.update_configuration(configuration, params) do
+           Configurations.update_configuration(configuration, params) do
       render(conn, "show.json", configuration: configuration)
     end
   end

--- a/apps/fz_http/lib/fz_http_web/controllers/root_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/root_controller.ex
@@ -4,15 +4,13 @@ defmodule FzHttpWeb.RootController do
   """
   use FzHttpWeb, :controller
 
-  alias FzHttp.Configurations, as: Conf
-
   def index(conn, _params) do
     conn
     |> render(
       "auth.html",
-      local_enabled: Conf.get!(:local_auth_enabled),
-      openid_connect_providers: Conf.get!(:parsed_openid_connect_providers),
-      saml_identity_providers: Conf.get!(:saml_identity_providers)
+      local_enabled: cache().get!(:local_auth_enabled),
+      openid_connect_providers: cache().get!(:parsed_openid_connect_providers),
+      saml_identity_providers: cache().get!(:saml_identity_providers)
     )
   end
 end

--- a/apps/fz_http/lib/fz_http_web/header_helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/header_helpers.ex
@@ -3,11 +3,13 @@ defmodule FzHttpWeb.HeaderHelpers do
   Helper functionalities with regards to headers
   """
 
+  import Actual.Application
+
   @remote_ip_headers ["x-forwarded-for"]
 
-  def external_trusted_proxies, do: conf(:external_trusted_proxies)
+  def external_trusted_proxies, do: app().fetch_env!(:fz_http, :external_trusted_proxies)
 
-  def clients, do: conf(:private_clients)
+  def clients, do: app().fetch_env!(:fz_http, :private_clients)
 
   def proxied?, do: not (external_trusted_proxies() == false)
 
@@ -17,9 +19,5 @@ defmodule FzHttpWeb.HeaderHelpers do
       proxies: external_trusted_proxies(),
       clients: clients()
     ]
-  end
-
-  defp conf(key) when is_atom(key) do
-    Application.fetch_env!(:fz_http, key)
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/device_live/admin/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/admin/show_live.ex
@@ -4,6 +4,7 @@ defmodule FzHttpWeb.DeviceLive.Admin.Show do
   """
   use FzHttpWeb, :live_view
   alias FzHttp.{Devices, Users}
+  import Wrapped.Application
 
   @impl Phoenix.LiveView
   def mount(%{"id" => device_id} = _params, _session, socket) do
@@ -51,7 +52,7 @@ defmodule FzHttpWeb.DeviceLive.Admin.Show do
       allowed_ips: Devices.allowed_ips(device),
       dns: Devices.dns(device),
       endpoint: Devices.endpoint(device),
-      port: Application.fetch_env!(:fz_vpn, :wireguard_port),
+      port: app().fetch_env!(:fz_vpn, :wireguard_port),
       mtu: Devices.mtu(device),
       persistent_keepalive: Devices.persistent_keepalive(device),
       config: Devices.as_config(device)

--- a/apps/fz_http/lib/fz_http_web/live/device_live/new_form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/new_form_component.ex
@@ -4,10 +4,10 @@ defmodule FzHttpWeb.DeviceLive.NewFormComponent do
   """
   use FzHttpWeb, :live_component
 
-  alias FzHttp.Configurations, as: Conf
   alias FzHttp.Devices
   alias FzHttp.Sites
   alias FzHttpWeb.ErrorHelpers
+  import Wrapped.Cache
 
   @impl Phoenix.LiveComponent
   def mount(socket) do
@@ -76,7 +76,7 @@ defmodule FzHttpWeb.DeviceLive.NewFormComponent do
 
   defp authorized_to_create?(socket) do
     has_role?(socket, :admin) ||
-      (Conf.get!(:allow_unprivileged_device_management) &&
+      (cache().get!(:allow_unprivileged_device_management) &&
          to_string(socket.assigns.current_user.id) == to_string(socket.assigns.target_user_id))
   end
 

--- a/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/show_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/device_live/unprivileged/show_live.ex
@@ -3,7 +3,8 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.Show do
   Shows a device for an unprivileged user.
   """
   use FzHttpWeb, :live_view
-  alias FzHttp.Configurations, as: Conf
+  import Wrapped.Cache
+  import Wrapped.Application
   alias FzHttp.Devices
   alias FzHttp.Users
 
@@ -43,7 +44,7 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.Show do
   def delete_device(device, socket) do
     if socket.assigns.current_user.id == device.user_id &&
          (has_role?(socket.assigns.current_user, :admin) ||
-            Conf.get!(:allow_unprivileged_device_management)) do
+            cache().get!(:allow_unprivileged_device_management)) do
       Devices.delete_device(device)
     else
       {:not_authorized}
@@ -56,7 +57,7 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.Show do
       user: Users.get_user!(device.user_id),
       page_title: device.name,
       allowed_ips: Devices.allowed_ips(device),
-      port: Application.fetch_env!(:fz_vpn, :wireguard_port),
+      port: app().fetch_env!(:fz_vpn, :wireguard_port),
       dns: Devices.dns(device),
       endpoint: Devices.endpoint(device),
       mtu: Devices.mtu(device),

--- a/apps/fz_http/lib/fz_http_web/live/hooks/live_auth.ex
+++ b/apps/fz_http/lib/fz_http_web/live/hooks/live_auth.ex
@@ -6,6 +6,7 @@ defmodule FzHttpWeb.LiveAuth do
   use Phoenix.Component
   alias FzHttpWeb.Auth.HTML.Authentication
   import FzHttpWeb.AuthorizationHelpers
+  import Wrapped.Cache
 
   require Logger
 
@@ -24,7 +25,7 @@ defmodule FzHttpWeb.LiveAuth do
          %{role: :unprivileged} = user,
          %{assigns: %{live_action: :new}, view: FzHttpWeb.DeviceLive.Unprivileged.Index} = socket
        ) do
-    if Application.fetch_env!(:fz_http, :allow_unprivileged_device_management) do
+    if cache().get!(:allow_unprivileged_device_management) do
       {:cont, assign_new(socket, :current_user, fn -> user end)}
     else
       {:halt, not_authorized(socket)}

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/customization.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/customization.html.heex
@@ -18,7 +18,7 @@
   <div class="block">
     <div class="field">
       <div class="control">
-        <%= for type <- Conf.logo_types do %>
+        <%= for type <- FzHttp.Configurations.logo_types do %>
           <label class="radio">
             <input
               type="radio"

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/customization_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/customization_live.ex
@@ -4,16 +4,14 @@ defmodule FzHttpWeb.SettingLive.Customization do
   """
   use FzHttpWeb, :live_view
 
-  alias FzHttp.Configurations, as: Conf
-
   @max_logo_size 1024 ** 2
   @page_title "Customization"
   @page_subtitle "Customize the look and feel of your Firezone web portal."
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    logo = Conf.get!(:logo)
-    logo_type = Conf.logo_type(logo)
+    logo = cache().get!(:logo)
+    logo_type = FzHttp.Configurations.logo_type(logo)
 
     {:ok,
      socket
@@ -39,14 +37,14 @@ defmodule FzHttpWeb.SettingLive.Customization do
 
   @impl Phoenix.LiveView
   def handle_event("save", %{"default" => "true"}, socket) do
-    {:ok, config} = Conf.update_configuration(%{logo: nil})
+    {:ok, config} = FzHttp.Configurations.update_configuration(%{logo: nil})
 
     {:noreply, assign(socket, :logo, config.logo)}
   end
 
   @impl Phoenix.LiveView
   def handle_event("save", %{"url" => url}, socket) do
-    {:ok, config} = Conf.update_configuration(%{logo: %{"url" => url}})
+    {:ok, config} = FzHttp.Configurations.update_configuration(%{logo: %{"url" => url}})
 
     {:noreply, assign(socket, :logo, config.logo)}
   end
@@ -61,7 +59,9 @@ defmodule FzHttpWeb.SettingLive.Customization do
 
         # enforce OK, error from update_configuration instead of consume_uploaded_entry
         {:ok, config} =
-          Conf.update_configuration(%{logo: %{"data" => data, "type" => entry.client_type}})
+          FzHttp.Configurations.update_configuration(%{
+            logo: %{"data" => data, "type" => entry.client_type}
+          })
 
         {:ok, config}
       end)

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/oidc_form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/oidc_form_component.ex
@@ -4,7 +4,7 @@ defmodule FzHttpWeb.SettingLive.OIDCFormComponent do
   """
   use FzHttpWeb, :live_component
 
-  alias FzHttp.Configurations, as: Conf
+  import Wrapped.Application
 
   def render(assigns) do
     ~H"""
@@ -179,7 +179,7 @@ defmodule FzHttpWeb.SettingLive.OIDCFormComponent do
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(:external_url, Application.fetch_env!(:fz_http, :external_url))
+     |> assign(:external_url, app().fetch_env!(:fz_http, :external_url))
      |> assign(:changeset, changeset)}
   end
 
@@ -206,7 +206,7 @@ defmodule FzHttpWeb.SettingLive.OIDCFormComponent do
                 |> Map.put(id, data)
             }
           end)
-          |> Conf.update_configuration()
+          |> FzHttp.Configurations.update_configuration()
 
         _ ->
           {:error, changeset}

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/saml_form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/saml_form_component.ex
@@ -4,7 +4,7 @@ defmodule FzHttpWeb.SettingLive.SAMLFormComponent do
   """
   use FzHttpWeb, :live_component
 
-  alias FzHttp.Configurations, as: Conf
+  import Wrapped.Application
 
   def render(assigns) do
     ~H"""
@@ -192,7 +192,7 @@ defmodule FzHttpWeb.SettingLive.SAMLFormComponent do
   end
 
   def update(assigns, socket) do
-    external_url = Application.fetch_env!(:fz_http, :external_url)
+    external_url = app().fetch_env!(:fz_http, :external_url)
 
     changeset =
       assigns.providers
@@ -232,7 +232,7 @@ defmodule FzHttpWeb.SettingLive.SAMLFormComponent do
                 |> Map.put(id, data)
             }
           end)
-          |> Conf.update_configuration()
+          |> FzHttp.Configurations.update_configuration()
 
         _ ->
           {:error, changeset}
@@ -240,7 +240,7 @@ defmodule FzHttpWeb.SettingLive.SAMLFormComponent do
 
     case update do
       {:ok, config} ->
-        Application.fetch_env!(:samly, Samly.Provider)
+        app().fetch_env!(:samly, Samly.Provider)
         |> FzHttp.SAML.StartProxy.set_identity_providers(config.saml_identity_providers)
         |> FzHttp.SAML.StartProxy.refresh()
 

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/security.html.heex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/security.html.heex
@@ -73,8 +73,8 @@
             type="checkbox"
             phx-click="toggle"
             phx-value-config="local_auth_enabled"
-            checked={Conf.get!(:local_auth_enabled)}
-            value={if(!Conf.get!(:local_auth_enabled), do: "on")}
+            checked={cache().get!(:local_auth_enabled)}
+            value={if(!cache().get!(:local_auth_enabled), do: "on")}
           />
           <span class="check"></span>
         </label>
@@ -95,8 +95,8 @@
             type="checkbox"
             phx-click="toggle"
             phx-value-config="allow_unprivileged_device_management"
-            checked={Conf.get!(:allow_unprivileged_device_management)}
-            value={if(!Conf.get!(:allow_unprivileged_device_management), do: "on")}
+            checked={cache().get!(:allow_unprivileged_device_management)}
+            value={if(!cache().get!(:allow_unprivileged_device_management), do: "on")}
           />
           <span class="check"></span>
         </label>
@@ -119,8 +119,8 @@
             type="checkbox"
             phx-click="toggle"
             phx-value-config="allow_unprivileged_device_configuration"
-            checked={Conf.get!(:allow_unprivileged_device_configuration)}
-            value={if(!Conf.get!(:allow_unprivileged_device_configuration), do: "on")}
+            checked={cache().get!(:allow_unprivileged_device_configuration)}
+            value={if(!cache().get!(:allow_unprivileged_device_configuration), do: "on")}
           />
           <span class="check"></span>
         </label>
@@ -152,8 +152,8 @@
             type="checkbox"
             phx-click="toggle"
             phx-value-config="disable_vpn_on_oidc_error"
-            checked={Conf.get!(:disable_vpn_on_oidc_error)}
-            value={if(!Conf.get!(:disable_vpn_on_oidc_error), do: "on")}
+            checked={cache().get!(:disable_vpn_on_oidc_error)}
+            value={if(!cache().get!(:disable_vpn_on_oidc_error), do: "on")}
           />
           <span class="check"></span>
         </label>

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/security_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/security_live.ex
@@ -7,7 +7,7 @@ defmodule FzHttpWeb.SettingLive.Security do
   import Ecto.Changeset
   import FzCommon.FzCrypto, only: [rand_string: 1]
 
-  alias FzHttp.Configurations, as: Conf
+  import Wrapped.Cache
   alias FzHttp.{Sites, Sites.Site}
 
   @page_title "Security Settings"
@@ -15,7 +15,7 @@ defmodule FzHttpWeb.SettingLive.Security do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    config_changeset = Conf.change_configuration()
+    config_changeset = FzHttp.Configurations.change_configuration()
 
     {:ok,
      socket
@@ -67,7 +67,7 @@ defmodule FzHttpWeb.SettingLive.Security do
   @impl Phoenix.LiveView
   def handle_event("toggle", %{"config" => config} = params, socket) do
     toggle_value = !!params["value"]
-    {:ok, _conf} = Conf.update_configuration(%{config => toggle_value})
+    {:ok, _conf} = FzHttp.Configurations.update_configuration(%{config => toggle_value})
     {:noreply, socket}
   end
 
@@ -80,7 +80,8 @@ defmodule FzHttpWeb.SettingLive.Security do
     providers =
       get_in(socket.assigns.config_changeset, [Access.key!(:data), Access.key!(field_key)])
 
-    {:ok, conf} = Conf.update_configuration(%{field_key => Map.delete(providers, key)})
+    {:ok, conf} =
+      FzHttp.Configurations.update_configuration(%{field_key => Map.delete(providers, key)})
 
     {:noreply,
      socket

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/unprivileged/account_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/unprivileged/account_live.ex
@@ -8,7 +8,7 @@ defmodule FzHttpWeb.SettingLive.Unprivileged.Account do
   """
   use FzHttpWeb, :live_view
 
-  alias FzHttp.Configurations, as: Conf
+  import Wrapped.Cache
   alias FzHttp.{MFA, Users}
   alias FzHttpWeb.{Endpoint, Presence}
 
@@ -22,7 +22,7 @@ defmodule FzHttpWeb.SettingLive.Unprivileged.Account do
 
     {:ok,
      socket
-     |> assign(:local_auth_enabled, Conf.get!(:local_auth_enabled))
+     |> assign(:local_auth_enabled, cache().get!(:local_auth_enabled))
      |> assign(:changeset, Users.change_user(socket.assigns.current_user))
      |> assign(:methods, MFA.list_methods(socket.assigns.current_user))
      |> assign(:page_title, @page_title)

--- a/apps/fz_http/lib/fz_http_web/live_helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/live_helpers.ex
@@ -6,6 +6,7 @@ defmodule FzHttpWeb.LiveHelpers do
   """
   use Phoenix.Component
   alias FzHttp.{Sites, Users}
+  import Wrapped.Application
 
   def live_modal(component, opts) do
     path = Keyword.fetch!(opts, :return_to)
@@ -36,7 +37,7 @@ defmodule FzHttpWeb.LiveHelpers do
   end
 
   def admin_email do
-    Application.fetch_env!(:fz_http, :admin_email)
+    app().fetch_env!(:fz_http, :admin_email)
   end
 
   def vpn_sessions_expire? do

--- a/apps/fz_http/lib/fz_http_web/oauth/pkce.ex
+++ b/apps/fz_http/lib/fz_http_web/oauth/pkce.ex
@@ -8,6 +8,7 @@ defmodule FzHttpWeb.OAuth.PKCE do
   @code_challenge_method :S256
 
   import Plug.Conn
+  import Wrapped.Application
 
   def put_cookie(conn, verifier) do
     put_resp_cookie(conn, @pkce_key, verifier, cookie_opts())
@@ -43,7 +44,7 @@ defmodule FzHttpWeb.OAuth.PKCE do
       max_age: @pkce_valid_duration,
       sign: true,
       same_site: "Lax",
-      secure: Application.fetch_env!(:fz_http, :cookie_secure)
+      secure: app().fetch_env!(:fz_http, :cookie_secure)
     ]
   end
 end

--- a/apps/fz_http/lib/fz_http_web/oidc/helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/oidc/helpers.ex
@@ -3,6 +3,8 @@ defmodule FzHttpWeb.OIDC.Helpers do
   Just some, ya know, helpers for OIDC flows.
   """
 
+  import Wrapped.Application
+
   # openid_connect expects providers as keys...
   def atomize_provider(key) do
     {:ok, String.to_existing_atom(key)}
@@ -11,6 +13,6 @@ defmodule FzHttpWeb.OIDC.Helpers do
   end
 
   def openid_connect do
-    Application.fetch_env!(:fz_http, :openid_connect)
+    app().fetch_env!(:fz_http, :openid_connect)
   end
 end

--- a/apps/fz_http/lib/fz_http_web/oidc/state.ex
+++ b/apps/fz_http/lib/fz_http_web/oidc/state.ex
@@ -7,6 +7,7 @@ defmodule FzHttpWeb.OIDC.State do
   @oidc_state_valid_duration 300
 
   import Plug.Conn
+  import Wrapped.Application
 
   def put_cookie(conn, state) do
     put_resp_cookie(conn, @oidc_state_key, state, cookie_opts())
@@ -33,7 +34,7 @@ defmodule FzHttpWeb.OIDC.State do
       max_age: @oidc_state_valid_duration,
       sign: true,
       same_site: "Lax",
-      secure: Application.fetch_env!(:fz_http, :cookie_secure)
+      secure: app().fetch_env!(:fz_http, :cookie_secure)
     ]
   end
 end

--- a/apps/fz_http/lib/fz_http_web/session.ex
+++ b/apps/fz_http/lib/fz_http_web/session.ex
@@ -3,6 +3,8 @@ defmodule FzHttpWeb.Session do
   Dynamically configures session.
   """
 
+  import Actual.Application
+
   # 4 hours
   @max_cookie_age 14_400
 
@@ -25,14 +27,14 @@ defmodule FzHttpWeb.Session do
   end
 
   defp cookie_secure do
-    Application.fetch_env!(:fz_http, :cookie_secure)
+    app().fetch_env!(:fz_http, :cookie_secure)
   end
 
   defp signing_salt do
-    Application.fetch_env!(:fz_http, :cookie_signing_salt)
+    app().fetch_env!(:fz_http, :cookie_signing_salt)
   end
 
   defp encryption_salt do
-    Application.fetch_env!(:fz_http, :cookie_encryption_salt)
+    app().fetch_env!(:fz_http, :cookie_encryption_salt)
   end
 end

--- a/apps/fz_http/lib/fz_http_web/templates/layout/admin.html.heex
+++ b/apps/fz_http/lib/fz_http_web/templates/layout/admin.html.heex
@@ -99,7 +99,7 @@
                 &nbsp;
                 <strong>
                   0.6.0 is here!
-                  <a href={"https://blog.firezone.dev/release-0-6-0/?utm_source=product&uid=#{Application.fetch_env!(:fz_http, :telemetry_id)}"}>
+                  <a href={"https://blog.firezone.dev/release-0-6-0/?utm_source=product&uid=#{app().fetch_env!(:fz_http, :telemetry_id)}"}>
                     Click here to read more.
                   </a>
                 </strong>

--- a/apps/fz_http/lib/fz_http_web/templates/shared/device_details.html.heex
+++ b/apps/fz_http/lib/fz_http_web/templates/shared/device_details.html.heex
@@ -19,14 +19,14 @@
       <td><%= @device.description %></td>
     </tr>
 
-    <%= if Application.fetch_env!(:fz_http, :wireguard_ipv4_enabled) do %>
+    <%= if app().fetch_env!(:fz_http, :wireguard_ipv4_enabled) do %>
       <tr>
         <td><strong>Interface IPv4</strong></td>
         <td><%= @device.ipv4 %></td>
       </tr>
     <% end %>
 
-    <%= if Application.fetch_env!(:fz_http, :wireguard_ipv6_enabled) do %>
+    <%= if app().fetch_env!(:fz_http, :wireguard_ipv6_enabled) do %>
       <tr>
         <td><strong>Interface IPv6</strong></td>
         <td><%= @device.ipv6 %></td>

--- a/apps/fz_http/lib/fz_http_web/user_from_auth.ex
+++ b/apps/fz_http/lib/fz_http_web/user_from_auth.ex
@@ -3,7 +3,6 @@ defmodule FzHttpWeb.UserFromAuth do
   Authenticates users.
   """
 
-  alias FzHttp.Configurations, as: Conf
   alias FzHttp.Users
   alias FzHttpWeb.Auth.HTML.Authentication
 
@@ -34,7 +33,7 @@ defmodule FzHttpWeb.UserFromAuth do
   end
 
   defp maybe_create_user(idp_field, provider_key, email) do
-    if Conf.auto_create_users?(idp_field, provider_key) do
+    if FzHttp.Configurations.auto_create_users?(idp_field, provider_key) do
       Users.create_unprivileged_user(%{email: email})
     else
       {:error, "not found"}

--- a/apps/fz_http/lib/fz_http_web/views/device_view.ex
+++ b/apps/fz_http/lib/fz_http_web/views/device_view.ex
@@ -1,13 +1,13 @@
 defmodule FzHttpWeb.DeviceView do
   use FzHttpWeb, :view
 
-  alias FzHttp.Configurations, as: Conf
+  import Wrapped.Cache
 
   def can_manage_devices?(user) do
-    has_role?(user, :admin) || Conf.get!(:allow_unprivileged_device_management)
+    has_role?(user, :admin) || cache().get!(:allow_unprivileged_device_management)
   end
 
   def can_configure_devices?(user) do
-    has_role?(user, :admin) || Conf.get!(:allow_unprivileged_device_configuration)
+    has_role?(user, :admin) || cache().get!(:allow_unprivileged_device_configuration)
   end
 end

--- a/apps/fz_http/lib/fz_http_web/views/layout_view.ex
+++ b/apps/fz_http/lib/fz_http_web/views/layout_view.ex
@@ -1,6 +1,8 @@
 defmodule FzHttpWeb.LayoutView do
   use FzHttpWeb, :view
 
+  import Wrapped.Application
+
   @doc """
   Generate a random feedback email to avoid spam.
   """

--- a/apps/fz_http/lib/fz_http_web/views/shared_view.ex
+++ b/apps/fz_http/lib/fz_http_web/views/shared_view.ex
@@ -1,3 +1,4 @@
 defmodule FzHttpWeb.SharedView do
   use FzHttpWeb, :view
+  import Wrapped.Application
 end

--- a/apps/fz_http/lib/wrapped/application.ex
+++ b/apps/fz_http/lib/wrapped/application.ex
@@ -1,0 +1,12 @@
+defmodule Wrapped.Application do
+  @moduledoc """
+  Wraps Application so it can be stubbed easily for tests that use Mox to
+  mock Application.fetch_env!/2 calls.
+  """
+
+  @app :fz_http
+
+  def app do
+    Application.fetch_env!(@app, :application_module)
+  end
+end

--- a/apps/fz_http/lib/wrapped/cache.ex
+++ b/apps/fz_http/lib/wrapped/cache.ex
@@ -1,0 +1,10 @@
+defmodule Wrapped.Cache do
+  @moduledoc """
+  Convenience wrapper for the Configurations Cache so it's possible
+  to stub more easily.
+  """
+
+  def cache do
+    Application.fetch_env!(:fz_http, :cache_module)
+  end
+end

--- a/apps/fz_http/test/fz_http/queries_test.exs
+++ b/apps/fz_http/test/fz_http/queries_test.exs
@@ -1,5 +1,5 @@
 defmodule FzHttp.QueriesTest do
-  use FzHttp.DataCase, async: false
+  use FzHttp.DataCase, async: true
 
   alias FzHttp.Queries.INET
 
@@ -7,29 +7,15 @@ defmodule FzHttp.QueriesTest do
     @expected_ipv4 %Postgrex.INET{address: {10, 3, 2, 2}, netmask: nil}
     @expected_ipv6 %Postgrex.INET{address: {64_768, 0, 0, 0, 0, 3, 2, 2}, netmask: nil}
 
-    setup context do
-      if ipv4_network = context[:ipv4_network] do
-        restore_env(:wireguard_ipv4_network, ipv4_network, &on_exit/1)
-      else
-        context
-      end
-    end
-
-    setup context do
-      if ipv6_network = context[:ipv6_network] do
-        restore_env(:wireguard_ipv6_network, ipv6_network, &on_exit/1)
-      else
-        context
-      end
-    end
-
-    @tag ipv4_network: "10.3.2.2/32"
     test "when ipv4 network is /32 returns null" do
+      stub_app_env(:wireguard_ipv4_network, "10.3.2.2/32")
+
       assert is_nil(INET.next_available(:ipv4))
     end
 
-    @tag ipv6_network: "fd00::3:2:2/128"
     test "when ipv6 network is /128 returns null" do
+      stub_app_env(:wireguard_ipv6_network, "fd00::3:2:2/128")
+
       assert is_nil(INET.next_available(:ipv6))
     end
   end
@@ -40,30 +26,16 @@ defmodule FzHttp.QueriesTest do
     @expected_ipv4 %Postgrex.INET{address: {10, 3, 2, 2}, netmask: 32}
     @expected_ipv6 %Postgrex.INET{address: {64_768, 0, 0, 0, 0, 3, 2, 2}, netmask: 128}
 
-    setup context do
-      if ipv4_network = context[:ipv4_network] do
-        restore_env(:wireguard_ipv4_network, ipv4_network, &on_exit/1)
-      else
-        context
-      end
-    end
-
-    setup context do
-      if ipv6_network = context[:ipv6_network] do
-        restore_env(:wireguard_ipv6_network, ipv6_network, &on_exit/1)
-      else
-        context
-      end
-    end
-
-    @tag ipv4_network: "10.3.2.0/30"
     test "when ipv4 network is /30 returns null", %{device: device} do
+      stub_app_env(:wireguard_ipv4_network, "10.3.2.0/30")
+
       assert device.ipv4 == @expected_ipv4
       assert is_nil(INET.next_available(:ipv4))
     end
 
-    @tag ipv6_network: "fd00::3:2:0/126"
     test "when ipv6 network is /126 returns null", %{device: device} do
+      stub_app_env(:wireguard_ipv6_network, "fd00::3:2:0/126")
+
       assert device.ipv6 == @expected_ipv6
       assert is_nil(INET.next_available(:ipv6))
     end
@@ -72,6 +44,13 @@ defmodule FzHttp.QueriesTest do
   describe "next_available/1 when available" do
     @expected_ipv4 %Postgrex.INET{address: {10, 3, 2, 2}, netmask: nil}
     @expected_ipv6 %Postgrex.INET{address: {64_768, 0, 0, 0, 0, 3, 2, 2}, netmask: nil}
+
+    setup do
+      stub_app_env(:wireguard_ipv4_network, "10.3.2.0/24")
+      stub_app_env(:wireguard_ipv6_network, "fd00::3:2:0/120")
+
+      :ok
+    end
 
     test "when ipv4 network is /24 returns 10.3.2.2" do
       assert INET.next_available(:ipv4) == @expected_ipv4

--- a/apps/fz_http/test/fz_http/rules_test.exs
+++ b/apps/fz_http/test/fz_http/rules_test.exs
@@ -3,6 +3,13 @@ defmodule FzHttp.RulesTest do
 
   alias FzHttp.Rules
 
+  setup do
+    stub_app_env(:wireguard_ipv4_network, "10.3.2.0/24")
+    stub_app_env(:wireguard_ipv6_network, "fd00::3:2:0/120")
+
+    :ok
+  end
+
   describe "list_rules/0" do
     setup [:create_rules]
 

--- a/apps/fz_http/test/fz_http/telemetry_test.exs
+++ b/apps/fz_http/test/fz_http/telemetry_test.exs
@@ -40,65 +40,63 @@ defmodule FzHttp.TelemetryTest do
   end
 
   describe "auth" do
-    setup context do
-      if context[:config] do
-        {key, value} = context[:config]
-        restore_env(key, value, &on_exit/1)
-      else
-        context
-      end
-    end
-
     test "count openid providers" do
       ping_data = Telemetry.ping_data()
 
       assert ping_data[:openid_providers] == 7
     end
 
-    @tag config: {:disable_vpn_on_oidc_error, true}
     test "disable vpn on oidc error enabled" do
+      stub_conf(:disable_vpn_on_oidc_error, true)
+
       ping_data = Telemetry.ping_data()
 
       assert ping_data[:disable_vpn_on_oidc_error]
     end
 
-    @tag config: {:disable_vpn_on_oidc_error, false}
     test "disable vpn on oidc error disabled" do
+      stub_conf(:disable_vpn_on_oidc_error, false)
+
       ping_data = Telemetry.ping_data()
 
       refute ping_data[:disable_vpn_on_oidc_error]
     end
 
-    @tag config: {:local_auth_enabled, true}
     test "local authentication enabled" do
+      stub_conf(:local_auth_enabled, true)
+
       ping_data = Telemetry.ping_data()
 
       assert ping_data[:local_authentication]
     end
 
-    @tag config: {:local_auth_enabled, false}
     test "local authentication disabled" do
+      stub_conf(:local_auth_enabled, false)
+
       ping_data = Telemetry.ping_data()
 
       refute ping_data[:local_authentication]
     end
 
-    @tag config: {:allow_unprivileged_device_management, true}
     test "unprivileged device management enabled" do
+      stub_conf(:allow_unprivileged_device_management, true)
+
       ping_data = Telemetry.ping_data()
 
       assert ping_data[:unprivileged_device_management]
     end
 
-    @tag config: {:allow_unprivileged_device_configuration, true}
     test "unprivileged device configuration enabled" do
+      stub_conf(:allow_unprivileged_device_configuration, true)
+
       ping_data = Telemetry.ping_data()
 
       assert ping_data[:unprivileged_device_configuration]
     end
 
-    @tag config: {:allow_unprivileged_device_configuration, false}
     test "unprivileged device configuration disabled" do
+      stub_conf(:allow_unprivileged_device_configuration, false)
+
       ping_data = Telemetry.ping_data()
 
       refute ping_data[:unprivileged_device_configuration]
@@ -106,33 +104,33 @@ defmodule FzHttp.TelemetryTest do
   end
 
   describe "database" do
-    setup context do
-      restore_env(FzHttp.Repo, context[:db_config], &on_exit/1)
-    end
-
-    @tag db_config: [hostname: "localhost"]
     test "local hostname" do
+      stub_app_env(FzHttp.Repo, hostname: "localhost")
+
       ping_data = Telemetry.ping_data()
 
       refute ping_data[:external_database]
     end
 
-    @tag db_config: [url: "postgres://127.0.0.1"]
     test "local url" do
+      stub_app_env(FzHttp.Repo, url: "postgres://127.0.0.1")
+
       ping_data = Telemetry.ping_data()
 
       refute ping_data[:external_database]
     end
 
-    @tag db_config: [hostname: "firezone.dev"]
     test "external hostname" do
+      stub_app_env(FzHttp.Repo, hostname: "firezone.dev")
+
       ping_data = Telemetry.ping_data()
 
       assert ping_data[:external_database]
     end
 
-    @tag db_config: [url: "postgres://firezone.dev"]
     test "external url" do
+      stub_app_env(FzHttp.Repo, url: "postgres://firezone.dev")
+
       ping_data = Telemetry.ping_data()
 
       assert ping_data[:external_database]
@@ -140,19 +138,17 @@ defmodule FzHttp.TelemetryTest do
   end
 
   describe "email" do
-    setup context do
-      restore_env(FzHttpWeb.Mailer, [from_email: context[:from_email]], &on_exit/1)
-    end
-
-    @tag from_email: "test@firezone.dev"
     test "outbound set" do
+      stub_app_env(FzHttpWeb.Mailer, from_email: "test@firezone.dev")
+
       ping_data = Telemetry.ping_data()
 
       assert ping_data[:outbound_email]
     end
 
-    @tag from_email: nil
     test "outbound unset" do
+      stub_app_env(FzHttpWeb.Mailer, from_email: nil)
+
       ping_data = Telemetry.ping_data()
 
       refute ping_data[:outbound_email]

--- a/apps/fz_http/test/fz_http_web/controllers/auth_controller_test.exs
+++ b/apps/fz_http/test/fz_http_web/controllers/auth_controller_test.exs
@@ -89,7 +89,7 @@ defmodule FzHttpWeb.AuthControllerTest do
         "password" => "password1234"
       }
 
-      restore_env(:local_auth_enabled, false, &on_exit/1)
+      stub_conf(:local_auth_enabled, false)
 
       test_conn = post(conn, ~p"/auth/identity/callback", params)
       assert text_response(test_conn, 401) == "Local auth disabled"
@@ -227,7 +227,7 @@ defmodule FzHttpWeb.AuthControllerTest do
     end
 
     test "prevents signing in when local_auth_disabled", %{unauthed_conn: conn, user: user} do
-      restore_env(:local_auth_enabled, false, &on_exit/1)
+      stub_conf(:local_auth_enabled, false)
 
       test_conn = get(conn, ~p"/auth/magic/#{user.sign_in_token}")
       assert text_response(test_conn, 401) == "Local auth disabled"

--- a/apps/fz_http/test/fz_http_web/controllers/json/configuration_controller_test.exs
+++ b/apps/fz_http/test/fz_http_web/controllers/json/configuration_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule FzHttpWeb.JSON.ConfigurationControllerTest do
   use FzHttpWeb.APICase
 
+  import Mox
+
   describe "show configuration" do
     test "renders configuration", %{conn: conn} do
       conn = get(conn, ~p"/v1/configuration")
@@ -10,9 +12,17 @@ defmodule FzHttpWeb.JSON.ConfigurationControllerTest do
 
   describe "update configuration" do
     test "renders configuration when data is valid", %{conn: conn} do
+      expect(Cache.Mock, :put!, fn :local_auth_enabled, val ->
+        assert val == true
+      end)
+
       conn = put(conn, ~p"/v1/configuration", configuration: %{"local_auth_enabled" => true})
 
       assert %{"local_auth_enabled" => true} = json_response(conn, 200)["data"]
+
+      expect(Cache.Mock, :put!, fn :local_auth_enabled, val ->
+        assert val == false
+      end)
 
       conn = put(conn, ~p"/v1/configuration", configuration: %{"local_auth_enabled" => false})
 

--- a/apps/fz_http/test/fz_http_web/live/device_live/admin/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/device_live/admin/index_test.exs
@@ -1,5 +1,5 @@
 defmodule FzHttpWeb.DeviceLive.Admin.IndexTest do
-  use FzHttpWeb.ConnCase, async: false
+  use FzHttpWeb.ConnCase, async: true
 
   describe "authenticated/device list" do
     setup :create_devices

--- a/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/index_test.exs
@@ -1,5 +1,5 @@
 defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
-  use FzHttpWeb.ConnCase, async: false
+  use FzHttpWeb.ConnCase, async: true
 
   describe "authenticated/device list" do
     test "includes the device name in the list", %{
@@ -28,7 +28,8 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
 
   describe "authenticated device management disabled" do
     setup do
-      restore_env(:allow_unprivileged_device_management, false, &on_exit/1)
+      stub_conf(:allow_unprivileged_device_management, false)
+      :ok
     end
 
     test "prevents navigating to /user_devices/new", %{unprivileged_conn: conn} do
@@ -48,7 +49,8 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
 
   describe "authenticated device configuration disabled" do
     setup do
-      restore_env(:allow_unprivileged_device_configuration, false, &on_exit/1)
+      stub_conf(:allow_unprivileged_device_configuration, false)
+      :ok
     end
 
     @tag fields: ~w(
@@ -97,7 +99,7 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
       {:ok, view, _html} = live(conn, path)
 
       # A pool of size 1 is always exhausted
-      restore_env(:wireguard_ipv4_network, "10.0.0.1/32", &on_exit/1)
+      stub_app_env(:wireguard_ipv4_network, "10.0.0.1/32")
 
       assert view
              |> element("#create-device")
@@ -112,7 +114,7 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.IndexTest do
       {:ok, view, _html} = live(conn, path)
 
       # A pool of size 1 is always exhausted
-      restore_env(:wireguard_ipv6_network, "fd00::3:2:0/128", &on_exit/1)
+      stub_app_env(:wireguard_ipv6_network, "fd00::3:2:0/128")
 
       assert view
              |> element("#create-device")

--- a/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/show_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/device_live/unprivileged/show_test.exs
@@ -42,7 +42,8 @@ defmodule FzHttpWeb.DeviceLive.Unprivileged.ShowTest do
       unprivileged_conn: conn
     } do
       {:ok, device: device} = create_device(user_id: user.id)
-      restore_env(:allow_unprivileged_device_management, false, &on_exit/1)
+
+      stub_conf(:allow_unprivileged_device_management, false)
 
       path = ~p"/user_devices/#{device}"
       {:ok, _view, html} = live(conn, path)

--- a/apps/fz_http/test/fz_http_web/live/user_live/show_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/show_test.exs
@@ -1,6 +1,5 @@
 defmodule FzHttpWeb.UserLive.ShowTest do
-  # XXX: Setting to true causes deadlocks. Figure out why.
-  use FzHttpWeb.ConnCase, async: false
+  use FzHttpWeb.ConnCase, async: true
 
   alias FzHttp.UsersFixtures
 

--- a/apps/fz_http/test/fz_http_web/user_from_auth_test.exs
+++ b/apps/fz_http/test/fz_http_web/user_from_auth_test.exs
@@ -27,7 +27,7 @@ defmodule FzHttpWeb.UserFromAuthTest do
   describe "find_or_create/2 via OIDC with auto create enabled" do
     @tag config: %{"oidc_test" => %{"auto_create_users" => true}}
     test "sign in creates user", %{config: config, email: email} do
-      restore_env(:openid_connect_providers, config, &on_exit/1)
+      stub_conf(:openid_connect_providers, config)
 
       assert {:ok, result} =
                UserFromAuth.find_or_create("oidc_test", %{"email" => email, "sub" => :noop})
@@ -39,7 +39,7 @@ defmodule FzHttpWeb.UserFromAuthTest do
   describe "find_or_create/2 via OIDC with auto create disabled" do
     @tag config: %{"oidc_test" => %{"auto_create_users" => false}}
     test "sign in returns error", %{email: email, config: config} do
-      restore_env(:openid_connect_providers, config, &on_exit/1)
+      stub_conf(:openid_connect_providers, config)
 
       assert {:error, "not found"} =
                UserFromAuth.find_or_create("oidc_test", %{"email" => email, "sub" => :noop})
@@ -51,7 +51,7 @@ defmodule FzHttpWeb.UserFromAuthTest do
   describe "find_or_create/2 via SAML with auto create enabled" do
     @tag config: %{"saml_test" => %{"auto_create_users" => true}}
     test "sign in creates user", %{config: config, email: email} do
-      restore_env(:saml_identity_providers, config, &on_exit/1)
+      stub_conf(:saml_identity_providers, config)
 
       assert {:ok, result} =
                UserFromAuth.find_or_create(:saml, "saml_test", %{"email" => email, "sub" => :noop})
@@ -63,7 +63,7 @@ defmodule FzHttpWeb.UserFromAuthTest do
   describe "find_or_create/2 via SAML with auto create disabled" do
     @tag config: %{"saml_test" => %{"auto_create_users" => false}}
     test "sign in returns error", %{email: email, config: config} do
-      restore_env(:saml_identity_providers, config, &on_exit/1)
+      stub_conf(:saml_identity_providers, config)
 
       assert {:error, "not found"} =
                UserFromAuth.find_or_create(:saml, "saml_test", %{"email" => email, "sub" => :noop})

--- a/apps/fz_http/test/support/api_case.ex
+++ b/apps/fz_http/test/support/api_case.ex
@@ -4,6 +4,7 @@ defmodule FzHttpWeb.APICase do
   """
 
   use ExUnit.CaseTemplate
+  use FzHttp.CaseTemplate
 
   using do
     quote do

--- a/apps/fz_http/test/support/case_template.ex
+++ b/apps/fz_http/test/support/case_template.ex
@@ -1,0 +1,29 @@
+defmodule FzHttp.CaseTemplate do
+  @moduledoc """
+  Our wrapper for the ExUnit.CaseTemplate to provide metaprogrammed
+  helpers to all tests.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      setup do
+        # Global stub passthrough for functions we're not interested in stubbing
+        Mox.stub(Application.Mock, :fetch_env!, fn app, key ->
+          Application.fetch_env!(app, key)
+        end)
+
+        Mox.stub(Cache.Mock, :get!, fn key ->
+          FzHttp.Configurations.Cache.get!(key)
+        end)
+
+        Mox.stub(Cache.Mock, :put!, fn key, val ->
+          FzHttp.Configurations.Cache.put!(key, val)
+        end)
+
+        :ok
+      end
+    end
+  end
+end

--- a/apps/fz_http/test/support/channel_case.ex
+++ b/apps/fz_http/test/support/channel_case.ex
@@ -16,6 +16,7 @@ defmodule FzHttpWeb.ChannelCase do
   """
 
   use ExUnit.CaseTemplate
+  use FzHttp.CaseTemplate
 
   alias Ecto.Adapters.SQL.Sandbox
 

--- a/apps/fz_http/test/support/conn_case.ex
+++ b/apps/fz_http/test/support/conn_case.ex
@@ -16,6 +16,7 @@ defmodule FzHttpWeb.ConnCase do
   """
 
   use ExUnit.CaseTemplate
+  use FzHttp.CaseTemplate
 
   alias Ecto.Adapters.SQL.Sandbox
   alias FzHttpWeb.Auth.HTML.Authentication
@@ -64,9 +65,7 @@ defmodule FzHttpWeb.ConnCase do
 
     {user,
      conn
-     |> Plug.Test.init_test_session(%{
-       "guardian_default_token" => conn.private.guardian_default_token
-     })}
+     |> Plug.Conn.put_session("guardian_default_token", conn.private.guardian_default_token)}
   end
 
   defp maybe_put_session(conn, %{session: session}) do

--- a/apps/fz_http/test/support/data_case.ex
+++ b/apps/fz_http/test/support/data_case.ex
@@ -15,6 +15,7 @@ defmodule FzHttp.DataCase do
   """
 
   use ExUnit.CaseTemplate
+  use FzHttp.CaseTemplate
 
   alias Ecto.Adapters.SQL.Sandbox
 

--- a/apps/fz_http/test/support/fixtures/configurations_fixtures.ex
+++ b/apps/fz_http/test/support/fixtures/configurations_fixtures.ex
@@ -1,0 +1,17 @@
+defmodule FzHttp.ConfigurationsFixtures do
+  @moduledoc """
+  Allows for easily updating configuration in tests.
+  """
+
+  alias FzHttp.{
+    Configurations,
+    Configurations.Configuration,
+    Repo
+  }
+
+  def update_conf(%Configuration{} = conf \\ Configurations.get_configuration!(), attrs) do
+    conf
+    |> Configuration.changeset(attrs)
+    |> Repo.update()
+  end
+end

--- a/apps/fz_http/test/support/mailer_case.ex
+++ b/apps/fz_http/test/support/mailer_case.ex
@@ -3,6 +3,7 @@ defmodule FzHttpWeb.MailerCase do
   A case template for Mailers.
   """
   use ExUnit.CaseTemplate
+  use FzHttp.CaseTemplate
 
   alias Ecto.Adapters.SQL.Sandbox
 

--- a/apps/fz_http/test/support/mocks/application.ex
+++ b/apps/fz_http/test/support/mocks/application.ex
@@ -1,0 +1,6 @@
+defmodule Application.MockBehaviour do
+  @moduledoc """
+  Mock Behaviour for Application fetch_env!/2.
+  """
+  @callback fetch_env!(atom(), atom()) :: any()
+end

--- a/apps/fz_http/test/support/mocks/cache.ex
+++ b/apps/fz_http/test/support/mocks/cache.ex
@@ -1,0 +1,7 @@
+defmodule Cache.MockBehaviour do
+  @moduledoc """
+  Mock behavior for stubbing/expecting in tests.
+  """
+  @callback get!(atom()) :: any()
+  @callback put!(atom(), any()) :: any()
+end

--- a/apps/fz_http/test/test_helper.exs
+++ b/apps/fz_http/test/test_helper.exs
@@ -1,4 +1,6 @@
 Mox.defmock(OpenIDConnect.Mock, for: OpenIDConnect.MockBehaviour)
+Mox.defmock(Application.Mock, for: Application.MockBehaviour)
+Mox.defmock(Cache.Mock, for: Cache.MockBehaviour)
 
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(FzHttp.Repo, :manual)

--- a/config/config.exs
+++ b/config/config.exs
@@ -80,7 +80,9 @@ config :fz_http,
   saml_entity_id: "urn:firezone.dev:firezone-app",
   saml_certfile_path: "apps/fz_http/priv/cert/saml_selfsigned.pem",
   saml_keyfile_path: "apps/fz_http/priv/cert/saml_selfsigned_key.pem",
-  openid_connect: OpenIDConnect
+  openid_connect: OpenIDConnect,
+  application_module: Application,
+  cache_module: FzHttp.Configurations.Cache
 
 config :fz_wall,
   cli: FzWall.CLI.Sandbox,

--- a/config/test.exs
+++ b/config/test.exs
@@ -125,8 +125,14 @@ config :fz_http, :openid_connect_providers, """
 
 config :fz_http, :saml_identity_providers, %{"test" => %{"label" => "SAML"}}
 
-# Provide mock for HTTPClient
+# Provide mock for OpenIDConnect
 config :fz_http, :openid_connect, OpenIDConnect.Mock
+
+# Provide mock for Application
+config :fz_http, :application_module, Application.Mock
+
+# Mock for the configuration cache
+config :fz_http, :cache_module, Cache.Mock
 
 config :fz_http, FzHttpWeb.Mailer, adapter: Swoosh.Adapters.Test, from_email: "test@firez.one"
 


### PR DESCRIPTION
Tests were intermittently failing for two reasons:

* We were modifying the Application env with `restore_env/3` (a custom function) between tests. This is not thread-safe.
* The Conf cache was also being modified between tests. This is a global memory store and is also not thread-safe.

This PR aims to mock both of these using Mox in order to provide for a manageable way to test the repurcussions of both Application env and Conf cache changes.