### PR TITLE
feat(relay): improve staging log filter

### DIFF
--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -614,7 +614,7 @@ module "relays" {
   image      = "relay"
   image_tag  = var.relay_image_tag
 
-  observability_log_level = "debug,relay=trace"
+  observability_log_level = "debug,relay=trace,hyper=off,wire=trace"
 
   application_name    = "relay"
   application_version = "0-0-1"


### PR DESCRIPTION
The `hyper` library outputs a lot of logs that are quite noisy so we turn those off. In addition, we activate the `wire` log target. The relay uses that one to emit all inbound and outbound traffic.