### PR TITLE
Gabi/fix relay expected message size

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,6 +70,6 @@ jobs:
       # This rule forces to use the relay between client and gateway.
       #
       - name: Disallow traffic between gateway and client container
-        run: iptables -I FORWARD 1 -s  172.28.0.100 -d 172.28.0.105 -j DROP && iptables -I FORWARD 1 -s  172.28.0.105 -d 172.28.0.100 -j DROP
+        run: sudo iptables -I FORWARD 1 -s  172.28.0.100 -d 172.28.0.105 -j DROP && iptables -I FORWARD 1 -s  172.28.0.105 -d 172.28.0.100 -j DROP
       - name: Test that client can ping resource
         run: docker compose exec -it client ping 172.20.0.100 -c 20

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,6 +70,8 @@ jobs:
       # This rule forces to use the relay between client and gateway.
       #
       - name: Disallow traffic between gateway and client container
-        run: sudo iptables -I FORWARD 1 -s  172.28.0.100 -d 172.28.0.105 -j DROP && iptables -I FORWARD 1 -s  172.28.0.105 -d 172.28.0.100 -j DROP
+        run: |
+          sudo iptables -I FORWARD 1 -s  172.28.0.100 -d 172.28.0.105 -j DROP
+          sudo iptables -I FORWARD 1 -s  172.28.0.105 -d 172.28.0.100 -j DROP
       - name: Test that client can ping resource
         run: docker compose exec -it client ping 172.20.0.100 -c 20

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,6 +23,12 @@ jobs:
             api.cache-to=scope=api,type=gha,mode=max
             web.cache-from=scope=web,type=gha
             web.cache-to=scope=web,type=gha,mode=max
+            client.cache-from=scope=rust,type=gha
+            client.cache-to=scope=rust,type=gha,mode=max
+            gateway.cache-from=scope=rust,type=gha
+            gateway.cache-to=scope=rust,type=gha,mode=max
+            relay.cache-from=scope=rust,type=gha
+            relay.cache-to=scope=rust,type=gha,mode=max
           files: docker-compose.yml
           push: false
       - name: Seed database
@@ -30,12 +36,40 @@ jobs:
       - name: Start docker compose in the background
         run: docker compose up -d
       - name: Test that client can ping resource
-        # FIXME: When the client sends the first packet trying to connect but there's no relay
-        # the portal responds with that and we don't try to continue the flow until we receive a success
-        # response with all the relays, thus we just sleep here waiting for the relay to have its presence tracked
-        # by the portal.
-        # The fix next will be:
-        # * If the relay list comes back as an error, retry a few times
-        # * If the it still comes as an error try a direct connection(local network)
-        # Right now this is working because we wait for the relay to be up and running before starting the client
+        run: docker compose exec -it client ping 172.20.0.100 -c 20
+
+  integration-test_relayed-flow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build images
+        uses: docker/bake-action@v3.1.0
+        with:
+          set: |
+            elixir.cache-from=scope=elixir,type=gha
+            elixir.cache-to=scope=elixir,type=gha,mode=max
+            api.cache-from=scope=api,type=gha
+            api.cache-to=scope=api,type=gha,mode=max
+            web.cache-from=scope=web,type=gha
+            web.cache-to=scope=web,type=gha,mode=max
+            client.cache-from=scope=rust,type=gha
+            client.cache-to=scope=rust,type=gha,mode=max
+            gateway.cache-from=scope=rust,type=gha
+            gateway.cache-to=scope=rust,type=gha,mode=max
+            relay.cache-from=scope=rust,type=gha
+            relay.cache-to=scope=rust,type=gha,mode=max
+          files: docker-compose.yml
+          push: false
+      - name: Seed database
+        run: docker compose run elixir /bin/sh -c "cd apps/domain && mix ecto.seed"
+      - name: Start docker compose in the background
+        run: docker compose up -d
+      # This rule forces to use the relay between client and gateway.
+      #
+      - name: Disallow traffic between gateway and client container
+        run: iptables -I FORWARD 1 -s  172.28.0.100 -d 172.28.0.105 -j DROP && iptables -I FORWARD 1 -s  172.28.0.105 -d 172.28.0.100 -j DROP
+      - name: Test that client can ping resource
         run: docker compose exec -it client ping 172.20.0.100 -c 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,8 +166,9 @@ services:
       api:
         condition: 'service_healthy'
     networks:
-      - app
-      - resources
+      app:
+        ipv4_address: 172.28.0.105
+      resources:
 
   resource:
     image: alpine:3.18
@@ -204,7 +205,6 @@ services:
     networks:
       app:
         ipv4_address: 172.28.0.101
-        ipv6_address: 2001:3990:3990::101
 
   api:
     build:
@@ -347,11 +347,10 @@ networks:
       config:
         - subnet: 172.20.0.0/16
   app:
-    enable_ipv6: true
+    enable_ipv6: false
     ipam:
       config:
         - subnet: 172.28.0.0/16
-        - subnet: 2001:3990:3990::/64
 
 volumes:
   postgres-data:

--- a/rust/relay/src/proptest.rs
+++ b/rust/relay/src/proptest.rs
@@ -1,5 +1,6 @@
 use crate::Binding;
 use proptest::arbitrary::any;
+use proptest::collection::vec;
 use proptest::strategy::Just;
 use proptest::strategy::Strategy;
 use proptest::string::string_regex;
@@ -27,6 +28,13 @@ pub fn allocation_lifetime() -> impl Strategy<Value = Lifetime> {
 
 pub fn channel_number() -> impl Strategy<Value = ChannelNumber> {
     (ChannelNumber::MIN..ChannelNumber::MAX).prop_map(|n| ChannelNumber::new(n).unwrap())
+}
+
+pub fn channel_payload() -> impl Strategy<Value = (Vec<u8>, usize)> {
+    vec(any::<u8>(), 0..(u16::MAX as usize)).prop_flat_map(|vec| {
+        let len = vec.len();
+        (Just(vec), 0..len)
+    })
 }
 
 pub fn username_salt() -> impl Strategy<Value = String> {

--- a/rust/relay/src/server/channel_data.rs
+++ b/rust/relay/src/server/channel_data.rs
@@ -25,10 +25,11 @@ impl<'a> ChannelData<'a> {
         }
 
         let length = u16::from_be_bytes([data[2], data[3]]);
+        let full_msg_length = 4usize + length as usize;
 
         let actual_payload_length = data.len() - 4;
 
-        if actual_payload_length != length as usize {
+        if data.len() < full_msg_length {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
@@ -39,7 +40,7 @@ impl<'a> ChannelData<'a> {
 
         Ok(ChannelData {
             channel: channel_number,
-            data: &data[4..],
+            data: &data[4..full_msg_length],
         })
     }
 

--- a/rust/relay/src/server/channel_data.rs
+++ b/rust/relay/src/server/channel_data.rs
@@ -33,7 +33,7 @@ impl<'a> ChannelData<'a> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "channel data message specified {length} bytes but got {actual_payload_length}"
+                    "channel data message specified {length} bytes but the payload is only {actual_payload_length} bytes"
                 ),
             ));
         }


### PR DESCRIPTION
This PR should fix the way we handle the `length` field in the `DataChannel` messages, previous to this fix relaying data (using the `webrtc-rs` crate) was impossible)

The new way to handle this is if the actual message is bigger than what this data field says we ignore the extra bytes (which I think is the correct way to do it according to spec)

Also, I added an integration test to verify relay messages using `iptables`, not the cleanest way to do it but the easiest, in this vein I tried to fix the caching for rust containers since 2 integration test in our current state would take ~20 minutes each.