### PR TITLE
feat(android): allow replacing fd on android from callbacks

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelManager.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelManager.kt
@@ -33,7 +33,7 @@ internal class TunnelManager @Inject constructor(
     private val listeners: MutableSet<WeakReference<TunnelListener>> = mutableSetOf()
 
     private val callback: ConnlibCallback = object: ConnlibCallback {
-        override fun onUpdateResources(resourceListJSON: String) {
+        override fun onUpdateResources(resourceListJSON: String): Int {
             // TODO: Call into client app to update resources list and routing table
             Log.d(TAG, "onUpdateResources: $resourceListJSON")
             moshi.adapter<List<Resource>>().fromJson(resourceListJSON)?.let { resources ->
@@ -41,6 +41,9 @@ internal class TunnelManager @Inject constructor(
                     it.get()?.onUpdateResources(resources)
                 }
             }
+
+            // TODO: Return the detached fd here
+            return -1
         }
 
         override fun onSetInterfaceConfig(
@@ -82,20 +85,26 @@ internal class TunnelManager @Inject constructor(
             return true
         }
 
-        override fun onAddRoute(cidrAddress: String) {
+        override fun onAddRoute(cidrAddress: String): Int {
             Log.d(TAG, "onAddRoute: $cidrAddress")
 
             listeners.onEach {
                 it.get()?.onAddRoute(cidrAddress)
             }
+
+            // TODO: Return the detached fd here
+            return -1
         }
 
-        override fun onRemoveRoute(cidrAddress: String) {
+        override fun onRemoveRoute(cidrAddress: String): Int {
             Log.d(TAG, "onRemoveRoute: $cidrAddress")
 
             listeners.onEach {
                 it.get()?.onRemoveRoute(cidrAddress)
             }
+
+            // TODO: Return the detached fd here
+            return -1
         }
 
         override fun onDisconnect(error: String?): Boolean {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/callback/ConnlibCallback.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/callback/ConnlibCallback.kt
@@ -5,11 +5,11 @@ interface ConnlibCallback {
 
     fun onTunnelReady(): Boolean
 
-    fun onAddRoute(cidrAddress: String)
+    fun onAddRoute(cidrAddress: String): Int
 
-    fun onRemoveRoute(cidrAddress: String)
+    fun onRemoveRoute(cidrAddress: String): Int
 
-    fun onUpdateResources(resourceListJSON: String)
+    fun onUpdateResources(resourceListJSON: String): Int
 
     fun onDisconnect(error: String?): Boolean
 

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -155,7 +155,7 @@ impl Callbacks for CallbackHandler {
         })
     }
 
-    fn on_add_route(&self, route: IpNetwork) -> Result<(), Self::Error> {
+    fn on_add_route(&self, route: IpNetwork) -> Result<RawFd, Self::Error> {
         self.env(|mut env| {
             let route = env.new_string(route.to_string()).map_err(|source| {
                 CallbackError::NewStringFailed {
@@ -163,17 +163,19 @@ impl Callbacks for CallbackHandler {
                     source,
                 }
             })?;
-            call_method(
-                &mut env,
+            let name = "onAddRoute";
+            env.call_method(
                 &self.callback_handler,
-                "onAddRoute",
-                "(Ljava/lang/String;)V",
+                name,
+                "(Ljava/lang/String;)I",
                 &[JValue::from(&route)],
             )
+            .and_then(|val| val.i())
+            .map_err(|source| CallbackError::CallMethodFailed { name, source })
         })
     }
 
-    fn on_remove_route(&self, route: IpNetwork) -> Result<(), Self::Error> {
+    fn on_remove_route(&self, route: IpNetwork) -> Result<RawFd, Self::Error> {
         self.env(|mut env| {
             let route = env.new_string(route.to_string()).map_err(|source| {
                 CallbackError::NewStringFailed {
@@ -181,20 +183,22 @@ impl Callbacks for CallbackHandler {
                     source,
                 }
             })?;
-            call_method(
-                &mut env,
+            let name = "onRemoveRoute";
+            env.call_method(
                 &self.callback_handler,
-                "onRemoveRoute",
-                "(Ljava/lang/String;)V",
+                name,
+                "(Ljava/lang/String;)I",
                 &[JValue::from(&route)],
             )
+            .and_then(|val| val.i())
+            .map_err(|source| CallbackError::CallMethodFailed { name, source })
         })
     }
 
     fn on_update_resources(
         &self,
         resource_list: Vec<ResourceDescription>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<RawFd, Self::Error> {
         self.env(|mut env| {
             let resource_list = env
                 .new_string(serde_json::to_string(&resource_list)?)
@@ -202,13 +206,15 @@ impl Callbacks for CallbackHandler {
                     name: "resource_list",
                     source,
                 })?;
-            call_method(
-                &mut env,
+            let name = "onUpdateResources";
+            env.call_method(
                 &self.callback_handler,
-                "onUpdateResources",
-                "(Ljava/lang/String;)V",
+                name,
+                "(Ljava/lang/String;)I",
                 &[JValue::from(&resource_list)],
             )
+            .and_then(|val| val.i())
+            .map_err(|source| CallbackError::CallMethodFailed { name, source })
         })
     }
 

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -105,25 +105,25 @@ impl Callbacks for CallbackHandler {
         Ok(())
     }
 
-    fn on_add_route(&self, route: IpNetwork) -> Result<(), Self::Error> {
+    fn on_add_route(&self, route: IpNetwork) -> Result<RawFd, Self::Error> {
         self.0.on_add_route(route.to_string());
-        Ok(())
+        Ok(-1)
     }
 
-    fn on_remove_route(&self, route: IpNetwork) -> Result<(), Self::Error> {
+    fn on_remove_route(&self, route: IpNetwork) -> Result<RawFd, Self::Error> {
         self.0.on_remove_route(route.to_string());
-        Ok(())
+        Ok(-1)
     }
 
     fn on_update_resources(
         &self,
         resource_list: Vec<ResourceDescription>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<RawFd, Self::Error> {
         self.0.on_update_resources(
             serde_json::to_string(&resource_list)
                 .expect("developer error: failed to serialize resource list"),
         );
-        Ok(())
+        Ok(-1)
     }
 
     fn on_disconnect(&self, error: Option<&Error>) -> Result<(), Self::Error> {

--- a/rust/connlib/clients/headless/src/main.rs
+++ b/rust/connlib/clients/headless/src/main.rs
@@ -33,20 +33,20 @@ impl Callbacks for CallbackHandler {
         Ok(())
     }
 
-    fn on_add_route(&self, _route: IpNetwork) -> Result<(), Self::Error> {
-        Ok(())
+    fn on_add_route(&self, _route: IpNetwork) -> Result<RawFd, Self::Error> {
+        Ok(-1)
     }
 
-    fn on_remove_route(&self, _route: IpNetwork) -> Result<(), Self::Error> {
-        Ok(())
+    fn on_remove_route(&self, _route: IpNetwork) -> Result<RawFd, Self::Error> {
+        Ok(-1)
     }
 
     fn on_update_resources(
         &self,
         resource_list: Vec<ResourceDescription>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<RawFd, Self::Error> {
         tracing::trace!(message = "Resources updated", ?resource_list);
-        Ok(())
+        Ok(-1)
     }
 
     fn on_disconnect(&self, error: Option<&Error>) -> Result<(), Self::Error> {

--- a/rust/connlib/gateway/src/main.rs
+++ b/rust/connlib/gateway/src/main.rs
@@ -30,20 +30,20 @@ impl Callbacks for CallbackHandler {
         Ok(())
     }
 
-    fn on_add_route(&self, _route: IpNetwork) -> Result<(), Self::Error> {
-        Ok(())
+    fn on_add_route(&self, _route: IpNetwork) -> Result<RawFd, Self::Error> {
+        Ok(-1)
     }
 
-    fn on_remove_route(&self, _route: IpNetwork) -> Result<(), Self::Error> {
-        Ok(())
+    fn on_remove_route(&self, _route: IpNetwork) -> Result<RawFd, Self::Error> {
+        Ok(-1)
     }
 
     fn on_update_resources(
         &self,
         resource_list: Vec<ResourceDescription>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<RawFd, Self::Error> {
         tracing::trace!("Resources updated, current list: {resource_list:?}");
-        Ok(())
+        Ok(-1)
     }
 
     fn on_disconnect(&self, error: Option<&Error>) -> Result<(), Self::Error> {

--- a/rust/connlib/libs/common/src/device_ref_unix.rs
+++ b/rust/connlib/libs/common/src/device_ref_unix.rs
@@ -1,3 +1,0 @@
-pub struct DeviceRef {
-    device_ref: std::os::fd::RawFd,
-}

--- a/rust/connlib/libs/common/src/device_ref_win.rs
+++ b/rust/connlib/libs/common/src/device_ref_win.rs
@@ -1,3 +1,0 @@
-pub struct DeviceRef {
-    device_ref: std::os::windows::io::RawHandle,
-}

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -73,14 +73,14 @@ pub trait Callbacks: Clone + Send + Sync {
     /// Called when the tunnel is connected.
     fn on_tunnel_ready(&self) -> StdResult<(), Self::Error>;
     /// Called when when a route is added.
-    fn on_add_route(&self, route: IpNetwork) -> StdResult<(), Self::Error>;
+    fn on_add_route(&self, route: IpNetwork) -> StdResult<RawFd, Self::Error>;
     /// Called when when a route is removed.
-    fn on_remove_route(&self, route: IpNetwork) -> StdResult<(), Self::Error>;
+    fn on_remove_route(&self, route: IpNetwork) -> StdResult<RawFd, Self::Error>;
     /// Called when the resource list changes.
     fn on_update_resources(
         &self,
         resource_list: Vec<ResourceDescription>,
-    ) -> StdResult<(), Self::Error>;
+    ) -> StdResult<RawFd, Self::Error>;
     /// Called when the tunnel is disconnected.
     ///
     /// If the tunnel disconnected due to a fatal error, `error` is the error
@@ -129,7 +129,7 @@ impl<CB: Callbacks> Callbacks for CallbackErrorFacade<CB> {
         result
     }
 
-    fn on_add_route(&self, route: IpNetwork) -> Result<()> {
+    fn on_add_route(&self, route: IpNetwork) -> Result<RawFd> {
         let result = self
             .0
             .on_add_route(route)
@@ -140,7 +140,7 @@ impl<CB: Callbacks> Callbacks for CallbackErrorFacade<CB> {
         result
     }
 
-    fn on_remove_route(&self, route: IpNetwork) -> Result<()> {
+    fn on_remove_route(&self, route: IpNetwork) -> Result<RawFd> {
         let result = self
             .0
             .on_remove_route(route)
@@ -151,7 +151,7 @@ impl<CB: Callbacks> Callbacks for CallbackErrorFacade<CB> {
         result
     }
 
-    fn on_update_resources(&self, resource_list: Vec<ResourceDescription>) -> Result<()> {
+    fn on_update_resources(&self, resource_list: Vec<ResourceDescription>) -> Result<RawFd> {
         let result = self
             .0
             .on_update_resources(resource_list)

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -267,13 +267,17 @@ impl IfaceDevice {
     }
 }
 
+fn get_last_error() -> Error {
+    Error::Io(io::Error::last_os_error())
+}
+
 // So, these functions take a mutable &self, this is not necessary in theory but it's correct!
 impl IfaceConfig {
     pub async fn add_route(
         &mut self,
         route: IpNetwork,
         callbacks: &CallbackErrorFacade<impl Callbacks>,
-    ) -> Result<()> {
+    ) -> Result<RawFd> {
         callbacks.on_add_route(route)
     }
 
@@ -281,8 +285,4 @@ impl IfaceConfig {
         tracing::info!("`up` unimplemented on macOS");
         Ok(())
     }
-}
-
-fn get_last_error() -> Error {
-    Error::Io(io::Error::last_os_error())
 }


### PR DESCRIPTION
Android requires us to `establish` the VPN each time its configuration changes. This means we will ~~potentially~~ likely get a new `fd`, so this PR attempts to update the fd in-place with as little packet loss as possible.

@conectado Not sure if this the preferred approach, open to suggestions on how best to accomplish.

Fixes firezone/product#656