### PR TITLE
Remove resource addresses and change reserved CGNAT ranges

### DIFF
--- a/elixir/apps/api/lib/api/client/views/resource.ex
+++ b/elixir/apps/api/lib/api/client/views/resource.ex
@@ -5,21 +5,10 @@ defmodule API.Client.Views.Resource do
     Enum.map(resources, &render/1)
   end
 
-  def render(%Resources.Resource{type: :dns} = resource) do
+  def render(%Resources.Resource{} = resource) do
     %{
       id: resource.id,
-      type: :dns,
-      address: resource.address,
-      name: resource.name,
-      ipv4: resource.ipv4,
-      ipv6: resource.ipv6
-    }
-  end
-
-  def render(%Resources.Resource{type: :cidr} = resource) do
-    %{
-      id: resource.id,
-      type: :cidr,
+      type: resource.type,
       address: resource.address,
       name: resource.name
     }

--- a/elixir/apps/api/lib/api/gateway/views/resource.ex
+++ b/elixir/apps/api/lib/api/gateway/views/resource.ex
@@ -7,8 +7,6 @@ defmodule API.Gateway.Views.Resource do
       type: :dns,
       address: resource.address,
       name: resource.name,
-      ipv4: resource.ipv4,
-      ipv6: resource.ipv6,
       filters: Enum.flat_map(resource.filters, &render_filter/1)
     }
   end

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -125,9 +125,7 @@ defmodule API.Client.ChannelTest do
                id: dns_resource.id,
                type: :dns,
                name: dns_resource.name,
-               address: dns_resource.address,
-               ipv4: dns_resource.ipv4,
-               ipv6: dns_resource.ipv6
+               address: dns_resource.address
              } in resources
 
       assert %{

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -95,8 +95,6 @@ defmodule API.Gateway.ChannelTest do
                id: resource.id,
                name: resource.name,
                type: :dns,
-               ipv4: resource.ipv4,
-               ipv6: resource.ipv6,
                filters: [
                  %{protocol: :tcp, port_range_end: 80, port_range_start: 80},
                  %{protocol: :tcp, port_range_end: 433, port_range_start: 433},
@@ -203,8 +201,6 @@ defmodule API.Gateway.ChannelTest do
                id: resource.id,
                name: resource.name,
                type: :dns,
-               ipv4: resource.ipv4,
-               ipv6: resource.ipv6,
                filters: [
                  %{protocol: :tcp, port_range_end: 80, port_range_start: 80},
                  %{protocol: :tcp, port_range_end: 433, port_range_start: 433},

--- a/elixir/apps/domain/lib/domain/network.ex
+++ b/elixir/apps/domain/lib/domain/network.ex
@@ -4,7 +4,7 @@ defmodule Domain.Network do
 
   @cidrs %{
     # Notice: those are also part of "resources_account_id_cidr_address_index" DB constraint
-    ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 10},
+    ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 11},
     ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 106}
   }
 

--- a/elixir/apps/domain/lib/domain/network.ex
+++ b/elixir/apps/domain/lib/domain/network.ex
@@ -5,7 +5,7 @@ defmodule Domain.Network do
   @cidrs %{
     # Notice: those are also part of "resources_account_id_cidr_address_index" DB constraint
     ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 11},
-    ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 106}
+    ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 107}
   }
 
   def cidrs, do: @cidrs

--- a/elixir/apps/domain/lib/domain/resources.ex
+++ b/elixir/apps/domain/lib/domain/resources.ex
@@ -142,46 +142,19 @@ defmodule Domain.Resources do
     with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_resources_permission()) do
       changeset = Resource.Changeset.create(subject.account, attrs, subject)
 
-      Ecto.Multi.new()
-      |> Ecto.Multi.insert(:resource, changeset, returning: true)
-      |> resolve_address_multi(:ipv4)
-      |> resolve_address_multi(:ipv6)
-      |> Ecto.Multi.update(:resource_with_address, fn
-        %{resource: %Resource{} = resource, ipv4: ipv4, ipv6: ipv6} ->
-          Resource.Changeset.finalize_create(resource, ipv4, ipv6)
-      end)
-      |> Repo.transaction()
-      |> case do
-        {:ok, %{resource_with_address: resource}} ->
-          # TODO: Add optimistic lock to resource.updated_at to serialize the resource updates
-          # TODO: Broadcast only to actors that have access to the resource
-          # {:ok, actors} = list_authorized_actors(resource)
-          # Phoenix.PubSub.broadcast(
-          #   Domain.PubSub,
-          #   "actor_client:#{subject.actor.id}",
-          #   {:resource_added, resource.id}
-          # )
+      with {:ok, resource} <- Repo.insert(changeset) do
+        # TODO: Add optimistic lock to resource.updated_at to serialize the resource updates
+        # TODO: Broadcast only to actors that have access to the resource
+        # {:ok, actors} = list_authorized_actors(resource)
+        # Phoenix.PubSub.broadcast(
+        #   Domain.PubSub,
+        #   "actor_client:#{subject.actor.id}",
+        #   {:resource_added, resource.id}
+        # )
 
-          {:ok, resource}
-
-        {:error, :resource, changeset, _effects_so_far} ->
-          {:error, changeset}
+        {:ok, resource}
       end
     end
-  end
-
-  defp resolve_address_multi(multi, type) do
-    Ecto.Multi.run(multi, type, fn
-      _repo, %{resource: %Resource{type: :cidr}} ->
-        {:ok, nil}
-
-      _repo, %{resource: %Resource{type: :dns} = resource} ->
-        if address = Map.get(resource, type) do
-          {:ok, address}
-        else
-          {:ok, Domain.Network.fetch_next_available_address!(resource.account_id, type)}
-        end
-    end)
   end
 
   def change_resource(%Resource{} = resource, attrs \\ %{}, %Auth.Subject{} = subject) do

--- a/elixir/apps/domain/lib/domain/resources/resource.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource.ex
@@ -12,9 +12,6 @@ defmodule Domain.Resources.Resource do
       field :ports, {:array, Domain.Types.Int4Range}, default: []
     end
 
-    field :ipv4, Domain.Types.IP
-    field :ipv6, Domain.Types.IP
-
     belongs_to :account, Domain.Accounts.Account
     has_many :connections, Domain.Resources.Connection, on_replace: :delete
     # TODO: where doesn't work on join tables so soft-deleted records will be preloaded,

--- a/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
@@ -33,15 +33,6 @@ defmodule Domain.Resources.Resource.Changeset do
     )
   end
 
-  def finalize_create(%Resource{} = resource, ipv4, ipv6) do
-    resource
-    |> change()
-    |> put_change(:ipv4, ipv4)
-    |> put_change(:ipv6, ipv6)
-    |> unique_constraint(:ipv4, name: :resources_account_id_ipv4_index)
-    |> unique_constraint(:ipv6, name: :resources_account_id_ipv6_index)
-  end
-
   defp validate_address(changeset) do
     if has_errors?(changeset, :type) do
       changeset

--- a/elixir/apps/domain/priv/repo/migrations/20231122195751_remove_resources_ipvx_address.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20231122195751_remove_resources_ipvx_address.exs
@@ -1,0 +1,25 @@
+defmodule Domain.Repo.Migrations.RemoveResourcesIpvxAddress do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resources) do
+      remove(
+        :ipv4,
+        references(:network_addresses,
+          column: :address,
+          type: :inet,
+          with: [account_id: :account_id]
+        )
+      )
+
+      remove(
+        :ipv6,
+        references(:network_addresses,
+          column: :address,
+          type: :inet,
+          with: [account_id: :account_id]
+        )
+      )
+    end
+  end
+end

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -443,15 +443,8 @@ IO.puts("")
   )
 
 IO.puts("Created resources:")
-
-IO.puts(
-  "  #{dns_google_resource.address} - DNS - #{dns_google_resource.ipv4} - gateways: #{gateway_name}"
-)
-
-IO.puts(
-  "  #{dns_gitlab_resource.address} - DNS - #{dns_gitlab_resource.ipv4} - gateways: #{gateway_name}"
-)
-
+IO.puts("  #{dns_google_resource.address} - DNS - gateways: #{gateway_name}")
+IO.puts("  #{dns_gitlab_resource.address} - DNS - gateways: #{gateway_name}")
 IO.puts("  #{cidr_resource.address} - CIDR - gateways: #{gateway_name}")
 IO.puts("")
 

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -732,7 +732,7 @@ defmodule Domain.ResourcesTest do
 
       attrs = %{"address" => "fd00:2021:1111::/102", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)
-      assert "can not be in the CIDR fd00:2021:1111::/106" in errors_on(changeset).address
+      assert "can not be in the CIDR fd00:2021:1111::/107" in errors_on(changeset).address
 
       attrs = %{"address" => "::/0", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)


### PR DESCRIPTION
- Resources don't have assigned internal IPvX addresses anymore
- Now we use reduced CGNAT range for internal address space to leave rest for gateway DNS handling

Closes #2691