### PR TITLE
android: Update auth URLs to follow convention; Fix JNI callback method signatures

### DIFF
--- a/elixir/apps/web/priv/static/.well-known/assetlinks.json
+++ b/elixir/apps/web/priv/static/.well-known/assetlinks.json
@@ -7,7 +7,8 @@
       "namespace": "android_app",
       "package_name": "dev.firezone.android",
       "sha256_cert_fingerprints": [
-        "82:86:46:E7:B7:FC:BD:01:4E:53:D5:92:E7:07:A6:90:B6:03:07:E5:02:E8:A9:20:EA:EE:54:6B:FA:E6:69:AA"
+        "82:86:46:E7:B7:FC:BD:01:4E:53:D5:92:E7:07:A6:90:B6:03:07:E5:02:E8:A9:20:EA:EE:54:6B:FA:E6:69:AA",
+        "CB:FA:24:CE:CE:87:AF:5C:EF:C4:E4:E8:04:BC:C1:B8:34:0B:4E:7E:77:E1:26:80:41:6D:A8:44:56:DF:BA:A5"
       ]
     }
   }

--- a/kotlin/android/PortalMock/server.rb
+++ b/kotlin/android/PortalMock/server.rb
@@ -7,14 +7,14 @@ require 'sinatra'
 set :bind, '0.0.0.0'
 set :port, 4568
 
-get '/auth' do
+get '/:slug/sign_in' do
   csrfToken = params['client_csrf_token']
-  dest = params['dest']
-  ERB.new("<h1>Auth page</h1><a href=\"/redirect?client_csrf_token=#{csrfToken}&dest=#{dest}\">Proceed</a>").result(binding)
+  ERB.new("<h1>Auth page</h1><a href=\"/redirect?client_csrf_token=#{csrfToken}&client_platform=android\">Proceed</a>")
+     .result(binding)
 end
 
 get '/redirect' do
-  dest = params['dest']
+  dest = 'https://app.firez.one/handle_client_auth_callback'
   csrfToken = params['client_csrf_token']
   authToken = File.read(File.join(__dir__, 'data', 'jwt'))
   redirect "#{dest}?client_csrf_token=#{csrfToken}&client_auth_token=#{authToken}"

--- a/kotlin/android/PortalMock/server.rb
+++ b/kotlin/android/PortalMock/server.rb
@@ -9,7 +9,7 @@ set :port, 4568
 
 get '/:slug/sign_in' do
   csrfToken = params['client_csrf_token']
-  ERB.new("<h1>Auth page</h1><a href=\"/redirect?client_csrf_token=#{csrfToken}&client_platform=android\">Proceed</a>")
+  ERB.new("<h1>Auth page</h1><a href=\"/redirect?client_csrf_token=#{csrfToken}\">Proceed</a>")
      .result(binding)
 end
 

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -67,7 +67,7 @@
             </intent-filter>
         </service>
             <receiver
-                android:name=".features.session.backend.BootShutdownReceiver"
+                android:name="dev.firezone.android.features.session.backend.BootShutdownReceiver"
                 android:exported="true">
                 <intent-filter>
                     <action android:name="android.intent.action.ACTION_SHUTDOWN" />

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -43,12 +43,13 @@
 
         <activity
             android:name="dev.firezone.android.features.applink.presentation.AppLinkHandlerActivity"
-            android:exported="false"
+            android:exported="true"
             android:launchMode="singleTop">
 
             <intent-filter
                 android:label="@string/app_name"
                 android:autoVerify="true">
+                <category android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -66,14 +66,14 @@
                 <action android:name="android.net.VpnService" />
             </intent-filter>
         </service>
-            <receiver
-                android:name="dev.firezone.android.features.session.backend.BootShutdownReceiver"
-                android:exported="true">
-                <intent-filter>
-                    <action android:name="android.intent.action.ACTION_SHUTDOWN" />
-                    <action android:name="android.intent.action.BOOT_COMPLETED" />
-                </intent-filter>
-            </receiver>
+        <receiver
+            android:name="dev.firezone.android.features.session.backend.BootShutdownReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.ACTION_SHUTDOWN" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -49,8 +49,6 @@
             <intent-filter
                 android:label="@string/app_name"
                 android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
@@ -66,6 +64,7 @@
                 <action android:name="android.net.VpnService" />
             </intent-filter>
         </service>
+
         <receiver
             android:name="dev.firezone.android.features.session.backend.BootShutdownReceiver"
             android:exported="true">

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -43,18 +43,8 @@
 
         <activity
             android:name="dev.firezone.android.features.applink.presentation.AppLinkHandlerActivity"
-            android:exported="true"
+            android:exported="false"
             android:launchMode="singleTop">
-
-            <!-- Using deeplink until applinks is setup -->
-            <!--<intent-filter android:label="AppLink">
-                    <action android:name="android.intent.action.VIEW" />
-
-                    <category android:name="android.intent.category.DEFAULT" />
-                    <category android:name="android.intent.category.BROWSABLE" />
-
-                    <data android:scheme="https" android:host="firezone.dev" android:pathPrefix="/auth" />
-                </intent-filter>-->
 
             <intent-filter
                 android:label="@string/app_name"
@@ -64,9 +54,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-                <data android:host="${hostName}" />
+                <data android:scheme="https" android:host="${hostName}" />
             </intent-filter>
         </activity>
 
@@ -78,7 +66,6 @@
                 <action android:name="android.net.VpnService" />
             </intent-filter>
         </service>
-        <!-- Causes cli builds to fail with lint error "Error: This class should provide a default constructor (a public constructor with no arguments"
             <receiver
                 android:name=".features.session.backend.BootShutdownReceiver"
                 android:exported="true">
@@ -87,7 +74,6 @@
                     <action android:name="android.intent.action.BOOT_COMPLETED" />
                 </intent-filter>
             </receiver>
-    -->
     </application>
 
 </manifest>

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -49,7 +49,7 @@
             <intent-filter
                 android:label="@string/app_name"
                 android:autoVerify="true">
-                <category android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/di/AppModule.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/di/AppModule.kt
@@ -42,10 +42,4 @@ object AppModule {
     internal fun provideSessionManager(
         sharedPreferences: SharedPreferences
     ): SessionManager = SessionManager(sharedPreferences)
-
-    @Provides
-    internal fun provideBroadcastReceiver(
-        @MainImmediateDispatcher coroutineDispatcher: CoroutineDispatcher,
-        sessionManager: SessionManager,
-    ): BootShutdownReceiver = BootShutdownReceiver(coroutineDispatcher, sessionManager)
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/applink/presentation/AppLinkHandlerActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/applink/presentation/AppLinkHandlerActivity.kt
@@ -2,6 +2,7 @@ package dev.firezone.android.features.applink.presentation
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,6 +28,7 @@ class AppLinkHandlerActivity : AppCompatActivity(R.layout.activity_app_link_hand
             when (action) {
                 is AppLinkViewAction.AuthFlowComplete -> {
                     // Continue with onboarding
+                    Log.d("AppLinkHandlerActivity", "AuthFlowComplete")
                 }
                 is AppLinkViewAction.ShowError -> showError()
                 else -> {}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/applink/presentation/AppLinkViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/applink/presentation/AppLinkViewModel.kt
@@ -28,7 +28,6 @@ internal class AppLinkViewModel @Inject constructor(
                 "handle_client_auth_callback" -> {
                     intent.data?.getQueryParameter("client_csrf_token")?.let { csrfToken ->
                         if (validateCsrfTokenUseCase(csrfToken).firstOrNull() == true) {
-                            System.loadLibrary("connlib")
                             val jwtToken = intent.data?.getQueryParameter("client_auth_token") ?: ""
                             saveJWTUseCase(jwtToken)
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/applink/presentation/AppLinkViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/applink/presentation/AppLinkViewModel.kt
@@ -28,6 +28,7 @@ internal class AppLinkViewModel @Inject constructor(
                 "handle_client_auth_callback" -> {
                     intent.data?.getQueryParameter("client_csrf_token")?.let { csrfToken ->
                         if (validateCsrfTokenUseCase(csrfToken).firstOrNull() == true) {
+                            System.loadLibrary("connlib")
                             val jwtToken = intent.data?.getQueryParameter("client_auth_token") ?: ""
                             saveJWTUseCase(jwtToken)
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/applink/presentation/AppLinkViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/applink/presentation/AppLinkViewModel.kt
@@ -1,6 +1,7 @@
 package dev.firezone.android.features.applink.presentation
 
 import android.content.Intent
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -24,7 +25,7 @@ internal class AppLinkViewModel @Inject constructor(
     fun parseAppLink(intent: Intent) {
         viewModelScope.launch {
             when (intent.data?.lastPathSegment) {
-                "callback" -> {
+                "handle_client_auth_callback" -> {
                     intent.data?.getQueryParameter("client_csrf_token")?.let { csrfToken ->
                         if (validateCsrfTokenUseCase(csrfToken).firstOrNull() == true) {
                             val jwtToken = intent.data?.getQueryParameter("client_auth_token") ?: ""
@@ -34,7 +35,9 @@ internal class AppLinkViewModel @Inject constructor(
                         }
                     }
                 }
-                else -> {}
+                else -> {
+                    Log.d("AppLink", "Unknown path segment: ${intent.data?.lastPathSegment}")
+                }
             }
         }
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/domain/AuthRepositoryImpl.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/domain/AuthRepositoryImpl.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import java.util.Base64
 import javax.inject.Inject
-import kotlin.random.Random
+import java.security.SecureRandom
 
 internal class AuthRepositoryImpl @Inject constructor(
     private val coroutineDispatcher: CoroutineDispatcher,
@@ -16,11 +16,10 @@ internal class AuthRepositoryImpl @Inject constructor(
 ) : AuthRepository {
 
     override fun generateCsrfToken(): Flow<String> = flow {
-        val str = (1..CSRF_LENGTH)
-            .map { Random.nextInt(0, chars.size).let { chars[it] } }
-            .joinToString("")
-
-        val encodedStr: String = Base64.getEncoder().encodeToString(str.toByteArray())
+        val random = SecureRandom.getInstanceStrong()
+        val bytes = ByteArray(CSRF_LENGTH)
+        random.nextBytes(bytes)
+        val encodedStr: String = Base64.getEncoder().encodeToString(bytes)
 
         sharedPreferences
             .edit()
@@ -33,6 +32,5 @@ internal class AuthRepositoryImpl @Inject constructor(
     companion object {
         private const val CSRF_KEY = "csrf"
         private const val CSRF_LENGTH = 24
-        private val chars : List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/presentation/AuthViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/presentation/AuthViewModel.kt
@@ -32,7 +32,7 @@ internal class AuthViewModel @Inject constructor(
 
             actionMutableLiveData.postValue(
                 AuthViewAction.LaunchAuthFlow(
-                    url = "${config.portalUrl}/auth?client_csrf_token=$token&dest=https://${BuildConfig.AUTH_DEST}/callback"
+                    url = "${config.portalUrl}/sign_in?client_csrf_token=$token&client_platform=android"
                 )
             )
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/backend/BootShutdownReceiver.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/backend/BootShutdownReceiver.kt
@@ -6,11 +6,10 @@ import android.content.Intent
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 
-internal class BootShutdownReceiver @Inject constructor(
+class BootShutdownReceiver @Inject constructor(
     private val coroutineDispatcher: CoroutineDispatcher,
     private val sessionManager: SessionManager
 ) : BroadcastReceiver() {
-
     override fun onReceive(context: Context, intent: Intent) {
         if (Intent.ACTION_BOOT_COMPLETED == intent.action) {
             sessionManager.connect()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/backend/BootShutdownReceiver.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/backend/BootShutdownReceiver.kt
@@ -1,20 +1,22 @@
 package dev.firezone.android.features.session.backend
 
 import android.content.BroadcastReceiver
+import android.util.Log
 import android.content.Context
 import android.content.Intent
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 
-class BootShutdownReceiver @Inject constructor(
-    private val coroutineDispatcher: CoroutineDispatcher,
-    private val sessionManager: SessionManager
-) : BroadcastReceiver() {
+internal class BootShutdownReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (Intent.ACTION_BOOT_COMPLETED == intent.action) {
-            sessionManager.connect()
+            Log.d("BootShutdownReceiver", "Boot completed. Attempting to connect.")
+            // TODO: Inject sessionManager to connect on boot
+            // sessionManager.connect()
         } else if (Intent.ACTION_SHUTDOWN == intent.action) {
-            sessionManager.disconnect()
+            Log.d("BootShutdownReceiver", "Shutting down. Attempting to disconnect.")
+            // TODO: Inject sessionManager to disconnect on shutdown
+            // sessionManager.disconnect()
         }
     }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/backend/BootShutdownReceiver.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/backend/BootShutdownReceiver.kt
@@ -11,11 +11,11 @@ internal class BootShutdownReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (Intent.ACTION_BOOT_COMPLETED == intent.action) {
             Log.d("BootShutdownReceiver", "Boot completed. Attempting to connect.")
-            // TODO: Inject sessionManager to connect on boot
-            // sessionManager.connect()
+            // TODO: Retrieve the session manager from the application context.
+            //sessionManager.connect()
         } else if (Intent.ACTION_SHUTDOWN == intent.action) {
             Log.d("BootShutdownReceiver", "Shutting down. Attempting to disconnect.")
-            // TODO: Inject sessionManager to disconnect on shutdown
+            // TODO: Retrieve the session manager from the application context.
             // sessionManager.disconnect()
         }
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/presentation/SessionFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/presentation/SessionFragment.kt
@@ -2,6 +2,7 @@ package dev.firezone.android.features.session.presentation
 
 import android.os.Bundle
 import android.view.View
+import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -22,7 +23,7 @@ internal class SessionFragment : Fragment(R.layout.fragment_session) {
 
         setupButtonListeners()
         setupActionObservers()
-
+        Log.d("SessionViewModel", "Starting session...")
         viewModel.startSession()
     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/webview/presentation/WebViewViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/webview/presentation/WebViewViewModel.kt
@@ -40,7 +40,7 @@ internal class WebViewViewModel @Inject constructor(
                 .collect {
                     actionMutableLiveData.postValue(
                         WebViewViewAction.FillPortalUrl(
-                            url = "${it.portalUrl}/auth"
+                            url = "${it.portalUrl}/sign_in"
                         )
                     )
                 }

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -125,7 +125,7 @@ impl Callbacks for CallbackHandler {
                 &mut env,
                 &self.callback_handler,
                 "onSetInterfaceConfig",
-                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)",
+                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
                 &[
                     JValue::from(&tunnel_address_v4),
                     JValue::from(&tunnel_address_v6),
@@ -138,7 +138,13 @@ impl Callbacks for CallbackHandler {
 
     fn on_tunnel_ready(&self) -> Result<(), Self::Error> {
         self.env(|mut env| {
-            call_method(&mut env, &self.callback_handler, "onTunnelReady", "()", &[])
+            call_method(
+                &mut env,
+                &self.callback_handler,
+                "onTunnelReady",
+                "()Z",
+                &[],
+            )
         })
     }
 
@@ -154,7 +160,7 @@ impl Callbacks for CallbackHandler {
                 &mut env,
                 &self.callback_handler,
                 "onAddRoute",
-                "(Ljava/lang/String;)",
+                "(Ljava/lang/String;)V",
                 &[JValue::from(&route)],
             )
         })
@@ -172,7 +178,7 @@ impl Callbacks for CallbackHandler {
                 &mut env,
                 &self.callback_handler,
                 "onRemoveRoute",
-                "(Ljava/lang/String;)",
+                "(Ljava/lang/String;)V",
                 &[JValue::from(&route)],
             )
         })
@@ -193,7 +199,7 @@ impl Callbacks for CallbackHandler {
                 &mut env,
                 &self.callback_handler,
                 "onUpdateResources",
-                "(Ljava/lang/String;)",
+                "(Ljava/lang/String;)V",
                 &[JValue::from(&resource_list)],
             )
         })
@@ -211,7 +217,7 @@ impl Callbacks for CallbackHandler {
                 &mut env,
                 &self.callback_handler,
                 "onDisconnect",
-                "(Ljava/lang/String;)",
+                "(Ljava/lang/String;)Z",
                 &[JValue::from(&error)],
             )
         })
@@ -229,7 +235,7 @@ impl Callbacks for CallbackHandler {
                 &mut env,
                 &self.callback_handler,
                 "onError",
-                "(Ljava/lang/String;)",
+                "(Ljava/lang/String;)Z",
                 &[JValue::from(&error)],
             )
         })


### PR DESCRIPTION
* Update callbacks and URLs according to #1868 
* Use `SecureRandom`, not `Random` to generate cryptographic tokens
* Minor app manifest cleanup
* Redirect with `client_platform=android` instead of `dest`
* Fix JNI method signatures so that callbacks work

@pratikvelani The AppLinkHandler doesn't seem to be called, because the AuthActivity is still the one that's launched when the `Sign In` button is clicked. Does it make sense to combine those two features into one, or is it better to keep them separate? I'm not an Android developer (obviously), but it seems like there's a lot of boilerplate being duplicated across the two features just to receive an AppLink intent.