### PR TITLE
Show flow actors

### DIFF
--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -8,7 +8,7 @@ defmodule Web.Gateways.Show do
            Gateways.fetch_gateway_by_id(id, socket.assigns.subject, preload: :group),
          {:ok, flows} <-
            Flows.list_flows_for(gateway, socket.assigns.subject,
-             preload: [:client, policy: [:resource, :actor_group]]
+             preload: [client: [:actor], policy: [:resource, :actor_group]]
            ) do
       :ok = Gateways.subscribe_for_gateways_presence_in_group(gateway.group)
       {:ok, assign(socket, gateway: gateway, flows: flows)}
@@ -154,12 +154,19 @@ defmodule Web.Gateways.Show do
             <.policy_name policy={flow.policy} />
           </.link>
         </:col>
-        <:col :let={flow} label="CLIENT (IP)">
+        <:col :let={flow} label="CLIENT, ACTOR (IP)">
           <.link
             navigate={~p"/#{@account}/clients/#{flow.client_id}"}
             class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
           >
             <%= flow.client.name %>
+          </.link>
+          owned by
+          <.link
+            navigate={~p"/#{@account}/actors/#{flow.client.actor_id}"}
+            class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
+          >
+            <%= flow.client.actor.name %>
           </.link>
           (<%= flow.client_remote_ip %>)
         </:col>

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -10,7 +10,7 @@ defmodule Web.Policies.Show do
            ),
          {:ok, flows} <-
            Flows.list_flows_for(policy, socket.assigns.subject,
-             preload: [:client, gateway: [:group]]
+             preload: [client: [:actor], gateway: [:group]]
            ) do
       {:ok, assign(socket, policy: policy, flows: flows)}
     else
@@ -116,12 +116,19 @@ defmodule Web.Policies.Show do
       <:col :let={flow} label="EXPIRES AT">
         <.relative_datetime datetime={flow.expires_at} />
       </:col>
-      <:col :let={flow} label="CLIENT (IP)">
+      <:col :let={flow} label="CLIENT, ACTOR (IP)">
         <.link
           navigate={~p"/#{@account}/clients/#{flow.client_id}"}
           class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
         >
           <%= flow.client.name %>
+        </.link>
+        owned by
+        <.link
+          navigate={~p"/#{@account}/actors/#{flow.client.actor_id}"}
+          class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
+        >
+          <%= flow.client.actor.name %>
         </.link>
         (<%= flow.client_remote_ip %>)
       </:col>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -10,7 +10,7 @@ defmodule Web.Resources.Show do
            ),
          {:ok, flows} <-
            Flows.list_flows_for(resource, socket.assigns.subject,
-             preload: [:client, gateway: [:group], policy: [:resource, :actor_group]]
+             preload: [client: [:actor], gateway: [:group], policy: [:resource, :actor_group]]
            ) do
       {:ok, assign(socket, resource: resource, flows: flows)}
     else
@@ -141,12 +141,19 @@ defmodule Web.Resources.Show do
             <.policy_name policy={flow.policy} />
           </.link>
         </:col>
-        <:col :let={flow} label="CLIENT (IP)">
+        <:col :let={flow} label="CLIENT, ACTOR (IP)">
           <.link
             navigate={~p"/#{@account}/clients/#{flow.client_id}"}
             class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
           >
             <%= flow.client.name %>
+          </.link>
+          owned by
+          <.link
+            navigate={~p"/#{@account}/actors/#{flow.client.actor_id}"}
+            class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
+          >
+            <%= flow.client.actor.name %>
           </.link>
           (<%= flow.client_remote_ip %>)
         </:col>

--- a/elixir/apps/web/test/web/live/gateways/show_test.exs
+++ b/elixir/apps/web/test/web/live/gateways/show_test.exs
@@ -144,7 +144,7 @@ defmodule Web.Live.Gateways.ShowTest do
     assert row["remote ip"] == to_string(gateway.last_seen_remote_ip)
     assert row["policy"] =~ flow.policy.actor_group.name
     assert row["policy"] =~ flow.policy.resource.name
-    assert row["client (ip)"] == "#{flow.client.name} (100.64.100.58)"
+    assert row["client, actor (ip)"] == "#{flow.client.name} (100.64.100.58)"
   end
 
   test "allows deleting gateways", %{

--- a/elixir/apps/web/test/web/live/gateways/show_test.exs
+++ b/elixir/apps/web/test/web/live/gateways/show_test.exs
@@ -126,7 +126,8 @@ defmodule Web.Live.Gateways.ShowTest do
         gateway: gateway
       )
 
-    flow = Repo.preload(flow, [:client, gateway: [:group], policy: [:actor_group, :resource]])
+    flow =
+      Repo.preload(flow, client: [:actor], gateway: [:group], policy: [:actor_group, :resource])
 
     {:ok, lv, _html} =
       conn
@@ -144,7 +145,10 @@ defmodule Web.Live.Gateways.ShowTest do
     assert row["remote ip"] == to_string(gateway.last_seen_remote_ip)
     assert row["policy"] =~ flow.policy.actor_group.name
     assert row["policy"] =~ flow.policy.resource.name
-    assert row["client, actor (ip)"] == "#{flow.client.name} (100.64.100.58)"
+
+    assert row["client, actor (ip)"] =~ flow.client.name
+    assert row["client, actor (ip)"] =~ "owned by #{flow.client.actor.name}"
+    assert row["client, actor (ip)"] =~ to_string(flow.client_remote_ip)
   end
 
   test "allows deleting gateways", %{

--- a/elixir/apps/web/test/web/live/policies/show_test.exs
+++ b/elixir/apps/web/test/web/live/policies/show_test.exs
@@ -137,7 +137,7 @@ defmodule Web.Live.Policies.ShowTest do
         policy: policy
       )
 
-    flow = Repo.preload(flow, [:client, gateway: [:group]])
+    flow = Repo.preload(flow, client: [:actor], gateway: [:group])
 
     {:ok, lv, _html} =
       conn
@@ -152,9 +152,11 @@ defmodule Web.Live.Policies.ShowTest do
 
     assert row["authorized at"]
     assert row["expires at"]
-    assert row["client, actor (ip)"] == "#{flow.client.name} (100.64.100.58)"
+    assert row["client, actor (ip)"] =~ flow.client.name
+    assert row["client, actor (ip)"] =~ "owned by #{flow.client.actor.name}"
+    assert row["client, actor (ip)"] =~ to_string(flow.client_remote_ip)
 
-    assert row["gateway (ip)"] ==
+    assert row["gateway (ip)"] =~
              "#{flow.gateway.group.name_prefix}-#{flow.gateway.name_suffix} (189.172.73.153)"
   end
 

--- a/elixir/apps/web/test/web/live/policies/show_test.exs
+++ b/elixir/apps/web/test/web/live/policies/show_test.exs
@@ -152,7 +152,7 @@ defmodule Web.Live.Policies.ShowTest do
 
     assert row["authorized at"]
     assert row["expires at"]
-    assert row["client (ip)"] == "#{flow.client.name} (100.64.100.58)"
+    assert row["client, actor (ip)"] == "#{flow.client.name} (100.64.100.58)"
 
     assert row["gateway (ip)"] ==
              "#{flow.gateway.group.name_prefix}-#{flow.gateway.name_suffix} (189.172.73.153)"

--- a/elixir/apps/web/test/web/live/resources/show_test.exs
+++ b/elixir/apps/web/test/web/live/resources/show_test.exs
@@ -177,7 +177,7 @@ defmodule Web.Live.Resources.ShowTest do
     assert row["gateway (ip)"] ==
              "#{flow.gateway.group.name_prefix}-#{flow.gateway.name_suffix} (189.172.73.153)"
 
-    assert row["client (ip)"] == "#{flow.client.name} (100.64.100.58)"
+    assert row["client, actor (ip)"] == "#{flow.client.name} (100.64.100.58)"
   end
 
   test "allows deleting resource", %{

--- a/elixir/apps/web/test/web/live/resources/show_test.exs
+++ b/elixir/apps/web/test/web/live/resources/show_test.exs
@@ -156,7 +156,8 @@ defmodule Web.Live.Resources.ShowTest do
         resource: resource
       )
 
-    flow = Repo.preload(flow, [:client, gateway: [:group], policy: [:actor_group, :resource]])
+    flow =
+      Repo.preload(flow, client: [:actor], gateway: [:group], policy: [:actor_group, :resource])
 
     {:ok, lv, _html} =
       conn
@@ -177,7 +178,9 @@ defmodule Web.Live.Resources.ShowTest do
     assert row["gateway (ip)"] ==
              "#{flow.gateway.group.name_prefix}-#{flow.gateway.name_suffix} (189.172.73.153)"
 
-    assert row["client, actor (ip)"] == "#{flow.client.name} (100.64.100.58)"
+    assert row["client, actor (ip)"] =~ flow.client.name
+    assert row["client, actor (ip)"] =~ "owned by #{flow.client.actor.name}"
+    assert row["client, actor (ip)"] =~ to_string(flow.client_remote_ip)
   end
 
   test "allows deleting resource", %{


### PR DESCRIPTION
It was hard to tell who exactly was authorized during a flow without clicking around:
<img width="1465" alt="Screenshot 2023-10-06 at 15 53 43" src="https://github.com/firezone/firezone/assets/1877644/26f7c865-714e-40fc-95d5-1b67e2de16cf">

Now it's possible:
<img width="1462" alt="Screenshot 2023-10-06 at 15 53 38" src="https://github.com/firezone/firezone/assets/1877644/d4ddfd95-fa94-47a0-a73b-b3cdd31994a7">
