### PR TITLE
Don't use any local tun interfaces for WebRTC ICE candidates

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -338,9 +338,7 @@ where
             move |ip| !resources.read().values().any(|res_ip| res_ip.contains(ip))
         }));
 
-        setting_engine.set_interface_filter(Box::new({
-            |name| !name.contains("utun") && name != "tun-firezone"
-        }));
+        setting_engine.set_interface_filter(Box::new(|name| !name.contains("tun")));
 
         let webrtc_api = APIBuilder::new()
             .with_media_engine(media_engine)


### PR DESCRIPTION
I was triaging #2163 and realized we probably want to filter _all_ `*tun*` interfaces, not just our own right?