### PR TITLE
Add resource type and expose it in WS API along with name

### DIFF
--- a/elixir/apps/api/lib/api/device/views/relay.ex
+++ b/elixir/apps/api/lib/api/device/views/relay.ex
@@ -8,7 +8,7 @@ defmodule API.Device.Views.Relay do
   def render(%Relays.Relay{} = relay, expires_at) do
     [
       maybe_render(relay, expires_at, relay.ipv4),
-      maybe_render(relay, expires_at, relay.ipv6)
+      maybe_render(relay, expires_at, "[#{relay.ipv6}]")
     ]
     |> List.flatten()
   end

--- a/elixir/apps/api/lib/api/device/views/resource.ex
+++ b/elixir/apps/api/lib/api/device/views/resource.ex
@@ -5,12 +5,23 @@ defmodule API.Device.Views.Resource do
     Enum.map(resources, &render/1)
   end
 
-  def render(%Resources.Resource{} = resource) do
+  def render(%Resources.Resource{type: :dns} = resource) do
     %{
       id: resource.id,
+      type: :dns,
       address: resource.address,
+      name: resource.name,
       ipv4: resource.ipv4,
       ipv6: resource.ipv6
+    }
+  end
+
+  def render(%Resources.Resource{type: :cidr} = resource) do
+    %{
+      id: resource.id,
+      type: :cidr,
+      address: resource.address,
+      name: resource.name
     }
   end
 end

--- a/elixir/apps/api/lib/api/gateway/views/resource.ex
+++ b/elixir/apps/api/lib/api/gateway/views/resource.ex
@@ -1,12 +1,23 @@
 defmodule API.Gateway.Views.Resource do
   alias Domain.Resources
 
-  def render(%Resources.Resource{} = resource) do
+  def render(%Resources.Resource{type: :dns} = resource) do
     %{
       id: resource.id,
+      type: :dns,
       address: resource.address,
+      name: resource.name,
       ipv4: resource.ipv4,
       ipv6: resource.ipv6
+    }
+  end
+
+  def render(%Resources.Resource{type: :cidr} = resource) do
+    %{
+      id: resource.id,
+      type: :cidr,
+      address: resource.address,
+      name: resource.name
     }
   end
 end

--- a/elixir/apps/api/test/api/device/channel_test.exs
+++ b/elixir/apps/api/test/api/device/channel_test.exs
@@ -136,8 +136,8 @@ defmodule API.Device.ChannelTest do
 
       ipv4_stun_uri = "stun:#{relay.ipv4}:#{relay.port}"
       ipv4_turn_uri = "turn:#{relay.ipv4}:#{relay.port}"
-      ipv6_stun_uri = "stun:#{relay.ipv6}:#{relay.port}"
-      ipv6_turn_uri = "turn:#{relay.ipv6}:#{relay.port}"
+      ipv6_stun_uri = "stun:[#{relay.ipv6}]:#{relay.port}"
+      ipv6_turn_uri = "turn:[#{relay.ipv6}]:#{relay.port}"
 
       assert [
                %{

--- a/elixir/apps/api/test/api/device/channel_test.exs
+++ b/elixir/apps/api/test/api/device/channel_test.exs
@@ -12,8 +12,16 @@ defmodule API.Device.ChannelTest do
     device = DevicesFixtures.create_device(subject: subject)
     gateway = GatewaysFixtures.create_gateway(account: account)
 
-    resource =
+    dns_resource =
       ResourcesFixtures.create_resource(
+        account: account,
+        gateways: [%{gateway_id: gateway.id}]
+      )
+
+    cidr_resource =
+      ResourcesFixtures.create_resource(
+        type: :cidr,
+        address: "192.168.1.1/28",
         account: account,
         gateways: [%{gateway_id: gateway.id}]
       )
@@ -37,7 +45,8 @@ defmodule API.Device.ChannelTest do
       subject: subject,
       device: device,
       gateway: gateway,
-      resource: resource,
+      dns_resource: dns_resource,
+      cidr_resource: cidr_resource,
       socket: socket
     }
   end
@@ -67,18 +76,26 @@ defmodule API.Device.ChannelTest do
 
     test "sends list of resources after join", %{
       device: device,
-      resource: resource
+      dns_resource: dns_resource,
+      cidr_resource: cidr_resource
     } do
       assert_push "init", %{resources: resources, interface: interface}
 
-      assert resources == [
-               %{
-                 address: resource.address,
-                 id: resource.id,
-                 ipv4: resource.ipv4,
-                 ipv6: resource.ipv6
-               }
-             ]
+      assert %{
+               id: dns_resource.id,
+               type: :dns,
+               name: dns_resource.name,
+               address: dns_resource.address,
+               ipv4: dns_resource.ipv4,
+               ipv6: dns_resource.ipv6
+             } in resources
+
+      assert %{
+               id: cidr_resource.id,
+               type: :cidr,
+               name: cidr_resource.name,
+               address: cidr_resource.address
+             } in resources
 
       assert interface == %{
                ipv4: device.ipv4,
@@ -96,12 +113,19 @@ defmodule API.Device.ChannelTest do
       assert_reply ref, :error, :not_found
     end
 
-    test "returns error when there are no online relays", %{resource: resource, socket: socket} do
+    test "returns error when there are no online relays", %{
+      dns_resource: resource,
+      socket: socket
+    } do
       ref = push(socket, "list_relays", %{"resource_id" => resource.id})
       assert_reply ref, :error, :offline
     end
 
-    test "returns list of online relays", %{account: account, resource: resource, socket: socket} do
+    test "returns list of online relays", %{
+      account: account,
+      dns_resource: resource,
+      socket: socket
+    } do
       relay = RelaysFixtures.create_relay(account: account)
       stamp_secret = Ecto.UUID.generate()
       :ok = Domain.Relays.connect_relay(relay, stamp_secret)
@@ -165,7 +189,7 @@ defmodule API.Device.ChannelTest do
     end
 
     test "returns error when all gateways are offline", %{
-      resource: resource,
+      dns_resource: resource,
       socket: socket
     } do
       attrs = %{
@@ -180,7 +204,7 @@ defmodule API.Device.ChannelTest do
 
     test "returns error when all gateways connected to the resource are offline", %{
       account: account,
-      resource: resource,
+      dns_resource: resource,
       socket: socket
     } do
       attrs = %{
@@ -197,7 +221,7 @@ defmodule API.Device.ChannelTest do
     end
 
     test "broadcasts request_connection to the gateways and then returns connect message", %{
-      resource: resource,
+      dns_resource: resource,
       gateway: gateway,
       device: device,
       socket: socket

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -134,6 +134,8 @@ defmodule API.Gateway.ChannelTest do
       assert payload.resource == %{
                address: resource.address,
                id: resource.id,
+               name: resource.name,
+               type: :dns,
                ipv4: resource.ipv4,
                ipv6: resource.ipv6
              }

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -96,8 +96,8 @@ defmodule API.Gateway.ChannelTest do
 
       ipv4_stun_uri = "stun:#{relay.ipv4}:#{relay.port}"
       ipv4_turn_uri = "turn:#{relay.ipv4}:#{relay.port}"
-      ipv6_stun_uri = "stun:#{relay.ipv6}:#{relay.port}"
-      ipv6_turn_uri = "turn:#{relay.ipv6}:#{relay.port}"
+      ipv6_stun_uri = "stun:[#{relay.ipv6}]:#{relay.port}"
+      ipv6_turn_uri = "turn:[#{relay.ipv6}]:#{relay.port}"
 
       assert [
                %{

--- a/elixir/apps/domain/lib/domain/actors/actor/query.ex
+++ b/elixir/apps/domain/lib/domain/actors/actor/query.ex
@@ -16,7 +16,7 @@ defmodule Domain.Actors.Actor.Query do
     where(queryable, [actors: actors], actors.id == ^id)
   end
 
-  def by_account_id(queryable, account_id) do
+  def by_account_id(queryable \\ all(), account_id) do
     where(queryable, [actors: actors], actors.account_id == ^account_id)
   end
 

--- a/elixir/apps/domain/lib/domain/network.ex
+++ b/elixir/apps/domain/lib/domain/network.ex
@@ -7,6 +7,8 @@ defmodule Domain.Network do
     ipv6: %Postgrex.INET{address: {64_768, 8_209, 4_369, 0, 0, 0, 0, 0}, netmask: 106}
   }
 
+  def cidrs, do: @cidrs
+
   def fetch_next_available_address!(account_id, type, opts \\ []) do
     unless Repo.in_transaction?() do
       raise "fetch_next_available_address/1 must be called inside a transaction"

--- a/elixir/apps/domain/lib/domain/resources.ex
+++ b/elixir/apps/domain/lib/domain/resources.ex
@@ -79,12 +79,17 @@ defmodule Domain.Resources do
   end
 
   defp resolve_address_multi(multi, type) do
-    Ecto.Multi.run(multi, type, fn _repo, %{resource: %Resource{} = resource} ->
-      if address = Map.get(resource, type) do
-        {:ok, address}
-      else
-        {:ok, Domain.Network.fetch_next_available_address!(resource.account_id, type)}
-      end
+    Ecto.Multi.run(multi, type, fn
+      _repo, %{resource: %Resource{type: :cidr}} ->
+        {:ok, nil}
+
+      _repo, %{resource: %Resource{type: :dns} = resource} ->
+        # TODO: make an index for the address column for cidrs to make sure ranges do not overlap ^
+        if address = Map.get(resource, type) do
+          {:ok, address}
+        else
+          {:ok, Domain.Network.fetch_next_available_address!(resource.account_id, type)}
+        end
     end)
   end
 

--- a/elixir/apps/domain/lib/domain/resources/resource.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource.ex
@@ -5,6 +5,8 @@ defmodule Domain.Resources.Resource do
     field :address, :string
     field :name, :string
 
+    field :type, Ecto.Enum, values: [:cidr, :dns]
+
     embeds_many :filters, Filter, on_replace: :delete do
       field :protocol, Ecto.Enum, values: [tcp: 6, udp: 17, icmp: 1, all: -1]
       field :ports, {:array, Domain.Types.Int4Range}, default: []

--- a/elixir/apps/domain/priv/repo/migrations/20230607175947_add_resources_type.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20230607175947_add_resources_type.exs
@@ -1,0 +1,16 @@
+defmodule Domain.Repo.Migrations.AddResourcesType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resources) do
+      add(:type, :string, null: false)
+    end
+
+    execute("""
+    ALTER TABLE resources
+    ADD CONSTRAINT resources_account_id_cidr_address_index
+    EXCLUDE USING gist (account_id WITH =, (address::inet) inet_ops WITH &&)
+    WHERE (type = 'cidr')
+    """)
+  end
+end

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -133,6 +133,7 @@ IO.puts("")
 {:ok, dns_resource} =
   Resources.create_resource(
     %{
+      type: :dns,
       address: "gitlab.mycorp.com",
       connections: [%{gateway_id: gateway.id}]
     },
@@ -142,6 +143,7 @@ IO.puts("")
 {:ok, cidr_resource} =
   Resources.create_resource(
     %{
+      type: :cidr,
       address: "172.172.0.1/16",
       connections: [%{gateway_id: gateway.id}]
     },
@@ -151,5 +153,5 @@ IO.puts("")
 IO.puts("Created resources:")
 
 IO.puts("  #{dns_resource.address} - DNS - #{dns_resource.ipv4} - gateways: #{gateway_name}")
-IO.puts("  #{cidr_resource.address} - CIDR - #{cidr_resource.ipv4} - gateways: #{gateway_name}")
+IO.puts("  #{cidr_resource.address} - CIDR - gateways: #{gateway_name}")
 IO.puts("")

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -144,7 +144,8 @@ defmodule Domain.ResourcesTest do
 
       assert errors_on(changeset) == %{
                address: ["can't be blank"],
-               connections: ["can't be blank"]
+               connections: ["can't be blank"],
+               type: ["can't be blank"]
              }
     end
 
@@ -156,8 +157,65 @@ defmodule Domain.ResourcesTest do
                address: ["can't be blank"],
                name: ["should be at most 255 character(s)"],
                filters: ["is invalid"],
-               connections: ["is invalid"]
+               connections: ["is invalid"],
+               type: ["can't be blank"]
              }
+    end
+
+    test "validates dns address", %{subject: subject} do
+      attrs = %{"address" => String.duplicate("a", 256), "type" => "dns"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      assert "should be at most 253 character(s)" in errors_on(changeset).address
+
+      attrs = %{"address" => "a", "type" => "dns"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      refute Map.has_key?(errors_on(changeset), :address)
+    end
+
+    test "validates cidr address", %{subject: subject} do
+      attrs = %{"address" => "192.168.1.256/28", "type" => "cidr"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      assert "is not a valid CIDR range" in errors_on(changeset).address
+
+      attrs = %{"address" => "192.168.1.1", "type" => "cidr"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      assert "is not a valid CIDR range" in errors_on(changeset).address
+
+      attrs = %{"address" => "100.64.0.0/8", "type" => "cidr"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      assert "can not be in the CIDR 100.64.0.0/10" in errors_on(changeset).address
+
+      attrs = %{"address" => "fd00:2011:1111::/102", "type" => "cidr"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      assert "can not be in the CIDR fd00:2011:1111::/106" in errors_on(changeset).address
+
+      attrs = %{"address" => "::/0", "type" => "cidr"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      refute Map.has_key?(errors_on(changeset), :address)
+
+      attrs = %{"address" => "0.0.0.0/0", "type" => "cidr"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      refute Map.has_key?(errors_on(changeset), :address)
+    end
+
+    test "does not allow cidr addresses to overlap", %{account: account, subject: subject} do
+      gateway = GatewaysFixtures.create_gateway(account: account)
+
+      ResourcesFixtures.create_resource(
+        account: account,
+        subject: subject,
+        type: :cidr,
+        address: "192.168.1.1/28"
+      )
+
+      attrs = %{
+        "address" => "192.168.1.8/26",
+        "type" => "cidr",
+        "connections" => [%{"gateway_id" => gateway.id}]
+      }
+
+      assert {:error, changeset} = create_resource(attrs, subject)
+      assert "can not overlap with other resource ranges" in errors_on(changeset).address
     end
 
     test "returns error on duplicate name", %{account: account, subject: subject} do
@@ -168,6 +226,7 @@ defmodule Domain.ResourcesTest do
       attrs = %{
         "name" => resource.name,
         "address" => address,
+        "type" => "dns",
         "connections" => [%{"gateway_id" => gateway.id}]
       }
 
@@ -175,7 +234,7 @@ defmodule Domain.ResourcesTest do
       assert errors_on(changeset) == %{name: ["has already been taken"]}
     end
 
-    test "creates a resource", %{account: account, subject: subject} do
+    test "creates a dns resource", %{account: account, subject: subject} do
       gateway = GatewaysFixtures.create_gateway(account: account)
       attrs = ResourcesFixtures.resource_attrs(connections: [%{gateway_id: gateway.id}])
       assert {:ok, resource} = create_resource(attrs, subject)
@@ -203,6 +262,47 @@ defmodule Domain.ResourcesTest do
                %Domain.Resources.Resource.Filter{ports: ["80", "433"], protocol: :tcp},
                %Domain.Resources.Resource.Filter{ports: ["100 - 200"], protocol: :udp}
              ] = resource.filters
+    end
+
+    test "creates a cidr resource", %{account: account, subject: subject} do
+      gateway = GatewaysFixtures.create_gateway(account: account)
+      address_count = Repo.aggregate(Domain.Network.Address, :count)
+
+      attrs =
+        ResourcesFixtures.resource_attrs(
+          connections: [%{gateway_id: gateway.id}],
+          type: :cidr,
+          name: nil,
+          address: "192.168.1.1/28"
+        )
+
+      assert {:ok, resource} = create_resource(attrs, subject)
+
+      assert resource.address == attrs.address
+      assert resource.name == attrs.address
+      assert resource.account_id == account.id
+
+      assert is_nil(resource.ipv4)
+      assert is_nil(resource.ipv6)
+
+      assert [
+               %Domain.Resources.Connection{
+                 resource_id: resource_id,
+                 gateway_id: gateway_id,
+                 account_id: account_id
+               }
+             ] = resource.connections
+
+      assert resource_id == resource.id
+      assert gateway_id == gateway.id
+      assert account_id == account.id
+
+      assert [
+               %Domain.Resources.Resource.Filter{ports: ["80", "433"], protocol: :tcp},
+               %Domain.Resources.Resource.Filter{ports: ["100 - 200"], protocol: :udp}
+             ] = resource.filters
+
+      assert Repo.aggregate(Domain.Network.Address, :count) == address_count
     end
 
     test "does not allow to reuse IP addresses within an account", %{

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -198,7 +198,10 @@ defmodule Domain.ResourcesTest do
       refute Map.has_key?(errors_on(changeset), :address)
     end
 
-    test "does not allow cidr addresses to overlap", %{account: account, subject: subject} do
+    test "does not allow cidr addresses to overlap for the same account", %{
+      account: account,
+      subject: subject
+    } do
       gateway = GatewaysFixtures.create_gateway(account: account)
 
       ResourcesFixtures.create_resource(
@@ -216,6 +219,9 @@ defmodule Domain.ResourcesTest do
 
       assert {:error, changeset} = create_resource(attrs, subject)
       assert "can not overlap with other resource ranges" in errors_on(changeset).address
+
+      subject = AuthFixtures.create_subject()
+      assert {:ok, _resource} = create_resource(attrs, subject)
     end
 
     test "returns error on duplicate name", %{account: account, subject: subject} do

--- a/elixir/apps/domain/test/support/fixtures/resources_fixtures.ex
+++ b/elixir/apps/domain/test/support/fixtures/resources_fixtures.ex
@@ -8,6 +8,7 @@ defmodule Domain.ResourcesFixtures do
     Enum.into(attrs, %{
       address: address,
       name: address,
+      type: :dns,
       filters: [
         %{protocol: :tcp, ports: [80, 433]},
         %{protocol: :udp, ports: [100..200]}


### PR DESCRIPTION
Additionally:
1. Fixed ipv6 formatting for stun/turn addresses
2. Fixed a tests that check for race conditions concurrently