### PR TITLE
Fix OIDC error matching to catch token and verify failures

### DIFF
--- a/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
+++ b/apps/fz_http/lib/fz_http_web/controllers/auth_controller.ex
@@ -85,20 +85,13 @@ defmodule FzHttpWeb.AuthController do
           |> redirect(to: ~p"/")
       end
     else
-      {:error, reason} ->
-        msg = "OpenIDConnect Error: #{reason}"
-        Logger.warn(msg)
+      # Error verifying state, claims or fetching tokens
+      {:error, error} ->
+        msg = "An OpenIDConnect error occurred. Details: #{inspect(error)}"
+        Logger.error(msg)
 
         conn
         |> put_flash(:error, msg)
-        |> redirect(to: ~p"/")
-
-      # Error verifying claims or fetching tokens
-      {:error, action, reason} ->
-        Logger.warn("OpenIDConnect Error during #{action}: #{inspect(reason)}")
-
-        conn
-        |> put_flash(:error, "Failed when performing this action: #{action}")
         |> redirect(to: ~p"/")
     end
   end

--- a/apps/fz_http/test/fz_http_web/controllers/auth_controller_test.exs
+++ b/apps/fz_http/test/fz_http_web/controllers/auth_controller_test.exs
@@ -218,7 +218,7 @@ defmodule FzHttpWeb.AuthControllerTest do
         })
 
       assert Phoenix.Flash.get(test_conn.assigns.flash, :error) ==
-               "OpenIDConnect Error: Cannot verify state"
+               "An OpenIDConnect error occurred. Details: \"Cannot verify state\""
     end
 
     @tag max_age: 0
@@ -226,7 +226,7 @@ defmodule FzHttpWeb.AuthControllerTest do
       test_conn = get(conn, ~p"/auth/oidc/google/callback", @params)
 
       assert Phoenix.Flash.get(test_conn.assigns.flash, :error) ==
-               "OpenIDConnect Error: Cannot verify state"
+               "An OpenIDConnect error occurred. Details: \"Cannot verify state\""
     end
   end
 


### PR DESCRIPTION
The phoenix process crashes with 'String.chars not implemented for ...` when the `fetch_tokens` or `verify` function fails in `openid_connect`. This is due to a change in the error response tuple that wasn't reflected in the error matches in `auth_controller.exs`.

Fixes #1426 
