### PR TITLE
Revert "Apple: Add support for magic links"

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -21,9 +21,6 @@ struct FirezoneApp: App {
     #if os(iOS)
       WindowGroup {
         AppView(model: model)
-          .onOpenURL { url in
-            model.appStore?.continueSignIn(appOpenedWithURL: url)
-          }
       }
     #else
       WindowGroup("Settings") {
@@ -46,12 +43,6 @@ struct FirezoneApp: App {
       // SwiftUI will show the first window group, so close it on launch
       let window = NSApp.windows[0]
       window.close()
-    }
-
-    func application(_: NSApplication, open urls: [URL]) {
-      if let openedWithURL = urls.first {
-        menuBar.appStore?.continueSignIn(appOpenedWithURL: openedWithURL)
-      }
     }
 
     func applicationWillTerminate(_: Notification) {}

--- a/swift/apple/Firezone/Info.plist
+++ b/swift/apple/Firezone/Info.plist
@@ -12,7 +12,6 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>firezone</string>
-				<string>firezone-fd0020211111</string>
 			</array>
 		</dict>
 	</array>

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AppView.swift
@@ -14,10 +14,6 @@ import SwiftUINavigation
 public final class AppViewModel: ObservableObject {
   @Published var welcomeViewModel: WelcomeViewModel?
 
-  public var appStore: AppStore? {
-    welcomeViewModel?.appStore
-  }
-
   public init() {
     Task {
       let tunnel = try await TunnelStore.loadOrCreate()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
@@ -43,7 +43,7 @@ final class WelcomeViewModel: ObservableObject {
     }
   }
 
-  public let appStore: AppStore
+  private let appStore: AppStore
 
   init(appStore: AppStore) {
     self.appStore = appStore

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthResponse.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthResponse.swift
@@ -16,7 +16,7 @@ struct AuthResponse {
   // The opaque auth token
   let token: String
 
-  init(portalURL: URL, token: String, actorName: String?) {
+  init(portalURL: URL, token: String, actorName: String?) throws {
     self.portalURL = portalURL
     self.actorName = actorName
     self.token = token
@@ -26,14 +26,14 @@ struct AuthResponse {
 #if DEBUG
   extension AuthResponse {
     static let invalid =
-      AuthResponse(
+      try! AuthResponse(
         portalURL: URL(string: "http://localhost:4568")!,
         token: "",
         actorName: nil
       )
 
     static let valid =
-      AuthResponse(
+      try! AuthResponse(
         portalURL: URL(string: "http://localhost:4568")!,
         token: "b1zwwwAdf=",
         actorName: "foobar"

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
@@ -9,7 +9,7 @@ import Dependencies
 import OSLog
 
 @MainActor
-public final class AppStore: ObservableObject {
+final class AppStore: ObservableObject {
   private let logger = Logger.make(for: AppStore.self)
 
   @Dependency(\.authStore) var auth
@@ -57,13 +57,5 @@ public final class AppStore: ObservableObject {
   private func signOutAndStopTunnel() {
     tunnel.stop()
     auth.signOut()
-  }
-
-  public func continueSignIn(appOpenedWithURL: URL) {
-    do {
-      try auth.continueSignIn(appOpenedWithURL: appOpenedWithURL)
-    } catch {
-      logger.error("Error continuing auth: \(String(describing: error))")
-    }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -84,11 +84,6 @@ final class AuthStore: ObservableObject {
     self.authResponse = authResponse
   }
 
-  func continueSignIn(appOpenedWithURL: URL) throws {
-    let authResponse = try auth.continueSignIn(appOpenedWithURL)
-    self.authResponse = authResponse
-  }
-
   func signIn() async throws {
     logger.trace("\(#function)")
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -17,7 +17,7 @@ public final class MenuBar: NSObject {
     let logger = Logger.make(for: MenuBar.self)
     @Dependency(\.mainQueue) private var mainQueue
 
-    public private(set) var appStore: AppStore? {
+    private var appStore: AppStore? {
       didSet {
         setupObservers()
       }

--- a/swift/apple/PortalMock/server.rb
+++ b/swift/apple/PortalMock/server.rb
@@ -7,19 +7,11 @@ set :bind, '0.0.0.0'
 set :port, 4568
 
 get '/:slug/sign_in' do
-  client_csrf_token = params['client_csrf_token']
-  ERB.new("<h1>Auth page</h1><p><a href=\"/redirect\">Proceed</a></p><p><a href=\"/#{client_csrf_token}/magiclink\">Magic Link (Copy link and open in External Browser)</a></p>")
+  ERB.new("<h1>Auth page</h1><a href=\"/redirect\">Proceed</a>")
      .result(binding)
 end
 
 get '/redirect' do
   client_auth_token = File.read('./data/client_auth_token').strip
   redirect "firezone://handle_client_auth_callback?client_auth_token=#{client_auth_token}&actor_name=Foo+Bar"
-end
-
-get '/:client_csrf_token/magiclink' do
-  client_csrf_token = params[:client_csrf_token]
-  client_auth_token = File.read('./data/client_auth_token').strip
-  ERB.new("<h1>Magic Link Page</h1><p><a href=\"firezone-fd0020211111://handle_client_auth_callback?client_auth_token=#{client_auth_token}&actor_name=Foo+Bar&client_csrf_token=#{client_csrf_token}\">Open Firezone App</a></p></p>")
-     .result(binding)
 end


### PR DESCRIPTION
Reverts firezone/firezone#1909

As discussed [in this thread](https://firezonehq.slack.com/archives/C04HRQTFY0Z/p1691797780786319), I didn't catch that this PR would introduce a potential token-stealing vulnerability into the application.

Magic link auth flow will be fixed in #1912 