### PR TITLE
Remove macos-11 from Rust tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,8 +50,6 @@ jobs:
             packages: -p firezone-headless-client -p firezone-gateway -p connlib-client-android
           - runs-on: ubuntu-22.04
             packages: -p firezone-headless-client -p firezone-gateway -p connlib-client-android
-          - runs-on: macos-11
-            packages: -p connlib-client-apple
           - runs-on: macos-12
             packages: -p connlib-client-apple
           - runs-on: macos-13


### PR DESCRIPTION
An updated Ring patch version is now causing it to fail to compile:

https://github.com/firezone/firezone/actions/runs/6488036555/job/17619659201