### PR TITLE
fix(portal): Increase `assert_receive` timeouts because GH is slow

### DIFF
--- a/elixir/apps/domain/test/domain/jobs/executors/global_test.exs
+++ b/elixir/apps/domain/test/domain/jobs/executors/global_test.exs
@@ -10,8 +10,8 @@ defmodule Domain.Jobs.Executors.GlobalTest do
   test "executes the handler on the interval" do
     assert {:ok, _pid} = start_link({{__MODULE__, :send_test_message}, 25, test_pid: self()})
 
-    assert_receive {:executed, _pid, time1}, 200
-    assert_receive {:executed, _pid, time2}, 200
+    assert_receive {:executed, _pid, time1}, 500
+    assert_receive {:executed, _pid, time2}, 500
 
     assert time1 < time2
   end

--- a/elixir/apps/domain/test/domain/network/address/query_test.exs
+++ b/elixir/apps/domain/test/domain/network/address/query_test.exs
@@ -105,7 +105,9 @@ defmodule Domain.Network.Address.QueryTest do
       end)
 
       ip1 = Repo.one(queryable)
-      assert_receive {:ip, ip2}, 1_000
+
+      # GitHub Actions is slow
+      assert_receive {:ip, ip2}, 3_000
 
       assert Enum.sort([ip1, ip2]) ==
                Enum.sort([


### PR DESCRIPTION
Fixes https://github.com/firezone/firezone/actions/runs/6363610658/job/17279335896 and https://github.com/firezone/firezone/actions/runs/6363673302/job/17279439543