### PR TITLE
refactor(android): Make app links more robust in the emulator

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -25,7 +25,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         ports:
           - 5432:5432
         env:
@@ -187,7 +187,7 @@ jobs:
       MAIN_BRANCH: main
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         ports:
           - 5432:5432
         env:
@@ -286,7 +286,7 @@ jobs:
         MIX_TEST_PARTITION: [1, 2, 3, 4]
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         ports:
           - 5432:5432
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # Dependencies
   postgres:
-    image: postgres:15
+    image: postgres:16
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:

--- a/elixir/apps/web/lib/web/auth.ex
+++ b/elixir/apps/web/lib/web/auth.ex
@@ -31,11 +31,11 @@ defmodule Web.Auth do
         client_csrf_token
       )
       when not is_nil(client_platform) do
-    platform_redirect_urls =
+    platform_redirects =
       Domain.Config.fetch_env!(:web, __MODULE__)
-      |> Keyword.fetch!(:platform_redirect_urls)
+      |> Keyword.fetch!(:platform_redirects)
 
-    if redirect_to = Map.get(platform_redirect_urls, client_platform) do
+    if redirects = Map.get(platform_redirects, client_platform) do
       {:ok, client_token} = Auth.create_client_token_from_subject(subject)
 
       query =
@@ -48,8 +48,11 @@ defmodule Web.Auth do
         |> Enum.reject(&is_nil(elem(&1, 1)))
         |> URI.encode_query()
 
+      redirect_method = Keyword.fetch!(redirects, :method)
+      redirect_dest = "#{Keyword.fetch!(redirects, :dest)}?#{query}"
+
       conn
-      |> Phoenix.Controller.redirect(external: "#{redirect_to}?#{query}")
+      |> Phoenix.Controller.redirect([{redirect_method, redirect_dest}])
     else
       conn
       |> Phoenix.Controller.put_flash(

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -214,7 +214,61 @@ defmodule Web.AuthControllerTest do
       assert subject.identity.last_seen_at
     end
 
-    test "redirects to the platform link when credentials are valid for account users", %{
+    test "redirects to the apple platform URI when credentials are valid for account users", %{
+      conn: conn
+    } do
+      account = Fixtures.Accounts.create_account()
+      provider = Fixtures.Auth.create_userpass_provider(account: account)
+      password = "Firezone1234"
+
+      actor =
+        Fixtures.Actors.create_actor(
+          type: :account_user,
+          account: account,
+          provider: provider
+        )
+
+      identity =
+        Fixtures.Auth.create_identity(
+          actor: actor,
+          account: account,
+          provider: provider,
+          provider_virtual_state: %{"password" => password, "password_confirmation" => password}
+        )
+
+      conn =
+        conn
+        |> post(
+          ~p"/#{provider.account_id}/sign_in/providers/#{provider.id}/verify_credentials",
+          %{
+            "userpass" => %{
+              "provider_identifier" => identity.provider_identifier,
+              "secret" => password
+            },
+            "client_platform" => "apple"
+          }
+        )
+
+      assert conn.assigns.flash == %{}
+
+      assert is_nil(get_session(conn, :user_return_to))
+
+      assert redirected_to = redirected_to(conn)
+      assert redirected_to_uri = URI.parse(redirected_to)
+      assert "firezone" = redirected_to_uri.scheme
+      assert "handle_client_auth_callback" = redirected_to_uri.host
+
+      assert %{
+               "identity_provider_identifier" => identity_provider_identifier,
+               "actor_name" => actor_name,
+               "client_auth_token" => _token
+             } = URI.decode_query(redirected_to_uri.query)
+
+      assert actor.name == actor_name
+      assert identity.provider_identifier == identity_provider_identifier
+    end
+
+    test "redirects to the android platform path when credentials are valid for account users", %{
       conn: conn
     } do
       account = Fixtures.Accounts.create_account()
@@ -262,8 +316,13 @@ defmodule Web.AuthControllerTest do
 
       assert %{
                "client_auth_token" => _token,
-               "client_csrf_token" => ^csrf_token
+               "client_csrf_token" => ^csrf_token,
+               "identity_provider_identifier" => identity_provider_identifier,
+               "actor_name" => actor_name
              } = URI.decode_query(redirected_to_uri.query)
+
+      assert actor.name == actor_name
+      assert identity.provider_identifier == identity_provider_identifier
     end
 
     test "redirects account users to app install page when mobile platform is invalid", %{

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -258,8 +258,6 @@ defmodule Web.AuthControllerTest do
 
       assert redirected_to = redirected_to(conn)
       assert redirected_to_uri = URI.parse(redirected_to)
-      assert redirected_to_uri.scheme == "https"
-      assert redirected_to_uri.host == "app.firez.one"
       assert redirected_to_uri.path == "/handle_client_auth_callback"
 
       assert %{

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -109,9 +109,9 @@ config :web,
   private_clients: [%{__struct__: Postgrex.INET, address: {172, 28, 0, 0}, netmask: 16}]
 
 config :web, Web.Auth,
-  platform_redirect_urls: %{
-    "apple" => "firezone://handle_client_auth_callback",
-    "android" => "https://app.firez.one/handle_client_auth_callback"
+  platform_redirects: %{
+    "apple" => [method: :external, dest: "firezone://handle_client_auth_callback"],
+    "android" => [method: :to, dest: "/handle_client_auth_callback"]
   }
 
 config :web, Web.Plugs.SecureHeaders,

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -18,10 +18,15 @@ config :domain, Domain.Repo,
 config :web, dev_routes: true
 
 config :web, Web.Endpoint,
-  http: [port: 13000],
+  http: [port: 13_000],
   code_reloader: true,
   debug_errors: true,
-  check_origin: ["//127.0.0.1", "//localhost"],
+  check_origin: [
+    # Android emulator
+    "//10.0.2.2",
+    "//127.0.0.1",
+    "//localhost"
+  ],
   watchers: [
     esbuild: {Esbuild, :install_and_run, [:web, ~w(--sourcemap=inline --watch)]},
     tailwind: {Tailwind, :install_and_run, [:web, ~w(--watch)]}
@@ -66,10 +71,10 @@ config :web, Web.Plugs.SecureHeaders,
 config :api, dev_routes: true
 
 config :api, API.Endpoint,
-  http: [port: 13001],
+  http: [port: 13_001],
   debug_errors: true,
   code_reloader: true,
-  check_origin: ["//127.0.0.1", "//localhost"],
+  check_origin: ["//10.0.2.2", "//127.0.0.1", "//localhost"],
   watchers: [],
   server: true
 

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -60,13 +60,10 @@ android {
             val localProperties = Properties()
             localProperties.load(FileInputStream(rootProject.file("local.properties")))
             buildConfigField("String", "TOKEN", "\"${localProperties.getProperty("token")}\"")
-            manifestPlaceholders["appLinkHostName"] = "10.0.2.2"
-            manifestPlaceholders["appLinkScheme"] = "http"
-            manifestPlaceholders["appLinkPort"] = "13000"
-            buildConfigField("String", "AUTH_HOST", "\"10.0.2.2\"")
-            buildConfigField("String", "AUTH_SCHEME", "\"http\"")
-            buildConfigField("Integer", "AUTH_PORT", "13000")
-            buildConfigField("String", "CONTROL_PLANE_URL", "\"ws://10.0.2.2:13001/\"")
+            buildConfigField("String", "AUTH_HOST", "\"app.firez.one\"")
+            buildConfigField("String", "AUTH_SCHEME", "\"https\"")
+            buildConfigField("Integer", "AUTH_PORT", "443")
+            buildConfigField("String", "CONTROL_PLANE_URL", "\"wss://api.firez.one/\"")
 
             // Docs on filter strings: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html
             buildConfigField("String", "CONNLIB_LOG_FILTER_STRING", "\"connlib_android=debug,firezone_tunnel=trace,libs_common=debug,firezone_client_connlib=debug,warn\"")
@@ -78,9 +75,6 @@ android {
         getByName("release") {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             buildConfigField("String", "TOKEN", "null")
-            manifestPlaceholders["appLinkHostName"] = "app.firez.one"
-            manifestPlaceholders["appLinkScheme"] = "https"
-            manifestPlaceholders["appLinkPort"] = "443"
             buildConfigField("String", "AUTH_HOST", "\"app.firezone.dev\"")
             buildConfigField("String", "AUTH_SCHEME", "\"https\"")
             buildConfigField("Integer", "AUTH_PORT", "443")

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -60,11 +60,13 @@ android {
             val localProperties = Properties()
             localProperties.load(FileInputStream(rootProject.file("local.properties")))
             buildConfigField("String", "TOKEN", "\"${localProperties.getProperty("token")}\"")
-            manifestPlaceholders["hostName"] = "app.firez.one"
-            buildConfigField("String", "AUTH_HOST", "\"app.firez.one\"")
-            buildConfigField("String", "AUTH_SCHEME", "\"https\"")
-            buildConfigField("Integer", "AUTH_PORT", "443")
-            buildConfigField("String", "CONTROL_PLANE_URL", "\"wss://api.firez.one/\"")
+            manifestPlaceholders["appLinkHostName"] = "10.0.2.2"
+            manifestPlaceholders["appLinkScheme"] = "http"
+            manifestPlaceholders["appLinkPort"] = "13000"
+            buildConfigField("String", "AUTH_HOST", "\"10.0.2.2\"")
+            buildConfigField("String", "AUTH_SCHEME", "\"http\"")
+            buildConfigField("Integer", "AUTH_PORT", "13000")
+            buildConfigField("String", "CONTROL_PLANE_URL", "\"ws://10.0.2.2:13001/\"")
 
             // Docs on filter strings: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html
             buildConfigField("String", "CONNLIB_LOG_FILTER_STRING", "\"connlib_android=debug,firezone_tunnel=trace,libs_common=debug,firezone_client_connlib=debug,warn\"")
@@ -76,7 +78,9 @@ android {
         getByName("release") {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             buildConfigField("String", "TOKEN", "null")
-            manifestPlaceholders["hostName"] = "app.firezone.dev"
+            manifestPlaceholders["appLinkHostName"] = "app.firez.one"
+            manifestPlaceholders["appLinkScheme"] = "https"
+            manifestPlaceholders["appLinkPort"] = "443"
             buildConfigField("String", "AUTH_HOST", "\"app.firezone.dev\"")
             buildConfigField("String", "AUTH_SCHEME", "\"https\"")
             buildConfigField("Integer", "AUTH_PORT", "443")

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -52,15 +52,17 @@
             android:exported="true"
             android:launchMode="singleTop">
 
-            <intent-filter>
+            <intent-filter
+                android:label="@string/app_name"
+                android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="${appLinkScheme" />
-                <data android:host="${appLinkHostName}" android:port="${appLinkPort" />
-                <data android:pathPattern="/handle_client_auth_callback" />
+                <data android:scheme="https" />
+                <data android:host="app.firez.one" />
+                <data android:pathPrefix="/handle_client_auth_callback" />
             </intent-filter>
         </activity>
 

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -52,14 +52,15 @@
             android:exported="true"
             android:launchMode="singleTop">
 
-            <intent-filter
-                android:label="@string/app_name"
-                android:autoVerify="true">
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="https" android:host="${hostName}" android:path="/handle_client_auth_callback" />
+                <data android:scheme="${appLinkScheme" />
+                <data android:host="${appLinkHostName}" android:port="${appLinkPort" />
+                <data android:pathPattern="/handle_client_auth_callback" />
             </intent-filter>
         </activity>
 

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
+                <!-- These must match the resulting URL from the Portal exactly.
+                     Don't use variables here otherwise this can break when testing in the emulator.
+                     For this to work in the emulator, you must use a host/IP that *both* the emulator and the
+                     host can access. E.g. 10.0.2.2 will not work. -->
                 <data android:scheme="https" />
                 <data android:host="app.firez.one" />
                 <data android:pathPrefix="/handle_client_auth_callback" />


### PR DESCRIPTION
Getting some weird behavior with AppLinks. They don't seem to work upon first use and require a few tries to function correctly.

Edit: Found the issue: Android Studio doesn't like when the Manifest contains variables for AppLinks. I added a note in the Manifest.

@conectado To test Applinks are working correctly, you can use the App Link Assistant:

<img width="930" alt="Screenshot 2023-09-28 at 11 15 11 PM" src="https://github.com/firezone/firezone/assets/167144/e4bd4674-d562-44ec-bdb8-3a5f97250b84">

Then from there you can click "Test App Links":

<img width="683" alt="Screenshot 2023-09-28 at 11 15 30 PM" src="https://github.com/firezone/firezone/assets/167144/f3dc8e0d-f58a-4a4b-9855-62472096dc9e">
