### PR TITLE
fix(windows): give the encrypted credential a unique name

### DIFF
--- a/rust/windows-client/src-tauri/src/client.rs
+++ b/rust/windows-client/src-tauri/src/client.rs
@@ -67,7 +67,6 @@ pub(crate) fn run() -> Result<()> {
             Ok(())
         }
         Some(Cmd::DebugPipeServer) => debug_commands::pipe_server(),
-        Some(Cmd::DebugToken) => debug_commands::token(),
         Some(Cmd::DebugWintun) => debug_commands::wintun(cli),
         // If we already tried to elevate ourselves, don't try again
         Some(Cmd::Elevated) => gui::run(GuiParams {

--- a/rust/windows-client/src-tauri/src/client/cli.rs
+++ b/rust/windows-client/src-tauri/src/client/cli.rs
@@ -13,7 +13,6 @@ pub struct Cli {
 pub enum CliCommands {
     Debug,
     DebugPipeServer,
-    DebugToken,
     DebugWintun,
     Elevated,
     OpenDeepLink(DeepLink),

--- a/rust/windows-client/src-tauri/src/client/debug_commands.rs
+++ b/rust/windows-client/src-tauri/src/client/debug_commands.rs
@@ -3,35 +3,10 @@
 
 use crate::client::cli::Cli;
 use anyhow::Result;
-use keyring::Entry;
 use tokio::runtime::Runtime;
 
 // TODO: In tauri-plugin-deep-link, this is the identifier in tauri.conf.json
 const PIPE_NAME: &str = "dev.firezone.client";
-
-/// Test encrypted credential storage
-pub fn token() -> Result<()> {
-    // TODO: Remove placeholder email
-    let entry = Entry::new_with_target("token", "firezone_windows_client", "username@example.com")?;
-    match entry.get_password() {
-        Ok(password) => {
-            println!("Placeholder password is '{password}'");
-
-            println!("Deleting password");
-            entry.delete_password()?;
-        }
-        Err(keyring::Error::NoEntry) => {
-            println!("No password in credential manager");
-
-            let new_password = "top_secret_password";
-            println!("Setting password to {new_password}");
-            entry.set_password(new_password)?;
-        }
-        Err(e) => return Err(e.into()),
-    }
-
-    Ok(())
-}
 
 pub fn open_deep_link(path: &url::Url) -> Result<()> {
     tracing_subscriber::fmt::init();

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -213,8 +213,8 @@ pub(crate) enum ControllerRequest {
 // The callback returns a human-readable name but those aren't good keys.
 fn keyring_entry() -> Result<keyring::Entry> {
     Ok(keyring::Entry::new_with_target(
-        "token",
-        "firezone_windows_client",
+        "dev.firezone.client/token",
+        "",
         "",
     )?)
 }
@@ -466,4 +466,26 @@ async fn run_controller(
     }
     tracing::debug!("GUI controller task exiting cleanly");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_keyring() -> anyhow::Result<()> {
+        // I used this test to find that `service` is not used - We have to namespace on our own.
+
+        keyring::Entry::new_with_target("dev.firezone.client/test_1/token", "", "")?
+            .set_password("test_password_1")?;
+
+        keyring::Entry::new_with_target("dev.firezone.client/test_2/token", "", "")?
+            .set_password("test_password_2")?;
+
+        let actual = keyring::Entry::new_with_target("dev.firezone.client/test_1/token", "", "")?
+            .get_password()?;
+        let expected = "test_password_1";
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
 }

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -474,17 +474,20 @@ mod tests {
     fn test_keyring() -> anyhow::Result<()> {
         // I used this test to find that `service` is not used - We have to namespace on our own.
 
-        keyring::Entry::new_with_target("dev.firezone.client/test_1/token", "", "")?
-            .set_password("test_password_1")?;
+        let name_1 = "dev.firezone.client/test_1/token";
+        let name_2 = "dev.firezone.client/test_2/token";
 
-        keyring::Entry::new_with_target("dev.firezone.client/test_2/token", "", "")?
-            .set_password("test_password_2")?;
+        keyring::Entry::new_with_target(name_1, "", "")?.set_password("test_password_1")?;
 
-        let actual = keyring::Entry::new_with_target("dev.firezone.client/test_1/token", "", "")?
-            .get_password()?;
+        keyring::Entry::new_with_target(name_2, "", "")?.set_password("test_password_2")?;
+
+        let actual = keyring::Entry::new_with_target(name_1, "", "")?.get_password()?;
         let expected = "test_password_1";
 
         assert_eq!(actual, expected);
+
+        keyring::Entry::new_with_target(name_1, "", "")?.delete_password()?;
+        keyring::Entry::new_with_target(name_2, "", "")?.delete_password()?;
 
         Ok(())
     }


### PR DESCRIPTION
I found out `keyring-rs` wasn't doing "firezone/token" internally, so our credential was just "token", which is too generic. I changed it to use our domain so it's "dev.firezone.client/token".