### PR TITLE
Update bot comments in-place to reduce notification spam

### DIFF
--- a/.github/workflows/_terraform.yml
+++ b/.github/workflows/_terraform.yml
@@ -83,12 +83,19 @@ jobs:
 
             [Terraform Cloud Plan](${{ steps.plan-run.outputs.run_link }})
             `;
-            // 3. Update previous comment
+            // 3. Update previous comment or create new one
             if (botComment) {
               github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: botComment.id,
+                body: output
+              });
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
                 body: output
               });
             }

--- a/.github/workflows/_terraform.yml
+++ b/.github/workflows/_terraform.yml
@@ -83,17 +83,12 @@ jobs:
 
             [Terraform Cloud Plan](${{ steps.plan-run.outputs.run_link }})
             `;
-            // 3. Delete previous comment so PR timeline makes sense
+            // 3. Update previous comment
             if (botComment) {
-              github.rest.issues.deleteComment({
+              github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: botComment.id,
+                body: output
               });
             }
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,21 +367,15 @@ jobs:
 
             `;
 
-            // 3. Delete previous comment so PR timeline makes sense
+            // 3. Update previous comment
             if (botComment) {
-              github.rest.issues.deleteComment({
+              github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: botComment.id,
+                body: output
               });
             }
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            });
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,12 +367,19 @@ jobs:
 
             `;
 
-            // 3. Update previous comment
+            // 3. Update previous comment or create new one
             if (botComment) {
               github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: botComment.id,
+                body: output
+              });
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
                 body: output
               });
             }


### PR DESCRIPTION
Updating a comment doesn't produce a notification, so this will fix comment spam on PRs.

History can be viewed in the comment itself like so:

<img width="658" alt="Screenshot 2023-11-30 at 7 23 29 AM" src="https://github.com/firezone/firezone/assets/167144/30846b58-336b-41de-88c3-c72947f4ec97">
