### PR TITLE
refactor(connlib): move side-effects up the callstack

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -165,7 +165,7 @@ where
                 continue;
             }
             Some(dns::ResolveStrategy::ForwardQuery(query)) => {
-                tunnel.role_state.lock().dns_query(query);
+                tunnel.role_state.lock().add_pending_dns_query(query);
                 continue;
             }
             None => {}
@@ -435,7 +435,7 @@ impl ClientState {
         }
     }
 
-    pub fn dns_query(&mut self, query: DnsQuery) {
+    pub fn add_pending_dns_query(&mut self, query: DnsQuery) {
         if self.dns_queries.push_back(query.into_owned()).is_err() {
             tracing::warn!("Too many DNS queries, dropping new ones");
         }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -247,7 +247,9 @@ impl ClientState {
             return Ok(None);
         };
 
-        let bytes = peer.encapsulate(packet, dest, buf)?;
+        let Some(bytes) = peer.encapsulate(packet, dest, buf)? else {
+            return Ok(None);
+        };
 
         Ok(Some(WriteTo::Network(bytes)))
     }

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -118,7 +118,11 @@ where
                 tracing::trace!("new_data_channel_opened");
                 let index = tunnel.next_index();
 
-                let peer_config = match tunnel.role_state.lock().create_peer_config_for_new_connection(resource_id, gateway_id, p_key) {
+                let peer_config = match tunnel
+                    .role_state
+                    .lock()
+                    .create_peer_config_for_new_connection(resource_id, gateway_id, p_key)
+                {
                     Ok(c) => c,
                     Err(e) => {
                         tunnel.peer_connections.lock().remove(&gateway_id);
@@ -129,13 +133,19 @@ where
                     }
                 };
 
-                d.on_close(on_dc_close_handler(index, gateway_id, tunnel.stop_peer_command_sender.clone()));
+                d.on_close(on_dc_close_handler(
+                    index,
+                    gateway_id,
+                    tunnel.stop_peer_command_sender.clone(),
+                ));
+                let d = d.detach().await.expect(
+                    "only fails if not opened or not enabled, both of which are always true for us",
+                );
 
                 let peer = Arc::new(Peer::new(
                     tunnel.private_key.clone(),
                     index,
                     peer_config.clone(),
-                    d.detach().await.expect("only fails if not opened or not enabled, both of which are always true for us"),
                     gateway_id,
                     None,
                 ));
@@ -144,19 +154,25 @@ where
                     let mut peers_by_ip = tunnel.peers_by_ip.write();
 
                     for ip in peer_config.ips {
-                        peers_by_ip.insert(ip, Arc::clone(&peer));
+                        peers_by_ip.insert(ip, (Arc::clone(&peer), d.clone()));
                     }
 
-                    tunnel.role_state.lock().gateway_awaiting_connection.remove(&gateway_id);
+                    tunnel
+                        .role_state
+                        .lock()
+                        .gateway_awaiting_connection
+                        .remove(&gateway_id);
                 }
 
                 if let Some(conn) = tunnel.peer_connections.lock().get(&gateway_id) {
-                    conn.on_peer_connection_state_change(
-                            on_peer_connection_state_change_handler(index, gateway_id, tunnel.stop_peer_command_sender.clone()),
-                    );
+                    conn.on_peer_connection_state_change(on_peer_connection_state_change_handler(
+                        index,
+                        gateway_id,
+                        tunnel.stop_peer_command_sender.clone(),
+                    ));
                 }
 
-                tokio::spawn(tunnel.clone().start_peer_handler(peer));
+                tokio::spawn(tunnel.clone().start_peer_handler(peer, d));
 
                 tunnel
                     .role_state

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -19,7 +19,7 @@ use webrtc::{
 use crate::control_protocol::{
     new_peer_connection, on_dc_close_handler, on_peer_connection_state_change_handler,
 };
-use crate::{peer::Peer, ClientState, Error, Request, Result, Tunnel};
+use crate::{peer::Peer, ClientState, ConnectedPeer, Error, Request, Result, Tunnel};
 
 #[tracing::instrument(level = "trace", skip(tunnel))]
 fn set_connection_state_update<CB>(
@@ -154,7 +154,13 @@ where
                     let mut peers_by_ip = tunnel.peers_by_ip.write();
 
                     for ip in peer_config.ips {
-                        peers_by_ip.insert(ip, (Arc::clone(&peer), d.clone()));
+                        peers_by_ip.insert(
+                            ip,
+                            ConnectedPeer {
+                                inner: peer.clone(),
+                                channel: d.clone(),
+                            },
+                        );
                     }
 
                     tunnel

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -9,3 +9,9 @@ mod device_channel;
 mod device_channel;
 
 pub(crate) use device_channel::*;
+use std::borrow::Cow;
+
+pub enum Packet<'a> {
+    Ipv4(Cow<'a, [u8]>),
+    Ipv6(Cow<'a, [u8]>),
+}

--- a/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
+++ b/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
@@ -9,6 +9,7 @@ use tokio::io::{unix::AsyncFd, Interest};
 
 use tun::{IfaceDevice, IfaceStream};
 
+use crate::device_channel::Packet;
 use crate::{Device, MAX_UDP_SIZE};
 
 mod tun;
@@ -31,12 +32,11 @@ impl DeviceIo {
     // Note: write is synchronous because it's non-blocking
     // and some losiness is acceptable and increseases performance
     // since we don't block the reading loops.
-    pub fn write4(&self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.get_ref().write4(buf)
-    }
-
-    pub fn write6(&self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.get_ref().write6(buf)
+    pub fn write(&self, packet: Packet<'_>) -> std::io::Result<usize> {
+        match packet {
+            Packet::Ipv4(msg) => self.0.get_ref().write4(&msg),
+            Packet::Ipv6(msg) => self.0.get_ref().write6(&msg),
+        }
     }
 }
 

--- a/rust/connlib/tunnel/src/device_channel/device_channel_win.rs
+++ b/rust/connlib/tunnel/src/device_channel/device_channel_win.rs
@@ -1,3 +1,4 @@
+use crate::device_channel::Packet;
 use crate::Device;
 use connlib_shared::{messages::Interface, CallbackErrorFacade, Callbacks, Result};
 use ip_network::IpNetwork;
@@ -12,11 +13,7 @@ impl DeviceIo {
         todo!()
     }
 
-    pub fn write4(&self, _: &[u8]) -> std::io::Result<usize> {
-        todo!()
-    }
-
-    pub fn write6(&self, _: &[u8]) -> std::io::Result<usize> {
+    pub fn write(&self, _: Packet<'_>) -> std::io::Result<usize> {
         todo!()
     }
 }

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -111,10 +111,12 @@ pub(crate) fn build_response(
     let udp_checksum = pkt.to_immutable().udp_checksum(&pkt.as_immutable_udp()?);
     pkt.as_udp()?.set_checksum(udp_checksum);
     pkt.set_ipv4_checksum();
-    match version {
-        Version::Ipv4 => Some(Packet::Ipv4(res_buf)),
-        Version::Ipv6 => Some(Packet::Ipv6(res_buf)),
-    }
+    let packet = match version {
+        Version::Ipv4 => Packet::Ipv4(res_buf),
+        Version::Ipv6 => Packet::Ipv6(res_buf),
+    };
+
+    Some(packet)
 }
 
 fn build_dns_with_answer<N>(

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -66,7 +66,8 @@ where
         };
 
         let bytes = match peer.encapsulate(packet, dest, &mut buf) {
-            Ok(b) => b,
+            Ok(Some(b)) => b,
+            Ok(None) => continue,
             Err(e) => {
                 on_error(&tunnel, dest, &peer, e).await;
                 continue;

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -61,7 +61,7 @@ where
 
         let dest = packet.destination();
 
-        let Some(peer) = peer_by_ip(&tunnel.peers_by_ip.read(), dest) else {
+        let Some((peer, channel)) = peer_by_ip(&tunnel.peers_by_ip.read(), dest) else {
             continue;
         };
 
@@ -73,7 +73,7 @@ where
             }
         };
 
-        if let Err(e) = peer.channel.write(&bytes).await {
+        if let Err(e) = channel.write(&bytes).await {
             on_error(&tunnel, dest, &peer, e.into()).await
         }
     }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -292,7 +292,7 @@ where
                         let callbacks = self.callbacks.clone();
                         async move {
                             if let Some(peer) = maybe_peer {
-                                let _ = peer.shutdown().await;
+                                let _ = peer.channel.close().await;
                             }
                             if let Err(e) = conn.close().await {
                                 tracing::warn!(%conn_id, error = ?e, "Can't close peer");

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -219,7 +219,10 @@ where
 
                     tokio::spawn(async move {
                         let bytes = match peer.update_timers() {
-                            Ok(bytes) => bytes,
+                            Ok(Some(bytes)) => bytes,
+                            Ok(None) => {
+                                return;
+                            }
                             Err(e) => {
                                 tracing::error!("Failed to update timers for peer: {e}");
                                 let _ = callbacks.on_error(&e);

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use connlib_shared::{
     messages::{ResourceDescription, ResourceId},
-    Callbacks, Error, Result,
+    Error, Result,
 };
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
@@ -75,14 +75,6 @@ where
             dns_resources,
             network_resources,
             translated_resource_addresses,
-        }
-    }
-
-    #[inline(always)]
-    pub(crate) async fn send_infallible<CB: Callbacks>(&self, data: Bytes, callbacks: &CB) {
-        if let Err(e) = self.channel.write(&data).await {
-            tracing::error!("Couldn't send packet to connected peer: {e}");
-            let _ = callbacks.on_error(&e.into());
         }
     }
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -11,7 +11,7 @@ use connlib_shared::{
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 use parking_lot::{Mutex, RwLock};
-use pnet_packet::MutablePacket;
+use pnet_packet::Packet;
 use secrecy::ExposeSecret;
 use webrtc::data::data_channel::DataChannel;
 
@@ -220,7 +220,7 @@ where
 
             packet.update_checksum();
         }
-        let packet = match self.tunnel.lock().encapsulate(packet.packet_mut(), buf) {
+        let packet = match self.tunnel.lock().encapsulate(packet.packet(), buf) {
             TunnResult::Done => return Ok(()),
             TunnResult::Err(e) => return Err(e.into()),
             TunnResult::WriteToNetwork(b) => b,

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::net::ToSocketAddrs;
-use std::{collections::HashMap, net::IpAddr, sync::Arc};
+use std::{collections::HashMap, net::IpAddr};
 
 use boringtun::noise::{Tunn, TunnResult};
 use boringtun::x25519::StaticSecret;
@@ -15,7 +15,6 @@ use ip_network_table::IpNetworkTable;
 use parking_lot::{Mutex, RwLock};
 use pnet_packet::Packet;
 use secrecy::ExposeSecret;
-use webrtc::data::data_channel::DataChannel;
 
 use crate::{
     device_channel, ip_packet::MutableIpPacket, resource_table::ResourceTable, PeerConfig,
@@ -27,7 +26,6 @@ pub(crate) struct Peer<TId> {
     pub tunnel: Mutex<Tunn>,
     pub index: u32,
     allowed_ips: RwLock<IpNetworkTable<()>>,
-    pub channel: Arc<DataChannel>,
     pub conn_id: TId,
     resources: Option<RwLock<ResourceTable<ExpiryingResource>>>,
     // Here we store the address that we obtained for the resource that the peer corresponds to.
@@ -82,7 +80,6 @@ where
         private_key: StaticSecret,
         index: u32,
         peer_config: PeerConfig,
-        channel: Arc<DataChannel>,
         conn_id: TId,
         resource: Option<(ResourceDescription, DateTime<Utc>)>,
     ) -> Peer<TId> {
@@ -111,7 +108,6 @@ where
             tunnel: Mutex::new(tunnel),
             index,
             allowed_ips,
-            channel,
             conn_id,
             resources,
             translated_resource_addresses: Default::default(),

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -15,7 +15,9 @@ use pnet_packet::Packet;
 use secrecy::ExposeSecret;
 use webrtc::data::data_channel::DataChannel;
 
-use crate::{ip_packet::MutableIpPacket, resource_table::ResourceTable, PeerConfig};
+use crate::{
+    device_channel, ip_packet::MutableIpPacket, resource_table::ResourceTable, PeerConfig,
+};
 
 type ExpiryingResource = (ResourceDescription, DateTime<Utc>);
 
@@ -249,4 +251,9 @@ where
 
         Some((dst, resource))
     }
+}
+
+pub enum WriteTo<'a> {
+    Network(Bytes),
+    Resource(device_channel::Packet<'a>),
 }

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -147,11 +147,6 @@ where
         Ok(Bytes::copy_from_slice(packet))
     }
 
-    pub(crate) async fn shutdown(&self) -> Result<()> {
-        self.channel.close().await?;
-        Ok(())
-    }
-
     pub(crate) fn is_emptied(&self) -> bool {
         self.resources.as_ref().is_some_and(|r| r.read().is_empty())
     }

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -80,7 +80,7 @@ where
 
     #[inline(always)]
     pub(crate) async fn send_infallible<CB: Callbacks>(&self, data: Bytes, callbacks: &CB) {
-        if let Err(e) = self.channel.write(&Bytes::copy_from_slice(&data)).await {
+        if let Err(e) = self.channel.write(&data).await {
             tracing::error!("Couldn't send packet to connected peer: {e}");
             let _ = callbacks.on_error(&e.into());
         }

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::net::{IpAddr, ToSocketAddrs};
 use std::sync::Arc;
 
@@ -10,8 +11,8 @@ use futures_util::SinkExt;
 
 use crate::ip_packet::MutableIpPacket;
 use crate::{
-    device_channel::DeviceIo, index::check_packet_index, peer::Peer, RoleState, Tunnel,
-    MAX_UDP_SIZE,
+    device_channel, device_channel::DeviceIo, index::check_packet_index, peer::Peer, RoleState,
+    Tunnel, MAX_UDP_SIZE,
 };
 
 impl<CB, TRoleState> Tunnel<CB, TRoleState>
@@ -236,8 +237,8 @@ where
 #[inline(always)]
 fn send_packet(device_io: &DeviceIo, packet: &mut [u8], dst_addr: IpAddr) -> std::io::Result<()> {
     match dst_addr {
-        IpAddr::V4(_) => device_io.write4(packet)?,
-        IpAddr::V6(_) => device_io.write6(packet)?,
+        IpAddr::V4(_) => device_io.write(device_channel::Packet::Ipv4(Cow::Borrowed(packet)))?,
+        IpAddr::V6(_) => device_io.write(device_channel::Packet::Ipv6(Cow::Borrowed(packet)))?,
     };
     Ok(())
 }

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -91,7 +91,7 @@ where
         src: &[u8],
         dst: &mut [u8],
     ) -> Result<()> {
-        if let Some(cookie) = self.verify_packet(peer, src).await? {
+        if let Some(cookie) = self.verify_packet(peer, src)? {
             peer.send_infallible(cookie, &self.callbacks).await;
 
             return Err(Error::UnderLoad);
@@ -141,7 +141,7 @@ where
 
     /// Consults the rate limiter for the provided buffer and checks that it parses into a valid wireguard packet.
     #[inline(always)]
-    async fn verify_packet(
+    fn verify_packet(
         self: &Arc<Self>,
         peer: &Peer<TRoleState::Id>,
         src: &[u8],

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -137,7 +137,7 @@ where
         };
 
         match write_to {
-            WriteTo::Network(packet) => peer.send_infallible(packet, self.callbacks()).await,
+            WriteTo::Network(packet) => peer.send_infallible(packet, &self.callbacks).await,
             WriteTo::Resource(packet) => {
                 device_writer.write(packet)?;
             }

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -143,7 +143,7 @@ where
     #[inline(always)]
     async fn verify_packet(
         self: &Arc<Self>,
-        peer: &Arc<Peer<TRoleState::Id>>,
+        peer: &Peer<TRoleState::Id>,
         src: &[u8],
     ) -> Result<Option<Bytes>> {
         /// The rate-limiter emits at most a cookie packet which is only 64 bytes.

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -92,9 +92,7 @@ where
             return Err(Error::BadPacket);
         }
 
-        let decapsulate_result = peer.tunnel.lock().decapsulate(None, src, dst);
-
-        let write_to = match decapsulate_result {
+        let write_to = match peer.tunnel.lock().decapsulate(None, src, dst) {
             TunnResult::Done => return Ok(()),
             TunnResult::Err(e) => {
                 tracing::error!(error = ?e, "decapsulate_packet");


### PR DESCRIPTION
This refactoring series removes the `channel` property from `Peer`. The idea here is that we want to move side-effects _up_ the callstack. Side-effects, esp. network access usually requires ownership over a certain resource like the data channel or the TUN device. It is easier to handle this ownership if we never give out references to these resources but instead keep them in the upper layer and keep the rest of the code side-effect free.