### PR TITLE
fix(connlib): don't immediately upload logs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4306,7 +4306,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
- "ring",
+ "ring 0.16.20",
  "untrusted 0.7.1",
 ]
 

--- a/rust/connlib/libs/client/src/lib.rs
+++ b/rust/connlib/libs/client/src/lib.rs
@@ -19,7 +19,7 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secrecy::{Secret, SecretString};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::Interval;
+use tokio::time::{Interval, MissedTickBehavior};
 use tokio::{runtime::Runtime, sync::Mutex, time::Instant};
 use url::Url;
 
@@ -253,8 +253,10 @@ where
 
 fn upload_interval() -> Interval {
     let duration = upload_interval_duration_from_env_or_default();
+    let mut interval = tokio::time::interval_at(Instant::now() + duration, duration);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-    tokio::time::interval_at(Instant::now() + duration, duration)
+    interval
 }
 
 /// Parses an interval from the _compile-time_ env variable `CONNLIB_LOG_UPLOAD_INTERVAL_SECS`.

--- a/rust/connlib/libs/client/src/lib.rs
+++ b/rust/connlib/libs/client/src/lib.rs
@@ -19,7 +19,8 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secrecy::{Secret, SecretString};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::{runtime::Runtime, sync::Mutex};
+use tokio::time::Interval;
+use tokio::{runtime::Runtime, sync::Mutex, time::Instant};
 use url::Url;
 
 mod control;
@@ -167,7 +168,7 @@ where
 
             tokio::spawn(async move {
                 let mut log_stats_interval = tokio::time::interval(Duration::from_secs(10));
-                let mut upload_logs_interval = tokio::time::interval(upload_interval_from_env_or_default());
+                let mut upload_logs_interval = upload_interval();
                 loop {
                     tokio::select! {
                         Some((msg, reference)) = control_plane_receiver.recv() => {
@@ -250,10 +251,16 @@ where
     }
 }
 
+fn upload_interval() -> Interval {
+    let duration = upload_interval_duration_from_env_or_default();
+
+    tokio::time::interval_at(Instant::now() + duration, duration)
+}
+
 /// Parses an interval from the _compile-time_ env variable `CONNLIB_LOG_UPLOAD_INTERVAL_SECS`.
 ///
 /// If not present or parsing as u64 fails, we fall back to a default interval of 1 hour.
-fn upload_interval_from_env_or_default() -> Duration {
+fn upload_interval_duration_from_env_or_default() -> Duration {
     const DEFAULT: Duration = Duration::from_secs(60 * 60);
 
     let Some(interval) = option_env!("CONNLIB_LOG_UPLOAD_INTERVAL_SECS") else {


### PR DESCRIPTION
By default, a new `Interval` fires immediately and then on every configuration duration. This would trigger an immediate log upload on startup despite no logs being present yet.

Delay the log upload to the first tick.

Related: #2224.