### PR TITLE
Don't automatically delete log files after successful upload

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -252,7 +252,6 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                 tokio::spawn(async move {
                     if let Err(e) = upload(path.clone(), url).await {
                         tracing::warn!("Failed to upload log file: {e}");
-                        return;
                     }
                 });
             }

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -254,9 +254,6 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                         tracing::warn!("Failed to upload log file: {e}");
                         return;
                     }
-                    if let Err(e) = tokio::fs::remove_file(&path).await {
-                        tracing::warn!("Failed to upload log file: {e}")
-                    }
                 });
             }
         }


### PR DESCRIPTION
Prevents cases where "Export logs" doesn't contain the full log cache.

Fixes #2886 