### PR TITLE
Update all tailwind classes to use primary/accent/neutral

### DIFF
--- a/elixir/apps/web/assets/tailwind.config.js
+++ b/elixir/apps/web/assets/tailwind.config.js
@@ -73,12 +73,7 @@ module.exports = {
         brand: "#FD4F00",
         primary: firezoneColors["heat-wave"],
         accent: firezoneColors["electric-violet"],
-        neutral: firezoneColors["chicago"],
-        fz_blue: colors.blue,
-        fz_red: colors.red,
-        fz_green: colors.green,
-        fz_yellow: colors.yellow,
-        fz_orange: colors.orange,
+        neutral: firezoneColors["chicago"]
       }
     },
   },

--- a/elixir/apps/web/assets/tailwind.config.js
+++ b/elixir/apps/web/assets/tailwind.config.js
@@ -5,6 +5,7 @@ const plugin = require("tailwindcss/plugin")
 const fs = require("fs")
 const path = require("path")
 const defaultTheme = require("tailwindcss/defaultTheme")
+const colors = require('tailwindcss/colors')
 
 const firezoneColors = {
   // See our brand palette in Figma.
@@ -38,18 +39,19 @@ const firezoneColors = {
     800: "#28005c",
     900: "#160033",
   },
-  // neutral: night-rider
-  "night-rider": {
-    50: "#fcfcfc",
-    100: "#f8f7f7",
-    200: "#ebebea",
-    300: "#dfdedd",
-    400: "#c7c4c2",
-    500: "#a7a3a0",
-    600: "#90867f",
-    700: "#766a60",
-    800: "#4c3e33",
-    900: "#1b140e",
+  // neutral: chicago
+  "chicago": {
+    50:  "#f6f6f6",
+    100: "#e7e7e7",
+    200: "#d1d1d1",
+    300: "#b0b0b0",
+    400: "#888888",
+    500: "#6d6d6d",
+    600: "#575757",
+    700: "#4f4f4f",
+    800: "#454545",
+    900: "#3d3d3d",
+    950: "#262626",
   },
 };
 
@@ -71,19 +73,12 @@ module.exports = {
         brand: "#FD4F00",
         primary: firezoneColors["heat-wave"],
         accent: firezoneColors["electric-violet"],
-        neutral: firezoneColors["night-rider"]
-        //primary: {
-        //  "50": "#eff6ff",
-        //  "100": "#dbeafe",
-        //  "200": "#bfdbfe",
-        //  "300": "#93c5fd",
-        //  "400": "#60a5fa",
-        //  "500": "#3b82f6",
-        //  "600": "#2563eb",
-        //  "700": "#1d4ed8",
-        //  "800": "#1e40af",
-        //  "900": "#1e3a8a"
-        //}
+        neutral: firezoneColors["chicago"],
+        fz_blue: colors.blue,
+        fz_red: colors.red,
+        fz_green: colors.green,
+        fz_yellow: colors.yellow,
+        fz_orange: colors.orange,
       }
     },
   },

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -345,9 +345,9 @@ defmodule Web.CoreComponents do
       id={@id}
       class={[
         "p-4 text-sm flash-#{@kind}",
-        @kind == :success && "text-fz_green-800 bg-fz_green-50",
-        @kind == :info && "text-fz_yellow-800 bg-fz_yellow-50",
-        @kind == :error && "text-fz_red-800 bg-fz_red-50",
+        @kind == :success && "text-green-800 bg-green-50",
+        @kind == :info && "text-yellow-800 bg-yellow-50",
+        @kind == :error && "text-red-800 bg-red-50",
         @style != "wide" && "mb-4 rounded"
       ]}
       role="alert"
@@ -691,10 +691,10 @@ defmodule Web.CoreComponents do
 
   def badge(assigns) do
     colors = %{
-      "success" => "bg-fz_green-100 text-fz_green-800 ",
-      "danger" => "bg-fz_red-100 text-fz_red-800",
-      "warning" => "bg-fz_yellow-100 text-fz_yellow-800",
-      "info" => "bg-fz_blue-100 text-fz_blue-800",
+      "success" => "bg-green-100 text-green-800 ",
+      "danger" => "bg-red-100 text-red-800",
+      "warning" => "bg-yellow-100 text-yellow-800",
+      "info" => "bg-blue-100 text-blue-800",
       "primary" => "bg-primary-400 text-primary-800",
       "accent" => "bg-accent-200 text-accent-800",
       "neutral" => "bg-neutral-100 text-neutral-800"
@@ -724,20 +724,20 @@ defmodule Web.CoreComponents do
   def dual_badge(assigns) do
     colors = %{
       "success" => %{
-        "dark" => "bg-fz_green-300 text-fz_green-800",
-        "light" => "bg-fz_green-100 text-fz_green-800"
+        "dark" => "bg-green-300 text-green-800",
+        "light" => "bg-green-100 text-green-800"
       },
       "danger" => %{
-        "dark" => "bg-fz_red-300 text-fz_red-800",
-        "light" => "bg-fz_red-100 text-fz_red-800"
+        "dark" => "bg-red-300 text-red-800",
+        "light" => "bg-red-100 text-red-800"
       },
       "warning" => %{
-        "dark" => "bg-fz_yellow-300 text-fz_yellow-800",
-        "light" => "bg-fz_yellow-100 text-fz_yellow-800"
+        "dark" => "bg-yellow-300 text-yellow-800",
+        "light" => "bg-yellow-100 text-yellow-800"
       },
       "info" => %{
-        "dark" => "bg-fz_blue-300 text-fz_blue-800",
-        "light" => "bg-fz_blue-100 text-fz_blue-800"
+        "dark" => "bg-blue-300 text-blue-800",
+        "light" => "bg-blue-100 text-blue-800"
       },
       "primary" => %{
         "dark" => "bg-primary-400 text-primary-800",
@@ -844,7 +844,7 @@ defmodule Web.CoreComponents do
         "flex items-center justify-center",
         "font-medium text-sm text-white",
         "rounded-full",
-        (@connected? && "bg-fz_green-500") || "bg-fz_orange-400 cursor-progress"
+        (@connected? && "bg-green-500") || "bg-orange-400 cursor-progress"
       ]}
       navigate={@navigate}
       {
@@ -918,8 +918,8 @@ defmodule Web.CoreComponents do
           text-xs font-medium
           rounded-l
           py-0.5 pl-2.5 pr-1.5
-          text-fz_blue-800
-          bg-fz_blue-100]}
+          text-blue-800
+          bg-blue-100]}
       >
         <%= @identity.provider.name %>
       </.link>
@@ -927,8 +927,8 @@ defmodule Web.CoreComponents do
         "text-xs font-medium",
         "rounded-r",
         "mr-2 py-0.5 pl-1.5 pr-2.5",
-        "text-fz_blue-800",
-        "bg-fz_blue-50"
+        "text-blue-800",
+        "bg-blue-50"
       ]}>
         <%= get_identity_email(@identity) %>
       </span>

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -918,8 +918,9 @@ defmodule Web.CoreComponents do
           text-xs font-medium
           rounded-l
           py-0.5 pl-2.5 pr-1.5
-          text-blue-800
-          bg-blue-100]}
+          text-neutral-800
+          bg-neutral-200
+        ]}
       >
         <%= @identity.provider.name %>
       </.link>
@@ -927,8 +928,8 @@ defmodule Web.CoreComponents do
         "text-xs font-medium",
         "rounded-r",
         "mr-2 py-0.5 pl-1.5 pr-2.5",
-        "text-blue-800",
-        "bg-blue-50"
+        "text-neutral-800",
+        "bg-neutral-100"
       ]}>
         <%= get_identity_email(@identity) %>
       </span>

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -39,7 +39,7 @@ defmodule Web.CoreComponents do
   """
   def p(assigns) do
     ~H"""
-    <p class="text-gray-700"><%= render_slot(@inner_block) %></p>
+    <p class="text-neutral-700"><%= render_slot(@inner_block) %></p>
     """
   end
 
@@ -63,7 +63,7 @@ defmodule Web.CoreComponents do
       text-sm text-left sm:text-base text-white
       inline-flex items-center
       space-x-4 p-4 pl-6
-      bg-gray-800
+      bg-neutral-800
       relative
     ], @class]} {@rest}>
       <code
@@ -74,7 +74,7 @@ defmodule Web.CoreComponents do
 
       <span class={~w[
           absolute bottom-1 right-1
-          text-gray-400
+          text-neutral-400
           transition
           cursor-pointer
           rounded
@@ -108,7 +108,7 @@ defmodule Web.CoreComponents do
     ~H"""
     <div id={@id} phx-hook="Copy" class={@class} {@rest}>
       <code data-copy phx-no-format><%= render_slot(@inner_block) %></code>
-      <span class={~w[text-gray-400 cursor-pointer rounded]}>
+      <span class={~w[text-neutral-400 cursor-pointer rounded]}>
         <.icon name="hero-clipboard-document" data-icon class="h-4 w-4" />
       </span>
     </div>
@@ -145,7 +145,7 @@ defmodule Web.CoreComponents do
     ~H"""
     <div class="mb-4">
       <div
-        class="border-gray-200 bg-slate-50 rounded-t"
+        class="border-neutral-200 bg-neutral-50 rounded-t"
         id={"#{@id}-container"}
         phx-hook="Tabs"
         {@rest}
@@ -161,7 +161,7 @@ defmodule Web.CoreComponents do
               <button
                 class={~w[
                 inline-block p-4 border-b-2 border-transparent rounded-t
-                hover:text-gray-600 hover:border-gray-300
+                hover:text-neutral-600 hover:border-neutral-300
               ]}
                 id={"#{tab.id}-tab"}
                 data-tabs-target={"##{tab.id}"}
@@ -181,7 +181,7 @@ defmodule Web.CoreComponents do
       <div id={@id}>
         <%= for tab <- @tab do %>
           <div
-            class="hidden rounded-b bg-gray-50"
+            class="hidden rounded-b bg-neutral-50"
             id={tab.id}
             role="tabpanel"
             aria-labelledby={"#{tab.id}-tab"}
@@ -219,7 +219,7 @@ defmodule Web.CoreComponents do
     <div class="grid grid-cols-1 p-4 xl:grid-cols-3 xl:gap-4">
       <div class="col-span-full">
         <div class="flex justify-between items-center">
-          <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">
+          <h1 class="text-xl font-semibold text-neutral-900 sm:text-2xl">
             <%= render_slot(@title) %>
           </h1>
           <div class="inline-flex justify-between items-center space-x-2">
@@ -253,15 +253,15 @@ defmodule Web.CoreComponents do
       class="flex flex-col md:flex-row justify-between items-start md:items-center space-y-3 md:space-y-0 p-4"
       aria-label="Table navigation"
     >
-      <span class="text-sm font-normal text-gray-500">
-        Showing <span class="font-semibold text-gray-900">1-10</span>
-        of <span class="font-semibold text-gray-900">1000</span>
+      <span class="text-sm font-normal text-neutral-500">
+        Showing <span class="font-semibold text-neutral-900">1-10</span>
+        of <span class="font-semibold text-neutral-900">1000</span>
       </span>
       <ul class="inline-flex items-stretch -space-x-px">
         <li>
           <a href="#" class={~w[
-              flex items-center justify-center h-full py-1.5 px-3 ml-0 text-gray-500 bg-white rounded-l
-              border border-gray-300 hover:bg-gray-100 hover:text-gray-700
+              flex items-center justify-center h-full py-1.5 px-3 ml-0 text-neutral-500 bg-white rounded-l
+              border border-neutral-300 hover:bg-neutral-100 hover:text-neutral-700
             ]}>
             <span class="sr-only">Previous</span>
             <.icon name="hero-chevron-left" class="w-5 h-5" />
@@ -269,16 +269,16 @@ defmodule Web.CoreComponents do
         </li>
         <li>
           <a href="#" class={~w[
-              flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-500 bg-white border
-              border-gray-300 hover:bg-gray-100 hover:text-gray-700
+              flex items-center justify-center text-sm py-2 px-3 leading-tight text-neutral-500 bg-white border
+              border-neutral-300 hover:bg-neutral-100 hover:text-neutral-700
             ]}>
             1
           </a>
         </li>
         <li>
           <a href="#" class={~w[
-              flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-500 bg-white
-              border border-gray-300 hover:bg-gray-100 hover:text-gray-700
+              flex items-center justify-center text-sm py-2 px-3 leading-tight text-neutral-500 bg-white
+              border border-neutral-300 hover:bg-neutral-100 hover:text-neutral-700
             ]}>
             2
           </a>
@@ -293,24 +293,24 @@ defmodule Web.CoreComponents do
         </li>
         <li>
           <a href="#" class={~w[
-              flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-500 bg-white
-              border border-gray-300 hover:bg-gray-100 hover:text-gray-700
+              flex items-center justify-center text-sm py-2 px-3 leading-tight text-neutral-500 bg-white
+              border border-neutral-300 hover:bg-neutral-100 hover:text-neutral-700
             ]}>
             ...
           </a>
         </li>
         <li>
           <a href="#" class={~w[
-              flex items-center justify-center text-sm py-2 px-3 leading-tight text-gray-500 bg-white
-              border border-gray-300 hover:bg-gray-100 hover:text-gray-700
+              flex items-center justify-center text-sm py-2 px-3 leading-tight text-neutral-500 bg-white
+              border border-neutral-300 hover:bg-neutral-100 hover:text-neutral-700
             ]}>
             <%= @total_pages %>
           </a>
         </li>
         <li>
           <a href="#" class={~w[
-              flex items-center justify-center h-full py-1.5 px-3 leading-tight text-gray-500 bg-white rounded-r
-              border border-gray-300 hover:bg-gray-100 hover:text-gray-700
+              flex items-center justify-center h-full py-1.5 px-3 leading-tight text-neutral-500 bg-white rounded-r
+              border border-neutral-300 hover:bg-neutral-100 hover:text-neutral-700
             ]}>
             <span class="sr-only">Next</span>
             <.icon name="hero-chevron-right" class="w-5 h-5" />
@@ -345,9 +345,9 @@ defmodule Web.CoreComponents do
       id={@id}
       class={[
         "p-4 text-sm flash-#{@kind}",
-        @kind == :success && "text-green-800 bg-green-50",
-        @kind == :info && "text-yellow-800 bg-yellow-50",
-        @kind == :error && "text-red-800 bg-red-50",
+        @kind == :success && "text-fz_green-800 bg-fz_green-50",
+        @kind == :info && "text-fz_yellow-800 bg-fz_yellow-50",
+        @kind == :error && "text-fz_red-800 bg-fz_red-50",
         @style != "wide" && "mb-4 rounded"
       ]}
       role="alert"
@@ -415,7 +415,7 @@ defmodule Web.CoreComponents do
 
   def label(assigns) do
     ~H"""
-    <label for={@for} class={["block mb-2 text-sm font-medium text-gray-900", @class]}>
+    <label for={@for} class={["block mb-2 text-sm font-medium text-neutral-900", @class]}>
       <%= render_slot(@inner_block) %>
     </label>
     """
@@ -684,19 +684,20 @@ defmodule Web.CoreComponents do
     """
   end
 
-  attr :type, :string, default: "default"
+  attr :type, :string, default: "neutral"
   attr :class, :string, default: nil
   attr :rest, :global
   slot :inner_block, required: true
 
   def badge(assigns) do
     colors = %{
-      "plan" => "bg-primary-500 text-white",
-      "success" => "bg-green-100 text-green-800 ",
-      "danger" => "bg-red-100 text-red-800",
-      "warning" => "bg-yellow-100 text-yellow-800",
-      "info" => "bg-blue-100 text-blue-800",
-      "default" => "bg-gray-100 text-gray-800"
+      "success" => "bg-fz_green-100 text-fz_green-800 ",
+      "danger" => "bg-fz_red-100 text-fz_red-800",
+      "warning" => "bg-fz_yellow-100 text-fz_yellow-800",
+      "info" => "bg-fz_blue-100 text-fz_blue-800",
+      "primary" => "bg-primary-400 text-primary-800",
+      "accent" => "bg-accent-200 text-accent-800",
+      "neutral" => "bg-neutral-100 text-neutral-800"
     }
 
     assigns = assign(assigns, colors: colors)
@@ -711,6 +712,65 @@ defmodule Web.CoreComponents do
       {@rest}
     >
       <%= render_slot(@inner_block) %>
+    </span>
+    """
+  end
+
+  attr :type, :string, default: "neutral"
+
+  slot :left, required: true
+  slot :right, required: true
+
+  def dual_badge(assigns) do
+    colors = %{
+      "success" => %{
+        "dark" => "bg-fz_green-300 text-fz_green-800",
+        "light" => "bg-fz_green-100 text-fz_green-800"
+      },
+      "danger" => %{
+        "dark" => "bg-fz_red-300 text-fz_red-800",
+        "light" => "bg-fz_red-100 text-fz_red-800"
+      },
+      "warning" => %{
+        "dark" => "bg-fz_yellow-300 text-fz_yellow-800",
+        "light" => "bg-fz_yellow-100 text-fz_yellow-800"
+      },
+      "info" => %{
+        "dark" => "bg-fz_blue-300 text-fz_blue-800",
+        "light" => "bg-fz_blue-100 text-fz_blue-800"
+      },
+      "primary" => %{
+        "dark" => "bg-primary-400 text-primary-800",
+        "light" => "bg-primary-100 text-primary-800"
+      },
+      "accent" => %{
+        "dark" => "bg-accent-100 text-accent-800",
+        "light" => "bg-accent-50 text-accent-800"
+      },
+      "neutral" => %{
+        "dark" => "bg-neutral-100 text-neutral-800",
+        "light" => "bg-neutral-50 text-neutral-800"
+      }
+    }
+
+    assigns = assign(assigns, colors: colors)
+
+    ~H"""
+    <span class="flex inline-flex">
+      <div class={[
+        "text-xs font-medium rounded-l py-0.5 pl-2.5 pr-1.5",
+        @colors[@type]["dark"]
+      ]}>
+        <%= render_slot(@left) %>
+      </div>
+      <span class={[
+        "text-xs font-medium",
+        "rounded-r",
+        "mr-2 py-0.5 pl-1.5 pr-2.5",
+        @colors[@type]["light"]
+      ]}>
+        <%= render_slot(@right) %>
+      </span>
     </span>
     """
   end
@@ -784,7 +844,7 @@ defmodule Web.CoreComponents do
         "flex items-center justify-center",
         "font-medium text-sm text-white",
         "rounded-full",
-        (@connected? && "bg-green-500") || "bg-orange-400 cursor-progress"
+        (@connected? && "bg-fz_green-500") || "bg-fz_orange-400 cursor-progress"
       ]}
       navigate={@navigate}
       {
@@ -822,7 +882,7 @@ defmodule Web.CoreComponents do
     ~H"""
     <.relative_datetime datetime={@schema.inserted_at} /> by
     <.link
-      class="text-blue-600 hover:underline"
+      class="text-accent-600 hover:underline"
       navigate={~p"/#{@schema.account_id}/actors/#{@schema.created_by_identity.actor.id}"}
     >
       <%= assigns.schema.created_by_identity.actor.name %>
@@ -834,7 +894,7 @@ defmodule Web.CoreComponents do
     ~H"""
     synced <.relative_datetime datetime={@schema.inserted_at} /> from
     <.link
-      class="text-blue-600 hover:underline"
+      class="text-accent-600 hover:underline"
       navigate={Web.Settings.IdentityProviders.Components.view_provider(@account, @schema.provider)}
     >
       <%= @schema.provider.name %>
@@ -858,8 +918,8 @@ defmodule Web.CoreComponents do
           text-xs font-medium
           rounded-l
           py-0.5 pl-2.5 pr-1.5
-          text-blue-800
-          bg-blue-100]}
+          text-fz_blue-800
+          bg-fz_blue-100]}
       >
         <%= @identity.provider.name %>
       </.link>
@@ -867,8 +927,8 @@ defmodule Web.CoreComponents do
         "text-xs font-medium",
         "rounded-r",
         "mr-2 py-0.5 pl-1.5 pr-2.5",
-        "text-blue-800",
-        "bg-blue-50"
+        "text-fz_blue-800",
+        "bg-fz_blue-50"
       ]}>
         <%= get_identity_email(@identity) %>
       </span>
@@ -904,8 +964,8 @@ defmodule Web.CoreComponents do
           "text-xs font-medium",
           "rounded-l",
           "py-0.5 pl-2.5 pr-1.5",
-          "text-blue-800",
-          "bg-blue-100",
+          "text-accent-800",
+          "bg-accent-100",
           "whitespace-nowrap"
         ]}
       >
@@ -917,8 +977,8 @@ defmodule Web.CoreComponents do
           "text-xs font-medium",
           if(Actors.group_synced?(@group), do: "rounded-r pl-1.5 pr-2.5", else: "rounded px-1.5"),
           "py-0.5",
-          "text-blue-800",
-          "bg-blue-50",
+          "text-neutral-800",
+          "bg-neutral-100",
           "whitespace-nowrap"
         ]}
       >
@@ -938,7 +998,7 @@ defmodule Web.CoreComponents do
     <code>
       <%= @schema.last_seen_remote_ip %>
     </code>
-    <span class="text-gray-500 inline-block">
+    <span class="text-neutral-500 inline-block">
       <%= [
         @schema.last_seen_remote_ip_location_region,
         @schema.last_seen_remote_ip_location_city
@@ -948,7 +1008,7 @@ defmodule Web.CoreComponents do
 
       <a
         :if={not is_nil(@schema.last_seen_remote_ip_location_lat)}
-        class="ml-1 text-blue-800"
+        class="ml-1 text-accent-800"
         target="_blank"
         href={"http://www.google.com/maps/place/#{@schema.last_seen_remote_ip_location_lat},#{@schema.last_seen_remote_ip_location_lon}"}
       >

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -455,9 +455,9 @@ defmodule Web.FormComponents do
   defp button_style("danger") do
     button_style() ++
       [
-        "text-fz_red-600",
-        "border border-fz_red-600",
-        "hover:text-white hover:bg-fz_red-600"
+        "text-red-600",
+        "border border-red-600",
+        "hover:text-white hover:bg-red-600"
       ]
   end
 

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -76,9 +76,9 @@ defmodule Web.FormComponents do
   def input(%{type: "radio"} = assigns) do
     ~H"""
     <div phx-feedback-for={@name}>
-      <label class="flex items-center gap-2 text-gray-900">
+      <label class="flex items-center gap-2 text-neutral-900">
         <input type="radio" id={@id} name={@name} value={@value} checked={@checked} class={~w[
-          w-4 h-4 border-gray-300]} {@rest} />
+          w-4 h-4 border-neutral-300]} {@rest} />
         <%= @label %>
         <%= if @inner_block, do: render_slot(@inner_block) %>
       </label>
@@ -118,7 +118,7 @@ defmodule Web.FormComponents do
     <div phx-feedback-for={@name}>
       <.label for={@id}><%= @label %></.label>
       <select id={@id} name={@name} class={~w[
-          bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded
+          bg-neutral-50 border border-neutral-300 text-neutral-900 text-sm rounded
           block w-full p-2.5]} multiple={@multiple} {@rest}>
         <option :if={@prompt} value=""><%= @prompt %></option>
         <%= Phoenix.HTML.Form.options_for_select(@options, @value) %>
@@ -167,10 +167,10 @@ defmodule Web.FormComponents do
           id={@id}
           value={value}
           class={[
-            "bg-gray-50 p-2.5 block w-full rounded border text-gray-900 text-sm",
-            "phx-no-feedback:border-gray-300",
-            "disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
-            "border-gray-300",
+            "bg-neutral-50 p-2.5 block w-full rounded border text-neutral-900 text-sm",
+            "phx-no-feedback:border-neutral-300",
+            "disabled:bg-neutral-50 disabled:text-neutral-500 disabled:border-neutral-200 disabled:shadow-none",
+            "border-neutral-300",
             @errors != [] && "border-rose-400"
           ]}
           {@rest}
@@ -212,19 +212,19 @@ defmodule Web.FormComponents do
       <.label :if={not is_nil(@label)} for={@id}><%= @label %></.label>
       <div class={[
         "flex items-center",
-        "text-sm text-gray-900 bg-gray-50",
-        "border-gray-300 border rounded",
+        "text-sm text-neutral-900 bg-neutral-50",
+        "border-neutral-300 border rounded",
         "w-full",
-        "phx-no-feedback:border-gray-300",
-        "focus-within:outline-none focus-within:border-blue-600",
-        "peer-disabled:bg-slate-50 peer-disabled:text-slate-500 peer-disabled:border-slate-200 peer-disabled:shadow-none",
+        "phx-no-feedback:border-neutral-300",
+        "focus-within:outline-none focus-within:border-accent-600",
+        "peer-disabled:bg-neutral-50 peer-disabled:text-neutral-500 peer-disabled:border-neutral-200 peer-disabled:shadow-none",
         @errors != [] && "border-rose-400"
       ]}>
         <div
           class={[
             "-mr-5",
             "select-none cursor-text",
-            "text-gray-500",
+            "text-neutral-500",
             "p-2.5 block"
           ]}
           id={"#{@id}-prefix"}
@@ -239,7 +239,7 @@ defmodule Web.FormComponents do
           id={@id}
           value={Phoenix.HTML.Form.normalize_value(@type, @value)}
           class={[
-            "text-sm text-gray-900 bg-transparent border-0",
+            "text-sm text-neutral-900 bg-transparent border-0",
             "p-2.5 block w-full",
             "focus:outline-none focus:border-0 focus:ring-0"
           ]}
@@ -261,10 +261,10 @@ defmodule Web.FormComponents do
         id={@id}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
-          "bg-gray-50 p-2.5 block w-full rounded border text-gray-900 text-sm",
-          "phx-no-feedback:border-gray-300",
-          "disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none",
-          "border-gray-300",
+          "bg-neutral-50 p-2.5 block w-full rounded border text-neutral-900 text-sm",
+          "phx-no-feedback:border-neutral-300",
+          "disabled:bg-neutral-50 disabled:text-neutral-500 disabled:border-neutral-200 disabled:shadow-none",
+          "border-neutral-300",
           @errors != [] && "border-rose-400"
         ]}
         {@rest}
@@ -287,22 +287,22 @@ defmodule Web.FormComponents do
     ~H"""
     <div class="inline-flex rounded-md shadow-sm" role="group">
       <button type="button" class={~w[
-          px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200
-          rounded-l hover:bg-gray-100 hover:text-blue-700
+          px-4 py-2 text-sm font-medium text-neutral-900 bg-white border border-neutral-200
+          rounded-l hover:bg-neutral-100 hover:text-accent-700
         ]}>
         <%= render_slot(@first) %>
       </button>
       <%= for middle <- @middle do %>
         <button type="button" class={~w[
-            px-4 py-2 text-sm font-medium text-gray-900 bg-white border-t border-b
-            border-gray-200 hover:bg-gray-100 hover:text-blue-700
+            px-4 py-2 text-sm font-medium text-neutral-900 bg-white border-t border-b
+            border-neutral-200 hover:bg-neutral-100 hover:text-accent-700
           ]}>
           <%= render_slot(middle) %>
         </button>
       <% end %>
       <button type="button" class={~w[
-          px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200
-          rounded-r hover:bg-gray-100 hover:text-blue-700
+          px-4 py-2 text-sm font-medium text-neutral-900 bg-white border border-neutral-200
+          rounded-r hover:bg-neutral-100 hover:text-accent-700
         ]}>
         <%= render_slot(@last) %>
       </button>
@@ -455,9 +455,9 @@ defmodule Web.FormComponents do
   defp button_style("danger") do
     button_style() ++
       [
-        "text-red-600",
-        "border border-red-600",
-        "hover:text-white hover:bg-red-600"
+        "text-fz_red-600",
+        "border border-fz_red-600",
+        "hover:text-white hover:bg-fz_red-600"
       ]
   end
 
@@ -465,7 +465,7 @@ defmodule Web.FormComponents do
     button_style() ++
       [
         "text-white",
-        "bg-accent-600",
+        "bg-accent-450",
         "hover:bg-accent-700"
       ]
   end

--- a/elixir/apps/web/lib/web/components/layouts/root.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/root.html.heex
@@ -32,7 +32,7 @@
     >
     </script>
   </head>
-  <body class="bg-gray-50">
+  <body class="bg-neutral-50">
     <%= @inner_content %>
   </body>
 </html>

--- a/elixir/apps/web/lib/web/components/navigation_components.ex
+++ b/elixir/apps/web/lib/web/components/navigation_components.ex
@@ -7,7 +7,7 @@ defmodule Web.NavigationComponents do
 
   def topbar(assigns) do
     ~H"""
-    <nav class="bg-gray-50 border-b border-gray-200 px-4 py-2.5 fixed left-0 right-0 top-0 z-50">
+    <nav class="bg-neutral-50 border-b border-neutral-200 px-4 py-2.5 fixed left-0 right-0 top-0 z-50">
       <div class="flex flex-wrap justify-between items-center">
         <div class="flex justify-start items-center">
           <button
@@ -15,8 +15,8 @@ defmodule Web.NavigationComponents do
             data-drawer-toggle="drawer-navigation"
             aria-controls="drawer-navigation"
             class={[
-              "p-2 mr-2 text-gray-600 rounded cursor-pointer md:hidden",
-              "hover:text-gray-900 hover:bg-gray-100"
+              "p-2 mr-2 text-neutral-600 rounded cursor-pointer md:hidden",
+              "hover:text-neutral-900 hover:bg-neutral-100"
             ]}
           >
             <.icon name="hero-bars-3-center-left" class="w-6 h-6" />
@@ -53,25 +53,28 @@ defmodule Web.NavigationComponents do
   def subject_dropdown(assigns) do
     ~H"""
     <div class="py-3 px-4">
-      <span class="block text-sm font-semibold text-gray-900">
+      <span class="block text-sm font-semibold text-neutral-900">
         <%= @subject.actor.name %>
       </span>
-      <span class="block text-sm text-gray-900 truncate">
+      <span class="block text-sm text-neutral-900 truncate">
         <%= @subject.identity.provider_identifier %>
       </span>
     </div>
-    <ul class="py-1 text-gray-700" aria-labelledby="user-menu-dropdown">
+    <ul class="py-1 text-neutral-700" aria-labelledby="user-menu-dropdown">
       <li>
         <.link navigate={~p"/#{@subject.account}/actors/#{@subject.actor}"} class={~w[
-          block py-2 px-4 text-sm hover:bg-gray-100
+          block py-2 px-4 text-sm hover:bg-neutral-100
         ]}>
           Profile
         </.link>
       </li>
     </ul>
-    <ul class="py-1 text-gray-700" aria-labelledby="user-menu-dropdown">
+    <ul class="py-1 text-neutral-700" aria-labelledby="user-menu-dropdown">
       <li>
-        <a href={~p"/#{@subject.account}/sign_out"} class="block py-2 px-4 text-sm hover:bg-gray-100">
+        <a
+          href={~p"/#{@subject.account}/sign_out"}
+          class="block py-2 px-4 text-sm hover:bg-neutral-100"
+        >
           Sign out
         </a>
       </li>
@@ -92,7 +95,7 @@ defmodule Web.NavigationComponents do
         w-64 h-screen
         pt-14 pb-8
         transition-transform -translate-x-full
-        bg-white border-r border-gray-200
+        bg-white border-r border-neutral-200
         md:translate-x-0
       ]} aria-label="Sidenav" id="drawer-navigation">
       <div class="overflow-y-auto py-1 px-1 h-full bg-white">
@@ -113,7 +116,7 @@ defmodule Web.NavigationComponents do
     ~H"""
     <button
       type="button"
-      class={["flex mx-3 text-sm bg-gray-800 rounded-full md:mr-0"]}
+      class={["flex mx-3 text-sm bg-neutral-800 rounded-full md:mr-0"]}
       id={"#{@id}-button"}
       aria-expanded="false"
       data-dropdown-toggle={"#{@id}-dropdown"}
@@ -124,7 +127,7 @@ defmodule Web.NavigationComponents do
       class={[
         "hidden",
         "z-50 my-4 w-56 text-base list-none bg-white rounded",
-        "divide-y divide-gray-100 shadow",
+        "divide-y divide-neutral-100 shadow",
         "rounded-xl"
       ]}
       id={"#{@id}-dropdown"}
@@ -138,23 +141,23 @@ defmodule Web.NavigationComponents do
   attr :navigate, :string, required: true
   slot :inner_block, required: true
   attr :current_path, :string, required: true
-  attr :active_class, :string, required: false, default: "bg-gray-100"
+  attr :active_class, :string, required: false, default: "bg-neutral-100"
 
   def sidebar_item(assigns) do
     ~H"""
     <li>
       <.link navigate={@navigate} class={~w[
       flex items-center p-2
-      text-base font-medium text-gray-900
+      text-base font-medium text-neutral-900
       rounded
       #{sidebar_item_active?(@current_path, @navigate) && @active_class}
-      hover:bg-gray-100
+      hover:bg-neutral-100
       group]}>
         <.icon name={@icon} class={~w[
           w-6 h-6
-          text-gray-500
+          text-neutral-700
           transition duration-75
-          group-hover:text-gray-900
+          group-hover:text-neutral-900
         ]} />
         <span class="ml-3"><%= render_slot(@inner_block) %></span>
       </.link>
@@ -171,7 +174,7 @@ defmodule Web.NavigationComponents do
   attr :id, :string, required: true, doc: "ID of the nav group container"
   attr :icon, :string, required: true
   attr :current_path, :string, required: true
-  attr :active_class, :string, required: false, default: "bg-gray-100"
+  attr :active_class, :string, required: false, default: "bg-neutral-100"
 
   slot :name, required: true
 
@@ -193,31 +196,31 @@ defmodule Web.NavigationComponents do
         type="button"
         class={~w[
           flex items-center p-2 w-full group rounded
-          text-base font-medium text-gray-900
+          text-base font-medium text-neutral-900
           transition duration-75
-          hover:bg-gray-100]}
+          hover:bg-neutral-100]}
         aria-controls={"dropdown-#{@id}"}
         data-collapse-toggle={"dropdown-#{@id}"}
         aria-hidden={@dropdown_hidden}
       >
         <.icon name={@icon} class={~w[
-          w-6 h-6 text-gray-500
+          w-6 h-6 text-neutral-800
           transition duration-75
-          group-hover:text-gray-900]} />
+          group-hover:text-neutral-900]} />
         <span class="flex-1 ml-3 text-left whitespace-nowrap"><%= render_slot(@name) %></span>
         <.icon name="hero-chevron-down-solid" class={~w[
-          w-6 h-6 text-gray-500
+          w-6 h-6 text-neutral-500
           transition duration-75
-          group-hover:text-gray-900]} />
+          group-hover:text-neutral-900]} />
       </button>
       <ul id={"dropdown-#{@id}"} class={if @dropdown_hidden, do: "hidden", else: ""}>
         <li :for={item <- @item}>
           <.link navigate={item.navigate} class={~w[
               flex items-center p-2 pl-11 w-full group rounded
-              text-base font-medium text-gray-900
+              text-base font-medium text-neutral-900
               #{String.starts_with?(@current_path, item.navigate) && @active_class}
               transition duration-75
-              hover:bg-gray-100]}>
+              hover:bg-neutral-100]}>
             <%= render_slot(item) %>
           </.link>
         </li>
@@ -243,7 +246,7 @@ defmodule Web.NavigationComponents do
         <li class="inline-flex items-center">
           <.link
             navigate={if @account, do: ~p"/#{@account}", else: @home_path}
-            class="inline-flex items-center text-gray-700 hover:text-gray-900"
+            class="inline-flex items-center text-neutral-700 hover:text-neutral-900"
           >
             <.icon name="hero-home-solid" class="w-4 h-4 mr-2" /> Home
           </.link>
@@ -264,19 +267,19 @@ defmodule Web.NavigationComponents do
   def breadcrumb(assigns) do
     ~H"""
     <li class="inline-flex items-center">
-      <div class="flex items-center text-gray-700">
+      <div class="flex items-center text-neutral-700">
         <.icon name="hero-chevron-right-solid" class="w-6 h-6" />
         <.link
           :if={not is_nil(@path)}
           navigate={@path}
-          class="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2"
+          class="ml-1 text-sm font-medium text-neutral-700 hover:text-neutral-900 md:ml-2"
         >
           <%= render_slot(@inner_block) %>
         </.link>
 
         <span
           :if={is_nil(@path)}
-          class="ml-1 text-sm font-medium text-gray-700 hover:text-gray-900 md:ml-2"
+          class="ml-1 text-sm font-medium text-neutral-700 hover:text-neutral-900 md:ml-2"
         >
           <%= render_slot(@inner_block) %>
         </span>

--- a/elixir/apps/web/lib/web/components/page_components.ex
+++ b/elixir/apps/web/lib/web/components/page_components.ex
@@ -14,7 +14,7 @@ defmodule Web.PageComponents do
 
   def section(assigns) do
     ~H"""
-    <div class="bg-white overflow-hidden border-solid border-slate-200 border-t">
+    <div class="bg-white overflow-hidden border-solid border-neutral-200 border-t">
       <.header>
         <:title>
           <%= render_slot(@title) %>
@@ -66,7 +66,7 @@ defmodule Web.PageComponents do
 
   def link_style do
     [
-      "text-blue-600",
+      "text-accent-600",
       "hover:underline"
     ]
   end

--- a/elixir/apps/web/lib/web/components/table_components.ex
+++ b/elixir/apps/web/lib/web/components/table_components.ex
@@ -12,7 +12,7 @@ defmodule Web.TableComponents do
 
   def table_header(assigns) do
     ~H"""
-    <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+    <thead class="text-xs text-neutral-700 uppercase bg-neutral-50">
       <tr>
         <th :for={col <- @columns} class={["px-4 py-3", Map.get(col, :class, "")]}>
           <%= col[:label] %>
@@ -67,7 +67,7 @@ defmodule Web.TableComponents do
           data-dropdown-toggle={"#{@id}-dropdown"}
           class={[
             "inline-flex items-center p-0.5 text-sm font-medium text-center",
-            "text-gray-500 hover:text-gray-800 rounded"
+            "text-neutral-500 hover:text-neutral-800 rounded"
           ]}
           type="button"
         >
@@ -76,11 +76,11 @@ defmodule Web.TableComponents do
         <div
           id={"#{@id}-dropdown"}
           class={[
-            "hidden z-10 w-44 bg-white rounded divide-y divide-gray-100",
-            "shadow border border-gray-300"
+            "hidden z-10 w-44 bg-white rounded divide-y divide-neutral-100",
+            "shadow border border-neutral-300"
           ]}
         >
-          <ul class="py-1 text-sm text-gray-700" aria-labelledby={"#{@id}-dropdown-button"}>
+          <ul class="py-1 text-sm text-neutral-700" aria-labelledby={"#{@id}-dropdown-button"}>
             <li :for={action <- @actions}>
               <%= render_slot(action, @mapper.(@row)) %>
             </li>
@@ -137,7 +137,7 @@ defmodule Web.TableComponents do
 
     ~H"""
     <div class="overflow-x-auto">
-      <table class="w-full text-sm text-left text-gray-500" id={@id}>
+      <table class="w-full text-sm text-left text-neutral-500" id={@id}>
         <.table_header columns={@col} actions={@action} />
         <tbody
           id={"#{@id}-rows"}
@@ -210,11 +210,11 @@ defmodule Web.TableComponents do
       end
 
     ~H"""
-    <table class="w-full text-sm text-left text-gray-500" id={@id}>
+    <table class="w-full text-sm text-left text-neutral-500" id={@id}>
       <.table_header columns={@col} actions={@action} />
 
       <tbody :for={group <- @groups} data-group-id={@group_id && @group_id.(group)}>
-        <tr class="bg-gray-100">
+        <tr class="bg-neutral-100">
           <td class="px-4 py-2" colspan={length(@col) + 1}>
             <%= render_slot(@group, group) %>
           </td>
@@ -269,7 +269,7 @@ defmodule Web.TableComponents do
 
   def vertical_table(assigns) do
     ~H"""
-    <table class={["w-full text-sm text-left text-gray-500", @class]} {@rest}>
+    <table class={["w-full text-sm text-left text-neutral-500", @class]} {@rest}>
       <tbody>
         <%= render_slot(@inner_block) %>
       </tbody>
@@ -302,12 +302,12 @@ defmodule Web.TableComponents do
 
   def vertical_table_row(assigns) do
     ~H"""
-    <tr class="border-b border-gray-200">
+    <tr class="border-b border-neutral-200">
       <th
         scope="row"
         class={[
-          "text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap",
-          "bg-gray-50",
+          "text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap",
+          "bg-neutral-50",
           @label_class
         ]}
       >
@@ -329,7 +329,7 @@ defmodule Web.TableComponents do
 
   def action_link(assigns) do
     ~H"""
-    <.link navigate={@navigate} class="block py-2 px-4 hover:bg-gray-100">
+    <.link navigate={@navigate} class="block py-2 px-4 hover:bg-neutral-100">
       <%= render_slot(@inner_block) %>
     </.link>
     """

--- a/elixir/apps/web/lib/web/controllers/home_html.ex
+++ b/elixir/apps/web/lib/web/controllers/home_html.ex
@@ -55,7 +55,7 @@ defmodule Web.HomeHTML do
               class="py-2"
             >
               Don't have an account?
-              <a href={~p"/sign_up"} class="font-medium text-accent-600 hover:text-accent-500">
+              <a href={~p"/sign_up"} class={["font-medium", link_style()]}>
                 Sign up here.
               </a>
             </p>

--- a/elixir/apps/web/lib/web/controllers/home_html.ex
+++ b/elixir/apps/web/lib/web/controllers/home_html.ex
@@ -3,19 +3,19 @@ defmodule Web.HomeHTML do
 
   def home(assigns) do
     ~H"""
-    <section class="bg-gray-50">
+    <section class="bg-neutral-50">
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
         <.logo />
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
-            <h1 class="text-xl text-center font-bold leading-tight tracking-tight text-gray-900 sm:text-2xl">
+            <h1 class="text-xl text-center font-bold leading-tight tracking-tight text-neutral-900 sm:text-2xl">
               Welcome to Firezone
             </h1>
 
             <h3
               :if={@accounts != []}
-              class="text-m font-bold leading-tight tracking-tight text-gray-900 sm:text-xl"
+              class="text-m font-bold leading-tight tracking-tight text-neutral-900 sm:text-xl"
             >
               Recently used accounts
             </h3>
@@ -55,7 +55,7 @@ defmodule Web.HomeHTML do
               class="py-2"
             >
               Don't have an account?
-              <a href={~p"/sign_up"} class="font-medium text-blue-600 hover:text-blue-500">
+              <a href={~p"/sign_up"} class="font-medium text-accent-600 hover:text-accent-500">
                 Sign up here.
               </a>
             </p>
@@ -71,9 +71,9 @@ defmodule Web.HomeHTML do
     <a href={~p"/#{@account}?#{@redirect_params}"} class={~w[
           w-full inline-flex items-center justify-center py-2.5 px-5
           bg-white rounded
-          text-sm font-medium text-gray-900
-          border border-gray-200
-          hover:bg-gray-100 hover:text-gray-900
+          text-sm font-medium text-neutral-900
+          border border-neutral-200
+          hover:bg-neutral-100 hover:text-neutral-900
     ]}>
       <%= @account.name %>
     </a>
@@ -83,9 +83,9 @@ defmodule Web.HomeHTML do
   def separator(assigns) do
     ~H"""
     <div class="flex items-center">
-      <div class="w-full h-0.5 bg-gray-200"></div>
-      <div class="px-5 text-center text-gray-500">or</div>
-      <div class="w-full h-0.5 bg-gray-200"></div>
+      <div class="w-full h-0.5 bg-neutral-200"></div>
+      <div class="px-5 text-center text-neutral-500">or</div>
+      <div class="w-full h-0.5 bg-neutral-200"></div>
     </div>
     """
   end

--- a/elixir/apps/web/lib/web/live/actors/components.ex
+++ b/elixir/apps/web/lib/web/live/actors/components.ex
@@ -13,10 +13,10 @@ defmodule Web.Actors.Components do
 
   def actor_status(assigns) do
     ~H"""
-    <span :if={Actors.actor_disabled?(@actor)} class="text-fz_red-800">
+    <span :if={Actors.actor_disabled?(@actor)} class="text-red-800">
       (Disabled)
     </span>
-    <span :if={Actors.actor_deleted?(@actor)} class="text-fz_red-800">
+    <span :if={Actors.actor_deleted?(@actor)} class="text-red-800">
       (Deleted)
     </span>
     """

--- a/elixir/apps/web/lib/web/live/actors/components.ex
+++ b/elixir/apps/web/lib/web/live/actors/components.ex
@@ -13,10 +13,10 @@ defmodule Web.Actors.Components do
 
   def actor_status(assigns) do
     ~H"""
-    <span :if={Actors.actor_disabled?(@actor)} class="text-red-800">
+    <span :if={Actors.actor_disabled?(@actor)} class="text-fz_red-800">
       (Disabled)
     </span>
-    <span :if={Actors.actor_deleted?(@actor)} class="text-red-800">
+    <span :if={Actors.actor_deleted?(@actor)} class="text-fz_red-800">
       (Deleted)
     </span>
     """
@@ -30,7 +30,7 @@ defmodule Web.Actors.Components do
     ~H"""
     <.link
       navigate={~p"/#{@account}/actors/#{@actor}"}
-      class={["font-medium text-blue-600 hover:underline", @class]}
+      class={["font-medium text-accent-600 hover:underline", @class]}
     >
       <%= @actor.name %>
     </.link>
@@ -86,7 +86,7 @@ defmodule Web.Actors.Components do
         options={Enum.map(@groups, fn group -> {group.name, group.id} end)}
         placeholder="Groups"
       />
-      <p class="mt-2 text-xs text-gray-500">
+      <p class="mt-2 text-xs text-neutral-500">
         Hold <kbd>Ctrl</kbd> (or <kbd>Command</kbd> on Mac) to select or unselect multiple groups.
       </p>
     </div>
@@ -185,14 +185,14 @@ defmodule Web.Actors.Components do
           type="radio"
           name="next"
           value={next_step_path(@type, @account)}
-          class={~w[w-4 h-4 border-gray-300]}
+          class={~w[w-4 h-4 border-neutral-300]}
           required
         />
-        <label for={"idp-option-#{@type}"} class="block ml-2 text-lg font-medium text-gray-900">
+        <label for={"idp-option-#{@type}"} class="block ml-2 text-lg font-medium text-neutral-900">
           <%= @name %>
         </label>
       </div>
-      <p class="ml-6 mb-6 text-sm text-gray-500">
+      <p class="ml-6 mb-6 text-sm text-neutral-500">
         <%= @description %>
       </p>
     </div>

--- a/elixir/apps/web/lib/web/live/actors/edit.ex
+++ b/elixir/apps/web/lib/web/live/actors/edit.ex
@@ -42,7 +42,7 @@ defmodule Web.Actors.Edit do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Edit User Details</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Edit User Details</h2>
           <.flash kind={:error} flash={@flash} />
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">

--- a/elixir/apps/web/lib/web/live/actors/index.ex
+++ b/elixir/apps/web/lib/web/live/actors/index.ex
@@ -80,7 +80,7 @@ defmodule Web.Actors.Index do
             <.relative_datetime datetime={last_seen_at(actor.identities)} />
           </:col>
           <:empty>
-            <div class="flex justify-center text-center text-slate-500 p-4">
+            <div class="flex justify-center text-center text-neutral-500 p-4">
               <div class="w-auto">
                 <div class="pb-4">
                   No actors to display

--- a/elixir/apps/web/lib/web/live/actors/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/new.ex
@@ -22,7 +22,7 @@ defmodule Web.Actors.New do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Choose type</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Choose type</h2>
           <.form id="identity-provider-type-form" for={@form} phx-submit="submit">
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <fieldset>

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
@@ -37,7 +37,7 @@ defmodule Web.Actors.ServiceAccounts.New do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">
             Create a Service Account
           </h2>
           <.flash kind={:error} flash={@flash} />

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new_identity.ex
@@ -44,7 +44,7 @@ defmodule Web.Actors.ServiceAccounts.NewIdentity do
       </:title>
       <:content>
         <div :if={is_nil(@identity)} class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Create a Token</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Create a Token</h2>
           <.flash kind={:error} flash={@flash} />
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -42,7 +42,7 @@ defmodule Web.Actors.Show do
       <:title>
         <%= actor_type(@actor.type) %>: <span class="font-bold"><%= @actor.name %></span>
         <span :if={@actor.id == @subject.actor.id} class="text-neutral-400">(you)</span>
-        <span :if={not is_nil(@actor.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@actor.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@actor.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/actors/#{@actor}/edit"}>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -166,7 +166,7 @@ defmodule Web.Actors.Show do
           <:col :let={client} label="NAME">
             <.link
               navigate={~p"/#{@account}/clients/#{client.id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <%= client.name %>
             </.link>
@@ -194,7 +194,7 @@ defmodule Web.Actors.Show do
           <:col :let={flow} label="POLICY">
             <.link
               navigate={~p"/#{@account}/policies/#{flow.policy_id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <Web.Policies.Components.policy_name policy={flow.policy} />
             </.link>
@@ -208,17 +208,14 @@ defmodule Web.Actors.Show do
           <:col :let={flow} label="GATEWAY (IP)">
             <.link
               navigate={~p"/#{@account}/gateways/#{flow.gateway_id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <%= flow.gateway.group.name %>-<%= flow.gateway.name %>
             </.link>
             (<%= flow.gateway_remote_ip %>)
           </:col>
           <:col :let={flow} :if={@flow_activities_enabled?} label="ACTIVITY">
-            <.link
-              navigate={~p"/#{@account}/flows/#{flow.id}"}
-              class="font-medium text-accent-600 hover:underline"
-            >
+            <.link navigate={~p"/#{@account}/flows/#{flow.id}"} class={["font-medium", link_style()]}>
               Show
             </.link>
           </:col>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -41,8 +41,8 @@ defmodule Web.Actors.Show do
     <.section>
       <:title>
         <%= actor_type(@actor.type) %>: <span class="font-bold"><%= @actor.name %></span>
-        <span :if={@actor.id == @subject.actor.id} class="text-gray-400">(you)</span>
-        <span :if={not is_nil(@actor.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={@actor.id == @subject.actor.id} class="text-neutral-400">(you)</span>
+        <span :if={not is_nil(@actor.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@actor.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/actors/#{@actor}/edit"}>
@@ -127,14 +127,14 @@ defmodule Web.Actors.Show do
               data-confirm="Are you sure want to delete this identity?"
               phx-value-id={identity.id}
               class={[
-                "block w-full py-2 px-4 hover:bg-gray-100"
+                "block w-full py-2 px-4 hover:bg-neutral-100"
               ]}
             >
               Delete
             </button>
           </:action>
           <:empty>
-            <div class="flex justify-center text-center text-slate-500 p-4">
+            <div class="flex justify-center text-center text-neutral-500 p-4">
               <div class="w-auto">
                 <div class="pb-4">
                   No authentication identities to display
@@ -166,7 +166,7 @@ defmodule Web.Actors.Show do
           <:col :let={client} label="NAME">
             <.link
               navigate={~p"/#{@account}/clients/#{client.id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <%= client.name %>
             </.link>
@@ -175,7 +175,7 @@ defmodule Web.Actors.Show do
             <.connection_status schema={client} />
           </:col>
           <:empty>
-            <div class="text-center text-slate-500 p-4">No clients to display</div>
+            <div class="text-center text-neutral-500 p-4">No clients to display</div>
           </:empty>
         </.table>
       </:content>
@@ -194,7 +194,7 @@ defmodule Web.Actors.Show do
           <:col :let={flow} label="POLICY">
             <.link
               navigate={~p"/#{@account}/policies/#{flow.policy_id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <Web.Policies.Components.policy_name policy={flow.policy} />
             </.link>
@@ -208,7 +208,7 @@ defmodule Web.Actors.Show do
           <:col :let={flow} label="GATEWAY (IP)">
             <.link
               navigate={~p"/#{@account}/gateways/#{flow.gateway_id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <%= flow.gateway.group.name %>-<%= flow.gateway.name %>
             </.link>
@@ -217,13 +217,13 @@ defmodule Web.Actors.Show do
           <:col :let={flow} :if={@flow_activities_enabled?} label="ACTIVITY">
             <.link
               navigate={~p"/#{@account}/flows/#{flow.id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               Show
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-slate-500 p-4">No authorizations to display</div>
+            <div class="text-center text-neutral-500 p-4">No authorizations to display</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/actors/users/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new.ex
@@ -33,7 +33,7 @@ defmodule Web.Actors.Users.New do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Create a User</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Create a User</h2>
           <.flash kind={:error} flash={@flash} />
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">

--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -53,7 +53,7 @@ defmodule Web.Actors.Users.NewIdentity do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Create an Identity</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Create an Identity</h2>
           <.flash kind={:error} flash={@flash} />
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">

--- a/elixir/apps/web/lib/web/live/clients/edit.ex
+++ b/elixir/apps/web/lib/web/live/clients/edit.ex
@@ -30,7 +30,7 @@ defmodule Web.Clients.Edit do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Edit client details</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Edit client details</h2>
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <div>

--- a/elixir/apps/web/lib/web/live/clients/index.ex
+++ b/elixir/apps/web/lib/web/live/clients/index.ex
@@ -30,7 +30,7 @@ defmodule Web.Clients.Index do
             <:col :let={client} label="NAME">
               <.link
                 navigate={~p"/#{@account}/clients/#{client.id}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <%= client.name %>
               </.link>
@@ -38,7 +38,7 @@ defmodule Web.Clients.Index do
             <:col :let={client} label="USER">
               <.link
                 navigate={~p"/#{@account}/actors/#{client.actor.id}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <%= client.actor.name %>
               </.link>

--- a/elixir/apps/web/lib/web/live/clients/index.ex
+++ b/elixir/apps/web/lib/web/live/clients/index.ex
@@ -30,7 +30,7 @@ defmodule Web.Clients.Index do
             <:col :let={client} label="NAME">
               <.link
                 navigate={~p"/#{@account}/clients/#{client.id}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <%= client.name %>
               </.link>
@@ -38,7 +38,7 @@ defmodule Web.Clients.Index do
             <:col :let={client} label="USER">
               <.link
                 navigate={~p"/#{@account}/actors/#{client.actor.id}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <%= client.actor.name %>
               </.link>
@@ -47,8 +47,8 @@ defmodule Web.Clients.Index do
               <.connection_status schema={client} />
             </:col>
             <:empty>
-              <div class="text-center text-slate-500 p-4">No clients to display</div>
-              <div class="text-center text-slate-500 mb-4">
+              <div class="text-center text-neutral-500 p-4">No clients to display</div>
+              <div class="text-center text-neutral-500 mb-4">
                 Clients are created automatically when user connects to a resource.
               </div>
             </:empty>
@@ -68,14 +68,14 @@ defmodule Web.Clients.Index do
   #         <label for="simple-search" class="sr-only">Search</label>
   #         <div class="relative w-full">
   #           <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-  #             <.icon name="hero-magnifying-glass" class="w-5 h-5 text-gray-500" />
+  #             <.icon name="hero-magnifying-glass" class="w-5 h-5 text-neutral-500" />
   #           </div>
   #           <input
   #             type="text"
   #             id="simple-search"
   # class =
   #   {[
-  #      "bg-gray-50 border border-gray-300 text-gray-900",
+  #      "bg-neutral-50 border border-neutral-300 text-neutral-900",
   #      "text-sm rounded-lg",
   #      "block w-full pl-10 p-2"
   #    ]}

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -37,7 +37,7 @@ defmodule Web.Clients.Show do
     <.section>
       <:title>
         Client Details
-        <span :if={not is_nil(@client.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@client.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@client.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/clients/#{@client}/edit"}>

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -59,7 +59,7 @@ defmodule Web.Clients.Show do
             <:value>
               <.link
                 navigate={~p"/#{@account}/actors/#{@client.actor.id}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <%= @client.actor.name %>
               </.link>
@@ -115,7 +115,7 @@ defmodule Web.Clients.Show do
           <:col :let={flow} label="POLICY">
             <.link
               navigate={~p"/#{@account}/policies/#{flow.policy_id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <.policy_name policy={flow.policy} />
             </.link>
@@ -123,17 +123,14 @@ defmodule Web.Clients.Show do
           <:col :let={flow} label="GATEWAY (IP)">
             <.link
               navigate={~p"/#{@account}/gateways/#{flow.gateway_id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <%= flow.gateway.group.name %>-<%= flow.gateway.name %>
             </.link>
             (<%= flow.gateway_remote_ip %>)
           </:col>
           <:col :let={flow} :if={@flow_activities_enabled?} label="ACTIVITY">
-            <.link
-              navigate={~p"/#{@account}/flows/#{flow.id}"}
-              class="font-medium text-accent-600 hover:underline"
-            >
+            <.link navigate={~p"/#{@account}/flows/#{flow.id}"} class={["font-medium", link_style()]}>
               Show
             </.link>
           </:col>

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -37,7 +37,7 @@ defmodule Web.Clients.Show do
     <.section>
       <:title>
         Client Details
-        <span :if={not is_nil(@client.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@client.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@client.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/clients/#{@client}/edit"}>
@@ -59,7 +59,7 @@ defmodule Web.Clients.Show do
             <:value>
               <.link
                 navigate={~p"/#{@account}/actors/#{@client.actor.id}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <%= @client.actor.name %>
               </.link>
@@ -115,7 +115,7 @@ defmodule Web.Clients.Show do
           <:col :let={flow} label="POLICY">
             <.link
               navigate={~p"/#{@account}/policies/#{flow.policy_id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <.policy_name policy={flow.policy} />
             </.link>
@@ -123,7 +123,7 @@ defmodule Web.Clients.Show do
           <:col :let={flow} label="GATEWAY (IP)">
             <.link
               navigate={~p"/#{@account}/gateways/#{flow.gateway_id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <%= flow.gateway.group.name %>-<%= flow.gateway.name %>
             </.link>
@@ -132,13 +132,13 @@ defmodule Web.Clients.Show do
           <:col :let={flow} :if={@flow_activities_enabled?} label="ACTIVITY">
             <.link
               navigate={~p"/#{@account}/flows/#{flow.id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               Show
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-slate-500 p-4">No authorizations to display</div>
+            <div class="text-center text-neutral-500 p-4">No authorizations to display</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -36,7 +36,7 @@ defmodule Web.Gateways.Show do
     <.section>
       <:title>
         Gateway: <code><%= @gateway.name %></code>
-        <span :if={not is_nil(@gateway.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@gateway.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:content>
         <.vertical_table id="gateway">

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -45,7 +45,7 @@ defmodule Web.Gateways.Show do
             <:value>
               <.link
                 navigate={~p"/#{@account}/sites/#{@gateway.group}"}
-                class="font-bold text-accent-600 hover:underline"
+                class={["font-bold", link_style()]}
               >
                 <%= @gateway.group.name %>
               </.link>

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -36,7 +36,7 @@ defmodule Web.Gateways.Show do
     <.section>
       <:title>
         Gateway: <code><%= @gateway.name %></code>
-        <span :if={not is_nil(@gateway.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@gateway.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:content>
         <.vertical_table id="gateway">
@@ -45,7 +45,7 @@ defmodule Web.Gateways.Show do
             <:value>
               <.link
                 navigate={~p"/#{@account}/sites/#{@gateway.group}"}
-                class="font-bold text-blue-600 hover:underline"
+                class="font-bold text-accent-600 hover:underline"
               >
                 <%= @gateway.group.name %>
               </.link>

--- a/elixir/apps/web/lib/web/live/groups/components.ex
+++ b/elixir/apps/web/lib/web/live/groups/components.ex
@@ -9,7 +9,7 @@ defmodule Web.Groups.Components do
     <span :if={not is_nil(@group.provider_id)}>
       Synced from
       <.link
-        class="font-medium text-blue-600 hover:underline"
+        class="font-medium text-accent-600 hover:underline"
         navigate={Web.Settings.IdentityProviders.Components.view_provider(@account, @group.provider)}
       >
         <%= @group.provider.name %>

--- a/elixir/apps/web/lib/web/live/groups/edit.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit.ex
@@ -31,7 +31,7 @@ defmodule Web.Groups.Edit do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Edit group details</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Edit group details</h2>
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <div>

--- a/elixir/apps/web/lib/web/live/groups/edit_actors.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit_actors.ex
@@ -48,12 +48,12 @@ defmodule Web.Groups.EditActors do
               <.icon
                 :if={removed?(actor, @removed_ids)}
                 name="hero-minus"
-                class="h-3.5 w-3.5 mr-2 text-fz_red-500"
+                class="h-3.5 w-3.5 mr-2 text-red-500"
               />
               <.icon
                 :if={added?(actor, @added_ids)}
                 name="hero-plus"
-                class="h-3.5 w-3.5 mr-2 text-fz_green-500"
+                class="h-3.5 w-3.5 mr-2 text-green-500"
               />
 
               <.actor_name_and_role
@@ -61,8 +61,8 @@ defmodule Web.Groups.EditActors do
                 actor={actor}
                 class={
                   cond do
-                    removed?(actor, @removed_ids) -> "text-fz_red-500"
-                    added?(actor, @added_ids) -> "text-fz_green-500"
+                    removed?(actor, @removed_ids) -> "text-red-500"
+                    added?(actor, @added_ids) -> "text-green-500"
                     true -> ""
                   end
                 }

--- a/elixir/apps/web/lib/web/live/groups/edit_actors.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit_actors.ex
@@ -48,12 +48,12 @@ defmodule Web.Groups.EditActors do
               <.icon
                 :if={removed?(actor, @removed_ids)}
                 name="hero-minus"
-                class="h-3.5 w-3.5 mr-2 text-red-500"
+                class="h-3.5 w-3.5 mr-2 text-fz_red-500"
               />
               <.icon
                 :if={added?(actor, @added_ids)}
                 name="hero-plus"
-                class="h-3.5 w-3.5 mr-2 text-green-500"
+                class="h-3.5 w-3.5 mr-2 text-fz_green-500"
               />
 
               <.actor_name_and_role
@@ -61,8 +61,8 @@ defmodule Web.Groups.EditActors do
                 actor={actor}
                 class={
                   cond do
-                    removed?(actor, @removed_ids) -> "text-red-500"
-                    added?(actor, @added_ids) -> "text-green-500"
+                    removed?(actor, @removed_ids) -> "text-fz_red-500"
+                    added?(actor, @added_ids) -> "text-fz_green-500"
                     true -> ""
                   end
                 }

--- a/elixir/apps/web/lib/web/live/groups/index.ex
+++ b/elixir/apps/web/lib/web/live/groups/index.ex
@@ -42,7 +42,7 @@ defmodule Web.Groups.Index do
             <:col :let={group} label="NAME" sortable="false">
               <.link
                 navigate={~p"/#{@account}/groups/#{group.id}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <%= group.name %>
               </.link>
@@ -64,7 +64,7 @@ defmodule Web.Groups.Index do
                 <:item :let={actor}>
                   <.link
                     navigate={~p"/#{@account}/actors/#{actor}"}
-                    class={["font-medium text-accent-600 hover:underline"]}
+                    class={["font-medium", link_style()]}
                   >
                     <%= actor.name %>
                   </.link>

--- a/elixir/apps/web/lib/web/live/groups/index.ex
+++ b/elixir/apps/web/lib/web/live/groups/index.ex
@@ -42,12 +42,12 @@ defmodule Web.Groups.Index do
             <:col :let={group} label="NAME" sortable="false">
               <.link
                 navigate={~p"/#{@account}/groups/#{group.id}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <%= group.name %>
               </.link>
 
-              <span :if={Actors.group_deleted?(group)} class="text-xs text-gray-100">
+              <span :if={Actors.group_deleted?(group)} class="text-xs text-neutral-100">
                 (deleted)
               </span>
             </:col>
@@ -64,7 +64,7 @@ defmodule Web.Groups.Index do
                 <:item :let={actor}>
                   <.link
                     navigate={~p"/#{@account}/actors/#{actor}"}
-                    class={["font-medium text-blue-600 hover:underline"]}
+                    class={["font-medium text-accent-600 hover:underline"]}
                   >
                     <%= actor.name %>
                   </.link>
@@ -81,7 +81,7 @@ defmodule Web.Groups.Index do
               <.source account={@account} group={group} />
             </:col>
             <:empty>
-              <div class="flex justify-center text-center text-slate-500 p-4">
+              <div class="flex justify-center text-center text-neutral-500 p-4">
                 <div class="w-auto">
                   <div class="pb-4">
                     No groups to display

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -31,7 +31,7 @@ defmodule Web.Groups.Show do
     <.section>
       <:title>
         Group: <code><%= @group.name %></code>
-        <span :if={not is_nil(@group.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@group.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@group.deleted_at)}>
         <.edit_button

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -31,7 +31,7 @@ defmodule Web.Groups.Show do
     <.section>
       <:title>
         Group: <code><%= @group.name %></code>
-        <span :if={not is_nil(@group.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@group.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@group.deleted_at)}>
         <.edit_button
@@ -80,7 +80,7 @@ defmodule Web.Groups.Show do
             />
           </:col>
           <:empty>
-            <div class="flex justify-center text-center text-slate-500 p-4">
+            <div class="flex justify-center text-center text-neutral-500 p-4">
               <div :if={not Actors.group_synced?(@group)} class="w-auto">
                 <div class="pb-4">
                   No actors in group

--- a/elixir/apps/web/lib/web/live/policies/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies/edit.ex
@@ -33,7 +33,7 @@ defmodule Web.Policies.Edit do
       <:title><%= "#{@page_title}: #{@policy.id}" %></:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Edit Policy details</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Edit Policy details</h2>
           <.simple_form
             for={@form}
             class="space-y-4 lg:space-y-6"

--- a/elixir/apps/web/lib/web/live/policies/index.ex
+++ b/elixir/apps/web/lib/web/live/policies/index.ex
@@ -54,7 +54,7 @@ defmodule Web.Policies.Index do
             <% end %>
           </:col>
           <:empty>
-            <div class="flex justify-center text-center text-slate-500 p-4">
+            <div class="flex justify-center text-center text-neutral-500 p-4">
               <div class="w-auto">
                 <div class="pb-4">
                   No policies to display

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -36,7 +36,7 @@ defmodule Web.Policies.New do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Policy details</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Policy details</h2>
           <.simple_form for={@form} phx-submit="submit" phx-change="validate">
             <.base_error form={@form} field={:base} />
             <.input

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -38,8 +38,8 @@ defmodule Web.Policies.Show do
     <.section>
       <:title>
         <%= @page_title %>: <code><%= @policy.id %></code>
-        <span :if={not is_nil(@policy.disabled_at)} class="text-fz_orange-600">(disabled)</span>
-        <span :if={not is_nil(@policy.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@policy.disabled_at)} class="text-orange-600">(disabled)</span>
+        <span :if={not is_nil(@policy.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@policy.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/policies/#{@policy}/edit"}>
@@ -80,7 +80,7 @@ defmodule Web.Policies.Show do
               <.link navigate={~p"/#{@account}/groups/#{@policy.actor_group_id}"} class={link_style()}>
                 <%= @policy.actor_group.name %>
               </.link>
-              <span :if={not is_nil(@policy.actor_group.deleted_at)} class="text-fz_red-600">
+              <span :if={not is_nil(@policy.actor_group.deleted_at)} class="text-red-600">
                 (deleted)
               </span>
             </:value>
@@ -93,7 +93,7 @@ defmodule Web.Policies.Show do
               <.link navigate={~p"/#{@account}/resources/#{@policy.resource_id}"} class={link_style()}>
                 <%= @policy.resource.name %>
               </.link>
-              <span :if={not is_nil(@policy.resource.deleted_at)} class="text-fz_red-600">
+              <span :if={not is_nil(@policy.resource.deleted_at)} class="text-red-600">
                 (deleted)
               </span>
             </:value>

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -38,8 +38,8 @@ defmodule Web.Policies.Show do
     <.section>
       <:title>
         <%= @page_title %>: <code><%= @policy.id %></code>
-        <span :if={not is_nil(@policy.disabled_at)} class="text-orange-600">(disabled)</span>
-        <span :if={not is_nil(@policy.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@policy.disabled_at)} class="text-fz_orange-600">(disabled)</span>
+        <span :if={not is_nil(@policy.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@policy.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/policies/#{@policy}/edit"}>
@@ -80,7 +80,7 @@ defmodule Web.Policies.Show do
               <.link navigate={~p"/#{@account}/groups/#{@policy.actor_group_id}"} class={link_style()}>
                 <%= @policy.actor_group.name %>
               </.link>
-              <span :if={not is_nil(@policy.actor_group.deleted_at)} class="text-red-600">
+              <span :if={not is_nil(@policy.actor_group.deleted_at)} class="text-fz_red-600">
                 (deleted)
               </span>
             </:value>
@@ -93,7 +93,7 @@ defmodule Web.Policies.Show do
               <.link navigate={~p"/#{@account}/resources/#{@policy.resource_id}"} class={link_style()}>
                 <%= @policy.resource.name %>
               </.link>
-              <span :if={not is_nil(@policy.resource.deleted_at)} class="text-red-600">
+              <span :if={not is_nil(@policy.resource.deleted_at)} class="text-fz_red-600">
                 (deleted)
               </span>
             </:value>
@@ -158,7 +158,7 @@ defmodule Web.Policies.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-slate-500 p-4">No authorizations to display</div>
+            <div class="text-center text-neutral-500 p-4">No authorizations to display</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/relay_groups/index.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/index.ex
@@ -40,7 +40,7 @@ defmodule Web.RelayGroups.Index do
               <.link
                 :if={not is_nil(group.account_id)}
                 navigate={~p"/#{@account}/relay_groups/#{group.id}"}
-                class="font-bold text-accent-600 hover:underline"
+                class={["font-bold", link_style()]}
               >
                 <%= group.name %>
               </.link>
@@ -53,7 +53,7 @@ defmodule Web.RelayGroups.Index do
               <.link
                 :if={relay.account_id}
                 navigate={~p"/#{@account}/relays/#{relay.id}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <code :if={relay.name} class="block text-xs">
                   <%= relay.name %>

--- a/elixir/apps/web/lib/web/live/relay_groups/index.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/index.ex
@@ -40,7 +40,7 @@ defmodule Web.RelayGroups.Index do
               <.link
                 :if={not is_nil(group.account_id)}
                 navigate={~p"/#{@account}/relay_groups/#{group.id}"}
-                class="font-bold text-blue-600 hover:underline"
+                class="font-bold text-accent-600 hover:underline"
               >
                 <%= group.name %>
               </.link>
@@ -53,7 +53,7 @@ defmodule Web.RelayGroups.Index do
               <.link
                 :if={relay.account_id}
                 navigate={~p"/#{@account}/relays/#{relay.id}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <code :if={relay.name} class="block text-xs">
                   <%= relay.name %>
@@ -83,7 +83,7 @@ defmodule Web.RelayGroups.Index do
               <.connection_status schema={relay} />
             </:col>
             <:empty>
-              <div class="flex justify-center text-center text-slate-500 p-4">
+              <div class="flex justify-center text-center text-neutral-500 p-4">
                 <div class="w-auto">
                   <div class="pb-4">
                     No relay instance groups to display
@@ -110,13 +110,13 @@ defmodule Web.RelayGroups.Index do
           <label for="simple-search" class="sr-only">Search</label>
           <div class="relative w-full">
             <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-              <.icon name="hero-magnifying-glass" class="w-5 h-5 text-gray-500" />
+              <.icon name="hero-magnifying-glass" class="w-5 h-5 text-neutral-500" />
             </div>
             <input
               type="text"
               id="simple-search"
               class={[
-                "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded",
+                "bg-neutral-50 border border-neutral-300 text-neutral-900 text-sm rounded",
                 "block w-full pl-10 p-2"
               ]}
               placeholder="Search"

--- a/elixir/apps/web/lib/web/live/relay_groups/show.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/show.ex
@@ -30,7 +30,7 @@ defmodule Web.RelayGroups.Show do
     <.section>
       <:title>
         Relay Instance Group: <code><%= @group.name %></code>
-        <span :if={not is_nil(@group.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@group.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={not is_nil(@group.account_id) and is_nil(@group.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/relay_groups/#{@group}/edit"}>

--- a/elixir/apps/web/lib/web/live/relay_groups/show.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/show.ex
@@ -68,7 +68,7 @@ defmodule Web.RelayGroups.Show do
             <:col :let={relay} label="INSTANCE">
               <.link
                 navigate={~p"/#{@account}/relays/#{relay.id}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <code :if={relay.name} class="block text-xs">
                   <%= relay.name %>

--- a/elixir/apps/web/lib/web/live/relay_groups/show.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/show.ex
@@ -30,7 +30,7 @@ defmodule Web.RelayGroups.Show do
     <.section>
       <:title>
         Relay Instance Group: <code><%= @group.name %></code>
-        <span :if={not is_nil(@group.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@group.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={not is_nil(@group.account_id) and is_nil(@group.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/relay_groups/#{@group}/edit"}>
@@ -68,7 +68,7 @@ defmodule Web.RelayGroups.Show do
             <:col :let={relay} label="INSTANCE">
               <.link
                 navigate={~p"/#{@account}/relays/#{relay.id}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <code :if={relay.name} class="block text-xs">
                   <%= relay.name %>
@@ -88,7 +88,7 @@ defmodule Web.RelayGroups.Show do
               <.connection_status schema={relay} />
             </:col>
             <:empty>
-              <div class="text-center text-slate-500 p-4">No relay instances to display</div>
+              <div class="text-center text-neutral-500 p-4">No relay instances to display</div>
             </:empty>
           </.table>
         </div>

--- a/elixir/apps/web/lib/web/live/relays/show.ex
+++ b/elixir/apps/web/lib/web/live/relays/show.ex
@@ -43,7 +43,7 @@ defmodule Web.Relays.Show do
             <code><%= @relay.ipv4 %></code>
           </:item>
         </.intersperse_blocks>
-        <span :if={not is_nil(@relay.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@relay.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:content>
         <div class="bg-white overflow-hidden">

--- a/elixir/apps/web/lib/web/live/relays/show.ex
+++ b/elixir/apps/web/lib/web/live/relays/show.ex
@@ -43,7 +43,7 @@ defmodule Web.Relays.Show do
             <code><%= @relay.ipv4 %></code>
           </:item>
         </.intersperse_blocks>
-        <span :if={not is_nil(@relay.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@relay.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:content>
         <div class="bg-white overflow-hidden">

--- a/elixir/apps/web/lib/web/live/resources/components.ex
+++ b/elixir/apps/web/lib/web/live/resources/components.ex
@@ -220,10 +220,10 @@ defmodule Web.Resources.Components do
             />
           </div>
 
-          <div class="w-64 no-grow text-gray-500">
+          <div class="w-64 no-grow text-neutral-500">
             <.link
               navigate={~p"/#{@account}/sites/#{gateway_group}"}
-              class="font-bold text-blue-600 hover:underline"
+              class="font-bold text-accent-600 hover:underline"
               target="_blank"
             >
               <%= gateway_group.name %>

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -43,7 +43,7 @@ defmodule Web.Resources.Edit do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Edit Resource details</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Edit Resource details</h2>
 
           <.form for={@form} phx-change={:change} phx-submit={:submit} class="space-y-4 lg:space-y-6">
             <.input

--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -40,7 +40,7 @@ defmodule Web.Resources.Index do
             <:col :let={resource} label="NAME">
               <.link
                 navigate={~p"/#{@account}/resources/#{resource.id}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <%= resource.name %>
               </.link>
@@ -54,7 +54,7 @@ defmodule Web.Resources.Index do
               <.link
                 :for={gateway_group <- resource.gateway_groups}
                 navigate={~p"/#{@account}/sites/#{gateway_group}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <.badge type="info">
                   <%= gateway_group.name %>
@@ -66,7 +66,7 @@ defmodule Web.Resources.Index do
                 <:empty>
                   None,
                   <.link
-                    class={link_style() ++ ["px-1"]}
+                    class={["px-1", link_style()]}
                     navigate={~p"/#{@account}/policies/new?resource_id=#{resource}"}
                   >
                     create a Policy

--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -40,7 +40,7 @@ defmodule Web.Resources.Index do
             <:col :let={resource} label="NAME">
               <.link
                 navigate={~p"/#{@account}/resources/#{resource.id}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <%= resource.name %>
               </.link>
@@ -54,7 +54,7 @@ defmodule Web.Resources.Index do
               <.link
                 :for={gateway_group <- resource.gateway_groups}
                 navigate={~p"/#{@account}/sites/#{gateway_group}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <.badge type="info">
                   <%= gateway_group.name %>
@@ -90,7 +90,7 @@ defmodule Web.Resources.Index do
               </.peek>
             </:col>
             <:empty>
-              <div class="flex justify-center text-center text-slate-500 p-4">
+              <div class="flex justify-center text-center text-neutral-500 p-4">
                 <div class="w-auto">
                   <div class="pb-4">
                     No resources to display

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -35,7 +35,7 @@ defmodule Web.Resources.New do
 
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Resource details</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Resource details</h2>
           <.form for={@form} class="space-y-4 lg:space-y-6" phx-submit="submit" phx-change="change">
             <.input
               field={@form[:name]}

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -76,7 +76,7 @@ defmodule Web.Resources.Show do
                   <:empty>
                     <.icon name="hero-exclamation-triangle" class="text-red-500 mr-1" /> None,
                     <.link
-                      class={link_style() ++ ["px-1"]}
+                      class={["px-1", link_style()]}
                       navigate={
                         if site_id = @params["site_id"] do
                           ~p"/#{@account}/policies/new?resource_id=#{@resource}&site_id=#{site_id}"
@@ -161,7 +161,7 @@ defmodule Web.Resources.Show do
           <:col :let={gateway_group} label="NAME">
             <.link
               navigate={~p"/#{@account}/sites/#{gateway_group}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <%= gateway_group.name %>
             </.link>
@@ -188,7 +188,7 @@ defmodule Web.Resources.Show do
           <:col :let={flow} label="POLICY">
             <.link
               navigate={~p"/#{@account}/policies/#{flow.policy_id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <.policy_name policy={flow.policy} />
             </.link>
@@ -196,14 +196,14 @@ defmodule Web.Resources.Show do
           <:col :let={flow} label="CLIENT, ACTOR (IP)">
             <.link
               navigate={~p"/#{@account}/clients/#{flow.client_id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <%= flow.client.name %>
             </.link>
             owned by
             <.link
               navigate={~p"/#{@account}/actors/#{flow.client.actor_id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <%= flow.client.actor.name %>
             </.link>
@@ -212,17 +212,14 @@ defmodule Web.Resources.Show do
           <:col :let={flow} label="GATEWAY (IP)">
             <.link
               navigate={~p"/#{@account}/gateways/#{flow.gateway_id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <%= flow.gateway.group.name %>-<%= flow.gateway.name %>
             </.link>
             (<%= flow.gateway_remote_ip %>)
           </:col>
           <:col :let={flow} label="ACTIVITY">
-            <.link
-              navigate={~p"/#{@account}/flows/#{flow.id}"}
-              class="font-medium text-accent-600 hover:underline"
-            >
+            <.link navigate={~p"/#{@account}/flows/#{flow.id}"} class={["font-medium", link_style()]}>
               Show
             </.link>
           </:col>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -41,7 +41,7 @@ defmodule Web.Resources.Show do
     <.section>
       <:title>
         Resource: <code><%= @resource.name %></code>
-        <span :if={not is_nil(@resource.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@resource.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@resource.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/resources/#{@resource.id}/edit?#{@params}"}>
@@ -74,7 +74,7 @@ defmodule Web.Resources.Show do
               <:value>
                 <.peek peek={@actor_groups_peek}>
                   <:empty>
-                    <.icon name="hero-exclamation-triangle" class="text-fz_red-500 mr-1" /> None,
+                    <.icon name="hero-exclamation-triangle" class="text-red-500 mr-1" /> None,
                     <.link
                       class={link_style() ++ ["px-1"]}
                       navigate={

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -41,7 +41,7 @@ defmodule Web.Resources.Show do
     <.section>
       <:title>
         Resource: <code><%= @resource.name %></code>
-        <span :if={not is_nil(@resource.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@resource.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@resource.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/resources/#{@resource.id}/edit?#{@params}"}>
@@ -74,7 +74,7 @@ defmodule Web.Resources.Show do
               <:value>
                 <.peek peek={@actor_groups_peek}>
                   <:empty>
-                    <.icon name="hero-exclamation-triangle" class="text-red-500 mr-1" /> None,
+                    <.icon name="hero-exclamation-triangle" class="text-fz_red-500 mr-1" /> None,
                     <.link
                       class={link_style() ++ ["px-1"]}
                       navigate={
@@ -109,7 +109,7 @@ defmodule Web.Resources.Show do
 
                   <:call_to_action>
                     <.link
-                      class={["text-gray-600", "hover:underline", "relative"]}
+                      class={["text-neutral-600", "hover:underline", "relative"]}
                       navigate={
                         if site_id = @params["site_id"] do
                           ~p"/#{@account}/policies/new?resource_id=#{@resource}&site_id=#{site_id}"
@@ -161,13 +161,13 @@ defmodule Web.Resources.Show do
           <:col :let={gateway_group} label="NAME">
             <.link
               navigate={~p"/#{@account}/sites/#{gateway_group}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <%= gateway_group.name %>
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-slate-500 p-4">No linked gateways to display</div>
+            <div class="text-center text-neutral-500 p-4">No linked gateways to display</div>
           </:empty>
         </.table>
       </:content>
@@ -188,7 +188,7 @@ defmodule Web.Resources.Show do
           <:col :let={flow} label="POLICY">
             <.link
               navigate={~p"/#{@account}/policies/#{flow.policy_id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <.policy_name policy={flow.policy} />
             </.link>
@@ -196,14 +196,14 @@ defmodule Web.Resources.Show do
           <:col :let={flow} label="CLIENT, ACTOR (IP)">
             <.link
               navigate={~p"/#{@account}/clients/#{flow.client_id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <%= flow.client.name %>
             </.link>
             owned by
             <.link
               navigate={~p"/#{@account}/actors/#{flow.client.actor_id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <%= flow.client.actor.name %>
             </.link>
@@ -212,7 +212,7 @@ defmodule Web.Resources.Show do
           <:col :let={flow} label="GATEWAY (IP)">
             <.link
               navigate={~p"/#{@account}/gateways/#{flow.gateway_id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <%= flow.gateway.group.name %>-<%= flow.gateway.name %>
             </.link>
@@ -221,13 +221,13 @@ defmodule Web.Resources.Show do
           <:col :let={flow} label="ACTIVITY">
             <.link
               navigate={~p"/#{@account}/flows/#{flow.id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               Show
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-slate-500 p-4">No authorizations to display</div>
+            <div class="text-center text-neutral-500 p-4">No authorizations to display</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/settings/account.ex
+++ b/elixir/apps/web/lib/web/live/settings/account.ex
@@ -41,7 +41,7 @@ defmodule Web.Settings.Account do
           Terminate account
         </h3>
         <p class="ml-4 mb-4 font-medium text-neutral-600">
-          <.icon name="hero-exclamation-circle" class="inline-block w-5 h-5 mr-1 text-fz_red-500" />
+          <.icon name="hero-exclamation-circle" class="inline-block w-5 h-5 mr-1 text-red-500" />
           To disable your account and schedule it for deletion, please <.link
             class="text-accent-600 hover:underline"
             href="mailto:support@firezone.dev"

--- a/elixir/apps/web/lib/web/live/settings/account.ex
+++ b/elixir/apps/web/lib/web/live/settings/account.ex
@@ -43,7 +43,7 @@ defmodule Web.Settings.Account do
         <p class="ml-4 mb-4 font-medium text-neutral-600">
           <.icon name="hero-exclamation-circle" class="inline-block w-5 h-5 mr-1 text-red-500" />
           To disable your account and schedule it for deletion, please <.link
-            class="text-accent-600 hover:underline"
+            class={link_style()}
             href="mailto:support@firezone.dev"
           >
         contact support

--- a/elixir/apps/web/lib/web/live/settings/account.ex
+++ b/elixir/apps/web/lib/web/live/settings/account.ex
@@ -37,13 +37,13 @@ defmodule Web.Settings.Account do
         Danger zone
       </:title>
       <:content>
-        <h3 class="ml-4 mb-4 font-bold text-gray-900">
+        <h3 class="ml-4 mb-4 font-bold text-neutral-900">
           Terminate account
         </h3>
-        <p class="ml-4 mb-4 font-medium text-gray-600">
-          <.icon name="hero-exclamation-circle" class="inline-block w-5 h-5 mr-1 text-red-500" />
+        <p class="ml-4 mb-4 font-medium text-neutral-600">
+          <.icon name="hero-exclamation-circle" class="inline-block w-5 h-5 mr-1 text-fz_red-500" />
           To disable your account and schedule it for deletion, please <.link
-            class="text-blue-600 hover:underline"
+            class="text-accent-600 hover:underline"
             href="mailto:support@firezone.dev"
           >
         contact support

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -39,7 +39,7 @@ defmodule Web.Settings.DNS do
         </p>
         <p class="ml-4 mb-4 font-medium text-neutral-600">
           <.link
-            class="text-accent-600 hover:underline"
+            class={link_style()}
             href="https://www.firezone.dev/kb/administer/dns?utm_source=product"
             target="_blank"
           >

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -30,16 +30,16 @@ defmodule Web.Settings.DNS do
         DNS
       </:title>
       <:content>
-        <p class="ml-4 mb-4 font-medium text-gray-600">
+        <p class="ml-4 mb-4 font-medium text-neutral-600">
           Configure the default resolver used by connected Clients in your Firezone account. Queries for
           defined Resources will <strong>always</strong>
           use Firezone's internal DNS. All other queries will
           use the resolver below if configured. If no resolver is configured, the client's default system
           resolver will be used.
         </p>
-        <p class="ml-4 mb-4 font-medium text-gray-600">
+        <p class="ml-4 mb-4 font-medium text-neutral-600">
           <.link
-            class="text-blue-600 hover:underline"
+            class="text-accent-600 hover:underline"
             href="https://www.firezone.dev/kb/administer/dns?utm_source=product"
             target="_blank"
           >
@@ -49,8 +49,8 @@ defmodule Web.Settings.DNS do
         </p>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
           <.flash kind={:success} flash={@flash} phx-click="lv:clear-flash" />
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Client DNS</h2>
-          <p class="mb-4 text-slate-500">
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Client DNS</h2>
+          <p class="mb-4 text-neutral-500">
             DNS servers will be used in the order they are listed below.
           </p>
 

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
@@ -29,7 +29,7 @@ defmodule Web.Settings.IdentityProviders.Components do
 
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-fz_red-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
       <span class="ml-3">
         No refresh token provided by IdP and access token expires on
         <.datetime datetime={@expires_at} /> UTC
@@ -50,7 +50,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-fz_red-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
       <span class="ml-3">
         Provisioning
         <span :if={@provider.adapter_state["status"]}>
@@ -80,7 +80,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-fz_red-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
       <span class="ml-3">
         Provisioning
         <span :if={@provider.adapter_state["status"]}>
@@ -117,7 +117,7 @@ defmodule Web.Settings.IdentityProviders.Components do
   def status(assigns) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-fz_green-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-green-500 rounded-full"></span>
       <span class="ml-3">
         Active
       </span>
@@ -149,7 +149,7 @@ defmodule Web.Settings.IdentityProviders.Components do
   def sync_status(%{provider: %{provisioner: :custom}} = assigns) do
     ~H"""
     <div :if={not is_nil(@provider.last_synced_at)} class="flex items-center">
-      <span class="w-3 h-3 bg-fz_green-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-green-500 rounded-full"></span>
       <span class="ml-3">
         Synced
         <.link
@@ -178,7 +178,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       </span>
     </div>
     <div :if={is_nil(@provider.last_synced_at)} class="flex items-center">
-      <span class="w-3 h-3 bg-fz_red-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
       <span class="ml-3">
         Never synced
       </span>
@@ -190,7 +190,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       when provisioner in [:just_in_time, :manual] do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-fz_green-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-green-500 rounded-full"></span>
       <span class="ml-3">
         Created
         <.link

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
@@ -152,10 +152,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       <span class="w-3 h-3 bg-green-500 rounded-full"></span>
       <span class="ml-3">
         Synced
-        <.link
-          navigate={~p"/#{@account}/actors?provider_id=#{@provider.id}"}
-          class="text-accent-600 hover:underline"
-        >
+        <.link navigate={~p"/#{@account}/actors?provider_id=#{@provider.id}"} class={link_style()}>
           <% identities_count_by_provider_id = @identities_count_by_provider_id[@provider.id] || 0 %>
           <%= identities_count_by_provider_id %>
           <.cardinal_number
@@ -165,10 +162,7 @@ defmodule Web.Settings.IdentityProviders.Components do
           />
         </.link>
         and
-        <.link
-          navigate={~p"/#{@account}/groups?provider_id=#{@provider.id}"}
-          class="text-accent-600 hover:underline"
-        >
+        <.link navigate={~p"/#{@account}/groups?provider_id=#{@provider.id}"} class={link_style()}>
           <% groups_count_by_provider_id = @groups_count_by_provider_id[@provider.id] || 0 %>
           <%= groups_count_by_provider_id %>
           <.cardinal_number number={groups_count_by_provider_id} one="group" other="groups" />
@@ -193,10 +187,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       <span class="w-3 h-3 bg-green-500 rounded-full"></span>
       <span class="ml-3">
         Created
-        <.link
-          navigate={~p"/#{@account}/actors?provider_id=#{@provider.id}"}
-          class="text-accent-600 hover:underline"
-        >
+        <.link navigate={~p"/#{@account}/actors?provider_id=#{@provider.id}"} class={link_style()}>
           <% identities_count_by_provider_id = @identities_count_by_provider_id[@provider.id] || 0 %>
           <%= identities_count_by_provider_id %>
           <.cardinal_number
@@ -206,10 +197,7 @@ defmodule Web.Settings.IdentityProviders.Components do
           />
         </.link>
         and
-        <.link
-          navigate={~p"/#{@account}/groups?provider_id=#{@provider.id}"}
-          class="text-accent-600 hover:underline"
-        >
+        <.link navigate={~p"/#{@account}/groups?provider_id=#{@provider.id}"} class={link_style()}>
           <% groups_count_by_provider_id = @groups_count_by_provider_id[@provider.id] || 0 %>
           <%= groups_count_by_provider_id %>
           <.cardinal_number number={groups_count_by_provider_id} one="group" other="groups" />

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
@@ -4,7 +4,7 @@ defmodule Web.Settings.IdentityProviders.Components do
   def status(%{provider: %{deleted_at: deleted_at}} = assigns) when not is_nil(deleted_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-gray-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-neutral-500 rounded-full"></span>
       <span class="ml-3">
         Deleted
       </span>
@@ -29,7 +29,7 @@ defmodule Web.Settings.IdentityProviders.Components do
 
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-fz_red-500 rounded-full"></span>
       <span class="ml-3">
         No refresh token provided by IdP and access token expires on
         <.datetime datetime={@expires_at} /> UTC
@@ -50,7 +50,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-fz_red-500 rounded-full"></span>
       <span class="ml-3">
         Provisioning
         <span :if={@provider.adapter_state["status"]}>
@@ -80,7 +80,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-fz_red-500 rounded-full"></span>
       <span class="ml-3">
         Provisioning
         <span :if={@provider.adapter_state["status"]}>
@@ -106,7 +106,7 @@ defmodule Web.Settings.IdentityProviders.Components do
   def status(%{provider: %{disabled_at: disabled_at}} = assigns) when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-gray-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-neutral-500 rounded-full"></span>
       <span class="ml-3">
         Disabled
       </span>
@@ -117,7 +117,7 @@ defmodule Web.Settings.IdentityProviders.Components do
   def status(assigns) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-green-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-fz_green-500 rounded-full"></span>
       <span class="ml-3">
         Active
       </span>
@@ -149,12 +149,12 @@ defmodule Web.Settings.IdentityProviders.Components do
   def sync_status(%{provider: %{provisioner: :custom}} = assigns) do
     ~H"""
     <div :if={not is_nil(@provider.last_synced_at)} class="flex items-center">
-      <span class="w-3 h-3 bg-green-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-fz_green-500 rounded-full"></span>
       <span class="ml-3">
         Synced
         <.link
           navigate={~p"/#{@account}/actors?provider_id=#{@provider.id}"}
-          class="text-blue-600 hover:underline"
+          class="text-accent-600 hover:underline"
         >
           <% identities_count_by_provider_id = @identities_count_by_provider_id[@provider.id] || 0 %>
           <%= identities_count_by_provider_id %>
@@ -167,7 +167,7 @@ defmodule Web.Settings.IdentityProviders.Components do
         and
         <.link
           navigate={~p"/#{@account}/groups?provider_id=#{@provider.id}"}
-          class="text-blue-600 hover:underline"
+          class="text-accent-600 hover:underline"
         >
           <% groups_count_by_provider_id = @groups_count_by_provider_id[@provider.id] || 0 %>
           <%= groups_count_by_provider_id %>
@@ -178,7 +178,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       </span>
     </div>
     <div :if={is_nil(@provider.last_synced_at)} class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-fz_red-500 rounded-full"></span>
       <span class="ml-3">
         Never synced
       </span>
@@ -190,12 +190,12 @@ defmodule Web.Settings.IdentityProviders.Components do
       when provisioner in [:just_in_time, :manual] do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-green-500 rounded-full"></span>
+      <span class="w-3 h-3 bg-fz_green-500 rounded-full"></span>
       <span class="ml-3">
         Created
         <.link
           navigate={~p"/#{@account}/actors?provider_id=#{@provider.id}"}
-          class="text-blue-600 hover:underline"
+          class="text-accent-600 hover:underline"
         >
           <% identities_count_by_provider_id = @identities_count_by_provider_id[@provider.id] || 0 %>
           <%= identities_count_by_provider_id %>
@@ -208,7 +208,7 @@ defmodule Web.Settings.IdentityProviders.Components do
         and
         <.link
           navigate={~p"/#{@account}/groups?provider_id=#{@provider.id}"}
-          class="text-blue-600 hover:underline"
+          class="text-accent-600 hover:underline"
         >
           <% groups_count_by_provider_id = @groups_count_by_provider_id[@provider.id] || 0 %>
           <%= groups_count_by_provider_id %>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/components.ex
@@ -6,7 +6,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Components do
     <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
       <.form for={@form} phx-change={:change} phx-submit={:submit}>
         <div class="mb-4">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">
             Step 1. Enable Admin SDK API
           </h2>
           Please visit following link and enable Admin SDK API for your Google Workspace account:
@@ -20,7 +20,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Components do
         </div>
 
         <div class="mb-4">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">
             Step 2. Configure OAuth consent screen
           </h2>
           Please make sure that following scopes are added to the OAuth application permissions: <.code_block
@@ -41,7 +41,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Components do
         </div>
 
         <div class="mb-4">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">
             Step 3: Create OAuth client
           </h2>
           Please make sure that OAuth client has following redirect URL's whitelisted: <.code_block
@@ -61,7 +61,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Components do
         </div>
 
         <div class="mb-4">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">
             Step 4. Configure client
           </h2>
 
@@ -76,7 +76,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Components do
                 placeholder="Name this identity provider"
                 required
               />
-              <p class="mt-2 text-xs text-gray-500">
+              <p class="mt-2 text-xs text-neutral-500">
                 A friendly name for this identity provider. This will be displayed to end-users.
               </p>
             </div>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -29,8 +29,8 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
     <.section>
       <:title>
         Identity Provider <code><%= @provider.name %></code>
-        <span :if={not is_nil(@provider.disabled_at)} class="text-fz_orange-600">(disabled)</span>
-        <span :if={not is_nil(@provider.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@provider.disabled_at)} class="text-orange-600">(disabled)</span>
+        <span :if={not is_nil(@provider.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@provider.deleted_at)}>
         <.edit_button navigate={

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -29,8 +29,8 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
     <.section>
       <:title>
         Identity Provider <code><%= @provider.name %></code>
-        <span :if={not is_nil(@provider.disabled_at)} class="text-orange-600">(disabled)</span>
-        <span :if={not is_nil(@provider.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@provider.disabled_at)} class="text-fz_orange-600">(disabled)</span>
+        <span :if={not is_nil(@provider.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@provider.deleted_at)}>
         <.edit_button navigate={

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
@@ -43,7 +43,7 @@ defmodule Web.Settings.IdentityProviders.Index do
       <:content>
         <p class="ml-4 mb-4 font-medium text-neutral-600">
           <.link
-            class="text-accent-600 hover:underline"
+            class={link_style()}
             href="https://www.firezone.dev/kb/authenticate?utm_source=product"
             target="_blank"
           >
@@ -57,7 +57,7 @@ defmodule Web.Settings.IdentityProviders.Index do
             <:col :let={provider} label="Name">
               <.link
                 navigate={view_provider(@account, provider)}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <%= provider.name %>
               </.link>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
@@ -41,9 +41,9 @@ defmodule Web.Settings.IdentityProviders.Index do
         </.add_button>
       </:action>
       <:content>
-        <p class="ml-4 mb-4 font-medium text-gray-600">
+        <p class="ml-4 mb-4 font-medium text-neutral-600">
           <.link
-            class="text-blue-600 hover:underline"
+            class="text-accent-600 hover:underline"
             href="https://www.firezone.dev/kb/authenticate?utm_source=product"
             target="_blank"
           >
@@ -57,7 +57,7 @@ defmodule Web.Settings.IdentityProviders.Index do
             <:col :let={provider} label="Name">
               <.link
                 navigate={view_provider(@account, provider)}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <%= provider.name %>
               </.link>
@@ -75,7 +75,7 @@ defmodule Web.Settings.IdentityProviders.Index do
               />
             </:col>
             <:empty>
-              <div class="flex justify-center text-center text-slate-500 p-4">
+              <div class="flex justify-center text-center text-neutral-500 p-4">
                 <div class="w-auto">
                   <div class="pb-4">
                     No identity providers to display

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/new.ex
@@ -35,7 +35,7 @@ defmodule Web.Settings.IdentityProviders.New do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">Choose type</h2>
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">Choose type</h2>
           <.form id="identity-provider-type-form" for={@form} phx-submit="submit">
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <fieldset>
@@ -109,19 +109,19 @@ defmodule Web.Settings.IdentityProviders.New do
           type="radio"
           name="next"
           value={next_step_path(@adapter, @account)}
-          class={~w[ w-4 h-4 border-gray-300 ]}
+          class={~w[ w-4 h-4 border-neutral-300 ]}
           required
         />
-        <label for={"idp-option-#{@adapter}"} class="block ml-2 text-lg font-medium text-gray-900">
+        <label for={"idp-option-#{@adapter}"} class="block ml-2 text-lg font-medium text-neutral-900">
           <%= @name %>
         </label>
         <%= if @adapter == :google_workspace do %>
-          <.badge class="ml-2" type="plan" title="Feature available on the Enterprise plan">
+          <.badge class="ml-2" type="primary" title="Feature available on the Enterprise plan">
             ENTERPRISE
           </.badge>
         <% end %>
       </div>
-      <p class="ml-6 mb-6 text-sm text-gray-500">
+      <p class="ml-6 mb-6 text-sm text-neutral-500">
         <%= @description %>
       </p>
     </div>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/components.ex
@@ -6,7 +6,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Components do
     <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
       <.form for={@form} phx-change={:change} phx-submit={:submit}>
         <div class="mb-4">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">
             Step 1. Create OAuth app in your identity provider
           </h2>
           Please make sure that following scopes are added to the OAuth application: <.code_block
@@ -31,7 +31,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Components do
         </div>
 
         <div class="mb-4">
-          <h2 class="mb-4 text-xl font-bold text-gray-900">
+          <h2 class="mb-4 text-xl font-bold text-neutral-900">
             2. Configure client
           </h2>
 
@@ -46,7 +46,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Components do
                 placeholder="Name this identity provider"
                 required
               />
-              <p class="mt-2 text-xs text-gray-500">
+              <p class="mt-2 text-xs text-neutral-500">
                 A friendly name for this identity provider. This will be displayed to end-users.
               </p>
             </div>
@@ -60,7 +60,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Components do
                   value="code"
                   disabled
                 />
-                <p class="mt-2 text-xs text-gray-500">
+                <p class="mt-2 text-xs text-neutral-500">
                   Firezone currently only supports <code>code</code> flows.
                 </p>
               </div>
@@ -73,7 +73,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Components do
                   placeholder="OpenID Connect scopes to request"
                   required
                 />
-                <p class="mt-2 text-xs text-gray-500">
+                <p class="mt-2 text-xs text-neutral-500">
                   A space-delimited list of scopes to request from your identity provider. In most cases you shouldn't need to change this.
                 </p>
               </div>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -28,8 +28,8 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
     <.section>
       <:title>
         Identity Provider <code><%= @provider.name %></code>
-        <span :if={not is_nil(@provider.disabled_at)} class="text-fz_orange-600">(disabled)</span>
-        <span :if={not is_nil(@provider.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@provider.disabled_at)} class="text-orange-600">(disabled)</span>
+        <span :if={not is_nil(@provider.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@provider.deleted_at)}>
         <.edit_button navigate={

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -28,8 +28,8 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
     <.section>
       <:title>
         Identity Provider <code><%= @provider.name %></code>
-        <span :if={not is_nil(@provider.disabled_at)} class="text-orange-600">(disabled)</span>
-        <span :if={not is_nil(@provider.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@provider.disabled_at)} class="text-fz_orange-600">(disabled)</span>
+        <span :if={not is_nil(@provider.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@provider.deleted_at)}>
         <.edit_button navigate={

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/saml/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/saml/components.ex
@@ -185,7 +185,11 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
                 >
                   <.icon name="hero-document-duplicate" class="w-5 h-5 mr-1" />
                 </button>
-                <button phx-click={toggle_scim_token()} title="Show SCIM token" class="text-accent-600">
+                <button
+                  phx-click={toggle_scim_token()}
+                  title="Show SCIM token"
+                  class="text-accent-600"
+                >
                   <.icon name="hero-eye" class="w-5 h-5 mr-1" />
                 </button>
 

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/saml/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/saml/components.ex
@@ -26,9 +26,9 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
 
   def provisioning_strategy_form(assigns) do
     ~H"""
-    <h2 class="mb-4 text-xl font-bold text-gray-900">Provisioning strategy</h2>
-    <ul class="mb-4 w-full sm:flex border border-gray-200 rounded">
-      <li class="w-full border-b border-gray-200 sm:border-b-0 sm:border-r">
+    <h2 class="mb-4 text-xl font-bold text-neutral-900">Provisioning strategy</h2>
+    <ul class="mb-4 w-full sm:flex border border-neutral-200 rounded">
+      <li class="w-full border-b border-neutral-200 sm:border-b-0 sm:border-r">
         <div class="text-lg font-medium p-3">
           <.input
             id="provisioning_strategy_jit"
@@ -40,11 +40,11 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
             required
           />
         </div>
-        <p class="px-4 py-2 text-sm text-gray-500">
+        <p class="px-4 py-2 text-sm text-neutral-500">
           Provision users and groups on the fly when they first sign in.
         </p>
       </li>
-      <li class="w-full border-b border-gray-200 sm:border-b-0 sm:border-r">
+      <li class="w-full border-b border-neutral-200 sm:border-b-0 sm:border-r">
         <div class="text-lg font-medium p-3">
           <.input
             id="provisioning_strategy_scim"
@@ -56,11 +56,11 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
             required
           />
         </div>
-        <p class="px-4 py-2 text-sm text-gray-500">
+        <p class="px-4 py-2 text-sm text-neutral-500">
           Provision users using the SCIM 2.0 protocol. Requires a supported identity provider.
         </p>
       </li>
-      <li class="w-full border-b border-gray-200 sm:border-b-0 sm:border-r">
+      <li class="w-full border-b border-neutral-200 sm:border-b-0 sm:border-r">
         <div class="text-lg font-medium p-3">
           <.input
             id="provisioning_strategy_manual"
@@ -72,7 +72,7 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
             required
           />
         </div>
-        <p class="px-4 py-2 text-sm text-gray-500">
+        <p class="px-4 py-2 text-sm text-neutral-500">
           Disable automatic provisioning and manually manage users and groups.
         </p>
       </li>
@@ -111,9 +111,9 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
             type="checkbox"
             field={@form[:jit_extract_groups]}
           />
-          <p class="ml-8 text-sm text-gray-500">
+          <p class="ml-8 text-sm text-neutral-500">
             <.link
-              class="text-blue-600 hover:underline"
+              class="text-accent-600 hover:underline"
               href="https://www.firezone.dev/kb/authenticate/user-group-sync?utm_source=product"
               target="_blank"
             >
@@ -134,12 +134,12 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
       <:title>Provisioning</:title>
     </.header>
     <div class="bg-white overflow-hidden">
-      <table class="w-full text-sm text-left text-gray-500">
+      <table class="w-full text-sm text-left text-neutral-500">
         <tbody>
-          <tr class="border-b border-gray-200">
+          <tr class="border-b border-neutral-200">
             <th
               scope="row"
-              class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+              class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
             >
               Type
             </th>
@@ -147,10 +147,10 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
               SCIM 2.0
             </td>
           </tr>
-          <tr class="border-b border-gray-200">
+          <tr class="border-b border-neutral-200">
             <th
               scope="row"
-              class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+              class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
             >
               Endpoint
             </th>
@@ -159,7 +159,7 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
                 <button
                   phx-click={JS.dispatch("phx:copy", to: "#endpoint-value")}
                   title="Copy Endpoint"
-                  class="text-blue-600"
+                  class="text-accent-600"
                 >
                   <.icon name="hero-document-duplicate" class="w-5 h-5 mr-1" />
                 </button>
@@ -169,10 +169,10 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
               </div>
             </td>
           </tr>
-          <tr class="border-b border-gray-200">
+          <tr class="border-b border-neutral-200">
             <th
               scope="row"
-              class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+              class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
             >
               Token
             </th>
@@ -181,11 +181,11 @@ defmodule Web.Settings.IdentityProviders.SAML.Components do
                 <button
                   phx-click={JS.dispatch("phx:copy", to: "#visible-token")}
                   title="Copy SCIM token"
-                  class="text-blue-600"
+                  class="text-accent-600"
                 >
                   <.icon name="hero-document-duplicate" class="w-5 h-5 mr-1" />
                 </button>
-                <button phx-click={toggle_scim_token()} title="Show SCIM token" class="text-blue-600">
+                <button phx-click={toggle_scim_token()} title="Show SCIM token" class="text-accent-600">
                   <.icon name="hero-eye" class="w-5 h-5 mr-1" />
                 </button>
 

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/saml/saml.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/saml/saml.ex
@@ -35,7 +35,7 @@ defmodule Web.Settings.IdentityProviders.SAML.New do
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
           <.form for={@form} id="saml-form" phx-change="change" phx-submit="submit">
-            <h2 class="mb-4 text-xl font-bold text-gray-900">SAML configuration</h2>
+            <h2 class="mb-4 text-xl font-bold text-neutral-900">SAML configuration</h2>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <div>
                 <.input
@@ -43,13 +43,13 @@ defmodule Web.Settings.IdentityProviders.SAML.New do
                   autocomplete="off"
                   field={@form[:name]}
                   class={[
-                    "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded",
+                    "bg-neutral-50 border border-neutral-300 text-neutral-900 text-sm rounded",
                     "block w-full p-2.5"
                   ]}
                   placeholder="Name this identity provider"
                   required
                 />
-                <p class="mt-2 text-xs text-gray-500">
+                <p class="mt-2 text-xs text-neutral-500">
                   A friendly name for this identity provider. This will be displayed to end-users.
                 </p>
               </div>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/saml/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/saml/show.ex
@@ -47,12 +47,12 @@ defmodule Web.Settings.IdentityProviders.SAML.Show do
         <.flash_group flash={@flash} />
 
         <div class="bg-white overflow-hidden">
-          <table class="w-full text-sm text-left text-gray-500">
+          <table class="w-full text-sm text-left text-neutral-500">
             <tbody>
-              <tr class="border-b border-gray-200">
+              <tr class="border-b border-neutral-200">
                 <th
                   scope="row"
-                  class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+                  class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
                 >
                   Name
                 </th>
@@ -60,10 +60,10 @@ defmodule Web.Settings.IdentityProviders.SAML.Show do
                   <%= @provider.name %>
                 </td>
               </tr>
-              <tr class="border-b border-gray-200">
+              <tr class="border-b border-neutral-200">
                 <th
                   scope="row"
-                  class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+                  class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
                 >
                   Type
                 </th>
@@ -71,10 +71,10 @@ defmodule Web.Settings.IdentityProviders.SAML.Show do
                   SAML 2.0
                 </td>
               </tr>
-              <tr class="border-b border-gray-200">
+              <tr class="border-b border-neutral-200">
                 <th
                   scope="row"
-                  class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+                  class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
                 >
                   Sign requests
                 </th>
@@ -82,10 +82,10 @@ defmodule Web.Settings.IdentityProviders.SAML.Show do
                   Yes
                 </td>
               </tr>
-              <tr class="border-b border-gray-200">
+              <tr class="border-b border-neutral-200">
                 <th
                   scope="row"
-                  class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+                  class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
                 >
                   Sign metadata
                 </th>
@@ -93,10 +93,10 @@ defmodule Web.Settings.IdentityProviders.SAML.Show do
                   Yes
                 </td>
               </tr>
-              <tr class="border-b border-gray-200">
+              <tr class="border-b border-neutral-200">
                 <th
                   scope="row"
-                  class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+                  class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
                 >
                   Require signed assertions
                 </th>
@@ -104,10 +104,10 @@ defmodule Web.Settings.IdentityProviders.SAML.Show do
                   Yes
                 </td>
               </tr>
-              <tr class="border-b border-gray-200">
+              <tr class="border-b border-neutral-200">
                 <th
                   scope="row"
-                  class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+                  class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
                 >
                   Require signed envelopes
                 </th>
@@ -115,10 +115,10 @@ defmodule Web.Settings.IdentityProviders.SAML.Show do
                   Yes
                 </td>
               </tr>
-              <tr class="border-b border-gray-200">
+              <tr class="border-b border-neutral-200">
                 <th
                   scope="row"
-                  class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+                  class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
                 >
                   Base URL
                 </th>
@@ -126,10 +126,10 @@ defmodule Web.Settings.IdentityProviders.SAML.Show do
                   Yes
                 </td>
               </tr>
-              <tr class="border-b border-gray-200">
+              <tr class="border-b border-neutral-200">
                 <th
                   scope="row"
-                  class="text-right px-6 py-4 font-medium text-gray-900 whitespace-nowrap bg-gray-50"
+                  class="text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap bg-neutral-50"
                 >
                   Created
                 </th>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
@@ -31,8 +31,8 @@ defmodule Web.Settings.IdentityProviders.System.Show do
     <.section>
       <:title>
         Identity Provider <code><%= @provider.name %></code>
-        <span :if={not is_nil(@provider.disabled_at)} class="text-fz_orange-600">(disabled)</span>
-        <span :if={not is_nil(@provider.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@provider.disabled_at)} class="text-orange-600">(disabled)</span>
+        <span :if={not is_nil(@provider.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@provider.deleted_at)}>
         <.button

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
@@ -31,8 +31,8 @@ defmodule Web.Settings.IdentityProviders.System.Show do
     <.section>
       <:title>
         Identity Provider <code><%= @provider.name %></code>
-        <span :if={not is_nil(@provider.disabled_at)} class="text-orange-600">(disabled)</span>
-        <span :if={not is_nil(@provider.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@provider.disabled_at)} class="text-fz_orange-600">(disabled)</span>
+        <span :if={not is_nil(@provider.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@provider.deleted_at)}>
         <.button

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -104,7 +104,7 @@ defmodule Web.SignIn do
             Meant to sign in from a client instead?
             <a
               href="https://firezone.dev/kb/user-guides?utm_source=product"
-              class="font-medium text-accent-600 hover:text-accent-500"
+              class={["font-medium", link_style()]}
             >
               Read the docs.
             </a>

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -40,13 +40,13 @@ defmodule Web.SignIn do
 
   def render(assigns) do
     ~H"""
-    <section class="bg-gray-50">
+    <section class="bg-neutral-50">
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
         <.logo />
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
-            <h1 class="text-xl text-center font-bold leading-tight tracking-tight text-gray-900 sm:text-2xl">
+            <h1 class="text-xl text-center font-bold leading-tight tracking-tight text-neutral-900 sm:text-2xl">
               <span>
                 Sign into <%= @account.name %>
               </span>
@@ -70,7 +70,7 @@ defmodule Web.SignIn do
               </:item>
 
               <:item :if={adapter_enabled?(@providers_by_adapter, :userpass)}>
-                <h3 class="text-m font-bold leading-tight tracking-tight text-gray-900 sm:text-xl">
+                <h3 class="text-m font-bold leading-tight tracking-tight text-neutral-900 sm:text-xl">
                   Sign in with username and password
                 </h3>
 
@@ -84,7 +84,7 @@ defmodule Web.SignIn do
               </:item>
 
               <:item :if={adapter_enabled?(@providers_by_adapter, :email)}>
-                <h3 class="text-m font-bold leading-tight tracking-tight text-gray-900 sm:text-xl">
+                <h3 class="text-m font-bold leading-tight tracking-tight text-neutral-900 sm:text-xl">
                   Sign in with email
                 </h3>
 
@@ -104,7 +104,7 @@ defmodule Web.SignIn do
             Meant to sign in from a client instead?
             <a
               href="https://firezone.dev/kb/user-guides?utm_source=product"
-              class="font-medium text-blue-600 hover:text-blue-500"
+              class="font-medium text-accent-600 hover:text-accent-500"
             >
               Read the docs.
             </a>
@@ -118,9 +118,9 @@ defmodule Web.SignIn do
   def separator(assigns) do
     ~H"""
     <div class="flex items-center">
-      <div class="w-full h-0.5 bg-gray-200"></div>
-      <div class="px-5 text-center text-gray-500">or</div>
-      <div class="w-full h-0.5 bg-gray-200"></div>
+      <div class="w-full h-0.5 bg-neutral-200"></div>
+      <div class="px-5 text-center text-neutral-500">or</div>
+      <div class="w-full h-0.5 bg-neutral-200"></div>
     </div>
     """
   end
@@ -215,9 +215,9 @@ defmodule Web.SignIn do
     <a href={~p"/#{@account}/sign_in/providers/#{@provider}/redirect?#{@params}"} class={~w[
           w-full inline-flex items-center justify-center py-2.5 px-5
           bg-white rounded
-          text-sm font-medium text-gray-900
-          border border-gray-200
-          hover:bg-gray-100 hover:text-gray-900
+          text-sm font-medium text-neutral-900
+          border border-neutral-200
+          hover:bg-neutral-100 hover:text-neutral-900
     ]}>
       Sign in with <%= @provider.name %>
     </a>

--- a/elixir/apps/web/lib/web/live/sign_in/email.ex
+++ b/elixir/apps/web/lib/web/live/sign_in/email.ex
@@ -93,7 +93,7 @@ defmodule Web.SignIn.Email do
               /> or
               <.link
                 navigate={~p"/#{@account_id_or_slug}?#{@redirect_params}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 use a different Sign In method
               </.link>

--- a/elixir/apps/web/lib/web/live/sign_in/email.ex
+++ b/elixir/apps/web/lib/web/live/sign_in/email.ex
@@ -31,13 +31,13 @@ defmodule Web.SignIn.Email do
 
   def render(assigns) do
     ~H"""
-    <section class="bg-gray-50">
+    <section class="bg-neutral-50">
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
         <.logo />
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
-            <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 sm:text-2xl">
+            <h1 class="text-xl font-bold leading-tight tracking-tight text-neutral-900 sm:text-2xl">
               Please check your email
             </h1>
             <.flash flash={@flash} kind={:error} phx-click={JS.hide(transition: "fade-out")} />
@@ -64,8 +64,8 @@ defmodule Web.SignIn.Email do
                   id="secret"
                   class={[
                     "block p-2.5 w-full text-sm",
-                    "bg-gray-50 text-gray-900",
-                    "rounded-l border-gray-300"
+                    "bg-neutral-50 text-neutral-900",
+                    "rounded-l border-neutral-300"
                   ]}
                   required
                   placeholder="Enter token from email"
@@ -93,7 +93,7 @@ defmodule Web.SignIn.Email do
               /> or
               <.link
                 navigate={~p"/#{@account_id_or_slug}?#{@redirect_params}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 use a different Sign In method
               </.link>
@@ -152,7 +152,7 @@ defmodule Web.SignIn.Email do
       />
       <span>
         Did not receive it?
-        <button type="submit" class="inline font-medium text-blue-600 hover:underline">
+        <button type="submit" class="inline font-medium text-accent-600 hover:underline">
           Resend email
         </button>
       </span>
@@ -166,9 +166,9 @@ defmodule Web.SignIn.Email do
       href={@url}
       class={[
         "w-1/2 m-2 inline-flex items-center justify-center py-2.5 px-5",
-        "text-sm font-medium text-gray-900 bg-white ",
-        "rounded border border-gray-200",
-        "hover:text-gray-900 hover:bg-gray-100"
+        "text-sm font-medium text-neutral-900 bg-white ",
+        "rounded border border-neutral-200",
+        "hover:text-neutral-900 hover:bg-neutral-100"
       ]}
     >
       Open <%= @name %>

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -141,7 +141,10 @@ defmodule Web.SignUp do
                   Sign In URL:
                 </td>
                 <td class={~w[border-b border-neutral-100 py-4 text-neutral-900]}>
-                  <.link class="font-medium text-accent-600 hover:underline" navigate={~p"/#{@account}"}>
+                  <.link
+                    class="font-medium text-accent-600 hover:underline"
+                    navigate={~p"/#{@account}"}
+                  >
                     <%= url(~p"/#{@account}") %>
                   </.link>
                 </td>

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -141,10 +141,7 @@ defmodule Web.SignUp do
                   Sign In URL:
                 </td>
                 <td class={~w[border-b border-neutral-100 py-4 text-neutral-900]}>
-                  <.link
-                    class="font-medium text-accent-600 hover:underline"
-                    navigate={~p"/#{@account}"}
-                  >
+                  <.link class={["font-medium", link_style()]} navigate={~p"/#{@account}"}>
                     <%= url(~p"/#{@account}") %>
                   </.link>
                 </td>
@@ -224,7 +221,7 @@ defmodule Web.SignUp do
       <p class="text-xs text-center">
         By signing up you agree to our <.link
           href="https://www.firezone.dev/terms"
-          class="text-accent-600 hover:underline"
+          class={link_style()}
         >Terms of Use</.link>.
       </p>
     </.simple_form>
@@ -247,7 +244,7 @@ defmodule Web.SignUp do
       <p class="text-xs text-center">
         By signing up you agree to our <.link
           href="https://www.firezone.dev/terms"
-          class="text-accent-600 hover:underline"
+          class={link_style()}
         >Terms of Use</.link>.
       </p>
     </div>

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -63,13 +63,13 @@ defmodule Web.SignUp do
 
   def render(assigns) do
     ~H"""
-    <section class="bg-gray-50">
+    <section class="bg-neutral-50">
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
         <.logo />
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
-            <h1 class="text-center text-xl font-bold leading-tight tracking-tight text-gray-900 sm:text-2xl">
+            <h1 class="text-center text-xl font-bold leading-tight tracking-tight text-neutral-900 sm:text-2xl">
               Welcome to Firezone
             </h1>
 
@@ -102,9 +102,9 @@ defmodule Web.SignUp do
   def separator(assigns) do
     ~H"""
     <div class="flex items-center">
-      <div class="w-full h-0.5 bg-gray-200"></div>
-      <div class="px-5 text-center text-gray-500">or</div>
-      <div class="w-full h-0.5 bg-gray-200"></div>
+      <div class="w-full h-0.5 bg-neutral-200"></div>
+      <div class="px-5 text-center text-neutral-500">or</div>
+      <div class="w-full h-0.5 bg-neutral-200"></div>
     </div>
     """
   end
@@ -112,7 +112,7 @@ defmodule Web.SignUp do
   def welcome(assigns) do
     ~H"""
     <div class="space-y-6">
-      <div class="text-center text-gray-900">
+      <div class="text-center text-neutral-900">
         Your account has been created!
         <p>Please check your email for sign in instructions.</p>
       </div>
@@ -121,27 +121,27 @@ defmodule Web.SignUp do
           <table class="border-collapse w-full text-sm">
             <tbody>
               <tr>
-                <td class={~w[border-b border-slate-100 py-4 text-gray-900]}>
+                <td class={~w[border-b border-neutral-100 py-4 text-neutral-900]}>
                   Account Name:
                 </td>
-                <td class={~w[border-b border-slate-100 py-4 text-gray-900]}>
+                <td class={~w[border-b border-neutral-100 py-4 text-neutral-900]}>
                   <%= @account.name %>
                 </td>
               </tr>
               <tr>
-                <td class={~w[border-b border-slate-100 py-4 text-gray-900]}>
+                <td class={~w[border-b border-neutral-100 py-4 text-neutral-900]}>
                   Account Slug:
                 </td>
-                <td class={~w[border-b border-slate-100 py-4 text-gray-900]}>
+                <td class={~w[border-b border-neutral-100 py-4 text-neutral-900]}>
                   <%= @account.slug %>
                 </td>
               </tr>
               <tr>
-                <td class={~w[border-b border-slate-100 py-4 text-gray-900]}>
+                <td class={~w[border-b border-neutral-100 py-4 text-neutral-900]}>
                   Sign In URL:
                 </td>
-                <td class={~w[border-b border-slate-100 py-4 text-gray-900]}>
-                  <.link class="font-medium text-blue-600 hover:underline" navigate={~p"/#{@account}"}>
+                <td class={~w[border-b border-neutral-100 py-4 text-neutral-900]}>
+                  <.link class="font-medium text-accent-600 hover:underline" navigate={~p"/#{@account}"}>
                     <%= url(~p"/#{@account}") %>
                   </.link>
                 </td>
@@ -150,7 +150,7 @@ defmodule Web.SignUp do
           </table>
         </div>
       </div>
-      <div class="text-base leading-7 text-center text-gray-900">
+      <div class="text-base leading-7 text-center text-neutral-900">
         <.form
           for={%{}}
           id="resend-email"
@@ -175,7 +175,7 @@ defmodule Web.SignUp do
 
   def sign_up_form(assigns) do
     ~H"""
-    <h3 class="text-center text-m font-bold leading-tight tracking-tight text-gray-900 sm:text-xl">
+    <h3 class="text-center text-m font-bold leading-tight tracking-tight text-neutral-900 sm:text-xl">
       Sign Up Now
     </h3>
     <.simple_form for={@form} class="space-y-4 lg:space-y-6" phx-submit="submit" phx-change="validate">
@@ -221,7 +221,7 @@ defmodule Web.SignUp do
       <p class="text-xs text-center">
         By signing up you agree to our <.link
           href="https://www.firezone.dev/terms"
-          class="text-blue-600 hover:underline"
+          class="text-accent-600 hover:underline"
         >Terms of Use</.link>.
       </p>
     </.simple_form>
@@ -231,7 +231,7 @@ defmodule Web.SignUp do
   def sign_up_disabled(assigns) do
     ~H"""
     <div class="space-y-6">
-      <div class="text-xl text-center text-gray-900">
+      <div class="text-xl text-center text-neutral-900">
         Sign-ups are currently disabled.
       </div>
       <div class="text-center">
@@ -244,7 +244,7 @@ defmodule Web.SignUp do
       <p class="text-xs text-center">
         By signing up you agree to our <.link
           href="https://www.firezone.dev/terms"
-          class="text-blue-600 hover:underline"
+          class="text-accent-600 hover:underline"
         >Terms of Use</.link>.
       </p>
     </div>

--- a/elixir/apps/web/lib/web/live/sites/edit.ex
+++ b/elixir/apps/web/lib/web/live/sites/edit.ex
@@ -33,7 +33,7 @@ defmodule Web.Sites.Edit do
                 <.input label="Name" field={@form[:name]} placeholder="Name of this Site" required />
               </div>
               <div>
-                <p class="text-lg text-slate-900 mb-2">
+                <p class="text-lg text-neutral-900 mb-2">
                   Data Routing -
                   <a
                     class={[link_style(), "text-sm"]}
@@ -54,7 +54,7 @@ defmodule Web.Sites.Edit do
                       checked={@form[:routing].value == :managed}
                       required
                     />
-                    <p class="ml-6 mb-4 text-sm text-slate-500 dark:text-slate-400">
+                    <p class="ml-6 mb-4 text-sm text-neutral-500 dark:text-neutral-400">
                       Firezone will route connections through our managed Relays only if a direct connection to a Gateway is not possible.
                       Firezone can never decrypt the contents of your traffic.
                     </p>
@@ -69,7 +69,7 @@ defmodule Web.Sites.Edit do
                       checked={@form[:routing].value == :stun_only}
                       required
                     />
-                    <p class="ml-6 mb-4 text-sm text-gray-500 dark:text-gray-400">
+                    <p class="ml-6 mb-4 text-sm text-neutral-500 dark:text-neutral-400">
                       Firezone will enforce direct connections to all Gateways in this Site. This could cause connectivity issues in rare cases.
                     </p>
                   </div>

--- a/elixir/apps/web/lib/web/live/sites/gateways/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/gateways/index.ex
@@ -46,7 +46,7 @@ defmodule Web.Sites.Gateways.Index do
           <:col :let={gateway} label="INSTANCE">
             <.link
               navigate={~p"/#{@account}/gateways/#{gateway.id}"}
-              class="font-medium text-accent-600 hover:underline"
+              class={["font-medium", link_style()]}
             >
               <%= gateway.name %>
             </.link>
@@ -67,7 +67,7 @@ defmodule Web.Sites.Gateways.Index do
               <div class="pb-4">
                 No gateways to display.
                 <.link
-                  class="font-medium text-blue-600 hover:underline"
+                  class={["font-medium", link_style()]}
                   navigate={~p"/#{@account}/sites/#{@group}/new_token"}
                 >
                   Deploy a gateway to connect resources.

--- a/elixir/apps/web/lib/web/live/sites/gateways/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/gateways/index.ex
@@ -67,7 +67,7 @@ defmodule Web.Sites.Gateways.Index do
               <div class="pb-4">
                 No gateways to display.
                 <.link
-                  class="font-medium text-fz_blue-600 hover:underline"
+                  class="font-medium text-blue-600 hover:underline"
                   navigate={~p"/#{@account}/sites/#{@group}/new_token"}
                 >
                   Deploy a gateway to connect resources.

--- a/elixir/apps/web/lib/web/live/sites/gateways/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/gateways/index.ex
@@ -46,7 +46,7 @@ defmodule Web.Sites.Gateways.Index do
           <:col :let={gateway} label="INSTANCE">
             <.link
               navigate={~p"/#{@account}/gateways/#{gateway.id}"}
-              class="font-medium text-blue-600 hover:underline"
+              class="font-medium text-accent-600 hover:underline"
             >
               <%= gateway.name %>
             </.link>
@@ -63,11 +63,11 @@ defmodule Web.Sites.Gateways.Index do
             <.connection_status schema={gateway} />
           </:col>
           <:empty>
-            <div class="flex flex-col items-center justify-center text-center text-slate-500 p-4">
+            <div class="flex flex-col items-center justify-center text-center text-neutral-500 p-4">
               <div class="pb-4">
                 No gateways to display.
                 <.link
-                  class="font-medium text-blue-600 hover:underline"
+                  class="font-medium text-fz_blue-600 hover:underline"
                   navigate={~p"/#{@account}/sites/#{@group}/new_token"}
                 >
                   Deploy a gateway to connect resources.

--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -32,10 +32,7 @@ defmodule Web.Sites.Index do
       <:content>
         <.table id="groups" rows={@groups} row_id={&"group-#{&1.id}"}>
           <:col :let={group} label="site">
-            <.link
-              navigate={~p"/#{@account}/sites/#{group}"}
-              class="font-bold text-accent-600 hover:underline"
-            >
+            <.link navigate={~p"/#{@account}/sites/#{group}"} class={["font-bold", link_style()]}>
               <%= group.name %>
             </.link>
           </:col>
@@ -57,7 +54,7 @@ defmodule Web.Sites.Index do
                   navigate={
                     ~p"/#{@account}/resources/#{connection.resource}?site_id=#{connection.gateway_group_id}"
                   }
-                  class="font-medium text-accent-600 hover:underline inline-block"
+                  class={["font-medium inline-block", link_style()]}
                   phx-no-format
                 ><%= connection.resource.name %></.link>
               </:item>
@@ -67,7 +64,7 @@ defmodule Web.Sites.Index do
                   and
                   <.link
                     navigate={~p"/#{@account}/sites/#{group}?#resources"}
-                    class="font-bold text-accent-600 hover:underline"
+                    class={["font-bold", link_style()]}
                   >
                     <%= count %> more.
                   </.link>
@@ -91,7 +88,7 @@ defmodule Web.Sites.Index do
               <:item :let={gateway}>
                 <.link
                   navigate={~p"/#{@account}/gateways/#{gateway}"}
-                  class="font-medium text-accent-600 hover:underline inline-block"
+                  class={["font-medium inline-block", link_style()]}
                   phx-no-format
                 ><%= gateway.name %></.link>
               </:item>
@@ -101,7 +98,7 @@ defmodule Web.Sites.Index do
                   and
                   <.link
                     navigate={~p"/#{@account}/sites/#{group}?#gateways"}
-                    class="font-bold text-accent-600 hover:underline"
+                    class={["font-bold", link_style()]}
                   >
                     <%= count %> more.
                   </.link>

--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -34,7 +34,7 @@ defmodule Web.Sites.Index do
           <:col :let={group} label="site">
             <.link
               navigate={~p"/#{@account}/sites/#{group}"}
-              class="font-bold text-blue-600 hover:underline"
+              class="font-bold text-accent-600 hover:underline"
             >
               <%= group.name %>
             </.link>
@@ -57,7 +57,7 @@ defmodule Web.Sites.Index do
                   navigate={
                     ~p"/#{@account}/resources/#{connection.resource}?site_id=#{connection.gateway_group_id}"
                   }
-                  class="font-medium text-blue-600 hover:underline inline-block"
+                  class="font-medium text-accent-600 hover:underline inline-block"
                   phx-no-format
                 ><%= connection.resource.name %></.link>
               </:item>
@@ -67,7 +67,7 @@ defmodule Web.Sites.Index do
                   and
                   <.link
                     navigate={~p"/#{@account}/sites/#{group}?#resources"}
-                    class="font-bold text-blue-600 hover:underline"
+                    class="font-bold text-accent-600 hover:underline"
                   >
                     <%= count %> more.
                   </.link>
@@ -91,7 +91,7 @@ defmodule Web.Sites.Index do
               <:item :let={gateway}>
                 <.link
                   navigate={~p"/#{@account}/gateways/#{gateway}"}
-                  class="font-medium text-blue-600 hover:underline inline-block"
+                  class="font-medium text-accent-600 hover:underline inline-block"
                   phx-no-format
                 ><%= gateway.name %></.link>
               </:item>
@@ -101,7 +101,7 @@ defmodule Web.Sites.Index do
                   and
                   <.link
                     navigate={~p"/#{@account}/sites/#{group}?#gateways"}
-                    class="font-bold text-blue-600 hover:underline"
+                    class="font-bold text-accent-600 hover:underline"
                   >
                     <%= count %> more.
                   </.link>
@@ -111,7 +111,7 @@ defmodule Web.Sites.Index do
           </:col>
 
           <:empty>
-            <div class="flex justify-center text-center text-slate-500 p-4">
+            <div class="flex justify-center text-center text-neutral-500 p-4">
               <div class="w-auto">
                 <div class="pb-4">
                   No sites to display

--- a/elixir/apps/web/lib/web/live/sites/new.ex
+++ b/elixir/apps/web/lib/web/live/sites/new.ex
@@ -27,7 +27,7 @@ defmodule Web.Sites.New do
                 <.input label="Name" field={@form[:name]} placeholder="Name of this Site" required />
               </div>
               <div>
-                <p class="text-lg text-slate-900 mb-2">
+                <p class="text-lg text-neutral-900 mb-2">
                   Data Routing -
                   <a
                     class={[link_style(), "text-sm"]}
@@ -50,13 +50,13 @@ defmodule Web.Sites.New do
                     >
                       <.badge
                         class="ml-2"
-                        type="plan"
+                        type="primary"
                         title="Feature available on the Enterprise plan"
                       >
                         ENTERPRISE
                       </.badge>
                     </.input>
-                    <p class="ml-6 mb-4 text-sm text-slate-500 dark:text-slate-400">
+                    <p class="ml-6 mb-4 text-sm text-neutral-500 dark:text-neutral-400">
                       Firezone will route connections through our managed Relays only if a direct connection to a Gateway is not possible.
                       Firezone can never decrypt the contents of your traffic.
                     </p>
@@ -71,7 +71,7 @@ defmodule Web.Sites.New do
                       checked={@form[:routing].value == :stun_only}
                       required
                     />
-                    <p class="ml-6 mb-4 text-sm text-gray-500 dark:text-gray-400">
+                    <p class="ml-6 mb-4 text-sm text-neutral-500 dark:text-neutral-400">
                       Firezone will enforce direct connections to all Gateways in this Site. This could cause connectivity issues in rare cases.
                     </p>
                   </div>

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -97,7 +97,7 @@ defmodule Web.Sites.Show do
             <:col :let={gateway} label="INSTANCE">
               <.link
                 navigate={~p"/#{@account}/gateways/#{gateway.id}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <%= gateway.name %>
               </.link>
@@ -119,7 +119,7 @@ defmodule Web.Sites.Show do
                   No gateways to display.
                   <span :if={is_nil(@group.deleted_at)}>
                     <.link
-                      class="font-medium text-blue-600 hover:underline"
+                      class={["font-medium", link_style()]}
                       navigate={~p"/#{@account}/sites/#{@group}/new_token"}
                     >
                       Deploy a gateway to connect resources.
@@ -152,7 +152,7 @@ defmodule Web.Sites.Show do
             <:col :let={resource} label="NAME">
               <.link
                 navigate={~p"/#{@account}/resources/#{resource}?site_id=#{@group}"}
-                class="font-medium text-accent-600 hover:underline"
+                class={["font-medium", link_style()]}
               >
                 <%= resource.name %>
               </.link>
@@ -165,7 +165,7 @@ defmodule Web.Sites.Show do
                 <:empty>
                   None,
                   <.link
-                    class={link_style() ++ ["px-1"]}
+                    class={["px-1", link_style()]}
                     navigate={~p"/#{@account}/policies/new?resource_id=#{resource}&site_id=#{@group}"}
                   >
                     create a Policy

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -46,7 +46,7 @@ defmodule Web.Sites.Show do
     <.section>
       <:title>
         Site: <code><%= @group.name %></code>
-        <span :if={not is_nil(@group.deleted_at)} class="text-fz_red-600">(deleted)</span>
+        <span :if={not is_nil(@group.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@group.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/sites/#{@group}/edit"}>
@@ -119,7 +119,7 @@ defmodule Web.Sites.Show do
                   No gateways to display.
                   <span :if={is_nil(@group.deleted_at)}>
                     <.link
-                      class="font-medium text-fz_blue-600 hover:underline"
+                      class="font-medium text-blue-600 hover:underline"
                       navigate={~p"/#{@account}/sites/#{@group}/new_token"}
                     >
                       Deploy a gateway to connect resources.

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -46,7 +46,7 @@ defmodule Web.Sites.Show do
     <.section>
       <:title>
         Site: <code><%= @group.name %></code>
-        <span :if={not is_nil(@group.deleted_at)} class="text-red-600">(deleted)</span>
+        <span :if={not is_nil(@group.deleted_at)} class="text-fz_red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@group.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/sites/#{@group}/edit"}>
@@ -97,7 +97,7 @@ defmodule Web.Sites.Show do
             <:col :let={gateway} label="INSTANCE">
               <.link
                 navigate={~p"/#{@account}/gateways/#{gateway.id}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <%= gateway.name %>
               </.link>
@@ -114,12 +114,12 @@ defmodule Web.Sites.Show do
               <.connection_status schema={gateway} />
             </:col>
             <:empty>
-              <div class="flex flex-col items-center justify-center text-center text-slate-500 p-4">
+              <div class="flex flex-col items-center justify-center text-center text-neutral-500 p-4">
                 <div class="pb-4">
                   No gateways to display.
                   <span :if={is_nil(@group.deleted_at)}>
                     <.link
-                      class="font-medium text-blue-600 hover:underline"
+                      class="font-medium text-fz_blue-600 hover:underline"
                       navigate={~p"/#{@account}/sites/#{@group}/new_token"}
                     >
                       Deploy a gateway to connect resources.
@@ -152,7 +152,7 @@ defmodule Web.Sites.Show do
             <:col :let={resource} label="NAME">
               <.link
                 navigate={~p"/#{@account}/resources/#{resource}?site_id=#{@group}"}
-                class="font-medium text-blue-600 hover:underline"
+                class="font-medium text-accent-600 hover:underline"
               >
                 <%= resource.name %>
               </.link>
@@ -192,7 +192,7 @@ defmodule Web.Sites.Show do
               </.peek>
             </:col>
             <:empty>
-              <div class="flex flex-col items-center justify-center text-center text-slate-500 p-4">
+              <div class="flex flex-col items-center justify-center text-center text-neutral-500 p-4">
                 <div class="pb-4">
                   No resources to display.
                 </div>

--- a/elixir/apps/web/test/web/live/sidebar_test.exs
+++ b/elixir/apps/web/test/web/live/sidebar_test.exs
@@ -38,7 +38,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/actors")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/actors']")
+    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/actors']")
     assert String.trim(Floki.text(item)) == "Actors"
   end
 
@@ -48,7 +48,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/groups")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/groups']")
+    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/groups']")
     assert String.trim(Floki.text(item)) == "Groups"
   end
 
@@ -58,7 +58,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/clients")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/clients']")
+    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/clients']")
     assert String.trim(Floki.text(item)) == "Clients"
   end
 
@@ -68,7 +68,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/sites")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/sites']")
+    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/sites']")
     assert String.trim(Floki.text(item)) == "Sites"
   end
 
@@ -78,7 +78,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/relay_groups")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/relay_groups']")
+    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/relay_groups']")
     assert String.trim(Floki.text(item)) == "Relays"
   end
 
@@ -88,7 +88,7 @@ defmodule Web.SidebarTest do
   #   conn: conn
   # } do
   #   {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/resources")
-  #   assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/resources']")
+  #   assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/resources']")
   #   assert String.trim(Floki.text(item)) == "Resources"
   # end
 
@@ -98,7 +98,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/policies")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/policies']")
+    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/policies']")
     assert String.trim(Floki.text(item)) == "Policies"
   end
 
@@ -108,7 +108,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/settings/account")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/settings/account']")
+    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/settings/account']")
     assert String.trim(Floki.text(item)) == "Account"
   end
 
@@ -123,7 +123,7 @@ defmodule Web.SidebarTest do
     assert item =
              Floki.find(
                html,
-               "a.bg-gray-100[href='/#{account.slug}/settings/identity_providers']"
+               "a.bg-neutral-100[href='/#{account.slug}/settings/identity_providers']"
              )
 
     assert String.trim(Floki.text(item)) == "Identity Providers"
@@ -143,7 +143,7 @@ defmodule Web.SidebarTest do
     assert item =
              Floki.find(
                html,
-               "a.bg-gray-100[href='/#{account.slug}/settings/identity_providers']"
+               "a.bg-neutral-100[href='/#{account.slug}/settings/identity_providers']"
              )
 
     assert String.trim(Floki.text(item)) == "Identity Providers"
@@ -155,7 +155,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = live(authorize_conn(conn, identity), ~p"/#{account}/settings/dns")
-    assert item = Floki.find(html, "a.bg-gray-100[href='/#{account.slug}/settings/dns']")
+    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/settings/dns']")
     assert String.trim(Floki.text(item)) == "DNS"
   end
 end


### PR DESCRIPTION
Updated portal to make sure we use primary/accent/neutral in as many places as possible.

Updated our neutral color palette to only have grayscale colors.

Also aliased the main colors (i.e. red/green/blue/yellow/orange) to use an `fz_` prefix to allow for easier find/replace if needed, as well as allowing easy customization of the colors later if needed.