### PR TITLE
Fix reuse connections

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -309,7 +309,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                     .send_with_ref(
                         EgressMessages::PrepareConnection {
                             resource_id: resource.id(),
-                            connected_gateway_ids: connected_gateway_ids.to_vec(),
+                            connected_gateway_ids,
                         },
                         reference,
                     )

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::{collections::HashSet, net::IpAddr};
 
 use firezone_tunnel::RTCSessionDescription;
 use serde::{Deserialize, Serialize};
@@ -141,7 +141,7 @@ impl From<ReplyMessages> for Messages {
 pub enum EgressMessages {
     PrepareConnection {
         resource_id: ResourceId,
-        connected_gateway_ids: Vec<GatewayId>,
+        connected_gateway_ids: HashSet<GatewayId>,
     },
     CreateLogSink {},
     RequestConnection(RequestConnection),
@@ -151,6 +151,8 @@ pub enum EgressMessages {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
+
     use connlib_shared::{
         control::PhoenixMessage,
         messages::{
@@ -256,7 +258,7 @@ mod test {
             "client",
             EgressMessages::PrepareConnection {
                 resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
-                connected_gateway_ids: vec![],
+                connected_gateway_ids: HashSet::new(),
             },
             None,
         );

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -135,6 +135,9 @@ pub enum ConnlibError {
     DNSFallbackKind(#[from] hickory_resolver::error::ResolveErrorKind),
     #[error("DNS proto error")]
     DnsProtoError(#[from] hickory_resolver::proto::error::ProtoError),
+    /// Connection is still being stablished, retry later
+    #[error("Pending connection")]
+    PendingConnection,
 }
 
 impl ConnlibError {

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -253,7 +253,7 @@ pub struct ClientState {
 pub struct AwaitingConnectionDetails {
     total_attemps: usize,
     response_received: bool,
-    gateways: Vec<GatewayId>,
+    gateways: HashSet<GatewayId>,
 }
 
 impl ClientState {

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -23,7 +23,7 @@ use hickory_resolver::lookup::Lookup;
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -239,7 +239,7 @@ pub struct ClientState {
 
     // TODO: Make private
     pub awaiting_connection: HashMap<ResourceId, AwaitingConnectionDetails>,
-    pub gateway_awaiting_connection: HashMap<GatewayId, Vec<IpNetwork>>,
+    pub gateway_awaiting_connection: HashSet<GatewayId>,
 
     awaiting_connection_timers: StreamMap<ResourceId, Instant>,
 
@@ -284,47 +284,32 @@ impl ClientState {
             return Err(Error::UnexpectedConnectionDetails);
         }
 
-        self.resources_gateways.insert(resource, gateway);
-
-        let found = {
-            let peer = connected_peers
-                .iter()
-                .find_map(|(_, p)| (p.conn_id == gateway).then_some(p))
-                .cloned();
-            if let Some(peer) = peer {
-                for ip in desc.ips() {
-                    tracing::trace!("deleteme: adding {ip}");
-                    peer.add_allowed_ip(ip);
-                    connected_peers.insert(ip, Arc::clone(&peer));
-                }
-                true
-            } else {
-                false
-            }
-        };
-
-        if found {
+        if self.gateway_awaiting_connection.contains(&gateway) {
             self.awaiting_connection.remove(&resource);
             self.awaiting_connection_timers.remove(resource);
+            return Err(Error::PendingConnection);
+        }
 
-            Ok(Some(ReuseConnection {
+        self.resources_gateways.insert(resource, gateway);
+
+        let peer = connected_peers
+            .iter()
+            .find_map(|(_, p)| (p.conn_id == gateway).then_some(p))
+            .cloned();
+        if let Some(peer) = peer {
+            for ip in desc.ips() {
+                peer.add_allowed_ip(ip);
+                connected_peers.insert(ip, Arc::clone(&peer));
+            }
+            self.awaiting_connection.remove(&resource);
+            self.awaiting_connection_timers.remove(resource);
+            return Ok(Some(ReuseConnection {
                 resource_id: resource,
                 gateway_id: gateway,
-            }))
-        } else {
-            let entry = self.gateway_awaiting_connection.entry(gateway).or_default();
-            let is_new = entry.is_empty();
-            entry.extend(desc.ips());
-
-            if is_new {
-                Ok(None)
-            } else {
-                Ok(Some(ReuseConnection {
-                    resource_id: resource,
-                    gateway_id: gateway,
-                }))
-            }
+            }));
         }
+
+        Ok(None)
     }
 
     pub fn on_connection_failed(&mut self, resource: ResourceId) {
@@ -351,17 +336,14 @@ impl ClientState {
 
         let resource_id = resource.id();
 
-        let connected_gateway_ids = self
+        let gateways = self
             .gateway_awaiting_connection
-            .clone()
-            .into_keys()
-            .chain(self.resources_gateways.values().cloned())
+            .iter()
+            .chain(self.resources_gateways.values())
+            .copied()
             .collect();
 
-        tracing::trace!(
-            gateways = ?connected_gateway_ids,
-            "connected_gateways"
-        );
+        tracing::trace!(?gateways, "connected_gateways");
 
         match self.awaiting_connection_timers.try_push(
             resource_id,
@@ -385,7 +367,7 @@ impl ClientState {
             AwaitingConnectionDetails {
                 total_attemps: 0,
                 response_received: false,
-                gateways: connected_gateway_ids,
+                gateways,
             },
         );
     }

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -141,22 +141,13 @@ where
                 ));
 
                 {
-                    let mut role_state = tunnel.role_state.lock();
-                    // Watch out! we need 2 locks, make sure you don't lock both at the same time anywhere else
                     let mut peers_by_ip = tunnel.peers_by_ip.write();
-
-                    if let Some(awaiting_ips) =
-                        role_state.gateway_awaiting_connection.remove(&gateway_id)
-                    {
-                        for ip in awaiting_ips {
-                            peer.add_allowed_ip(ip);
-                            peers_by_ip.insert(ip, Arc::clone(&peer));
-                        }
-                    }
 
                     for ip in peer_config.ips {
                         peers_by_ip.insert(ip, Arc::clone(&peer));
                     }
+
+                    tunnel.role_state.lock().gateway_awaiting_connection.remove(&gateway_id);
                 }
 
                 if let Some(conn) = tunnel.peer_connections.lock().get(&gateway_id) {

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -130,10 +130,6 @@ where
                             for ip in peer_config.ips {
                                 peers_by_ip.insert(ip, Arc::clone(&peer));
                             }
-
-                            for (resource, expires_at) in tunnel.role_state.lock().remove_awaiting_client_resources(&client_id) {
-                                peer.add_resource(resource, expires_at);
-                            }
                         }
 
                         if let Some(conn) = tunnel.peer_connections.lock().get(&client_id) {
@@ -170,21 +166,13 @@ where
         client_id: ClientId,
         expires_at: DateTime<Utc>,
     ) {
-        // We need to hold the write mutex for peers_by_ip.
-        // this is needed because otherwise the peer can be created while
-        // we call add_awaiting_client_resource. Creating a race condition
-        // where the resources are never added to the peer
-        let mut peers_by_ip = self.peers_by_ip.write();
-        if let Some(peer) = peers_by_ip
+        if let Some(peer) = self
+            .peers_by_ip
+            .write()
             .iter_mut()
             .find_map(|(_, p)| (p.conn_id == client_id).then_some(p))
         {
             peer.add_resource(resource, expires_at);
-        } else {
-            // Holding two mutexes here
-            self.role_state
-                .lock()
-                .add_awaiting_client_resource(client_id, resource, expires_at);
-        };
+        }
     }
 }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -3,14 +3,12 @@ use crate::{
     peer_by_ip, Device, Event, RoleState, Tunnel, ICE_GATHERING_TIMEOUT_SECONDS,
     MAX_CONCURRENT_ICE_GATHERING, MAX_UDP_SIZE,
 };
-use chrono::{DateTime, Utc};
 use connlib_shared::error::ConnlibError;
-use connlib_shared::messages::{ClientId, Interface as InterfaceConfig, ResourceDescription};
+use connlib_shared::messages::{ClientId, Interface as InterfaceConfig};
 use connlib_shared::Callbacks;
 use futures::channel::mpsc::Receiver;
 use futures_bounded::{PushError, StreamMap};
 use futures_util::SinkExt;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 use std::time::Duration;
@@ -82,7 +80,6 @@ where
 /// [`Tunnel`] state specific to gateways.
 pub struct GatewayState {
     candidate_receivers: StreamMap<ClientId, RTCIceCandidateInit>,
-    extra_resources_for_client: HashMap<ClientId, Vec<(ResourceDescription, DateTime<Utc>)>>,
 }
 
 impl GatewayState {
@@ -97,27 +94,6 @@ impl GatewayState {
             }
         }
     }
-
-    pub fn add_awaiting_client_resource(
-        &mut self,
-        client_id: ClientId,
-        resource: ResourceDescription,
-        expires_at: DateTime<Utc>,
-    ) {
-        self.extra_resources_for_client
-            .entry(client_id)
-            .or_default()
-            .push((resource, expires_at));
-    }
-
-    pub fn remove_awaiting_client_resources(
-        &mut self,
-        client_id: &ClientId,
-    ) -> Vec<(ResourceDescription, DateTime<Utc>)> {
-        self.extra_resources_for_client
-            .remove(client_id)
-            .unwrap_or_default()
-    }
 }
 
 impl Default for GatewayState {
@@ -127,7 +103,6 @@ impl Default for GatewayState {
                 Duration::from_secs(ICE_GATHERING_TIMEOUT_SECONDS),
                 MAX_CONCURRENT_ICE_GATHERING,
             ),
-            extra_resources_for_client: Default::default(),
         }
     }
 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -30,9 +30,9 @@ use webrtc::{
 
 use futures::channel::mpsc;
 use futures_util::{SinkExt, StreamExt};
-use std::hash::Hash;
 use std::task::{Context, Poll};
 use std::{collections::HashMap, fmt, io, net::IpAddr, sync::Arc, time::Duration};
+use std::{collections::HashSet, hash::Hash};
 use tokio::time::Interval;
 use webrtc::ice_transport::ice_candidate::RTCIceCandidateInit;
 
@@ -341,7 +341,7 @@ pub enum Event<TId> {
     },
     ConnectionIntent {
         resource: ResourceDescription,
-        connected_gateway_ids: Vec<GatewayId>,
+        connected_gateway_ids: HashSet<GatewayId>,
         reference: usize,
     },
     DnsQuery(DnsQuery<'static>),


### PR DESCRIPTION
There were 2 bugs:
* `gateway_awaiting_connections` should represent gateways were there is an on-going connection intent but are not connected yet but currently we were creating an empty entry when there was no entry, even if there is a connection established, this would cause the next resource connection intent to stop early without adding the allowed ip, thus never using the connection.
* There was a race condition, where if the `ReuseConnection` was sent to the gateway when the connection wasn't established, the gateway would just ignore the message, but this connection intent would never be sent again.

Now that I'm writing this maybe the best solution is, if there is a pending connection to a gateway, we just do nothing. That way upper layers would just retry the message and we send `ReuseConnection` once the connection is established instead of buffering the requests...

Edit: that's exactly the fix I made.