### PR TITLE
security(gateway): Don't run systemd gateways as root

### DIFF
--- a/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
@@ -58,7 +58,18 @@ defmodule Web.RelayGroups.NewToken do
               selected={@selected_tab == "systemd-instructions"}
             >
               <p class="p-4">
-                1. Create a new systemd unit file:
+                1. Create an unprivileged user and group to run the relay:
+              </p>
+
+              <.code_block
+                id="code-sample-systemd0"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+              >sudo groupadd -f firezone \
+    && id -u firezone &>/dev/null || sudo useradd -r -g firezone -s /sbin/nologin firezone</.code_block>
+
+              <p class="p-4">
+                2. Create a new systemd unit file:
               </p>
 
               <.code_block
@@ -68,7 +79,7 @@ defmodule Web.RelayGroups.NewToken do
               >sudo nano /etc/systemd/system/firezone-relay.service</.code_block>
 
               <p class="p-4">
-                2. Copy-paste the following contents into the file:
+                3. Copy-paste the following contents into the file:
               </p>
 
               <.code_block
@@ -79,11 +90,11 @@ defmodule Web.RelayGroups.NewToken do
               ><%= systemd_command(@env) %></.code_block>
 
               <p class="p-4">
-                3. Save by pressing <kbd>Ctrl</kbd>+<kbd>X</kbd>, then <kbd>Y</kbd>, then <kbd>Enter</kbd>.
+                4. Save by pressing <kbd>Ctrl</kbd>+<kbd>X</kbd>, then <kbd>Y</kbd>, then <kbd>Enter</kbd>.
               </p>
 
               <p class="p-4">
-                4. Reload systemd configuration:
+                5. Reload systemd configuration:
               </p>
 
               <.code_block
@@ -93,7 +104,7 @@ defmodule Web.RelayGroups.NewToken do
               >sudo systemctl daemon-reload</.code_block>
 
               <p class="p-4">
-                5. Start the service:
+                6. Start the service:
               </p>
 
               <.code_block
@@ -103,7 +114,7 @@ defmodule Web.RelayGroups.NewToken do
               >sudo systemctl start firezone-relay</.code_block>
 
               <p class="p-4">
-                6. Enable the service to start on boot:
+                7. Enable the service to start on boot:
               </p>
 
               <.code_block
@@ -302,8 +313,6 @@ defmodule Web.RelayGroups.NewToken do
         chgrp firezone /usr/local/bin/firezone-relay; \\
         chmod 0750 /usr/local/bin/firezone-relay; \\
       fi; \\
-      groupadd -f firezone; \\
-      id -u firezone &>/dev/null || useradd -r -g firezone -s /sbin/nologin firezone; \\
       mkdir -p /var/lib/firezone; \\
       chown firezone:firezone /var/lib/firezone; \\
       chmod 0775 /var/lib/firezone; \\

--- a/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
@@ -23,7 +23,7 @@ defmodule Web.RelayGroups.NewToken do
          group: group,
          env: env,
          connected?: false,
-         selected_tab: "docker-instructions"
+         selected_tab: "systemd-instructions"
        )}
     else
       _other -> raise Web.LiveErrors.NotFoundError
@@ -52,12 +52,98 @@ defmodule Web.RelayGroups.NewToken do
 
           <.tabs :if={@env} id="deployment-instructions">
             <:tab
+              id="systemd-instructions"
+              label="systemd"
+              phx_click="tab_selected"
+              selected={@selected_tab == "systemd-instructions"}
+            >
+              <p class="p-4">
+                1. Create a new systemd unit file:
+              </p>
+
+              <.code_block
+                id="code-sample-systemd1"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+              >sudo nano /etc/systemd/system/firezone-relay.service</.code_block>
+
+              <p class="p-4">
+                2. Copy-paste the following contents into the file:
+              </p>
+
+              <.code_block
+                id="code-sample-systemd2"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+                phx-update="ignore"
+              ><%= systemd_command(@env) %></.code_block>
+
+              <p class="p-4">
+                3. Save by pressing <kbd>Ctrl</kbd>+<kbd>X</kbd>, then <kbd>Y</kbd>, then <kbd>Enter</kbd>.
+              </p>
+
+              <p class="p-4">
+                4. Reload systemd configuration:
+              </p>
+
+              <.code_block
+                id="code-sample-systemd4"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+              >sudo systemctl daemon-reload</.code_block>
+
+              <p class="p-4">
+                5. Start the service:
+              </p>
+
+              <.code_block
+                id="code-sample-systemd5"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+              >sudo systemctl start firezone-relay</.code_block>
+
+              <p class="p-4">
+                6. Enable the service to start on boot:
+              </p>
+
+              <.code_block
+                id="code-sample-systemd6"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+              >sudo systemctl enable firezone-relay</.code_block>
+              <hr />
+
+              <h4 class="p-4 text-xl font-semibold">
+                Troubleshooting
+              </h4>
+
+              <p class="p-4">
+                Check the status of the service:
+              </p>
+
+              <.code_block
+                id="code-sample-systemd7"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+              >sudo systemctl status firezone-relay</.code_block>
+
+              <p class="p-4">
+                Check the logs:
+              </p>
+
+              <.code_block
+                id="code-sample-systemd8"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+              >sudo journalctl -u firezone-relay.service</.code_block>
+            </:tab>
+            <:tab
               id="docker-instructions"
               label="Docker"
               phx_click="tab_selected"
               selected={@selected_tab == "docker-instructions"}
             >
-              <p class="pl-4 mb-2">
+              <p class="p-4">
                 Copy-paste this command to your server and replace <code>PUBLIC_IP4_ADDR</code>
                 and <code>PUBLIC_IP6_ADDR</code>
                 with your public IP addresses:
@@ -65,94 +151,36 @@ defmodule Web.RelayGroups.NewToken do
 
               <.code_block
                 id="code-sample-docker1"
-                class="w-full rounded-b"
+                class="w-full text-xs whitespace-pre-line"
                 phx-no-format
                 phx-update="ignore"
               ><%= docker_command(@env) %></.code_block>
 
               <hr />
 
-              <p class="pl-4 mb-2 mt-4 text-xl font-semibold">
+              <h4 class="p-4 text-xl font-semibold">
                 Troubleshooting
-              </p>
+              </h4>
 
-              <p class="pl-4 mb-2 mt-4">
+              <p class="p-4">
                 Check the container status:
               </p>
 
-              <.code_block id="code-sample-docker2" class="w-full" phx-no-format>docker ps --filter "name=firezone-relay"</.code_block>
+              <.code_block
+                id="code-sample-docker2"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+              >docker ps --filter "name=firezone-relay"</.code_block>
 
-              <p class="pl-4 mb-2 mt-4">
+              <p class="p-4">
                 Check the container logs:
               </p>
 
-              <.code_block id="code-sample-docker3" class="w-full rounded-b" phx-no-format>docker logs firezone-relay</.code_block>
-            </:tab>
-            <:tab
-              id="systemd-instructions"
-              label="Systemd"
-              phx_click="tab_selected"
-              selected={@selected_tab == "systemd-instructions"}
-            >
-              <p class="pl-4 mb-2">
-                1. Create a systemd unit file with the following content:
-              </p>
-
-              <.code_block id="code-sample-systemd1" class="w-full" phx-no-format>sudo nano /etc/systemd/system/firezone-relay.service</.code_block>
-
-              <p class="pl-4 mb-2 mt-4">
-                2. Copy-paste the following content into the file and replace
-                <code>PUBLIC_IP4_ADDR</code>
-                and <code>PUBLIC_IP6_ADDR</code>
-                with your public IP addresses::
-              </p>
-
               <.code_block
-                id="code-sample-systemd2"
-                class="w-full rounded-b"
+                id="code-sample-docker3"
+                class="w-full text-xs whitespace-pre-line"
                 phx-no-format
-                phx-update="ignore"
-              ><%= systemd_command(@env) %></.code_block>
-
-              <p class="pl-4 mb-2 mt-4">
-                3. Save by pressing <kbd>Ctrl</kbd>+<kbd>X</kbd>, then <kbd>Y</kbd>, then <kbd>Enter</kbd>.
-              </p>
-
-              <p class="pl-4 mb-2 mt-4">
-                4. Reload systemd configuration:
-              </p>
-
-              <.code_block id="code-sample-systemd4" class="w-full" phx-no-format>sudo systemctl daemon-reload</.code_block>
-
-              <p class="pl-4 mb-2 mt-4">
-                5. Start the service:
-              </p>
-
-              <.code_block id="code-sample-systemd5" class="w-full" phx-no-format>sudo systemctl start firezone-relay</.code_block>
-
-              <p class="pl-4 mb-2 mt-4">
-                6. Enable the service to start on boot:
-              </p>
-
-              <.code_block id="code-sample-systemd6" class="w-full" phx-no-format>sudo systemctl enable firezone-relay</.code_block>
-
-              <hr />
-
-              <p class="pl-4 mb-2 mt-4 text-xl font-semibold">
-                Troubleshooting
-              </p>
-
-              <p class="pl-4 mb-2 mt-4">
-                Check the status of the service:
-              </p>
-
-              <.code_block id="code-sample-systemd7" class="w-full rounded-b" phx-no-format>sudo systemctl status firezone-relay</.code_block>
-
-              <p class="pl-4 mb-2 mt-4">
-                Check the logs:
-              </p>
-
-              <.code_block id="code-sample-systemd8" class="w-full rounded-b" phx-no-format>sudo journalctl -u firezone-relay.service</.code_block>
+              >docker logs firezone-relay</.code_block>
             </:tab>
           </.tabs>
 
@@ -223,7 +251,7 @@ defmodule Web.RelayGroups.NewToken do
       "--health-cmd=\"lsof -i UDP | grep firezone-relay\"",
       "--name=firezone-relay",
       "--cap-add=NET_ADMIN",
-      "--volume /etc/firezone",
+      "--volume /var/lib/firezone",
       "--sysctl net.ipv4.ip_forward=1",
       "--sysctl net.ipv4.conf.all.src_valid_mark=1",
       "--sysctl net.ipv6.conf.all.disable_ipv6=0",
@@ -248,7 +276,7 @@ defmodule Web.RelayGroups.NewToken do
     [Service]
     Type=simple
     #{Enum.map_join(env, "\n", fn {key, value} -> "Environment=\"#{key}=#{value}\"" end)}
-    ExecStartPre=/bin/sh -c 'set -xue; \\
+    ExecStartPre=/bin/sh -c 'set -ue; \\
       if [ ! -e /usr/local/bin/firezone-relay ]; then \\
         FIREZONE_VERSION=$(curl -Ls \\
           -H "Accept: application/vnd.github+json" \\
@@ -270,14 +298,22 @@ defmodule Web.RelayGroups.NewToken do
             echo "Unsupported architecture"; \\
             exit 1 ;; \\
         esac; \\
-        wget -O /usr/local/bin/firezone-relay $bin_url; \\
-        chmod +x /usr/local/bin/firezone-relay; \\
-        mkdir -p /etc/firezone; \\
-        chmod 0755 /etc/firezone; \\
+        curl -Ls $bin_url -o /usr/local/bin/firezone-relay; \\
+        chgrp firezone /usr/local/bin/firezone-relay; \\
+        chmod 0750 /usr/local/bin/firezone-relay; \\
       fi; \\
+      groupadd -f firezone; \\
+      id -u firezone &>/dev/null || useradd -r -g firezone -s /sbin/nologin firezone; \\
+      mkdir -p /var/lib/firezone; \\
+      chown firezone:firezone /var/lib/firezone; \\
+      chmod 0775 /var/lib/firezone; \\
     '
-    AmbientCapabilities=CAP_NET_ADMIN
-    ExecStart=/bin/sh -c 'FIREZONE_NAME=$(hostname); /usr/local/bin/firezone-relay'
+    ExecStart=/usr/bin/sudo \\
+      --preserve-env=FIREZONE_NAME,FIREZONE_ID,FIREZONE_TOKEN,PUBLIC_IP4_ADDR,PUBLIC_IP6_ADDR,RUST_LOG,LOG_FORMAT \\
+      -u firezone \\
+      -g firezone \\
+      FIREZONE_NAME=$(hostname) \\
+      /usr/local/bin/firezone-relay
     TimeoutStartSec=3s
     TimeoutStopSec=15s
     Restart=always

--- a/elixir/apps/web/test/web/live/relay_groups/new_token_test.exs
+++ b/elixir/apps/web/test/web/live/relay_groups/new_token_test.exs
@@ -33,8 +33,8 @@ defmodule Web.Live.RelayGroups.NewTokenTest do
     assert html =~ "docker run"
     assert html =~ "Waiting for connection..."
 
-    assert Regex.run(~r/FIREZONE_ID=([^&]+)/, html) |> List.last()
-    token = Regex.run(~r/FIREZONE_TOKEN=([^&]+)/, html) |> List.last() |> String.trim("&quot;")
+    assert Regex.run(~r/FIREZONE_ID=([^& ]+)/, html) |> List.last()
+    token = Regex.run(~r/FIREZONE_TOKEN=([^& ]+)/, html) |> List.last() |> String.trim("&quot;")
 
     :ok = Domain.Relays.subscribe_for_relays_presence_in_group(group)
     relay = Fixtures.Relays.create_relay(account: account, group: group)

--- a/elixir/apps/web/test/web/live/relay_groups/new_token_test.exs
+++ b/elixir/apps/web/test/web/live/relay_groups/new_token_test.exs
@@ -33,8 +33,8 @@ defmodule Web.Live.RelayGroups.NewTokenTest do
     assert html =~ "docker run"
     assert html =~ "Waiting for connection..."
 
-    assert Regex.run(~r/FIREZONE_ID=([^ ]+)/, html) |> List.last()
-    token = Regex.run(~r/FIREZONE_TOKEN=([^ ]+)/, html) |> List.last() |> String.trim("&quot;")
+    assert Regex.run(~r/FIREZONE_ID=([^&]+)/, html) |> List.last()
+    token = Regex.run(~r/FIREZONE_TOKEN=([^&]+)/, html) |> List.last() |> String.trim("&quot;")
 
     :ok = Domain.Relays.subscribe_for_relays_presence_in_group(group)
     relay = Fixtures.Relays.create_relay(account: account, group: group)

--- a/elixir/apps/web/test/web/live/sites/new_token_test.exs
+++ b/elixir/apps/web/test/web/live/sites/new_token_test.exs
@@ -31,8 +31,8 @@ defmodule Web.Live.Sites.NewTokenTest do
     assert html =~ "docker run"
     assert html =~ "Waiting for connection..."
 
-    assert Regex.run(~r/FIREZONE_ID=([^ ]+)/, html) |> List.last()
-    token = Regex.run(~r/FIREZONE_TOKEN=([^ ]+)/, html) |> List.last() |> String.trim("&quot;")
+    assert Regex.run(~r/FIREZONE_ID=([^&]+)/, html) |> List.last()
+    token = Regex.run(~r/FIREZONE_TOKEN=([^&]+)/, html) |> List.last() |> String.trim("&quot;")
 
     :ok = Domain.Gateways.subscribe_for_gateways_presence_in_group(group)
     gateway = Fixtures.Gateways.create_gateway(account: account, group: group)

--- a/elixir/apps/web/test/web/live/sites/new_token_test.exs
+++ b/elixir/apps/web/test/web/live/sites/new_token_test.exs
@@ -31,8 +31,8 @@ defmodule Web.Live.Sites.NewTokenTest do
     assert html =~ "docker run"
     assert html =~ "Waiting for connection..."
 
-    assert Regex.run(~r/FIREZONE_ID=([^&]+)/, html) |> List.last()
-    token = Regex.run(~r/FIREZONE_TOKEN=([^&]+)/, html) |> List.last() |> String.trim("&quot;")
+    assert Regex.run(~r/FIREZONE_ID=([^& ]+)/, html) |> List.last()
+    token = Regex.run(~r/FIREZONE_TOKEN=([^& ]+)/, html) |> List.last() |> String.trim("&quot;")
 
     :ok = Domain.Gateways.subscribe_for_gateways_presence_in_group(group)
     gateway = Fixtures.Gateways.create_gateway(account: account, group: group)

--- a/scripts/gateway-docker-upgrade.sh
+++ b/scripts/gateway-docker-upgrade.sh
@@ -33,7 +33,7 @@ do
           --health-cmd="ip link | grep tun-firezone" \
           --name="$RUNNING_NAME" \
           --cap-add=NET_ADMIN \
-          --volume /etc/firezone \
+          --volume /var/lib/firezone \
           --env-file variables.env \
           --sysctl net.ipv4.ip_forward=1 \
           --sysctl net.ipv4.conf.all.src_valid_mark=1 \


### PR DESCRIPTION
Docker-based gateways won't have working IPv6 (good point @AndrewDryga), so I started testing the systemd gateways more and found some issues I fixed.

* Update default tab order for Deploy gateways page to prefer systemd
* Update unit file to run gateway as unprivileged user
* Remove dependency on `wget` in unit file
* Fix iptables logic so rules as re-created on reboot
* Use `/var/lib/firezone` instead of `/etc/firezone` for writing runtime files (`/etc/` is often mounted read-only on hardened systems)