### PR TITLE
Stub out client app directories in monorepo structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 .github/ @AndrewDryga @jamilbk
 elixir/ @AndrewDryga
 terraform/ @AndrewDryga
-www/ @jamilbk
+website/ @jamilbk
 rust/ @conectado
+swift/ @roop @francesca64
+kotlin/ @pratikvelani @francesca64

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,4 +34,3 @@ updates:
     schedule:
       interval: "weekly"
   # TODO: Apple package ecosystem
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,13 @@ updates:
     directory: "rust/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "rust/connlib/clients/android"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "kotlin/"
+    schedule:
+      interval: "weekly"
+  # TODO: Apple package ecosystem
+

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -41,21 +41,21 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: Assemble Release
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build assembleRelease
       # TODO: Is this relevant for the Android client?
+      # - name: Validate Gradle wrapper
+      #   uses: gradle/wrapper-validation-action@v1
+      # - uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       ~/.gradle/caches
+      #       ~/.gradle/wrapper
+      #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-gradle-
+      # - name: Assemble Release
+      #   uses: gradle/gradle-build-action@v2
+      #   with:
+      #     arguments: build assembleRelease
       # - name: Move artifact
       #   run: |
       #     mv ./rust/connlib/clients/android/lib/build/outputs/aar/lib-release.aar ./connlib-${{ needs.draft-release.outputs.tag_name }}.aar

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - "kotlin/**"
       - ".github/workflows/kotlin.yml"
+  merge_group:
+    types: [checks_requested]
   workflow_call:
 
 # Cancel old workflow runs if new code is pushed

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -1,0 +1,64 @@
+name: Kotlin
+on:
+  pull_request:
+    paths:
+      - "kotlin/**"
+      - ".github/workflows/kotlin.yml"
+  workflow_call:
+
+# Cancel old workflow runs if new code is pushed
+concurrency:
+  group: "kotlin-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.release_drafter.outputs.tag_name }}
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          commitish: cloud
+        id: release_drafter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # TODO: Add a basic CI for the Android client
+  # See rust.yml how we build, package and release connlib as an example
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./kotlin
+    needs:
+      - draft-release
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Assemble Release
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build assembleRelease
+      # TODO: Is this relevant for the Android client?
+      # - name: Move artifact
+      #   run: |
+      #     mv ./rust/connlib/clients/android/lib/build/outputs/aar/lib-release.aar ./connlib-${{ needs.draft-release.outputs.tag_name }}.aar
+      # - uses: actions/upload-artifact@v3
+      #   with:
+      #     name: connlib-android
+      #     path: |
+      #       ./connlib-${{ needs.draft-release.outputs.tag_name }}.aar

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,40 @@
+name: Swift
+on:
+  pull_request:
+    paths:
+      - "swift/**"
+      - ".github/workflows/swift.yml"
+  workflow_call:
+
+# Cancel old workflow runs if new code is pushed
+concurrency:
+  group: "swift-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.release_drafter.outputs.tag_name }}
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          commitish: cloud
+        id: release_drafter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # TODO: Add a basic CI for the Apple client
+  # See rust.yml how we build, package and release connlib as an example
+  build:
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: ./swift
+    needs:
+      - draft-release
+    steps:
+      - uses: actions/checkout@v3
+      # TODO: Build Apple client from the CLI

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - "swift/**"
       - ".github/workflows/swift.yml"
+  merge_group:
+    types: [checks_requested]
   workflow_call:
 
 # Cancel old workflow runs if new code is pushed

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,0 +1,24 @@
+# Firezone Android client
+
+## Prerequisites for developing locally
+
+1. Install a recent `ruby` for your platform. Ruby is used for the mock auth
+   server.
+1. Install needed gems and start mock auth server:
+
+```
+cd server
+bundle install
+ruby server.rb
+```
+
+1. Add the following to a `./local.properties` file:
+
+```gradle
+sdk.dir=/path/to/your/ANDROID_HOME
+```
+
+Replace `/path/to/your/ANDROID_HOME` with the path to your locally installed
+Android SDK. On macOS this is `/Users/jamil/Library./Android/sdk`
+
+1. Perform a test build: `./gradlew build`

--- a/swift/README.md
+++ b/swift/README.md
@@ -1,0 +1,25 @@
+# Firezone Apple Client
+
+Firezone app clients for macOS and iOS.
+
+## Builidng
+
+Clone this repo:
+
+```bash
+git clone https://github.com/firezone/firezone
+cd swift
+```
+
+Rename and populate developer team ID file:
+
+```bash
+cp Firezone/Developer.xcconfig.template Firezone/Developer.xcconfig
+vim Firezone/Developer.xcconfig
+```
+
+Open project in Xcode:
+
+```bash
+open Firezone.xcodeproj
+```


### PR DESCRIPTION
Stubs out the client app dirs and basic CI workflow for the client apps in preparation to move them into this repository.

After this is merged @roop @pratikvelani you should be able to add the client repos here.