### PR TITLE
Add a required-status-checks job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
       - integration-tests
       - elixir
       - kotlin
+      - swift
       - rust
       - static-analysis
       - terraform

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,7 @@ jobs:
         run: docker compose logs httpbin
 
   # Makes managing the required status checks easier, and moves that source of truth to code
+  # TODO: Use https://registry.terraform.io/providers/integrations/github/latest/docs instead
   required-status-checks:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,3 +159,16 @@ jobs:
       - name: Show httpbin logs
         if: "!cancelled()"
         run: docker compose logs httpbin
+
+  # Makes managing the required status checks easier, and moves that source of truth to code
+  required-status-checks:
+    runs-on: ubuntu-latest
+    needs:
+      - integration-tests
+      - elixir
+      - kotlin
+      - rust
+      - static-analysis
+      - terraform
+    steps:
+      - run: echo "No-op"


### PR DESCRIPTION
Prevents us from have to manually add all our checks to the Required status checks settings.