### PR TITLE
Apple: Handle comma in resource names

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/DisplayableResources.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/DisplayableResources.swift
@@ -46,7 +46,7 @@ extension DisplayableResources {
   public func toData() -> Data? {
     ("\(versionString),"
       + (orderedResources.flatMap { [$0.name, $0.location] })
-      .map { $0.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) }.compactMap { $0 }
+      .map { $0.addingPercentEncoding(withAllowedCharacters: .alphanumerics) }.compactMap { $0 }
       .joined(separator: ",")).data(using: .utf8)
   }
 


### PR DESCRIPTION
Fixes #2836.

We use the comma as a separator when passing the resources from the tunnel process to the app process, but previously used .urlHostAllowed when percent-encoding, which means commas weren't percent-encoded. We fix that by using .alphanumerics, which percent-encodes commas as well.