### PR TITLE
Remove erroneously copied functions from connlib apple

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -113,37 +113,3 @@ pub unsafe extern "system" fn Java_dev_firezone_connlib_Session_disconnect(
     let session = unsafe { &mut *session_ptr };
     session.disconnect(None)
 }
-
-/// # Safety
-/// Pointers must be valid
-#[allow(non_snake_case)]
-#[no_mangle]
-pub unsafe extern "system" fn Java_dev_firezone_connlib_Session_bump_sockets(
-    session_ptr: *const Session<CallbackHandler>,
-) -> bool {
-    if session_ptr.is_null() {
-        return false;
-    }
-
-    unsafe { (*session_ptr).bump_sockets() };
-
-    // TODO: See https://github.com/WireGuard/wireguard-apple/blob/2fec12a6e1f6e3460b6ee483aa00ad29cddadab1/Sources/WireGuardKitGo/api-apple.go#LL197C6-L197C50
-    true
-}
-
-/// # Safety
-/// Pointers must be valid
-#[allow(non_snake_case)]
-#[no_mangle]
-pub unsafe extern "system" fn Java_dev_firezone_connlib_disable_some_roaming_for_broken_mobile_semantics(
-    session_ptr: *const Session<CallbackHandler>,
-) -> bool {
-    if session_ptr.is_null() {
-        return false;
-    }
-
-    unsafe { (*session_ptr).disable_some_roaming_for_broken_mobile_semantics() };
-
-    // TODO: See https://github.com/WireGuard/wireguard-apple/blob/2fec12a6e1f6e3460b6ee483aa00ad29cddadab1/Sources/WireGuardKitGo/api-apple.go#LL197C6-L197C50
-    true
-}


### PR DESCRIPTION
Removes functions from the android FFI that aren't needed. Why? These were mistakenly copied from the apple FFI when I was prototyping this back in April.