### PR TITLE
Change dependabot updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: cargo
     directory: rust/
     schedule:
-      interval: monthly
+      interval: weekly
     groups:
       otel:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,19 @@ updates:
   - package-ecosystem: mix
     directory: elixir/
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: cargo
     directory: rust/
     schedule:
-      interval: daily
+      interval: monthly
     groups:
       otel:
         patterns:
@@ -34,31 +34,31 @@ updates:
   - package-ecosystem: gradle
     directory: rust/connlib/clients/android/connlib/
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: gradle
     directory: kotlin/android/
     schedule:
-      interval: daily
+      interval: monthly
     ignore:
       # Depends on JDK version which is bundled with Android Studio (JDK 17)
       - dependency-name: org.jetbrains.kotlin:kotlin-gradle-plugin
   - package-ecosystem: gradle
     directory: kotlin/android/app/
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: swift
     directory: swift/apple/FirezoneKit/
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: npm
     directory: website/
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: npm
     directory: elixir/apps/web/assets/
     schedule:
-      interval: daily
+      interval: monthly
   - package-ecosystem: terraform
     directory: terraform/environments/staging/
     schedule:
-      interval: daily
+      interval: monthly


### PR DESCRIPTION
* `daily` is way too noisy
* we run the risk of tracking dependency updates too closely: a bad update would cause issues. `monthly` increases the odds the community will find any problems with said dependency and time for the maintainer to fix it
* this doesn't affect security alerts (the main reason I had picked `daily` to begin with) -- those are configured separately in repo settings