### PR TITLE
Hotfix merged typos, Sign In form content, Sign Up email content

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -62,7 +62,7 @@ Now you can verify that it's working by connecting to a websocket:
   <summary>Gateway</summary>
 
 ```bash
-# Note: The token value below is an example.  The token value you will need is generated and printed out when seeding the database, as described earlier in the document.
+# Note: The token value below is an example. The token value you will need is generated and printed out when seeding the database, as described earlier in the document.
 ❯ export GATEWAY_TOKEN_FROM_SEEDS="SFMyNTY.g2gDaAJtAAAAJDNjZWYwNTY2LWFkZmQtNDhmZS1hMGYxLTU4MDY3OTYwOGY2Zm0AAABAamp0enhSRkpQWkdCYy1vQ1o5RHkyRndqd2FIWE1BVWRwenVScjJzUnJvcHg3NS16bmhfeHBfNWJUNU9uby1yYm4GAJXr4emIAWIAAVGA.jz0s-NohxgdAXeRMjIQ9kLBOyd7CmKXWi2FHY-Op8GM"
 
 ❯ websocat --header="User-Agent: iOS/12.7 (iPhone) connlib/0.7.412" "ws://127.0.0.1:13000/gateway/websocket?token=${GATEWAY_TOKEN_FROM_SEEDS}&external_id=thisisrandomandpersistent&name=kkX1&public_key=kceI60D6PrwOIiGoVz6hD7VYCgD1H57IVQlPJTTieUE="
@@ -80,7 +80,7 @@ Now you can verify that it's working by connecting to a websocket:
   <summary>Relay</summary>
 
 ```bash
-# Note: The token value below is an example.  The token value you will need is generated and printed out when seeding the database, as described earlier in the document.
+# Note: The token value below is an example. The token value you will need is generated and printed out when seeding the database, as described earlier in the document.
 ❯ export RELAY_TOKEN_FROM_SEEDS="SFMyNTY.g2gDaAJtAAAAJDcyODZiNTNkLTA3M2UtNGM0MS05ZmYxLWNjODQ1MWRhZDI5OW0AAABARVg3N0dhMEhLSlVWTGdjcE1yTjZIYXRkR25mdkFEWVFyUmpVV1d5VHFxdDdCYVVkRVUzbzktRmJCbFJkSU5JS24GAMDq4emIAWIAAVGA.fLlZsUMS0VJ4RCN146QzUuINmGubpsxoyIf3uhRHdiQ"
 
 ❯ websocat --header="User-Agent: Linux/5.2.6 (Debian; x86_64) relay/0.7.412" "ws://127.0.0.1:8081/relay/websocket?token=${RELAY_TOKEN_FROM_SEEDS}&ipv4=24.12.79.100&ipv6=4d36:aa7f:473c:4c61:6b9e:2416:9917:55cc"
@@ -101,7 +101,7 @@ Now you can verify that it's working by connecting to a websocket:
   <summary>Client</summary>
 
 ```bash
-# Note: The token value below is an example.  The token value you will need is generated and printed out when seeding the database, as described earlier in the document.
+# Note: The token value below is an example. The token value you will need is generated and printed out when seeding the database, as described earlier in the document.
 ❯ export CLIENT_TOKEN_FROM_SEEDS="SFMyNTY.g2gDaAN3CGlkZW50aXR5bQAAACQ3ZGE3ZDFjZC0xMTFjLTQ0YTctYjVhYy00MDI3YjlkMjMwZTV3Bmlnbm9yZW4GAJhGr7WKAWIACTqA.mrPu5eFVwkfRml7zzHb5uYfosLGaYVHq03-wE02xUNc"
 
 # Panel will only accept token if it's coming with this User-Agent header and from IP 172.28.0.1

--- a/elixir/apps/domain/lib/domain/auth/adapters/email.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/email.ex
@@ -42,15 +42,10 @@ defmodule Domain.Auth.Adapters.Email do
 
   @impl true
   def provider_changeset(%Ecto.Changeset{} = changeset) do
-    %{
-      outbound_email_adapter: outbound_email_adapter
-    } =
-      Domain.Config.fetch_resolved_configs!(changeset.data.account_id, [:outbound_email_adapter])
-
-    if is_nil(outbound_email_adapter) do
-      Ecto.Changeset.add_error(changeset, :adapter, "email adapter is not configured")
-    else
+    if Domain.Config.fetch_env!(:domain, :outbound_email_adapter_configured?) do
       changeset
+    else
+      Ecto.Changeset.add_error(changeset, :adapter, "email adapter is not configured")
     end
   end
 

--- a/elixir/apps/domain/lib/domain/crypto.ex
+++ b/elixir/apps/domain/lib/domain/crypto.ex
@@ -53,7 +53,7 @@ defmodule Domain.Crypto do
 
   defp replace_ambiguous_characters("", acc), do: acc
 
-  for {mapping, replacement} <- Enum.zip(~c"-+/lO0=", ~c"ptusxyz") do
+  for {mapping, replacement} <- Enum.zip(~c"-+/lO0=_", ~c"ptusxyzw") do
     defp replace_ambiguous_characters(<<unquote(mapping)::utf8, rest::binary>>, acc),
       do: replace_ambiguous_characters(rest, <<acc::binary, unquote(replacement)::utf8>>)
   end

--- a/elixir/apps/domain/test/domain/actors_test.exs
+++ b/elixir/apps/domain/test/domain/actors_test.exs
@@ -1690,7 +1690,7 @@ defmodule Domain.ActorsTest do
         Task.async(fn ->
           allow_child_sandbox_access(test_pid)
 
-          Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+          Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
           account = Fixtures.Accounts.create_account()
           provider = Fixtures.Auth.create_email_provider(account: account)
@@ -1924,7 +1924,7 @@ defmodule Domain.ActorsTest do
         Task.async(fn ->
           allow_child_sandbox_access(test_pid)
 
-          Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+          Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
           account = Fixtures.Accounts.create_account()
           provider = Fixtures.Auth.create_email_provider(account: account)

--- a/elixir/apps/domain/test/domain/auth/adapters/email_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/email_test.exs
@@ -5,7 +5,7 @@ defmodule Domain.Auth.Adapters.EmailTest do
 
   describe "identity_changeset/2" do
     setup do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
       account = Fixtures.Accounts.create_account()
       provider = Fixtures.Auth.create_email_provider(account: account)
@@ -42,7 +42,7 @@ defmodule Domain.Auth.Adapters.EmailTest do
 
   describe "provider_changeset/1" do
     test "returns changeset as is" do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
       account = Fixtures.Accounts.create_account()
       changeset = %Ecto.Changeset{data: %Domain.Auth.Provider{account_id: account.id}}
@@ -59,7 +59,7 @@ defmodule Domain.Auth.Adapters.EmailTest do
 
   describe "ensure_provisioned/1" do
     test "does nothing for a provider" do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider()
       assert ensure_provisioned(provider) == {:ok, provider}
     end
@@ -67,7 +67,7 @@ defmodule Domain.Auth.Adapters.EmailTest do
 
   describe "ensure_deprovisioned/1" do
     test "does nothing for a provider" do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider()
       assert ensure_deprovisioned(provider) == {:ok, provider}
     end
@@ -96,7 +96,7 @@ defmodule Domain.Auth.Adapters.EmailTest do
 
   describe "verify_secret/2" do
     setup do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
       account = Fixtures.Accounts.create_account()
       provider = Fixtures.Auth.create_email_provider(account: account)

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -27,7 +27,7 @@ defmodule Domain.AuthTest do
     test "returns error when provider is deleted" do
       account = Fixtures.Accounts.create_account()
       Fixtures.Auth.create_userpass_provider(account: account)
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       identity =
@@ -44,7 +44,7 @@ defmodule Domain.AuthTest do
     end
 
     test "returns provider" do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider()
       assert {:ok, fetched_provider} = fetch_provider_by_id(provider.id)
       assert fetched_provider.id == provider.id
@@ -141,7 +141,7 @@ defmodule Domain.AuthTest do
     test "returns error when provider is disabled" do
       account = Fixtures.Accounts.create_account()
       Fixtures.Auth.create_userpass_provider(account: account)
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       identity =
@@ -167,7 +167,7 @@ defmodule Domain.AuthTest do
     test "returns error when provider is deleted" do
       account = Fixtures.Accounts.create_account()
       Fixtures.Auth.create_userpass_provider(account: account)
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       identity =
@@ -184,7 +184,7 @@ defmodule Domain.AuthTest do
     end
 
     test "returns provider" do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider()
       assert {:ok, fetched_provider} = fetch_active_provider_by_id(provider.id)
       assert fetched_provider.id == provider.id
@@ -195,7 +195,7 @@ defmodule Domain.AuthTest do
     test "returns all not soft-deleted providers for a given account" do
       account = Fixtures.Accounts.create_account()
 
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       Fixtures.Auth.create_userpass_provider(account: account)
       email_provider = Fixtures.Auth.create_email_provider(account: account)
       token_provider = Fixtures.Auth.create_token_provider(account: account)
@@ -235,7 +235,7 @@ defmodule Domain.AuthTest do
     test "returns active providers for a given account" do
       account = Fixtures.Accounts.create_account()
 
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       userpass_provider = Fixtures.Auth.create_userpass_provider(account: account)
       email_provider = Fixtures.Auth.create_email_provider(account: account)
       token_provider = Fixtures.Auth.create_token_provider(account: account)
@@ -459,7 +459,7 @@ defmodule Domain.AuthTest do
     test "returns error if email provider is already enabled", %{
       account: account
     } do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       Fixtures.Auth.create_email_provider(account: account)
       attrs = Fixtures.Auth.provider_attrs(adapter: :email)
       assert {:error, changeset} = create_provider(account, attrs)
@@ -510,7 +510,7 @@ defmodule Domain.AuthTest do
     } do
       attrs = Fixtures.Auth.provider_attrs()
 
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
       assert {:ok, provider} = create_provider(account, attrs)
 
@@ -529,7 +529,7 @@ defmodule Domain.AuthTest do
     test "returns error when email provider is disabled", %{
       account: account
     } do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, nil)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, false)
       attrs = Fixtures.Auth.provider_attrs()
 
       assert {:error, changeset} = create_provider(account, attrs)
@@ -571,7 +571,7 @@ defmodule Domain.AuthTest do
 
     test "persists identity that created the provider", %{account: account} do
       attrs = Fixtures.Auth.provider_attrs()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
       actor = Fixtures.Actors.create_actor(account: account, type: :account_admin_user)
       identity = Fixtures.Auth.create_identity(account: account, actor: actor)
@@ -714,7 +714,7 @@ defmodule Domain.AuthTest do
   describe "disable_provider/2" do
     setup do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       actor =
@@ -861,7 +861,7 @@ defmodule Domain.AuthTest do
       identity = Fixtures.Auth.create_identity(account: account, actor: actor)
       subject = Fixtures.Auth.create_subject(identity: identity)
 
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
       {:ok, provider} = disable_provider(provider, subject)
 
@@ -896,7 +896,7 @@ defmodule Domain.AuthTest do
     test "does not allow to enable providers in other accounts", %{
       subject: subject
     } do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider()
       assert enable_provider(provider, subject) == {:error, :not_found}
     end
@@ -916,7 +916,7 @@ defmodule Domain.AuthTest do
   describe "delete_provider/2" do
     setup do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       actor =
@@ -1326,7 +1326,7 @@ defmodule Domain.AuthTest do
   describe "upsert_identity/3" do
     test "creates an identity" do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
       provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
 
@@ -1354,7 +1354,7 @@ defmodule Domain.AuthTest do
 
     test "updates existing identity" do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
       provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
       actor = Fixtures.Actors.create_actor(account: account, provider: provider)
@@ -1378,7 +1378,7 @@ defmodule Domain.AuthTest do
 
     test "returns error when identifier is invalid" do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       actor =
@@ -1401,7 +1401,7 @@ defmodule Domain.AuthTest do
   describe "new_identity/3" do
     setup do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
       actor = Fixtures.Actors.create_actor(account: account, type: :account_admin_user)
 
@@ -1451,7 +1451,7 @@ defmodule Domain.AuthTest do
   describe "create_identity/4" do
     test "creates an identity" do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
       provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
 
@@ -1470,7 +1470,7 @@ defmodule Domain.AuthTest do
 
     test "returns error on missing permissions" do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       actor =
@@ -1527,7 +1527,7 @@ defmodule Domain.AuthTest do
 
     test "returns error when identifier is invalid" do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       actor =
@@ -1548,7 +1548,7 @@ defmodule Domain.AuthTest do
 
     test "updates existing identity" do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
       provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
       actor = Fixtures.Actors.create_actor(account: account, provider: provider)
@@ -1570,7 +1570,7 @@ defmodule Domain.AuthTest do
   describe "replace_identity/3" do
     setup do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       actor =
@@ -1662,7 +1662,7 @@ defmodule Domain.AuthTest do
   describe "delete_identity/2" do
     setup do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       actor =
@@ -1781,7 +1781,7 @@ defmodule Domain.AuthTest do
   describe "delete_actor_identities/1" do
     setup do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
 
       %{
@@ -1815,7 +1815,7 @@ defmodule Domain.AuthTest do
   describe "sign_in/5" do
     setup do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
       user_agent = Fixtures.Auth.user_agent()
       remote_ip = Fixtures.Auth.remote_ip()
@@ -2329,7 +2329,7 @@ defmodule Domain.AuthTest do
   describe "sign_in/2" do
     setup do
       account = Fixtures.Accounts.create_account()
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
       user_agent = Fixtures.Auth.user_agent()
       remote_ip = Fixtures.Auth.remote_ip()
@@ -2503,7 +2503,7 @@ defmodule Domain.AuthTest do
     end
 
     test "returns identity and url without changes for other providers" do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       account = Fixtures.Accounts.create_account()
       provider = Fixtures.Auth.create_email_provider(account: account)
       identity = Fixtures.Auth.create_identity(account: account, provider: provider)
@@ -2614,7 +2614,7 @@ defmodule Domain.AuthTest do
     test "returns error when subject has no access to given provider", %{
       subject: subject
     } do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider()
       assert ensure_has_access_to(subject, provider) == {:error, :unauthorized}
     end
@@ -2623,7 +2623,7 @@ defmodule Domain.AuthTest do
       subject: subject,
       account: account
     } do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
       provider = Fixtures.Auth.create_email_provider(account: account)
       assert ensure_has_access_to(subject, provider) == :ok
     end

--- a/elixir/apps/web/lib/web/controllers/home_html.ex
+++ b/elixir/apps/web/lib/web/controllers/home_html.ex
@@ -24,7 +24,7 @@ defmodule Web.HomeHTML do
               <.account_button :for={account <- @accounts} account={account} />
             </div>
 
-            <.separator if={@accounts != []} />
+            <.separator :if={@accounts != []} />
 
             <.form :let={f} for={%{}} action={~p"/"} class="space-y-4 lg:space-y-6">
               <.input

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -47,7 +47,9 @@ defmodule Web.SignIn do
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow dark:bg-gray-800 md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
             <h1 class="text-xl text-center font-bold leading-tight tracking-tight text-gray-900 sm:text-2xl dark:text-white">
-              <%= @account.name %> Admin Portal
+              <span>
+                Sign into <%= @account.name %>
+              </span>
             </h1>
 
             <.flash flash={@flash} kind={:error} />
@@ -97,7 +99,7 @@ defmodule Web.SignIn do
             </.intersperse_blocks>
           </div>
         </div>
-        <div class="mx-auto p-6 sm:p-8">
+        <div :if={is_nil(@params["client_platform"])} class="mx-auto p-6 sm:p-8">
           <p class="py-2">
             <%= # TODO: Add link to client instructions docs %> Meant to sign in from a client instead?
             <a href="https://firezone.dev/docs" class="font-medium text-blue-600 hover:text-blue-500">

--- a/elixir/apps/web/lib/web/live/sign_in/email.ex
+++ b/elixir/apps/web/lib/web/live/sign_in/email.ex
@@ -43,27 +43,9 @@ defmodule Web.SignIn.Email do
             <.flash flash={@flash} kind={:error} phx-click={JS.hide(transition: "fade-out")} />
             <.flash flash={@flash} kind={:info} phx-click={JS.hide(transition: "fade-out")} />
 
-            <div :if={is_nil(@client_platform)}>
+            <div>
               <p>
-                Should the provided email be registered, a sign-in link will be dispatched to your email account.
-                Please click this link to proceed with your login.
-              </p>
-              <.resend
-                account_id_or_slug={@account_id_or_slug}
-                provider_id={@provider_id}
-                provider_identifier={@provider_identifier}
-                client_platform={@client_platform}
-                client_csrf_token={@client_csrf_token}
-              />
-              <div class="flex">
-                <.dev_email_provider_link url="https://mail.google.com/mail/" name="Gmail" />
-                <.email_provider_link url="https://mail.google.com/mail/" name="Gmail" />
-                <.email_provider_link url="https://outlook.live.com/mail/" name="Outlook" />
-              </div>
-            </div>
-            <div :if={not is_nil(@client_platform)}>
-              <p>
-                Should the provided email be registered, a sign-in token will be dispatched to your email account.
+                Should the provided email be registered, a sign-in link and token are dispatched to your email account.
                 Please copy and paste this token into the form below to proceed with your login.
               </p>
 
@@ -117,6 +99,11 @@ defmodule Web.SignIn.Email do
                 use a different Sign In method
               </.link>
               .
+            </div>
+            <div class="flex">
+              <.dev_email_provider_link url="https://mail.google.com/mail/" name="Gmail" />
+              <.email_provider_link url="https://mail.google.com/mail/" name="Gmail" />
+              <.email_provider_link url="https://outlook.live.com/mail/" name="Outlook" />
             </div>
           </div>
         </div>

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -291,7 +291,6 @@ defmodule Web.SignUp do
             Web.Mailer.AuthEmail.sign_up_link_email(
               account,
               identity,
-              identity.provider_virtual_state.sign_in_token,
               socket.assigns.user_agent,
               socket.assigns.real_ip
             )

--- a/elixir/apps/web/lib/web/mailer/auth_email.ex
+++ b/elixir/apps/web/lib/web/mailer/auth_email.ex
@@ -9,21 +9,9 @@ defmodule Web.Mailer.AuthEmail do
   def sign_up_link_email(
         %Domain.Accounts.Account{} = account,
         %Domain.Auth.Identity{} = identity,
-        email_secret,
         user_agent,
         remote_ip
       ) do
-    params =
-      %{
-        identity_id: identity.id,
-        secret: email_secret
-      }
-
-    sign_in_url =
-      url(
-        ~p"/#{account}/sign_in/providers/#{identity.provider_id}/verify_sign_in_token?#{params}"
-      )
-
     sign_in_form_url = url(~p"/#{account}")
 
     default_email()
@@ -31,12 +19,6 @@ defmodule Web.Mailer.AuthEmail do
     |> to(identity.provider_identifier)
     |> render_body(__MODULE__, :sign_up_link,
       account: account,
-      sign_in_token_created_at:
-        Cldr.DateTime.to_string!(identity.provider_state["sign_in_token_created_at"], Web.CLDR,
-          format: :short
-        ) <> " UTC",
-      secret: email_secret,
-      sign_in_url: sign_in_url,
       sign_in_form_url: sign_in_form_url,
       user_agent: user_agent,
       remote_ip: "#{:inet.ntoa(remote_ip)}"

--- a/elixir/apps/web/lib/web/mailer/auth_email/sign_in_link.html.heex
+++ b/elixir/apps/web/lib/web/mailer/auth_email/sign_in_link.html.heex
@@ -4,27 +4,26 @@
   Dear Firezone user,
 </p>
 
-<div :if={is_nil(@client_platform)}>
-  <p>
-    Here is the <a href={@sign_in_url} target="_blank">magic sign-in link</a>
-    you requested to sign in to <b>"<%= @account.name %>"</b>.
-    It is valid for 15 minutes.
-  </p>
-
-  <small>
-    If the link didn't work, please copy this link and open it in your browser: <%= @sign_in_url %>
-  </small>
-</div>
-
-<div :if={not is_nil(@client_platform)}>
+<div>
   <p>
     Please copy the code and paste it into the Firezone application to proceed with
     signing in to <b>"<%= @account.name %>"</b>:
   </p>
+
   <p style="font-weight:bold; margin-top:1rem; margin-bottom:1rem;">
     <code><%= @secret %></code>
   </p>
-  <p>It is valid for 15 minutes.</p>
+
+  <p>
+    or click on the <a href={@sign_in_url} target="_blank">magic sign-in link</a>
+    if you are on the same device where you are trying to sign in.
+  </p>
+
+  <p>
+    <small>
+      This email is valid for 15 minutes.
+    </small>
+  </p>
 </div>
 
 <p>

--- a/elixir/apps/web/lib/web/mailer/auth_email/sign_in_link.text.heex
+++ b/elixir/apps/web/lib/web/mailer/auth_email/sign_in_link.text.heex
@@ -1,18 +1,16 @@
 Dear Firezone user,
-<%= if is_nil(@client_platform) do %>
-Here is the magic sign-in link you requested to sign in to "<%= @account.name %>":
 
-<%= @sign_in_url %>
-
-Please copy this link and open it in your browser. It is valid for 15 minutes.
-<% else %>
 Please copy the code and paste it into the Firezone application to proceed with
 the sign in to "<%= @account.name %>":
 
 <%= @secret %>
 
-It is valid for 15 minutes.
-<% end %>
+or click on the magic sign-in if you are on the same device where you are trying to sign in:
+
+<%= @sign_in_url %>
+
+This email is valid for 15 minutes.
+
 If you did not request this action and have received this email in error, you can safely ignore
 and discard this email. However, if you continue to receive multiple unsolicited emails of this nature,
 we strongly recommend contacting your system administrator to report the issue.

--- a/elixir/apps/web/lib/web/mailer/auth_email/sign_up_link.html.heex
+++ b/elixir/apps/web/lib/web/mailer/auth_email/sign_up_link.html.heex
@@ -1,19 +1,7 @@
 <h3>Thank you for signing up for Firezone!</h3>
 
 <div>
-  <p>
-    Here is the <a href={@sign_in_url} target="_blank">sign-in link</a>
-    to access your account <b>"<%= @account.name %>"</b>.
-    It is valid for 15 minutes.
-  </p>
-
-  <small>
-    If the link didn't work, please copy this link and open it in your browser. <%= @sign_in_url %>
-  </small>
-</div>
-
-<div>
-  <p>In future you can always access the sign in form at the following URL:</p>
+  <p>You can sign in to your account <b>"<%= @account.name %>"</b> using following link:</p>
 
   <small>
     <%= @sign_in_form_url %>
@@ -28,7 +16,6 @@
 
 <p>
   <b>Request details:</b>
-  <br /> Time: <%= @sign_in_token_created_at %>
   <br /> IP address: <%= @remote_ip %>
   <br /> User Agent: <%= @user_agent %>
   <br /> Account ID: <%= @account.id %>

--- a/elixir/apps/web/lib/web/mailer/auth_email/sign_up_link.text.heex
+++ b/elixir/apps/web/lib/web/mailer/auth_email/sign_up_link.text.heex
@@ -1,13 +1,6 @@
 Thank you for signing up for Firezone!
 
-
-Here is the sign-in link to access your account "<%= @account.name %>":
-
-<%= @sign_in_url %>
-
-Please copy this link and open it in your browser. It is valid for 15 minutes.
-
-In future you can always access the sign in form at the following URL:
+You can sign in to your account "<%= @account.name %>" using following link:
 
 <%= @sign_in_form_url %>
 
@@ -16,7 +9,6 @@ and discard this email. However, if you continue to receive multiple unsolicited
 we strongly recommend contacting your system administrator to report the issue.
 
 Request details:
-  Time: <%= @sign_in_token_created_at %>
   IP address: <%= @remote_ip %>
   User Agent: <%= @user_agent %>
   Account ID: <%= @account.id %>

--- a/elixir/apps/web/test/web/acceptance/auth/email_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/email_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Acceptance.SignIn.EmailTest do
   use Web.AcceptanceCase, async: true
 
   feature "renders success on invalid email to prevent enumeration attacks", %{session: session} do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     Fixtures.Auth.create_email_provider(account: account)
@@ -18,7 +18,7 @@ defmodule Web.Acceptance.SignIn.EmailTest do
   end
 
   feature "allows to log in using email link", %{session: session} do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     provider = Fixtures.Auth.create_email_provider(account: account)

--- a/elixir/apps/web/test/web/acceptance/auth/openid_connect_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/openid_connect_test.exs
@@ -13,10 +13,10 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
 
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("#{account.name} Admin Portal"))
+    |> assert_el(Query.text("Sign into #{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
-    |> assert_el(Query.text("#{account.name} Admin Portal"))
+    |> assert_el(Query.text("Sign into #{account.name}"))
     |> assert_path(~p"/#{account.id}")
     |> assert_el(Query.text("You may not authenticate to this account."))
   end
@@ -41,7 +41,7 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
 
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("#{account.name} Admin Portal"))
+    |> assert_el(Query.text("Sign into #{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
     |> assert_el(Query.css("#user-menu-button"))

--- a/elixir/apps/web/test/web/acceptance/auth/userpass_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/userpass_test.exs
@@ -139,7 +139,7 @@ defmodule Web.Acceptance.Auth.UserPassTest do
   defp password_login_flow(session, account, username, password) do
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("#{account.name} Admin Portal"))
+    |> assert_el(Query.text("Sign into #{account.name}"))
     |> assert_el(Query.text("Sign in with username and password"))
     |> fill_form(%{
       "userpass[provider_identifier]" => username,

--- a/elixir/apps/web/test/web/acceptance/auth_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth_test.exs
@@ -15,7 +15,7 @@ defmodule Web.Acceptance.AuthTest do
 
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("#{account.name} Admin Portal"))
+    |> assert_el(Query.text("Sign into #{account.name}"))
     |> assert_el(Query.link("Sign in with #{openid_connect_provider.name}"))
     |> assert_el(Query.text("Sign in with username and password"))
     |> assert_el(Query.text("Sign in with a magic link"))

--- a/elixir/apps/web/test/web/acceptance/auth_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth_test.exs
@@ -4,7 +4,7 @@ defmodule Web.Acceptance.AuthTest do
   feature "renders all sign in options", %{session: session} do
     account = Fixtures.Accounts.create_account()
 
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     Fixtures.Auth.create_userpass_provider(account: account)
     Fixtures.Auth.create_email_provider(account: account)

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -2,7 +2,7 @@ defmodule Web.AuthControllerTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
     %{}
   end
 
@@ -1168,7 +1168,7 @@ defmodule Web.AuthControllerTest do
 
   describe "sign_out/2" do
     test "redirects to the sign in page and renews the session", %{conn: conn} do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
       account = Fixtures.Accounts.create_account()
       provider = Fixtures.Auth.create_email_provider(account: account)
@@ -1207,7 +1207,7 @@ defmodule Web.AuthControllerTest do
     end
 
     test "broadcasts to the given live_socket_id", %{conn: conn} do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
       account = Fixtures.Accounts.create_account()
       provider = Fixtures.Auth.create_email_provider(account: account)
@@ -1227,7 +1227,7 @@ defmodule Web.AuthControllerTest do
     end
 
     test "does not remove current account id from list of recent ones", %{conn: conn} do
-      Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
       account = Fixtures.Accounts.create_account()
       provider = Fixtures.Auth.create_email_provider(account: account)
@@ -1286,7 +1286,7 @@ defmodule Web.AuthControllerTest do
   end
 
   test "keeps up to 5 recent accounts the used signed in to", %{conn: conn} do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     {conn, account_ids} =
       Enum.reduce(1..6, {conn, []}, fn _i, {conn, account_ids} ->

--- a/elixir/apps/web/test/web/live/actors/service_accounts/new_identity_test.exs
+++ b/elixir/apps/web/test/web/live/actors/service_accounts/new_identity_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Actors.ServiceAccounts.NewIdentityTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :service_account, account: account)

--- a/elixir/apps/web/test/web/live/actors/service_accounts/new_test.exs
+++ b/elixir/apps/web/test/web/live/actors/service_accounts/new_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Actors.ServiceAccount.NewTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)

--- a/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
+++ b/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Actors.User.NewIdentityTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)

--- a/elixir/apps/web/test/web/live/actors/users/new_test.exs
+++ b/elixir/apps/web/test/web/live/actors/users/new_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Actors.User.NewTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)

--- a/elixir/apps/web/test/web/live/settings/account/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/account/index_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.Account.IndexTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     identity = Fixtures.Auth.create_identity(account: account, actor: [type: :account_admin_user])

--- a/elixir/apps/web/test/web/live/settings/dns/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/dns/index_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.DNS.IndexTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     identity = Fixtures.Auth.create_identity(account: account, actor: [type: :account_admin_user])

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.EditTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.NewTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/show_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.ShowTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)

--- a/elixir/apps/web/test/web/live/settings/identity_providers/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/index_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.IdentityProviders.IndexTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)

--- a/elixir/apps/web/test/web/live/settings/identity_providers/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/new_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.IdentityProviders.NewTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/edit_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.EditTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/new_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.NewTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/show_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.ShowTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)

--- a/elixir/apps/web/test/web/live/settings/identity_providers/system/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/system/show_test.exs
@@ -2,7 +2,7 @@ defmodule Web.Live.Settings.IdentityProviders.System.ShowTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     provider = Fixtures.Auth.create_email_provider(account: account)

--- a/elixir/apps/web/test/web/live/sign_in/email_test.exs
+++ b/elixir/apps/web/test/web/live/sign_in/email_test.exs
@@ -2,7 +2,7 @@ defmodule Web.SignIn.EmailTest do
   use Web.ConnCase, async: true
 
   setup do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
     provider = Fixtures.Auth.create_email_provider(account: account)

--- a/elixir/apps/web/test/web/live/sign_in_test.exs
+++ b/elixir/apps/web/test/web/live/sign_in_test.exs
@@ -60,5 +60,6 @@ defmodule Web.SignInTest do
 
     assert html =~ ~s|value="ios"|
     assert html =~ ~s|value="csrf-token"|
+    refute html =~ ~s|Meant to sign in from a client instead?|
   end
 end

--- a/elixir/apps/web/test/web/live/sign_in_test.exs
+++ b/elixir/apps/web/test/web/live/sign_in_test.exs
@@ -2,7 +2,7 @@ defmodule Web.SignInTest do
   use Web.ConnCase, async: true
 
   test "renders active providers on the page", %{conn: conn} do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
 
@@ -47,7 +47,7 @@ defmodule Web.SignInTest do
   end
 
   test "takes client params from session", %{conn: conn} do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
     account = Fixtures.Accounts.create_account()
     Fixtures.Auth.create_email_provider(account: account)
 

--- a/elixir/apps/web/test/web/live/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up_test.exs
@@ -18,7 +18,7 @@ defmodule Web.Live.SignUpTest do
   end
 
   test "creates new account and sends a welcome email", %{conn: conn} do
-    Domain.Config.put_system_env_override(:outbound_email_adapter, Swoosh.Adapters.Postmark)
+    Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account_name = "FooBar"
 

--- a/elixir/apps/web/test/web/live/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up_test.exs
@@ -54,14 +54,6 @@ defmodule Web.Live.SignUpTest do
 
     assert_email_sent(fn email ->
       assert email.subject == "Welcome to Firezone"
-
-      verify_sign_in_token_path =
-        ~p"/#{account}/sign_in/providers/#{provider.id}/verify_sign_in_token"
-
-      assert email.text_body =~ "#{verify_sign_in_token_path}"
-      assert email.text_body =~ "identity_id=#{identity.id}"
-      assert email.text_body =~ "secret="
-
       assert email.text_body =~ url(~p"/#{account}")
     end)
   end

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -79,6 +79,8 @@ config :domain, :enabled_features,
 
 config :domain, docker_registry: "us-east1-docker.pkg.dev/firezone-staging/firezone"
 
+config :domain, outbound_email_adapter_configured?: false
+
 ###############################
 ##### Web #####################
 ###############################

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -11,6 +11,8 @@ config :domain, Domain.Repo,
   port: String.to_integer(System.get_env("DATABASE_PORT", "5432")),
   password: System.get_env("DATABASE_PASSWORD", "postgres")
 
+config :domain, outbound_email_adapter_configured?: true
+
 ###############################
 ##### Web #####################
 ###############################

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -73,6 +73,8 @@ if config_env() == :prod do
 
   config :domain, docker_registry: compile_config!(:docker_registry)
 
+  config :domain, outbound_email_adapter_configured?: !!compile_config!(:outbound_email_adapter)
+
   ###############################
   ##### Web #####################
   ###############################


### PR DESCRIPTION
I fixed a few typos that slipped in in the last UX PR. Also a few minor changes:

Sign In as a client doesn't show the "client" link in the bottom any more:
<img width="1728" alt="Screenshot 2023-11-14 at 13 46 24" src="https://github.com/firezone/firezone/assets/1877644/7226078c-7f66-41b5-9fd4-e6e44b56fd35">

Extra ---or--- separator is removed when there are no recently used accounts:
<img width="1728" alt="Screenshot 2023-11-14 at 13 46 29" src="https://github.com/firezone/firezone/assets/1877644/c2463ca5-0967-4fe7-ac60-5f5179ea30d8">

Emails send after you sign up don't include sign in link right away, just a link to a form so that you won't loose in in future. Addresses "Session token is expired/incognito windows" in #2631
<img width="1728" alt="Screenshot 2023-11-14 at 14 32 30" src="https://github.com/firezone/firezone/assets/1877644/4f6d4c79-b5ed-448a-9915-2616ed71c9b9">

I've allowed email token to be used along with magic link when signing in as @jefferenced requested multiple times:
<img width="1728" alt="Screenshot 2023-11-14 at 14 23 58" src="https://github.com/firezone/firezone/assets/1877644/8b9b5afe-5c65-4893-b6ef-107a0b683c31">
<img width="1728" alt="Screenshot 2023-11-14 at 14 24 50" src="https://github.com/firezone/firezone/assets/1877644/c02db5df-5158-4bf3-93ff-80d9d6c82cbe">

Closes #2299