### PR TITLE
Hotfix default PK values on connectivity_checks table

### DIFF
--- a/apps/fz_http/priv/repo/migrations/20221223190406_migrate_pks_to_uuid.exs
+++ b/apps/fz_http/priv/repo/migrations/20221223190406_migrate_pks_to_uuid.exs
@@ -5,7 +5,7 @@ defmodule FzHttp.Repo.Migrations.MigratePksToUuid do
     ## connectivity_checks
     alter table("connectivity_checks") do
       remove(:id)
-      add(:id, :binary_id, primary_key: true)
+      add(:id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()"))
     end
 
     ## devices
@@ -31,7 +31,7 @@ defmodule FzHttp.Repo.Migrations.MigratePksToUuid do
     ## oidc_connections
     alter table("oidc_connections") do
       remove(:id)
-      add(:id, :binary_id, primary_key: true)
+      add(:id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()"))
     end
 
     ## users

--- a/apps/fz_http/priv/repo/migrations/20230113184557_add_default_pks_values.exs
+++ b/apps/fz_http/priv/repo/migrations/20230113184557_add_default_pks_values.exs
@@ -1,0 +1,35 @@
+defmodule FzHttp.Repo.Migrations.AddDefaultPksValues do
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    ALTER TABLE connectivity_checks
+    ALTER COLUMN id
+    SET DEFAULT gen_random_uuid();
+    """)
+
+    execute("""
+    ALTER TABLE oidc_connections
+    ALTER COLUMN id
+    SET DEFAULT gen_random_uuid();
+    """)
+
+    execute("""
+    ALTER TABLE api_tokens
+    ALTER COLUMN id
+    SET DEFAULT gen_random_uuid();
+    """)
+
+    execute("""
+    ALTER TABLE configurations
+    ALTER COLUMN id
+    SET DEFAULT gen_random_uuid();
+    """)
+
+    execute("""
+    ALTER TABLE mfa_methods
+    ALTER COLUMN id
+    SET DEFAULT gen_random_uuid();
+    """)
+  end
+end


### PR DESCRIPTION
The migration is edited in place. Otherwise, the users that partially upgraded to 0.7 won't be able to proceed.

Another migration is added to add default values for every table that did not have it to make things consistent and make sure that both users that have failed migration executed and the ones that executed it successfully will end up with the same schema.

Closes #1295