### PR TITLE
 fix(ios): portal connectivity and tunnel setup

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -70,7 +70,7 @@ Now you can verify that it's working by connecting to a websocket:
 ❯ {"event":"phx_join","topic":"gateway","payload":{},"ref":"unique_string_ref","join_ref":"unique_join_ref"}
 
 {"ref":"unique_string_ref","payload":{"status":"ok","response":{}},"topic":"gateway","event":"phx_reply"}
-{"ref":null,"payload":{"interface":{"ipv6":"fd00:2011:1111::35:f630","ipv4":"100.77.125.87"},"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true},"topic":"gateway","event":"init"}
+{"ref":null,"payload":{"interface":{"ipv6":"fd00:2021:1111::35:f630","ipv4":"100.77.125.87"},"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true},"topic":"gateway","event":"init"}
 ```
 
 </details>
@@ -112,7 +112,7 @@ Now you can verify that it's working by connecting to a websocket:
 ❯ {"event":"phx_join","topic":"device","payload":{},"ref":"unique_string_ref","join_ref":"unique_join_ref"}
 
 {"ref":"unique_string_ref","topic":"device","event":"phx_reply","payload":{"status":"ok","response":{}}}
-{"ref":null,"topic":"device","event":"init","payload":{"interface":{"ipv6":"fd00:2011:1111::11:f4bd","upstream_dns":[],"ipv4":"100.71.71.245"},"resources":[{"id":"4429d3aa-53ea-4c03-9435-4dee2899672b","name":"172.20.0.1/16","type":"cidr","address":"172.20.0.0/16"},{"id":"85a1cffc-70d3-46dd-aa6b-776192af7b06","name":"gitlab.mycorp.com","type":"dns","address":"gitlab.mycorp.com","ipv6":"fd00:2011:1111::5:b370","ipv4":"100.85.109.146"}]}}
+{"ref":null,"topic":"device","event":"init","payload":{"interface":{"ipv6":"fd00:2021:1111::11:f4bd","upstream_dns":[],"ipv4":"100.71.71.245"},"resources":[{"id":"4429d3aa-53ea-4c03-9435-4dee2899672b","name":"172.20.0.1/16","type":"cidr","address":"172.20.0.0/16"},{"id":"85a1cffc-70d3-46dd-aa6b-776192af7b06","name":"gitlab.mycorp.com","type":"dns","address":"gitlab.mycorp.com","ipv6":"fd00:2021:1111::5:b370","ipv4":"100.85.109.146"}]}}
 
 # List online relays for a Resource
 ❯ {"event":"list_relays","topic":"device","payload":{"resource_id":"4429d3aa-53ea-4c03-9435-4dee2899672b"},"ref":"unique_list_relays_ref"}

--- a/elixir/apps/domain/lib/domain/network.ex
+++ b/elixir/apps/domain/lib/domain/network.ex
@@ -4,7 +4,7 @@ defmodule Domain.Network do
 
   @cidrs %{
     ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 10},
-    ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 106}
+    ipv6: %Postgrex.INET{address: {0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, 0}, netmask: 106}
   }
 
   def cidrs, do: @cidrs

--- a/elixir/apps/domain/lib/domain/network.ex
+++ b/elixir/apps/domain/lib/domain/network.ex
@@ -4,7 +4,7 @@ defmodule Domain.Network do
 
   @cidrs %{
     ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 10},
-    ipv6: %Postgrex.INET{address: {0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, 0}, netmask: 106}
+    ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 106}
   }
 
   def cidrs, do: @cidrs

--- a/elixir/apps/domain/lib/domain/network.ex
+++ b/elixir/apps/domain/lib/domain/network.ex
@@ -4,7 +4,7 @@ defmodule Domain.Network do
 
   @cidrs %{
     ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 10},
-    ipv6: %Postgrex.INET{address: {64_768, 8_209, 4_369, 0, 0, 0, 0, 0}, netmask: 106}
+    ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 106}
   }
 
   def cidrs, do: @cidrs

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -356,9 +356,9 @@ defmodule Domain.ResourcesTest do
       assert {:error, changeset} = create_resource(attrs, subject)
       assert "can not be in the CIDR 100.64.0.0/10" in errors_on(changeset).address
 
-      attrs = %{"address" => "fd00:2011:1111::/102", "type" => "cidr"}
+      attrs = %{"address" => "fd00:2021:1111::/102", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)
-      assert "can not be in the CIDR fd00:2011:1111::/106" in errors_on(changeset).address
+      assert "can not be in the CIDR fd00:2021:1111::/106" in errors_on(changeset).address
 
       attrs = %{"address" => "::/0", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3307,6 +3307,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3768,6 +3769,15 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted 0.7.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/rust/connlib/libs/client/src/messages.rs
+++ b/rust/connlib/libs/client/src/messages.rs
@@ -164,7 +164,7 @@ mod test {
             IngressMessages::Init(InitClient {
                 interface: Interface {
                     ipv4: "100.72.112.111".parse().unwrap(),
-                    ipv6: "fd00:2011:1111::13:efb9".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::13:efb9".parse().unwrap(),
                     upstream_dns: vec![],
                 },
                 resources: vec![
@@ -177,7 +177,7 @@ mod test {
                         id: "03000143-e25e-45c7-aafb-144990e57dcd".parse().unwrap(),
                         address: "gitlab.mycorp.com".to_string(),
                         ipv4: "100.126.44.50".parse().unwrap(),
-                        ipv6: "fd00:2011:1111::e:7758".parse().unwrap(),
+                        ipv6: "fd00:2021:1111::e:7758".parse().unwrap(),
                         name: "gitlab.mycorp.com".to_string(),
                     }),
                 ],
@@ -189,7 +189,7 @@ mod test {
             "payload": {
                 "interface": {
                     "ipv4": "100.72.112.111",
-                    "ipv6": "fd00:2011:1111::13:efb9",
+                    "ipv6": "fd00:2021:1111::13:efb9",
                     "upstream_dns": []
                 },
                 "resources": [
@@ -203,7 +203,7 @@ mod test {
                         "address": "gitlab.mycorp.com",
                         "id": "03000143-e25e-45c7-aafb-144990e57dcd",
                         "ipv4": "100.126.44.50",
-                        "ipv6": "fd00:2011:1111::e:7758",
+                        "ipv6": "fd00:2021:1111::e:7758",
                         "name": "gitlab.mycorp.com",
                         "type": "dns"
                     }

--- a/rust/connlib/libs/common/Cargo.toml
+++ b/rust/connlib/libs/common/Cargo.toml
@@ -13,7 +13,7 @@ base64 = { version = "0.21", default-features = false, features = ["std"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 futures =  { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
 futures-util =  { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }
-tokio-tungstenite = { version = "0.19", default-features = false, features = ["connect", "handshake", "rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.19", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
 webrtc = { version = "0.8" }
 uuid = { version = "1.4", default-features = false, features = ["std", "v4", "serde"] }
 thiserror = { version = "1.0", default-features = false }

--- a/rust/connlib/libs/gateway/src/messages.rs
+++ b/rust/connlib/libs/gateway/src/messages.rs
@@ -125,7 +125,7 @@ mod test {
                 "device": {
                     "id": "3a25ff38-f8d7-47de-9b30-c7c40c206083",
                     "peer": {
-                        "ipv6": "fd00:2011:1111::3a:ab1b",
+                        "ipv6": "fd00:2021:1111::3a:ab1b",
                         "public_key": "OR2dYCLwMEtwqtjOxSm4SU7BbHJDfM8ZCqK7HKXXxDw=",
                         "ipv4": "100.114.114.30",
                         "persistent_keepalive": 25,
@@ -172,7 +172,7 @@ mod test {
             IngressMessages::Init(InitGateway {
                 interface: Interface {
                     ipv4: "100.115.164.78".parse().unwrap(),
-                    ipv6: "fd00:2011:1111::2c:f6ab".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
                     upstream_dns: vec![],
                 },
                 ipv4_masquerade_enabled: true,
@@ -186,7 +186,7 @@ mod test {
             "payload": {
                 "interface": {
                     "ipv4": "100.115.164.78",
-                    "ipv6": "fd00:2011:1111::2c:f6ab"
+                    "ipv6": "fd00:2021:1111::2c:f6ab"
                 },
                 "ipv4_masquerade_enabled": true,
                 "ipv6_masquerade_enabled": true

--- a/swift/apple/Firezone/Firezone.entitlements
+++ b/swift/apple/Firezone/Firezone.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.networking.multipath</key>
-	<true/>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
 		<string>packet-tunnel-provider</string>


### PR DESCRIPTION
This PR fixes issues with the iOS client connecting to the portal and setting up the tunnel.

- portal IPv6 unique-local prefix typo
- Use `rustls-webpki-roots` instead of `rustls-native-roots` for tokio tungstenite since the latter [only supports macOS, Linux, and Windows](https://github.com/rustls/rustls-native-certs) while the former seems to work on all platforms(?)
- Remove Multipath TCP entitlement for iOS since it's not relevant for us.

@conectado After this is merged, we _almost_ have a working tunnel on iOS. I believe the error we're hitting now is the 4-byte address family header that we need to add and strip from each packet written to / read from the tunnel. See below log for sample output when attempting to connect to the `HTTPbin` resource:

```
dev.firezone.firezone.network-extension	packet-tunnel	debug	16:10:13.401705-0700	FirezoneNetworkExtensioniOS	Adapter state changed to: tunnelReady
dev.firezone.firezone.network-extension	packet-tunnel	debug	16:10:13.401731-0700	FirezoneNetworkExtensioniOS	Beginning path monitoring
com.apple.network	path	default	16:10:13.402211-0700	FirezoneNetworkExtensioniOS	nw_path_evaluator_start [1ACDE975-615B-4557-BF7C-678F3594452E <NULL> generic, multipath service: 1, attribution: developer]
	path: satisfied (Path is satisfied), interface: en0[802.11], scoped, ipv4, ipv6, dns
com.apple.network	path	info	16:10:13.402235-0700	FirezoneNetworkExtensioniOS	nw_path_evaluator_call_update_handler [1ACDE975-615B-4557-BF7C-678F3594452E] scheduling update
com.apple.network	path	info	16:10:13.402261-0700	FirezoneNetworkExtensioniOS	nw_path_evaluator_call_update_handler_block_invoke [1ACDE975-615B-4557-BF7C-678F3594452E] delivering update
com.apple.network		debug	16:10:13.402286-0700	FirezoneNetworkExtensioniOS	nw_path_copy_interface_with_generation Cache miss for interface for index 3 (generation 4574)
com.apple.network		debug	16:10:13.402312-0700	FirezoneNetworkExtensioniOS	nw_path_copy_interface_with_generation Cache miss for interface for index 31 (generation 141)
dev.firezone.firezone.network-extension	packet-tunnel	debug	16:10:13.402363-0700	FirezoneNetworkExtensioniOS	Suppressing calls to disableSomeRoamingForBrokenMobileSemantics() and bumpSockets()
dev.firezone.firezone	connlib	debug	16:10:14.368105-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:10:15.369018-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:10:16.095618-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:10:16.370908-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:10:17.372035-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:10:18.373423-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:10:20.402863-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:10:24.381581-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:10:32.374566-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:10:38.137437-0700	FirezoneNetworkExtensioniOS	Text("{\"ref\":null,\"topic\":\"phoenix\",\"event\":\"phx_reply\",\"payload\":{\"status\":\"ok\",\"response\":{}}}")
dev.firezone.firezone	connlib	debug	16:10:38.137757-0700	FirezoneNetworkExtensioniOS	Phoenix status message
dev.firezone.firezone	connlib	debug	16:10:48.376339-0700	FirezoneNetworkExtensioniOS	Reading from iface 76 bytes
dev.firezone.firezone	connlib	debug	16:11:08.148369-0700	FirezoneNetworkExtensioniOS	Text("{\"ref\":null,\"topic\":\"phoenix\",\"event\":\"phx_reply\",\"payload\":{\"status\":\"ok\",\"response\":{}}}")
dev.firezone.firezone	connlib	debug	16:11:08.148654-0700	FirezoneNetworkExtensioniOS	Phoenix status message
```