### PR TITLE
macOS: Don't sign out on rebooting the Mac

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/TunnelShutdownEvent.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/TunnelShutdownEvent.swift
@@ -39,6 +39,7 @@ public struct TunnelShutdownEvent: Codable, CustomStringConvertible {
   }
 
   public enum Action {
+    case doNothing
     case signoutImmediately
     case retryThenSignout
   }
@@ -50,8 +51,10 @@ public struct TunnelShutdownEvent: Codable, CustomStringConvertible {
   public var action: Action {
     switch reason {
     case .stopped(let reason):
-      if reason == .userInitiated || reason == .userLogout || reason == .userSwitch {
+      if reason == .userInitiated {
         return .signoutImmediately
+      } else if reason == .userLogout || reason == .userSwitch {
+        return .doNothing
       } else {
         return .retryThenSignout
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -199,6 +199,8 @@ final class AuthStore: ObservableObject {
         }
       case .retryThenSignout:
         self.retryStartTunnel()
+      case .doNothing:
+        break
       }
     } else {
       self.logger.log("\(#function): Tunnel shutdown event not found")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -15,6 +15,7 @@ enum TunnelStoreError: Error {
   case cannotSaveToTunnelWhenConnected
   case cannotSignOutWhenConnected
   case stopAlreadyBeingAttempted
+  case startTunnelErrored(Error)
 }
 
 public struct TunnelProviderKeys {
@@ -173,7 +174,11 @@ final class TunnelStore: ObservableObject {
     try await tunnel.loadFromPreferences()
 
     let session = castToSession(tunnel.connection)
-    try session.startTunnel()
+    do {
+      try session.startTunnel()
+    } catch {
+      throw TunnelStoreError.startTunnelErrored(error)
+    }
     try await withCheckedThrowingContinuation { continuation in
       self.startTunnelContinuation = continuation
     }


### PR DESCRIPTION
Fixes #2809.

Tested the case where the user:
  - while being signed in and connected in the Firezone app, logs out of macOS
  - logs in as another user

In the above case, the app:
  - sees that there's a token reference stored in the tunnel, but is unable to access the token (the token is per user)
  - so the app signs the user out

This PR is stacked on top of PR #2804.