### PR TITLE
fix(portal): Increase receive timeout to alleviate test flakiness

### DIFF
--- a/elixir/apps/domain/test/domain/jobs/executors/global_test.exs
+++ b/elixir/apps/domain/test/domain/jobs/executors/global_test.exs
@@ -91,6 +91,6 @@ defmodule Domain.Jobs.Executors.GlobalTest do
     name = {Domain.Jobs.Executors.Global, __MODULE__, :send_test_message}
     assert :global.whereis_name(name) == new_leader_pid
 
-    assert_receive {:executed, ^new_leader_pid, _time}, 200
+    assert_receive {:executed, ^new_leader_pid, _time}, 1000
   end
 end


### PR DESCRIPTION
The increase I added to the other process receive timeouts seemed to fix the flakiness there, so trying it for this last test as well.

GH runners can be very slow.

https://github.com/firezone/firezone/actions/runs/7484945854/job/20372602149