### PR TITLE
RemoteIp.Options.proxies expect list of strings not INETs

### DIFF
--- a/apps/fz_http/lib/fz_http_web/header_helpers.ex
+++ b/apps/fz_http/lib/fz_http_web/header_helpers.ex
@@ -5,7 +5,10 @@ defmodule FzHttpWeb.HeaderHelpers do
 
   @remote_ip_headers ["x-forwarded-for"]
 
-  def external_trusted_proxies, do: FzHttp.Config.fetch_env!(:fz_http, :external_trusted_proxies)
+  def external_trusted_proxies do
+    FzHttp.Config.fetch_env!(:fz_http, :external_trusted_proxies)
+    |> Enum.map(&to_string/1)
+  end
 
   def clients, do: FzHttp.Config.fetch_env!(:fz_http, :private_clients)
 
@@ -14,7 +17,7 @@ defmodule FzHttpWeb.HeaderHelpers do
   def remote_ip_opts do
     [
       headers: @remote_ip_headers,
-      proxies: Enum.join(external_trusted_proxies(), ", "),
+      proxies: external_trusted_proxies(),
       clients: clients()
     ]
   end

--- a/apps/fz_http/test/fz_http_web/header_helpers_test.exs
+++ b/apps/fz_http/test/fz_http_web/header_helpers_test.exs
@@ -5,13 +5,13 @@ defmodule FzHttpWeb.HeaderHelpersTest do
   describe "remote_ip_opts/0" do
     test "returns a list of options for remote_ip/2" do
       FzHttp.Config.put_env_override(:fz_http, :external_trusted_proxies, [
-        "127.0.0.1",
-        "10.10.10.0/16"
+        %Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil},
+        %Postgrex.INET{address: {10, 10, 10, 0}, netmask: 16}
       ])
 
       assert remote_ip_opts() == [
                headers: ["x-forwarded-for"],
-               proxies: "127.0.0.1, 10.10.10.0/16",
+               proxies: ["127.0.0.1", "10.10.10.0/16"],
                clients: ["172.28.0.0/16"]
              ]
     end

--- a/apps/fz_http/test/fz_http_web/header_helpers_test.exs
+++ b/apps/fz_http/test/fz_http_web/header_helpers_test.exs
@@ -3,7 +3,17 @@ defmodule FzHttpWeb.HeaderHelpersTest do
   import FzHttpWeb.HeaderHelpers
 
   describe "remote_ip_opts/0" do
-    test "returns a list of options for remote_ip/2" do
+    test "returns an empty proxies list for remote_ip/2" do
+      FzHttp.Config.put_env_override(:fz_http, :external_trusted_proxies, [])
+
+      assert remote_ip_opts() == [
+               headers: ["x-forwarded-for"],
+               proxies: [],
+               clients: ["172.28.0.0/16"]
+             ]
+    end
+
+    test "returns a list of options for remote_ip/2 with ipv4 proxies" do
       FzHttp.Config.put_env_override(:fz_http, :external_trusted_proxies, [
         %Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil},
         %Postgrex.INET{address: {10, 10, 10, 0}, netmask: 16}
@@ -12,6 +22,19 @@ defmodule FzHttpWeb.HeaderHelpersTest do
       assert remote_ip_opts() == [
                headers: ["x-forwarded-for"],
                proxies: ["127.0.0.1", "10.10.10.0/16"],
+               clients: ["172.28.0.0/16"]
+             ]
+    end
+
+    test "returns a list of options for remote_ip/2 with ipv6 proxies" do
+      FzHttp.Config.put_env_override(:fz_http, :external_trusted_proxies, [
+        %Postgrex.INET{address: {1, 0, 0, 0, 0, 0, 0, 0}, netmask: 106},
+        %Postgrex.INET{address: {1, 1, 1, 1, 1, 1, 1, 1}, netmask: nil}
+      ])
+
+      assert remote_ip_opts() == [
+               headers: ["x-forwarded-for"],
+               proxies: ["1::/106", "1:1:1:1:1:1:1:1"],
                clients: ["172.28.0.0/16"]
              ]
     end


### PR DESCRIPTION
RemoteIp actually expects a list of _strings_, not a comma-separate string. Updated test to reflect, and tested manually as well.

Fixes #1455 