### PR TITLE
Add version suffix to cookie signing salt

### DIFF
--- a/apps/fz_http/lib/fz_http_web/session.ex
+++ b/apps/fz_http/lib/fz_http_web/session.ex
@@ -29,7 +29,12 @@ defmodule FzHttpWeb.Session do
   end
 
   defp signing_salt do
-    FzHttp.Config.fetch_env!(:fz_http, :cookie_signing_salt)
+    [vsn | _] =
+      Application.spec(:fz_http, :vsn)
+      |> to_string()
+      |> String.split("+")
+
+    FzHttp.Config.fetch_env!(:fz_http, :cookie_signing_salt) <> vsn
   end
 
   defp encryption_salt do

--- a/apps/fz_http/test/fz_http_web/acceptance/authentication_test.exs
+++ b/apps/fz_http/test/fz_http_web/acceptance/authentication_test.exs
@@ -65,8 +65,9 @@ defmodule FzHttpWeb.Acceptance.AuthenticationTest do
       |> fill_form(%{"email" => "foo@bar.com"})
       |> click(Query.button("Send"))
       |> assert_el(Query.text("Reset Password"))
-      |> visit(~p"/dev/mailbox")
-      |> assert_el(Query.text("Empty mailbox..."))
+
+      emails = Swoosh.Adapters.Local.Storage.Memory.all()
+      refute Enum.find(emails, &(&1.to == "foo@bar.com"))
     end
 
     feature "can reset password using email link", %{session: session} do


### PR DESCRIPTION
This will make sure that users need to reauthenticate every time a new version is deployed.

Closes https://github.com/firezone/firezone/issues/1358