### PR TITLE
refactor(connlib): refresh dns addresses

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -372,7 +372,6 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                     for connection in connections {
                         let resource_id = connection.resource_id;
                         if let Err(err) = control_signaler
-                            // TODO: create a reference number and keep track for the response
                             .send_with_ref(EgressMessages::ReuseConnection(connection), resource_id)
                             .await
                         {

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -366,6 +366,21 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                     }
                 });
             }
+            Ok(firezone_tunnel::Event::RefreshResources { connections }) => {
+                let mut control_signaler = self.phoenix_channel.clone();
+                tokio::spawn(async move {
+                    for connection in connections {
+                        let resource_id = connection.resource_id;
+                        if let Err(err) = control_signaler
+                            // TODO: create a reference number and keep track for the response
+                            .send_with_ref(EgressMessages::ReuseConnection(connection), resource_id)
+                            .await
+                        {
+                            tracing::warn!(%resource_id, ?err, "failed to refresh resource dns: {err:#?}");
+                        }
+                    }
+                });
+            }
             Err(e) => {
                 tracing::error!("Tunnel failed: {e}");
             }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -616,7 +616,7 @@ impl ClientState {
         tracing::warn!("external_ips: {addr_v4:?}");
         tracing::warn!("internal_ips: {internal_ips:?}");
 
-        // Same note as for ipv4, though an exhaustion is not a realistic scneario.
+        // Same note as for ipv4, though an exhaustion is not a realistic scenario.
         let addr_v6 = addrs.iter().copied().filter(IpAddr::is_ipv6).collect_vec();
         let len = addr_v6.len();
         let internal_ips_v6 = internal_ips

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -648,11 +648,10 @@ impl IpProvider {
 
 impl Default for ClientState {
     fn default() -> Self {
-        // TODO: Before merging change this to 300 seconds!
         // With this single timer this might mean that some DNS are refreshed too often
         // however... this also mean any resource is refresh within a 5 mins interval
         // therefore, only the first time it's added that happens, after that it doesn't matter.
-        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        let mut interval = tokio::time::interval(Duration::from_secs(300));
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Self {
             active_candidate_receivers: StreamMap::new(

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -754,7 +754,7 @@ impl RoleState for ClientState {
                 Poll::Pending => {}
             }
 
-            if let Poll::Ready(_) = self.refresh_dns_timer.poll_tick(cx) {
+            if self.refresh_dns_timer.poll_tick(cx).is_ready() {
                 let mut connections = Vec::new();
                 for resource in self.dns_resources_internal_ips.keys() {
                     let Some(gateway_id) = self.resources_gateways.get(&resource.id) else {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -8,7 +8,10 @@ use boringtun::{
 };
 
 use bytes::Bytes;
-use connlib_shared::{messages::Key, CallbackErrorFacade, Callbacks, Error};
+use connlib_shared::{
+    messages::{Key, ResourceId, ReuseConnection},
+    CallbackErrorFacade, Callbacks, Dname, Error,
+};
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 use ip_packet::IpPacket;
@@ -446,6 +449,9 @@ pub enum Event<TId> {
         resource: ResourceDescription,
         connected_gateway_ids: HashSet<GatewayId>,
         reference: usize,
+    },
+    RefreshResources {
+        connections: Vec<ReuseConnection>,
     },
     DnsQuery(DnsQuery<'static>),
 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -9,8 +9,8 @@ use boringtun::{
 
 use bytes::Bytes;
 use connlib_shared::{
-    messages::{Key, ResourceId, ReuseConnection},
-    CallbackErrorFacade, Callbacks, Dname, Error,
+    messages::{Key, ReuseConnection},
+    CallbackErrorFacade, Callbacks, Error,
 };
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;


### PR DESCRIPTION
Fix for #2956 this is achieved by refreshing access to every resource every 5 minutes.

There's still an open question for this PR:

When the gateway resolves an ip the gateway allows access to a DNS resource it resolves the address and allow access to that ip for that client.

Right now, until the access for that resource doesn't expire that access isn't revoked.

We could change it so that we require the client to refresh such access(with this PR those refresh queries are already being made every 5 minutes) every x minutes on top of the `expires_at` or we can keep `expires_at` as to mean "allow access until `expires_at` for whatever this resource resolves to".
cc @jamilbk @AndrewDryga  