### PR TITLE
feat(relay): push spans to OTLP-receiver

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2719,6 +2719,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "once_cell",
+ "opentelemetry_api",
  "opentelemetry_sdk",
  "phoenix-channel",
  "prometheus-client",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -878,6 +878,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1069,27 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1300,6 +1330,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1454,31 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "gcp_auth"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab5724fa45095bf1965ff491e75182818ba13f2a8755b04d484a9ec6408b622"
+dependencies = [
+ "async-trait",
+ "base64 0.21.3",
+ "dirs-next",
+ "hyper",
+ "hyper-rustls",
+ "ring",
+ "rustls 0.20.9",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.22",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "which",
 ]
 
 [[package]]
@@ -1638,6 +1703,20 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.20.9",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2298,33 +2377,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-otlp"
-version = "0.12.0"
+name = "opentelemetry-semantic-conventions"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
+checksum = "24e33428e6bf08c6f7fcea4ddb8e358fab0fe48ab877a87c70c6ebe20f673ce5"
 dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http",
  "opentelemetry",
- "opentelemetry-proto",
- "prost",
- "thiserror",
- "tokio",
- "tonic",
 ]
 
 [[package]]
-name = "opentelemetry-proto"
-version = "0.2.0"
+name = "opentelemetry-stackdriver"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
+checksum = "ff78d1abfa634182471924e542004d1b46996a31a481da114eda4abaad9d5b61"
 dependencies = [
+ "async-trait",
  "futures",
- "futures-util",
+ "gcp_auth",
+ "hex",
+ "http",
+ "hyper",
  "opentelemetry",
+ "opentelemetry-semantic-conventions",
  "prost",
+ "prost-types",
+ "thiserror",
  "tonic",
 ]
 
@@ -2422,7 +2499,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.1",
 ]
@@ -2674,6 +2751,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,11 +2847,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -2830,7 +2936,7 @@ dependencies = [
  "hex-literal",
  "once_cell",
  "opentelemetry",
- "opentelemetry-otlp",
+ "opentelemetry-stackdriver",
  "phoenix-channel",
  "prometheus-client",
  "proptest",
@@ -2985,6 +3091,18 @@ dependencies = [
  "ring",
  "sct 0.6.1",
  "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3497,7 +3615,7 @@ dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix 0.37.22",
  "windows-sys 0.48.0",
 ]
@@ -3648,6 +3766,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.9",
+ "tokio",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
@@ -3678,7 +3807,7 @@ dependencies = [
  "rustls 0.21.2",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tungstenite",
  "webpki-roots",
 ]
@@ -3708,6 +3837,7 @@ dependencies = [
  "axum",
  "base64 0.13.1",
  "bytes",
+ "flate2",
  "futures-core",
  "futures-util",
  "h2",
@@ -3719,7 +3849,9 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util",
  "tower",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2362,6 +2362,8 @@ dependencies = [
  "percent-encoding",
  "rand",
  "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2827,6 +2829,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "once_cell",
+ "opentelemetry",
  "opentelemetry-otlp",
  "phoenix-channel",
  "prometheus-client",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -303,6 +303,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1480,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1626,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1596,6 +1638,18 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -2244,6 +2298,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-otlp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
+dependencies = [
+ "futures",
+ "futures-util",
+ "opentelemetry",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "opentelemetry_api"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +2649,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,8 +2827,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "once_cell",
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry-otlp",
  "phoenix-channel",
  "prometheus-client",
  "proptest",
@@ -3516,6 +3623,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,6 +3695,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,11 +3734,16 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3636,6 +3790,16 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -18,6 +18,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-stackdriver = { version = "0.7.2", features = ["opentelemetry"] }
 tracing-opentelemetry = "0.19.0"
 opentelemetry-otlp = "0.12.0"
+opentelemetry = { version = "0.19.0", features = ["rt-tokio"] }
 env_logger = "0.10.0"
 bytes = "1.4.0"
 sha2 = "0.10.6"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.8.5"
 stun_codec = "0.3.1"
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "net", "time"] }
 tracing = { version = "0.1.37", features = ["log"] }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 tracing-stackdriver = { version = "0.7.2", features = ["opentelemetry"] }
 tracing-opentelemetry = "0.19.0"
 opentelemetry-otlp = "0.12.0"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -17,8 +17,7 @@ tracing = { version = "0.1.37", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-stackdriver = { version = "0.7.2", features = ["opentelemetry"] }
 tracing-opentelemetry = "0.19.0"
-opentelemetry_sdk = "0.19.0"
-opentelemetry_api = "0.19.0"
+opentelemetry-otlp = "0.12.0"
 env_logger = "0.10.0"
 bytes = "1.4.0"
 sha2 = "0.10.6"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -16,8 +16,8 @@ tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "net", "t
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 tracing-stackdriver = { version = "0.7.2", features = ["opentelemetry"] }
+opentelemetry-stackdriver = { version = "0.16.0", default-features = false, features = ["gcp_auth"] }
 tracing-opentelemetry = "0.19.0"
-opentelemetry-otlp = "0.12.0"
 opentelemetry = { version = "0.19.0", features = ["rt-tokio"] }
 env_logger = "0.10.0"
 bytes = "1.4.0"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -18,6 +18,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-stackdriver = { version = "0.7.2", features = ["opentelemetry"] }
 tracing-opentelemetry = "0.19.0"
 opentelemetry_sdk = "0.19.0"
+opentelemetry_api = "0.19.0"
 env_logger = "0.10.0"
 bytes = "1.4.0"
 sha2 = "0.10.6"

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -183,7 +183,7 @@ fn setup_tracing(args: &Args) -> Result<()> {
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();
 
-    let registry = tracing_subscriber::registry().with(log_layer(&args)?.with_filter(env_filter));
+    let registry = tracing_subscriber::registry().with(log_layer(args)?.with_filter(env_filter));
 
     match args.otlp_receiver {
         None => registry.try_init(),

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
         let tracer = opentelemetry_otlp::new_pipeline()
             .tracing()
             .with_exporter(otlp_exporter)
-            .install_simple()?;
+            .install_batch(opentelemetry::runtime::Tokio)?;
 
         tracing_subscriber::registry()
             .with(

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -67,7 +67,7 @@ struct Args {
 
     /// Where to send trace data to.
     #[arg(long, env)]
-    trace_receiver: Option<TraceReceiver>,
+    trace_collector: Option<TraceCollector>,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
@@ -78,7 +78,7 @@ enum LogFormat {
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
-enum TraceReceiver {
+enum TraceCollector {
     /// Sends traces to Google Cloud Trace.
     GoogleCloudTrace,
     // TODO: Extend with OTLP receiver
@@ -191,7 +191,7 @@ async fn main() -> Result<()> {
 ///
 /// See [`log_layer`] for details on the base log layer.
 ///
-/// If the user has specified [`TraceReceiver::GoogleCloudTrace`], we will attempt to connec to Google Cloud Trace.
+/// If the user has specified [`TraceCollector::GoogleCloudTrace`], we will attempt to connec to Google Cloud Trace.
 /// This requires authentication.
 /// Here is how we will attempt to obtain those, for details see <https://docs.rs/gcp_auth/0.9.0/gcp_auth/struct.AuthenticationManager.html#method.new>.
 ///
@@ -202,9 +202,9 @@ async fn main() -> Result<()> {
 async fn setup_tracing(args: &Args) -> Result<()> {
     let registry = tracing_subscriber::registry();
 
-    match args.trace_receiver {
+    match args.trace_collector {
         None => registry.with(log_layer(args, None)).try_init(),
-        Some(TraceReceiver::GoogleCloudTrace) => {
+        Some(TraceCollector::GoogleCloudTrace) => {
             let authorizer = opentelemetry_stackdriver::GcpAuthorizer::new()
                 .await
                 .context("Failed to find GCP credentials")?;

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -2,6 +2,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use futures::channel::mpsc;
 use futures::{future, FutureExt, SinkExt, StreamExt};
+use opentelemetry_api::trace::TracerProvider as _;
+use opentelemetry_sdk::trace;
 use phoenix_channel::{Error, Event, PhoenixChannel};
 use prometheus_client::registry::Registry;
 use rand::rngs::StdRng;
@@ -73,19 +75,28 @@ async fn main() -> Result<()> {
         .from_env_lossy();
 
     if let Some(project_id) = args.google_cloud_project_id {
+        let provider = trace::TracerProvider::builder().build();
+        let relay_tracer = provider.tracer("relay");
+
+        opentelemetry_api::global::set_tracer_provider(provider); // Need to set the provider globally for spanIds to work, not sure why because we are setting a tracer further down already as well.
+
         tracing_subscriber::registry()
             .with(
                 tracing_stackdriver::layer()
                     .with_cloud_trace(CloudTraceConfiguration { project_id })
                     .with_filter(env_filter),
             )
-            .with(tracing_opentelemetry::layer().with_tracer(
-                opentelemetry_sdk::export::trace::stdout::new_pipeline().install_simple(),
-            ))
+            .with(
+                tracing_opentelemetry::layer().with_tracer(relay_tracer), // Need to set a tracer to attach spanIds to logs.
+            )
             .init()
     } else {
         tracing_subscriber::fmt().with_env_filter(env_filter).init()
     }
+
+    // Must create a root span for traces to be sampled.
+    let root = tracing::error_span!("root");
+    let _root = root.enter();
 
     let public_addr = match (args.public_ip4_addr, args.public_ip6_addr) {
         (Some(ip4), Some(ip6)) => IpStack::Dual { ip4, ip6 },

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -62,7 +62,7 @@ struct Args {
     rng_seed: Option<u64>,
 
     /// How to format the logs.
-    #[arg(long, env)]
+    #[arg(long, env, default_value = "human")]
     log_format: LogFormat,
 
     /// Where to send trace data to.
@@ -70,9 +70,8 @@ struct Args {
     trace_receiver: Option<TraceReceiver>,
 }
 
-#[derive(clap::ValueEnum, Debug, Default, Clone, Copy)]
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
 enum LogFormat {
-    #[default]
     Human,
     Json,
     GoogleCloud,

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -640,29 +640,6 @@ module "relays" {
   portal_token         = var.relay_portal_token
 }
 
-// TODO: Not sure where this goes? :shrug:
-module "agent_policy" {
-  source     = "terraform-google-modules/cloud-operations/google//modules/agent-policy"
-  version    = "~> 0.2.3"
-
-  project_id = module.google-cloud-project.project.project_id
-  policy_id  = "ops-agents-example-policy"
-  agent_rules = [
-    {
-      type               = "ops-agent"
-      version            = "current-major"
-      package_state      = "installed"
-      enable_autoupgrade = true
-    },
-  ]
-  group_labels = [
-    {
-      application_name = "relay" // How do we say that we only want the ops-agent on machines that run the relay?
-    }
-  ]
-  os_types = []
-}
-
 # Enable SSH on staging
 resource "google_compute_firewall" "ssh" {
   project = module.google-cloud-project.project.project_id

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -640,6 +640,29 @@ module "relays" {
   portal_token         = var.relay_portal_token
 }
 
+// TODO: Not sure where this goes? :shrug:
+module "agent_policy" {
+  source     = "terraform-google-modules/cloud-operations/google//modules/agent-policy"
+  version    = "~> 0.2.3"
+
+  project_id = module.google-cloud-project.project.project_id
+  policy_id  = "ops-agents-example-policy"
+  agent_rules = [
+    {
+      type               = "ops-agent"
+      version            = "current-major"
+      package_state      = "installed"
+      enable_autoupgrade = true
+    },
+  ]
+  group_labels = [
+    {
+      application_name = "relay" // How do we say that we only want the ops-agent on machines that run the relay?
+    }
+  ]
+  os_types = []
+}
+
 # Enable SSH on staging
 resource "google_compute_firewall" "ssh" {
   project = module.google-cloud-project.project.project_id

--- a/terraform/modules/relay-app/main.tf
+++ b/terraform/modules/relay-app/main.tf
@@ -23,8 +23,12 @@ locals {
       value = var.observability_log_level
     },
     {
-      name  = "GOOGLE_CLOUD_PROJECT_ID"
-      value = var.project_id
+      name  = "LOG_FORMAT"
+      value = "google_cloud=${var.project_id}"
+    },
+    {
+      name  = "OTLP_RECEIVER"
+      value = "localhost:4317" // This is where the ops-agent runs the OTLP-receiver: https://cloud.google.com/trace/docs/otlp#combined-receiver-types
     },
     {
       name  = "METRICS_ADDR"

--- a/terraform/modules/relay-app/main.tf
+++ b/terraform/modules/relay-app/main.tf
@@ -129,6 +129,9 @@ resource "google_compute_instance_template" "application" {
     container-vm = data.google_compute_image.coreos.name
   }, local.application_labels)
 
+  // TODO We need to include the ops-agent configuration file here
+  // See https://cloud.google.com/trace/docs/otlp#config-otlp.
+
   scheduling {
     automatic_restart   = true
     on_host_maintenance = "MIGRATE"

--- a/terraform/modules/relay-app/main.tf
+++ b/terraform/modules/relay-app/main.tf
@@ -23,12 +23,8 @@ locals {
       value = var.observability_log_level
     },
     {
-      name  = "LOG_FORMAT"
-      value = "google_cloud=${var.project_id}"
-    },
-    {
-      name  = "OTLP_RECEIVER"
-      value = "localhost:4317" // This is where the ops-agent runs the OTLP-receiver: https://cloud.google.com/trace/docs/otlp#combined-receiver-types
+      name  = "GOOGLE_CLOUD_PROJECT_ID"
+      value = var.project_id
     },
     {
       name  = "METRICS_ADDR"
@@ -132,9 +128,6 @@ resource "google_compute_instance_template" "application" {
   labels = merge({
     container-vm = data.google_compute_image.coreos.name
   }, local.application_labels)
-
-  // TODO We need to include the ops-agent configuration file here
-  // See https://cloud.google.com/trace/docs/otlp#config-otlp.
 
   scheduling {
     automatic_restart   = true

--- a/terraform/modules/relay-app/main.tf
+++ b/terraform/modules/relay-app/main.tf
@@ -23,8 +23,12 @@ locals {
       value = var.observability_log_level
     },
     {
-      name  = "GOOGLE_CLOUD_PROJECT_ID"
-      value = var.project_id
+      name  = "LOG_FORMAT"
+      value = "google-cloud"
+    },
+    {
+      name  = "TRACE_RECEIVER"
+      value = "google-cloud-trace"
     },
     {
       name  = "METRICS_ADDR"


### PR DESCRIPTION
When I built https://github.com/firezone/firezone/pull/1994, I hadn't yet fully understood how tracing works on Google Cloud. Logs and traces are separated in Google Cloud. Most importantly, traces need to be _pushed_ to Google Cloud whereas logs are scraped automatically. Logs can _reference_ traces via particular fields, in particular `logging.googleapis.com/spanId` and `projects/{project_id}/traces/{trace_id}`.

Within the container-optimised OS that we are running on, we are already authenticated to all the Google APIs. Thus, we can utilize the `GcpAuthorizer` from the `opentelemetry_stackdriver` module which will automatically obtain a token from the internal metadata endpoint. Thus no external configuration is necessary.

We split the configuration for logs / traces into two components:

- `LOG_FORMAT`: Specifies how the logs are formatted. Can be `human`, `json` or `google-cloud`.
- `TRACE_RECEIVER`: Optional. Specifies where the traces are sent to. If specified, we will also slightly tweak the log configuration to embed the project ID which allows Google Cloud Trace to cross-reference log entries with traces.