### PR TITLE
connlib(fix): don't add candidates that are also resources

### DIFF
--- a/rust/connlib/tunnel/src/control_protocol.rs
+++ b/rust/connlib/tunnel/src/control_protocol.rs
@@ -49,6 +49,10 @@ where
         conn_id: TRoleState::Id,
         ice_candidate: RTCIceCandidate,
     ) -> Result<()> {
+        if !self.role_state.lock().filter_candidate(&ice_candidate) {
+            return Ok(());
+        }
+
         tracing::info!(%ice_candidate, %conn_id, "adding new remote candidate");
         let peer_connection = self
             .peer_connections

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -11,6 +11,7 @@ use futures_bounded::{PushError, StreamMap};
 use ip_network_table::IpNetworkTable;
 use itertools::Itertools;
 use std::collections::VecDeque;
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 use std::time::Duration;
@@ -142,5 +143,14 @@ impl RoleState for GatewayState {
         }
 
         peers_to_stop
+    }
+
+    fn filter_candidate(&self, candidate: &RTCIceCandidate) -> bool {
+        // We don't really need to also filter in gateway side but no harm done
+        let Ok(addr) = candidate.address.parse::<IpAddr>() else {
+            return true;
+        };
+
+        self.peers_by_ip.longest_match(addr).is_none()
     }
 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -560,4 +560,5 @@ pub trait RoleState: Default + Send + 'static {
     fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Event<Self::Id>>;
     fn remove_peers(&mut self, conn_id: Self::Id);
     fn refresh_peers(&mut self) -> VecDeque<Self::Id>;
+    fn filter_candidate(&self, candidate: &RTCIceCandidate) -> bool;
 }


### PR DESCRIPTION
[Partially](https://github.com/firezone/firezone/issues/3150#issuecomment-1886210332) fixes #3150 

Note: we don't use `ip_filter` in webrtc's API because then we would need to share additional state on tunnel creation with webrtc. This means that some extra sockets are opened that won't be used but it's worth the simplification.