### PR TITLE
Run publish workflow on release publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   push-images-to-production-artifacts:
     if:
-      ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' || inputs.foolproof == true }}
+      ${{ github.event_name == 'release' || (github.ref == 'refs/heads/main' && inputs.foolproof == true) }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -123,7 +123,7 @@ jobs:
             "Apply Run from GitHub Actions CI ${{ inputs.tag || github.sha }}"
 
   publish-images-to-ghcr:
-    if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
+    if: ${{ github.event_name == 'release' }}
     needs: deploy-production
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,7 @@ concurrency:
 jobs:
   push-images-to-production-artifacts:
     if:
-      ${{ github.ref == 'refs/heads/main' && (github.event_name == 'release' ||
-      inputs.foolproof == true ) }}
+      ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' || inputs.foolproof == true }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -76,7 +75,7 @@ jobs:
           done
 
   deploy-production:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     needs: push-images-to-production-artifacts
     runs-on: ubuntu-22.04
     permissions:
@@ -124,7 +123,7 @@ jobs:
             "Apply Run from GitHub Actions CI ${{ inputs.tag || github.sha }}"
 
   publish-images-to-ghcr:
-    if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'release' }}
+    if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
     needs: deploy-production
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
When a release draft is published, run this workflow so that customers will be able to pull associated Docker images.