### PR TITLE
Add `make version` command to set version in components

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -11,8 +11,7 @@ permissions:
 
 env:
   # Don't change this directly. Instead, use `make version` from the repo root.
-  MAJOR_VERSION: 1
-  MINOR_VERSION: 20231001
+  MAJOR_VERSION: 20231001
 
 jobs:
   update_release_draft:
@@ -28,4 +27,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: ${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ github.run_number }}
+          version: ${{ env.MAJOR_VERSION }}.${{ github.run_number }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,11 +9,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # Don't change this directly. Instead, use `make version` from the repo root.
-  MAJOR_VERSION: 1
-  MINOR_VERSION: 20231001
-
 jobs:
   update_release_draft:
     permissions:
@@ -28,4 +23,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: ${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ github.run_number }}
+          # mark:automatic-version
+          version: 1.20231001.0

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -11,7 +11,8 @@ permissions:
 
 env:
   # Don't change this directly. Instead, use `make version` from the repo root.
-  MAJOR_VERSION: 20231001
+  MAJOR_VERSION: 1
+  MINOR_VERSION: 20231001
 
 jobs:
   update_release_draft:
@@ -27,4 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: ${{ env.MAJOR_VERSION }}.${{ github.run_number }}
+          version: ${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ github.run_number }}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# Format:
+# MAJOR: This is "1" for now. Don't change it.
+# MINOR: This is the current version of the portal API in YYYYMMDD format. Consumers (connlib, REST) will request
+#        this API from the portal with the X-Firezone-API-Version request header.
+# PATCH: Increment this each time you want to publish a new Firezone version.
 version = 1.20231001.0
 
 version:

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,4 @@ version:
 	@find .github/ -name "*.yml" -exec sed -i '' -e '/mark:automatic-version/{n;s/[0-9]*\.[0-9]*\.[0-9]*/$(version)/;}' {} \;
 	@find swift/ -name "project.pbxproj" -exec sed -i '' -e 's/MARKETING_VERSION = .*;/MARKETING_VERSION = $(version);/' {} \;
 	@find kotlin/ -name "build.gradle.kts" -exec sed -i '' -e '/mark:automatic-version/{n;s/versionName =.*/versionName = "$(version)"/;}' {} \;
+	@cd rust && cargo check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+version = 1.20231001.0
+
+version:
+	@find elixir/ -name "mix.exs" -exec sed -i '' -e '/mark:automatic-version/{n;s/[0-9]*\.[0-9]*\.[0-9]*/$(version)/;}' {} \;
+	@find rust/ -name "Cargo.toml" -exec sed -i '' -e '/mark:automatic-version/{n;s/[0-9]*\.[0-9]*\.[0-9]*/$(version)/;}' {} \;
+	@find .github/ -name "*.yml" -exec sed -i '' -e '/mark:automatic-version/{n;s/[0-9]*\.[0-9]*\.[0-9]*/$(version)/;}' {} \;
+	@find swift/ -name "project.pbxproj" -exec sed -i '' -e 's/MARKETING_VERSION = .*;/MARKETING_VERSION = $(version);/' {} \;
+	@find kotlin/ -name "build.gradle.kts" -exec sed -i '' -e '/mark:automatic-version/{n;s/versionName =.*/versionName = "$(version)"/;}' {} \;

--- a/elixir/apps/api/mix.exs
+++ b/elixir/apps/api/mix.exs
@@ -4,7 +4,8 @@ defmodule API.MixProject do
   def project do
     [
       app: :api,
-      version: version(),
+      # mark:automatic-version
+      version: "1.20231001.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -22,10 +23,6 @@ defmodule API.MixProject do
       aliases: aliases(),
       deps: deps()
     ]
-  end
-
-  def version do
-    System.get_env("APPLICATION_VERSION", "0.0.0+git.0.deadbeef")
   end
 
   def application do

--- a/elixir/apps/domain/mix.exs
+++ b/elixir/apps/domain/mix.exs
@@ -4,7 +4,8 @@ defmodule Domain.MixProject do
   def project do
     [
       app: :domain,
-      version: version(),
+      # mark:automatic-version
+      version: "1.20231001.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -22,11 +23,6 @@ defmodule Domain.MixProject do
       aliases: aliases(),
       deps: deps()
     ]
-  end
-
-  def version do
-    # Use dummy version for dev and test
-    System.get_env("APPLICATION_VERSION", "0.0.0+git.0.deadbeef")
   end
 
   def application do

--- a/elixir/apps/web/mix.exs
+++ b/elixir/apps/web/mix.exs
@@ -4,7 +4,8 @@ defmodule Web.MixProject do
   def project do
     [
       app: :web,
-      version: version(),
+      # mark:automatic-version
+      version: "1.20231001.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -15,10 +16,6 @@ defmodule Web.MixProject do
       aliases: aliases(),
       deps: deps()
     ]
-  end
-
-  def version do
-    System.get_env("APPLICATION_VERSION", "0.0.0+git.0.deadbeef")
   end
 
   def application do

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -46,8 +46,9 @@ android {
         applicationId = "dev.firezone.android"
         minSdk = 29
         targetSdk = 33
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = (System.currentTimeMillis() / 1000 / 10).toInt()
+        // mark:automatic-version
+        versionName = "1.20231001.0"
         multiDexEnabled = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -8,8 +8,6 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <!-- XXX: Set usesCleartextTraffic to false for added security when APIMock is removed or served over https -->
-
     <queries>
         <intent>
             <action android:name="android.support.customtabs.action.CustomTabsService" />

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "connlib-android"
-version = "0.1.6"
+version = "1.20231001.0"
 dependencies = [
  "firezone-client-connlib",
  "ip_network",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "connlib-apple"
-version = "0.1.6"
+version = "1.20231001.0"
 dependencies = [
  "anyhow",
  "diva",
@@ -1154,7 +1154,7 @@ checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "firezone-client-connlib"
-version = "0.1.0"
+version = "1.20231001.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gateway-connlib"
-version = "0.1.0"
+version = "1.20231001.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-tunnel"
-version = "0.1.0"
+version = "1.20231001.0"
 dependencies = [
  "async-trait",
  "boringtun",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.1.0"
+version = "1.20231001.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1441,7 +1441,7 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "headless"
-version = "0.1.0"
+version = "1.20231001.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "headless-utils"
-version = "0.1.0"
+version = "1.20231001.0"
 dependencies = [
  "clap",
  "ctrlc",
@@ -1859,7 +1859,7 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libs-common"
-version = "0.1.0"
+version = "1.20231001.0"
 dependencies = [
  "base64 0.21.4",
  "boringtun",
@@ -2424,7 +2424,7 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "phoenix-channel"
-version = "0.1.0"
+version = "1.20231001.0"
 dependencies = [
  "base64 0.21.4",
  "futures",
@@ -2751,7 +2751,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "relay"
-version = "0.1.0"
+version = "1.20231001.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "connlib-android"
-version = "0.1.6"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 [lib]

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "connlib-apple"
-version = "0.1.6"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 [features]

--- a/rust/connlib/clients/headless/Cargo.toml
+++ b/rust/connlib/clients/headless/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "headless"
-version = "0.1.0"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/connlib/gateway/Cargo.toml
+++ b/rust/connlib/gateway/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "gateway"
-version = "0.1.0"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/connlib/headless-utils/Cargo.toml
+++ b/rust/connlib/headless-utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "headless-utils"
-version = "0.1.0"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/connlib/libs/client/Cargo.toml
+++ b/rust/connlib/libs/client/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "firezone-client-connlib"
-version = "0.1.0"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 [features]

--- a/rust/connlib/libs/common/Cargo.toml
+++ b/rust/connlib/libs/common/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libs-common"
-version = "0.1.0"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/connlib/libs/gateway/Cargo.toml
+++ b/rust/connlib/libs/gateway/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "firezone-gateway-connlib"
-version = "0.1.0"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 [dependencies]

--- a/rust/connlib/libs/tunnel/Cargo.toml
+++ b/rust/connlib/libs/tunnel/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "firezone-tunnel"
-version = "0.1.0"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 [dependencies]

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "phoenix-channel"
-version = "0.1.0"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "relay"
-version = "0.1.0"
+# mark:automatic-version
+version = "1.20231001.0"
 edition = "2021"
 
 [dependencies]

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -543,7 +543,7 @@
 					"${CONNLIB_TARGET_DIR}/x86_64-apple-ios/debug",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.20231001.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "${APP_ID}.network-extension";
@@ -585,7 +585,7 @@
 					"${CONNLIB_TARGET_DIR}/x86_64-apple-ios/release",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.20231001.0;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "${APP_ID}.network-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -627,7 +627,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/debug";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.20231001.0;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "${APP_ID}.network-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -668,7 +668,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/release";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.20231001.0;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "${APP_ID}.network-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -863,7 +863,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.20231001.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${APP_ID}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -915,7 +915,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.20231001.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${APP_ID}";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Fixes #2213 

This will allow us to fetch the actual Firezone version that's in use from within the language runtimes themselves without resorting to an external mechanism to do so. This is useful in connlib for example when selecting the Portal API to use with `X-Firezone-API-Version`, and useful in log printing.

Since platforms enforce semantic version, I propose the convention:

`1.20231001.34` where MAJOR is `1` for Firezone 1.0, MINOR is our API version, and PATCH is the release of that API version that is published on the repo.

Given this system, publishing a release would consist of:

1. Edit `Makefile` to set the patch and minor versions appropriately depending on whether there are breaking portal API changes.
2. `make version`
3. `git add .; git commit; git push` -- this opens a PR with the new version numbers. In this PR we can discuss whether to stop-ship or go.
4. PR merged, release is drafted and deployed to staging with the new tag and version numbers
5. build artifacts are uploaded to drafted release, everything is tagged and versioned appropriately without having to introduce another commit
6. If all looks good, publish release