### PR TITLE
CI/PR labeling improvements

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,44 @@
+name: PR Preview
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check_labels:
+    name: Check labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for required labels
+        uses: andymckay/labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          labels: |
+            size
+            priority
+            value
+            area
+            kind
+
+      - name: Check for unapproved labels
+        run: |
+          labels=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/labels \
+          | jq -r '.[].name')
+          required_labels=("size" "priority" "value" "area" "kind")
+          for label in $required_labels
+          do
+            if ! echo $labels | grep -q $label; then
+              echo "::error::Missing label '$label'"
+              exit 1
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Work related to first point in issue [#1316](https://github.com/firezone/firezone/issues/1316)

- [ ] We should apply a labeling schema that will allow marking value, size, etc for PRs manually and instead of using an auto labeler a CI check should simply check for required labels and fail if they are not set.

    Labels:

    - size/S-XL (number of line changes; can be auto-labeled);
    - priority/important-longterm,important-soon
    - value/S-XL (business value of a PR)
    - area/panel,gateway,documentation,CI,infrastructure (can be auto-labeled by checking folders for changed files)
    - good first issue (for new contributors)
    - kind/bug,design,documentation,cleanup,flake,regression,support,feature


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
