### PR TITLE
Use 4c builder for kotlin builds

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./gradlew spotlessCheck
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-firezone-4c
     defaults:
       run:
         working-directory: ./kotlin/android


### PR DESCRIPTION
Now that we're building with `--release`, this will be of more benefit.