### PR TITLE
Return fd onRemoveRoute as well

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -115,11 +115,13 @@ class TunnelService : VpnService() {
             override fun onRemoveRoute(
                 addr: String,
                 prefix: Int,
-            ) {
+            ): Int {
                 Log.d(TAG, "onRemoveRoute: $addr/$prefix")
-                val cidr = Cidr(addr, prefix)
-
-                tunnelRepository.removeRoute(cidr)
+                val route = Cidr(addr, prefix)
+                tunnelRepository.removeRoute(route)
+                val fd = buildVpnService().establish()?.detachFd() ?: -1
+                protect(fd)
+                return fd
             }
 
             override fun getSystemDefaultResolvers(): String {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/callback/ConnlibCallback.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/callback/ConnlibCallback.kt
@@ -12,14 +12,14 @@ interface ConnlibCallback {
     fun onTunnelReady(): Boolean
 
     fun onAddRoute(
-        cidrAddress: String,
+        addr: String,
         prefix: Int,
     ): Int
 
     fun onRemoveRoute(
         addr: String,
         prefix: Int,
-    )
+    ): Int
 
     fun onUpdateResources(resourceListJSON: String)
 

--- a/rust/connlib/clients/android/connlib/build.gradle.kts
+++ b/rust/connlib/clients/android/connlib/build.gradle.kts
@@ -88,10 +88,11 @@ fun copyJniShared(task: Task, buildType: String) = task.apply {
 }
 
 cargo {
-    if (gradle.startParameter.taskNames.any{it.toLowerCase().contains("debug")}) {
-        profile = "debug"
-    } else {
+    // TODO: Read the build variant from the android plugin instead
+    if (gradle.startParameter.taskNames.any{it.lowercase().contains("release")}) {
         profile = "release"
+    } else {
+        profile = "debug"
     }
     prebuiltToolchains = true
     verbose = true

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -109,9 +109,9 @@ impl Callbacks for CallbackHandler {
         Ok(None)
     }
 
-    fn on_remove_route(&self, route: IpNetwork) -> Result<(), Self::Error> {
+    fn on_remove_route(&self, route: IpNetwork) -> Result<Option<RawFd>, Self::Error> {
         self.inner.on_remove_route(route.to_string());
-        Ok(())
+        Ok(None)
     }
 
     fn on_update_resources(

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -42,8 +42,8 @@ pub trait Callbacks: Clone + Send + Sync {
     }
 
     /// Called when when a route is removed.
-    fn on_remove_route(&self, _: IpNetwork) -> Result<(), Self::Error> {
-        Ok(())
+    fn on_remove_route(&self, _: IpNetwork) -> Result<Option<RawFd>, Self::Error> {
+        Ok(None)
     }
 
     /// Called when the resource list changes.

--- a/rust/connlib/shared/src/callbacks_error_facade.rs
+++ b/rust/connlib/shared/src/callbacks_error_facade.rs
@@ -56,7 +56,7 @@ impl<CB: Callbacks> Callbacks for CallbackErrorFacade<CB> {
         result
     }
 
-    fn on_remove_route(&self, route: IpNetwork) -> Result<()> {
+    fn on_remove_route(&self, route: IpNetwork) -> Result<Option<RawFd>> {
         let result = self
             .0
             .on_remove_route(route)


### PR DESCRIPTION
Implements the function signatures for `onRemoveRoute` as well.

Getting this error still though:

<img width="1633" alt="Screenshot 2023-10-10 at 8 25 17 AM" src="https://github.com/firezone/firezone/assets/167144/3dc09f1b-10e1-401b-a1ef-64f1a09e35d5">

Android simulator, Pixel, API 34