### PR TITLE
feat(devops): Add AWS VPC terraform

### DIFF
--- a/terraform/environments/staging/.terraform.lock.hcl
+++ b/terraform/environments/staging/.terraform.lock.hcl
@@ -23,6 +23,29 @@ provider "registry.terraform.io/cyrilgdn/postgresql" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.31.0"
+  constraints = ">= 5.20.0"
+  hashes = [
+    "h1:ltxyuBWIy9cq0kIKDJH1jeWJy/y7XJLjS4QrsQK4plA=",
+    "zh:0cdb9c2083bf0902442384f7309367791e4640581652dda456f2d6d7abf0de8d",
+    "zh:2fe4884cb9642f48a5889f8dff8f5f511418a18537a9dfa77ada3bcdad391e4e",
+    "zh:36d8bdd72fe61d816d0049c179f495bc6f1e54d8d7b07c45b62e5e1696882a89",
+    "zh:539dd156e3ec608818eb21191697b230117437a58587cbd02ce533202a4dd520",
+    "zh:6a53f4b57ac4eb3479fc0d8b6e301ca3a27efae4c55d9f8bd24071b12a03361c",
+    "zh:6faeb8ff6792ca7af1c025255755ad764667a300291cc10cea0c615479488c87",
+    "zh:7d9423149b323f6d0df5b90c4d9029e5455c670aea2a7eb6fef4684ba7eb2e0b",
+    "zh:8235badd8a5d0993421cacf5ead48fac73d3b5a25c8a68599706a404b1f70730",
+    "zh:860b4f60842b2879c5128b7e386c8b49adeda9287fed12c5cd74861bb659bbcd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b021fceaf9382c8fe3c6eb608c24d01dce3d11ba7e65bb443d51ca9b90e9b237",
+    "zh:b38b0bfc1c69e714e80cf1c9ea06e687ee86aa9f45694be28eb07adcebbe0489",
+    "zh:c972d155f6c01af9690a72adfb99cfc24ef5ef311ca92ce46b9b13c5c153f572",
+    "zh:e0dd29920ec84fdb6026acff44dcc1fb1a24a0caa093fa04cdbc713d384c651d",
+    "zh:e3127ebd2cb0374cd1808f911e6bffe2f4ac4d84317061381242353f3a7bc27d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "5.10.0"
   constraints = "~> 5.2"

--- a/terraform/environments/staging/aws.tf
+++ b/terraform/environments/staging/aws.tf
@@ -1,0 +1,43 @@
+provider "aws" {
+  region = local.aws_region
+}
+
+locals {
+  aws_region = "us-east-1"
+
+  vpc_name = "Staging"
+  vpc_cidr = "10.0.0.0/16"
+  num_azs  = 2
+  azs      = slice(data.aws_availability_zones.available.names, 0, local.num_azs)
+
+  ssh_keypair_name = "fz-staging"
+
+  tags = {
+    Terraform   = true
+    Environment = "staging"
+  }
+}
+
+################################################################################
+# Networking
+################################################################################
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = local.vpc_name
+  cidr = local.vpc_cidr
+
+  enable_ipv6                                   = true
+  public_subnet_assign_ipv6_address_on_creation = true
+
+  private_subnet_enable_dns64                                   = false
+  private_subnet_enable_resource_name_dns_aaaa_record_on_launch = false
+
+  azs                         = local.azs
+  public_subnets              = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
+  private_subnets             = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k + local.num_azs)]
+  public_subnet_ipv6_prefixes = range(0, local.num_azs)
+
+  tags = local.tags
+}

--- a/terraform/environments/staging/aws_data.tf
+++ b/terraform/environments/staging/aws_data.tf
@@ -1,0 +1,17 @@
+data "aws_availability_zones" "available" {}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical as shown here: https://ubuntu.com/server/docs/cloud-images/amazon-ec2
+}


### PR DESCRIPTION
Why:

* The AWS infrastructure has previously been terraformed outside the mono repo.  This commit is the beginning of bringing all of that infrastructure into the mono repo.  This commit is only standing up the VPC and related networking structures in AWS.