### PR TITLE
fix(android): Use `log` feature for tracing on Android

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -766,9 +766,9 @@ dependencies = [
  "firezone-client-connlib",
  "ip_network",
  "jni 0.21.1",
- "log",
  "serde_json",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1232,7 +1232,6 @@ dependencies = [
  "itertools 0.11.0",
  "libc",
  "libs-common",
- "log",
  "netlink-packet-core",
  "netlink-packet-route",
  "parking_lot",
@@ -1816,7 +1815,6 @@ dependencies = [
  "futures",
  "futures-util",
  "ip_network",
- "log",
  "os_info",
  "parking_lot",
  "rand",

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -13,9 +13,9 @@ mock = ["firezone-client-connlib/mock"]
 
 [dependencies]
 android_logger = "0.13"
+tracing = { version = "0.1", features = ["log", "std", "attributes"] }
 firezone-client-connlib = { path = "../../libs/client" }
 jni = { version = "0.21.1", features = ["invocation"] }
 ip_network = "0.4"
-log = "0.4"
 serde_json = "1"
 thiserror = "1"

--- a/rust/connlib/libs/common/Cargo.toml
+++ b/rust/connlib/libs/common/Cargo.toml
@@ -32,9 +32,6 @@ chrono = { workspace = true }
 parking_lot = "0.12"
 ring = "0.16"
 
-# Needed for Android logging until tracing is working
-log = "0.4"
-
 # smbios fails to build on iOS and Android
 [target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dependencies]
 smbios-lib = "0.9"
@@ -44,6 +41,7 @@ swift-bridge = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.13"
+tracing = { version = "0.1", default-features = false, features = ["log", "std", "attributes"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = { version = "0.12", default-features = false, features = ["tokio_socket"] }

--- a/rust/connlib/libs/tunnel/Cargo.toml
+++ b/rust/connlib/libs/tunnel/Cargo.toml
@@ -27,9 +27,6 @@ pnet_packet = { version = "0.34" }
 # TODO: research replacing for https://github.com/algesten/str0m
 webrtc = { version = "0.8" }
 
-# Needed for Android logging until tracing is fixed
-log = "0.4"
-
 # Linux tunnel dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
 netlink-packet-route = { version = "0.15", default-features = false }
@@ -39,6 +36,7 @@ rtnetlink = { version = "0.12", default-features = false, features = ["tokio_soc
 # Android tunnel dependencies
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.13"
+tracing = { version = "0.1", default-features = false, features = ["log", "std", "attributes"] }
 
 # Windows tunnel dependencies
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/rust/connlib/libs/tunnel/src/tun_android.rs
+++ b/rust/connlib/libs/tunnel/src/tun_android.rs
@@ -123,7 +123,7 @@ impl IfaceDevice {
 
         let mtu = unsafe { ifr.ifr_ifru.ifru_mtu };
 
-        log::debug!("MTU for {} is {}", name, mtu);
+        tracing::debug!("MTU for {} is {}", name, mtu);
         Ok(mtu as _)
     }
 
@@ -157,7 +157,7 @@ impl IfaceConfig {
     }
 
     pub async fn up(&mut self) -> Result<()> {
-        log::debug!("`up` unimplemented on Android");
+        tracing::debug!("`up` unimplemented on Android");
         Ok(())
     }
 }


### PR DESCRIPTION
Enables the `log` feature in `tracing` in order for `android_logger` to function with Logcat.