### PR TITLE
Add email confirmation field in portal

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/email.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/email.ex
@@ -36,6 +36,10 @@ defmodule Domain.Auth.Adapters.Email do
     changeset
     |> Domain.Validator.trim_change(:provider_identifier)
     |> Domain.Validator.validate_email(:provider_identifier)
+    |> Ecto.Changeset.validate_confirmation(:provider_identifier,
+      required: true,
+      message: "email does not match"
+    )
     |> Ecto.Changeset.put_change(:provider_state, state)
     |> Ecto.Changeset.put_change(:provider_virtual_state, virtual_state)
   end

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -110,7 +110,8 @@ admin_actor_email = "firezone@localhost"
 
 {:ok, unprivileged_actor_email_identity} =
   Auth.create_identity(unprivileged_actor, email_provider, %{
-    provider_identifier: unprivileged_actor_email
+    provider_identifier: unprivileged_actor_email,
+    provider_identifier_confirmation: unprivileged_actor_email
   })
 
 {:ok, unprivileged_actor_userpass_identity} =
@@ -129,7 +130,8 @@ unprivileged_actor_userpass_identity =
 
 {:ok, admin_actor_email_identity} =
   Auth.create_identity(admin_actor, email_provider, %{
-    provider_identifier: admin_actor_email
+    provider_identifier: admin_actor_email,
+    provider_identifier_confirmation: admin_actor_email
   })
 
 {:ok, _admin_actor_userpass_identity} =

--- a/elixir/apps/domain/test/domain/auth/adapters/email_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/email_test.exs
@@ -38,6 +38,25 @@ defmodule Domain.Auth.Adapters.EmailTest do
       assert %Ecto.Changeset{} = changeset = identity_changeset(provider, changeset)
       assert changeset.changes.provider_identifier == "X"
     end
+
+    test "validates email confirmation", %{provider: provider} do
+      changeset =
+        %Auth.Identity{}
+        |> Ecto.Changeset.cast(
+          %{
+            provider_identifier: Fixtures.Auth.email(),
+            provider_identifier_confirmation: ""
+          },
+          [:provider_identifier]
+        )
+
+      assert %Ecto.Changeset{} = changeset = identity_changeset(provider, changeset)
+
+      assert changeset.errors == [
+               provider_identifier_confirmation:
+                 {"email does not match", [validation: :confirmation]}
+             ]
+    end
   end
 
   describe "provider_changeset/1" do

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -1339,7 +1339,11 @@ defmodule Domain.AuthTest do
           provider: provider
         )
 
-      attrs = %{provider_identifier: provider_identifier}
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
       assert {:ok, identity} = upsert_identity(actor, provider, attrs)
 
       assert identity.provider_id == provider.id
@@ -1370,7 +1374,11 @@ defmodule Domain.AuthTest do
           provider_state: %{"foo" => "bar"}
         )
 
-      attrs = %{provider_identifier: provider_identifier}
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
       assert {:ok, updated_identity} = upsert_identity(actor, provider, attrs)
 
       assert Repo.aggregate(Auth.Identity, :count) == 1
@@ -1390,13 +1398,23 @@ defmodule Domain.AuthTest do
           provider: provider
         )
 
-      attrs = %{provider_identifier: Ecto.UUID.generate()}
+      provider_identifier = Ecto.UUID.generate()
+
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
       assert {:error, changeset} = upsert_identity(actor, provider, attrs)
       assert errors_on(changeset) == %{provider_identifier: ["is an invalid email address"]}
 
-      attrs = %{provider_identifier: nil}
+      attrs = %{provider_identifier: nil, provider_identifier_confirmation: nil}
       assert {:error, changeset} = upsert_identity(actor, provider, attrs)
       assert errors_on(changeset) == %{provider_identifier: ["can't be blank"]}
+
+      attrs = %{provider_identifier: Fixtures.Auth.email()}
+      assert {:error, changeset} = upsert_identity(actor, provider, attrs)
+      assert errors_on(changeset) == %{provider_identifier_confirmation: ["email does not match"]}
     end
   end
 
@@ -1466,7 +1484,11 @@ defmodule Domain.AuthTest do
 
       subject = Fixtures.Auth.create_subject(actor: actor)
 
-      attrs = %{provider_identifier: provider_identifier}
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
       assert {:ok, _identity} = create_identity(actor, provider, attrs, subject)
     end
 
@@ -1539,13 +1561,23 @@ defmodule Domain.AuthTest do
           provider: provider
         )
 
-      attrs = %{provider_identifier: Ecto.UUID.generate()}
+      provider_identifier = Ecto.UUID.generate()
+
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
       assert {:error, changeset} = create_identity(actor, provider, attrs)
       assert errors_on(changeset) == %{provider_identifier: ["is an invalid email address"]}
 
-      attrs = %{provider_identifier: nil}
+      attrs = %{provider_identifier: nil, provider_identifier_confirmation: nil}
       assert {:error, changeset} = create_identity(actor, provider, attrs)
       assert errors_on(changeset) == %{provider_identifier: ["can't be blank"]}
+
+      attrs = %{provider_identifier: Fixtures.Auth.email()}
+      assert {:error, changeset} = create_identity(actor, provider, attrs)
+      assert errors_on(changeset) == %{provider_identifier_confirmation: ["email does not match"]}
     end
 
     test "updates existing identity" do
@@ -1563,7 +1595,11 @@ defmodule Domain.AuthTest do
         provider_state: %{"foo" => "bar"}
       )
 
-      attrs = %{provider_identifier: provider_identifier}
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
       assert {:error, changeset} = create_identity(actor, provider, attrs)
       assert errors_on(changeset) == %{provider_identifier: ["has already been taken"]}
     end
@@ -1605,13 +1641,23 @@ defmodule Domain.AuthTest do
       identity: identity,
       subject: subject
     } do
-      attrs = %{provider_identifier: Ecto.UUID.generate()}
+      provider_identifier = Ecto.UUID.generate()
+
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
       assert {:error, changeset} = replace_identity(identity, attrs, subject)
       assert errors_on(changeset) == %{provider_identifier: ["is an invalid email address"]}
 
-      attrs = %{provider_identifier: nil}
+      attrs = %{provider_identifier: nil, provider_identifier_confirmation: nil}
       assert {:error, changeset} = replace_identity(identity, attrs, subject)
       assert errors_on(changeset) == %{provider_identifier: ["can't be blank"]}
+
+      attrs = %{provider_identifier: Fixtures.Auth.email()}
+      assert {:error, changeset} = replace_identity(identity, attrs, subject)
+      assert errors_on(changeset) == %{provider_identifier_confirmation: ["email does not match"]}
 
       refute Repo.get(Auth.Identity, identity.id).deleted_at
     end
@@ -1621,7 +1667,12 @@ defmodule Domain.AuthTest do
       provider: provider,
       subject: subject
     } do
-      attrs = %{provider_identifier: Fixtures.Auth.random_provider_identifier(provider)}
+      provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
+
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
 
       assert {:ok, new_identity} = replace_identity(identity, attrs, subject)
 

--- a/elixir/apps/domain/test/support/fixtures/auth.ex
+++ b/elixir/apps/domain/test/support/fixtures/auth.ex
@@ -242,6 +242,7 @@ defmodule Domain.Fixtures.Auth do
       end)
 
     attrs = Map.put(attrs, :provider_identifier, provider_identifier)
+    attrs = Map.put(attrs, :provider_identifier_confirmation, provider_identifier)
 
     {:ok, identity} = Auth.upsert_identity(actor, provider, attrs)
 

--- a/elixir/apps/web/lib/web/live/actors/components.ex
+++ b/elixir/apps/web/lib/web/live/actors/components.ex
@@ -132,6 +132,14 @@ defmodule Web.Actors.Components do
         autocomplete="off"
       />
     </div>
+    <div>
+      <.input
+        label="Email Confirmation"
+        placeholder="Email Confirmation"
+        field={@form[:provider_identifier_confirmation]}
+        autocomplete="off"
+      />
+    </div>
     """
   end
 

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -21,6 +21,10 @@ defmodule Web.SignUp do
       |> Ecto.Changeset.cast(attrs, [:email])
       |> Ecto.Changeset.validate_required([:email])
       |> Ecto.Changeset.validate_format(:email, ~r/.+@.+/)
+      |> Ecto.Changeset.validate_confirmation(:email,
+        required: true,
+        message: "email does not match"
+      )
       |> Ecto.Changeset.cast_embed(:account,
         with: fn _account, attrs -> Accounts.Account.Changeset.create(attrs) end
       )
@@ -316,7 +320,8 @@ defmodule Web.SignUp do
           :identity,
           fn _repo, %{actor: actor, provider: provider} ->
             Auth.create_identity(actor, provider, %{
-              provider_identifier: registration.email
+              provider_identifier: registration.email,
+              provider_identifier_confirmation: registration.email
             })
           end
         )

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -260,6 +260,8 @@ defmodule Web.SignUp do
       socket.assigns.actor_name_changed? ||
         payload["_target"] == ["registration", "actor", "name"]
 
+    attrs = Map.put(attrs, "email_confirmation", attrs["email"])
+
     changeset =
       attrs
       |> maybe_put_default_account_name(account_name_changed?)
@@ -275,7 +277,11 @@ defmodule Web.SignUp do
      )}
   end
 
-  def handle_event("submit", %{"registration" => attrs}, socket) do
+  def handle_event("submit", %{"registration" => orig_attrs}, socket) do
+    attrs =
+      put_in(orig_attrs, ["actor", "type"], :account_admin_user)
+      |> Map.put("email_confirmation", orig_attrs["email"])
+
     changeset =
       attrs
       |> maybe_put_default_account_name()

--- a/elixir/apps/web/test/web/live/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up_test.exs
@@ -13,7 +13,8 @@ defmodule Web.Live.SignUpTest do
              "registration[actor][_persistent_id]",
              "registration[actor][name]",
              "registration[actor][type]",
-             "registration[email]"
+             "registration[email]",
+             "registration[email_confirmation]"
            ]
   end
 
@@ -24,10 +25,13 @@ defmodule Web.Live.SignUpTest do
 
     {:ok, lv, _html} = live(conn, ~p"/sign_up")
 
+    email = Fixtures.Auth.email()
+
     attrs = %{
       account: %{name: account_name},
       actor: %{name: "John Doe"},
-      email: "jdoe@test.local"
+      email: email,
+      email_confirmation: email
     }
 
     assert html =
@@ -50,7 +54,7 @@ defmodule Web.Live.SignUpTest do
 
     identity = Repo.one(Domain.Auth.Identity)
     assert identity.account_id == account.id
-    assert identity.provider_identifier == "jdoe@test.local"
+    assert identity.provider_identifier == email
 
     assert_email_sent(fn email ->
       assert email.subject == "Welcome to Firezone"
@@ -94,7 +98,8 @@ defmodule Web.Live.SignUpTest do
            |> form("form", registration: attrs)
            |> render_submit()
            |> form_validation_errors() == %{
-             "registration[email]" => ["has invalid format"]
+             "registration[email]" => ["has invalid format"],
+             "registration[email_confirmation]" => ["email does not match"]
            }
   end
 

--- a/elixir/apps/web/test/web/live/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up_test.exs
@@ -13,8 +13,7 @@ defmodule Web.Live.SignUpTest do
              "registration[actor][_persistent_id]",
              "registration[actor][name]",
              "registration[actor][type]",
-             "registration[email]",
-             "registration[email_confirmation]"
+             "registration[email]"
            ]
   end
 
@@ -30,8 +29,7 @@ defmodule Web.Live.SignUpTest do
     attrs = %{
       account: %{name: account_name},
       actor: %{name: "John Doe"},
-      email: email,
-      email_confirmation: email
+      email: email
     }
 
     assert html =
@@ -98,8 +96,7 @@ defmodule Web.Live.SignUpTest do
            |> form("form", registration: attrs)
            |> render_submit()
            |> form_validation_errors() == %{
-             "registration[email]" => ["has invalid format"],
-             "registration[email_confirmation]" => ["email does not match"]
+             "registration[email]" => ["has invalid format"]
            }
   end
 


### PR DESCRIPTION
Why:

* When using the Email Auth Provider (a.k.a. Magic Link), a mistyped email address when adding a new identity or signing up could allow an unauthorized person access to your Firezone account.  To help prevent this, an email confirmation field has been added during signup and during identity creation in the portal.