### PR TITLE
fix(rust): install toolchain in base layer

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,6 +2,7 @@ FROM lukemathwalker/cargo-chef:latest-rust-1.72-slim-bookworm as chef
 
 # See https://github.com/LukeMathWalker/cargo-chef/issues/231.
 COPY rust-toolchain.toml rust-toolchain.toml
+RUN rustup show
 
 WORKDIR /build
 


### PR DESCRIPTION
Copying the `rust-toolchain.toml` file in is one thing but if we want to avoid repeatedly installing it, we should do that in the same layer too.