### PR TITLE
portal: Policies CRUD views

### DIFF
--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -162,7 +162,7 @@
         <ul id="dropdown-pages" class="py-2 space-y-2">
           <li>
             <.link
-              navigate={~p"/users"}
+              navigate={~p"/#{@subject.account}/users"}
               class="flex items-center p-2 pl-11 w-full text-base font-medium text-gray-900 rounded-lg transition duration-75 group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
             >
               Users
@@ -170,7 +170,7 @@
           </li>
           <li>
             <.link
-              navigate={~p"/groups"}
+              navigate={~p"/#{@subject.account}/groups"}
               class="flex items-center p-2 pl-11 w-full text-base font-medium text-gray-900 rounded-lg transition duration-75 group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
             >
               Groups
@@ -178,7 +178,7 @@
           </li>
           <li>
             <.link
-              navigate={~p"/devices"}
+              navigate={~p"/#{@subject.account}/devices"}
               class="flex items-center p-2 pl-11 w-full text-base font-medium text-gray-900 rounded-lg transition duration-75 group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
             >
               Devices
@@ -188,7 +188,7 @@
       </li>
       <li>
         <.link
-          navigate={~p"/gateways"}
+          navigate={~p"/#{@subject.account}/gateways"}
           class="flex items-center p-2 text-base font-medium text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group"
         >
           <.icon
@@ -200,7 +200,7 @@
       </li>
       <li>
         <.link
-          navigate={~p"/resources"}
+          navigate={~p"/#{@subject.account}/resources"}
           class="flex items-center p-2 text-base font-medium text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group"
         >
           <.icon
@@ -212,7 +212,7 @@
       </li>
       <li>
         <.link
-          navigate={~p"/policies"}
+          navigate={~p"/#{@subject.account}/policies"}
           class="flex items-center p-2 text-base font-medium text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group"
         >
           <.icon
@@ -242,7 +242,7 @@
         <ul id="dropdown-settings" class="py-2 space-y-2">
           <li>
             <.link
-              navigate={~p"/settings/account"}
+              navigate={~p"/#{@subject.account}/settings/account"}
               class="flex items-center p-2 pl-11 w-full text-base font-medium text-gray-900 rounded-lg transition duration-75 group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
             >
               Account
@@ -250,7 +250,7 @@
           </li>
           <li>
             <.link
-              navigate={~p"/settings/identity_providers"}
+              navigate={~p"/#{@subject.account}/settings/identity_providers"}
               class="flex items-center p-2 pl-11 w-full text-base font-medium text-gray-900 rounded-lg transition duration-75 group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
             >
               Identity Providers
@@ -258,7 +258,7 @@
           </li>
           <li>
             <.link
-              navigate={~p"/settings/dns"}
+              navigate={~p"/#{@subject.account}/settings/dns"}
               class="flex items-center p-2 pl-11 w-full text-base font-medium text-gray-900 rounded-lg transition duration-75 group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
             >
               DNS
@@ -266,7 +266,7 @@
           </li>
           <li>
             <.link
-              navigate={~p"/settings/api_tokens"}
+              navigate={~p"/#{@subject.account}/settings/api_tokens"}
               class="flex items-center p-2 pl-11 w-full text-base font-medium text-gray-900 rounded-lg transition duration-75 group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
             >
               API

--- a/elixir/apps/web/lib/web/components/layouts/root.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark" style="scrollbar-gutter: stable;">
+<html lang="en" style="scrollbar-gutter: stable;">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/elixir/apps/web/lib/web/live/devices_live/index.ex
+++ b/elixir/apps/web/lib/web/live/devices_live/index.ex
@@ -6,8 +6,8 @@ defmodule Web.DevicesLive.Index do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Devices", path: ~p"/devices"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Devices", path: ~p"/#{@subject.account}/devices"}
         ]} />
       </:breadcrumbs>
       <:title>
@@ -86,7 +86,7 @@ defmodule Web.DevicesLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/devices/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/devices/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   v1.01 Linux
@@ -94,7 +94,7 @@ defmodule Web.DevicesLive.Index do
               </th>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   John Doe
@@ -149,7 +149,7 @@ defmodule Web.DevicesLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/devices/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/devices/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   v1.01 iOS
@@ -157,7 +157,7 @@ defmodule Web.DevicesLive.Index do
               </th>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Steve Johnson
@@ -212,7 +212,7 @@ defmodule Web.DevicesLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/devices/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/devices/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   v1.01 macOS
@@ -220,7 +220,7 @@ defmodule Web.DevicesLive.Index do
               </th>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Steinberg, Gabriel
@@ -272,7 +272,7 @@ defmodule Web.DevicesLive.Index do
           </tbody>
         </table>
       </div>
-      <.paginator page={3} total_pages={100} collection_base_path={~p"/devices"} />
+      <.paginator page={3} total_pages={100} collection_base_path={~p"/#{@subject.account}/devices"} />
     </div>
     """
   end

--- a/elixir/apps/web/lib/web/live/devices_live/show.ex
+++ b/elixir/apps/web/lib/web/live/devices_live/show.ex
@@ -6,9 +6,12 @@ defmodule Web.DevicesLive.Show do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Devices", path: ~p"/devices"},
-          %{label: "Jamil's Macbook Pro", path: ~p"/devices/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Devices", path: ~p"/#{@subject.account}/devices"},
+          %{
+            label: "Jamil's Macbook Pro",
+            path: ~p"/#{@subject.account}/devices/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          }
         ]} />
       </:breadcrumbs>
       <:title>
@@ -39,7 +42,7 @@ defmodule Web.DevicesLive.Show do
             </th>
             <td class="px-6 py-4">
               <.link
-                navigate={~p"/users/55DDA8CB-69A7-48FC-9048-639021C205A2"}
+                navigate={~p"/#{@subject.account}/users/55DDA8CB-69A7-48FC-9048-639021C205A2"}
                 class="text-blue-600 hover:underline"
               >
                 Andrew Dryga

--- a/elixir/apps/web/lib/web/live/gateways_live/edit.ex
+++ b/elixir/apps/web/lib/web/live/gateways_live/edit.ex
@@ -6,10 +6,16 @@ defmodule Web.GatewaysLive.Edit do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Gateways", path: ~p"/gateways"},
-          %{label: "gcp-primary", path: ~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"},
-          %{label: "Edit", path: ~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Gateways", path: ~p"/#{@subject.account}/gateways"},
+          %{
+            label: "gcp-primary",
+            path: ~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          },
+          %{
+            label: "Edit",
+            path: ~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+          }
         ]} />
       </:breadcrumbs>
       <:title>

--- a/elixir/apps/web/lib/web/live/gateways_live/index.ex
+++ b/elixir/apps/web/lib/web/live/gateways_live/index.ex
@@ -6,15 +6,15 @@ defmodule Web.GatewaysLive.Index do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Gateways", path: ~p"/gateways"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Gateways", path: ~p"/#{@subject.account}/gateways"}
         ]} />
       </:breadcrumbs>
       <:title>
         All gateways
       </:title>
       <:actions>
-        <.add_button navigate={~p"/gateways/new"}>
+        <.add_button navigate={~p"/#{@subject.account}/gateways/new"}>
           Add Gateway
         </.add_button>
       </:actions>
@@ -99,7 +99,7 @@ defmodule Web.GatewaysLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   hungry-hippo
@@ -111,7 +111,7 @@ defmodule Web.GatewaysLive.Index do
               </td>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   GitLab, Jira, Confluence, and 2 more
@@ -165,7 +165,7 @@ defmodule Web.GatewaysLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   gcp-primary
@@ -177,7 +177,7 @@ defmodule Web.GatewaysLive.Index do
               </td>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   10.56.7.0/24
@@ -231,7 +231,7 @@ defmodule Web.GatewaysLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   gcp-secondary
@@ -243,7 +243,7 @@ defmodule Web.GatewaysLive.Index do
               </td>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   10.56.7.0/24
@@ -297,7 +297,7 @@ defmodule Web.GatewaysLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   wavering-walrus
@@ -313,7 +313,7 @@ defmodule Web.GatewaysLive.Index do
               </td>
               <td class="px-4 py-4">
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   GitLab, Jira, Confluence, and 2 more
@@ -364,7 +364,7 @@ defmodule Web.GatewaysLive.Index do
           </tbody>
         </table>
       </div>
-      <.paginator page={3} total_pages={100} collection_base_path={~p"/gateways"} />
+      <.paginator page={3} total_pages={100} collection_base_path={~p"/#{@subject.account}/gateways"} />
     </div>
     """
   end

--- a/elixir/apps/web/lib/web/live/gateways_live/new.ex
+++ b/elixir/apps/web/lib/web/live/gateways_live/new.ex
@@ -6,9 +6,9 @@ defmodule Web.GatewaysLive.New do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Gateways", path: ~p"/gateways"},
-          %{label: "Add Gateway", path: ~p"/gateways/new"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Gateways", path: ~p"/#{@subject.account}/gateways"},
+          %{label: "Add Gateway", path: ~p"/#{@subject.account}/gateways/new"}
         ]} />
       </:breadcrumbs>
       <:title>

--- a/elixir/apps/web/lib/web/live/gateways_live/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways_live/show.ex
@@ -6,16 +6,21 @@ defmodule Web.GatewaysLive.Show do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Gateways", path: ~p"/gateways"},
-          %{label: "gcp-primary", path: ~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Gateways", path: ~p"/#{@subject.account}/gateways"},
+          %{
+            label: "gcp-primary",
+            path: ~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          }
         ]} />
       </:breadcrumbs>
       <:title>
         Viewing Gateway <code>gcp-primary</code>
       </:title>
       <:actions>
-        <.edit_button navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}>
+        <.edit_button navigate={
+          ~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+        }>
           Edit Gateway
         </.edit_button>
       </:actions>
@@ -175,7 +180,7 @@ defmodule Web.GatewaysLive.Show do
               class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
             >
               <.link
-                navigate={~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                navigate={~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
                 Engineering GitLab
@@ -191,7 +196,7 @@ defmodule Web.GatewaysLive.Show do
               class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
             >
               <.link
-                navigate={~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                navigate={~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
                 SJC VPC-1

--- a/elixir/apps/web/lib/web/live/groups_live/edit.ex
+++ b/elixir/apps/web/lib/web/live/groups_live/edit.ex
@@ -6,10 +6,16 @@ defmodule Web.GroupsLive.Edit do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Groups", path: ~p"/groups"},
-          %{label: "Engineering", path: ~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"},
-          %{label: "Edit", path: ~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Groups", path: ~p"/#{@subject.account}/groups"},
+          %{
+            label: "Engineering",
+            path: ~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          },
+          %{
+            label: "Edit",
+            path: ~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+          }
         ]} />
       </:breadcrumbs>
       <:title>

--- a/elixir/apps/web/lib/web/live/groups_live/index.ex
+++ b/elixir/apps/web/lib/web/live/groups_live/index.ex
@@ -6,15 +6,15 @@ defmodule Web.GroupsLive.Index do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Groups", path: ~p"/groups"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Groups", path: ~p"/#{@subject.account}/groups"}
         ]} />
       </:breadcrumbs>
       <:title>
         All groups
       </:title>
       <:actions>
-        <.add_button navigate={~p"/groups/new"}>
+        <.add_button navigate={~p"/#{@subject.account}/groups/new"}>
           Add a new group
         </.add_button>
       </:actions>
@@ -80,7 +80,7 @@ defmodule Web.GroupsLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Engineering
@@ -119,7 +119,9 @@ defmodule Web.GroupsLive.Index do
                     </li>
                     <li>
                       <.link
-                        navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}
+                        navigate={
+                          ~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+                        }
                         class="block py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
                       >
                         Edit
@@ -143,7 +145,7 @@ defmodule Web.GroupsLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   DevOps
@@ -201,7 +203,7 @@ defmodule Web.GroupsLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Human Resources
@@ -255,7 +257,7 @@ defmodule Web.GroupsLive.Index do
           </tbody>
         </table>
       </div>
-      <.paginator page={3} total_pages={100} collection_base_path={~p"/groups"} />
+      <.paginator page={3} total_pages={100} collection_base_path={~p"/#{@subject.account}/groups"} />
     </div>
     """
   end

--- a/elixir/apps/web/lib/web/live/groups_live/new.ex
+++ b/elixir/apps/web/lib/web/live/groups_live/new.ex
@@ -6,9 +6,9 @@ defmodule Web.GroupsLive.New do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Groups", path: ~p"/groups"},
-          %{label: "Add Group", path: ~p"/groups/new"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Groups", path: ~p"/#{@subject.account}/groups"},
+          %{label: "Add Group", path: ~p"/#{@subject.account}/groups/new"}
         ]} />
       </:breadcrumbs>
       <:title>

--- a/elixir/apps/web/lib/web/live/groups_live/show.ex
+++ b/elixir/apps/web/lib/web/live/groups_live/show.ex
@@ -6,16 +6,21 @@ defmodule Web.GroupsLive.Show do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Groups", path: ~p"/groups"},
-          %{label: "Engineering", path: ~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Groups", path: ~p"/#{@subject.account}/groups"},
+          %{
+            label: "Engineering",
+            path: ~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          }
         ]} />
       </:breadcrumbs>
       <:title>
         Viewing Group <code>Engineering</code>
       </:title>
       <:actions>
-        <.edit_button navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}>
+        <.edit_button navigate={
+          ~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+        }>
           Edit Group
         </.edit_button>
       </:actions>
@@ -46,7 +51,7 @@ defmodule Web.GroupsLive.Show do
               Created manually by
               <.link
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
-                navigate={~p"/users/BEE2202A-2598-401D-A6C1-8CC09FFB853A"}
+                navigate={~p"/#{@subject.account}/users/BEE2202A-2598-401D-A6C1-8CC09FFB853A"}
               >
                 Jamil Bou Kheir
               </.link>
@@ -92,7 +97,7 @@ defmodule Web.GroupsLive.Show do
               class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
             >
               <.link
-                navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
                 Bou Kheir, Jamil
@@ -108,7 +113,7 @@ defmodule Web.GroupsLive.Show do
               class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
             >
               <.link
-                navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
                 Dryga, Andrew

--- a/elixir/apps/web/lib/web/live/policies_live/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies_live/edit.ex
@@ -1,0 +1,59 @@
+defmodule Web.PoliciesLive.Edit do
+  use Web, :live_view
+
+  def render(assigns) do
+    ~H"""
+    <.section_header>
+      <:breadcrumbs>
+        <.breadcrumbs entries={[
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Policies", path: ~p"/#{@subject.account}/policies"},
+          %{
+            label: "Engineering access to GitLab",
+            path: ~p"/#{@subject.account}/policies/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          },
+          %{
+            label: "Edit",
+            path: ~p"/#{@subject.account}/policies/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+          }
+        ]} />
+      </:breadcrumbs>
+      <:title>
+        Edit Policy <code>Engineering access to GitLab</code>
+      </:title>
+    </.section_header>
+    <!-- Edit Policy -->
+    <section class="bg-white dark:bg-gray-900">
+      <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
+        <h2 class="mb-4 text-xl font-bold text-gray-900 dark:text-white">Edit Policy details</h2>
+        <form action="#">
+          <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
+            <div>
+              <.label for="name">
+                Name
+              </.label>
+              <input
+                autocomplete="off"
+                type="text"
+                name="name"
+                id="policy-name"
+                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500"
+                value="Engineering access to GitLab"
+                required
+              />
+            </div>
+          </div>
+          <div class="flex items-center space-x-4">
+            <button
+              type="submit"
+              class="text-white bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800"
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+    """
+  end
+end

--- a/elixir/apps/web/lib/web/live/policies_live/index.ex
+++ b/elixir/apps/web/lib/web/live/policies_live/index.ex
@@ -3,7 +3,189 @@ defmodule Web.PoliciesLive.Index do
 
   def render(assigns) do
     ~H"""
-    Listing Policies
+    <.section_header>
+      <:breadcrumbs>
+        <.breadcrumbs entries={[
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Policies", path: ~p"/#{@subject.account}/policies"}
+        ]} />
+      </:breadcrumbs>
+      <:title>
+        All Policies
+      </:title>
+      <:actions>
+        <.add_button navigate={~p"/#{@subject.account}/policies/new"}>
+          Add a new Policy
+        </.add_button>
+      </:actions>
+    </.section_header>
+    <!-- Policies table -->
+    <div class="bg-white dark:bg-gray-800 overflow-hidden">
+      <div class="flex flex-col md:flex-row items-center justify-between space-y-3 md:space-y-0 md:space-x-4 p-4">
+        <div class="w-full md:w-1/2">
+          <form class="flex items-center">
+            <label for="simple-search" class="sr-only">Search</label>
+            <div class="relative w-full">
+              <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                <.icon name="hero-magnifying-glass" class="w-5 h-5 text-gray-500 dark:text-gray-400" />
+              </div>
+              <input
+                type="text"
+                id="simple-search"
+                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full pl-10 p-2 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500"
+                placeholder="Search"
+              />
+            </div>
+          </form>
+        </div>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+          <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+            <tr>
+              <th scope="col" class="px-4 py-3">
+                <div class="flex items-center">
+                  Name
+                  <a href="#">
+                    <.icon name="hero-chevron-up-down-solid" class="w-4 h-4 ml-1" />
+                  </a>
+                </div>
+              </th>
+              <th scope="col" class="px-4 py-3">
+                <div class="flex items-center">
+                  Group
+                  <a href="#">
+                    <.icon name="hero-chevron-up-down-solid" class="w-4 h-4 ml-1" />
+                  </a>
+                </div>
+              </th>
+              <th scope="col" class="px-4 py-3">
+                <div class="flex items-center">
+                  Resource
+                  <a href="#">
+                    <.icon name="hero-chevron-up-down-solid" class="w-4 h-4 ml-1" />
+                  </a>
+                </div>
+              </th>
+              <th scope="col" class="px-4 py-3">
+                <span class="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-b dark:border-gray-700">
+              <th
+                scope="row"
+                class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+              >
+                <.link
+                  navigate={~p"/#{@subject.account}/policies/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
+                >
+                  Engineering access to Gitlab
+                </.link>
+              </th>
+              <td class="px-4 py-3">
+                <.link
+                  class="inline-block"
+                  navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                >
+                  <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
+                    Engineering
+                  </span>
+                </.link>
+              </td>
+              <td class="px-4 py-3">
+                <.link
+                  class="text-blue-600 dark:text-blue-500 hover:underline"
+                  navigate={~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                >
+                  GitLab
+                </.link>
+              </td>
+              <td class="px-4 py-3 flex items-center justify-end">
+                <.link navigate="#" class="text-blue-600 dark:text-blue-500 hover:underline">
+                  Delete
+                </.link>
+              </td>
+            </tr>
+            <tr class="border-b dark:border-gray-700">
+              <th
+                scope="row"
+                class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+              >
+                <.link
+                  navigate={~p"/#{@subject.account}/policies/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
+                >
+                  IT access to Staging VPC
+                </.link>
+              </th>
+              <td class="px-4 py-3">
+                <.link
+                  class="inline-block"
+                  navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                >
+                  <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
+                    IT
+                  </span>
+                </.link>
+              </td>
+              <td class="px-4 py-3">
+                <.link
+                  class="text-blue-600 dark:text-blue-500 hover:underline"
+                  navigate={~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                >
+                  Staging VPC
+                </.link>
+              </td>
+              <td class="px-4 py-3 flex items-center justify-end">
+                <.link navigate="#" class="text-blue-600 dark:text-blue-500 hover:underline">
+                  Delete
+                </.link>
+              </td>
+            </tr>
+            <tr class="border-b dark:border-gray-700">
+              <th
+                scope="row"
+                class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+              >
+                <.link
+                  navigate={~p"/#{@subject.account}/policies/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
+                >
+                  Admin access to Jira
+                </.link>
+              </th>
+              <td class="px-4 py-3">
+                <.link
+                  class="inline-block"
+                  navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                >
+                  <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
+                    Admin
+                  </span>
+                </.link>
+              </td>
+              <td class="px-4 py-3">
+                <.link
+                  class="text-blue-600 dark:text-blue-500 hover:underline"
+                  navigate={~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                >
+                  Jira
+                </.link>
+              </td>
+              <td class="px-4 py-3 flex items-center justify-end">
+                <.link navigate="#" class="text-blue-600 dark:text-blue-500 hover:underline">
+                  Delete
+                </.link>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <.paginator page={3} total_pages={100} collection_base_path={~p"/#{@subject.account}/gateways"} />
+    </div>
     """
   end
 end

--- a/elixir/apps/web/lib/web/live/policies_live/new.ex
+++ b/elixir/apps/web/lib/web/live/policies_live/new.ex
@@ -3,7 +3,81 @@ defmodule Web.PoliciesLive.New do
 
   def render(assigns) do
     ~H"""
-    Add Policy
+    <.section_header>
+      <:breadcrumbs>
+        <.breadcrumbs entries={[
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Policies", path: ~p"/#{@subject.account}/policies"},
+          %{label: "Add policy", path: ~p"/#{@subject.account}/policies/new"}
+        ]} />
+      </:breadcrumbs>
+      <:title>
+        Add a new Policy
+      </:title>
+    </.section_header>
+    <!-- Add Policy -->
+    <section class="bg-white dark:bg-gray-900">
+      <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
+        <h2 class="mb-4 text-xl font-bold text-gray-900 dark:text-white">Policy details</h2>
+        <form action="#">
+          <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
+            <div>
+              <.label for="group">
+                Group
+              </.label>
+
+              <select
+                id="group"
+                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+              >
+                <option>Everyone</option>
+                <option>DevOps</option>
+                <option selected>Engineering</option>
+                <option>IT</option>
+                <option>Admin</option>
+              </select>
+            </div>
+            <div>
+              <.label for="resource">
+                Resource
+              </.label>
+              <select
+                id="resource"
+                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+              >
+                <option>GitLab</option>
+                <option>Jira</option>
+                <option>10.0.0.0/24</option>
+                <option>24.119.103.223</option>
+                <option>fc00::1</option>
+              </select>
+            </div>
+            <div>
+              <.label for="policy-name">
+                Name
+              </.label>
+              <input
+                autocomplete="off"
+                type="text"
+                name="name"
+                value="Engineering access to GitLab"
+                id="policy-name"
+                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500"
+                placeholder="Enter a name for this policy"
+              />
+            </div>
+          </div>
+          <div class="flex items-center space-x-4">
+            <button
+              type="submit"
+              class="text-white bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800"
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
     """
   end
 end

--- a/elixir/apps/web/lib/web/live/policies_live/show.ex
+++ b/elixir/apps/web/lib/web/live/policies_live/show.ex
@@ -3,7 +3,143 @@ defmodule Web.PoliciesLive.Show do
 
   def render(assigns) do
     ~H"""
-    Viewing Policy
+    <.section_header>
+      <:breadcrumbs>
+        <.breadcrumbs entries={[
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Policies", path: ~p"/#{@subject.account}/policies"},
+          %{label: "Engineering access to GitLab", path: ~p"/#{@subject.account}/policies/new"}
+        ]} />
+      </:breadcrumbs>
+      <:title>
+        Viewing Policy <code>Engineering access to GitLab</code>
+      </:title>
+      <:actions>
+        <.edit_button navigate={
+          ~p"/#{@subject.account}/policies/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+        }>
+          Edit Policy
+        </.edit_button>
+      </:actions>
+    </.section_header>
+    <!-- Show Policy -->
+    <div class="bg-white dark:bg-gray-800 overflow-hidden">
+      <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+        <tbody>
+          <tr class="border-b border-gray-200 dark:border-gray-700">
+            <th
+              scope="row"
+              class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50 dark:text-white dark:bg-gray-800"
+            >
+              Name
+            </th>
+            <td class="px-6 py-4">
+              Engineering access to GitLab
+            </td>
+          </tr>
+          <tr class="border-b border-gray-200 dark:border-gray-700">
+            <th
+              scope="row"
+              class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50 dark:text-white dark:bg-gray-800"
+            >
+              Group
+            </th>
+            <td class="px-6 py-4">
+              Engineering
+            </td>
+          </tr>
+          <tr class="border-b border-gray-200 dark:border-gray-700">
+            <th
+              scope="row"
+              class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50 dark:text-white dark:bg-gray-800"
+            >
+              Resource
+            </th>
+            <td class="px-6 py-4">
+              GitLab
+            </td>
+          </tr>
+          <tr class="border-b border-gray-200 dark:border-gray-700">
+            <th
+              scope="row"
+              class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50 dark:text-white dark:bg-gray-800"
+            >
+              Created
+            </th>
+            <td class="px-6 py-4">
+              4/15/22 12:32 PM by
+              <.link
+                class="text-blue-600 hover:underline"
+                navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+              >
+                Andrew Dryga
+              </.link>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="grid grid-cols-1 p-4 xl:grid-cols-3 xl:gap-4 dark:bg-gray-900">
+      <div class="col-span-full mb-4 xl:mb-2">
+        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl dark:text-white">
+          Logs
+        </h1>
+      </div>
+    </div>
+    <div class="relative overflow-x-auto">
+      <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+        <thead class="text-xs text-gray-900 uppercase dark:text-gray-400">
+          <tr>
+            <th scope="col" class="px-6 py-3">
+              Authorized at
+            </th>
+            <th scope="col" class="px-6 py-3">
+              Device
+            </th>
+            <th scope="col" class="px-6 py-3">
+              User
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="bg-white dark:bg-gray-800">
+            <th
+              scope="row"
+              class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+            >
+              May 1, 2023 8:45p
+            </th>
+            <td class="px-6 py-4">
+              <.link
+                class="text-blue-600 dark:text-blue-500 hover:underline"
+                navigate={~p"/#{@subject.account}/devices/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+              >
+                2425BD07A38D
+              </.link>
+            </td>
+            <td class="px-6 py-4">
+              <.link
+                class="text-blue-600 dark:text-blue-500 hover:underline"
+                navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+              >
+                <%= "Thomas Eizinger <thomas@eizinger.io>" %>
+              </.link>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <.section_header>
+      <:title>
+        Danger zone
+      </:title>
+      <:actions>
+        <.delete_button>
+          Delete Policy
+        </.delete_button>
+      </:actions>
+    </.section_header>
     """
   end
 end

--- a/elixir/apps/web/lib/web/live/resources_live/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources_live/edit.ex
@@ -6,17 +6,23 @@ defmodule Web.ResourcesLive.Edit do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Resources", path: ~p"/resources"},
-          %{label: "GitLab", path: ~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"},
-          %{label: "Edit", path: ~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Resources", path: ~p"/#{@subject.account}/resources"},
+          %{
+            label: "GitLab",
+            path: ~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          },
+          %{
+            label: "Edit",
+            path: ~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+          }
         ]} />
       </:breadcrumbs>
       <:title>
         Edit Resource
       </:title>
     </.section_header>
-    <!-- Update Resource -->
+    <!-- Edit Resource -->
     <section class="bg-white dark:bg-gray-900">
       <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
         <h2 class="mb-4 text-xl font-bold text-gray-900 dark:text-white">Edit Resource details</h2>

--- a/elixir/apps/web/lib/web/live/resources_live/index.ex
+++ b/elixir/apps/web/lib/web/live/resources_live/index.ex
@@ -6,15 +6,15 @@ defmodule Web.ResourcesLive.Index do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Resources", path: ~p"/resources"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Resources", path: ~p"/#{@subject.account}/resources"}
         ]} />
       </:breadcrumbs>
       <:title>
         All Resources
       </:title>
       <:actions>
-        <.add_button navigate={~p"/resources/new"}>
+        <.add_button navigate={~p"/#{@subject.account}/resources/new"}>
           Add a new Resource
         </.add_button>
       </:actions>
@@ -99,7 +99,7 @@ defmodule Web.ResourcesLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   GitLab
@@ -110,28 +110,28 @@ defmodule Web.ResourcesLive.Index do
               </td>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   sjc-egress-1</.link>, <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   sjc-egress-2</.link>,
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   sjc-egress-3
                 </.link>
               </td>
               <td class="px-4 py-3">
-                <.link navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
+                <.link navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
                   <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
                     Engineering
                   </span>
                 </.link>
-                <.link navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
+                <.link navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
                   <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
                     DevOps
                   </span>
@@ -180,7 +180,7 @@ defmodule Web.ResourcesLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Staging
@@ -191,19 +191,19 @@ defmodule Web.ResourcesLive.Index do
               </td>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   private-vpc
                 </.link>
               </td>
               <td class="px-4 py-3">
-                <.link navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
+                <.link navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
                   <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
                     Engineering
                   </span>
                 </.link>
-                <.link navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
+                <.link navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
                   <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
                     IT
                   </span>
@@ -252,7 +252,7 @@ defmodule Web.ResourcesLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Production
@@ -263,24 +263,24 @@ defmodule Web.ResourcesLive.Index do
               </td>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   prod-gw-1</.link>,
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   prod-gw-2
                 </.link>
               </td>
               <td class="px-4 py-3">
-                <.link navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
+                <.link navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
                   <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
                     eng-prod
                   </span>
                 </.link>
-                <.link navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
+                <.link navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
                   <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
                     sec-prod
                   </span>
@@ -329,7 +329,7 @@ defmodule Web.ResourcesLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Jira
@@ -340,19 +340,19 @@ defmodule Web.ResourcesLive.Index do
               </td>
               <td class="px-4 py-3">
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   prod-gw-1</.link>,
                 <.link
-                  navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   prod-gw-2
                 </.link>
               </td>
               <td class="px-4 py-3">
-                <.link navigate={~p"/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
+                <.link navigate={~p"/#{@subject.account}/groups/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}>
                   <span class="bg-gray-100 text-gray-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-gray-900 dark:text-gray-300">
                     Engineering
                   </span>
@@ -398,7 +398,7 @@ defmodule Web.ResourcesLive.Index do
           </tbody>
         </table>
       </div>
-      <.paginator page={3} total_pages={100} collection_base_path={~p"/gateways"} />
+      <.paginator page={3} total_pages={100} collection_base_path={~p"/#{@subject.account}/gateways"} />
     </div>
     """
   end

--- a/elixir/apps/web/lib/web/live/resources_live/new.ex
+++ b/elixir/apps/web/lib/web/live/resources_live/new.ex
@@ -6,9 +6,9 @@ defmodule Web.ResourcesLive.New do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Resources", path: ~p"/resources"},
-          %{label: "Add resource", path: ~p"/resources/new"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Resources", path: ~p"/#{@subject.account}/resources"},
+          %{label: "Add resource", path: ~p"/#{@subject.account}/resources/new"}
         ]} />
       </:breadcrumbs>
       <:title>

--- a/elixir/apps/web/lib/web/live/resources_live/show.ex
+++ b/elixir/apps/web/lib/web/live/resources_live/show.ex
@@ -6,21 +6,26 @@ defmodule Web.ResourcesLive.Show do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Resources", path: ~p"/resources"},
-          %{label: "Engineering Jira", path: ~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Resources", path: ~p"/#{@subject.account}/resources"},
+          %{
+            label: "Engineering Jira",
+            path: ~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          }
         ]} />
       </:breadcrumbs>
       <:title>
         Viewing Resource <code>Engineering Jira</code>
       </:title>
       <:actions>
-        <.edit_button navigate={~p"/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}>
+        <.edit_button navigate={
+          ~p"/#{@subject.account}/resources/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+        }>
           Edit Resource
         </.edit_button>
       </:actions>
     </.section_header>
-    <!-- Gateway details -->
+    <!-- Resource details -->
     <div class="bg-white dark:bg-gray-800 overflow-hidden">
       <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
         <tbody>
@@ -68,7 +73,7 @@ defmodule Web.ResourcesLive.Show do
               4/15/22 12:32 PM by
               <.link
                 class="text-blue-600 hover:underline"
-                navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
               >
                 Andrew Dryga
               </.link>
@@ -77,7 +82,7 @@ defmodule Web.ResourcesLive.Show do
         </tbody>
       </table>
     </div>
-    <!-- Linked Resources table -->
+    <!-- Linked Gateways table -->
     <div class="grid grid-cols-1 p-4 xl:grid-cols-3 xl:gap-4 dark:bg-gray-900">
       <div class="col-span-full mb-4 xl:mb-2">
         <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl dark:text-white">
@@ -107,7 +112,7 @@ defmodule Web.ResourcesLive.Show do
               class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
             >
               <.link
-                navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
                 aws-primary
@@ -128,7 +133,7 @@ defmodule Web.ResourcesLive.Show do
               class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
             >
               <.link
-                navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
                 aws-secondary
@@ -149,7 +154,7 @@ defmodule Web.ResourcesLive.Show do
               class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
             >
               <.link
-                navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
                 gcp-primary
@@ -170,7 +175,7 @@ defmodule Web.ResourcesLive.Show do
               class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
             >
               <.link
-                navigate={~p"/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                navigate={~p"/#{@subject.account}/gateways/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
                 gcp-secondary

--- a/elixir/apps/web/lib/web/live/users_live/edit.ex
+++ b/elixir/apps/web/lib/web/live/users_live/edit.ex
@@ -6,10 +6,16 @@ defmodule Web.UsersLive.Edit do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Users", path: ~p"/users"},
-          %{label: "Bou Kheir, Jamil", path: ~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"},
-          %{label: "Edit", path: ~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Users", path: ~p"/#{@subject.account}/users"},
+          %{
+            label: "Bou Kheir, Jamil",
+            path: ~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          },
+          %{
+            label: "Edit",
+            path: ~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+          }
         ]} />
       </:breadcrumbs>
       <:title>

--- a/elixir/apps/web/lib/web/live/users_live/index.ex
+++ b/elixir/apps/web/lib/web/live/users_live/index.ex
@@ -6,15 +6,15 @@ defmodule Web.UsersLive.Index do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Users", path: ~p"/users"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Users", path: ~p"/#{@subject.account}/users"}
         ]} />
       </:breadcrumbs>
       <:title>
         All users
       </:title>
       <:actions>
-        <.add_button navigate={~p"/users/new"}>
+        <.add_button navigate={~p"/#{@subject.account}/users/new"}>
           Add a new user
         </.add_button>
       </:actions>
@@ -88,7 +88,7 @@ defmodule Web.UsersLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Bou Kheir, Jamil
@@ -127,7 +127,9 @@ defmodule Web.UsersLive.Index do
                     </li>
                     <li>
                       <.link
-                        navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}
+                        navigate={
+                          ~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+                        }
                         class="block py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
                       >
                         Edit
@@ -151,7 +153,7 @@ defmodule Web.UsersLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Dryga, Andrew
@@ -190,7 +192,9 @@ defmodule Web.UsersLive.Index do
                     </li>
                     <li>
                       <.link
-                        navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}
+                        navigate={
+                          ~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+                        }
                         class="block py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
                       >
                         Edit
@@ -214,7 +218,7 @@ defmodule Web.UsersLive.Index do
                 class="px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white"
               >
                 <.link
-                  navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+                  navigate={~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
                   class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
                 >
                   Steinberg, Gabriel
@@ -253,7 +257,9 @@ defmodule Web.UsersLive.Index do
                     </li>
                     <li>
                       <.link
-                        navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}
+                        navigate={
+                          ~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+                        }
                         class="block py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
                       >
                         Edit
@@ -274,7 +280,7 @@ defmodule Web.UsersLive.Index do
           </tbody>
         </table>
       </div>
-      <.paginator page={3} total_pages={100} collection_base_path={~p"/users"} />
+      <.paginator page={3} total_pages={100} collection_base_path={~p"/#{@subject.account}/users"} />
     </div>
     """
   end

--- a/elixir/apps/web/lib/web/live/users_live/new.ex
+++ b/elixir/apps/web/lib/web/live/users_live/new.ex
@@ -6,9 +6,9 @@ defmodule Web.UsersLive.New do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Users", path: ~p"/users"},
-          %{label: "Add user", path: ~p"/users/new"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Users", path: ~p"/#{@subject.account}/users"},
+          %{label: "Add user", path: ~p"/#{@subject.account}/users/new"}
         ]} />
       </:breadcrumbs>
       <:title>

--- a/elixir/apps/web/lib/web/live/users_live/show.ex
+++ b/elixir/apps/web/lib/web/live/users_live/show.ex
@@ -6,16 +6,21 @@ defmodule Web.UsersLive.Show do
     <.section_header>
       <:breadcrumbs>
         <.breadcrumbs entries={[
-          %{label: "Home", path: ~p"/"},
-          %{label: "Users", path: ~p"/users"},
-          %{label: "Bou Kheir, Jamil", path: ~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"}
+          %{label: "Home", path: ~p"/#{@subject.account}/dashboard"},
+          %{label: "Users", path: ~p"/#{@subject.account}/users"},
+          %{
+            label: "Bou Kheir, Jamil",
+            path: ~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89"
+          }
         ]} />
       </:breadcrumbs>
       <:title>
         Viewing User <code>Bou Kheir, Jamil</code>
       </:title>
       <:actions>
-        <.edit_button navigate={~p"/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"}>
+        <.edit_button navigate={
+          ~p"/#{@subject.account}/users/DF43E951-7DFB-4921-8F7F-BF0F8D31FA89/edit"
+        }>
           Edit user
         </.edit_button>
       </:actions>
@@ -90,7 +95,7 @@ defmodule Web.UsersLive.Show do
             </th>
             <td class="px-6 py-4">
               <.link
-                navigate={~p"/groups/55DDA8CB-69A7-48FC-9048-639021C205A2"}
+                navigate={~p"/#{@subject.account}/groups/55DDA8CB-69A7-48FC-9048-639021C205A2"}
                 class="text-blue-600 hover:underline"
               >
                 Engineering

--- a/elixir/apps/web/lib/web/router.ex
+++ b/elixir/apps/web/lib/web/router.ex
@@ -96,15 +96,7 @@ defmodule Web.Router do
         {Web.Auth, :ensure_account_admin_user_actor}
       ] do
       live "/dashboard", DashboardLive
-    end
-  end
 
-  scope "/", Web do
-    pipe_through [:browser, :ensure_authenticated]
-
-    get "/", AuthController, :sign_out
-
-    live_session :ensure_authenticated2 do
       # Users
       live "/users", UsersLive.Index
       live "/users/new", UsersLive.New


### PR DESCRIPTION
@AndrewDryga ~~Was still hitting some redirect issues so I'll wait for those to be resolved before continuing on building more views.~~ Edit: After some sleep and coffee, I figured it out. Nice work on the sign in form!

I went ahead and scoped existing dashboard links with `@account` and fixed a dark mode issue -- you may want to cherry-pick those commits. I'll add these to authenticated routes and integrate into what you have so far.

As I was going through last night exploring your route approach I thought of some edge cases; can discuss next week. I think the main one that came to mind was that we probably want to differentiate between login flows initiated directly in the browser (this is an admin logging into the dashboard) vs login flows initiated from a client app (these will terminate with a final redirect to respective `dest` whitelisted URL). Maybe it makes sense to segregate these flows?

If a regular user tries login directly from the browser maybe we want to show them something like "Please login from your Firezone application instead" as they should only be able to initiate logins from a client application. Or maybe there's simply no possibility to end up at the final Android App Link or `firezone://` URI with a login initiated directly from the browser?