### PR TITLE
Boot minimal app for DB changes

### DIFF
--- a/apps/fz_http/lib/fz_http/application.ex
+++ b/apps/fz_http/lib/fz_http/application.ex
@@ -58,4 +58,11 @@ defmodule FzHttp.Application do
       FzHttpWeb.Presence
     ]
   end
+
+  defp children(:database) do
+    [
+      FzHttp.Repo,
+      FzHttp.Vault
+    ]
+  end
 end

--- a/docs/docs/administer/troubleshoot.mdx
+++ b/docs/docs/administer/troubleshoot.mdx
@@ -145,8 +145,8 @@ to reset the admin user's password. The password for the user specified by
 in `$HOME/.firezone/.env` will be reset to the `DEFAULT_ADMIN_PASSWORD` variable.
 
 ```shell
-  cd $HOME/.firezone
-  docker compose exec firezone bin/create-or-reset-admin
+cd $HOME/.firezone
+docker compose exec firezone bin/create-or-reset-admin
 ```
 
 **Note**: If local authentication is disabled, resetting the admin user's

--- a/docs/docs/deploy/docker/README.mdx
+++ b/docs/docs/deploy/docker/README.mdx
@@ -79,7 +79,7 @@ installation process, follow the steps below to install manually.
    Optionally modify other secrets as needed.
 1. Create the first admin:
   ```shell
-  docker compose exec firezone bin/create-or-reset-admin
+  docker compose run --rm firezone bin/create-or-reset-admin
   ```
 1. Bring the services up: `docker compose up -d`
 

--- a/omnibus/cookbooks/firezone/recipes/create_admin.rb
+++ b/omnibus/cookbooks/firezone/recipes/create_admin.rb
@@ -21,7 +21,7 @@
 include_recipe 'firezone::config'
 
 execute 'create_admin' do
-  command 'bin/firezone rpc "FzHttp.Release.create_admin_user"'
+  command 'bin/firezone eval "FzHttp.Release.create_admin_user"'
   cwd node['firezone']['app_directory']
   environment(Firezone::Config.app_env(node))
   user node['firezone']['user']

--- a/rel/overlays/bin/create-api-token
+++ b/rel/overlays/bin/create-api-token
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
-exec ./firezone rpc FzHttp.Release.create_api_token
+exec ./firezone eval FzHttp.Release.create_api_token

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,7 +161,7 @@ firezoneSetup() {
   echo "Resetting DB password..."
   $dc -f $installDir/docker-compose.yml exec postgres psql -p 5432 -U postgres -d firezone -h 127.0.0.1 -c "ALTER ROLE postgres WITH PASSWORD '${db_pass}'"
   echo "Creating admin..."
-  $dc -f $installDir/docker-compose.yml exec firezone bin/create-or-reset-admin
+  $dc -f $installDir/docker-compose.yml run --rm firezone bin/create-or-reset-admin
   echo "Upping firezone services..."
   $dc -f $installDir/docker-compose.yml up -d firezone caddy
 


### PR DESCRIPTION
Adds a minimal supervision tree for making DB changes from the `FzHttp.Release` module. This allows the `bin/create-or-reset-admin` and `bin/create-api-token` commands to be with `docker compose exec` or `docker compose run --rm` indiscriminately.

Starting the FzHttp.Repo directly is more involved it's not compiled into the release as an OTP app.