### PR TITLE
Install Rust before computing cache keys

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,11 @@ jobs:
         working-directory: ./rust
     steps:
       - uses: actions/checkout@v2
+
+      # This implicitly triggers installation of the toolchain in the `rust-toolchain.toml` file.
+      # If we don't do this here, our cache action will compute a cache key based on the Rust version shipped on GitHub's runner which might differ from the one we use.
+      - run: rustup show
+
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check
       - run: cargo clippy -- -D warnings


### PR DESCRIPTION
The `Swatinem/rust-cache@v2` action computes a cache key based on the default Rust toolchain. This one might differ from what we specify in the `rust-toolchain` file and thus we might not actually cache anything.