### PR TITLE
connlib: more logging and longer timeouts for ice

### DIFF
--- a/rust/connlib/shared/src/control.rs
+++ b/rust/connlib/shared/src/control.rs
@@ -441,6 +441,7 @@ impl PhoenixSender {
     ) -> Result<()> {
         // We don't care about the reply type when serializing
         let str = serde_json::to_string(&PhoenixMessage::<_, ()>::new(topic, payload, reference))?;
+        tracing::trace!(message = str, "phoenix channel sending message");
         self.sender.send(Message::text(str)).await?;
         Ok(())
     }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -506,6 +506,7 @@ where
         registry = register_default_interceptors(registry, &mut media_engine)?;
         let mut setting_engine = SettingEngine::default();
         setting_engine.set_interface_filter(Box::new(|name| !name.contains("tun")));
+        setting_engine.set_ice_timeouts(None, Some(Duration::from_secs(2 * 60)), None);
 
         let webrtc_api = APIBuilder::new()
             .with_media_engine(media_engine)


### PR DESCRIPTION
Seeing how there are failing connections where both ends receives all candidates, in some cases with a lot of candidates we might be hitting the 30 seconds default time out.