### PR TITLE
fix(connlib): format with `cargo fmt`

### DIFF
--- a/rust/connlib/libs/gateway/src/control.rs
+++ b/rust/connlib/libs/gateway/src/control.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
-use firezone_tunnel::{ControlSignal, Tunnel};
 use boringtun::x25519::StaticSecret;
+use firezone_tunnel::{ControlSignal, Tunnel};
 use libs_common::{
     error_type::ErrorType::{Fatal, Recoverable},
     messages::ResourceDescription,

--- a/rust/connlib/libs/tunnel/src/lib.rs
+++ b/rust/connlib/libs/tunnel/src/lib.rs
@@ -2,15 +2,15 @@
 //!
 //! This is both the wireguard and ICE implementation that should work in tandem.
 //! [Tunnel] is the main entry-point for this crate.
-use ip_network::IpNetwork;
-use ip_network_table::IpNetworkTable;
 use boringtun::{
     noise::{
-        errors::WireGuardError, handshake::parse_handshake_anon, rate_limiter::RateLimiter,
-        Packet, Tunn, TunnResult,
+        errors::WireGuardError, handshake::parse_handshake_anon, rate_limiter::RateLimiter, Packet,
+        Tunn, TunnResult,
     },
     x25519::{PublicKey, StaticSecret},
 };
+use ip_network::IpNetwork;
+use ip_network_table::IpNetworkTable;
 use libs_common::{
     error_type::ErrorType::{Fatal, Recoverable},
     Callbacks,

--- a/rust/connlib/libs/tunnel/src/peer.rs
+++ b/rust/connlib/libs/tunnel/src/peer.rs
@@ -1,13 +1,10 @@
 use std::{net::IpAddr, sync::Arc};
 
+use boringtun::noise::{Tunn, TunnResult};
 use bytes::Bytes;
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
-use boringtun::noise::{Tunn, TunnResult};
-use libs_common::{
-    error_type::ErrorType,
-    Callbacks,
-};
+use libs_common::{error_type::ErrorType, Callbacks};
 use parking_lot::Mutex;
 use webrtc::data::data_channel::DataChannel;
 


### PR DESCRIPTION
Runs `cargo fmt` on the entire `rust/` directory. This somehow doesn't seem to be enforced, I think that is because we changed the previous CI to now only run for the `relay` crate.

I'd like to merge this first to avoid the diff and in a 2nd PR, we can work on unifying CI again.