### PR TITLE
Do retry-then-signout when startTunnel() fails as well

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
@@ -64,12 +64,8 @@ import SwiftUI
     }
 
     func startTunnel() async {
-      do {
-        if case .signedIn = self.loginStatus {
-          try await appStore.tunnel.start()
-        }
-      } catch {
-        logger.error("Error starting tunnel: \(String(describing: error))")
+      if case .signedIn = self.loginStatus {
+        appStore.auth.startTunnel()
       }
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
@@ -30,35 +30,6 @@ final class AppStore: ObservableObject {
       self?.objectWillChange.send()
     }
     .store(in: &cancellables)
-
-    auth.$loginStatus
-      .receive(on: mainQueue)
-      .sink { [weak self] loginStatus in
-        Task { [weak self] in
-          await self?.handleLoginStatusChanged(loginStatus)
-        }
-      }
-      .store(in: &cancellables)
-  }
-
-  private func handleLoginStatusChanged(_ loginStatus: AuthStore.LoginStatus) async {
-    logger.log("\(#function): login status = \(loginStatus)")
-    switch loginStatus {
-    case .signedIn:
-      do {
-        try await tunnel.start()
-      } catch {
-        logger.error("\(#function): Error starting tunnel: \(String(describing: error))")
-      }
-    case .signedOut:
-      do {
-        try await tunnel.stop()
-      } catch {
-        logger.error("\(#function): Error stopping tunnel: \(String(describing: error))")
-      }
-    case .uninitialized:
-      break
-    }
   }
 
   private func signOutAndStopTunnel() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -208,6 +208,7 @@ final class AuthStore: ObservableObject {
         try await tunnelStore.start()
       } catch {
         logger.error("\(#function): Error starting tunnel: \(String(describing: error))")
+        self.retryStartTunnel()
       }
     }
   }
@@ -239,6 +240,7 @@ final class AuthStore: ObservableObject {
           try await tunnelStore.start()
         } catch {
           logger.error("\(#function): Error starting tunnel: \(String(describing: error))")
+          self.retryStartTunnel()
         }
       }
     case .signedOut:

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -201,14 +201,8 @@
     }
 
     @objc private func reconnectButtonTapped() {
-      Task {
-        if case .signedIn = appStore?.auth.loginStatus {
-          do {
-            try await appStore?.tunnel.start()
-          } catch {
-            logger.error("error connecting to tunnel (reconnect): \(String(describing: error))")
-          }
-        }
+      if case .signedIn = appStore?.auth.loginStatus {
+        appStore?.auth.startTunnel()
       }
     }
 


### PR DESCRIPTION
Fixes #2718

It appears that #2687 missed the case where the tunnel failed to start for some reason, so the tunnel status never goes to "Connecting" and then back to "Disconnected" -- we were reacting to the tunnel status becoming "Disconnected".

In this PR, we do the retry when startTunnel() throws an error as well.
