### PR TITLE
Update Account DNS settings UI

### DIFF
--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -4,7 +4,11 @@ defmodule API.Client.ChannelTest do
 
   setup do
     account = Fixtures.Accounts.create_account()
-    Fixtures.Config.upsert_configuration(account: account, clients_upstream_dns: ["1.1.1.1"])
+
+    Fixtures.Config.upsert_configuration(
+      account: account,
+      clients_upstream_dns: [%{address: "1.1.1.1"}]
+    )
 
     actor_group = Fixtures.Actors.create_group(account: account)
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
@@ -134,7 +138,7 @@ defmodule API.Client.ChannelTest do
                ipv4: client.ipv4,
                ipv6: client.ipv6,
                upstream_dns: [
-                 %Postgrex.INET{address: {1, 1, 1, 1}}
+                 %Domain.Config.Configuration.ClientsUpstreamDNS{address: "1.1.1.1"}
                ]
              }
     end

--- a/elixir/apps/domain/lib/domain/config/configuration.ex
+++ b/elixir/apps/domain/lib/domain/config/configuration.ex
@@ -3,7 +3,9 @@ defmodule Domain.Config.Configuration do
   alias Domain.Config.Logo
 
   schema "configurations" do
-    field :clients_upstream_dns, {:array, :string}, default: []
+    embeds_many :clients_upstream_dns, ClientsUpstreamDNS, on_replace: :delete, primary_key: false do
+      field :address, :string
+    end
 
     embeds_one :logo, Logo, on_replace: :delete
 

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -443,23 +443,20 @@ defmodule Domain.Config.Definitions do
   @doc """
   Comma-separated list of upstream DNS servers to use for clients.
 
-  It can be either an IP address or a FQDN if you intend to use a DNS-over-TLS server.
+  It can be one of the following:
+    - IP address
+    - FQDN if you intend to use a DNS-over-TLS server
+    - URI if you intent to use a DNS-over-HTTPS server
 
   Leave this blank to omit the `DNS` section from generated configs,
   which will make clients use default system-provided DNS even when VPN session is active.
   """
   defconfig(
     :clients_upstream_dns,
-    {:array, ",", {:one_of, [Types.IP, :string]}, validate_unique: true},
+    {:json_array, {:embed, Domain.Config.Configuration.ClientsUpstreamDNS},
+     validate_unique: true},
     default: [],
-    changeset: fn
-      Types.IP, changeset, _key ->
-        changeset
-
-      :string, changeset, key ->
-        changeset
-        |> Domain.Validator.trim_change(key)
-    end
+    changeset: {Domain.Config.Configuration.Changeset, :clients_upstream_dns_changeset, []}
   )
 
   ##############################################

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -459,7 +459,6 @@ defmodule Domain.Config.Definitions do
       :string, changeset, key ->
         changeset
         |> Domain.Validator.trim_change(key)
-        |> Domain.Validator.validate_fqdn(key)
     end
   )
 

--- a/elixir/apps/domain/priv/repo/migrations/20230926211345_update_clients_upstream_dns_column_type.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20230926211345_update_clients_upstream_dns_column_type.exs
@@ -1,0 +1,23 @@
+defmodule Domain.Repo.Migrations.UpdateClientsUpstreamDnsColumnType do
+  use Ecto.Migration
+
+  # def change do
+  #  alter table("configurations") do
+  #    modify(:clients_upstream_dns, {:array, :map},
+  #      from: {:array, :string},
+  #      default: [],
+  #      null: false
+  #    )
+  #  end
+  # end
+
+  @drop_column "ALTER TABLE configurations DROP COLUMN clients_upstream_dns;"
+
+  def change do
+    execute(@drop_column)
+
+    alter table("configurations") do
+      add(:clients_upstream_dns, {:array, :map}, default: [], null: false)
+    end
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20230926211345_update_clients_upstream_dns_column_type.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20230926211345_update_clients_upstream_dns_column_type.exs
@@ -1,20 +1,8 @@
 defmodule Domain.Repo.Migrations.UpdateClientsUpstreamDnsColumnType do
   use Ecto.Migration
 
-  # def change do
-  #  alter table("configurations") do
-  #    modify(:clients_upstream_dns, {:array, :map},
-  #      from: {:array, :string},
-  #      default: [],
-  #      null: false
-  #    )
-  #  end
-  # end
-
-  @drop_column "ALTER TABLE configurations DROP COLUMN clients_upstream_dns;"
-
   def change do
-    execute(@drop_column)
+    execute("ALTER TABLE configurations DROP COLUMN clients_upstream_dns;")
 
     alter table("configurations") do
       add(:clients_upstream_dns, {:array, :map}, default: [], null: false)

--- a/elixir/apps/domain/test/domain/config_test.exs
+++ b/elixir/apps/domain/test/domain/config_test.exs
@@ -438,23 +438,6 @@ defmodule Domain.ConfigTest do
       %{account: account}
     end
 
-    test "returns error when changeset is invalid", %{account: account} do
-      config = get_account_config_by_account_id(account.id)
-
-      attrs = %{
-        clients_upstream_dns: ["!!!"]
-      }
-
-      assert {:error, changeset} = update_config(config, attrs)
-
-      assert errors_on(changeset) == %{
-               clients_upstream_dns: [
-                 "!!! is not a valid FQDN",
-                 "must be one of: Elixir.Domain.Types.IP, string"
-               ]
-             }
-    end
-
     test "returns error when trying to change overridden value", %{account: account} do
       put_system_env_override(:clients_upstream_dns, ["1.2.3.4"])
 

--- a/elixir/apps/domain/test/domain/config_test.exs
+++ b/elixir/apps/domain/test/domain/config_test.exs
@@ -92,7 +92,9 @@ defmodule Domain.ConfigTest do
     test "returns source and config values", %{account: account} do
       assert fetch_resolved_configs!(account.id, [:clients_upstream_dns, :clients_upstream_dns]) ==
                %{
-                 clients_upstream_dns: [%Postgrex.INET{address: {1, 1, 1, 1}, netmask: nil}]
+                 clients_upstream_dns: [
+                   %Domain.Config.Configuration.ClientsUpstreamDNS{address: "1.1.1.1"}
+                 ]
                }
     end
 
@@ -141,7 +143,7 @@ defmodule Domain.ConfigTest do
                %{
                  clients_upstream_dns:
                    {{:db, :clients_upstream_dns},
-                    [%Postgrex.INET{address: {1, 1, 1, 1}, netmask: nil}]}
+                    [%Domain.Config.Configuration.ClientsUpstreamDNS{address: "1.1.1.1"}]}
                }
     end
 
@@ -438,13 +440,29 @@ defmodule Domain.ConfigTest do
       %{account: account}
     end
 
+    test "returns error when changeset is invalid", %{account: account} do
+      config = get_account_config_by_account_id(account.id)
+
+      attrs = %{
+        clients_upstream_dns: [%{address: "!!!"}]
+      }
+
+      assert {:error, changeset} = update_config(config, attrs)
+
+      assert errors_on(changeset) == %{
+               clients_upstream_dns: [
+                 %{address: ["does not contain a scheme or a host", "!!! is not a valid FQDN"]}
+               ]
+             }
+    end
+
     test "returns error when trying to change overridden value", %{account: account} do
-      put_system_env_override(:clients_upstream_dns, ["1.2.3.4"])
+      put_system_env_override(:clients_upstream_dns, [%{address: "1.2.3.4"}])
 
       config = get_account_config_by_account_id(account.id)
 
       attrs = %{
-        clients_upstream_dns: ["4.1.2.3"]
+        clients_upstream_dns: [%{address: "4.1.2.3"}]
       }
 
       assert {:error, changeset} = update_config(config, attrs)
@@ -461,27 +479,39 @@ defmodule Domain.ConfigTest do
       config = get_account_config_by_account_id(account.id)
 
       attrs = %{
-        clients_upstream_dns: ["   foobar.com", "google.com   "]
+        clients_upstream_dns: [%{address: "   foobar.com"}, %{address: "google.com   "}]
       }
 
       assert {:ok, config} = update_config(config, attrs)
-      assert config.clients_upstream_dns == ["foobar.com", "google.com"]
+
+      assert config.clients_upstream_dns == [
+               %Domain.Config.Configuration.ClientsUpstreamDNS{address: "foobar.com"},
+               %Domain.Config.Configuration.ClientsUpstreamDNS{address: "google.com"}
+             ]
     end
 
     test "changes database config value when it did not exist", %{account: account} do
       config = get_account_config_by_account_id(account.id)
-      attrs = %{clients_upstream_dns: ["foobar.com", "google.com"]}
+      attrs = %{clients_upstream_dns: [%{address: "foobar.com"}, %{address: "google.com"}]}
       assert {:ok, config} = update_config(config, attrs)
-      assert config.clients_upstream_dns == attrs.clients_upstream_dns
+
+      assert config.clients_upstream_dns == [
+               %Domain.Config.Configuration.ClientsUpstreamDNS{address: "foobar.com"},
+               %Domain.Config.Configuration.ClientsUpstreamDNS{address: "google.com"}
+             ]
     end
 
     test "changes database config value when it existed", %{account: account} do
       Fixtures.Config.upsert_configuration(account: account)
 
       config = get_account_config_by_account_id(account.id)
-      attrs = %{clients_upstream_dns: ["foobar.com", "google.com"]}
+      attrs = %{clients_upstream_dns: [%{address: "foobar.com"}, %{address: "google.com"}]}
       assert {:ok, config} = update_config(config, attrs)
-      assert config.clients_upstream_dns == attrs.clients_upstream_dns
+
+      assert config.clients_upstream_dns == [
+               %Domain.Config.Configuration.ClientsUpstreamDNS{address: "foobar.com"},
+               %Domain.Config.Configuration.ClientsUpstreamDNS{address: "google.com"}
+             ]
     end
   end
 end

--- a/elixir/apps/domain/test/support/fixtures/config.ex
+++ b/elixir/apps/domain/test/support/fixtures/config.ex
@@ -4,7 +4,7 @@ defmodule Domain.Fixtures.Config do
 
   def configuration_attrs(attrs \\ %{}) do
     Enum.into(attrs, %{
-      clients_upstream_dns: ["1.1.1.1"]
+      clients_upstream_dns: [%{address: "1.1.1.1"}]
     })
   end
 

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -291,7 +291,7 @@ defmodule Web.CoreComponents do
   attr :id, :string, default: "flash", doc: "the optional id of flash container"
   attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
   attr :title, :string, default: nil
-  attr :kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup"
+  attr :kind, :atom, values: [:success, :info, :error], doc: "used for styling and flash lookup"
   attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
   attr :style, :string, default: "pill"
 
@@ -304,6 +304,7 @@ defmodule Web.CoreComponents do
       id={@id}
       class={[
         "p-4 text-sm flash-#{@kind}",
+        @kind == :success && "text-green-800 bg-green-50 dark:bg-gray-800 dark:text-green-400",
         @kind == :info && "text-yellow-800 bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300",
         @kind == :error && "text-red-800 bg-red-50 dark:bg-gray-800 dark:text-red-400",
         @style != "wide" && "mb-4 rounded-lg"

--- a/elixir/apps/web/test/web/live/settings/dns/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/dns/index_test.exs
@@ -153,4 +153,29 @@ defmodule Web.Live.Settings.DNS.IndexTest do
            |> form("form", %{configuration: %{clients_upstream_dns: %{"1" => addr}}})
            |> render_change() =~ "should not contain duplicates"
   end
+
+  test "does not display 'cannot be empty' error message", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    attrs = %{
+      configuration: %{
+        clients_upstream_dns: %{"0" => %{address: "8.8.8.8"}}
+      }
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/dns")
+
+    lv
+    |> form("form", attrs)
+    |> render_submit()
+
+    refute lv
+           |> form("form", %{configuration: %{clients_upstream_dns: %{"0" => %{address: ""}}}})
+           |> render_change() =~ "can&#39;t be blank"
+  end
 end

--- a/elixir/apps/web/test/web/live/settings/dns/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/dns/index_test.exs
@@ -1,0 +1,140 @@
+defmodule Web.Live.Settings.DNS.IndexTest do
+  use Web.ConnCase, async: true
+
+  setup do
+    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+
+    account = Fixtures.Accounts.create_account()
+    identity = Fixtures.Auth.create_identity(account: account, actor: [type: :account_admin_user])
+
+    %{
+      account: account,
+      identity: identity
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{account: account, conn: conn} do
+    assert live(conn, ~p"/#{account}/settings/dns") ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}/sign_in",
+                 flash: %{"error" => "You must log in to access this page."}
+               }}}
+  end
+
+  test "renders breadcrumbs item", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/dns")
+
+    assert item = Floki.find(html, "[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "DNS Settings"
+  end
+
+  test "renders form", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/dns")
+
+    form = lv |> form("form")
+
+    assert find_inputs(form) == [
+             "clients_upstream_dns",
+             "resolver"
+           ]
+  end
+
+  test "saves custom DNS server address", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    attrs = %{
+      "resolver" => "custom",
+      "clients_upstream_dns" => "8.8.8.8"
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/dns")
+
+    lv
+    |> form("form", %{"resolver" => "custom"})
+    |> render_change()
+
+    assert lv
+           |> form("form", attrs)
+           |> render_submit() =~ "DNS settings have been updated!"
+  end
+
+  test "removes duplicate DNS addresses upon save", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    attrs = %{
+      "resolver" => "custom",
+      "clients_upstream_dns" => "8.8.8.8, 8.8.8.8"
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/dns")
+
+    lv
+    |> form("form", %{"resolver" => "custom"})
+    |> render_change()
+
+    lv
+    |> form("form", attrs)
+    |> render_submit()
+
+    assert lv
+           |> element("input[name='clients_upstream_dns']")
+           |> render() =~ "value=\"8.8.8.8\""
+  end
+
+  test "disables address field when system resolver selected", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    attrs = %{
+      "resolver" => "custom",
+      "clients_upstream_dns" => "8.8.8.8"
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/dns")
+
+    lv
+    |> form("form", %{"resolver" => "custom"})
+    |> render_change()
+
+    assert lv
+           |> form("form", attrs)
+           |> render_change() =~ "8.8.8.8"
+
+    lv |> form("form", %{"resolver" => "system"}) |> render_change()
+
+    assert lv
+           |> element("input[name='clients_upstream_dns']")
+           |> render() =~ "disabled"
+  end
+end

--- a/elixir/apps/web/test/web/live/settings/dns/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/dns/index_test.exs
@@ -18,7 +18,7 @@ defmodule Web.Live.Settings.DNS.IndexTest do
              {:error,
               {:redirect,
                %{
-                 to: ~p"/#{account}/sign_in",
+                 to: ~p"/#{account}",
                  flash: %{"error" => "You must log in to access this page."}
                }}}
   end


### PR DESCRIPTION
Why:

* The previous Account DNS Settings page was only a static page.  This commit enables the form on the page to actually save and update the DNS settings for a given account.