### PR TITLE
fix(portal): Add page_title to all portal pages

### DIFF
--- a/elixir/apps/web/lib/web/components/table_components.ex
+++ b/elixir/apps/web/lib/web/components/table_components.ex
@@ -289,7 +289,7 @@ defmodule Web.TableComponents do
         scope="row"
         class={[
           "text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap",
-          "bg-neutral-50",
+          "bg-neutral-50 w-1/5",
           @label_class
         ]}
       >

--- a/elixir/apps/web/lib/web/live/actors/edit.ex
+++ b/elixir/apps/web/lib/web/live/actors/edit.ex
@@ -17,7 +17,7 @@ defmodule Web.Actors.Edit do
           actor: actor,
           groups: groups,
           form: to_form(changeset),
-          page_title: "Edit actor #{actor.name}"
+          page_title: "Actors"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/actors/edit.ex
+++ b/elixir/apps/web/lib/web/live/actors/edit.ex
@@ -17,7 +17,7 @@ defmodule Web.Actors.Edit do
           actor: actor,
           groups: groups,
           form: to_form(changeset),
-          page_title: "Actors"
+          page_title: "Edit #{actor.name}"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/actors/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/new.ex
@@ -4,8 +4,10 @@ defmodule Web.Actors.New do
 
   def mount(_params, _session, socket) do
     socket =
-      socket
-      |> assign(:form, %{})
+      assign(socket,
+        form: %{},
+        page_title: "Actors"
+      )
 
     {:ok, socket}
   end

--- a/elixir/apps/web/lib/web/live/actors/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/new.ex
@@ -6,7 +6,7 @@ defmodule Web.Actors.New do
     socket =
       assign(socket,
         form: %{},
-        page_title: "Actors"
+        page_title: "New Actor"
       )
 
     {:ok, socket}

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
@@ -13,7 +13,7 @@ defmodule Web.Actors.ServiceAccounts.New do
         assign(socket,
           groups: groups,
           form: to_form(changeset),
-          page_title: "Actors"
+          page_title: "New Service Account"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
@@ -12,7 +12,8 @@ defmodule Web.Actors.ServiceAccounts.New do
       socket =
         assign(socket,
           groups: groups,
-          form: to_form(changeset)
+          form: to_form(changeset),
+          page_title: "Actors"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new_identity.ex
@@ -12,7 +12,9 @@ defmodule Web.Actors.ServiceAccounts.NewIdentity do
         assign(socket,
           actor: actor,
           encoded_token: nil,
-          form: to_form(changeset)
+          form: to_form(changeset),
+          page_title: "Actors"
+
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new_identity.ex
@@ -13,7 +13,7 @@ defmodule Web.Actors.ServiceAccounts.NewIdentity do
           actor: actor,
           encoded_token: nil,
           form: to_form(changeset),
-          page_title: "Actors"
+          page_title: "New Service Account Token"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new_identity.ex
@@ -14,7 +14,6 @@ defmodule Web.Actors.ServiceAccounts.NewIdentity do
           encoded_token: nil,
           form: to_form(changeset),
           page_title: "Actors"
-
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -59,7 +59,7 @@ defmodule Web.Actors.Show do
       </:action>
       <:content flash={@flash}>
         <.vertical_table id="actor">
-          <.vertical_table_row label_class="w-1/5">
+          <.vertical_table_row>
             <:label>Name</:label>
             <:value><%= @actor.name %>
               <.actor_status actor={@actor} /></:value>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -29,7 +29,7 @@ defmodule Web.Actors.Show do
          actor: actor,
          flows: flows,
          tokens: tokens,
-         page_title: "Actors",
+         page_title: "Actor #{actor.name}",
          flow_activities_enabled?: Domain.Config.flow_activities_enabled?()
        )}
     else

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -29,7 +29,7 @@ defmodule Web.Actors.Show do
          actor: actor,
          flows: flows,
          tokens: tokens,
-         page_title: actor.name,
+         page_title: "Actors",
          flow_activities_enabled?: Domain.Config.flow_activities_enabled?()
        )}
     else

--- a/elixir/apps/web/lib/web/live/actors/users/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new.ex
@@ -10,7 +10,8 @@ defmodule Web.Actors.Users.New do
       socket =
         assign(socket,
           groups: groups,
-          form: to_form(changeset)
+          form: to_form(changeset),
+          page_title: "Actors"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/actors/users/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new.ex
@@ -11,7 +11,7 @@ defmodule Web.Actors.Users.New do
         assign(socket,
           groups: groups,
           form: to_form(changeset),
-          page_title: "Actors"
+          page_title: "New User"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -25,7 +25,7 @@ defmodule Web.Actors.Users.NewIdentity do
           providers: providers,
           provider: provider,
           form: to_form(changeset),
-          page_title: "Actors"
+          page_title: "New User Identity"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -24,7 +24,8 @@ defmodule Web.Actors.Users.NewIdentity do
           actor: actor,
           providers: providers,
           provider: provider,
-          form: to_form(changeset)
+          form: to_form(changeset),
+          page_title: "Actors"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/clients/edit.ex
+++ b/elixir/apps/web/lib/web/live/clients/edit.ex
@@ -6,7 +6,7 @@ defmodule Web.Clients.Edit do
     with {:ok, client} <- Clients.fetch_client_by_id(id, socket.assigns.subject),
          nil <- client.deleted_at do
       changeset = Clients.change_client(client)
-      socket = assign(socket, client: client, form: to_form(changeset))
+      socket = assign(socket, client: client, form: to_form(changeset), page_title: "Clients")
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/clients/edit.ex
+++ b/elixir/apps/web/lib/web/live/clients/edit.ex
@@ -6,7 +6,14 @@ defmodule Web.Clients.Edit do
     with {:ok, client} <- Clients.fetch_client_by_id(id, socket.assigns.subject),
          nil <- client.deleted_at do
       changeset = Clients.change_client(client)
-      socket = assign(socket, client: client, form: to_form(changeset), page_title: "Clients")
+
+      socket =
+        assign(socket,
+          client: client,
+          form: to_form(changeset),
+          page_title: "Edit Client #{client.name}"
+        )
+
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError
@@ -27,7 +34,7 @@ defmodule Web.Clients.Edit do
 
     <.section>
       <:title>
-        Editing client: <code>Engineering</code>
+        Editing client: <code><%= @client.name %></code>
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">

--- a/elixir/apps/web/lib/web/live/clients/index.ex
+++ b/elixir/apps/web/lib/web/live/clients/index.ex
@@ -5,7 +5,14 @@ defmodule Web.Clients.Index do
   def mount(_params, _session, socket) do
     with {:ok, clients} <- Clients.list_clients(socket.assigns.subject, preload: :actor) do
       :ok = Clients.subscribe_for_clients_presence_in_account(socket.assigns.subject.account)
-      {:ok, assign(socket, clients: clients)}
+
+      socket =
+        assign(socket,
+          clients: clients,
+          page_title: "Clients"
+        )
+
+      {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -17,7 +17,7 @@ defmodule Web.Clients.Show do
           client: client,
           flows: flows,
           flow_activities_enabled?: Config.flow_activities_enabled?(),
-          page_title: "Clients"
+          page_title: "Client #{client.name}"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -16,7 +16,8 @@ defmodule Web.Clients.Show do
           socket,
           client: client,
           flows: flows,
-          flow_activities_enabled?: Config.flow_activities_enabled?()
+          flow_activities_enabled?: Config.flow_activities_enabled?(),
+          page_title: "Clients"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/flows/show.ex
+++ b/elixir/apps/web/lib/web/live/flows/show.ex
@@ -13,7 +13,8 @@ defmodule Web.Flows.Show do
                resource: []
              ]
            ) do
-      {:ok, assign(socket, flow: flow)}
+      socket = assign(socket, flow: flow, page_title: "Flows")
+      {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/flows/show.ex
+++ b/elixir/apps/web/lib/web/live/flows/show.ex
@@ -13,7 +13,7 @@ defmodule Web.Flows.Show do
                resource: []
              ]
            ) do
-      socket = assign(socket, flow: flow, page_title: "Flows")
+      socket = assign(socket, flow: flow, page_title: "Flow #{flow.id}")
       {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -10,7 +10,8 @@ defmodule Web.Gateways.Show do
       socket =
         assign(
           socket,
-          gateway: gateway
+          gateway: gateway,
+          page_title: "Gateway #{gateway.name}"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/groups/edit.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit.ex
@@ -8,7 +8,7 @@ defmodule Web.Groups.Edit do
          nil <- group.deleted_at,
          false <- Actors.group_synced?(group) do
       changeset = Actors.change_group(group)
-      socket = assign(socket, group: group, form: to_form(changeset))
+      socket = assign(socket, group: group, form: to_form(changeset), page_title: "Groups")
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/groups/edit.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit.ex
@@ -8,7 +8,10 @@ defmodule Web.Groups.Edit do
          nil <- group.deleted_at,
          false <- Actors.group_synced?(group) do
       changeset = Actors.change_group(group)
-      socket = assign(socket, group: group, form: to_form(changeset), page_title: "Groups")
+
+      socket =
+        assign(socket, group: group, form: to_form(changeset), page_title: "Edit #{group.name}")
+
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/groups/edit_actors.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit_actors.ex
@@ -18,7 +18,8 @@ defmodule Web.Groups.EditActors do
          current_member_ids: current_member_ids,
          actors: actors,
          added_ids: [],
-         removed_ids: []
+         removed_ids: [],
+         page_title: "Groups"
        )}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/groups/edit_actors.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit_actors.ex
@@ -19,7 +19,7 @@ defmodule Web.Groups.EditActors do
          actors: actors,
          added_ids: [],
          removed_ids: [],
-         page_title: "Groups"
+         page_title: "Edit Actors in #{group.name}"
        )}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/groups/new.ex
+++ b/elixir/apps/web/lib/web/live/groups/new.ex
@@ -5,7 +5,7 @@ defmodule Web.Groups.New do
   def mount(_params, _session, socket) do
     changeset = Actors.new_group()
 
-    {:ok, assign(socket, form: to_form(changeset), page_title: "Groups"),
+    {:ok, assign(socket, form: to_form(changeset), page_title: "New Group"),
      temporary_assigns: [form: %Phoenix.HTML.Form{}]}
   end
 

--- a/elixir/apps/web/lib/web/live/groups/new.ex
+++ b/elixir/apps/web/lib/web/live/groups/new.ex
@@ -5,7 +5,7 @@ defmodule Web.Groups.New do
   def mount(_params, _session, socket) do
     changeset = Actors.new_group()
 
-    {:ok, assign(socket, form: to_form(changeset)),
+    {:ok, assign(socket, form: to_form(changeset), page_title: "Groups"),
      temporary_assigns: [form: %Phoenix.HTML.Form{}]}
   end
 

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -13,7 +13,8 @@ defmodule Web.Groups.Show do
                created_by_identity: [:actor]
              ]
            ) do
-      {:ok, assign(socket, group: group)}
+      socket = assign(socket, group: group, page_title: "Groups")
+      {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -13,7 +13,7 @@ defmodule Web.Groups.Show do
                created_by_identity: [:actor]
              ]
            ) do
-      socket = assign(socket, group: group, page_title: "Groups")
+      socket = assign(socket, group: group, page_title: "Group #{group.name}")
       {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/policies/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies/edit.ex
@@ -10,7 +10,15 @@ defmodule Web.Policies.Edit do
            ),
          nil <- policy.deleted_at do
       form = to_form(Policies.Policy.Changeset.update(policy, %{}))
-      socket = assign(socket, policy: policy, page_title: "Edit Policy", form: form)
+
+      socket =
+        assign(socket,
+          policy: policy,
+          page_title: "Edit Policy",
+          form: form,
+          page_title: "Policies"
+        )
+
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError
@@ -25,7 +33,7 @@ defmodule Web.Policies.Edit do
         <.policy_name policy={@policy} />
       </.breadcrumb>
       <.breadcrumb path={~p"/#{@account}/policies/#{@policy}/edit"}>
-        <%= @page_title %>
+        Edit
       </.breadcrumb>
     </.breadcrumbs>
 

--- a/elixir/apps/web/lib/web/live/policies/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies/edit.ex
@@ -14,7 +14,6 @@ defmodule Web.Policies.Edit do
       socket =
         assign(socket,
           policy: policy,
-          page_title: "Edit Policy",
           form: form,
           page_title: "Policies"
         )

--- a/elixir/apps/web/lib/web/live/policies/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies/edit.ex
@@ -15,7 +15,7 @@ defmodule Web.Policies.Edit do
         assign(socket,
           policy: policy,
           form: form,
-          page_title: "Policies"
+          page_title: "Edit #{policy.id}"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -14,7 +14,7 @@ defmodule Web.Policies.New do
           actor_groups: actor_groups,
           params: Map.take(params, ["site_id"]),
           resource_id: params["resource_id"],
-          page_title: "Add Policy",
+          page_title: "Policies",
           form: form
         )
 
@@ -28,11 +28,11 @@ defmodule Web.Policies.New do
     ~H"""
     <.breadcrumbs account={@account}>
       <.breadcrumb path={~p"/#{@account}/policies"}>Policies</.breadcrumb>
-      <.breadcrumb path={~p"/#{@account}/policies/new"}><%= @page_title %></.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/policies/new"}>Add Policy</.breadcrumb>
     </.breadcrumbs>
     <.section>
       <:title>
-        <%= @page_title %>
+        Add Policy
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -14,7 +14,7 @@ defmodule Web.Policies.New do
           actor_groups: actor_groups,
           params: Map.take(params, ["site_id"]),
           resource_id: params["resource_id"],
-          page_title: "Policies",
+          page_title: "New Policy",
           form: form
         )
 

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -16,7 +16,7 @@ defmodule Web.Policies.Show do
         assign(socket,
           policy: policy,
           flows: flows,
-          page_title: "Policies",
+          page_title: "Policy #{policy.id}",
           flow_activities_enabled?: Config.flow_activities_enabled?()
         )
 

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -16,7 +16,7 @@ defmodule Web.Policies.Show do
         assign(socket,
           policy: policy,
           flows: flows,
-          page_title: "Policy",
+          page_title: "Policies",
           flow_activities_enabled?: Config.flow_activities_enabled?()
         )
 
@@ -37,7 +37,7 @@ defmodule Web.Policies.Show do
 
     <.section>
       <:title>
-        <%= @page_title %>: <code><%= @policy.id %></code>
+        Policy: <code><%= @policy.id %></code>
         <span :if={not is_nil(@policy.disabled_at)} class="text-primary-600">(disabled)</span>
         <span :if={not is_nil(@policy.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>

--- a/elixir/apps/web/lib/web/live/relay_groups/edit.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/edit.ex
@@ -7,7 +7,7 @@ defmodule Web.RelayGroups.Edit do
          {:ok, group} <- Relays.fetch_group_by_id(id, socket.assigns.subject),
          nil <- group.deleted_at do
       changeset = Relays.change_group(group)
-      socket = assign(socket, group: group, form: to_form(changeset))
+      socket = assign(socket, group: group, form: to_form(changeset), page_title: "Relays")
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/relay_groups/edit.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/edit.ex
@@ -7,7 +7,10 @@ defmodule Web.RelayGroups.Edit do
          {:ok, group} <- Relays.fetch_group_by_id(id, socket.assigns.subject),
          nil <- group.deleted_at do
       changeset = Relays.change_group(group)
-      socket = assign(socket, group: group, form: to_form(changeset), page_title: "Relays")
+
+      socket =
+        assign(socket, group: group, form: to_form(changeset), page_title: "Edit #{group.name}")
+
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/relay_groups/index.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/index.ex
@@ -8,7 +8,14 @@ defmodule Web.RelayGroups.Index do
     with true <- Domain.Config.self_hosted_relays_enabled?(),
          {:ok, groups} <- Relays.list_groups(subject, preload: [:relays]) do
       :ok = Relays.subscribe_for_relays_presence_in_account(socket.assigns.account)
-      {:ok, assign(socket, groups: groups)}
+
+      socket =
+        assign(socket,
+          groups: groups,
+          page_title: "Relays"
+        )
+
+      {:ok, socket}
     else
       _other -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/relay_groups/new.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new.ex
@@ -6,7 +6,7 @@ defmodule Web.RelayGroups.New do
     with true <- Domain.Config.self_hosted_relays_enabled?() do
       changeset = Relays.new_group()
 
-      {:ok, assign(socket, form: to_form(changeset, page_title: "Relays")),
+      {:ok, assign(socket, form: to_form(changeset, page_title: "New Relay Group")),
        temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/relay_groups/new.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new.ex
@@ -6,7 +6,7 @@ defmodule Web.RelayGroups.New do
     with true <- Domain.Config.self_hosted_relays_enabled?() do
       changeset = Relays.new_group()
 
-      {:ok, assign(socket, form: to_form(changeset)),
+      {:ok, assign(socket, form: to_form(changeset, page_title: "Relays")),
        temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError
@@ -21,7 +21,7 @@ defmodule Web.RelayGroups.New do
     </.breadcrumbs>
     <.section>
       <:title>
-        Add a new Relay Instance Group
+        Add Relay Instance Group
       </:title>
       <:content>
         <div class="py-8 px-4 mx-auto max-w-2xl lg:py-16">

--- a/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
@@ -23,7 +23,8 @@ defmodule Web.RelayGroups.NewToken do
          group: group,
          env: env,
          connected?: false,
-         selected_tab: "systemd-instructions"
+         selected_tab: "systemd-instructions",
+         page_title: "Relays"
        )}
     else
       _other -> raise Web.LiveErrors.NotFoundError
@@ -42,7 +43,7 @@ defmodule Web.RelayGroups.NewToken do
 
     <.section>
       <:title>
-        Deploy a new Relay
+        Deploy Relay
       </:title>
       <:content>
         <div class="py-8 px-4 mx-auto max-w-2xl lg:py-16">

--- a/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
@@ -24,7 +24,7 @@ defmodule Web.RelayGroups.NewToken do
          env: env,
          connected?: false,
          selected_tab: "systemd-instructions",
-         page_title: "Relays"
+         page_title: "New Relay"
        )}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/relay_groups/show.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/show.ex
@@ -12,7 +12,7 @@ defmodule Web.RelayGroups.Show do
              ]
            ) do
       :ok = Relays.subscribe_for_relays_presence_in_group(group)
-      socket = assign(socket, group: group, page_title: "Relays")
+      socket = assign(socket, group: group, page_title: "Relay Group #{group.name}")
       {:ok, socket}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/relay_groups/show.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/show.ex
@@ -12,7 +12,8 @@ defmodule Web.RelayGroups.Show do
              ]
            ) do
       :ok = Relays.subscribe_for_relays_presence_in_group(group)
-      {:ok, assign(socket, group: group)}
+      socket = assign(socket, group: group, page_title: "Relays")
+      {:ok, socket}
     else
       _other -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/relays/show.ex
+++ b/elixir/apps/web/lib/web/live/relays/show.ex
@@ -7,7 +7,7 @@ defmodule Web.Relays.Show do
          {:ok, relay} <-
            Relays.fetch_relay_by_id(id, socket.assigns.subject, preload: :group) do
       :ok = Relays.subscribe_for_relays_presence_in_group(relay.group)
-      socket = assign(socket, relay: relay, page_title: "Relays")
+      socket = assign(socket, relay: relay, page_title: "Relay #{relay.name}")
       {:ok, socket}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/relays/show.ex
+++ b/elixir/apps/web/lib/web/live/relays/show.ex
@@ -7,7 +7,8 @@ defmodule Web.Relays.Show do
          {:ok, relay} <-
            Relays.fetch_relay_by_id(id, socket.assigns.subject, preload: :group) do
       :ok = Relays.subscribe_for_relays_presence_in_group(relay.group)
-      {:ok, assign(socket, relay: relay)}
+      socket = assign(socket, relay: relay, page_title: "Relays")
+      {:ok, socket}
     else
       _other -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -17,7 +17,8 @@ defmodule Web.Resources.Edit do
           gateway_groups: gateway_groups,
           form: form,
           params: Map.take(params, ["site_id"]),
-          traffic_filters_enabled?: Config.traffic_filters_enabled?()
+          traffic_filters_enabled?: Config.traffic_filters_enabled?(),
+          page_title: "Resources"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -18,7 +18,7 @@ defmodule Web.Resources.Edit do
           form: form,
           params: Map.take(params, ["site_id"]),
           traffic_filters_enabled?: Config.traffic_filters_enabled?(),
-          page_title: "Resources"
+          page_title: "Edit #{resource.name}"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -9,11 +9,14 @@ defmodule Web.Resources.Index do
            ),
          {:ok, resource_actor_groups_peek} <-
            Resources.peek_resource_actor_groups(resources, 3, socket.assigns.subject) do
-      {:ok,
-       assign(socket,
-         resources: resources,
-         resource_actor_groups_peek: resource_actor_groups_peek
-       )}
+      socket =
+        assign(socket,
+          resources: resources,
+          resource_actor_groups_peek: resource_actor_groups_peek,
+          page_title: "Resources"
+        )
+
+      {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -14,7 +14,8 @@ defmodule Web.Resources.New do
           name_changed?: false,
           form: to_form(changeset),
           params: Map.take(params, ["site_id"]),
-          traffic_filters_enabled?: Config.traffic_filters_enabled?()
+          traffic_filters_enabled?: Config.traffic_filters_enabled?(),
+          page_title: "Resources"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -15,7 +15,7 @@ defmodule Web.Resources.New do
           form: to_form(changeset),
           params: Map.take(params, ["site_id"]),
           traffic_filters_enabled?: Config.traffic_filters_enabled?(),
-          page_title: "Resources"
+          page_title: "New Resource"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -21,7 +21,8 @@ defmodule Web.Resources.Show do
           actor_groups_peek: Map.fetch!(actor_groups_peek, resource.id),
           flows: flows,
           params: Map.take(params, ["site_id"]),
-          traffic_filters_enabled?: Config.traffic_filters_enabled?()
+          traffic_filters_enabled?: Config.traffic_filters_enabled?(),
+          page_title: "Resources"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -22,7 +22,7 @@ defmodule Web.Resources.Show do
           flows: flows,
           params: Map.take(params, ["site_id"]),
           traffic_filters_enabled?: Config.traffic_filters_enabled?(),
-          page_title: "Resources"
+          page_title: "Resource #{resource.name}"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/settings/account.ex
+++ b/elixir/apps/web/lib/web/live/settings/account.ex
@@ -1,6 +1,10 @@
 defmodule Web.Settings.Account do
   use Web, :live_view
 
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, page_title: "Account")}
+  end
+
   def render(assigns) do
     ~H"""
     <.breadcrumbs account={@account}>

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -11,7 +11,7 @@ defmodule Web.Settings.DNS do
       |> add_new_server()
       |> to_form()
 
-    socket = assign(socket, config: config, form: form)
+    socket = assign(socket, config: config, form: form, page_title: "DNS")
 
     {:ok, socket}
   end

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/edit.ex
@@ -11,7 +11,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Edit do
         assign(socket,
           provider: provider,
           form: to_form(changeset),
-          page_title: "Identity Providers"
+          page_title: "Edit #{provider.name}"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/edit.ex
@@ -10,7 +10,8 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Edit do
       socket =
         assign(socket,
           provider: provider,
-          form: to_form(changeset)
+          form: to_form(changeset),
+          page_title: "Identity Providers"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/new.ex
@@ -16,7 +16,8 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.New do
     socket =
       assign(socket,
         id: id,
-        form: to_form(changeset)
+        form: to_form(changeset),
+        page_title: "Identity Providers"
       )
 
     {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/new.ex
@@ -17,7 +17,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.New do
       assign(socket,
         id: id,
         form: to_form(changeset),
-        page_title: "Identity Providers"
+        page_title: "New Identity Provider"
       )
 
     {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -17,7 +17,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
          provider: provider,
          identities_count_by_provider_id: identities_count_by_provider_id,
          groups_count_by_provider_id: groups_count_by_provider_id,
-         page_title: "Identity Providers"
+         page_title: "Identity Provider #{provider.name}"
        )}
     else
       _ -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -16,7 +16,8 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
        assign(socket,
          provider: provider,
          identities_count_by_provider_id: identities_count_by_provider_id,
-         groups_count_by_provider_id: groups_count_by_provider_id
+         groups_count_by_provider_id: groups_count_by_provider_id,
+         page_title: "Identity Providers"
        )}
     else
       _ -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
@@ -16,7 +16,7 @@ defmodule Web.Settings.IdentityProviders.Index do
           identities_count_by_provider_id: identities_count_by_provider_id,
           groups_count_by_provider_id: groups_count_by_provider_id,
           providers: providers,
-          page_title: "Identity Providers Settings"
+          page_title: "Identity Providers"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/new.ex
@@ -4,7 +4,7 @@ defmodule Web.Settings.IdentityProviders.New do
 
   def mount(_params, _session, socket) do
     {:ok, adapters} = Auth.list_provider_adapters()
-    socket = assign(socket, form: %{}, adapters: adapters, page_title: "Identity Providers")
+    socket = assign(socket, form: %{}, adapters: adapters, page_title: "New Identity Provider")
     {:ok, socket}
   end
 

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/new.ex
@@ -4,7 +4,7 @@ defmodule Web.Settings.IdentityProviders.New do
 
   def mount(_params, _session, socket) do
     {:ok, adapters} = Auth.list_provider_adapters()
-    socket = assign(socket, form: %{}, adapters: adapters)
+    socket = assign(socket, form: %{}, adapters: adapters, page_title: "Identity Providers")
     {:ok, socket}
   end
 

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/edit.ex
@@ -11,7 +11,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Edit do
         assign(socket,
           provider: provider,
           form: to_form(changeset),
-          page_title: "Identity Providers"
+          page_title: "Edit #{provider.name}"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/edit.ex
@@ -10,7 +10,8 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Edit do
       socket =
         assign(socket,
           provider: provider,
-          form: to_form(changeset)
+          form: to_form(changeset),
+          page_title: "Identity Providers"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/new.ex
@@ -17,7 +17,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.New do
       assign(socket,
         id: id,
         form: to_form(changeset),
-        page_title: "Identity Providers"
+        page_title: "New Identity Provider"
       )
 
     {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/new.ex
@@ -16,7 +16,8 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.New do
     socket =
       assign(socket,
         id: id,
-        form: to_form(changeset)
+        form: to_form(changeset),
+        page_title: "Identity Providers"
       )
 
     {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -8,7 +8,13 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
            Auth.fetch_provider_by_id(provider_id, socket.assigns.subject,
              preload: [created_by_identity: [:actor]]
            ) do
-      {:ok, assign(socket, provider: provider)}
+      socket =
+        assign(socket,
+          provider: provider,
+          page_title: "Identity Providers"
+        )
+
+      {:ok, socket}
     else
       _ -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -11,7 +11,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
       socket =
         assign(socket,
           provider: provider,
-          page_title: "Identity Providers"
+          page_title: "Identity Provider #{provider.name}"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
@@ -8,7 +8,9 @@ defmodule Web.Settings.IdentityProviders.System.Show do
            Auth.fetch_provider_by_id(provider_id, socket.assigns.subject,
              preload: [created_by_identity: [:actor]]
            ) do
-      socket = assign(socket, provider: provider, page_title: "Identity Providers")
+      socket =
+        assign(socket, provider: provider, page_title: "Identity Provider #{provider.name}")
+
       {:ok, socket}
     else
       _ -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
@@ -8,7 +8,8 @@ defmodule Web.Settings.IdentityProviders.System.Show do
            Auth.fetch_provider_by_id(provider_id, socket.assigns.subject,
              preload: [created_by_identity: [:actor]]
            ) do
-      {:ok, assign(socket, provider: provider)}
+      socket = assign(socket, provider: provider, page_title: "Identity Providers")
+      {:ok, socket}
     else
       _ -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -19,7 +19,7 @@ defmodule Web.SignIn do
           params: params,
           account: account,
           providers_by_adapter: providers_by_adapter,
-          page_title: "Sign in"
+          page_title: "Sign In"
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/sign_in/email.ex
+++ b/elixir/apps/web/lib/web/live/sign_in/email.ex
@@ -21,7 +21,8 @@ defmodule Web.SignIn.Email do
         account_id_or_slug: account_id_or_slug,
         provider_id: provider_id,
         resent: params["resent"],
-        params: params
+        params: params,
+        page_title: "Sign In"
       )
 
     {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -53,7 +53,8 @@ defmodule Web.SignUp do
         real_ip: real_ip,
         sign_up_enabled?: Config.sign_up_enabled?(),
         account_name_changed?: false,
-        actor_name_changed?: false
+        actor_name_changed?: false,
+        page_title: "Sign Up"
       )
 
     {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/sites/edit.ex
+++ b/elixir/apps/web/lib/web/live/sites/edit.ex
@@ -7,7 +7,10 @@ defmodule Web.Sites.Edit do
     with {:ok, group} <- Gateways.fetch_group_by_id(id, socket.assigns.subject),
          nil <- group.deleted_at do
       changeset = Gateways.change_group(group)
-      socket = assign(socket, group: group, form: to_form(changeset), page_title: "Sites")
+
+      socket =
+        assign(socket, group: group, form: to_form(changeset), page_title: "Edit #{group.name}")
+
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/sites/edit.ex
+++ b/elixir/apps/web/lib/web/live/sites/edit.ex
@@ -7,7 +7,7 @@ defmodule Web.Sites.Edit do
     with {:ok, group} <- Gateways.fetch_group_by_id(id, socket.assigns.subject),
          nil <- group.deleted_at do
       changeset = Gateways.change_group(group)
-      socket = assign(socket, group: group, form: to_form(changeset))
+      socket = assign(socket, group: group, form: to_form(changeset), page_title: "Sites")
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
     else
       _other -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/sites/gateways/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/gateways/index.ex
@@ -14,7 +14,7 @@ defmodule Web.Sites.Gateways.Index do
            ) do
       gateways = Enum.sort_by(gateways, & &1.online?, :desc)
       :ok = Gateways.subscribe_for_gateways_presence_in_group(group)
-      socket = assign(socket, group: group, gateways: gateways, page_title: "Sites")
+      socket = assign(socket, group: group, gateways: gateways, page_title: "Site Gateways")
       {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/sites/gateways/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/gateways/index.ex
@@ -14,7 +14,8 @@ defmodule Web.Sites.Gateways.Index do
            ) do
       gateways = Enum.sort_by(gateways, & &1.online?, :desc)
       :ok = Gateways.subscribe_for_gateways_presence_in_group(group)
-      {:ok, assign(socket, group: group, gateways: gateways)}
+      socket = assign(socket, group: group, gateways: gateways, page_title: "Sites")
+      {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -8,7 +8,14 @@ defmodule Web.Sites.Index do
     with {:ok, groups} <-
            Gateways.list_groups(subject, preload: [:gateways, connections: [:resource]]) do
       :ok = Gateways.subscribe_for_gateways_presence_in_account(socket.assigns.account)
-      {:ok, assign(socket, groups: groups)}
+
+      socket =
+        assign(socket,
+          groups: groups,
+          page_title: "Sites"
+        )
+
+      {:ok, socket}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError
     end

--- a/elixir/apps/web/lib/web/live/sites/new.ex
+++ b/elixir/apps/web/lib/web/live/sites/new.ex
@@ -6,7 +6,7 @@ defmodule Web.Sites.New do
   def mount(_params, _session, socket) do
     changeset = Gateways.new_group()
 
-    socket = assign(socket, form: to_form(changeset), page_title: "Sites")
+    socket = assign(socket, form: to_form(changeset), page_title: "New Site")
     {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
   end
 

--- a/elixir/apps/web/lib/web/live/sites/new.ex
+++ b/elixir/apps/web/lib/web/live/sites/new.ex
@@ -6,8 +6,8 @@ defmodule Web.Sites.New do
   def mount(_params, _session, socket) do
     changeset = Gateways.new_group()
 
-    {:ok, assign(socket, form: to_form(changeset)),
-     temporary_assigns: [form: %Phoenix.HTML.Form{}]}
+    socket = assign(socket, form: to_form(changeset), page_title: "Sites")
+    {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
   end
 
   def render(assigns) do

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -22,7 +22,8 @@ defmodule Web.Sites.NewToken do
          group: group,
          env: env,
          connected?: false,
-         selected_tab: "systemd-instructions"
+         selected_tab: "systemd-instructions",
+         page_title: "Sites"
        )}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -23,7 +23,7 @@ defmodule Web.Sites.NewToken do
          env: env,
          connected?: false,
          selected_tab: "systemd-instructions",
-         page_title: "Sites"
+         page_title: "New Site Gateway"
        )}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -27,7 +27,8 @@ defmodule Web.Sites.Show do
        assign(socket,
          group: group,
          gateways: gateways,
-         resource_actor_groups_peek: resource_actor_groups_peek
+         resource_actor_groups_peek: resource_actor_groups_peek,
+         page_title: "Sites"
        )}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -28,7 +28,7 @@ defmodule Web.Sites.Show do
          group: group,
          gateways: gateways,
          resource_actor_groups_peek: resource_actor_groups_peek,
-         page_title: "Sites"
+         page_title: "Site #{group.name}"
        )}
     else
       {:error, _reason} -> raise Web.LiveErrors.NotFoundError


### PR DESCRIPTION
Why:

* When navigating around the portal, the title in the browser tab would
      not show the accurate title of the current page.  This commit adds
      `page_title` to all pages.  The value of the page title has been
      choosen to correspond with the portal's left hand nav menu.


Additional:
* Along with the page titles, the `vertical_table` component was updated to make the left hand headers use a class of `w-1/5` for consistency across pages and to move the info a little further left on each page to try and align it closer with other info on the page.

Here's an example of before and after:

<img width="1060" alt="before" src="https://github.com/firezone/firezone/assets/2646332/6c56b550-98a5-4331-b1d3-c65ed9e24330">

<img width="1058" alt="after" src="https://github.com/firezone/firezone/assets/2646332/c4753fee-ddea-4c67-9d5e-5b924260ea20">

