### PR TITLE
connlib: Connection mock

### DIFF
--- a/rust/connlib/README.md
+++ b/rust/connlib/README.md
@@ -10,6 +10,8 @@ anything released here until this notice is removed. You have been warned.
 
 ## Building Connlib
 
+Setting the `CONNLIB_MOCK` environment variable when packaging for Apple or Android will activate the `mock` feature flag, replacing connlib's normal connection logic with a mock for testing purposes.
+
 1. You'll need a Rust toolchain installed if you don't have one already. We
    recommend following the instructions at https://rustup.rs.
 1. `rustup show` will install all needed targets since they are added to `rust-toolchain.toml`.

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -3,6 +3,9 @@ name = "connlib-android"
 version = "0.1.6"
 edition = "2021"
 
+[features]
+mock = ["firezone-client-connlib/mock"]
+
 [dependencies]
 jni = { version = "0.21.1", features = ["invocation"] }
 firezone-client-connlib = { path = "../../libs/client" }

--- a/rust/connlib/clients/android/lib/build.gradle.kts
+++ b/rust/connlib/clients/android/lib/build.gradle.kts
@@ -85,6 +85,11 @@ cargo {
     module  = "../"
     libname = "connlib"
     targets = listOf("arm", "arm64", "x86", "x86_64")
+    features {
+        if (System.getenv("CONNLIB_MOCK") != null) {
+            defaultAnd(listOf("mock").toTypedArray())
+        }
+    }
 }
 
 tasks.whenTaskAdded {

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -3,6 +3,9 @@ name = "connlib-apple"
 version = "0.1.6"
 edition = "2021"
 
+[features]
+mock = ["firezone-client-connlib/mock"]
+
 [build-dependencies]
 anyhow = "1.0.71"
 diva = "0.1.0"

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -45,16 +45,20 @@ else
   fi
 fi
 
+if [[ -n "$CONNLIB_MOCK" ]]; then
+  LIPO_ARGS="--features mock"
+fi
+
 # if [ $ENABLE_PREVIEWS == "NO" ]; then
 
   if [[ $CONFIGURATION == "Release" ]]; then
       echo "BUILDING FOR RELEASE ($TARGETS)"
 
-      cargo lipo --release --manifest-path ./Cargo.toml  --targets $TARGETS
+      cargo lipo --release --manifest-path ./Cargo.toml  --targets $TARGETS $LIPO_ARGS
   else
       echo "BUILDING FOR DEBUG ($TARGETS)"
 
-      cargo lipo --manifest-path ./Cargo.toml  --targets $TARGETS
+      cargo lipo --manifest-path ./Cargo.toml  --targets $TARGETS $LIPO_ARGS
   fi
 
 # else

--- a/rust/connlib/libs/client/Cargo.toml
+++ b/rust/connlib/libs/client/Cargo.toml
@@ -3,6 +3,9 @@ name = "firezone-client-connlib"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+mock = ["libs-common/mock"]
+
 [dependencies]
 tokio = { version = "1.27", default-features = false, features = ["sync"] }
 tracing = { version = "0.1", default-features = false, features = ["std", "attributes"] }

--- a/rust/connlib/libs/common/Cargo.toml
+++ b/rust/connlib/libs/common/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
+mock = []
 jni-bindings = ["boringtun/jni-bindings"]
 
 [dependencies]

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -146,7 +146,7 @@ where
     fn connect_inner(runtime: &Runtime, portal_url: Url, token: String, callbacks: CB) {
         runtime.spawn(async move {
             let private_key = StaticSecret::random_from_rng(OsRng);
-            let self_id = uuid::Uuid::new_v4();
+            let self_id = Uuid::new_v4();
             let name_suffix: String = thread_rng().sample_iter(&Alphanumeric).take(8).map(char::from).collect();
 
             let connect_url = fatal_error!(get_websocket_path(portal_url, token, T::socket_path(), &Key(PublicKey::from(&private_key).to_bytes()), &self_id.to_string(), &name_suffix), callbacks);

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -204,14 +204,13 @@ where
     }
 
     fn connect_mock(callbacks: CB) {
-        const DELAY: Duration = Duration::from_secs(1);
-        std::thread::sleep(DELAY);
+        std::thread::sleep(Duration::from_secs(1));
         callbacks.on_connect(TunnelAddresses {
             address4: "100.100.111.2".parse().unwrap(),
             address6: "fd00:0222:2021:1111::2".parse().unwrap(),
         });
         std::thread::spawn(move || {
-            std::thread::sleep(DELAY);
+            std::thread::sleep(Duration::from_secs(3));
             callbacks.on_update_resources(ResourceList {
                 resources: vec![
                     serde_json::to_string(&ResourceDescription::Cidr(ResourceDescriptionCidr {

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -125,7 +125,7 @@ where
             .enable_all()
             .build()?;
 
-        if matches!(std::env::var("CONNLIB_MOCK").as_deref(), Ok("1" | "true")) {
+        if cfg!(feature = "mock") {
             Self::connect_mock(callbacks);
         } else {
             Self::connect_inner(&runtime, portal_url, token, callbacks);


### PR DESCRIPTION
Resolves firezone/product#607

Setting the env var `CONNLIB_MOCK` when building through either `build-rust.sh` or `gradle` will activate the `mock` feature. 