### PR TITLE
refactor(windows): remove ResourceDisplay

### DIFF
--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -1,5 +1,8 @@
 //! Message types that are used by both the gateway and client.
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::{
+    borrow::Cow,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+};
 
 use chrono::{serde::ts_seconds, DateTime, Utc};
 use ip_network::IpNetwork;
@@ -181,6 +184,22 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => r.id,
             ResourceDescription::Cidr(r) => r.id,
+        }
+    }
+
+    /// What the GUI clients should show as the user-friendly display name, e.g. `Firezone GitHub`
+    pub fn name(&self) -> &str {
+        match self {
+            ResourceDescription::Dns(r) => &r.name,
+            ResourceDescription::Cidr(r) => &r.name,
+        }
+    }
+
+    /// What the GUI clients should paste to the clipboard, e.g. `https://github.com/firezone`
+    pub fn pastable(&self) -> Cow<'_, str> {
+        match self {
+            ResourceDescription::Dns(r) => Cow::from(&r.address),
+            ResourceDescription::Cidr(r) => Cow::from(r.address.to_string()),
         }
     }
 }

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -14,7 +14,7 @@ use connlib_client_shared::{file_logger, ResourceDescription};
 use connlib_shared::messages::ResourceId;
 use secrecy::{ExposeSecret, SecretString};
 use std::{net::IpAddr, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
-use system_tray_menu::{Event as TrayMenuEvent, Resource as ResourceDisplay};
+use system_tray_menu::Event as TrayMenuEvent;
 use tauri::{Manager, SystemTray, SystemTrayEvent};
 use tokio::{
     sync::{mpsc, oneshot, Notify},
@@ -434,7 +434,6 @@ async fn run_controller(
                     continue;
                 };
                 let resources = session.callback_handler.resources.load().as_ref().clone();
-                let resources: Vec<_> = resources.into_iter().map(ResourceDisplay::from).collect();
                 // TODO: Save the user name between runs of the app
                 let actor_name = controller
                     .session

--- a/rust/windows-client/src-tauri/src/client/gui/system_tray_menu.rs
+++ b/rust/windows-client/src-tauri/src/client/gui/system_tray_menu.rs
@@ -2,34 +2,6 @@ use connlib_client_shared::ResourceDescription;
 use std::str::FromStr;
 use tauri::{CustomMenuItem, SystemTrayMenu, SystemTrayMenuItem, SystemTraySubmenu};
 
-/// The information needed for the GUI to display a resource inside the Firezone VPN
-// TODO: Just make these methods on `ResourceDescription`
-pub(crate) struct Resource {
-    pub id: connlib_shared::messages::ResourceId,
-    /// User-friendly name, e.g. "GitLab"
-    pub name: String,
-    /// What will be copied to the clipboard to paste into a web browser
-    pub pastable: String,
-}
-
-impl From<ResourceDescription> for Resource {
-    fn from(x: ResourceDescription) -> Self {
-        match x {
-            ResourceDescription::Dns(x) => Self {
-                id: x.id,
-                name: x.name,
-                pastable: x.address,
-            },
-            ResourceDescription::Cidr(x) => Self {
-                id: x.id,
-                name: x.name,
-                // TODO: CIDRs aren't URLs right?
-                pastable: x.address.to_string(),
-            },
-        }
-    }
-}
-
 #[derive(Debug, PartialEq)]
 pub(crate) enum Event {
     About,
@@ -64,7 +36,7 @@ impl FromStr for Event {
     }
 }
 
-pub(crate) fn signed_in(user_name: &str, resources: &[Resource]) -> SystemTrayMenu {
+pub(crate) fn signed_in(user_name: &str, resources: &[ResourceDescription]) -> SystemTrayMenu {
     let mut menu = SystemTrayMenu::new()
         .add_item(
             CustomMenuItem::new("".to_string(), format!("Signed in as {user_name}")).disabled(),
@@ -73,12 +45,13 @@ pub(crate) fn signed_in(user_name: &str, resources: &[Resource]) -> SystemTrayMe
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(CustomMenuItem::new("".to_string(), "Resources").disabled());
 
-    for Resource { id, name, pastable } in resources {
+    for res in resources {
+        let id = res.id();
         let submenu = SystemTrayMenu::new().add_item(CustomMenuItem::new(
             format!("/resource/{id}"),
-            pastable.to_string(),
+            res.pastable().to_string(),
         ));
-        menu = menu.add_submenu(SystemTraySubmenu::new(name, submenu));
+        menu = menu.add_submenu(SystemTraySubmenu::new(res.name(), submenu));
     }
 
     menu = menu

--- a/rust/windows-client/src-tauri/src/client/gui/system_tray_menu.rs
+++ b/rust/windows-client/src-tauri/src/client/gui/system_tray_menu.rs
@@ -49,7 +49,7 @@ pub(crate) fn signed_in(user_name: &str, resources: &[ResourceDescription]) -> S
         let id = res.id();
         let submenu = SystemTrayMenu::new().add_item(CustomMenuItem::new(
             format!("/resource/{id}"),
-            res.pastable().to_string(),
+            res.pastable(),
         ));
         menu = menu.add_submenu(SystemTraySubmenu::new(res.name(), submenu));
     }


### PR DESCRIPTION
... and move its methods into ResourceDescription.

This was a TODO from some pull request in the last few days. I assume the goal is to share this function between all clients if needed. It doesn't reduce the number of lines of code, since I could have removed ResourceDisplay and done this on-the-fly when building the systray menu, as an alternative.