### PR TITLE
ci(terraform): ensure relay `cloud-init` config is valid

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,6 +25,10 @@ jobs:
       TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
       TF_WORKSPACE: "staging"
     steps:
+      - name: Validate cloud-init
+        run: |
+          sudo apt-get install -y cloud-init
+          sudo cloud-init schema --config-file terraform/modules/relay-app/templates/cloud-init.yaml
       - name: Get Terraform Version
         run: |
           TERRAFORM_VERSION=$(cat .tool-versions | grep terraform | awk '{ print $NF; }')

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,10 +25,6 @@ jobs:
       TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
       TF_WORKSPACE: "staging"
     steps:
-      - name: Validate cloud-init
-        run: |
-          sudo apt-get install -y cloud-init
-          sudo cloud-init schema --config-file terraform/modules/relay-app/templates/cloud-init.yaml
       - name: Get Terraform Version
         run: |
           TERRAFORM_VERSION=$(cat .tool-versions | grep terraform | awk '{ print $NF; }')
@@ -37,6 +33,12 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
       - uses: actions/checkout@v4
+
+      - name: Validate cloud-init
+        run: |
+          sudo apt-get install -y cloud-init
+          sudo cloud-init schema --config-file terraform/modules/relay-app/templates/cloud-init.yaml
+
       - name: Check Formatting
         working-directory: terraform
         run: |

--- a/terraform/modules/relay-app/templates/cloud-init.yaml
+++ b/terraform/modules/relay-app/templates/cloud-init.yaml
@@ -6,7 +6,7 @@ users:
 
 write_files:
   - path: /etc/otelcol-contrib/config.yaml
-    permissions: 0644
+    permissions: "0644"
     owner: root
     content: |
       receivers:
@@ -71,7 +71,7 @@ write_files:
             exporters: [googlecloud]
 
   - path: /etc/systemd/system/otel-collector.service
-    permissions: 0644
+    permissions: "0644"
     owner: root
     content: |
       [Unit]


### PR DESCRIPTION
I found the following in the serial port logs on GC:

> [   24.279297] cloud-init[742]: 2023-09-20 19:34:00,095 - schema.py[WARNING]: Invalid cloud-config provided: Please run 'sudo cloud-init schema --system' to see the schema errors.

Not sure if it causes any problems at the moment because the spans seem to import fine but I figured it cannot hurt to add a linter to our CI.