### PR TITLE
connlib: Fix resource list JSON

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "diva",
  "firezone-client-connlib",
  "libc",
+ "serde_json",
  "swift-bridge",
  "swift-bridge-build",
  "walkdir",

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -3,7 +3,7 @@
 // However, this consideration has made it idiomatic for Java FFI in the Rust
 // ecosystem, so it's used here for consistency.
 
-use firezone_client_connlib::{Callbacks, Error, ResourceList, Session, TunnelAddresses};
+use firezone_client_connlib::{Callbacks, Error, ResourceDescription, Session, TunnelAddresses};
 use jni::{
     objects::{JClass, JObject, JString, JValue},
     JNIEnv,
@@ -45,7 +45,7 @@ impl Callbacks for CallbackHandler {
         todo!()
     }
 
-    fn on_update_resources(&self, _resource_list: ResourceList) {
+    fn on_update_resources(&self, _resource_list: Vec<ResourceDescription>) {
         todo!()
     }
 

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -16,6 +16,7 @@ walkdir = "2.3.3"
 libc = "0.2"
 swift-bridge = { workspace = true }
 firezone-client-connlib = { path = "../../libs/client" }
+serde_json = "1"
 
 [lib]
 name = "connlib"

--- a/rust/connlib/clients/apple/Sources/Connlib/CallbackHandler.swift
+++ b/rust/connlib/clients/apple/Sources/Connlib/CallbackHandler.swift
@@ -46,9 +46,9 @@ public class CallbackHandler {
     // Unimplemented
   }
 
-  func onUpdateResources(resourceList: ResourceList) {
-    logger.debug("CallbackHandler.onUpdateResources: \(resourceList.resources.toString(), privacy: .public)")
-    delegate?.onUpdateResources(resourceList: resourceList.resources.toString())
+  func onUpdateResources(resourceList: RustString) {
+    logger.debug("CallbackHandler.onUpdateResources: \(resourceList.toString(), privacy: .public)")
+    delegate?.onUpdateResources(resourceList: resourceList.toString())
   }
 
   func onDisconnect(error: SwiftConnlibError) {

--- a/rust/connlib/clients/headless/src/main.rs
+++ b/rust/connlib/clients/headless/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use std::{net::Ipv4Addr, str::FromStr};
 
 use firezone_client_connlib::{
-    get_user_agent, Callbacks, Error, ResourceList, Session, TunnelAddresses,
+    get_user_agent, Callbacks, Error, ResourceDescription, Session, TunnelAddresses,
 };
 use url::Url;
 
@@ -21,7 +21,7 @@ impl Callbacks for CallbackHandler {
 
     fn on_remove_route(&self, _route: String) {}
 
-    fn on_update_resources(&self, resource_list: ResourceList) {
+    fn on_update_resources(&self, resource_list: Vec<ResourceDescription>) {
         tracing::trace!("Resources updated, current list: {resource_list:?}");
     }
 

--- a/rust/connlib/gateway/src/main.rs
+++ b/rust/connlib/gateway/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use std::{net::Ipv4Addr, str::FromStr};
 
-use firezone_gateway_connlib::{Callbacks, Error, ResourceList, Session, TunnelAddresses};
+use firezone_gateway_connlib::{Callbacks, Error, ResourceDescription, Session, TunnelAddresses};
 use url::Url;
 
 #[derive(Clone)]
@@ -18,7 +18,7 @@ impl Callbacks for CallbackHandler {
 
     fn on_remove_route(&self, _route: String) {}
 
-    fn on_update_resources(&self, resource_list: ResourceList) {
+    fn on_update_resources(&self, resource_list: Vec<ResourceDescription>) {
         tracing::trace!("Resources updated, current list: {resource_list:?}");
     }
 

--- a/rust/connlib/libs/client/src/lib.rs
+++ b/rust/connlib/libs/client/src/lib.rs
@@ -18,6 +18,8 @@ pub type Session<CB> = libs_common::Session<
     CB,
 >;
 
-pub use libs_common::{get_user_agent, Callbacks, Error, ResourceList, TunnelAddresses};
+pub use libs_common::{
+    get_user_agent, messages::ResourceDescription, Callbacks, Error, TunnelAddresses,
+};
 use messages::Messages;
 use messages::ReplyMessages;

--- a/rust/connlib/libs/common/src/lib.rs
+++ b/rust/connlib/libs/common/src/lib.rs
@@ -13,9 +13,7 @@ pub mod messages;
 pub use error::ConnlibError as Error;
 pub use error::Result;
 
-pub use session::{
-    Callbacks, ControlSession, ResourceList, Session, TunnelAddresses, DNS_SENTINEL,
-};
+pub use session::{Callbacks, ControlSession, Session, TunnelAddresses, DNS_SENTINEL};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const LIB_NAME: &str = "connlib";

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -50,12 +50,6 @@ pub struct Session<T, U, V, R, M, CB: Callbacks> {
     _phantom: PhantomData<(T, U, V, R, M)>,
 }
 
-/// Resource list that will be displayed to the users.
-#[derive(Debug)]
-pub struct ResourceList {
-    pub resources: Vec<String>,
-}
-
 /// Tunnel addresses to be surfaced to the client apps.
 #[derive(Debug)]
 pub struct TunnelAddresses {
@@ -76,7 +70,7 @@ pub trait Callbacks: Clone + Send + Sync {
     /// Called when when a route is removed.
     fn on_remove_route(&self, route: String);
     /// Called when the resource list changes.
-    fn on_update_resources(&self, resource_list: ResourceList);
+    fn on_update_resources(&self, resource_list: Vec<ResourceDescription>);
     /// Called when the tunnel is disconnected.
     ///
     /// If the tunnel disconnected due to a fatal error, `error` is the error
@@ -257,14 +251,12 @@ where
             for resource in &resources {
                 callbacks.on_add_route(serde_json::to_string(&resource.address).unwrap());
             }
-            callbacks.on_update_resources(ResourceList {
-                resources: resources
+            callbacks.on_update_resources(
+                resources
                     .into_iter()
-                    .map(|resource| {
-                        serde_json::to_string(&ResourceDescription::Cidr(resource)).unwrap()
-                    })
+                    .map(ResourceDescription::Cidr)
                     .collect(),
-            });
+            );
         });
     }
 

--- a/rust/connlib/libs/gateway/src/lib.rs
+++ b/rust/connlib/libs/gateway/src/lib.rs
@@ -19,4 +19,4 @@ pub type Session<CB> = libs_common::Session<
     CB,
 >;
 
-pub use libs_common::{Callbacks, Error, ResourceList, TunnelAddresses};
+pub use libs_common::{messages::ResourceDescription, Callbacks, Error, TunnelAddresses};

--- a/rust/connlib/libs/tunnel/src/lib.rs
+++ b/rust/connlib/libs/tunnel/src/lib.rs
@@ -222,7 +222,7 @@ where
         let resource_list = {
             let mut resources = self.resources.write();
             resources.insert(resource_description);
-            resources.resource_list()?
+            resources.resource_list()
         };
         self.callbacks.on_update_resources(resource_list);
         Ok(())

--- a/rust/connlib/libs/tunnel/src/resource_table.rs
+++ b/rust/connlib/libs/tunnel/src/resource_table.rs
@@ -2,10 +2,7 @@
 use std::{collections::HashMap, net::IpAddr, ptr::NonNull};
 
 use ip_network_table::IpNetworkTable;
-use libs_common::{
-    messages::{Id, ResourceDescription},
-    ResourceList,
-};
+use libs_common::messages::{Id, ResourceDescription};
 
 // Oh boy... here we go
 /// The resource table type
@@ -152,11 +149,7 @@ impl ResourceTable {
         }
     }
 
-    pub fn resource_list(&self) -> Result<ResourceList, serde_json::Error> {
-        self.id_table
-            .values()
-            .map(serde_json::to_string)
-            .collect::<Result<_, _>>()
-            .map(|resources| ResourceList { resources })
+    pub fn resource_list(&self) -> Vec<ResourceDescription> {
+        self.id_table.values().cloned().collect()
     }
 }


### PR DESCRIPTION
Addresses one of the issues raised in firezone/product#634

Previously, we were joining a `Vec` of serialized JSON objects into a comma-separated string, which isn't valid JSON. Now the entire thing is simply serialized, `Vec` and all.

Additionally, I've moved serialization to happen just before the FFI boundary, which removes some indirection from connlib and will avoid a deserialization step when writing non-FFI clients.