### PR TITLE
Update Docker IPv6 CIDR to use 2001:db8:1::/64

### DIFF
--- a/docs/docs/deploy/docker/README.mdx
+++ b/docs/docs/deploy/docker/README.mdx
@@ -111,7 +111,7 @@ to the public internet. To enable IPv6 support in Docker-deployed Firezone, foll
     "ipv6": true,
     "ip6tables": true,
     "experimental": true,
-    "fixed-cidr-v6": "fd00:1::/80"
+    “fixed-cidr-v6”: “2001:db8:1::/64”
   }
   ```
   This enables IPv6 NAT and configures IPv6 forwarding for Docker containers.


### PR DESCRIPTION
See https://github.com/firezone/firezone/issues/1202#issuecomment-1357294785

Fixes #1202 