### PR TITLE
[legacy] Print wireguard config field when value is 0

### DIFF
--- a/apps/fz_http/lib/fz_http_web/views/wireguard_config_view.ex
+++ b/apps/fz_http/lib/fz_http_web/views/wireguard_config_view.ex
@@ -117,7 +117,7 @@ defmodule FzHttpWeb.WireguardConfigView do
   end
 
   defp field_empty?(nil), do: true
-  defp field_empty?(0), do: true
+  defp field_empty?(0), do: false
   defp field_empty?([]), do: true
 
   defp field_empty?(field) when is_binary(field) do


### PR DESCRIPTION
Fixes #1918 