### PR TITLE
Remove macos-14 runner from swift build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-.github/ @AndrewDryga @jamilbk
-elixir/ @AndrewDryga
-terraform/ @AndrewDryga
-website/ @jamilbk
-rust/ @conectado
-swift/ @roop
-kotlin/ @pratikvelani
+# .github/ @AndrewDryga @jamilbk
+# elixir/ @AndrewDryga
+# terraform/ @AndrewDryga
+# website/ @jamilbk
+# rust/ @conectado
+# swift/ @roop
+# kotlin/ @pratikvelani

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,14 +29,18 @@ jobs:
             platform: iOS
             destination: generic/platform=iOS
             xcode: "15.0"
-          - sdk: macosx
-            runs-on: macos-14
-            platform: macOS
-            destination: platform=macOS
-          - sdk: iphoneos
-            runs-on: macos-14
-            platform: iOS
-            destination: generic/platform=iOS
+          # TODO: Enable when GH Actions has macos-14 runners. Until this, this depends
+          # on self-hosted runners which can be less reliable and have issues with things
+          # like sccache.
+          # See https://github.com/firezone/firezone/actions/runs/6608338431/job/17946908445
+          # - sdk: macosx
+          #   runs-on: macos-14
+          #   platform: macOS
+          #   destination: platform=macOS
+          # - sdk: iphoneos
+          #   runs-on: macos-14
+          #   platform: iOS
+          #   destination: generic/platform=iOS
     permissions:
       contents: read
       id-token: 'write'


### PR DESCRIPTION
Temporarily disable self-hosted runners (`macos-14`) until official GH runners can back them up.