### PR TITLE
apple: Tunnel stack

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3,11 +3,11 @@ Do Not Translate or Localize
 
 This software incorporates material from third parties.
 
-Please refer to this document for the license terms of the components that this product depends and use.
+Please refer to this document for the license terms of the components that this product uses directly or as a derivate of.
 
 ===
 
-This product depends on and uses Boringtun source code:
+Portions of the Firezone product contain derivate work from the https://github.com/cloudflare/boringtun. Its license is included below:
 
 Copyright (c) 2019 Cloudflare, Inc. All rights reserved.
 
@@ -18,3 +18,27 @@ Redistribution and use in source and binary forms, with or without modification,
     3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===
+
+Portions of this product contain derivate work from https://github.com/wireguard/wireguard-apple. Its license is included below:
+
+Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rust/connlib/clients/apple/Sources/Connlib/CallbackHandler.swift
+++ b/rust/connlib/clients/apple/Sources/Connlib/CallbackHandler.swift
@@ -62,11 +62,11 @@ public class CallbackHandler {
   func onDisconnect(error: RustString) {
     logger.debug("CallbackHandler.onDisconnect: \(error.toString(), privacy: .public)")
     let error = error.toString()
-    var optional_error = Optional.some(error)
+    var optionalError = Optional.some(error)
     if error.isEmpty {
-      optional_error = Optional.none
+      optionalError = Optional.none
     }
-    delegate?.onDisconnect(error: optional_error)
+    delegate?.onDisconnect(error: optionalError)
   }
 
   func onError(error: RustString) {

--- a/rust/connlib/libs/tunnel/src/device_channel_unix.rs
+++ b/rust/connlib/libs/tunnel/src/device_channel_unix.rs
@@ -61,7 +61,7 @@ impl DeviceChannel {
 }
 
 pub(crate) async fn create_iface() -> Result<(IfaceConfig, DeviceChannel)> {
-    let dev = Arc::new(IfaceDevice::new().await?.set_non_blocking()?);
+    let dev = Arc::new(IfaceDevice::new(None).await?.set_non_blocking()?);
     let async_dev = Arc::clone(&dev);
     let device_channel = DeviceChannel(AsyncFd::new(async_dev)?);
     let iface_config = IfaceConfig(dev);

--- a/rust/connlib/libs/tunnel/src/device_channel_unix.rs
+++ b/rust/connlib/libs/tunnel/src/device_channel_unix.rs
@@ -61,7 +61,7 @@ impl DeviceChannel {
 }
 
 pub(crate) async fn create_iface() -> Result<(IfaceConfig, DeviceChannel)> {
-    let dev = Arc::new(IfaceDevice::new(None).await?.set_non_blocking()?);
+    let dev = Arc::new(IfaceDevice::new().await?.set_non_blocking()?);
     let async_dev = Arc::clone(&dev);
     let device_channel = DeviceChannel(AsyncFd::new(async_dev)?);
     let iface_config = IfaceConfig(dev);

--- a/rust/connlib/libs/tunnel/src/device_channel_unix.rs
+++ b/rust/connlib/libs/tunnel/src/device_channel_unix.rs
@@ -61,7 +61,7 @@ impl DeviceChannel {
 }
 
 pub(crate) async fn create_iface() -> Result<(IfaceConfig, DeviceChannel)> {
-    let dev = Arc::new(IfaceDevice::new("utun").await?.set_non_blocking()?);
+    let dev = Arc::new(IfaceDevice::new().await?.set_non_blocking()?);
     let async_dev = Arc::clone(&dev);
     let device_channel = DeviceChannel(AsyncFd::new(async_dev)?);
     let iface_config = IfaceConfig(dev);

--- a/rust/connlib/libs/tunnel/src/tun_android.rs
+++ b/rust/connlib/libs/tunnel/src/tun_android.rs
@@ -33,7 +33,7 @@ impl IfaceDevice {
         0
     }
 
-    pub async fn new(_name: &str) -> Result<Self> {
+    pub async fn new() -> Result<Self> {
         // TODO: This won't actually work for non-root users...
         let fd = unsafe { open(b"/dev/net/tun\0".as_ptr() as _, O_RDWR) };
         // TODO: everything!

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -130,9 +130,9 @@ impl IfaceDevice {
                 sc_reserved: Default::default(),
             };
 
-            let len: *mut u32 = &mut (size_of::<sockaddr_ctl>() as u32);
+            let mut len = size_of::<sockaddr_ctl>() as u32;
             let ret = unsafe {
-                getpeername(fd, &mut addr as *mut sockaddr_ctl as _, len)
+                getpeername(fd, &mut addr as *mut sockaddr_ctl as _, &mut len as *mut socklen_t)
             };
             if ret != 0 || addr.sc_family != AF_SYSTEM as u8 {
                 continue;

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -1,9 +1,9 @@
 use ip_network::IpNetwork;
 use libc::{
-    close, ctl_info, fcntl, getpeername, getsockopt, ioctl, iovec, msghdr, recvmsg, sendmsg, sockaddr,
-    sockaddr_ctl, sockaddr_in, socket, socklen_t, AF_INET, AF_INET6, AF_SYSTEM,
-    CTLIOCGINFO, F_GETFL, F_SETFL, IF_NAMESIZE, IPPROTO_IP, O_NONBLOCK,
-    SOCK_STREAM, SYSPROTO_CONTROL, UTUN_OPT_IFNAME,
+    close, ctl_info, fcntl, getpeername, getsockopt, ioctl, iovec, msghdr, recvmsg, sendmsg,
+    sockaddr, sockaddr_ctl, sockaddr_in, socket, socklen_t, AF_INET, AF_INET6, AF_SYSTEM,
+    CTLIOCGINFO, F_GETFL, F_SETFL, IF_NAMESIZE, IPPROTO_IP, O_NONBLOCK, SOCK_STREAM,
+    SYSPROTO_CONTROL, UTUN_OPT_IFNAME,
 };
 use libs_common::{CallbackErrorFacade, Callbacks, Error, Result, DNS_SENTINEL};
 use std::{
@@ -131,7 +131,11 @@ impl IfaceDevice {
 
             let mut len = size_of::<sockaddr_ctl>() as u32;
             let ret = unsafe {
-                getpeername(fd, &mut addr as *mut sockaddr_ctl as _, &mut len as *mut socklen_t)
+                getpeername(
+                    fd,
+                    &mut addr as *mut sockaddr_ctl as _,
+                    &mut len as *mut socklen_t,
+                )
             };
             if ret != 0 || addr.sc_family != AF_SYSTEM as u8 {
                 continue;

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -99,11 +99,10 @@ impl IfaceDevice {
     // packets if we want to be allowed in the iOS and macOS App Stores. This has the
     // unfortunate side effect that we're not allowed to create or destroy the tunnel
     // interface ourselves. The file descriptor should already be opened by the NetworkExtension for us
-    // by this point. So instead, we iterate through the 1024 possible file descriptors
-    // looking for the one corresponding to the utun interface we have access to read and
-    // write from.
+    // by this point. So instead, we iterate through all file descriptors looking for the one corresponding
+    // to the utun interface we have access to read and write from.
     //
-    // Inspired heavily by WireGuard's implementation for Apple:
+    // Credit to Jason Donenfeld (@zx2c4) for figuring this out in the WireGuard Apple app:
     // https://github.com/WireGuard/wireguard-apple/blob/master/Sources/WireGuardKit/WireGuardAdapter.swift
     pub async fn new(_: Option<&str>) -> Result<Self> {
         let mut info = ctl_info {

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -1,22 +1,22 @@
 use ip_network::IpNetwork;
 use libc::{
-    close, connect, ctl_info, fcntl, getsockopt, ioctl, iovec, msghdr, recvmsg, sendmsg, sockaddr,
-    sockaddr_ctl, sockaddr_in, socket, socklen_t, AF_INET, AF_INET6, AF_SYSTEM, AF_SYS_CONTROL,
-    CTLIOCGINFO, F_GETFL, F_SETFL, IF_NAMESIZE, IPPROTO_IP, O_NONBLOCK, PF_SYSTEM, SOCK_DGRAM,
+    close, ctl_info, fcntl, getpeername, getsockopt, ioctl, iovec, msghdr, recvmsg, sendmsg, sockaddr,
+    sockaddr_ctl, sockaddr_in, socket, socklen_t, AF_INET, AF_INET6, AF_SYSTEM,
+    CTLIOCGINFO, F_GETFL, F_SETFL, IF_NAMESIZE, IPPROTO_IP, O_NONBLOCK,
     SOCK_STREAM, SYSPROTO_CONTROL, UTUN_OPT_IFNAME,
 };
 use libs_common::{CallbackErrorFacade, Callbacks, Error, Result, DNS_SENTINEL};
 use std::{
     ffi::{c_int, c_short, c_uchar},
     io,
-    mem::{size_of, size_of_val},
+    mem::size_of,
     os::fd::{AsRawFd, RawFd},
     sync::Arc,
 };
 
 use super::InterfaceConfig;
 
-const CTRL_NAME: &[u8] = b"com.apple.net.utun_control";
+const CTL_NAME: &[u8] = b"com.apple.net.utun_control";
 const SIOCGIFMTU: u64 = 0x0000_0000_c020_6933;
 
 #[derive(Debug)]
@@ -65,26 +65,6 @@ union IfrIfru {
     ifru_functional_type: u32,
 }
 
-// On Darwin tunnel can only be named utunXXX
-pub fn parse_utun_name(name: &str) -> Result<u32> {
-    if !name.starts_with("utun") {
-        return Err(Error::InvalidTunnelName);
-    }
-
-    match name.get(4..) {
-        None | Some("") => {
-            // The name is simply "utun"
-            Ok(0)
-        }
-        Some(idx) => {
-            // Everything past utun should represent an integer index
-            idx.parse::<u32>()
-                .map_err(|_| Error::InvalidTunnelName)
-                .map(|x| x + 1)
-        }
-    }
-}
-
 impl IfaceDevice {
     fn write(&self, src: &[u8], af: u8) -> usize {
         let mut hdr = [0, 0, 0, af];
@@ -115,54 +95,64 @@ impl IfaceDevice {
         }
     }
 
-    pub async fn new(name: &str) -> Result<Self> {
-        let idx = parse_utun_name(name)?;
-
-        let fd = match unsafe { socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL) } {
-            -1 => return Err(get_last_error()),
-            fd => fd,
-        };
-
+    // On Apple platforms, we must use a NetworkExtension for reading and writing
+    // packets if we want to be allowed in the iOS and macOS App Stores. This has the
+    // unfortunate side effect that we're not allowed to create or destroy the tunnel
+    // interface ourselves. The file descriptor should already be opened by the NetworkExtension for us
+    // by this point. So instead, we iterate through the 1024 possible file descriptors
+    // looking for the one corresponding to the utun interface we have access to read and
+    // write from.
+    //
+    // Inspired heavily by WireGuard's implementation for Apple:
+    // https://github.com/WireGuard/wireguard-apple/blob/master/Sources/WireGuardKit/WireGuardAdapter.swift
+    pub async fn new() -> Result<Self> {
         let mut info = ctl_info {
             ctl_id: 0,
             ctl_name: [0; 96],
         };
-        info.ctl_name[..CTRL_NAME.len()]
+        info.ctl_name[..CTL_NAME.len()]
             // SAFETY: We only care about maintaining the same byte value not the same value,
             // meaning that the slice &[u8] here is just a blob of bytes for us, we need this conversion
             // just because `c_char` is i8 (for some reason).
             // One thing I don't like about this is that `ctl_name` is actually a nul-terminated string,
             // which we are only getting because `CTRL_NAME` is less than 96 bytes long and we are 0-value
             // initializing the array we should be using a CStr to be explicit... but this is slightly easier.
-            .copy_from_slice(unsafe { &*(CTRL_NAME as *const [u8] as *const [i8]) });
+            .copy_from_slice(unsafe { &*(CTL_NAME as *const [u8] as *const [i8]) });
 
-        if unsafe { ioctl(fd, CTLIOCGINFO, &mut info as *mut ctl_info) } < 0 {
-            unsafe { close(fd) };
-            return Err(get_last_error());
+        for fd in 0..1024 {
+            // initialize empty sockaddr_ctl to be populated by getpeername
+            let mut addr = sockaddr_ctl {
+                sc_len: size_of::<sockaddr_ctl>() as u8,
+                sc_family: 0 as u8,
+                ss_sysaddr: 0 as u16,
+                sc_id: info.ctl_id,
+                sc_unit: 0 as u32,
+                sc_reserved: Default::default(),
+            };
+
+            if unsafe {
+                getpeername(
+                    fd,
+                    &mut addr as *mut sockaddr_ctl as _,
+                    &mut 0u32 as *mut _
+                )
+            } != 0 || addr.sc_family != AF_SYSTEM as u8
+            {
+                continue;
+            }
+
+            if info.ctl_id == 0 {
+                if unsafe { ioctl(fd, CTLIOCGINFO, &mut info as *mut ctl_info) } != 0 {
+                    continue;
+                }
+            }
+
+            if addr.sc_id == info.ctl_id {
+                return Ok(Self { fd })
+            };
         }
 
-        let addr = sockaddr_ctl {
-            sc_len: size_of::<sockaddr_ctl>() as u8,
-            sc_family: AF_SYSTEM as u8,
-            ss_sysaddr: AF_SYS_CONTROL as u16,
-            sc_id: info.ctl_id,
-            sc_unit: idx,
-            sc_reserved: Default::default(),
-        };
-
-        if unsafe {
-            connect(
-                fd,
-                &addr as *const sockaddr_ctl as _,
-                size_of_val(&addr) as _,
-            )
-        } < 0
-        {
-            unsafe { close(fd) };
-            return Err(get_last_error());
-        }
-
-        Ok(Self { fd })
+        return Err(get_last_error());
     }
 
     pub fn set_non_blocking(self) -> Result<Self> {
@@ -261,6 +251,7 @@ impl IfaceDevice {
 }
 
 // So, these functions take a mutable &self, this is not necessary in theory but it's correct!
+/* BEGIN mark-for-removal */
 impl IfaceConfig {
     #[tracing::instrument(level = "trace", skip(self, callbacks))]
     pub async fn set_iface_config(
@@ -284,6 +275,7 @@ impl IfaceConfig {
         Ok(())
     }
 }
+/* END mark-for-removal */
 
 fn get_last_error() -> Error {
     Error::Io(io::Error::last_os_error())

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -95,7 +95,7 @@ impl IfaceDevice {
         }
     }
 
-    pub async fn new(_: Option<&str>) -> Result<Self> {
+    pub async fn new() -> Result<Self> {
         let mut info = ctl_info {
             ctl_id: 0,
             ctl_name: [0; 96],

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -149,7 +149,7 @@ impl IfaceDevice {
             };
         }
 
-        return Err(get_last_error());
+        Err(get_last_error())
     }
 
     pub fn set_non_blocking(self) -> Result<Self> {

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -142,7 +142,9 @@ impl IfaceDevice {
             }
 
             if info.ctl_id == 0 {
-                if unsafe { ioctl(fd, CTLIOCGINFO, &mut info as *mut ctl_info) } != 0 {
+                let ret = unsafe { ioctl(fd, CTLIOCGINFO, &mut info as *mut ctl_info) };
+
+                if ret != 0 {
                     continue;
                 }
             }

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -145,8 +145,8 @@ impl IfaceDevice {
             }
 
             if addr.sc_id == info.ctl_id {
-                return Ok(Self { fd })
-            };
+                return Ok(Self { fd });
+            }
         }
 
         Err(get_last_error())
@@ -248,7 +248,6 @@ impl IfaceDevice {
 }
 
 // So, these functions take a mutable &self, this is not necessary in theory but it's correct!
-/* BEGIN mark-for-removal */
 impl IfaceConfig {
     #[tracing::instrument(level = "trace", skip(self, callbacks))]
     pub async fn set_iface_config(
@@ -268,11 +267,10 @@ impl IfaceConfig {
     }
 
     pub async fn up(&mut self) -> Result<()> {
-        tracing::error!("`up` unimplemented on macOS");
+        tracing::info!("`up` unimplemented on macOS");
         Ok(())
     }
 }
-/* END mark-for-removal */
 
 fn get_last_error() -> Error {
     Error::Io(io::Error::last_os_error())

--- a/rust/connlib/libs/tunnel/src/tun_linux.rs
+++ b/rust/connlib/libs/tunnel/src/tun_linux.rs
@@ -79,6 +79,10 @@ impl IfaceDevice {
     }
 
     pub async fn new() -> Result<IfaceDevice> {
+        let iface_name = IFACE_NAME.as_bytes();
+
+        debug_assert!(iface_name.len() < IFNAMSIZ);
+
         let fd = match unsafe { open(TUN_FILE.as_ptr() as _, O_RDWR) } {
             -1 => return Err(get_last_error()),
             fd => fd,
@@ -91,9 +95,7 @@ impl IfaceDevice {
             },
         };
 
-        debug_assert!(IFACE_NAME.len() < ifr.ifr_name.len());
-
-        ifr.ifr_name[..IFACE_NAME.len()].copy_from_slice(&IFACE_NAME);
+        ifr.ifr_name[..iface_name.len()].copy_from_slice(&iface_name);
 
         if unsafe { ioctl(fd, TUNSETIFF as _, &ifr) } < 0 {
             return Err(get_last_error());

--- a/rust/connlib/libs/tunnel/src/tun_linux.rs
+++ b/rust/connlib/libs/tunnel/src/tun_linux.rs
@@ -19,6 +19,7 @@ use super::InterfaceConfig;
 #[derive(Debug)]
 pub(crate) struct IfaceConfig(pub(crate) Arc<IfaceDevice>);
 
+const IFACE_NAME: String = "tun-firezone".to_string();
 const TUNSETIFF: u64 = 0x4004_54ca;
 const TUN_FILE: &[u8] = b"/dev/net/tun\0";
 const RT_PROT_STATIC: u8 = 4;
@@ -77,13 +78,12 @@ impl IfaceDevice {
         }
     }
 
-    pub async fn new(name: &str) -> Result<IfaceDevice> {
+    pub async fn new() -> Result<IfaceDevice> {
         let fd = match unsafe { open(TUN_FILE.as_ptr() as _, O_RDWR) } {
             -1 => return Err(get_last_error()),
             fd => fd,
         };
 
-        let iface_name = name.as_bytes();
         let mut ifr = ifreq {
             ifr_name: [0; IFNAMSIZ],
             ifr_ifru: IfrIfru {
@@ -91,24 +91,20 @@ impl IfaceDevice {
             },
         };
 
-        if iface_name.len() >= ifr.ifr_name.len() {
-            return Err(Error::InvalidTunnelName);
-        }
+        debug_assert!(IFACE_NAME.len() < ifr.ifr_name.len());
 
-        ifr.ifr_name[..iface_name.len()].copy_from_slice(iface_name);
+        ifr.ifr_name[..IFACE_NAME.len()].copy_from_slice(&IFACE_NAME);
 
         if unsafe { ioctl(fd, TUNSETIFF as _, &ifr) } < 0 {
             return Err(get_last_error());
         }
-
-        let name = name.to_string();
 
         let (connection, handle, _) = new_connection()?;
         let join_handle = tokio::spawn(connection);
         let interface_index = handle
             .link()
             .get()
-            .match_name(name.clone())
+            .match_name(IFACE_NAME.clone())
             .execute()
             .try_next()
             .await?

--- a/swift/apple/FirezoneKit/Package.resolved
+++ b/swift/apple/FirezoneKit/Package.resolved
@@ -55,15 +55,6 @@
       }
     },
     {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log",
-      "state" : {
-        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
-        "version" : "1.5.2"
-      }
-    },
-    {
       "identity" : "swiftui-navigation",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",

--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -30,7 +30,7 @@ class NetworkSettings {
   let tunnelAddressIPv4: String
   let tunnelAddressIPv6: String
   let dnsAddress: String
-    
+
     // In theory we could update the MTU dynamically based on the network environment,
     // but 1280 is guaranteed to work everywhere.
   let tunnelMTU = NSNumber(1280)
@@ -154,7 +154,7 @@ class NetworkSettings {
     }
     tunnelNetworkSettings.dnsSettings = dnsSettings
     tunnelNetworkSettings.mtu = tunnelMTU
-    
+
     self.hasUnappliedChanges = false
     logger.debug("Attempting to set network settings")
     packetTunnelProvider.setTunnelNetworkSettings(tunnelNetworkSettings) { error in

--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -156,6 +156,7 @@ class NetworkSettings {
     tunnelNetworkSettings.mtu = tunnelMTU
     
     self.hasUnappliedChanges = false
+    logger.debug("Attempting to set network settings")
     packetTunnelProvider.setTunnelNetworkSettings(tunnelNetworkSettings) { error in
       if let error = error {
         logger.error("NetworkSettings.apply: Error: \(error, privacy: .public)")

--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -30,6 +30,10 @@ class NetworkSettings {
   let tunnelAddressIPv4: String
   let tunnelAddressIPv6: String
   let dnsAddress: String
+    
+    // In theory we could update the MTU dynamically based on the network environment,
+    // but 1280 is guaranteed to work everywhere.
+  let tunnelMTU = NSNumber(1280)
 
   // Modifiable values
   private(set) var dnsFallbackStrategy: DNSFallbackStrategy
@@ -149,7 +153,8 @@ class NetworkSettings {
         dnsSettings.matchDomains = [""]
     }
     tunnelNetworkSettings.dnsSettings = dnsSettings
-
+    tunnelNetworkSettings.mtu = tunnelMTU
+    
     self.hasUnappliedChanges = false
     packetTunnelProvider.setTunnelNetworkSettings(tunnelNetworkSettings) { error in
       if let error = error {

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -17,17 +17,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   static let logger = Logger(subsystem: "dev.firezone.firezone", category: "packet-tunnel")
 
   private var adapter: Adapter?
-  
-  // Add a first light log to the NetworkExtension
-  override init() {
-    Self.logger.log(level: .debug, "first light")
-    super.init()
-  }
 
   override func startTunnel(
     options _: [String: NSObject]? = nil,
     completionHandler: @escaping (Error?) -> Void
   ) {
+    Self.logger.trace("\(#function)")
     guard let tunnelProviderProtocol = self.protocolConfiguration as? NETunnelProviderProtocol else {
       completionHandler(PacketTunnelProviderError.savedProtocolConfigurationIsInvalid)
       return

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -17,6 +17,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   static let logger = Logger(subsystem: "dev.firezone.firezone", category: "packet-tunnel")
 
   private var adapter: Adapter?
+  
+  // Add a first light log to the NetworkExtension
+  override init() {
+    Self.logger.log(level: .debug, "first light")
+    super.init()
+  }
 
   override func startTunnel(
     options _: [String: NSObject]? = nil,

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -4,37 +4,51 @@ Firezone app clients for macOS and iOS.
 
 ## Pre-requisites
 
-  - Rust
+- Rust
 
 ## Building
 
- 1. Clone this repo:
+1. Clone this repo:
 
-    ```bash
-    git clone https://github.com/firezone/firezone
-    ```
+   ```bash
+   git clone https://github.com/firezone/firezone
+   ```
 
- 2. `cd` to the Apple clients code
+1. `cd` to the Apple clients code
 
-    ```bash
-    cd swift/apple
-    ```
+   ```bash
+   cd swift/apple
+   ```
 
- 3. Rename and populate developer team ID file:
+1. Rename and populate developer team ID file:
 
-    ```bash
-    cp Firezone/xcconfig/Developer.xcconfig.template Firezone/xcconfig/Developer.xcconfig
-    vim Firezone/xcconfig/Developer.xcconfig
-    ```
+   ```bash
+   cp Firezone/xcconfig/Developer.xcconfig.template Firezone/xcconfig/Developer.xcconfig
+   vim Firezone/xcconfig/Developer.xcconfig
+   ```
 
- 4. Open project in Xcode:
+1. Open project in Xcode:
 
-    ```bash
-    open Firezone.xcodeproj
-    ```
+```bash
+open Firezone.xcodeproj
+```
 
-    Build the Firezone target
+Build the Firezone target
 
+## Debugging
+
+[This Network Extension debugging guide](https://developer.apple.com/forums/thread/725805)
+is a great resource to use as a starting point.
+
+### NetworkExtension not loading (macOS)
+
+Try clearing your LaunchAgent db:
+
+```bash
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -delete
+```
+
+**Note**: You MUST reboot after doing this!
 
 ## Cleaning up
 

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -50,7 +50,7 @@ Try clearing your LaunchAgent db:
 
 **Note**: You MUST reboot after doing this!
 
-### Outdated version of NetworkExtension not loading
+### Outdated version of NetworkExtension loading
 
 If you're making changes to the Network Extension and it doesn't seem to be
 reflected when you run/debug, it could be that PluginKit is still launching your

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -50,7 +50,33 @@ Try clearing your LaunchAgent db:
 
 **Note**: You MUST reboot after doing this!
 
+### Outdated version of NetworkExtension not loading
+
+If you're making changes to the Network Extension and it doesn't seem to be
+reflected when you run/debug, it could be that PluginKit is still launching your
+old NetworkExtension. Try this to remove it:
+
+```bash
+pluginkit -v -m -D -i <bundle-id>
+pluginkit -a <path>
+pluginkit -r <path>
+```
+
 ## Cleaning up
+
+Occasionally you might encounter strange issues where it seems like the artifacts
+being debugged don't match the code, among other things. In these cases it's good
+to clean up using one of the methods below.
+
+### Resetting Xcode package cache
+
+Removes cached packages, built extensions, etc.
+
+```bash
+rm -rf ~/Library/Developer/Xcode/Derived\ Data
+```
+
+### Removing build artifacts
 
 To cleanup Swift build objects:
 


### PR DESCRIPTION
This PR adds the remaining bits of the Apple tunnel stack for macOS and iOS devices.

- [x] Find file descriptor corresponding to NE-managed tunnel interface
- [ ] Testing