### PR TITLE
chore(windows): Use version from Cargo toml to support automatic versioning

### DIFF
--- a/rust/windows-client/src-tauri/tauri.conf.json
+++ b/rust/windows-client/src-tauri/tauri.conf.json
@@ -7,8 +7,7 @@
     "withGlobalTauri": true
   },
   "package": {
-    "productName": "Firezone Windows Client",
-    "version": "1.0.0"
+    "productName": "Firezone Windows Client"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
JSON doesn't support comments, so we can't easily maintain the package version like we do elsewhere in the codebase.

Luckily Tauri [will pull this](https://tauri.app/v1/api/config/#packageconfig) from the toml if it's missing in the JSON config.