### PR TITLE
connlib: Simpler FFI

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -3,12 +3,12 @@
 // However, this consideration has made it idiomatic for Java FFI in the Rust
 // ecosystem, so it's used here for consistency.
 
-use firezone_client_connlib::{Callbacks, Error, ResourceDescription, Session, TunnelAddresses};
+use firezone_client_connlib::{Callbacks, Error, ResourceDescription, Session};
 use jni::{
     objects::{JClass, JObject, JString, JValue},
     JNIEnv,
 };
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 /// This should be called once after the library is loaded by the system.
 #[allow(non_snake_case)]
@@ -29,7 +29,12 @@ pub extern "system" fn Java_dev_firezone_connlib_Logger_init(_: JNIEnv, _: JClas
 pub struct CallbackHandler;
 
 impl Callbacks for CallbackHandler {
-    fn on_set_interface_config(&self, _tunnel_addresses: TunnelAddresses, _dns_address: Ipv4Addr) {
+    fn on_set_interface_config(
+        &self,
+        _tunnel_address_v4: Ipv4Addr,
+        _tunnel_address_v6: Ipv6Addr,
+        _dns_address: Ipv4Addr,
+    ) {
         todo!()
     }
 

--- a/rust/connlib/clients/apple/Sources/Connlib/CallbackHandler.swift
+++ b/rust/connlib/clients/apple/Sources/Connlib/CallbackHandler.swift
@@ -29,11 +29,11 @@ public class CallbackHandler {
   public weak var delegate: CallbackHandlerDelegate?
   private let logger = Logger(subsystem: "dev.firezone.firezone", category: "callbackhandler")
 
-  func onSetInterfaceConfig(tunnelAddresses: TunnelAddresses, dnsAddress: RustString) {
-    logger.debug("CallbackHandler.onSetInterfaceConfig: IPv4: \(tunnelAddresses.address4.toString(), privacy: .public), IPv6: \(tunnelAddresses.address6.toString(), privacy: .public), DNS: \(dnsAddress.toString(), privacy: .public)")
+  func onSetInterfaceConfig(tunnelAddressIPv4: RustString, tunnelAddressIPv6: RustString, dnsAddress: RustString) {
+    logger.debug("CallbackHandler.onSetInterfaceConfig: IPv4: \(tunnelAddressIPv4.toString(), privacy: .public), IPv6: \(tunnelAddressIPv6.toString(), privacy: .public), DNS: \(dnsAddress.toString(), privacy: .public)")
     delegate?.onSetInterfaceConfig(
-      tunnelAddressIPv4: tunnelAddresses.address4.toString(),
-      tunnelAddressIPv6: tunnelAddresses.address6.toString(),
+      tunnelAddressIPv4: tunnelAddressIPv4.toString(),
+      tunnelAddressIPv6: tunnelAddressIPv6.toString(),
       dnsAddress: dnsAddress.toString()
     )
   }

--- a/rust/connlib/clients/headless/src/main.rs
+++ b/rust/connlib/clients/headless/src/main.rs
@@ -1,17 +1,24 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use std::{net::Ipv4Addr, str::FromStr};
-
-use firezone_client_connlib::{
-    get_user_agent, Callbacks, Error, ResourceDescription, Session, TunnelAddresses,
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    str::FromStr,
 };
+
+use firezone_client_connlib::{get_user_agent, Callbacks, Error, ResourceDescription, Session};
 use url::Url;
 
 #[derive(Clone)]
 pub struct CallbackHandler;
 
 impl Callbacks for CallbackHandler {
-    fn on_set_interface_config(&self, _tunnel_addresses: TunnelAddresses, _dns_address: Ipv4Addr) {}
+    fn on_set_interface_config(
+        &self,
+        _tunnel_address_v4: Ipv4Addr,
+        _tunnel_address_v6: Ipv6Addr,
+        _dns_address: Ipv4Addr,
+    ) {
+    }
 
     fn on_tunnel_ready(&self) {
         tracing::trace!("Tunnel connected");

--- a/rust/connlib/gateway/src/main.rs
+++ b/rust/connlib/gateway/src/main.rs
@@ -1,14 +1,23 @@
 use anyhow::{Context, Result};
-use std::{net::Ipv4Addr, str::FromStr};
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
 
-use firezone_gateway_connlib::{Callbacks, Error, ResourceDescription, Session, TunnelAddresses};
+use firezone_gateway_connlib::{Callbacks, Error, ResourceDescription, Session};
 use url::Url;
 
 #[derive(Clone)]
 pub struct CallbackHandler;
 
 impl Callbacks for CallbackHandler {
-    fn on_set_interface_config(&self, _tunnel_addresses: TunnelAddresses, _dns_address: Ipv4Addr) {}
+    fn on_set_interface_config(
+        &self,
+        _tunnel_address_v4: Ipv4Addr,
+        _tunnel_address_v6: Ipv6Addr,
+        _dns_address: Ipv4Addr,
+    ) {
+    }
 
     fn on_tunnel_ready(&self) {
         tracing::trace!("Tunnel connected with address");

--- a/rust/connlib/libs/client/src/lib.rs
+++ b/rust/connlib/libs/client/src/lib.rs
@@ -18,8 +18,6 @@ pub type Session<CB> = libs_common::Session<
     CB,
 >;
 
-pub use libs_common::{
-    get_user_agent, messages::ResourceDescription, Callbacks, Error, TunnelAddresses,
-};
+pub use libs_common::{get_user_agent, messages::ResourceDescription, Callbacks, Error};
 use messages::Messages;
 use messages::ReplyMessages;

--- a/rust/connlib/libs/common/src/lib.rs
+++ b/rust/connlib/libs/common/src/lib.rs
@@ -13,7 +13,7 @@ pub mod messages;
 pub use error::ConnlibError as Error;
 pub use error::Result;
 
-pub use session::{Callbacks, ControlSession, Session, TunnelAddresses, DNS_SENTINEL};
+pub use session::{Callbacks, ControlSession, Session, DNS_SENTINEL};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const LIB_NAME: &str = "connlib";

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -270,8 +270,6 @@ where
     }
 
     fn disconnect_inner(runtime: &Mutex<Option<Runtime>>, callbacks: &CB, error: Option<Error>) {
-        callbacks.on_disconnect(error.as_ref());
-
         // 1. Close the websocket connection
         // 2. Free the device handle (UNIX)
         // 3. Close the file descriptor (UNIX)
@@ -284,6 +282,8 @@ where
         // Furthermore, we will depend on Drop impls to do the list above so,
         // implement them :)
         *runtime.lock() = None;
+
+        callbacks.on_disconnect(error.as_ref());
     }
 
     /// Cleanup a [Session].

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -50,19 +50,15 @@ pub struct Session<T, U, V, R, M, CB: Callbacks> {
     _phantom: PhantomData<(T, U, V, R, M)>,
 }
 
-/// Tunnel addresses to be surfaced to the client apps.
-#[derive(Debug)]
-pub struct TunnelAddresses {
-    /// IPv4 Address.
-    pub address4: Ipv4Addr,
-    /// IPv6 Address.
-    pub address6: Ipv6Addr,
-}
-
 /// Traits that will be used by connlib to callback the client upper layers.
 pub trait Callbacks: Clone + Send + Sync {
     /// Called when the tunnel address is set.
-    fn on_set_interface_config(&self, tunnel_addresses: TunnelAddresses, dns_address: Ipv4Addr);
+    fn on_set_interface_config(
+        &self,
+        tunnel_address_v4: Ipv4Addr,
+        tunnel_address_v6: Ipv6Addr,
+        dns_address: Ipv4Addr,
+    );
     /// Called when the tunnel is connected.
     fn on_tunnel_ready(&self);
     /// Called when when a route is added.
@@ -242,10 +238,8 @@ where
     fn connect_mock(callbacks: CB) {
         std::thread::sleep(Duration::from_secs(1));
         callbacks.on_set_interface_config(
-            TunnelAddresses {
-                address4: "100.100.111.2".parse().unwrap(),
-                address6: "fd00:0222:2021:1111::2".parse().unwrap(),
-            },
+            "100.100.111.2".parse().unwrap(),
+            "fd00:0222:2021:1111::2".parse().unwrap(),
             DNS_SENTINEL,
         );
         callbacks.on_tunnel_ready();

--- a/rust/connlib/libs/gateway/src/lib.rs
+++ b/rust/connlib/libs/gateway/src/lib.rs
@@ -19,4 +19,4 @@ pub type Session<CB> = libs_common::Session<
     CB,
 >;
 
-pub use libs_common::{messages::ResourceDescription, Callbacks, Error, TunnelAddresses};
+pub use libs_common::{messages::ResourceDescription, Callbacks, Error};

--- a/rust/connlib/libs/tunnel/src/tun_android.rs
+++ b/rust/connlib/libs/tunnel/src/tun_android.rs
@@ -1,7 +1,7 @@
 use super::InterfaceConfig;
 use ip_network::IpNetwork;
 use libc::{close, open, O_RDWR};
-use libs_common::{Callbacks, Error, Result, TunnelAddresses, DNS_SENTINEL};
+use libs_common::{Callbacks, Error, Result, DNS_SENTINEL};
 use std::{
     os::fd::{AsRawFd, RawFd},
     sync::Arc,
@@ -75,13 +75,7 @@ impl IfaceConfig {
         config: &InterfaceConfig,
         callbacks: &impl Callbacks,
     ) -> Result<()> {
-        callbacks.on_set_interface_config(
-            TunnelAddresses {
-                address4: config.ipv4,
-                address6: config.ipv6,
-            },
-            DNS_SENTINEL,
-        );
+        callbacks.on_set_interface_config(config.ipv4, config.ipv6, DNS_SENTINEL);
         Ok(())
     }
 

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -5,7 +5,7 @@ use libc::{
     CTLIOCGINFO, F_GETFL, F_SETFL, IF_NAMESIZE, IPPROTO_IP, O_NONBLOCK, PF_SYSTEM, SOCK_DGRAM,
     SOCK_STREAM, SYSPROTO_CONTROL, UTUN_OPT_IFNAME,
 };
-use libs_common::{Callbacks, Error, Result, TunnelAddresses, DNS_SENTINEL};
+use libs_common::{Callbacks, Error, Result, DNS_SENTINEL};
 use std::{
     ffi::{c_int, c_short, c_uchar},
     io,
@@ -268,13 +268,7 @@ impl IfaceConfig {
         config: &InterfaceConfig,
         callbacks: &impl Callbacks,
     ) -> Result<()> {
-        callbacks.on_set_interface_config(
-            TunnelAddresses {
-                address4: config.ipv4,
-                address6: config.ipv6,
-            },
-            DNS_SENTINEL,
-        );
+        callbacks.on_set_interface_config(config.ipv4, config.ipv6, DNS_SENTINEL);
         Ok(())
     }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -330,12 +330,12 @@ extension Adapter: CallbackHandlerDelegate {
     }
   }
 
-  public func onDisconnect(error: Error) {
+  public func onDisconnect(error: Optional<String>) {
     // Unimplemented
   }
 
-  public func onError(error: Error) {
+  public func onError(error: String) {
     let logger = Logger(subsystem: "dev.firezone.firezone", category: "packet-tunnel")
-    logger.log(level: .error, "Internal connlib error: \(String(describing: error), privacy: .public)")
+    logger.log(level: .error, "Internal connlib error: \(error, privacy: .public)")
   }
 }


### PR DESCRIPTION
As per discussion from the client sync,
- this removes `TunnelAddresses` in favor of simply passing the IPv4 and IPv6 addresses as two separate strings.
- this changes `onDisconnect`'s semantics to be called _after_ disconnect instead of before. 

Additionally, as per earlier discussion, errors are now passed as strings. These errors already weren't intended to be actionable on the client side, so the ability to handle them programmatically is unnecessary. When internationalization is added down the road, we'll likely replace these with error codes for looking up localized strings; until then, this design improves diagnostics and reduces complexity.

Closes #1796
Closes #1822