### PR TITLE
connlib: break read on 0-sized read

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -241,8 +241,13 @@ where
                         };
 
                         if let Err(e) = peer_channel.write(&bytes).await {
-                            tracing::error!("Failed to send packet to peer: {e}");
-                            let _ = callbacks.on_error(&e.into());
+                            let err = e.into();
+                            tracing::error!("Failed to send packet to peer: {err:?}");
+                            let _ = callbacks.on_error(&err);
+
+                            if err.is_fatal_connection_error() {
+                                let _ = stop_command_sender.send((peer_index, peer_conn_id)).await;
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
To clarify this PR fixes 2 bug:
* Now even if it's not an error we break the peer handling loop, since that considers cases such as 0-sized read.
* In peer refresh we cleanup connections that return a fatal error.