### PR TITLE
Scope by job name as well

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -458,8 +458,8 @@ jobs:
             APPLICATION_NAME=${{ env.APPLICATION_NAME }}
             APPLICATION_VERSION=0.0.0-sha.${{ github.sha }}
           context: elixir/
-          cache-from: type=gha,scope=${{ env.APPLICATION_NAME }}-${{ github.sha }}
-          cache-to: type=gha,mode=max,scope=${{ env.APPLICATION_NAME }}-${{ github.sha }}
+          cache-from: type=gha,scope=${{ env.APPLICATION_NAME }}-${{ github.job }}-${{ github.sha }}
+          cache-to: type=gha,mode=max,scope=${{ env.APPLICATION_NAME }}-${{ github.job }}-${{ github.sha }}
           file: elixir/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.GCLOUD_PROJECT }}/firezone/${{ env.APPLICATION_NAME }}:${{ env.TAG }} , ${{ env.REGISTRY }}/${{ env.GCLOUD_PROJECT }}/firezone/${{ env.APPLICATION_NAME }}:${{ github.sha }}
@@ -518,8 +518,8 @@ jobs:
             APPLICATION_NAME=${{ env.APPLICATION_NAME }}
             APPLICATION_VERSION=0.0.0-sha.${{ github.sha }}
           context: elixir/
-          cache-from: type=gha,scope=${{ env.APPLICATION_NAME }}-${{ github.sha }}
-          cache-to: type=gha,mode=max,scope=${{ env.APPLICATION_NAME }}-${{ github.sha }}
+          cache-from: type=gha,scope=${{ env.APPLICATION_NAME }}-${{ github.job }}-${{ github.sha }}
+          cache-to: type=gha,mode=max,scope=${{ env.APPLICATION_NAME }}-${{ github.job }}-${{ github.sha }}
           file: elixir/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.GCLOUD_PROJECT }}/firezone/${{ env.APPLICATION_NAME }}:${{ env.TAG }} , ${{ env.REGISTRY }}/${{ env.GCLOUD_PROJECT }}/firezone/${{ env.APPLICATION_NAME }}:${{ github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,12 +17,12 @@ jobs:
         uses: docker/bake-action@v3
         with:
           set: |
-            elixir.cache-from=scope=elixir,type=gha
-            elixir.cache-to=scope=elixir,type=gha,mode=max
-            api.cache-from=scope=api,type=gha
-            api.cache-to=scope=api,type=gha,mode=max
-            web.cache-from=scope=web,type=gha
-            web.cache-to=scope=web,type=gha,mode=max
+            elixir.cache-from=scope=elixir-${{ github.job }},type=gha
+            elixir.cache-to=scope=elixir-${{ github.job }},type=gha,mode=max
+            api.cache-from=scope=api-${{ github.job }},type=gha
+            api.cache-to=scope=api-${{ github.job }},type=gha,mode=max
+            web.cache-from=scope=web-${{ github.job }},type=gha
+            web.cache-to=scope=web-${{ github.job }},type=gha,mode=max
           files: docker-compose.yml
           push: false
       - name: Seed database


### PR DESCRIPTION
Another possible race condition can be that the `integration_test` job and `elixir` jobs overwrite each other's Docker cache if they're running at the same time.