### PR TITLE
Add Sign up ENV flag

### DIFF
--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -113,6 +113,10 @@ defmodule Domain.Config do
     end
   end
 
+  def sign_up_enabled? do
+    compile_config!(Definitions, :sign_up_enabled)
+  end
+
   ## Test helpers
 
   if Mix.env() != :test do

--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -114,7 +114,7 @@ defmodule Domain.Config do
   end
 
   def sign_up_enabled? do
-    compile_config!(Definitions, :sign_up_enabled)
+    compile_config!(Definitions, :feature_sign_up_enabled)
   end
 
   ## Test helpers

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -604,4 +604,13 @@ defmodule Domain.Config.Definitions do
     default: nil,
     changeset: {Logo, :changeset, []}
   )
+
+  ##############################################
+  ## Sign-ups Enabled Flag
+  ##############################################
+
+  @doc """
+  Boolean flag to turn Sign-ups on/off.
+  """
+  defconfig(:sign_up_enabled, :boolean, default: true)
 end

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -606,11 +606,11 @@ defmodule Domain.Config.Definitions do
   )
 
   ##############################################
-  ## Sign-ups Enabled Flag
+  ## Feature Flags
   ##############################################
 
   @doc """
   Boolean flag to turn Sign-ups on/off.
   """
-  defconfig(:sign_up_enabled, :boolean, default: true)
+  defconfig(:feature_sign_up_enabled, :boolean, default: true)
 end

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -41,7 +41,7 @@ defmodule Web.SignUp do
       assign(socket,
         form: to_form(changeset),
         account: nil,
-        sign_up_enabled: Config.sign_up_enabled?()
+        sign_up_enabled?: Config.sign_up_enabled?()
       )
 
     {:ok, socket}
@@ -70,9 +70,9 @@ defmodule Web.SignUp do
               </:separator>
 
               <:item>
-                <.sign_up_form :if={@account == nil && @sign_up_enabled} flash={@flash} form={@form} />
-                <.welcome :if={@account && @sign_up_enabled} account={@account} />
-                <.sign_up_disabled :if={!@sign_up_enabled} />
+                <.sign_up_form :if={@account == nil && @sign_up_enabled?} flash={@flash} form={@form} />
+                <.welcome :if={@account && @sign_up_enabled?} account={@account} />
+                <.sign_up_disabled :if={!@sign_up_enabled?} />
               </:item>
             </.intersperse_blocks>
           </div>
@@ -197,6 +197,29 @@ defmodule Web.SignUp do
     """
   end
 
+  def sign_up_disabled(assigns) do
+    ~H"""
+    <div class="space-y-6">
+      <div class="text-xl text-center text-gray-900 dark:text-white">
+        Sign-ups are currently disabled.
+      </div>
+      <div class="text-center">
+        Please contact
+        <a class={link_style()} href="mailto:sales@firezone.dev?subject=Firezone Sign Up Request">
+          sales@firezone.dev
+        </a>
+        for more information.
+      </div>
+      <p class="text-xs text-center">
+        By signing up you agree to our <.link
+          href="https://www.firezone.dev/terms"
+          class="text-blue-600 dark:text-blue-500 hover:underline"
+        >Terms of Use</.link>.
+      </p>
+    </div>
+    """
+  end
+
   def handle_event("validate", %{"registration" => attrs}, socket) do
     changeset =
       %Registration{}
@@ -216,7 +239,7 @@ defmodule Web.SignUp do
       |> Registration.changeset(attrs)
       |> Map.put(:action, :insert)
 
-    if changeset.valid? && socket.assigns.sign_up_enabled do
+    if changeset.valid? && socket.assigns.sign_up_enabled? do
       registration = Ecto.Changeset.apply_changes(changeset)
 
       multi =
@@ -271,28 +294,5 @@ defmodule Web.SignUp do
     else
       {:noreply, assign(socket, form: to_form(changeset))}
     end
-  end
-
-  def sign_up_disabled(assigns) do
-    ~H"""
-    <div class="space-y-6">
-      <div class="text-xl text-center text-gray-900 dark:text-white">
-        Sign-ups are currently disabled.
-      </div>
-      <div class="text-center">
-        Please contact
-        <a class={link_style()} href="mailto:sales@firezone.dev?subject=Firezone Sign Up Request">
-          sales@firezone.dev
-        </a>
-        for more information.
-      </div>
-      <p class="text-xs text-center">
-        By signing up you agree to our <.link
-          href="https://www.firezone.dev/terms"
-          class="text-blue-600 dark:text-blue-500 hover:underline"
-        >Terms of Use</.link>.
-      </p>
-    </div>
-    """
   end
 end

--- a/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
@@ -80,7 +80,7 @@ defmodule Web.Live.SignUpTest do
   end
 
   test "renders signup disabled message", %{conn: conn} do
-    Domain.Config.put_system_env_override(:sign_up_enabled, false)
+    Domain.Config.put_system_env_override(:feature_sign_up_enabled, false)
 
     {:ok, _lv, html} = live(conn, ~p"/sign_up")
 

--- a/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
@@ -78,4 +78,13 @@ defmodule Web.Live.SignUpTest do
              "registration[email]" => ["has invalid format"]
            }
   end
+
+  test "renders signup disabled message", %{conn: conn} do
+    Domain.Config.put_system_env_override(:sign_up_enabled, false)
+
+    {:ok, _lv, html} = live(conn, ~p"/sign_up")
+
+    assert html =~ "Sign-ups are currently disabled"
+    assert html =~ "sales@firezone.dev"
+  end
 end


### PR DESCRIPTION
Why:

* During the beta launch, sign-ups will need to be disabled to make sure no unexpected accounts are created.