### PR TITLE
refactor(relay): rename crate to `firezone-relay`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,7 +209,7 @@ services:
       cache_from:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/firezone/cache/relay:main
       args:
-        PACKAGE: relay
+        PACKAGE: firezone-relay
     image: us-east1-docker.pkg.dev/firezone-staging/firezone/relay:${VERSION:-main}
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep relay"]

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -79,7 +79,7 @@ Now you can verify that it's working by connecting to a websocket:
 
 ```elixir
 ❯ export RELAY_TOKEN_FROM_SEEDS="SFMyNTY.g2gDaAJtAAAAJDcyODZiNTNkLTA3M2UtNGM0MS05ZmYxLWNjODQ1MWRhZDI5OW0AAABARVg3N0dhMEhLSlVWTGdjcE1yTjZIYXRkR25mdkFEWVFyUmpVV1d5VHFxdDdCYVVkRVUzbzktRmJCbFJkSU5JS24GAMDq4emIAWIAAVGA.fLlZsUMS0VJ4RCN146QzUuINmGubpsxoyIf3uhRHdiQ"
-❯ websocat --header="User-Agent: Linux/5.2.6 (Debian; x86_64) relay/0.7.412" "ws://127.0.0.1:8081/relay/websocket?token=${RELAY_TOKEN_FROM_SEEDS}&ipv4=24.12.79.100&ipv6=4d36:aa7f:473c:4c61:6b9e:2416:9917:55cc"
+❯ websocat --header="User-Agent: Linux/5.2.6 (Debian; x86_64) firezone-relay/0.7.412" "ws://127.0.0.1:8081/firezone-relay/websocket?token=${RELAY_TOKEN_FROM_SEEDS}&ipv4=24.12.79.100&ipv6=4d36:aa7f:473c:4c61:6b9e:2416:9917:55cc"
 
 # Here is what you will see in docker logs firezone-api-1
 # {"time":"2023-06-05T23:16:01.537Z","severity":"info","message":"CONNECTED TO API.Relay.Socket in 251ms\n  Transport: :websocket\n  Serializer: Phoenix.Socket.V1.JSONSerializer\n  Parameters: %{\"ipv4\" => \"24.12.79.100\", \"ipv6\" => \"4d36:aa7f:473c:4c61:6b9e:2416:9917:55cc\", \"stamp_secret\" => \"[FILTERED]\", \"token\" => \"[FILTERED]\"}","metadata":{"domain":["elixir"],"erl_level":"info"}}

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -79,7 +79,7 @@ Now you can verify that it's working by connecting to a websocket:
 
 ```elixir
 ❯ export RELAY_TOKEN_FROM_SEEDS="SFMyNTY.g2gDaAJtAAAAJDcyODZiNTNkLTA3M2UtNGM0MS05ZmYxLWNjODQ1MWRhZDI5OW0AAABARVg3N0dhMEhLSlVWTGdjcE1yTjZIYXRkR25mdkFEWVFyUmpVV1d5VHFxdDdCYVVkRVUzbzktRmJCbFJkSU5JS24GAMDq4emIAWIAAVGA.fLlZsUMS0VJ4RCN146QzUuINmGubpsxoyIf3uhRHdiQ"
-❯ websocat --header="User-Agent: Linux/5.2.6 (Debian; x86_64) firezone-relay/0.7.412" "ws://127.0.0.1:8081/firezone-relay/websocket?token=${RELAY_TOKEN_FROM_SEEDS}&ipv4=24.12.79.100&ipv6=4d36:aa7f:473c:4c61:6b9e:2416:9917:55cc"
+❯ websocat --header="User-Agent: Linux/5.2.6 (Debian; x86_64) firezone-relay/0.7.412" "ws://127.0.0.1:8081/relay/websocket?token=${RELAY_TOKEN_FROM_SEEDS}&ipv4=24.12.79.100&ipv6=4d36:aa7f:473c:4c61:6b9e:2416:9917:55cc"
 
 # Here is what you will see in docker logs firezone-api-1
 # {"time":"2023-06-05T23:16:01.537Z","severity":"info","message":"CONNECTED TO API.Relay.Socket in 251ms\n  Transport: :websocket\n  Serializer: Phoenix.Socket.V1.JSONSerializer\n  Parameters: %{\"ipv4\" => \"24.12.79.100\", \"ipv6\" => \"4d36:aa7f:473c:4c61:6b9e:2416:9917:55cc\", \"stamp_secret\" => \"[FILTERED]\", \"token\" => \"[FILTERED]\"}","metadata":{"domain":["elixir"],"erl_level":"info"}}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1292,6 +1292,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "firezone-relay"
+version = "1.20231001.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64 0.21.4",
+ "bytecodec",
+ "bytes",
+ "clap",
+ "derive_more",
+ "difference",
+ "env_logger",
+ "futures",
+ "hex",
+ "hex-literal",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_api",
+ "phoenix-channel",
+ "proptest",
+ "rand",
+ "redis",
+ "secrecy",
+ "serde",
+ "sha2",
+ "socket2 0.5.4",
+ "stun_codec",
+ "test-strategy",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-opentelemetry 0.21.0",
+ "tracing-stackdriver",
+ "tracing-subscriber",
+ "trackable 1.3.0",
+ "url",
+ "uuid",
+ "webrtc",
+]
+
+[[package]]
 name = "firezone-tunnel"
 version = "1.20231001.0"
 dependencies = [
@@ -2925,48 +2967,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "relay"
-version = "1.20231001.0"
-dependencies = [
- "anyhow",
- "axum",
- "base64 0.21.4",
- "bytecodec",
- "bytes",
- "clap",
- "derive_more",
- "difference",
- "env_logger",
- "futures",
- "hex",
- "hex-literal",
- "once_cell",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_api",
- "phoenix-channel",
- "proptest",
- "rand",
- "redis",
- "secrecy",
- "serde",
- "sha2",
- "socket2 0.5.4",
- "stun_codec",
- "test-strategy",
- "tokio",
- "tracing",
- "tracing-core",
- "tracing-opentelemetry 0.21.0",
- "tracing-stackdriver",
- "tracing-subscriber",
- "trackable 1.3.0",
- "url",
- "uuid",
- "webrtc",
-]
 
 [[package]]
 name = "reqwest"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "relay"
+name = "firezone-relay"
 # mark:automatic-version
 version = "1.20231001.0"
 edition = "2021"

--- a/rust/relay/README.md
+++ b/rust/relay/README.md
@@ -16,7 +16,7 @@ Relaying of data through other means such as DATA frames is not supported.
 
 ## Building
 
-You can build the server using: `cargo build --release --bin relay`
+You can build the server using: `cargo build --release --bin firezone-relay`
 
 ## Running
 

--- a/rust/relay/run_smoke_test.sh
+++ b/rust/relay/run_smoke_test.sh
@@ -23,7 +23,7 @@ relay="$target_directory/debug/firezone-relay"
 
 export PUBLIC_IP4_ADDR=127.0.0.1;
 export RNG_SEED=0;
-export RUST_LOG=firezone-relay=debug;
+export RUST_LOG=firezone_relay=debug;
 
 # Client and relay run in the background.
 $client 2>&1 | sed "s/^/${RED}[ client]${NC} /" &

--- a/rust/relay/run_smoke_test.sh
+++ b/rust/relay/run_smoke_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cargo build --package relay --bin relay --example client --example gateway
+cargo build --package relay --bin firezone-relay --example client --example gateway
 
 cleanup() {
   pkill -P $$ || true # Kill all child-processes of the current process.
@@ -19,11 +19,11 @@ NC=$(echo -e '\033[0m')
 target_directory=$(cargo metadata --format-version 1 | jq -r '.target_directory')
 client="$target_directory/debug/examples/client"
 gateway="$target_directory/debug/examples/gateway"
-relay="$target_directory/debug/relay"
+relay="$target_directory/debug/firezone-relay"
 
 export PUBLIC_IP4_ADDR=127.0.0.1;
 export RNG_SEED=0;
-export RUST_LOG=relay=debug;
+export RUST_LOG=firezone-relay=debug;
 
 # Client and relay run in the background.
 $client 2>&1 | sed "s/^/${RED}[ client]${NC} /" &

--- a/rust/relay/run_smoke_test.sh
+++ b/rust/relay/run_smoke_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cargo build --package relay --bin firezone-relay --example client --example gateway
+cargo build --bin firezone-relay --example client --example gateway
 
 cleanup() {
   pkill -P $$ || true # Kill all child-processes of the current process.

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -1,5 +1,9 @@
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
+use firezone_relay::{
+    AddressFamily, Allocation, AllocationId, Command, IpStack, Server, Sleep, SocketAddrExt,
+    UdpSocket,
+};
 use futures::channel::mpsc;
 use futures::{future, FutureExt, SinkExt, StreamExt};
 use opentelemetry::{sdk, KeyValue};
@@ -7,10 +11,6 @@ use opentelemetry_otlp::WithExportConfig;
 use phoenix_channel::{Error, Event, PhoenixChannel, SecureUrl};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use relay::{
-    AddressFamily, Allocation, AllocationId, Command, IpStack, Server, Sleep, SocketAddrExt,
-    UdpSocket,
-};
 use secrecy::{Secret, SecretString};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -123,7 +123,7 @@ async fn main() -> Result<()> {
 
     let mut eventloop = Eventloop::new(server, channel, public_addr)?;
 
-    tokio::spawn(relay::health_check::serve(args.health_check_addr));
+    tokio::spawn(firezone_relay::health_check::serve(args.health_check_addr));
 
     tracing::info!("Listening for incoming traffic on UDP port 3478");
 

--- a/rust/relay/tests/regression.rs
+++ b/rust/relay/tests/regression.rs
@@ -1,9 +1,9 @@
 use bytecodec::{DecodeExt, EncodeExt};
-use rand::rngs::mock::StepRng;
-use relay::{
+use firezone_relay::{
     AddressFamily, Allocate, AllocationId, Attribute, Binding, ChannelBind, ChannelData,
     ClientMessage, Command, IpStack, Refresh, Server,
 };
+use rand::rngs::mock::StepRng;
 use secrecy::SecretString;
 use std::collections::HashMap;
 use std::iter;
@@ -21,7 +21,7 @@ use Output::{CreateAllocation, FreeAllocation, Wake};
 
 #[proptest]
 fn can_answer_stun_request_from_ip4_address(
-    #[strategy(relay::proptest::binding())] request: Binding,
+    #[strategy(firezone_relay::proptest::binding())] request: Binding,
     source: SocketAddrV4,
     public_relay_addr: Ipv4Addr,
 ) {
@@ -41,13 +41,13 @@ fn can_answer_stun_request_from_ip4_address(
 
 #[proptest]
 fn deallocate_once_time_expired(
-    #[strategy(relay::proptest::transaction_id())] transaction_id: TransactionId,
-    #[strategy(relay::proptest::allocation_lifetime())] lifetime: Lifetime,
-    #[strategy(relay::proptest::username_salt())] username_salt: String,
+    #[strategy(firezone_relay::proptest::transaction_id())] transaction_id: TransactionId,
+    #[strategy(firezone_relay::proptest::allocation_lifetime())] lifetime: Lifetime,
+    #[strategy(firezone_relay::proptest::username_salt())] username_salt: String,
     source: SocketAddrV4,
     public_relay_addr: Ipv4Addr,
-    #[strategy(relay::proptest::now())] now: SystemTime,
-    #[strategy(relay::proptest::nonce())] nonce: Uuid,
+    #[strategy(firezone_relay::proptest::now())] now: SystemTime,
+    #[strategy(firezone_relay::proptest::nonce())] nonce: Uuid,
 ) {
     let mut server = TestServer::new(public_relay_addr).with_nonce(nonce);
     let secret = server.auth_secret();
@@ -82,12 +82,12 @@ fn deallocate_once_time_expired(
 
 #[proptest]
 fn unauthenticated_allocate_triggers_authentication(
-    #[strategy(relay::proptest::transaction_id())] transaction_id: TransactionId,
-    #[strategy(relay::proptest::allocation_lifetime())] lifetime: Lifetime,
-    #[strategy(relay::proptest::username_salt())] username_salt: String,
+    #[strategy(firezone_relay::proptest::transaction_id())] transaction_id: TransactionId,
+    #[strategy(firezone_relay::proptest::allocation_lifetime())] lifetime: Lifetime,
+    #[strategy(firezone_relay::proptest::username_salt())] username_salt: String,
     source: SocketAddrV4,
     public_relay_addr: Ipv4Addr,
-    #[strategy(relay::proptest::now())] now: SystemTime,
+    #[strategy(firezone_relay::proptest::now())] now: SystemTime,
 ) {
     // Nonces are generated randomly and we control the randomness in the test, thus this is deterministic.
     let first_nonce = Uuid::from_u128(0x0);
@@ -132,15 +132,15 @@ fn unauthenticated_allocate_triggers_authentication(
 
 #[proptest]
 fn when_refreshed_in_time_allocation_does_not_expire(
-    #[strategy(relay::proptest::transaction_id())] allocate_transaction_id: TransactionId,
-    #[strategy(relay::proptest::transaction_id())] refresh_transaction_id: TransactionId,
-    #[strategy(relay::proptest::allocation_lifetime())] allocate_lifetime: Lifetime,
-    #[strategy(relay::proptest::allocation_lifetime())] refresh_lifetime: Lifetime,
-    #[strategy(relay::proptest::username_salt())] username_salt: String,
+    #[strategy(firezone_relay::proptest::transaction_id())] allocate_transaction_id: TransactionId,
+    #[strategy(firezone_relay::proptest::transaction_id())] refresh_transaction_id: TransactionId,
+    #[strategy(firezone_relay::proptest::allocation_lifetime())] allocate_lifetime: Lifetime,
+    #[strategy(firezone_relay::proptest::allocation_lifetime())] refresh_lifetime: Lifetime,
+    #[strategy(firezone_relay::proptest::username_salt())] username_salt: String,
     source: SocketAddrV4,
     public_relay_addr: Ipv4Addr,
-    #[strategy(relay::proptest::now())] now: SystemTime,
-    #[strategy(relay::proptest::nonce())] nonce: Uuid,
+    #[strategy(firezone_relay::proptest::now())] now: SystemTime,
+    #[strategy(firezone_relay::proptest::nonce())] nonce: Uuid,
 ) {
     let mut server = TestServer::new(public_relay_addr).with_nonce(nonce);
     let secret = server.auth_secret().to_owned();
@@ -209,14 +209,14 @@ fn when_refreshed_in_time_allocation_does_not_expire(
 }
 #[proptest]
 fn when_receiving_lifetime_0_for_existing_allocation_then_delete(
-    #[strategy(relay::proptest::transaction_id())] allocate_transaction_id: TransactionId,
-    #[strategy(relay::proptest::transaction_id())] refresh_transaction_id: TransactionId,
-    #[strategy(relay::proptest::allocation_lifetime())] allocate_lifetime: Lifetime,
-    #[strategy(relay::proptest::username_salt())] username_salt: String,
+    #[strategy(firezone_relay::proptest::transaction_id())] allocate_transaction_id: TransactionId,
+    #[strategy(firezone_relay::proptest::transaction_id())] refresh_transaction_id: TransactionId,
+    #[strategy(firezone_relay::proptest::allocation_lifetime())] allocate_lifetime: Lifetime,
+    #[strategy(firezone_relay::proptest::username_salt())] username_salt: String,
     source: SocketAddrV4,
     public_relay_addr: Ipv4Addr,
-    #[strategy(relay::proptest::now())] now: SystemTime,
-    #[strategy(relay::proptest::nonce())] nonce: Uuid,
+    #[strategy(firezone_relay::proptest::now())] now: SystemTime,
+    #[strategy(firezone_relay::proptest::nonce())] nonce: Uuid,
 ) {
     let mut server = TestServer::new(public_relay_addr).with_nonce(nonce);
     let secret = server.auth_secret().to_owned();
@@ -288,18 +288,19 @@ fn when_receiving_lifetime_0_for_existing_allocation_then_delete(
 
 #[proptest]
 fn ping_pong_relay(
-    #[strategy(relay::proptest::transaction_id())] allocate_transaction_id: TransactionId,
-    #[strategy(relay::proptest::transaction_id())] channel_bind_transaction_id: TransactionId,
-    #[strategy(relay::proptest::allocation_lifetime())] lifetime: Lifetime,
-    #[strategy(relay::proptest::username_salt())] username_salt: String,
-    #[strategy(relay::proptest::channel_number())] channel: ChannelNumber,
+    #[strategy(firezone_relay::proptest::transaction_id())] allocate_transaction_id: TransactionId,
+    #[strategy(firezone_relay::proptest::transaction_id())]
+    channel_bind_transaction_id: TransactionId,
+    #[strategy(firezone_relay::proptest::allocation_lifetime())] lifetime: Lifetime,
+    #[strategy(firezone_relay::proptest::username_salt())] username_salt: String,
+    #[strategy(firezone_relay::proptest::channel_number())] channel: ChannelNumber,
     source: SocketAddrV4,
     peer: SocketAddrV4,
     public_relay_addr: Ipv4Addr,
-    #[strategy(relay::proptest::now())] now: SystemTime,
+    #[strategy(firezone_relay::proptest::now())] now: SystemTime,
     peer_to_client_ping: [u8; 32],
     client_to_peer_ping: [u8; 32],
-    #[strategy(relay::proptest::nonce())] nonce: Uuid,
+    #[strategy(firezone_relay::proptest::nonce())] nonce: Uuid,
 ) {
     let _ = env_logger::try_init();
 
@@ -377,14 +378,14 @@ fn ping_pong_relay(
 
 #[proptest]
 fn can_make_ipv6_allocation(
-    #[strategy(relay::proptest::transaction_id())] transaction_id: TransactionId,
-    #[strategy(relay::proptest::allocation_lifetime())] lifetime: Lifetime,
-    #[strategy(relay::proptest::username_salt())] username_salt: String,
+    #[strategy(firezone_relay::proptest::transaction_id())] transaction_id: TransactionId,
+    #[strategy(firezone_relay::proptest::allocation_lifetime())] lifetime: Lifetime,
+    #[strategy(firezone_relay::proptest::username_salt())] username_salt: String,
     source: SocketAddrV4,
     public_relay_ip4_addr: Ipv4Addr,
     public_relay_ip6_addr: Ipv6Addr,
-    #[strategy(relay::proptest::now())] now: SystemTime,
-    #[strategy(relay::proptest::nonce())] nonce: Uuid,
+    #[strategy(firezone_relay::proptest::now())] now: SystemTime,
+    #[strategy(firezone_relay::proptest::nonce())] nonce: Uuid,
 ) {
     let mut server =
         TestServer::new((public_relay_ip4_addr, public_relay_ip6_addr)).with_nonce(nonce);


### PR DESCRIPTION
With the recent renames, I think it is more appropriate that this package is called `firezone-relay`. Whilst it is (almost) TURN compliant, it is still a product and should thus be branded accordingly.