### PR TITLE
Shutdown tunnel on quit in macos

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -154,9 +154,9 @@
       let menuItem = createMenuItem(
         menu,
         title: "Quit",
-        action: #selector(NSApplication.terminate(_:)),
+        action: #selector(quitButtonTapped),
         key: "q",
-        target: nil
+        target: self
       )
       if let appName = Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String {
         menuItem.title = "Quit \(appName)"
@@ -235,6 +235,10 @@
     @objc private func aboutButtonTapped() {
       NSApp.activate(ignoringOtherApps: true)
       NSApp.orderFrontStandardAboutPanel(self)
+    }
+
+    @objc private func quitButtonTapped() {
+      NSApp.terminate(self)
     }
 
     private func openSettingsWindow() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -376,6 +376,14 @@
         resourcesUnavailableReasonMenuItem.title = "Disconnected"
         resourcesSeparatorMenuItem.isHidden = false
       }
+      quitMenuItem.title = {
+        switch self.tunnelStatus {
+        case .connected, .connecting:
+          return "Disconnect and Quit"
+        default:
+          return "Quit"
+        }
+      }()
     }
 
     private func handleMenuVisibilityOrStatusChanged() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -238,7 +238,14 @@
     }
 
     @objc private func quitButtonTapped() {
-      NSApp.terminate(self)
+      Task {
+        do {
+          try await appStore?.tunnel.stop()
+        } catch {
+          logger.error("\(#function): Error stopping tunnel: \(error)")
+        }
+        NSApp.terminate(self)
+      }
     }
 
     private func openSettingsWindow() {


### PR DESCRIPTION
Fixes #2565

With this PR, the 'Quit' menu item (in the macOS status item menu) disconnects the tunnel (if tunnel is active) before quitting. While the tunnel is connected, the menu item's title is changed to 'Disconnect and Quit'.

Depends on #2687 (and this PR currently includes those commits), so opened as draft.

**Edit:** Now made ready for review.
