### PR TITLE
fix(ci): Be explicit about which Docker platforms to pull and push for

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
 
           for image in "${IMAGES[@]}"; do
             SOURCE_TAG=${{ steps.login-staging.outputs.registry }}/firezone/${image}:${{ inputs.tag || github.sha }}
-            docker pull ${SOURCE_TAG}
+            docker pull --platform linux/amd64 ${SOURCE_TAG}
 
             echo "Retagging ${image} from ${SOURCE_TAG}"
 
@@ -156,7 +156,7 @@ jobs:
 
           for image in "${IMAGES[@]}"; do
             SOURCE_TAG=${{ steps.login.outputs.registry }}/firezone/${image}:${{ inputs.tag || github.sha }}
-            docker pull ${SOURCE_TAG}
+            docker pull --all-tags ${SOURCE_TAG}
 
             echo "Retagging ${image} from ${SOURCE_TAG}"
 


### PR DESCRIPTION
This was a subtle bug inserted when I updated our merge artifacts build to comply with the new API in the `actions/upload-artifact@v4` action #3100 

This was working before because the order in which the `docker buildx metadata` commands pushed digests to the registry happened to push `linux/amd64` first, causing that one to appear first in the manifest list, and therefore selected by default for pulls (docker doesn't automatically pull to match your platform). This meant that the `Publish` workflow pulled this image by default and it worked.

In the Publish workflow, we were issuing `docker pull` without the `--platform` specifier which was now automatically pulling the `linux/arm64` image which causes a segfault when run on `linux/amd64` docker without multi-arch support.

The permanent fix going forward is to always ensure `docker pull --platform` is set properly when pulling images for deployment.