### PR TITLE
Add optional name field to relays

### DIFF
--- a/elixir/apps/api/lib/api/relay/socket.ex
+++ b/elixir/apps/api/lib/api/relay/socket.ex
@@ -28,7 +28,7 @@ defmodule API.Relay.Socket do
 
       attrs =
         attrs
-        |> Map.take(~w[ipv4 ipv6])
+        |> Map.take(~w[ipv4 ipv6 name])
         |> Map.put("last_seen_user_agent", user_agent)
         |> Map.put("last_seen_remote_ip", real_ip)
         |> Map.put("last_seen_remote_ip_location_region", location_region)

--- a/elixir/apps/api/test/api/relay/socket_test.exs
+++ b/elixir/apps/api/test/api/relay/socket_test.exs
@@ -43,6 +43,19 @@ defmodule API.Relay.SocketTest do
       assert relay.last_seen_version == @connlib_version
     end
 
+    test "creates a new named relay" do
+      token = Fixtures.Relays.create_token()
+      encrypted_secret = Relays.encode_token!(token)
+
+      attrs =
+        connect_attrs(token: encrypted_secret)
+        |> Map.put("name", "us-east1-x381")
+
+      assert {:ok, socket} = connect(Socket, attrs, connect_info: @connect_info)
+      assert relay = Map.fetch!(socket.assigns, :relay)
+      assert relay.name == "us-east1-x381"
+    end
+
     test "uses region code to put default coordinates" do
       token = Fixtures.Relays.create_token()
       encrypted_secret = Relays.encode_token!(token)

--- a/elixir/apps/domain/lib/domain/relays/relay.ex
+++ b/elixir/apps/domain/lib/domain/relays/relay.ex
@@ -2,6 +2,8 @@ defmodule Domain.Relays.Relay do
   use Domain, :schema
 
   schema "relays" do
+    field :name, :string
+
     field :ipv4, Domain.Types.IP
     field :ipv6, Domain.Types.IP
 

--- a/elixir/apps/domain/lib/domain/relays/relay/changeset.ex
+++ b/elixir/apps/domain/lib/domain/relays/relay/changeset.ex
@@ -3,14 +3,14 @@ defmodule Domain.Relays.Relay.Changeset do
   alias Domain.Version
   alias Domain.Relays
 
-  @upsert_fields ~w[ipv4 ipv6 port
+  @upsert_fields ~w[ipv4 ipv6 port name
                     last_seen_user_agent
                     last_seen_remote_ip
                     last_seen_remote_ip_location_region
                     last_seen_remote_ip_location_city
                     last_seen_remote_ip_location_lat
                     last_seen_remote_ip_location_lon]a
-  @conflict_replace_fields ~w[ipv4 ipv6 port
+  @conflict_replace_fields ~w[ipv4 ipv6 port name
                               last_seen_user_agent
                               last_seen_remote_ip
                               last_seen_remote_ip_location_region
@@ -37,6 +37,7 @@ defmodule Domain.Relays.Relay.Changeset do
     |> cast(attrs, @upsert_fields)
     |> validate_required(~w[last_seen_user_agent last_seen_remote_ip]a)
     |> validate_required_one_of(~w[ipv4 ipv6]a)
+    |> validate_length(:name, min: 1, max: 255)
     |> validate_number(:port, greater_than_or_equal_to: 1, less_than_or_equal_to: 65_535)
     |> unique_constraint(:ipv4, name: :relays_unique_address_index)
     |> unique_constraint(:ipv6, name: :relays_unique_address_index)

--- a/elixir/apps/domain/priv/repo/migrations/20231101014812_add_relays_name.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20231101014812_add_relays_name.exs
@@ -1,0 +1,9 @@
+defmodule Domain.Repo.Migrations.AddRelaysName do
+  use Ecto.Migration
+
+  def change do
+    alter table(:relays) do
+      add(:name, :string)
+    end
+  end
+end

--- a/elixir/apps/web/lib/web/live/relay_groups/index.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/index.ex
@@ -55,6 +55,9 @@ defmodule Web.RelayGroups.Index do
                 navigate={~p"/#{@account}/relays/#{relay.id}"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
+                <code :if={relay.name} class="block text-xs">
+                  <%= relay.name %>
+                </code>
                 <code :if={relay.ipv4} class="block text-xs">
                   <%= relay.ipv4 %>
                 </code>

--- a/elixir/apps/web/lib/web/live/relays/show.ex
+++ b/elixir/apps/web/lib/web/live/relays/show.ex
@@ -43,6 +43,22 @@ defmodule Web.Relays.Show do
               <:value><%= @relay.group.name %></:value>
             </.vertical_table_row>
             <.vertical_table_row>
+              <:label>Remote IPv4</:label>
+              <:value>
+                <code><%= @relay.ipv4 %></code>
+              </:value>
+            </.vertical_table_row>
+            <.vertical_table_row>
+              <:label>Remote IPv6</:label>
+              <:value>
+                <code><%= @relay.ipv6 %></code>
+              </:value>
+            </.vertical_table_row>
+            <.vertical_table_row>
+              <:label>Name</:label>
+              <:value><%= @relay.name %></:value>
+            </.vertical_table_row>
+            <.vertical_table_row>
               <:label>Status</:label>
               <:value>
                 <.connection_status schema={@relay} />
@@ -62,19 +78,6 @@ defmodule Web.Relays.Show do
                 <.relative_datetime datetime={@relay.last_seen_at} />
               </:value>
             </.vertical_table_row>
-            <.vertical_table_row>
-              <:label>Remote IPv4</:label>
-              <:value>
-                <code><%= @relay.ipv4 %></code>
-              </:value>
-            </.vertical_table_row>
-            <.vertical_table_row>
-              <:label>Remote IPv6</:label>
-              <:value>
-                <code><%= @relay.ipv6 %></code>
-              </:value>
-            </.vertical_table_row>
-
             <.vertical_table_row>
               <:label>Version</:label>
               <:value>


### PR DESCRIPTION
The idea is to allow users to explicitly name them so they are easier to identify in the UI.

@thomaseizinger we will need to add an optional `FIREZONE_NAME` environment variable for the relays and send it along with other attributes when you connect to a WebSocket.