### PR TITLE
Add feature flags for TODOs and Flows

### DIFF
--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -113,8 +113,18 @@ defmodule Domain.Config do
     end
   end
 
+  ## Feature flag helpers
+
   def sign_up_enabled? do
     compile_config!(Definitions, :feature_sign_up_enabled)
+  end
+
+  def flows_enabled? do
+    compile_config!(Definitions, :feature_flows_enabled)
+  end
+
+  def todos_enabled? do
+    compile_config!(Definitions, :feature_todos_enabled)
   end
 
   ## Test helpers

--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -119,8 +119,8 @@ defmodule Domain.Config do
     compile_config!(Definitions, :feature_sign_up_enabled)
   end
 
-  def flows_enabled? do
-    compile_config!(Definitions, :feature_flows_enabled)
+  def flow_activities_enabled? do
+    compile_config!(Definitions, :feature_flow_activities_enabled)
   end
 
   def todos_enabled? do

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -615,9 +615,9 @@ defmodule Domain.Config.Definitions do
   defconfig(:feature_sign_up_enabled, :boolean, default: true)
 
   @doc """
-  Boolean flag to turn UI flows on/off.
+  Boolean flag to turn UI flow activities on/off.
   """
-  defconfig(:feature_flows_enabled, :boolean, default: false)
+  defconfig(:feature_flow_activities_enabled, :boolean, default: false)
 
   @doc """
   Boolean flag to turn UI TODOs on/off.

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -613,4 +613,14 @@ defmodule Domain.Config.Definitions do
   Boolean flag to turn Sign-ups on/off.
   """
   defconfig(:feature_sign_up_enabled, :boolean, default: true)
+
+  @doc """
+  Boolean flag to turn UI flows on/off.
+  """
+  defconfig(:feature_flows_enabled, :boolean, default: false)
+
+  @doc """
+  Boolean flag to turn UI TODOs on/off.
+  """
+  defconfig(:feature_todos_enabled, :boolean, default: false)
 end

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -15,10 +15,11 @@ defmodule Web.Clients.Show do
           client: client,
           flows: flows,
           todos_enabled?: Config.todos_enabled?(),
-          flows_enabled?: Config.flows_enabled?()
+          flow_activities_enabled?: Config.flow_activities_enabled?()
         )
 
-      {:ok, socket}
+      {:ok, socket,
+       temporary_assigns: [flows: [], todos_enabled?: nil, flow_activities_enabled?: nil]}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError
     end
@@ -125,7 +126,7 @@ defmodule Web.Clients.Show do
             </.link>
             (<%= flow.gateway_remote_ip %>)
           </:col>
-          <:col :let={flow} :if={@flows_enabled?} label="ACTIVITY">
+          <:col :let={flow} :if={@flow_activities_enabled?} label="ACTIVITY">
             <.link
               navigate={~p"/#{@account}/flows/#{flow.id}"}
               class="font-medium text-blue-600 dark:text-blue-500 hover:underline"

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -18,7 +18,7 @@ defmodule Web.Gateways.Show do
           gateway: gateway,
           flows: flows,
           todos_enabled?: Config.todos_enabled?(),
-          flows_enabled?: Config.flows_enabled?()
+          flow_activities_enabled?: Config.flow_activities_enabled?()
         )
 
       {:ok, socket}
@@ -153,7 +153,7 @@ defmodule Web.Gateways.Show do
             </.link>
             (<%= flow.client_remote_ip %>)
           </:col>
-          <:col :let={flow} :if={@flows_enabled?} label="ACTIVITY">
+          <:col :let={flow} :if={@flow_activities_enabled?} label="ACTIVITY">
             <.link
               navigate={~p"/#{@account}/flows/#{flow.id}"}
               class="font-medium text-blue-600 dark:text-blue-500 hover:underline"

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -17,7 +17,7 @@ defmodule Web.Policies.Show do
           policy: policy,
           flows: flows,
           page_title: "Policy",
-          flows_enabled?: Config.flows_enabled?()
+          flow_activities_enabled?: Config.flow_activities_enabled?()
         )
 
       {:ok, socket}
@@ -128,7 +128,7 @@ defmodule Web.Policies.Show do
             </.link>
             (<%= flow.gateway_remote_ip %>)
           </:col>
-          <:col :let={flow} :if={@flows_enabled?} label="ACTIVITY">
+          <:col :let={flow} :if={@flow_activities_enabled?} label="ACTIVITY">
             <.link navigate={~p"/#{@account}/flows/#{flow.id}"} class={link_style()}>
               Show
             </.link>

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -1,7 +1,7 @@
 defmodule Web.Policies.Show do
   use Web, :live_view
   import Web.Policies.Components
-  alias Domain.{Policies, Flows}
+  alias Domain.{Policies, Flows, Config}
 
   def mount(%{"id" => id}, _session, socket) do
     with {:ok, policy} <-
@@ -12,7 +12,15 @@ defmodule Web.Policies.Show do
            Flows.list_flows_for(policy, socket.assigns.subject,
              preload: [client: [:actor], gateway: [:group]]
            ) do
-      {:ok, assign(socket, policy: policy, flows: flows, page_title: "Policy")}
+      socket =
+        assign(socket,
+          policy: policy,
+          flows: flows,
+          page_title: "Policy",
+          flows_enabled?: Config.flows_enabled?()
+        )
+
+      {:ok, socket}
     else
       _other -> raise Web.LiveErrors.NotFoundError
     end
@@ -120,7 +128,7 @@ defmodule Web.Policies.Show do
             </.link>
             (<%= flow.gateway_remote_ip %>)
           </:col>
-          <:col :let={flow} label="ACTIVITY">
+          <:col :let={flow} :if={@flows_enabled?} label="ACTIVITY">
             <.link navigate={~p"/#{@account}/flows/#{flow.id}"} class={link_style()}>
               Show
             </.link>

--- a/elixir/apps/web/lib/web/live/relays/show.ex
+++ b/elixir/apps/web/lib/web/live/relays/show.ex
@@ -1,11 +1,19 @@
 defmodule Web.Relays.Show do
   use Web, :live_view
-  alias Domain.Relays
+  alias Domain.{Relays, Config}
 
   def mount(%{"id" => id}, _session, socket) do
     with {:ok, relay} <-
            Relays.fetch_relay_by_id(id, socket.assigns.subject, preload: :group) do
       :ok = Relays.subscribe_for_relays_presence_in_group(relay.group)
+
+      socket =
+        assign(
+          socket,
+          relay: relay,
+          todos_enabled?: Config.todos_enabled?()
+        )
+
       {:ok, assign(socket, relay: relay)}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError
@@ -89,7 +97,7 @@ defmodule Web.Relays.Show do
                 <%= @relay.last_seen_user_agent %>
               </:value>
             </.vertical_table_row>
-            <.vertical_table_row>
+            <.vertical_table_row :if={@todos_enabled?}>
               <:label>Deployment Method</:label>
               <:value>TODO: Docker</:value>
             </.vertical_table_row>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -1,7 +1,7 @@
 defmodule Web.Resources.Show do
   use Web, :live_view
   import Web.Policies.Components
-  alias Domain.{Resources, Flows}
+  alias Domain.{Resources, Flows, Config}
 
   def mount(%{"id" => id}, _session, socket) do
     with {:ok, resource} <-
@@ -12,7 +12,15 @@ defmodule Web.Resources.Show do
            Flows.list_flows_for(resource, socket.assigns.subject,
              preload: [client: [:actor], gateway: [:group], policy: [:resource, :actor_group]]
            ) do
-      {:ok, assign(socket, resource: resource, flows: flows)}
+      socket =
+        assign(
+          socket,
+          resource: resource,
+          flows: flows,
+          todos_enabled?: Config.todos_enabled?()
+        )
+
+      {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError
     end


### PR DESCRIPTION
Why:

* Some sections of the UI were still displaying `TODO` and needed to be hidden for beta release, so a feature flag was created.  Also, the 'Flows' are not ready to be utilized in the UI at this time, so a feature flag was created to hide any mention of 'Flows'.