### PR TITLE
Add traffic filter feature flag

### DIFF
--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -116,24 +116,23 @@ defmodule Domain.Config do
   ## Feature flag helpers
 
   defp feature_enabled?(feature) do
-    compile_config!(Definitions, feature) ||
-      compile_config!(Definitions, :all_features_enabled, %{})
+    fetch_env!(:domain, :enabled_features) |> Keyword.fetch!(feature)
   end
 
   def sign_up_enabled? do
-    feature_enabled?(:feature_sign_up_enabled)
+    feature_enabled?(:signups)
   end
 
   def flow_activities_enabled? do
-    feature_enabled?(:feature_flow_activities_enabled)
+    feature_enabled?(:flow_activities)
   end
 
   def todos_enabled? do
-    feature_enabled?(:feature_todos_enabled)
+    feature_enabled?(:todos)
   end
 
   def traffic_filters_enabled? do
-    feature_enabled?(:feature_traffic_filters_enabled)
+    feature_enabled?(:traffic_filters)
   end
 
   ## Test helpers
@@ -187,6 +186,11 @@ defmodule Domain.Config do
         :error ->
           application_env
       end
+    end
+
+    def feature_flag_override(feature, value) do
+      enabled_features = fetch_env!(:domain, :enabled_features) |> Keyword.put(feature, value)
+      put_env_override(:enabled_features, enabled_features)
     end
 
     defp pdict_key_function(app, key), do: {app, key}

--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -115,16 +115,25 @@ defmodule Domain.Config do
 
   ## Feature flag helpers
 
+  defp feature_enabled?(feature) do
+    compile_config!(Definitions, feature) ||
+      compile_config!(Definitions, :all_features_enabled, %{})
+  end
+
   def sign_up_enabled? do
-    compile_config!(Definitions, :feature_sign_up_enabled)
+    feature_enabled?(:feature_sign_up_enabled)
   end
 
   def flow_activities_enabled? do
-    compile_config!(Definitions, :feature_flow_activities_enabled)
+    feature_enabled?(:feature_flow_activities_enabled)
   end
 
   def todos_enabled? do
-    compile_config!(Definitions, :feature_todos_enabled)
+    feature_enabled?(:feature_todos_enabled)
+  end
+
+  def traffic_filters_enabled? do
+    feature_enabled?(:feature_traffic_filters_enabled)
   end
 
   ## Test helpers

--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -116,7 +116,8 @@ defmodule Domain.Config do
   ## Feature flag helpers
 
   defp feature_enabled?(feature) do
-    fetch_env!(:domain, :enabled_features) |> Keyword.fetch!(feature)
+    fetch_env!(:domain, :enabled_features)
+    |> Keyword.fetch!(feature)
   end
 
   def sign_up_enabled? do

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -610,6 +610,11 @@ defmodule Domain.Config.Definitions do
   ##############################################
 
   @doc """
+  Boolean flag to enable all features
+  """
+  defconfig(:all_features_enabled, :boolean, default: false)
+
+  @doc """
   Boolean flag to turn Sign-ups on/off.
   """
   defconfig(:feature_sign_up_enabled, :boolean, default: true)
@@ -623,4 +628,9 @@ defmodule Domain.Config.Definitions do
   Boolean flag to turn UI TODOs on/off.
   """
   defconfig(:feature_todos_enabled, :boolean, default: false)
+
+  @doc """
+  Boolean flag to turn Resource traffic filters on/off.
+  """
+  defconfig(:feature_traffic_filters_enabled, :boolean, default: false)
 end

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -610,11 +610,6 @@ defmodule Domain.Config.Definitions do
   ##############################################
 
   @doc """
-  Boolean flag to enable all features
-  """
-  defconfig(:all_features_enabled, :boolean, default: false)
-
-  @doc """
   Boolean flag to turn Sign-ups on/off.
   """
   defconfig(:feature_sign_up_enabled, :boolean, default: true)

--- a/elixir/apps/web/lib/web/live/resources/components.ex
+++ b/elixir/apps/web/lib/web/live/resources/components.ex
@@ -6,10 +6,10 @@ defmodule Web.Resources.Components do
 
   def map_filters_form_attrs(attrs) do
     attrs =
-      if !Domain.Config.traffic_filters_enabled?() do
-        Map.put(attrs, "filters", %{"all" => %{"enabled" => "true", "protocol" => "all"}})
-      else
+      if Domain.Config.traffic_filters_enabled?() do
         attrs
+      else
+        Map.put(attrs, "filters", %{"all" => %{"enabled" => "true", "protocol" => "all"}})
       end
 
     Map.update(attrs, "filters", [], fn filters ->

--- a/elixir/apps/web/lib/web/live/resources/components.ex
+++ b/elixir/apps/web/lib/web/live/resources/components.ex
@@ -5,6 +5,13 @@ defmodule Web.Resources.Components do
   defp pretty_print_ports(ports), do: Enum.join(ports, ", ")
 
   def map_filters_form_attrs(attrs) do
+    attrs =
+      if !Domain.Config.traffic_filters_enabled?() do
+        Map.put(attrs, "filters", %{"all" => %{"enabled" => "true", "protocol" => "all"}})
+      else
+        attrs
+      end
+
     Map.update(attrs, "filters", [], fn filters ->
       filters =
         for {id, filter_attrs} <- filters,

--- a/elixir/apps/web/lib/web/live/resources/components.ex
+++ b/elixir/apps/web/lib/web/live/resources/components.ex
@@ -153,6 +153,15 @@ defmodule Web.Resources.Components do
     """
   end
 
+  attr :form, :any, required: true
+
+  def beta_filters_form(assigns) do
+    ~H"""
+    <.input type="hidden" name={"#{@form.name}[all][protocol]"} value="all" />
+    <.input type="hidden" name={"#{@form.name}[all][enabled]"} value="true" />
+    """
+  end
+
   def map_connections_form_attrs(attrs) do
     Map.update(attrs, "connections", [], fn connections ->
       for {id, connection_attrs} <- connections,

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -1,14 +1,13 @@
 defmodule Web.Resources.New do
   use Web, :live_view
   import Web.Resources.Components
-  alias Domain.Gateways
-  alias Domain.Resources
+  alias Domain.{Gateways, Resources}
 
   def mount(params, _session, socket) do
     with {:ok, gateway_groups} <- Gateways.list_groups(socket.assigns.subject) do
       changeset = Resources.new_resource(socket.assigns.account)
 
-      {:ok, assign(socket, params: Map.take(params, ["site_id"])),
+      {:ok, assign(socket, params: Map.take(params, ["site_id"], traffic_filters_enabled?: true)),
        temporary_assigns: [
          gateway_groups: gateway_groups,
          form: to_form(changeset)
@@ -51,7 +50,7 @@ defmodule Web.Resources.New do
               phx-debounce="300"
             />
 
-            <.filters_form form={@form[:filters]} />
+            <.filters_form :if={@traffic_filters_enabled?} form={@form[:filters]} />
 
             <.connections_form
               :if={is_nil(@params["site_id"])}

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -1,17 +1,22 @@
 defmodule Web.Resources.New do
   use Web, :live_view
   import Web.Resources.Components
-  alias Domain.{Gateways, Resources}
+  alias Domain.{Gateways, Resources, Config}
 
   def mount(params, _session, socket) do
     with {:ok, gateway_groups} <- Gateways.list_groups(socket.assigns.subject) do
       changeset = Resources.new_resource(socket.assigns.account)
 
-      {:ok, assign(socket, params: Map.take(params, ["site_id"], traffic_filters_enabled?: true)),
-       temporary_assigns: [
-         gateway_groups: gateway_groups,
-         form: to_form(changeset)
-       ]}
+      socket =
+        assign(
+          socket,
+          gateway_groups: gateway_groups,
+          form: to_form(changeset),
+          params: Map.take(params, ["site_id"]),
+          traffic_filters_enabled?: Config.traffic_filters_enabled?()
+        )
+
+      {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
@@ -80,7 +80,7 @@ defmodule Web.Live.SignUpTest do
   end
 
   test "renders signup disabled message", %{conn: conn} do
-    Domain.Config.put_system_env_override(:feature_sign_up_enabled, false)
+    Domain.Config.feature_flag_override(:signups, false)
 
     {:ok, _lv, html} = live(conn, ~p"/sign_up")
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -71,6 +71,12 @@ config :domain, Domain.Instrumentation,
   client_logs_enabled: true,
   client_logs_bucket: "logs"
 
+config :domain, :enabled_features,
+  traffic_filters: true,
+  signups: true,
+  flow_activities: true,
+  todos: true
+
 ###############################
 ##### Web #####################
 ###############################

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -65,6 +65,12 @@ if config_env() == :prod do
     client_logs_enabled: compile_config!(:instrumentation_client_logs_enabled),
     client_logs_bucket: compile_config!(:instrumentation_client_logs_bucket)
 
+  config :domain, :enabled_features,
+    traffic_filters: compile_config!(:feature_traffic_filters_enabled),
+    signups: compile_config!(:feature_signups_enabled),
+    flow_activities: compile_config!(:feature_flow_activities_enabled),
+    todos: compile_config!(:feature_todos_enabled)
+
   ###############################
   ##### Web #####################
   ###############################

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -67,7 +67,7 @@ if config_env() == :prod do
 
   config :domain, :enabled_features,
     traffic_filters: compile_config!(:feature_traffic_filters_enabled),
-    signups: compile_config!(:feature_signups_enabled),
+    signups: compile_config!(:feature_sign_up_enabled),
     flow_activities: compile_config!(:feature_flow_activities_enabled),
     todos: compile_config!(:feature_todos_enabled)
 


### PR DESCRIPTION
Why:

* The traffic filter functionality is not quite ready in the system as a whole, so the web UI will give the ability to hide the section of the forms to allow for a better end user experience.