### PR TITLE
Soft limit CIDR range for IPv6 network to 288230376151711744 devices

### DIFF
--- a/apps/fz_http/test/fz_http/devices/device/query_test.exs
+++ b/apps/fz_http/test/fz_http/devices/device/query_test.exs
@@ -140,7 +140,7 @@ defmodule FzHttp.Devices.Device.QueryTest do
       queryable = next_available_address(cidr, offset, [gateway_ip])
 
       assert Repo.one(queryable) == %Postgrex.INET{
-               address: {64_768, 0, 0, 0, 32767, 65535, 65535, 65534}
+               address: {64_768, 0, 0, 0, 32_767, 65_535, 65_535, 65_534}
              }
     end
 

--- a/apps/fz_http/test/fz_http/devices/device/query_test.exs
+++ b/apps/fz_http/test/fz_http/devices/device/query_test.exs
@@ -112,6 +112,38 @@ defmodule FzHttp.Devices.Device.QueryTest do
       assert Repo.one(queryable) == %Postgrex.INET{address: {64_768, 0, 0, 0, 0, 3, 3, 4}}
     end
 
+    test "selects available IPv6 at end of CIDR range" do
+      cidr = string_to_inet("fd00::/106")
+      gateway_ip = string_to_inet("fd00::3:3:3")
+      offset = 4_194_304
+
+      queryable = next_available_address(cidr, offset, [gateway_ip])
+
+      assert Repo.one(queryable) == %Postgrex.INET{address: {64_768, 0, 0, 0, 0, 0, 63, 65_535}}
+    end
+
+    test "works when offset is out of IPv6 CIDR range" do
+      cidr = string_to_inet("fd00::/106")
+      gateway_ip = string_to_inet("fd00::3:3:3")
+      offset = 4_194_305
+
+      queryable = next_available_address(cidr, offset, [gateway_ip])
+
+      assert Repo.one(queryable) == %Postgrex.INET{address: {64_768, 0, 0, 0, 0, 0, 64, 0}}
+    end
+
+    test "works when netmask allows a large number of devices" do
+      cidr = string_to_inet("fd00::/70")
+      gateway_ip = string_to_inet("fd00::3:3:3")
+      offset = 9_223_372_036_854_775_807
+
+      queryable = next_available_address(cidr, offset, [gateway_ip])
+
+      assert Repo.one(queryable) == %Postgrex.INET{
+               address: {64_768, 0, 0, 0, 32767, 65535, 65535, 65534}
+             }
+    end
+
     test "selects nothing when IPv6 CIDR range is exhausted" do
       cidr = string_to_inet("fd00::3:2:0/126")
       gateway_ip = string_to_inet("fd00::3:2:1")

--- a/apps/fz_http/test/fz_http/devices_test.exs
+++ b/apps/fz_http/test/fz_http/devices_test.exs
@@ -83,7 +83,7 @@ defmodule FzHttp.DevicesTest do
     end
 
     test "soft limit max network range for IPv6", %{device: device} do
-      FzHttp.Config.maybe_put_env_override(:wireguard_ipv6_network, "fd00::/20")
+      FzHttp.Config.put_env(:wireguard_ipv6_network, "fd00::/20")
       attrs = %{@device_attrs | ipv4: nil, ipv6: nil, user_id: device.user_id}
       assert {:ok, _device} = Devices.create_device(attrs)
     end

--- a/apps/fz_http/test/fz_http/devices_test.exs
+++ b/apps/fz_http/test/fz_http/devices_test.exs
@@ -82,6 +82,12 @@ defmodule FzHttp.DevicesTest do
       refute is_nil(device.ipv6)
     end
 
+    test "soft limit max network range for IPv6", %{device: device} do
+      FzHttp.Config.maybe_put_env_override(:wireguard_ipv6_network, "fd00::/20")
+      attrs = %{@device_attrs | ipv4: nil, ipv6: nil, user_id: device.user_id}
+      assert {:ok, _device} = Devices.create_device(attrs)
+    end
+
     test "returns error when device IP can't be assigned due to CIDR pool exhaustion", %{
       device: device
     } do


### PR DESCRIPTION
That should be enough for most of users (c).

Closes #1340