### PR TITLE
connlib: fix how we handle disconnect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,9 +170,8 @@ services:
         ipv4_address: 172.28.0.105
       resources:
 
-  resource:
-    image: alpine:3.18
-    command: tail -f /dev/null
+  httpbin:
+    image: kennethreitz/httpbin
     networks:
       resources:
         ipv4_address: 172.20.0.100

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -874,6 +874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
+dependencies = [
+ "nix 0.26.2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1296,7 @@ name = "gateway"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ctrlc",
  "firezone-gateway-connlib",
  "ip_network",
  "tracing",
@@ -1353,6 +1364,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ctrlc",
  "firezone-client-connlib",
  "ip_network",
  "tracing",

--- a/rust/connlib/clients/headless/Cargo.toml
+++ b/rust/connlib/clients/headless/Cargo.toml
@@ -13,3 +13,4 @@ tracing-subscriber = { version = "0.3" }
 tracing = { version = "0.1" }
 anyhow = { version = "1.0" }
 clap = { version = "4.3", features = ["derive"] }
+ctrlc  = "3.4"

--- a/rust/connlib/clients/headless/src/main.rs
+++ b/rust/connlib/clients/headless/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> Result<()> {
     let (tx, rx) = std::sync::mpsc::channel();
     ctrlc::set_handler(move || tx.send(()).expect("Could not send stop signal on channel."))
         .expect("Error setting Ctrl-C handler");
-    rx.recv().expect("Could not recieve ctrl-c signal");
+    rx.recv().expect("Could not receive ctrl-c signal");
 
     session.disconnect(None);
     Ok(())

--- a/rust/connlib/clients/headless/src/main.rs
+++ b/rust/connlib/clients/headless/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use ctrlc;
 use ip_network::IpNetwork;
 use std::{
     net::{Ipv4Addr, Ipv6Addr},

--- a/rust/connlib/gateway/Cargo.toml
+++ b/rust/connlib/gateway/Cargo.toml
@@ -12,3 +12,4 @@ url = { version = "2.3.1", default-features = false }
 tracing-subscriber = { version = "0.3" }
 tracing = { version = "0.1" }
 anyhow = { version = "1.0" }
+ctrlc  = "3.4"

--- a/rust/connlib/gateway/src/main.rs
+++ b/rust/connlib/gateway/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
     let (tx, rx) = std::sync::mpsc::channel();
     ctrlc::set_handler(move || tx.send(()).expect("Could not send stop signal on channel."))
         .expect("Error setting Ctrl-C handler");
-    rx.recv().expect("Could not recieve ctrl-c signal");
+    rx.recv().expect("Could not receive ctrl-c signal");
 
     session.disconnect(None);
     Ok(())

--- a/rust/connlib/gateway/src/main.rs
+++ b/rust/connlib/gateway/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use ctrlc;
 use ip_network::IpNetwork;
 use std::{
     net::{Ipv4Addr, Ipv6Addr},
@@ -45,8 +46,9 @@ impl Callbacks for CallbackHandler {
     }
 
     fn on_disconnect(&self, error: Option<&Error>) -> Result<(), Self::Error> {
-        tracing::trace!("Tunnel disconnected: {error:?}");
-        Ok(())
+        tracing::warn!("Tunnel disconnected: {error:?}");
+        // Note that we can't panic here, since we already hooked the panic to this function.
+        std::process::exit(0);
     }
 
     fn on_error(&self, error: &Error) -> Result<(), Self::Error> {
@@ -64,7 +66,12 @@ fn main() -> Result<()> {
     let url = parse_env_var::<Url>(URL_ENV_VAR)?;
     let secret = parse_env_var::<String>(SECRET_ENV_VAR)?;
     let mut session = Session::connect(url, secret, CallbackHandler).unwrap();
-    session.wait_for_ctrl_c().unwrap();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    ctrlc::set_handler(move || tx.send(()).expect("Could not send stop signal on channel."))
+        .expect("Error setting Ctrl-C handler");
+    rx.recv().expect("Could not recieve ctrl-c signal");
+
     session.disconnect(None);
     Ok(())
 }

--- a/rust/connlib/gateway/src/main.rs
+++ b/rust/connlib/gateway/src/main.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use ctrlc;
 use ip_network::IpNetwork;
 use std::{
     net::{Ipv4Addr, Ipv6Addr},

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -390,7 +390,7 @@ where
         // So always yield and if you spawn a blocking tasks rewrite this.
         // Furthermore, we will depend on Drop impls to do the list above so,
         // implement them :)
-        // if there's no reciever the runtime is already stopped
+        // if there's no receiver the runtime is already stopped
         // there's an edge case where this is called before the thread is listening for stop threads.
         // but I believe in that case the channel will be in a signaled state achieving the same result
         if let Err(err) = runtime_stopper.try_send(()) {


### PR DESCRIPTION
Basically we were having a panic inside a panic before, when I tried to drop the runtime in `on_disconnect` since you can't drop a runtime within a runtime. This PR spawns a new thread that listen for disconnection and stops the runtime right there.

This also fixes the timer for reconnections.

Note: That I first stop it and the drop it which is redundant but I rather be safe :)