### PR TITLE
fix: endpoint migration when `EXTERNAL_URL` is not present

### DIFF
--- a/apps/fz_http/priv/repo/migrations/20221219020354_move_wireguard_optional_fields_to_sites.exs
+++ b/apps/fz_http/priv/repo/migrations/20221219020354_move_wireguard_optional_fields_to_sites.exs
@@ -32,7 +32,7 @@ defmodule FzHttp.Repo.Migrations.MoveWireguardOptionalFieldsToSites do
 
     execute("""
       UPDATE sites
-      SET endpoint = '#{URI.parse(System.get_env("EXTERNAL_URL", "localhost")).host}'
+      SET endpoint = '#{URI.parse(System.get_env("EXTERNAL_URL", "https://localhost/")).host}'
       WHERE endpoint IS NULL
     """)
   end


### PR DESCRIPTION
For `URI.parse` to work the URI needs to be a FQDN otherwise `nil` is returned.