### PR TITLE
fix(relay): only listen for traces & metrics on localhost

### DIFF
--- a/terraform/modules/elixir-app/templates/cloud-init.yaml
+++ b/terraform/modules/elixir-app/templates/cloud-init.yaml
@@ -12,8 +12,8 @@ write_files:
       receivers:
         otlp:
           protocols:
-            grpc:
             http:
+              endpoint: localhost:4318
       exporters:
         googlecloud:
           log:

--- a/terraform/modules/relay-app/templates/cloud-init.yaml
+++ b/terraform/modules/relay-app/templates/cloud-init.yaml
@@ -14,7 +14,6 @@ write_files:
           protocols:
             grpc:
               endpoint: localhost:4317
-            http:
       exporters:
         googlecloud:
           log:

--- a/terraform/modules/relay-app/templates/cloud-init.yaml
+++ b/terraform/modules/relay-app/templates/cloud-init.yaml
@@ -13,6 +13,7 @@ write_files:
         otlp:
           protocols:
             grpc:
+              endpoint: localhost:4317
             http:
       exporters:
         googlecloud:


### PR DESCRIPTION
This fixes two warnings in our logs that tell us to not listen on `0.0.0.0`. See https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks.

I don't use the HTTP receiver for sending traces or metrics so that one can safely be disabled.