### PR TITLE
Use more informative log filepath

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -165,8 +165,16 @@ defmodule API.Client.Channel do
     OpenTelemetry.Ctx.attach(socket.assigns.opentelemetry_ctx)
     OpenTelemetry.Tracer.set_current_span(socket.assigns.opentelemetry_span_ctx)
 
+    account_slug = socket.assigns.subject.account.slug
+
+    actor_name =
+      socket.assigns.subject.actor.name
+      |> String.downcase()
+      |> String.replace(" ", "_")
+      |> String.replace(~r/[^a-zA-Z0-9_-]/iu, "")
+
     OpenTelemetry.Tracer.with_span "client.create_log_sink" do
-      case Instrumentation.create_remote_log_sink(socket.assigns.client) do
+      case Instrumentation.create_remote_log_sink(socket.assigns.client, actor_name, account_slug) do
         {:ok, signed_url} -> {:reply, {:ok, signed_url}, socket}
         {:error, :disabled} -> {:reply, {:error, :disabled}, socket}
       end

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -211,6 +211,9 @@ defmodule API.Client.ChannelTest do
       GoogleCloudPlatform.mock_instance_metadata_token_endpoint(bypass)
       GoogleCloudPlatform.mock_sign_blob_endpoint(bypass, "foo")
 
+      {:ok, actor} = Domain.Actors.fetch_actor_by_id(client.actor_id)
+      {:ok, account} = Domain.Accounts.fetch_account_by_id(actor.account_id)
+
       ref = push(socket, "create_log_sink", %{})
       assert_reply ref, :ok, signed_url
 
@@ -218,7 +221,11 @@ defmodule API.Client.ChannelTest do
       assert signed_uri.scheme == "https"
       assert signed_uri.host == "storage.googleapis.com"
 
-      assert String.starts_with?(signed_uri.path, "/logs/clients/#{client.id}/")
+      assert String.starts_with?(
+               signed_uri.path,
+               "/logs/clients/#{account.slug}/#{actor.name}/#{client.id}/"
+             )
+
       assert String.ends_with?(signed_uri.path, ".json")
     end
   end

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -214,6 +214,12 @@ defmodule API.Client.ChannelTest do
       {:ok, actor} = Domain.Actors.fetch_actor_by_id(client.actor_id)
       {:ok, account} = Domain.Accounts.fetch_account_by_id(actor.account_id)
 
+      actor_name =
+        actor.name
+        |> String.downcase()
+        |> String.replace(" ", "_")
+        |> String.replace(~r/[^a-zA-Z0-9_-]/iu, "")
+
       ref = push(socket, "create_log_sink", %{})
       assert_reply ref, :ok, signed_url
 
@@ -223,7 +229,7 @@ defmodule API.Client.ChannelTest do
 
       assert String.starts_with?(
                signed_uri.path,
-               "/logs/clients/#{account.slug}/#{actor.name}/#{client.id}/"
+               "/logs/clients/#{account.slug}/#{actor_name}/#{client.id}/"
              )
 
       assert String.ends_with?(signed_uri.path, ".json")

--- a/elixir/apps/domain/lib/domain/actors/actor.ex
+++ b/elixir/apps/domain/lib/domain/actors/actor.ex
@@ -7,7 +7,7 @@ defmodule Domain.Actors.Actor do
     field :name, :string
 
     has_many :identities, Domain.Auth.Identity, where: [deleted_at: nil]
-    has_many :clients, Domain.Clients.Client, where: [deleted_at: nil]
+    has_many :clients, Domain.Clients.Client, where: [deleted_at: nil], preload_order: [desc: :last_seen_at]
     has_many :memberships, Domain.Actors.Membership, on_replace: :delete
     # TODO: where doesn't work on join tables so soft-deleted records will be preloaded,
     # ref https://github.com/firezone/firezone/issues/2162

--- a/elixir/apps/domain/lib/domain/actors/actor.ex
+++ b/elixir/apps/domain/lib/domain/actors/actor.ex
@@ -7,7 +7,11 @@ defmodule Domain.Actors.Actor do
     field :name, :string
 
     has_many :identities, Domain.Auth.Identity, where: [deleted_at: nil]
-    has_many :clients, Domain.Clients.Client, where: [deleted_at: nil], preload_order: [desc: :last_seen_at]
+
+    has_many :clients, Domain.Clients.Client,
+      where: [deleted_at: nil],
+      preload_order: [desc: :last_seen_at]
+
     has_many :memberships, Domain.Actors.Membership, on_replace: :delete
     # TODO: where doesn't work on join tables so soft-deleted records will be preloaded,
     # ref https://github.com/firezone/firezone/issues/2162

--- a/elixir/apps/domain/lib/domain/clients.ex
+++ b/elixir/apps/domain/lib/domain/clients.ex
@@ -3,6 +3,7 @@ defmodule Domain.Clients do
   alias Domain.{Repo, Auth, Validator}
   alias Domain.Actors
   alias Domain.Clients.{Client, Authorizer, Presence}
+  require Ecto.Query
 
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
@@ -83,6 +84,7 @@ defmodule Domain.Clients do
       {:ok, clients} =
         Client.Query.not_deleted()
         |> Authorizer.for_subject(subject)
+        |> Ecto.Query.order_by([clients: clients], desc: clients.last_seen_at, desc: clients.id)
         |> Repo.list()
 
       clients =

--- a/elixir/apps/domain/lib/domain/instrumentation.ex
+++ b/elixir/apps/domain/lib/domain/instrumentation.ex
@@ -1,23 +1,28 @@
 defmodule Domain.Instrumentation do
+  alias Domain.Accounts
+  alias Domain.Actors
   alias Domain.Clients
   alias Domain.GoogleCloudPlatform
 
   def create_remote_log_sink(%Clients.Client{} = client) do
     config = config!()
-    enabled? = Keyword.fetch!(config, :client_logs_enabled)
 
-    if enabled? and GoogleCloudPlatform.enabled?() do
+    with {:ok, actor} <- Actors.fetch_actor_by_id(client.actor_id),
+         {:ok, account} <- Accounts.fetch_account_by_id(actor.account_id),
+         true <- Keyword.fetch!(config, :client_logs_enabled),
+         true <- GoogleCloudPlatform.enabled?() do
       now = DateTime.utc_now() |> DateTime.to_iso8601()
 
       bucket =
         Application.fetch_env!(:domain, __MODULE__)
         |> Keyword.fetch!(:client_logs_bucket)
 
-      filename = "clients/#{client.id}/#{now}-#{System.unique_integer([:positive])}.json"
+      filename =
+        "clients/#{account.slug}/#{actor.name}/#{client.id}/#{now}-#{System.unique_integer([:positive])}.json"
 
       GoogleCloudPlatform.sign_url(bucket, filename, verb: "PUT")
     else
-      {:error, :disabled}
+      _ -> {:error, :disabled}
     end
   end
 

--- a/elixir/apps/domain/test/domain/instrumentation_test.exs
+++ b/elixir/apps/domain/test/domain/instrumentation_test.exs
@@ -18,6 +18,8 @@ defmodule Domain.InstrumentationTest do
       GoogleCloudPlatform.mock_sign_blob_endpoint(bypass, "foo")
 
       client = Fixtures.Clients.create_client()
+      {:ok, actor} = Domain.Actors.fetch_actor_by_id(client.actor_id)
+      {:ok, account} = Domain.Accounts.fetch_account_by_id(actor.account_id)
 
       assert {:ok, signed_url} = create_remote_log_sink(client)
 
@@ -25,7 +27,11 @@ defmodule Domain.InstrumentationTest do
       assert signed_uri.scheme == "https"
       assert signed_uri.host == "storage.googleapis.com"
 
-      assert String.starts_with?(signed_uri.path, "/logs/clients/#{client.id}/")
+      assert String.starts_with?(
+               signed_uri.path,
+               "/logs/clients/#{account.slug}/#{actor.name}/#{client.id}/"
+             )
+
       assert String.ends_with?(signed_uri.path, ".json")
     end
   end

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -20,6 +20,7 @@ defmodule Web.Actors.Show do
       {:ok,
        assign(socket,
          actor: actor,
+         clients: Enum.sort_by(actor.clients, & &1.last_seen_at, :desc),
          flows: flows,
          page_title: actor.name,
          flow_activities_enabled?: Domain.Config.flow_activities_enabled?()

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -17,7 +17,6 @@ defmodule Web.Actors.Show do
            Flows.list_flows_for(actor, socket.assigns.subject,
              preload: [gateway: [:group], client: [], policy: [:resource, :actor_group]]
            ) do
-
       {:ok,
        assign(socket,
          actor: actor,

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -17,10 +17,10 @@ defmodule Web.Actors.Show do
            Flows.list_flows_for(actor, socket.assigns.subject,
              preload: [gateway: [:group], client: [], policy: [:resource, :actor_group]]
            ) do
+
       {:ok,
        assign(socket,
          actor: actor,
-         clients: Enum.sort_by(actor.clients, & &1.last_seen_at, :desc),
          flows: flows,
          page_title: actor.name,
          flow_activities_enabled?: Domain.Config.flow_activities_enabled?()

--- a/elixir/apps/web/lib/web/live/clients/index.ex
+++ b/elixir/apps/web/lib/web/live/clients/index.ex
@@ -1,11 +1,9 @@
 defmodule Web.Clients.Index do
   use Web, :live_view
-
   alias Domain.Clients
 
   def mount(_params, _session, socket) do
     with {:ok, clients} <- Clients.list_clients(socket.assigns.subject, preload: :actor) do
-      clients = Enum.sort_by(clients, & &1.last_seen_at, :desc)
       {:ok, assign(socket, clients: clients)}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/clients/index.ex
+++ b/elixir/apps/web/lib/web/live/clients/index.ex
@@ -5,7 +5,7 @@ defmodule Web.Clients.Index do
 
   def mount(_params, _session, socket) do
     with {:ok, clients} <- Clients.list_clients(socket.assigns.subject, preload: :actor) do
-      clients = Enum.sort_by(clients, & &1.online?, :desc)
+      clients = Enum.sort_by(clients, & &1.last_seen_at, :desc)
       {:ok, assign(socket, clients: clients)}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError


### PR DESCRIPTION
* Sort clients list by `last_seen_at` desc. This handles the `online?` case too. Before, they were sorted by `asc` which made it hard to see which recent clients were connected
* Scope the client log filename by account slug and actor name so it's easier to find.