### PR TITLE
connlib: fix logging string for macos

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -177,7 +177,7 @@ impl WrappedSession {
             device_id,
             CallbackHandler {
                 inner: Arc::new(callback_handler),
-                handle: init_logging(log_dir.into(), log_filter.clone()),
+                handle: init_logging(log_dir.into(), log_filter),
             },
         )
         .map_err(|err| err.to_string())?;

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -150,10 +150,10 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> file_logger::Handle {
     let (file_layer, handle) = file_logger::layer(&log_dir);
 
     let _ = tracing_subscriber::registry()
-        .with(tracing_oslog::OsLogger::new(
-            "dev.firezone.firezone",
-            "connlib",
-        ))
+        .with(
+            tracing_oslog::OsLogger::new("dev.firezone.firezone", "connlib")
+                .with_filter(EnvFilter::new(log_filter.clone())),
+        )
         .with(file_layer.with_filter(EnvFilter::new(log_filter)))
         .try_init();
 
@@ -177,7 +177,7 @@ impl WrappedSession {
             device_id,
             CallbackHandler {
                 inner: Arc::new(callback_handler),
-                handle: init_logging(log_dir.into(), log_filter),
+                handle: init_logging(log_dir.into(), log_filter.clone()),
             },
         )
         .map_err(|err| err.to_string())?;


### PR DESCRIPTION
filter for macos wasn't being applied correctly, this fixes that.