### PR TITLE
connlib: disconnect on token expiration

### DIFF
--- a/rust/connlib/shared/src/control.rs
+++ b/rust/connlib/shared/src/control.rs
@@ -385,6 +385,8 @@ pub struct UnknownError(pub String);
 pub enum KnownError {
     #[serde(rename = "unmatched topic")]
     UnmatchedTopic,
+    #[serde(rename = "token_expired")]
+    TokenExpired,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -141,6 +141,8 @@ pub enum ConnlibError {
     /// Connection is still being stablished, retry later
     #[error("Pending connection")]
     PendingConnection,
+    #[error("Token has expired")]
+    TokenExpired,
 }
 
 impl ConnlibError {


### PR DESCRIPTION
Previously, we just expected the portal to disconnects us and 401 on the retry, right now we harden that behaviour by also just disconnecting when token expiration.

This seems to work, there's another part to this which is not only handling the replies but also handling the message generated by the portal, I'll implement that when I can easily test expirying tokens, for now this makes the client much more stable.