### PR TITLE
fix(relay): ensure smoke test script fails on error

### DIFF
--- a/rust/relay/examples/client.rs
+++ b/rust/relay/examples/client.rs
@@ -60,7 +60,7 @@ async fn new_turn_client() -> Result<Client, Error> {
         stun_serv_addr: "localhost:3478".to_owned(),
         turn_serv_addr: "localhost:3478".to_owned(),
         username: "2000000000:client".to_owned(), // 2000000000 expires in 2033, plenty of time
-        password: "7U2fprz59mnpPZ/y2Eh8nmJ4d9Oqr98WhgFqlmuZVJ4".to_owned(),
+        password: "+Qou8TSjw9q3JMnWET7MbFsQh/agwz/LURhpfX7a0hE".to_owned(),
         realm: "firezone".to_owned(),
         software: String::new(),
         rto_in_ms: 0,

--- a/rust/relay/examples/gateway.rs
+++ b/rust/relay/examples/gateway.rs
@@ -61,7 +61,7 @@ async fn new_turn_client(conn: Arc<UdpSocket>) -> Result<Client, Error> {
         stun_serv_addr: "localhost:3478".to_owned(),
         turn_serv_addr: "localhost:3478".to_owned(),
         username: "2000000000:gateway".to_owned(), // 2000000000 expires in 2033, plenty of time
-        password: "HBIRJkYyMerpPMKnKxWoWEOG3VEK9egVLLy9GYKcTXM".to_owned(),
+        password: "aFq1CUAeKEknjsmA+K4vSLyEwajQgOwGZYl5P4r1sMQ".to_owned(),
         realm: "firezone".to_owned(),
         software: String::new(),
         rto_in_ms: 0,

--- a/rust/relay/run_smoke_test.sh
+++ b/rust/relay/run_smoke_test.sh
@@ -31,3 +31,5 @@ $client 2>&1 | sed "s/^/${RED}[ client]${NC} /" &
 $relay 2>&1 | sed "s/^/${GREEN}[  relay]${NC} /" &
 
 $gateway 2>&1 | sed "s/^/${BLUE}[gateway]${NC} /"
+
+exit "${PIPESTATUS[0]}"

--- a/rust/relay/run_smoke_test.sh
+++ b/rust/relay/run_smoke_test.sh
@@ -21,9 +21,9 @@ client="$target_directory/debug/examples/client"
 gateway="$target_directory/debug/examples/gateway"
 relay="$target_directory/debug/relay"
 
-export RELAY_PUBLIC_IP4_ADDR=127.0.0.1;
-export RELAY_LISTEN_IP4_ADDR=127.0.0.1;
-export RELAY_RNG_SEED=0;
+export PUBLIC_IP4_ADDR=127.0.0.1;
+export LISTEN_IP4_ADDR=127.0.0.1;
+export RNG_SEED=0;
 export RUST_LOG=relay=debug;
 
 # Client and relay run in the background.

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
 
     let server = Server::new(args.public_ip4_addr, make_rng(args.rng_seed));
 
-    tracing::info!("Relay auth secret: {}", hex::encode(server.auth_secret()));
+    tracing::info!("Relay auth secret: {}", server.auth_secret());
 
     let channel = if let Some(mut portal_url) = args.portal_ws_url {
         if portal_url.scheme() == "ws" && !args.allow_insecure_ws {


### PR DESCRIPTION
Due to a silly bash mistake (I hate bash), the error from the gateway binary wasn't actually propagated to the script. Thus, we did not notice that it was been broken for a while.

Attempting to fix it turned up that we were double-hexing the relay secret and using invalid passwords for the clients.