### PR TITLE
fix(connlib): never delete allowed ips for a peer given dns

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -664,7 +664,7 @@ impl Default for ClientState {
         // however... this also mean any resource is refresh within a 5 mins interval
         // therefore, only the first time it's added that happens, after that it doesn't matter.
         // TODO: CHANGEME to 300 again.
-        let mut interval = tokio::time::interval(Duration::from_secs(10));
+        let mut interval = tokio::time::interval(Duration::from_secs(300));
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Self {
             active_candidate_receivers: StreamMap::new(

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -663,7 +663,6 @@ impl Default for ClientState {
         // With this single timer this might mean that some DNS are refreshed too often
         // however... this also mean any resource is refresh within a 5 mins interval
         // therefore, only the first time it's added that happens, after that it doesn't matter.
-        // TODO: CHANGEME to 300 again.
         let mut interval = tokio::time::interval(Duration::from_secs(300));
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Self {

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -193,7 +193,6 @@ impl Default for PacketTransformGateway {
 
 #[derive(Default)]
 pub struct PacketTransformClient {
-    // TODO: we need to refresh the translations ips periodically, just add a timer to resend allow access
     translations: RwLock<BiMap<IpAddr, IpAddr>>,
 }
 


### PR DESCRIPTION
Fixes #3094 

This will make the "packet unallowed" messages you might see in connlib and make connections smoother.