### PR TITLE
Build Apple on macos-14

### DIFF
--- a/.github/README_CI.md
+++ b/.github/README_CI.md
@@ -16,9 +16,9 @@ gcloud iam service-accounts add-iam-policy-binding "github-actions@github-iam-38
 
 for more details see https://github.com/google-github-actions/auth.
 
-## Larger runners
+## Larger GitHub-hosted runners
 
-We've configured two larger runners to use in workflows:
+We've configured two GitHub-hosted larger runners to use in workflows:
 
 - `ubuntu-22.04.firezone-4c`
 - `ubuntu-22.04-firezone-16c`
@@ -30,3 +30,28 @@ Before you run your jobs on these larger runners, please ensure your workload is
 **CPU-bound** or **Memory-size-bound** so that your workflow / job will actually
 benefit from the extra cores. Many workloads are IO-bound and won't see a marked
 difference using a larger runner.
+
+## Self-hosted runners
+
+We've also configured a self-hosted M1 runner to run macOS workloads:
+
+- `macos-14`
+
+You can target it with either the `macos-14` label, `self-hosted` label, or a
+combination of the two. It's running at the Firezone HQ and basically costs
+nothing to execute jobs on.
+
+It should have the following software on it:
+
+- Docker Desktop
+- Xcode 15
+- Homebrew
+
+<!-- TODO: Add instructions when Dogfood is working
+You may log into the self-hosted runner remotely via Apple Remote Desktop
+if you need to make any changes to its configuration. To do so, make
+sure your Firezone client is connected to the Dogfood account, then:
+1. Open Screen Sharing.app
+2. Connect to macos-14.firezone.dev
+3. Log in with the "macOS M1 Firezone Builder GitHub Actions self-hosted Runner" credentials in Firezone Engineering 1Password
+-->

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,22 +17,22 @@ jobs:
             runs-on: macos-13
             platform: macOS
             destination: platform=macOS
-            xcode: 14.3
+            xcode: "14.3"
           - sdk: iphoneos
             runs-on: macos-13
             platform: iOS
             destination: generic/platform=iOS
-            xcode: 14.3
+            xcode: "14.3"
           - sdk: macosx
             runs-on: macos-13
             platform: macOS
             destination: platform=macOS
-            xcode: 15.0
+            xcode: "15.0"
           - sdk: iphoneos
             runs-on: macos-13
             platform: iOS
             destination: generic/platform=iOS
-            xcode: 15.0
+            xcode: "15.0"
           - sdk: macosx
             runs-on: macos-14
             platform: macOS

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,10 +17,22 @@ jobs:
             runs-on: macos-13
             platform: macOS
             destination: platform=macOS
+            xcode: 14.3
           - sdk: iphoneos
             runs-on: macos-13
             platform: iOS
             destination: generic/platform=iOS
+            xcode: 14.3
+          - sdk: macosx
+            runs-on: macos-13
+            platform: macOS
+            destination: platform=macOS
+            xcode: 15.0
+          - sdk: iphoneos
+            runs-on: macos-13
+            platform: iOS
+            destination: generic/platform=iOS
+            xcode: 15.0
           - sdk: macosx
             runs-on: macos-14
             platform: macOS
@@ -108,7 +120,11 @@ jobs:
           ONLY_ACTIVE_ARCH: no
           # Needed because `productbuild` doesn't support picking this up automatically like Xcode does
           INSTALLER_CODE_SIGN_IDENTITY: "3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
+          REQUESTED_XCODE_VERSION: ${{ matrix.xcode }}
         run: |
+          # Set Xcode version to use if provided
+          [[ ! -z "$REQUESTED_XCODE_VERSION" ]] && sudo xcode-select -s /Applications/Xcode_$REQUESTED_XCODE_VERSION.app
+
           # Copy xcconfig templates
           cp Firezone/xcconfig/Developer.xcconfig.firezone Firezone/xcconfig/Developer.xcconfig
           cp Firezone/xcconfig/Server.xcconfig.${{ env.CLIENT_ENV }} Firezone/xcconfig/Server.xcconfig

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,22 +15,18 @@ jobs:
         include:
           - sdk: macosx
             runs-on: macos-13
-            xcode: "14.3"
             platform: macOS
             destination: platform=macOS
           - sdk: iphoneos
             runs-on: macos-13
-            xcode: "14.3"
             platform: iOS
             destination: generic/platform=iOS
           - sdk: macosx
             runs-on: macos-14
-            xcode: "15"
             platform: macOS
             destination: platform=macOS
           - sdk: iphoneos
             runs-on: macos-14
-            xcode: "15"
             platform: iOS
             destination: generic/platform=iOS
     permissions:
@@ -113,9 +109,6 @@ jobs:
           # Needed because `productbuild` doesn't support picking this up automatically like Xcode does
           INSTALLER_CODE_SIGN_IDENTITY: "3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
         run: |
-          # Explicitly select Xcode version to use
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
-
           # Needed by the linter built into the build process
           brew install swift-format
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -109,9 +109,6 @@ jobs:
           # Needed because `productbuild` doesn't support picking this up automatically like Xcode does
           INSTALLER_CODE_SIGN_IDENTITY: "3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
         run: |
-          # Needed by the linter built into the build process
-          brew install swift-format
-
           # Copy xcconfig templates
           cp Firezone/xcconfig/Developer.xcconfig.firezone Firezone/xcconfig/Developer.xcconfig
           cp Firezone/xcconfig/Server.xcconfig.${{ env.CLIENT_ENV }} Firezone/xcconfig/Server.xcconfig
@@ -127,7 +124,7 @@ jobs:
           if [ "${{ matrix.platform }}" = "iOS" ]; then
             # Build archive
             xcodebuild archive \
-              -archivePath ~/Firezone.xcarchive \
+              -archivePath $RUNNER_TEMP/Firezone.xcarchive \
               -configuration Release \
               -scheme Firezone \
               -sdk ${{ matrix.sdk }} \
@@ -135,12 +132,12 @@ jobs:
             # Export IPA
             xcodebuild \
               -exportArchive \
-              -archivePath ~/Firezone.xcarchive \
-              -exportPath ~/ \
+              -archivePath $RUNNER_TEMP/Firezone.xcarchive \
+              -exportPath $RUNNER_TEMP/ \
               -exportOptionsPlist Firezone/ExportOptions.plist
 
             # Save resulting file to use for upload
-            echo "app_bundle=~/Firezone.ipa" >> "$GITHUB_OUTPUT"
+            echo "app_bundle=$RUNNER_TEMP/Firezone.ipa" >> "$GITHUB_OUTPUT"
           elif [ "${{ matrix.platform }}" = "macOS" ]; then
             # Build app bundle
             xcodebuild build \
@@ -149,14 +146,14 @@ jobs:
               -sdk ${{ matrix.sdk }} \
               -destination '${{ matrix.destination }}'
             # Move it from randomized build output dir to somewhere we can find it
-            mv ~/Library/Developer/Xcode/DerivedData/Firezone-*/Build/Products/Release/Firezone.app ~/.
+            mv ~/Library/Developer/Xcode/DerivedData/Firezone-*/Build/Products/Release/Firezone.app $RUNNER_TEMP/.
             # Create signed installer pkg
             productbuild \
               --sign "${{ env.INSTALLER_CODE_SIGN_IDENTITY }}" \
-              --component ~/Firezone.app /Applications ~/Firezone.pkg
+              --component $RUNNER_TEMP/Firezone.app /Applications $RUNNER_TEMP/Firezone.pkg
 
             # Save resulting file to use for upload
-            echo "app_bundle=~/Firezone.pkg" >> "$GITHUB_OUTPUT"
+            echo "app_bundle=$RUNNER_TEMP/Firezone.pkg" >> "$GITHUB_OUTPUT"
           else
             echo "Unsupported platform"
             exit 1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,15 +8,29 @@ env:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        target:
+        include:
           - sdk: macosx
+            runs-on: macos-13
+            xcode: "14.3"
             platform: macOS
             destination: platform=macOS
           - sdk: iphoneos
+            runs-on: macos-13
+            xcode: "14.3"
+            platform: iOS
+            destination: generic/platform=iOS
+          - sdk: macosx
+            runs-on: macos-14
+            xcode: "15"
+            platform: macOS
+            destination: platform=macOS
+          - sdk: iphoneos
+            runs-on: macos-14
+            xcode: "15"
             platform: iOS
             destination: generic/platform=iOS
     permissions:
@@ -32,15 +46,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ${{ matrix.target.platform }}
+          key: ${{ matrix.platform }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
+          key: ${{ matrix.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
           restore-keys: |
-            ${{ matrix.target.platform }}-swift-
+            ${{ matrix.platform }}-swift-
       - name: Install the Apple build certificate and provisioning profile
         env:
           BUILD_CERT: ${{ secrets.APPLE_BUILD_CERTIFICATE_BASE64 }}
@@ -64,10 +78,10 @@ jobs:
           echo -n "$BUILD_CERT" | base64 --decode -o $BUILD_CERT_PATH
 
           # Matrix won't let us access secrets (for good reason), so use an explicit conditional here instead
-          if [ "${{ matrix.target.platform }}" = "iOS" ]; then
+          if [ "${{ matrix.platform }}" = "iOS" ]; then
             echo -n "$IOS_APP_PP" | base64 --decode -o "$PP_PATH"/app.mobileprovision
             echo -n "$IOS_NE_PP" | base64 --decode -o "$PP_PATH"/ne.mobileprovision
-          elif [ "${{ matrix.target.platform }}" = "macOS" ]; then
+          elif [ "${{ matrix.platform }}" = "macOS" ]; then
             echo -n "$MACOS_APP_PP" | base64 --decode -o "$PP_PATH"/app.provisionprofile
             echo -n "$MACOS_NE_PP" | base64 --decode -o "$PP_PATH"/ne.provisionprofile
 
@@ -87,7 +101,7 @@ jobs:
           # import certificate to keychain
           security import $BUILD_CERT_PATH -P "$BUILD_CERT_PASS" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
 
-          if [ "${{ matrix.target.platform }}" = "macOS" ]; then
+          if [ "${{ matrix.platform }}" = "macOS" ]; then
             security import $INSTALLER_CERT_PATH -P "$INSTALLER_CERT_PASS" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           fi
           security list-keychain -d user -s $KEYCHAIN_PATH
@@ -100,7 +114,7 @@ jobs:
           INSTALLER_CODE_SIGN_IDENTITY: "3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
         run: |
           # Explicitly select Xcode version to use
-          sudo xcode-select -s /Applications/Xcode_14.3.app
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
 
           # Needed by the linter built into the build process
           brew install swift-format
@@ -117,14 +131,14 @@ jobs:
 
           # Unfortunately the macOS app requires an installer package to make it into the App Store,
           # while iOS requires an ipa. The process for building each of these is slightly different.
-          if [ "${{ matrix.target.platform }}" = "iOS" ]; then
+          if [ "${{ matrix.platform }}" = "iOS" ]; then
             # Build archive
             xcodebuild archive \
               -archivePath ~/Firezone.xcarchive \
               -configuration Release \
               -scheme Firezone \
-              -sdk ${{ matrix.target.sdk }} \
-              -destination '${{ matrix.target.destination }}'
+              -sdk ${{ matrix.sdk }} \
+              -destination '${{ matrix.destination }}'
             # Export IPA
             xcodebuild \
               -exportArchive \
@@ -134,13 +148,13 @@ jobs:
 
             # Save resulting file to use for upload
             echo "app_bundle=~/Firezone.ipa" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.target.platform }}" = "macOS" ]; then
+          elif [ "${{ matrix.platform }}" = "macOS" ]; then
             # Build app bundle
             xcodebuild build \
               -configuration Release \
               -scheme Firezone \
-              -sdk ${{ matrix.target.sdk }} \
-              -destination '${{ matrix.target.destination }}'
+              -sdk ${{ matrix.sdk }} \
+              -destination '${{ matrix.destination }}'
             # Move it from randomized build output dir to somewhere we can find it
             mv ~/Library/Developer/Xcode/DerivedData/Firezone-*/Build/Products/Release/Firezone.app ~/.
             # Create signed installer pkg
@@ -169,7 +183,7 @@ jobs:
           xcrun altool \
             --upload-app \
             -f ${{ steps.build.outputs.app_bundle }} \
-            -t ${{ matrix.target.platform }} \
+            -t ${{ matrix.platform }} \
             --apiKey $API_KEY_ID \
             --apiIssuer $ISSUER_ID
       - uses: actions/cache/save@v3
@@ -179,4 +193,4 @@ jobs:
           path: ~/Library/Developer/Xcode/DerivedData
           # Swift benefits heavily from build cache, so aggressively write a new one
           # on each build on `main` and attempt to restore it in PR builds with broader restore-key.
-          key: ${{ matrix.target.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
+          key: ${{ matrix.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -774,7 +774,6 @@ version = "1.20231001.0"
 dependencies = [
  "anyhow",
  "connlib-client-shared",
- "diva",
  "ip_network",
  "libc",
  "secrecy",
@@ -1104,17 +1103,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
-]
-
-[[package]]
-name = "diva"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4962b19d77f25a52081b27cd0404773376bda79b395801dcb771646206a20b06"
-dependencies = [
- "libc",
- "log",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -9,7 +9,6 @@ mock = ["connlib-client-shared/mock"]
 
 [build-dependencies]
 anyhow = "1.0.75"
-diva = "0.1.0"
 swift-bridge-build = "0.1.52"
 walkdir = "2.3.3"
 

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -22,12 +22,19 @@ for var in $(env | awk -F= '{print $1}'); do
   && [[ "$var" != "CONFIGURATION" ]] \
   && [[ "$var" != "NATIVE_ARCH" ]] \
   && [[ "$var" != "ONLY_ACTIVE_ARCH" ]] \
+  && [[ "$var" != "ARCHS" ]] \
+  && [[ "$var" != "SDKROOT" ]] \
+  && [[ "$var" != "OBJROOT" ]] \
+  && [[ "$var" != "SYMROOT" ]] \
+  && [[ "$var" != "SRCROOT" ]] \
+  && [[ "$var" != "TARGETED_DEVICE_FAMILY" ]] \
   && [[ "$var" != "CONNLIB_TARGET_DIR" ]]; then
   unset $var
   fi
 done
 
-# Use pristine path; the PATH from Xcode is polluted with stuff we don't want.
+# Use pristine path; the PATH from Xcode is polluted with stuff we don't want which can
+# confuse rustc.
 export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:$HOME/.cargo/bin"
 
 printenv
@@ -42,9 +49,8 @@ if [[ -z "$PLATFORM_NAME" ]]; then
   exit 1
 fi
 
-base_dir=$(xcrun --sdk $PLATFORM_NAME --show-sdk-path)
-export INCLUDE_PATH="$base_dir/usr/include"
-export LIBRARY_PATH="$base_dir/usr/lib"
+export INCLUDE_PATH="$SDK_ROOT/usr/include"
+export LIBRARY_PATH="$SDK_ROOT/usr/lib"
 export RUSTFLAGS="-Clink-arg=-fuse-ld=$(brew --prefix llvm@15)/bin/ld64.lld -Clink-arg=-dead_strip -Clink-arg=-lSystem -Clink-arg=-L$LIBRARY_PATH -Clink-arg=-L$INCLUDE_PATH"
 if [[ "$?" != "0" ]]; then
   echo "Failed to set RUSTFLAGS: Is LLVM 15 installed?"

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -51,11 +51,7 @@ fi
 
 export INCLUDE_PATH="$SDK_ROOT/usr/include"
 export LIBRARY_PATH="$SDK_ROOT/usr/lib"
-export RUSTFLAGS="-Clink-arg=-fuse-ld=$(brew --prefix llvm@15)/bin/ld64.lld -Clink-arg=-dead_strip -Clink-arg=-lSystem -Clink-arg=-L$LIBRARY_PATH -Clink-arg=-L$INCLUDE_PATH"
-if [[ "$?" != "0" ]]; then
-  echo "Failed to set RUSTFLAGS: Is LLVM 15 installed?"
-  exit 1
-fi
+export RUSTFLAGS="-Clink-arg=-dead_strip -Clink-arg=-lSystem -Clink-arg=-L$LIBRARY_PATH -Clink-arg=-L$INCLUDE_PATH"
 
 TARGETS=""
 if [[ "$PLATFORM_NAME" = "macosx" ]]; then

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -28,7 +28,7 @@ for var in $(env | awk -F= '{print $1}'); do
 done
 
 # Use pristine path; the PATH from Xcode is polluted with stuff we don't want.
-export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.cargo/bin"
+export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:$HOME/.cargo/bin"
 
 printenv
 
@@ -45,6 +45,7 @@ fi
 base_dir=$(xcrun --sdk $PLATFORM_NAME --show-sdk-path)
 export INCLUDE_PATH="$base_dir/usr/include"
 export LIBRARY_PATH="$base_dir/usr/lib"
+export RUSTFLAGS="-Clink-arg=-fuse-ld=$(brew --prefix llvm)/bin/ld64.lld -Clink-arg=-dead_strip -Clink-arg=-lSystem -Clink-arg=-L$LIBRARY_PATH -Clink-arg=-L$INCLUDE_PATH"
 
 TARGETS=""
 if [[ "$PLATFORM_NAME" = "macosx" ]]; then

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -6,6 +6,30 @@
 
 set -e
 
+# Sanitize the environment to prevent Xcode's shenanigans from leaking
+# into our highly evolved Rust-based build system.
+for var in $(env | awk -F= '{print $1}'); do
+  # standard vars
+  if [[ "$var" != "PATH" ]] \
+  && [[ "$var" != "HOME" ]] \
+  && [[ "$var" != "USER" ]] \
+  && [[ "$var" != "LOGNAME" ]] \
+  && [[ "$var" != "TERM" ]] \
+  && [[ "$var" != "PWD" ]] \
+  && [[ "$var" != "SHELL" ]] \
+  && [[ "$var" != "SHELL" ]] \
+  && [[ "$var" != "TMPDIR" ]] \
+  && [[ "$var" != "XPC_FLAGS" ]] \
+  && [[ "$var" != "XPC_SERVICE_NAME" ]] \
+  # Needed vars from Xcode
+  \ && [[ "$var" != "PLATFORM_NAME" ]] \
+  && [[ "$var" != "CONFIGURATION" ]] \
+  && [[ "$var" != "NATIVE_ARCH" ]] \
+  && [[ "$var" != "CONNLIB_TARGET_DIR" ]]; then
+  unset $var
+  fi
+done
+
 if [[ $1 == "clean" ]]; then
   echo "Skipping build during 'clean'"
   exit 0
@@ -16,27 +40,10 @@ if [[ -z "$PLATFORM_NAME" ]]; then
   exit 1
 fi
 
-# Use the lld linker from llvm. Fixes issues with building Rust with Xcode 15's
-# for aarch64-apple-ios.
-#
-# lld is also faster than the default macOS LD64 linker.
-#
-# `brew` is not in our PATH in this script, so adjust PATH temporarily just for
-# this command to avoid polluting the build env.
-# We use llvm@15 because that's what's installed on our CI.
-lld_path="$(PATH=/opt/homebrew/bin:/usr/local/bin:$PATH brew --prefix llvm@15):/usr/bin/ld64.lld"
-if [[ $? -ne 0 ]]; then
-  echo "Could not find llvm@15. Maybe try 'brew install llvm@15' or update this script to use a newer llvm if available."
-  exit 1
-fi
-
 base_dir=$(xcrun --sdk $PLATFORM_NAME --show-sdk-path)
-
 export PATH="$HOME/.cargo/bin:$PATH"
-export INCLUDE_PATH="$base_dir/usr/include:${INCLUDE_PATH:-}"
-export LIBRARY_PATH="$base_dir/usr/lib:${LIBRARY_PATH:-}"
-export RUSTFLAGS="-C link-arg=-F$base_dir/System/Library/Frameworks -C link-arg=-fuse-ld=$lld_path"
-export CFLAGS="-L ${LIBRARY_PATH} -I ${INCLUDE_PATH}"
+export INCLUDE_PATH="$base_dir/usr/include"
+export LIBRARY_PATH="$base_dir/usr/lib"
 
 TARGETS=""
 if [[ "$PLATFORM_NAME" = "macosx" ]]; then
@@ -48,7 +55,7 @@ if [[ "$PLATFORM_NAME" = "macosx" ]]; then
       else
         if [[ $NATIVE_ARCH == "x86_64" ]]; then
           TARGETS="--target x86_64-apple-darwin"
-	else
+        else
           echo "Unsupported native arch for $PLATFORM_NAME: $NATIVE_ARCH"
         fi
       fi

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -21,6 +21,7 @@ for var in $(env | awk -F= '{print $1}'); do
   && [[ "$var" != "PLATFORM_NAME" ]] \
   && [[ "$var" != "CONFIGURATION" ]] \
   && [[ "$var" != "NATIVE_ARCH" ]] \
+  && [[ "$var" != "ONLY_ACTIVE_ARCH" ]] \
   && [[ "$var" != "CONNLIB_TARGET_DIR" ]]; then
   unset $var
   fi

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -30,6 +30,8 @@ done
 # Use pristine path; the PATH from Xcode is polluted with stuff we don't want.
 export PATH="$HOME/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
+printenv
+
 if [[ $1 == "clean" ]]; then
   echo "Skipping build during 'clean'"
   exit 0

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -11,43 +11,43 @@ if [[ $1 == "clean" ]]; then
   exit 0
 fi
 
-# Default PLATFORM_NAME to macosx if not set.
-: "${PLATFORM_NAME:=macosx}"
-
-export PATH="$HOME/.cargo/bin:$PATH"
-base_dir=$(xcrun --sdk $PLATFORM_NAME --show-sdk-path)
-export INCLUDE_PATH="${base_dir}/usr/include"
-export LIBRARY_PATH="${base_dir}/usr/lib:${LIBRARY_PATH:-}"
-export RUSTFLAGS="-C link-arg=-F$base_dir/System/Library/Frameworks"
-# `-Qunused-arguments` stops clang from failing while building *ring*
-# (but the library search path is still necessary when building the framework!)
-# See https://github.com/briansmith/ring/issues/1332
-export CFLAGS="-L ${LIBRARY_PATH} -I ${INCLUDE_PATH} -Qunused-arguments"
-
-# Borrowed from https://github.com/signalapp/libsignal/commit/02899cac643a14b2ced7c058cc15a836a2165b6d
-# Thanks to @francesca64 for the fix
-if [[ -n "${DEVELOPER_SDK_DIR:-}" ]]; then
-  # Assume we're in Xcode, which means we're probably cross-compiling.
-  # In this case, we need to add an extra library search path for build scripts and proc-macros,
-  # which run on the host instead of the target.
-  # (macOS Big Sur does not have linkable libraries in /usr/lib/.)
-  if [[ "$XCODE_VERSION_MAJOR" -lt "1500" ]]; then
-    # It appears we may not need this workaround with the new linker in Xcode 15, but GitHub Actions
-    # currently has spotty support for Xcode 15 on its macOS 13 VMs, so we'll keep this workaround for now.
-    export LIBRARY_PATH="${DEVELOPER_SDK_DIR}/MacOSX.sdk/usr/lib:${LIBRARY_PATH}"
-  fi
+if [[ -z "$PLATFORM_NAME" ]]; then
+  echo "PLATFORM_NAME is not set"
+  exit 1
 fi
 
-TARGETS=()
+# Use the lld linker from llvm. Fixes issues with building Rust with Xcode 15's
+# for aarch64-apple-ios.
+#
+# lld is also faster than the default macOS LD64 linker.
+#
+# `brew` is not in our PATH in this script, so adjust PATH temporarily just for
+# this command to avoid polluting the build env.
+# We use llvm@15 because that's what's installed on our CI.
+lld_path="$(PATH=/opt/homebrew/bin:/usr/local/bin:$PATH brew --prefix llvm@15):/usr/bin/ld64.lld"
+if [[ $? -ne 0 ]]; then
+  echo "Could not find llvm@15. Maybe try 'brew install llvm@15' or update this script to use a newer llvm if available."
+  exit 1
+fi
+
+base_dir=$(xcrun --sdk $PLATFORM_NAME --show-sdk-path)
+
+export PATH="$HOME/.cargo/bin:$PATH"
+export INCLUDE_PATH="$base_dir/usr/include:${INCLUDE_PATH:-}"
+export LIBRARY_PATH="$base_dir/usr/lib:${LIBRARY_PATH:-}"
+export RUSTFLAGS="-C link-arg=-F$base_dir/System/Library/Frameworks -C link-arg=-fuse-ld=$lld_path"
+export CFLAGS="-L ${LIBRARY_PATH} -I ${INCLUDE_PATH}"
+
+TARGETS=""
 if [[ "$PLATFORM_NAME" = "macosx" ]]; then
     if [[ $CONFIGURATION == "Release" ]] || [[ -z "$NATIVE_ARCH" ]]; then
-      TARGETS=("aarch64-apple-darwin" "x86_64-apple-darwin")
+      TARGETS="--target aarch64-apple-darwin --target x86_64-apple-darwin"
     else
       if [[ $NATIVE_ARCH == "arm64" ]]; then
-        TARGETS=("aarch64-apple-darwin")
+        TARGETS="--target aarch64-apple-darwin"
       else
         if [[ $NATIVE_ARCH == "x86_64" ]]; then
-          TARGETS=("x86_64-apple-darwin")
+          TARGETS="--target x86_64-apple-darwin"
 	else
           echo "Unsupported native arch for $PLATFORM_NAME: $NATIVE_ARCH"
         fi
@@ -55,7 +55,7 @@ if [[ "$PLATFORM_NAME" = "macosx" ]]; then
     fi
 else
   if [[ "$PLATFORM_NAME" = "iphoneos" ]]; then
-    TARGETS="aarch64-apple-ios"
+    TARGETS="--target aarch64-apple-ios"
   else
     echo "Unsupported platform: $PLATFORM_NAME"
     exit 1
@@ -77,9 +77,6 @@ if [[ -n "$CONNLIB_TARGET_DIR" ]]; then
   set +x
 fi
 
-for target in "${TARGETS[@]}"
-do
-  set -x
-  cargo build --verbose --target=$target $CONFIGURATION_ARGS
-  set +x
-done
+set -x
+cargo build --verbose $TARGETS $CONFIGURATION_ARGS
+set +x

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -15,7 +15,6 @@ for var in $(env | awk -F= '{print $1}'); do
   && [[ "$var" != "TERM" ]] \
   && [[ "$var" != "PWD" ]] \
   && [[ "$var" != "SHELL" ]] \
-  && [[ "$var" != "SHELL" ]] \
   && [[ "$var" != "TMPDIR" ]] \
   && [[ "$var" != "XPC_FLAGS" ]] \
   && [[ "$var" != "XPC_SERVICE_NAME" ]] \
@@ -28,7 +27,7 @@ for var in $(env | awk -F= '{print $1}'); do
 done
 
 # Use pristine path; the PATH from Xcode is polluted with stuff we don't want.
-export PATH="$HOME/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.cargo/bin"
 
 printenv
 

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -10,8 +10,7 @@ set -e
 # into our highly evolved Rust-based build system.
 for var in $(env | awk -F= '{print $1}'); do
   # standard vars
-  if [[ "$var" != "PATH" ]] \
-  && [[ "$var" != "HOME" ]] \
+  if [[ "$var" != "HOME" ]] \
   && [[ "$var" != "USER" ]] \
   && [[ "$var" != "LOGNAME" ]] \
   && [[ "$var" != "TERM" ]] \
@@ -21,8 +20,7 @@ for var in $(env | awk -F= '{print $1}'); do
   && [[ "$var" != "TMPDIR" ]] \
   && [[ "$var" != "XPC_FLAGS" ]] \
   && [[ "$var" != "XPC_SERVICE_NAME" ]] \
-  # Needed vars from Xcode
-  \ && [[ "$var" != "PLATFORM_NAME" ]] \
+  && [[ "$var" != "PLATFORM_NAME" ]] \
   && [[ "$var" != "CONFIGURATION" ]] \
   && [[ "$var" != "NATIVE_ARCH" ]] \
   && [[ "$var" != "CONNLIB_TARGET_DIR" ]]; then
@@ -40,8 +38,10 @@ if [[ -z "$PLATFORM_NAME" ]]; then
   exit 1
 fi
 
+# Use pristine path; the PATH from Xcode is polluted with stuff we don't want.
+export PATH="$HOME/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
 base_dir=$(xcrun --sdk $PLATFORM_NAME --show-sdk-path)
-export PATH="$HOME/.cargo/bin:$PATH"
 export INCLUDE_PATH="$base_dir/usr/include"
 export LIBRARY_PATH="$base_dir/usr/lib"
 

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -9,7 +9,6 @@ set -e
 # Sanitize the environment to prevent Xcode's shenanigans from leaking
 # into our highly evolved Rust-based build system.
 for var in $(env | awk -F= '{print $1}'); do
-  # standard vars
   if [[ "$var" != "HOME" ]] \
   && [[ "$var" != "USER" ]] \
   && [[ "$var" != "LOGNAME" ]] \
@@ -28,6 +27,9 @@ for var in $(env | awk -F= '{print $1}'); do
   fi
 done
 
+# Use pristine path; the PATH from Xcode is polluted with stuff we don't want.
+export PATH="$HOME/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
 if [[ $1 == "clean" ]]; then
   echo "Skipping build during 'clean'"
   exit 0
@@ -37,9 +39,6 @@ if [[ -z "$PLATFORM_NAME" ]]; then
   echo "PLATFORM_NAME is not set"
   exit 1
 fi
-
-# Use pristine path; the PATH from Xcode is polluted with stuff we don't want.
-export PATH="$HOME/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 base_dir=$(xcrun --sdk $PLATFORM_NAME --show-sdk-path)
 export INCLUDE_PATH="$base_dir/usr/include"

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -37,8 +37,6 @@ done
 # confuse rustc.
 export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:$HOME/.cargo/bin"
 
-printenv
-
 if [[ $1 == "clean" ]]; then
   echo "Skipping build during 'clean'"
   exit 0
@@ -51,7 +49,6 @@ fi
 
 export INCLUDE_PATH="$SDK_ROOT/usr/include"
 export LIBRARY_PATH="$SDK_ROOT/usr/lib"
-export RUSTFLAGS="-Clink-arg=-dead_strip -Clink-arg=-lSystem -Clink-arg=-L$LIBRARY_PATH -Clink-arg=-L$INCLUDE_PATH"
 
 TARGETS=""
 if [[ "$PLATFORM_NAME" = "macosx" ]]; then

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -45,7 +45,11 @@ fi
 base_dir=$(xcrun --sdk $PLATFORM_NAME --show-sdk-path)
 export INCLUDE_PATH="$base_dir/usr/include"
 export LIBRARY_PATH="$base_dir/usr/lib"
-export RUSTFLAGS="-Clink-arg=-fuse-ld=$(brew --prefix llvm)/bin/ld64.lld -Clink-arg=-dead_strip -Clink-arg=-lSystem -Clink-arg=-L$LIBRARY_PATH -Clink-arg=-L$INCLUDE_PATH"
+export RUSTFLAGS="-Clink-arg=-fuse-ld=$(brew --prefix llvm@15)/bin/ld64.lld -Clink-arg=-dead_strip -Clink-arg=-lSystem -Clink-arg=-L$LIBRARY_PATH -Clink-arg=-L$INCLUDE_PATH"
+if [[ "$?" != "0" ]]; then
+  echo "Failed to set RUSTFLAGS: Is LLVM 15 installed?"
+  exit 1
+fi
 
 TARGETS=""
 if [[ "$PLATFORM_NAME" = "macosx" ]]; then

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -569,7 +569,7 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "23402aaa-f72c-4947-a795-23a9cf495968";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos";
+				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -609,7 +609,7 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "23402aaa-f72c-4947-a795-23a9cf495968";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos";
+				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -559,10 +559,6 @@
 					"@executable_path/../../Frameworks",
 				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "${CONNLIB_TARGET_DIR}/aarch64-apple-ios/debug";
-				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = (
-					"${CONNLIB_TARGET_DIR}/aarch64-apple-ios-sim/debug",
-					"${CONNLIB_TARGET_DIR}/x86_64-apple-ios/debug",
-				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MARKETING_VERSION = 1.20231001.0;
 				ONLY_ACTIVE_ARCH = YES;
@@ -573,7 +569,7 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "23402aaa-f72c-4947-a795-23a9cf495968";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = "iphoneos";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -604,10 +600,6 @@
 					"@executable_path/../../Frameworks",
 				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "${CONNLIB_TARGET_DIR}/aarch64-apple-ios/release";
-				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = (
-					"${CONNLIB_TARGET_DIR}/aarch64-apple-ios-sim/release",
-					"${CONNLIB_TARGET_DIR}/x86_64-apple-ios/release",
-				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MARKETING_VERSION = 1.20231001.0;
 				OTHER_LDFLAGS = "-lconnlib";
@@ -617,7 +609,7 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "23402aaa-f72c-4947-a795-23a9cf495968";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = "iphoneos";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -794,7 +786,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = "macosx iphoneos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -850,7 +842,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = "macosx iphoneos";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
@@ -878,25 +870,22 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
-				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MARKETING_VERSION = 1.20231001.0;
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "${APP_ID}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "b32a5853-699d-4f19-85d3-5b13b1ac5dbb";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "70055d90-0252-4ee5-a60c-4d6f3840ee62";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_MODULE = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
@@ -931,13 +920,9 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
-				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
@@ -950,7 +935,7 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "b32a5853-699d-4f19-85d3-5b13b1ac5dbb";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "70055d90-0252-4ee5-a60c-4d6f3840ee62";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_MODULE = NO;
 				SWIFT_INSTALL_OBJC_HEADER = NO;

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -1,10 +1,17 @@
 # Firezone Apple Client
 
-Firezone app clients for macOS and iOS.
+Firezone clients for macOS and iOS.
 
 ## Pre-requisites
 
-- Rust
+1. Rust: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+1. Request your Firezone email added to our Apple Developer Account
+1. Open Xcode, go to Settings -> Account and log in. Click "Download manual
+   profiles" button.
+1. Install signing keys from 1password "Engineering" vault.
+
+Automatic signing has been disabled because it doesn't easily work with our
+CI/CD pipeline.
 
 ## Building
 

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -109,3 +109,9 @@ To cleanup both Swift and Rust build objects:
 cd swift/apple
 ./cleanup.sh all
 ```
+
+### Wiping connlib log directory
+
+```
+rm -rf $HOME/Library/Group\ Containers/47R2M6779T.group.dev.firezone.firezone/Library/Caches/logs/connlib
+```


### PR DESCRIPTION
- Update CI to run on our self-hosted M1 runner as well (macos-14)
- Sanitize build environment in `build-rust.sh` to keep only needed ENV vars from Xcode
- Build both `x86_64` and `aarch64` targets with a single `cargo build` instead of a loop
- Store artifacts in ephemeral locations

Fixes #2329 