### PR TITLE
feat(relay): add smoke test script

### DIFF
--- a/.github/workflows/rust-pass-checks.yml
+++ b/.github/workflows/rust-pass-checks.yml
@@ -42,4 +42,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
-

--- a/.github/workflows/rust-pass-checks.yml
+++ b/.github/workflows/rust-pass-checks.yml
@@ -37,3 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
+  relay_smoke:
+    name: Smoke-test relay
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,4 +113,3 @@ jobs:
         with:
           workspaces: ./rust
       - run: ./run_smoke_test.sh
-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,3 +96,21 @@ jobs:
           workspaces: ./rust
       - run: sudo apt-get install -y musl-tools
       - run: cargo build --bin relay --target x86_64-unknown-linux-musl
+
+  relay_smoke:
+    name: Smoke-test relay
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./rust/relay
+    steps:
+      - uses: actions/checkout@v3
+
+      # This implicitly triggers installation of the toolchain in the `rust-toolchain.toml` file.
+      # If we don't do this here, our cache action will compute a cache key based on the Rust version shipped on GitHub's runner which might differ from the one we use.
+      - run: rustup show
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./rust
+      - run: ./run_smoke_test.sh
+

--- a/rust/relay/examples/client.rs
+++ b/rust/relay/examples/client.rs
@@ -64,7 +64,7 @@ async fn new_turn_client() -> Result<Client, Error> {
         realm: "firezone".to_owned(),
         software: String::new(),
         rto_in_ms: 0,
-        conn: Arc::new(UdpSocket::bind("0.0.0.0:0").await?),
+        conn: Arc::new(UdpSocket::bind("127.0.0.1:0").await?),
         vnet: None,
     })
     .await?;

--- a/rust/relay/examples/gateway.rs
+++ b/rust/relay/examples/gateway.rs
@@ -1,28 +1,24 @@
 use anyhow::Result;
 use redis::AsyncCommands;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
-use webrtc::turn::client::*;
 use webrtc::turn::Error;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
-    let turn_client = new_turn_client(socket.clone()).await?;
+    let socket = UdpSocket::bind("127.0.0.1:0").await?;
+    let listening_addr = socket.local_addr()?;
 
-    let remote_addr = turn_client.send_binding_request().await?;
-
-    println!("Our external address is {remote_addr}");
+    println!("Our listening address is {listening_addr}");
 
     let redis_client = redis::Client::open("redis://localhost:6379")?;
     let mut redis_connection = redis_client.get_async_connection().await?;
 
     redis_connection
-        .rpush("gateway_addr", remote_addr.to_string())
+        .rpush("gateway_addr", listening_addr.to_string())
         .await?;
     let relay_addr = redis_connection
         .blpop::<_, (String, String)>("client_relay_addr", 10)
@@ -30,46 +26,28 @@ async fn main() -> Result<()> {
         .1
         .parse::<SocketAddr>()?;
 
-    println!("Client's relay address is {remote_addr}");
+    println!("Client's relay address is {relay_addr}");
 
     tokio::time::timeout(Duration::from_secs(5), ping_pong(socket, relay_addr)).await??;
 
     Ok(())
 }
 
-async fn ping_pong(socket: Arc<UdpSocket>, relay_addr: SocketAddr) -> Result<(), Error> {
-    let ping = rand::random::<[u8; 32]>();
+async fn ping_pong(socket: UdpSocket, relay_addr: SocketAddr) -> Result<(), Error> {
+    for _ in 0..1000 {
+        let ping = rand::random::<[u8; 32]>();
 
-    socket.send_to(&ping, relay_addr).await?;
+        socket.send_to(&ping, relay_addr).await?;
 
-    println!("Sent ping to client: {}", hex::encode(ping));
+        println!("Sent ping to client: {}", hex::encode(ping));
 
-    let mut pong = [0u8; 32];
-    socket.recv_from(&mut pong).await?;
+        let mut pong = [0u8; 32];
+        socket.recv_from(&mut pong).await?;
 
-    println!("Received pong from client: {}", hex::encode(pong));
+        println!("Received pong from client: {}", hex::encode(pong));
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    assert_eq!(ping, pong);
+        assert_eq!(ping, pong);
+    }
 
     Ok(())
-}
-
-async fn new_turn_client(conn: Arc<UdpSocket>) -> Result<Client, Error> {
-    let client = Client::new(ClientConfig {
-        stun_serv_addr: "localhost:3478".to_owned(),
-        turn_serv_addr: "localhost:3478".to_owned(),
-        username: "2000000000:gateway".to_owned(), // 2000000000 expires in 2033, plenty of time
-        password: "aFq1CUAeKEknjsmA+K4vSLyEwajQgOwGZYl5P4r1sMQ".to_owned(),
-        realm: "firezone".to_owned(),
-        software: String::new(),
-        rto_in_ms: 0,
-        conn,
-        vnet: None,
-    })
-    .await?;
-
-    client.listen().await?;
-    Ok(client)
 }

--- a/rust/relay/proptest-regressions/server/channel_data.txt
+++ b/rust/relay/proptest-regressions/server/channel_data.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc b1e7a16b3aa07627a9ba6274672a74c5ebd0096bfe708f0f4e6414b07525430d # shrinks to input = _ChannelDataEncodingRoundtripArgs { channel_number: 32768, payload: [] }

--- a/rust/relay/src/server/channel_data.rs
+++ b/rust/relay/src/server/channel_data.rs
@@ -17,7 +17,7 @@ impl<'a> ChannelData<'a> {
         }
 
         let channel_number = u16::from_be_bytes([data[0], data[1]]);
-        if channel_number < 0x4000 || channel_number > 0x7FFF {
+        if !(0x4000..=0x7FFF).contains(&channel_number) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "channel number out of bounds",

--- a/rust/relay/src/server/channel_data.rs
+++ b/rust/relay/src/server/channel_data.rs
@@ -1,7 +1,7 @@
 use bytes::{BufMut, BytesMut};
 use std::io;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ChannelData<'a> {
     channel: u16,
     data: &'a [u8],
@@ -17,6 +17,13 @@ impl<'a> ChannelData<'a> {
         }
 
         let channel_number = u16::from_be_bytes([data[0], data[1]]);
+        if channel_number < 0x4000 || channel_number > 0x7FFF {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "channel number out of bounds",
+            ));
+        }
+
         let length = u16::from_be_bytes([data[2], data[3]]);
 
         let actual_payload_length = data.len() - 4;
@@ -37,13 +44,15 @@ impl<'a> ChannelData<'a> {
     }
 
     pub fn new(channel: u16, data: &'a [u8]) -> Self {
+        debug_assert!(channel > 0x400);
+        debug_assert!(channel < 0x7FFF);
         ChannelData { channel, data }
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut message = BytesMut::with_capacity(2 + 2 + self.data.len());
 
-        message.put_u16(self.channel);
+        message.put_slice(&self.channel.to_be_bytes());
         message.put_u16(self.data.len() as u16);
         message.put_slice(self.data);
 
@@ -59,4 +68,21 @@ impl<'a> ChannelData<'a> {
     }
 }
 
-// TODO: tests
+#[cfg(all(test, feature = "proptest"))]
+mod tests {
+    use super::*;
+    use stun_codec::rfc5766::attributes::ChannelNumber;
+
+    #[test_strategy::proptest]
+    fn channel_data_encoding_roundtrip(
+        #[strategy(crate::proptest::channel_number())] channel: ChannelNumber,
+        payload: Vec<u8>,
+    ) {
+        let channel_data = ChannelData::new(channel.value(), &payload);
+        let encoded = channel_data.to_bytes();
+
+        let parsed = ChannelData::parse(&encoded).unwrap();
+
+        assert_eq!(channel_data, parsed)
+    }
+}


### PR DESCRIPTION
I finally figured out why the smoke test script was being funny. It turns out that the TURN client I still had lying around in the `gateway` binary was reading from the UDP socket in the background and thus sometimes grabbed the relayed data and wanted to interpret it as a STUN packet.

However, for this test, the `gateway` doesn't actually need a TURN client at all. It communicates with the relay as if it were the `client` itself.

By modifying the script to only work on localhost, we can avoid use of a TURN client altogether in the relay and make this script deterministic which is a big win for our CI confidence!