### PR TITLE
Use public Logger from FirezoneKit

### DIFF
--- a/rust/connlib/clients/apple/Sources/Connlib/CallbackHandler.swift
+++ b/rust/connlib/clients/apple/Sources/Connlib/CallbackHandler.swift
@@ -3,7 +3,7 @@
 //
 
 import NetworkExtension
-import os.log
+import OSLog
 
 // When the FFI changes from the Rust side, change the CallbackHandler
 // functions along with that, but not the delegate protocol.
@@ -27,7 +27,7 @@ public protocol CallbackHandlerDelegate: AnyObject {
 
 public class CallbackHandler {
   public weak var delegate: CallbackHandlerDelegate?
-  private let logger = Logger(subsystem: "dev.firezone.firezone", category: "callbackhandler")
+  private let logger = Logger.make(for: CallbackHandler.self)
 
   func onSetInterfaceConfig(tunnelAddressIPv4: RustString, tunnelAddressIPv6: RustString, dnsAddress: RustString) {
     logger.debug("CallbackHandler.onSetInterfaceConfig: IPv4: \(tunnelAddressIPv4.toString(), privacy: .public), IPv6: \(tunnelAddressIPv6.toString(), privacy: .public), DNS: \(dnsAddress.toString(), privacy: .public)")

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -136,8 +136,8 @@ impl Callbacks for CallbackHandler {
 fn init_logging() {
     use tracing_subscriber::layer::SubscriberExt as _;
     let collector = tracing_subscriber::registry().with(tracing_oslog::OsLogger::new(
-        "dev.firezone.connlib",
-        "default",
+        "dev.firezone.firezone",
+        "connlib",
     ));
     // This will fail if called more than once, but that doesn't really matter.
     if tracing::subscriber::set_global_default(collector).is_ok() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Logger.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Logger.swift
@@ -8,7 +8,7 @@ import Dependencies
 import Foundation
 import OSLog
 
-extension Logger {
+public extension Logger {
   static func make(for type: (some Any).Type) -> Logger {
     make(category: String(describing: type))
   }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -6,7 +6,7 @@
 import Foundation
 import NetworkExtension
 import FirezoneKit
-import os.log
+import OSLog
 
 public enum AdapterError: Error {
   /// Failure to perform an operation in such state.
@@ -55,7 +55,7 @@ public class Adapter {
   typealias StartTunnelCompletionHandler = ((AdapterError?) -> Void)
   typealias StopTunnelCompletionHandler = (() -> Void)
 
-  private let logger = Logger(subsystem: "dev.firezone.firezone", category: "packet-tunnel")
+  private let logger = Logger.make(category: "packet-tunnel")
 
   private var callbackHandler: CallbackHandler
 


### PR DESCRIPTION
Enables the NetworkExtension to use the Logger helpers so that its bundle id is used for the logging subsystem