### PR TITLE
Remove sed from elixir mix.exs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ version = 1.20231001.0
 .PHONY: version
 
 version:
+	# Elixir can set its Application version from a file, but other components aren't so flexible.
 	@echo $(version) > elixir/VERSION
-	@find elixir/ -name "mix.exs" -exec sed -i '' -e '/mark:automatic-version/{n;s/[0-9]*\.[0-9]*\.[0-9]*/$(version)/;}' {} \;
 	@find rust/ -name "Cargo.toml" -exec sed -i '' -e '/mark:automatic-version/{n;s/[0-9]*\.[0-9]*\.[0-9]*/$(version)/;}' {} \;
 	@find .github/ -name "*.yml" -exec sed -i '' -e '/mark:automatic-version/{n;s/[0-9]*\.[0-9]*\.[0-9]*/$(version)/;}' {} \;
 	@find swift/ -name "project.pbxproj" -exec sed -i '' -e 's/MARKETING_VERSION = .*;/MARKETING_VERSION = $(version);/' {} \;

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -2,7 +2,7 @@ ARG ALPINE_VERSION=3.18.4
 ARG OTP_VERSION=26.1.1
 ARG ELIXIR_VERSION=1.15.6
 
-ARG BUILDER_IMAGE="ghcr.io/firezone/elixir:${ELIXIR_VERSION}-otp-${OTP_VERSION}"
+ARG BUILDER_IMAGE="firezone/elixir:${ELIXIR_VERSION}-otp-${OTP_VERSION}"
 ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
 
 FROM ${BUILDER_IMAGE} as compiler
@@ -57,6 +57,10 @@ COPY apps apps
 RUN mix compile
 
 FROM ${BUILDER_IMAGE} as builder
+
+# Install build deps
+RUN apk add --update --no-cache \
+    git
 
 WORKDIR /app
 

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -2,7 +2,7 @@ ARG ALPINE_VERSION=3.18.4
 ARG OTP_VERSION=26.1.1
 ARG ELIXIR_VERSION=1.15.6
 
-ARG BUILDER_IMAGE="firezone/elixir:${ELIXIR_VERSION}-otp-${OTP_VERSION}"
+ARG BUILDER_IMAGE="ghcr.io/firezone/elixir:${ELIXIR_VERSION}-otp-${OTP_VERSION}"
 ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
 
 FROM ${BUILDER_IMAGE} as compiler
@@ -57,10 +57,6 @@ COPY apps apps
 RUN mix compile
 
 FROM ${BUILDER_IMAGE} as builder
-
-# Install build deps
-RUN apk add --update --no-cache \
-    git
 
 WORKDIR /app
 


### PR DESCRIPTION
Automatic version replacement isn't needed in `elixir/` since the version is defined in Elixir script.