### PR TITLE
Read client_platform and client_csrf_token from params

### DIFF
--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -20,30 +20,33 @@ defmodule Web.FormComponents do
       <.input field={@form[:email]} type="email" />
       <.input name="my-input" errors={["oh no!"]} />
   """
-  attr :id, :any, default: nil
-  attr :name, :any
-  attr :label, :string, default: nil
-  attr :value, :any
+  attr(:id, :any, default: nil)
+  attr(:name, :any)
+  attr(:label, :string, default: nil)
+  attr(:value, :any)
 
-  attr :type, :string,
+  attr(:type, :string,
     default: "text",
     values: ~w(checkbox color date datetime-local email file hidden month number password
                range radio search select tel text textarea taglist time url week)
+  )
 
-  attr :field, Phoenix.HTML.FormField,
+  attr(:field, Phoenix.HTML.FormField,
     doc: "a form field struct retrieved from the form, for example: @form[:email]"
+  )
 
-  attr :errors, :list, default: []
-  attr :checked, :boolean, doc: "the checked flag for checkbox and radio inputs"
-  attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
-  attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
-  attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
+  attr(:errors, :list, default: [])
+  attr(:checked, :boolean, doc: "the checked flag for checkbox and radio inputs")
+  attr(:prompt, :string, default: nil, doc: "the prompt for select inputs")
+  attr(:options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2")
+  attr(:multiple, :boolean, default: false, doc: "the multiple flag for select inputs")
 
-  attr :rest, :global,
+  attr(:rest, :global,
     include: ~w(autocomplete cols disabled form list max maxlength min minlength
                 pattern placeholder readonly required rows size step)
+  )
 
-  slot :inner_block
+  slot(:inner_block)
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns
@@ -211,10 +214,10 @@ defmodule Web.FormComponents do
     """
   end
 
-  attr :name, :any
-  attr :value, :any
-  attr :checked, :boolean
-  attr :rest, :global
+  attr(:name, :any)
+  attr(:value, :any)
+  attr(:checked, :boolean)
+  attr(:rest, :global)
 
   def checkbox(assigns) do
     ~H"""
@@ -234,9 +237,9 @@ defmodule Web.FormComponents do
   @doc """
   Render a button group.
   """
-  slot :first, required: true, doc: "First button"
-  slot :middle, required: false, doc: "Middle button(s)"
-  slot :last, required: true, doc: "Last button"
+  slot(:first, required: true, doc: "First button")
+  slot(:middle, required: false, doc: "Middle button(s)")
+  slot(:last, required: true, doc: "Last button")
 
   def button_group(assigns) do
     ~H"""
@@ -282,11 +285,11 @@ defmodule Web.FormComponents do
       <.button>Send!</.button>
       <.button phx-click="go" class="ml-2">Send!</.button>
   """
-  attr :type, :string, default: nil
-  attr :class, :string, default: nil
-  attr :rest, :global, include: ~w(disabled form name value navigate)
+  attr(:type, :string, default: nil)
+  attr(:class, :string, default: nil)
+  attr(:rest, :global, include: ~w(disabled form name value navigate))
 
-  slot :inner_block, required: true
+  slot(:inner_block, required: true)
 
   def button(assigns) do
     ~H"""
@@ -318,8 +321,8 @@ defmodule Web.FormComponents do
     </.submit_button>
   """
 
-  attr :rest, :global
-  slot :inner_block, required: true
+  attr(:rest, :global)
+  slot(:inner_block, required: true)
 
   def submit_button(assigns) do
     ~H"""
@@ -342,8 +345,8 @@ defmodule Web.FormComponents do
       Edit user
     </.delete_button>
   """
-  slot :inner_block, required: true
-  attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
+  slot(:inner_block, required: true)
+  attr(:rest, :global, doc: "the arbitrary HTML attributes to add to the flash container")
 
   def delete_button(assigns) do
     ~H"""
@@ -368,8 +371,8 @@ defmodule Web.FormComponents do
       Add user
     </.add_button>
   """
-  attr :navigate, :any, required: true, doc: "Path to navigate to"
-  slot :inner_block, required: true
+  attr(:navigate, :any, required: true, doc: "Path to navigate to")
+  slot(:inner_block, required: true)
 
   def add_button(assigns) do
     ~H"""
@@ -393,8 +396,8 @@ defmodule Web.FormComponents do
       Edit user
     </.edit_button>
   """
-  attr :navigate, :any, required: true, doc: "Path to navigate to"
-  slot :inner_block, required: true
+  attr(:navigate, :any, required: true, doc: "Path to navigate to")
+  slot(:inner_block, required: true)
 
   def edit_button(assigns) do
     ~H"""
@@ -423,15 +426,16 @@ defmodule Web.FormComponents do
         </:actions>
       </.simple_form>
   """
-  attr :for, :any, required: true, doc: "the datastructure for the form"
-  attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
+  attr(:for, :any, required: true, doc: "the datastructure for the form")
+  attr(:as, :any, default: nil, doc: "the server side parameter to collect all input under")
 
-  attr :rest, :global,
+  attr(:rest, :global,
     include: ~w(autocomplete name rel action enctype method novalidate target),
     doc: "the arbitrary HTML attributes to apply to the form tag"
+  )
 
-  slot :inner_block, required: true
-  slot :actions, doc: "the slot for form actions, such as a submit button"
+  slot(:inner_block, required: true)
+  slot(:actions, doc: "the slot for form actions, such as a submit button")
 
   def simple_form(assigns) do
     ~H"""

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -20,33 +20,30 @@ defmodule Web.FormComponents do
       <.input field={@form[:email]} type="email" />
       <.input name="my-input" errors={["oh no!"]} />
   """
-  attr(:id, :any, default: nil)
-  attr(:name, :any)
-  attr(:label, :string, default: nil)
-  attr(:value, :any)
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
 
-  attr(:type, :string,
+  attr :type, :string,
     default: "text",
     values: ~w(checkbox color date datetime-local email file hidden month number password
                range radio search select tel text textarea taglist time url week)
-  )
 
-  attr(:field, Phoenix.HTML.FormField,
+  attr :field, Phoenix.HTML.FormField,
     doc: "a form field struct retrieved from the form, for example: @form[:email]"
-  )
 
-  attr(:errors, :list, default: [])
-  attr(:checked, :boolean, doc: "the checked flag for checkbox and radio inputs")
-  attr(:prompt, :string, default: nil, doc: "the prompt for select inputs")
-  attr(:options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2")
-  attr(:multiple, :boolean, default: false, doc: "the multiple flag for select inputs")
+  attr :errors, :list, default: []
+  attr :checked, :boolean, doc: "the checked flag for checkbox and radio inputs"
+  attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
+  attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
+  attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
 
-  attr(:rest, :global,
+  attr :rest, :global,
     include: ~w(autocomplete cols disabled form list max maxlength min minlength
                 pattern placeholder readonly required rows size step)
-  )
 
-  slot(:inner_block)
+  slot :inner_block
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns
@@ -180,13 +177,13 @@ defmodule Web.FormComponents do
 
   def input(%{type: "hidden"} = assigns) do
     ~H"""
-      <input
-        type={@type}
-        name={@name}
-        id={@id}
-        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-        {@rest}
-      />
+    <input
+      type={@type}
+      name={@name}
+      id={@id}
+      value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+      {@rest}
+    />
     """
   end
 
@@ -214,10 +211,10 @@ defmodule Web.FormComponents do
     """
   end
 
-  attr(:name, :any)
-  attr(:value, :any)
-  attr(:checked, :boolean)
-  attr(:rest, :global)
+  attr :name, :any
+  attr :value, :any
+  attr :checked, :boolean
+  attr :rest, :global
 
   def checkbox(assigns) do
     ~H"""
@@ -237,9 +234,9 @@ defmodule Web.FormComponents do
   @doc """
   Render a button group.
   """
-  slot(:first, required: true, doc: "First button")
-  slot(:middle, required: false, doc: "Middle button(s)")
-  slot(:last, required: true, doc: "Last button")
+  slot :first, required: true, doc: "First button"
+  slot :middle, required: false, doc: "Middle button(s)"
+  slot :last, required: true, doc: "Last button"
 
   def button_group(assigns) do
     ~H"""
@@ -285,11 +282,11 @@ defmodule Web.FormComponents do
       <.button>Send!</.button>
       <.button phx-click="go" class="ml-2">Send!</.button>
   """
-  attr(:type, :string, default: nil)
-  attr(:class, :string, default: nil)
-  attr(:rest, :global, include: ~w(disabled form name value navigate))
+  attr :type, :string, default: nil
+  attr :class, :string, default: nil
+  attr :rest, :global, include: ~w(disabled form name value navigate)
 
-  slot(:inner_block, required: true)
+  slot :inner_block, required: true
 
   def button(assigns) do
     ~H"""
@@ -321,8 +318,8 @@ defmodule Web.FormComponents do
     </.submit_button>
   """
 
-  attr(:rest, :global)
-  slot(:inner_block, required: true)
+  attr :rest, :global
+  slot :inner_block, required: true
 
   def submit_button(assigns) do
     ~H"""
@@ -345,8 +342,8 @@ defmodule Web.FormComponents do
       Edit user
     </.delete_button>
   """
-  slot(:inner_block, required: true)
-  attr(:rest, :global, doc: "the arbitrary HTML attributes to add to the flash container")
+  slot :inner_block, required: true
+  attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
 
   def delete_button(assigns) do
     ~H"""
@@ -371,8 +368,8 @@ defmodule Web.FormComponents do
       Add user
     </.add_button>
   """
-  attr(:navigate, :any, required: true, doc: "Path to navigate to")
-  slot(:inner_block, required: true)
+  attr :navigate, :any, required: true, doc: "Path to navigate to"
+  slot :inner_block, required: true
 
   def add_button(assigns) do
     ~H"""
@@ -396,8 +393,8 @@ defmodule Web.FormComponents do
       Edit user
     </.edit_button>
   """
-  attr(:navigate, :any, required: true, doc: "Path to navigate to")
-  slot(:inner_block, required: true)
+  attr :navigate, :any, required: true, doc: "Path to navigate to"
+  slot :inner_block, required: true
 
   def edit_button(assigns) do
     ~H"""
@@ -426,16 +423,15 @@ defmodule Web.FormComponents do
         </:actions>
       </.simple_form>
   """
-  attr(:for, :any, required: true, doc: "the datastructure for the form")
-  attr(:as, :any, default: nil, doc: "the server side parameter to collect all input under")
+  attr :for, :any, required: true, doc: "the datastructure for the form"
+  attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
 
-  attr(:rest, :global,
+  attr :rest, :global,
     include: ~w(autocomplete name rel action enctype method novalidate target),
     doc: "the arbitrary HTML attributes to apply to the form tag"
-  )
 
-  slot(:inner_block, required: true)
-  slot(:actions, doc: "the slot for form actions, such as a submit button")
+  slot :inner_block, required: true
+  slot :actions, doc: "the slot for form actions, such as a submit button"
 
   def simple_form(assigns) do
     ~H"""

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -129,7 +129,6 @@ defmodule Web.FormComponents do
     """
   end
 
-  # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(%{type: "taglist"} = assigns) do
     values =
       if is_nil(assigns.value),
@@ -176,6 +175,19 @@ defmodule Web.FormComponents do
     """
   end
 
+  def input(%{type: "hidden"} = assigns) do
+    ~H"""
+      <input
+        type={@type}
+        name={@name}
+        id={@id}
+        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+        {@rest}
+      />
+    """
+  end
+
+  # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(assigns) do
     ~H"""
     <div phx-feedback-for={@name}>

--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -14,7 +14,7 @@ defmodule Web.AuthController do
     http_only: true
   ]
 
-  action_fallback Web.FallbackController
+  action_fallback(Web.FallbackController)
 
   @doc """
   This is a callback for the UserPass provider which checks login and password to authenticate the user.
@@ -65,10 +65,9 @@ defmodule Web.AuthController do
         %{
           "account_id_or_slug" => account_id_or_slug,
           "provider_id" => provider_id,
-          "email" =>
-            %{
-              "provider_identifier" => provider_identifier
-            }
+          "email" => %{
+            "provider_identifier" => provider_identifier
+          }
         } = params
       ) do
     _ =
@@ -82,10 +81,9 @@ defmodule Web.AuthController do
         |> Web.Mailer.deliver()
       end
 
-    redirect_params = %{
-      "provider_identifier" => provider_identifier,
-      "client_platform" => params["client_platform"],
-    }
+    redirect_params =
+      Map.take(params, ["client_platform"])
+      |> Map.merge(%{"provider_identifier" => provider_identifier})
 
     conn
     |> maybe_put_resent_flash(params)

--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -68,7 +68,7 @@ defmodule Web.AuthController do
           "email" =>
             %{
               "provider_identifier" => provider_identifier
-            } = form
+            }
         } = params
       ) do
     _ =
@@ -76,18 +76,21 @@ defmodule Web.AuthController do
            {:ok, identity} <-
              Domain.Auth.fetch_identity_by_provider_and_identifier(provider, provider_identifier),
            {:ok, identity} <- Domain.Auth.Adapters.Email.request_sign_in_token(identity) do
-        params = Map.take(form, ["client_platform", "client_csrf_token"])
+        sign_in_link_params = Map.take(params, ["client_platform", "client_csrf_token"])
 
-        Web.Mailer.AuthEmail.sign_in_link_email(identity, params)
+        Web.Mailer.AuthEmail.sign_in_link_email(identity, sign_in_link_params)
         |> Web.Mailer.deliver()
       end
 
-    redirect_params = Map.take(form, ["client_platform", "provider_identifier"])
+    redirect_params = %{
+      "provider_identifier" => provider_identifier,
+      "client_platform" => params["client_platform"],
+    }
 
     conn
     |> maybe_put_resent_flash(params)
-    |> put_session(:client_platform, form["client_platform"])
-    |> put_session(:client_csrf_token, form["client_csrf_token"])
+    |> put_session(:client_platform, params["client_platform"])
+    |> put_session(:client_csrf_token, params["client_csrf_token"])
     |> redirect(
       to: ~p"/#{account_id_or_slug}/sign_in/providers/email/#{provider_id}?#{redirect_params}"
     )

--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -14,7 +14,7 @@ defmodule Web.AuthController do
     http_only: true
   ]
 
-  action_fallback(Web.FallbackController)
+  action_fallback Web.FallbackController
 
   @doc """
   This is a callback for the UserPass provider which checks login and password to authenticate the user.

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -358,8 +358,8 @@ defmodule Web.AuthControllerTest do
           %{
             "email" => %{
               "provider_identifier" => identity.provider_identifier,
-              "client_platform" => "platform"
-            }
+            },
+            "client_platform" => "platform"
           }
         )
 

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -357,7 +357,7 @@ defmodule Web.AuthControllerTest do
           ~p"/#{provider.account_id}/sign_in/providers/#{provider.id}/request_magic_link",
           %{
             "email" => %{
-              "provider_identifier" => identity.provider_identifier,
+              "provider_identifier" => identity.provider_identifier
             },
             "client_platform" => "platform"
           }


### PR DESCRIPTION
Fixes a small bug where `client_platform` wasn't being added to the redirect_params in the magic link auth flow, so the token form input was never shown.

Also adds a `hidden` type input that omits the `class=` attribute and `div` wrapper.

Feel free to build off this or close and open a more thorough fix if this is not the desired approach.