### PR TITLE
refactor(connlib): Use `newtype` pattern for all entity UUIDs from Portal

### DIFF
--- a/rust/connlib/libs/client/src/control.rs
+++ b/rust/connlib/libs/client/src/control.rs
@@ -10,7 +10,7 @@ use libs_common::{
 };
 
 use async_trait::async_trait;
-use firezone_tunnel::{ControlSignal, PeerId, Request, Tunnel};
+use firezone_tunnel::{ControlSignal, ConnId, Request, Tunnel};
 use tokio::sync::{mpsc::Receiver, Mutex};
 
 #[async_trait]
@@ -191,7 +191,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                 Err(err) => err,
             };
 
-            tunnel.cleanup_connection(PeerId::from(resource_id));
+            tunnel.cleanup_connection(ConnId::from(resource_id));
             tracing::error!("Error request connection details: {err}");
             let _ = tunnel.callbacks().on_error(&err);
         });
@@ -227,7 +227,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                 Some(reference) => {
                     let resource_id: ResourceId = reference.parse().unwrap();
                     // TODO: Rate limit the number of attempts of getting the relays before just trying a local network connection
-                    self.tunnel.cleanup_connection(PeerId::from(resource_id));
+                    self.tunnel.cleanup_connection(ConnId::from(resource_id));
                 }
                 None => {
                     tracing::error!(

--- a/rust/connlib/libs/client/src/control.rs
+++ b/rust/connlib/libs/client/src/control.rs
@@ -10,7 +10,7 @@ use libs_common::{
 };
 
 use async_trait::async_trait;
-use firezone_tunnel::{ConnId, ControlSignal, Request, Tunnel};
+use firezone_tunnel::{ControlSignal, Request, Tunnel};
 use tokio::sync::{mpsc::Receiver, Mutex};
 
 #[async_trait]
@@ -191,7 +191,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                 Err(err) => err,
             };
 
-            tunnel.cleanup_connection(ConnId::from(resource_id));
+            tunnel.cleanup_connection(resource_id.into());
             tracing::error!("Error request connection details: {err}");
             let _ = tunnel.callbacks().on_error(&err);
         });
@@ -236,7 +236,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                         return;
                     };
                     // TODO: Rate limit the number of attempts of getting the relays before just trying a local network connection
-                    self.tunnel.cleanup_connection(ConnId::from(resource_id));
+                    self.tunnel.cleanup_connection(resource_id.into());
                 }
                 None => {
                     tracing::error!(

--- a/rust/connlib/libs/client/src/messages.rs
+++ b/rust/connlib/libs/client/src/messages.rs
@@ -4,7 +4,8 @@ use firezone_tunnel::RTCSessionDescription;
 use serde::{Deserialize, Serialize};
 
 use libs_common::messages::{
-    Id, Interface, Key, Relay, RequestConnection, ResourceDescription, ReuseConnection,
+    GatewayId, Interface, Key, Relay, RequestConnection, ResourceDescription, ResourceId,
+    ReuseConnection,
 };
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
@@ -16,21 +17,21 @@ pub struct InitClient {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct RemoveResource {
-    pub id: Id,
+    pub id: ResourceId,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ConnectionDetails {
     pub relays: Vec<Relay>,
-    pub resource_id: Id,
-    pub gateway_id: Id,
+    pub resource_id: ResourceId,
+    pub gateway_id: GatewayId,
     pub gateway_remote_ip: IpAddr,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Connect {
     pub gateway_rtc_session_description: RTCSessionDescription,
-    pub resource_id: Id,
+    pub resource_id: ResourceId,
     pub gateway_public_key: Key,
     pub persistent_keepalive: u64,
 }
@@ -110,8 +111,8 @@ impl From<ReplyMessages> for Messages {
 #[allow(clippy::large_enum_variant, clippy::enum_variant_names)]
 pub enum EgressMessages {
     PrepareConnection {
-        resource_id: Id,
-        connected_gateway_ids: Vec<Id>,
+        resource_id: ResourceId,
+        connected_gateway_ids: Vec<GatewayId>,
     },
     RequestConnection(RequestConnection),
     ReuseConnection(ReuseConnection),

--- a/rust/connlib/libs/common/src/messages.rs
+++ b/rust/connlib/libs/common/src/messages.rs
@@ -4,6 +4,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use chrono::{serde::ts_seconds, DateTime, Utc};
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use uuid::Uuid;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 
@@ -11,8 +12,36 @@ mod key;
 
 pub use key::Key;
 
-/// General type for handling portal's id (UUID v4)
-pub type Id = Uuid;
+#[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+pub struct GatewayId(Uuid);
+#[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+pub struct ResourceId(Uuid);
+#[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+pub struct ClientId(Uuid);
+#[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+pub struct ActorId(Uuid);
+
+impl FromStr for ResourceId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(ResourceId(Uuid::parse_str(s)?))
+    }
+}
+
+impl FromStr for GatewayId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(GatewayId(Uuid::parse_str(s)?))
+    }
+}
+
+impl ToString for ResourceId {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
 
 /// Represents a wireguard peer.
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
@@ -36,9 +65,9 @@ pub struct Peer {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RequestConnection {
     /// Gateway id for the connection
-    pub gateway_id: Id,
+    pub gateway_id: GatewayId,
     /// Resource id the request is for.
-    pub resource_id: Id,
+    pub resource_id: ResourceId,
     /// The preshared key the client generated for the connection that it is trying to establish.
     pub client_preshared_key: Key,
     /// Client's local RTC Session Description that the client will use for this connection.
@@ -52,9 +81,9 @@ pub struct RequestConnection {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ReuseConnection {
     /// Resource id the request is for.
-    pub resource_id: Id,
+    pub resource_id: ResourceId,
     /// Id of the gateway we want to re-use
-    pub gateway_id: Id,
+    pub gateway_id: GatewayId,
 }
 
 // Custom implementation of partial eq to ignore client_rtc_sdp
@@ -78,7 +107,7 @@ pub enum ResourceDescription {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ResourceDescriptionDns {
     /// Resource's id.
-    pub id: Id,
+    pub id: ResourceId,
     /// Internal resource's domain name.
     pub address: String,
     /// Resource's ipv4 mapping.
@@ -126,7 +155,7 @@ impl ResourceDescription {
         }
     }
 
-    pub fn id(&self) -> Id {
+    pub fn id(&self) -> ResourceId {
         match self {
             ResourceDescription::Dns(r) => r.id,
             ResourceDescription::Cidr(r) => r.id,
@@ -145,7 +174,7 @@ impl ResourceDescription {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ResourceDescriptionCidr {
     /// Resource's id.
-    pub id: Id,
+    pub id: ResourceId,
     /// CIDR that this resource points to.
     pub address: IpNetwork,
     /// Name of the resource.

--- a/rust/connlib/libs/common/src/messages.rs
+++ b/rust/connlib/libs/common/src/messages.rs
@@ -4,7 +4,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use chrono::{serde::ts_seconds, DateTime, Utc};
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 use uuid::Uuid;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 
@@ -37,9 +37,9 @@ impl FromStr for GatewayId {
     }
 }
 
-impl ToString for ResourceId {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl fmt::Display for ResourceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/rust/connlib/libs/gateway/src/control.rs
+++ b/rust/connlib/libs/gateway/src/control.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use boringtun::x25519::StaticSecret;
-use firezone_tunnel::{ControlSignal, ConnId, Tunnel};
+use firezone_tunnel::{ConnId, ControlSignal, Tunnel};
 use libs_common::{
     control::{MessageResult, PhoenixSenderWithTopic, Reference},
     messages::{GatewayId, ResourceDescription},

--- a/rust/connlib/libs/gateway/src/control.rs
+++ b/rust/connlib/libs/gateway/src/control.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use boringtun::x25519::StaticSecret;
-use firezone_tunnel::{ConnId, ControlSignal, Tunnel};
+use firezone_tunnel::{ControlSignal, Tunnel};
 use libs_common::{
     control::{MessageResult, PhoenixSenderWithTopic, Reference},
     messages::{GatewayId, ResourceDescription},
@@ -100,12 +100,12 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                         }))
                         .await
                     {
-                        tunnel.cleanup_connection(ConnId::from(connection_request.client.id));
+                        tunnel.cleanup_connection(connection_request.client.id.into());
                         let _ = tunnel.callbacks().on_error(&err);
                     }
                 }
                 Err(err) => {
-                    tunnel.cleanup_connection(ConnId::from(connection_request.client.id));
+                    tunnel.cleanup_connection(connection_request.client.id.into());
                     let _ = tunnel.callbacks().on_error(&err);
                 }
             }

--- a/rust/connlib/libs/gateway/src/control.rs
+++ b/rust/connlib/libs/gateway/src/control.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use boringtun::x25519::StaticSecret;
-use firezone_tunnel::{ControlSignal, PeerId, Tunnel};
+use firezone_tunnel::{ControlSignal, ConnId, Tunnel};
 use libs_common::{
     control::{MessageResult, PhoenixSenderWithTopic, Reference},
     messages::{GatewayId, ResourceDescription},
@@ -100,12 +100,12 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                         }))
                         .await
                     {
-                        tunnel.cleanup_connection(PeerId::from(connection_request.client.id));
+                        tunnel.cleanup_connection(ConnId::from(connection_request.client.id));
                         let _ = tunnel.callbacks().on_error(&err);
                     }
                 }
                 Err(err) => {
-                    tunnel.cleanup_connection(PeerId::from(connection_request.client.id));
+                    tunnel.cleanup_connection(ConnId::from(connection_request.client.id));
                     let _ = tunnel.callbacks().on_error(&err);
                 }
             }

--- a/rust/connlib/libs/gateway/src/messages.rs
+++ b/rust/connlib/libs/gateway/src/messages.rs
@@ -2,7 +2,9 @@ use std::net::IpAddr;
 
 use chrono::{serde::ts_seconds, DateTime, Utc};
 use firezone_tunnel::RTCSessionDescription;
-use libs_common::messages::{Id, Interface, Peer, Relay, ResourceDescription};
+use libs_common::messages::{
+    ActorId, ClientId, Interface, Peer, Relay, ResourceDescription, ResourceId,
+};
 use serde::{Deserialize, Serialize};
 
 // TODO: Should this have a resource?
@@ -15,12 +17,12 @@ pub struct InitGateway {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Actor {
-    pub id: Id,
+    pub id: ActorId,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Client {
-    pub id: Id,
+    pub id: ClientId,
     pub rtc_session_description: RTCSessionDescription,
     pub peer: Peer,
 }
@@ -60,20 +62,20 @@ pub struct Metrics {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Metric {
-    pub client_id: Id,
-    pub resource_id: Id,
+    pub client_id: ClientId,
+    pub resource_id: ResourceId,
     pub rx_bytes: u32,
     pub tx_bytes: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct RemoveResource {
-    pub id: Id,
+    pub id: ResourceId,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct AllowAccess {
-    pub client_id: Id,
+    pub client_id: ClientId,
     pub resource: ResourceDescription,
     #[serde(with = "ts_seconds")]
     pub expires_at: DateTime<Utc>,

--- a/rust/connlib/libs/tunnel/src/control_protocol.rs
+++ b/rust/connlib/libs/tunnel/src/control_protocol.rs
@@ -24,7 +24,7 @@ use webrtc::{
     },
 };
 
-use crate::{peer::Peer, ControlSignal, PeerConfig, ConnId, Tunnel};
+use crate::{peer::Peer, ConnId, ControlSignal, PeerConfig, Tunnel};
 
 mod candidate_parser;
 

--- a/rust/connlib/libs/tunnel/src/control_protocol.rs
+++ b/rust/connlib/libs/tunnel/src/control_protocol.rs
@@ -8,7 +8,10 @@ use tracing::instrument;
 
 use libs_common::{
     control::Reference,
-    messages::{Id, Key, Relay, RequestConnection, ResourceDescription, ReuseConnection},
+    messages::{
+        ClientId, GatewayId, Key, Relay, RequestConnection, ResourceDescription, ResourceId,
+        ReuseConnection,
+    },
     Callbacks, Error, Result,
 };
 use rand_core::OsRng;
@@ -21,7 +24,7 @@ use webrtc::{
     },
 };
 
-use crate::{peer::Peer, ControlSignal, PeerConfig, Tunnel};
+use crate::{peer::Peer, ControlSignal, PeerConfig, PeerId, Tunnel};
 
 mod candidate_parser;
 
@@ -43,7 +46,7 @@ where
         data_channel: Arc<RTCDataChannel>,
         index: u32,
         peer_config: PeerConfig,
-        conn_id: Id,
+        peer_id: PeerId,
         resources: Option<(ResourceDescription, DateTime<Utc>)>,
     ) -> Result<()> {
         tracing::trace!(
@@ -65,7 +68,7 @@ where
             index,
             &peer_config,
             channel,
-            conn_id,
+            peer_id,
             resources,
         ));
 
@@ -74,19 +77,25 @@ where
             let mut gateway_awaiting_connection = self.gateway_awaiting_connection.lock();
             let mut peers_by_ip = self.peers_by_ip.write();
             // In the gateway this will always be none, no harm done
-            if let Some(awaiting_ips) = gateway_awaiting_connection.remove(&conn_id) {
-                for ip in awaiting_ips {
-                    peer.add_allowed_ip(ip);
-                    peers_by_ip.insert(ip, Arc::clone(&peer));
+            match peer_id {
+                PeerId::Gateway(gateway_id) => {
+                    if let Some(awaiting_ips) = gateway_awaiting_connection.remove(&gateway_id) {
+                        for ip in awaiting_ips {
+                            peer.add_allowed_ip(ip);
+                            peers_by_ip.insert(ip, Arc::clone(&peer));
+                        }
+                    }
                 }
+                PeerId::Client(_) => {}
+                PeerId::Resource(_) => {}
             }
             for ip in peer_config.ips {
                 peers_by_ip.insert(ip, Arc::clone(&peer));
             }
         }
 
-        if let Some(conn) = self.peer_connections.lock().get(&conn_id) {
-            self.set_connection_state_with_peer(conn, index, conn_id)
+        if let Some(conn) = self.peer_connections.lock().get(&peer_id) {
+            self.set_connection_state_with_peer(conn, index, peer_id)
         }
 
         data_channel.on_close({
@@ -95,7 +104,7 @@ where
                 tracing::debug!("channel_closed");
                 let tunnel = tunnel.clone();
                 Box::pin(async move {
-                    tunnel.stop_peer(index, conn_id).await;
+                    tunnel.stop_peer(index, peer_id).await;
                 })
             })
         });
@@ -143,13 +152,17 @@ where
     fn handle_connection_state_update_initiator(
         self: &Arc<Self>,
         state: RTCPeerConnectionState,
-        gateway_id: Id,
-        resource_id: Id,
+        gateway_id: GatewayId,
+        resource_id: ResourceId,
     ) {
         tracing::trace!("peer_state");
         if state == RTCPeerConnectionState::Failed {
-            self.awaiting_connection.lock().remove(&resource_id);
-            self.peer_connections.lock().remove(&gateway_id);
+            self.awaiting_connection
+                .lock()
+                .remove(&PeerId::from(resource_id));
+            self.peer_connections
+                .lock()
+                .remove(&PeerId::from(gateway_id));
             self.gateway_awaiting_connection.lock().remove(&gateway_id);
         }
     }
@@ -158,8 +171,8 @@ where
     fn set_connection_state_update_initiator(
         self: &Arc<Self>,
         peer_connection: &Arc<RTCPeerConnection>,
-        gateway_id: Id,
-        resource_id: Id,
+        gateway_id: GatewayId,
+        resource_id: ResourceId,
     ) {
         let tunnel = Arc::clone(self);
         peer_connection.on_peer_connection_state_change(Box::new(
@@ -176,11 +189,13 @@ where
     fn handle_connection_state_update_responder(
         self: &Arc<Self>,
         state: RTCPeerConnectionState,
-        client_id: Id,
+        client_id: ClientId,
     ) {
         tracing::trace!(?state, "peer_state");
         if state == RTCPeerConnectionState::Failed {
-            self.peer_connections.lock().remove(&client_id);
+            self.peer_connections
+                .lock()
+                .remove(&PeerId::from(client_id));
         }
     }
 
@@ -188,7 +203,7 @@ where
     fn set_connection_state_update_responder(
         self: &Arc<Self>,
         peer_connection: &Arc<RTCPeerConnection>,
-        client_id: Id,
+        client_id: ClientId,
     ) {
         let tunnel = Arc::clone(self);
         peer_connection.on_peer_connection_state_change(Box::new(
@@ -206,11 +221,11 @@ where
         self: &Arc<Self>,
         state: RTCPeerConnectionState,
         index: u32,
-        conn_id: Id,
+        peer_id: PeerId,
     ) {
         tracing::trace!(?state, "peer_state_update");
         if state == RTCPeerConnectionState::Failed {
-            self.stop_peer(index, conn_id).await;
+            self.stop_peer(index, peer_id).await;
         }
     }
 
@@ -219,7 +234,7 @@ where
         self: &Arc<Self>,
         peer_connection: &Arc<RTCPeerConnection>,
         index: u32,
-        conn_id: Id,
+        peer_id: PeerId,
     ) {
         let tunnel = Arc::clone(self);
         peer_connection.on_peer_connection_state_change(Box::new(
@@ -227,7 +242,7 @@ where
                 let tunnel = Arc::clone(&tunnel);
                 Box::pin(async move {
                     tunnel
-                        .handle_connection_state_update_with_peer(state, index, conn_id)
+                        .handle_connection_state_update_with_peer(state, index, peer_id)
                         .await
                 })
             },
@@ -243,7 +258,7 @@ where
     /// This function blocks until all ICE candidates are gathered so it might block for a long time.
     ///
     /// # Parameters
-    /// - `resource_id`: Id of the resource we are going to request the connection to.
+    /// - `resource_id`: ResourceId of the resource we are going to request the connection to.
     /// - `relays`: The list of relays used for that connection.
     ///
     /// # Returns
@@ -251,8 +266,8 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     pub async fn request_connection(
         self: &Arc<Self>,
-        resource_id: Id,
-        gateway_id: Id,
+        resource_id: ResourceId,
+        gateway_id: GatewayId,
         relays: Vec<Relay>,
         reference: Option<Reference>,
     ) -> Result<Request> {
@@ -270,7 +285,9 @@ where
             .map_err(|_| Error::InvalidReference)?;
         {
             let mut awaiting_connections = self.awaiting_connection.lock();
-            let Some(awaiting_connection) = awaiting_connections.get_mut(&resource_id) else {
+            let Some(awaiting_connection) =
+                awaiting_connections.get_mut(&PeerId::from(resource_id))
+            else {
                 return Err(Error::UnexpectedConnectionDetails);
             };
             awaiting_connection.response_received = true;
@@ -304,7 +321,7 @@ where
                 let mut peers_by_ip = self.peers_by_ip.write();
                 let peer = peers_by_ip
                     .iter()
-                    .find_map(|(_, p)| (p.conn_id == gateway_id).then_some(p))
+                    .find_map(|(_, p)| (p.peer_id == PeerId::from(gateway_id)).then_some(p))
                     .cloned();
                 if let Some(peer) = peer {
                     for ip in resource_description.ips() {
@@ -318,7 +335,9 @@ where
             };
 
             if found {
-                self.awaiting_connection.lock().remove(&resource_id);
+                self.awaiting_connection
+                    .lock()
+                    .remove(&PeerId::from(resource_id));
                 return Ok(Request::ReuseConnection(ReuseConnection {
                     resource_id,
                     gateway_id,
@@ -328,7 +347,7 @@ where
         let peer_connection = {
             let peer_connection = Arc::new(self.initialize_peer_request(relays).await?);
             let mut peer_connections = self.peer_connections.lock();
-            peer_connections.insert(gateway_id, Arc::clone(&peer_connection));
+            peer_connections.insert(PeerId::from(gateway_id), Arc::clone(&peer_connection));
             peer_connection
         };
 
@@ -357,8 +376,14 @@ where
                 let Some(gateway_public_key) =
                     tunnel.gateway_public_keys.lock().remove(&gateway_id)
                 else {
-                    tunnel.awaiting_connection.lock().remove(&resource_id);
-                    tunnel.peer_connections.lock().remove(&gateway_id);
+                    tunnel
+                        .awaiting_connection
+                        .lock()
+                        .remove(&PeerId::from(resource_id));
+                    tunnel
+                        .peer_connections
+                        .lock()
+                        .remove(&PeerId::from(gateway_id));
                     tunnel
                         .gateway_awaiting_connection
                         .lock()
@@ -376,18 +401,24 @@ where
                 };
 
                 if let Err(e) = tunnel
-                    .handle_channel_open(d, index, peer_config, gateway_id, None)
+                    .handle_channel_open(d, index, peer_config, PeerId::from(gateway_id), None)
                     .await
                 {
                     tracing::error!(err = ?e, "channel_open");
                     let _ = tunnel.callbacks.on_error(&e);
-                    tunnel.peer_connections.lock().remove(&gateway_id);
+                    tunnel
+                        .peer_connections
+                        .lock()
+                        .remove(&PeerId::from(gateway_id));
                     tunnel
                         .gateway_awaiting_connection
                         .lock()
                         .remove(&gateway_id);
                 }
-                tunnel.awaiting_connection.lock().remove(&resource_id);
+                tunnel
+                    .awaiting_connection
+                    .lock()
+                    .remove(&PeerId::from(resource_id));
             })
         }));
 
@@ -422,7 +453,7 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     pub async fn received_offer_response(
         self: &Arc<Self>,
-        resource_id: Id,
+        resource_id: ResourceId,
         mut rtc_sdp: RTCSessionDescription,
         gateway_public_key: PublicKey,
     ) -> Result<()> {
@@ -434,7 +465,7 @@ where
         let peer_connection = self
             .peer_connections
             .lock()
-            .get(&gateway_id)
+            .get(&PeerId::from(gateway_id))
             .ok_or(Error::UnknownResource)?
             .clone();
         self.gateway_public_keys
@@ -479,7 +510,7 @@ where
         sdp_session: RTCSessionDescription,
         peer: PeerConfig,
         relays: Vec<Relay>,
-        client_id: Id,
+        client_id: ClientId,
         expires_at: DateTime<Utc>,
         resource: ResourceDescription,
     ) -> Result<RTCSessionDescription> {
@@ -488,7 +519,7 @@ where
         let tunnel = Arc::clone(self);
         self.peer_connections
             .lock()
-            .insert(client_id, Arc::clone(&peer_connection));
+            .insert(PeerId::from(client_id), Arc::clone(&peer_connection));
 
         self.set_connection_state_update_responder(&peer_connection, client_id);
 
@@ -522,7 +553,7 @@ where
                                 data_channel,
                                 index,
                                 peer,
-                                client_id,
+                                PeerId::from(client_id),
                                 Some((resource, expires_at)),
                             )
                             .await
@@ -531,7 +562,10 @@ where
                             tracing::error!(err = ?e, "channel_open");
                             // Note: handle_channel_open can only error out before insert to peers_by_ip
                             // otherwise we would need to clean that up too!
-                            let conn = tunnel.peer_connections.lock().remove(&client_id);
+                            let conn = tunnel
+                                .peer_connections
+                                .lock()
+                                .remove(&PeerId::from(client_id));
                             if let Some(conn) = conn {
                                 if let Err(e) = conn.close().await {
                                     tracing::error!(error = ?e, "webrtc_close_channel");
@@ -562,14 +596,14 @@ where
     pub fn allow_access(
         &self,
         resource: ResourceDescription,
-        client_id: Id,
+        client_id: ClientId,
         expires_at: DateTime<Utc>,
     ) {
         if let Some(peer) = self
             .peers_by_ip
             .write()
             .iter_mut()
-            .find_map(|(_, p)| (p.conn_id == client_id).then_some(p))
+            .find_map(|(_, p)| (p.peer_id == PeerId::from(client_id)).then_some(p))
         {
             peer.add_resource(resource, expires_at);
         }
@@ -577,7 +611,7 @@ where
 
     /// Clean up a connection to a resource.
     // FIXME: this cleanup connection is wrong!
-    pub fn cleanup_connection(&self, id: Id) {
+    pub fn cleanup_connection(&self, id: PeerId) {
         self.awaiting_connection.lock().remove(&id);
         self.peer_connections.lock().remove(&id);
     }

--- a/rust/connlib/libs/tunnel/src/iface_handler.rs
+++ b/rust/connlib/libs/tunnel/src/iface_handler.rs
@@ -8,7 +8,7 @@ use crate::{
     device_channel::{DeviceIo, IfaceConfig},
     dns,
     peer::EncapsulatedPacket,
-    ControlSignal, PeerId, Tunnel, MAX_UDP_SIZE,
+    ControlSignal, ConnId, Tunnel, MAX_UDP_SIZE,
 };
 
 const MAX_SIGNAL_CONNECTION_DELAY: Duration = Duration::from_secs(2);
@@ -26,14 +26,14 @@ where
             // create_peer_connection hasn't added the thing to peer_connections
             // and we are finding another packet to the same address (otherwise we would just use peer_connections here)
             let mut awaiting_connection = self.awaiting_connection.lock();
-            let peer_id = PeerId::from(resource.id());
-            if awaiting_connection.get(&peer_id).is_none() {
+            let conn_id = ConnId::from(resource.id());
+            if awaiting_connection.get(&conn_id).is_none() {
                 tracing::trace!(
                     resource_ip = %dst_addr,
                     "resource_connection_intent",
                 );
 
-                awaiting_connection.insert(peer_id, Default::default());
+                awaiting_connection.insert(conn_id, Default::default());
                 let dev = Arc::clone(self);
 
                 let mut connected_gateway_ids: Vec<_> = dev
@@ -55,7 +55,7 @@ where
                         let reference = {
                             let mut awaiting_connections = dev.awaiting_connection.lock();
                             let Some(awaiting_connection) =
-                                awaiting_connections.get_mut(&PeerId::from(resource.id()))
+                                awaiting_connections.get_mut(&ConnId::from(resource.id()))
                             else {
                                 break;
                             };
@@ -71,7 +71,7 @@ where
                             .await
                         {
                             // Not a deadlock because this is a different task
-                            dev.awaiting_connection.lock().remove(&peer_id);
+                            dev.awaiting_connection.lock().remove(&conn_id);
                             tracing::error!(error = ?e, "start_resource_connection");
                             let _ = dev.callbacks.on_error(&e);
                         }
@@ -91,7 +91,7 @@ where
             TunnResult::Done => Ok(()),
             TunnResult::Err(WireGuardError::ConnectionExpired)
             | TunnResult::Err(WireGuardError::NoCurrentSession) => {
-                self.stop_peer(encapsulated_packet.index, encapsulated_packet.peer_id)
+                self.stop_peer(encapsulated_packet.index, encapsulated_packet.conn_id)
                     .await;
                 Ok(())
             }
@@ -115,7 +115,7 @@ where
                         webrtc::data::Error::ErrStreamClosed
                             | webrtc::data::Error::Sctp(webrtc::sctp::Error::ErrStreamClosed)
                     ) {
-                        self.stop_peer(encapsulated_packet.index, encapsulated_packet.peer_id)
+                        self.stop_peer(encapsulated_packet.index, encapsulated_packet.conn_id)
                             .await;
                     }
                     let err = e.into();

--- a/rust/connlib/libs/tunnel/src/iface_handler.rs
+++ b/rust/connlib/libs/tunnel/src/iface_handler.rs
@@ -8,7 +8,7 @@ use crate::{
     device_channel::{DeviceIo, IfaceConfig},
     dns,
     peer::EncapsulatedPacket,
-    ControlSignal, ConnId, Tunnel, MAX_UDP_SIZE,
+    ConnId, ControlSignal, Tunnel, MAX_UDP_SIZE,
 };
 
 const MAX_SIGNAL_CONNECTION_DELAY: Duration = Duration::from_secs(2);

--- a/rust/connlib/libs/tunnel/src/iface_handler.rs
+++ b/rust/connlib/libs/tunnel/src/iface_handler.rs
@@ -8,7 +8,7 @@ use crate::{
     device_channel::{DeviceIo, IfaceConfig},
     dns,
     peer::EncapsulatedPacket,
-    ControlSignal, Tunnel, MAX_UDP_SIZE,
+    ControlSignal, PeerId, Tunnel, MAX_UDP_SIZE,
 };
 
 const MAX_SIGNAL_CONNECTION_DELAY: Duration = Duration::from_secs(2);
@@ -26,14 +26,14 @@ where
             // create_peer_connection hasn't added the thing to peer_connections
             // and we are finding another packet to the same address (otherwise we would just use peer_connections here)
             let mut awaiting_connection = self.awaiting_connection.lock();
-            let id = resource.id();
-            if awaiting_connection.get(&id).is_none() {
+            let peer_id = PeerId::from(resource.id());
+            if awaiting_connection.get(&peer_id).is_none() {
                 tracing::trace!(
                     resource_ip = %dst_addr,
                     "resource_connection_intent",
                 );
 
-                awaiting_connection.insert(id, Default::default());
+                awaiting_connection.insert(peer_id, Default::default());
                 let dev = Arc::clone(self);
 
                 let mut connected_gateway_ids: Vec<_> = dev
@@ -55,7 +55,7 @@ where
                         let reference = {
                             let mut awaiting_connections = dev.awaiting_connection.lock();
                             let Some(awaiting_connection) =
-                                awaiting_connections.get_mut(&resource.id())
+                                awaiting_connections.get_mut(&PeerId::from(resource.id()))
                             else {
                                 break;
                             };
@@ -71,7 +71,7 @@ where
                             .await
                         {
                             // Not a deadlock because this is a different task
-                            dev.awaiting_connection.lock().remove(&id);
+                            dev.awaiting_connection.lock().remove(&peer_id);
                             tracing::error!(error = ?e, "start_resource_connection");
                             let _ = dev.callbacks.on_error(&e);
                         }
@@ -91,7 +91,7 @@ where
             TunnResult::Done => Ok(()),
             TunnResult::Err(WireGuardError::ConnectionExpired)
             | TunnResult::Err(WireGuardError::NoCurrentSession) => {
-                self.stop_peer(encapsulated_packet.index, encapsulated_packet.conn_id)
+                self.stop_peer(encapsulated_packet.index, encapsulated_packet.peer_id)
                     .await;
                 Ok(())
             }
@@ -115,7 +115,7 @@ where
                         webrtc::data::Error::ErrStreamClosed
                             | webrtc::data::Error::Sctp(webrtc::sctp::Error::ErrStreamClosed)
                     ) {
-                        self.stop_peer(encapsulated_packet.index, encapsulated_packet.conn_id)
+                        self.stop_peer(encapsulated_packet.index, encapsulated_packet.peer_id)
                             .await;
                     }
                     let err = e.into();

--- a/rust/connlib/libs/tunnel/src/lib.rs
+++ b/rust/connlib/libs/tunnel/src/lib.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 use libs_common::{messages::Key, Callbacks, Error, DNS_SENTINEL};
+use serde::{Deserialize, Serialize};
 
 use async_trait::async_trait;
 use itertools::Itertools;
@@ -30,7 +31,9 @@ use webrtc::{
 use std::{collections::HashMap, net::IpAddr, sync::Arc, time::Duration};
 
 use libs_common::{
-    messages::{Id, Interface as InterfaceConfig, ResourceDescription},
+    messages::{
+        ClientId, GatewayId, Interface as InterfaceConfig, ResourceDescription, ResourceId,
+    },
     CallbackErrorFacade, Result,
 };
 
@@ -80,6 +83,31 @@ const REFRESH_MTU_INTERVAL: Duration = Duration::from_secs(30);
 // Note: Taken from boringtun
 const HANDSHAKE_RATE_LIMIT: u64 = 100;
 
+#[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+pub enum PeerId {
+    Gateway(GatewayId),
+    Client(ClientId),
+    Resource(ResourceId),
+}
+
+impl From<GatewayId> for PeerId {
+    fn from(id: GatewayId) -> Self {
+        Self::Gateway(id)
+    }
+}
+
+impl From<ClientId> for PeerId {
+    fn from(id: ClientId) -> Self {
+        Self::Client(id)
+    }
+}
+
+impl From<ResourceId> for PeerId {
+    fn from(id: ResourceId) -> Self {
+        Self::Resource(id)
+    }
+}
+
 /// Represent's the tunnel actual peer's config
 /// Obtained from libs_common's Peer
 #[derive(Clone)]
@@ -112,7 +140,7 @@ pub trait ControlSignal {
     async fn signal_connection_to(
         &self,
         resource: &ResourceDescription,
-        connected_gateway_ids: &[Id],
+        connected_gateway_ids: &[GatewayId],
         reference: usize,
     ) -> Result<()>;
 }
@@ -136,14 +164,14 @@ pub struct Tunnel<C: ControlSignal, CB: Callbacks> {
     private_key: StaticSecret,
     public_key: PublicKey,
     peers_by_ip: RwLock<IpNetworkTable<Arc<Peer>>>,
-    peer_connections: Mutex<HashMap<Id, Arc<RTCPeerConnection>>>,
-    awaiting_connection: Mutex<HashMap<Id, AwaitingConnectionDetails>>,
-    gateway_awaiting_connection: Mutex<HashMap<Id, Vec<IpNetwork>>>,
-    resources_gateways: Mutex<HashMap<Id, Id>>,
+    peer_connections: Mutex<HashMap<PeerId, Arc<RTCPeerConnection>>>,
+    awaiting_connection: Mutex<HashMap<PeerId, AwaitingConnectionDetails>>,
+    gateway_awaiting_connection: Mutex<HashMap<GatewayId, Vec<IpNetwork>>>,
+    resources_gateways: Mutex<HashMap<ResourceId, GatewayId>>,
     webrtc_api: API,
     resources: RwLock<ResourceTable<ResourceDescription>>,
     control_signaler: C,
-    gateway_public_keys: Mutex<HashMap<Id, PublicKey>>,
+    gateway_public_keys: Mutex<HashMap<GatewayId, PublicKey>>,
     callbacks: CallbackErrorFacade<CB>,
 }
 
@@ -153,14 +181,14 @@ pub struct Tunnel<C: ControlSignal, CB: Callbacks> {
 pub struct TunnelStats {
     public_key: String,
     peers_by_ip: HashMap<IpNetwork, PeerStats>,
-    peer_connections: Vec<Id>,
-    resource_gateways: HashMap<Id, Id>,
+    peer_connections: Vec<PeerId>,
+    resource_gateways: HashMap<ResourceId, GatewayId>,
     dns_resources: HashMap<String, ResourceDescription>,
     network_resources: HashMap<IpNetwork, ResourceDescription>,
-    gateway_public_keys: HashMap<Id, String>,
+    gateway_public_keys: HashMap<GatewayId, String>,
 
-    awaiting_connection: HashMap<Id, AwaitingConnectionDetails>,
-    gateway_awaiting_connection: HashMap<Id, Vec<IpNetwork>>,
+    awaiting_connection: HashMap<PeerId, AwaitingConnectionDetails>,
+    gateway_awaiting_connection: HashMap<GatewayId, Vec<IpNetwork>>,
 }
 
 impl<C, CB> Tunnel<C, CB>
@@ -328,9 +356,9 @@ where
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn stop_peer(&self, index: u32, conn_id: Id) {
+    async fn stop_peer(&self, index: u32, peer_id: PeerId) {
         self.peers_by_ip.write().retain(|_, p| p.index != index);
-        let conn = self.peer_connections.lock().remove(&conn_id);
+        let conn = self.peer_connections.lock().remove(&peer_id);
         if let Some(conn) = conn {
             if let Err(e) = conn.close().await {
                 tracing::warn!(error = ?e, "Can't close peer");
@@ -346,7 +374,7 @@ where
             TunnResult::Done => {}
             TunnResult::Err(WireGuardError::ConnectionExpired)
             | TunnResult::Err(WireGuardError::NoCurrentSession) => {
-                self.stop_peer(peer.index, peer.conn_id).await;
+                self.stop_peer(peer.index, peer.peer_id).await;
                 let _ = peer.shutdown().await;
             }
             TunnResult::Err(e) => tracing::error!(error = ?e, "timer_error"),
@@ -378,7 +406,7 @@ where
             peer.expire_resources();
             if peer.is_emptied() {
                 tracing::trace!(index = peer.index, "peer_expired");
-                let conn = self.peer_connections.lock().remove(&peer.conn_id);
+                let conn = self.peer_connections.lock().remove(&peer.peer_id);
                 let p = peer.clone();
 
                 // We are holding a Mutex, particularly a write one, we don't want to make a blocking call

--- a/rust/connlib/libs/tunnel/src/peer.rs
+++ b/rust/connlib/libs/tunnel/src/peer.rs
@@ -12,7 +12,7 @@ use libs_common::{
 use parking_lot::{Mutex, RwLock};
 use webrtc::data::data_channel::DataChannel;
 
-use crate::{ip_packet::MutableIpPacket, resource_table::ResourceTable, PeerId};
+use crate::{ip_packet::MutableIpPacket, resource_table::ResourceTable, ConnId};
 
 use super::PeerConfig;
 
@@ -23,7 +23,7 @@ pub(crate) struct Peer {
     pub index: u32,
     pub allowed_ips: RwLock<IpNetworkTable<()>>,
     pub channel: Arc<DataChannel>,
-    pub peer_id: PeerId,
+    pub conn_id: ConnId,
     pub resources: Option<RwLock<ResourceTable<ExpiryingResource>>>,
     // Here we store the address that we obtained for the resource that the peer corresponds to.
     // This can have the following problem:
@@ -43,7 +43,7 @@ pub(crate) struct Peer {
 pub(crate) struct PeerStats {
     pub index: u32,
     pub allowed_ips: Vec<IpNetwork>,
-    pub peer_id: PeerId,
+    pub conn_id: ConnId,
     pub dns_resources: HashMap<String, ExpiryingResource>,
     pub network_resources: HashMap<IpNetwork, ExpiryingResource>,
     pub translated_resource_addresses: HashMap<IpAddr, ResourceId>,
@@ -52,7 +52,7 @@ pub(crate) struct PeerStats {
 #[derive(Debug)]
 pub(crate) struct EncapsulatedPacket<'a> {
     pub index: u32,
-    pub peer_id: PeerId,
+    pub conn_id: ConnId,
     pub channel: Arc<DataChannel>,
     pub encapsulate_result: TunnResult<'a>,
 }
@@ -71,7 +71,7 @@ impl Peer {
         PeerStats {
             index: self.index,
             allowed_ips,
-            peer_id: self.peer_id,
+            conn_id: self.conn_id,
             dns_resources,
             network_resources,
             translated_resource_addresses,
@@ -91,7 +91,7 @@ impl Peer {
         index: u32,
         config: &PeerConfig,
         channel: Arc<DataChannel>,
-        peer_id: PeerId,
+        conn_id: ConnId,
         resource: Option<(ResourceDescription, DateTime<Utc>)>,
     ) -> Self {
         Self::new(
@@ -99,7 +99,7 @@ impl Peer {
             index,
             config.ips.clone(),
             channel,
-            peer_id,
+            conn_id,
             resource,
         )
     }
@@ -109,7 +109,7 @@ impl Peer {
         index: u32,
         ips: Vec<IpNetwork>,
         channel: Arc<DataChannel>,
-        peer_id: PeerId,
+        conn_id: ConnId,
         resource: Option<(ResourceDescription, DateTime<Utc>)>,
     ) -> Peer {
         let mut allowed_ips = IpNetworkTable::new();
@@ -127,7 +127,7 @@ impl Peer {
             index,
             allowed_ips,
             channel,
-            peer_id,
+            conn_id,
             resources,
             translated_resource_addresses: Default::default(),
         }
@@ -219,7 +219,7 @@ impl Peer {
         }
         Ok(EncapsulatedPacket {
             index: self.index,
-            peer_id: self.peer_id,
+            conn_id: self.conn_id,
             channel: self.channel.clone(),
             encapsulate_result: self.tunnel.lock().encapsulate(src, dst),
         })

--- a/rust/connlib/libs/tunnel/src/peer_handler.rs
+++ b/rust/connlib/libs/tunnel/src/peer_handler.rs
@@ -145,6 +145,6 @@ where
 
         let peer_stats = peer.stats();
         tracing::debug!(peer = ?peer_stats, "peer_stopped");
-        self.stop_peer(peer.index, peer.conn_id).await;
+        self.stop_peer(peer.index, peer.peer_id).await;
     }
 }

--- a/rust/connlib/libs/tunnel/src/peer_handler.rs
+++ b/rust/connlib/libs/tunnel/src/peer_handler.rs
@@ -145,6 +145,6 @@ where
 
         let peer_stats = peer.stats();
         tracing::debug!(peer = ?peer_stats, "peer_stopped");
-        self.stop_peer(peer.index, peer.peer_id).await;
+        self.stop_peer(peer.index, peer.conn_id).await;
     }
 }

--- a/rust/connlib/libs/tunnel/src/resource_table.rs
+++ b/rust/connlib/libs/tunnel/src/resource_table.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, net::IpAddr, rc::Rc};
 use chrono::{DateTime, Utc};
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
-use libs_common::messages::{Id, ResourceDescription};
+use libs_common::messages::{ResourceDescription, ResourceId};
 
 pub(crate) trait Resource {
     fn description(&self) -> &ResourceDescription;
@@ -26,7 +26,7 @@ impl Resource for (ResourceDescription, DateTime<Utc>) {
 ///
 /// This is specifically crafted for our use case, so the API is particularly made for us and not generic
 pub(crate) struct ResourceTable<T> {
-    id_table: HashMap<Id, Rc<T>>,
+    id_table: HashMap<ResourceId, Rc<T>>,
     network_table: IpNetworkTable<Rc<T>>,
     dns_name: HashMap<String, Rc<T>>,
 }
@@ -88,7 +88,7 @@ where
     }
 
     /// Gets the resource by id
-    pub fn get_by_id(&self, id: &Id) -> Option<&T> {
+    pub fn get_by_id(&self, id: &ResourceId) -> Option<&T> {
         self.id_table.get(id).map(AsRef::as_ref)
     }
 


### PR DESCRIPTION
Wraps all UUIDs in their respective entity types.

Fixes #2090 