### PR TITLE
feat(relay): handle failed allocations

### DIFF
--- a/rust/relay/src/allocation.rs
+++ b/rust/relay/src/allocation.rs
@@ -1,0 +1,70 @@
+use crate::server::AllocationId;
+use crate::udp_socket::UdpSocket;
+use anyhow::Result;
+use futures::channel::mpsc;
+use futures::{SinkExt, StreamExt};
+use std::convert::Infallible;
+use std::net::{Ipv4Addr, SocketAddr};
+use tokio::task;
+
+pub struct Allocation {
+    /// The handle to the task that is running the allocation.
+    ///
+    /// Stored here to make resource-cleanup easy.
+    handle: task::JoinHandle<()>,
+    pub sender: mpsc::Sender<(Vec<u8>, SocketAddr)>,
+}
+
+impl Allocation {
+    pub fn new(
+        relay_data_sender: mpsc::Sender<(Vec<u8>, SocketAddr, AllocationId)>,
+        id: AllocationId,
+        listen_ip4_addr: Ipv4Addr,
+        port: u16,
+    ) -> Self {
+        let (client_to_peer_sender, client_to_peer_receiver) = mpsc::channel(1);
+
+        let task = tokio::spawn(async move {
+            let Err(e) = forward_incoming_relay_data(relay_data_sender, client_to_peer_receiver, id, listen_ip4_addr, port).await else {
+                unreachable!()
+            };
+
+            // TODO: Do we need to clean this up in the server? It will eventually timeout if not refreshed.
+            tracing::warn!("Allocation task for {id} failed: {e}");
+        });
+
+        Self {
+            handle: task,
+            sender: client_to_peer_sender,
+        }
+    }
+}
+
+impl Drop for Allocation {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+async fn forward_incoming_relay_data(
+    mut relayed_data_sender: mpsc::Sender<(Vec<u8>, SocketAddr, AllocationId)>,
+    mut client_to_peer_receiver: mpsc::Receiver<(Vec<u8>, SocketAddr)>,
+    id: AllocationId,
+    listen_ip4_addr: Ipv4Addr,
+    port: u16,
+) -> Result<Infallible> {
+    let mut socket = UdpSocket::bind((listen_ip4_addr, port)).await?;
+
+    loop {
+        tokio::select! {
+            result = socket.recv() => {
+                let (data, sender) = result?;
+                relayed_data_sender.send((data.to_vec(), sender, id)).await?;
+            }
+
+            Some((data, recipient)) = client_to_peer_receiver.next() => {
+                socket.send_to(&data, recipient).await?;
+            }
+        }
+    }
+}

--- a/rust/relay/src/allocation.rs
+++ b/rust/relay/src/allocation.rs
@@ -34,8 +34,9 @@ impl Allocation {
                 unreachable!()
             };
 
-            // TODO: Do we need to clean this up in the server? It will eventually timeout if not refreshed.
             tracing::warn!("Allocation task for {id} failed: {e}");
+
+            // With the task stopping, the channel will be closed and any attempt to send data to it will fail.
         });
 
         Self {

--- a/rust/relay/src/lib.rs
+++ b/rust/relay/src/lib.rs
@@ -1,3 +1,4 @@
+mod allocation;
 mod auth;
 mod rfc8656;
 mod server;
@@ -9,6 +10,7 @@ mod udp_socket;
 #[cfg(feature = "proptest")]
 pub mod proptest;
 
+pub use allocation::Allocation;
 pub use server::{
     Allocate, AllocationId, Attribute, Binding, ChannelBind, ChannelData, ClientMessage, Command,
     CreatePermission, Refresh, Server,

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -1,18 +1,16 @@
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use futures::channel::mpsc;
-use futures::{future, FutureExt, SinkExt, StreamExt};
+use futures::{future, FutureExt, StreamExt};
 use phoenix_channel::{Error, Event, PhoenixChannel};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use relay::{AllocationId, Command, Server, Sleep, UdpSocket};
+use relay::{Allocation, AllocationId, Command, Server, Sleep, UdpSocket};
 use std::collections::{HashMap, VecDeque};
-use std::convert::Infallible;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::pin::Pin;
 use std::task::Poll;
 use std::time::SystemTime;
-use tokio::task;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -179,14 +177,6 @@ struct Eventloop<R> {
 
     client_send_buffer: VecDeque<(Vec<u8>, SocketAddr)>,
     allocation_send_buffer: VecDeque<(Vec<u8>, SocketAddr, AllocationId)>,
-}
-
-struct Allocation {
-    /// The handle to the task that is running the allocation.
-    ///
-    /// Stored here to make resource-cleanup easy.
-    handle: task::JoinHandle<()>,
-    sender: mpsc::Sender<(Vec<u8>, SocketAddr)>,
 }
 
 impl<R> Eventloop<R>
@@ -377,60 +367,6 @@ where
             }
 
             return Poll::Pending;
-        }
-    }
-}
-
-impl Allocation {
-    fn new(
-        relay_data_sender: mpsc::Sender<(Vec<u8>, SocketAddr, AllocationId)>,
-        id: AllocationId,
-        listen_ip4_addr: Ipv4Addr,
-        port: u16,
-    ) -> Self {
-        let (client_to_peer_sender, client_to_peer_receiver) = mpsc::channel(1);
-
-        let task = tokio::spawn(async move {
-            let Err(e) = forward_incoming_relay_data(relay_data_sender, client_to_peer_receiver, id, listen_ip4_addr, port).await else {
-                unreachable!()
-            };
-
-            // TODO: Do we need to clean this up in the server? It will eventually timeout if not refreshed.
-            tracing::warn!("Allocation task for {id} failed: {e}");
-        });
-
-        Self {
-            handle: task,
-            sender: client_to_peer_sender,
-        }
-    }
-}
-
-impl Drop for Allocation {
-    fn drop(&mut self) {
-        self.handle.abort();
-    }
-}
-
-async fn forward_incoming_relay_data(
-    mut relayed_data_sender: mpsc::Sender<(Vec<u8>, SocketAddr, AllocationId)>,
-    mut client_to_peer_receiver: mpsc::Receiver<(Vec<u8>, SocketAddr)>,
-    id: AllocationId,
-    listen_ip4_addr: Ipv4Addr,
-    port: u16,
-) -> Result<Infallible> {
-    let mut socket = UdpSocket::bind((listen_ip4_addr, port)).await?;
-
-    loop {
-        tokio::select! {
-            result = socket.recv() => {
-                let (data, sender) = result?;
-                relayed_data_sender.send((data.to_vec(), sender, id)).await?;
-            }
-
-            Some((data, recipient)) = client_to_peer_receiver.next() => {
-                socket.send_to(&data, recipient).await?;
-            }
         }
     }
 }

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -338,6 +338,11 @@ where
         }
     }
 
+    /// An allocation failed.
+    pub fn handle_allocation_failed(&mut self, id: AllocationId) {
+        self.delete_allocation(id)
+    }
+
     /// Return the next command to be executed.
     pub fn next_command(&mut self) -> Option<Command> {
         self.pending_commands.pop_front()


### PR DESCRIPTION
This patch series refactors how we handle allocations in the relay to make it easier to forward a failure to the `Server`. Each allocation runs in a separate task (to allow for parallelization). If the allocation fails, this channel is automatically closed.

Previously, this would erroneously trigger a `debug_assert!`. Now, we invoke a callback on `Server` to allow it to clean up its internal resources for the allocation.

At the same time, we simplify the buffering around data that is destined for a certain allocation. Instead of having an additional buffer in the event-loop, we increase the channel size to 10. Any exceeding items will be dropped to avoid memory growth. This means that the `Server` is never blocked on a slow allocation.

Given that we are running on top of an unreliable protocol anyway, I'd say this is fine.