### PR TITLE
Fix cache for Docker buildx

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -458,8 +458,8 @@ jobs:
             APPLICATION_NAME=${{ env.APPLICATION_NAME }}
             APPLICATION_VERSION=0.0.0-sha.${{ github.sha }}
           context: elixir/
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ env.APPLICATION_NAME }}-${{ github.sha }}
+          cache-to: type=gha,mode=max,scope=${{ env.APPLICATION_NAME }}-${{ github.sha }}
           file: elixir/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.GCLOUD_PROJECT }}/firezone/${{ env.APPLICATION_NAME }}:${{ env.TAG }} , ${{ env.REGISTRY }}/${{ env.GCLOUD_PROJECT }}/firezone/${{ env.APPLICATION_NAME }}:${{ github.sha }}
@@ -518,8 +518,8 @@ jobs:
             APPLICATION_NAME=${{ env.APPLICATION_NAME }}
             APPLICATION_VERSION=0.0.0-sha.${{ github.sha }}
           context: elixir/
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ env.APPLICATION_NAME }}-${{ github.sha }}
+          cache-to: type=gha,mode=max,scope=${{ env.APPLICATION_NAME }}-${{ github.sha }}
           file: elixir/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.GCLOUD_PROJECT }}/firezone/${{ env.APPLICATION_NAME }}:${{ env.TAG }} , ${{ env.REGISTRY }}/${{ env.GCLOUD_PROJECT }}/firezone/${{ env.APPLICATION_NAME }}:${{ github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,13 +18,19 @@ jobs:
         with:
           set: |
             elixir.cache-from.scope=elixir
+            elixir.cache-from.type=gha
             elixir.cache-to.scope=elixir
+            elixir.cache-to.type=gha
             elixir.cache-to.mode=max
             api.cache-from.scope=api
+            api.cache-from.type=gha
             api.cache-to.scope=api
+            api.cache-to.type=gha
             api.cache-to.mode=max
             web.cache-from.scope=web
+            web.cache-from.type=gha
             web.cache-to.scope=web
+            web.cache-to.type=gha
             web.cache-to.mode=max
           files: docker-compose.yml
           push: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,21 +17,12 @@ jobs:
         uses: docker/bake-action@v3
         with:
           set: |
-            elixir.cache-from.scope=elixir
-            elixir.cache-from.type=gha
-            elixir.cache-to.scope=elixir
-            elixir.cache-to.type=gha
-            elixir.cache-to.mode=max
-            api.cache-from.scope=api
-            api.cache-from.type=gha
-            api.cache-to.scope=api
-            api.cache-to.type=gha
-            api.cache-to.mode=max
-            web.cache-from.scope=web
-            web.cache-from.type=gha
-            web.cache-to.scope=web
-            web.cache-to.type=gha
-            web.cache-to.mode=max
+            elixir.cache-from=scope=elixir,type=gha
+            elixir.cache-to=scope=elixir,type=gha,mode=max
+            api.cache-from=scope=api,type=gha
+            api.cache-to=scope=api,type=gha,mode=max
+            web.cache-from=scope=web,type=gha
+            web.cache-to=scope=web,type=gha,mode=max
           files: docker-compose.yml
           push: false
       - name: Seed database

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,6 +16,16 @@ jobs:
       - name: Build images
         uses: docker/bake-action@v3
         with:
+          set: |
+            elixir.cache-from.scope=elixir
+            elixir.cache-to.scope=elixir
+            elixir.cache-to.mode=max
+            api.cache-from.scope=api
+            api.cache-to.scope=api
+            api.cache-to.mode=max
+            web.cache-from.scope=web
+            web.cache-to.scope=web
+            web.cache-to.mode=max
           files: docker-compose.yml
           push: false
       - name: Seed database

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -38,9 +38,9 @@ ARG APPLICATION_VERSION=0.0.0-dev.docker
 
 # Install pipeline and compile assets for Web app
 RUN cd apps/web \
+    && mix compile \
     && mix assets.setup \
-    && mix assets.deploy \
-    && cd ../../
+    && mix assets.deploy
 
 # Compile the release
 RUN mix compile

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -38,7 +38,6 @@ ARG APPLICATION_VERSION=0.0.0-dev.docker
 
 # Install pipeline and compile assets for Web app
 RUN cd apps/web \
-    && mix compile \
     && mix assets.setup \
     && mix assets.deploy
 


### PR DESCRIPTION
~~This is an attempt to fix the CI bug [here](https://github.com/firezone/firezone/actions/runs/5491388141/jobs/10007864417#step:4:1638) possibly introduced in [d9eb2d18](https://github.com/firezone/firezone/commit/d9eb2d18#diff-88bd94db0d5cfd5f0617b7c4ed48c0212597378ed7e28714c5d86c95999b4c7dR29) and uncovered / exacerbated in Elixir 1.15~~

Edit: looks like this ended up being a couple cache issues with GitHub actions:
1. The `elixir_api-container-build` cache would always overwrite the `elixir_web-container-build` on subsequent builds of the same `github.ref_name` (cache is scoped to branch name by default), leading to the consistent error `Elixir.Web.Mailer.NoopAdapter does not exist` whenever a branch was pushed to more than once.
2. The same thing happens with the `integration_test-basic-flow` job because the `api` service gets built after the `web` service in docker-compose.yml, overwriting its cache

For some reason it seems the `APPLICATION_NAME` ARG is not busting the Docker cache properly on GitHub actions for elixir container builds, so the fix here was to [use `scope=`](https://docs.docker.com/build/cache/backends/gha/#scope) to segregate the cache layers between builds of the same branch.