### PR TITLE
fix(gateway): Fallback to `get_hostname()` for systemd deployments

### DIFF
--- a/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
@@ -318,7 +318,7 @@ defmodule Web.RelayGroups.NewToken do
       chmod 0775 /var/lib/firezone; \\
     '
     ExecStart=/usr/bin/sudo \\
-      --preserve-env=FIREZONE_ID,FIREZONE_TOKEN,PUBLIC_IP4_ADDR,PUBLIC_IP6_ADDR,RUST_LOG,LOG_FORMAT \\
+      --preserve-env=FIREZONE_NAME,FIREZONE_ID,FIREZONE_TOKEN,PUBLIC_IP4_ADDR,PUBLIC_IP6_ADDR,RUST_LOG,LOG_FORMAT \\
       -u firezone \\
       -g firezone \\
       /usr/local/bin/firezone-relay

--- a/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
@@ -318,10 +318,9 @@ defmodule Web.RelayGroups.NewToken do
       chmod 0775 /var/lib/firezone; \\
     '
     ExecStart=/usr/bin/sudo \\
-      --preserve-env=FIREZONE_NAME,FIREZONE_ID,FIREZONE_TOKEN,PUBLIC_IP4_ADDR,PUBLIC_IP6_ADDR,RUST_LOG,LOG_FORMAT \\
+      --preserve-env=FIREZONE_ID,FIREZONE_TOKEN,PUBLIC_IP4_ADDR,PUBLIC_IP6_ADDR,RUST_LOG,LOG_FORMAT \\
       -u firezone \\
       -g firezone \\
-      FIREZONE_NAME=$(hostname) \\
       /usr/local/bin/firezone-relay
     TimeoutStartSec=3s
     TimeoutStopSec=15s

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -284,7 +284,7 @@ defmodule Web.Sites.NewToken do
       ip6tables-nft -t nat -C POSTROUTING -o e+ -j MASQUERADE || ip6tables-nft -t nat -A POSTROUTING -o e+ -j MASQUERADE; \\
     '
     ExecStart=/usr/bin/sudo \\
-      --preserve-env=FIREZONE_ID,FIREZONE_TOKEN,FIREZONE_API_URL,RUST_LOG \\
+      --preserve-env=FIREZONE_NAME,FIREZONE_ID,FIREZONE_TOKEN,FIREZONE_API_URL,RUST_LOG \\
       -u firezone \\
       -g firezone \\
       /usr/local/bin/firezone-gateway

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -284,10 +284,9 @@ defmodule Web.Sites.NewToken do
       ip6tables-nft -t nat -C POSTROUTING -o e+ -j MASQUERADE || ip6tables-nft -t nat -A POSTROUTING -o e+ -j MASQUERADE; \\
     '
     ExecStart=/usr/bin/sudo \\
-      --preserve-env=FIREZONE_NAME,FIREZONE_ID,FIREZONE_TOKEN,FIREZONE_API_URL,RUST_LOG \\
+      --preserve-env=FIREZONE_ID,FIREZONE_TOKEN,FIREZONE_API_URL,RUST_LOG \\
       -u firezone \\
       -g firezone \\
-      FIREZONE_NAME=$(hostname) \\
       /usr/local/bin/firezone-gateway
     TimeoutStartSec=3s
     TimeoutStopSec=15s


### PR DESCRIPTION
Fixes #3025 