### PR TITLE
connlib: decouple data and control plane and fix backoff reset

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -687,7 +687,9 @@ impl RoleState for ClientState {
                 }
 
                 Poll::Ready((id, Some(Err(e)))) => {
-                    tracing::warn!(resource_id = %id, "Connection establishment timeout: {e}")
+                    tracing::warn!(resource_id = %id, "Connection establishment timeout: {e}");
+                    self.awaiting_connection.remove(&id);
+                    self.awaiting_connection_timers.remove(id);
                 }
                 Poll::Ready((_, None)) => continue,
                 Poll::Pending => {}

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -214,13 +214,6 @@ where
         resource_addresses: Vec<IpNetwork>,
     ) -> Result<()> {
         tracing::trace!(?peer_config.ips, "new_data_channel_open");
-        let device = self.device.load().clone().ok_or(Error::NoIface)?;
-        let callbacks = self.callbacks.clone();
-        for ip in &peer_config.ips {
-            if let Ok(res) = device.add_route(*ip, &callbacks) {
-                assert!(res.is_none(),  "gateway does not run on android and thus never produces a new device upon `add_route`");
-            }
-        }
 
         let peer = Arc::new(Peer::new(
             self.private_key.clone(),

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -16,6 +16,9 @@ use std::task::{ready, Context, Poll};
 use std::time::Duration;
 use webrtc::ice_transport::ice_candidate::RTCIceCandidate;
 
+const PEERS_IPV4: &str = "100.64.0.0/11";
+const PEERS_IPV6: &str = "fd00:2021:1111::/107";
+
 impl<CB> Tunnel<CB, GatewayState>
 where
     CB: Callbacks + 'static,
@@ -25,6 +28,10 @@ where
     pub fn set_interface(&self, config: &InterfaceConfig) -> connlib_shared::Result<()> {
         // Note: the dns fallback strategy is irrelevant for gateways
         let device = Arc::new(Device::new(config, self.callbacks())?);
+
+        let result_v4 = device.add_route(PEERS_IPV4.parse().unwrap(), self.callbacks());
+        let result_v6 = device.add_route(PEERS_IPV6.parse().unwrap(), self.callbacks());
+        result_v4.or(result_v6)?;
 
         self.device.store(Some(device.clone()));
         self.no_device_waker.wake();

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -9,7 +9,8 @@ use connlib_shared::{get_user_agent, login_url, Callbacks, Mode};
 use firezone_cli_utils::{setup_global_subscriber, CommonArgs};
 use firezone_tunnel::{GatewayState, Tunnel};
 use futures::{future, TryFutureExt};
-use phoenix_channel::SecureUrl;
+use messages::{EgressMessages, IngressMessages};
+use phoenix_channel::{PhoenixChannel, SecureUrl};
 use secrecy::{Secret, SecretString};
 use std::convert::Infallible;
 use std::pin::pin;
@@ -34,8 +35,7 @@ async fn main() -> Result<()> {
         cli.common.firezone_id,
     )?;
 
-    let task =
-        tokio::spawn(async move { run_loop(connect_url, private_key).await }).map_err(Into::into);
+    let task = tokio::spawn(async move { run(connect_url, private_key).await }).map_err(Into::into);
 
     let ctrl_c = pin!(ctrl_c().map_err(anyhow::Error::new));
 
@@ -46,43 +46,14 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn run_loop(connect_url: Url, private_key: StaticSecret) -> Result<Infallible> {
-    let tunnel = Arc::new(Tunnel::new(private_key, CallbackHandler).await?);
+async fn run(connect_url: Url, private_key: StaticSecret) -> Result<Infallible> {
+    let tunnel: Arc<Tunnel<_, GatewayState>> =
+        Arc::new(Tunnel::new(private_key, CallbackHandler).await?);
     let mut exponential_backoff = ExponentialBackoffBuilder::default()
         .with_max_elapsed_time(None)
         .build();
 
-    loop {
-        run(
-            tunnel.clone(),
-            connect_url.clone(),
-            &mut exponential_backoff,
-        )
-        .await
-        // Just satisfying the type system
-        .and(Ok(()))
-        .or_else(client_errors)?;
-
-        let Some(backoff) = exponential_backoff.next_backoff() else {
-            panic!("Gateway should backoff forever");
-        };
-
-        tokio::time::sleep(backoff).await;
-    }
-}
-
-async fn run(
-    tunnel: Arc<Tunnel<CallbackHandler, GatewayState>>,
-    connect_url: Url,
-    exponential_backoff: &mut ExponentialBackoff,
-) -> Result<Infallible> {
-    let (portal, init) = phoenix_channel::init::<InitGateway, _, _>(
-        Secret::new(SecureUrl::from_url(connect_url)),
-        get_user_agent(),
-        PHOENIX_TOPIC,
-        (),
-    )
-    .await??;
+    let (portal, init) = connect_to_portal(&mut exponential_backoff, &connect_url).await?;
 
     exponential_backoff.reset();
 
@@ -90,14 +61,107 @@ async fn run(
         .set_interface(&init.interface)
         .context("Failed to set interface")?;
 
-    let mut eventloop = Eventloop::new(tunnel, portal);
-
-    future::poll_fn(|cx| eventloop.poll(cx))
+    let (portal_tx, portal_rx) = tokio::sync::mpsc::channel(1_000);
+    let (portal_sender_tx, portal_sender_rx) = tokio::sync::mpsc::channel(1_000);
+    let portal_task = tokio::spawn(async move {
+        portal_loop(
+            portal,
+            portal_tx,
+            portal_sender_rx,
+            exponential_backoff,
+            connect_url,
+        )
         .await
-        .context("Eventloop failed")
+        .context("Connection to portal failed")
+    });
+
+    let mut eventloop = Eventloop::new(tunnel, portal_rx, portal_sender_tx);
+
+    let eventloop_task = tokio::spawn(async move {
+        future::poll_fn(|cx| eventloop.poll(cx))
+            .await
+            .context("Eventloop failed")
+    });
+
+    future::try_select(portal_task, eventloop_task)
+        .await
+        .map_err(|e| e.factor_first().0)?;
+
+    unreachable!("should never exit without error");
 }
 
-/// Maps our [`anyhow::Error`] to either a permanent or transient [`backoff`] error.
+async fn portal_loop(
+    mut portal: PhoenixChannel<IngressMessages, EgressMessages>,
+    tx: tokio::sync::mpsc::Sender<IngressMessages>,
+    mut rx: tokio::sync::mpsc::Receiver<EgressMessages>,
+    mut exponential_backoff: ExponentialBackoff,
+    connect_url: Url,
+) -> Result<Infallible> {
+    loop {
+        handle_portal_messages(portal, tx.clone(), &mut rx).await?;
+        (portal, _) = connect_to_portal(&mut exponential_backoff, &connect_url).await?;
+        exponential_backoff.reset();
+    }
+}
+
+async fn handle_portal_messages(
+    mut portal: PhoenixChannel<IngressMessages, EgressMessages>,
+    tx: tokio::sync::mpsc::Sender<IngressMessages>,
+    rx: &mut tokio::sync::mpsc::Receiver<EgressMessages>,
+) -> Result<()> {
+    loop {
+        tokio::select! {
+            result = future::poll_fn(|cx| portal.poll(cx)) => {
+                match result {
+                    Ok(phoenix_channel::Event::InboundMessage { topic: _, msg }) => {
+                        tx.send(msg).await?;
+                    }
+                    Err(e) => {
+                        client_errors(e.into())?;
+                        return Ok(());
+                    }
+                    _ => {}
+                }
+            }
+            message = rx.recv() => {
+                portal.send(PHOENIX_TOPIC, message);
+            }
+        }
+    }
+}
+
+async fn connect_to_portal(
+    exponential_backoff: &mut ExponentialBackoff,
+    connect_url: &Url,
+) -> Result<(PhoenixChannel<IngressMessages, EgressMessages>, InitGateway)> {
+    loop {
+        let result = phoenix_channel::init::<InitGateway, _, _>(
+            Secret::new(SecureUrl::from_url(connect_url.clone())),
+            get_user_agent(),
+            PHOENIX_TOPIC,
+            (),
+        )
+        .await;
+
+        if let Ok(Ok((portal, init))) = result {
+            tracing::debug!("connected to portal");
+            return Ok((portal, init));
+        }
+
+        if let Err(e) = result {
+            client_errors(e.into())?;
+        }
+
+        let Some(next_backoff) = exponential_backoff.next_backoff() else {
+            panic!("exponential backoff should never end");
+        };
+
+        tracing::debug!(retrying_in=?next_backoff, "portal disconnected");
+        tokio::time::sleep(next_backoff).await;
+    }
+}
+
+/// Keep HTTP errors as is convert all other errors to Ok, used to find out if we should keep retrying connection.
 fn client_errors(e: anyhow::Error) -> Result<()> {
     // As per HTTP spec, retrying client-errors without modifying the request is pointless. Thus we abort the backoff.
     if e.chain().any(is_client_error) {


### PR DESCRIPTION
This fixes #2503 
Also:
* decouples data-plane and control-plane on the gateway
* fixes a thing were a client would stop retrying connecting to a resource if it failed too many times
* add all routes on start instead of on a per-route basis