### PR TITLE
feat(elixir): use RUN caches

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -29,7 +29,7 @@ COPY config/ config/
 
 ARG MIX_ENV="prod"
 RUN mix deps.get --only ${MIX_ENV}
-RUN mix deps.compile --skip-umbrella-children
+RUN --mount=type=cache,target=./_build mix deps.compile --skip-umbrella-children
 
 COPY priv priv
 COPY apps apps
@@ -37,17 +37,18 @@ COPY apps apps
 ARG APPLICATION_VERSION=0.0.0-dev.docker
 
 # Install pipeline and compile assets for Web app
-RUN cd apps/web \
+RUN --mount=type=cache,target=./_build cd apps/web \
     && mix assets.setup \
     && mix assets.deploy
 
 # Compile the release
-RUN mix compile
+RUN --mount=type=cache,target=./_build mix compile
 
 COPY rel rel
 
 ARG APPLICATION_NAME
-RUN mix release ${APPLICATION_NAME}
+RUN --mount=type=cache,target=./_build mix release ${APPLICATION_NAME}
+RUN --mount=type=cache,target=./_build cp -r /app/_build/${MIX_ENV}/rel/${APPLICATION_NAME} /app/${APPLICATION_NAME}
 
 # start a new build stage so that the final image will only contain
 # the compiled release and other runtime necessities
@@ -57,8 +58,6 @@ RUN apk add -u --no-cache libstdc++ ncurses-libs openssl curl
 
 WORKDIR /app
 
-ARG MIX_ENV="prod"
-
 ARG APPLICATION_NAME
 ARG APPLICATION_VERSION=0.0.0-dev.docker
 
@@ -66,7 +65,7 @@ ENV APPLICATION_NAME=$APPLICATION_NAME
 ENV APPLICATION_VERSION=$APPLICATION_VERSION
 
 # Only copy the final release from the build stage
-COPY --from=builder /app/_build/${MIX_ENV}/rel/${APPLICATION_NAME} ./
+COPY --from=builder /app/${APPLICATION_NAME} ./
 
 # Change user to "default" to limit runtime privileges
 # USER default


### PR DESCRIPTION
In my local testing using the docker-compose file, I had to rebuild the containers several times which always takes quite a while if the commands don't have access to a build cache.

I think there are probably more ways of optimising this Dockerfile. For example, using these caches it is usually not necessary to compile the dependencies separately from the apps because it behaves as an incremental build without docker if anything changes.

I don't know the ins and outs of elixir though so I didn't want to touch that bit but very likely, this can probably just be combined into a single(?) `RUN` step that downloads dependencies and compiles the requested app.