### PR TITLE
Don't cache Elixir build in static_analysis workflow

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -34,20 +34,12 @@ jobs:
         env:
           cache-name: cache-elixir-deps
         with:
+          # XXX: We've purposefully omitted caching the _build directory here because we
+          # force-recompile in the pre-commit run below in order to catch any compilation warnings.
           path: deps
           key: ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-
-      - uses: actions/cache@v3
-        name: Elixir Build Cache
-        env:
-          cache-name: cache-elixir-build
-        with:
-          path: _build
-          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-
-            ${{ github.workflow }}-${{ runner.os }}-
       - uses: actions/cache@v3.0.11
         name: Setup ruby cache
         with:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -29,15 +29,25 @@ jobs:
         with:
           otp-version: '25'
           elixir-version: '1.14'
-      - uses: actions/cache@v3.0.11
-        name: Setup Elixir cache
+      - uses: actions/cache@v3
+        name: Elixir Deps Cache
+        env:
+          cache-name: cache-elixir-deps
         with:
-          path: |
-            deps
-            _build
-          key: ${{ runner.os }}-${{ github.ref }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
+          path: deps
+          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.ref }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
+            ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-
+      - uses: actions/cache@v3
+        name: Elixir Build Cache
+        env:
+          cache-name: cache-elixir-build
+        with:
+          path: _build
+          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-
+            ${{ github.workflow }}-${{ runner.os }}-
       - uses: actions/cache@v3.0.11
         name: Setup ruby cache
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,19 +42,16 @@ jobs:
           cache-name: cache-elixir-deps
         with:
           path: deps
-          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ env.cache-name }}-
       - uses: actions/cache@v3
         name: Elixir Build Cache
         env:
           cache-name: cache-elixir-build
         with:
           path: _build
-          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-
-            ${{ github.workflow }}-${{ runner.os }}-
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Setup Database

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,14 +36,25 @@ jobs:
         with:
           otp-version: '25'
           elixir-version: '1.14'
-      - uses: actions/cache@v3.0.11
+      - uses: actions/cache@v3
+        name: Elixir Deps Cache
+        env:
+          cache-name: cache-elixir-deps
         with:
-          path: |
-            deps
-            _build
-          key: ${{ runner.os }}-${{ github.ref }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
+          path: deps
+          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.ref }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
+            ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-
+      - uses: actions/cache@v3
+        name: Elixir Build Cache
+        env:
+          cache-name: cache-elixir-build
+        with:
+          path: _build
+          key: ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ github.workflow }}-${{ runner.os }}-${{ env.cache-name }}-
+            ${{ github.workflow }}-${{ runner.os }}-
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Setup Database

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,12 @@ repos:
   - repo: local
     hooks:
       # Elixir config
+      - id: mix-compile
+        name: 'elixir: mix compile'
+        entry: mix compile --force --warnings-as-errors
+        language: system
+        pass_filenames: false
+        files: \.ex$
       - id: mix-format
         name: 'elixir: mix format'
         entry: mix format --check-formatted
@@ -18,12 +24,6 @@ repos:
         language: system
         pass_filenames: false
         files: \.exs*$
-      - id: mix-compile
-        name: 'elixir: mix compile'
-        entry: mix compile --force --warnings-as-errors
-        language: system
-        pass_filenames: false
-        files: \.ex$
       - id: codespell
         name: 'python: codespell'
         entry: codespell


### PR DESCRIPTION
Still [having issues](https://github.com/firezone/firezone/actions/runs/3759257641) with the Elixir cache.

Things tried that didn't work:
- Namespacing by branch name. Github does this already.
- Removing the `restore-keys` in order to only restore the cache if it's a direct hit.

The `static_analysis` workflow runs `mix compile --force --warnings-as-errors` which doesn't use the build cache, so it's removed, which fixes the problem.