### PR TITLE
Disable `on_demand` cert provisioning for Caddy

### DIFF
--- a/docker-compose.desktop.yml
+++ b/docker-compose.desktop.yml
@@ -33,10 +33,9 @@ services:
       - |
         cat <<EOF > /etc/caddy/Caddyfile && caddy run --config /etc/caddy/Caddyfile
 
-        https:// {
+        ${EXTERNAL_URL} {
           log
           reverse_proxy * 172.25.0.100:${PHOENIX_PORT:-13000}
-          ${TLS_OPTS:-}
         }
         EOF
     deploy:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,10 +29,9 @@ services:
       - |
         cat <<EOF > /etc/caddy/Caddyfile && caddy run --config /etc/caddy/Caddyfile
 
-        https:// {
+        ${EXTERNAL_URL} {
           log
           reverse_proxy * 172.25.0.100:${PHOENIX_PORT:-13000}
-          ${TLS_OPTS:-}
         }
         EOF
     network_mode: "host"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,22 +97,6 @@ promptContact() {
   esac
 }
 
-promptACME() {
-  read -p "Would you like to enable automatic SSL cert provisioning? Requires a valid DNS record and port 80 to be reachable. (Y/n): " acme
-  case $acme in
-    n|N)
-      tlsOpts="tls internal {
-                on_demand
-              }"
-      ;;
-    *)
-      tlsOpts="tls {
-                on_demand
-              }"
-      ;;
-  esac
-}
-
 promptTelemetry() {
   read -p "Firezone collects crash and performance logs to help us improve the product. Would you like to disable this? (N/y): " telem
   case $telem in
@@ -145,7 +129,6 @@ firezoneSetup() {
   sed -i.bak "s/DEFAULT_ADMIN_EMAIL=.*/DEFAULT_ADMIN_EMAIL=$1/" "$installDir/.env"
   sed -i.bak "s~EXTERNAL_URL=.*~EXTERNAL_URL=$2~" "$installDir/.env"
   sed -i.bak "s/DATABASE_PASSWORD=.*/DATABASE_PASSWORD=$db_pass/" "$installDir/.env"
-  echo "TLS_OPTS=\"$3\"" >> "$installDir/.env"
   echo "TELEMETRY_ENABLED=$telemEnabled" >> "$installDir/.env"
   echo "TID=$tid" >> "$installDir/.env"
 
@@ -220,18 +203,16 @@ main() {
   adminUser=""
   externalUrl=""
   defaultInstallDir="$HOME/.firezone"
-  tlsOpts=""
   promptEmail "Enter the administrator email you'd like to use for logging into this Firezone instance: "
   promptInstallDir "Enter the desired installation directory ($defaultInstallDir): "
   promptExternalUrl "Enter the external URL that will be used to access this instance. ($defaultExternalUrl): "
-  promptACME
   promptContact
   promptTelemetry
   read -p "Press <ENTER> to install or Ctrl-C to abort."
   if [ $telemEnabled = "true" ]; then
     capture "install" "email-not-collected@dummy.domain"
   fi
-  firezoneSetup $adminUser $externalUrl "$tlsOpts"
+  firezoneSetup $adminUser $externalUrl
 }
 
 dockerCheck


### PR DESCRIPTION
As described in the Caddy documentation, `on_demand` [must be restricted](https://caddyserver.com/docs/automatic-https#using-on-demand-tls) to prevent abuse. In our case, **it was not**, leading to DoS vector in which a malicious client could DoS the `caddy` service by repeatedly initiating TLS requests with invalid domains at a rate high enough for the ACME service to block the Firezone server.

Verified the new caddy configuration works as expected.

Credit to @icekom for responsibly disclosing this issue.