### PR TITLE
Use tunnelOverheadBytes to properly set tunnel interface MTU

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -31,9 +31,8 @@ class NetworkSettings {
   let tunnelAddressIPv6: String
   let dnsAddress: String
 
-    // In theory we could update the MTU dynamically based on the network environment,
-    // but 1280 is guaranteed to work everywhere.
-  let tunnelMTU = NSNumber(1280)
+  // WireGuard has an 80-byte overhead.
+  let tunnelOverheadBytes = NSNumber(80)
 
   // Modifiable values
   private(set) var dnsFallbackStrategy: DNSFallbackStrategy
@@ -153,7 +152,7 @@ class NetworkSettings {
         dnsSettings.matchDomains = [""]
     }
     tunnelNetworkSettings.dnsSettings = dnsSettings
-    tunnelNetworkSettings.mtu = tunnelMTU
+    tunnelNetworkSettings.tunnelOverheadBytes = tunnelOverheadBytes
 
     self.hasUnappliedChanges = false
     logger.debug("Attempting to set network settings")


### PR DESCRIPTION
Apple provides a mechanism to calculate a smarter MTU for the tunnel interface that is created.

This will be automatically adjusted depending on the MTU of the underlying physical device.