### PR TITLE
Fix "edit this page" link in docs

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -63,7 +63,7 @@ const config = {
         docs: {
           routeBasePath: "/docs",
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/firezone/firezone/tree/master/www/docs",
+          editUrl: "https://github.com/firezone/firezone/tree/master/www/",
           docLayoutComponent: "@theme/DocPage",
         },
         blog: {

--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -63,7 +63,7 @@ const config = {
         docs: {
           routeBasePath: "/docs",
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/firezone/firezone/tree/master/www/",
+          editUrl: "https://github.com/firezone/firezone/blob/master/www/",
           docLayoutComponent: "@theme/DocPage",
         },
         blog: {


### PR DESCRIPTION
Remove `docs/` trailing part of `presets[].docs.editUrl` so the "Edit this page" link in the footer of every doc page points to the correct Github url.

Also replaces the `/tree/` part with `/blob/` as gh redirects you to that route anyway if you access the page via `/tree/` (seems like they're deprecating `/tree/`? I don't know..)

---

For example [Enable SSO with Okta (SAML 2.0)](https://www.firezone.dev/docs/authenticate/saml/okta/) points to \
`https://github.com/firezone/firezone/tree/master/www/docs/docs/authenticate/saml/okta.mdx` while it should point to \
`https://github.com/firezone/firezone/blob/master/www/docs/authenticate/saml/okta.mdx`