### PR TITLE
Cast external_url back to string before being consumed in config

### DIFF
--- a/apps/fz_http/lib/fz_http/config/definitions.ex
+++ b/apps/fz_http/lib/fz_http/config/definitions.ex
@@ -157,6 +157,7 @@ defmodule FzHttp.Config.Definitions do
       changeset
       |> FzHttp.Validator.validate_uri(key)
       |> FzHttp.Validator.normalize_url(key)
+      |> to_string()
     end
   )
 


### PR DESCRIPTION
Fixes the below issue and in many other places where `external_url` is used without being explicitly cast with `Kernel.to_string/1`, and ended as an `%URI{}` struct.

Tests were passing because they were mocked with `external_url` as a string in `put_env_override/3`

```
firezone-firezone-1  | Request: GET /settings/security/oidc/mOo-_KFG/edit
firezone-firezone-1  | ** (exit) an exception was raised:
firezone-firezone-1  |     ** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1
firezone-firezone-1  |         (elixir 1.14.3) lib/io.ex:670: IO.chardata_to_string(%URI{scheme: "https", authority: "docker-dev.firezone.dev", userinfo: nil, host: "docker-dev.firezone.dev", port: 443, path: "/", query: nil, fragment: nil})
firezone-firezone-1  |         (elixir 1.14.3) lib/path.ex:548: Path.join/2
firezone-firezone-1  |         (fz_http 0.7.16) lib/fz_http_web/live/setting_live/oidc_form_component.ex:136: anonymous fn/3 in FzHttpWeb.SettingLive.OIDCFormComponent.render/1
firezone-firezone-1  |         (phoenix_live_view 0.18.11) lib/phoenix_live_view/diff.ex:387: Phoenix.LiveView.Diff.traverse/7
firezone-firezone-1  |         (phoenix_live_view 0.18.11) lib/phoenix_live_view/diff.ex:521: anonymous fn/4 in Phoenix.LiveView.Diff.traverse_dynamic/7
firezone-firezone-1  |         (elixir 1.14.3) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
firezone-firezone-1  |         (phoenix_live_view 0.18.11) lib/phoenix_live_view/diff.ex:387: Phoenix.LiveView.Diff.traverse/7
firezone-firezone-1  |         (phoenix_live_view 0.18.11) lib/phoenix_live_view/diff.ex:521: anonymous fn/4 in Phoenix.LiveView.Diff.traverse_dynamic/7
```