### PR TITLE
fix(connlib): handle expiration messages correctly

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -1,4 +1,5 @@
 use async_compression::tokio::bufread::GzipEncoder;
+use connlib_shared::control::ChannelError;
 use connlib_shared::control::KnownError;
 use connlib_shared::control::Reason;
 use connlib_shared::messages::{DnsServer, GatewayResponse, IpDnsServer};
@@ -12,7 +13,7 @@ use crate::messages::{
     GatewayIceCandidates, InitClient, Messages,
 };
 use connlib_shared::{
-    control::{ErrorInfo, ErrorReply, PhoenixSenderWithTopic, Reference},
+    control::{ErrorInfo, PhoenixSenderWithTopic, Reference},
     messages::{GatewayId, ResourceDescription, ResourceId},
     Callbacks,
     Error::{self},
@@ -271,12 +272,12 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
     #[tracing::instrument(level = "trace", skip(self))]
     pub async fn handle_error(
         &mut self,
-        reply_error: ErrorReply,
+        reply_error: ChannelError,
         reference: Option<Reference>,
         topic: String,
     ) -> Result<()> {
-        match (reply_error.error, reference) {
-            (ErrorInfo::Offline, Some(reference)) => {
+        match (reply_error, reference) {
+            (ChannelError::ErrorReply(ErrorInfo::Offline), Some(reference)) => {
                 let Ok(resource_id) = reference.parse::<ResourceId>() else {
                     tracing::warn!("The portal responded with an Offline error. Is the Resource associated with any online Gateways or Relays?");
                     return Ok(());
@@ -284,12 +285,23 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                 // TODO: Rate limit the number of attempts of getting the relays before just trying a local network connection
                 self.tunnel.cleanup_connection(resource_id);
             }
-            (ErrorInfo::Reason(Reason::Known(KnownError::UnmatchedTopic)), _) => {
+            (
+                ChannelError::ErrorReply(ErrorInfo::Reason(Reason::Known(
+                    KnownError::UnmatchedTopic,
+                ))),
+                _,
+            ) => {
                 if let Err(e) = self.phoenix_channel.get_sender().join_topic(topic).await {
                     tracing::debug!(err = ?e, "couldn't join topic: {e:#?}");
                 }
             }
-            (ErrorInfo::Reason(Reason::Known(KnownError::TokenExpired)), _) => {
+            (
+                ChannelError::ErrorReply(ErrorInfo::Reason(Reason::Known(
+                    KnownError::TokenExpired,
+                ))),
+                _,
+            )
+            | (ChannelError::ErrorMsg(Error::TokenExpired), _) => {
                 return Err(Error::TokenExpired);
             }
             _ => {}

--- a/rust/connlib/shared/src/control.rs
+++ b/rust/connlib/shared/src/control.rs
@@ -592,7 +592,7 @@ mod tests {
           "ref": null,
           "topic": "client",
           "payload": {}
-        }        
+        }
         "#;
         let actual_reply: Payload<(), ()> = serde_json::from_str(actual_reply).unwrap();
         let expected_reply =

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -153,6 +153,8 @@ pub enum ConnlibError {
     TokenExpired,
     #[error("Too many concurrent gateway connection requests")]
     TooManyConnectionRequests,
+    #[error("Channel connection closed by portal")]
+    ClosedByPortal,
 }
 
 impl ConnlibError {


### PR DESCRIPTION
While working on #3288 I saw a few messages that we don't explicitly handle from the portal.

This PR changes it so that we handle them correctly and we don't just depend on coincidental behavior..