### PR TITLE
fix(windows): put the bundle version back in tauri.conf.json to fix CI

### DIFF
--- a/rust/windows-client/src-tauri/tauri.conf.json
+++ b/rust/windows-client/src-tauri/tauri.conf.json
@@ -7,7 +7,8 @@
     "withGlobalTauri": true
   },
   "package": {
-    "productName": "firezone-windows-client"
+    "productName": "firezone-windows-client",
+    "version": "1.0.0"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
PR #2949 will make this redundant and I'll remove it from tauri.conf.json again