### PR TITLE
fix(android): Fixed auth redirect and clear accountId issue

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/PreferenceRepository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/PreferenceRepository.kt
@@ -15,5 +15,7 @@ internal interface PreferenceRepository {
 
     fun validateCsrfToken(value: String): Flow<Boolean>
 
-    fun clear()
+    fun clearToken()
+
+    fun clearAll()
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/PreferenceRepositoryImpl.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/PreferenceRepositoryImpl.kt
@@ -52,7 +52,15 @@ internal class PreferenceRepositoryImpl
                 emit(token == value)
             }.flowOn(coroutineDispatcher)
 
-        override fun clear() {
+        override fun clearToken() {
+            sharedPreferences.edit().apply {
+                remove(CSRF_KEY)
+                remove(TOKEN_KEY)
+                apply()
+            }
+        }
+
+        override fun clearAll() {
             sharedPreferences.edit().clear().apply()
         }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthActivity.kt
@@ -26,14 +26,12 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
         binding = ActivityAuthBinding.inflate(layoutInflater)
 
         setupActionObservers()
-
-        viewModel.startAuthFlow()
     }
 
     override fun onResume() {
         super.onResume()
 
-        viewModel.startAuthFlow()
+        viewModel.onActivityResume()
     }
 
     private fun setupActionObservers() {
@@ -63,7 +61,6 @@ class AuthActivity : AppCompatActivity(R.layout.activity_auth) {
 
             try {
                 intent.launchUrl(this@AuthActivity, Uri.parse(url))
-                finish()
             } catch (e: Exception) {
                 showChromeAppRequiredError()
             }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
@@ -24,7 +24,9 @@ internal class AuthViewModel
         private val actionMutableLiveData = MutableLiveData<ViewAction>()
         val actionLiveData: LiveData<ViewAction> = actionMutableLiveData
 
-        fun startAuthFlow() =
+        private var authFlowLaunched: Boolean = false
+
+        fun onActivityResume() =
             try {
                 viewModelScope.launch {
                     val config =
@@ -36,9 +38,10 @@ internal class AuthViewModel
                             .firstOrNull() ?: throw Exception("csrfToken cannot be null")
 
                     actionMutableLiveData.postValue(
-                        if (config.token != null) {
+                        if (authFlowLaunched || config.token != null) {
                             ViewAction.NavigateToSignInFragment
                         } else {
+                            authFlowLaunched = true
                             ViewAction.LaunchAuthFlow(
                                 url = "$AUTH_URL${config.accountId}?client_csrf_token=$csrfToken&client_platform=android",
                             )

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelManager.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelManager.kt
@@ -77,8 +77,8 @@ internal class TunnelManager
             val intent = Intent(appContext, TunnelService::class.java)
             intent.action = TunnelService.ACTION_DISCONNECT
             appContext.startService(intent)
-            tunnelRepository.clear()
-            preferenceRepository.clear()
+            tunnelRepository.clearAll()
+            preferenceRepository.clearToken()
         }
 
         internal companion object {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/data/TunnelRepository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/data/TunnelRepository.kt
@@ -28,7 +28,7 @@ interface TunnelRepository {
 
     fun getRoutes(): List<Cidr>
 
-    fun clear()
+    fun clearAll()
 
     fun addListener(callback: SharedPreferences.OnSharedPreferenceChangeListener)
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/data/TunnelRepositoryImpl.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/data/TunnelRepositoryImpl.kt
@@ -110,7 +110,7 @@ class TunnelRepositoryImpl
                 return moshi.adapter<List<Cidr>>().fromJson(json) ?: emptyList()
             }
 
-        override fun clear() {
+        override fun clearAll() {
             synchronized(lock) {
                 sharedPreferences.edit().clear().apply()
             }


### PR DESCRIPTION
- Updated the chrome tab launch flow to fix unexpected behaviour when closing the browser.
- Updated the signout functionality to not delete `accountId`.

Fixes #2184 
Fixes #2185 