### PR TITLE
refactor(apple): guard packetTunnelProvider in one place

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -350,10 +350,11 @@ extension Adapter: CallbackHandlerDelegate {
           dnsAddress: dnsAddress)
       case .tunnelReady:
         if let networkSettings = self.networkSettings {
-          if let packetTunnelProvider = self.packetTunnelProvider {
-            networkSettings.apply(
-              on: packetTunnelProvider, logger: self.logger, completionHandler: nil)
-          }
+          networkSettings.apply(
+            on: packetTunnelProvider,
+            logger: self.logger,
+            completionHandler: nil
+          )
         }
 
       case .stoppingTunnel, .stoppedTunnel, .stoppingTunnelTemporarily, .stoppedTunnelTemporarily:
@@ -377,15 +378,12 @@ extension Adapter: CallbackHandlerDelegate {
         self.logger.error("Adapter.onTunnelReady: No network settings")
         return
       }
-      guard let packetTunnelProvider = self.packetTunnelProvider else {
-        self.logger.error("Adapter.onTunnelReady: No packet tunnel provider")
-        return
-      }
+
       // Connlib's up, set it as the default DNS
       networkSettings.setMatchDomains([""])
       networkSettings.apply(on: packetTunnelProvider, logger: self.logger) { error in
         if let error = error {
-          packetTunnelProvider.handleTunnelShutdown(
+          self.packetTunnelProvider?.handleTunnelShutdown(
             dueTo: .networkSettingsApplyFailure,
             errorMessage: error.localizedDescription)
           onStarted?(AdapterError.setNetworkSettings(error))
@@ -408,10 +406,6 @@ extension Adapter: CallbackHandlerDelegate {
         self.logger.error("Adapter.onAddRoute: No network settings")
         return
       }
-      guard let packetTunnelProvider = self.packetTunnelProvider else {
-        self.logger.error("Adapter.onAddRoute: No packet tunnel provider")
-        return
-      }
 
       networkSettings.addRoute(route)
       if case .tunnelReady = self.state {
@@ -427,10 +421,6 @@ extension Adapter: CallbackHandlerDelegate {
       self.logger.log("Adapter.onRemoveRoute(\(route, privacy: .public))")
       guard let networkSettings = self.networkSettings else {
         self.logger.error("Adapter.onRemoveRoute: No network settings")
-        return
-      }
-      guard let packetTunnelProvider = self.packetTunnelProvider else {
-        self.logger.error("Adapter.onRemoveRoute: No packet tunnel provider")
         return
       }
       networkSettings.removeRoute(route)
@@ -460,10 +450,6 @@ extension Adapter: CallbackHandlerDelegate {
       // Update DNS in case resource domains is changing
       guard let networkSettings = self.networkSettings else {
         self.logger.error("Adapter.onUpdateResources: No network settings")
-        return
-      }
-      guard let packetTunnelProvider = self.packetTunnelProvider else {
-        self.logger.error("Adapter.onUpdateResources: No packet tunnel provider")
         return
       }
       let updatedResourceDomains = networkResources.compactMap { $0.resourceLocation.domain }

--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -68,7 +68,10 @@ class NetworkSettings {
     logger: Logger,
     completionHandler: ((Error?) -> Void)?
   ) {
-    guard let packetTunnelProvider = packetTunnelProvider else { return }
+    guard let packetTunnelProvider = packetTunnelProvider else {
+      logger.error("\(#function): packetTunnelProvider not initialized! This should not happen.")
+      return
+    }
 
     guard self.hasUnappliedChanges else {
       logger.error("NetworkSettings.apply: No changes to apply")


### PR DESCRIPTION
Just a minor cleanup suggestion to consolidate guards in one place.

We could also make `networkSettings` a non-optional type which would clean things up further (will it always be initialized while the Adapter is?)

Draft because stacked on #3012 