### PR TITLE
fix(windows): app title in Task Manager

### DIFF
--- a/rust/windows-client/src-tauri/tauri.conf.json
+++ b/rust/windows-client/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
         "icons/firezone.ico"
       ],
       "publisher": "Firezone",
-      "shortDescription": "The Firezone Windows client"
+      "shortDescription": "Firezone Windows client"
     },
     "security": {
       "csp": null


### PR DESCRIPTION
Didn't realize shortDescription shows up as the name in Task Manager. That "The " looks weird in there.