### PR TITLE
chore(rust): Bump to 1.72.1

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Start docker compose in the background
         run: docker compose up -d
       - name: Test that client can ping resource
-        run: docker compose exec -it client ping 172.20.0.100 -c 10
+        run: docker compose exec -it client timeout 60 bash -c 'until ping -W 1 -c 1 172.20.0.100 &>/dev/null; do true; done'
+
 
   integration-test_relayed-flow:
     runs-on: ubuntu-latest
@@ -74,4 +75,4 @@ jobs:
           sudo iptables -I FORWARD 1 -s  172.28.0.100 -d 172.28.0.105 -j DROP
           sudo iptables -I FORWARD 1 -s  172.28.0.105 -d 172.28.0.100 -j DROP
       - name: Test that client can ping resource
-        run: docker compose exec -it client ping 172.20.0.100 -c 10
+        run: docker compose exec -it client timeout 60 bash -c 'until ping -W 1 -c 1 172.20.0.100 &>/dev/null; do true; done'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - uses: actions/cache@v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,8 @@ services:
     devices:
       - "/dev/net/tun:/dev/net/tun"
     depends_on:
+      gateway:
+        condition: 'service_healthy'
       httpbin:
         condition: 'service_healthy'
       api:
@@ -143,6 +145,8 @@ services:
         ipv4_address: 172.28.0.100
 
   gateway:
+    healthcheck:
+      test: [ "CMD-SHELL", "ip link | grep tun-firezone" ]
     environment:
       FZ_URL: "ws://api:8081/"
       FZ_SECRET: "SFMyNTY.g2gDaAJtAAAAJDNjZWYwNTY2LWFkZmQtNDhmZS1hMGYxLTU4MDY3OTYwOGY2Zm0AAABAamp0enhSRkpQWkdCYy1vQ1o5RHkyRndqd2FIWE1BVWRwenVScjJzUnJvcHg3NS16bmhfeHBfNWJUNU9uby1yYm4GAEC0b0KJAWIAAVGA.9Oirn9t8rvQpfOhW7hwGBFVzeMm9di0xYGTlwf9cFFk"
@@ -176,10 +180,6 @@ services:
     image: kennethreitz/httpbin
     healthcheck:
       test: [ "CMD-SHELL", "ps -C gunicorn" ]
-      start_period: 20s
-      interval: 30s
-      retries: 5
-      timeout: 5s
     networks:
       resources:
         ipv4_address: 172.20.0.100

--- a/rust/.dockerignore
+++ b/rust/.dockerignore
@@ -1,3 +1,3 @@
 target/
-clients/android/connlib/build/
-clients/android/connlib/jniLibs/
+connlib/clients/android/connlib/build/
+connlib/clients/android/connlib/jniLibs/

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,8 @@ members = [
   "connlib/gateway",
 ]
 
+resolver = "2"
+
 [workspace.dependencies]
 boringtun = { version = "0.6", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "oldtime", "serde"] }

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70-slim as BUILDER
+FROM rust:1.72-slim as BUILDER
 ARG PACKAGE
 WORKDIR /build/
 COPY . ./
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=./target \
 RUN --mount=type=cache,target=./target \
     mv ./target/release/$PACKAGE /usr/local/bin/$PACKAGE
 
-FROM debian:11.7-slim
+FROM debian:12-slim
 ARG PACKAGE
 WORKDIR /app/
 COPY --from=BUILDER /usr/local/bin/$PACKAGE .

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -1,5 +1,5 @@
 // Swift bridge generated code triggers this below
-#![allow(improper_ctypes, non_camel_case_types)]
+#![allow(clippy::unnecessary_cast, improper_ctypes, non_camel_case_types)]
 
 use firezone_client_connlib::{file_logger, Callbacks, Error, ResourceDescription, Session};
 use ip_network::IpNetwork;

--- a/rust/connlib/libs/client/src/control.rs
+++ b/rust/connlib/libs/client/src/control.rs
@@ -244,7 +244,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
             Messages::IceCandidates(ice_candidate) => self.add_ice_candidate(ice_candidate).await,
             Messages::SignedLogUrl(url) => {
                 let Some(path) = self.tunnel.callbacks().roll_log_file() else {
-                    return Ok(())
+                    return Ok(());
                 };
 
                 tokio::spawn(async move {

--- a/rust/connlib/libs/client/src/file_logger.rs
+++ b/rust/connlib/libs/client/src/file_logger.rs
@@ -75,7 +75,7 @@ impl Handle {
         let mut inner = try_unlock(&self.inner);
         let new_writer = inner.create_new_writer()?;
         let Some((_, name)) = inner.current.replace(new_writer) else {
-            return Ok(None)
+            return Ok(None);
         };
 
         Ok(Some(inner.directory.join(name)))

--- a/rust/connlib/libs/client/src/lib.rs
+++ b/rust/connlib/libs/client/src/lib.rs
@@ -259,7 +259,7 @@ fn upload_interval_from_env_or_default() -> Duration {
     let Some(interval) = option_env!("CONNLIB_LOG_UPLOAD_INTERVAL_SECS") else {
         tracing::warn!(interval = ?DEFAULT, "Env variable `CONNLIB_LOG_UPLOAD_INTERVAL_SECS` was not set during compile-time, falling back to default");
 
-        return DEFAULT
+        return DEFAULT;
     };
 
     let interval = match interval.parse() {

--- a/rust/connlib/libs/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/libs/tunnel/src/control_protocol/client.rs
@@ -106,7 +106,8 @@ where
             .map_err(|_| Error::InvalidReference)?;
         {
             let mut awaiting_connections = self.awaiting_connection.lock();
-            let Some(awaiting_connection) = awaiting_connections.get_mut(&resource_id.into()) else {
+            let Some(awaiting_connection) = awaiting_connections.get_mut(&resource_id.into())
+            else {
                 return Err(Error::UnexpectedConnectionDetails);
             };
             awaiting_connection.response_received = true;
@@ -196,7 +197,10 @@ where
                 let Some(gateway_public_key) =
                     tunnel.gateway_public_keys.lock().remove(&gateway_id)
                 else {
-                    tunnel.awaiting_connection.lock().remove(&resource_id.into());
+                    tunnel
+                        .awaiting_connection
+                        .lock()
+                        .remove(&resource_id.into());
                     tunnel.peer_connections.lock().remove(&gateway_id.into());
                     tunnel
                         .gateway_awaiting_connection

--- a/rust/relay/src/allocation.rs
+++ b/rust/relay/src/allocation.rs
@@ -31,7 +31,15 @@ impl Allocation {
         let (client_to_peer_sender, client_to_peer_receiver) = mpsc::channel(MAX_BUFFERED_ITEMS);
 
         let task = tokio::spawn(async move {
-            let Err(e) = forward_incoming_relay_data(relay_data_sender, client_to_peer_receiver, id, family, port).await else {
+            let Err(e) = forward_incoming_relay_data(
+                relay_data_sender,
+                client_to_peer_receiver,
+                id,
+                family,
+                port,
+            )
+            .await
+            else {
                 unreachable!()
             };
 

--- a/rust/relay/tests/regression.rs
+++ b/rust/relay/tests/regression.rs
@@ -459,12 +459,20 @@ impl TestServer {
         for expected_output in output {
             let Some(actual_output) = self.server.next_command() else {
                 let msg = match expected_output {
-                    Output::SendMessage((recipient, msg)) => format!("to send message {:?} to {recipient}", msg),
+                    Output::SendMessage((recipient, msg)) => {
+                        format!("to send message {:?} to {recipient}", msg)
+                    }
                     Wake(time) => format!("to be woken at {time:?}"),
-                    CreateAllocation(port, family) => format!("to create allocation on port {port} for address family {family}"),
-                    FreeAllocation(port, family) => format!("to free allocation on port {port} for address family {family}"),
-                    Output::SendChannelData((peer, _)) => format!("to send channel data from {peer} to client"),
-                    Output::Forward((peer, _, _)) => format!("to forward data to peer {peer}")
+                    CreateAllocation(port, family) => {
+                        format!("to create allocation on port {port} for address family {family}")
+                    }
+                    FreeAllocation(port, family) => {
+                        format!("to free allocation on port {port} for address family {family}")
+                    }
+                    Output::SendChannelData((peer, _)) => {
+                        format!("to send channel data from {peer} to client")
+                    }
+                    Output::Forward((peer, _, _)) => format!("to forward data to peer {peer}"),
                 };
 
                 panic!("No commands produced but expected {msg}");

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.71.0"
+channel = "1.72.1"
 components = ["rustfmt", "clippy"]
 targets = [
   "x86_64-unknown-linux-musl",


### PR DESCRIPTION
Fixes an issue pulling the `1.70-slim` image. Also introduces a few compiler fixes/enhancements.

Changelog:

https://releases.rs/docs/1.72.0/
https://releases.rs/docs/1.72.1/