### PR TITLE
feat(windows): log Git version used to build the client

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2054,6 +2054,7 @@ dependencies = [
  "connlib-client-shared",
  "connlib-shared",
  "firezone-cli-utils",
+ "git-version",
  "hostname",
  "ipconfig",
  "keyring",
@@ -2456,6 +2457,26 @@ dependencies = [
  "libc",
  "system-deps 6.2.0",
  "winapi",
+]
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
 ]
 
 [[package]]

--- a/rust/windows-client/src-tauri/Cargo.toml
+++ b/rust/windows-client/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.4", features = ["derive",  "env"] }
 connlib-client-shared = { workspace = true }
 connlib-shared = { workspace = true }
 firezone-cli-utils = { workspace = true }
+git-version = "0.3.9"
 # Same crate Hickory uses
 hostname = "0.3.1"
 # This is the same crate hickory uses to get system resolvers

--- a/rust/windows-client/src-tauri/src/client.rs
+++ b/rust/windows-client/src-tauri/src/client.rs
@@ -14,6 +14,17 @@ mod resolvers;
 mod settings;
 mod wintun_install;
 
+/// Output of `git describe` at compile time
+/// e.g. `1.0.0-pre.4-20-ged5437c88-modified` where:
+///
+/// * `1.0.0-pre.4` is the most recent ancestor tag
+/// * `20` is the number of commits since then
+/// * `g` doesn't mean anything
+/// * `ed5437c88` is the Git commit hash
+/// * `-modified` is present if the working dir has any changes from that commit number
+const GIT_VERSION: &str =
+    git_version::git_version!(args = ["--always", "--dirty=-modified", "--tags"]);
+
 /// Prevents a problem where changing the args to `gui::run` breaks static analysis on non-Windows targets, where the gui is stubbed out
 #[allow(dead_code)]
 pub(crate) struct GuiParams {

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -123,7 +123,7 @@ pub(crate) fn run(params: client::GuiParams) -> Result<()> {
             // It's hard to set it up before Tauri's setup, because Tauri knows where all the config and data go in AppData and I don't want to replicate their logic.
             let logging_handles = client::logging::setup(&advanced_settings.log_filter)?;
             tracing::info!("started log");
-            tracing::info!("GIT_VERSION = {}", crate::GIT_VERSION);
+            tracing::info!("GIT_VERSION = {}", crate::client::GIT_VERSION);
             // I checked this on my dev system to make sure Powershell is doing what I expect and passing the argument back to us after relaunch
             tracing::debug!("flag_elevated: {flag_elevated}");
 

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -123,6 +123,7 @@ pub(crate) fn run(params: client::GuiParams) -> Result<()> {
             // It's hard to set it up before Tauri's setup, because Tauri knows where all the config and data go in AppData and I don't want to replicate their logic.
             let logging_handles = client::logging::setup(&advanced_settings.log_filter)?;
             tracing::info!("started log");
+            tracing::info!("GIT_VERSION = {}", crate::GIT_VERSION);
             // I checked this on my dev system to make sure Powershell is doing what I expect and passing the argument back to us after relaunch
             tracing::debug!("flag_elevated: {flag_elevated}");
 

--- a/rust/windows-client/src-tauri/src/main.rs
+++ b/rust/windows-client/src-tauri/src/main.rs
@@ -3,6 +3,17 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+/// Output of `git describe` at compile time
+/// e.g. `1.0.0-pre.4-20-ged5437c88-modified` where:
+///
+/// * `1.0.0-pre.4` is the most recent ancestor tag
+/// * `20` is the number of commits since then
+/// * `g` doesn't mean anything
+/// * `ed5437c88` is the Git commit hash
+/// * `-modified` is present if the working dir has any changes from that commit number
+const GIT_VERSION: &str =
+    git_version::git_version!(args = ["--always", "--dirty=-modified", "--tags"]);
+
 fn main() -> anyhow::Result<()> {
     client::run()
 }

--- a/rust/windows-client/src-tauri/src/main.rs
+++ b/rust/windows-client/src-tauri/src/main.rs
@@ -3,17 +3,6 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-/// Output of `git describe` at compile time
-/// e.g. `1.0.0-pre.4-20-ged5437c88-modified` where:
-///
-/// * `1.0.0-pre.4` is the most recent ancestor tag
-/// * `20` is the number of commits since then
-/// * `g` doesn't mean anything
-/// * `ed5437c88` is the Git commit hash
-/// * `-modified` is present if the working dir has any changes from that commit number
-const GIT_VERSION: &str =
-    git_version::git_version!(args = ["--always", "--dirty=-modified", "--tags"]);
-
 fn main() -> anyhow::Result<()> {
     client::run()
 }


### PR DESCRIPTION
Fulfills #3141 

It took a little longer than I expected but since I'll be leaving the client running all the time even on my dev laptop, I want to easily see what version I built, even if I've changed branches since building it.