### PR TITLE
feat: dynamically configure network & redis for LAN integration test

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -120,11 +120,11 @@ ENV PACKAGE=${PACKAGE}
 
 CMD $PACKAGE
 
-# Build an image for GitHub Actions which includes debug asserts
+# Build an image for GitHub Actions which includes debug asserts and test utilities
 FROM runtime AS debug
 
 RUN set -xe \
-  && apk add --no-cache iperf3
+  && apk add --no-cache iperf3 jq
 
 ARG TARGET
 COPY --from=builder /build/target/${TARGET}/debug/${PACKAGE} .

--- a/rust/connection-tests/docker-compose.lan.yml
+++ b/rust/connection-tests/docker-compose.lan.yml
@@ -1,4 +1,5 @@
 version: "3.8"
+name: lan-integration-test
 
 services:
   dialer:
@@ -13,16 +14,23 @@ services:
     init: true
     environment:
       ROLE: "dialer"
-      REDIS_HOST: redis # All services share the `app` network.
     cap_add:
       - NET_ADMIN
-    # depends_on:
-    #   relay:
-    #     condition: "service_healthy"
-    #   redis:
-    #     condition: "service_healthy"
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        set -ex
+
+        export REDIS_HOST=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/containers/lan-integration-test-redis-1/json | jq -r '.NetworkSettings.Networks."lan-integration-test_app".IPAddress')
+
+        firezone-connection-tests
+    depends_on:
+      - redis
     networks:
       - app
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
   listener:
     build:
@@ -36,62 +44,31 @@ services:
     init: true
     environment:
       ROLE: "listener"
-      REDIS_HOST: redis # All services share the `app` network.
     cap_add:
       - NET_ADMIN
-    # depends_on:
-    #   relay:
-    #     condition: "service_healthy"
-    #   redis:
-    #     condition: "service_healthy"
-    networks:
-      app:
-        ipv4_address: 172.28.0.101
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        set -ex
 
-  # relay:
-  #   environment:
-  #     PUBLIC_IP4_ADDR: 172.28.0.102
-  #     PUBLIC_IP6_ADDR: fcff:3990:3990::101
-  #     LOWEST_PORT: 55555
-  #     HIGHEST_PORT: 55666
-  #     RUST_LOG: "debug"
-  #     RUST_BACKTRACE: 1
-  #   build:
-  #     target: debug
-  #     context: ..
-  #     cache_from:
-  #       - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
-  #     args:
-  #       PACKAGE: firezone-relay
-  #   init: true
-  #   healthcheck:
-  #     Poor man's netstat -- Check for listening on 3478 (D96 in hex)
-  #     test: ["CMD-SHELL", "cat /proc/net/udp | grep D96"]
-  #     start_period: 20s
-  #     interval: 30s
-  #     retries: 5
-  #     timeout: 5s
-  #   ports:
-  #     # XXX: Only 111 ports are used for local dev / testing because Docker Desktop
-  #     # allocates a userland proxy process for each forwarded port X_X.
-  #     #
-  #     # Large ranges here will bring your machine to its knees.
-  #     - "55555-55666:55555-55666/udp"
-  #     - 3478:3478/udp
-  #   networks:
-  #     app:
-  #       ipv4_address: 172.28.0.102
+        export REDIS_HOST=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/containers/lan-integration-test-redis-1/json | jq -r '.NetworkSettings.Networks."lan-integration-test_app".IPAddress')
+
+        firezone-connection-tests
+    depends_on:
+      - redis
+    networks:
+      - app
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
   redis:
     image: "redis:7-alpine"
-    # healthcheck:
-    #   test: ["CMD-SHELL", "echo 'ready';"]
+    healthcheck:
+      test: ["CMD-SHELL", "echo 'ready';"]
     networks:
       - app
 
 networks:
   app:
    # enable_ipv6: true Disable until we find a workaround for https://github.com/moby/moby/issues/41438.
-     ipam:
-      config:
-        - subnet: 172.28.0.0/24

--- a/rust/connection-tests/src/main.rs
+++ b/rust/connection-tests/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     net::Ipv4Addr,
     str::FromStr,
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use anyhow::{bail, Context as _, Result};
@@ -23,8 +23,6 @@ const MAX_UDP_SIZE: usize = (1 << 16) - 1;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tokio::time::sleep(Duration::from_secs(1)).await; // Until redis is up.
-
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::builder().parse("info,boringtun=debug,str0m=debug")?)
         .init();


### PR DESCRIPTION
This also uses the docker healthcheck again for the redis container.