### PR TITLE
fix(connlib): don't unnecessarily `cfg` for apple

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg(any(target_os = "macos", target_os = "ios"))]
 // Swift bridge generated code triggers this below
 #![allow(improper_ctypes, non_camel_case_types)]
 


### PR DESCRIPTION
This file type-checks and compiles just fine on my local Linux machine without the `cfg` attributes. Remove them to allow `cargo clippy --all-targets` to be more useful in local development.