### PR TITLE
ci: install musl target via `rust-toolchain.toml` file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,6 @@ jobs:
       - run: rustup show
 
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y musl-tools
         with:
           workspaces: ./rust
       - run: sudo apt-get install -y musl-tools

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
       - run: rustup show
 
       - uses: Swatinem/rust-cache@v2
-      - run: rustup target add x86_64-unknown-linux-musl
+      - run: sudo apt-get install -y musl-tools
       - run: cargo build --bin relay --target x86_64-unknown-linux-musl
 
   relay_smoke:

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.70.0"
 components = ["rustfmt", "clippy"]
+targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Targets specified in the `rust-toolchain.toml` file are automatically installed by `rustup`. This avoid setup steps for other devs and also simplifies the CI setup.

To be able to compile native code to musl, we do need `musl-gcc` which comes with the `musl-tools` package on ubuntu.