### PR TITLE
Remove handling account ID in app, prevent changing settings when signed in

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AuthView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AuthView.swift
@@ -19,15 +19,8 @@ final class AuthViewModel: ObservableObject {
   private var cancellables = Set<AnyCancellable>()
 
   func signInButtonTapped() async {
-    guard let accountId = authStore.tunnelStore.tunnelAuthStatus.accountId(),
-      !accountId.isEmpty
-    else {
-      settingsUndefined()
-      return
-    }
-
     do {
-      try await authStore.signIn(accountId: accountId)
+      try await authStore.signIn()
     } catch {
       dump(error)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
@@ -60,7 +60,9 @@ import SwiftUI
     }
 
     func signOutButtonTapped() {
-      appStore.auth.signOut()
+      Task {
+        await appStore.auth.signOut()
+      }
     }
 
     func startTunnel() async {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
@@ -88,7 +88,7 @@ import SwiftUI
         Section(header: Text("Authentication")) {
           Group {
             switch self.model.loginStatus {
-            case .signedIn(_, let actorName):
+            case .signedIn(let actorName):
               HStack {
                 Text(actorName.isEmpty ? "Signed in" : "Signed in as")
                 Spacer()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
@@ -169,11 +169,11 @@ public struct SettingsView: View {
         isPresented: $isShowingConfirmationAlert,
         presenting: confirmationAlertContinueAction,
         actions: { confirmationAlertContinueAction in
-          Button("Continue") {
-            confirmationAlertContinueAction.performAction(on: self)
-          }
           Button("Cancel", role: .cancel) {
             // Nothing to do
+          }
+          Button("Continue") {
+            confirmationAlertContinueAction.performAction(on: self)
           }
         },
         message: { _ in
@@ -196,11 +196,11 @@ public struct SettingsView: View {
         isPresented: $isShowingConfirmationAlert,
         presenting: confirmationAlertContinueAction,
         actions: { confirmationAlertContinueAction in
-          Button("Continue") {
-            confirmationAlertContinueAction.performAction(on: self)
-          }
           Button("Cancel", role: .cancel) {
             // Nothing to do
+          }
+          Button("Continue", role: .destructive) {
+            confirmationAlertContinueAction.performAction(on: self)
           }
         },
         message: { _ in

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/SettingsView.swift
@@ -46,8 +46,15 @@ public final class SettingsViewModel: ObservableObject {
 
   func saveAdvancedSettings() {
     Task {
-      guard let authBaseURL = URL(string: advancedSettings.authBaseURLString) else {
-        fatalError("Saved authBaseURL is invalid")
+      if case .signedIn = authStore.tunnelStore.tunnelAuthStatus {
+        await authStore.signOut()
+      }
+      let authBaseURLString = advancedSettings.authBaseURLString
+      guard URL(string: authBaseURLString) != nil else {
+        logger.error(
+          "Not saving advanced settings because authBaseURL '\(authBaseURLString, privacy: .public)' is invalid"
+        )
+        return
       }
       do {
         try await authStore.tunnelStore.saveAdvancedSettings(advancedSettings)
@@ -57,7 +64,6 @@ public final class SettingsViewModel: ObservableObject {
       await MainActor.run {
         advancedSettings.isSavedToDisk = true
       }
-      // TODO: Should sign out the user if signed in
     }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
@@ -55,10 +55,6 @@ import SwiftUINavigationCore
 
       defer { bindDestination() }
 
-      if case .accountNotSetup = appStore.tunnel.tunnelAuthStatus {
-        destination = .undefinedSettingsAlert(.undefinedSettings)
-      }
-
       appStore.auth.$loginStatus
         .receive(on: mainQueue)
         .sink(receiveValue: { [weak self] loginStatus in

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Keychain/Keychain.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Keychain/Keychain.swift
@@ -25,7 +25,7 @@ public actor Keychain {
   public typealias PersistentRef = Data
 
   public struct TokenAttributes {
-    let authURLString: String
+    let authBaseURLString: String
     let actorName: String
   }
 
@@ -56,7 +56,7 @@ public actor Keychain {
           kSecClass: kSecClassGenericPassword,
           kSecAttrLabel: "Firezone access token (\(tokenAttributes.actorName))",
           kSecAttrDescription: "Firezone access token",
-          kSecAttrService: tokenAttributes.authURLString,
+          kSecAttrService: tokenAttributes.authBaseURLString,
           // The UUID uniquifies this item in the keychain
           kSecAttrAccount: "\(tokenAttributes.actorName): \(UUID().uuidString)",
           kSecValueData: token.data(using: .utf8) as Any,
@@ -72,7 +72,7 @@ public actor Keychain {
           kSecClass: kSecClassGenericPassword,
           kSecAttrLabel: "Firezone access token (\(tokenAttributes.actorName))",
           kSecAttrDescription: "Firezone access token",
-          kSecAttrService: tokenAttributes.authURLString,
+          kSecAttrService: tokenAttributes.authBaseURLString,
           // The UUID uniquifies this item in the keychain
           kSecAttrAccount: "\(tokenAttributes.actorName): \(UUID().uuidString)",
           kSecValueData: token.data(using: .utf8) as Any,
@@ -100,7 +100,7 @@ public actor Keychain {
         let checkForStaleItemsQuery =
           [
             kSecClass: kSecClassGenericPassword,
-            kSecAttrService: tokenAttributes.authURLString,
+            kSecAttrService: tokenAttributes.authBaseURLString,
             kSecMatchLimit: kSecMatchLimitAll,
             kSecReturnPersistentRef: true,
           ] as [CFString: Any]
@@ -217,7 +217,7 @@ public actor Keychain {
                     .startIndex..<(account.lastIndex(of: ":")
                     ?? account.endIndex)])
               let attributes = TokenAttributes(
-                authURLString: service,
+                authBaseURLString: service,
                 actorName: actorName)
               continuation.resume(returning: attributes)
               return
@@ -244,14 +244,14 @@ public actor Keychain {
     }
   }
 
-  func search(authURLString: String) async -> PersistentRef? {
+  func search(authBaseURLString: String) async -> PersistentRef? {
     return await withCheckedContinuation { [weak self] continuation in
       self?.workQueue.async {
         let query =
           [
             kSecClass: kSecClassGenericPassword,
             kSecAttrDescription: "Firezone access token",
-            kSecAttrService: authURLString,
+            kSecAttrService: authBaseURLString,
             kSecReturnPersistentRef: true,
           ] as [CFString: Any]
         var result: CFTypeRef?

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Keychain/KeychainStorage.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Keychain/KeychainStorage.swift
@@ -12,7 +12,7 @@ struct KeychainStorage: Sendable {
     @Sendable (Keychain.Token, Keychain.TokenAttributes) async throws -> Keychain.PersistentRef
   var delete: @Sendable (Keychain.PersistentRef) async throws -> Void
   var loadAttributes: @Sendable (Keychain.PersistentRef) async -> Keychain.TokenAttributes?
-  var searchByAuthURL: @Sendable (URL) async -> Keychain.PersistentRef?
+  var searchByAuthBaseURL: @Sendable (URL) async -> Keychain.PersistentRef?
 }
 
 extension KeychainStorage: DependencyKey {
@@ -23,7 +23,7 @@ extension KeychainStorage: DependencyKey {
       store: { try await keychain.store(token: $0, tokenAttributes: $1) },
       delete: { try await keychain.delete(persistentRef: $0) },
       loadAttributes: { await keychain.loadAttributes(persistentRef: $0) },
-      searchByAuthURL: { await keychain.search(authURLString: $0.absoluteString) }
+      searchByAuthBaseURL: { await keychain.search(authBaseURLString: $0.absoluteString) }
     )
   }
 
@@ -45,7 +45,7 @@ extension KeychainStorage: DependencyKey {
       loadAttributes: { ref in
         storage.value[ref]?.1
       },
-      searchByAuthURL: { _ in
+      searchByAuthBaseURL: { _ in
         nil
       }
     )

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneError.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneError.swift
@@ -7,5 +7,4 @@
 import Foundation
 
 enum FirezoneError: Error {
-  case missingTeamId
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -6,25 +6,6 @@
 
 import Foundation
 
-struct AccountSettings {
-  var accountId: String = "" {
-    didSet { if oldValue != accountId { isSavedToDisk = false } }
-  }
-
-  var isSavedToDisk = true
-
-  var isValid: Bool {
-    !accountId.isEmpty
-      && accountId.unicodeScalars.allSatisfy { Self.teamIdAllowedCharacterSet.contains($0) }
-  }
-
-  static let teamIdAllowedCharacterSet: CharacterSet = {
-    var pathAllowed = CharacterSet.urlPathAllowed
-    pathAllowed.remove("/")
-    return pathAllowed
-  }()
-}
-
 struct AdvancedSettings: Equatable {
   var authBaseURLString: String {
     didSet { if oldValue != authBaseURLString { isSavedToDisk = false } }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -46,3 +46,9 @@ struct AdvancedSettings: Equatable {
   // Note: To see what the connlibLogFilterString values mean, see:
   // https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html
 }
+
+extension AdvancedSettings: CustomStringConvertible {
+  var description: String {
+    "(\(authBaseURLString), \(apiURLString), \(connlibLogFilterString))"
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
@@ -36,7 +36,7 @@ final class AppStore: ObservableObject {
     Task {
       do {
         try await tunnel.stop()
-        auth.signOut()
+        await auth.signOut()
       } catch {
         logger.error("\(#function): Error stopping tunnel: \(String(describing: error))")
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -233,6 +233,10 @@ final class AuthStore: ObservableObject {
         } catch {
           logger.error("\(#function): Error stopping tunnel: \(String(describing: error))")
         }
+        if tunnelStore.tunnelAuthStatus != .signedOut {
+          // Bring tunnelAuthStatus in line, in case it's out of touch with the login status
+          try await tunnelStore.saveAuthStatus(.signedOut)
+        }
       }
     case .uninitialized:
       break

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -126,8 +126,6 @@ final class AuthStore: ObservableObject {
     switch tunnelAuthStatus {
     case .tunnelUninitialized:
       return .uninitialized
-    case .accountNotSetup:
-      return .signedOut
     case .signedOut:
       return .signedOut
     case .signedIn(let tunnelAuthBaseURL, let tokenReference):
@@ -242,7 +240,7 @@ final class AuthStore: ObservableObject {
     if let tokenRef = await keychain.searchByAuthBaseURL(authBaseURL) {
       return .signedIn(authBaseURL: authBaseURL, tokenReference: tokenRef)
     } else {
-      return .signedOut(authBaseURL: authBaseURL)
+      return .signedOut
     }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -19,8 +19,14 @@ enum TunnelStoreError: Error {
 
 public struct TunnelProviderKeys {
   static let keyAuthBaseURLString = "authBaseURLString"
-  static let keyAccountId = "accountId"  // Unused
   public static let keyConnlibLogFilter = "connlibLogFilter"
+
+  // The following key is not added to the tunnel provider.
+  // The key is defined so that the key can be removed if it exists
+  // in a tunnel provider configuration. A tunnel configuration
+  // created by an earlier version of the app could have this
+  // key, and we use this key definition to remove it.
+  static let keyAccountId = "accountId"
 }
 
 final class TunnelStore: ObservableObject {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -16,6 +16,7 @@ enum TunnelStoreError: Error {
 
 public struct TunnelProviderKeys {
   static let keyAuthBaseURLString = "authBaseURLString"
+  static let keyAccountId = "accountId"  // Unused
   public static let keyConnlibLogFilter = "connlibLogFilter"
 }
 
@@ -405,6 +406,7 @@ extension NETunnelProviderManager {
         protocolConfiguration.passwordReference = tokenReference
       }
 
+      providerConfig.removeValue(forKey: TunnelProviderKeys.keyAccountId)
       protocolConfiguration.providerConfiguration = providerConfig
 
       ensureTunnelConfigurationIsValid()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -93,6 +93,7 @@ final class TunnelStore: ObservableObject {
   }
 
   func saveAuthStatus(_ tunnelAuthStatus: TunnelAuthStatus) async throws {
+    Self.logger.log("TunnelStore.\(#function) \(tunnelAuthStatus, privacy: .public)")
     guard let tunnel = tunnel else {
       fatalError("Tunnel not initialized yet")
     }
@@ -107,6 +108,7 @@ final class TunnelStore: ObservableObject {
   }
 
   func saveAdvancedSettings(_ advancedSettings: AdvancedSettings) async throws {
+    Self.logger.log("TunnelStore.\(#function) \(advancedSettings, privacy: .public)")
     guard let tunnel = tunnel else {
       fatalError("Tunnel not initialized yet")
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -103,6 +103,7 @@ final class TunnelStore: ObservableObject {
       throw TunnelStoreError.cannotSaveToTunnelWhenConnected
     }
 
+    try await tunnel.loadFromPreferences()
     try await tunnel.saveAuthStatus(tunnelAuthStatus)
     self.tunnelAuthStatus = tunnelAuthStatus
   }
@@ -118,6 +119,7 @@ final class TunnelStore: ObservableObject {
       throw TunnelStoreError.cannotSaveToTunnelWhenConnected
     }
 
+    try await tunnel.loadFromPreferences()
     try await tunnel.saveAdvancedSettings(advancedSettings)
     self.tunnelAuthStatus = tunnel.authStatus()
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -41,7 +41,7 @@
     private var connectingAnimationTimer: Timer?
 
     let settingsViewModel: SettingsViewModel
-    private var loginStatus: AuthStore.LoginStatus = .signedOut(accountId: nil)
+    private var loginStatus: AuthStore.LoginStatus = .signedOut
     private var tunnelStatus: NEVPNStatus = .invalid
 
     public init(settingsViewModel: SettingsViewModel) {
@@ -210,8 +210,6 @@
       Task {
         do {
           try await appStore?.auth.signIn()
-        } catch FirezoneError.missingTeamId {
-          openSettingsWindow()
         } catch {
           logger.error("Error signing in: \(String(describing: error))")
         }
@@ -316,7 +314,7 @@
         signInMenuItem.target = self
         signInMenuItem.isEnabled = true
         signOutMenuItem.isHidden = true
-      case .signedIn(_, let actorName):
+      case .signedIn(let actorName):
         signInMenuItem.title = actorName.isEmpty ? "Signed in" : "Signed in as \(actorName)"
         signInMenuItem.target = nil
         signOutMenuItem.isHidden = false

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -217,7 +217,9 @@
     }
 
     @objc private func signOutButtonTapped() {
-      appStore?.auth.signOut()
+      Task {
+        await appStore?.auth.signOut()
+      }
     }
 
     @objc private func settingsButtonTapped() {


### PR DESCRIPTION
This PR

  - Addresses the Apple clients part of #2791 
  - Fixes #2668

The Settings UI change of separating Logs and Advanced settings is not part of this PR.

