### PR TITLE
"Magic Link" -> "Email"

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -300,7 +300,7 @@ Interactive Elixir (1.15.2) - press Ctrl+C to exit (type h() ENTER for help)
 iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)1> {:ok, account} = Domain.Accounts.create_account(%{name: "Firezone", slug: "firezone"})
 {:ok, ...}
 
-iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)2> {:ok, magic_link_provider} = Domain.Auth.create_provider(account, %{name: "Magic Link", adapter: :email, adapter_config: %{}})
+iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)2> {:ok, magic_link_provider} = Domain.Auth.create_provider(account, %{name: "One-Time Password", adapter: :email, adapter_config: %{}})
 {:ok, ...}
 
 iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)3> {:ok, actor} = Domain.Actors.create_actor(account, %{type: :account_admin_user, name: "Andrii Dryga"})

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -300,7 +300,7 @@ Interactive Elixir (1.15.2) - press Ctrl+C to exit (type h() ENTER for help)
 iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)1> {:ok, account} = Domain.Accounts.create_account(%{name: "Firezone", slug: "firezone"})
 {:ok, ...}
 
-iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)2> {:ok, magic_link_provider} = Domain.Auth.create_provider(account, %{name: "One-Time Password", adapter: :email, adapter_config: %{}})
+iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)2> {:ok, magic_link_provider} = Domain.Auth.create_provider(account, %{name: "Email", adapter: :email, adapter_config: %{}})
 {:ok, ...}
 
 iex(web@web-3vmw.us-east1-d.c.firezone-staging.internal)3> {:ok, actor} = Domain.Actors.create_actor(account, %{type: :account_admin_user, name: "Andrii Dryga"})

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -100,7 +100,7 @@ defmodule Domain.Config.Definitions do
        Providers:
 
         * `openid_connect` is used to authenticate users via OpenID Connect, this is recommended for production use;
-        * `email` is used to authenticate users via one-time passwords sent to the email;
+        * `email` is used to authenticate users via sign in tokens sent to the email;
         * `token` is used to authenticate service accounts using an API token;
         * `userpass` is used to authenticate users with username and password, should be used
         with extreme care and is not recommended for production use.
@@ -460,7 +460,7 @@ defmodule Domain.Config.Definitions do
   )
 
   ##############################################
-  ## Userpass / SAML / OIDC / OTP authentication
+  ## Userpass / SAML / OIDC / Email authentication
   ##############################################
 
   @doc """

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -100,7 +100,7 @@ defmodule Domain.Config.Definitions do
        Providers:
 
         * `openid_connect` is used to authenticate users via OpenID Connect, this is recommended for production use;
-        * `email` is used to authenticate users via magic links sent to the email;
+        * `email` is used to authenticate users via one-time passwords sent to the email;
         * `token` is used to authenticate service accounts using an API token;
         * `userpass` is used to authenticate users with username and password, should be used
         with extreme care and is not recommended for production use.
@@ -460,7 +460,7 @@ defmodule Domain.Config.Definitions do
   )
 
   ##############################################
-  ## Userpass / SAML / OIDC / Magic Link authentication
+  ## Userpass / SAML / OIDC / OTP authentication
   ##############################################
 
   @doc """

--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -170,7 +170,7 @@ defmodule Web.AuthController do
         redirect_params = put_if_not_empty(redirect_params, "provider_identifier", identity_id)
 
         conn
-        |> put_flash(:error, "The sign in link is invalid or expired.")
+        |> put_flash(:error, "The one-time password is invalid or expired.")
         |> redirect(
           to: ~p"/#{account_id_or_slug}/sign_in/providers/email/#{provider_id}?#{redirect_params}"
         )

--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -170,7 +170,7 @@ defmodule Web.AuthController do
         redirect_params = put_if_not_empty(redirect_params, "provider_identifier", identity_id)
 
         conn
-        |> put_flash(:error, "The one-time password is invalid or expired.")
+        |> put_flash(:error, "The sign in token is invalid or expired.")
         |> redirect(
           to: ~p"/#{account_id_or_slug}/sign_in/providers/email/#{provider_id}?#{redirect_params}"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
@@ -125,7 +125,7 @@ defmodule Web.Settings.IdentityProviders.Components do
     """
   end
 
-  def adapter_name(:email), do: "One-Time Password"
+  def adapter_name(:email), do: "Email"
   def adapter_name(:userpass), do: "Username & Password"
   def adapter_name(:token), do: "API Access Token"
   def adapter_name(:workos), do: "WorkOS"

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
@@ -125,7 +125,7 @@ defmodule Web.Settings.IdentityProviders.Components do
     """
   end
 
-  def adapter_name(:email), do: "Magic Link"
+  def adapter_name(:email), do: "One-Time Password"
   def adapter_name(:userpass), do: "Username & Password"
   def adapter_name(:token), do: "API Access Token"
   def adapter_name(:workos), do: "WorkOS"

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -85,7 +85,7 @@ defmodule Web.SignIn do
 
               <:item :if={adapter_enabled?(@providers_by_adapter, :email)}>
                 <h3 class="text-m font-bold leading-tight tracking-tight text-gray-900 sm:text-xl">
-                  Sign in with a one-time password
+                  Sign in with email
                 </h3>
 
                 <.providers_group_form
@@ -200,7 +200,7 @@ defmodule Web.SignIn do
 
       <:actions>
         <.button phx-disable-with="Sending..." class="w-full">
-          Request one-time password
+          Request sign in link
         </.button>
       </:actions>
     </.simple_form>

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -200,7 +200,7 @@ defmodule Web.SignIn do
 
       <:actions>
         <.button phx-disable-with="Sending..." class="w-full">
-          Request sign in link
+          Request sign in token
         </.button>
       </:actions>
     </.simple_form>

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -85,7 +85,7 @@ defmodule Web.SignIn do
 
               <:item :if={adapter_enabled?(@providers_by_adapter, :email)}>
                 <h3 class="text-m font-bold leading-tight tracking-tight text-gray-900 sm:text-xl">
-                  Sign in with a magic link
+                  Sign in with a one-time password
                 </h3>
 
                 <.providers_group_form
@@ -200,7 +200,7 @@ defmodule Web.SignIn do
 
       <:actions>
         <.button phx-disable-with="Sending..." class="w-full">
-          Request sign in link
+          Request one-time password
         </.button>
       </:actions>
     </.simple_form>

--- a/elixir/apps/web/lib/web/live/sign_in/email.ex
+++ b/elixir/apps/web/lib/web/live/sign_in/email.ex
@@ -45,7 +45,7 @@ defmodule Web.SignIn.Email do
 
             <div>
               <p>
-                Should the provided email be registered, a one-time password has been sent to your email account.
+                Should the provided email be registered, a sign in token has been sent to your email account.
                 Please copy and paste this into the form below to proceed with your login.
               </p>
               <form

--- a/elixir/apps/web/lib/web/live/sign_in/email.ex
+++ b/elixir/apps/web/lib/web/live/sign_in/email.ex
@@ -45,8 +45,8 @@ defmodule Web.SignIn.Email do
 
             <div>
               <p>
-                Should the provided email be registered, a sign-in link and token are dispatched to your email account.
-                Please copy and paste this token into the form below to proceed with your login.
+                Should the provided email be registered, a one-time password has been sent to your email account.
+                Please copy and paste this into the form below to proceed with your login.
               </p>
               <form
                 id="verify-sign-in-token"

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -254,7 +254,7 @@ defmodule Web.SignUp do
           :provider,
           fn _repo, %{account: account} ->
             Auth.create_provider(account, %{
-              name: "One-Time Password",
+              name: "Email",
               adapter: :email,
               adapter_config: %{}
             })

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -101,7 +101,7 @@ defmodule Web.SignUp do
     ~H"""
     <div class="space-y-6">
       <div class="text-center text-gray-900">
-        Your account has been created! Please check your email for a sign in link.
+        Your account has been created! Please check your email for sign in instructions.
       </div>
       <div class="text-center">
         <div class="px-12">
@@ -254,7 +254,7 @@ defmodule Web.SignUp do
           :provider,
           fn _repo, %{account: account} ->
             Auth.create_provider(account, %{
-              name: "Magic Link",
+              name: "One-Time Password",
               adapter: :email,
               adapter_config: %{}
             })

--- a/elixir/apps/web/lib/web/mailer/auth_email.ex
+++ b/elixir/apps/web/lib/web/mailer/auth_email.ex
@@ -44,7 +44,7 @@ defmodule Web.Mailer.AuthEmail do
       )
 
     default_email()
-    |> subject("Firezone One-Time Password")
+    |> subject("Firezone sign in token")
     |> to(identity.provider_identifier)
     |> render_body(__MODULE__, :sign_in_link,
       account: identity.account,

--- a/elixir/apps/web/lib/web/mailer/auth_email.ex
+++ b/elixir/apps/web/lib/web/mailer/auth_email.ex
@@ -44,7 +44,7 @@ defmodule Web.Mailer.AuthEmail do
       )
 
     default_email()
-    |> subject("Firezone Sign In Link")
+    |> subject("Firezone One-Time Password")
     |> to(identity.provider_identifier)
     |> render_body(__MODULE__, :sign_in_link,
       account: identity.account,

--- a/elixir/apps/web/lib/web/mailer/auth_email/sign_in_link.html.heex
+++ b/elixir/apps/web/lib/web/mailer/auth_email/sign_in_link.html.heex
@@ -1,4 +1,4 @@
-<h3>Magic sign-in link</h3>
+<h3>One-Time Password</h3>
 
 <p>
   Dear Firezone user,
@@ -6,7 +6,7 @@
 
 <div>
   <p>
-    Please copy the code and paste it into the Firezone application to proceed with
+    Please copy the password below and paste it into the Firezone application to proceed with
     signing in to <b>"<%= @account.name %>"</b>:
   </p>
 
@@ -15,7 +15,7 @@
   </p>
 
   <p>
-    or click on the <a href={@sign_in_url} target="_blank">magic sign-in link</a>
+    or click <a href={@sign_in_url} target="_blank">this link</a>
     if you are on the same device where you are trying to sign in.
   </p>
 

--- a/elixir/apps/web/lib/web/mailer/auth_email/sign_in_link.html.heex
+++ b/elixir/apps/web/lib/web/mailer/auth_email/sign_in_link.html.heex
@@ -1,4 +1,4 @@
-<h3>One-Time Password</h3>
+<h3>Sign in token</h3>
 
 <p>
   Dear Firezone user,
@@ -6,7 +6,7 @@
 
 <div>
   <p>
-    Please copy the password below and paste it into the Firezone application to proceed with
+    Please copy the token below and paste it into the Firezone application to proceed with
     signing in to <b>"<%= @account.name %>"</b>:
   </p>
 

--- a/elixir/apps/web/test/web/acceptance/auth/email_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/email_test.exs
@@ -9,11 +9,11 @@ defmodule Web.Acceptance.SignIn.EmailTest do
 
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in with a magic link"))
+    |> assert_el(Query.text("Sign in with a one-time password"))
     |> fill_form(%{
       "email[provider_identifier]" => "foo@bar.com"
     })
-    |> click(Query.button("Request sign in link"))
+    |> click(Query.button("Request one-time password"))
     |> assert_el(Query.text("Please check your email"))
   end
 
@@ -40,14 +40,14 @@ defmodule Web.Acceptance.SignIn.EmailTest do
   defp email_login_flow(session, account, email) do
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in with a magic link"))
+    |> assert_el(Query.text("Sign in with a one-time password"))
     |> fill_form(%{
       "email[provider_identifier]" => email
     })
-    |> click(Query.button("Request sign in link"))
+    |> click(Query.button("Request one-time password"))
     |> assert_el(Query.text("Please check your email"))
     |> click(Query.link("Open Local"))
-    |> click(Query.link("Firezone Sign In Link"))
+    |> click(Query.link("Firezone One-Time Password"))
     |> assert_el(Query.text("Text body"))
 
     email_text = text(session, Query.css("body"))

--- a/elixir/apps/web/test/web/acceptance/auth/email_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/email_test.exs
@@ -9,11 +9,11 @@ defmodule Web.Acceptance.SignIn.EmailTest do
 
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in with a one-time password"))
+    |> assert_el(Query.text("Sign in with email"))
     |> fill_form(%{
       "email[provider_identifier]" => "foo@bar.com"
     })
-    |> click(Query.button("Request one-time password"))
+    |> click(Query.button("Request sign in token"))
     |> assert_el(Query.text("Please check your email"))
   end
 
@@ -40,14 +40,14 @@ defmodule Web.Acceptance.SignIn.EmailTest do
   defp email_login_flow(session, account, email) do
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in with a one-time password"))
+    |> assert_el(Query.text("Sign in with email"))
     |> fill_form(%{
       "email[provider_identifier]" => email
     })
-    |> click(Query.button("Request one-time password"))
+    |> click(Query.button("Request sign in token"))
     |> assert_el(Query.text("Please check your email"))
     |> click(Query.link("Open Local"))
-    |> click(Query.link("Firezone One-Time Password"))
+    |> click(Query.link("Firezone sign in token"))
     |> assert_el(Query.text("Text body"))
 
     email_text = text(session, Query.css("body"))

--- a/elixir/apps/web/test/web/acceptance/auth_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth_test.exs
@@ -18,7 +18,7 @@ defmodule Web.Acceptance.AuthTest do
     |> assert_el(Query.text("Sign into #{account.name}"))
     |> assert_el(Query.link("Sign in with #{openid_connect_provider.name}"))
     |> assert_el(Query.text("Sign in with username and password"))
-    |> assert_el(Query.text("Sign in with a one-time password"))
+    |> assert_el(Query.text("Sign in with email"))
   end
 
   describe "sign out" do

--- a/elixir/apps/web/test/web/acceptance/auth_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth_test.exs
@@ -18,7 +18,7 @@ defmodule Web.Acceptance.AuthTest do
     |> assert_el(Query.text("Sign into #{account.name}"))
     |> assert_el(Query.link("Sign in with #{openid_connect_provider.name}"))
     |> assert_el(Query.text("Sign in with username and password"))
-    |> assert_el(Query.text("Sign in with a magic link"))
+    |> assert_el(Query.text("Sign in with a one-time password"))
   end
 
   describe "sign out" do

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -439,7 +439,7 @@ defmodule Web.AuthControllerTest do
         )
 
       assert_email_sent(fn email ->
-        assert email.subject == "Firezone Sign In Link"
+        assert email.subject == "Firezone One-Time Password"
 
         verify_sign_in_token_path =
           ~p"/#{account}/sign_in/providers/#{provider.id}/verify_sign_in_token"
@@ -472,7 +472,7 @@ defmodule Web.AuthControllerTest do
         )
 
       assert_email_sent(fn email ->
-        assert email.subject == "Firezone Sign In Link"
+        assert email.subject == "Firezone One-Time Password"
         assert email.text_body =~ "Please copy the code and paste it into"
       end)
 
@@ -552,7 +552,7 @@ defmodule Web.AuthControllerTest do
       assert redirected_to(conn) ==
                ~p"/#{provider.account_id}/sign_in/providers/email/#{provider}?provider_identifier=#{identity_id}"
 
-      assert flash(conn, :error) == "The sign in link is invalid or expired."
+      assert flash(conn, :error) == "The one-time password is invalid or expired."
     end
 
     test "redirects back to the form when sign in token is invalid", %{conn: conn} do
@@ -575,7 +575,7 @@ defmodule Web.AuthControllerTest do
                  "&client_csrf_token=foo" <>
                  "&provider_identifier=#{identity.id}"
 
-      assert flash(conn, :error) == "The sign in link is invalid or expired."
+      assert flash(conn, :error) == "The one-time password is invalid or expired."
     end
 
     test "redirects back to the form when browser token is invalid", %{conn: conn} do
@@ -613,7 +613,7 @@ defmodule Web.AuthControllerTest do
                  "&client_csrf_token=bar" <>
                  "&provider_identifier=#{identity.id}"
 
-      assert flash(conn, :error) == "The sign in link is invalid or expired."
+      assert flash(conn, :error) == "The one-time password is invalid or expired."
     end
 
     test "redirects back to the form when browser token is not set", %{conn: conn} do
@@ -646,7 +646,7 @@ defmodule Web.AuthControllerTest do
                ~p"/#{account}/sign_in/providers/email/#{provider}" <>
                  "?provider_identifier=#{identity.id}"
 
-      assert flash(conn, :error) == "The sign in link is invalid or expired."
+      assert flash(conn, :error) == "The one-time password is invalid or expired."
     end
 
     test "redirects to the return to path when credentials are valid", %{conn: conn} do

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -439,7 +439,7 @@ defmodule Web.AuthControllerTest do
         )
 
       assert_email_sent(fn email ->
-        assert email.subject == "Firezone One-Time Password"
+        assert email.subject == "Firezone sign in token"
 
         verify_sign_in_token_path =
           ~p"/#{account}/sign_in/providers/#{provider.id}/verify_sign_in_token"
@@ -472,7 +472,7 @@ defmodule Web.AuthControllerTest do
         )
 
       assert_email_sent(fn email ->
-        assert email.subject == "Firezone One-Time Password"
+        assert email.subject == "Firezone sign in token"
         assert email.text_body =~ "Please copy the code and paste it into"
       end)
 
@@ -552,7 +552,7 @@ defmodule Web.AuthControllerTest do
       assert redirected_to(conn) ==
                ~p"/#{provider.account_id}/sign_in/providers/email/#{provider}?provider_identifier=#{identity_id}"
 
-      assert flash(conn, :error) == "The one-time password is invalid or expired."
+      assert flash(conn, :error) == "The sign in token is invalid or expired."
     end
 
     test "redirects back to the form when sign in token is invalid", %{conn: conn} do
@@ -575,7 +575,7 @@ defmodule Web.AuthControllerTest do
                  "&client_csrf_token=foo" <>
                  "&provider_identifier=#{identity.id}"
 
-      assert flash(conn, :error) == "The one-time password is invalid or expired."
+      assert flash(conn, :error) == "The sign in token is invalid or expired."
     end
 
     test "redirects back to the form when browser token is invalid", %{conn: conn} do
@@ -613,7 +613,7 @@ defmodule Web.AuthControllerTest do
                  "&client_csrf_token=bar" <>
                  "&provider_identifier=#{identity.id}"
 
-      assert flash(conn, :error) == "The one-time password is invalid or expired."
+      assert flash(conn, :error) == "The sign in token is invalid or expired."
     end
 
     test "redirects back to the form when browser token is not set", %{conn: conn} do
@@ -646,7 +646,7 @@ defmodule Web.AuthControllerTest do
                ~p"/#{account}/sign_in/providers/email/#{provider}" <>
                  "?provider_identifier=#{identity.id}"
 
-      assert flash(conn, :error) == "The one-time password is invalid or expired."
+      assert flash(conn, :error) == "The sign in token is invalid or expired."
     end
 
     test "redirects to the return to path when credentials are valid", %{conn: conn} do

--- a/elixir/apps/web/test/web/live/settings/identity_providers/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/index_test.exs
@@ -93,7 +93,7 @@ defmodule Web.Live.Settings.IdentityProviders.IndexTest do
       assert row["sync status"] =~ "Created 1 identity and 0 groups"
     end)
     |> with_table_row("name", email_provider.name, fn row ->
-      assert row["type"] == "Magic Link"
+      assert row["type"] == "One-Time Password"
       assert row["status"] =~ "Disabled"
       assert row["sync status"] =~ "Created 0 identities and 0 groups"
     end)

--- a/elixir/apps/web/test/web/live/settings/identity_providers/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/index_test.exs
@@ -93,7 +93,7 @@ defmodule Web.Live.Settings.IdentityProviders.IndexTest do
       assert row["sync status"] =~ "Created 1 identity and 0 groups"
     end)
     |> with_table_row("name", email_provider.name, fn row ->
-      assert row["type"] == "One-Time Password"
+      assert row["type"] == "Email"
       assert row["status"] =~ "Disabled"
       assert row["sync status"] =~ "Created 0 identities and 0 groups"
     end)

--- a/elixir/apps/web/test/web/live/sign_in/email_test.exs
+++ b/elixir/apps/web/test/web/live/sign_in/email_test.exs
@@ -135,7 +135,7 @@ defmodule Web.SignIn.EmailTest do
                "&client_csrf_token=foo" <>
                "&provider_identifier=#{identity.id}"
 
-    assert conn.assigns.flash["error"] == "The sign in link is invalid or expired."
+    assert conn.assigns.flash["error"] == "The one-time password is invalid or expired."
   end
 
   test "allows to resend magic link", %{

--- a/elixir/apps/web/test/web/live/sign_in/email_test.exs
+++ b/elixir/apps/web/test/web/live/sign_in/email_test.exs
@@ -135,7 +135,7 @@ defmodule Web.SignIn.EmailTest do
                "&client_csrf_token=foo" <>
                "&provider_identifier=#{identity.id}"
 
-    assert conn.assigns.flash["error"] == "The one-time password is invalid or expired."
+    assert conn.assigns.flash["error"] == "The sign in token is invalid or expired."
   end
 
   test "allows to resend magic link", %{

--- a/elixir/apps/web/test/web/live/sign_in_test.exs
+++ b/elixir/apps/web/test/web/live/sign_in_test.exs
@@ -10,7 +10,7 @@ defmodule Web.SignInTest do
 
     {:ok, _lv, html} = live(conn, ~p"/#{account}")
 
-    assert html =~ "Sign in with a one-time password"
+    assert html =~ "Sign in with email"
     refute html =~ "Sign in with username and password"
 
     userpass_provider = Fixtures.Auth.create_userpass_provider(account: account)
@@ -41,7 +41,7 @@ defmodule Web.SignInTest do
 
     {:ok, _provider} = Domain.Auth.delete_provider(email_provider, subject)
     {:ok, _lv, html} = live(conn, ~p"/#{account}")
-    refute html =~ "Sign in with a one-time password"
+    refute html =~ "Sign in with email"
 
     assert html =~ "Vault"
   end

--- a/elixir/apps/web/test/web/live/sign_in_test.exs
+++ b/elixir/apps/web/test/web/live/sign_in_test.exs
@@ -10,7 +10,7 @@ defmodule Web.SignInTest do
 
     {:ok, _lv, html} = live(conn, ~p"/#{account}")
 
-    assert html =~ "Sign in with a magic link"
+    assert html =~ "Sign in with a one-time password"
     refute html =~ "Sign in with username and password"
 
     userpass_provider = Fixtures.Auth.create_userpass_provider(account: account)
@@ -41,7 +41,7 @@ defmodule Web.SignInTest do
 
     {:ok, _provider} = Domain.Auth.delete_provider(email_provider, subject)
     {:ok, _lv, html} = live(conn, ~p"/#{account}")
-    refute html =~ "Sign in with a magic link"
+    refute html =~ "Sign in with a one-time password"
 
     assert html =~ "Vault"
   end


### PR DESCRIPTION
Updates user-facing terminology to `One-Time Password` to more accurately reflect this sign in method and match docs more consistently

Refs #2688 
Refs #2021 
