### PR TITLE
refactor(relay): move primary UDP socket to separate task

### DIFF
--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -329,12 +329,8 @@ where
             }
 
             // Priority 5: Accept new allocations / answer STUN requests etc
-            if let Poll::Ready((buffer, sender)) = self
-                .inbound_data_receiver
-                .poll_next_unpin(cx)
-                .map(|maybe_item| {
-                    maybe_item.context("Channel to primary UDP socket task has been closed")
-                })?
+            if let Poll::Ready(Some((buffer, sender))) =
+                self.inbound_data_receiver.poll_next_unpin(cx)
             {
                 self.server
                     .handle_client_input(&buffer, sender, SystemTime::now());

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -271,7 +271,7 @@ where
                 continue; // Attempt to process more commands.
             }
 
-            // Priority 3: Forward data to allocations.
+            // Priority 2: Forward data to allocations.
             if let Some((data, receiver, id)) = self.allocation_send_buffer.pop_front() {
                 let Some(allocation) = self.allocations.get_mut(&id) else {
                     tracing::debug!("Unknown allocation {id}");
@@ -314,13 +314,13 @@ where
                 continue;
             }
 
-            // Priority 4: Handle time-sensitive tasks:
+            // Priority 3: Handle time-sensitive tasks:
             if self.sleep.poll_unpin(cx).is_ready() {
                 self.server.handle_deadline_reached(SystemTime::now());
                 continue; // Handle potentially new commands.
             }
 
-            // Priority 5: Handle relayed data (we prioritize latency for existing allocations over making new ones)
+            // Priority 4: Handle relayed data (we prioritize latency for existing allocations over making new ones)
             if let Poll::Ready(Some((data, sender, allocation))) =
                 self.relay_data_receiver.poll_next_unpin(cx)
             {
@@ -328,7 +328,7 @@ where
                 continue; // Handle potentially new commands.
             }
 
-            // Priority 6: Accept new allocations / answer STUN requests etc
+            // Priority 5: Accept new allocations / answer STUN requests etc
             if let Poll::Ready((buffer, sender)) = self
                 .inbound_data_receiver
                 .poll_next_unpin(cx)
@@ -341,7 +341,7 @@ where
                 continue; // Handle potentially new commands.
             }
 
-            // Priority 7: Handle portal messages
+            // Priority 6: Handle portal messages
             match self.channel.as_mut().map(|c| c.poll(cx)) {
                 Some(Poll::Ready(Ok(Event::InboundMessage {
                     msg: InboundPortalMessage::Init {},


### PR DESCRIPTION
Currently, the primary UDP socket is polled within the `Eventloop`. In order to not block the `Server` on the readiness of the socket, we buffer all outgoing packets in a `VecDeque`.

This isn't particularly ergonomic.

In addition, whilst implementing the IPv6 support, I ran into a limitation with this model. In case we operate in dual-stack mode, I need to poll two UDP sockets but it is not clear in which order they should be polled. The solution I am going for now is to have two separate tasks, one per IP family and have them both write into the same channel.

In order to keep #1814 smaller, I this PR represents a pure refactoring towards that solution.