### PR TITLE
Remove paid runners

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-22.04-firezone-4c
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir
@@ -321,7 +321,7 @@ jobs:
   acceptance-test:
     permissions:
       checks: write
-    runs-on: ubuntu-22.04-firezone-4c
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
   # less overhead to keep things in GH actions. See work on building these
   # in GCP with Cloud Build: https://github.com/firezone/firezone/pull/2234
   build-images:
-    runs-on: ubuntu-22.04-firezone-4c
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
These aren't worth the cost for us at the moment -- they shave maybe 10-15% off the total CI time and the $$ would be better spent on dedicated servers which we can also use to run regression tests, etc.

<img width="949" alt="Screenshot 2023-11-02 at 2 21 21 PM" src="https://github.com/firezone/firezone/assets/167144/9cbb17ef-6e0c-4d20-a938-45a64ed76c25">
