### PR TITLE
fix(ci): Inherit secrets from calling workflow to allow contributors' PRs to run

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,5 +1,6 @@
 name: "Setup Rust"
 description: "Sets up the correct Rust version and caching via sccache and a GCP backend"
+secrets: inherit
 inputs:
   targets:
     description: "Additional targets to install"


### PR DESCRIPTION
Attempting to fix the issue seen [here](https://github.com/firezone/firezone/actions/runs/7331666670). Unfortunately the docs aren't super clear on this so it may take some trial and error.

https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow