### PR TITLE
feat(ci): be explicit about `runner.arch` and key usage

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
@@ -104,7 +104,7 @@ jobs:
 
   update_release_draft:
     needs: deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # write permission is required to create a github release
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
 
   integration-tests:
     needs: build-images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -81,7 +81,7 @@ jobs:
           reporter: java-junit
 
   type-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir
@@ -149,7 +149,7 @@ jobs:
         run: mix dialyzer --format dialyxir
 
   static-analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir
@@ -209,7 +209,7 @@ jobs:
         run: mix deps.unlock --check-unused
 
   migrations-and-seed-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -42,7 +42,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ ${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Install Dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: mix deps.get --only $MIX_ENV
@@ -58,7 +58,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Compile Application
         run: mix compile --warnings-as-errors
       - name: Setup Database
@@ -108,7 +108,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Install Dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: mix deps.get --only $MIX_ENV
@@ -124,7 +124,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Compile Application
         run: mix compile --warnings-as-errors
       - uses: actions/cache/restore@v3
@@ -132,10 +132,10 @@ jobs:
         id: plt_cache
         with:
           path: elixir/priv/plts
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('elixir/mix.lock') }}
           # This will make sure that we can incrementally build the PLT from older cache and save it under a new key
           restore-keys: |
-            ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-
+            ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-
       - name: Create PLTs
         if: ${{ steps.plt_cache.outputs.cache-hit != 'true' }}
         run: mix dialyzer --plt
@@ -143,7 +143,7 @@ jobs:
         if: ${{ steps.plt_cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main' }}
         name: Save PLT cache
         with:
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('elixir/mix.lock') }}
           path: elixir/priv/plts
       - name: Run Dialyzer
         run: mix dialyzer --format dialyxir
@@ -175,7 +175,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Install Dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: mix deps.get --only $MIX_ENV
@@ -191,7 +191,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Compile Application
         run: mix compile --force --warnings-as-errors
       - name: Check Formatting
@@ -254,7 +254,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Install Dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: mix deps.get --only $MIX_ENV
@@ -270,7 +270,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Compile
         run: mix compile --warnings-as-errors
       - name: Download main branch DB dump
@@ -382,7 +382,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Install Dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: mix deps.get --only $MIX_ENV
@@ -398,7 +398,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Compile Application
         run: mix compile --warnings-as-errors
       # Front-End deps cache
@@ -412,7 +412,7 @@ jobs:
             elixir/apps/web/assets/node_modules
             elixir/esbuild-*
             elixir/tailwind-*
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/pnpm-lock.yaml') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/pnpm-lock.yaml') }}
       - name: Install Front-End Dependencies
         if: ${{ steps.pnpm-web-deps-cache.outputs.cache-hit != 'true' }}
         run: |
@@ -428,7 +428,7 @@ jobs:
             elixir/apps/web/assets/node_modules
             elixir/esbuild-*
             elixir/tailwind-*
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/pnpm-lock.yaml') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/pnpm-lock.yaml') }}
       # Front-End build cache, it rarely changes so we cache it agressively too
       - uses: actions/cache/restore@v3
         name: Web Assets Cache
@@ -439,7 +439,7 @@ jobs:
           path: |
             elixir/apps/web/assets/tmp
             elixir/apps/web/priv/static
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/**') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/**') }}
       - name: Build Web Assets
         if: ${{ steps.pnpm-web-build-cache.outputs.cache-hit != 'true' }}
         run: |
@@ -454,7 +454,7 @@ jobs:
           path: |
             elixir/apps/web/assets/tmp
             elixir/apps/web/priv/static
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/**') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/**') }}
       # Run tests
       - name: Setup Database
         run: |

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -42,7 +42,7 @@ jobs:
           path: |
             elixir/deps
             elixir/_build/${{ env.MIX_ENV }}
-          key: ubuntu-22.04-${{ runner.arch }}-${{ ${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.cache-name }}-${{ hashFiles('elixir/mix.lock') }}
       - name: Install Dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: mix deps.get --only $MIX_ENV

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   static-analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./kotlin/android
@@ -38,7 +38,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ${{ runner.os }}
+          key: ubuntu-22.04
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ubuntu-22.04
+          key: ubuntu-22.04-${{ runner.arch }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           workspaces: ./rust
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          key: ${{ matrix.runs-on }}
+          key: ${{ matrix.runs-on }}-${{ runner.arch }}
       - run: cargo fmt -- --check
       - run: |
           cargo doc --all-features --no-deps --document-private-items ${{ matrix.packages }}
@@ -67,7 +67,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # Prevents runner.os caches from conflicting
-          key: ${{ matrix.runs-on }}
+          key: ${{ matrix.runs-on }}-${{ runner.arch }}
           workspaces: ./rust
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test --all-features ${{ matrix.packages }}
@@ -84,6 +84,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ubuntu-22.04
+          key: ${{ ubuntu-22.04 }}-runner.arch
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: ./run_smoke_test.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,12 +13,12 @@ jobs:
       matrix:
         runs-on:
           # We only need to run static analysis checks per OS family
-          - ubuntu-latest
+          - ubuntu-22.04
           - macos-13
           - windows-2022
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         include:
-          - runs-on: ubuntu-latest
+          - runs-on: ubuntu-22.04
             packages: # Intentionally blank as a package catch-all linter
           - runs-on: macos-13
             packages: -p connlib-client-apple
@@ -33,6 +33,7 @@ jobs:
         with:
           workspaces: ./rust
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          key: ${{ matrix.runs-on }}
       - run: cargo fmt -- --check
       - run: |
           cargo doc --all-features --no-deps --document-private-items ${{ matrix.packages }}
@@ -72,7 +73,7 @@ jobs:
       - run: cargo test --all-features ${{ matrix.packages }}
 
   smoke-test-relay:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./rust/relay
@@ -83,5 +84,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
+          key: ubuntu-22.04
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: ./run_smoke_test.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,6 +84,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ${{ ubuntu-22.04 }}-runner.arch
+          key: ubuntu-22.04-${{ runner.arch }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: ./run_smoke_test.sh

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ubuntu-22.04
+          key: ubuntu-22.04-${{ runner.arch }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check version is up to date
         run: |
@@ -37,9 +37,9 @@ jobs:
         name: Restore Python Cache
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          key: ubuntu-22.04-${{ runner.arch }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ubuntu-22.04-${{ runner.arch }}-pip-
       - name: Install Python Dependencies
         run: |
           pip install -r requirements.txt
@@ -52,4 +52,4 @@ jobs:
         name: Save Python Cache
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          key: ubuntu-22.04-${{ runner.arch }}-pip-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   version-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Update toolchain
@@ -12,6 +12,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
+          key: ubuntu-22.04
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check version is up to date
         run: |
@@ -26,7 +27,7 @@ jobs:
             exit 1
           fi
   global-linter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -54,15 +54,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ${{ matrix.platform }}
+          key: ${{ matrix.runs-on }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ matrix.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
+          key: ${{ matrix.runs-on }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
           restore-keys: |
-            ${{ matrix.platform }}-swift-
+            ${{ matrix.runs-on }}-swift-
       - name: Install the Apple build certificate and provisioning profile
         env:
           BUILD_CERT: ${{ secrets.APPLE_BUILD_CERTIFICATE_BASE64 }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -54,15 +54,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust
-          key: ${{ matrix.runs-on }}
+          key: ${{ matrix.runs-on }}-${{ runner.arch }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/cache/restore@v3
         name: Restore Swift DerivedData Cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ matrix.runs-on }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
+          key: ${{ matrix.runs-on }}-${{ runner.arch }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
           restore-keys: |
-            ${{ matrix.runs-on }}-swift-
+            ${{ matrix.runs-on }}-${{ runner.arch }}-swift-
       - name: Install the Apple build certificate and provisioning profile
         env:
           BUILD_CERT: ${{ secrets.APPLE_BUILD_CERTIFICATE_BASE64 }}
@@ -199,4 +199,4 @@ jobs:
           path: ~/Library/Developer/Xcode/DerivedData
           # Swift benefits heavily from build cache, so aggressively write a new one
           # on each build on `main` and attempt to restore it in PR builds with broader restore-key.
-          key: ${{ matrix.platform }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
+          key: ${{ matrix.runs-on }}-${{ runner.arch }}-swift-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   plan-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Getting a cache collision issue causing the x86_64 `macos-13` Rust cache to be restored onto `macos-14` runners which are `arm64`. Figured it's a good idea to go ahead and be explicit about architecture and OS versions since we'll also be running tests on `ubuntu-22.04` for `arm64` and `windows-2022` `arm64`.