### PR TITLE
Try 4c runner for build-images to see speed difference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   # less overhead to keep things in GH actions. See work on building these
   # in GCP with Cloud Build: https://github.com/firezone/firezone/pull/2234
   build-images:
-    runs-on: ubuntu-22.04-firezone-16c
+    runs-on: ubuntu-22.04-firezone-4c
     strategy:
       matrix:
         include:


### PR DESCRIPTION
It's not too expensive, but I want to see if it's worth the 4x cost over the 4c runner:

<img width="869" alt="Screenshot 2023-10-09 at 8 02 25 PM" src="https://github.com/firezone/firezone/assets/167144/bcd539de-77fb-4eda-ab2c-c97b66e0e792">
