### PR TITLE
connlib: limit the number of relays used per-connection

### DIFF
--- a/rust/connlib/tunnel/src/control_protocol.rs
+++ b/rust/connlib/tunnel/src/control_protocol.rs
@@ -25,6 +25,8 @@ mod client;
 mod gateway;
 
 const ICE_CANDIDATE_BUFFER: usize = 100;
+// We should use not more than 1-2 relays (WebRTC in Firefox breaks at 5) due to combinatoric
+// complexity of checking all the ICE candidate pairs
 const MAX_RELAYS: usize = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/connlib/tunnel/src/control_protocol.rs
+++ b/rust/connlib/tunnel/src/control_protocol.rs
@@ -25,6 +25,7 @@ mod client;
 mod gateway;
 
 const ICE_CANDIDATE_BUFFER: usize = 100;
+const MAX_RELAYS: usize = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
@@ -113,6 +114,7 @@ pub async fn new_peer_connection(
                     credential_type: RTCIceCredentialType::Password,
                 },
             })
+            .take(MAX_RELAYS)
             .collect(),
         ..Default::default()
     };


### PR DESCRIPTION
Fixes #2499 

@AndrewDryga This should be accompanied by a portal-side PR that:
* Sorts gateway somehow
* Stop sending STUN servers: we only need TURN URLs since webrtc already fall back onto STUN URLs when it fails to allocate.

Right now, if we merge this without removing TURN URLs we might not get a connection where TURN is needed.

I think we should leave the `Stun` type in the message, for hole-punched only connections that we want to implement in the function. Which from connlib's side shouldn't need any change if we lave it like this, the portal should only send STUN urls in that case.
