### PR TITLE
Merge firezone/containers into elixir/Dockerfile for better reuse and maintainability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             build-args: |
               PACKAGE=firezone-headless-client
           - image_name: elixir
-            target: builder
+            target: compiler
             context: elixir
             build-args: |
               APPLICATION_NAME=api
@@ -91,7 +91,8 @@ jobs:
           # This will write the cache on main even if integration tests fail,
           # but it'll just be corrected on the next successful build.
           cache-to: >-
-            type=registry,ref=${{ steps.login.outputs.registry }}/firezone/cache/${{ matrix.image_name }}:${{ env.CACHE_TAG }}
+            type=registry,ref=${{ steps.login.outputs.registry
+            }}/firezone/cache/${{ matrix.image_name }}:${{ env.CACHE_TAG }}
           file: ${{ matrix.context }}/Dockerfile
           push: true
           target: ${{ matrix.target }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -304,22 +304,13 @@ services:
   elixir:
     build:
       context: elixir
-      target: builder
+      target: compiler
       cache_from:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/firezone/cache/elixir:main
       args:
         APPLICATION_NAME: api
     image: us-east1-docker.pkg.dev/firezone-staging/firezone/elixir
     hostname: elixir
-    volumes:
-      - elixir-build-cache:/app/_build
-      - ./elixir/apps:/app/apps
-      - ./elixir/config:/app/config
-      - ./elixir/priv:/app/priv
-      - ./elixir/rel:/app/rel
-      - ./elixir/mix.exs:/app/mix.exs
-      - ./elixir/mix.lock:/app/mix.lock
-      - assets-build-cache:/app/apps/web/assets/node_modules
     environment:
       # Web Server
       EXTERNAL_URL: http://localhost:8081/

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -119,7 +119,7 @@ RUN set -xe \
     ) \
     && make -j$(getconf _NPROCESSORS_ONLN)
 
-# Install to temporary location, stip the install, install runtime deps and copy to the final location
+# Install to temporary location, strip the install, install runtime deps and copy to the final location
 RUN set -xe \
     && make DESTDIR=/tmp install \
     && cd /tmp && rm -rf /tmp/erlang-build \

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,13 +1,210 @@
-ARG ALPINE_VERSION=3.18.4
-ARG OTP_VERSION=26.1.1
-ARG ELIXIR_VERSION=1.15.6
-# Commit hash for firezone/containers repository which is used to build the image
-ARG BUILD_HASH="de432689b9df208df2f58aca63be0094ab666353"
+ARG ALPINE_VERSION="3.18.4"
+ARG ERLANG_VERSION="26.1.1"
+ARG ERLANG_DOWNLOAD_SHA256="30de56e687cef15c73ef2e2e5bc8a94d28f959656e716e0a65092af7d360af57"
+ARG ELIXIR_VERSION="1.15.6"
+ARG ELIXIR_DOWNLOAD_SHA256="385fc1958bcf9023a748acf8c42179a0c6123c89744396840bdcd661ee130177"
 
-ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
-ARG BUILDER_IMAGE="us-central1-docker.pkg.dev/firezone-containers/elixir/${ELIXIR_VERSION}-otp-${OTP_VERSION}:${BUILD_HASH}"
+FROM alpine:${ALPINE_VERSION} as base
 
-FROM ${BUILDER_IMAGE} as compiler
+# Important!  Update this no-op ENV variable when this Dockerfile
+# is updated with the current date. It will force refresh of all
+# of the base images and things like `apk add` won't be using
+# old cached versions when the Dockerfile is built.
+ENV REFRESHED_AT=2023-10-05 \
+    LANG=C.UTF-8 \
+    HOME=/app/ \
+    TERM=xterm
+
+# Add tagged repos as well as the edge repo so that we can selectively install edge packages
+ARG ALPINE_VERSION
+RUN set -xe \
+    && ALPINE_MINOR_VERSION=$(echo ${ALPINE_VERSION} | cut -d'.' -f1,2) \
+    && echo "@main http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_MINOR_VERSION}/main" >> /etc/apk/repositories \
+    && echo "@community http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_MINOR_VERSION}/community" >> /etc/apk/repositories \
+    && echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+
+RUN set -xe \
+    # Upgrade Alpine and base packages
+    && apk --no-cache --update-cache --available upgrade \
+    # Install bash, Erlang/OTP and Elixir runtime dependencies
+    && apk add --no-cache --update-cache \
+    bash \
+    libstdc++ \
+    ca-certificates \
+    ncurses \
+    openssl \
+    pcre \
+    unixodbc \
+    zlib \
+    # Update ca certificates
+    && update-ca-certificates --fresh
+
+FROM base AS build_erlang
+
+# Install bash and Erlang/OTP deps
+RUN set -xe \
+    && apk add --no-cache --update-cache --virtual .fetch-deps \
+    curl \
+    libgcc \
+    lksctp-tools \
+    zlib-dev
+
+# Install Erlang/OTP build deps
+RUN set -xe \
+    && apk add --no-cache --virtual .build-deps \
+    dpkg-dev \
+    dpkg \
+    gcc \
+    g++ \
+    libc-dev \
+    linux-headers \
+    make \
+    autoconf \
+    ncurses-dev \
+    openssl-dev \
+    unixodbc-dev \
+    lksctp-tools-dev \
+    tar
+
+# Download OTP
+ARG ERLANG_VERSION
+ARG ERLANG_DOWNLOAD_SHA256
+WORKDIR /tmp/erlang-build
+RUN set -xe \
+    && curl -fSL -o otp-src.tar.gz "https://github.com/erlang/otp/releases/download/OTP-${ERLANG_VERSION}/otp_src_${ERLANG_VERSION}.tar.gz" \
+    && tar -xzf otp-src.tar.gz -C /tmp/erlang-build --strip-components=1 \
+    # && sha256sum otp-src.tar.gz && exit 1 \
+    && echo "${ERLANG_DOWNLOAD_SHA256}  otp-src.tar.gz" | sha256sum -c -
+
+# Configure & Build
+RUN set -xe \
+    && export ERL_TOP=/tmp/erlang-build \
+    && export CPPFLAGS="-D_BSD_SOURCE $CPPFLAGS" \
+    && export gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
+    && ./configure \
+    --build="$gnuArch" \
+    --prefix=/usr/local \
+    --sysconfdir=/etc \
+    --mandir=/usr/share/man \
+    --infodir=/usr/share/info \
+    --without-javac \
+    --without-jinterface \
+    --without-wx \
+    --without-debugger \
+    --without-observer \
+    --without-cosEvent \
+    --without-cosEventDomain \
+    --without-cosFileTransfer \
+    --without-cosNotification \
+    --without-cosProperty \
+    --without-cosTime \
+    --without-cosTransactions \
+    --without-et \
+    --without-gs \
+    --without-ic \
+    --without-megaco \
+    --without-orber \
+    --without-percept \
+    --without-odbc \
+    --without-typer \
+    --enable-threads \
+    --enable-shared-zlib \
+    --enable-dynamic-ssl-lib \
+    --enable-ssl=dynamic-ssl-lib \
+    $(if [[ "${TARGET}" != *"amd64"* ]]; then echo "--disable-jit"; fi) \
+    && $( \
+    if [[ "${TARGETARCH}" == *"amd64"* ]]; \
+    then export CFLAGS="-g -O2 -fstack-clash-protection -fcf-protection=full"; \
+    else export CFLAGS="-g -O2 -fstack-clash-protection"; fi \
+    ) \
+    && make -j$(getconf _NPROCESSORS_ONLN)
+
+# Install to temporary location, stip the install, install runtime deps and copy to the final location
+RUN set -xe \
+    && make DESTDIR=/tmp install \
+    && cd /tmp && rm -rf /tmp/erlang-build \
+    && find /tmp/usr/local -regex '/tmp/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
+    && find /tmp/usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
+    && find /tmp/usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+    # Strip install to reduce size
+    && scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /tmp/usr/local | xargs -r strip --strip-all \
+    && scanelf --nobanner -E ET_DYN -BF '%F' --recursive /tmp/usr/local | xargs -r strip --strip-unneeded \
+    && runDeps="$( \
+    scanelf --needed --nobanner --format '%n#p' --recursive /tmp/usr/local \
+    | tr ',' '\n' \
+    | sort -u \
+    | awk 'system("[ -e /tmp/usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )" \
+    && ln -s /tmp/usr/local/lib/erlang /usr/local/lib/erlang \
+    && /tmp/usr/local/bin/erl -eval "beam_lib:strip_release('/tmp/usr/local/lib/erlang/lib')" -s init stop > /dev/null \
+    && (/usr/bin/strip /tmp/usr/local/lib/erlang/erts-*/bin/* || true) \
+    && apk add --no-cache --virtual .erlang-runtime-deps $runDeps lksctp-tools ca-certificates
+
+# Cleanup after Erlang install
+RUN set -xe \
+    && apk del .fetch-deps .build-deps \
+    && rm -rf /var/cache/apk/*
+
+WORKDIR ${HOME}
+
+CMD ["erl"]
+
+FROM base AS build_elixir
+
+# Install Elixir build deps
+RUN set -xe \
+    && apk add --no-cache --virtual .build-deps \
+    make \
+    curl \
+    tar \
+    git
+
+# Download Elixir
+ARG ELIXIR_VERSION
+ARG ELIXIR_DOWNLOAD_SHA256
+WORKDIR /tmp/elixir-build
+RUN set -xe \
+    && curl -fSL -o elixir-src.tar.gz "https://github.com/elixir-lang/elixir/archive/refs/tags/v${ELIXIR_VERSION}.tar.gz" \
+    && mkdir -p /tmp/usr/local/src/elixir \
+    && tar -xzC /tmp/usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+    # && sha256sum elixir-src.tar.gz && exit 1 \
+    && echo "${ELIXIR_DOWNLOAD_SHA256}  elixir-src.tar.gz" | sha256sum -c - \
+    && rm elixir-src.tar.gz
+
+COPY --from=build_erlang /tmp/usr/local /usr/local
+
+# Compile Elixir
+RUN set -xe \
+    && cd /tmp/usr/local/src/elixir \
+    && make DESTDIR=/tmp install clean \
+    && find /tmp/usr/local/src/elixir/ -type f -not -regex "/tmp/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+    && find /tmp/usr/local/src/elixir/ -type d -depth -empty -delete \
+    && rm -rf /tmp/elixir-build \
+    && apk del .build-deps
+
+# Cleanup apk cache
+RUN rm -rf /var/cache/apk/*
+
+WORKDIR ${HOME}
+
+CMD ["iex"]
+
+FROM base as elixir
+
+WORKDIR ${HOME}
+
+# Copy Erlang/OTP and Elixir installations
+COPY --from=build_erlang /tmp/usr/local /usr/local
+COPY --from=build_elixir /tmp/usr/local /usr/local
+
+# Install hex + rebar
+RUN set -xe \
+    && mix local.hex --force \
+    && mix local.rebar --force
+
+CMD ["bash"]
+
+FROM elixir as compiler
 
 WORKDIR /app
 
@@ -57,7 +254,7 @@ RUN cd apps/web \
 # Copy the rest of the application files and compile them
 RUN mix compile
 
-FROM ${BUILDER_IMAGE} as builder
+FROM elixir as builder
 
 # Install build deps
 RUN apk add --update --no-cache \
@@ -78,36 +275,13 @@ RUN mix release ${APPLICATION_NAME}
 # start a new build stage so that the final image will only contain
 # the compiled release and other runtime necessities
 
-FROM ${RUNNER_IMAGE} AS runtime
-
-ENV LANG=C.UTF-8 \
-    HOME=/app/ \
-    TERM=xterm
-
-ARG RUNNER_IMAGE
-RUN set -xe \
-    && ALPINE_MINOR_VERSION=$(echo ${RUNNER_IMAGE} | cut -d ':' -f 2 | cut -d '.' -f 1,2) \
-    && echo "@main http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_MINOR_VERSION}/main" >> /etc/apk/repositories \
-    && echo "@community http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_MINOR_VERSION}/community" >> /etc/apk/repositories \
-    && echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+FROM base AS runtime
 
 RUN set -xe \
-    # Upgrade Alpine and base packages
-    && apk --no-cache --update-cache --available upgrade \
-    # Install bash, Erlang/OTP and Elixir deps
+    # Install Firezone runtime deps
     && apk add --no-cache --update-cache \
-    bash \
-    libstdc++ \
-    ca-certificates \
-    ncurses \
-    openssl \
-    pcre \
-    unixodbc \
-    zlib \
     curl \
-    tini \
-    # Update ca certificates
-    && update-ca-certificates --fresh
+    tini
 
 # Create default user and home directory, set owner to default
 RUN set -xe \

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,9 +1,11 @@
 ARG ALPINE_VERSION=3.18.4
 ARG OTP_VERSION=26.1.1
 ARG ELIXIR_VERSION=1.15.6
+# Commit hash for firezone/containers repository which is used to build the image
+ARG BUILD_HASH="de432689b9df208df2f58aca63be0094ab666353"
 
-ARG BUILDER_IMAGE="firezone/elixir:${ELIXIR_VERSION}-otp-${OTP_VERSION}"
 ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
+ARG BUILDER_IMAGE="us-central1-docker.pkg.dev/firezone-containers/elixir/${ELIXIR_VERSION}-otp-${OTP_VERSION}:${BUILD_HASH}"
 
 FROM ${BUILDER_IMAGE} as compiler
 


### PR DESCRIPTION
Upsides:
1. We don't need to maintain a separate repo and Dockerfile just for Elixir image (permissions, runner labels, etc)
2. No need to push intermediate images to the container registry
3. No need to copy-paste alpine/erlang/elixir version and hashes from `firezone/containers` to `elixir/dockerfile` every time they change
4. No need to cross-compile for local dev environments, better experience building with slow internet connection
5. One command to test if our code works on our containers but a different alpine/erlang/elixir version

Downsides:
1. Locally devs will need to compile Erlang at least once per version, but the whole build takes ~6 minutes on my M1 Max. It also takes only 8 minutes on the free GitHub Actions runner without any cache.
2. Worse experience on slow machines

FYI: there is no performance penalty once we have cache layers, still takes 30 seconds on CI.