### PR TITLE
fix(connlib): Persist logging guard for the duration of the session

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -57,6 +57,8 @@ internal class SessionViewModel @Inject constructor(
     }
 
     fun onDisconnect() {
+        tunnelManager.disconnect()
+        tunnelManager.removeListener(tunnelListener)
         actionMutableLiveData.postValue(ViewAction.NavigateToSignInFragment)
     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -158,11 +158,12 @@ class TunnelService: VpnService() {
     }
 
     private fun disconnect() {
+        Log.d(TAG, "Attempting to disconnect session")
         try {
             sessionPtr?.let {
+                Log.d(TAG, "calling TunnelSession.disconnect")
                 TunnelSession.disconnect(it)
             }
-            tunnelRepository.setState(Tunnel.State.Down)
         } catch (exception: Exception) {
             Log.e(TAG, exception.message.toString())
         }
@@ -230,7 +231,7 @@ class TunnelService: VpnService() {
             NOTIFICATION_CHANNEL_NAME,
             NotificationManager.IMPORTANCE_DEFAULT
         )
-        chan.description = "firezone vpn status"
+        chan.description = "firezone connection status"
 
         manager.createNotificationChannel(chan)
 
@@ -252,13 +253,13 @@ class TunnelService: VpnService() {
         const val ACTION_CONNECT = "dev.firezone.android.tunnel.CONNECT"
         const val ACTION_DISCONNECT = "dev.firezone.android.tunnel.DISCONNECT"
 
-        private const val NOTIFICATION_CHANNEL_ID = "firezone-vpn-status"
-        private const val NOTIFICATION_CHANNEL_NAME = "firezone-vpn-status"
+        private const val NOTIFICATION_CHANNEL_ID = "firezone-connection-status"
+        private const val NOTIFICATION_CHANNEL_NAME = "firezone-connection-status"
         private const val STATUS_NOTIFICATION_ID = 1337
-        private const val NOTIFICATION_TITLE = "Firezone Vpn Status"
+        private const val NOTIFICATION_TITLE = "Firezone Connection Status"
 
         private const val TAG: String = "TunnelService"
-        private const val SESSION_NAME: String = "Firezone VPN"
+        private const val SESSION_NAME: String = "Firezone Connection"
         private const val DEFAULT_MTU: Int = 1280
     }
 }

--- a/kotlin/android/app/src/main/res/values/strings.xml
+++ b/kotlin/android/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
 	<string name="error_dialog_message">Ops, something went wrong. Please try again later.</string>
 	<string name="error_dialog_button_text">Ok</string>
 	<string name="enable_vpn_permission">Enable VPN Permission</string>
-	<string name="vpn_permission_description">This app requires VPN permission to function effectively and provide you with a secure and private browsing experience. The VPN service encrypts your internet connection, ensuring that your data remains protected from potential threats and unauthorized access.\n\nRest assured, we highly prioritize your online privacy, and the VPN permission is solely used for providing the VPN service within the app. We do not monitor or log your online activities.\n\nTo proceed and enjoy the benefits of a secure connection, please grant the VPN permission by tapping the button below.</string>
+	<string name="vpn_permission_description">Firezone requires the VPN permission in order to route packets from your device to protected resources in a secure manner. All communication is end-to-end encrypted; we can never decrypt or otherwise monitor your communication. Please grant the VPN permission by tapping the button below.</string>
 	<string name="request_permission">Request Permission</string>
 	<string name="enter_team_id">Enter team id</string>
 	<string name="sign_in_debug_user">Sign In (Debug User)</string>

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "ip_network",
  "jni 0.21.1",
  "log",
+ "once_cell",
  "serde_json",
  "thiserror",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -150,21 +150,9 @@ checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_log-sys"
-version = "0.3.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
-
-[[package]]
-name = "android_logger"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c494134f746c14dc653a35a4ea5aca24ac368529da5370ecf41fe0341c35772f"
-dependencies = [
- "android_log-sys",
- "env_logger",
- "log",
- "once_cell",
-]
+checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
 
 [[package]]
 name = "android_system_properties"
@@ -779,15 +767,14 @@ dependencies = [
 name = "connlib-android"
 version = "0.1.6"
 dependencies = [
- "android_logger",
  "firezone-client-connlib",
  "ip_network",
  "jni 0.21.1",
  "log",
- "once_cell",
  "serde_json",
  "thiserror",
  "tracing",
+ "tracing-android",
  "tracing-appender",
  "tracing-subscriber",
 ]
@@ -1238,7 +1225,6 @@ checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 name = "firezone-client-connlib"
 version = "0.1.0"
 dependencies = [
- "android_logger",
  "async-trait",
  "backoff",
  "boringtun",
@@ -1249,6 +1235,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-android",
  "tracing-appender",
  "tracing-stackdriver",
  "tracing-subscriber",
@@ -1274,7 +1261,6 @@ dependencies = [
 name = "firezone-tunnel"
 version = "0.1.0"
 dependencies = [
- "android_logger",
  "async-trait",
  "boringtun",
  "bytes",
@@ -1298,6 +1284,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-android",
  "webrtc",
  "wintun",
 ]
@@ -1915,7 +1902,6 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 name = "libs-common"
 version = "0.1.0"
 dependencies = [
- "android_logger",
  "async-trait",
  "backoff",
  "base64 0.21.4",
@@ -1940,6 +1926,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tracing",
+ "tracing-android",
  "tracing-appender",
  "url",
  "uuid",
@@ -3725,6 +3712,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-android"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12612be8f868a09c0ceae7113ff26afe79d81a24473a393cb9120ece162e86c0"
+dependencies = [
+ "android_log-sys",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -787,6 +787,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -803,6 +804,7 @@ dependencies = [
  "swift-bridge",
  "swift-bridge-build",
  "tracing",
+ "tracing-appender",
  "tracing-oslog",
  "tracing-subscriber",
  "walkdir",
@@ -1521,6 +1523,7 @@ dependencies = [
  "firezone-client-connlib",
  "ip_network",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "url",
 ]
@@ -1936,6 +1939,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tracing",
+ "tracing-appender",
  "url",
  "uuid",
  "webrtc",

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -12,6 +12,7 @@ doc = false
 mock = ["firezone-client-connlib/mock"]
 
 [dependencies]
+once_cell = "1.18"
 android_logger = "0.13"
 tracing = { version = "0.1", features = ["log-always", "std", "attributes"] }
 tracing-subscriber = "0.3"

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -12,9 +12,8 @@ doc = false
 mock = ["firezone-client-connlib/mock"]
 
 [dependencies]
-once_cell = "1.18"
-android_logger = "0.13"
-tracing = { version = "0.1", features = ["log-always", "std", "attributes"] }
+tracing-android = "0.2"
+tracing = { version = "0.1", features = ["std", "attributes"] }
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 firezone-client-connlib = { path = "../../libs/client" }

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -13,7 +13,7 @@ mock = ["firezone-client-connlib/mock"]
 
 [dependencies]
 android_logger = "0.13"
-tracing = { version = "0.1", features = ["log", "std", "attributes"] }
+tracing = { version = "0.1", features = ["log-always", "std", "attributes"] }
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 firezone-client-connlib = { path = "../../libs/client" }

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -15,6 +15,7 @@ mock = ["firezone-client-connlib/mock"]
 android_logger = "0.13"
 tracing = { version = "0.1", features = ["log", "std", "attributes"] }
 tracing-subscriber = "0.3"
+tracing-appender = "0.2"
 firezone-client-connlib = { path = "../../libs/client" }
 jni = { version = "0.21.1", features = ["invocation"] }
 ip_network = "0.4"

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -32,7 +32,10 @@ impl Clone for CallbackHandler {
         // dumb pointers but the wrappers don't implement `Clone`.
         //
         // SAFETY: `self` is guaranteed to be valid and `Self` is POD.
-        unsafe { std::ptr::read(self) }
+        Self {
+            vm: unsafe { std::ptr::read(&self.vm) },
+            callback_handler: self.callback_handler.clone(),
+        }
     }
 }
 

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
 };
 use thiserror::Error;
 use tracing::log::LevelFilter;
+use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::prelude::*;
 
 pub struct CallbackHandler {
@@ -77,7 +78,7 @@ fn call_method(
         .map_err(|source| CallbackError::CallMethodFailed { name, source })
 }
 
-fn init_logging(log_dir: PathBuf) {
+fn init_logging(log_dir: PathBuf) -> WorkerGuard {
     // Initializes integration with Logcat for Android
     // This can be called many times, but will only initialize logging once
     android_logger::init_once(
@@ -90,11 +91,13 @@ fn init_logging(log_dir: PathBuf) {
             .with_tag("connlib"),
     );
 
-    let (file_layer, _guard) = file_logger::layer(log_dir);
+    let (file_layer, guard) = file_logger::layer(log_dir);
 
     // Calling init twice causes a panic; instead use try_init which will fail
     // gracefully if this is called more than once.
     let _ = tracing_subscriber::registry().with(file_layer).try_init();
+
+    guard
 }
 
 impl Callbacks for CallbackHandler {
@@ -260,14 +263,14 @@ impl Callbacks for CallbackHandler {
 fn throw(env: &mut JNIEnv, class: &str, msg: impl Into<JNIString>) {
     if let Err(err) = env.throw_new(class, msg) {
         // We can't panic, since unwinding across the FFI boundary is UB...
-        log::error!("failed to throw Java exception: {err}");
+        tracing::error!("failed to throw Java exception: {err}");
     }
 }
 
 fn catch_and_throw<F: FnOnce(&mut JNIEnv) -> R, R>(env: &mut JNIEnv, f: F) -> Option<R> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(env)))
         .map_err(|info| {
-            log::error!("catching Rust panic");
+            tracing::error!("catching Rust panic");
             throw(
                 env,
                 "java/lang/Exception",
@@ -334,12 +337,13 @@ fn connect(
         callback_handler,
     };
 
-    init_logging(log_dir.into());
+    let guard = init_logging(log_dir.into());
 
     Session::connect(
         portal_url.as_str(),
         portal_token,
         device_id,
+        Some(guard),
         callback_handler,
     )
     .map_err(Into::into)

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -390,15 +390,14 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_TunnelSession_dis
     _: JClass,
     session: *mut Session<CallbackHandler>,
 ) {
-    if let Some(session) = session.as_mut() {
-        catch_and_throw(&mut env, |_| {
-            session.disconnect(None);
-        });
-    } else {
-        throw(
-            &mut env,
-            "java/lang/NullPointerException",
-            "Cannot disconnect because \"session\" is null",
-        );
-    }
+    tracing::debug!("disconnecting");
+
+    let mut session = Box::from_raw(session);
+    tracing::debug!("{}", session.callbacks.0.callback_handler.is_null());
+
+    catch_and_throw(&mut env, |_| {
+        session.disconnect(None);
+    });
+
+    tracing::debug!("disconnected");
 }

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -22,6 +22,7 @@ tracing = "0.1"
 # TODO: https://github.com/Absolucy/tracing-oslog/pull/9
 tracing-oslog = { git = "https://github.com/sbag13/tracing-oslog", rev = "0f82b8051c65de86191e1350afc7a26d5c670c29" }
 tracing-subscriber = "0.3"
+tracing-appender = "0.2"
 
 [lib]
 name = "connlib"

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
+use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::prelude::*;
 
 #[swift_bridge::bridge]
@@ -135,23 +136,18 @@ impl Callbacks for CallbackHandler {
     }
 }
 
-fn init_logging(log_dir: PathBuf) {
-    let (file_layer, _guard) = file_logger::layer(log_dir.clone());
+fn init_logging(log_dir: PathBuf) -> WorkerGuard {
+    let (file_layer, guard) = file_logger::layer(log_dir.clone());
 
-    let collector = tracing_subscriber::registry()
+    let _ = tracing_subscriber::registry()
         .with(tracing_oslog::OsLogger::new(
             "dev.firezone.firezone",
             "connlib",
         ))
-        .with(file_layer);
+        .with(file_layer)
+        .try_init();
 
-    match tracing::subscriber::set_global_default(collector) {
-        Ok(()) => tracing::info!(
-            "File logging initialized! Logging to {:?}",
-            log_dir.display()
-        ),
-        Err(e) => tracing::error!("Failed to initialize logging! {}", e),
-    }
+    guard
 }
 
 impl WrappedSession {
@@ -162,12 +158,13 @@ impl WrappedSession {
         log_dir: String,
         callback_handler: ffi::CallbackHandler,
     ) -> Result<Self, String> {
-        init_logging(log_dir.into());
+        let guard = init_logging(log_dir.into());
 
         Session::connect(
             portal_url.as_str(),
             token,
             device_id,
+            Some(guard),
             CallbackHandler(callback_handler.into()),
         )
         .map(|session| Self { session })

--- a/rust/connlib/clients/headless/Cargo.toml
+++ b/rust/connlib/clients/headless/Cargo.toml
@@ -12,6 +12,7 @@ ip_network = "0.4"
 url = { version = "2.4.1", default-features = false }
 tracing-subscriber = { version = "0.3" }
 tracing = { version = "0.1" }
+tracing-appender = "0.2"
 anyhow = { version = "1.0" }
 clap = { version = "4.4", features = ["derive"] }
 ctrlc  = "3.4"

--- a/rust/connlib/clients/headless/src/main.rs
+++ b/rust/connlib/clients/headless/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> Result<()> {
         url,
         secret,
         device_id,
-        Some(init_logging(log_dir.into())),
+        Some(init_logging(log_dir)),
         CallbackHandler,
     )
     .unwrap();

--- a/rust/connlib/clients/headless/src/main.rs
+++ b/rust/connlib/clients/headless/src/main.rs
@@ -7,6 +7,7 @@ use std::{
     path::PathBuf,
     str::FromStr,
 };
+use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{fmt, prelude::*};
 
 use firezone_client_connlib::{
@@ -75,8 +76,8 @@ fn block_on_ctrl_c() {
     rx.recv().expect("Could not receive ctrl-c signal");
 }
 
-fn init_logging(log_dir: PathBuf) {
-    let (file_layer, _guard) = file_logger::layer(log_dir);
+fn init_logging(log_dir: PathBuf) -> WorkerGuard {
+    let (file_layer, guard) = file_logger::layer(log_dir);
 
     // Calling init twice causes a panic; instead use try_init which will fail
     // gracefully if this is called more than once.
@@ -84,6 +85,8 @@ fn init_logging(log_dir: PathBuf) {
         .with(fmt::layer())
         .with(file_layer)
         .try_init();
+
+    guard
 }
 
 fn main() -> Result<()> {
@@ -99,9 +102,10 @@ fn main() -> Result<()> {
     let device_id = get_device_id();
     let log_dir = parse_env_var::<PathBuf>(LOG_DIR_ENV_VAR).unwrap_or(DEFAULT_LOG_DIR.into());
 
-    init_logging(log_dir);
+    let guard = init_logging(log_dir);
 
-    let mut session = Session::connect(url, secret, device_id, CallbackHandler).unwrap();
+    let mut session =
+        Session::connect(url, secret, device_id, Some(guard), CallbackHandler).unwrap();
     tracing::info!("Started new session");
 
     block_on_ctrl_c();

--- a/rust/connlib/gateway/src/main.rs
+++ b/rust/connlib/gateway/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
     let url = parse_env_var::<Url>(URL_ENV_VAR)?;
     let secret = parse_env_var::<String>(SECRET_ENV_VAR)?;
     let device_id = get_device_id();
-    let mut session = Session::connect(url, secret, device_id, CallbackHandler).unwrap();
+    let mut session = Session::connect(url, secret, device_id, None, CallbackHandler).unwrap();
 
     let (tx, rx) = std::sync::mpsc::channel();
     ctrlc::set_handler(move || tx.send(()).expect("Could not send stop signal on channel."))

--- a/rust/connlib/libs/client/Cargo.toml
+++ b/rust/connlib/libs/client/Cargo.toml
@@ -20,8 +20,8 @@ boringtun = { workspace = true }
 backoff = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-tracing = { version = "0.1", default-features = false, features = ["log-always", "std", "attributes"] }
-android_logger = "0.13"
+tracing = { version = "0.1", default-features = false, features = ["std", "attributes"] }
+tracing-android = "0.2"
 
 [dev-dependencies]
 serde_json = { version = "1.0", default-features = false, features = ["std"] }

--- a/rust/connlib/libs/client/Cargo.toml
+++ b/rust/connlib/libs/client/Cargo.toml
@@ -20,7 +20,7 @@ boringtun = { workspace = true }
 backoff = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-tracing = { version = "0.1", default-features = false, features = ["log", "std", "attributes"] }
+tracing = { version = "0.1", default-features = false, features = ["log-always", "std", "attributes"] }
 android_logger = "0.13"
 
 [dev-dependencies]

--- a/rust/connlib/libs/common/Cargo.toml
+++ b/rust/connlib/libs/common/Cargo.toml
@@ -45,7 +45,7 @@ smbios-lib = "0.9"
 swift-bridge = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.13"
+tracing-android = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = { version = "0.13", default-features = false, features = ["tokio_socket"] }

--- a/rust/connlib/libs/common/Cargo.toml
+++ b/rust/connlib/libs/common/Cargo.toml
@@ -32,6 +32,7 @@ chrono = { workspace = true }
 parking_lot = "0.12"
 ring = "0.16"
 tokio-stream = { version = "0.1", features = ["time"] }
+tracing-appender = "0.2"
 
 # Needed for Android logging until tracing is working
 log = "0.4"

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -58,8 +58,7 @@ pub struct Session<T, U, V, R, M, CB: Callbacks> {
     runtime_stopper: tokio::sync::mpsc::Sender<StopRuntime>,
     // The guard must not be dropped before the runtime is dropped, otherwise logs won't get
     // flushed to the logfile.
-    #[allow(dead_code)]
-    logging_guard: Option<WorkerGuard>,
+    _logging_guard: Option<WorkerGuard>,
     callbacks: CallbackErrorFacade<CB>,
     _phantom: PhantomData<(T, U, V, R, M)>,
 }
@@ -380,16 +379,6 @@ where
     /// Further cleanup should be done here. (Otherwise we can just drop [Session]).
     pub fn disconnect(&mut self, error: Option<Error>) {
         Self::disconnect_inner(self.runtime_stopper.clone(), &self.callbacks, error)
-    }
-
-    // TODO: See https://github.com/WireGuard/wireguard-apple/blob/2fec12a6e1f6e3460b6ee483aa00ad29cddadab1/Sources/WireGuardKitGo/api-apple.go#L177
-    pub fn bump_sockets(&self) {
-        tracing::error!("`bump_sockets` is unimplemented");
-    }
-
-    // TODO: See https://github.com/WireGuard/wireguard-apple/blob/2fec12a6e1f6e3460b6ee483aa00ad29cddadab1/Sources/WireGuardKitGo/api-apple.go#LL197C6-L197C50
-    pub fn disable_some_roaming_for_broken_mobile_semantics(&self) {
-        tracing::error!("`disable_some_roaming_for_broken_mobile_semantics` is unimplemented");
     }
 }
 

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -221,7 +221,7 @@ where
         portal_url: impl TryInto<Url>,
         token: String,
         device_id: String,
-        logging_guard: Option<WorkerGuard>,
+        _logging_guard: Option<WorkerGuard>,
         callbacks: CB,
     ) -> Result<Self> {
         // TODO: We could use tokio::runtime::current() to get the current runtime
@@ -234,7 +234,7 @@ where
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let this = Self {
             runtime_stopper: tx.clone(),
-            logging_guard,
+            _logging_guard,
             callbacks,
             _phantom: PhantomData,
         };

--- a/rust/connlib/libs/common/src/session.rs
+++ b/rust/connlib/libs/common/src/session.rs
@@ -59,7 +59,7 @@ pub struct Session<T, U, V, R, M, CB: Callbacks> {
     // The guard must not be dropped before the runtime is dropped, otherwise logs won't get
     // flushed to the logfile.
     _logging_guard: Option<WorkerGuard>,
-    callbacks: CallbackErrorFacade<CB>,
+    pub callbacks: CallbackErrorFacade<CB>,
     _phantom: PhantomData<(T, U, V, R, M)>,
 }
 
@@ -353,8 +353,8 @@ where
         error: Option<Error>,
     ) {
         // 1. Close the websocket connection
-        // 2. Free the device handle (UNIX)
-        // 3. Close the file descriptor (UNIX)
+        // 2. Free the device handle (Linux)
+        // 3. Close the file descriptor (Linux/Android)
         // 4. Remove the mapping
 
         // The way we cleanup the tasks is we drop the runtime
@@ -366,6 +366,7 @@ where
         // if there's no receiver the runtime is already stopped
         // there's an edge case where this is called before the thread is listening for stop threads.
         // but I believe in that case the channel will be in a signaled state achieving the same result
+
         if let Err(err) = runtime_stopper.try_send(StopRuntime) {
             tracing::error!("Couldn't stop runtime: {err}");
         }

--- a/rust/connlib/libs/tunnel/Cargo.toml
+++ b/rust/connlib/libs/tunnel/Cargo.toml
@@ -38,7 +38,7 @@ rtnetlink = { version = "0.13", default-features = false, features = ["tokio_soc
 
 # Android tunnel dependencies
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.13"
+tracing-android = "0.2"
 
 # Windows tunnel dependencies
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/rust/connlib/libs/tunnel/src/tun_android.rs
+++ b/rust/connlib/libs/tunnel/src/tun_android.rs
@@ -156,7 +156,7 @@ impl IfaceConfig {
     }
 
     pub async fn up(&mut self) -> Result<()> {
-        tracing::debug!("`up` unimplemented on Android");
+        tracing::debug!("`up` unimplemented");
         Ok(())
     }
 }

--- a/rust/connlib/libs/tunnel/src/tun_android.rs
+++ b/rust/connlib/libs/tunnel/src/tun_android.rs
@@ -123,7 +123,6 @@ impl IfaceDevice {
 
         let mtu = unsafe { ifr.ifr_ifru.ifru_mtu };
 
-        log::debug!("MTU for {} is {}", name, mtu);
         Ok(mtu as _)
     }
 
@@ -157,7 +156,7 @@ impl IfaceConfig {
     }
 
     pub async fn up(&mut self) -> Result<()> {
-        log::debug!("`up` unimplemented on Android");
+        tracing::debug!("`up` unimplemented on Android");
         Ok(())
     }
 }

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -221,7 +221,6 @@ impl IfaceDevice {
 
         let mtu = unsafe { ifr.ifr_ifru.ifru_mtu };
 
-        tracing::debug!("MTU for {} is {}", name, mtu);
         Ok(unsafe { ifr.ifr_ifru.ifru_mtu } as _)
     }
 

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -273,7 +273,7 @@ impl IfaceConfig {
     }
 
     pub async fn up(&mut self) -> Result<()> {
-        tracing::debug!("`up` unimplemented on darwin");
+        tracing::debug!("`up` unimplemented");
         Ok(())
     }
 }

--- a/rust/connlib/libs/tunnel/src/tun_darwin.rs
+++ b/rust/connlib/libs/tunnel/src/tun_darwin.rs
@@ -219,8 +219,6 @@ impl IfaceDevice {
             return Err(get_last_error());
         }
 
-        let mtu = unsafe { ifr.ifr_ifru.ifru_mtu };
-
         Ok(unsafe { ifr.ifr_ifru.ifru_mtu } as _)
     }
 

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -13,7 +13,7 @@ hex-literal = "0.4.1"
 rand = "0.8.5"
 stun_codec = "0.3.1"
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "net", "time"] }
-tracing = { version = "0.1.37", features = ["log-always"] }
+tracing = { version = "0.1.37", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 tracing-stackdriver = { version = "0.7.2", features = ["opentelemetry"] }
 tracing-opentelemetry = "0.19.0"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -13,7 +13,7 @@ hex-literal = "0.4.1"
 rand = "0.8.5"
 stun_codec = "0.3.1"
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "net", "time"] }
-tracing = { version = "0.1.37", features = ["log"] }
+tracing = { version = "0.1.37", features = ["log-always"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 tracing-stackdriver = { version = "0.7.2", features = ["opentelemetry"] }
 tracing-opentelemetry = "0.19.0"


### PR DESCRIPTION
This allows the file logger to write events as they're emitted so that we (attempt to) capture everything for the lifetime of the session.

Sample:

```json
{"time":"2023-09-13T13:28:26.396615Z","target":"libs_common::session","logging.googleapis.com/sourceLocation":{"file":"connlib/libs/common/src/session.rs","line":"324"},"severity":"DEBUG","message":"Attempting connection to portal..."}
{"time":"2023-09-13T13:28:26.436317Z","target":"log","severity":"DEBUG","logFile":"/Users/jamil/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.21.7/src/client/hs.rs","logLine":73,"logModulePath":"rustls::client::hs","logTarget":"rustls::client::hs","message":"No cached session for DnsName(\"api.firez.one\")"}
{"time":"2023-09-13T13:28:26.43694Z","target":"log","severity":"DEBUG","logFile":"/Users/jamil/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.21.7/src/client/hs.rs","logLine":132,"logModulePath":"rustls::client::hs","logTarget":"rustls::client::hs","message":"Not resuming any session"}
{"time":"2023-09-13T13:28:26.446781Z","target":"log","severity":"DEBUG","logFile":"/Users/jamil/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.21.7/src/client/hs.rs","logLine":615,"logModulePath":"rustls::client::hs","logTarget":"rustls::client::hs","message":"Using ciphersuite TLS13_AES_256_GCM_SHA384"}
{"time":"2023-09-13T13:28:26.447046Z","target":"log","severity":"DEBUG","logFile":"/Users/jamil/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.21.7/src/client/tls13.rs","logLine":142,"logModulePath":"rustls::client::tls13","logTarget":"rustls::client::tls13","message":"Not resuming"}
{"time":"2023-09-13T13:28:26.449001Z","target":"log","severity":"DEBUG","logFile":"/Users/jamil/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.21.7/src/client/tls13.rs","logLine":381,"logModulePath":"rustls::client::tls13","logTarget":"rustls::client::tls13","message":"TLS1.3 encrypted extensions: []"}
{"time":"2023-09-13T13:28:26.449266Z","target":"log","severity":"DEBUG","logFile":"/Users/jamil/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.21.7/src/client/hs.rs","logLine":472,"logModulePath":"rustls::client::hs","logTarget":"rustls::client::hs","message":"ALPN protocol is None"}
{"time":"2023-09-13T13:28:26.544357Z","target":"libs_common::session","logging.googleapis.com/sourceLocation":{"file":"connlib/libs/common/src/session.rs","line":"327"},"severity":"WARNING","error":"PortalConnectionError(Http(Response { status: 404, version: HTTP/1.1, headers: {\"cache-control\": \"max-age=0, private, must-revalidate\", \"content-length\": \"9\", \"date\": \"Wed, 13 Sep 2023 13:28:25 GMT\", \"server\": \"Cowboy\", \"strict-transport-security\": \"max-age=63072000; includeSubDomains; preload\", \"x-request-id\": \"F4R4XmBOoVfqEVkAAAVh\", \"via\": \"1.1 google\", \"alt-svc\": \"h3=\\\":443\\\"; ma=2592000,h3-29=\\\":443\\\"; ma=2592000\", \"connection\": \"close\"}, body: Some([78, 111, 116, 32, 102, 111, 117, 110, 100]) }))","message":"Portal connection error"}
{"time":"2023-09-13T13:28:26.544838Z","target":"libs_common::session","logging.googleapis.com/sourceLocation":{"file":"connlib/libs/common/src/session.rs","line":"330"},"severity":"WARNING","message":"Error connecting to portal, retrying in 42 seconds"}
{"time":"2023-09-13T13:28:36.087416Z","target":"tunnel_state","logging.googleapis.com/sourceLocation":{"file":"connlib/libs/client/src/control.rs","line":"255"},"severity":"DEBUG","message":"TunnelStats {\n    public_key: \"BQCIkQ7iNdQxEnZo6lGwR8prKJgMlJGL+UPj+C50J0s=\",\n    peers_by_ip: {},\n    peer_connections: [\n        7482154e-107d-4981-8f5e-4becf1a9bfd2,\n    ],\n    resource_gateways: {\n        2a39fb5e-f7f4-44da-9163-5675c009a2ae: 7482154e-107d-4981-8f5e-4becf1a9bfd2,\n    },\n    dns_resources: {},\n    network_resources: {\n        V4(\n            Ipv4Network {\n                network_address: 172.31.83.10,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 01c6a1ea-2540-4ec8-9caa-0015ddfffb55,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.83.10,\n                        netmask: 32,\n                    },\n                ),\n                name: \"TCP / UDPbin\",\n            },\n        ),\n        V4(\n            Ipv4Network {\n                network_address: 172.31.92.238,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 115ab626-ac3e-4890-b613-07f90bc1afb3,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.92.238,\n                        netmask: 32,\n                    },\n                ),\n                name: \"Performance Testing\",\n            },\n        ),\n        V4(\n            Ipv4Network {\n                network_address: 172.31.82.179,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 2a39fb5e-f7f4-44da-9163-5675c009a2ae,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.82.179,\n                        netmask: 32,\n                    },\n                ),\n                name: \"HTTPbin\",\n            },\n        ),\n        V4(\n            Ipv4Network {\n                network_address: 172.31.93.123,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 196b9f86-0789-4c2e-8afd-3b3cd59e1462,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.93.123,\n                        netmask: 32,\n                    },\n                ),\n                name: \"IPerf3\",\n            },\n        ),\n    },\n    gateway_public_keys: {},\n    awaiting_connection: {\n        2a39fb5e-f7f4-44da-9163-5675c009a2ae: AwaitingConnectionDetails {\n            total_attemps: 31,\n            response_received: true,\n        },\n    },\n    gateway_awaiting_connection: {\n        7482154e-107d-4981-8f5e-4becf1a9bfd2: [],\n    },\n}"}
{"time":"2023-09-13T13:28:46.087297Z","target":"tunnel_state","logging.googleapis.com/sourceLocation":{"file":"connlib/libs/client/src/control.rs","line":"255"},"severity":"DEBUG","message":"TunnelStats {\n    public_key: \"BQCIkQ7iNdQxEnZo6lGwR8prKJgMlJGL+UPj+C50J0s=\",\n    peers_by_ip: {},\n    peer_connections: [\n        7482154e-107d-4981-8f5e-4becf1a9bfd2,\n    ],\n    resource_gateways: {\n        2a39fb5e-f7f4-44da-9163-5675c009a2ae: 7482154e-107d-4981-8f5e-4becf1a9bfd2,\n    },\n    dns_resources: {},\n    network_resources: {\n        V4(\n            Ipv4Network {\n                network_address: 172.31.82.179,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 2a39fb5e-f7f4-44da-9163-5675c009a2ae,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.82.179,\n                        netmask: 32,\n                    },\n                ),\n                name: \"HTTPbin\",\n            },\n        ),\n        V4(\n            Ipv4Network {\n                network_address: 172.31.83.10,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 01c6a1ea-2540-4ec8-9caa-0015ddfffb55,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.83.10,\n                        netmask: 32,\n                    },\n                ),\n                name: \"TCP / UDPbin\",\n            },\n        ),\n        V4(\n            Ipv4Network {\n                network_address: 172.31.92.238,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 115ab626-ac3e-4890-b613-07f90bc1afb3,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.92.238,\n                        netmask: 32,\n                    },\n                ),\n                name: \"Performance Testing\",\n            },\n        ),\n        V4(\n            Ipv4Network {\n                network_address: 172.31.93.123,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 196b9f86-0789-4c2e-8afd-3b3cd59e1462,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.93.123,\n                        netmask: 32,\n                    },\n                ),\n                name: \"IPerf3\",\n            },\n        ),\n    },\n    gateway_public_keys: {},\n    awaiting_connection: {\n        2a39fb5e-f7f4-44da-9163-5675c009a2ae: AwaitingConnectionDetails {\n            total_attemps: 31,\n            response_received: true,\n        },\n    },\n    gateway_awaiting_connection: {\n        7482154e-107d-4981-8f5e-4becf1a9bfd2: [],\n    },\n}"}
{"time":"2023-09-13T13:28:53.703612Z","target":"log","severity":"WARNING","logFile":"/Users/jamil/.cargo/git/checkouts/webrtc-316f277f555c12ed/672e728/mdns/src/conn/mod.rs","logLine":359,"logModulePath":"webrtc_mdns::conn","logTarget":"webrtc_mdns::conn","message":"Failed to parse mDNS packet parsing/packing of this type isn't available yet"}
{"time":"2023-09-13T13:28:54.709612Z","target":"log","severity":"WARNING","logFile":"/Users/jamil/.cargo/git/checkouts/webrtc-316f277f555c12ed/672e728/mdns/src/conn/mod.rs","logLine":359,"logModulePath":"webrtc_mdns::conn","logTarget":"webrtc_mdns::conn","message":"Failed to parse mDNS packet parsing/packing of this type isn't available yet"}
{"time":"2023-09-13T13:28:56.086942Z","target":"tunnel_state","logging.googleapis.com/sourceLocation":{"file":"connlib/libs/client/src/control.rs","line":"255"},"severity":"DEBUG","message":"TunnelStats {\n    public_key: \"BQCIkQ7iNdQxEnZo6lGwR8prKJgMlJGL+UPj+C50J0s=\",\n    peers_by_ip: {},\n    peer_connections: [\n        7482154e-107d-4981-8f5e-4becf1a9bfd2,\n    ],\n    resource_gateways: {\n        2a39fb5e-f7f4-44da-9163-5675c009a2ae: 7482154e-107d-4981-8f5e-4becf1a9bfd2,\n    },\n    dns_resources: {},\n    network_resources: {\n        V4(\n            Ipv4Network {\n                network_address: 172.31.82.179,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 2a39fb5e-f7f4-44da-9163-5675c009a2ae,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.82.179,\n                        netmask: 32,\n                    },\n                ),\n                name: \"HTTPbin\",\n            },\n        ),\n        V4(\n            Ipv4Network {\n                network_address: 172.31.93.123,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 196b9f86-0789-4c2e-8afd-3b3cd59e1462,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.93.123,\n                        netmask: 32,\n                    },\n                ),\n                name: \"IPerf3\",\n            },\n        ),\n        V4(\n            Ipv4Network {\n                network_address: 172.31.83.10,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 01c6a1ea-2540-4ec8-9caa-0015ddfffb55,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.83.10,\n                        netmask: 32,\n                    },\n                ),\n                name: \"TCP / UDPbin\",\n            },\n        ),\n        V4(\n            Ipv4Network {\n                network_address: 172.31.92.238,\n                netmask: 32,\n            },\n        ): Cidr(\n            ResourceDescriptionCidr {\n                id: 115ab626-ac3e-4890-b613-07f90bc1afb3,\n                address: V4(\n                    Ipv4Network {\n                        network_address: 172.31.92.238,\n                        netmask: 32,\n                    },\n                ),\n                name: \"Performance Testing\",\n            },\n        ),\n    },\n    gateway_public_keys: {},\n    awaiting_connection: {\n        2a39fb5e-f7f4-44da-9163-5675c009a2ae: AwaitingConnectionDetails {\n            total_attemps: 31,\n            response_received: true,\n        },\n    },\n    gateway_awaiting_connection: {\n        7482154e-107d-4981-8f5e-4becf1a9bfd2: [],\n    },\n}"}
{"time":"2023-09-13T13:28:57.52105Z","target":"firezone_tunnel::tun","logging.googleapis.com/sourceLocation":{"file":"connlib/libs/tunnel/src/tun_darwin.rs","line":"224"},"severity":"DEBUG","message":"MTU for utun7 is 1420"}
```


Sample log attached:

[connlib.log.zip](https://github.com/firezone/firezone/files/12598066/connlib.log.zip)
