### PR TITLE
Disable CODEOWNERS for the time being

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-.github/ @AndrewDryga @jamilbk
-elixir/ @AndrewDryga
-terraform/ @AndrewDryga
-website/ @jamilbk
-rust/ @conectado
-swift/ @roop
-kotlin/ @pratikvelani
+# .github/ @AndrewDryga @jamilbk
+# elixir/ @AndrewDryga
+# terraform/ @AndrewDryga
+# website/ @jamilbk
+# rust/ @conectado
+# swift/ @roop
+# kotlin/ @pratikvelani


### PR DESCRIPTION
Unfortunately the only thing this is accomplishing at the moment is spamming the listed CODEOWNER to review PRs based on file changes with no option to disable this. This is not always great system because it assumes reviewers align perfectly to subdirectories of the mono repo, which may not always be the case.

Since we're a small team (for now), I think it's safe to assume the author of the PR can be entrusted to select the proper reviewers for their PRs.

See this issue: https://github.com/orgs/community/discussions/22479