### PR TITLE
feat(relay): better integration with google cloud trace

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -858,6 +858,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +952,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1428,6 +1460,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "headless"
 version = "0.1.0"
 dependencies = [
@@ -1587,6 +1631,16 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2181,6 +2235,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "opentelemetry"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
 name = "os_info"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2720,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "once_cell",
+ "opentelemetry_sdk",
  "phoenix-channel",
  "prometheus-client",
  "proptest",
@@ -2632,6 +2733,7 @@ dependencies = [
  "test-strategy",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-stackdriver",
  "tracing-subscriber",
  "trackable 1.3.0",
@@ -3537,6 +3639,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00a39dcf9bfc1742fa4d6215253b33a6e474be78275884c216fc2a06267b3600"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-oslog"
 version = "0.1.2"
 source = "git+https://github.com/sbag13/tracing-oslog?rev=0f82b8051c65de86191e1350afc7a26d5c670c29#0f82b8051c65de86191e1350afc7a26d5c670c29"
@@ -3568,11 +3684,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac98e757a488cc11d6a84a52d223b970e11c99e5158cc2ff07b8544ccc260078"
 dependencies = [
  "Inflector",
+ "opentelemetry",
  "serde",
  "serde_json",
  "thiserror",
  "time 0.3.22",
  "tracing-core",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -3748,6 +3866,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -15,7 +15,9 @@ stun_codec = "0.3.1"
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "net", "time"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-tracing-stackdriver = "0.7.2"
+tracing-stackdriver = { version = "0.7.2", features = ["opentelemetry"] }
+tracing-opentelemetry = "0.19.0"
+opentelemetry_sdk = "0.19.0"
 env_logger = "0.10.0"
 bytes = "1.4.0"
 sha2 = "0.10.6"

--- a/terraform/modules/relay-app/main.tf
+++ b/terraform/modules/relay-app/main.tf
@@ -23,8 +23,8 @@ locals {
       value = var.observability_log_level
     },
     {
-      name  = "JSON_LOG"
-      value = "true"
+      name  = "GOOGLE_CLOUD_PROJECT_ID"
+      value = var.project_id
     },
     {
       name  = "METRICS_ADDR"


### PR DESCRIPTION
The relay already uses spans for its internal logging but up until now, those were only useful when using the regular stdout logger. For `JSON_LOG=true`, we did emit the spans but not in a format that worked with Google Cloud Trace.

We are changing the configuration of the binary to remove `JSON_LOG` and instead configure it with the Google Cloud "project id". If that one is set, we configure the logs such that they properly integrate with Google Cloud Trace by emitting unique span IDs for all messages. This should give us much better observability throughout a request that is being processed by the relay.

The `JSON_LOG` configuration option has been bugging me for a while because it was implicitly (a little bit) geared towards Google Stackdriver. We now make this explicit by requiring the project ID. That is a much cleaner integration IMO.