### PR TITLE
feat(relay): enable debug logs for otel collector

### DIFF
--- a/terraform/modules/relay-app/templates/cloud-init.yaml
+++ b/terraform/modules/relay-app/templates/cloud-init.yaml
@@ -18,6 +18,7 @@ write_files:
         googlecloud:
           log:
             default_log_name: opentelemetry.io/collector-exported-log
+        debug:
       processors:
         memory_limiter:
           check_interval: 1s
@@ -56,6 +57,9 @@ write_files:
             - set(attributes["exported_instrumentation_version"], attributes["instrumentation_version"])
             - delete_key(attributes, "instrumentation_version")
       service:
+        telemetry:
+          logs:
+            level: "debug"
         pipelines:
           traces:
             receivers: [otlp]

--- a/terraform/modules/relay-app/templates/cloud-init.yaml
+++ b/terraform/modules/relay-app/templates/cloud-init.yaml
@@ -19,6 +19,7 @@ write_files:
           log:
             default_log_name: opentelemetry.io/collector-exported-log
         debug:
+          verbosity: detailed
       processors:
         memory_limiter:
           check_interval: 1s


### PR DESCRIPTION
The `debug` exporter prints statements like the following to stdout:

> 2023-09-07T09:57:43.468-0700    info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 2}

Activating debug logs should give us overall more insight into what this thing is doing.