### PR TITLE
connlib: update the url scheme for http/https

### DIFF
--- a/rust/connlib/libs/common/src/error.rs
+++ b/rust/connlib/libs/common/src/error.rs
@@ -27,6 +27,9 @@ pub enum ConnlibError {
     /// Provided string was not formatted as a URL.
     #[error("Badly formatted URI")]
     UriError,
+    /// Provided an unsupported uri string.
+    #[error("Unsupported URI scheme: Must be http://, https://, ws:// or wss://")]
+    UriScheme,
     /// Serde's serialize error.
     #[error(transparent)]
     SerializeError(#[from] serde_json::Error),

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -415,6 +415,19 @@ where
     }
 }
 
+fn set_ws_scheme(url: &mut Url) -> Result<()> {
+    let scheme = match url.scheme() {
+        "http" => "ws",
+        "https" => "wss",
+        "ws" => "ws",
+        "wss" => "wss",
+        _ => return Err(Error::UriScheme),
+    };
+    url.set_scheme(scheme)
+        .expect("Developer error: the match before this should make sure we can set this");
+    Ok(())
+}
+
 fn get_websocket_path(
     mut url: Url,
     secret: String,
@@ -423,6 +436,8 @@ fn get_websocket_path(
     external_id: &str,
     name_suffix: &str,
 ) -> Result<Url> {
+    set_ws_scheme(&mut url)?;
+
     {
         let mut paths = url.path_segments_mut().map_err(|_| Error::UriError)?;
         paths.pop_if_empty();

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -417,10 +417,8 @@ where
 
 fn set_ws_scheme(url: &mut Url) -> Result<()> {
     let scheme = match url.scheme() {
-        "http" => "ws",
-        "https" => "wss",
-        "ws" => "ws",
-        "wss" => "wss",
+        "http" | "ws" => "ws",
+        "https" | "wss" => "wss",
         _ => return Err(Error::UriScheme),
     };
     url.set_scheme(scheme)


### PR DESCRIPTION
This just updates the portal's url scheme based on what we discussed with @jamilbk 