### PR TITLE
apple: Sign out user on error and other fixes

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -61,7 +61,13 @@ final class TunnelStore: ObservableObject {
           protocolConfiguration: tunnel.protocolConfiguration as? NETunnelProviderProtocol)
       } else {
         let tunnel = NETunnelProviderManager()
-        tunnel.localizedDescription = "Firezone"
+        tunnel.localizedDescription = {
+          #if DEBUG
+            return "Firezone (\(Bundle.main.bundleIdentifier ?? ""))"
+          #else
+            return "Firezone"
+          #endif
+        }()
         tunnel.protocolConfiguration = TunnelAuthStatus.accountNotSetup.toProtocolConfiguration()
         try await tunnel.saveToPreferences()
         Self.logger.log("\(#function): Tunnel created")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -56,6 +56,7 @@ final class TunnelStore: ObservableObject {
       if let tunnel = managers.first {
         Self.logger.log("\(#function): Tunnel already exists")
         self.tunnel = tunnel
+        self.status = tunnel.connection.status
         self.tunnelAuthStatus = TunnelAuthStatus(
           protocolConfiguration: tunnel.protocolConfiguration as? NETunnelProviderProtocol)
       } else {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -321,9 +321,15 @@ enum TunnelAuthStatus {
     switch self {
     case .tunnelUninitialized, .accountNotSetup:
       return nil
-    case .signedOut(_, let accountId):
+    case .signedOut(let authBaseURL, let accountId):
+      guard authBaseURL == AppInfoPlistConstants.authBaseURL else {
+        return nil
+      }
       return accountId
-    case .signedIn(_, let accountId, _):
+    case .signedIn(let authBaseURL, let accountId, _):
+      guard authBaseURL == AppInfoPlistConstants.authBaseURL else {
+        return nil
+      }
       return accountId
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -312,8 +312,8 @@
         signInMenuItem.title = "Initializing"
         signInMenuItem.target = nil
         signOutMenuItem.isHidden = true
-      case .signedOut:
-        signInMenuItem.title = "Sign In"
+      case .signedOut(let accountId):
+        signInMenuItem.title = ((accountId == nil) ? "Enter Account ID" : "Sign In")
         signInMenuItem.target = self
         signInMenuItem.isEnabled = true
         signOutMenuItem.isHidden = true

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -315,6 +315,7 @@
       case .signedOut:
         signInMenuItem.title = "Sign In"
         signInMenuItem.target = self
+        signInMenuItem.isEnabled = true
         signOutMenuItem.isHidden = true
       case .signedIn(_, let actorName):
         signInMenuItem.title = actorName.isEmpty ? "Signed in" : "Signed in as \(actorName)"


### PR DESCRIPTION
- When the tunnel errors out (either while starting the tunnel, or later), assume it's a problem with the token and sign the user out. Fixes #2304.
- Include app id in the keychain storage scope. It might not fix the problem with macOS 12 keychain prompt, but this is the right thing to do.
- Use 'Enter Account ID' in macOS (refs #2331)

Edit: This PR had earlier changed PRODUCT_BUNDLE_IDENTIFIER. That commit is removed now.