### PR TITLE
Update LICENSE to include component license clarification for subcomponents

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,3 @@
-Copyright (c) 2021-present Firezone, Inc.
-
-Portions of this software are licensed as follows:
-
-* All content residing under the "elixir/" directory of this repository, if that directory exists, is licensed under the "Elastic License 2.0" license defined in "elixir/LICENSE".
-* All third party components incorporated into the Firezone Software are licensed under the original license provided by the owner of the applicable component.
-* Content outside of the above mentioned directories or restrictions above is available under the "Apache 2.0 License" license as defined below.
-
-
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -196,7 +186,7 @@ Portions of this software are licensed as follows:
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Engineering
+   Copyright 2021-present Firezone, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,13 @@
+Copyright (c) 2021-present Firezone, Inc.
+
+Portions of this software are licensed as follows:
+
+* All content residing under the "elixir/" directory of this repository, if that directory exists, is licensed under the "Elastic License 2.0" license defined in "elixir/LICENSE".
+* All third party components incorporated into the Firezone Software are licensed under the original license provided by the owner of the applicable component.
+* Content outside of the above mentioned directories or restrictions above is available under the "Apache 2.0 License" license as defined below.
+
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-**Note**: 🚧 The `main` branch is undergoing major restructuring in preparation for the 1.0 release 🚧.
+**Note**: 🚧 The `main` branch is undergoing major restructuring in preparation
+for the 1.0 release 🚧.
 
-See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for the branch tracking the latest 0.7 release.
+See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for
+the branch tracking the latest 0.7 release.
 
 <!-- FIXME
 [Read the announcement](https://www.firezone.dev/blog/announcing-1.0).
@@ -33,30 +35,39 @@ See the [`legacy` branch](https://github.com/firezone/firezone/tree/legacy) for 
 ## [Firezone](https://www.firezone.dev/?utm_source=readme) is a self-hosted VPN server and Linux firewall
 
 - Manage remote access through an intuitive web interface and CLI utility.
-- [Deploy on your own infrastructure](https://docs.firezone.dev/deploy?utm_source=readme) to keep control of your network traffic.
-- Built on [WireGuard®](https://www.wireguard.com/) to be stable, performant, and lightweight.
+- [Deploy on your own infrastructure](https://docs.firezone.dev/deploy?utm_source=readme)
+  to keep control of your network traffic.
+- Built on [WireGuard®](https://www.wireguard.com/) to be stable, performant,
+  and lightweight.
 
 ![Firezone Architecture](https://user-images.githubusercontent.com/52545545/183804397-ae81ca4e-6972-41f9-80d4-b431a077119d.png)
 
 ## Get Started
 
-Follow our [deploy guide](https://docs.firezone.dev/deploy) to install your self-hosted instance of Firezone.
+Follow our [deploy guide](https://docs.firezone.dev/deploy) to install your
+self-hosted instance of Firezone.
 
-Or, if you're on a [supported platform](https://docs.firezone.dev/deploy/docker/supported-platforms?utm_source=readme),
-try our [auto-install script](https://docs.firezone.dev/deploy/docker/#option-1-automatic-install).
+Or, if you're on a
+[supported platform](https://docs.firezone.dev/deploy/docker/supported-platforms?utm_source=readme),
+try our
+[auto-install script](https://docs.firezone.dev/deploy/docker/#option-1-automatic-install).
 
-Using Firezone in production at your organization? Contact us to learn about our [Enterprise Plan](https://www.firezone.dev/contact/sales?utm_source=readme).
+Using Firezone in production at your organization? Contact us to learn about our
+[Enterprise Plan](https://www.firezone.dev/contact/sales?utm_source=readme).
 
 ## Features
 
 ![firezone-usage](https://user-images.githubusercontent.com/52545545/147392573-fe4cb936-a0a8-436f-a69b-c0a9587de58b.gif)
 
-- **Fast:** Uses WireGuard® to be [3-4 times](https://wireguard.com/performance/) faster than OpenVPN.
-- **SSO Integration:** Authenticate using any identity provider with an OpenID Connect (OIDC) connector.
+- **Fast:** Uses WireGuard® to be
+  [3-4 times](https://wireguard.com/performance/) faster than OpenVPN.
+- **SSO Integration:** Authenticate using any identity provider with an OpenID
+  Connect (OIDC) connector.
 - **Containerized:** All dependencies are bundled via Docker.
 - **Simple:** Takes minutes to set up. Manage via a simple CLI.
 - **Secure:** Runs unprivileged. HTTPS enforced. Encrypted cookies.
-- **Firewall included:** Uses Linux [nftables](https://netfilter.org) to block unwanted egress traffic.
+- **Firewall included:** Uses Linux [nftables](https://netfilter.org) to block
+  unwanted egress traffic.
 
 ### Anti-features
 
@@ -69,16 +80,16 @@ Firezone is **not:**
 
 ## Documentation
 
-Additional documentation on general usage, troubleshooting, and configuration can be found at
-[https://docs.firezone.dev](https://docs.firezone.dev).
+Additional documentation on general usage, troubleshooting, and configuration
+can be found at [https://docs.firezone.dev](https://docs.firezone.dev).
 
 ## Get Help
 
 If you're looking for help installing, configuring, or using Firezone, check our
 community support options:
 
-1. [Discussion Forums](https://discourse.firez.one/?utm_source=readme): Ask questions, report
-   bugs, and suggest features.
+1. [Discussion Forums](https://discourse.firez.one/?utm_source=readme): Ask
+   questions, report bugs, and suggest features.
 1. [Public Slack Group](https://join.slack.com/t/firezone-users/shared_invite/zt-111043zus-j1lP_jP5ohv52FhAayzT6w):
    Join live discussions, meet other users, and get to know the contributors.
 1. [Open a PR](https://github.com/firezone/firezone/issues): Contribute a bugfix
@@ -95,10 +106,11 @@ If you need help deploying or maintaining Firezone for your business, consider
 
 [![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=for-the-badge)](https://cloudsmith.com)
 
-Package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com).
-Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
-enables your organization to create, store and share packages in any format, to any place, with total
-confidence.
+Package repository hosting is graciously provided by
+[Cloudsmith](https://cloudsmith.com). Cloudsmith is the only fully hosted,
+cloud-native, universal package management solution, that enables your
+organization to create, store and share packages in any format, to any place,
+with total confidence.
 
 ## Developing and Contributing
 
@@ -110,6 +122,15 @@ See [SECURITY.md](SECURITY.md).
 
 ## License
 
-See [LICENSE](LICENSE).
+Portions of this software are licensed as follows:
+
+- All content residing under the "elixir/" directory of this repository, if that
+  directory exists, is licensed under the "Elastic License 2.0" license defined
+  in "elixir/LICENSE".
+- All third party components incorporated into the Firezone Software are
+  licensed under the original license provided by the owner of the applicable
+  component.
+- Content outside of the above mentioned directories or restrictions above is
+  available under the "Apache 2.0 License" license as defined in "LICENSE".
 
 WireGuard® is a registered trademark of Jason A. Donenfeld.

--- a/elixir/LICENSE
+++ b/elixir/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.


### PR DESCRIPTION
This updates the license for the admin portal (`elixir/`) to the Elastic License v2, keeping other components Apache 2.0 licensed.

What does this mean for 1.0 going forward?

[Elastic's FAQ](https://www.elastic.co/licensing/elastic-license/faq) is broadly applicable to Firezone as well. Most notably, MSPs may still use Firezone to provide general remote access services for third party users, just not to the Firezone admin portal itself (and REST API).

### Why?
We would lose a little bit of business, though one could argue that the tradeoff is worth it due to increased market exposure/distribution.

The main, tangible reasons for us today involve the negative impact this has on our ability to reach product-market fit:
1. We lose the direct feedback channel with paying customers, isolating them (and us) from our roadmap.
2. Reseller licenses should be offered as part of a proper partner alliance / reseller program when we have the resources to support it, which will result in a much better experience for all parties involved (and restore the lost feedback channel).
3. Having outdated, unpatched, and potentially buggy Firezone instances running in the wild that we have no visibility or insight into is a major liability to our brand and reputation and may even result in a legal liability depending on the jurisdiction and severity of the issue. See [this example](https://aws.amazon.com/marketplace/pp/prodview-xgj7kkar35gus) and [this one](https://aws.amazon.com/marketplace/pp/prodview-jyd73dot3zrnw).

