### PR TITLE
fix(portal): Allow users to manually provision OIDC users

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/openid_connect.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/openid_connect.ex
@@ -126,6 +126,8 @@ defmodule Domain.Auth.Adapters.OpenIDConnect do
       |> Repo.fetch_and_update(
         with: fn identity ->
           Identity.Changeset.update_identity_provider_state(identity, identity_state)
+          # if an email was used in provider identifier and it's replaced by sub claim
+          # later, we want to use the ID from sub claim as provider_identifier
           |> Ecto.Changeset.put_change(:provider_identifier, provider_identifier)
         end
       )

--- a/elixir/apps/domain/test/support/mocks/openid_connect.ex
+++ b/elixir/apps/domain/test/support/mocks/openid_connect.ex
@@ -153,13 +153,14 @@ defmodule Domain.Mocks.OpenIDConnect do
     claims =
       Map.merge(
         %{
-          "email" => identity.provider_identifier,
+          "email" => identity.provider_identifier <> "@example.com",
           "sub" => identity.provider_identifier,
           "aud" => provider.adapter_config["client_id"],
           "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix()
         },
         claims
       )
+      |> Map.filter(fn {_, v} -> not is_nil(v) end)
 
     {sign_openid_connect_token(claims), claims}
   end

--- a/elixir/apps/web/lib/web/live/actors/components.ex
+++ b/elixir/apps/web/lib/web/live/actors/components.ex
@@ -125,6 +125,27 @@ defmodule Web.Actors.Components do
     """
   end
 
+  def provider_form(%{provider: %{adapter: :openid_connect}} = assigns) do
+    ~H"""
+    <div>
+      <.input
+        label="Email or Sub claim"
+        placeholder="Email or Sub claim"
+        field={@form[:provider_identifier]}
+        autocomplete="off"
+      />
+    </div>
+    <div>
+      <.input
+        label="Email or Sub claim Confirmation"
+        placeholder="Email or Sub claim Confirmation"
+        field={@form[:provider_identifier_confirmation]}
+        autocomplete="off"
+      />
+    </div>
+    """
+  end
+
   def provider_form(%{provider: %{adapter: :userpass}} = assigns) do
     ~H"""
     <div>

--- a/elixir/apps/web/lib/web/live/actors/components.ex
+++ b/elixir/apps/web/lib/web/live/actors/components.ex
@@ -129,16 +129,20 @@ defmodule Web.Actors.Components do
     ~H"""
     <div>
       <.input
-        label="Email or Sub claim"
-        placeholder="Email or Sub claim"
+        label="Email"
+        placeholder="Email"
         field={@form[:provider_identifier]}
         autocomplete="off"
       />
+      <p class="mt-2 text-xs text-neutral-500">
+        The token <code>sub</code> claim value or userinfo <code>email</code> value.
+        This will be used to match the user to this identity when signing in for the first time.
+      </p>
     </div>
     <div>
       <.input
-        label="Email or Sub claim Confirmation"
-        placeholder="Email or Sub claim Confirmation"
+        label="Email Confirmation"
+        placeholder="Email Confirmation"
         field={@form[:provider_identifier_confirmation]}
         autocomplete="off"
       />

--- a/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
+++ b/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
@@ -5,8 +5,15 @@ defmodule Web.Live.Actors.User.NewIdentityTest do
     Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
-    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
     provider = Fixtures.Auth.create_email_provider(account: account)
+
+    actor =
+      Fixtures.Actors.create_actor(
+        type: :account_admin_user,
+        account: account,
+        provider: provider
+      )
+
     identity = Fixtures.Auth.create_identity(account: account, provider: provider, actor: actor)
 
     %{


### PR DESCRIPTION
Before, any user logging into via the OIDC connector would need to have an identity created beforehand with their known `sub` id. This presented a chicken-and-egg scenario where this was only populated in the `Identity Providers` settings flow by an admin, preventing regular users from signing in.

With this change, Admins can now create identities for actors and specify an `email` address or `sub` claim value to match against for incoming authentications to the connector.

This will allow end-users to authenticate with the configured OIDC connector.

Fixes #3308 