### PR TITLE
refactor(windows): give name to worker thread

### DIFF
--- a/rust/connlib/tunnel/src/device_channel/tun_windows.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_windows.rs
@@ -130,7 +130,7 @@ impl Tun {
 
         let (packet_tx, packet_rx) = mpsc::channel(5);
 
-        let recv_thread = start_recv_thread(packet_tx, Arc::clone(&session));
+        let recv_thread = start_recv_thread(packet_tx, Arc::clone(&session))?;
         let packet_rx = std::sync::Mutex::new(packet_rx);
 
         Ok(Self {
@@ -228,27 +228,29 @@ impl Tun {
 fn start_recv_thread(
     packet_tx: mpsc::Sender<wintun::Packet>,
     session: Arc<wintun::Session>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::spawn(move || {
-        loop {
-            match session.receive_blocking() {
-                Ok(pkt) => {
-                    // TODO: Don't allocate here if we can help it
-                    if packet_tx.blocking_send(pkt).is_err() {
-                        // Most likely the receiver was dropped and we're closing down the connlib session.
+) -> io::Result<std::thread::JoinHandle<()>> {
+    std::thread::Builder::new()
+        .name("Firezone wintun worker".into())
+        .spawn(move || {
+            loop {
+                match session.receive_blocking() {
+                    Ok(pkt) => {
+                        // TODO: Don't allocate here if we can help it
+                        if packet_tx.blocking_send(pkt).is_err() {
+                            // Most likely the receiver was dropped and we're closing down the connlib session.
+                            break;
+                        }
+                    }
+                    // We get an Error::String when `Session::shutdown` is called
+                    Err(wintun::Error::String(_)) => break,
+                    Err(e) => {
+                        tracing::error!("wintun::Session::receive_blocking: {e:#?}");
                         break;
                     }
                 }
-                // We get an Error::String when `Session::shutdown` is called
-                Err(wintun::Error::String(_)) => break,
-                Err(e) => {
-                    tracing::error!("wintun::Session::receive_blocking: {e:#?}");
-                    break;
-                }
             }
-        }
-        tracing::debug!("recv_task exiting gracefully");
-    })
+            tracing::debug!("recv_task exiting gracefully");
+        })
 }
 
 /// Sets MTU on the interface


### PR DESCRIPTION
This came up while dealing with the COM stuff for #3000, but it's out of scope, so I made it its own PR.