### PR TITLE
fix(relay): wait for channel binding in smoke test script

### DIFF
--- a/rust/relay/examples/client.rs
+++ b/rust/relay/examples/client.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use redis::AsyncCommands;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::UdpSocket;
 use webrtc::turn::client::*;
 use webrtc::turn::Error;
@@ -32,6 +33,10 @@ async fn main() -> Result<()> {
     // The webrtc-rs client has no concept of explicitly creating a channel.
     // Instead, it will implicitly create one when trying to send data to a remote.
     relay_conn.send_to(b"HOLEPUNCH", gateway_addr).await?;
+
+    // `webrtc-ts` does not block on the creation of the channel binding.
+    // Wait for some amount of time here to avoid race conditions.
+    tokio::time::sleep(Duration::from_millis(10)).await;
 
     println!("Created channel to gateway");
 

--- a/rust/relay/examples/gateway.rs
+++ b/rust/relay/examples/gateway.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
 }
 
 async fn ping_pong(socket: UdpSocket, relay_addr: SocketAddr) -> Result<(), Error> {
-    for _ in 0..1000 {
+    for _ in 0..1 {
         let ping = rand::random::<[u8; 32]>();
 
         socket.send_to(&ping, relay_addr).await?;

--- a/rust/relay/examples/gateway.rs
+++ b/rust/relay/examples/gateway.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
 }
 
 async fn ping_pong(socket: UdpSocket, relay_addr: SocketAddr) -> Result<(), Error> {
-    for _ in 0..1 {
+    for _ in 0..1000 {
         let ping = rand::random::<[u8; 32]>();
 
         socket.send_to(&ping, relay_addr).await?;


### PR DESCRIPTION
`webrtc-rs` has a race condition where `send_to` does not actually await the channel binding, thus attempting to send something through the channel from the other end my fail because we receive the bytes from the relay before the library registers that there is an active channel.

This should hopefully fix the flakiness of the smoke test script.