### PR TITLE
Fix bugs with OIDC and SAML forms

### DIFF
--- a/apps/fz_http/lib/fz_http/configurations/configuration/openid_connect_provider.ex
+++ b/apps/fz_http/lib/fz_http/configurations/configuration/openid_connect_provider.ex
@@ -26,10 +26,14 @@ defmodule FzHttp.Configurations.Configuration.OpenIDConnectProvider do
     field :auto_create_users, :boolean
   end
 
-  def changeset(struct \\ %__MODULE__{}, data) do
+  def create_changeset(attrs) do
+    changeset(%__MODULE__{}, attrs)
+  end
+
+  def changeset(struct, attrs) do
     struct
     |> cast(
-      data,
+      attrs,
       [
         :id,
         :label,

--- a/apps/fz_http/lib/fz_http/configurations/configuration/saml_identity_provider.ex
+++ b/apps/fz_http/lib/fz_http/configurations/configuration/saml_identity_provider.ex
@@ -24,9 +24,13 @@ defmodule FzHttp.Configurations.Configuration.SAMLIdentityProvider do
     field :auto_create_users, :boolean
   end
 
-  def changeset(struct \\ %__MODULE__{}, data) do
+  def create_changeset(attrs) do
+    changeset(%__MODULE__{}, attrs)
+  end
+
+  def changeset(struct, attrs) do
     struct
-    |> cast(data, [
+    |> cast(attrs, [
       :id,
       :label,
       :base_url,

--- a/apps/fz_http/lib/fz_http_web/live/setting_live/oidc_form_component.ex
+++ b/apps/fz_http/lib/fz_http_web/live/setting_live/oidc_form_component.ex
@@ -3,6 +3,7 @@ defmodule FzHttpWeb.SettingLive.OIDCFormComponent do
   Form for OIDC configs
   """
   use FzHttpWeb, :live_component
+  alias FzHttp.Configurations
 
   def render(assigns) do
     ~H"""
@@ -174,55 +175,50 @@ defmodule FzHttpWeb.SettingLive.OIDCFormComponent do
       assigns.providers
       |> Map.get(assigns.provider_id, %{})
       |> Map.put(:id, assigns.provider_id)
-      |> FzHttp.Configurations.Configuration.OpenIDConnectProvider.changeset()
+      |> Configurations.Configuration.OpenIDConnectProvider.create_changeset()
 
-    {:ok,
-     socket
-     |> assign(assigns)
-     |> assign(:external_url, FzHttp.Config.fetch_env!(:fz_http, :external_url))
-     |> assign(:changeset, changeset)}
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(:external_url, FzHttp.Config.fetch_env!(:fz_http, :external_url))
+      |> assign(:changeset, changeset)
+
+    {:ok, socket}
   end
 
   def handle_event("save", %{"open_id_connect_provider" => params}, socket) do
-    changeset =
-      params
-      |> FzHttp.Configurations.Configuration.OpenIDConnectProvider.changeset()
-      |> render_changeset_errors()
+    create_changeset = Configurations.Configuration.OpenIDConnectProvider.create_changeset(params)
 
-    update =
-      case changeset do
-        %{valid?: true} ->
-          {:ok, _} =
-            changeset
-            |> Ecto.Changeset.apply_changes()
-            |> Map.from_struct()
-            |> Map.new(fn {k, v} -> {to_string(k), v} end)
-            |> then(fn data ->
-              id = Map.get(data, "id")
+    if create_changeset.valid? do
+      new_attrs =
+        create_changeset
+        |> Ecto.Changeset.apply_changes()
+        |> Map.from_struct()
 
-              %{
-                openid_connect_providers:
-                  socket.assigns.providers
-                  |> Map.delete(socket.assigns.provider_id)
-                  |> Map.put(id, data)
-                  |> Map.values()
-              }
-            end)
-            |> FzHttp.Configurations.update_configuration()
+      new_attrs =
+        socket.assigns.providers
+        |> Map.get(socket.assigns.provider_id, %{})
+        |> Map.merge(new_attrs)
 
-        _ ->
-          {:error, changeset}
-      end
+      providers =
+        socket.assigns.providers
+        |> Map.delete(socket.assigns.provider_id)
+        |> Map.values()
 
-    case update do
-      {:ok, _config} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Updated successfully.")
-         |> redirect(to: socket.assigns.return_to)}
+      {:ok, _changeset} =
+        FzHttp.Configurations.update_configuration(%{
+          openid_connect_providers: providers ++ [new_attrs]
+        })
 
-      {:error, changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
+      socket =
+        socket
+        |> put_flash(:info, "Updated successfully.")
+        |> redirect(to: socket.assigns.return_to)
+
+      {:noreply, socket}
+    else
+      socket = assign(socket, :changeset, render_changeset_errors(create_changeset))
+      {:noreply, socket}
     end
   end
 end


### PR DESCRIPTION
1. When OIDC/SAML is deleted the state of the LV socket becomes invalid and basically makes it looks like everything was deleted
2. When there is more than one OIDC/SAML config trying to delete it leads to a crash
3. Updates of OIDC/SAML were messy and hard to follow, they are reworked and more tests are added around them

Closes #1382