### PR TITLE
refactor(connlib): move static `LOGGING_GUARD` to `init_logging` function

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -25,8 +25,6 @@ pub struct CallbackHandler {
     callback_handler: GlobalRef,
 }
 
-static LOGGING_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
-
 impl Clone for CallbackHandler {
     fn clone(&self) -> Self {
         // This is essentially a `memcpy` to bypass redundant checks from
@@ -84,6 +82,8 @@ fn call_method(
 }
 
 fn init_logging(log_dir: PathBuf) {
+    static LOGGING_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
+
     // On Android, logging state is persisted indefinitely after the System.loadLibrary
     // call, which means that a disconnect and tunnel process restart will not
     // reinitialize the guard. This is a problem because the guard remains tied to


### PR DESCRIPTION
Static variables can be declared within functions if that is their only scope. Reducing the scope of variables makes it easier to understand the code.