### PR TITLE
fix(relay): reduce log-spam from `h2` and `tower` crates

### DIFF
--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -614,7 +614,7 @@ module "relays" {
   image      = "relay"
   image_tag  = var.relay_image_tag
 
-  observability_log_level = "debug,relay=trace,hyper=off,wire=trace"
+  observability_log_level = "debug,relay=trace,hyper=off,h2=warn,tower=warn,wire=trace"
 
   application_name    = "relay"
   application_version = "0-0-1"


### PR DESCRIPTION
Those two crates log a fair amount of data on `debug` which is enabled globally. Set them to `warn` to be notified about actual problems.