### PR TITLE
check yaml on CI workflow files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
         description: Forces to replace line ending by the UNIX 'lf' character.
         exclude: '(^website/public/images/|^kotlin/android/gradlew.bat)'
       - id: check-yaml
-        exclude: ^.github/workflows/
       - id: check-merge-conflict
       - id: end-of-file-fixer
         exclude: ^website/public/images/


### PR DESCRIPTION
May not be necessary since GitHub does this already, but for devs that may be using pre-commit, this will check their YAML for syntax errors.