### PR TITLE
Do *not* explicitly attempt to pull images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,6 @@ jobs:
           docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.seed'
       - name: Start docker compose in the background
         run: |
-          docker compose pull
           docker compose up -d \
             api \
             web \


### PR DESCRIPTION
Seems to make Docker think they need to be rebuilt.