### PR TITLE
chore(ci): update Relay smoke test script to follow job naming convention

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -394,15 +394,6 @@ jobs:
           name: Elixir Acceptance Test Report
           path: elixir/_build/test/lib/*/test-junit-report.xml
           reporter: java-junit
-  # elixir/draft-release:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     tag_name: ${{ steps.release_drafter.outputs.tag_name }}
-  #   steps:
-  #     - uses: release-drafter/release-drafter@v5
-  #       id: release_drafter
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   elixir_web-container-build:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/rust-pass-checks.yml
+++ b/.github/workflows/rust-pass-checks.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
-  rust_relay-smoke-test:
+  rust_smoke-test-relay:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/rust-pass-checks.yml
+++ b/.github/workflows/rust-pass-checks.yml
@@ -37,8 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
-  relay_smoke:
-    name: Smoke-test relay
+  rust_relay-smoke-test:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/rust-pass-checks.yml
+++ b/.github/workflows/rust-pass-checks.yml
@@ -12,10 +12,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  rust_draft-release:
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No build required"'
   rust_test:
     strategy:
       matrix:
@@ -27,10 +23,6 @@ jobs:
           - windows-2019
           - windows-2022
     runs-on: ${{ matrix.runs-on }}
-    steps:
-      - run: 'echo "No build required"'
-  rust_build-android:
-    runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
   rust_cross-compile-relay: # cross is separate from test because cross-compiling yields different artifacts and we cannot reuse the cache.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,7 +97,7 @@ jobs:
       - run: sudo apt-get install -y musl-tools
       - run: cargo build --bin relay --target x86_64-unknown-linux-musl
 
-  rust_relay-smoke-test:
+  rust_smoke-test-relay:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,18 +19,6 @@ defaults:
     working-directory: ./rust
 
 jobs:
-  rust_draft-release:
-    runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.release_drafter.outputs.tag_name }}
-    steps:
-      - uses: release-drafter/release-drafter@v5
-        with:
-          commitish: main
-        id: release_drafter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   rust_test:
     strategy:
       fail-fast: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,8 +97,7 @@ jobs:
       - run: sudo apt-get install -y musl-tools
       - run: cargo build --bin relay --target x86_64-unknown-linux-musl
 
-  relay_smoke:
-    name: Smoke-test relay
+  rust_relay-smoke-test:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/swift-pass-checks.yml
+++ b/.github/workflows/swift-pass-checks.yml
@@ -13,10 +13,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  swift_draft-release:
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No build required"'
   swift_build:
     strategy:
       matrix:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,18 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  swift_draft-release:
-    runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.release_drafter.outputs.tag_name }}
-    steps:
-      - uses: release-drafter/release-drafter@v5
-        with:
-          commitish: main
-        id: release_drafter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   swift_build:
     strategy:
       matrix:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -32,8 +32,6 @@ jobs:
     defaults:
       run:
         working-directory: ./swift
-    needs:
-      - swift_draft-release
     steps:
       - uses: actions/checkout@v3
       - run: rustup show


### PR DESCRIPTION
Didn't catch this earlier, but I'd like to use this naming convention for jobs going forward since they're easier to identify in the Branch protection rules settings and Actions settings.