### PR TITLE
fix(apple): Get DNS working reliably when no upstream is configured

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -30,11 +30,13 @@
 		794C38152970A2660029F38F /* FirezoneKit in Frameworks */ = {isa = PBXBuildFile; productRef = 794C38142970A2660029F38F /* FirezoneKit */; };
 		794C38172970A26A0029F38F /* FirezoneKit in Frameworks */ = {isa = PBXBuildFile; productRef = 794C38162970A26A0029F38F /* FirezoneKit */; };
 		79756C6629704A7A0018E2D5 /* FirezoneKit in Frameworks */ = {isa = PBXBuildFile; productRef = 79756C6529704A7A0018E2D5 /* FirezoneKit */; };
+		8D28EB992B35FBD70083621C /* Resolv.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D28EB982B35FBD70083621C /* Resolv.swift */; };
+		8D28EB9A2B35FBD70083621C /* Resolv.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D28EB982B35FBD70083621C /* Resolv.swift */; };
 		8D2F64EF2A973F7000B6176A /* PrimaryMacAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D2F64EC2A97336C00B6176A /* PrimaryMacAddress.swift */; };
 		8DC08BCB2B296C4500675F46 /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC08BCA2B296C4500675F46 /* libresolv.9.tbd */; };
 		8DC08BCD2B296C5900675F46 /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC08BCC2B296C5900675F46 /* libresolv.9.tbd */; };
-		8DC08BCF2B29791E00675F46 /* DnsResolvers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC08BCE2B29791E00675F46 /* DnsResolvers.swift */; };
-		8DC08BD02B29791E00675F46 /* DnsResolvers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC08BCE2B29791E00675F46 /* DnsResolvers.swift */; };
+		8DC08BCF2B29791E00675F46 /* DNSResolvers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC08BCE2B29791E00675F46 /* DNSResolvers.swift */; };
+		8DC08BD02B29791E00675F46 /* DNSResolvers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC08BCE2B29791E00675F46 /* DNSResolvers.swift */; };
 		8DC08BD22B297B7B00675F46 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC08BD12B297B7B00675F46 /* libresolv.tbd */; };
 		8DC08BD42B297B8200675F46 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC08BD32B297B8200675F46 /* libresolv.tbd */; };
 		8DC08BD62B297DA400675F46 /* FirezoneNetworkExtension-Bridging-Header.h in Sources */ = {isa = PBXBuildFile; fileRef = 6FE455112A5D13A2006549B1 /* FirezoneNetworkExtension-Bridging-Header.h */; };
@@ -117,10 +119,11 @@
 		6FE455112A5D13A2006549B1 /* FirezoneNetworkExtension-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FirezoneNetworkExtension-Bridging-Header.h"; sourceTree = "<group>"; };
 		6FE93AFA2A738D7E002D278A /* NetworkSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSettings.swift; sourceTree = "<group>"; };
 		6FFECD5B2AD6998400E00273 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		8D28EB982B35FBD70083621C /* Resolv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resolv.swift; sourceTree = "<group>"; };
 		8D2F64EC2A97336C00B6176A /* PrimaryMacAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryMacAddress.swift; sourceTree = "<group>"; };
 		8DC08BCA2B296C4500675F46 /* libresolv.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.9.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.2.sdk/usr/lib/libresolv.9.tbd; sourceTree = DEVELOPER_DIR; };
 		8DC08BCC2B296C5900675F46 /* libresolv.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.9.tbd; path = usr/lib/libresolv.9.tbd; sourceTree = SDKROOT; };
-		8DC08BCE2B29791E00675F46 /* DnsResolvers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DnsResolvers.swift; sourceTree = "<group>"; };
+		8DC08BCE2B29791E00675F46 /* DNSResolvers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSResolvers.swift; sourceTree = "<group>"; };
 		8DC08BD12B297B7B00675F46 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
 		8DC08BD32B297B8200675F46 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.2.sdk/usr/lib/libresolv.tbd; sourceTree = DEVELOPER_DIR; };
 		8DCC021928D512AC007E12D2 /* Firezone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Firezone.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -190,7 +193,8 @@
 				6FE4550E2A5D112C006549B1 /* connlib-client-apple.swift */,
 				8D2F64EC2A97336C00B6176A /* PrimaryMacAddress.swift */,
 				6FE455112A5D13A2006549B1 /* FirezoneNetworkExtension-Bridging-Header.h */,
-				8DC08BCE2B29791E00675F46 /* DnsResolvers.swift */,
+				8DC08BCE2B29791E00675F46 /* DNSResolvers.swift */,
+				8D28EB982B35FBD70083621C /* Resolv.swift */,
 			);
 			path = FirezoneNetworkExtension;
 			sourceTree = "<group>";
@@ -501,13 +505,14 @@
 			files = (
 				8DC08BD72B297DB400675F46 /* FirezoneNetworkExtension-Bridging-Header.h in Sources */,
 				6FE455092A5D110D006549B1 /* CallbackHandler.swift in Sources */,
+				8D28EB992B35FBD70083621C /* Resolv.swift in Sources */,
 				6FE4550F2A5D112C006549B1 /* connlib-client-apple.swift in Sources */,
 				05CF1D17290B1FE700CF4755 /* PacketTunnelProvider.swift in Sources */,
 				6FE454F62A5BFB93006549B1 /* Adapter.swift in Sources */,
 				6FA39A042A6A7248000F0157 /* NetworkResource.swift in Sources */,
 				6FE4550C2A5D111E006549B1 /* SwiftBridgeCore.swift in Sources */,
 				6FE93AFB2A738D7E002D278A /* NetworkSettings.swift in Sources */,
-				8DC08BCF2B29791E00675F46 /* DnsResolvers.swift in Sources */,
+				8DC08BCF2B29791E00675F46 /* DNSResolvers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -516,9 +521,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DC08BD62B297DA400675F46 /* FirezoneNetworkExtension-Bridging-Header.h in Sources */,
-				8DC08BD02B29791E00675F46 /* DnsResolvers.swift in Sources */,
+				8DC08BD02B29791E00675F46 /* DNSResolvers.swift in Sources */,
 				8D2F64EF2A973F7000B6176A /* PrimaryMacAddress.swift in Sources */,
 				6FE4550A2A5D110D006549B1 /* CallbackHandler.swift in Sources */,
+				8D28EB9A2B35FBD70083621C /* Resolv.swift in Sources */,
 				6FE455102A5D112C006549B1 /* connlib-client-apple.swift in Sources */,
 				05CF1D16290B1FE700CF4755 /* PacketTunnelProvider.swift in Sources */,
 				6FE454F72A5BFB93006549B1 /* Adapter.swift in Sources */,

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -502,9 +502,10 @@ extension Adapter: CallbackHandlerDelegate {
     }
   }
 
-  public func getSystemDefaultResolvers() {
-    let resolvers = Resolv().getservers().map(Resolv.getnameinfo)
+  public func getSystemDefaultResolvers() -> [String] {
+    let resolvers = DNSResolvers.getDNSResolvers()
     self.logger.info("getSystemDefaultResolvers: \(resolvers)")
+    return resolvers
   }
 
   public func onError(error: String) {

--- a/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
+++ b/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
@@ -26,7 +26,7 @@ public protocol CallbackHandlerDelegate: AnyObject {
   func onRemoveRoute(_: String)
   func onUpdateResources(resourceList: String)
   func onDisconnect(error: String?)
-  func getSystemDefaultResolvers()
+  func getSystemDefaultResolvers() -> [String]
   func onError(error: String)
 }
 
@@ -84,7 +84,7 @@ public class CallbackHandler {
   }
 
   func getSystemDefaultResolvers() -> RustString {
-    let resolvers = Resolv().getservers().map(Resolv.getnameinfo)
+    let resolvers = delegate?.getSystemDefaultResolvers() ?? []
     logger.log("CallbackHandler.getSystemDefaultResolvers: \(resolvers, privacy: .public)")
     do {
       return try String(decoding: JSONEncoder().encode(resolvers), as: UTF8.self).intoRustString()

--- a/swift/apple/FirezoneNetworkExtension/DNSResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/DNSResolvers.swift
@@ -1,0 +1,19 @@
+//
+//  DNSResolvers.swift
+//  Firezone
+//
+//  Created by Jamil Bou Kheir on 12/12/23.
+//
+//  Returns the system's DNS Resolvers on macOS
+
+import Foundation
+
+public class DNSResolvers {
+  // FIXME: We need to find a method of finding the system's default resolvers that
+  // works on both macOS and iOS. See https://github.com/firezone/firezone/issues/2939
+  private static let resolvers = ["1.1.1.1", "1.0.0.1"]
+
+  public static func getDNSResolvers() -> [String] {
+    return resolvers
+  }
+}

--- a/swift/apple/FirezoneNetworkExtension/Resolv.swift
+++ b/swift/apple/FirezoneNetworkExtension/Resolv.swift
@@ -1,10 +1,9 @@
 //
-//  DnsResolvers.swift
+//  Resolv.swift
 //  Firezone
 //
-//  Created by Jamil Bou Kheir on 12/12/23.
+//  Created by Jamil Bou Kheir on 12/22/23.
 //
-//  Wraps libresolv to return the system's default resolvers
 
 public class Resolv {
   var state = __res_9_state()


### PR DESCRIPTION
DNS has been broken on Apple for nearly two weeks now, so pushing up a fix that will at least make resolutions reliable when using Firezone. This PR sets the system resolvers on Apple platforms to Cloudflare's DNS if the Firezone admin has _not_ configured a different upstream in the portal instead.

This fix will need to remain in place until we have a reliable method to get the system default resolvers using `SystemConfiguration` framework or the low-level functions it uses.

Unfortunately, the solution we came up with on #2967 does not work in the scenario where the `reasserting` state is entered by going from WiFi -> No Internet -> WiFi because the system resolvers just go empty in that scenario.

We'll need a reliable method to return the non-connlib resolvers with the tunnel up and active.