### PR TITLE
Update dependabot package-ecosystems; set schedule to `daily`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,4 +39,7 @@ updates:
     directory: "kotlin/android"
     schedule:
       interval: "daily"
-  # TODO: Apple package ecosystem
+  - package-ecosystem: "swift"
+    directory: "swift/apple/FirezoneKit"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,19 @@ updates:
   - package-ecosystem: "mix" # See documentation for possible values
     directory: "elixir/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "cargo"
     directory: "rust/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     groups:
       otel:
         patterns:
@@ -34,9 +34,9 @@ updates:
   - package-ecosystem: "gradle"
     directory: "rust/connlib/clients/android/connlib"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "gradle"
     directory: "kotlin/android"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   # TODO: Apple package ecosystem

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "mix" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directory: "elixir/" # Location of package manifests
     schedule:
       interval: "weekly"
   - package-ecosystem: "pip"
@@ -14,10 +14,6 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -35,12 +31,12 @@ updates:
           - "tracing-stackdriver"
         update-types:
           - "minor"
-  - package-ecosystem: "maven"
-    directory: "rust/connlib/clients/android"
+  - package-ecosystem: "gradle"
+    directory: "rust/connlib/clients/android/connlib"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "maven"
-    directory: "kotlin/"
+  - package-ecosystem: "gradle"
+    directory: "kotlin/android"
     schedule:
       interval: "weekly"
   # TODO: Apple package ecosystem

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: "mix" # See documentation for possible values
-    directory: "elixir/" # Location of package manifests
+  - package-ecosystem: "mix"
+    directory: "elixir/"
     schedule:
       interval: "daily"
   - package-ecosystem: "pip"
@@ -32,14 +32,22 @@ updates:
         update-types:
           - "minor"
   - package-ecosystem: "gradle"
-    directory: "rust/connlib/clients/android/connlib"
+    directory: "rust/connlib/clients/android/connlib/"
     schedule:
       interval: "daily"
   - package-ecosystem: "gradle"
-    directory: "kotlin/android"
+    directory: "kotlin/android/"
     schedule:
       interval: "daily"
   - package-ecosystem: "swift"
-    directory: "swift/apple/FirezoneKit"
+    directory: "swift/apple/FirezoneKit/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "website/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "elixir/apps/web/assets/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
- Update dependabot dependency check to `daily`; it's our only supply chain scanner at the moment
- Configure dependabot to alert on security issues
- Fix some directory path configurations
- Remove ruby
- Add Swift
- Use `gradle`, not `maven` ecosystem
- Add @firezone/engineering to code scanning / security alerting management
- Remove Ruby and add Java/Kotlin and Swift to CodeQL

<img width="801" alt="Screenshot 2023-10-16 at 5 02 48 PM" src="https://github.com/firezone/firezone/assets/167144/c2b11580-f819-4b9c-b28e-c20d9f24c93e">


Fixes #1687 