### PR TITLE
relay: remove `--allow-insecure-ws` flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,7 +207,6 @@ services:
       app:
         ipv4_address: 172.28.0.101
         ipv6_address: 2001:3990:3990::101
-    command: "--allow-insecure-ws"
 
   api:
     build:

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -58,9 +58,6 @@ struct Args {
     /// If omitted, we won't connect to the portal on startup.
     #[arg(long, env)]
     portal_token: Option<String>,
-    /// Whether to allow connecting to the portal over an insecure connection.
-    #[arg(long)]
-    allow_insecure_ws: bool,
     /// A seed to use for all randomness operations.
     ///
     /// Only available in debug builds.
@@ -109,9 +106,6 @@ async fn main() -> Result<()> {
 
     let channel = if let Some(token) = args.portal_token {
         let mut url = args.portal_ws_url.clone();
-        if url.scheme() == "ws" && !args.allow_insecure_ws {
-            bail!("Refusing to connect to portal over insecure connection, pass --allow-insecure-ws to override")
-        }
         if !url.path().is_empty() {
             tracing::warn!("Overwriting path component of portal URL with '/relay/websocket'");
         }


### PR DESCRIPTION
Previously, I thought it might be helpful to refuse a insecure connections to the portal unless the user explicitly opts-in to this. In our CI and testing environment, this however proved to cause more headaches than it helps.

This PR removes this flag and assumes that users are smart enough that they should protect self-hosted portals with transport-level encryption.