### PR TITLE
chore(deps): Group netlink dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
     schedule:
       interval: weekly
     groups:
+      netlink:
+        patterns:
+          - rtnetlink
+          - netlink-packet-*
       otel:
         patterns:
           - opentelemetry


### PR DESCRIPTION
This won't fix the issue in #2863 but will at least give Dependabot a better chance at bumping them successfully.