### PR TITLE
refactor(connlib): don't store `WorkerGuard` in `Session`

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -351,7 +351,6 @@ fn connect(
         portal_url.as_str(),
         portal_token,
         device_id,
-        None,
         callback_handler,
     )
     .map_err(Into::into)

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -25,8 +25,6 @@ pub struct CallbackHandler {
     callback_handler: GlobalRef,
 }
 
-static LOGGING_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
-
 impl Clone for CallbackHandler {
     fn clone(&self) -> Self {
         // This is essentially a `memcpy` to bypass redundant checks from
@@ -84,6 +82,8 @@ fn call_method(
 }
 
 fn init_logging(log_dir: PathBuf) {
+    static LOGGING_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
+
     // On Android, logging state is persisted indefinitely after the System.loadLibrary
     // call, which means that a disconnect and tunnel process restart will not
     // reinitialize the guard. This is a problem because the guard remains tied to

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -65,6 +65,7 @@ mod ffi {
 /// This is used by the apple client to interact with our code.
 pub struct WrappedSession {
     session: Session<CallbackHandler>,
+    _guard: WorkerGuard,
 }
 
 // SAFETY: `CallbackHandler.swift` promises to be thread-safe.
@@ -158,15 +159,17 @@ impl WrappedSession {
         log_dir: String,
         callback_handler: ffi::CallbackHandler,
     ) -> Result<Self, String> {
-        Session::connect(
+        let _guard = init_logging(log_dir.into());
+
+        let session = Session::connect(
             portal_url.as_str(),
             token,
             device_id,
-            Some(init_logging(log_dir.into())),
             CallbackHandler(callback_handler.into()),
         )
-        .map(|session| Self { session })
-        .map_err(|err| err.to_string())
+        .map_err(|err| err.to_string())?;
+
+        Self { session, _guard }
     }
 
     fn disconnect(&mut self) {

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -169,7 +169,7 @@ impl WrappedSession {
         )
         .map_err(|err| err.to_string())?;
 
-        Self { session, _guard }
+        Ok(Self { session, _guard })
     }
 
     fn disconnect(&mut self) {

--- a/rust/connlib/clients/headless/src/main.rs
+++ b/rust/connlib/clients/headless/src/main.rs
@@ -101,15 +101,9 @@ fn main() -> Result<()> {
     let secret = parse_env_var::<String>(SECRET_ENV_VAR)?;
     let device_id = get_device_id();
     let log_dir = parse_env_var::<PathBuf>(LOG_DIR_ENV_VAR).unwrap_or(DEFAULT_LOG_DIR.into());
+    let _guard = init_logging(log_dir);
 
-    let mut session = Session::connect(
-        url,
-        secret,
-        device_id,
-        Some(init_logging(log_dir)),
-        CallbackHandler,
-    )
-    .unwrap();
+    let mut session = Session::connect(url, secret, device_id, CallbackHandler).unwrap();
     tracing::info!("Started new session");
 
     block_on_ctrl_c();

--- a/rust/connlib/gateway/src/main.rs
+++ b/rust/connlib/gateway/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
     let url = parse_env_var::<Url>(URL_ENV_VAR)?;
     let secret = parse_env_var::<String>(SECRET_ENV_VAR)?;
     let device_id = get_device_id();
-    let mut session = Session::connect(url, secret, device_id, None, CallbackHandler).unwrap();
+    let mut session = Session::connect(url, secret, device_id, CallbackHandler).unwrap();
 
     let (tx, rx) = std::sync::mpsc::channel();
     ctrlc::set_handler(move || tx.send(()).expect("Could not send stop signal on channel."))


### PR DESCRIPTION
The various client platforms are too different in how they handle logging. Contrary to what I suggested in the initial PR, I no longer think that storing the guard within the session is a good idea.

For the headless client for example, we block on CTRL+C anyway and thus can simplify have the guard stay alive for the entirety of the program. For Apple, we can store the guard in the `WrappedSession`. For Android, we store it in a static variable anyway.

Lastly, whilst working on the log-upload, I've encountered circular dependencies caused by this as I would have to store more than just the `WorkerGuard` in the `Session`.