### PR TITLE
fix(relay): delete correct label from exported metrics

### DIFF
--- a/terraform/modules/relay-app/templates/cloud-init.yaml
+++ b/terraform/modules/relay-app/templates/cloud-init.yaml
@@ -45,16 +45,7 @@ write_files:
             - delete_key(attributes, "instance")
             - set(attributes["exported_project_id"], attributes["project_id"])
             - delete_key(attributes, "project_id")
-            - set(attributes["exported_service_name"], attributes["service_name"])
-            - delete_key(attributes, "service_name")
-            - set(attributes["exported_service_namespace"], attributes["service_namespace"])
-            - delete_key(attributes, "service_namespace")
-            - set(attributes["exported_service_instance_id"], attributes["service_instance_id"])
-            - delete_key(attributes, "service_instance_id")
-            - set(attributes["exported_instrumentation_source"], attributes["instrumentation_source"])
-            - delete_key(attributes, "instrumentation_source")
-            - set(attributes["exported_instrumentation_version"], attributes["instrumentation_version"])
-            - delete_key(attributes, "instrumentation_version")
+            - delete_key(attributes, "service.name")
       service:
         pipelines:
           traces:


### PR DESCRIPTION
The documentation isn't super clear here: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/googlecloudexporter/README.md#preventing-metric-label-collisions

I think we might have to delete the `service.name` label instead of `service_name` because that is how I am setting (and probably exporting) it.