### PR TITLE
Add tests to ensure path changes when modal is dismissed

### DIFF
--- a/apps/fz_http/test/fz_http_web/acceptance/admin_test.exs
+++ b/apps/fz_http/test/fz_http_web/acceptance/admin_test.exs
@@ -224,6 +224,7 @@ defmodule FzHttpWeb.Acceptance.AdminTest do
       |> click(Query.button("Generate Configuration"))
       |> assert_el(Query.text("Device added!"))
       |> click(Query.css("button[phx-click=\"close\"]"))
+      |> assert_path(~p"/users/#{user.id}")
       |> assert_el(Query.link("Add Device"))
       |> assert_el(Query.link("big-leg-007"))
 
@@ -647,11 +648,13 @@ defmodule FzHttpWeb.Acceptance.AdminTest do
       session =
         session
         |> click(Query.css("button[aria-label=\"close\"]"))
+        |> assert_path(~p"/settings/account")
         |> assert_el(Query.text("API Tokens"))
         |> assert_el(Query.link("Delete"))
         |> click(Query.link(api_token.id))
         |> assert_el(Query.text("API token secret:"))
         |> click(Query.css("button[aria-label=\"close\"]"))
+        |> assert_path(~p"/settings/account")
         |> assert_el(Query.link("Delete"))
 
       accept_confirm(session, fn session ->

--- a/apps/fz_http/test/fz_http_web/acceptance/admin_test.exs
+++ b/apps/fz_http/test/fz_http_web/acceptance/admin_test.exs
@@ -224,9 +224,9 @@ defmodule FzHttpWeb.Acceptance.AdminTest do
       |> click(Query.button("Generate Configuration"))
       |> assert_el(Query.text("Device added!"))
       |> click(Query.css("button[phx-click=\"close\"]"))
-      |> assert_path(~p"/users/#{user.id}")
       |> assert_el(Query.link("Add Device"))
       |> assert_el(Query.link("big-leg-007"))
+      |> assert_path(~p"/users/#{user.id}")
 
       assert device = Repo.one(FzHttp.Devices.Device)
       assert device.name == "big-leg-007"
@@ -648,14 +648,13 @@ defmodule FzHttpWeb.Acceptance.AdminTest do
       session =
         session
         |> click(Query.css("button[aria-label=\"close\"]"))
-        |> assert_path(~p"/settings/account")
         |> assert_el(Query.text("API Tokens"))
         |> assert_el(Query.link("Delete"))
         |> click(Query.link(api_token.id))
         |> assert_el(Query.text("API token secret:"))
         |> click(Query.css("button[aria-label=\"close\"]"))
-        |> assert_path(~p"/settings/account")
         |> assert_el(Query.link("Delete"))
+        |> assert_path(~p"/settings/account")
 
       accept_confirm(session, fn session ->
         click(session, Query.link("Delete"))

--- a/apps/fz_http/test/fz_http_web/acceptance/unprivileged_user_test.exs
+++ b/apps/fz_http/test/fz_http_web/acceptance/unprivileged_user_test.exs
@@ -50,6 +50,7 @@ defmodule FzHttpWeb.Acceptance.UnprivilegedUserTest do
       |> assert_el(Query.text("Device added!"))
       |> click(Query.css("button[phx-click=\"close\"]"))
       |> assert_el(Query.text("big-head-007"))
+      |> assert_path(~p"/user_devices")
 
       assert device = Repo.one(FzHttp.Devices.Device)
       assert device.name == "big-head-007"
@@ -82,6 +83,7 @@ defmodule FzHttpWeb.Acceptance.UnprivilegedUserTest do
       |> assert_el(Query.text("Device added!"))
       |> click(Query.css("button[phx-click=\"close\"]"))
       |> assert_el(Query.text("big-hand-007"))
+      |> assert_path(~p"/user_devices")
 
       assert device = Repo.one(FzHttp.Devices.Device)
       assert device.name == "big-hand-007"


### PR DESCRIPTION
Refs #1353 

I was looking for a `refute_el` helper to check for `.modal.is-active` *not* being on the page, but that would take time to write 😅 

This checks to ensure the URL is updated, which should cause the `@live_action` to change, the view to be patched, and the modal to be dismissed, but isn't the most straightforward way to make sure the modal isn't visible.

We've hit this problem twice before (am not successful this morning finding the relevant issues):

* If the WebSocket is flapping, the event may not register. But usually the browser will refresh if this is the case (we have a red indicator in the upper-right to indicate if the websocket is not connected, i.e. the views aren't "live")
* A CSS bug caused the click event to target the wrong LiveView PID (the modal's parent I believe), which ended up crashing it because it didn't have the "close" event handler defined. I believe the escape keydown still closed the view though in that case.

This feels more like the first issue, given the acceptance test is passing.