### PR TITLE
fix(apple): In case tunnel crashes, try to reconnect

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -198,6 +198,7 @@ public final class AuthStore: ObservableObject {
       }
     } else {
       self.logger.log("\(#function): Tunnel shutdown event not found")
+      self.retryStartTunnel()
     }
   }
 


### PR DESCRIPTION
When the tunnel crashes, we won't have a chance to write why the tunnel disconnected in a file in the tunnel process. In that case too, this PR makes the app try to reconnect.

Fixes #2898

