### PR TITLE
Fix dns bad nxdomain

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1221,6 +1221,7 @@ dependencies = [
  "base64 0.21.7",
  "boringtun",
  "chrono",
+ "dns-lookup",
  "domain",
  "futures",
  "futures-util",
@@ -1632,6 +1633,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "dns-lookup"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2 0.5.5",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2057,6 +2070,7 @@ dependencies = [
  "bytes",
  "chrono",
  "connlib-shared",
+ "dns-lookup",
  "domain",
  "futures",
  "futures-bounded",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,6 +30,7 @@ webrtc = "0.9"
 str0m = "0.4"
 futures-bounded = "0.2.1"
 domain = { version = "0.9", features = ["serde"] }
+dns-lookup = "2.0"
 
 connlib-client-android = { path = "connlib/clients/android"}
 connlib-client-apple = { path = "connlib/clients/apple"}

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -37,6 +37,7 @@ ring = "0.17"
 hickory-resolver = { workspace = true }
 domain = { workspace = true }
 libc = "0.2"
+dns-lookup = { workspace = true }
 
 # Needed for Android logging until tracing is working
 log = "0.4"

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -29,6 +29,7 @@ futures-bounded = { workspace = true }
 hickory-resolver = { workspace = true }
 arc-swap = "1.6.0"
 bimap = "0.6"
+dns-lookup = { workspace = true }
 
 # TODO: research replacing for https://github.com/algesten/str0m
 webrtc = { workspace = true }

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -13,7 +13,6 @@ use connlib_shared::{
     },
     Callbacks, Dname, Error, Result,
 };
-use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
 use ip_network::IpNetwork;
 use std::{net::ToSocketAddrs, sync::Arc};
 use webrtc::ice_transport::{
@@ -288,6 +287,9 @@ fn resolve_addresses(addr: &str) -> std::io::Result<Vec<IpNetwork>> {
         (Err(e), Err(_)) => Err(e),
     }
 }
+
+#[cfg(not(target_os = "windows"))]
+use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
 
 #[cfg(not(target_os = "windows"))]
 fn resolve_address_family(

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -103,6 +103,8 @@ where
                     return Err(Error::InvalidResource);
                 }
 
+                // TODO: we should make this async, this is acceptable for now though
+                // in the future we will use hickory-resolver for this anyways.
                 resolve_addresses(&domain.to_string())?
             }
             ResourceDescription::Cidr(ref cidr) => vec![cidr.address],

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -264,6 +264,12 @@ where
     }
 }
 
+#[cfg(target_os = "windows")]
+fn resolve_addresses(_: &str) -> std::io::Result<Vec<IpNetwork>> {
+    unimplemented!()
+}
+
+#[cfg(not(target_os = "windows"))]
 fn resolve_addresses(addr: &str) -> std::io::Result<Vec<IpNetwork>> {
     let addr_v4: std::io::Result<Vec<_>> = resolve_address_family(addr, AF_INET)
         .map_err(|e| e.into())

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -15,7 +15,6 @@ use connlib_shared::{
 };
 use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
 use ip_network::IpNetwork;
-use libc::{AF_INET, AF_INET6, SOCK_STREAM};
 use std::{net::ToSocketAddrs, sync::Arc};
 use webrtc::ice_transport::{
     ice_role::RTCIceRole, ice_transport_state::RTCIceTransportState, RTCIceTransport,
@@ -271,6 +270,7 @@ fn resolve_addresses(_: &str) -> std::io::Result<Vec<IpNetwork>> {
 
 #[cfg(not(target_os = "windows"))]
 fn resolve_addresses(addr: &str) -> std::io::Result<Vec<IpNetwork>> {
+    use libc::{AF_INET, AF_INET6};
     let addr_v4: std::io::Result<Vec<_>> = resolve_address_family(addr, AF_INET)
         .map_err(|e| e.into())
         .and_then(|a| a.collect());
@@ -289,10 +289,13 @@ fn resolve_addresses(addr: &str) -> std::io::Result<Vec<IpNetwork>> {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 fn resolve_address_family(
     addr: &str,
     family: i32,
 ) -> std::result::Result<AddrInfoIter, LookupError> {
+    use libc::SOCK_STREAM;
+
     dns_lookup::getaddrinfo(
         Some(addr),
         None,


### PR DESCRIPTION
Some dns servers return NXDOMAIN for queries where the address exists but there is no
answer for the given query type(e.g. AAAA-only records). This is not up to spec and
musl PROPERLY assumes that means there is no record of any type. Saddly, this happens even
with google DNS so we can expect it to happen everywhere. So we use getaddrinfo to separate
requests for A and AAAA queries and preventing this.

Seems to work locally, though the exact situation where we have a record that returns NXDOMAIN while it exists is easier to reproduce in staging, we should test it after we merge.

Fixes #3215 