### PR TITLE
fix(connection): set a `Connection`s remote-socket from WG activity

### DIFF
--- a/rust/connection-tests/src/main.rs
+++ b/rust/connection-tests/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(1)).await; // Until redis is up.
 
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::builder().parse("info,boringtun=debug")?)
+        .with_env_filter(EnvFilter::builder().parse("info,boringtun=debug,str0m=debug")?)
         .init();
 
     let role = std::env::var("ROLE")


### PR DESCRIPTION
It appears that sometimes, the dialer already considers the connection as connected whilst the other party is still finishing the ICE handshake. In that case, the dialer will start wireguard activity. Once the tunnel is fully established, the dialer will then start to send data which can lead to a `NotConnected` error in case the listener hasn't yet finished the handshake and updated the state. This is only a local inconsistency which we can fix by also updating the `remote_socket` field based on activity on the wireguard tunnel.

For future debugging, we also raise the log level of `str0m` to see the STUN messages that are being exchanged.

Fixes: #3178.
