### PR TITLE
feat(relay): allow configuration of OTLP exporter

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2980,6 +2980,7 @@ dependencies = [
  "test-strategy",
  "tokio",
  "tracing",
+ "tracing-core",
  "tracing-opentelemetry",
  "tracing-stackdriver",
  "tracing-subscriber",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2377,6 +2377,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-otlp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
+dependencies = [
+ "futures",
+ "futures-util",
+ "opentelemetry",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,6 +2967,7 @@ dependencies = [
  "hex-literal",
  "once_cell",
  "opentelemetry",
+ "opentelemetry-otlp",
  "opentelemetry-stackdriver",
  "phoenix-channel",
  "prometheus-client",

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -19,6 +19,7 @@ tracing-stackdriver = { version = "0.7.2", features = ["opentelemetry"] }
 opentelemetry-stackdriver = { version = "0.16.0", default-features = false, features = ["gcp_auth", "tls-native-roots"] }
 tracing-opentelemetry = "0.19.0"
 opentelemetry = { version = "0.19.0", features = ["rt-tokio"] }
+opentelemetry-otlp = "0.12.0"
 env_logger = "0.10.0"
 bytes = "1.4.0"
 sha2 = "0.10.6"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -21,6 +21,7 @@ tracing-opentelemetry = "0.19.0"
 opentelemetry = { version = "0.19.0", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.12.0"
 env_logger = "0.10.0"
+tracing-core = "0.1.31"
 bytes = "1.4.0"
 sha2 = "0.10.6"
 base64 = "0.21.4"

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -22,7 +22,7 @@ use std::pin::Pin;
 use std::task::Poll;
 use std::time::SystemTime;
 use tracing::level_filters::LevelFilter;
-use tracing::Subscriber;
+use tracing::{Span, Subscriber};
 use tracing_stackdriver::CloudTraceConfiguration;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -96,11 +96,8 @@ enum TraceCollector {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
-    setup_tracing(&args).await?;
-
-    // Must create a root span for traces to be sampled.
-    let root = tracing::error_span!("root");
-    let _root = root.enter();
+    let root_span = setup_tracing(&args).await?;
+    let _guard = root_span.enter();
 
     let public_addr = match (args.public_ip4_addr, args.public_ip6_addr) {
         (Some(ip4), Some(ip6)) => IpStack::Dual { ip4, ip6 },
@@ -213,7 +210,7 @@ async fn main() -> Result<()> {
 /// ## Integration with OTLP
 ///
 /// If the user has specified [`TraceCollector::Otlp`], we will set up an OTLP-exporter that connects to an OTLP collector specified at `Args.otlp_grpc_endpoint`.
-async fn setup_tracing(args: &Args) -> Result<()> {
+async fn setup_tracing(args: &Args) -> Result<Span> {
     // Use `tracing_core` directly for the temp logger because that one does not initialize a `log` logger.
     // A `log` Logger cannot be unset once set, so we can't use that for our temp logger during the setup.
     let temp_logger_guard = tracing_core::dispatcher::set_default(
@@ -287,7 +284,14 @@ async fn setup_tracing(args: &Args) -> Result<()> {
     }
     .context("Failed to init tracing")?;
 
-    Ok(())
+    // If we have a trace collector, we must define a root span, otherwise traces will not be sampled, i.e. discarded.
+    let root_span = if args.trace_collector.is_some() {
+        tracing::error_span!("root")
+    } else {
+        Span::none()
+    };
+
+    Ok(root_span)
 }
 
 /// Constructs the base log layer.

--- a/terraform/modules/relay-app/main.tf
+++ b/terraform/modules/relay-app/main.tf
@@ -28,7 +28,7 @@ locals {
     },
     {
       name  = "TRACE_COLLECTOR"
-      value = "google-cloud-trace"
+      value = "otlp"
     },
     {
       name  = "METRICS_ADDR"


### PR DESCRIPTION
Allows configuration of an OTLP collector as an alternative to Google Cloud Trace. We also add a temporary logger that allows us to print things to stdout as we are setting up the more complicated tracing infrastructure. This might be prove helpful during debugging!