### PR TITLE
apple: Exporting logs, preventing multiple Settings windows

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -71,6 +71,15 @@
         "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
         "version" : "1.0.2"
       }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "43ec568034b3731101dbf7670765d671c30f54f3",
+        "version" : "0.9.16"
+      }
     }
   ],
   "version" : 2

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -19,14 +19,14 @@ struct FirezoneApp: App {
 
   var body: some Scene {
     #if os(iOS)
-    WindowGroup {
-      AppView(model: model)
-    }
+      WindowGroup {
+        AppView(model: model)
+      }
     #else
-    WindowGroup("Settings", id: "firezone-settings") {
-      SettingsView(model: appDelegate.settingsViewModel)
-    }
-    .handlesExternalEvents(matching: ["settings"])
+      WindowGroup("Settings", id: "firezone-settings") {
+        SettingsView(model: appDelegate.settingsViewModel)
+      }
+      .handlesExternalEvents(matching: ["settings"])
     #endif
   }
 }

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -19,14 +19,14 @@ struct FirezoneApp: App {
 
   var body: some Scene {
     #if os(iOS)
-      WindowGroup {
-        AppView(model: model)
-      }
+    WindowGroup {
+      AppView(model: model)
+    }
     #else
-      WindowGroup("Settings") {
-        SettingsView(model: appDelegate.settingsViewModel)
-      }
-      .handlesExternalEvents(matching: ["settings"])
+    WindowGroup("Settings", id: "firezone-settings") {
+      SettingsView(model: appDelegate.settingsViewModel)
+    }
+    .handlesExternalEvents(matching: ["settings"])
     #endif
   }
 }

--- a/swift/apple/Firezone/Firezone.entitlements
+++ b/swift/apple/Firezone/Firezone.entitlements
@@ -6,11 +6,13 @@
 	<array>
 		<string>packet-tunnel-provider</string>
 	</array>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>${APP_GROUP_ID}</string>
 	</array>
-	<key>com.apple.security.app-sandbox</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/swift/apple/FirezoneKit/Package.swift
+++ b/swift/apple/FirezoneKit/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.0.0"),
-    .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0"))
+    .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0")),
   ],
   targets: [
     .target(

--- a/swift/apple/FirezoneKit/Package.swift
+++ b/swift/apple/FirezoneKit/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.0.0"),
+    .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0"))
   ],
   targets: [
     .target(
@@ -23,6 +24,7 @@ let package = Package(
         .product(name: "SwiftUINavigation", package: "swiftui-navigation"),
         .product(name: "SwiftUINavigationCore", package: "swiftui-navigation"),
         .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "ZIPFoundation", package: "ZIPFoundation"),
       ]
     ),
     .testTarget(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/AuthClient/AuthClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/AuthClient/AuthClient.swift
@@ -88,6 +88,9 @@ private final class WebAuthenticationSession: NSObject,
       // We want to load any SSO cookies that the user may have set in their default browser
       session.prefersEphemeralWebBrowserSession = false
 
+      #if os(macOS)
+      NSApp.activate(ignoringOtherApps: true)
+      #endif
       session.start()
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/AuthClient/AuthClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/AuthClient/AuthClient.swift
@@ -89,7 +89,7 @@ private final class WebAuthenticationSession: NSObject,
       session.prefersEphemeralWebBrowserSession = false
 
       #if os(macOS)
-      NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate(ignoringOtherApps: true)
       #endif
       session.start()
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
@@ -155,7 +155,7 @@ public struct SettingsView: View {
           .disabled(!isTeamIdValid(model.settings.accountId))
         }
         ExportLogsButton(isProcessing: $isExportingLogs) {
-          self.exportLogsButtonTapped()
+          self.exportLogsWithSavePanelOnMac()
         }
       }
     }
@@ -197,7 +197,7 @@ public struct SettingsView: View {
   }
 
   #if os(macOS)
-    func exportLogsButtonTapped() {
+    func exportLogsWithSavePanelOnMac() {
       self.isExportingLogs = true
 
       let savePanel = NSSavePanel()
@@ -241,14 +241,6 @@ public struct SettingsView: View {
         }
       }
     }
-  #elseif os(iOS)
-    func exportLogsButtonTapped() {
-      self.isExportingLogs = true
-      Task {
-        let logsTempZipFileURL = try await createLogZipBundle()
-        self.isPresentingExportLogShareSheet = true
-      }
-    }
   #endif
 
   private func logZipBundleFilename() -> String {
@@ -265,7 +257,8 @@ public struct SettingsView: View {
       throw SettingsViewError.logFolderIsUnavailable
     }
     let zipFileURL =
-      destinationURL ?? fileManager.temporaryDirectory.appendingPathComponent(logZipBundleFilename())
+      destinationURL
+      ?? fileManager.temporaryDirectory.appendingPathComponent(logZipBundleFilename())
     if fileManager.fileExists(atPath: zipFileURL.path) {
       try fileManager.removeItem(at: zipFileURL)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
@@ -203,7 +203,7 @@ public struct SettingsView: View {
       let savePanel = NSSavePanel()
       savePanel.prompt = "Save"
       savePanel.nameFieldLabel = "Save log zip bundle to:"
-      savePanel.nameFieldStringValue = "firezone-logs.zip"
+      savePanel.nameFieldStringValue = logZipBundleFilename()
 
       guard
         let window = NSApp.windows.first(where: {
@@ -251,6 +251,13 @@ public struct SettingsView: View {
     }
   #endif
 
+  private func logZipBundleFilename() -> String {
+    let dateFormatter = ISO8601DateFormatter()
+    dateFormatter.formatOptions = [.withFullDate, .withTime, .withTimeZone]
+    let timeStampString = dateFormatter.string(from: Date())
+    return "firezone_logs_\(timeStampString).zip"
+  }
+
   @discardableResult
   private func createLogZipBundle(destinationURL: URL? = nil) async throws -> URL {
     let fileManager = FileManager.default
@@ -258,7 +265,7 @@ public struct SettingsView: View {
       throw SettingsViewError.logFolderIsUnavailable
     }
     let zipFileURL =
-      destinationURL ?? fileManager.temporaryDirectory.appendingPathComponent("firezone_logs.zip")
+      destinationURL ?? fileManager.temporaryDirectory.appendingPathComponent(logZipBundleFilename())
     if fileManager.fileExists(atPath: zipFileURL.path) {
       try fileManager.removeItem(at: zipFileURL)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
@@ -60,6 +60,7 @@ public struct SettingsView: View {
   @Environment(\.dismiss) var dismiss
 
   let teamIdAllowedCharacterSet: CharacterSet
+  @State private var isExportingLogs = false
 
   public init(model: SettingsViewModel) {
     self.model = model
@@ -82,9 +83,13 @@ public struct SettingsView: View {
 
   #if os(iOS)
     private var ios: some View {
-      NavigationView {
-        VStack {
+      NavigationView() {
+        VStack(spacing: 10) {
           form
+          ExportLogsButton(isProcessing: $isExportingLogs) {
+            self.exportLogsButtonTapped()
+          }
+          Spacer()
         }
         .toolbar {
           ToolbarItem(placement: .navigationBarTrailing) {
@@ -120,6 +125,9 @@ public struct SettingsView: View {
             }
           )
           .disabled(!isTeamIdValid(model.settings.accountId))
+        }
+        ExportLogsButton(isProcessing: $isExportingLogs) {
+          self.exportLogsButtonTapped()
         }
       }
     }
@@ -158,6 +166,37 @@ public struct SettingsView: View {
   func cancelButtonTapped() {
     model.load()
     dismiss()
+  }
+
+  func exportLogsButtonTapped() {
+    self.isExportingLogs = true
+    Task {
+      try await Task.sleep(nanoseconds: 2_000_000_000)
+      self.isExportingLogs = false
+    }
+  }
+}
+
+struct ExportLogsButton: View {
+  @Binding var isProcessing: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Label(
+        title: { Text("Export Logs") },
+        icon: {
+          if isProcessing {
+            ProgressView().controlSize(.small)
+              .frame(minWidth: 12)
+          } else {
+            Image(systemName: "arrow.up.doc")
+              .frame(minWidth: 12)
+          }
+        })
+      .labelStyle(.titleAndIcon)
+    }
+    .disabled(isProcessing)
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -8,7 +8,10 @@ import Foundation
 
 public struct SharedAccess {
   public static var baseFolderURL: URL {
-    guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppInfoPlistConstants.appGroupId) else {
+    guard
+      let url = FileManager.default.containerURL(
+        forSecurityApplicationGroupIdentifier: AppInfoPlistConstants.appGroupId)
+    else {
       fatalError("Shared folder unavailable")
     }
     return url

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -1,0 +1,65 @@
+//
+//  SharedAccess.swift
+//  (c) 2023 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+
+public struct SharedAccess {
+  public static var baseFolderURL: URL {
+    guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppInfoPlistConstants.appGroupId) else {
+      fatalError("Shared folder unavailable")
+    }
+    return url
+  }
+
+  public static var cacheFolderURL: URL? {
+    let url = baseFolderURL.appendingPathComponent("Library").appendingPathComponent("Caches")
+    guard ensureDirectoryExists(at: url.path) else {
+      return nil
+    }
+    return url
+  }
+
+  public static var logFolderURL: URL? {
+    if let url = cacheFolderURL?.appendingPathComponent("logs") {
+      guard ensureDirectoryExists(at: url.path) else {
+        return nil
+      }
+      return url
+    }
+    NSLog("Can't access cacheFolderURL to create logFolderURL")
+    return nil
+  }
+
+  public static var connlibLogFolderURL: URL? {
+    if let url = logFolderURL?.appendingPathComponent("connlib") {
+      guard ensureDirectoryExists(at: url.path) else {
+        return nil
+      }
+      return url
+    }
+    NSLog("Can't access logFolderURL to create connlibLogFolderURL")
+    return nil
+  }
+
+  private static func ensureDirectoryExists(at path: String) -> Bool {
+    let fileManager = FileManager.default
+    do {
+      var isDirectory: ObjCBool = false
+      if fileManager.fileExists(atPath: path, isDirectory: &isDirectory) {
+        if isDirectory.boolValue {
+          return true
+        } else {
+          try fileManager.removeItem(atPath: path)
+        }
+      }
+      try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
+      return true
+    } catch {
+      NSLog("Error while ensuring directory '\(path)' exists: \(error)")
+      return false
+    }
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -110,7 +110,7 @@ final class AuthStore: ObservableObject {
     guard case .signedOut(let accountId) = self.loginStatus, let accountId = accountId,
       !accountId.isEmpty
     else {
-      logger.debug("No account-id found in tunnel")
+      logger.log("No account-id found in tunnel")
       throw FirezoneError.missingTeamId
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -244,7 +244,12 @@
     }
 
     private func openSettingsWindow() {
-      NSWorkspace.shared.open(URL(string: "firezone://settings")!)
+      if let settingsWindow = NSApp.windows.first(where: { $0.identifier?.rawValue.hasPrefix("firezone-settings") ?? false }) {
+        NSApp.activate(ignoringOtherApps: true)
+        settingsWindow.makeKeyAndOrderFront(self)
+      } else {
+        NSWorkspace.shared.open(URL(string: "firezone://settings")!)
+      }
     }
 
     private func updateStatusItemIcon() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -244,7 +244,9 @@
     }
 
     private func openSettingsWindow() {
-      if let settingsWindow = NSApp.windows.first(where: { $0.identifier?.rawValue.hasPrefix("firezone-settings") ?? false }) {
+      if let settingsWindow = NSApp.windows.first(where: {
+        $0.identifier?.rawValue.hasPrefix("firezone-settings") ?? false
+      }) {
         NSApp.activate(ignoringOtherApps: true)
         settingsWindow.makeKeyAndOrderFront(self)
       } else {

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -283,7 +283,8 @@ extension Adapter {
       do {
         self.state = .startingTunnel(
           session: try WrappedSession.connect(
-            controlPlaneURLString, token, self.getDeviceId(), self.connlibLogFolderPath, logFilterString,
+            controlPlaneURLString, token, self.getDeviceId(), self.connlibLogFolderPath,
+            logFilterString,
             self.callbackHandler),
           onStarted: { error in
             if let error = error {

--- a/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
+++ b/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
@@ -40,7 +40,7 @@ public class CallbackHandler {
     dnsAddress: RustString,
     dnsFallbackStrategy: RustString
   ) {
-    logger.debug(
+    logger.log(
       """
         CallbackHandler.onSetInterfaceConfig:
           IPv4: \(tunnelAddressIPv4.toString(), privacy: .public)
@@ -57,27 +57,27 @@ public class CallbackHandler {
   }
 
   func onTunnelReady() {
-    logger.debug("CallbackHandler.onTunnelReady")
+    logger.log("CallbackHandler.onTunnelReady")
     delegate?.onTunnelReady()
   }
 
   func onAddRoute(route: RustString) {
-    logger.debug("CallbackHandler.onAddRoute: \(route.toString(), privacy: .public)")
+    logger.log("CallbackHandler.onAddRoute: \(route.toString(), privacy: .public)")
     delegate?.onAddRoute(route.toString())
   }
 
   func onRemoveRoute(route: RustString) {
-    logger.debug("CallbackHandler.onRemoveRoute: \(route.toString(), privacy: .public)")
+    logger.log("CallbackHandler.onRemoveRoute: \(route.toString(), privacy: .public)")
     delegate?.onRemoveRoute(route.toString())
   }
 
   func onUpdateResources(resourceList: RustString) {
-    logger.debug("CallbackHandler.onUpdateResources: \(resourceList.toString(), privacy: .public)")
+    logger.log("CallbackHandler.onUpdateResources: \(resourceList.toString(), privacy: .public)")
     delegate?.onUpdateResources(resourceList: resourceList.toString())
   }
 
   func onDisconnect(error: RustString) {
-    logger.debug("CallbackHandler.onDisconnect: \(error.toString(), privacy: .public)")
+    logger.log("CallbackHandler.onDisconnect: \(error.toString(), privacy: .public)")
     let error = error.toString()
     var optionalError = Optional.some(error)
     if error.isEmpty {
@@ -87,7 +87,7 @@ public class CallbackHandler {
   }
 
   func onError(error: RustString) {
-    logger.debug("CallbackHandler.onError: \(error.toString(), privacy: .public)")
+    logger.log("CallbackHandler.onError: \(error.toString(), privacy: .public)")
     delegate?.onError(error: error.toString())
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/Connlib.xcfilelist
+++ b/swift/apple/FirezoneNetworkExtension/Connlib.xcfilelist
@@ -2,5 +2,4 @@ $(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated/connlib-apple/connlib-
 $(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated/connlib-apple/connlib-apple.h
 $(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated/SwiftBridgeCore.h
 $(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated/SwiftBridgeCore.swift
-$(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/CallbackHandler.swift
 $(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/connlib.h

--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -98,7 +98,7 @@ class NetworkSettings {
       return
     }
 
-    logger.debug("NetworkSettings.apply: Applying network settings")
+    logger.log("NetworkSettings.apply: Applying network settings")
 
     var tunnelIPv4Routes: [NEIPv4Route] = []
     var tunnelIPv6Routes: [NEIPv6Route] = []
@@ -121,7 +121,7 @@ class NetworkSettings {
           let validNetworkPrefixLength = Self.validNetworkPrefixLength(
             fromString: networkPrefixLengthString, maximumValue: 32)
           let ipv4SubnetMask = Self.ipv4SubnetMask(networkPrefixLength: validNetworkPrefixLength)
-          logger.debug(
+          logger.log(
             """
             NetworkSettings.apply:
               Adding IPv4 route: \(address, privacy: .public) (subnet mask: \(ipv4SubnetMask, privacy: .public)
@@ -137,7 +137,7 @@ class NetworkSettings {
           }
           let validNetworkPrefixLength = Self.validNetworkPrefixLength(
             fromString: networkPrefixLengthString, maximumValue: 128)
-          logger.debug(
+          logger.log(
             """
             NetworkSettings.apply:
               Adding IPv6 route: \(address, privacy: .public) (prefix length: \(validNetworkPrefixLength, privacy: .public)
@@ -182,14 +182,14 @@ class NetworkSettings {
     tunnelNetworkSettings.tunnelOverheadBytes = tunnelOverheadBytes
 
     self.hasUnappliedChanges = false
-    logger.debug("Attempting to set network settings")
+    logger.log("Attempting to set network settings")
     packetTunnelProvider.setTunnelNetworkSettings(tunnelNetworkSettings) { error in
       if let error = error {
         logger.error("NetworkSettings.apply: Error: \(error, privacy: .public)")
       } else {
         guard !self.hasUnappliedChanges else {
           // Changes were made while the packetTunnelProvider was setting the network settings
-          logger.debug(
+          logger.log(
             """
             NetworkSettings.apply:
               Applying changes made to network settings while we were applying the network settings
@@ -197,7 +197,7 @@ class NetworkSettings {
           self.apply(on: packetTunnelProvider, logger: logger, completionHandler: completionHandler)
           return
         }
-        logger.debug("NetworkSettings.apply: Applied successfully")
+        logger.log("NetworkSettings.apply: Applied successfully")
       }
       completionHandler?(error)
     }


### PR DESCRIPTION
Fixes #2018.
Fixes #2172.

This PR:
  - Sets up app groups so that the main app and the tunnel can have a shared disk location. It passes a subfolder of that location for conn lib's log location.
  - Adds an "Export Logs" button in Settings that exports logs (opens a save dialog in macOS, opens a share sheet in iOS)
  - Prevents opening multiple settings windows in macOS
