### PR TITLE
connlib: fix DNS PTR record query

### DIFF
--- a/rust/connlib/libs/common/src/messages.rs
+++ b/rust/connlib/libs/common/src/messages.rs
@@ -90,7 +90,7 @@ impl ResourceDescription {
             ResourceDescription::Cidr(_) => None,
         }
     }
-    
+
     pub fn ips(&self) -> Vec<IpNetwork> {
         match self {
             ResourceDescription::Dns(r) => vec![r.ipv4.into(), r.ipv6.into()],

--- a/rust/connlib/libs/common/src/messages.rs
+++ b/rust/connlib/libs/common/src/messages.rs
@@ -90,6 +90,7 @@ impl ResourceDescription {
             ResourceDescription::Cidr(_) => None,
         }
     }
+    
     pub fn ips(&self) -> Vec<IpNetwork> {
         match self {
             ResourceDescription::Dns(r) => vec![r.ipv4.into(), r.ipv6.into()],

--- a/rust/connlib/libs/common/src/messages.rs
+++ b/rust/connlib/libs/common/src/messages.rs
@@ -84,12 +84,19 @@ pub struct ResourceDescriptionDns {
 }
 
 impl ResourceDescription {
+    pub fn dns_name(&self) -> Option<&str> {
+        match self {
+            ResourceDescription::Dns(r) => Some(&r.name),
+            ResourceDescription::Cidr(_) => None,
+        }
+    }
     pub fn ips(&self) -> Vec<IpNetwork> {
         match self {
             ResourceDescription::Dns(r) => vec![r.ipv4.into(), r.ipv6.into()],
             ResourceDescription::Cidr(r) => vec![r.address],
         }
     }
+
     pub fn ipv4(&self) -> Option<Ipv4Addr> {
         match self {
             ResourceDescription::Dns(r) => Some(r.ipv4),


### PR DESCRIPTION
Some programs(such as `ping`) after resolving the dns name do a reverse dns lookup using PTR, if this doesn't respond the program hangs making performance slower.

This PR fixes it by handling PTR queries.