### PR TITLE
Add Swift build cache to CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -55,7 +55,6 @@ jobs:
           cp Firezone/xcconfig/Developer.xcconfig.ci-${{ matrix.target.platform }} Firezone/xcconfig/Developer.xcconfig
           cp Firezone/xcconfig/Server.xcconfig.ci Firezone/xcconfig/Server.xcconfig
           xcodebuild archive \
-            -arch ${{ matrix.target.arch }} \
             -configuration Release \
             -scheme Firezone \
             -sdk ${{ matrix.target.sdk }} \

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -47,7 +47,8 @@ jobs:
             ${{ matrix.target.destination }}-swift-
       - name: Build app
         env:
-          ONLY_ACTIVE_ARCH: yes
+          # Allow cross-compiling
+          ONLY_ACTIVE_ARCH: no
         run: |
           sudo xcode-select -s /Applications/Xcode_14.3.app
           brew install swift-format

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -39,9 +39,8 @@ jobs:
         name: Restore Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/**/Package.resolved', 'swift/**/*.swift') }}-${{ github.sha }}
-          restore_keys: |
-            ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/**/Package.resolved', 'swift/**/*.swift') }}-
+          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
+          restore-keys: |
             ${{ matrix.target.platform }}-swift-
       - name: Build app
         env:
@@ -57,6 +56,6 @@ jobs:
         name: Save Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          # Swift benefits heavily from build cache, so write a new one on each build on `main`
-          # and attempt to restore it in PR builds with a broader restory-key.
-          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/**/Package.resolved', 'swift/**/*.swift') }}-${{ github.sha }}
+          # Swift benefits heavily from build cache, so aggressively write a new one
+          # on each build on `main` and attempt to restore it in PR builds with broader restore-key.
+          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -36,13 +36,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ${{ matrix.target.platform }}
+          key: ${{ matrix.target.destination }}
           # save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
+          key: ${{ matrix.target.destination }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
           restore-keys: |
             ${{ matrix.target.platform }}-swift-
       - name: Build app
@@ -66,4 +66,4 @@ jobs:
           path: ~/Library/Developer/Xcode/DerivedData
           # Swift benefits heavily from build cache, so aggressively write a new one
           # on each build on `main` and attempt to restore it in PR builds with broader restore-key.
-          key: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
+          key: ${{ matrix.target.destination }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -39,9 +39,9 @@ jobs:
         name: Restore Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/**/Package.resolved', 'swift/**/*.swift') }}
+          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/**/Package.resolved', 'swift/**/*.swift') }}-${{ github.sha }}
           restore_keys: |
-            ${{ matrix.target.platform }}-swift-${{ github.ref }}
+            ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/**/Package.resolved', 'swift/**/*.swift') }}-
             ${{ matrix.target.platform }}-swift-
       - name: Build app
         env:
@@ -57,4 +57,6 @@ jobs:
         name: Save Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/**/Package.resolved', 'swift/**/*.swift') }}
+          # Swift benefits heavily from build cache, so write a new one on each build on `main`
+          # and attempt to restore it in PR builds with a broader restory-key.
+          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/**/Package.resolved', 'swift/**/*.swift') }}-${{ github.sha }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,15 +9,10 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ${{ matrix.runs-on.os }}
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          # Builds are more IO-bound than CPU-bound so using a larger GitHub-hosted
-          # runner isn't worth it.
-          - os: macos-13
-            xcode-ver: "14.3"
         target:
           - sdk: macosx
             platform: macOS
@@ -29,7 +24,7 @@ jobs:
       contents: read
     defaults:
       run:
-        working-directory: ./swift
+        working-directory: ./swift/apple
     steps:
       - uses: actions/checkout@v4
       - name: Update toolchain
@@ -39,35 +34,27 @@ jobs:
         with:
           workspaces: ./rust
           key: ${{ matrix.target.platform }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
-        name: Restore SwiftPM Cache
+        name: Restore Swift DerivedData Cache
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages/checkouts
-          key:
-            ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}
-            ${{ matrix.target.platform }}-
-      - run: |
-          sudo ls -al /Applications/
-      - name: Select Xcode
-        run: |
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.runs-on.xcode-ver }}.app
-      - name: Install swift-format
-        run: brew install swift-format
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ matrix.target.platform }}-swift-${{ github.ref }}
+          restore_keys: |
+            ${{ matrix.target.platform }}-swift-${{ github.ref }}
+            ${{ matrix.target.platform }}-swift-
       - name: Build app
         env:
           ONLY_ACTIVE_ARCH: no
-        working-directory: ./swift/apple
         run: |
+          sudo xcode-select -s /Applications/Xcode_14.3.app
+          brew install swift-format # linting
           cp Firezone/xcconfig/Developer.xcconfig.ci-${{ matrix.target.platform }} Firezone/xcconfig/Developer.xcconfig
           cp Firezone/xcconfig/Server.xcconfig.ci Firezone/xcconfig/Server.xcconfig
           xcodebuild archive -configuration Release -scheme Firezone -sdk ${{ matrix.target.sdk }} -destination '${{ matrix.target.destination }}' CODE_SIGNING_ALLOWED=NO
       - uses: actions/cache/save@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
-        name: Save SwiftPM Cache
+        # if: ${{ github.ref == 'refs/heads/main' }}
+        name: Save Swift DerivedData Cache
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages/checkouts
-          key:
-            ${{ matrix.target.platform }}-spm-${{ hashFiles('**/Package.resolved') }}
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ matrix.target.platform }}-swift-${{ github.ref }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,6 +24,7 @@ jobs:
             destination: platform=macOS
           - sdk: iphoneos
             platform: iOS
+            arch: arm64
             destination: generic/platform=iOS
     permissions:
       contents: read
@@ -44,7 +45,7 @@ jobs:
         name: Restore Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
+          key: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
           restore-keys: |
             ${{ matrix.target.platform }}-swift-
       - name: Build app
@@ -69,4 +70,4 @@ jobs:
           path: ~/Library/Developer/Xcode/DerivedData
           # Swift benefits heavily from build cache, so aggressively write a new one
           # on each build on `main` and attempt to restore it in PR builds with broader restore-key.
-          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
+          key: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -50,8 +50,7 @@ jobs:
             ${{ matrix.target.destination }}-swift-
       - name: Build app
         env:
-          # Allow cross-compiling
-          # ONLY_ACTIVE_ARCH: yes
+          ONLY_ACTIVE_ARCH: yes
         run: |
           sudo xcode-select -s /Applications/Xcode_14.3.app
           brew install swift-format

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Build app
         env:
           ONLY_ACTIVE_ARCH: yes
-          CODE_SIGNING_ALLOWED: no
         run: |
           sudo xcode-select -s /Applications/Xcode_14.3.app
           brew install swift-format
@@ -58,7 +57,7 @@ jobs:
             -configuration Release \
             -scheme Firezone \
             -sdk ${{ matrix.target.sdk }} \
-            -destination '${{ matrix.target.destination }}'
+            -destination '${{ matrix.target.destination }}' CODE_SIGNING_ALLOWED=no
       - uses: actions/cache/save@v3
         # if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Swift DerivedData Cache

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,15 +15,9 @@ jobs:
       matrix:
         target:
           - sdk: macosx
-            arch: x86_64
             platform: macOS
-            destination: platform=macOS,arch=x86_64
-          - sdk: macosx
-            arch: arm64
-            platform: macOS
-            destination: platform=macOS,arch=arm64
+            destination: platform=macOS
           - sdk: iphoneos
-            arch: arm64
             platform: iOS
             destination: generic/platform=iOS
     permissions:
@@ -39,18 +33,18 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ${{ matrix.target.destination }}
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
+          key: ${{ matrix.target.platform }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ matrix.target.destination }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
+          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
           restore-keys: |
-            ${{ matrix.target.destination }}-swift-
+            ${{ matrix.target.platform }}-swift-
       - name: Build app
         env:
-          ONLY_ACTIVE_ARCH: yes
+          ONLY_ACTIVE_ARCH: no
         run: |
           sudo xcode-select -s /Applications/Xcode_14.3.app
           brew install swift-format
@@ -60,12 +54,13 @@ jobs:
             -configuration Release \
             -scheme Firezone \
             -sdk ${{ matrix.target.sdk }} \
-            -arch ${{ matrix.target.arch }} CODE_SIGNING_ALLOWED=no
+            -destination '${{ matrix.target.destination }}' \
+            CODE_SIGNING_ALLOWED=no
       - uses: actions/cache/save@v3
-        # if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
           # Swift benefits heavily from build cache, so aggressively write a new one
           # on each build on `main` and attempt to restore it in PR builds with broader restore-key.
-          key: ${{ matrix.target.destination }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
+          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,6 +16,11 @@ jobs:
         target:
           - sdk: macosx
             platform: macOS
+            arch: x86_64
+            destination: platform=macOS
+          - sdk: macosx
+            platform: macOS
+            arch: arm64
             destination: platform=macOS
           - sdk: iphoneos
             platform: iOS
@@ -44,13 +49,19 @@ jobs:
             ${{ matrix.target.platform }}-swift-
       - name: Build app
         env:
-          ONLY_ACTIVE_ARCH: no
+          ONLY_ACTIVE_ARCH: yes
+          CODESIGNING_ALLOWED: no
         run: |
           sudo xcode-select -s /Applications/Xcode_14.3.app
           brew install swift-format
           cp Firezone/xcconfig/Developer.xcconfig.ci-${{ matrix.target.platform }} Firezone/xcconfig/Developer.xcconfig
           cp Firezone/xcconfig/Server.xcconfig.ci Firezone/xcconfig/Server.xcconfig
-          xcodebuild archive -configuration Release -scheme Firezone -sdk ${{ matrix.target.sdk }} -destination '${{ matrix.target.destination }}' CODE_SIGNING_ALLOWED=NO
+          xcodebuild archive \
+            -arch ${{ matrix.target.arch }} \
+            -configuration Release \
+            -scheme Firezone \
+            -sdk ${{ matrix.target.sdk }} \
+            -destination '${{ matrix.target.destination }}'
       - uses: actions/cache/save@v3
         # if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Swift DerivedData Cache

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,7 +22,7 @@ jobs:
             destination: platform=macOS,arch=arm64
           - sdk: iphoneos
             platform: iOS
-            destination: generic/platform=iOS,arch=arm64
+            destination: generic/platform=iOS
     permissions:
       contents: read
     defaults:
@@ -44,10 +44,11 @@ jobs:
           path: ~/Library/Developer/Xcode/DerivedData
           key: ${{ matrix.target.destination }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}-
           restore-keys: |
-            ${{ matrix.target.platform }}-swift-
+            ${{ matrix.target.destination }}-swift-
       - name: Build app
         env:
           ONLY_ACTIVE_ARCH: yes
+          CODE_SIGNING_ALLOWED: no
         run: |
           sudo xcode-select -s /Applications/Xcode_14.3.app
           brew install swift-format
@@ -57,8 +58,7 @@ jobs:
             -configuration Release \
             -scheme Firezone \
             -sdk ${{ matrix.target.sdk }} \
-            -destination '${{ matrix.target.destination }}' CODESIGNING_ALLOWED=no
-
+            -destination '${{ matrix.target.destination }}'
       - uses: actions/cache/save@v3
         # if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Swift DerivedData Cache

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Build app
         env:
           ONLY_ACTIVE_ARCH: yes
-          CODESIGNING_ALLOWED: no
         run: |
           sudo xcode-select -s /Applications/Xcode_14.3.app
           brew install swift-format
@@ -58,7 +57,8 @@ jobs:
             -configuration Release \
             -scheme Firezone \
             -sdk ${{ matrix.target.sdk }} \
-            -destination '${{ matrix.target.destination }}'
+            -destination '${{ matrix.target.destination }}' CODESIGNING_ALLOWED=no
+
       - uses: actions/cache/save@v3
         # if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Swift DerivedData Cache

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,12 +15,15 @@ jobs:
       matrix:
         target:
           - sdk: macosx
+            arch: x86_64
             platform: macOS
             destination: platform=macOS,arch=x86_64
           - sdk: macosx
+            arch: arm64
             platform: macOS
             destination: platform=macOS,arch=arm64
           - sdk: iphoneos
+            arch: arm64
             platform: iOS
             destination: generic/platform=iOS
     permissions:
@@ -48,7 +51,7 @@ jobs:
       - name: Build app
         env:
           # Allow cross-compiling
-          ONLY_ACTIVE_ARCH: no
+          # ONLY_ACTIVE_ARCH: yes
         run: |
           sudo xcode-select -s /Applications/Xcode_14.3.app
           brew install swift-format
@@ -58,7 +61,7 @@ jobs:
             -configuration Release \
             -scheme Firezone \
             -sdk ${{ matrix.target.sdk }} \
-            -destination '${{ matrix.target.destination }}' CODE_SIGNING_ALLOWED=no
+            -arch ${{ matrix.target.arch }} CODE_SIGNING_ALLOWED=no
       - uses: actions/cache/save@v3
         # if: ${{ github.ref == 'refs/heads/main' }}
         name: Save Swift DerivedData Cache

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,16 +16,13 @@ jobs:
         target:
           - sdk: macosx
             platform: macOS
-            arch: x86_64
-            destination: platform=macOS
+            destination: platform=macOS,arch=x86_64
           - sdk: macosx
             platform: macOS
-            arch: arm64
-            destination: platform=macOS
+            destination: platform=macOS,arch=arm64
           - sdk: iphoneos
             platform: iOS
-            arch: arm64
-            destination: generic/platform=iOS
+            destination: generic/platform=iOS,arch=arm64
     permissions:
       contents: read
     defaults:


### PR DESCRIPTION
- Cache build outputs as well as package manager resolved cache
- Write a new cache on `main` if anything in `swift/` or `rust/` changes, and match on successively broader `restore-keys`. Swift loves cached builds but its build cache is fairly large, so I thought this might be an improvement over simply writing the cache to `github.sha` in case anything outside of those directories changes.
- ~~Split macOS `x86_64` and `aarch64` builds with a matrix to parallelize them, will join them into the final bundle during the `cd` stage~~ Edit: We want to build these together in order to create a Universal Binary artifact more easily.