### PR TITLE
fix(ci): Fix flaky integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,8 @@ services:
     devices:
       - "/dev/net/tun:/dev/net/tun"
     depends_on:
+      httpbin:
+        condition: 'service_healthy'
       api:
         condition: 'service_healthy'
     networks:
@@ -172,6 +174,12 @@ services:
 
   httpbin:
     image: kennethreitz/httpbin
+    healthcheck:
+      test: [ "CMD-SHELL", "ps -C gunicorn" ]
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 5s
     networks:
       resources:
         ipv4_address: 172.20.0.100

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -19,9 +19,17 @@ COPY ./docker-init.sh .
 ENV RUST_BACKTRACE=1
 ENV PATH "/app:$PATH"
 ENV PACKAGE_NAME ${PACKAGE}
-RUN apt-get update -y \
-    && apt-get install -y iputils-ping iptables lsof iproute2 curl iperf3 ca-certificates \
-    && apt-get clean \
+RUN apt-get -qq update \
+    && DEBIAN_FRONTEND=noninteractive \
+    apt-get -qq install \
+      iputils-ping \
+      iptables \
+      lsof \
+      iproute2 \
+      curl \
+      iperf3 \
+      ca-certificates \
+    && apt-get -qq clean \
     && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["docker-init.sh"]


### PR DESCRIPTION
We consistently seem to be getting integration test failures whenever the `rust/` workspace is changed now. Opening this to test some CI runs to unblock the pipeline.