### PR TITLE
fix(apple): Don't close fd on `disconnect`

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -23,12 +23,6 @@ mod ffi {
             callback_handler: CallbackHandler,
         ) -> Result<WrappedSession, String>;
 
-        #[swift_bridge(swift_name = "bumpSockets")]
-        fn bump_sockets(&self);
-
-        #[swift_bridge(swift_name = "disableSomeRoamingForBrokenMobileSemantics")]
-        fn disable_some_roaming_for_broken_mobile_semantics(&self);
-
         fn disconnect(&mut self);
     }
 
@@ -166,15 +160,6 @@ impl WrappedSession {
         )
         .map(|session| Self { session })
         .map_err(|err| err.to_string())
-    }
-
-    fn bump_sockets(&self) {
-        self.session.bump_sockets()
-    }
-
-    fn disable_some_roaming_for_broken_mobile_semantics(&self) {
-        self.session
-            .disable_some_roaming_for_broken_mobile_semantics()
     }
 
     fn disconnect(&mut self) {

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -1,9 +1,8 @@
 use ip_network::IpNetwork;
 use libc::{
-    ctl_info, fcntl, getpeername, getsockopt, ioctl, iovec, msghdr, recvmsg, sendmsg,
-    sockaddr, sockaddr_ctl, sockaddr_in, socklen_t, AF_INET, AF_INET6, AF_SYSTEM, CTLIOCGINFO,
-    F_GETFL, F_SETFL, IF_NAMESIZE, IPPROTO_IP, O_NONBLOCK, SOCK_STREAM, SYSPROTO_CONTROL,
-    UTUN_OPT_IFNAME,
+    ctl_info, fcntl, getpeername, getsockopt, ioctl, iovec, msghdr, recvmsg, sendmsg, sockaddr,
+    sockaddr_ctl, sockaddr_in, socklen_t, AF_INET, AF_INET6, AF_SYSTEM, CTLIOCGINFO, F_GETFL,
+    F_SETFL, IF_NAMESIZE, IPPROTO_IP, O_NONBLOCK, SOCK_STREAM, SYSPROTO_CONTROL, UTUN_OPT_IFNAME,
 };
 use libs_common::{CallbackErrorFacade, Callbacks, Error, Result, DNS_SENTINEL};
 use std::{

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -1,6 +1,6 @@
 use ip_network::IpNetwork;
 use libc::{
-    close, ctl_info, fcntl, getpeername, getsockopt, ioctl, iovec, msghdr, recvmsg, sendmsg,
+    ctl_info, fcntl, getpeername, getsockopt, ioctl, iovec, msghdr, recvmsg, sendmsg,
     sockaddr, sockaddr_ctl, sockaddr_in, socklen_t, AF_INET, AF_INET6, AF_SYSTEM, CTLIOCGINFO,
     F_GETFL, F_SETFL, IF_NAMESIZE, IPPROTO_IP, O_NONBLOCK, SOCK_STREAM, SYSPROTO_CONTROL,
     UTUN_OPT_IFNAME,

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -105,9 +105,9 @@ public class Adapter {
     networkMonitor?.cancel()
 
     // Shutdown the tunnel
-    if case .tunnelReady(let wrappedSession) = self.state {
+    if case .tunnelReady(let session) = self.state {
       logger.debug("Adapter.deinit: Shutting down connlib")
-      wrappedSession.disconnect()
+      session.disconnect()
     }
   }
 
@@ -248,14 +248,7 @@ extension Adapter {
       }
 
     case .tunnelReady(let session):
-      if path.status == .satisfied {
-        self.logger.debug(
-          "Suppressing calls to disableSomeRoamingForBrokenMobileSemantics() and bumpSockets()")
-        // #if os(iOS)
-        // wrappedSession.disableSomeRoamingForBrokenMobileSemantics()
-        // #endif
-        // wrappedSession.bumpSockets()
-      } else {
+      if path.status != .satisfied {
         self.logger.debug("Adapter.didReceivePathUpdate: Offline. Shutting down connlib.")
         self.packetTunnelProvider?.reasserting = true
         self.state = .stoppingTunnelTemporarily(session: session, onStopped: nil)


### PR DESCRIPTION
When path.status changes to `.unsatisfied`, we call `disconnect()`. This was closing the tunnel `fd`, causing the PacketTunnelProvider interface to go down. Then, when `connect()` was being called later, the `fd` was still closed.

This PR simply removes the `close(fd)` call and assumes the PacketTunnelProvider will do that appropriately.


After some more discussion with @conectado we determined that boringtun and webrtc-rs probably handle the edge cases needed by `bumpSockets` and `disableSomeRoamingForBrokenMobileSemantics`, so those are removed as well.

Refs firezone/product#656