### PR TITLE
refactor(connlib): use events to handle ICE candidates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
 name = "connlib-client-shared"
 version = "1.20231001.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "backoff",
  "chrono",
@@ -1245,7 +1246,7 @@ dependencies = [
  "connlib-shared",
  "firezone-tunnel",
  "futures",
- "futures-bounded",
+ "futures-bounded 0.1.0",
  "headless-utils",
  "phoenix-channel",
  "secrecy",
@@ -1283,6 +1284,7 @@ dependencies = [
  "connlib-shared",
  "domain",
  "futures",
+ "futures-bounded 0.2.0",
  "futures-util",
  "ip_network",
  "ip_network_table",
@@ -1340,6 +1342,15 @@ name = "futures-bounded"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b07bbbe7d7e78809544c6f718d875627addc73a7c3582447abc052cd3dc67e0"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-bounded"
+version = "0.2.0"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=feat/stream-map#1e4ad64558159dfc94b50daf701b3ee7315553b9"
 dependencies = [
  "futures-timer",
  "futures-util",

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 mock = ["connlib-shared/mock"]
 
 [dependencies]
+anyhow = "1.0.75"
 tokio = { version = "1.32", default-features = false, features = ["sync", "rt"] }
 tokio-util = "0.7.9"
 secrecy = { workspace = true }

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -14,7 +14,7 @@ use connlib_shared::{
 };
 
 use async_trait::async_trait;
-use firezone_tunnel::{ClientIceState, ControlSignal, Request, Tunnel};
+use firezone_tunnel::{ClientState, ControlSignal, Request, Tunnel};
 use tokio::sync::Mutex;
 use tokio_util::codec::{BytesCodec, FramedRead};
 use url::Url;
@@ -43,7 +43,7 @@ impl ControlSignal for ControlSignaler {
 }
 
 pub struct ControlPlane<CB: Callbacks> {
-    pub tunnel: Arc<Tunnel<ControlSignaler, CB, ClientIceState>>,
+    pub tunnel: Arc<Tunnel<ControlSignaler, CB, ClientState>>,
     pub control_signaler: ControlSignaler,
     pub tunnel_init: Mutex<bool>,
 }

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -279,8 +279,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
     pub async fn handle_tunnel_event(&mut self, event: firezone_tunnel::Event<GatewayId>) {
         match event {
             firezone_tunnel::Event::SignalIceCandidate { conn_id, candidate } => {
-                // TODO: How to handle this error?
-                let _ = self
+                if let Err(e) = self
                     .control_signaler
                     .control_signal
                     .send(EgressMessages::BroadcastIceCandidates(
@@ -289,7 +288,10 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                             candidates: vec![candidate],
                         },
                     ))
-                    .await;
+                    .await
+                {
+                    tracing::error!("Failed to signal ICE candidate: {e}")
+                }
             }
         }
     }

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -149,8 +149,7 @@ where
                 }
             });
 
-            let phoenix_sender = connection.sender_with_topic("client".to_owned());
-            let control_signaler = ControlSignaler { control_signal: phoenix_sender.clone() };
+            let control_signaler = ControlSignaler { control_signal: connection.sender_with_topic("client".to_owned()) };
             let tunnel = fatal_error!(
                 Tunnel::new(private_key, control_signaler.clone(), callbacks.clone()).await,
                 runtime_stopper,

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -49,6 +49,12 @@ impl fmt::Display for ClientId {
     }
 }
 
+impl fmt::Display for GatewayId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// Represents a wireguard peer.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Peer {

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -25,6 +25,7 @@ domain = "0.8"
 boringtun = { workspace = true }
 chrono = { workspace = true }
 pnet_packet = { version = "0.34" }
+futures-bounded = { git = "https://github.com/libp2p/rust-libp2p", branch = "feat/stream-map" }
 
 # TODO: research replacing for https://github.com/algesten/str0m
 webrtc = { version = "0.8" }

--- a/rust/connlib/tunnel/src/control_protocol.rs
+++ b/rust/connlib/tunnel/src/control_protocol.rs
@@ -206,7 +206,7 @@ where
             .waiting_ice_candidate_receivers
             .lock()
             .remove(&conn_id)
-            .ok_or_else(|| Error::Other("missing ICE candidate receiver"))?;
+            .ok_or(Error::ControlProtocolError)?;
         match self
             .active_ice_candidate_receivers
             .lock()

--- a/rust/connlib/tunnel/src/control_protocol.rs
+++ b/rust/connlib/tunnel/src/control_protocol.rs
@@ -195,7 +195,15 @@ where
 
             let mut ice_candidate_tx = ice_candidate_tx.clone();
             Box::pin(async move {
-                if ice_candidate_tx.send(candidate).await.is_err() {
+                let ice_candidate = match candidate.to_json() {
+                    Ok(ice_candidate) => ice_candidate,
+                    Err(e) => {
+                        tracing::warn!("Failed to serialize ICE candidate to JSON: {e}",);
+                        return;
+                    }
+                };
+
+                if ice_candidate_tx.send(ice_candidate).await.is_err() {
                     debug_assert!(false, "receiver was dropped before sender")
                 }
             })

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -160,7 +160,11 @@ where
             }
         }
         let peer_connection = {
-            let peer_connection = Arc::new(self.initialize_peer_request(relays, gateway_id).await?);
+            let (peer_connection, receiver) = self.new_peer_connection(relays).await?;
+            self.ice_state
+                .lock()
+                .add_waiting_receiver(gateway_id, receiver);
+            let peer_connection = Arc::new(peer_connection);
             let mut peer_connections = self.peer_connections.lock();
             peer_connections.insert(gateway_id.into(), Arc::clone(&peer_connection));
             peer_connection

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -73,7 +73,8 @@ where
         expires_at: DateTime<Utc>,
         resource: ResourceDescription,
     ) -> Result<RTCSessionDescription> {
-        let peer_connection = self.initialize_peer_request(relays, client_id).await?;
+        let (peer_connection, receiver) = self.new_peer_connection(relays).await?;
+        self.ice_state.lock().add_new_receiver(client_id, receiver);
 
         let index = self.next_index();
         let tunnel = Arc::clone(self);

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -28,7 +28,7 @@ pub(crate) enum SendPacket {
 // as we can therefore we won't do it.
 //
 // See: https://stackoverflow.com/a/55093896
-impl<C, CB> Tunnel<C, CB>
+impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -28,7 +28,7 @@ pub(crate) enum SendPacket {
 // as we can therefore we won't do it.
 //
 // See: https://stackoverflow.com/a/55093896
-impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
+impl<C, CB, TRoleState> Tunnel<C, CB, TRoleState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,

--- a/rust/connlib/tunnel/src/ice.rs
+++ b/rust/connlib/tunnel/src/ice.rs
@@ -1,0 +1,91 @@
+use crate::IceState;
+use connlib_shared::messages::{ClientId, GatewayId};
+use futures::channel::mpsc::Receiver;
+use futures_bounded::StreamMap;
+use std::collections::HashMap;
+use std::task::{ready, Context, Poll};
+use std::time::Duration;
+use webrtc::ice_transport::ice_candidate::RTCIceCandidate;
+
+pub struct ClientIceState {
+    active_ice_candidate_receivers: StreamMap<GatewayId, RTCIceCandidate>,
+    waiting_ice_candidate_receivers:
+        HashMap<GatewayId, futures::channel::mpsc::Receiver<RTCIceCandidate>>,
+}
+
+impl ClientIceState {
+    pub fn activate_ice_candidate_receiver(&mut self, id: GatewayId) {
+        let Some(receiver) = self.waiting_ice_candidate_receivers.remove(&id) else {
+            return;
+        };
+
+        let _ = self.active_ice_candidate_receivers.try_push(id, receiver);
+    }
+}
+
+impl Default for ClientIceState {
+    fn default() -> Self {
+        Self {
+            active_ice_candidate_receivers: StreamMap::new(Duration::from_secs(5 * 60), 100),
+            waiting_ice_candidate_receivers: Default::default(),
+        }
+    }
+}
+
+impl IceState for ClientIceState {
+    type Id = GatewayId;
+
+    fn add_new_receiver(&mut self, id: Self::Id, receiver: Receiver<RTCIceCandidate>) {
+        self.waiting_ice_candidate_receivers.insert(id, receiver);
+    }
+
+    fn poll_next_ice_candidate(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<(Self::Id, RTCIceCandidate)> {
+        loop {
+            match ready!(self.active_ice_candidate_receivers.poll_next_unpin(cx)) {
+                (id, Some(Ok(c))) => return Poll::Ready((id, c)),
+                (id, Some(Err(e))) => {
+                    tracing::warn!(gateway_id = %id, "ICE gathering timed out: {e}")
+                }
+                (_, None) => {}
+            }
+        }
+    }
+}
+
+pub struct GatewayIceState {
+    ice_candidate_receivers: StreamMap<ClientId, RTCIceCandidate>,
+}
+
+impl Default for GatewayIceState {
+    fn default() -> Self {
+        Self {
+            ice_candidate_receivers: StreamMap::new(Duration::from_secs(5 * 60), 100),
+        }
+    }
+}
+
+impl IceState for GatewayIceState {
+    type Id = ClientId;
+
+    fn add_new_receiver(&mut self, id: Self::Id, receiver: Receiver<RTCIceCandidate>) {
+        let _ = self.ice_candidate_receivers.try_push(id, receiver);
+    }
+
+    fn poll_next_ice_candidate(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<(Self::Id, RTCIceCandidate)> {
+        loop {
+            match ready!(self.ice_candidate_receivers.poll_next_unpin(cx)) {
+                (id, Some(Ok(c))) => return Poll::Ready((id, c)),
+                (id, Some(Err(e))) => {
+                    tracing::warn!(gateway_id = %id, "ICE gathering timed out: {e}")
+                }
+                (_, None) => {}
+            }
+        }
+    }
+}

--- a/rust/connlib/tunnel/src/ice.rs
+++ b/rust/connlib/tunnel/src/ice.rs
@@ -2,7 +2,6 @@ use crate::PollNextIceCandidate;
 use connlib_shared::messages::{ClientId, GatewayId};
 use futures::channel::mpsc::Receiver;
 use futures_bounded::{PushError, StreamMap};
-use futures_util::stream::BoxStream;
 use std::collections::HashMap;
 use std::task::{ready, Context, Poll};
 use std::time::Duration;

--- a/rust/connlib/tunnel/src/iface_handler.rs
+++ b/rust/connlib/tunnel/src/iface_handler.rs
@@ -8,15 +8,16 @@ use crate::{
     device_channel::{DeviceIo, IfaceConfig},
     dns,
     peer::EncapsulatedPacket,
-    ConnId, ControlSignal, Tunnel, MAX_UDP_SIZE,
+    ConnId, ControlSignal, IceState, Tunnel, MAX_UDP_SIZE,
 };
 
 const MAX_SIGNAL_CONNECTION_DELAY: Duration = Duration::from_secs(2);
 
-impl<C, CB> Tunnel<C, CB>
+impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,
+    TIceState: IceState,
 {
     #[inline(always)]
     fn connection_intent(self: &Arc<Self>, src: &[u8], dst_addr: &IpAddr) {

--- a/rust/connlib/tunnel/src/iface_handler.rs
+++ b/rust/connlib/tunnel/src/iface_handler.rs
@@ -8,7 +8,7 @@ use crate::{
     device_channel::{DeviceIo, IfaceConfig},
     dns,
     peer::EncapsulatedPacket,
-    ConnId, ControlSignal, IceState, Tunnel, MAX_UDP_SIZE,
+    ConnId, ControlSignal, PollNextIceCandidate, Tunnel, MAX_UDP_SIZE,
 };
 
 const MAX_SIGNAL_CONNECTION_DELAY: Duration = Duration::from_secs(2);
@@ -17,7 +17,7 @@ impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,
-    TIceState: IceState,
+    TIceState: PollNextIceCandidate,
 {
     #[inline(always)]
     fn connection_intent(self: &Arc<Self>, src: &[u8], dst_addr: &IpAddr) {

--- a/rust/connlib/tunnel/src/iface_handler.rs
+++ b/rust/connlib/tunnel/src/iface_handler.rs
@@ -4,20 +4,21 @@ use boringtun::noise::{errors::WireGuardError, Tunn, TunnResult};
 use bytes::Bytes;
 use connlib_shared::{Callbacks, Error, Result};
 
+use crate::role_state::RoleState;
 use crate::{
     device_channel::{DeviceIo, IfaceConfig},
     dns,
     peer::EncapsulatedPacket,
-    ConnId, ControlSignal, PollNextIceCandidate, Tunnel, MAX_UDP_SIZE,
+    ConnId, ControlSignal, Tunnel, MAX_UDP_SIZE,
 };
 
 const MAX_SIGNAL_CONNECTION_DELAY: Duration = Duration::from_secs(2);
 
-impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
+impl<C, CB, TRoleState> Tunnel<C, CB, TRoleState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,
-    TIceState: PollNextIceCandidate,
+    TRoleState: RoleState,
 {
     #[inline(always)]
     fn connection_intent(self: &Arc<Self>, src: &[u8], dst_addr: &IpAddr) {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -24,7 +24,6 @@ use webrtc::{
         interceptor_registry::register_default_interceptors, media_engine::MediaEngine,
         setting_engine::SettingEngine, APIBuilder, API,
     },
-    ice_transport::ice_candidate::RTCIceCandidate,
     interceptor::registry::Registry,
     peer_connection::RTCPeerConnection,
 };
@@ -32,6 +31,7 @@ use webrtc::{
 use futures::channel::mpsc;
 use std::task::{ready, Context, Poll};
 use std::{collections::HashMap, fmt, net::IpAddr, sync::Arc, time::Duration};
+use webrtc::ice_transport::ice_candidate::RTCIceCandidateInit;
 
 use connlib_shared::{
     messages::{
@@ -217,12 +217,12 @@ pub struct TunnelStats {
 pub trait IceState: Send + 'static + Default {
     type Id: fmt::Debug;
 
-    fn add_new_receiver(&mut self, id: Self::Id, receiver: mpsc::Receiver<RTCIceCandidate>);
+    fn add_new_receiver(&mut self, id: Self::Id, receiver: mpsc::Receiver<RTCIceCandidateInit>);
 
     fn poll_next_ice_candidate(
         &mut self,
         cx: &mut Context<'_>,
-    ) -> Poll<(Self::Id, RTCIceCandidate)>;
+    ) -> Poll<(Self::Id, RTCIceCandidateInit)>;
 }
 
 impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
@@ -279,7 +279,7 @@ where
 pub enum Event<TId> {
     SignalIceCandidate {
         conn_id: TId,
-        candidate: RTCIceCandidate,
+        candidate: RTCIceCandidateInit,
     },
 }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -75,22 +75,6 @@ pub enum ConnId {
     Resource(ResourceId),
 }
 
-impl ConnId {
-    pub fn into_client_id(self) -> Option<ClientId> {
-        match self {
-            ConnId::Client(inner) => Some(inner),
-            _ => None,
-        }
-    }
-
-    pub fn into_gateway_id(self) -> Option<GatewayId> {
-        match self {
-            ConnId::Gateway(inner) => Some(inner),
-            _ => None,
-        }
-    }
-}
-
 impl From<GatewayId> for ConnId {
     fn from(id: GatewayId) -> Self {
         Self::Gateway(id)

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -4,16 +4,17 @@ use boringtun::noise::{handshake::parse_handshake_anon, Packet, TunnResult};
 use bytes::Bytes;
 use connlib_shared::{Callbacks, Error, Result};
 
+use crate::role_state::RoleState;
 use crate::{
-    device_channel::DeviceIo, index::check_packet_index, peer::Peer, ControlSignal,
-    PollNextIceCandidate, Tunnel, MAX_UDP_SIZE,
+    device_channel::DeviceIo, index::check_packet_index, peer::Peer, ControlSignal, Tunnel,
+    MAX_UDP_SIZE,
 };
 
-impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
+impl<C, CB, TRoleState> Tunnel<C, CB, TRoleState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,
-    TIceState: PollNextIceCandidate,
+    TRoleState: RoleState,
 {
     #[inline(always)]
     fn is_wireguard_packet_ok(&self, parsed_packet: &Packet, peer: &Peer) -> bool {

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -5,14 +5,15 @@ use bytes::Bytes;
 use connlib_shared::{Callbacks, Error, Result};
 
 use crate::{
-    device_channel::DeviceIo, index::check_packet_index, peer::Peer, ControlSignal, Tunnel,
-    MAX_UDP_SIZE,
+    device_channel::DeviceIo, index::check_packet_index, peer::Peer, ControlSignal, IceState,
+    Tunnel, MAX_UDP_SIZE,
 };
 
-impl<C, CB> Tunnel<C, CB>
+impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,
+    TIceState: IceState,
 {
     #[inline(always)]
     fn is_wireguard_packet_ok(&self, parsed_packet: &Packet, peer: &Peer) -> bool {

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -5,15 +5,15 @@ use bytes::Bytes;
 use connlib_shared::{Callbacks, Error, Result};
 
 use crate::{
-    device_channel::DeviceIo, index::check_packet_index, peer::Peer, ControlSignal, IceState,
-    Tunnel, MAX_UDP_SIZE,
+    device_channel::DeviceIo, index::check_packet_index, peer::Peer, ControlSignal,
+    PollNextIceCandidate, Tunnel, MAX_UDP_SIZE,
 };
 
 impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,
-    TIceState: IceState,
+    TIceState: PollNextIceCandidate,
 {
     #[inline(always)]
     fn is_wireguard_packet_ok(&self, parsed_packet: &Packet, peer: &Peer) -> bool {

--- a/rust/connlib/tunnel/src/resource_sender.rs
+++ b/rust/connlib/tunnel/src/resource_sender.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use connlib_shared::{messages::ResourceDescription, Callbacks, Error, Result};
 
-impl<C, CB> Tunnel<C, CB>
+impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,

--- a/rust/connlib/tunnel/src/resource_sender.rs
+++ b/rust/connlib/tunnel/src/resource_sender.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use connlib_shared::{messages::ResourceDescription, Callbacks, Error, Result};
 
-impl<C, CB, TIceState> Tunnel<C, CB, TIceState>
+impl<C, CB, TRoleState> Tunnel<C, CB, TRoleState>
 where
     C: ControlSignal + Send + Sync + 'static,
     CB: Callbacks + 'static,

--- a/rust/connlib/tunnel/src/role_state.rs
+++ b/rust/connlib/tunnel/src/role_state.rs
@@ -21,6 +21,8 @@ pub trait RoleState: Default + Send + 'static {
 /// For how long we will attempt to gather ICE candidates before aborting.
 ///
 /// Chosen arbitrarily.
+/// Very likely, the actual WebRTC connection will timeout before this.
+/// This timeout is just here to eventually clean-up tasks if they are somehow broken.
 const ICE_GATHERING_TIMEOUT_SECONDS: u64 = 5 * 60;
 
 /// How many concurrent ICE gathering attempts we are allow.

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -179,24 +179,13 @@ impl Eventloop {
                     conn_id: client,
                     candidate,
                 }) => {
-                    let ice_candidate = match candidate.to_json() {
-                        Ok(ice_candidate) => ice_candidate,
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to serialize ICE candidate to JSON: {:#}",
-                                anyhow::Error::new(e)
-                            );
-                            continue;
-                        }
-                    };
-
-                    tracing::debug!(%client, candidate = %ice_candidate.candidate, "Sending ICE candidate to client");
+                    tracing::debug!(%client, candidate = %candidate.candidate, "Sending ICE candidate to client");
 
                     let _id = self.portal.send(
                         PHOENIX_TOPIC,
                         EgressMessages::BroadcastIceCandidates(BroadcastClientIceCandidates {
                             client_ids: vec![client],
-                            candidates: vec![ice_candidate],
+                            candidates: vec![candidate],
                         }),
                     );
                     continue;

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -13,15 +13,12 @@ use std::convert::Infallible;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use tokio::sync::mpsc;
-use webrtc::ice_transport::ice_candidate::RTCIceCandidate;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 
 pub const PHOENIX_TOPIC: &str = "gateway";
 
-pub struct Eventloop<'a> {
+pub struct Eventloop {
     tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler>>,
-    control_rx: &'a mut mpsc::Receiver<(ClientId, RTCIceCandidate)>,
     portal: PhoenixChannel<IngressMessages, ()>,
 
     // TODO: Strongly type request reference (currently `String`)
@@ -32,15 +29,13 @@ pub struct Eventloop<'a> {
     print_stats_timer: tokio::time::Interval,
 }
 
-impl<'a> Eventloop<'a> {
+impl Eventloop {
     pub(crate) fn new(
         tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler>>,
-        control_rx: &'a mut mpsc::Receiver<(ClientId, RTCIceCandidate)>,
         portal: PhoenixChannel<IngressMessages, ()>,
-    ) -> Eventloop<'a> {
+    ) -> Self {
         Self {
             tunnel,
-            control_rx,
             portal,
 
             // TODO: Pick sane values for timeouts and size.
@@ -54,34 +49,10 @@ impl<'a> Eventloop<'a> {
     }
 }
 
-impl Eventloop<'_> {
+impl Eventloop {
     #[tracing::instrument(name = "Eventloop::poll", skip_all, level = "debug")]
     pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Result<Infallible>> {
         loop {
-            if let Poll::Ready(Some((client, ice_candidate))) = self.control_rx.poll_recv(cx) {
-                let ice_candidate = match ice_candidate.to_json() {
-                    Ok(ice_candidate) => ice_candidate,
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to serialize ICE candidate to JSON: {:#}",
-                            anyhow::Error::new(e)
-                        );
-                        continue;
-                    }
-                };
-
-                tracing::debug!(%client, candidate = %ice_candidate.candidate, "Sending ICE candidate to client");
-
-                let _id = self.portal.send(
-                    PHOENIX_TOPIC,
-                    EgressMessages::BroadcastIceCandidates(BroadcastClientIceCandidates {
-                        client_ids: vec![client],
-                        candidates: vec![ice_candidate],
-                    }),
-                );
-                continue;
-            }
-
             match self.connection_request_tasks.poll_unpin(cx) {
                 Poll::Ready(((client, reference), Ok(Ok(gateway_rtc_session_description)))) => {
                     tracing::debug!(%client, %reference, "Connection is ready");
@@ -201,6 +172,37 @@ impl Eventloop<'_> {
                     continue;
                 }
                 _ => {}
+            }
+
+            match self.tunnel.poll_next_event(cx) {
+                Poll::Ready(firezone_tunnel::Event::SignalIceCandidate { conn_id, candidate }) => {
+                    let Some(client) = conn_id.into_client_id() else {
+                        continue;
+                    };
+
+                    let ice_candidate = match candidate.to_json() {
+                        Ok(ice_candidate) => ice_candidate,
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to serialize ICE candidate to JSON: {:#}",
+                                anyhow::Error::new(e)
+                            );
+                            continue;
+                        }
+                    };
+
+                    tracing::debug!(%client, candidate = %ice_candidate.candidate, "Sending ICE candidate to client");
+
+                    let _id = self.portal.send(
+                        PHOENIX_TOPIC,
+                        EgressMessages::BroadcastIceCandidates(BroadcastClientIceCandidates {
+                            client_ids: vec![client],
+                            candidates: vec![ice_candidate],
+                        }),
+                    );
+                    continue;
+                }
+                Poll::Pending => {}
             }
 
             if self.print_stats_timer.poll_tick(cx).is_ready() {

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -7,7 +7,7 @@ use crate::CallbackHandler;
 use anyhow::Result;
 use connlib_shared::messages::ClientId;
 use connlib_shared::Error;
-use firezone_tunnel::{GatewayIceState, Tunnel};
+use firezone_tunnel::{GatewayState, Tunnel};
 use phoenix_channel::PhoenixChannel;
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -18,7 +18,7 @@ use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 pub const PHOENIX_TOPIC: &str = "gateway";
 
 pub struct Eventloop {
-    tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler, GatewayIceState>>,
+    tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler, GatewayState>>,
     portal: PhoenixChannel<IngressMessages, ()>,
 
     // TODO: Strongly type request reference (currently `String`)
@@ -31,7 +31,7 @@ pub struct Eventloop {
 
 impl Eventloop {
     pub(crate) fn new(
-        tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler, GatewayIceState>>,
+        tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler, GatewayState>>,
         portal: PhoenixChannel<IngressMessages, ()>,
     ) -> Self {
         Self {

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use connlib_shared::{get_device_id, get_user_agent, login_url, Callbacks, Mode};
-use firezone_tunnel::{GatewayIceState, Tunnel};
+use firezone_tunnel::{GatewayState, Tunnel};
 use futures::{future, TryFutureExt};
 use headless_utils::{setup_global_subscriber, CommonArgs};
 use phoenix_channel::SecureUrl;
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
 }
 
 async fn run(
-    tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler, GatewayIceState>>,
+    tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler, GatewayState>>,
     connect_url: Url,
 ) -> Result<Infallible> {
     let (portal, init) = phoenix_channel::init::<InitGateway, _, _>(

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use connlib_shared::{get_device_id, get_user_agent, login_url, Callbacks, Mode};
-use firezone_tunnel::Tunnel;
+use firezone_tunnel::{GatewayIceState, Tunnel};
 use futures::{future, TryFutureExt};
 use headless_utils::{setup_global_subscriber, CommonArgs};
 use phoenix_channel::SecureUrl;
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
 }
 
 async fn run(
-    tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler>>,
+    tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler, GatewayIceState>>,
     connect_url: Url,
 ) -> Result<Infallible> {
     let (portal, init) = phoenix_channel::init::<InitGateway, _, _>(

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -5,7 +5,6 @@ use anyhow::{Context, Result};
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
-use connlib_shared::messages::ClientId;
 use connlib_shared::{get_device_id, get_user_agent, login_url, Callbacks, Mode};
 use firezone_tunnel::Tunnel;
 use futures::future;
@@ -15,10 +14,8 @@ use secrecy::{Secret, SecretString};
 use std::convert::Infallible;
 use std::pin::pin;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 use tracing_subscriber::layer;
 use url::Url;
-use webrtc::ice_transport::ice_candidate::RTCIceCandidate;
 
 mod control;
 mod eventloop;
@@ -35,11 +32,7 @@ async fn main() -> Result<()> {
         SecretString::new(cli.common.secret),
         get_device_id(),
     )?;
-
-    // Note: This channel is only needed because [`Tunnel`] does not (yet) have a synchronous, poll-like interface. If it would have, ICE candidates would be emitted as events and we could just hand them to the phoenix channel.
-    let (control_tx, mut control_rx) = mpsc::channel(1);
-    let signaler = ControlSignaler::new(control_tx);
-    let tunnel = Arc::new(Tunnel::new(private_key, signaler, CallbackHandler).await?);
+    let tunnel = Arc::new(Tunnel::new(private_key, ControlSignaler, CallbackHandler).await?);
 
     let mut backoff = ExponentialBackoffBuilder::default()
         .with_max_elapsed_time(None)
@@ -47,7 +40,7 @@ async fn main() -> Result<()> {
 
     let eventloop = async {
         loop {
-            let error = match run(tunnel.clone(), &mut control_rx, connect_url.clone()).await {
+            let error = match run(tunnel.clone(), connect_url.clone()).await {
                 Err(e) => e,
                 Ok(never) => match never {},
             };
@@ -66,7 +59,6 @@ async fn main() -> Result<()> {
 
 async fn run(
     tunnel: Arc<Tunnel<ControlSignaler, CallbackHandler>>,
-    control_rx: &mut mpsc::Receiver<(ClientId, RTCIceCandidate)>,
     connect_url: Url,
 ) -> Result<Infallible> {
     let (portal, init) = phoenix_channel::init::<InitGateway, _, _>(
@@ -82,7 +74,7 @@ async fn run(
         .await
         .context("Failed to set interface")?;
 
-    let mut eventloop = Eventloop::new(tunnel, control_rx, portal);
+    let mut eventloop = Eventloop::new(tunnel, portal);
 
     future::poll_fn(|cx| eventloop.poll(cx)).await
 }


### PR DESCRIPTION
Instead of using the `ControlSignal` trait for ICE candidates, we introduce a `poll_next_event` function on `Tunnel` that reads ICE candidates from the various receivers connected to the callbacks of the `PeerConnection`.

There are still a few TODOs in the code and it relies on unpublished code in `futures-bounded` but I am putting it up for early review and to see whether CI passes.