### PR TITLE
Filter out nil IPs before adding to the nftables ruleset

### DIFF
--- a/apps/fz_wall/lib/fz_wall/cli/live.ex
+++ b/apps/fz_wall/lib/fz_wall/cli/live.ex
@@ -67,11 +67,17 @@ defmodule FzWall.CLI.Live do
   end
 
   @doc """
-  Adds device ip to the user's sets.
+  Adds device ip(s) to the user's sets, omitting missing IPs.
   """
   def add_device(device) do
     list_dev_sets(device.user_id)
-    |> Enum.each(fn set_spec -> add_elem(set_spec.name, device[set_spec.ip_type]) end)
+    |> Enum.filter(fn set_spec ->
+      # Only call add_elem/2 for IPs that are present
+      device[set_spec.ip_type]
+    end)
+    |> Enum.each(fn set_spec ->
+      add_elem(set_spec.name, device[set_spec.ip_type])
+    end)
   end
 
   @doc """


### PR DESCRIPTION
This edgecase happens when `WIREGUARD_IPV4_ENABLED` or `WIREGUARD_IPV6_ENABLED` are set to `false`; when a new device is generated, we don't allocate an IP for it. This causes a failed function match, and should be handled instead by simply skipping the `nil` IP from being added to the user's `nftables` group.

**Note**: This functionality will be removed with the release of the gateway's eBPF packet filter in 0.8.

Fixes #1331 