### PR TITLE
Redirect to client platform callback url when user is already signed in

### DIFF
--- a/elixir/apps/web/lib/web/auth.ex
+++ b/elixir/apps/web/lib/web/auth.ex
@@ -247,8 +247,14 @@ defmodule Web.Auth do
   """
   def redirect_if_user_is_authenticated(%Plug.Conn{} = conn, _opts) do
     if conn.assigns[:subject] do
+      client_platform =
+        Plug.Conn.get_session(conn, :client_platform) || conn.query_params["client_platform"]
+
+      client_csrf_token =
+        Plug.Conn.get_session(conn, :client_csrf_token) || conn.query_params["client_csrf_token"]
+
       conn
-      |> Phoenix.Controller.redirect(to: signed_in_path(conn.assigns.subject))
+      |> signed_in_redirect(conn.assigns[:subject], client_platform, client_csrf_token)
       |> Plug.Conn.halt()
     else
       conn

--- a/elixir/apps/web/test/web/auth_test.exs
+++ b/elixir/apps/web/test/web/auth_test.exs
@@ -197,14 +197,28 @@ defmodule Web.AuthTest do
   end
 
   describe "redirect_if_user_is_authenticated/2" do
-    test "redirects if user is authenticated", %{conn: conn, admin_subject: subject} do
+    test "redirects if user is authenticated to the signed in path", %{
+      conn: conn,
+      admin_subject: subject
+    } do
       conn =
         conn
         |> assign(:subject, subject)
+        |> fetch_query_params()
         |> redirect_if_user_is_authenticated([])
 
       assert conn.halted
       assert redirected_to(conn) == signed_in_path(subject)
+    end
+
+    test "redirects clients to platform specific urls", %{conn: conn, admin_subject: subject} do
+      conn =
+        %{conn | query_params: %{"client_platform" => "apple"}}
+        |> assign(:subject, subject)
+        |> redirect_if_user_is_authenticated([])
+
+      assert conn.halted
+      assert redirected_to(conn) =~ "firezone://handle_client_auth_callback"
     end
 
     test "does not redirect if user is not authenticated", %{conn: conn} do


### PR DESCRIPTION
This will fix the issue with shows a dashboard when you sign in and browser cookie is still fresh