### PR TITLE
Update web signup page and add tests

### DIFF
--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -19,6 +19,7 @@ defmodule Web.SignUp do
     def changeset(%Registration{} = registration, attrs) do
       registration
       |> Ecto.Changeset.cast(attrs, [:email])
+      |> Ecto.Changeset.validate_required([:email])
       |> Ecto.Changeset.validate_format(:email, ~r/.+@.+/)
       |> Ecto.Changeset.cast_embed(:account,
         with: fn _account, attrs -> Accounts.Account.Changeset.create(attrs) end
@@ -239,8 +240,8 @@ defmodule Web.SignUp do
         )
         |> Ecto.Multi.run(
           :identity,
-          fn _repo, %{provider: provider} ->
-            Auth.create_identity(provider, registration.email, %{
+          fn _repo, %{actor: actor, provider: provider} ->
+            Auth.create_identity(actor, provider, %{
               provider_identifier: registration.email
             })
           end

--- a/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
@@ -1,0 +1,81 @@
+defmodule Web.Live.SignUpTest do
+  use Web.ConnCase, async: true
+
+  test "renders signup form", %{conn: conn} do
+    {:ok, lv, _html} = live(conn, ~p"/sign_up")
+
+    form = form(lv, "form")
+
+    assert find_inputs(form) == [
+             "registration[account][_persistent_id]",
+             "registration[account][name]",
+             "registration[account][slug]",
+             "registration[actor][_persistent_id]",
+             "registration[actor][name]",
+             "registration[actor][type]",
+             "registration[email]"
+           ]
+  end
+
+  test "creates new account", %{conn: conn} do
+    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+
+    account_name = "FooBar"
+
+    {:ok, lv, _html} = live(conn, ~p"/sign_up")
+
+    attrs = %{
+      account: %{name: account_name},
+      actor: %{name: "John Doe"},
+      email: "jdoe@test.local"
+    }
+
+    assert html =
+             lv
+             |> form("form", registration: attrs)
+             |> render_submit()
+
+    assert html =~ "Your account has been created!"
+    assert html =~ account_name
+  end
+
+  test "renders changeset errors on input change", %{conn: conn} do
+    {:ok, lv, _html} = live(conn, ~p"/sign_up")
+
+    attrs = %{
+      account: %{name: "FooBar"},
+      actor: %{name: "John Doe"},
+      email: "jdoe@test.local"
+    }
+
+    lv
+    |> form("form", registration: attrs)
+    |> validate_change(
+      %{registration: %{account: %{name: ""}, actor: %{name: ""}, email: ""}},
+      fn form, _html ->
+        assert form_validation_errors(form) == %{
+                 "registration[account][name]" => ["can't be blank"],
+                 "registration[actor][name]" => ["can't be blank"],
+                 "registration[email]" => ["can't be blank"]
+               }
+      end
+    )
+  end
+
+  test "renders changeset errors on submit", %{conn: conn} do
+    attrs = %{
+      account: %{name: "FooBar"},
+      actor: %{name: "John Doe"},
+      email: "jdoe"
+    }
+
+    {:ok, lv, _html} = live(conn, ~p"/sign_up")
+
+    assert lv
+           |> form("form", registration: attrs)
+           |> render_submit()
+           |> form_validation_errors() == %{
+             "registration[email]" => ["has invalid format"]
+           }
+  end
+end


### PR DESCRIPTION
Why:

* The signup page was failing to allow signups due to a change in one of the domain functions.  This happened due to the UI not having tests for the sign up page.  The sign up page has been updated to use the new domain function signature and has also had some tests added to hopefully prevent regressions.