### PR TITLE
feat(relay): serve metrics conditionally based on passed socket addr

### DIFF
--- a/rust/relay/src/metrics.rs
+++ b/rust/relay/src/metrics.rs
@@ -5,15 +5,13 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Router, Server};
 use prometheus_client::registry::Registry;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 const CONTENT_TYPE: &str = "application/openmetrics-text;charset=utf-8;version=1.0.0";
-const PORT: u16 = 8080;
 
-pub async fn serve(addr: impl Into<IpAddr>, registry: Registry) -> Result<()> {
+pub async fn serve(addr: impl Into<SocketAddr>, registry: Registry) -> Result<()> {
     let addr = addr.into();
-    let addr = SocketAddr::new(addr, PORT);
 
     let service = Router::new()
         .route("/metrics", get(metrics))


### PR DESCRIPTION
While developing IPv6 support, I ran into a limitations with how I designed the prometheus metrics integration. Currently, we just use the IPv4 listen socket to server the metrics. That however no longer works with IPv6 support because the relay may now operate in IPv6 only mode for example.

To circumvent this, we introduce a dedicated configuration option where the user needs to pass the socket addr for the metrics endpoint. If omitted, the metrics won't be served at all.