### PR TITLE
fix(connlib): Fix `getSystemDefaultResolvers` while tunnel session is active

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -33,7 +33,6 @@ pub struct ControlPlane<CB: Callbacks> {
     pub tunnel: Arc<Tunnel<CB, ClientState>>,
     pub phoenix_channel: PhoenixSenderWithTopic,
     pub tunnel_init: Mutex<bool>,
-    pub system_dns_servers: Option<Vec<IpAddr>>,
     // It's a Mutex<Option<_>> because we need the init message to initialize the resolver
     // also, in platforms with split DNS and no configured upstream dns this will be None.
     //
@@ -42,16 +41,16 @@ pub struct ControlPlane<CB: Callbacks> {
 }
 
 fn create_resolver(
-    system_dns_servers: &Option<Vec<IpAddr>>,
     upstream_dns: Vec<DnsServer>,
+    callbacks: &impl Callbacks,
 ) -> Option<TokioAsyncResolver> {
     let dns_servers = if upstream_dns.is_empty() {
-        let Some(dns_servers) = system_dns_servers else {
+        let Ok(Some(dns_servers)) = callbacks.get_system_default_resolvers() else {
             return None;
         };
         let mut dns_servers = dns_servers
-            .iter()
-            .filter(|ip| ip != &&IpAddr::from(DNS_SENTINEL))
+            .into_iter()
+            .filter(|ip| ip != &IpAddr::from(DNS_SENTINEL))
             .peekable();
         if dns_servers.peek().is_none() {
             tracing::error!("No system default DNS servers available! Can't initialize resolver. DNS will be broken.");
@@ -61,7 +60,7 @@ fn create_resolver(
         dns_servers
             .map(|ip| {
                 DnsServer::IpPort(IpDnsServer {
-                    address: (*ip, DNS_PORT).into(),
+                    address: (ip, DNS_PORT).into(),
                 })
             })
             .collect()
@@ -110,7 +109,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
 
         self.tunnel.set_upstream_dns(&interface.upstream_dns);
         *self.fallback_resolver.lock() =
-            create_resolver(&self.system_dns_servers, interface.upstream_dns);
+            create_resolver(interface.upstream_dns, self.tunnel.callbacks());
         for resource_description in resources {
             self.add_resource(resource_description);
         }

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -172,7 +172,6 @@ where
                 tunnel: Arc::new(tunnel),
                 phoenix_channel: connection.sender_with_topic("client".to_owned()),
                 tunnel_init: Mutex::new(false),
-                system_dns_servers: callbacks.get_system_default_resolvers().ok().flatten(),
                 fallback_resolver: parking_lot::Mutex::new(None),
             };
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -141,9 +141,9 @@ class Adapter {
 
       self.logger.log("Adapter.start: Starting connlib")
       do {
-        // We can only the system's default resolvers before connlib starts, and then they'll
-        // be overwritten from the ones from connlib. So cache them here for getSystemDefaultResolvers
-        // retrieve them later.
+        // We can only get the system's default resolvers before connlib starts, and then they'll
+        // be overwritten by the ones from connlib. So cache them here for getSystemDefaultResolvers
+        // to retrieve them later.
         self.callbackHandler.setSystemDefaultResolvers(
           resolvers: Resolv().getservers().map(Resolv.getnameinfo)
         )

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -141,6 +141,12 @@ class Adapter {
 
       self.logger.log("Adapter.start: Starting connlib")
       do {
+        // We can only the system's default resolvers before connlib starts, and then they'll
+        // be overwritten from the ones from connlib. So cache them here for getSystemDefaultResolvers
+        // retrieve them later.
+        self.callbackHandler.setSystemDefaultResolvers(
+          resolvers: Resolv().getservers().map(Resolv.getnameinfo)
+        )
         self.state = .startingTunnel(
           session: try WrappedSession.connect(
             self.controlPlaneURLString,
@@ -332,6 +338,12 @@ extension Adapter {
       self.logger.log("Adapter.didReceivePathUpdate: Back online. Starting connlib.")
 
       do {
+        // We can only the system's default resolvers before connlib starts, and then they'll
+        // be overwritten from the ones from connlib. So cache them here for getSystemDefaultResolvers
+        // retrieve them later.
+        self.callbackHandler.setSystemDefaultResolvers(
+          resolvers: Resolv().getservers().map(Resolv.getnameinfo)
+        )
         self.state = .startingTunnel(
           session: try WrappedSession.connect(
             controlPlaneURLString,
@@ -537,11 +549,5 @@ extension Adapter: CallbackHandlerDelegate {
         }
       }
     }
-  }
-
-  public func getSystemDefaultResolvers() -> [String] {
-    let resolvers = Resolv().getservers().map(Resolv.getnameinfo)
-    self.logger.info("getSystemDefaultResolvers: \(resolvers)")
-    return resolvers
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -338,9 +338,9 @@ extension Adapter {
       self.logger.log("Adapter.didReceivePathUpdate: Back online. Starting connlib.")
 
       do {
-        // We can only the system's default resolvers before connlib starts, and then they'll
-        // be overwritten from the ones from connlib. So cache them here for getSystemDefaultResolvers
-        // retrieve them later.
+        // We can only get the system's default resolvers before connlib starts, and then they'll
+        // be overwritten by the ones from connlib. So cache them here for getSystemDefaultResolvers
+        // to retrieve them later.
         self.callbackHandler.setSystemDefaultResolvers(
           resolvers: Resolv().getservers().map(Resolv.getnameinfo)
         )

--- a/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
+++ b/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
@@ -26,11 +26,11 @@ public protocol CallbackHandlerDelegate: AnyObject {
   func onRemoveRoute(_: String)
   func onUpdateResources(resourceList: String)
   func onDisconnect(error: String?)
-  func getSystemDefaultResolvers() -> [String]
 }
 
 public class CallbackHandler {
   public weak var delegate: CallbackHandlerDelegate?
+  private var systemDefaultResolvers: RustString = "[]".intoRustString()
   private let logger = Logger.make(for: CallbackHandler.self)
 
   func onSetInterfaceConfig(
@@ -82,13 +82,25 @@ public class CallbackHandler {
     delegate?.onDisconnect(error: optionalError)
   }
 
-  func getSystemDefaultResolvers() -> RustString {
-    let resolvers = delegate?.getSystemDefaultResolvers() ?? []
-    logger.log("CallbackHandler.getSystemDefaultResolvers: \(resolvers, privacy: .public)")
+  func setSystemDefaultResolvers(resolvers: [String]) {
+    logger.log(
+      "CallbackHandler.setSystemDefaultResolvers: \(resolvers, privacy: .public)")
     do {
-      return try String(decoding: JSONEncoder().encode(resolvers), as: UTF8.self).intoRustString()
+      self.systemDefaultResolvers = try String(
+        decoding: JSONEncoder().encode(resolvers), as: UTF8.self
+      )
+      .intoRustString()
     } catch {
-      return "[]".intoRustString()
+      logger.log("CallbackHandler.setSystemDefaultResolvers: \(error, privacy: .public)")
+      self.systemDefaultResolvers = "[]".intoRustString()
     }
+  }
+
+  func getSystemDefaultResolvers() -> RustString {
+    logger.log(
+      "CallbackHandler.getSystemDefaultResolvers: \(self.systemDefaultResolvers, privacy: .public)"
+    )
+
+    return systemDefaultResolvers
   }
 }


### PR DESCRIPTION
Reverts firezone/firezone#3198

This was actually functioning well for non-Apple platforms. Marking as a draft until #3235 PR is opened

Fixes #3235 