### PR TITLE
ci(windows): speed up CI/CD steps for building Windows artifacts

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -64,44 +64,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - run: cargo test --all-features ${{ matrix.packages }}
 
-  # TODO: Remove when windows build works reliably in cd.yml
-  # These `temp-` jobs serve as a sanity check to early exit if there's an issue in the workflow
-  temp-build-windows-artifacts:
-    runs-on: windows-2019
-    defaults:
-      run:
-        working-directory: ./rust
-    strategy:
-      fail-fast: false
-      # The matrix is 1x1 to match the style of build-push-linux-release-artifacts
-      # In the future we could try to cross-compile aarch64-windows here.
-      matrix:
-        name:
-          - package: hello-world
-            artifact: hello-world
-    env:
-      BINARY_DEST_PATH: ${{ matrix.name.artifact }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
-        with:
-          targets: x86_64-pc-windows-msvc
-      - name: Build release binaries
-        run: |
-          cargo `
-          build `
-          --release -p ${{ matrix.name.package }}
-          cp target/release/${{ matrix.name.package }}.exe "${{ env.BINARY_DEST_PATH }}-x64.exe"
-          pwd
-          ls *.exe
-      - name: Save build artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.name.artifact }}-x64.exe
-          path: ${{ github.workspace }}/rust/${{ env.BINARY_DEST_PATH }}-x64.exe
-
   # This should be identical to `build-push-windows-release-artifacts` in `cd.yml` except for the permissions, needs, and uploading step
-  temp-build-tauri:
+  build-tauri:
     runs-on: windows-2019
     defaults:
       run:
@@ -123,10 +87,11 @@ jobs:
           targets: x86_64-pc-windows-msvc
       - name: Build release binaries
         run: |
-          cargo install tauri-cli
+          # npm installs a binary, which is faster than building tauri-cli with Cargo
+          npm install -g @tauri-apps/cli
 
           # Tauri build already defaults to '--release'
-          cargo tauri build
+          tauri build
 
           # Used for release artifact
           cp target/release/${{ matrix.name.package }}.exe "${{ env.BINARY_DEST_PATH }}-x64.exe"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -270,10 +270,10 @@ jobs:
           targets: x86_64-pc-windows-msvc
       - name: Build release binaries
         run: |
-          cargo install tauri-cli
+          npm install -g @tauri-apps/cli
 
           # Tauri build already defaults to '--release'
-          cargo tauri build
+          tauri build
 
           # Used for release artifact
           cp target/release/${{ matrix.name.package }}.exe "${{ env.BINARY_DEST_PATH }}-x64.exe"


### PR DESCRIPTION
This is faster to review than #2757.

It removes the "hello world" build and switches from Cargo to npm so Tauri installs faster.