### PR TITLE
Fix radio button toggle on Sites edit page

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/edit.ex
+++ b/elixir/apps/web/lib/web/live/sites/edit.ex
@@ -55,7 +55,9 @@ defmodule Web.Sites.Edit do
                       field={@form[:routing]}
                       value="managed"
                       label={pretty_print_routing(:managed)}
-                      checked={@form[:routing].value == :managed}
+                      checked={
+                        @form[:routing].value == :managed || @form[:routing].value == "managed"
+                      }
                       required
                     >
                       <.badge
@@ -78,7 +80,9 @@ defmodule Web.Sites.Edit do
                       field={@form[:routing]}
                       value="stun_only"
                       label={pretty_print_routing(:stun_only)}
-                      checked={@form[:routing].value == :stun_only}
+                      checked={
+                        @form[:routing].value == :stun_only || @form[:routing].value == "stun_only"
+                      }
                       required
                     />
                     <p class="ml-6 mb-4 text-sm text-neutral-500">


### PR DESCRIPTION
Why:

* The Sites edit page was toggling the routing option in the page on and off every time a change to the page was made (i.e. every time something was clicked or typed).  This was causing the Site to not be editable in certain situations.  It ended up being because the form field value being set was not consistently the same type.  It would come back as either an atom or a string, but the radio button input was only checking for atoms.

Fixes: #3239