### PR TITLE
Don't create interface if it already exists

### DIFF
--- a/rel/overlays/bin/bootstrap
+++ b/rel/overlays/bin/bootstrap
@@ -11,6 +11,10 @@
 
 setup_interface()
 {
+  if [ ! -d "/sys/class/net/${WIREGUARD_INTERFACE_NAME}" ]; then
+    ip link add ${WIREGUARD_INTERFACE_NAME} type wireguard
+  fi
+
   ip link add ${WIREGUARD_INTERFACE_NAME} type wireguard
 
   if [ "$WIREGUARD_IPV4_ENABLED" = "true" ]; then


### PR DESCRIPTION
This is now needed because `set -e` was added to the calling script. Before, we simply allowed the command to fail silently.

Fixes #1485 