### PR TITLE
fix(Apple): Attempt to fix window selectedness of the authentication webview

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -92,6 +92,8 @@ struct FirezoneApp: App {
       _ = AppStore.WindowDefinition.allCases.map { $0.window()?.close() }
     }
 
-    func applicationWillTerminate(_: Notification) {}
+    func applicationWillTerminate(_: Notification) {
+      self.appStore?.authStore.cancelSignIn()
+    }
   }
 #endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/AuthClient/AuthClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/AuthClient/AuthClient.swift
@@ -88,9 +88,6 @@ private final class WebAuthenticationSession: NSObject,
       // We want to load any SSO cookies that the user may have set in their default browser
       session.prefersEphemeralWebBrowserSession = false
 
-      #if os(macOS)
-        NSApp.activate(ignoringOtherApps: true)
-      #endif
       session.start()
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -160,6 +160,10 @@ public final class AuthStore: ObservableObject {
     resetReconnectionAttemptsRemaining()
   }
 
+  public func cancelSignIn() {
+    auth.cancelSignIn()
+  }
+
   func startTunnel() {
     logger.trace("\(#function)")
 


### PR DESCRIPTION
Attempt to fix #2881.

I can't reproduce the exact issue anymore, but I'm guessing activating the app causes the web view window to lose selectedness. So we don't do that in the PR.

Also, this PR fixes the scenario where the app is quit while the web view is shown -- we now close the webview window in that case.
