### PR TITLE
Set hasUnappliedChanges = true when setting Resources

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -54,6 +54,7 @@ class NetworkSettings {
     if self.resourceDomains != sortedResourceDomains {
       self.resourceDomains = sortedResourceDomains
     }
+    self.hasUnappliedChanges = true
   }
 
   func apply(


### PR DESCRIPTION
Reverts a bug I introduced in #2894 

Fixes #2920 