### PR TITLE
Allow IPv6 remote_ips in StatsUpdater

### DIFF
--- a/apps/fz_common/lib/fz_net.ex
+++ b/apps/fz_common/lib/fz_net.ex
@@ -78,4 +78,11 @@ defmodule FzCommon.FzNet do
         err
     end
   end
+
+  def endpoint_to_ip(endpoint) do
+    endpoint
+    |> String.replace(~r{:\d+$}, "")
+    |> String.trim_leading("[")
+    |> String.trim_trailing("]")
+  end
 end

--- a/apps/fz_common/test/fz_net_test.exs
+++ b/apps/fz_common/test/fz_net_test.exs
@@ -138,4 +138,18 @@ defmodule FzCommon.FzNetTest do
       end
     end
   end
+
+  describe "endpoint_to_ip/1" do
+    test "IPv4" do
+      assert "192.168.1.1" == FzNet.endpoint_to_ip("192.168.1.1:4562")
+    end
+
+    test "short IPv6s" do
+      assert "2600::1" == FzNet.endpoint_to_ip("[2600::1]:4562")
+    end
+
+    test "expanded IPv6s" do
+      assert "2600:1:1:1:1:1:1:1" == FzNet.endpoint_to_ip("[2600:1:1:1:1:1:1:1]:4562")
+    end
+  end
 end

--- a/apps/fz_http/lib/fz_http/devices/stats_updater.ex
+++ b/apps/fz_http/lib/fz_http/devices/stats_updater.ex
@@ -1,6 +1,7 @@
 defmodule FzHttp.Devices.StatsUpdater do
   @moduledoc """
-  Extracts
+  Extracts WireGuard data about each peer and adds it to
+  the correspond device.
   """
 
   import Ecto.Query, warn: false
@@ -16,7 +17,7 @@ defmodule FzHttp.Devices.StatsUpdater do
           attrs = %{
             rx_bytes: String.to_integer(data.rx_bytes),
             tx_bytes: String.to_integer(data.tx_bytes),
-            remote_ip: remote_ip(data.endpoint),
+            remote_ip: FzCommon.FzNet.endpoint_to_ip(data.endpoint),
             latest_handshake: latest_handshake(data.latest_handshake)
           }
 
@@ -44,12 +45,6 @@ defmodule FzHttp.Devices.StatsUpdater do
           where: d.public_key == ^public_key
       )
     end
-  end
-
-  defp remote_ip(endpoint) do
-    endpoint
-    |> String.split(":")
-    |> Enum.at(0)
   end
 
   defp latest_handshake(epoch) do


### PR DESCRIPTION
This fixes a bug where we assumed a peer's `endpoint` (and therefore device `remote_ip`) would always be an IPv4 address.

Fixes #1196 