### PR TITLE
feat(connlib): remove `ip-filter` from `SettingEngine`

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -17,7 +17,6 @@ use hickory_resolver::proto::rr::RecordType;
 use itertools::Itertools;
 use parking_lot::{Mutex, RwLock};
 use peer::{Peer, PeerStats};
-use resource_table::ResourceTable;
 use tokio::{task::AbortHandle, time::MissedTickBehavior};
 use webrtc::{
     api::{
@@ -364,7 +363,6 @@ where
         let peers_by_ip = RwLock::new(IpNetworkTable::new());
         let next_index = Default::default();
         let peer_connections = Default::default();
-        let resources: Arc<RwLock<ResourceTable<ResourceDescription>>> = Default::default();
         let device = Default::default();
         let iface_handler_abort = Default::default();
 
@@ -377,11 +375,6 @@ where
         registry = register_default_interceptors(registry, &mut media_engine)?;
         let mut setting_engine = SettingEngine::default();
         setting_engine.detach_data_channels();
-        setting_engine.set_ip_filter(Box::new({
-            let resources = Arc::clone(&resources);
-            move |ip| !resources.read().values().any(|res_ip| res_ip.contains(ip))
-        }));
-
         setting_engine.set_interface_filter(Box::new(|name| !name.contains("tun")));
 
         let webrtc_api = APIBuilder::new()


### PR DESCRIPTION
In a prior state of connlib, the resources where held inside `Tunnel`. These now moved to `ClientState` because they are irrelevant for the gateway. As part of that, there was an oversight that these resources were also shared in the callback of `SettingEngine` to apply an IP filter to the ICE candidate gathering.

Re-introducing this functionality would be quite hard now because we don't have access to the resource table in the constructor and sharing that state again with `Tunnel` would go completely against the current path forward. We are going to get rid of webrtc eventually and the IP filter is a mere optimisation, thus I don't think it is worth putting the effort into keeping it.