### PR TITLE
connlib: try to reuse old ips even with new peers

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -3,8 +3,9 @@ use crate::device_channel::{Device, Packet};
 use crate::ip_packet::{IpPacket, MutableIpPacket};
 use crate::peer::PacketTransformClient;
 use crate::{
-    dns, ConnectedPeer, DnsFallbackStrategy, DnsQuery, Event, PeerConfig, RoleState, Tunnel,
-    DNS_QUERIES_QUEUE_SIZE, ICE_GATHERING_TIMEOUT_SECONDS, MAX_CONCURRENT_ICE_GATHERING,
+    dns, get_v4, get_v6, ConnectedPeer, DnsFallbackStrategy, DnsQuery, Event, PeerConfig,
+    RoleState, Tunnel, DNS_QUERIES_QUEUE_SIZE, ICE_GATHERING_TIMEOUT_SECONDS,
+    MAX_CONCURRENT_ICE_GATHERING,
 };
 use boringtun::x25519::{PublicKey, StaticSecret};
 use connlib_shared::error::{ConnlibError as Error, ConnlibError};
@@ -192,7 +193,7 @@ pub struct ClientState {
     pub dns_strategy: DnsFallbackStrategy,
     forwarded_dns_queries: BoundedQueue<DnsQuery<'static>>,
 
-    pub ip_provider: IpProvider,
+    ip_provider: IpProvider,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -382,12 +383,14 @@ impl ClientState {
         tracing::trace!(resource_ip = %destination, "resource_connection_intent");
 
         let Some(resource) = self.get_cidr_resource_by_destination(destination) else {
+            tracing::trace!(?self.dns_resources_internal_ips, "checking for dns");
             if let Some(resource) = self
                 .dns_resources_internal_ips
                 .iter()
                 .find_map(|(r, i)| i.contains(&destination).then_some(r))
                 .cloned()
             {
+                tracing::trace!(?resource, %destination, "expired_dns_connection_intent");
                 self.on_connection_intent_dns(&resource);
             }
             return;
@@ -567,6 +570,37 @@ impl ClientState {
             tracing::warn!("Too many DNS queries, dropping new ones");
         }
     }
+
+    pub fn get_or_assign_ip(
+        &mut self,
+        resource: &DnsResource,
+        addrs: &[IpAddr],
+    ) -> Vec<(IpAddr, IpAddr)> {
+        let internal_ips = self
+            .dns_resources_internal_ips
+            .get(resource)
+            .cloned()
+            .unwrap_or(Vec::new());
+        let addr_v4 = addrs.iter().copied().filter(IpAddr::is_ipv4);
+        let internal_ips_v4 = internal_ips
+            .iter()
+            .copied()
+            .filter_map(get_v4)
+            .chain(&mut self.ip_provider.ipv4)
+            .map(Into::<IpAddr>::into)
+            .zip(addr_v4);
+
+        let addr_v6 = addrs.iter().copied().filter(IpAddr::is_ipv6);
+        let internal_ips_v6 = internal_ips
+            .iter()
+            .copied()
+            .filter_map(get_v6)
+            .chain(&mut self.ip_provider.ipv6)
+            .map(Into::<IpAddr>::into)
+            .zip(addr_v6);
+
+        internal_ips_v4.chain(internal_ips_v6).collect()
+    }
 }
 
 pub struct IpProvider {
@@ -580,14 +614,6 @@ impl IpProvider {
             ipv4: Box::new(ipv4.hosts()),
             ipv6: Box::new(ipv6.subnets_with_prefix(128).map(|ip| ip.network_address())),
         }
-    }
-
-    pub fn next_ipv4(&mut self) -> Option<Ipv4Addr> {
-        self.ipv4.next()
-    }
-
-    pub fn next_ipv6(&mut self) -> Option<Ipv6Addr> {
-        self.ipv6.next()
     }
 }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -334,8 +334,6 @@ impl ClientState {
             return;
         }
 
-        tracing::trace!(?resource, "resource_connection_intent");
-
         const MAX_SIGNAL_CONNECTION_DELAY: Duration = Duration::from_secs(2);
 
         let resource_id = resource.id;
@@ -383,14 +381,12 @@ impl ClientState {
         tracing::trace!(resource_ip = %destination, "resource_connection_intent");
 
         let Some(resource) = self.get_cidr_resource_by_destination(destination) else {
-            tracing::trace!(?self.dns_resources_internal_ips, "checking for dns");
             if let Some(resource) = self
                 .dns_resources_internal_ips
                 .iter()
                 .find_map(|(r, i)| i.contains(&destination).then_some(r))
                 .cloned()
             {
-                tracing::trace!(?resource, %destination, "expired_dns_connection_intent");
                 self.on_connection_intent_dns(&resource);
             }
             return;

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -21,7 +21,7 @@ use crate::{
     client::DnsResource,
     control_protocol::{new_ice_connection, IceConnection},
     device_channel::Device,
-    dns, get_v4,
+    dns,
     peer::PacketTransformClient,
     PEER_QUEUE_SIZE,
 };

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -21,7 +21,7 @@ use crate::{
     client::DnsResource,
     control_protocol::{new_ice_connection, IceConnection},
     device_channel::Device,
-    dns,
+    dns, get_v4,
     peer::PacketTransformClient,
     PEER_QUEUE_SIZE,
 };
@@ -263,12 +263,13 @@ where
             DnsResource::from_description(&resource_description, domain_response.domain.clone());
 
         let mut role_state = self.role_state.lock();
-        let addrs: Vec<_> = domain_response
-            .address
+
+        let addrs: Vec<_> = role_state
+            .get_or_assign_ip(&resource_description, &domain_response.address)
             .iter()
-            .filter_map(|addr| {
+            .filter_map(|(internal_ip, external_ip)| {
                 peer.transform
-                    .get_or_assign_translation(addr, &mut role_state.ip_provider)
+                    .get_or_assign_translation(internal_ip, external_ip)
             })
             .collect();
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -200,19 +200,15 @@ pub struct PacketTransformClient {
 impl PacketTransformClient {
     pub fn get_or_assign_translation(
         &self,
+        internal_ip: &IpAddr,
         external_ip: &IpAddr,
-        ip_provider: &mut IpProvider,
     ) -> Option<IpAddr> {
         let mut translations = self.translations.write();
         if let Some(internal_ip) = translations.get_by_right(external_ip) {
             return Some(*internal_ip);
         }
-        let internal_ip = match external_ip {
-            IpAddr::V4(_) => ip_provider.next_ipv4()?.into(),
-            IpAddr::V6(_) => ip_provider.next_ipv6()?.into(),
-        };
-        translations.insert(internal_ip, *external_ip);
-        Some(internal_ip)
+        translations.insert(*internal_ip, *external_ip);
+        Some(*internal_ip)
     }
 }
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -16,7 +16,6 @@ use parking_lot::{Mutex, RwLock};
 use pnet_packet::Packet;
 use secrecy::ExposeSecret;
 
-use crate::client::IpProvider;
 use crate::MAX_UDP_SIZE;
 use crate::{device_channel, ip_packet::MutableIpPacket, PeerConfig};
 


### PR DESCRIPTION
When a peer expired the os might have cached the old internal ips that we used, then with a new peer we were assigning new ips and that cached ip might have been wrong, then the tunnel would be in state where it would send the wrong response to this ips.

With this PR we try to always reuse the old ip if there's any available.