### PR TITLE
fix(relay): add config for Google Project ID when using OTLP exporter

### DIFF
--- a/terraform/modules/relay-app/main.tf
+++ b/terraform/modules/relay-app/main.tf
@@ -31,6 +31,10 @@ locals {
       value = "otlp"
     },
     {
+      name  = "GOOGLE_CLOUD_PROJECT_ID"
+      value = var.project_id
+    },
+    {
       name  = "METRICS_ADDR"
       value = "0.0.0.0:8080"
     },


### PR DESCRIPTION
If we aren't configured to use the Google Cloud Trace exporter, then we currently have no way of configuring the Google Project Id for the relay. This in turn means that we cannot set span IDs for the Google Cloud logging format.

Add a configuration option and also emit a warning if we are configured to emit Google Cloud logging but don't have the ID set.