### PR TITLE
fix(android): When chrome is not installed/enabled or the default browser

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -64,6 +64,7 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
 
             try {
                 intent.launchUrl(this@AuthActivity, Uri.parse(url))
+                finish()
             } catch (e: Exception) {
                 showChromeAppRequiredError()
             }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/signin/ui/SignInFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/signin/ui/SignInFragment.kt
@@ -34,7 +34,6 @@ internal class SignInFragment : Fragment(R.layout.fragment_sign_in) {
                         AuthActivity::class.java,
                     ),
                 )
-                requireActivity().finish()
             }
             btSettings.setOnClickListener {
                 findNavController().navigate(

--- a/kotlin/android/app/src/main/java/dev/firezone/android/util/CustomTabsHelper.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/util/CustomTabsHelper.kt
@@ -3,7 +3,10 @@ package dev.firezone.android.util
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
+
 class CustomTabsHelper {
     companion object {
         val STABLE_PACKAGE = "com.android.chrome"
@@ -45,6 +48,24 @@ class CustomTabsHelper {
                 sPackageNameToUse = LOCAL_PACKAGE
             }
             return sPackageNameToUse
+        }
+
+        fun checkIfChromeAppIsDefault() =
+            sPackageNameToUse == STABLE_PACKAGE ||
+                sPackageNameToUse == BETA_PACKAGE ||
+                sPackageNameToUse == DEV_PACKAGE ||
+                sPackageNameToUse == LOCAL_PACKAGE
+
+        fun checkIfChromeIsInstalled(context: Context): Boolean = try {
+            val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.packageManager.getPackageInfo(STABLE_PACKAGE, PackageManager.PackageInfoFlags.of(0L))
+            } else {
+                @Suppress("DEPRECATION")
+                context.packageManager.getPackageInfo(STABLE_PACKAGE, 0)
+            }
+            info.applicationInfo.enabled
+        } catch (e: PackageManager.NameNotFoundException) {
+            false
         }
     }
 }

--- a/kotlin/android/app/src/main/res/values/strings.xml
+++ b/kotlin/android/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
 	<string name="request_permission">Request Permission</string>
 	<string name="enter_team_id">Enter team id</string>
 	<string name="sign_in_debug_user">Sign In (Debug User)</string>
+	<string name="signing_in_requires_chrome_browser">Signing in requires chrome browser</string>
 	<!-- Error Dialog -->
 
 </resources>


### PR DESCRIPTION
Fixes #2225 
- Set Chrome app has a hard requirement for seamless user experience with app link.
- Check if Chrome is not installed/enabled, then show an error toast.
- If Chrome is not set as the default browser, use the Chrome stable version package name to force open the sign-in flow in Chrome.

Fixes #2184 
- Closing webview moves back to sign-in page.




_Applinks is supported in Firefox but is disabled by default (https://support.mozilla.org/en-US/kb/set-firefox-android-open-links-native-apps) ..why 🤦‍♂️??_ 

Later based on user's browser we can update the redirected page to include instructions to enable the link, something like this:

![Screenshot_1696581921](https://github.com/firezone/firezone/assets/1523745/2587b3de-7e85-4b82-aa99-61e58b8dc0b3)



