### PR TITLE
Add repo reorganization notice for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 **Note**: 🚧 The `main` branch is undergoing major restructuring in preparation for the 1.0 release 🚧.
+
 See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for the branch tracking the latest 0.7 release.
 
 <!-- TODO: [Read the announcement](https://www.firezone.dev/blog/announcing-1.0). -->

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-<p align="center">
-  **Note**: 🚧 This repository is undergoing major reorganization for the 1.0 release 🚧.
-  <!-- TODO: [Read the announcement](https://www.firezone.dev/blog/announcing-1.0). -->
-  See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for the branch tracking the latest 0.7 release.
-</p>
+**Note**: 🚧 This repository is undergoing major reorganization for the 1.0 release 🚧. See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for the branch tracking the latest 0.7 release.
+
+<!-- TODO: [Read the announcement](https://www.firezone.dev/blog/announcing-1.0). -->
 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/52545545/144147936-39f3e416-8ba0-4f24-915e-f0515f85bb64.png" alt="firezone logo" width="305"/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Note**: 🚧 This repository is undergoing major reorganization for the 1.0 release 🚧.
+**Note**: 🚧 The `main` branch is undergoing major restructuring in preparation for the 1.0 release 🚧.
 See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for the branch tracking the latest 0.7 release.
 
 <!-- TODO: [Read the announcement](https://www.firezone.dev/blog/announcing-1.0). -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-**Note**: 🚧 This repository is undergoing major reorganization for the 1.0 release 🚧. See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for the branch tracking the latest 0.7 release.
+<p align="center">
+**Note**: 🚧 This repository is undergoing major reorganization for the 1.0 release 🚧.
+See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for the branch tracking the latest 0.7 release.
+</p>
 
 <!-- TODO: [Read the announcement](https://www.firezone.dev/blog/announcing-1.0). -->
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 <p align="center">
+  **Note**: 🚧 This repository is undergoing major reorganization for the 1.0 release 🚧.
+  <!-- TODO: [Read the announcement](https://www.firezone.dev/blog/announcing-1.0). -->
+  See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for the branch tracking the latest 0.7 release.
+</p>
+
+<p align="center">
   <img src="https://user-images.githubusercontent.com/52545545/144147936-39f3e416-8ba0-4f24-915e-f0515f85bb64.png" alt="firezone logo" width="305"/>
 </p>
 <p align="center">
@@ -24,9 +30,9 @@
 
 ## [Firezone](https://www.firezone.dev/?utm_source=readme) is a self-hosted VPN server and Linux firewall
 
-* Manage remote access through an intuitive web interface and CLI utility.
-* [Deploy on your own infrastructure](https://docs.firezone.dev/deploy?utm_source=readme) to keep control of your network traffic.
-* Built on [WireGuard®](https://www.wireguard.com/) to be stable, performant, and lightweight.
+- Manage remote access through an intuitive web interface and CLI utility.
+- [Deploy on your own infrastructure](https://docs.firezone.dev/deploy?utm_source=readme) to keep control of your network traffic.
+- Built on [WireGuard®](https://www.wireguard.com/) to be stable, performant, and lightweight.
 
 ![Firezone Architecture](https://user-images.githubusercontent.com/52545545/183804397-ae81ca4e-6972-41f9-80d4-b431a077119d.png)
 
@@ -43,21 +49,21 @@ Using Firezone in production at your organization? Contact us to learn about our
 
 ![firezone-usage](https://user-images.githubusercontent.com/52545545/147392573-fe4cb936-a0a8-436f-a69b-c0a9587de58b.gif)
 
-* **Fast:** Uses WireGuard® to be [3-4 times](https://wireguard.com/performance/) faster than OpenVPN.
-* **SSO Integration:** Authenticate using any identity provider with an OpenID Connect (OIDC) connector.
-* **Containerized:** All dependencies are bundled via Docker.
-* **Simple:** Takes minutes to set up. Manage via a simple CLI.
-* **Secure:** Runs unprivileged. HTTPS enforced. Encrypted cookies.
-* **Firewall included:** Uses Linux [nftables](https://netfilter.org) to block unwanted egress traffic.
+- **Fast:** Uses WireGuard® to be [3-4 times](https://wireguard.com/performance/) faster than OpenVPN.
+- **SSO Integration:** Authenticate using any identity provider with an OpenID Connect (OIDC) connector.
+- **Containerized:** All dependencies are bundled via Docker.
+- **Simple:** Takes minutes to set up. Manage via a simple CLI.
+- **Secure:** Runs unprivileged. HTTPS enforced. Encrypted cookies.
+- **Firewall included:** Uses Linux [nftables](https://netfilter.org) to block unwanted egress traffic.
 
 ### Anti-features
 
 Firezone is **not:**
 
-* An inbound firewall
-* A tool for creating mesh networks
-* A full-featured router
-* An IPSec or OpenVPN server
+- An inbound firewall
+- A tool for creating mesh networks
+- A full-featured router
+- An IPSec or OpenVPN server
 
 ## Documentation
 
@@ -70,11 +76,11 @@ If you're looking for help installing, configuring, or using Firezone, check our
 community support options:
 
 1. [Discussion Forums](https://discourse.firez.one/?utm_source=readme): Ask questions, report
-  bugs, and suggest features.
+   bugs, and suggest features.
 1. [Public Slack Group](https://join.slack.com/t/firezone-users/shared_invite/zt-111043zus-j1lP_jP5ohv52FhAayzT6w):
-  Join live discussions, meet other users, and get to know the contributors.
+   Join live discussions, meet other users, and get to know the contributors.
 1. [Open a PR](https://github.com/firezone/firezone/issues): Contribute a bugfix
-  or make a contribution to Firezone.
+   or make a contribution to Firezone.
 
 If you need help deploying or maintaining Firezone for your business, consider
 [contacting us about our paid support plan](https://www.firezone.dev/sales?utm_source=readme).
@@ -87,7 +93,7 @@ If you need help deploying or maintaining Firezone for your business, consider
 
 [![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=for-the-badge)](https://cloudsmith.com)
 
-Package repository hosting is graciously provided by  [Cloudsmith](https://cloudsmith.com).
+Package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com).
 Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
 enables your organization to create, store and share packages in any format, to any place, with total
 confidence.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-<p align="center">
 **Note**: 🚧 This repository is undergoing major reorganization for the 1.0 release 🚧.
 See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for the branch tracking the latest 0.7 release.
-</p>
 
 <!-- TODO: [Read the announcement](https://www.firezone.dev/blog/announcing-1.0). -->
 


### PR DESCRIPTION
Add a reorganization disclaimer pointing to the old `legacy` branch.

Will have a new README prepared with appropriate marketing content later alongside the 1.0 announcement blogpost. This will keep engineers unblocked and things tidy in the meantime.