### PR TITLE
fix(relay): don't panic if waking time is in the past

### DIFF
--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -452,14 +452,18 @@ where
                         tracing::info!("Freeing addresses of allocation {id}");
                     }
                     Command::Wake { deadline } => {
-                        if let Some(duration) = deadline.duration_since(now) {
-                            tracing::trace!(?duration, "Suspending event loop")
-                        } else {
-                            tracing::warn!(
-                                ?deadline,
-                                ?now,
-                                "Wake time is already in the past, waking now"
-                            )
+                        match deadline.duration_since(now) {
+                            Ok(duration) => {
+                                tracing::trace!(?duration, "Suspending event loop")
+                            }
+                            Err(e) => {
+                                let difference = e.duration();
+
+                                tracing::warn!(
+                                    ?difference,
+                                    "Wake time is already in the past, waking now"
+                                )
+                            }
                         }
 
                         Pin::new(&mut self.sleep).reset(deadline);

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -450,6 +450,14 @@ where
                         tracing::info!("Freeing addresses of allocation {id}");
                     }
                     Command::Wake { deadline } => {
+                        let now = SystemTime::now();
+
+                        if let Some(duration) = deadline.duration_since(now) {
+                            tracing::trace!("Putting event-loop to sleep for at most {duration:?}")
+                        } else {
+                            tracing::warn!("Server wants to be woken at {deadline:?} but it is already {now:?}")
+                        }
+
                         Pin::new(&mut self.sleep).reset(deadline);
                     }
                     Command::ForwardData { id, data, receiver } => {


### PR DESCRIPTION
To be resource efficient, the relay's event loop suspends if there is no activity on its sockets. Certain operations however need to happen at a specified time, for example, allocations need to be freed if not renewed after a specified TTL. To achieve this, the relay implementation has a mechanism where it can request the event-loop to wake up at a specified deadline.

Previously, we assumed that this deadline was always in the future. For reasons not yet known, we encountered a situation where this deadline was in the past.

We fix this by:

1) Scheduling an immediate wake-up instead of panicking
2) Logging a warning to help with debugging if this ever occurs again