### PR TITLE
fix(relay): use correct name in terraform script

### DIFF
--- a/terraform/modules/relay-app/main.tf
+++ b/terraform/modules/relay-app/main.tf
@@ -27,7 +27,7 @@ locals {
       value = "google-cloud"
     },
     {
-      name  = "TRACE_RECEIVER"
+      name  = "TRACE_COLLECTOR"
       value = "google-cloud-trace"
     },
     {


### PR DESCRIPTION
In #1995, we last-minute renamed the env variable from `TRACE_RECEIVER` to `TRACE_COLLECTOR` but forgot to also rename it in the terraform config.