### PR TITLE
fix(gateway): Use `sudo tee` instead of `sudo cat` to write files as root

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -199,7 +199,7 @@ defmodule Web.Sites.NewToken do
     id -u firezone &>/dev/null || sudo useradd -r -g firezone -s /sbin/nologin firezone
 
     # Create systemd unit file
-    sudo cat << EOF > /etc/systemd/system/firezone-gateway.service
+    cat << EOF | sudo tee /etc/systemd/system/firezone-gateway.service
     [Unit]
     Description=Firezone Gateway
     After=network.target
@@ -224,7 +224,7 @@ defmodule Web.Sites.NewToken do
     EOF
 
     # Create ExecStartPre script
-    sudo cat << EOF > /usr/local/bin/firezone-gateway-init
+    cat << EOF | sudo tee /usr/local/bin/firezone-gateway-init
     #!/bin/sh
 
     set -ue


### PR DESCRIPTION
Fixes an issue with input/output redirection that is preventing the systemd gateway install script from working properly.