### PR TITLE
Remove required-status-checks workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,19 +174,3 @@ jobs:
       - name: Show httpbin logs
         if: "!cancelled()"
         run: docker compose logs httpbin
-
-  # Makes managing the required status checks easier, and moves that source of truth to code
-  # TODO: Use https://registry.terraform.io/providers/integrations/github/latest/docs instead
-  required-status-checks:
-    if: 'always()'
-    runs-on: ubuntu-latest
-    needs:
-      - integration-tests
-      - elixir
-      - kotlin
-      - swift
-      - rust
-      - static-analysis
-      - terraform
-    steps:
-      - run: echo "No-op"


### PR DESCRIPTION
We are hitting this: https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt

We could employ the workaround listed there, but that would be more hacky. Instead, I'll make sure @firezone/engineering has access to update the repo settings for required status checks so that we aren't blocked on merging PRs whenever the CI job structure changes.