### PR TITLE
deps(rust): instruct dependabot to group all opentelemetry dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,16 @@ updates:
     directory: "rust/"
     schedule:
       interval: "weekly"
+    groups:
+      otel:
+        patterns:
+          - "opentelemetry"
+          - "opentelemetry_api"
+          - "opentelemetry-otlp"
+          - "tracing-opentelemetry"
+          - "tracing-stackdriver"
+        update-types:
+          - "minor"
   - package-ecosystem: "maven"
     directory: "rust/connlib/clients/android"
     schedule:


### PR DESCRIPTION
In case of new semver-minor releases, these dependencies need to be bumped together, otherwise things don't compile