### PR TITLE
docker: fix building for macos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       FZ_SECRET: "SFMyNTY.g2gDaANkAAhpZGVudGl0eW0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACDZI3ehOZSu3JOSMREkvzrtKjs8jkrW6fpbVw9opDYmi24GANjCD-qIAWIB4TOA.XhoLEDjIzuv1SXEVUV6lfIHW12n5-J5aBDUKCl8ovMk"
     build:
       context: rust
+      dockerfile: Dockerfile.dev
       args:
         PACKAGE: headless
     image: firezone-headless
@@ -125,6 +126,7 @@ services:
       FZ_SECRET: "SFMyNTY.g2gDaAJtAAAAJDNjZWYwNTY2LWFkZmQtNDhmZS1hMGYxLTU4MDY3OTYwOGY2Zm0AAABAamp0enhSRkpQWkdCYy1vQ1o5RHkyRndqd2FIWE1BVWRwenVScjJzUnJvcHg3NS16bmhfeHBfNWJUNU9uby1yYm4GAJXr4emIAWIAAVGA.jz0s-NohxgdAXeRMjIQ9kLBOyd7CmKXWi2FHY-Op8GM"
     build:
       context: rust
+      dockerfile: Dockerfile.dev
       args:
         PACKAGE: gateway
     image: firezone-gateway
@@ -152,6 +154,7 @@ services:
     - "49152-65535/udp"
     build:
       context: rust
+      dockerfile: Dockerfile.dev
       args:
         PACKAGE: relay
     image: firezone-relay

--- a/rust/Dockerfile.dev
+++ b/rust/Dockerfile.dev
@@ -1,0 +1,20 @@
+FROM rust:1.70-slim as BUILDER
+ARG PACKAGE
+WORKDIR /build/
+COPY . ./
+RUN --mount=type=cache,target=./target \
+    --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/rustup,sharing=locked \
+    cargo build -p $PACKAGE --release
+
+RUN --mount=type=cache,target=./target \
+    mv ./target/release/$PACKAGE /usr/local/bin/$PACKAGE
+
+FROM debian:11.7-slim
+ARG PACKAGE
+WORKDIR /app/
+COPY --from=BUILDER /usr/local/bin/$PACKAGE .
+ENV RUST_BACKTRACE=1
+ENV PATH "/app:$PATH"
+ENV PACKAGE_NAME ${PACKAGE}
+CMD ${PACKAGE_NAME}


### PR DESCRIPTION
There are problems building the docker images in macos using musl due to ring's problems therefore we started using slim-debian with glibc for development.