### PR TITLE
Use account slugs as URI param and fix auth redirects bug

### DIFF
--- a/elixir/apps/web/lib/web/auth.ex
+++ b/elixir/apps/web/lib/web/auth.ex
@@ -30,7 +30,7 @@ defmodule Web.Auth do
         client_platform,
         client_csrf_token
       )
-      when not is_nil(client_platform) do
+      when not is_nil(client_platform) and client_platform != "" do
     platform_redirects =
       Domain.Config.fetch_env!(:web, __MODULE__)
       |> Keyword.fetch!(:platform_redirects)

--- a/elixir/apps/web/lib/web/auth.ex
+++ b/elixir/apps/web/lib/web/auth.ex
@@ -3,7 +3,7 @@ defmodule Web.Auth do
   alias Domain.{Auth, Accounts}
 
   def signed_in_path(%Auth.Subject{actor: %{type: :account_admin_user}} = subject) do
-    ~p"/#{subject.account.slug || subject.account}/sites"
+    ~p"/#{subject.account}/sites"
   end
 
   def put_subject_in_session(conn, %Auth.Subject{} = subject) do

--- a/elixir/apps/web/lib/web/auth.ex
+++ b/elixir/apps/web/lib/web/auth.ex
@@ -1,6 +1,6 @@
 defmodule Web.Auth do
   use Web, :verified_routes
-  alias Domain.Auth
+  alias Domain.{Auth, Accounts}
 
   def signed_in_path(%Auth.Subject{actor: %{type: :account_admin_user}} = subject) do
     ~p"/#{subject.account.slug || subject.account}/sites"
@@ -24,6 +24,21 @@ defmodule Web.Auth do
   If the platform is known, we direct them to the application through a deep link or an app link;
   if not, we guide them to the install instructions accompanied by an error message.
   """
+
+  def signed_in_redirect(
+        %Plug.Conn{path_params: %{"account_id_or_slug" => account_id_or_slug}} = conn,
+        %Auth.Subject{account: %Accounts.Account{} = account},
+        _client_platform,
+        _client_csrf_token
+      )
+      when not is_nil(account_id_or_slug) and account_id_or_slug != account.id and
+             account_id_or_slug != account.slug do
+    conn
+    |> Web.Auth.renew_session()
+    |> Plug.Conn.delete_session(:user_return_to)
+    |> Phoenix.Controller.redirect(to: ~p"/#{account_id_or_slug}")
+  end
+
   def signed_in_redirect(
         conn,
         %Auth.Subject{} = subject,

--- a/elixir/apps/web/lib/web/auth.ex
+++ b/elixir/apps/web/lib/web/auth.ex
@@ -59,7 +59,7 @@ defmodule Web.Auth do
         :info,
         "Please use a client application to access Firezone."
       )
-      |> Phoenix.Controller.redirect(to: ~p"/#{conn.path_params["account_id_or_slug"]}")
+      |> Phoenix.Controller.redirect(to: ~p"/#{subject.account}")
     end
   end
 
@@ -78,13 +78,13 @@ defmodule Web.Auth do
     |> Phoenix.Controller.redirect(to: redirect_to)
   end
 
-  def signed_in_redirect(conn, %Auth.Subject{} = _subject, _client_platform, _client_csrf_token) do
+  def signed_in_redirect(conn, %Auth.Subject{} = subject, _client_platform, _client_csrf_token) do
     conn
     |> Phoenix.Controller.put_flash(
       :info,
       "Please use a client application to access Firezone."
     )
-    |> Phoenix.Controller.redirect(to: ~p"/#{conn.path_params["account_id_or_slug"]}")
+    |> Phoenix.Controller.redirect(to: ~p"/#{subject.account}")
   end
 
   @doc """

--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -193,7 +193,7 @@ defmodule Web.AuthController do
   def redirect_to_idp(
         conn,
         %{
-          "account_id_or_slug" => account_id_or_slug,
+          "account_id_or_slug" => account_id,
           "provider_id" => provider_id
         } = params
       ) do
@@ -202,7 +202,7 @@ defmodule Web.AuthController do
       conn = put_session(conn, :client_csrf_token, params["client_csrf_token"])
 
       redirect_url =
-        url(~p"/#{account_id_or_slug}/sign_in/providers/#{provider.id}/handle_callback")
+        url(~p"/#{account_id}/sign_in/providers/#{provider.id}/handle_callback")
 
       redirect_to_idp(conn, redirect_url, provider)
     else
@@ -211,7 +211,7 @@ defmodule Web.AuthController do
 
         conn
         |> put_flash(:error, "You may not use this method to sign in.")
-        |> redirect(to: ~p"/#{account_id_or_slug}?#{redirect_params}")
+        |> redirect(to: ~p"/#{account_id}?#{redirect_params}")
     end
   end
 
@@ -231,7 +231,7 @@ defmodule Web.AuthController do
   This controller handles IdP redirect back to the Firezone when user signs in.
   """
   def handle_idp_callback(conn, %{
-        "account_id_or_slug" => account_id_or_slug,
+        "account_id_or_slug" => account_id,
         "provider_id" => provider_id,
         "state" => state,
         "code" => code
@@ -245,7 +245,7 @@ defmodule Web.AuthController do
 
     with {:ok, code_verifier, conn} <- verify_state_and_fetch_verifier(conn, provider_id, state) do
       payload = {
-        url(~p"/#{account_id_or_slug}/sign_in/providers/#{provider_id}/handle_callback"),
+        url(~p"/#{account_id}/sign_in/providers/#{provider_id}/handle_callback"),
         code_verifier,
         code
       }
@@ -263,18 +263,18 @@ defmodule Web.AuthController do
         {:error, :not_found} ->
           conn
           |> put_flash(:error, "You may not use this method to sign in.")
-          |> redirect(to: ~p"/#{account_id_or_slug}?#{redirect_params}")
+          |> redirect(to: ~p"/#{account_id}?#{redirect_params}")
 
         {:error, _reason} ->
           conn
           |> put_flash(:error, "You may not authenticate to this account.")
-          |> redirect(to: ~p"/#{account_id_or_slug}?#{redirect_params}")
+          |> redirect(to: ~p"/#{account_id}?#{redirect_params}")
       end
     else
       {:error, :invalid_state, conn} ->
         conn
         |> put_flash(:error, "Your session has expired, please try again.")
-        |> redirect(to: ~p"/#{account_id_or_slug}?#{redirect_params}")
+        |> redirect(to: ~p"/#{account_id}?#{redirect_params}")
     end
   end
 

--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -42,7 +42,7 @@ defmodule Web.AuthController do
         } = params
       ) do
     redirect_params =
-      Map.take(params, ["client_platform", "client_csrf_token"])
+      take_non_empty_params(params, ["client_platform", "client_csrf_token"])
 
     with {:ok, provider} <- Domain.Auth.fetch_active_provider_by_id(provider_id),
          {:ok, subject} <-
@@ -94,7 +94,8 @@ defmodule Web.AuthController do
                preload: :account
              ),
            {:ok, identity} <- Domain.Auth.Adapters.Email.request_sign_in_token(identity) do
-        sign_in_link_params = Map.take(params, ["client_platform", "client_csrf_token"])
+        sign_in_link_params =
+          take_non_empty_params(params, ["client_platform", "client_csrf_token"])
 
         <<email_secret::binary-size(5), nonce::binary>> =
           identity.provider_virtual_state.sign_in_token
@@ -115,7 +116,8 @@ defmodule Web.AuthController do
       end
 
     redirect_params =
-      Map.take(params, ["client_platform", "client_csrf_token"])
+      params
+      |> take_non_empty_params(["client_platform", "client_csrf_token"])
       |> Map.put("provider_identifier", provider_identifier)
 
     conn
@@ -150,8 +152,8 @@ defmodule Web.AuthController do
     client_csrf_token = get_session(conn, :client_csrf_token) || params["client_csrf_token"]
 
     redirect_params =
-      put_if_not_nil(:client_platform, client_platform)
-      |> put_if_not_nil(:client_csrf_token, client_csrf_token)
+      put_if_not_empty(:client_platform, client_platform)
+      |> put_if_not_empty(:client_csrf_token, client_csrf_token)
 
     with {:ok, provider} <- Domain.Auth.fetch_active_provider_by_id(provider_id),
          nonce = get_session(conn, :sign_in_nonce) || "=",
@@ -176,7 +178,7 @@ defmodule Web.AuthController do
         |> redirect(to: ~p"/#{account_id_or_slug}?#{redirect_params}")
 
       {:error, _reason} ->
-        redirect_params = put_if_not_nil(redirect_params, "provider_identifier", identity_id)
+        redirect_params = put_if_not_empty(redirect_params, "provider_identifier", identity_id)
 
         conn
         |> put_flash(:error, "The sign in link is invalid or expired.")
@@ -193,7 +195,7 @@ defmodule Web.AuthController do
   def redirect_to_idp(
         conn,
         %{
-          "account_id_or_slug" => account_id,
+          "account_id_or_slug" => account_id_or_slug,
           "provider_id" => provider_id
         } = params
       ) do
@@ -202,16 +204,16 @@ defmodule Web.AuthController do
       conn = put_session(conn, :client_csrf_token, params["client_csrf_token"])
 
       redirect_url =
-        url(~p"/#{account_id}/sign_in/providers/#{provider.id}/handle_callback")
+        url(~p"/#{provider.account_id}/sign_in/providers/#{provider.id}/handle_callback")
 
       redirect_to_idp(conn, redirect_url, provider)
     else
       {:error, :not_found} ->
-        redirect_params = Map.take(params, ["client_platform", "client_csrf_token"])
+        redirect_params = take_non_empty_params(params, ["client_platform", "client_csrf_token"])
 
         conn
         |> put_flash(:error, "You may not use this method to sign in.")
-        |> redirect(to: ~p"/#{account_id}?#{redirect_params}")
+        |> redirect(to: ~p"/#{account_id_or_slug}?#{redirect_params}")
     end
   end
 
@@ -240,8 +242,8 @@ defmodule Web.AuthController do
     client_csrf_token = get_session(conn, :client_csrf_token)
 
     redirect_params =
-      put_if_not_nil(:client_platform, client_platform)
-      |> put_if_not_nil(:client_csrf_token, client_csrf_token)
+      put_if_not_empty(:client_platform, client_platform)
+      |> put_if_not_empty(:client_csrf_token, client_csrf_token)
 
     with {:ok, code_verifier, conn} <- verify_state_and_fetch_verifier(conn, provider_id, state) do
       payload = {
@@ -353,7 +355,12 @@ defmodule Web.AuthController do
     )
   end
 
-  defp put_if_not_nil(map \\ %{}, key, value)
-  defp put_if_not_nil(map, _key, nil), do: map
-  defp put_if_not_nil(map, key, value), do: Map.put(map, key, value)
+  defp take_non_empty_params(map, keys) do
+    map |> Map.take(keys) |> Map.reject(fn {_key, value} -> value in ["", nil] end)
+  end
+
+  defp put_if_not_empty(map \\ %{}, key, value)
+  defp put_if_not_empty(map, _key, ""), do: map
+  defp put_if_not_empty(map, _key, nil), do: map
+  defp put_if_not_empty(map, key, value), do: Map.put(map, key, value)
 end

--- a/elixir/apps/web/lib/web/live/auth/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/auth/sign_in.ex
@@ -17,8 +17,8 @@ defmodule Web.Auth.SignIn do
         end)
         |> Map.drop([:token])
 
-      query_params = Map.take(params, ["client_platform", "client_csrf_token"])
-      session_params = Map.take(session, ["client_platform", "client_csrf_token"])
+      query_params = take_non_empty_params(params, ["client_platform", "client_csrf_token"])
+      session_params = take_non_empty_params(session, ["client_platform", "client_csrf_token"])
       params = Map.merge(session_params, query_params)
 
       {:ok, socket,
@@ -32,6 +32,10 @@ defmodule Web.Auth.SignIn do
       _other ->
         raise Web.LiveErrors.NotFoundError
     end
+  end
+
+  defp take_non_empty_params(map, keys) do
+    map |> Map.take(keys) |> Map.reject(fn {_key, value} -> value in ["", nil] end)
   end
 
   def render(assigns) do

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/components.ex
@@ -47,10 +47,10 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Components do
           Please make sure that OAuth client has following redirect URL's whitelisted: <.code_block
             :for={
               {type, redirect_url} <- [
-                sign_in: url(~p"/#{@account}/sign_in/providers/#{@id}/handle_callback"),
+                sign_in: url(~p"/#{@account.id}/sign_in/providers/#{@id}/handle_callback"),
                 connect:
                   url(
-                    ~p"/#{@account}/settings/identity_providers/google_workspace/#{@id}/handle_callback"
+                    ~p"/#{@account.id}/settings/identity_providers/google_workspace/#{@id}/handle_callback"
                   )
               ]
             }

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/connect.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/connect.ex
@@ -12,7 +12,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Connect do
     with {:ok, provider} <- Domain.Auth.fetch_provider_by_id(provider_id) do
       redirect_url =
         url(
-          ~p"/#{account}/settings/identity_providers/google_workspace/#{provider}/handle_callback"
+          ~p"/#{account.id}/settings/identity_providers/google_workspace/#{provider}/handle_callback"
         )
 
       Web.AuthController.redirect_to_idp(conn, redirect_url, provider)
@@ -36,7 +36,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Connect do
            Web.AuthController.verify_state_and_fetch_verifier(conn, provider_id, state) do
       payload = {
         url(
-          ~p"/#{account}/settings/identity_providers/google_workspace/#{provider_id}/handle_callback"
+          ~p"/#{account.id}/settings/identity_providers/google_workspace/#{provider_id}/handle_callback"
         ),
         code_verifier,
         code

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/connect.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/connect.ex
@@ -12,7 +12,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Connect do
     with {:ok, provider} <- Domain.Auth.fetch_provider_by_id(provider_id) do
       redirect_url =
         url(
-          ~p"/#{account.id}/settings/identity_providers/google_workspace/#{provider}/handle_callback"
+          ~p"/#{provider.account_id}/settings/identity_providers/google_workspace/#{provider}/handle_callback"
         )
 
       Web.AuthController.redirect_to_idp(conn, redirect_url, provider)

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/edit.ex
@@ -56,7 +56,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Edit do
       socket =
         redirect(socket,
           to:
-            ~p"/#{socket.assigns.account}/settings/identity_providers/google_workspace/#{provider}/redirect"
+            ~p"/#{socket.assigns.account.id}/settings/identity_providers/google_workspace/#{provider}/redirect"
         )
 
       {:noreply, socket}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/new.ex
@@ -70,7 +70,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.New do
       socket =
         redirect(socket,
           to:
-            ~p"/#{socket.assigns.account}/settings/identity_providers/google_workspace/#{provider}/redirect"
+            ~p"/#{socket.assigns.account.id}/settings/identity_providers/google_workspace/#{provider}/redirect"
         )
 
       {:noreply, socket}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -55,7 +55,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
         <.button
           style="primary"
           navigate={
-            ~p"/#{@account}/settings/identity_providers/google_workspace/#{@provider}/redirect"
+            ~p"/#{@account.id}/settings/identity_providers/google_workspace/#{@provider}/redirect"
           }
           icon="hero-arrow-path"
         >

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/components.ex
@@ -17,10 +17,10 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Components do
           ><%= scope %></.code_block> Please make sure that OAuth client has following redirect URL's whitelisted: <.code_block
             :for={
               {type, redirect_url} <- [
-                sign_in: url(~p"/#{@account}/sign_in/providers/#{@id}/handle_callback"),
+                sign_in: url(~p"/#{@account.id}/sign_in/providers/#{@id}/handle_callback"),
                 connect:
                   url(
-                    ~p"/#{@account}/settings/identity_providers/google_workspace/#{@id}/handle_callback"
+                    ~p"/#{@account.id}/settings/identity_providers/google_workspace/#{@id}/handle_callback"
                   )
               ]
             }

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/connect.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/connect.ex
@@ -12,7 +12,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Connect do
     with {:ok, provider} <- Domain.Auth.fetch_provider_by_id(provider_id) do
       redirect_url =
         url(
-          ~p"/#{account.id}/settings/identity_providers/openid_connect/#{provider.id}/handle_callback"
+          ~p"/#{provider.account_id}/settings/identity_providers/openid_connect/#{provider.id}/handle_callback"
         )
 
       Web.AuthController.redirect_to_idp(conn, redirect_url, provider)

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/connect.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/connect.ex
@@ -12,7 +12,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Connect do
     with {:ok, provider} <- Domain.Auth.fetch_provider_by_id(provider_id) do
       redirect_url =
         url(
-          ~p"/#{account}/settings/identity_providers/openid_connect/#{provider.id}/handle_callback"
+          ~p"/#{account.id}/settings/identity_providers/openid_connect/#{provider.id}/handle_callback"
         )
 
       Web.AuthController.redirect_to_idp(conn, redirect_url, provider)
@@ -36,7 +36,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Connect do
            Web.AuthController.verify_state_and_fetch_verifier(conn, provider_id, state) do
       payload = {
         url(
-          ~p"/#{account}/settings/identity_providers/openid_connect/#{provider_id}/handle_callback"
+          ~p"/#{account.id}/settings/identity_providers/openid_connect/#{provider_id}/handle_callback"
         ),
         code_verifier,
         code

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/edit.ex
@@ -59,7 +59,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Edit do
       socket =
         redirect(socket,
           to:
-            ~p"/#{socket.assigns.account}/settings/identity_providers/openid_connect/#{provider}/redirect"
+            ~p"/#{socket.assigns.account.id}/settings/identity_providers/openid_connect/#{provider}/redirect"
         )
 
       {:noreply, socket}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/new.ex
@@ -70,7 +70,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.New do
       socket =
         redirect(socket,
           to:
-            ~p"/#{socket.assigns.account}/settings/identity_providers/openid_connect/#{provider}/redirect"
+            ~p"/#{socket.assigns.account.id}/settings/identity_providers/openid_connect/#{provider}/redirect"
         )
 
       {:noreply, socket}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -54,7 +54,9 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
       <:action>
         <.button
           style="primary"
-          navigate={~p"/#{@account}/settings/identity_providers/openid_connect/#{@provider}/redirect"}
+          navigate={
+            ~p"/#{@account.id}/settings/identity_providers/openid_connect/#{@provider}/redirect"
+          }
           icon="hero-arrow-path"
         >
           Reconnect

--- a/elixir/apps/web/lib/web/protocols.ex
+++ b/elixir/apps/web/lib/web/protocols.ex
@@ -5,3 +5,8 @@ end
 defimpl Phoenix.HTML.Safe, for: Domain.Types.IPPort do
   def to_iodata(%Domain.Types.IPPort{} = ip_port), do: Domain.Types.IPPort.to_string(ip_port)
 end
+
+defimpl Phoenix.Param, for: Domain.Accounts.Account do
+  def to_param(%Domain.Accounts.Account{slug: slug}) when not is_nil(slug), do: slug
+  def to_param(%Domain.Accounts.Account{id: id}), do: id
+end

--- a/elixir/apps/web/test/web/acceptance/auth/openid_connect_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/openid_connect_test.exs
@@ -17,7 +17,7 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
     |> assert_el(Query.text("#{account.name} Admin Portal"))
-    |> assert_path(~p"/#{account}")
+    |> assert_path(~p"/#{account.id}")
     |> assert_el(Query.text("You may not authenticate to this account."))
   end
 

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -442,7 +442,7 @@ defmodule Web.AuthControllerTest do
         assert email.subject == "Firezone Sign In Link"
 
         verify_sign_in_token_path =
-          ~p"/#{account.id}/sign_in/providers/#{provider.id}/verify_sign_in_token"
+          ~p"/#{account}/sign_in/providers/#{provider.id}/verify_sign_in_token"
 
         assert email.text_body =~ "#{verify_sign_in_token_path}"
         assert email.text_body =~ "identity_id=#{identity.id}"

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -377,7 +377,7 @@ defmodule Web.AuthControllerTest do
                "info" => "Please use a client application to access Firezone."
              }
 
-      assert redirected_to(conn) == ~p"/#{account.id}"
+      assert redirected_to(conn) == ~p"/#{account}"
       assert is_nil(get_session(conn, :user_return_to))
     end
 

--- a/elixir/apps/web/test/web/live/actors/index_test.exs
+++ b/elixir/apps/web/test/web/live/actors/index_test.exs
@@ -46,7 +46,7 @@ defmodule Web.Live.Actors.IndexTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/actors")
 
-    assert button = Floki.find(html, "a[href='/#{account.id}/actors/new']")
+    assert button = Floki.find(html, "a[href='/#{account.slug}/actors/new']")
     assert Floki.text(button) =~ "Add Actor"
   end
 

--- a/elixir/apps/web/test/web/live/groups/index_test.exs
+++ b/elixir/apps/web/test/web/live/groups/index_test.exs
@@ -46,7 +46,7 @@ defmodule Web.Live.Groups.IndexTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/groups")
 
-    assert button = Floki.find(html, "a[href='/#{account.id}/groups/new']")
+    assert button = Floki.find(html, "a[href='/#{account.slug}/groups/new']")
     assert Floki.text(button) =~ "Add Group"
   end
 

--- a/elixir/apps/web/test/web/live/nav/sidebar_test.exs
+++ b/elixir/apps/web/test/web/live/nav/sidebar_test.exs
@@ -38,7 +38,7 @@ defmodule Web.Live.Nav.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/actors")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.id}/actors']")
+    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/actors']")
     assert String.trim(Floki.text(item)) == "Actors"
   end
 
@@ -48,7 +48,7 @@ defmodule Web.Live.Nav.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/groups")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.id}/groups']")
+    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/groups']")
     assert String.trim(Floki.text(item)) == "Groups"
   end
 
@@ -58,7 +58,7 @@ defmodule Web.Live.Nav.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/clients")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.id}/clients']")
+    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/clients']")
     assert String.trim(Floki.text(item)) == "Clients"
   end
 
@@ -68,7 +68,7 @@ defmodule Web.Live.Nav.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/sites")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.id}/sites']")
+    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/sites']")
     assert String.trim(Floki.text(item)) == "Sites"
   end
 
@@ -78,7 +78,7 @@ defmodule Web.Live.Nav.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/relay_groups")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.id}/relay_groups']")
+    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/relay_groups']")
     assert String.trim(Floki.text(item)) == "Relays"
   end
 
@@ -88,7 +88,7 @@ defmodule Web.Live.Nav.SidebarTest do
   #   conn: conn
   # } do
   #   {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/resources")
-  #   assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.id}/resources']")
+  #   assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/resources']")
   #   assert String.trim(Floki.text(item)) == "Resources"
   # end
 
@@ -98,7 +98,7 @@ defmodule Web.Live.Nav.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/policies")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.id}/policies']")
+    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/policies']")
     assert String.trim(Floki.text(item)) == "Policies"
   end
 
@@ -108,7 +108,7 @@ defmodule Web.Live.Nav.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/settings/account")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.id}/settings/account']")
+    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/settings/account']")
     assert String.trim(Floki.text(item)) == "Account"
   end
 
@@ -121,7 +121,10 @@ defmodule Web.Live.Nav.SidebarTest do
       live(authorize_conn(conn, identity), ~p"/#{account}/settings/identity_providers")
 
     assert item =
-             Floki.find(html, "a.bg-gray-100[href='/#{account.id}/settings/identity_providers']")
+             Floki.find(
+               html,
+               "a.bg-gray-100[href='/#{account.slug}/settings/identity_providers']"
+             )
 
     assert String.trim(Floki.text(item)) == "Identity Providers"
   end
@@ -138,7 +141,10 @@ defmodule Web.Live.Nav.SidebarTest do
       )
 
     assert item =
-             Floki.find(html, "a.bg-gray-100[href='/#{account.id}/settings/identity_providers']")
+             Floki.find(
+               html,
+               "a.bg-gray-100[href='/#{account.slug}/settings/identity_providers']"
+             )
 
     assert String.trim(Floki.text(item)) == "Identity Providers"
   end
@@ -149,7 +155,7 @@ defmodule Web.Live.Nav.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/settings/dns")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.id}/settings/dns']")
+    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/settings/dns']")
     assert String.trim(Floki.text(item)) == "DNS"
   end
 end

--- a/elixir/apps/web/test/web/live/policies/index_test.exs
+++ b/elixir/apps/web/test/web/live/policies/index_test.exs
@@ -46,7 +46,7 @@ defmodule Web.Live.Policies.IndexTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/policies")
 
-    assert button = Floki.find(html, "a[href='/#{account.id}/policies/new']")
+    assert button = Floki.find(html, "a[href='/#{account.slug}/policies/new']")
     assert Floki.text(button) =~ "Add Policy"
   end
 

--- a/elixir/apps/web/test/web/live/relay_groups/index_test.exs
+++ b/elixir/apps/web/test/web/live/relay_groups/index_test.exs
@@ -46,7 +46,7 @@ defmodule Web.Live.RelayGroups.IndexTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/relay_groups")
 
-    assert button = Floki.find(html, "a[href='/#{account.id}/relay_groups/new']")
+    assert button = Floki.find(html, "a[href='/#{account.slug}/relay_groups/new']")
     assert Floki.text(button) =~ "Add Instance Group"
   end
 

--- a/elixir/apps/web/test/web/live/resources/index_test.exs
+++ b/elixir/apps/web/test/web/live/resources/index_test.exs
@@ -46,7 +46,7 @@ defmodule Web.Live.Resources.IndexTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/resources")
 
-    assert button = Floki.find(html, "a[href='/#{account.id}/resources/new']")
+    assert button = Floki.find(html, "a[href='/#{account.slug}/resources/new']")
     assert Floki.text(button) =~ "Add Resource"
   end
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/connect_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/connect_test.exs
@@ -74,7 +74,7 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.Connect do
 
       callback_url =
         url(
-          ~p"/#{account}/settings/identity_providers/google_workspace/#{provider.id}/handle_callback"
+          ~p"/#{account.id}/settings/identity_providers/google_workspace/#{provider.id}/handle_callback"
         )
 
       {state, verifier} = conn.cookies["fz_auth_state_#{provider.id}"] |> :erlang.binary_to_term()

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
@@ -107,7 +107,7 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.EditTest do
               {:redirect,
                %{
                  to:
-                   ~p"/#{account}/settings/identity_providers/google_workspace/#{provider}/redirect"
+                   ~p"/#{account.id}/settings/identity_providers/google_workspace/#{provider}/redirect"
                }}}
 
     assert provider.name == provider_attrs.name

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
@@ -94,7 +94,7 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.NewTest do
               {:redirect,
                %{
                  to:
-                   ~p"/#{account}/settings/identity_providers/google_workspace/#{provider}/redirect"
+                   ~p"/#{account.id}/settings/identity_providers/google_workspace/#{provider}/redirect"
                }}}
 
     assert provider.name == provider_attrs.name

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/show_test.exs
@@ -239,6 +239,6 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.ShowTest do
            |> render()
            |> Floki.attribute("href")
            |> hd() ==
-             ~p"/#{account}/settings/identity_providers/google_workspace/#{provider}/redirect"
+             ~p"/#{account.id}/settings/identity_providers/google_workspace/#{provider}/redirect"
   end
 end

--- a/elixir/apps/web/test/web/live/settings/identity_providers/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/index_test.exs
@@ -58,7 +58,7 @@ defmodule Web.Live.Settings.IdentityProviders.IndexTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/settings/identity_providers")
 
-    assert button = Floki.find(html, "a[href='/#{account.id}/settings/identity_providers/new']")
+    assert button = Floki.find(html, "a[href='/#{account.slug}/settings/identity_providers/new']")
     assert Floki.text(button) =~ "Add Identity Provider"
   end
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/connect_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/connect_test.exs
@@ -72,7 +72,7 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.Connect do
 
       callback_url =
         url(
-          ~p"/#{account}/settings/identity_providers/openid_connect/#{provider.id}/handle_callback"
+          ~p"/#{account.id}/settings/identity_providers/openid_connect/#{provider.id}/handle_callback"
         )
 
       {state, verifier} = conn.cookies["fz_auth_state_#{provider.id}"] |> :erlang.binary_to_term()

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/edit_test.exs
@@ -102,7 +102,7 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.EditTest do
               {:redirect,
                %{
                  to:
-                   ~p"/#{account}/settings/identity_providers/openid_connect/#{provider}/redirect"
+                   ~p"/#{account.id}/settings/identity_providers/openid_connect/#{provider}/redirect"
                }}}
 
     assert provider.name == provider_attrs.name

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/new_test.exs
@@ -96,7 +96,7 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.NewTest do
               {:redirect,
                %{
                  to:
-                   ~p"/#{account}/settings/identity_providers/openid_connect/#{provider}/redirect"
+                   ~p"/#{account.id}/settings/identity_providers/openid_connect/#{provider}/redirect"
                }}}
 
     assert provider.name == provider_attrs.name

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/show_test.exs
@@ -178,6 +178,6 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.ShowTest do
            |> render()
            |> Floki.attribute("href")
            |> hd() ==
-             ~p"/#{account}/settings/identity_providers/openid_connect/#{provider}/redirect"
+             ~p"/#{account.id}/settings/identity_providers/openid_connect/#{provider}/redirect"
   end
 end

--- a/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up/sign_up_test.exs
@@ -56,13 +56,13 @@ defmodule Web.Live.SignUpTest do
       assert email.subject == "Welcome to Firezone"
 
       verify_sign_in_token_path =
-        ~p"/#{account.id}/sign_in/providers/#{provider.id}/verify_sign_in_token"
+        ~p"/#{account}/sign_in/providers/#{provider.id}/verify_sign_in_token"
 
       assert email.text_body =~ "#{verify_sign_in_token_path}"
       assert email.text_body =~ "identity_id=#{identity.id}"
       assert email.text_body =~ "secret="
 
-      assert email.text_body =~ url(~p"/#{account.id}")
+      assert email.text_body =~ url(~p"/#{account}")
     end)
   end
 

--- a/elixir/apps/web/test/web/live/sites/index_test.exs
+++ b/elixir/apps/web/test/web/live/sites/index_test.exs
@@ -46,7 +46,7 @@ defmodule Web.Live.Sites.IndexTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/sites")
 
-    assert button = Floki.find(html, "a[href='/#{account.id}/sites/new']")
+    assert button = Floki.find(html, "a[href='/#{account.slug}/sites/new']")
     assert Floki.text(button) =~ "Add Site"
   end
 


### PR DESCRIPTION
The only exception for this is IdP redirect URL's that must be configured on a third-party system, we will keep using ID's for them so that if slug changes users don't need to go and reconfigured all the IdPs.