### PR TITLE
Fix/docker compose up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
   client:
     environment:
       FZ_URL: "ws://api:8081/"
-      FZ_SECRET: "SFMyNTY.g2gDaANkAAhpZGVudGl0eW0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACDZI3ehOZSu3JOSMREkvzrtKjs8jkrW6fpbVw9opDYmi24GANjCD-qIAWIB4TOA.XhoLEDjIzuv1SXEVUV6lfIHW12n5-J5aBDUKCl8ovMk"
+      FZ_SECRET: "SFMyNTY.g2gDaANkAAhpZGVudGl0eW0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACAZ_F7tY7RZcWcaeGbwM9H9EBDdj2U4QPu2sBzD8Z_7R24GAMH8mfqIAWIB4TOA.2IZ089fjvNLoCsirq2PwNTfMHXf3285F6YcNquk6niU"
     build:
       context: rust
       dockerfile: Dockerfile.dev
@@ -140,7 +140,7 @@ services:
   gateway:
     environment:
       FZ_URL: "ws://api:8081/"
-      FZ_SECRET: "SFMyNTY.g2gDaAJtAAAAJDNjZWYwNTY2LWFkZmQtNDhmZS1hMGYxLTU4MDY3OTYwOGY2Zm0AAABAamp0enhSRkpQWkdCYy1vQ1o5RHkyRndqd2FIWE1BVWRwenVScjJzUnJvcHg3NS16bmhfeHBfNWJUNU9uby1yYm4GAJXr4emIAWIAAVGA.jz0s-NohxgdAXeRMjIQ9kLBOyd7CmKXWi2FHY-Op8GM"
+      FZ_SECRET: "SFMyNTY.g2gDaAJtAAAAJDNjZWYwNTY2LWFkZmQtNDhmZS1hMGYxLTU4MDY3OTYwOGY2Zm0AAABAamp0enhSRkpQWkdCYy1vQ1o5RHkyRndqd2FIWE1BVWRwenVScjJzUnJvcHg3NS16bmhfeHBfNWJUNU9uby1yYm4GAFvAb_mIAWIAAVGA.1DaY3H3fKzW5sqcciJqlHyG0uFctzOewofsVRGS7NrQ"
     build:
       context: rust
       dockerfile: Dockerfile.dev
@@ -159,13 +159,22 @@ services:
       - api
     networks:
       - app
+      - resources
+
+  resource:
+    image: alpine:3.18
+    networks:
+      - resources
 
   relay:
+    init: true
     environment:
       PUBLIC_IP4_ADDR: 172.28.0.101
       LISTEN_IP4_ADDR: 172.28.0.101
       PORTAL_WS_URL: "ws://api:8081/"
-      PORTAL_TOKEN: "SFMyNTY.g2gDaAJtAAAAJDcyODZiNTNkLTA3M2UtNGM0MS05ZmYxLWNjODQ1MWRhZDI5OW0AAABARVg3N0dhMEhLSlVWTGdjcE1yTjZIYXRkR25mdkFEWVFyUmpVV1d5VHFxdDdCYVVkRVUzbzktRmJCbFJkSU5JS24GAMDq4emIAWIAAVGA.fLlZsUMS0VJ4RCN146QzUuINmGubpsxoyIf3uhRHdiQ"
+      PORTAL_TOKEN: "SFMyNTY.g2gDaAJtAAAAJDcyODZiNTNkLTA3M2UtNGM0MS05ZmYxLWNjODQ1MWRhZDI5OW0AAABARVg3N0dhMEhLSlVWTGdjcE1yTjZIYXRkR25mdkFEWVFyUmpVV1d5VHFxdDdCYVVkRVUzbzktRmJCbFJkSU5JS24GAJZ5vfiIAWIAAVGA.F1J6PxmFwmlSYtsUnkw2Z7IjpMkB1oS7wxtzQBqlFFM"
+      RUST_LOG: "debug"
+      RUST_BACKTRACE: 1
     ports:
     - "3478/udp"
     - "49152-65535/udp"
@@ -176,7 +185,8 @@ services:
         PACKAGE: relay
     image: firezone-relay
     depends_on:
-      - api
+      api:
+        condition: 'service_healthy'
     networks:
       app:
         ipv4_address: 172.28.0.101
@@ -239,6 +249,16 @@ services:
         condition: 'service_healthy'
       postgres:
         condition: 'service_healthy'
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -f localhost:8081/healthz"
+        ]
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 5s
     networks:
       - app
 
@@ -312,6 +332,10 @@ services:
       - app
 
 networks:
+  resources:
+    ipam:
+      config:
+        - subnet: 172.172.0.0/16
   app:
     enable_ipv6: true
     ipam:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,7 +332,7 @@ networks:
   resources:
     ipam:
       config:
-        - subnet: 172.172.0.0/16
+        - subnet: 172.20.0.0/16
   app:
     enable_ipv6: true
     ipam:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,11 +163,11 @@ services:
 
   resource:
     image: alpine:3.18
+    command: tail -f /dev/null
     networks:
       - resources
 
   relay:
-    init: true
     environment:
       PUBLIC_IP4_ADDR: 172.28.0.101
       LISTEN_IP4_ADDR: 172.28.0.101
@@ -175,9 +175,6 @@ services:
       PORTAL_TOKEN: "SFMyNTY.g2gDaAJtAAAAJDcyODZiNTNkLTA3M2UtNGM0MS05ZmYxLWNjODQ1MWRhZDI5OW0AAABARVg3N0dhMEhLSlVWTGdjcE1yTjZIYXRkR25mdkFEWVFyUmpVV1d5VHFxdDdCYVVkRVUzbzktRmJCbFJkSU5JS24GAJZ5vfiIAWIAAVGA.F1J6PxmFwmlSYtsUnkw2Z7IjpMkB1oS7wxtzQBqlFFM"
       RUST_LOG: "debug"
       RUST_BACKTRACE: 1
-    ports:
-    - "3478/udp"
-    - "49152-65535/udp"
     build:
       context: rust
       dockerfile: Dockerfile.dev

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -91,8 +91,8 @@ unprivileged_subject =
   Auth.build_subject(
     unprivileged_actor_userpass_identity,
     DateTime.utc_now() |> DateTime.add(365, :day),
-    "iOS/12.5 (iPhone) connlib/0.7.412",
-    {172, 28, 0, 1}
+    "Debian/11.0.0 connlib/0.1.0",
+    {172, 28, 0, 100}
   )
 
 admin_subject =

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -198,7 +198,7 @@ IO.puts("")
   Resources.create_resource(
     %{
       type: :cidr,
-      address: "172.172.0.1/16",
+      address: "172.20.0.1/16",
       connections: [%{gateway_group_id: gateway_group.id}]
     },
     admin_subject

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "futures-util",
  "ip_network",
  "os_info",
+ "rand",
  "rand_core 0.6.4",
  "rtnetlink",
  "serde",

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -24,7 +24,7 @@ ENV PACKAGE_NAME ${PACKAGE}
 # to move it inside, these are passed as the variables `$0`, `$1`, `$2`, etc...
 # this means that this will ignore after the first arguments
 # if we ever combine this with `CMD` in exec form  so always use shell form
-# (Note we could use shell-form here, but this is the same made explict)
+# (Note we could use shell-form here, but this is the same made explicit)
 ENTRYPOINT ["/bin/sh", "-c", "$PACKAGE_NAME $0"]
 # *sigh* if we don't add this $0 becomes /bin/sh in the command above
 CMD [""]

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -26,3 +26,5 @@ ENV PACKAGE_NAME ${PACKAGE}
 # if we ever combine this with `CMD` in exec form  so always use shell form
 # (Note we could use shell-form here, but this is the same made explict)
 ENTRYPOINT ["/bin/sh", "-c", "$PACKAGE_NAME $0"]
+# *sigh* if we don't add this $0 becomes /bin/sh in the command above
+CMD [""]

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -18,4 +18,11 @@ COPY --from=BUILDER /usr/local/bin/$PACKAGE .
 ENV RUST_BACKTRACE=1
 ENV PATH "/app:$PATH"
 ENV PACKAGE_NAME ${PACKAGE}
-CMD ${PACKAGE_NAME}
+# Some black magics here:
+# we need to use `/bin/sh -c` so that the env variable is correctly replaced
+# but then everything in `CMD` is placed after the executed string, so we need
+# to move it inside, these are passed as the variables `$0`, `$1`, `$2`, etc...
+# this means that this will ignore after the first arguments 
+# if we ever combine this with `CMD` in exec form  so always use shell form
+# (Note we could use shell-form here, but this is the same made explict)
+ENTRYPOINT ["/bin/sh", "-c", "$PACKAGE_NAME $0"]

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -22,7 +22,7 @@ ENV PACKAGE_NAME ${PACKAGE}
 # we need to use `/bin/sh -c` so that the env variable is correctly replaced
 # but then everything in `CMD` is placed after the executed string, so we need
 # to move it inside, these are passed as the variables `$0`, `$1`, `$2`, etc...
-# this means that this will ignore after the first arguments 
+# this means that this will ignore after the first arguments
 # if we ever combine this with `CMD` in exec form  so always use shell form
 # (Note we could use shell-form here, but this is the same made explict)
 ENTRYPOINT ["/bin/sh", "-c", "$PACKAGE_NAME $0"]

--- a/rust/Dockerfile.dev
+++ b/rust/Dockerfile.dev
@@ -23,7 +23,7 @@ ENV PACKAGE_NAME ${PACKAGE}
 # to move it inside, these are passed as the variables `$0`, `$1`, `$2`, etc...
 # this means that this will ignore after the first arguments
 # if we ever combine this with `CMD` in exec form  so always use shell form
-# (Note we could use shell-form here, but this is the same made explict)
+# (Note we could use shell-form here, but this is the same made explicit)
 ENTRYPOINT ["/bin/sh", "-c", "$PACKAGE_NAME $0"]
 # *sigh* if we don't add this $0 becomes /bin/sh in the command above
 CMD [""]

--- a/rust/Dockerfile.dev
+++ b/rust/Dockerfile.dev
@@ -17,4 +17,13 @@ COPY --from=BUILDER /usr/local/bin/$PACKAGE .
 ENV RUST_BACKTRACE=1
 ENV PATH "/app:$PATH"
 ENV PACKAGE_NAME ${PACKAGE}
-CMD ${PACKAGE_NAME}
+# Some black magics here:
+# we need to use `/bin/sh -c` so that the env variable is correctly replaced
+# but then everything in `CMD` is placed after the executed string, so we need
+# to move it inside, these are passed as the variables `$0`, `$1`, `$2`, etc...
+# this means that this will ignore after the first arguments
+# if we ever combine this with `CMD` in exec form  so always use shell form
+# (Note we could use shell-form here, but this is the same made explict)
+ENTRYPOINT ["/bin/sh", "-c", "$PACKAGE_NAME $0"]
+# *sigh* if we don't add this $0 becomes /bin/sh in the command above
+CMD [""]

--- a/rust/connlib/libs/common/Cargo.toml
+++ b/rust/connlib/libs/common/Cargo.toml
@@ -26,6 +26,7 @@ backoff = { version = "0.4", default-features = false }
 ip_network = { version = "0.4", default-features = false, features = ["serde"] }
 boringtun = { workspace = true }
 os_info = { version = "3", default-features = false }
+rand = { version = "0.8", default-features = false, features = ["std"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 swift-bridge = { workspace = true }


### PR DESCRIPTION
This PR fixes `docker compose up` but it doesn't have the test client -> resource flow working but it prevent anything from erroring at startup.

This fixes:
* tokens (use the correct token for the client user agent we are using)
* randomize `name_suffix` at start up for connlib (we will eventually allow options to set it manually)
* remove port ranges for relay (see firezone/product#613)