### PR TITLE
connlib: improve logging and detect channel close earlier

### DIFF
--- a/rust/connlib/libs/client/src/control.rs
+++ b/rust/connlib/libs/client/src/control.rs
@@ -230,9 +230,8 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
     pub(super) async fn stats_event(&mut self) {
-        // TODO
+        tracing::debug!(target: "tunnel_state", "{:#?}", self.tunnel.stats());
     }
 }
 

--- a/rust/connlib/libs/common/src/messages/key.rs
+++ b/rust/connlib/libs/common/src/messages/key.rs
@@ -1,4 +1,5 @@
 use base64::{display::Base64Display, engine::general_purpose::STANDARD, Engine};
+use boringtun::x25519::PublicKey;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use std::{fmt, str::FromStr};
@@ -34,6 +35,12 @@ impl FromStr for Key {
             key_bytes.copy_from_slice(&bytes_decoded);
             Ok(Key(key_bytes))
         }
+    }
+}
+
+impl From<PublicKey> for Key {
+    fn from(value: PublicKey) -> Self {
+        Self(value.to_bytes())
     }
 }
 

--- a/rust/connlib/libs/gateway/src/control.rs
+++ b/rust/connlib/libs/gateway/src/control.rs
@@ -134,9 +134,8 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
     pub(super) async fn stats_event(&mut self) {
-        tracing::debug!("TODO: STATS EVENT");
+        tracing::debug!(target: "tunnel_state", "{:#?}", self.tunnel.stats());
     }
 }
 

--- a/rust/connlib/libs/tunnel/src/resource_table.rs
+++ b/rust/connlib/libs/tunnel/src/resource_table.rs
@@ -2,6 +2,7 @@
 use std::{collections::HashMap, net::IpAddr, ptr::NonNull};
 
 use chrono::{DateTime, Utc};
+use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 use libs_common::messages::{Id, ResourceDescription};
 
@@ -60,6 +61,22 @@ where
 {
     pub fn values(&self) -> impl Iterator<Item = &T> {
         self.id_table.values()
+    }
+
+    pub fn network_resources(&self) -> HashMap<IpNetwork, T> {
+        // Safety: Due to internal consistency, since the value is stored the reference should be valid
+        self.network_table
+            .iter()
+            .map(|(wg_ip, res)| (wg_ip, unsafe { res.as_ref() }.clone()))
+            .collect()
+    }
+
+    pub fn dns_resources(&self) -> HashMap<String, T> {
+        // Safety: Due to internal consistency, since the value is stored the reference should be valid
+        self.dns_name
+            .iter()
+            .map(|(name, res)| (name.clone(), unsafe { res.as_ref() }.clone()))
+            .collect()
     }
 
     /// Tells you if it's empty


### PR DESCRIPTION
This detects earlier when a channel disconnects and closes the peer but more importantly it prints periodically some stats about the tunnel that will make debugging easier.