### PR TITLE
Rework MFA methods

### DIFF
--- a/apps/fz_http/assets/js/hooks.js
+++ b/apps/fz_http/assets/js/hooks.js
@@ -92,7 +92,8 @@ Hooks.RenderConfig = {
   updated: renderConfig
 }
 Hooks.RenderQR = {
-  mounted: renderQR
+  mounted: renderQR,
+  updated: renderQR
 }
 Hooks.GenerateKeyPair = {
   mounted: generateKeyPair

--- a/apps/fz_http/lib/fz_http/mfa/method.ex
+++ b/apps/fz_http/lib/fz_http/mfa/method.ex
@@ -1,49 +1,16 @@
 defmodule FzHttp.MFA.Method do
-  @moduledoc """
-  Multi Factor Authentication methods
-  """
   use FzHttp, :schema
-  import Ecto.Changeset
 
   schema "mfa_methods" do
     field :name, :string
     field :type, Ecto.Enum, values: [:totp, :native, :portable]
-    field :credential_id, :string
     field :last_used_at, :utc_datetime_usec
     field :payload, FzHttp.Encrypted.Map
-    field :secret, :string, virtual: true
+
     field :code, :string, virtual: true
 
     belongs_to :user, FzHttp.Users.User
 
     timestamps()
   end
-
-  @doc false
-  def changeset(method, attrs) do
-    method
-    |> cast(attrs, [:name, :type, :credential_id, :payload, :last_used_at, :secret, :code])
-    |> update_change(:name, &String.trim/1)
-    |> cast_payload()
-    |> validate_required([:name, :type, :payload])
-    |> validate_code()
-  end
-
-  defp cast_payload(%{changes: %{secret: secret}} = changeset) do
-    put_change(changeset, :payload, %{"secret" => secret})
-  end
-
-  defp cast_payload(changeset), do: changeset
-
-  defp validate_code(%{changes: %{code: code}} = changeset) do
-    secret = Base.decode64!(fetch_field!(changeset, :payload)["secret"])
-
-    if NimbleTOTP.valid?(secret, code, since: fetch_field!(changeset, :last_used_at)) do
-      put_change(changeset, :last_used_at, DateTime.utc_now())
-    else
-      add_error(changeset, :code, "is not valid")
-    end
-  end
-
-  defp validate_code(changeset), do: changeset
 end

--- a/apps/fz_http/lib/fz_http/mfa/method/changeset.ex
+++ b/apps/fz_http/lib/fz_http/mfa/method/changeset.ex
@@ -49,6 +49,9 @@ defmodule FzHttp.MFA.Method.Changeset do
       {:data, nil} ->
         changeset
 
+      {:data, %{}} ->
+        add_error(changeset, :payload, "is invalid")
+
       {:changes, %{}} ->
         changeset
         |> add_error(:payload, "is invalid")

--- a/apps/fz_http/lib/fz_http/mfa/method/changeset.ex
+++ b/apps/fz_http/lib/fz_http/mfa/method/changeset.ex
@@ -1,0 +1,64 @@
+defmodule FzHttp.MFA.Method.Changeset do
+  use FzHttp, :changeset
+  alias FzHttp.MFA.Method
+
+  @create_fields [:name, :type, :payload, :code]
+
+  def create_changeset(user_id, attrs) do
+    %Method{user_id: user_id}
+    |> cast(attrs, @create_fields)
+    |> validate_required(@create_fields)
+    |> validate_length(:name, min: 1, max: 255)
+    |> trim_change(:name)
+    |> unique_constraint(:name)
+    |> assoc_constraint(:user)
+    |> changeset()
+  end
+
+  def use_code_changeset(%Method{} = method, attrs) do
+    method
+    |> cast(attrs, [:code])
+    |> validate_required([:code])
+    |> changeset()
+  end
+
+  defp changeset(changeset) do
+    changeset
+    |> use_code()
+    |> redact_field(:code)
+  end
+
+  defp use_code(changeset) do
+    if changed?(changeset, :code) and not has_errors?(changeset, :code) do
+      validate_code(changeset)
+    else
+      changeset
+    end
+  end
+
+  def validate_code(changeset) do
+    with {_data_or_changes, %{"secret" => encoded_secret}} <- fetch_field(changeset, :payload),
+         {:ok, secret} <- Base.decode64(encoded_secret),
+         # Notice: last_used_at will be nil when creating a new method,
+         # but NimbleTOTP.valid?/3 accepts that
+         {_data_or_changes, last_used_at} <- fetch_field(changeset, :last_used_at),
+         {:ok, code} <- fetch_change(changeset, :code),
+         true <- NimbleTOTP.valid?(secret, code, since: last_used_at) do
+      put_change(changeset, :last_used_at, DateTime.utc_now())
+    else
+      {:data, nil} ->
+        changeset
+
+      {:changes, %{}} ->
+        changeset
+        |> add_error(:payload, "is invalid")
+        |> add_error(:code, "can not be verified")
+
+      :error ->
+        add_error(changeset, :code, "can not be verified")
+
+      false ->
+        add_error(changeset, :code, "is invalid")
+    end
+  end
+end

--- a/apps/fz_http/lib/fz_http/mfa/method/query.ex
+++ b/apps/fz_http/lib/fz_http/mfa/method/query.ex
@@ -1,0 +1,32 @@
+defmodule FzHttp.MFA.Method.Query do
+  use FzHttp, :query
+
+  def all do
+    from(users in FzHttp.MFA.Method, as: :methods)
+  end
+
+  def by_id(queryable \\ all(), id) do
+    where(queryable, [methods: methods], methods.id == ^id)
+  end
+
+  def by_user_id(queryable \\ all(), user_id) do
+    where(queryable, [methods: methods], methods.user_id == ^user_id)
+  end
+
+  def by_type(queryable \\ all(), type) do
+    where(queryable, [methods: methods], methods.type == ^type)
+  end
+
+  def order_by_last_usage(queryable \\ all()) do
+    order_by(queryable, [methods: methods], desc: methods.last_used_at)
+  end
+
+  def select_distinct_user_ids_count(queryable \\ all()) do
+    queryable
+    |> select([methods: methods], count(methods.user_id, :distinct))
+  end
+
+  def with_limit(queryable \\ all(), count) do
+    limit(queryable, ^count)
+  end
+end

--- a/apps/fz_http/lib/fz_http/repo.ex
+++ b/apps/fz_http/lib/fz_http/repo.ex
@@ -22,4 +22,11 @@ defmodule FzHttp.Repo do
   Alias of `Ecto.Repo.one!/2` added for naming convenience.
   """
   def fetch!(queryable, opts \\ []), do: __MODULE__.one!(queryable, opts)
+
+  @doc """
+  Similar to `Ecto.Repo.all/2`, fetches all results from the query but return a tuple.
+  """
+  def list(queryable, opts \\ []) do
+    {:ok, __MODULE__.all(queryable, opts)}
+  end
 end

--- a/apps/fz_http/lib/fz_http/telemetry.ex
+++ b/apps/fz_http/lib/fz_http/telemetry.ex
@@ -102,8 +102,8 @@ defmodule FzHttp.Telemetry do
         in_docker: in_docker?(),
         device_count: Devices.count(),
         max_devices_for_users: Devices.max_count_by_user_id(),
-        users_with_mfa: MFA.count_distinct_by_user_id(),
-        users_with_mfa_totp: MFA.count_distinct_totp_by_user_id(),
+        users_with_mfa: MFA.count_users_with_method(),
+        users_with_mfa_totp: MFA.count_users_with_totp_method(),
         openid_providers: length(FzHttp.Configurations.get!(:openid_connect_providers)),
         saml_providers: length(FzHttp.Configurations.get!(:saml_identity_providers)),
         unprivileged_device_management:

--- a/apps/fz_http/lib/fz_http/users.ex
+++ b/apps/fz_http/lib/fz_http/users.ex
@@ -46,7 +46,7 @@ defmodule FzHttp.Users do
 
     User.Query.all()
     |> hydrate_fields(hydrate)
-    |> Repo.all()
+    |> Repo.list()
   end
 
   defp hydrate_fields(queryable, []), do: queryable

--- a/apps/fz_http/lib/fz_http/validator.ex
+++ b/apps/fz_http/lib/fz_http/validator.ex
@@ -5,6 +5,14 @@ defmodule FzHttp.Validator do
   import Ecto.Changeset
   alias FzCommon.FzNet
 
+  def changed?(changeset, field) do
+    Map.has_key?(changeset.changes, field)
+  end
+
+  def has_errors?(changeset, field) do
+    Keyword.has_key?(changeset.errors, field)
+  end
+
   def validate_email(changeset, field) do
     validate_format(changeset, field, ~r/@/, message: "is invalid email address")
   end

--- a/apps/fz_http/lib/fz_http_web/auth/html/authentication.ex
+++ b/apps/fz_http/lib/fz_http_web/auth/html/authentication.ex
@@ -57,17 +57,10 @@ defmodule FzHttpWeb.Auth.HTML.Authentication do
     Users.update_last_signed_in(user, auth)
     %{provider: provider_id} = auth
 
-    conn =
-      with :identity <- provider_id,
-           true <- FzHttp.MFA.exists?(user) do
-        Plug.Conn.put_session(conn, "mfa_required_at", DateTime.utc_now())
-      else
-        _ -> conn
-      end
-      # XXX: OIDC and SAML provider IDs can be strings, so normalize to string here
-      |> Plug.Conn.put_session("login_method", to_string(provider_id))
-
-    __MODULE__.Plug.sign_in(conn, user)
+    conn
+    |> Plug.Conn.put_session("login_method", provider_id)
+    |> Plug.Conn.put_session("logged_in_at", DateTime.utc_now())
+    |> __MODULE__.Plug.sign_in(user)
   end
 
   def sign_out(conn) do

--- a/apps/fz_http/lib/fz_http_web/controllers/json/user_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/json/user_controller.ex
@@ -19,8 +19,9 @@ defmodule FzHttpWeb.JSON.UserController do
 
   @doc api_doc: [action: "List all Users"]
   def index(conn, _params) do
-    users = Users.list_users()
-    render(conn, "index.json", users: users)
+    with {:ok, users} <- Users.list_users() do
+      render(conn, "index.json", users: users)
+    end
   end
 
   @doc """

--- a/apps/fz_http/lib/fz_http_web/error_helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/error_helpers.ex
@@ -2,7 +2,6 @@ defmodule FzHttpWeb.ErrorHelpers do
   @moduledoc """
   Conveniences for translating and building error messages.
   """
-
   use Phoenix.HTML
   import Ecto.Changeset, only: [traverse_errors: 2]
 
@@ -25,7 +24,10 @@ defmodule FzHttpWeb.ErrorHelpers do
     values = Keyword.get_values(form.errors, field)
 
     Enum.map(values, fn error ->
-      content_tag(:span, translate_error(error), class: "help-block")
+      content_tag(:span, translate_error(error),
+        class: "help-block"
+        # XXX: data: [phx_error_for: input_id(form, field)]
+      )
     end)
   end
 

--- a/apps/fz_http/lib/fz_http_web/live/mfa_live/register_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/mfa_live/register_component.ex
@@ -3,24 +3,49 @@ defmodule FzHttpWeb.MFA.RegisterComponent do
   MFA registration container
   """
   use FzHttpWeb, :live_component
+  alias FzHttp.MFA
 
-  import Ecto.Changeset
-  alias FzHttp.{MFA, Repo}
-
-  @steps ~w(pick_type register verify save)a
-  @next_steps @steps |> Enum.zip(Enum.drop(@steps, 1)) |> Map.new()
+  @steps [
+    {:pick_type, fields: ~w[type]a},
+    {:register, fields: ~w[name]a},
+    {:verify, fields: ~w[code]a},
+    {:save, []}
+  ]
 
   @impl Phoenix.LiveComponent
   def mount(socket) do
-    {:ok, socket |> assign(%{step: :pick_type, changeset: MFA.new_method()})}
+    secret = NimbleTOTP.secret()
+
+    socket =
+      socket
+      |> assign(:secret, secret)
+      |> assign(:params, %{"payload" => %{"secret" => Base.encode64(secret)}})
+      |> assign(:remaining_steps, @steps)
+
+    {:ok, socket}
   end
 
   @impl Phoenix.LiveComponent
-  def render(assigns) do
+  def update(assigns, socket) do
+    changeset = MFA.create_method_changeset(socket.assigns.params, assigns.user.id)
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(:changeset, changeset)
+
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveComponent
+  def render(%{remaining_steps: [{step, _opts} | _rest]} = assigns) do
+    assigns = Map.put(assigns, :step, step)
+
     ~H"""
     <div id="register-mfa">
       <%= live_modal(
         FzHttpWeb.MFA.RegisterStepsComponent.render_step(%{
+          secret: @secret,
           step: @step,
           changeset: @changeset,
           parent: @myself,
@@ -37,46 +62,55 @@ defmodule FzHttpWeb.MFA.RegisterComponent do
   end
 
   @impl Phoenix.LiveComponent
-  def handle_event("next", params, %{assigns: %{step: :verify, changeset: changeset}} = socket) do
-    changeset = MFA.change_method(apply_changes(changeset), params)
+  def handle_event(
+        "next",
+        params,
+        %{assigns: %{remaining_steps: [{_step, step_opts} | rest_steps]}} = socket
+      ) do
+    params = Map.merge(socket.assigns.params, params)
+    changeset = MFA.create_method_changeset(params, socket.assigns.user.id)
 
-    next_step =
-      if changeset.valid? do
-        Map.fetch!(@next_steps, :verify)
-      else
-        :verify
-      end
+    step_fields = Keyword.fetch!(step_opts, :fields)
+    error_fields = changeset.errors |> Keyword.keys()
 
-    {:noreply,
-     socket
-     |> assign(:changeset, changeset)
-     |> assign(:step, next_step)}
+    if Enum.any?(step_fields, &(&1 in error_fields)) do
+      socket = assign(socket, :changeset, render_changeset_errors(changeset))
+      {:noreply, socket}
+    else
+      socket =
+        socket
+        # XXX: The form helpers should not render errors if changeset.action is nil,
+        # but we use custom form helpers and they do not respect this,
+        # so we need to reset list of errors every time we move to the next step.
+        # https://hexdocs.pm/phoenix_html/Phoenix.HTML.Form.html#module-a-note-on-errors
+        |> assign(:changeset, %{changeset | errors: []})
+        |> assign(:params, params)
+        |> assign(:remaining_steps, rest_steps)
+
+      {:noreply, socket}
+    end
   end
 
   @impl Phoenix.LiveComponent
-  def handle_event("next", params, %{assigns: %{step: step, changeset: changeset}} = socket) do
-    {:noreply,
-     socket
-     |> assign(:changeset, MFA.change_method(apply_changes(changeset), params))
-     |> assign(:step, Map.fetch!(@next_steps, step))}
-  end
+  def handle_event("save", params, socket) do
+    params = Map.merge(socket.assigns.params, params)
 
-  @impl Phoenix.LiveComponent
-  def handle_event("save", _params, %{assigns: %{changeset: changeset}} = socket) do
-    changeset = put_change(changeset, :user_id, socket.assigns.user.id)
-
-    case Repo.insert(changeset) do
+    case MFA.create_method(params, socket.assigns.user.id) do
       {:ok, _method} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "MFA method added!")
-         |> push_redirect(to: socket.assigns.return_to)}
+        socket =
+          socket
+          |> put_flash(:info, "MFA method added!")
+          |> push_redirect(to: socket.assigns.return_to)
+
+        {:noreply, socket}
 
       {:error, changeset} ->
-        {:noreply,
-         socket
-         |> assign(:changeset, changeset)
-         |> assign(:step, :save)}
+        socket =
+          socket
+          |> assign(:changeset, changeset)
+          |> assign(:step, :save)
+
+        {:noreply, socket}
     end
   end
 end

--- a/apps/fz_http/lib/fz_http_web/live/mfa_live/register_steps_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/mfa_live/register_steps_component.ex
@@ -11,7 +11,7 @@ defmodule FzHttpWeb.MFA.RegisterStepsComponent do
 
   def pick_type(assigns) do
     ~H"""
-    <form id="mfa-method-form" phx-target={@parent} phx-submit="next" phx_change="validate">
+    <form id="mfa-method-form" phx-target={@parent} phx-submit="next">
       <h4>Choose authenticator type</h4>
       <hr />
 
@@ -51,7 +51,7 @@ defmodule FzHttpWeb.MFA.RegisterStepsComponent do
       |> Map.put(:secret_base32_encoded, Base.encode32(assigns.secret))
 
     ~H"""
-    <form id="mfa-method-form" phx-target={@parent} phx-submit="next" phx_change="validate">
+    <form id="mfa-method-form" phx-target={@parent} phx-submit="next">
       <h4>Register Authenticator</h4>
       <hr />
 
@@ -94,7 +94,7 @@ defmodule FzHttpWeb.MFA.RegisterStepsComponent do
 
   def verify(assigns) do
     ~H"""
-    <form id="mfa-method-form" phx-target={@parent} phx-submit="next" phx_change="validate">
+    <form id="mfa-method-form" phx-target={@parent} phx-submit="next">
       <h4>Verify Code</h4>
       <hr />
 

--- a/apps/fz_http/lib/fz_http_web/live/mfa_live/register_steps_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/mfa_live/register_steps_component.ex
@@ -3,16 +3,15 @@ defmodule FzHttpWeb.MFA.RegisterStepsComponent do
   MFA registration steps
   """
   use Phoenix.Component
-
   import FzHttpWeb.ErrorHelpers
 
   def render_step(assigns) do
-    apply(__MODULE__, assigns[:step], [assigns])
+    apply(__MODULE__, assigns.step, [assigns])
   end
 
   def pick_type(assigns) do
     ~H"""
-    <form id="mfa-method-form" phx-target={@parent} phx-submit="next">
+    <form id="mfa-method-form" phx-target={@parent} phx-submit="next" phx_change="validate">
       <h4>Choose authenticator type</h4>
       <hr />
 
@@ -43,30 +42,18 @@ defmodule FzHttpWeb.MFA.RegisterStepsComponent do
   end
 
   def register(assigns) do
-    secret = NimbleTOTP.secret()
+    otpauth_uri =
+      NimbleTOTP.otpauth_uri("Firezone:#{assigns.user.email}", assigns.secret, issuer: "Firezone")
 
     assigns =
-      Map.merge(
-        assigns,
-        %{
-          secret: secret,
-          secret_base32_encoded: Base.encode32(secret),
-          secret_base64_encoded: Base.encode64(secret),
-          uri:
-            NimbleTOTP.otpauth_uri(
-              "Firezone:#{assigns[:user].email}",
-              secret,
-              issuer: "Firezone"
-            )
-        }
-      )
+      assigns
+      |> Map.put(:uri, otpauth_uri)
+      |> Map.put(:secret_base32_encoded, Base.encode32(assigns.secret))
 
     ~H"""
-    <form id="mfa-method-form" phx-target={@parent} phx-submit="next">
+    <form id="mfa-method-form" phx-target={@parent} phx-submit="next" phx_change="validate">
       <h4>Register Authenticator</h4>
       <hr />
-
-      <input value={@secret_base64_encoded} type="hidden" name="secret" />
 
       <div class="has-text-centered">
         <canvas data-qrdata={@uri} id="register-totp" phx-hook="RenderQR" />
@@ -87,13 +74,16 @@ defmodule FzHttpWeb.MFA.RegisterStepsComponent do
           <div class="field">
             <p class="control">
               <input
-                class="input"
+                class={"input #{input_error_class(@changeset, :name)}"}
                 type="text"
                 name="name"
-                placeholder="Name"
-                value="My Authenticator"
+                value={Map.get(@changeset.changes, :name, "My Authenticator")}
+                placeholder="name"
                 required
               />
+            </p>
+            <p class="help is-danger">
+              <%= error_tag(@changeset, :name) %>
             </p>
           </div>
         </div>
@@ -104,7 +94,7 @@ defmodule FzHttpWeb.MFA.RegisterStepsComponent do
 
   def verify(assigns) do
     ~H"""
-    <form id="mfa-method-form" phx-target={@parent} phx-submit="next">
+    <form id="mfa-method-form" phx-target={@parent} phx-submit="next" phx_change="validate">
       <h4>Verify Code</h4>
       <hr />
 
@@ -122,6 +112,9 @@ defmodule FzHttpWeb.MFA.RegisterStepsComponent do
                 placeholder="123456"
                 required
               />
+            </p>
+            <p class="help is-danger">
+              <%= error_tag(@changeset, :code) %>
             </p>
           </div>
         </div>

--- a/apps/fz_http/lib/fz_http_web/live/rule_live/rule_list_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/rule_live/rule_list_component.ex
@@ -91,7 +91,9 @@ defmodule FzHttpWeb.RuleLive.RuleListComponent do
   end
 
   defp users do
-    Users.list_users()
+    {:ok, users} = Users.list_users()
+
+    users
     |> Stream.map(&{&1.id, &1.email})
     |> Map.new()
   end

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/oidc_form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/oidc_form_component.ex
@@ -185,7 +185,7 @@ defmodule FzHttpWeb.SettingLive.OIDCFormComponent do
     changeset =
       params
       |> FzHttp.Configurations.Configuration.OpenIDConnectProvider.changeset()
-      |> Map.put(:action, :validate)
+      |> render_changeset_errors()
 
     update =
       case changeset do

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/saml_form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/saml_form_component.ex
@@ -212,7 +212,7 @@ defmodule FzHttpWeb.SettingLive.SAMLFormComponent do
     changeset =
       params
       |> FzHttp.Configurations.Configuration.SAMLIdentityProvider.changeset()
-      |> Map.put(:action, :validate)
+      |> render_changeset_errors()
 
     update =
       case changeset do

--- a/apps/fz_http/lib/fz_http_web/live/user_live/index_live.ex
+++ b/apps/fz_http/lib/fz_http_web/live/user_live/index_live.ex
@@ -10,11 +10,15 @@ defmodule FzHttpWeb.UserLive.Index do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok,
-     socket
-     |> assign(:users, Users.list_users(hydrate: [:device_count]))
-     |> assign(:changeset, Users.change_user())
-     |> assign(:page_title, @page_title)}
+    with {:ok, users} <- Users.list_users(hydrate: [:device_count]) do
+      socket =
+        socket
+        |> assign(:users, users)
+        |> assign(:changeset, Users.change_user())
+        |> assign(:page_title, @page_title)
+
+      {:ok, socket}
+    end
   end
 
   @impl Phoenix.LiveView

--- a/apps/fz_http/lib/fz_http_web/live_helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/live_helpers.ex
@@ -63,4 +63,12 @@ defmodule FzHttpWeb.LiveHelpers do
   defp http_success?(_) do
     false
   end
+
+  def do_not_render_changeset_errors(%Ecto.Changeset{} = changeset) do
+    %{changeset | action: nil}
+  end
+
+  def render_changeset_errors(%Ecto.Changeset{} = changeset) do
+    %{changeset | action: :validate}
+  end
 end

--- a/apps/fz_http/priv/repo/migrations/20230116200524_add_not_null_to_mfa_methods.exs
+++ b/apps/fz_http/priv/repo/migrations/20230116200524_add_not_null_to_mfa_methods.exs
@@ -1,0 +1,13 @@
+defmodule FzHttp.Repo.Migrations.AddNotNullToMfaMethods do
+  use Ecto.Migration
+
+  def change do
+    alter table("mfa_methods") do
+      remove(:credential_id, :string)
+      modify(:payload, :bytea, null: false)
+      modify(:last_used_at, :utc_datetime_usec, null: false)
+    end
+
+    create(index(:mfa_methods, [:name], unique: true))
+  end
+end

--- a/apps/fz_http/priv/repo/migrations/20230116200524_add_not_null_to_mfa_methods.exs
+++ b/apps/fz_http/priv/repo/migrations/20230116200524_add_not_null_to_mfa_methods.exs
@@ -2,6 +2,23 @@ defmodule FzHttp.Repo.Migrations.AddNotNullToMfaMethods do
   use Ecto.Migration
 
   def change do
+    execute("""
+    UPDATE mfa_methods
+    SET last_used_at = '1970-01-01 00:00:00+00'::timestamptz
+    WHERE last_used_at IS NULL
+    """)
+
+    # Installations that have empty payload fields (which means MFA doesn't work for them)
+    # will be unable to decrypt it and will get an error:
+    #
+    #   ** (ArgumentError) cannot load `"..."`as type FzHttp.Encrypted.Map
+    #   for field :payload in %FzHttp.MFA.Method{...}
+    execute("""
+    UPDATE mfa_methods
+    SET payload = '#{Base.encode64(:crypto.strong_rand_bytes(32))}'
+    WHERE payload IS NULL
+    """)
+
     alter table("mfa_methods") do
       remove(:credential_id, :string)
       modify(:payload, :bytea, null: false)

--- a/apps/fz_http/test/fz_http/mfa_test.exs
+++ b/apps/fz_http/test/fz_http/mfa_test.exs
@@ -125,7 +125,7 @@ defmodule FzHttp.MFATest do
       user = UsersFixtures.create_user()
 
       attrs = %{
-        type: :unsecure,
+        type: :insecure,
         payload: %{},
         code: 10
       }

--- a/apps/fz_http/test/fz_http/mfa_test.exs
+++ b/apps/fz_http/test/fz_http/mfa_test.exs
@@ -1,71 +1,223 @@
 defmodule FzHttp.MFATest do
   use FzHttp.DataCase, async: true
-
+  alias FzHttp.UsersFixtures
+  alias FzHttp.MFAFixtures
   alias FzHttp.MFA
 
-  setup :create_user
+  describe "count_users_with_method/0" do
+    test "returns 0 when there are no methods" do
+      assert MFA.count_users_with_method() == 0
+    end
 
-  setup %{user: user} do
-    {:ok, method} = create_method(user)
+    test "returns count of users with at least one method" do
+      MFAFixtures.create_totp_method()
+      MFAFixtures.create_totp_method()
 
-    {:ok, method: method}
-  end
+      user = UsersFixtures.create_user()
+      MFAFixtures.create_totp_method(user: user)
+      MFAFixtures.create_totp_method(user: user)
 
-  describe "trimmed fields" do
-    test "trims expected fields" do
-      changeset =
-        MFA.new_method(%{
-          "name" => " foo "
-        })
-
-      assert %Ecto.Changeset{
-               changes: %{
-                 name: "foo"
-               }
-             } = changeset
+      assert MFA.count_users_with_method() == 3
     end
   end
 
-  describe "types" do
-    test "totp", %{user: user} do
-      assert {:ok, _method} = create_method(user, type: :totp)
+  describe "fetch_method_by_id/1" do
+    test "returns error when method is not found" do
+      assert MFA.fetch_method_by_id(Ecto.UUID.generate()) == {:error, :not_found}
     end
 
-    test "native", %{user: user} do
-      assert {:ok, _method} = create_method(user, type: :native)
+    test "returns error when id is not a valid UUIDv4" do
+      assert MFA.fetch_method_by_id("foo") == {:error, :not_found}
     end
 
-    test "portable", %{user: user} do
-      assert {:ok, _method} = create_method(user, type: :portable)
-    end
-
-    test "fails to create unknown", %{user: user} do
-      assert {:error, _changeset} = create_method(user, type: :unknown)
+    test "returns method by id" do
+      method = MFAFixtures.create_totp_method()
+      assert {:ok, returned_method} = MFA.fetch_method_by_id(method.id)
+      assert returned_method.id == method.id
+      refute returned_method.code
     end
   end
 
-  describe "queries" do
-    test "count_distinct_by_user_id", %{user: user} do
-      Enum.each(1..5, fn _ -> create_method(user) end)
-      assert MFA.count_distinct_by_user_id() == 1
+  describe "fetch_last_used_method_by_user_id/1" do
+    test "returns error when method user id is not found" do
+      assert MFA.fetch_last_used_method_by_user_id(Ecto.UUID.generate()) == {:error, :not_found}
     end
 
-    test "list in descending order", %{user: user} do
-      Enum.each(1..5, fn _ -> create_method(user) end)
-      methods = MFA.list_methods(user)
-      assert methods == Enum.sort_by(methods, & &1.last_used_at, {:desc, DateTime})
+    test "returns error when user id is not a valid UUIDv4" do
+      assert MFA.fetch_last_used_method_by_user_id("foo") == {:error, :not_found}
     end
 
-    test "get last used method", %{user: user} do
-      Enum.each(1..5, fn _ -> create_method(user) end)
-      methods = MFA.list_methods(user)
-      method = MFA.most_recent_method(user)
-      assert method == Enum.max_by(methods, & &1.last_used_at, DateTime)
+    test "returns method by user id" do
+      user = UsersFixtures.create_user()
+      method = MFAFixtures.create_totp_method(user: user)
+      assert {:ok, returned_method} = MFA.fetch_last_used_method_by_user_id(user.id)
+      assert returned_method.id == method.id
+    end
+  end
+
+  describe "list_methods_for_user/1" do
+    test "returns empty list when there are no methods" do
+      user = UsersFixtures.create_user()
+      assert MFA.list_methods_for_user(user) == {:ok, []}
     end
 
-    test "get nil if no methods are present", %{user: user, method: method} do
-      MFA.delete_method(method)
-      assert nil == MFA.most_recent_method(user)
+    test "returns empty list when user has no methods" do
+      MFAFixtures.create_totp_method()
+      user = UsersFixtures.create_user()
+      assert MFA.list_methods_for_user(user) == {:ok, []}
+    end
+
+    test "returns methods for user" do
+      user = UsersFixtures.create_user()
+      method1 = MFAFixtures.create_totp_method(user: user)
+      method2 = MFAFixtures.create_totp_method(user: user)
+
+      assert {:ok, methods} = MFA.list_methods_for_user(user)
+
+      assert Enum.count(methods) == 2
+      assert Enum.sort([method1.id, method2.id]) == Enum.sort(Enum.map(methods, & &1.id))
+    end
+  end
+
+  describe "delete_method_by_id/2" do
+    test "returns error when method is not found" do
+      user = UsersFixtures.create_user()
+      assert MFA.delete_method_by_id(Ecto.UUID.generate(), user) == {:error, :not_found}
+    end
+
+    test "returns error when id is not a valid UUIDv4" do
+      user = UsersFixtures.create_user()
+      assert MFA.delete_method_by_id("foo", user) == {:error, :not_found}
+    end
+
+    test "deletes method by id" do
+      user = UsersFixtures.create_user()
+      method = MFAFixtures.create_totp_method(user: user)
+      assert {:ok, deleted_method} = MFA.delete_method_by_id(method.id, user)
+      assert deleted_method.id == method.id
+      refute Repo.one(MFA.Method)
+    end
+
+    test "does not allow to delete method that belongs to other user" do
+      method = MFAFixtures.create_totp_method()
+      user = UsersFixtures.create_user()
+      assert MFA.delete_method_by_id(method.id, user) == {:error, :not_found}
+      assert Repo.one(MFA.Method)
+    end
+  end
+
+  describe "create_method/2" do
+    test "returns changeset error when required attrs are missing" do
+      user = UsersFixtures.create_user()
+
+      assert {:error, changeset} = MFA.create_method(%{}, user.id)
+      refute changeset.valid?
+
+      assert errors_on(changeset) == %{
+               code: ["can't be blank"],
+               name: ["can't be blank"],
+               payload: ["can't be blank"],
+               type: ["can't be blank"]
+             }
+    end
+
+    test "returns error on invalid attrs" do
+      user = UsersFixtures.create_user()
+
+      attrs = %{
+        type: :unsecure,
+        payload: %{},
+        code: 10
+      }
+
+      assert {:error, changeset} = MFA.create_method(attrs, user.id)
+      refute changeset.valid?
+
+      assert errors_on(changeset) == %{
+               code: ["is invalid"],
+               type: ["is invalid"],
+               name: ["can't be blank"]
+             }
+
+      attrs = %{payload: %{}, code: "10"}
+      assert {:error, changeset} = MFA.create_method(attrs, user.id)
+      refute changeset.valid?
+      assert "is invalid" in errors_on(changeset).payload
+
+      attrs = MFAFixtures.totp_method_attrs(code: "10")
+      assert {:error, changeset} = MFA.create_method(attrs, user.id)
+      refute changeset.valid?
+      assert "is invalid" in errors_on(changeset).code
+    end
+
+    test "returns error when name is already taken" do
+      user = UsersFixtures.create_user()
+
+      attrs = MFAFixtures.totp_method_attrs()
+      assert {:ok, _user} = MFA.create_method(attrs, user.id)
+      assert {:error, changeset} = MFA.create_method(attrs, user.id)
+      refute changeset.valid?
+      assert "has already been taken" in errors_on(changeset).name
+    end
+
+    test "creates a TOTP MFA method" do
+      user = UsersFixtures.create_user()
+      attrs = MFAFixtures.totp_method_attrs()
+      assert {:ok, method} = MFA.create_method(attrs, user.id)
+
+      assert method.name == attrs.name
+      assert method.type == attrs.type
+      assert method.payload == attrs.payload
+      assert method.user_id == user.id
+      refute method.code
+    end
+
+    test "trims name" do
+      user = UsersFixtures.create_user()
+
+      attrs = MFAFixtures.totp_method_attrs()
+      updated_attrs = Map.put(attrs, :name, " #{attrs.name} ")
+
+      assert {:ok, user} = MFA.create_method(updated_attrs, user.id)
+      assert user.name == attrs.name
+    end
+  end
+
+  describe "use_method/2" do
+    test "returns changeset error when required attrs are missing" do
+      attrs = MFAFixtures.totp_method_attrs()
+      method = MFAFixtures.create_totp_method(attrs)
+
+      assert {:error, changeset} = MFA.use_method(method, %{})
+      refute changeset.valid?
+
+      assert errors_on(changeset) == %{
+               code: ["can't be blank"]
+             }
+    end
+
+    test "returns error on invalid code" do
+      attrs = MFAFixtures.totp_method_attrs()
+      method = MFAFixtures.create_totp_method(attrs)
+
+      assert {:error, changeset} = MFA.use_method(method, %{"code" => "123456"})
+      refute changeset.valid?
+
+      assert errors_on(changeset) == %{
+               code: ["is invalid"]
+             }
+    end
+
+    test "uses the code and updated last_used_at" do
+      attrs = MFAFixtures.totp_method_attrs()
+
+      method =
+        MFAFixtures.create_totp_method(attrs)
+        |> MFAFixtures.rotate_totp_method_key()
+
+      assert {:ok, updated_method} = MFA.use_method(method, %{"code" => attrs.code})
+
+      assert DateTime.compare(updated_method.last_used_at, method.last_used_at) in [:gt, :eq]
     end
   end
 end

--- a/apps/fz_http/test/fz_http/telemetry_test.exs
+++ b/apps/fz_http/test/fz_http/telemetry_test.exs
@@ -1,7 +1,7 @@
 defmodule FzHttp.TelemetryTest do
   use FzHttp.DataCase, async: true
-
   alias FzHttp.Telemetry
+  alias FzHttp.MFAFixtures
 
   describe "user" do
     setup :create_user
@@ -14,12 +14,12 @@ defmodule FzHttp.TelemetryTest do
 
     test "count mfa", %{user: user} do
       {:ok, [user: other_user]} = create_user(%{})
-      {:ok, _method} = create_method(user, type: :totp)
-      {:ok, _method} = create_method(other_user, type: :portable)
+      MFAFixtures.create_totp_method(user: user)
+      MFAFixtures.create_totp_method(user: other_user)
       ping_data = Telemetry.ping_data()
 
       assert ping_data[:users_with_mfa] == 2
-      assert ping_data[:users_with_mfa_totp] == 1
+      assert ping_data[:users_with_mfa_totp] == 2
     end
   end
 

--- a/apps/fz_http/test/fz_http_web/controllers/json/user_controller_test.exs
+++ b/apps/fz_http/test/fz_http_web/controllers/json/user_controller_test.exs
@@ -28,6 +28,7 @@ defmodule FzHttpWeb.JSON.UserControllerTest do
 
       actual =
         Users.list_users()
+        |> elem(1)
         |> Enum.map(fn u -> u.id end)
         |> Enum.sort()
 

--- a/apps/fz_http/test/fz_http_web/live/user_live/index_test.exs
+++ b/apps/fz_http/test/fz_http_web/live/user_live/index_test.exs
@@ -26,8 +26,9 @@ defmodule FzHttpWeb.UserLive.IndexTest do
     } do
       path = ~p"/users"
       {:ok, _view, html} = live(conn, path)
+      {:ok, users} = Users.list_users(hydrate: [:device_count])
 
-      for user <- Users.list_users(hydrate: [:device_count]) do
+      for user <- users do
         assert html =~ "<td id=\"user-#{user.id}-device-count\">#{user.device_count}</td>"
       end
     end

--- a/apps/fz_http/test/support/acceptance_case/auth.ex
+++ b/apps/fz_http/test/support/acceptance_case/auth.ex
@@ -47,7 +47,8 @@ defmodule FzHttpWeb.AcceptanceCase.Auth do
       cookie =
         %{
           "guardian_default_token" => token,
-          "login_method" => "identity"
+          "login_method" => "identity",
+          "logged_in_at" => DateTime.utc_now()
         }
         |> :erlang.term_to_binary()
 

--- a/apps/fz_http/test/support/fixtures/mfa_fixtures.ex
+++ b/apps/fz_http/test/support/fixtures/mfa_fixtures.ex
@@ -1,0 +1,43 @@
+defmodule FzHttp.MFAFixtures do
+  alias FzHttp.Repo
+  alias FzHttp.MFA
+  alias FzHttp.UsersFixtures
+
+  def totp_method_attrs(attrs \\ %{}) do
+    secret = NimbleTOTP.secret()
+
+    Enum.into(attrs, %{
+      name: "Test Default #{counter()}",
+      type: :totp,
+      payload: %{"secret" => Base.encode64(secret)},
+      code: NimbleTOTP.verification_code(secret)
+    })
+  end
+
+  def create_totp_method(attrs \\ %{}) do
+    attrs = Enum.into(attrs, %{})
+
+    {user, attrs} =
+      Map.pop_lazy(attrs, :user, fn ->
+        UsersFixtures.create_user()
+      end)
+
+    attrs = totp_method_attrs(attrs)
+    {:ok, method} = MFA.create_method(attrs, user.id)
+    method
+  end
+
+  @doc """
+  By default, TOTP methods would not code reuse for 30 seconds after it was created,
+  so we hack around it by moving `last_used_at` timestamp back in past.
+  """
+  def rotate_totp_method_key(%MFA.Method{} = method) do
+    method
+    |> Ecto.Changeset.change(last_used_at: DateTime.utc_now() |> DateTime.add(-3600, :second))
+    |> Repo.update!()
+  end
+
+  defp counter do
+    System.unique_integer([:positive])
+  end
+end

--- a/apps/fz_http/test/support/test_helpers.ex
+++ b/apps/fz_http/test/support/test_helpers.ex
@@ -6,7 +6,6 @@ defmodule FzHttp.TestHelpers do
   alias FzHttp.{
     ConnectivityChecksFixtures,
     DevicesFixtures,
-    MFA,
     NotificationsFixtures,
     Repo,
     RulesFixtures,
@@ -196,20 +195,6 @@ defmodule FzHttp.TestHelpers do
   def clear_users(_) do
     {count, _result} = Repo.delete_all(User)
     {:ok, count: count}
-  end
-
-  def create_method(user, attrs \\ %{}) do
-    secret = NimbleTOTP.secret()
-
-    MFA.create_method(
-      Enum.into(attrs, %{
-        name: "Test Default",
-        type: :totp,
-        secret: Base.encode64(secret),
-        code: NimbleTOTP.verification_code(secret)
-      }),
-      user.id
-    )
   end
 
   def create_notifications(opts \\ []) do


### PR DESCRIPTION
1. We enforce `last_used_at` to be not nil at the database level
2. The `name` is now unique to prevent ambiguity, it also can't be longer than 255 chars
3. The MFA module was rewritten to follow the style applied to Users before with much better test coverage, its API changed to be less generic (like just create/update -> create/use_code)
4. The multi-step form was reworked to use new methods instead of changeset and doing direct `Repo.insert/1`.

Closes #1323