### PR TITLE
Remove duplicate ios/macos builds

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -14,16 +14,6 @@ jobs:
             runs-on: macos-13
             platform: macOS
             destination: platform=macOS
-            xcode: "14.3"
-          - sdk: iphoneos
-            runs-on: macos-13
-            platform: iOS
-            destination: generic/platform=iOS
-            xcode: "14.3"
-          - sdk: macosx
-            runs-on: macos-13
-            platform: macOS
-            destination: platform=macOS
             xcode: "15.0"
           - sdk: iphoneos
             runs-on: macos-13


### PR DESCRIPTION
We're uploading dupe builds of the client on macOS and iOS because we're testing the build on Xcode 14 and 15.

Since Xcode 15 is stable now, builds for 14 can be removed.