### PR TITLE
apple: Separate auth URL and control plane URL

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -58,4 +58,5 @@ jobs:
         working-directory: ./swift/apple
         run: |
           cp Firezone/xcconfig/Developer.xcconfig.ci-${{ matrix.target.platform }} Firezone/xcconfig/Developer.xcconfig
+          cp Firezone/xcconfig/Server.xcconfig.ci Firezone/xcconfig/Server.xcconfig
           xcodebuild archive -configuration Release -scheme Firezone -sdk ${{ matrix.target.sdk }} -destination '${{ matrix.target.destination }}' CODE_SIGNING_ALLOWED=NO

--- a/swift/apple/Firezone/Info.plist
+++ b/swift/apple/Firezone/Info.plist
@@ -15,5 +15,13 @@
 			</array>
 		</dict>
 	</array>
+	<key>AuthURLScheme</key>
+	<string>$(AUTH_URL_SCHEME)</string>
+	<key>AuthURLHost</key>
+	<string>$(AUTH_URL_HOST)</string>
+	<key>ControlPlaneURLScheme</key>
+	<string>$(CONTROL_PLANE_URL_SCHEME)</string>
+	<key>ControlPlaneURLHost</key>
+	<string>$(CONTROL_PLANE_URL_HOST)</string>
 </dict>
 </plist>

--- a/swift/apple/Firezone/xcconfig/AllConfigs.xcconfig
+++ b/swift/apple/Firezone/xcconfig/AllConfigs.xcconfig
@@ -1,2 +1,3 @@
 #include "Developer.xcconfig"
+#include "Server.xcconfig"
 #include "Build.xcconfig"

--- a/swift/apple/Firezone/xcconfig/Server.xcconfig.ci
+++ b/swift/apple/Firezone/xcconfig/Server.xcconfig.ci
@@ -1,0 +1,9 @@
+// Configure the Authentication URL and the Control Plane URL
+
+
+// For staging:
+
+AUTH_URL_SCHEME = https
+AUTH_URL_HOST = app.firez.one
+CONTROL_PLANE_URL_SCHEME = wss
+CONTROL_PLANE_URL_HOST = api.firez.one

--- a/swift/apple/Firezone/xcconfig/Server.xcconfig.template
+++ b/swift/apple/Firezone/xcconfig/Server.xcconfig.template
@@ -1,0 +1,25 @@
+// Configure the Authentication URL and the Control Plane URL
+
+
+// For development:
+
+// AUTH_URL_SCHEME = http
+// AUTH_URL_HOST = localhost:8080
+// CONTROL_PLANE_URL_SCHEME = ws
+// CONTROL_PLANE_URL_HOST = localhost:8081
+
+
+// For staging:
+
+// AUTH_URL_SCHEME = https
+// AUTH_URL_HOST = app.firez.one
+// CONTROL_PLANE_URL_SCHEME = wss
+// CONTROL_PLANE_URL_HOST = api.firez.one
+
+
+// For production:
+
+// AUTH_URL_SCHEME = https
+// AUTH_URL_HOST = app.firezone.dev
+// CONTROL_PLANE_URL_SCHEME = wss
+// CONTROL_PLANE_URL_HOST = api.firezone.dev

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AuthView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AuthView.swift
@@ -20,13 +20,13 @@ final class AuthViewModel: ObservableObject {
   private var cancellables = Set<AnyCancellable>()
 
   func signInButtonTapped() async {
-    guard let portalURL = settingsClient.fetchSettings()?.portalURL else {
+    guard let teamId = settingsClient.fetchSettings()?.teamId else {
       settingsUndefined()
       return
     }
 
     do {
-      try await authStore.signIn(portalURL: portalURL)
+      try await authStore.signIn(teamId: teamId)
     } catch {
       dump(error)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AuthView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AuthView.swift
@@ -20,7 +20,7 @@ final class AuthViewModel: ObservableObject {
   private var cancellables = Set<AnyCancellable>()
 
   func signInButtonTapped() async {
-    guard let teamId = settingsClient.fetchSettings()?.teamId else {
+    guard let teamId = settingsClient.fetchSettings()?.teamId, !teamId.isEmpty else {
       settingsUndefined()
       return
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
@@ -43,7 +43,8 @@ final class MainViewModel: ObservableObject {
         try await appStore.tunnel.start(authResponse: authResponse)
       }
     } catch {
-      logger.error("Error starting tunnel: \(String(describing: error))")
+      logger.error("Error starting tunnel: \(String(describing: error)) -- signing out")
+      appStore.auth.signOut()
     }
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
@@ -18,6 +18,10 @@ public final class SettingsViewModel: ObservableObject {
   public init() {
     settings = Settings()
 
+    load()
+  }
+
+  func load() {
     if let storedSettings = settingsClient.fetchSettings() {
       settings = storedSettings
     }
@@ -64,7 +68,18 @@ public struct SettingsView: View {
 
   #if os(macOS)
     private var mac: some View {
-      form
+      VStack(spacing: 50) {
+        form
+        HStack(spacing: 30) {
+          Button("Cancel", action: {
+            self.cancelButtonTapped()
+          })
+          Button("Save", action: {
+            self.saveButtonTapped()
+          })
+          .disabled(!isTeamIdValid(model.settings.teamId))
+        }
+      }
     }
   #endif
 
@@ -82,15 +97,9 @@ public struct SettingsView: View {
         )
       }
     }
-    .navigationTitle("Settings")
+    .navigationTitle("Settings - Firezone")
     .toolbar {
       ToolbarItem(placement: .primaryAction) {
-        #if os(macOS)
-        Button("Done") {
-          self.doneButtonTapped()
-        }
-        .disabled(!isTeamIdValid(model.settings.teamId))
-        #endif
       }
     }
   }
@@ -99,8 +108,13 @@ public struct SettingsView: View {
     !teamId.isEmpty && teamId.unicodeScalars.allSatisfy { teamIdAllowedCharacterSet.contains($0) }
   }
 
-  func doneButtonTapped() {
+  func saveButtonTapped() {
     model.save()
+    dismiss()
+  }
+
+  func cancelButtonTapped() {
+    model.load()
     dismiss()
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
@@ -16,7 +16,7 @@ public final class SettingsViewModel: ObservableObject {
   public var onSettingsSaved: () -> Void = unimplemented()
 
   public init() {
-    settings = Settings(portalURL: nil)
+    settings = Settings()
 
     if let storedSettings = settingsClient.fetchSettings() {
       settings = storedSettings
@@ -65,11 +65,12 @@ public struct SettingsView: View {
     Form {
       Section {
         FormTextField(
-          title: "Portal URL",
-          placeholder: "http://localhost:4567",
+          title: "Team URL:",
+          baseURLString: AuthStore.getAuthBaseURLFromInfoPlist().absoluteString,
+          placeholder: "team-id",
           text: Binding(
-            get: { model.settings.portalURL?.absoluteString ?? "" },
-            set: { model.settings.portalURL = URL(string: $0) }
+            get: { model.settings.teamId },
+            set: { model.settings.teamId = $0 }
           )
         )
       }
@@ -94,6 +95,7 @@ public struct SettingsView: View {
 
 struct FormTextField: View {
   let title: String
+  let baseURLString: String
   let placeholder: String
   let text: Binding<String>
 
@@ -113,14 +115,19 @@ struct FormTextField: View {
       }
     #else
     HStack(spacing: 30) {
-        Spacer()
-        TextField(title, text: text, prompt: Text(placeholder))
+      Spacer()
+      VStack(alignment: .leading) {
+        Label(title, image: "")
+          .labelStyle(.titleOnly)
+          .multilineTextAlignment(.leading)
+        TextField(baseURLString, text: text, prompt: Text(placeholder))
           .autocorrectionDisabled()
-          .multilineTextAlignment(.trailing)
+          .multilineTextAlignment(.leading)
           .foregroundColor(.secondary)
           .frame(maxWidth: 360)
-        Spacer()
       }
+      Spacer()
+    }
     #endif
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
@@ -33,8 +33,15 @@ public struct SettingsView: View {
   @ObservedObject var model: SettingsViewModel
   @Environment(\.dismiss) var dismiss
 
+  let teamIdAllowedCharacterSet: CharacterSet
+
   public init(model: SettingsViewModel) {
     self.model = model
+    self.teamIdAllowedCharacterSet = {
+      var pathAllowed = CharacterSet.urlPathAllowed
+      pathAllowed.remove("/")
+      return pathAllowed
+    }()
   }
 
   public var body: some View {
@@ -82,9 +89,14 @@ public struct SettingsView: View {
         Button("Done") {
           self.doneButtonTapped()
         }
+        .disabled(!isTeamIdValid(model.settings.teamId))
         #endif
       }
     }
+  }
+
+  private func isTeamIdValid(_ teamId: String) -> Bool {
+    !teamId.isEmpty && teamId.unicodeScalars.allSatisfy { teamIdAllowedCharacterSet.contains($0) }
   }
 
   func doneButtonTapped() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
@@ -55,7 +55,7 @@ final class WelcomeViewModel: ObservableObject {
 
     defer { bindDestination() }
 
-    if settingsClient.fetchSettings()?.portalURL == nil {
+    if settingsClient.fetchSettings()?.teamId == nil {
       destination = .undefinedSettingsAlert(.undefinedSettings)
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneError.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneError.swift
@@ -7,5 +7,5 @@
 import Foundation
 
 enum FirezoneError: Error {
-  case missingPortalURL
+  case missingTeamId
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/SettingsClient/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/SettingsClient/Settings.swift
@@ -7,5 +7,5 @@
 import Foundation
 
 struct Settings: Codable, Hashable {
-  var portalURL: URL?
+  var teamId: String = ""
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
@@ -46,7 +46,8 @@ final class AppStore: ObservableObject {
       do {
         try await tunnel.start(authResponse: authResponse)
       } catch {
-        logger.error("Error starting tunnel: \(String(describing: error))")
+        logger.error("Error starting tunnel: \(String(describing: error)) -- signing out")
+        auth.signOut()
       }
     } else {
       tunnel.stop()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -87,7 +87,7 @@ final class AuthStore: ObservableObject {
   func signIn() async throws {
     logger.trace("\(#function)")
 
-    guard let teamId = settingsClient.fetchSettings()?.teamId else {
+    guard let teamId = settingsClient.fetchSettings()?.teamId, !teamId.isEmpty else {
       logger.debug("No team-id found in settings")
       throw FirezoneError.missingTeamId
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -223,7 +223,7 @@ public final class MenuBar: NSObject {
       Task {
         do {
           try await appStore?.auth.signIn()
-        } catch FirezoneError.missingPortalURL {
+        } catch FirezoneError.missingTeamId {
           openSettingsWindow()
         } catch {
           logger.error("Error signing in: \(String(describing: error))")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -212,7 +212,8 @@ public final class MenuBar: NSObject {
             do {
               try await appStore?.tunnel.start(authResponse: authResponse)
             } catch {
-              logger.error("error connecting to tunnel: \(String(describing: error))")
+              logger.error("error connecting to tunnel: \(String(describing: error)) -- signing out")
+              appStore?.auth.signOut()
             }
           }
         }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -82,11 +82,11 @@ public class Adapter {
   private var displayableResources = DisplayableResources()
 
   /// Starting parameters
-  private var portalURLString: String
+  private var controlPlaneURLString: String
   private var token: String
 
-  public init(portalURLString: String, token: String, packetTunnelProvider: NEPacketTunnelProvider) {
-    self.portalURLString = portalURLString
+  public init(controlPlaneURLString: String, token: String, packetTunnelProvider: NEPacketTunnelProvider) {
+    self.controlPlaneURLString = controlPlaneURLString
     self.token = token
     self.packetTunnelProvider = packetTunnelProvider
     self.callbackHandler = CallbackHandler()
@@ -123,7 +123,7 @@ public class Adapter {
       self.logger.debug("Adapter.start: Starting connlib")
       do {
         self.state = .startingTunnel(
-          session: try WrappedSession.connect(self.portalURLString, self.token, self.callbackHandler),
+          session: try WrappedSession.connect(self.controlPlaneURLString, self.token, self.callbackHandler),
           onStarted: completionHandler
         )
       } catch let error {
@@ -238,7 +238,7 @@ extension Adapter {
 
         do {
           self.state = .startingTunnel(
-            session: try WrappedSession.connect(portalURLString, token, self.callbackHandler),
+            session: try WrappedSession.connect(controlPlaneURLString, token, self.callbackHandler),
             onStarted: { error in
               if let error = error {
                 self.logger.error("Adapter.didReceivePathUpdate: Error starting connlib: \(error, privacy: .public)")

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -29,7 +29,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     let providerConfiguration = tunnelProviderProtocol.providerConfiguration
-    guard let portalURLString = providerConfiguration?["portalURL"] as? String else {
+    guard let controlPlaneURLString = providerConfiguration?["controlPlaneURL"] as? String else {
       completionHandler(PacketTunnelProviderError.savedProtocolConfigurationIsInvalid)
       return
     }
@@ -37,7 +37,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       completionHandler(PacketTunnelProviderError.savedProtocolConfigurationIsInvalid)
       return
     }
-    let adapter = Adapter(portalURLString: portalURLString, token: token, packetTunnelProvider: self)
+    let adapter = Adapter(controlPlaneURLString: controlPlaneURLString, token: token, packetTunnelProvider: self)
     self.adapter = adapter
     do {
       try adapter.start() { error in

--- a/swift/apple/PortalMock/server.rb
+++ b/swift/apple/PortalMock/server.rb
@@ -13,5 +13,5 @@ end
 
 get '/redirect' do
   client_auth_token = File.read('./data/client_auth_token').strip
-  redirect "firezone://handle_client_auth_callback?client_auth_token=#{client_auth_token}"
+  redirect "firezone://handle_client_auth_callback?client_auth_token=#{client_auth_token}&actor_name=Foo+Bar"
 end

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -20,11 +20,16 @@ Firezone app clients for macOS and iOS.
    cd swift/apple
    ```
 
-1. Rename and populate developer team ID file:
+1. Rename and populate xcconfig files:
 
    ```bash
    cp Firezone/xcconfig/Developer.xcconfig.template Firezone/xcconfig/Developer.xcconfig
    vim Firezone/xcconfig/Developer.xcconfig
+   ```
+
+   ```bash
+   cp Firezone/xcconfig/Server.xcconfig.template Firezone/xcconfig/Server.xcconfig
+   vim Firezone/xcconfig/Server.xcconfig
    ```
 
 1. Open project in Xcode:


### PR DESCRIPTION
Auth base URL and Control Plane URL are configurable in a new Server.xcconfig (so that we can have Server_Dev.xcconfig, Server_Staging.xcconfig, and Server_Prod.xcconfig and switch between them by copying / symbolic linking).

App's Settings View takes in Team ID instead of a URL. App forms auth URL from Auth base URL from Server.xcconfig and the Team ID in settings. Tunnel passes control plane URL from Server.xcconfig to connlib.

~~Marked as draft because this PR depends on #1881.~~ #1881 has been merged.
