### PR TITLE
fix(gateway): Fix gateway systemd command for non-bash shells

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -192,11 +192,11 @@ defmodule Web.Sites.NewToken do
 
   defp systemd_command(env) do
     """
-    ( function install-firezone {
+    ( install_firezone() {
 
     # Create firezone user and group
     sudo groupadd -f firezone
-    id -u firezone &>/dev/null || sudo useradd -r -g firezone -s /sbin/nologin firezone
+    id -u firezone > /dev/null 2>&1 || sudo useradd -r -g firezone -s /sbin/nologin firezone
 
     # Create systemd unit file
     cat << EOF | sudo tee /etc/systemd/system/firezone-gateway.service
@@ -298,7 +298,7 @@ defmodule Web.Sites.NewToken do
     sudo systemctl start firezone-gateway
 
     }
-    install-firezone )
+    install_firezone )
     """
   end
 


### PR DESCRIPTION
Fixes a couple issues detected when running the command under the plain POSIX shell `/bin/sh`.