### PR TITLE
Connlib/fix stability issues

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
  "swift-bridge",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "tracing",
  "url",
@@ -3432,6 +3433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.2",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/rust/connlib/libs/client/src/control.rs
+++ b/rust/connlib/libs/client/src/control.rs
@@ -18,7 +18,7 @@ impl ControlSignal for ControlSignaler {
     async fn signal_connection_to(
         &self,
         resource: &ResourceDescription,
-        connected_gateway_ids: &Vec<Id>,
+        connected_gateway_ids: &[Id],
         reference: usize,
     ) -> Result<()> {
         self.control_signal
@@ -27,7 +27,7 @@ impl ControlSignal for ControlSignaler {
             .send_with_ref(
                 EgressMessages::PrepareConnection {
                     resource_id: resource.id(),
-                    connected_gateway_ids: connected_gateway_ids.clone(),
+                    connected_gateway_ids: connected_gateway_ids.to_vec(),
                 },
                 reference,
             )

--- a/rust/connlib/libs/common/Cargo.toml
+++ b/rust/connlib/libs/common/Cargo.toml
@@ -31,6 +31,7 @@ rand = { version = "0.8", default-features = false, features = ["std"] }
 chrono = { workspace = true }
 parking_lot = "0.12"
 ring = "0.16"
+tokio-stream = { version = "0.1", features = ["time"] }
 
 # Needed for Android logging until tracing is working
 log = "0.4"

--- a/rust/connlib/libs/common/src/control.rs
+++ b/rust/connlib/libs/common/src/control.rs
@@ -152,12 +152,6 @@ where
         let send_messages = futures::StreamExt::map(receiver, Ok)
             .forward(write)
             .map_err(Error::from);
-        // let send_messages = async {
-        //     while let Some(item) = receiver.next().await {
-        //         write.send(item).await?;
-        //     }
-        //     Ok(())
-        // };
 
         let phoenix_heartbeat = tokio::spawn(async move {
             let mut timer = tokio::time::interval(HEARTBEAT);

--- a/rust/connlib/libs/common/src/control.rs
+++ b/rust/connlib/libs/common/src/control.rs
@@ -11,9 +11,10 @@ use futures::{
     channel::mpsc::{channel, Receiver, Sender},
     TryStreamExt,
 };
-use futures_util::{Future, SinkExt, StreamExt};
+use futures_util::{Future, SinkExt, StreamExt, TryFutureExt};
 use rand_core::{OsRng, RngCore};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tokio_stream::StreamExt as _;
 use tokio_tungstenite::{
     connect_async,
     tungstenite::{self, handshake::client::Request},
@@ -24,6 +25,10 @@ use url::Url;
 use crate::{get_user_agent, Error, Result};
 
 const CHANNEL_SIZE: usize = 1_000;
+const HEARTBEAT: Duration = Duration::from_secs(30);
+const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(35);
+
+pub type Reference = String;
 
 /// Main struct to interact with the control-protocol channel.
 ///
@@ -79,7 +84,7 @@ where
     I: DeserializeOwned,
     R: DeserializeOwned,
     M: From<I> + From<R>,
-    F: Fn(MessageResult<M>) -> Fut,
+    F: Fn(MessageResult<M>, Option<Reference>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
 {
     /// Starts the tunnel with the parameters given in [Self::new].
@@ -110,7 +115,10 @@ where
             handler, receiver, ..
         } = self;
 
-        let process_messages = read.try_for_each(|message| async {
+        let process_messages = tokio_stream::StreamExt::map(read.timeout(HEARTBEAT_TIMEOUT), |m| {
+            m.map_err(Error::from)?.map_err(Error::from)
+        })
+        .try_for_each(|message| async {
             Self::message_process(handler, message).await;
             Ok(())
         });
@@ -141,13 +149,26 @@ where
         // Furthermore can this also happen if write errors out? *that* I'd assume is possible...
         // What option is left? write a new future to forward items.
         // For now we should never assume that an item arrived the portal because we sent it!
-        let send_messages = receiver.map(Ok).forward(write);
+        let send_messages = futures::StreamExt::map(receiver, Ok)
+            .forward(write)
+            .map_err(Error::from);
+        // let send_messages = async {
+        //     while let Some(item) = receiver.next().await {
+        //         write.send(item).await?;
+        //     }
+        //     Ok(())
+        // };
 
         let phoenix_heartbeat = tokio::spawn(async move {
-            let mut timer = tokio::time::interval(Duration::from_secs(30));
+            let mut timer = tokio::time::interval(HEARTBEAT);
             loop {
                 timer.tick().await;
-                let Ok(_) = sender.send("phoenix", EgressControlMessage::Heartbeat(Empty {})).await else { break };
+                let Ok(_) = sender
+                    .send("phoenix", EgressControlMessage::Heartbeat(Empty {}))
+                    .await
+                else {
+                    break;
+                };
             }
         });
 
@@ -174,30 +195,28 @@ where
         match message.into_text() {
             Ok(m_str) => match serde_json::from_str::<PhoenixMessage<I, R>>(&m_str) {
                 Ok(m) => match m.payload {
-                    Payload::Message(m) => handler(Ok(m.into())).await,
+                    Payload::Message(payload) => handler(Ok(payload.into()), m.reference).await,
                     Payload::Reply(status) => match status {
                         ReplyMessage::PhxReply(phx_reply) => match phx_reply {
                             // TODO: Here we should pass error info to a subscriber
                             PhxReply::Error(info) => {
                                 tracing::warn!("Portal error: {info:?}");
-                                handler(Err(ErrorReply {
-                                    error: info,
-                                    reference: m.reference,
-                                }))
-                                .await
+                                handler(Err(ErrorReply { error: info }), m.reference).await
                             }
                             PhxReply::Ok(reply) => match reply {
                                 OkReply::NoMessage(Empty {}) => {
-                                    tracing::trace!("Phoenix status message")
+                                    tracing::trace!(target: "phoenix_status", "Phoenix status message")
                                 }
-                                OkReply::Message(m) => handler(Ok(m.into())).await,
+                                OkReply::Message(payload) => {
+                                    handler(Ok(payload.into()), m.reference).await
+                                }
                             },
                         },
                         ReplyMessage::PhxError(Empty {}) => tracing::error!("Phoenix error"),
                     },
                 },
                 Err(e) => {
-                    tracing::error!("Error deserializing message {m_str}: {e:?}");
+                    tracing::error!(message = "Error deserializing message", message_string =  m_str, error = ?e);
                 }
             },
             _ => tracing::error!("Received message that is not text"),
@@ -254,8 +273,6 @@ pub type MessageResult<M> = std::result::Result<M, ErrorReply>;
 pub struct ErrorReply {
     /// Information of the error
     pub error: ErrorInfo,
-    /// Reference to the message that caused the error
-    pub reference: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]

--- a/rust/connlib/libs/common/src/error.rs
+++ b/rust/connlib/libs/common/src/error.rs
@@ -21,6 +21,9 @@ pub enum ConnlibError {
     /// Request error for websocket connection.
     #[error("Error forming request: {0}")]
     RequestError(#[from] tokio_tungstenite::tungstenite::http::Error),
+    /// Websocket heartbeat timedout
+    #[error("Websocket heartbeat timedout")]
+    WebsocketTimeout(#[from] tokio_stream::Elapsed),
     /// Error during websocket connection.
     #[error("Portal connection error: {0}")]
     PortalConnectionError(#[from] tokio_tungstenite::tungstenite::error::Error),
@@ -99,6 +102,12 @@ pub enum ConnlibError {
     /// A panic occurred with a non-string payload.
     #[error("Panicked with a non-string payload")]
     PanicNonStringPayload,
+    /// Recieved connection details that might be stale
+    #[error("Unexpected connection details")]
+    UnexpectedConnectionDetails,
+    /// Invalid phoenix channel reference
+    #[error("Invalid phoenix channel reply reference")]
+    InvalidReference,
 }
 
 #[cfg(target_os = "linux")]

--- a/rust/connlib/libs/common/src/error.rs
+++ b/rust/connlib/libs/common/src/error.rs
@@ -102,7 +102,7 @@ pub enum ConnlibError {
     /// A panic occurred with a non-string payload.
     #[error("Panicked with a non-string payload")]
     PanicNonStringPayload,
-    /// Recieved connection details that might be stale
+    /// Received connection details that might be stale
     #[error("Unexpected connection details")]
     UnexpectedConnectionDetails,
     /// Invalid phoenix channel reference

--- a/rust/connlib/libs/gateway/src/control.rs
+++ b/rust/connlib/libs/gateway/src/control.rs
@@ -33,7 +33,7 @@ impl ControlSignal for ControlSignaler {
     async fn signal_connection_to(
         &self,
         resource: &ResourceDescription,
-        _connected_gateway_ids: &Vec<Id>,
+        _connected_gateway_ids: &[Id],
         _: usize,
     ) -> Result<()> {
         tracing::warn!("A message to network resource: {resource:?} was discarded, gateways aren't meant to be used as clients.");

--- a/rust/connlib/libs/gateway/src/control.rs
+++ b/rust/connlib/libs/gateway/src/control.rs
@@ -4,7 +4,7 @@ use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use boringtun::x25519::StaticSecret;
 use firezone_tunnel::{ControlSignal, Tunnel};
 use libs_common::{
-    control::{MessageResult, PhoenixSenderWithTopic},
+    control::{MessageResult, PhoenixSenderWithTopic, Reference},
     messages::{Id, ResourceDescription},
     Callbacks, ControlSession, Result,
 };
@@ -33,7 +33,8 @@ impl ControlSignal for ControlSignaler {
     async fn signal_connection_to(
         &self,
         resource: &ResourceDescription,
-        _connected_gateway_ids: Vec<Id>,
+        _connected_gateway_ids: &Vec<Id>,
+        _: usize,
     ) -> Result<()> {
         tracing::warn!("A message to network resource: {resource:?} was discarded, gateways aren't meant to be used as clients.");
         Ok(())
@@ -42,11 +43,14 @@ impl ControlSignal for ControlSignaler {
 
 impl<CB: Callbacks + 'static> ControlPlane<CB> {
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn start(mut self, mut receiver: Receiver<MessageResult<IngressMessages>>) -> Result<()> {
+    async fn start(
+        mut self,
+        mut receiver: Receiver<(MessageResult<IngressMessages>, Option<Reference>)>,
+    ) -> Result<()> {
         let mut interval = tokio::time::interval(Duration::from_secs(10));
         loop {
             tokio::select! {
-                Some(msg) = receiver.recv() => {
+                Some((msg, _)) = receiver.recv() => {
                     match msg {
                         Ok(msg) => self.handle_message(msg).await?,
                         Err(_msg_reply) => todo!(),
@@ -144,7 +148,7 @@ impl<CB: Callbacks + 'static> ControlSession<IngressMessages, CB> for ControlPla
     #[tracing::instrument(level = "trace", skip(private_key, callbacks))]
     async fn start(
         private_key: StaticSecret,
-        receiver: Receiver<MessageResult<IngressMessages>>,
+        receiver: Receiver<(MessageResult<IngressMessages>, Option<Reference>)>,
         control_signal: PhoenixSenderWithTopic,
         callbacks: CB,
     ) -> Result<()> {

--- a/rust/connlib/libs/tunnel/src/control_protocol.rs
+++ b/rust/connlib/libs/tunnel/src/control_protocol.rs
@@ -275,8 +275,8 @@ where
             let Some(awaiting_connection) = awaiting_connections.get_mut(&resource_id) else {
                 return Err(Error::UnexpectedConnectionDetails);
             };
-            awaiting_connection.1 = true;
-            if dbg!(awaiting_connection.0) != dbg!(reference)
+            awaiting_connection.response_recieved = true;
+            if awaiting_connection.total_attemps != reference
                 || resource_description
                     .ips()
                     .iter()

--- a/rust/connlib/libs/tunnel/src/control_protocol.rs
+++ b/rust/connlib/libs/tunnel/src/control_protocol.rs
@@ -258,7 +258,7 @@ where
         relays: Vec<Relay>,
         reference: Option<Reference>,
     ) -> Result<Request> {
-        tracing::trace!("Recieved gateways and relays for resource, requesting connection");
+        tracing::trace!("Received gateways and relays for resource, requesting connection");
         let resource_description = self
             .resources
             .read()

--- a/rust/connlib/libs/tunnel/src/control_protocol.rs
+++ b/rust/connlib/libs/tunnel/src/control_protocol.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use tracing::instrument;
 
 use libs_common::{
+    control::Reference,
     messages::{Id, Key, Relay, RequestConnection, ResourceDescription, ReuseConnection},
     Callbacks, Error, Result,
 };
@@ -255,16 +256,39 @@ where
         resource_id: Id,
         gateway_id: Id,
         relays: Vec<Relay>,
+        reference: Option<Reference>,
     ) -> Result<Request> {
-        self.resources_gateways
-            .lock()
-            .insert(resource_id, gateway_id);
+        tracing::trace!("Recieved gateways and relays for resource, requesting connection");
         let resource_description = self
             .resources
             .read()
             .get_by_id(&resource_id)
             .ok_or(Error::UnknownResource)?
             .clone();
+
+        let reference: usize = reference
+            .ok_or(Error::InvalidReference)?
+            .parse()
+            .map_err(|_| Error::InvalidReference)?;
+        {
+            let mut awaiting_connections = self.awaiting_connection.lock();
+            let Some(awaiting_connection) = awaiting_connections.get_mut(&resource_id) else {
+                return Err(Error::UnexpectedConnectionDetails);
+            };
+            awaiting_connection.1 = true;
+            if dbg!(awaiting_connection.0) != dbg!(reference)
+                || resource_description
+                    .ips()
+                    .iter()
+                    .any(|&ip| self.peers_by_ip.read().exact_match(ip).is_some())
+            {
+                return Err(Error::UnexpectedConnectionDetails);
+            }
+        }
+
+        self.resources_gateways
+            .lock()
+            .insert(resource_id, gateway_id);
         {
             let mut gateway_awaiting_connection = self.gateway_awaiting_connection.lock();
             if let Some(g) = gateway_awaiting_connection.get_mut(&gateway_id) {
@@ -278,23 +302,38 @@ where
             }
         }
         {
-            let mut peers_by_ip = self.peers_by_ip.write();
-            let peer = peers_by_ip
-                .iter()
-                .find_map(|(_, p)| (p.conn_id == gateway_id).then_some(p))
-                .cloned();
-            if let Some(peer) = peer {
-                for ip in resource_description.ips() {
-                    peer.add_allowed_ip(ip);
-                    peers_by_ip.insert(ip, Arc::clone(&peer));
+            let found = {
+                let mut peers_by_ip = self.peers_by_ip.write();
+                let peer = peers_by_ip
+                    .iter()
+                    .find_map(|(_, p)| (p.conn_id == gateway_id).then_some(p))
+                    .cloned();
+                if let Some(peer) = peer {
+                    for ip in resource_description.ips() {
+                        peer.add_allowed_ip(ip);
+                        peers_by_ip.insert(ip, Arc::clone(&peer));
+                    }
+                    true
+                } else {
+                    false
                 }
+            };
+
+            if found {
+                self.awaiting_connection.lock().remove(&resource_id);
                 return Ok(Request::ReuseConnection(ReuseConnection {
                     resource_id,
                     gateway_id,
                 }));
             }
         }
-        let peer_connection = self.initialize_peer_request(relays).await?;
+        let peer_connection = {
+            let peer_connection = Arc::new(self.initialize_peer_request(relays).await?);
+            let mut peer_connections = self.peer_connections.lock();
+            peer_connections.insert(gateway_id, Arc::clone(&peer_connection));
+            peer_connection
+        };
+
         self.set_connection_state_update_initiator(&peer_connection, gateway_id, resource_id);
 
         let data_channel = peer_connection.create_data_channel("data", None).await?;
@@ -359,10 +398,6 @@ where
             .local_description()
             .await
             .expect("Developer error: set_local_description was just called above");
-
-        self.peer_connections
-            .lock()
-            .insert(gateway_id, peer_connection);
 
         Ok(Request::NewConnection(RequestConnection {
             resource_id,

--- a/rust/connlib/libs/tunnel/src/lib.rs
+++ b/rust/connlib/libs/tunnel/src/lib.rs
@@ -122,7 +122,7 @@ pub trait ControlSignal {
     async fn signal_connection_to(
         &self,
         resource: &ResourceDescription,
-        connected_gateway_ids: &Vec<Id>,
+        connected_gateway_ids: &[Id],
         reference: usize,
     ) -> Result<()>;
 }
@@ -659,7 +659,7 @@ where
                                 // and we are finding another packet to the same address (otherwise we would just use peer_connections here)
                                 let mut awaiting_connection = dev.awaiting_connection.lock();
                                 let id = resource.id();
-                                if !awaiting_connection.get(&id).is_some() {
+                                if awaiting_connection.get(&id).is_none() {
                                     tracing::trace!(
                                         message = "Found new intent to send packets to resource",
                                         resource_ip = %dst_addr


### PR DESCRIPTION
When we lost networks(or change them), the phoenix channel didn't detect that the connection was lost, since the underlying websocket doesn't return an error if it's not closed gracefully.

So we expect the heartbeat at some point to consider the connection down.

Furthermore, while the connection is down sending the connection intents to the portal fails silently, so now we re-try the message until we get  a response and built some race-condition protections in case we get multiple or stale responses.