### PR TITLE
refactor(connlib): encapsulate `Device`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
 name = "firezone-tunnel"
 version = "1.20231001.0"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "boringtun",
  "bytes",

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { workspace = true }
 pnet_packet = { version = "0.34" }
 futures-bounded = { workspace = true }
 hickory-resolver = { workspace = true }
+arc-swap = "1.6.0"
 
 # TODO: research replacing for https://github.com/algesten/str0m
 webrtc = { workspace = true }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -115,7 +115,6 @@ where
             .load()
             .as_ref()
             .ok_or(Error::ControlProtocolError)?
-            .config
             .add_route(route, self.callbacks())
             .await?;
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -77,7 +77,7 @@ where
                 return Ok(());
             };
 
-            device.io.write(pkt)?;
+            device.write(pkt)?;
         }
 
         Ok(())

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -177,7 +177,7 @@ where
                     ));
                 }
 
-                tokio::spawn(tunnel.clone().start_peer_handler(peer, d));
+                tokio::spawn(tunnel.start_peer_handler(peer, d));
 
                 tunnel
                     .role_state

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -71,7 +71,7 @@ where
                                 let _ = tunnel.callbacks().on_error(&e);
                                 return;
                             };
-                            let iface_config = device.config;
+                            let iface_config = &device.config;
                             for &ip in &peer_config.ips {
                                 if let Err(e) = iface_config.add_route(ip, tunnel.callbacks()).await
                                 {

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -71,9 +71,8 @@ where
                                 let _ = tunnel.callbacks().on_error(&e);
                                 return;
                             };
-                            let iface_config = &device.config;
                             for &ip in &peer_config.ips {
-                                if let Err(e) = iface_config.add_route(ip, tunnel.callbacks()).await
+                                if let Err(e) = device.add_route(ip, tunnel.callbacks()).await
                                 {
                                     let _ = tunnel.callbacks.on_error(&e);
                                 }

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -65,7 +65,7 @@ where
                     tracing::trace!(?peer_config.ips, "new_data_channel_open");
                     Box::pin(async move {
                         {
-                            let Some(device) = tunnel.device.read().clone() else {
+                            let Some(device) = tunnel.device.load().clone() else {
                                 let e = Error::NoIface;
                                 tracing::error!(err = ?e, "channel_open");
                                 let _ = tunnel.callbacks().on_error(&e);

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -72,9 +72,13 @@ where
                                 return;
                             };
                             for &ip in &peer_config.ips {
-                                if let Err(e) = device.add_route(ip, tunnel.callbacks()).await
-                                {
-                                    let _ = tunnel.callbacks.on_error(&e);
+                                match device.add_route(ip, tunnel.callbacks()).await {
+                                    Ok(maybe_new_device) => {
+                                        assert!(maybe_new_device.is_none(), "gateway does not run on android and thus never produces a new device upon `add_route`")
+                                    }
+                                    Err(e) => {
+                                        let _ = tunnel.callbacks.on_error(&e);
+                                    }
                                 }
                             }
                         }

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -8,8 +8,45 @@ mod device_channel;
 #[path = "device_channel/device_channel_win.rs"]
 mod device_channel;
 
+use crate::ip_packet::MutableIpPacket;
 pub(crate) use device_channel::*;
 use std::borrow::Cow;
+use std::io;
+use std::sync::Arc;
+use std::task::{ready, Context, Poll};
+
+#[derive(Clone)]
+pub struct Device {
+    pub(crate) config: Arc<IfaceConfig>, // TODO: Make private
+    io: DeviceIo,
+}
+
+impl Device {
+    pub(crate) fn poll_read<'b>(
+        &mut self,
+        buf: &'b mut [u8],
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<Option<MutableIpPacket<'b>>>> {
+        let res = ready!(self.io.poll_read(&mut buf[..self.config.mtu()], cx))?;
+
+        if res == 0 {
+            return Poll::Ready(Ok(None));
+        }
+
+        Poll::Ready(Ok(Some(MutableIpPacket::new(&mut buf[..res]).ok_or_else(
+            || {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "received bytes are not an IP packet",
+                )
+            },
+        )?)))
+    }
+
+    pub fn write(&self, packet: Packet<'_>) -> io::Result<usize> {
+        self.io.write(packet)
+    }
+}
 
 pub enum Packet<'a> {
     Ipv4(Cow<'a, [u8]>),

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -17,7 +17,7 @@ use std::io;
 use std::task::{ready, Context, Poll};
 
 pub struct Device {
-    pub(crate) config: IfaceConfig, // TODO: Make private
+    config: IfaceConfig,
     io: DeviceIo,
 }
 

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -15,7 +15,6 @@ use std::io;
 use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 
-#[derive(Clone)]
 pub struct Device {
     pub(crate) config: Arc<IfaceConfig>, // TODO: Make private
     io: DeviceIo,

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -9,7 +9,9 @@ mod device_channel;
 mod device_channel;
 
 use crate::ip_packet::MutableIpPacket;
+use connlib_shared::{Callbacks, Error};
 pub(crate) use device_channel::*;
+use ip_network::IpNetwork;
 use std::borrow::Cow;
 use std::io;
 use std::task::{ready, Context, Poll};
@@ -39,6 +41,14 @@ impl Device {
                 )
             },
         )?)))
+    }
+
+    pub(crate) async fn add_route(
+        &self,
+        route: IpNetwork,
+        callbacks: &impl Callbacks<Error = Error>,
+    ) -> Result<Option<Device>, Error> {
+        self.config.add_route(route, callbacks).await
     }
 
     pub fn write(&self, packet: Packet<'_>) -> io::Result<usize> {

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -12,11 +12,10 @@ use crate::ip_packet::MutableIpPacket;
 pub(crate) use device_channel::*;
 use std::borrow::Cow;
 use std::io;
-use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 
 pub struct Device {
-    pub(crate) config: Arc<IfaceConfig>, // TODO: Make private
+    pub(crate) config: IfaceConfig, // TODO: Make private
     io: DeviceIo,
 }
 

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -23,7 +23,7 @@ pub struct Device {
 
 impl Device {
     pub(crate) fn poll_read<'b>(
-        &mut self,
+        &self,
         buf: &'b mut [u8],
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<Option<MutableIpPacket<'b>>>> {

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -51,6 +51,10 @@ impl Device {
         self.config.add_route(route, callbacks).await
     }
 
+    pub(crate) async fn refresh_mtu(&self) -> Result<usize, Error> {
+        self.config.refresh_mtu().await
+    }
+
     pub fn write(&self, packet: Packet<'_>) -> io::Result<usize> {
         self.io.write(packet)
     }

--- a/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
+++ b/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
@@ -11,8 +11,7 @@ use tokio::io::{unix::AsyncFd, Ready};
 
 use tun::{IfaceDevice, IfaceStream};
 
-use crate::device_channel::Packet;
-use crate::Device;
+use crate::device_channel::{Device, Packet};
 
 mod tun;
 

--- a/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
+++ b/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
@@ -5,7 +5,7 @@ use std::sync::{
 };
 use std::task::{ready, Context, Poll};
 
-use connlib_shared::{messages::Interface, CallbackErrorFacade, Callbacks, Result};
+use connlib_shared::{messages::Interface, Callbacks, Error, Result};
 use ip_network::IpNetwork;
 use tokio::io::{unix::AsyncFd, Ready};
 
@@ -65,7 +65,7 @@ impl IfaceConfig {
     pub(crate) async fn add_route(
         &self,
         route: IpNetwork,
-        callbacks: &CallbackErrorFacade<impl Callbacks>,
+        callbacks: &impl Callbacks<Error = Error>,
     ) -> Result<Option<Device>> {
         let Some((iface, stream)) = self.iface.add_route(route, callbacks).await? else {
             return Ok(None);
@@ -82,7 +82,7 @@ impl IfaceConfig {
 
 pub(crate) async fn create_iface(
     config: &Interface,
-    callbacks: &CallbackErrorFacade<impl Callbacks>,
+    callbacks: &impl Callbacks<Error = Error>,
 ) -> Result<Device> {
     let (iface, stream) = IfaceDevice::new(config, callbacks).await?;
     iface.up().await?;

--- a/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
+++ b/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
@@ -73,10 +73,10 @@ impl IfaceConfig {
         };
         let io = DeviceIo(stream);
         let mtu = iface.mtu().await?;
-        let config = Arc::new(IfaceConfig {
+        let config = IfaceConfig {
             iface,
             mtu: AtomicUsize::new(mtu),
-        });
+        };
         Ok(Some(Device { io, config }))
     }
 }
@@ -89,10 +89,10 @@ pub(crate) async fn create_iface(
     iface.up().await?;
     let io = DeviceIo(stream);
     let mtu = iface.mtu().await?;
-    let config = Arc::new(IfaceConfig {
+    let config = IfaceConfig {
         iface,
         mtu: AtomicUsize::new(mtu),
-    });
+    };
 
     Ok(Device { io, config })
 }

--- a/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
+++ b/rust/connlib/tunnel/src/device_channel/device_channel_unix.rs
@@ -20,7 +20,6 @@ pub(crate) struct IfaceConfig {
     iface: IfaceDevice,
 }
 
-#[derive(Clone)]
 pub(crate) struct DeviceIo(Arc<AsyncFd<IfaceStream>>);
 
 impl DeviceIo {

--- a/rust/connlib/tunnel/src/device_channel/device_channel_win.rs
+++ b/rust/connlib/tunnel/src/device_channel/device_channel_win.rs
@@ -4,7 +4,6 @@ use connlib_shared::{messages::Interface, CallbackErrorFacade, Callbacks, Result
 use ip_network::IpNetwork;
 use std::task::{Context, Poll};
 
-#[derive(Clone)]
 pub(crate) struct DeviceIo;
 
 pub(crate) struct IfaceConfig;

--- a/rust/connlib/tunnel/src/device_channel/device_channel_win.rs
+++ b/rust/connlib/tunnel/src/device_channel/device_channel_win.rs
@@ -1,6 +1,6 @@
 use crate::device_channel::Packet;
 use crate::Device;
-use connlib_shared::{messages::Interface, CallbackErrorFacade, Callbacks, Result};
+use connlib_shared::{messages::Interface, Callbacks, Result};
 use ip_network::IpNetwork;
 use std::task::{Context, Poll};
 
@@ -30,15 +30,12 @@ impl IfaceConfig {
     pub(crate) async fn add_route(
         &self,
         _: IpNetwork,
-        _: &CallbackErrorFacade<impl Callbacks>,
+        _: &impl Callbacks,
     ) -> Result<Option<Device>> {
         todo!()
     }
 }
 
-pub(crate) async fn create_iface(
-    _: &Interface,
-    _: &CallbackErrorFacade<impl Callbacks>,
-) -> Result<Device> {
+pub(crate) async fn create_iface(_: &Interface, _: &impl Callbacks) -> Result<Device> {
     todo!()
 }

--- a/rust/connlib/tunnel/src/device_channel/tun/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun/tun_android.rs
@@ -1,7 +1,6 @@
 use closeable::Closeable;
 use connlib_shared::{
-    messages::Interface as InterfaceConfig, CallbackErrorFacade, Callbacks, Error, Result,
-    DNS_SENTINEL,
+    messages::Interface as InterfaceConfig, Callbacks, Error, Result, DNS_SENTINEL,
 };
 use ip_network::IpNetwork;
 use libc::{
@@ -108,7 +107,7 @@ impl IfaceStream {
 impl IfaceDevice {
     pub async fn new(
         config: &InterfaceConfig,
-        callbacks: &CallbackErrorFacade<impl Callbacks>,
+        callbacks: &impl Callbacks<Error = Error>,
     ) -> Result<(Self, Arc<AsyncFd<IfaceStream>>)> {
         let fd = callbacks
             .on_set_interface_config(
@@ -175,7 +174,7 @@ impl IfaceDevice {
     pub async fn add_route(
         &self,
         route: IpNetwork,
-        callbacks: &CallbackErrorFacade<impl Callbacks>,
+        callbacks: &impl Callbacks<Error = Error>,
     ) -> Result<Option<(Self, Arc<AsyncFd<IfaceStream>>)>> {
         self.0.get_ref().close();
         let fd = callbacks.on_add_route(route)?.ok_or(Error::NoFd)?;

--- a/rust/connlib/tunnel/src/device_channel/tun/tun_darwin.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun/tun_darwin.rs
@@ -1,6 +1,5 @@
 use connlib_shared::{
-    messages::Interface as InterfaceConfig, CallbackErrorFacade, Callbacks, Error, Result,
-    DNS_SENTINEL,
+    messages::Interface as InterfaceConfig, Callbacks, Error, Result, DNS_SENTINEL,
 };
 use ip_network::IpNetwork;
 use libc::{
@@ -138,7 +137,7 @@ impl IfaceStream {
 impl IfaceDevice {
     pub async fn new(
         config: &InterfaceConfig,
-        callbacks: &CallbackErrorFacade<impl Callbacks>,
+        callbacks: &impl Callbacks<Error = Error>,
     ) -> Result<(Self, Arc<AsyncFd<IfaceStream>>)> {
         let mut info = ctl_info {
             ctl_id: 0,
@@ -241,7 +240,7 @@ impl IfaceDevice {
     pub async fn add_route(
         &self,
         route: IpNetwork,
-        callbacks: &CallbackErrorFacade<impl Callbacks>,
+        callbacks: &impl Callbacks<Error = Error>,
     ) -> Result<Option<(Self, Arc<AsyncFd<IfaceStream>>)>> {
         // This will always be None in macos
         callbacks.on_add_route(route)?;

--- a/rust/connlib/tunnel/src/device_channel/tun/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun/tun_linux.rs
@@ -1,6 +1,4 @@
-use connlib_shared::{
-    messages::Interface as InterfaceConfig, CallbackErrorFacade, Callbacks, Error, Result,
-};
+use connlib_shared::{messages::Interface as InterfaceConfig, Callbacks, Error, Result};
 use futures::TryStreamExt;
 use ip_network::IpNetwork;
 use libc::{
@@ -103,7 +101,7 @@ impl IfaceStream {
 impl IfaceDevice {
     pub async fn new(
         config: &InterfaceConfig,
-        cb: &CallbackErrorFacade<impl Callbacks>,
+        cb: &impl Callbacks,
     ) -> Result<(Self, Arc<AsyncFd<IfaceStream>>)> {
         debug_assert!(IFACE_NAME.as_bytes().len() < IFNAMSIZ);
 
@@ -175,7 +173,7 @@ impl IfaceDevice {
     pub async fn add_route(
         &self,
         route: IpNetwork,
-        _callbacks: &CallbackErrorFacade<impl Callbacks>,
+        _: &impl Callbacks,
     ) -> Result<Option<(Self, Arc<AsyncFd<IfaceStream>>)>> {
         let req = self
             .handle
@@ -215,11 +213,11 @@ impl IfaceDevice {
         Ok(None)
     }
 
-    #[tracing::instrument(level = "trace", skip(self, _callbacks))]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub async fn set_iface_config(
         &self,
         config: &InterfaceConfig,
-        _callbacks: &CallbackErrorFacade<impl Callbacks>,
+        _: &impl Callbacks,
     ) -> Result<()> {
         let ips = self
             .handle

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -6,6 +6,7 @@ use connlib_shared::messages::{ClientId, Interface as InterfaceConfig};
 use connlib_shared::Callbacks;
 use futures::channel::mpsc::Receiver;
 use futures_bounded::{PushError, StreamMap};
+use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 use std::time::Duration;
 use webrtc::ice_transport::ice_candidate::RTCIceCandidateInit;
@@ -17,7 +18,7 @@ where
     /// Sets the interface configuration and starts background tasks.
     #[tracing::instrument(level = "trace", skip(self))]
     pub async fn set_interface(&self, config: &InterfaceConfig) -> connlib_shared::Result<()> {
-        let device = create_iface(config, self.callbacks()).await?;
+        let device = Arc::new(create_iface(config, self.callbacks()).await?);
 
         *self.device.write() = Some(device.clone());
         self.no_device_waker.wake();

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -20,7 +20,7 @@ where
     pub async fn set_interface(&self, config: &InterfaceConfig) -> connlib_shared::Result<()> {
         let device = Arc::new(create_iface(config, self.callbacks()).await?);
 
-        *self.device.write() = Some(device.clone());
+        self.device.store(Some(device.clone()));
         self.no_device_waker.wake();
 
         tracing::debug!("background_loop_started");

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -403,7 +403,7 @@ where
                     let callbacks = self.callbacks.clone();
 
                     async move {
-                        if let Err(e) = device.config.refresh_mtu().await {
+                        if let Err(e) = device.refresh_mtu().await {
                             tracing::error!(error = ?e, "refresh_mtu");
                             let _ = callbacks.on_error(&e);
                         }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -129,7 +129,7 @@ pub struct Tunnel<CB: Callbacks, TRoleState: RoleState> {
 
     peers_to_stop: Mutex<VecDeque<TRoleState::Id>>,
 
-    device: RwLock<Option<Device>>,
+    device: RwLock<Option<Arc<Device>>>,
     read_buf: Mutex<Box<[u8; MAX_UDP_SIZE]>>,
     write_buf: Mutex<Box<[u8; MAX_UDP_SIZE]>>,
     no_device_waker: AtomicWaker,
@@ -144,7 +144,7 @@ where
             {
                 let mut guard = self.device.write();
 
-                if let Some(device) = guard.as_mut() {
+                if let Some(device) = guard.as_ref() {
                     match self.poll_device(device, cx) {
                         Poll::Ready(Ok(Some(event))) => return Poll::Ready(Ok(event)),
                         Poll::Ready(Ok(None)) => {
@@ -175,7 +175,7 @@ where
 
     pub(crate) fn poll_device(
         &self,
-        device: &mut Device,
+        device: &Device,
         cx: &mut Context<'_>,
     ) -> Poll<Result<Option<Event<GatewayId>>>> {
         loop {

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -19,8 +19,10 @@ where
         peer: Arc<Peer<TRoleState::Id>>,
         channel: Arc<DataChannel>,
     ) {
+        let device = Arc::clone(&self.device);
+
         loop {
-            let Some(device) = self.device.read().clone() else {
+            let Some(device) = device.load().clone() else {
                 tracing::debug!("Device temporarily not available");
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 continue;

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -14,45 +15,44 @@ where
     CB: Callbacks + 'static,
     TRoleState: RoleState,
 {
-    pub(crate) async fn start_peer_handler(
-        self: Arc<Self>,
+    pub(crate) fn start_peer_handler(
+        &self,
         peer: Arc<Peer<TRoleState::Id>>,
         channel: Arc<DataChannel>,
-    ) {
+    ) -> impl Future<Output = ()> + Send + 'static {
         let device = Arc::clone(&self.device);
+        let callbacks = self.callbacks.clone();
+        let mut sender = self.stop_peer_command_sender.clone();
 
-        loop {
-            let Some(device) = device.load().clone() else {
-                tracing::debug!("Device temporarily not available");
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                continue;
-            };
-            let result =
-                peer_handler(self.callbacks.clone(), &peer, channel.clone(), &device).await;
+        async move {
+            loop {
+                let Some(device) = device.load().clone() else {
+                    tracing::debug!("Device temporarily not available");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    continue;
+                };
+                let result = peer_handler(&callbacks, &peer, channel.clone(), &device).await;
 
-            if matches!(result, Err(ref err) if err.raw_os_error() == Some(9)) {
-                tracing::warn!("bad_file_descriptor");
-                continue;
+                if matches!(result, Err(ref err) if err.raw_os_error() == Some(9)) {
+                    tracing::warn!("bad_file_descriptor");
+                    continue;
+                }
+
+                if let Err(e) = result {
+                    tracing::error!(err = ?e, "peer_handle_error");
+                }
+
+                break;
             }
 
-            if let Err(e) = result {
-                tracing::error!(err = ?e, "peer_handle_error");
-            }
-
-            break;
+            tracing::debug!(peer = ?peer.stats(), "peer_stopped");
+            let _ = sender.send(peer.conn_id).await;
         }
-
-        tracing::debug!(peer = ?peer.stats(), "peer_stopped");
-        let _ = self
-            .stop_peer_command_sender
-            .clone()
-            .send(peer.conn_id)
-            .await;
     }
 }
 
 async fn peer_handler<TId>(
-    callbacks: impl Callbacks,
+    callbacks: &impl Callbacks,
     peer: &Arc<Peer<TId>>,
     channel: Arc<DataChannel>,
     device: &Device,

--- a/rust/connlib/tunnel/src/peer_handler.rs
+++ b/rust/connlib/tunnel/src/peer_handler.rs
@@ -25,7 +25,8 @@ where
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 continue;
             };
-            let result = peer_handler(self.callbacks.clone(), &peer, channel.clone(), device).await;
+            let result =
+                peer_handler(self.callbacks.clone(), &peer, channel.clone(), &device).await;
 
             if matches!(result, Err(ref err) if err.raw_os_error() == Some(9)) {
                 tracing::warn!("bad_file_descriptor");
@@ -52,7 +53,7 @@ async fn peer_handler<TId>(
     callbacks: impl Callbacks,
     peer: &Arc<Peer<TId>>,
     channel: Arc<DataChannel>,
-    device: Device,
+    device: &Device,
 ) -> std::io::Result<()>
 where
     TId: Copy,


### PR DESCRIPTION
We encapsulate the internals of `Device` by providing high-level functions on `Device` itself and make all the fields private. From the outside, each consumer this only has an `Arc<Device>` that they can interact with.

To achieve this, we use the `arc-swap` crate to atomically swap out the reference to the `Arc<Device>` instead of relying on an `RwLock`. Note that the _reference_ to this `ArcSwapOption` is also wrapped in an `Arc` because we need to share this pointer across many `peer_handler`s.

Once we get rid of `Arc<Tunnel>`, this will become a lot simpler.