### PR TITLE
Mention potentially missing asdf plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,16 @@ according to the versions laid out in the [.tool-versions](.tool-versions) file.
 
 If using asdf, simply run `asdf install` from the project root.
 
+You may need to install the required plugins first:
+
+```bash
+asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
+asdf plugin add erlang https://github.com/asdf-vm/asdf-erlang.git
+asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
+asdf plugin-add python https://github.com/asdf-community/asdf-python.git
+```
+
 This is used to run static analysis checks during [pre-commit](#pre-commit) and
 for any local, non-Docker development or testing.
 


### PR DESCRIPTION
I wasn't previously using `asdf` and trying to install the required toolchain versions failed with a request to install the plugins first.