### PR TITLE
fix(ci): Revert runtime to musl

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,17 +113,17 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             shortname: x64
             platform: linux/amd64
-          - target: aarch64-unknown-linux-gnu # E.g. AWS Graviton
+          - target: aarch64-unknown-linux-musl # E.g. AWS Graviton
             shortname: arm64
             platform: linux/arm64
-          - target: armv7-unknown-linux-gnueabihf # E.g. Raspberry Pi
+          - target: armv7-unknown-linux-musleabihf # E.g. Raspberry Pi
             platform: linux/arm/v7
             shortname: arm
           # Requires ring v0.17 which a number of our dependencies don't yet support
-          # - target: mips64-unknown-linux-gnuabi64 # E.g. UniFi Routers
+          # - target: mips64-unknown-linux-muslabi64 # E.g. UniFi Routers
           #   platform: linux/mips64le
         name:
           - package: firezone-linux-client
@@ -141,14 +141,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
-          targets: aarch64-unknown-linux-gnu armv7-unknown-linux-gnueabihf x86_64-unknown-linux-gnu
+          targets: aarch64-unknown-linux-musl armv7-unknown-linux-musleabihf x86_64-unknown-linux-musl
       - uses: taiki-e/install-action@v2
         with:
           tool: cross
       - name: Build release binaries
-        env:
-          # Enable statically-linked libc runtime
-          RUSTFLAGS: "-C target-feature=+crt-static"
         run: |
           set -xe
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,8 +2,8 @@
 ARG DEBIAN_VERSION="12-slim"
 ARG CARGO_CHEF_VERSION="0.1.62"
 ARG RUSTUP_VERSION="1.26.0"
-ARG RUSTUP_x86_DOWNLOAD_SHA256="0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db"
-ARG RUSTUP_aarch64_DOWNLOAD_SHA256="673e336c81c65e6b16dcdede33f4cc9ed0f08bde1dbe7a935f113605292dc800"
+ARG RUSTUP_x86_DOWNLOAD_SHA256="7aa9e2a380a9958fc1fc426a3323209b2c86181c6816640979580f62ff7d48d4"
+ARG RUSTUP_aarch64_DOWNLOAD_SHA256="b1962dfc18e1fd47d01341e6897cace67cddfabf547ef394e8883939bd6e002e"
 ARG RUST_VERSION="1.74.1"
 
 FROM debian:${DEBIAN_VERSION} as rust
@@ -38,8 +38,8 @@ ARG RUST_VERSION
 RUN set -eux; \
   arch="$(uname -m)"; \
   case "$arch" in \
-  x86_64) rustTarget='x86_64-unknown-linux-gnu'; rustupSha256=${RUSTUP_x86_DOWNLOAD_SHA256} ;; \
-  aarch64) rustTarget='aarch64-unknown-linux-gnu'; rustupSha256=${RUSTUP_aarch64_DOWNLOAD_SHA256} ;; \
+  x86_64) rustTarget='x86_64-unknown-linux-musl'; rustupSha256=${RUSTUP_x86_DOWNLOAD_SHA256} ;; \
+  aarch64) rustTarget='aarch64-unknown-linux-musl'; rustupSha256=${RUSTUP_aarch64_DOWNLOAD_SHA256} ;; \
   *) echo >&2 "unsupported architecture: $arch"; exit 1 ;; \
   esac; \
   url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustTarget}/rustup-init"; \


### PR DESCRIPTION
Turns out #3276 was only part of the problem. After that was fixed, the issue did turn out to be the statically-linked libc runtime. Staging was using dynamic linking and so didn't hit the issue.

This reverts back to musl which has been tested as @AndrewDryga noted.