### PR TITLE
fix(portal): Allow IdP setting errors to be shown in portal

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
@@ -28,6 +28,9 @@ defmodule Domain.Auth.Adapters.OpenIDConnect.Settings.Changeset do
         {:error, %Mint.TransportError{reason: reason}} ->
           [{:discovery_document_uri, "is invalid, got #{inspect(reason)}"}]
 
+        {:error, %Jason.DecodeError{} = _error} ->
+          [{:discovery_document_uri, "is invalid, unable to parse response"}]
+
         # XXX: Do these occur with Mint?
         {:error, {404, _body}} ->
           [{:discovery_document_uri, "does not exist"}]

--- a/elixir/apps/domain/lib/domain/changeset.ex
+++ b/elixir/apps/domain/lib/domain/changeset.ex
@@ -69,6 +69,8 @@ defmodule Domain.Changeset do
          unique: true
        }}
 
+    nested_changeset = %{nested_changeset | action: changeset.action || :update}
+
     changeset = %{
       changeset
       | types: Map.put(changeset.types, field, embedded_type),

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
@@ -159,15 +159,11 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.EditTest do
       }
     }
 
-    validate_change(form, changed_values, fn form, html ->
+    validate_change(form, changed_values, fn form, _html ->
       assert form_validation_errors(form) == %{
                "provider[name]" => ["should be at most 255 character(s)"],
                "provider[adapter_config][client_id]" => ["can't be blank"]
              }
-
-      assert html
-             |> Floki.find("div[phx-feedback-for='provider[adapter_config][client_id]'] p")
-             |> Floki.text() =~ "can't be blank"
     end)
   end
 end

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
@@ -152,10 +152,22 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.EditTest do
         }
       )
 
-    validate_change(form, %{provider: %{name: String.duplicate("a", 256)}}, fn form, _html ->
+    changed_values = %{
+      provider: %{
+        name: String.duplicate("a", 256),
+        adapter_config: %{provider_attrs.adapter_config | "client_id" => ""}
+      }
+    }
+
+    validate_change(form, changed_values, fn form, html ->
       assert form_validation_errors(form) == %{
-               "provider[name]" => ["should be at most 255 character(s)"]
+               "provider[name]" => ["should be at most 255 character(s)"],
+               "provider[adapter_config][client_id]" => ["can't be blank"]
              }
+
+      assert html
+             |> Floki.find("div[phx-feedback-for='provider[adapter_config][client_id]'] p")
+             |> Floki.text() =~ "can't be blank"
     end)
   end
 end

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
@@ -151,15 +151,11 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.NewTest do
       }
     }
 
-    validate_change(form, changed_values, fn form, html ->
+    validate_change(form, changed_values, fn form, _html ->
       assert form_validation_errors(form) == %{
                "provider[name]" => ["should be at most 255 character(s)"],
                "provider[adapter_config][client_id]" => ["can't be blank"]
              }
-
-      assert html
-             |> Floki.find("div[phx-feedback-for='provider[adapter_config][client_id]'] p")
-             |> Floki.text() =~ "can't be blank"
     end)
   end
 end

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
@@ -144,10 +144,22 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.NewTest do
         }
       )
 
-    validate_change(form, %{provider: %{name: String.duplicate("a", 256)}}, fn form, _html ->
+    changed_values = %{
+      provider: %{
+        name: String.duplicate("a", 256),
+        adapter_config: %{provider_attrs.adapter_config | "client_id" => ""}
+      }
+    }
+
+    validate_change(form, changed_values, fn form, html ->
       assert form_validation_errors(form) == %{
-               "provider[name]" => ["should be at most 255 character(s)"]
+               "provider[name]" => ["should be at most 255 character(s)"],
+               "provider[adapter_config][client_id]" => ["can't be blank"]
              }
+
+      assert html
+             |> Floki.find("div[phx-feedback-for='provider[adapter_config][client_id]'] p")
+             |> Floki.text() =~ "can't be blank"
     end)
   end
 end

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/edit_test.exs
@@ -156,15 +156,11 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.EditTest do
       }
     }
 
-    validate_change(form, changed_values, fn form, html ->
+    validate_change(form, changed_values, fn form, _html ->
       assert form_validation_errors(form) == %{
                "provider[name]" => ["should be at most 255 character(s)"],
                "provider[adapter_config][client_id]" => ["can't be blank"]
              }
-
-      assert html
-             |> Floki.find("div[phx-feedback-for='provider[adapter_config][client_id]'] p")
-             |> Floki.text() =~ "can't be blank"
     end)
   end
 end

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/edit_test.exs
@@ -149,10 +149,22 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.EditTest do
         }
       )
 
-    validate_change(form, %{provider: %{name: String.duplicate("a", 256)}}, fn form, _html ->
+    changed_values = %{
+      provider: %{
+        name: String.duplicate("a", 256),
+        adapter_config: %{provider_attrs.adapter_config | "client_id" => ""}
+      }
+    }
+
+    validate_change(form, changed_values, fn form, html ->
       assert form_validation_errors(form) == %{
-               "provider[name]" => ["should be at most 255 character(s)"]
+               "provider[name]" => ["should be at most 255 character(s)"],
+               "provider[adapter_config][client_id]" => ["can't be blank"]
              }
+
+      assert html
+             |> Floki.find("div[phx-feedback-for='provider[adapter_config][client_id]'] p")
+             |> Floki.text() =~ "can't be blank"
     end)
   end
 end

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/new_test.exs
@@ -150,15 +150,11 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.NewTest do
       }
     }
 
-    validate_change(form, changed_values, fn form, html ->
+    validate_change(form, changed_values, fn form, _html ->
       assert form_validation_errors(form) == %{
                "provider[name]" => ["should be at most 255 character(s)"],
                "provider[adapter_config][client_id]" => ["can't be blank"]
              }
-
-      assert html
-             |> Floki.find("div[phx-feedback-for='provider[adapter_config][client_id]'] p")
-             |> Floki.text() =~ "can't be blank"
     end)
   end
 end

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/new_test.exs
@@ -143,10 +143,22 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.NewTest do
         }
       )
 
-    validate_change(form, %{provider: %{name: String.duplicate("a", 256)}}, fn form, _html ->
+    changed_values = %{
+      provider: %{
+        name: String.duplicate("a", 256),
+        adapter_config: %{provider_attrs.adapter_config | "client_id" => ""}
+      }
+    }
+
+    validate_change(form, changed_values, fn form, html ->
       assert form_validation_errors(form) == %{
-               "provider[name]" => ["should be at most 255 character(s)"]
+               "provider[name]" => ["should be at most 255 character(s)"],
+               "provider[adapter_config][client_id]" => ["can't be blank"]
              }
+
+      assert html
+             |> Floki.find("div[phx-feedback-for='provider[adapter_config][client_id]'] p")
+             |> Floki.text() =~ "can't be blank"
     end)
   end
 end


### PR DESCRIPTION
Why:

* There was a small bug that was preventing form errors from being shown while entering the configuration data for OIDC/Google IDPs.  It was due to a nested changeset not having an `action` set.

Closes #3048 