### PR TITLE
feat(connlib): implement name() and mtu() for android

### DIFF
--- a/rust/connlib/libs/tunnel/Cargo.toml
+++ b/rust/connlib/libs/tunnel/Cargo.toml
@@ -24,6 +24,7 @@ boringtun = { workspace = true }
 chrono = { workspace = true }
 pnet_packet = { version = "0.34" }
 
+
 # TODO: research replacing for https://github.com/algesten/str0m
 webrtc = { version = "0.8" }
 

--- a/rust/connlib/libs/tunnel/Cargo.toml
+++ b/rust/connlib/libs/tunnel/Cargo.toml
@@ -24,7 +24,6 @@ boringtun = { workspace = true }
 chrono = { workspace = true }
 pnet_packet = { version = "0.34" }
 
-
 # TODO: research replacing for https://github.com/algesten/str0m
 webrtc = { version = "0.8" }
 

--- a/rust/connlib/libs/tunnel/src/tun_android.rs
+++ b/rust/connlib/libs/tunnel/src/tun_android.rs
@@ -75,7 +75,7 @@ impl IfaceDevice {
     }
 
     pub fn set_non_blocking(self) -> Result<Self> {
-        // Anrdoid already opens the tun device in non-blocking mode and we can't change it from
+        // Android already opens the tun device in non-blocking mode and we can't change it from
         // here.
         log::debug!("`set_non_blocking` unimplemented on Android");
         Ok(self)

--- a/rust/connlib/libs/tunnel/src/tun_android.rs
+++ b/rust/connlib/libs/tunnel/src/tun_android.rs
@@ -1,12 +1,43 @@
 use super::InterfaceConfig;
 use ip_network::IpNetwork;
-use libc::{close, read, write};
+use libc::{
+    close, ioctl, read, sockaddr, sockaddr_in, socket, write, AF_INET, IFNAMSIZ, IPPROTO_IP,
+    SIOCGIFMTU, SOCK_STREAM,
+};
 use libs_common::{CallbackErrorFacade, Callbacks, Error, Result, DNS_SENTINEL};
 use std::{
+    ffi::{c_int, c_short, c_uchar},
     io,
     os::fd::{AsRawFd, RawFd},
     sync::Arc,
 };
+
+#[repr(C)]
+union IfrIfru {
+    ifru_addr: sockaddr,
+    ifru_addr_v4: sockaddr_in,
+    ifru_addr_v6: sockaddr_in,
+    ifru_dstaddr: sockaddr,
+    ifru_broadaddr: sockaddr,
+    ifru_flags: c_short,
+    ifru_metric: c_int,
+    ifru_mtu: c_int,
+    ifru_phys: c_int,
+    ifru_media: c_int,
+    ifru_intval: c_int,
+    ifru_wake_flags: u32,
+    ifru_route_refcnt: u32,
+    ifru_cap: [c_int; 2],
+    ifru_functional_type: u32,
+}
+
+#[repr(C)]
+pub struct ifreq {
+    ifr_name: [c_uchar; IFNAMSIZ],
+    ifr_ifru: IfrIfru,
+}
+
+const TUNGETIFF: u64 = 0x800454d2;
 
 #[derive(Debug)]
 pub(crate) struct IfaceConfig(pub(crate) Arc<IfaceDevice>);
@@ -44,18 +75,52 @@ impl IfaceDevice {
     }
 
     pub fn set_non_blocking(self) -> Result<Self> {
-        // Anrdoid already opens the tun device in non-blocking mode for us
+        // Anrdoid already opens the tun device in non-blocking mode and we can't change it from
+        // here.
         log::debug!("`set_non_blocking` unimplemented on Android");
         Ok(self)
     }
 
+    pub fn name(&self) -> Result<String> {
+        let mut ifr = ifreq {
+            ifr_name: [0; IFNAMSIZ],
+            ifr_ifru: unsafe { std::mem::zeroed() },
+        };
+
+        match unsafe { ioctl(self.fd, TUNGETIFF as _, &mut ifr) } {
+            0 => {
+                let name_cstr = unsafe { std::ffi::CStr::from_ptr(ifr.ifr_name.as_ptr() as _) };
+                Ok(name_cstr.to_string_lossy().into_owned())
+            }
+            _ => Err(get_last_error()),
+        }
+    }
+
+    /// Get the current MTU value
     pub async fn mtu(&self) -> Result<usize> {
-        // We stick with a hardcoded MTU of 1280 for now. This could be improved by
-        // finding the MTU of the underlying physical interface and subtracting 80
-        // from it for the WireGuard overhead, but that's a lot of complexity
-        // for little gain.
-        log::debug!("`mtu` unimplemented on Android; using 1280");
-        Ok(1280)
+        let fd = match unsafe { socket(AF_INET, SOCK_STREAM, IPPROTO_IP) } {
+            -1 => return Err(get_last_error()),
+            fd => fd,
+        };
+
+        let name = self.name()?;
+        let iface_name: &[u8] = name.as_ref();
+        let mut ifr = ifreq {
+            ifr_name: [0; IFNAMSIZ],
+            ifr_ifru: IfrIfru { ifru_mtu: 0 },
+        };
+
+        ifr.ifr_name[..iface_name.len()].copy_from_slice(iface_name);
+
+        if unsafe { ioctl(fd, SIOCGIFMTU as _, &ifr) } < 0 {
+            return Err(get_last_error());
+        }
+
+        unsafe { close(fd) };
+
+        log::debug!("MTU for {} is {}", name, unsafe { ifr.ifr_ifru.ifru_mtu });
+
+        Ok(unsafe { ifr.ifr_ifru.ifru_mtu } as _)
     }
 
     pub fn write4(&self, src: &[u8]) -> usize {
@@ -72,6 +137,10 @@ impl IfaceDevice {
             n => Ok(&mut dst[..n as usize]),
         }
     }
+}
+
+fn get_last_error() -> Error {
+    Error::Io(io::Error::last_os_error())
 }
 
 impl IfaceConfig {

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -168,7 +168,7 @@ impl IfaceDevice {
     }
 
     pub fn name(&self) -> Result<String> {
-        let mut tunnel_name = [0u8; 256];
+        let mut tunnel_name = [0u8; IF_NAMESIZE];
         let mut tunnel_name_len = tunnel_name.len() as socklen_t;
         if unsafe {
             getsockopt(

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -212,7 +212,7 @@ impl IfaceDevice {
 
         let mtu = unsafe { ifr.ifr_ifru.ifru_mtu };
 
-        log::debug!("MTU for {} is {}", name, mtu);
+        tracing::debug!("MTU for {} is {}", name, mtu);
         Ok(unsafe { ifr.ifr_ifru.ifru_mtu } as _)
     }
 

--- a/rust/connlib/libs/tunnel/src/wrapped_socket.rs
+++ b/rust/connlib/libs/tunnel/src/wrapped_socket.rs
@@ -1,0 +1,28 @@
+use libc::{close, socket};
+use std::ffi::c_int;
+use std::os::fd::RawFd;
+
+pub struct WrappedSocket {
+    fd: RawFd,
+}
+
+impl WrappedSocket {
+    pub fn new(domain: c_int, sock_type: c_int, protocol: c_int) -> Self {
+        let fd = unsafe { socket(domain, sock_type, protocol) };
+        Self { fd }
+    }
+
+    pub fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+impl Drop for WrappedSocket {
+    fn drop(&mut self) {
+        if self.fd == -1 {
+            return;
+        }
+
+        unsafe { close(self.fd) };
+    }
+}


### PR DESCRIPTION
Implement `name()` to retrieve the tunnel name via `TUNGETIFF`, then use that to retrieve the mtu via `SIOCGIFMTU`.

Verified to be working:

```
2023-08-23 20:25:50.211  4830-4928  connlib                 dev.firezone.android                 D  firezone_tunnel::tun: MTU for tun0 is 1280
```

Will update the `log::debug!` calls to tracing in the next PR.