### PR TITLE
refactor(portal): Use ghcr.io for public pulls of prod images

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -494,6 +494,11 @@ locals {
       name  = "AUTH_PROVIDER_ADAPTERS"
       value = "email,openid_connect,google_workspace,token"
     },
+    # Registry from which Docker install scripts pull from
+    {
+      name  = "DOCKER_REGISTRY"
+      value = "ghcr.io/firezone"
+    },
     # Telemetry
     {
       name  = "TELEMETRY_ENABLED"

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -447,6 +447,11 @@ locals {
       name  = "AUTH_PROVIDER_ADAPTERS"
       value = "email,openid_connect,google_workspace,token"
     },
+    # Registry from which Docker install scripts pull from
+    {
+      name  = "DOCKER_REGISTRY"
+      value = "${module.google-artifact-registry.url}/${module.google-artifact-registry.repo}"
+    },
     # Telemetry
     {
       name  = "TELEMETRY_ENABLED"

--- a/terraform/modules/elixir-app/main.tf
+++ b/terraform/modules/elixir-app/main.tf
@@ -40,10 +40,6 @@ locals {
       value = "Elixir.Domain.GoogleCloudPlatform"
     },
     {
-      name  = "DOCKER_REGISTRY"
-      value = "${var.container_registry}/${var.image_repo}"
-    },
-    {
       name = "PLATFORM_ADAPTER_CONFIG"
       value = jsonencode({
         project_id            = var.project_id


### PR DESCRIPTION
Noticed our public pulls are coming from `pkg.dev` for prod, so this PR fixes that so that they're from `ghcr.io` to avoid bandwidth fees and segregate public pulls from our own infra pulls.

<img width="463" alt="Screenshot 2024-01-03 at 12 42 51 PM" src="https://github.com/firezone/firezone/assets/167144/22f49996-fe6b-47c7-965f-23d14c9e4e59">
