### PR TITLE
rust: fix dockerfile for building multiple images in parallel

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -3,8 +3,8 @@ ARG PACKAGE
 WORKDIR /build/
 COPY . ./
 RUN --mount=type=cache,target=./target \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/rustup \
+    --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/rustup,sharing=locked \
     apt update && apt install -y musl-tools && \
     cargo build -p $PACKAGE --release --target x86_64-unknown-linux-musl
 


### PR DESCRIPTION
When using `docker compose build` or any other way of building docker images in parallel the way the cache was working with the rust's Dockerfile made the caches between images overlap and corrupt each other. We add a `locked` which prevents multiple writers to the same cache to fix this behaviour.