### PR TITLE
Update resource index to link to individual site

### DIFF
--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -53,7 +53,7 @@ defmodule Web.Resources.Index do
             <:col :let={resource} label="sites">
               <.link
                 :for={gateway_group <- resource.gateway_groups}
-                navigate={~p"/#{@account}/sites"}
+                navigate={~p"/#{@account}/sites/#{gateway_group}"}
                 class="font-medium text-blue-600 dark:text-blue-500 hover:underline"
               >
                 <.badge type="info">


### PR DESCRIPTION
Small bug fix in the Resource index view.  All the entries in the `SITES` column were linking to the sites index, rather than an individual site show page.

Closes: #2624 