### PR TITLE
ci: specify workspace directory for cache action correctly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-      - run: sudo apt-get install -y musl-tools
+      - run: rustup target add x86_64-unknown-linux-musl
       - run: cargo build --bin relay --target x86_64-unknown-linux-musl
 
   relay_smoke:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
       - run: rustup show
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./rust
       - run: cargo fmt -- --check
       - run: cargo doc --no-deps --document-private-items
         env:
@@ -47,7 +49,9 @@ jobs:
       - run: rustup show
 
       - uses: Swatinem/rust-cache@v2
-      - run: rustup target add x86_64-unknown-linux-musl
+        with:
+          workspaces: ./rust
+      - run: sudo apt-get install -y musl-tools
       - run: cargo build --bin relay --target x86_64-unknown-linux-musl
 
   relay_smoke:
@@ -64,4 +68,6 @@ jobs:
       - run: rustup show
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./rust
       - run: ./run_smoke_test.sh

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.70.0"
 components = ["rustfmt", "clippy"]
+targets = ["x86_64-unknown-linux-musl"]

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
 channel = "1.70.0"
 components = ["rustfmt", "clippy"]
-targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Previously, the cache action didn't actually do anything because we failed to specify the correct path to the workspace.