### PR TITLE
fix(portal): revert `check_origin: :conn` for the WebSocket connection on `web`

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -324,7 +324,7 @@ firezone-staging
 ############
 
 # Stream all Elixir error logs:
-> gcloud logging read "jsonPayload.message.erl_level=error"
+> gcloud logging read "jsonPayload.message.severity=ERROR"
 
 # Stream Web app logs (portal UI):
 > gcloud logging read 'jsonPayload."cos.googleapis.com/container_name":web'

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -303,3 +303,35 @@ iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)5> {:ok, identity} = Dom
 iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)6> Web.Mailer.AuthEmail.sign_in_link_email(identity) |> Web.Mailer.deliver()
 {:ok, %{id: "d24dbe9a-d0f5-4049-ac0d-0df793725a80"}}
 ```
+
+## Viewing logs
+
+Logs can be viewed via th [Logs Explorer](https://console.cloud.google.com/logs)
+in GCP, or via the `gcloud` CLI:
+
+```bash
+# First, login
+> gcloud auth login
+
+# Always make sure you're in the correct environment
+> gcloud config get project
+firezone-staging
+
+# Now you can stream logs directly to your terminal.
+
+############
+# Examples #
+############
+
+# Stream all Elixir error logs:
+> gcloud logging read "jsonPayload.message.erl_level=error"
+
+# Stream Web app logs (portal UI):
+> gcloud logging read 'jsonPayload."cos.googleapis.com/container_name":web'
+
+# Stream API app logs (connlib control plane):
+> gcloud logging read 'jsonPayload."cos.googleapis.com/container_name":api'
+
+# For more info on the filter expression syntax, see:
+# https://cloud.google.com/logging/docs/view/logging-query-language
+```

--- a/elixir/apps/web/lib/web/endpoint.ex
+++ b/elixir/apps/web/lib/web/endpoint.ex
@@ -39,7 +39,6 @@ defmodule Web.Endpoint do
 
   socket "/live", Phoenix.LiveView.Socket,
     websocket: [
-      check_origin: :conn,
       connect_info: [
         :user_agent,
         :peer_data,


### PR DESCRIPTION
Looks like it broke the staging WS connections. Getting a failure of Liveview socket connection on `app.firez.one`:

```
insertId: 1o7nymzg12jh1k5
jsonPayload:
  cos.googleapis.com/container_id: 89b4633e81432e43dfbaa3957324fd5ead3f2362737bac84648a8f839b6eb16c
  cos.googleapis.com/container_name: klt-web-cpap
  cos.googleapis.com/stream: stdout
  message:
    domain:
    - elixir
    erl_level: error
    logging.googleapis.com/sourceLocation:
      file: lib/phoenix/socket/transport.ex
      function: Elixir.Phoenix.Socket.Transport.check_origin/5
      line: 344
    message: |+
      Could not check origin for Phoenix.Socket transport.

      Origin of the request: https://app.firez.one

      This happens when you are attempting a socket connection to
      a different host than the one configured in your config/
      files. For example, in development the host is configured
      to "localhost" but you may be trying to access it from
      "127.0.0.1". To fix this issue, you may either:

        1. update [url: [host: ...]] to your actual host in the
           config file for your current environment (recommended)

        2. pass the :check_origin option when configuring your
           endpoint or when configuring the transport in your
           UserSocket module, explicitly outlining which origins
           are allowed:

              check_origin: ["https://example.com",
                             "//another.com:888", "//other.com"]

    severity: ERROR
    time: '2023-08-26T21:24:36.002Z'
  time: '2023-08-26T21:24:36.002628434Z'
logName: projects/firezone-staging/logs/cos_containers
receiveTimestamp: '2023-08-26T21:24:36.402398476Z'
resource:
  labels:
    instance_id: '8218473336234347240'
    project_id: firezone-staging
    zone: us-east1-d
  type: gce_instance
timestamp: '2023-08-26T21:24:36.002628434Z'
```