### PR TITLE
Rename Authorizations -> Activity

### DIFF
--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -187,7 +187,7 @@ defmodule Web.Actors.Show do
     <.section>
       <:title>Activity</:title>
       <:help>
-        Attempts to access resources by this actor. 
+        Attempts to access resources by this actor.
       </:help>
       <:content>
         <.table id="flows" rows={@flows} row_id={&"flows-#{&1.id}"}>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -223,7 +223,7 @@ defmodule Web.Actors.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No activity to display</div>
+            <div class="text-center text-neutral-500 p-4">No activity to display. Activities are created when the client attempts to access a resource.</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -186,6 +186,9 @@ defmodule Web.Actors.Show do
 
     <.section>
       <:title>Activity</:title>
+      <:help>
+        Attempts to access resources by this actor. 
+      </:help>
       <:content>
         <.table id="flows" rows={@flows} row_id={&"flows-#{&1.id}"}>
           <:col :let={flow} label="AUTHORIZED AT">
@@ -223,7 +226,7 @@ defmodule Web.Actors.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No activity to display. Activities are created when the client attempts to access a resource.</div>
+            <div class="text-center text-neutral-500 p-4">No activity to display.</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -185,7 +185,7 @@ defmodule Web.Actors.Show do
     </.section>
 
     <.section>
-      <:title>Authorizations</:title>
+      <:title>Activity</:title>
       <:content>
         <.table id="flows" rows={@flows} row_id={&"flows-#{&1.id}"}>
           <:col :let={flow} label="AUTHORIZED AT">
@@ -223,7 +223,7 @@ defmodule Web.Actors.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No authorizations to display</div>
+            <div class="text-center text-neutral-500 p-4">No activity to display</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -101,6 +101,9 @@ defmodule Web.Clients.Show do
 
     <.section>
       <:title>Activity</:title>
+      <:help>
+        Attempts by the actor using this client to access resources.
+      </:help>
       <:content>
         <.table id="flows" rows={@flows} row_id={&"flows-#{&1.id}"}>
           <:col :let={flow} label="AUTHORIZED AT">
@@ -135,7 +138,7 @@ defmodule Web.Clients.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No activity to display</div>
+            <div class="text-center text-neutral-500 p-4">No activity to display.</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -100,7 +100,7 @@ defmodule Web.Clients.Show do
     </.section>
 
     <.section>
-      <:title>Authorizations</:title>
+      <:title>Activity</:title>
       <:content>
         <.table id="flows" rows={@flows} row_id={&"flows-#{&1.id}"}>
           <:col :let={flow} label="AUTHORIZED AT">
@@ -135,7 +135,7 @@ defmodule Web.Clients.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No authorizations to display</div>
+            <div class="text-center text-neutral-500 p-4">No activity to display</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -119,7 +119,7 @@ defmodule Web.Policies.Show do
 
     <.section>
       <:title>
-        Authorizations
+        Activity
       </:title>
       <:content>
         <.table id="flows" rows={@flows} row_id={&"flows-#{&1.id}"}>
@@ -151,7 +151,7 @@ defmodule Web.Policies.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No authorizations to display</div>
+            <div class="text-center text-neutral-500 p-4">No activity to display</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -121,6 +121,9 @@ defmodule Web.Policies.Show do
       <:title>
         Activity
       </:title>
+      <:help>
+        Attempts by actors to access the resource governed by this policy.
+      </:help>
       <:content>
         <.table id="flows" rows={@flows} row_id={&"flows-#{&1.id}"}>
           <:col :let={flow} label="AUTHORIZED AT">
@@ -151,7 +154,7 @@ defmodule Web.Policies.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No activity to display</div>
+            <div class="text-center text-neutral-500 p-4">No activity to display.</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -177,6 +177,9 @@ defmodule Web.Resources.Show do
       <:title>
         Activity
       </:title>
+      <:help>
+        Attempts by actors to access this resource.
+      </:help>
       <:content>
         <.table id="flows" rows={@flows} row_id={&"flows-#{&1.id}"}>
           <:col :let={flow} label="AUTHORIZED AT">
@@ -224,7 +227,7 @@ defmodule Web.Resources.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No activity to display</div>
+            <div class="text-center text-neutral-500 p-4">No activity to display.</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -175,7 +175,7 @@ defmodule Web.Resources.Show do
 
     <.section>
       <:title>
-        Authorizations
+        Activity
       </:title>
       <:content>
         <.table id="flows" rows={@flows} row_id={&"flows-#{&1.id}"}>
@@ -224,7 +224,7 @@ defmodule Web.Resources.Show do
             </.link>
           </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No authorizations to display</div>
+            <div class="text-center text-neutral-500 p-4">No activity to display</div>
           </:empty>
         </.table>
       </:content>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -52,7 +52,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
         <.button
           :if={is_nil(@provider.disabled_at)}
           phx-click="disable"
-          data-confirm="Are you sure want to disable this provider? All authorizations will be revoked and actors won't be able to use it to access Firezone."
+          data-confirm="Are you sure want to disable this provider? All users signed into this provider will be immediately signed out."
         >
           Disable
         </.button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
@@ -45,7 +45,7 @@ defmodule Web.Settings.IdentityProviders.System.Show do
         <.button
           :if={is_nil(@provider.disabled_at)}
           phx-click="disable"
-          data-confirm="Are you sure want to disable this provider? All authorizations will be revoked and actors won't be able to use it to access Firezone."
+          data-confirm="Are you sure want to disable this provider? All users signed into this provider will be immediately signed out."
         >
           Disable Identity Provider
         </.button>


### PR DESCRIPTION
Authorizations creates confusion with Authentication. What this is referring to most closely resembles "Network Activity", so renaming to Activity.

Fixes https://firezonehq.slack.com/archives/C04HRQTFY0Z/p1703141913585009?thread_ts=1703105862.234659&cid=C04HRQTFY0Z