### PR TITLE
API Token CLI

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -6,7 +6,10 @@
   ],
   inputs: [
     "*.{heex,ex,exs}",
-    "{config,apps,priv}/**/*.{heex,ex,exs}"
+    "{config,priv}/**/*.{heex,ex,exs}",
+    "apps/{fz_vpn,fz_wall}/**/*.{heex,ex,exs}",
+    "apps/fz_http/*.exs",
+    "apps/fz_http/{lib,test,priv}/**/*.{heex,ex,exs}"
   ],
   plugins: [
     Phoenix.LiveView.HTMLFormatter

--- a/apps/fz_http/test/fz_http/release_test.exs
+++ b/apps/fz_http/test/fz_http/release_test.exs
@@ -6,7 +6,13 @@ defmodule FzHttp.ReleaseTest do
 
   use FzHttp.DataCase, async: true
 
-  alias FzHttp.{Release, Users, Users.User}
+  alias FzHttp.{
+    ApiTokens,
+    Release,
+    Users,
+    UsersFixtures,
+    Users.User
+  }
 
   describe "migrate/0" do
     test "function runs without error" do
@@ -27,6 +33,19 @@ defmodule FzHttp.ReleaseTest do
       {:ok, second_user} = Release.create_admin_user()
 
       assert second_user.password_hash != new_first_user.password_hash
+    end
+  end
+
+  describe "create_api_token/1" do
+    test "creates api_token_token for default admin user" do
+      admin_user =
+        UsersFixtures.user(%{
+          role: :admin,
+          email: FzHttp.Config.fetch_env!(:fz_http, :admin_email)
+        })
+
+      assert :ok = Release.create_api_token()
+      assert ApiTokens.count_by_user_id(admin_user.id) == 1
     end
   end
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -62,3 +62,5 @@ config :fz_vpn,
   # XXX: Bump test coverage by adding a stubbed out module for FzVpn.StatsPushService
   supervised_children: [FzVpn.Interface.WGAdapter.Sandbox, FzVpn.Server],
   wg_adapter: FzVpn.Interface.WGAdapter.Sandbox
+
+config :argon2_elixir, t_cost: 1, m_cost: 8

--- a/rel/overlays/bin/create-api-token
+++ b/rel/overlays/bin/create-api-token
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+exec ./firezone rpc FzHttp.Release.create_api_token


### PR DESCRIPTION
Adds a mechanism for generating API tokens from the CLI. Requires the default admin user to be present. From there the token can be used to create additional admins. In the future, we could allow specifying a user's email to generate the token for.

Generate like so:

```
docker compose run --rm firezone bin/create-api-token
```