### PR TITLE
Elixir/domain ops

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -284,6 +284,15 @@ Interactive Elixir (1.15.2) - press Ctrl+C to exit (type h() ENTER for help)
 iex(web@web-w2f6.us-east1-d.c.firezone-staging.internal)1>
 ```
 
+### Quickly provisioning an account
+
+Useful for onboarding beta customers. See the `Domain.Ops.provision_account/1`
+function:
+
+```elixir
+iex> Domain.Ops.provision_account(%{account_name: "Customer Account", slug: "customer_account", account_admin_name: "Test User", account_email: "test@firezone.localhost"})
+```
+
 ### Creating an account on staging instance using CLI
 
 ```elixir

--- a/elixir/apps/domain/lib/domain/ops.ex
+++ b/elixir/apps/domain/lib/domain/ops.ex
@@ -18,7 +18,7 @@ defmodule Domain.Ops do
       {:ok, actor} =
         Domain.Actors.create_actor(account, %{type: :account_admin_user, name: account_admin_name})
 
-      {:ok, identity} =
+      {:ok, _identity} =
         Domain.Auth.upsert_identity(actor, magic_link_provider, %{
           provider_identifier: account_admin_email,
           provider_identifier_confirmation: account_admin_email

--- a/elixir/apps/domain/lib/domain/ops.ex
+++ b/elixir/apps/domain/lib/domain/ops.ex
@@ -1,13 +1,11 @@
 defmodule Domain.Ops do
-  def initialize_account(
-        %{
-          account_name: account_name,
-          account_slug: account_slug,
-          account_admin_name: account_admin_name,
-          account_admin_email: account_admin_email
-        }
-      ) do
-    Domain.Repo.transaction fn ->
+  def provision_account(%{
+        account_name: account_name,
+        account_slug: account_slug,
+        account_admin_name: account_admin_name,
+        account_admin_email: account_admin_email
+      }) do
+    Domain.Repo.transaction(fn ->
       {:ok, account} = Domain.Accounts.create_account(%{name: account_name, slug: account_slug})
 
       {:ok, magic_link_provider} =
@@ -25,6 +23,6 @@ defmodule Domain.Ops do
           provider_identifier: account_admin_email,
           provider_identifier_confirmation: account_admin_email
         })
-    end
+    end)
   end
 end

--- a/elixir/apps/domain/lib/domain/ops.ex
+++ b/elixir/apps/domain/lib/domain/ops.ex
@@ -1,0 +1,30 @@
+defmodule Domain.Ops do
+  def initialize_account(
+        %{
+          account_name: account_name,
+          account_slug: account_slug,
+          account_admin_name: account_admin_name,
+          account_admin_email: account_admin_email
+        }
+      ) do
+    Domain.Repo.transaction fn ->
+      {:ok, account} = Domain.Accounts.create_account(%{name: account_name, slug: account_slug})
+
+      {:ok, magic_link_provider} =
+        Domain.Auth.create_provider(account, %{
+          name: "Email",
+          adapter: :email,
+          adapter_config: %{}
+        })
+
+      {:ok, actor} =
+        Domain.Actors.create_actor(account, %{type: :account_admin_user, name: account_admin_name})
+
+      {:ok, identity} =
+        Domain.Auth.upsert_identity(actor, magic_link_provider, %{
+          provider_identifier: account_admin_email,
+          provider_identifier_confirmation: account_admin_email
+        })
+    end
+  end
+end

--- a/elixir/apps/domain/test/domain/ops_test.exs
+++ b/elixir/apps/domain/test/domain/ops_test.exs
@@ -1,0 +1,34 @@
+defmodule Domain.OpsTest do
+  use Domain.DataCase, async: true
+  import Domain.Ops
+
+  describe "provision_account/1" do
+    setup do
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
+    end
+
+    test "provisions an account when valid input is provider" do
+      params = %{
+        account_name: "Test Account",
+        account_slug: "test_account",
+        account_admin_name: "Test Admin",
+        account_admin_email: "test_admin@firezone.local"
+      }
+
+      assert {:ok, _} = provision_account(params)
+      assert {:ok, _} = Domain.Accounts.fetch_account_by_id_or_slug("test_account")
+    end
+
+    test "returns an error when invalid input is provided" do
+      params = %{
+        account_name: "Test Account",
+        account_slug: "test_account",
+        account_admin_name: "Test Admin",
+        account_admin_email: "invalid"
+      }
+
+      # provision_account/1 catches the invalid params and raises MatchError
+      assert_raise(MatchError, fn -> provision_account(params) end)
+    end
+  end
+end


### PR DESCRIPTION
Adds a helper method we can call from a live IEX to provision an account when signups are disabled.