### PR TITLE
Be louder about Omnibus->Docker migration

### DIFF
--- a/omnibus/package-scripts/firezone/postinst
+++ b/omnibus/package-scripts/firezone/postinst
@@ -50,9 +50,11 @@ echo
 echo "=> https://docs.firezone.dev/administer/upgrade/?utm_source=product"
 echo
 echo
-echo "Heads up! Firezone 0.7.x will be the last release to support Omnibus."
-echo "Firezone 0.8 and above will support containerized deployments only."
+echo "Heads up! Firezone 0.7.x will be the last release to offer Omnibus packages."
+echo "We *highly* recommend migrating your Omnibus install to Docker ASAP to avoid"
+echo "unexpected issues with future releases."
+echo
 echo "Read more about the transition in our migration guide:"
 echo
-echo "=> https://docs.firezone.dev/administer/migrate/?utm_source=product"
+echo "=> https://firezone.dev/docs/administer/migrate/?utm_source=product"
 echo $normal


### PR DESCRIPTION
Still getting some users tripping up on Omnibus issues, so I'm going to cut a final 0.7.30 release, and then cut the CI pipeline that's building and publishing those. Since all Omnibus installs are effectively handicapped since 0.7.14-ish?