### PR TITLE
Fix IPv6 routing for Docker-based deployments

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -92,8 +92,10 @@ volumes:
 
 networks:
   firezone-network:
+    enable_ipv6: true
     driver: bridge
     ipam:
       config:
         - subnet: 172.25.0.0/16
         - subnet: 2001:3990:3990::/64
+          gateway: 2001:3990:3990::1

--- a/docs/docs/deploy/docker/README.mdx
+++ b/docs/docs/deploy/docker/README.mdx
@@ -95,7 +95,38 @@ Then, make sure your Firezone services have the `restart: always` or `restart: u
 specified in the `docker-compose.yml` file. This is the default used in the docker-compose.prod.yml
 production template file.
 
-## Step 4: Install Client Apps
+## Step 4: Enable IPv6 (optional)
+
+By default, Firezone ships with IPv6 connectivity enabled inside the tunnel but not routable
+to the public internet. To enable IPv6 support in Docker-deployed Firezone, follow the steps below.
+
+1. Enable IPv6 support within Docker by adding the following to `/etc/docker/daemon.json`:
+  ```json
+  {
+    "ipv6": true,
+    "ip6tables": true,
+    "experimental": true,
+    "fixed-cidr-v6": "fd00:1::/80"
+  }
+  ```
+  This turns IPv6 NAT and sets up routing for Docker containers in a similar way to how Docker's
+  IPv4 functionality works.
+2. Enable router advertisements on boot for your default egress interface:
+  ```
+  egress=`ip route show default 0.0.0.0/0 | grep -oP '(?<=dev ).*' | cut -f1 -d' ' | tr -d '\n'`
+  sudo echo "net.ipv6.conf.${egress}.accept_ra=2" >> /etc/sysctl.conf
+  ```
+3. Reboot
+
+You should now be able to ping google from with a docker container:
+```
+docker run --rm -t busybox ping6 -c 4 google.com
+```
+
+You shouldn't need to manually add any `iptables` rules to enable IPv6 SNAT/masquerading.
+Firezone handles this for you by default.
+
+## Step 5: Install Client Apps
 
 Once successfully deployed, users and devices can be added to
 connect to the VPN server:

--- a/docs/docs/deploy/docker/README.mdx
+++ b/docs/docs/deploy/docker/README.mdx
@@ -117,7 +117,7 @@ to the public internet. To enable IPv6 support in Docker-deployed Firezone, foll
   ```
 3. Reboot
 
-You should now be able to ping google from with a docker container:
+You should now be able to ping google from within a docker container:
 ```
 docker run --rm -t busybox ping6 -c 4 google.com
 ```

--- a/docs/docs/deploy/docker/README.mdx
+++ b/docs/docs/deploy/docker/README.mdx
@@ -109,8 +109,7 @@ to the public internet. To enable IPv6 support in Docker-deployed Firezone, foll
     "fixed-cidr-v6": "fd00:1::/80"
   }
   ```
-  This turns IPv6 NAT and sets up routing for Docker containers in a similar way to how Docker's
-  IPv4 functionality works.
+  This enables IPv6 NAT and configures IPv6 forwarding for Docker containers.
 2. Enable router advertisements on boot for your default egress interface:
   ```
   egress=`ip route show default 0.0.0.0/0 | grep -oP '(?<=dev ).*' | cut -f1 -d' ' | tr -d '\n'`
@@ -123,7 +122,7 @@ You should now be able to ping google from with a docker container:
 docker run --rm -t busybox ping6 -c 4 google.com
 ```
 
-You shouldn't need to manually add any `iptables` rules to enable IPv6 SNAT/masquerading.
+You shouldn't need to manually add any `iptables` rules to enable IPv6 SNAT/masquerading for tunneled traffic -- Firezone handles this for you by default on start.
 Firezone handles this for you by default.
 
 ## Step 5: Install Client Apps

--- a/docs/docs/deploy/docker/README.mdx
+++ b/docs/docs/deploy/docker/README.mdx
@@ -114,7 +114,7 @@ to the public internet. To enable IPv6 support in Docker-deployed Firezone, foll
 2. Enable router advertisements on boot for your default egress interface:
   ```
   egress=`ip route show default 0.0.0.0/0 | grep -oP '(?<=dev ).*' | cut -f1 -d' ' | tr -d '\n'`
-  sudo echo "net.ipv6.conf.${egress}.accept_ra=2" >> /etc/sysctl.conf
+  sudo bash -c "echo net.ipv6.conf.${egress}.accept_ra=2 >> /etc/sysctl.conf"
   ```
 3. Reboot
 


### PR DESCRIPTION
IPv6 routing is disabled by default on Docker. To have IPv6 work in Firezone
the same way IPv4 currently does (and IPv6 on Omnibus), four things are
generally required:

1. First, ensure your Docker host has IPv6 correctly set up with a quick
    ping test:
  ```
  > ping6 -c 4 google.com

  PING google.com(sfo03s32-in-x0e.1e100.net (2607:f8b0:4005:814::200e)) 56 data bytes
  64 bytes from sfo03s32-in-x0e.1e100.net (2607:f8b0:4005:814::200e): icmp_seq=1 ttl=51 time=1.96 ms
  64 bytes from sfo03s32-in-x0e.1e100.net (2607:f8b0:4005:814::200e): icmp_seq=2 ttl=51 time=1.94 ms
  64 bytes from sfo03s32-in-x0e.1e100.net (2607:f8b0:4005:814::200e): icmp_seq=3 ttl=51 time=1.92 ms
  64 bytes from sfo03s32-in-x0e.1e100.net (2607:f8b0:4005:814::200e): icmp_seq=4 ttl=51 time=1.90 ms
  ```
2. Add an IPv6 address, subnet, and `enable_ipv6: true` to the Docker
    compose. **Note**: Various Googling around the interwebs will uncover
    the myth that `enable_ipv6` is not supported on Docker Compose file
    versions 3+ -- this seems to be incorrect. Leaving out `enable_ipv6: true`
    prevented Docker from automatically assigning IPv6 addresses for
    containers attaching to that network.
3. Add the following to `/etc/docker/daemon.json`:
  ```json
  {
    "ipv6": true,
    "ip6tables": true,
    "experimental": true,
    "fixed-cidr-v6": "fd00:dead:beef::/80"
  }
  ```
4. The above causes Docker to automatically add `ip6tables` rules to
  set up IPv6 NAT/Masquerade for containers. However, this breaks DHCPv6
  Router Advertisements, so you'll need to re-enable them for your
  default interface with:
  ```
  egress=`ip route show default 0.0.0.0/0 | grep -oP '(?<=dev ).*' | cut -f1 -d' ' | tr -d '\n'`
  sudo bash -c "echo net.ipv6.conf.${egress}.accept_ra=2 >> /etc/sysctl.conf"
  ```

Fixes #1202 