### PR TITLE
ci: optimize caching further

### DIFF
--- a/.github/actions/gcp-docker-login/action.yml
+++ b/.github/actions/gcp-docker-login/action.yml
@@ -1,0 +1,29 @@
+name: "GCP docker registry login"
+description: "Login to the GCP docker registry"
+inputs:
+  project:
+    description: "The GCP project name"
+    required: true
+outputs:
+  registry:
+    description: "The full name of the registry we logged into"
+    value: "us-east1-docker.pkg.dev"/${{ inputs.project }}
+runs:
+  using: "composite"
+  steps:
+    - id: auth
+      uses: google-github-actions/auth@v1
+      with:
+        token_format: access_token
+        workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
+        service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
+        export_environment_variables: false
+    - name: Change current gcloud account
+      shell: bash
+      run: gcloud --quiet config set project ${{ inputs.project }}
+    - name: Login to Google Artifact Registry
+      uses: docker/login-action@v3
+      with:
+        registry: "us-east1-docker.pkg.dev"
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}

--- a/.github/actions/gcp-docker-login/action.yml
+++ b/.github/actions/gcp-docker-login/action.yml
@@ -7,7 +7,7 @@ inputs:
 outputs:
   registry:
     description: "The full name of the registry we logged into"
-    value: "us-east1-docker.pkg.dev"/${{ inputs.project }}
+    value: ${{ format('us-east1-docker.pkg.dev/{0}', inputs.project) }}
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.context }}/
           cache-from: |
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache-${{ github.ref }}
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache-refs/heads/main
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ github.ref }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:refs/heads/main
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
           cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           # but it'll just be corrected on the next successful build.
           cache-to:
             ${{ github.ref == 'refs/heads/main' &&
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache,mode=max }}
+            format('type=registry,ref={0}/{1}/firezone/{2}:buildcache,mode=max ', env.GCP_REGISTRY, env.GCP_PROJECT, matrix.image_name) || '' }}
           file: ${{ matrix.cache_scope }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - uses: actions/checkout@v4
-      - name: Sanitize github.ref_name
-        run: |
-          REF="${{ github.ref_name }}" # `ref_name` contains `/` which is not a valid docker image tag.
-          CACHE_TAG="${REF//\//-}"
-          echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
       - name: Build Docker images
         uses: docker/build-push-action@v5
         with:
@@ -83,11 +78,11 @@ jobs:
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.context }}/
           cache-from: |
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ matrix.image_name }}-buildcache:main
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ github.ref_name }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:main
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
-          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ matrix.image_name }}:buildcache:${{ env.CACHE_TAG }}
+          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ github.ref_name }}
           file: ${{ matrix.context }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,37 +34,37 @@ jobs:
           - image_name: api
             target: runtime
             push: ${{ github.ref == 'refs/heads/main' }}
-            cache_scope: elixir
+            context: elixir
             build-args: |
               APPLICATION_NAME=api
           - image_name: web
             target: runtime
             push: ${{ github.ref == 'refs/heads/main' }}
-            cache_scope: elixir
+            context: elixir
             build-args: |
               APPLICATION_NAME=web
           - image_name: gateway
             target: runtime
             push: ${{ github.ref == 'refs/heads/main' }}
-            cache_scope: rust
+            context: rust
             build-args: |
               PACKAGE=firezone-gateway
           - image_name: relay
             target: runtime
             push: ${{ github.ref == 'refs/heads/main' }}
-            cache_scope: rust
+            context: rust
             build-args: |
               PACKAGE=relay
           - image_name: client
             target: runtime
             push: false
-            cache_scope: rust
+            context: rust
             build-args: |
               PACKAGE=firezone-headless-client
           - image_name: elixir
             target: builder
             push: false
-            cache_scope: elixir
+            context: elixir
             build-args: |
               APPLICATION_NAME=api
     permissions:
@@ -100,14 +100,14 @@ jobs:
         with:
           platforms: linux/amd64
           build-args: ${{ matrix.build-args }}
-          context: ${{ matrix.cache_scope }}/
+          context: ${{ matrix.context }}/
           cache-from: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
           cache-to:
             ${{ github.ref == 'refs/heads/main' &&
             format('type=registry,ref={0}/{1}/firezone/{2}:buildcache,mode=max', env.GCP_REGISTRY, env.GCP_PROJECT, matrix.image_name) || '' }}
-          file: ${{ matrix.cache_scope }}/Dockerfile
+          file: ${{ matrix.context }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/
           push: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - uses: actions/checkout@v4
+      - name: Sanitize github.ref_name
+        run: |
+          REF="${{ github.ref_name }}"
+          CACHE_TAG="${REF//\//-}"
+          echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
       - name: Build Docker images
         uses: docker/build-push-action@v5
         with:
@@ -78,11 +83,11 @@ jobs:
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.context }}/
           cache-from: |
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ github.ref_name }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
             type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:main
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
-          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ github.ref_name }}
+          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ env.CACHE_TAG }}
           file: ${{ matrix.context }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.context }}/
           cache-from: |
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ github.ref }}
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:refs/heads/main
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache-${{ github.ref }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache-refs/heads/main
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
           cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           # but it'll just be corrected on the next successful build.
           cache-to:
             ${{ github.ref == 'refs/heads/main' &&
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache,mode=max }}
           file: ${{ matrix.cache_scope }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           # but it'll just be corrected on the next successful build.
           cache-to:
             ${{ github.ref == 'refs/heads/main' &&
-            format('type=registry,ref={0}/{1}/firezone/{2}:buildcache,mode=max ', env.GCP_REGISTRY, env.GCP_PROJECT, matrix.image_name) || '' }}
+            format('type=registry,ref={0}/{1}/firezone/{2}:buildcache,mode=max', env.GCP_REGISTRY, env.GCP_PROJECT, matrix.image_name) || '' }}
           file: ${{ matrix.cache_scope }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Sanitize github.ref_name
         run: |
-          REF="${{ github.ref_name }}"
+          REF="${{ github.ref_name }}" # `ref_name` contains `/` which is not a valid docker image tag.
           CACHE_TAG="${REF//\//-}"
           echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
       - name: Build Docker images
@@ -83,11 +83,11 @@ jobs:
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.context }}/
           cache-from: |
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:main
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ matrix.image_name }}-buildcache:main
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
-          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ env.CACHE_TAG }}
+          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ matrix.image_name }}:buildcache:${{ env.CACHE_TAG }}
           file: ${{ matrix.context }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
               APPLICATION_NAME=api
     permissions:
       contents: read
+      id-token: write
     env:
       # mark:automatic-version
       VERSION: "1.20231001.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,21 +76,10 @@ jobs:
           REF="${{ github.ref_name }}" # `ref_name` contains `/` which is not a valid docker image tag.
           CACHE_TAG="${REF//\//-}"
           echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
-      - id: auth
-        uses: google-github-actions/auth@v1
+      - uses: .github/actions/gcp-docker-login
+        id: login
         with:
-          token_format: access_token
-          workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
-          service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
-          export_environment_variables: false
-      - name: Change current gcloud account
-        run: gcloud --quiet config set project ${{ env.GCP_PROJECT }}
-      - name: Login to Google Artifact Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GCP_REGISTRY }}
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+          project: firezone-staging
       - name: Build Docker images
         uses: docker/build-push-action@v5
         with:
@@ -98,20 +87,20 @@ jobs:
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.context }}/
           cache-from: |
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:main
+            type=registry,ref=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
+            type=registry,ref=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}-buildcache:main
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
-          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
+          cache-to: type=registry,ref=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
           file: ${{ matrix.context }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/
           push: false
           target: ${{ matrix.target }}
           tags: |
-            ${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:${{ env.VERSION }}
-            ${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:${{ github.sha }}
-            ${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:latest
+            ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ env.VERSION }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ github.sha }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:latest
           outputs: type=docker,dest=/tmp/${{ matrix.image_name }}.tar
       - name: Upload built images as artifacts
         uses: actions/upload-artifact@v3
@@ -198,26 +187,12 @@ jobs:
           - web
           - relay
           - gateway
-    env:
-      GCP_PROJECT: firezone-staging
-      GCP_REGISTRY: us-east1-docker.pkg.dev
     steps:
-      - id: auth
-        uses: google-github-actions/auth@v1
+      - uses: .github/actions/gcp-docker-login
+        id: login
         with:
-          token_format: access_token
-          workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
-          service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
-          export_environment_variables: false
-      - name: Change current gcloud account
-        run: gcloud --quiet config set project ${{ env.GCP_PROJECT }}
-      - name: Login to Google Artifact Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GCP_REGISTRY }}
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+          project: firezone-staging
       - name: Push images
         if: ${{ github.ref == 'refs/heads/main' }}
         run:
-          docker push ${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }} --all-tags
+          docker push ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }} --all-tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,21 @@ jobs:
           REF="${{ github.ref_name }}" # `ref_name` contains `/` which is not a valid docker image tag.
           CACHE_TAG="${REF//\//-}"
           echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
+          service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
+          export_environment_variables: false
+      - name: Change current gcloud account
+        run: gcloud --quiet config set project ${{ env.GCP_PROJECT }}
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GCP_REGISTRY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
       - name: Build Docker images
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,5 +195,4 @@ jobs:
           project: firezone-staging
       - name: Push images
         if: ${{ github.ref == 'refs/heads/main' }}
-        run:
-          docker push ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }} --all-tags
+        run: docker push ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }} --all-tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           REF="${{ github.ref_name }}" # `ref_name` contains `/` which is not a valid docker image tag.
           CACHE_TAG="${REF//\//-}"
           echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
-      - uses: .github/actions/gcp-docker-login
+      - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
           project: firezone-staging
@@ -189,7 +189,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: .github/actions/gcp-docker-login
+      - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
           project: firezone-staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.context }}/
           cache-from: |
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ github.ref }}
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:refs/heads/main
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ github.ref_name }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:main
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
-          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ github.ref }}
+          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ github.ref_name }}
           file: ${{ matrix.context }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,10 @@ jobs:
           platforms: linux/amd64
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.cache_scope }}/
-          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-from: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache
           cache-to:
             ${{ github.ref == 'refs/heads/main' &&
-            format('type=gha,mode=max,scope={0}', matrix.cache_scope) || '' }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache }}
           file: ${{ matrix.cache_scope }}/Dockerfile
           push: ${{ matrix.push}}
           target: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,12 @@ jobs:
           platforms: linux/amd64
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.context }}/
-          cache-from: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache
+          cache-from: |
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ github.ref }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:refs/heads/main
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
-          cache-to:
-            ${{ github.ref == 'refs/heads/main' &&
-            format('type=registry,ref={0}/{1}/firezone/{2}:buildcache,mode=max', env.GCP_REGISTRY, env.GCP_PROJECT, matrix.image_name) || '' }}
+          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}:buildcache:${{ github.ref }}
           file: ${{ matrix.context }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - uses: actions/checkout@v4
+      - name: Sanitize github.ref_name
+        run: |
+          REF="${{ github.ref_name }}" # `ref_name` contains `/` which is not a valid docker image tag.
+          CACHE_TAG="${REF//\//-}"
+          echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
       - name: Build Docker images
         uses: docker/build-push-action@v5
         with:
@@ -78,11 +83,11 @@ jobs:
           build-args: ${{ matrix.build-args }}
           context: ${{ matrix.context }}/
           cache-from: |
-            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ github.ref_name }}
+            type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
             type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:main
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
-          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ github.ref_name }}
+          cache-to: type=registry,ref=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }}-buildcache:${{ env.CACHE_TAG }}
           file: ${{ matrix.context }}/Dockerfile
           # pushing is handled in a later step; this action doesn't allow output and push
           # in the same step :-/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,5 +220,4 @@ jobs:
       - name: Push images
         if: ${{ github.ref == 'refs/heads/main' }}
         run:
-          docker push ${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT
-          }}/firezone/${{ matrix.image_name }} --all-tags
+          docker push ${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/firezone/${{ matrix.image_name }} --all-tags

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -42,11 +42,9 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -54,11 +52,9 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Compile Dependencies
@@ -91,8 +87,7 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/save@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Elixir Build Cache
@@ -101,8 +96,7 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
 
   type-check:
     runs-on: ubuntu-latest
@@ -126,11 +120,9 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -138,11 +130,9 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Compile Dependencies
@@ -175,8 +165,7 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/save@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Elixir Build Cache
@@ -185,8 +174,7 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/save@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Save PLT cache
@@ -219,11 +207,9 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -231,11 +217,9 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Compile Dependencies
@@ -261,8 +245,7 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/save@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Elixir Build Cache
@@ -271,8 +254,7 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
 
   migrations-and-seed-test:
     runs-on: ubuntu-latest
@@ -315,11 +297,9 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -327,11 +307,9 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Compile
@@ -386,8 +364,7 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/save@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Elixir Build Cache
@@ -396,8 +373,7 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
 
   acceptance-test:
     runs-on: ubuntu-latest
@@ -453,11 +429,9 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -465,11 +439,9 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/restore@v3
         name: pnpm Deps Cache
         env:
@@ -477,8 +449,7 @@ jobs:
         with:
           path: elixir/apps/web/assets/node_modules
           key:
-            ${{ runner.os }}-${{ env.cache-name }}-${{
-            hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - uses: actions/cache/restore@v3
         name: Assets Cache
         env:
@@ -486,11 +457,9 @@ jobs:
         with:
           path: elixir/apps/web/priv/static/dist
           key:
-            ${{ runner.os }}-${{ env.cache-name }}-${{
-            hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys:
-            ${{ runner.os }}-${{ env.cache-name }}-${{
-            hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: |
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &
@@ -552,8 +521,7 @@ jobs:
         with:
           path: elixir/deps
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/save@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Elixir Build Cache
@@ -562,8 +530,7 @@ jobs:
         with:
           path: elixir/_build
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{
-            env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
       - uses: actions/cache/save@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Save pnpm Deps Cache
@@ -572,8 +539,7 @@ jobs:
         with:
           path: elixir/apps/web/assets/node_modules
           key:
-            ${{ runner.os }}-${{ env.cache-name }}-${{
-            hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - uses: actions/cache/save@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Assets Cache
@@ -582,5 +548,4 @@ jobs:
         with:
           path: elixir/apps/web/priv/static/dist
           key:
-            ${{ runner.os }}-${{ env.cache-name }}-${{
-            hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -44,6 +44,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
@@ -54,6 +55,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
@@ -122,6 +124,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
@@ -132,6 +135,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
@@ -207,6 +211,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
@@ -217,6 +222,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
@@ -297,6 +303,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
@@ -307,6 +314,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
@@ -429,6 +437,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
@@ -439,6 +448,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: pnpm Deps Cache
@@ -457,6 +467,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys:
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
             ${{ runner.os }}-${{ env.cache-name }}-
       - run: |
           export DISPLAY=:99

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -44,7 +44,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -54,7 +54,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Compile Dependencies
@@ -122,7 +122,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -132,7 +132,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Compile Dependencies
@@ -148,8 +148,6 @@ jobs:
           cache-name: cache-erlang-plt-${{ env.MIX_ENV }}
         with:
           key:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-plt
-          restore-keys: |
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-plt
           path: elixir/priv/plts
       - name: Create PLTs
@@ -209,7 +207,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -219,7 +217,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Compile Dependencies
@@ -299,7 +297,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -309,7 +307,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - name: Install Dependencies
         run: mix deps.get --only $MIX_ENV
       - name: Compile
@@ -431,7 +429,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: Restore Elixir Build Cache
         env:
@@ -441,7 +439,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
           restore-keys:
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('**/elixir/mix.lock') }}
+            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-
       - uses: actions/cache/restore@v3
         name: pnpm Deps Cache
         env:
@@ -459,7 +457,7 @@ jobs:
           key:
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys:
-            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-${{ env.cache-name }}-
       - run: |
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -41,11 +41,10 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key:
-            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*',
-            '**/gradle-wrapper.properties') }}
+            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*','**/gradle-wrapper.properties') }}
           restore-keys:
-            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*',
-            '**/gradle-wrapper.properties') }}
+            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*','**/gradle-wrapper.properties') }}
+            ${{ runner.os }}-gradle-
       - name: Create Local Properties File
         run: touch local.properties
       - name: Setup Gradle

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           workspaces: ./rust
           shared-key: ${{ runner.os }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+#          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update toolchain
         run: rustup show
+        working-directory: ./rust
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -34,17 +34,6 @@ jobs:
           java-version: 11
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - uses: actions/cache/restore@v3
-        name: Restore Gradle Cache
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key:
-            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*','**/gradle-wrapper.properties') }}
-          restore-keys:
-            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*','**/gradle-wrapper.properties') }}
-            ${{ runner.os }}-gradle-
       - name: Create Local Properties File
         run: touch local.properties
       - name: Setup Gradle
@@ -60,13 +49,3 @@ jobs:
       - name: Android Test Report
         uses: asadmansr/android-test-report-action@v1.2.0
         if: "!cancelled()"
-      - uses: actions/cache/save@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
-        name: Save Gradle Cache
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key:
-            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*',
-            '**/gradle-wrapper.properties') }}

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          shared-key: ${{ runner.os }}
+          key: ${{ runner.os }}
 #          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           workspaces: ./rust
           key: ${{ runner.os }}
-#          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,5 +60,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: ./run_smoke_test.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo fmt -- --check
       - run: |
           cargo doc --all-features --no-deps --document-private-items ${{ matrix.packages }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,9 +25,7 @@ jobs:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         include:
           - runs-on: ubuntu-latest
-            packages:
-              -p firezone-headless-client -p firezone-gateway -p
-              connlib-client-android
+            packages: -p firezone-headless-client -p firezone-gateway -p connlib-client-android
           - runs-on: macos-13
             packages: -p connlib-client-apple
           - runs-on: windows-2022
@@ -40,8 +38,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          shared-key: ${{ runner.os }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo fmt -- --check
       - run: |
           cargo doc --all-features --no-deps --document-private-items ${{ matrix.packages }}
@@ -52,11 +49,7 @@ jobs:
       - run: cargo test --all-features ${{ matrix.packages }}
 
   smoke-test-relay:
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      matrix:
-        runs-on:
-          - ubuntu-latest
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./rust/relay
@@ -67,6 +60,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          shared-key: ${{ runner.os }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: ./run_smoke_test.sh

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           workspaces: ./rust
           shared-key: ${{ runner.os }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+#          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore SwiftPM Cache
         with:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          shared-key: ${{ runner.os }}
+          key: ${{ runner.os }}
 #          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore SwiftPM Cache

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           workspaces: ./rust
           key: ${{ matrix.target.platform }}
-#          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore SwiftPM Cache
         with:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ${{ matrix.platform }}
+          key: ${{ matrix.target.platform }}
 #          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore SwiftPM Cache

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update toolchain
         run: rustup show
+        working-directory: ./rust
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -43,11 +43,9 @@ jobs:
         with:
           path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages/checkouts
           key:
-            ${{ matrix.target.platform }}-spm-${{
-            hashFiles('**/Package.resolved') }}
+            ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ matrix.target.platform }}-spm-${{
-            hashFiles('**/Package.resolved') }}
+            ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}
       - run: |
           sudo ls -al /Applications/
       - name: Select Xcode
@@ -69,5 +67,4 @@ jobs:
         with:
           path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages/checkouts
           key:
-            ${{ matrix.target.platform }}-spm-${{
-            hashFiles('**/Package.resolved') }}
+            ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ${{ runner.os }}
+          key: ${{ matrix.platform }}
 #          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore SwiftPM Cache

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -45,6 +45,7 @@ jobs:
           key:
             ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
+            ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}
             ${{ matrix.target.platform }}-
       - run: |
           sudo ls -al /Applications/

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -45,7 +45,7 @@ jobs:
           key:
             ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}
+            ${{ matrix.target.platform }}-
       - run: |
           sudo ls -al /Applications/
       - name: Select Xcode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -305,6 +305,8 @@ services:
     build:
       context: elixir
       target: builder
+      cache_from:
+        - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/firezone/elixir-buildcache:main
       args:
         APPLICATION_NAME: api
     image: us-east1-docker.pkg.dev/firezone-staging/firezone/elixir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
   web:
     build:
       context: elixir
+      cache_from:
+        - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/firezone/web-buildcache:main
       args:
         APPLICATION_NAME: web
     image: us-east1-docker.pkg.dev/firezone-staging/firezone/web
@@ -117,6 +119,8 @@ services:
     build:
       context: rust
       dockerfile: Dockerfile
+      cache_from:
+        - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/firezone/client-buildcache:main
       args:
         PACKAGE: firezone-headless-client
     image: us-east1-docker.pkg.dev/firezone-staging/firezone/client
@@ -151,6 +155,8 @@ services:
     build:
       context: rust
       dockerfile: Dockerfile
+      cache_from:
+        - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/firezone/gateway-buildcache:main
       args:
         PACKAGE: firezone-gateway
     image: us-east1-docker.pkg.dev/firezone-staging/firezone/gateway
@@ -200,6 +206,8 @@ services:
     build:
       context: rust
       dockerfile: Dockerfile
+      cache_from:
+        - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/firezone/relay-buildcache:main
       args:
         PACKAGE: relay
     image: us-east1-docker.pkg.dev/firezone-staging/firezone/relay
@@ -226,6 +234,8 @@ services:
   api:
     build:
       context: elixir
+      cache_from:
+        - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/firezone/api-buildcache:main
       args:
         APPLICATION_NAME: api
     image: us-east1-docker.pkg.dev/firezone-staging/firezone/api

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,8 @@
 FROM lukemathwalker/cargo-chef:latest-rust-1.72-slim-bookworm as chef
+
+# See https://github.com/LukeMathWalker/cargo-chef/issues/231.
+COPY rust-toolchain.toml rust-toolchain.toml
+
 WORKDIR /build
 
 FROM chef as planner

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -80,6 +80,6 @@ fi
 for target in "${TARGETS[@]}"
 do
   set -x
-  cargo build --target=$target $CONFIGURATION_ARGS
+  cargo build --verbose --target=$target $CONFIGURATION_ARGS
   set +x
 done


### PR DESCRIPTION
This patch-set aims to make several improvements to our CI caching:

1. Use of registry as build cache: Pushes a separate image to our docker registry at GCP that contains the cache layers. This happens for every PR & main. As a result, we can restore from **both** which should make repeated runs of CI on an individual PR faster and give us a good baseline cache for new PRs from `main`. See https://docs.docker.com/build/ci/github-actions/cache/#registry-cache for details. As a nice side-effect, this allows us to use the 10 GB we have on GitHub actions for other jobs.
2. We make better use of `restore-keys` by also attempting to restore the cache if the fingerprint of our lockfiles doesn't match. This is useful for CI runs that upgrade dependencies. Those will restore a cache that is still useful although doesn't quite match. That is better[^1] than not hitting the cache at all.
3. There were two tiny bugs in our Swift and Android builds:
a. We used `rustup show` in the wrong directory and thus did not actually install the toolchain properly.
b. We used `shared-key` instead of `key` for the https://github.com/Swatinem/rust-cache action and thus did not differentiate between jobs properly.
5. Our Dockerfile for Rust had a bug where it did not copy in the `rust-toolchain.toml` file in the `chef` layer and thus also did not use the correctly toolchain.
6. We remove the dedicated gradle cache because the build action already comes with a cache configuration: https://github.com/firezone/firezone/actions/runs/6416847209/job/17421412150#step:10:25

[^1]: Over time, this may mean that our caches grow a bit. In an ideal world, we automatically remove files from the caches that haven't been used in a while. The cache action we use for Rust does that automatically: https://github.com/Swatinem/rust-cache?tab=readme-ov-file#cache-details. As a workaround, we can just purge all caches every now and then.