### PR TITLE
connlib: resource_table UB fixes

### DIFF
--- a/rust/connlib/libs/tunnel/src/lib.rs
+++ b/rust/connlib/libs/tunnel/src/lib.rs
@@ -193,6 +193,7 @@ where
             let resources = self.resources.read();
             (resources.network_resources(), resources.dns_resources())
         };
+
         let gateway_public_keys = self
             .gateway_public_keys
             .lock()
@@ -307,6 +308,7 @@ where
         }
         let resource_list = {
             let mut resources = self.resources.write();
+            tracing::debug!("{resource_description:?}");
             resources.insert(resource_description);
             resources.resource_list()
         };


### PR DESCRIPTION
fixes firezone/product#679

Originally I was using pointers to `HashMap` elements to store the resource_table, the problem is that if there is a realloc those pointers would be invalidated. So now, we are wrapping the elements in `Rc` and removing most unsafety.