### PR TITLE
fix(apple): Fix getting system dns resolvers

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -122,6 +122,14 @@ class Adapter {
   /// - Parameters:
   ///   - completionHandler: completion handler.
   public func start(completionHandler: @escaping (AdapterError?) -> Void) throws {
+
+    self.systemDNSResolvers = DNSResolvers.getDNSResolverAddresses()
+    self.logger.log(
+      "Adapter.start: Got system DNS resolvers: \(self.systemDNSResolvers, privacy: .public)"
+    )
+
+    self.beginPathMonitoring()
+
     workQueue.async { [weak self] in
       guard let self = self else { return }
 
@@ -139,11 +147,6 @@ class Adapter {
       if self.connlibLogFolderPath.isEmpty {
         self.logger.error("Cannot get shared log folder for connlib")
       }
-
-      self.systemDNSResolvers = DNSResolvers.getDNSResolverAddresses()
-      self.logger.log(
-        "Adapter.start: Got system DNS resolvers: \(systemDNSResolvers, privacy: .public)"
-      )
 
       self.logger.log("Adapter.start: Starting connlib")
       do {
@@ -395,7 +398,6 @@ extension Adapter: CallbackHandlerDelegate {
         } else {
           onStarted?(nil)
           self.state = .tunnelReady(session: session)
-          self.beginPathMonitoring()
         }
       }
     }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -503,7 +503,7 @@ extension Adapter: CallbackHandlerDelegate {
   }
 
   public func getSystemDefaultResolvers() {
-    let resolvers = Resolv().getservers().map(Resolv.getnameinfo)
+    let resolvers = DNSResolvers.getDNSResolverAddresses()
     self.logger.info("getSystemDefaultResolvers: \(resolvers)")
   }
 

--- a/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
+++ b/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
@@ -26,7 +26,7 @@ public protocol CallbackHandlerDelegate: AnyObject {
   func onRemoveRoute(_: String)
   func onUpdateResources(resourceList: String)
   func onDisconnect(error: String?)
-  func getSystemDefaultResolvers()
+  func getSystemDefaultResolvers() -> [String]
   func onError(error: String)
 }
 
@@ -84,7 +84,7 @@ public class CallbackHandler {
   }
 
   func getSystemDefaultResolvers() -> RustString {
-    let resolvers = DNSResolvers.getDNSResolverAddresses()
+    let resolvers = delegate?.getSystemDefaultResolvers() ?? []
     logger.log("CallbackHandler.getSystemDefaultResolvers: \(resolvers, privacy: .public)")
     do {
       return try String(decoding: JSONEncoder().encode(resolvers), as: UTF8.self).intoRustString()

--- a/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
+++ b/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
@@ -84,7 +84,7 @@ public class CallbackHandler {
   }
 
   func getSystemDefaultResolvers() -> RustString {
-    let resolvers = Resolv().getservers().map(Resolv.getnameinfo)
+    let resolvers = DNSResolvers.getDNSResolverAddresses()
     logger.log("CallbackHandler.getSystemDefaultResolvers: \(resolvers, privacy: .public)")
     do {
       return try String(decoding: JSONEncoder().encode(resolvers), as: UTF8.self).intoRustString()

--- a/swift/apple/FirezoneNetworkExtension/DnsResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/DnsResolvers.swift
@@ -6,6 +6,12 @@
 //
 //  Wraps libresolv to return the system's default resolvers
 
+struct DNSResolvers {
+  public static func getDNSResolverAddresses() -> [String] {
+    return Resolv().getservers().map(Resolv.getnameinfo)
+  }
+}
+
 public class Resolv {
   var state = __res_9_state()
 


### PR DESCRIPTION
Probably fixes #2939.

The adapter keeps track of the system resolver and updates it when the path changes.

When connlib asks for it, it gives the stored system resolver rather than querying at that time (so it doesn't matter that /etc/resolv.conf has the firezone DNS server at that time).

Fixes #2945 
