### PR TITLE
Prevent DNS sentinel from being used as a fallback resolver

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -47,6 +47,7 @@ fn create_resolver(
             return None;
         };
         if dns_servers.is_empty() {
+            tracing::error!("No system default DNS servers available! Can't initialize resolver. DNS will be broken.");
             return None;
         }
         dns_servers

--- a/rust/connlib/shared/src/callbacks_error_facade.rs
+++ b/rust/connlib/shared/src/callbacks_error_facade.rs
@@ -1,5 +1,5 @@
 use crate::messages::ResourceDescription;
-use crate::{Callbacks, Error, Result, DNS_SENTINEL};
+use crate::{Callbacks, Error, Result};
 use ip_network::IpNetwork;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
@@ -99,22 +99,5 @@ impl<CB: Callbacks> Callbacks for CallbackErrorFacade<CB> {
         self.0
             .get_system_default_resolvers()
             .map_err(|err| Error::GetSystemDefaultResolverFailed(err.to_string()))
-            .map(|resolvers| {
-                if let Some(mut resolvers) = resolvers {
-                    resolvers.retain(|resolver| {
-                        if *resolver == DNS_SENTINEL {
-                            tracing::warn!("Found our DNS Sentinel {:?} in the list of returned system resolvers. Ignoring...", resolver);
-                            // Remove the sentinel from the list of resolvers
-                            false
-                        } else {
-                            true
-                        }
-                    });
-
-                    Some(resolvers)
-                } else {
-                    Some(vec![])
-                }
-            })
     }
 }

--- a/rust/connlib/shared/src/callbacks_error_facade.rs
+++ b/rust/connlib/shared/src/callbacks_error_facade.rs
@@ -1,5 +1,5 @@
 use crate::messages::ResourceDescription;
-use crate::{Callbacks, Error, Result};
+use crate::{Callbacks, Error, Result, DNS_SENTINEL};
 use ip_network::IpNetwork;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
@@ -99,5 +99,22 @@ impl<CB: Callbacks> Callbacks for CallbackErrorFacade<CB> {
         self.0
             .get_system_default_resolvers()
             .map_err(|err| Error::GetSystemDefaultResolverFailed(err.to_string()))
+            .map(|resolvers| {
+                if let Some(mut resolvers) = resolvers {
+                    resolvers.retain(|resolver| {
+                        if *resolver == DNS_SENTINEL {
+                            tracing::warn!("Found our DNS Sentinel {:?} in the list of returned system resolvers. Ignoring...", resolver);
+                            // Remove the sentinel from the list of resolvers
+                            false
+                        } else {
+                            true
+                        }
+                    });
+
+                    Some(resolvers)
+                } else {
+                    Some(vec![])
+                }
+            })
     }
 }


### PR DESCRIPTION
Prevent the edge case where our DNS sentinel could be used as a fallback resolver. I didn't observe this in the wild, but we should avoid it in case.