### PR TITLE
fix(ci): Disable IPv6 in Docker-based integration tests due to flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,6 +418,6 @@ jobs:
       - name: Show API logs
         if: "!cancelled()"
         run: docker compose logs api
-      - name: Show httpbin logs
+      - name: Show iperf3 logs
         if: "!cancelled()"
-        run: docker compose logs httpbin
+        run: docker compose logs iperf3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -361,15 +361,16 @@ services:
     networks:
       - app
 
+# IPv6 is currently causing flakiness with GH actions and on our testbed.
+# Disabling until there's more time to debug.
 networks:
   resources:
-    enable_ipv6: true
+    # enable_ipv6: true
     ipam:
       config:
         - subnet: 172.20.0.0/24
-        - subnet: fc00:ff:1::/48
+          # - subnet: fc00:ff:1::/48
   app:
-    # Currently not working on testbed
     # enable_ipv6: true
     ipam:
       config:


### PR DESCRIPTION
Getting IPv6-related timeouts and flakiness. It's disabled for the testbed and the connection tests so following suit here since we don't have tests that use IPv6.