### PR TITLE
 CI/PR labeling improvements - Automatically generate and publish API docs in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install Elixir
+      run: |
+        sudo apt update
+        sudo apt install -y esl-erlang elixir
+
+    - name: Install dependencies
+      run: mix deps.get
+
+    - name: Generate Docs
+      run: mix docs
+
+    - name: Publish Docs
+      run: |
+        mkdir -p docs
+        mv doc/* docs/
+        
+        git add docs/
+        git commit -m "Generate API docs"
+        git remote set-url origin https://${{ GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+       
+        git push origin main

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,12 @@ defmodule FirezoneUmbrella.MixProject do
       ],
       docs: [
         logo: "apps/fz_http/assets/static/images/logo.svg",
-        extras: ["README.md", "SECURITY.md", "CONTRIBUTING.md"]
+        extras: ["README.md", "SECURITY.md", "CONTRIBUTING.md"],
+        output: "doc/",
+        exclude: [
+          private: true,
+          #private module ...
+        ]
       ],
       deps: deps(),
       dialyzer: [
@@ -64,6 +69,7 @@ defmodule FirezoneUmbrella.MixProject do
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:dialyxir, "~> 1.1", only: [:dev], runtime: false},
       {:junit_formatter, "~> 3.3", only: [:test]},
+      {:ex_doc, "~> 0.24", only: :dev, runtime: false},
 
       # Formatter doesn't track dependencies of children applications
       {:phoenix, "~> 1.7.0"},


### PR DESCRIPTION
Work related to first point in issue [#1316](https://github.com/firezone/firezone/issues/1316)

- [ ] Automatically generate and publish API docs in CI

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
