### PR TITLE
fix(docs): Prevent adding typo single-quote to JSON examples

### DIFF
--- a/elixir/apps/web/test/support/documentation/docs_generator.ex
+++ b/elixir/apps/web/test/support/documentation/docs_generator.ex
@@ -338,7 +338,7 @@ defmodule Web.Documentation.Generator do
   defp b_req_body(params) when params == %{}, do: ""
 
   defp b_req_body(params) do
-    i(1, "--data-binary @- << EOF\n#{Jason.encode!(params, pretty: true)}'\nEOF")
+    i(1, "--data-binary @- << EOF\n#{Jason.encode!(params, pretty: true)}\nEOF")
   end
 
   defp b_resp_headers(conn) do

--- a/website/src/app/docs/reference/rest-api/configurations/readme.mdx
+++ b/website/src/app/docs/reference/rest-api/configurations/readme.mdx
@@ -102,7 +102,7 @@ $ curl -i \
     ],
     "vpn_session_duration": 100
   }
-}'
+}
 EOF
 
 HTTP/1.1 200

--- a/website/src/app/docs/reference/rest-api/devices/readme.mdx
+++ b/website/src/app/docs/reference/rest-api/devices/readme.mdx
@@ -224,7 +224,7 @@ $ curl -i \
     "use_default_persistent_keepalive": false,
     "user_id": "95138a8e-c89f-41b4-b62c-a5b8c23a0b8c"
   }
-}'
+}
 EOF
 
 HTTP/1.1 201
@@ -361,7 +361,7 @@ $ curl -i \
     "use_default_mtu": false,
     "use_default_persistent_keepalive": false
   }
-}'
+}
 EOF
 
 HTTP/1.1 200

--- a/website/src/app/docs/reference/rest-api/rules/readme.mdx
+++ b/website/src/app/docs/reference/rest-api/rules/readme.mdx
@@ -91,7 +91,7 @@ $ curl -i \
     "port_type": "udp",
     "user_id": "def4dacc-6367-4320-a0fb-4675b9b571cf"
   }
-}'
+}
 EOF
 
 HTTP/1.1 201
@@ -164,7 +164,7 @@ $ curl -i \
     "port_range": "1 - 2",
     "port_type": "udp"
   }
-}'
+}
 EOF
 
 HTTP/1.1 200

--- a/website/src/app/docs/reference/rest-api/users/readme.mdx
+++ b/website/src/app/docs/reference/rest-api/users/readme.mdx
@@ -119,7 +119,7 @@ $ curl -i \
     "password_confirmation": "test1234test",
     "role": "unprivileged"
   }
-}'
+}
 EOF
 
 HTTP/1.1 201
@@ -153,7 +153,7 @@ $ curl -i \
     "email": "new-user@test",
     "role": "unprivileged"
   }
-}'
+}
 EOF
 
 HTTP/1.1 201
@@ -187,7 +187,7 @@ $ curl -i \
     "email": "new-user@test",
     "role": "admin"
   }
-}'
+}
 EOF
 
 HTTP/1.1 201
@@ -221,7 +221,7 @@ $ curl -i \
     "email": "test@test.com",
     "password": "test1234"
   }
-}'
+}
 EOF
 
 HTTP/1.1 422
@@ -288,7 +288,7 @@ $ curl -i \
   --data-binary @- << EOF
 {
   "user": {}
-}'
+}
 EOF
 
 HTTP/1.1 200
@@ -322,7 +322,7 @@ $ curl -i \
   --data-binary @- << EOF
 {
   "user": {}
-}'
+}
 EOF
 
 HTTP/1.1 200


### PR DESCRIPTION
Fixes #1968 