### PR TITLE
Increase load peer timeout

### DIFF
--- a/apps/fz_vpn/lib/fz_vpn/server.ex
+++ b/apps/fz_vpn/lib/fz_vpn/server.ex
@@ -10,7 +10,7 @@ defmodule FzVpn.Server do
   alias FzVpn.Keypair
 
   @process_opts Application.compile_env(:fz_vpn, :server_process_opts, [])
-  @init_timeout 1_000
+  @init_timeout 10_000
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, %{}, @process_opts)


### PR DESCRIPTION
Temporary workaround for a rare issue where many peers (> hundreds) cause a timeout for the `GenServer.call` function, preventing the `wireguard_public_key` from being set properly.

This will be removed in 0.8, so only an increased timeout is needed for now.