### PR TITLE
Add dynamic/managed groups and default Everyone one

### DIFF
--- a/elixir/apps/domain/lib/domain/actors.ex
+++ b/elixir/apps/domain/lib/domain/actors.ex
@@ -393,7 +393,7 @@ defmodule Domain.Actors do
       |> Repo.fetch_and_update(
         with: fn actor ->
           actor = maybe_preload_not_synced_memberships(actor, attrs)
-          synced_groups = list_not_editable_groups(attrs)
+          synced_groups = list_readonly_groups(attrs)
           changeset = Actor.Changeset.update(actor, attrs, synced_groups, subject)
 
           after_commit_cb = fn _group ->
@@ -432,7 +432,7 @@ defmodule Domain.Actors do
     end
   end
 
-  defp list_not_editable_groups(attrs) do
+  defp list_readonly_groups(attrs) do
     (Map.get(attrs, "memberships") || Map.get(attrs, :memberships) || [])
     |> Enum.flat_map(fn membership ->
       if group_id = Map.get(membership, "group_id") || Map.get(membership, :group_id) do

--- a/elixir/apps/domain/lib/domain/actors/actor/query.ex
+++ b/elixir/apps/domain/lib/domain/actors/actor/query.ex
@@ -10,6 +10,10 @@ defmodule Domain.Actors.Actor.Query do
     |> where([actors: actors], is_nil(actors.deleted_at))
   end
 
+  def not_disabled(queryable \\ not_deleted()) do
+    where(queryable, [actors: actors], is_nil(actors.disabled_at))
+  end
+
   def by_id(queryable \\ not_deleted(), id)
 
   def by_id(queryable, {:in, ids}) do
@@ -32,10 +36,6 @@ defmodule Domain.Actors.Actor.Query do
     where(queryable, [actors: actors], actors.type == ^type)
   end
 
-  def not_disabled(queryable \\ not_deleted()) do
-    where(queryable, [actors: actors], is_nil(actors.disabled_at))
-  end
-
   def preload_few_groups_for_each_actor(queryable \\ not_deleted(), limit) do
     queryable
     |> with_joined_memberships(limit)
@@ -46,6 +46,12 @@ defmodule Domain.Actors.Actor.Query do
       count: group_counts.count,
       item: groups
     })
+  end
+
+  def select_distinct_ids(queryable) do
+    queryable
+    |> select([actors: actors], actors.id)
+    |> distinct(true)
   end
 
   def with_joined_memberships(queryable, limit) do

--- a/elixir/apps/domain/lib/domain/actors/group.ex
+++ b/elixir/apps/domain/lib/domain/actors/group.ex
@@ -13,7 +13,7 @@ defmodule Domain.Actors.Group do
       foreign_key: :actor_group_id,
       where: [deleted_at: nil]
 
-    embeds_many :membership_rules, Domain.Actors.MembershipRule
+    embeds_many :membership_rules, Domain.Actors.MembershipRule, on_replace: :delete
     has_many :memberships, Domain.Actors.Membership, on_replace: :delete
 
     # TODO: where doesn't work on join tables so soft-deleted records will be preloaded,

--- a/elixir/apps/domain/lib/domain/actors/group.ex
+++ b/elixir/apps/domain/lib/domain/actors/group.ex
@@ -3,6 +3,7 @@ defmodule Domain.Actors.Group do
 
   schema "actor_groups" do
     field :name, :string
+    field :type, Ecto.Enum, values: ~w[managed dynamic static]a
 
     # Those fields will be set for groups we synced from IdP's
     belongs_to :provider, Domain.Auth.Provider
@@ -12,12 +13,14 @@ defmodule Domain.Actors.Group do
       foreign_key: :actor_group_id,
       where: [deleted_at: nil]
 
+    embeds_many :membership_rules, Domain.Actors.MembershipRule
     has_many :memberships, Domain.Actors.Membership, on_replace: :delete
+
     # TODO: where doesn't work on join tables so soft-deleted records will be preloaded,
     # ref https://github.com/firezone/firezone/issues/2162
     has_many :actors, through: [:memberships, :actor]
 
-    field :created_by, Ecto.Enum, values: ~w[identity provider]a
+    field :created_by, Ecto.Enum, values: ~w[system identity provider]a
     belongs_to :created_by_identity, Domain.Auth.Identity
 
     belongs_to :account, Domain.Accounts.Account

--- a/elixir/apps/domain/lib/domain/actors/group/changeset.ex
+++ b/elixir/apps/domain/lib/domain/actors/group/changeset.ex
@@ -13,21 +13,32 @@ defmodule Domain.Actors.Group.Changeset do
 
   def create(%Accounts.Account{} = account, attrs, %Auth.Subject{} = subject) do
     %Actors.Group{memberships: []}
-    |> cast(attrs, ~w[name]a)
-    |> validate_required(~w[name]a)
+    |> cast(attrs, ~w[name type]a)
+    |> validate_required(~w[name type]a)
+    |> validate_inclusion(:type, ~w[dynamic static]a)
     |> changeset()
     |> put_change(:account_id, account.id)
-    |> cast_assoc(:memberships,
-      with: &Actors.Membership.Changeset.for_group(account.id, &1, &2)
-    )
+    |> cast_membership_assocs(account.id)
     |> put_change(:created_by, :identity)
     |> put_change(:created_by_identity_id, subject.identity.id)
+  end
+
+  def create(%Accounts.Account{} = account, attrs) do
+    %Actors.Group{memberships: []}
+    |> cast(attrs, ~w[name]a)
+    |> validate_required(~w[name]a)
+    |> put_change(:type, :managed)
+    |> changeset()
+    |> put_change(:account_id, account.id)
+    |> cast_membership_assocs(account.id)
+    |> put_change(:created_by, :system)
   end
 
   def create(%Auth.Provider{} = provider, attrs) do
     %Actors.Group{memberships: []}
     |> cast(attrs, ~w[name provider_identifier]a)
     |> validate_required(~w[name provider_identifier]a)
+    |> put_change(:type, :static)
     |> changeset()
     |> put_change(:provider_id, provider.id)
     |> put_change(:account_id, provider.account_id)
@@ -38,10 +49,9 @@ defmodule Domain.Actors.Group.Changeset do
     group
     |> cast(attrs, ~w[name]a)
     |> validate_required(~w[name]a)
+    |> validate_inclusion(:type, ~w[dynamic static]a)
     |> changeset()
-    |> cast_assoc(:memberships,
-      with: &Actors.Membership.Changeset.for_group(group.account_id, &1, &2)
-    )
+    |> cast_membership_assocs(group.account_id)
   end
 
   defp changeset(changeset) do
@@ -49,5 +59,23 @@ defmodule Domain.Actors.Group.Changeset do
     |> trim_change(:name)
     |> validate_length(:name, min: 1, max: 64)
     |> unique_constraint(:name, name: :actor_groups_account_id_name_index)
+  end
+
+  defp cast_membership_assocs(changeset, account_id) do
+    case fetch_field(changeset, :type) do
+      {_data_or_changes, :static} ->
+        cast_assoc(changeset, :memberships,
+          with: &Actors.Membership.Changeset.for_group(account_id, &1, &2)
+        )
+
+      {_data_or_changes, type} when type in [:dynamic, :managed] ->
+        cast_embed(changeset, :membership_rules,
+          with: &Actors.MembershipRule.Changeset.changeset(&1, &2)
+        )
+
+
+      _other ->
+        changeset
+    end
   end
 end

--- a/elixir/apps/domain/lib/domain/actors/group/query.ex
+++ b/elixir/apps/domain/lib/domain/actors/group/query.ex
@@ -10,6 +10,14 @@ defmodule Domain.Actors.Group.Query do
     |> where([groups: groups], is_nil(groups.deleted_at))
   end
 
+  def not_editable(queryable \\ not_deleted()) do
+    where(queryable, [groups: groups], not is_nil(groups.provider_id) or groups.type != :static)
+  end
+
+  def editable(queryable \\ not_deleted()) do
+    where(queryable, [groups: groups], is_nil(groups.provider_id) and groups.type == :static)
+  end
+
   def by_id(queryable \\ not_deleted(), id)
 
   def by_id(queryable, {:in, ids}) do
@@ -20,16 +28,22 @@ defmodule Domain.Actors.Group.Query do
     where(queryable, [groups: groups], groups.id == ^id)
   end
 
+  def by_type(queryable \\ not_deleted(), type)
+
+  def by_type(queryable, {:in, types}) do
+    where(queryable, [groups: groups], groups.type in ^types)
+  end
+
+  def by_type(queryable, type) do
+    where(queryable, [groups: groups], groups.type == ^type)
+  end
+
   def by_account_id(queryable \\ not_deleted(), account_id) do
     where(queryable, [groups: groups], groups.account_id == ^account_id)
   end
 
   def by_provider_id(queryable \\ not_deleted(), provider_id) do
     where(queryable, [groups: groups], groups.provider_id == ^provider_id)
-  end
-
-  def by_not_empty_provider_id(queryable \\ not_deleted()) do
-    where(queryable, [groups: groups], not is_nil(groups.provider_id))
   end
 
   def by_provider_identifier(queryable \\ not_deleted(), provider_identifier)

--- a/elixir/apps/domain/lib/domain/actors/group/sync.ex
+++ b/elixir/apps/domain/lib/domain/actors/group/sync.ex
@@ -77,6 +77,7 @@ defmodule Domain.Actors.Group.Sync do
     provider_identifiers_to_upsert
     |> Enum.reduce_while({:ok, []}, fn provider_identifier, {:ok, acc} ->
       attrs = Map.get(attrs_by_provider_identifier, provider_identifier)
+      attrs = Map.put(attrs, "type", :managed)
 
       case upsert_group(repo, provider, attrs) do
         {:ok, group} ->

--- a/elixir/apps/domain/lib/domain/actors/membership_rule.ex
+++ b/elixir/apps/domain/lib/domain/actors/membership_rule.ex
@@ -3,7 +3,7 @@ defmodule Domain.Actors.MembershipRule do
 
   @primary_key false
   embedded_schema do
-    # `true` is a special operator which allows to select all account users
+    # `true` is a special operator which allows to select all account identities
     field :operator, Ecto.Enum, values: ~w[true contains does_not_contain is_in is_not_in]a
 
     field :path, {:array, :string}

--- a/elixir/apps/domain/lib/domain/actors/membership_rule.ex
+++ b/elixir/apps/domain/lib/domain/actors/membership_rule.ex
@@ -1,0 +1,12 @@
+defmodule Domain.Actors.MembershipRule do
+  use Domain, :schema
+
+  @primary_key false
+  embedded_schema do
+    field :operator, Ecto.Enum,
+      values: ~w[all_users equals_to does_not_equal_to contains does_not_contain is_in is_not_in]a
+
+    field :jsonpath, :string
+    field :value, :string
+  end
+end

--- a/elixir/apps/domain/lib/domain/actors/membership_rule.ex
+++ b/elixir/apps/domain/lib/domain/actors/membership_rule.ex
@@ -3,10 +3,10 @@ defmodule Domain.Actors.MembershipRule do
 
   @primary_key false
   embedded_schema do
-    field :operator, Ecto.Enum,
-      values: ~w[all_users equals_to does_not_equal_to contains does_not_contain is_in is_not_in]a
+    # `true` is a special operator which allows to select all account users
+    field :operator, Ecto.Enum, values: ~w[true contains does_not_contain is_in is_not_in]a
 
-    field :jsonpath, :string
-    field :value, :string
+    field :path, {:array, :string}
+    field :values, {:array, :string}
   end
 end

--- a/elixir/apps/domain/lib/domain/actors/membership_rule/changeset.ex
+++ b/elixir/apps/domain/lib/domain/actors/membership_rule/changeset.ex
@@ -2,7 +2,7 @@ defmodule Domain.Actors.MembershipRule.Changeset do
   use Domain, :changeset
   alias Domain.Actors.MembershipRule
 
-  @fields ~w[operator jsonpath value]a
+  @fields ~w[operator path values]a
 
   def changeset(membership_rule \\ %MembershipRule{}, attrs) do
     membership_rule
@@ -12,15 +12,33 @@ defmodule Domain.Actors.MembershipRule.Changeset do
 
   defp validate_rule(changeset) do
     case fetch_field(changeset, :operator) do
-      {_data_or_changes, :all_users} ->
-        validate_required(changeset, ~w[operator]a)
+      {_data_or_changes, true} ->
+        changeset
+        |> validate_required(~w[operator]a)
+        |> delete_change(:path)
+        |> delete_change(:values)
+
+      {_data_or_changes, operator} when operator in [:contains, :does_not_contain] ->
+        changeset
+        |> validate_required(@fields)
+        |> validate_path()
+        |> validate_length(:values, min: 1, max: 1)
 
       _other ->
         changeset
         |> validate_required(@fields)
-        |> validate_format(:jsonpath, ~r/^\$\.(claims|userinfo)\./,
-          message: "only $.claims. or $.userinfo. fields are currently supported"
-        )
+        |> validate_path()
+        |> validate_length(:values, min: 1, max: 32)
     end
+  end
+
+  defp validate_path(changeset) do
+    validate_change(changeset, :path, fn
+      :path, [head | _tail] when head in ["claims", "userinfo"] ->
+        []
+
+      :path, _path ->
+        ["only `claims` or `userinfo` fields are currently supported"]
+    end)
   end
 end

--- a/elixir/apps/domain/lib/domain/actors/membership_rule/changeset.ex
+++ b/elixir/apps/domain/lib/domain/actors/membership_rule/changeset.ex
@@ -1,0 +1,26 @@
+defmodule Domain.Actors.MembershipRule.Changeset do
+  use Domain, :changeset
+  alias Domain.Actors.MembershipRule
+
+  @fields ~w[operator jsonpath value]a
+
+  def changeset(membership_rule \\ %MembershipRule{}, attrs) do
+    membership_rule
+    |> cast(attrs, @fields)
+    |> validate_rule()
+  end
+
+  defp validate_rule(changeset) do
+    case fetch_field(changeset, :operator) do
+      {_data_or_changes, :all_users} ->
+        validate_required(changeset, ~w[operator]a)
+
+      _other ->
+        changeset
+        |> validate_required(@fields)
+        |> validate_format(:jsonpath, ~r/^\$\.(claims|userinfo)\./,
+          message: "only $.claims. or $.userinfo. fields are currently supported"
+        )
+    end
+  end
+end

--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace.ex
@@ -26,7 +26,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace do
   @impl true
   def capabilities do
     [
-      provisioners: [:just_in_time, :custom],
+      provisioners: [:custom],
       default_provisioner: :custom,
       parent_adapter: :openid_connect
     ]

--- a/elixir/apps/domain/lib/domain/auth/adapters/openid_connect.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/openid_connect.ex
@@ -23,8 +23,8 @@ defmodule Domain.Auth.Adapters.OpenIDConnect do
   @impl true
   def capabilities do
     [
-      provisioners: [:just_in_time, :manual],
-      default_provisioner: :just_in_time,
+      provisioners: [:manual],
+      default_provisioner: :manual,
       parent_adapter: :openid_connect
     ]
   end
@@ -119,9 +119,10 @@ defmodule Domain.Auth.Adapters.OpenIDConnect do
            fetch_state(provider, token_params) do
       Identity.Query.not_disabled()
       |> Identity.Query.by_provider_id(provider.id)
-      |> Identity.Query.by_provider_claims(
+      |> maybe_by_provider_claims(
+        provider,
         provider_identifier,
-        identity_state["claims"]["email"] || identity_state["userinfo"]["email"]
+        identity_state
       )
       |> Repo.fetch_and_update(
         with: fn identity ->
@@ -139,6 +140,23 @@ defmodule Domain.Auth.Adapters.OpenIDConnect do
       {:error, :expired_token} -> {:error, :expired}
       {:error, :invalid_token} -> {:error, :invalid}
       {:error, :internal_error} -> {:error, :internal_error}
+    end
+  end
+
+  defp maybe_by_provider_claims(
+         queryable,
+         provider,
+         provider_identifier,
+         identity_state
+       ) do
+    if provider.provisioner == :manual do
+      Identity.Query.by_provider_claims(
+        queryable,
+        provider_identifier,
+        identity_state["claims"]["email"] || identity_state["userinfo"]["email"]
+      )
+    else
+      Identity.Query.by_provider_identifier(queryable, provider_identifier)
     end
   end
 

--- a/elixir/apps/domain/lib/domain/auth/identity/sync.ex
+++ b/elixir/apps/domain/lib/domain/auth/identity/sync.ex
@@ -52,6 +52,9 @@ defmodule Domain.Auth.Identity.Sync do
         {:ok, actor_ids_by_provider_identifier}
       end
     )
+    |> Ecto.Multi.run(:recalculate_dynamic_groups, fn _repo, _effects_so_far ->
+      Domain.Actors.update_dynamic_group_memberships(provider.account_id)
+    end)
   end
 
   defp fetch_and_lock_provider_identities_query(provider) do

--- a/elixir/apps/domain/lib/domain/ops.ex
+++ b/elixir/apps/domain/lib/domain/ops.ex
@@ -11,7 +11,7 @@ defmodule Domain.Ops do
       {:ok, _everyone_group} =
         Domain.Actors.create_managed_group(account, %{
           name: "Everyone",
-          membership_rules: [%{operator: "all_users"}]
+          membership_rules: [%{operator: true}]
         })
 
       {:ok, magic_link_provider} =

--- a/elixir/apps/domain/lib/domain/ops.ex
+++ b/elixir/apps/domain/lib/domain/ops.ex
@@ -8,6 +8,12 @@ defmodule Domain.Ops do
     Domain.Repo.transaction(fn ->
       {:ok, account} = Domain.Accounts.create_account(%{name: account_name, slug: account_slug})
 
+      {:ok, _everyone_group} =
+        Domain.Actors.create_managed_group(account, %{
+          name: "Everyone",
+          membership_rules: [%{operator: "all_users"}]
+        })
+
       {:ok, magic_link_provider} =
         Domain.Auth.create_provider(account, %{
           name: "Email",

--- a/elixir/apps/domain/lib/domain/validator.ex
+++ b/elixir/apps/domain/lib/domain/validator.ex
@@ -4,10 +4,6 @@ defmodule Domain.Validator do
   """
   import Ecto.Changeset
 
-  def changed?(changeset, field) do
-    Map.has_key?(changeset.changes, field)
-  end
-
   def empty?(changeset, field) do
     case fetch_field(changeset, field) do
       :error -> true

--- a/elixir/apps/domain/priv/repo/migrations/20240202170655_add_actor_groups_type_and_membership_rules.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20240202170655_add_actor_groups_type_and_membership_rules.exs
@@ -1,0 +1,13 @@
+defmodule Domain.Repo.Migrations.AddActorGroupsTypeAndMembershipRules do
+  use Ecto.Migration
+
+  def change do
+    alter table(:actor_groups) do
+      add(:type, :string)
+      add(:membership_rules, {:array, :map}, default: [])
+    end
+
+    execute("UPDATE actor_groups SET type = 'static'")
+    execute("ALTER TABLE actor_groups ALTER COLUMN type SET NOT NULL")
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20240202212135_set_oidc_providers_provisioner_to_manual.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20240202212135_set_oidc_providers_provisioner_to_manual.exs
@@ -1,0 +1,7 @@
+defmodule Domain.Repo.Migrations.SetOidcProvidersProvisionerToManual do
+  use Ecto.Migration
+
+  def change do
+    execute("UPDATE auth_providers SET provisioner = 'manual' WHERE adapter = 'openid_connect'")
+  end
+end

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -136,6 +136,12 @@ _unprivileged_actor_userpass_identity =
     }
   })
 
+{:ok, _admin_actor_oidc_identity} =
+  Auth.create_identity(admin_actor, oidc_provider, %{
+    provider_identifier: admin_actor_email,
+    provider_identifier_confirmation: admin_actor_email
+  })
+
 # Other Account Users
 other_unprivileged_actor_email = "other-unprivileged-1@localhost"
 other_admin_actor_email = "other@localhost"

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -148,11 +148,20 @@ _unprivileged_actor_userpass_identity =
     }
   })
 
-{:ok, _admin_actor_oidc_identity} =
+{:ok, admin_actor_oidc_identity} =
   Auth.create_identity(admin_actor, oidc_provider, %{
     provider_identifier: admin_actor_email,
     provider_identifier_confirmation: admin_actor_email
   })
+
+admin_actor_oidc_identity
+|> Ecto.Changeset.change(
+  created_by: :provider,
+  provider_id: oidc_provider.id,
+  provider_identifier: admin_actor_email,
+  provider_state: %{"claims" => %{"email" => admin_actor_email, "group" => "users"}}
+)
+|> Repo.update!()
 
 # Other Account Users
 other_unprivileged_actor_email = "other-unprivileged-1@localhost"

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -42,13 +42,13 @@ IO.puts("")
 {:ok, everyone_group} =
   Domain.Actors.create_managed_group(account, %{
     name: "Everyone",
-    membership_rules: [%{operator: "all_users"}]
+    membership_rules: [%{operator: true}]
   })
 
 {:ok, _everyone_group} =
   Domain.Actors.create_managed_group(other_account, %{
     name: "Everyone",
-    membership_rules: [%{operator: "all_users"}]
+    membership_rules: [%{operator: true}]
   })
 
 {:ok, email_provider} =

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -39,6 +39,18 @@ end
 
 IO.puts("")
 
+{:ok, everyone_group} =
+  Domain.Actors.create_managed_group(account, %{
+    name: "Everyone",
+    membership_rules: [%{operator: "all_users"}]
+  })
+
+{:ok, _everyone_group} =
+  Domain.Actors.create_managed_group(other_account, %{
+    name: "Everyone",
+    membership_rules: [%{operator: "all_users"}]
+  })
+
 {:ok, email_provider} =
   Auth.create_provider(account, %{
     name: "Email",
@@ -280,16 +292,11 @@ IO.puts("")
 
 IO.puts("Created Actor Groups: ")
 
-{:ok, eng_group} = Actors.create_group(%{name: "Engineering"}, admin_subject)
-{:ok, finance_group} = Actors.create_group(%{name: "Finance"}, admin_subject)
+{:ok, eng_group} = Actors.create_group(%{name: "Engineering", type: :static}, admin_subject)
+{:ok, finance_group} = Actors.create_group(%{name: "Finance", type: :static}, admin_subject)
+{:ok, synced_group} = Actors.create_group(%{name: "Synced Group", type: :static}, admin_subject)
 
-{:ok, all_group} =
-  Actors.create_group(
-    %{name: "All Employees", provider_id: oidc_provider.id, provider_identifier: "foo"},
-    admin_subject
-  )
-
-for group <- [eng_group, finance_group, all_group] do
+for group <- [eng_group, finance_group, synced_group] do
   IO.puts("  Name: #{group.name}  ID: #{group.id}")
 end
 
@@ -307,7 +314,7 @@ finance_group
   admin_subject
 )
 
-all_group
+synced_group
 |> Repo.preload(:memberships)
 |> Actors.update_group(
   %{
@@ -318,6 +325,18 @@ all_group
   },
   admin_subject
 )
+
+synced_group
+|> Ecto.Changeset.change(
+  created_by: :provider,
+  provider_id: oidc_provider.id,
+  provider_identifier: "dummy_oidc_group_id"
+)
+|> Repo.update!()
+
+oidc_provider
+|> Ecto.Changeset.change(last_synced_at: DateTime.utc_now())
+|> Repo.update!()
 
 IO.puts("")
 
@@ -640,7 +659,7 @@ IO.puts("")
   Policies.create_policy(
     %{
       name: "All Access To Google",
-      actor_group_id: all_group.id,
+      actor_group_id: everyone_group.id,
       resource_id: dns_google_resource.id
     },
     admin_subject
@@ -650,7 +669,7 @@ IO.puts("")
   Policies.create_policy(
     %{
       name: "All Access To firez.one",
-      actor_group_id: all_group.id,
+      actor_group_id: synced_group.id,
       resource_id: firez_one.id
     },
     admin_subject
@@ -660,7 +679,7 @@ IO.puts("")
   Policies.create_policy(
     %{
       name: "All Access To firez.one",
-      actor_group_id: all_group.id,
+      actor_group_id: everyone_group.id,
       resource_id: example_dns.id
     },
     admin_subject
@@ -670,7 +689,7 @@ IO.puts("")
   Policies.create_policy(
     %{
       name: "All Access To firezone.dev",
-      actor_group_id: all_group.id,
+      actor_group_id: everyone_group.id,
       resource_id: firezone_dev.id
     },
     admin_subject
@@ -680,7 +699,7 @@ IO.puts("")
   Policies.create_policy(
     %{
       name: "All Access To ip6only.me",
-      actor_group_id: all_group.id,
+      actor_group_id: synced_group.id,
       resource_id: ip6only.id
     },
     admin_subject
@@ -700,7 +719,7 @@ IO.puts("")
   Policies.create_policy(
     %{
       name: "All Access To Network",
-      actor_group_id: all_group.id,
+      actor_group_id: synced_group.id,
       resource_id: cidr_resource.id
     },
     admin_subject

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -1673,7 +1673,8 @@ defmodule Domain.AuthTest do
                   delete_identities: [],
                   insert_identities: [],
                   update_identities_and_actors: [],
-                  actor_ids_by_provider_identifier: %{}
+                  actor_ids_by_provider_identifier: %{},
+                  recalculate_dynamic_groups: []
                 }}
     end
 
@@ -1782,6 +1783,27 @@ defmodule Domain.AuthTest do
 
       assert updated_identity.provider_virtual_state == %{}
       assert updated_identity.provider_state == %{}
+    end
+
+    test "updates dynamic group memberships", %{
+      account: account,
+      provider: provider,
+      actor: actor
+    } do
+      provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
+
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
+      group = Fixtures.Actors.create_managed_group(account: account)
+
+      assert {:ok, _identity} = upsert_identity(actor, provider, attrs)
+
+      group = Repo.preload(group, :memberships, force: true)
+      assert [membership] = group.memberships
+      assert membership.actor_id == actor.id
     end
 
     test "returns error when identifier is invalid", %{
@@ -1915,6 +1937,29 @@ defmodule Domain.AuthTest do
       assert is_nil(identity.deleted_at)
     end
 
+    test "updates dynamic group memberships", %{
+      account: account,
+      provider: provider,
+      actor: actor,
+      subject: subject
+    } do
+      provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
+
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
+      group = Fixtures.Actors.create_managed_group(account: account)
+
+      assert {:ok, _identity} = create_identity(actor, provider, attrs, subject)
+
+      group = Repo.preload(group, :memberships, force: true)
+      assert [membership] = group.memberships
+      assert membership.actor_id == actor.id
+      assert membership.group_id == group.id
+    end
+
     test "returns error when identity already exists", %{
       account: account,
       provider: provider,
@@ -2010,6 +2055,34 @@ defmodule Domain.AuthTest do
       assert %{password_hash: _} = identity.provider_virtual_state.changes
       assert identity.account_id == provider.account_id
       assert is_nil(identity.deleted_at)
+    end
+
+    test "updates dynamic group memberships" do
+      account = Fixtures.Accounts.create_account()
+      provider = Fixtures.Auth.create_userpass_provider(account: account)
+      provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
+
+      actor =
+        Fixtures.Actors.create_actor(
+          type: :account_admin_user,
+          account: account,
+          provider: provider
+        )
+
+      password = "Firezone1234"
+
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_virtual_state: %{"password" => password, "password_confirmation" => password}
+      }
+
+      group = Fixtures.Actors.create_managed_group(account: account)
+
+      assert {:ok, _identity} = create_identity(actor, provider, attrs)
+
+      group = Repo.preload(group, :memberships, force: true)
+      assert [membership] = group.memberships
+      assert membership.actor_id == actor.id
     end
 
     test "returns error when identifier is invalid" do
@@ -2151,6 +2224,29 @@ defmodule Domain.AuthTest do
       assert Repo.get(Auth.Identity, identity.id).deleted_at
     end
 
+    test "updates dynamic group memberships", %{
+      account: account,
+      identity: identity,
+      provider: provider,
+      subject: subject
+    } do
+      provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
+
+      attrs = %{
+        provider_identifier: provider_identifier,
+        provider_identifier_confirmation: provider_identifier
+      }
+
+      group = Fixtures.Actors.create_managed_group(account: account)
+
+      assert {:ok, identity} = replace_identity(identity, attrs, subject)
+
+      group = Repo.preload(group, :memberships, force: true)
+      assert [membership] = group.memberships
+      assert membership.actor_id == identity.actor_id
+      assert membership.group_id == group.id
+    end
+
     test "deletes tokens of replaced identity and broadcasts disconnect message", %{
       account: account,
       identity: identity,
@@ -2250,6 +2346,24 @@ defmodule Domain.AuthTest do
       assert deleted_identity.deleted_at
 
       assert Repo.get(Auth.Identity, identity.id).deleted_at
+    end
+
+    test "updates dynamic group memberships", %{
+      account: account,
+      provider: provider,
+      actor: actor,
+      subject: subject
+    } do
+      identity = Fixtures.Auth.create_identity(account: account, provider: provider, actor: actor)
+
+      group = Fixtures.Actors.create_managed_group(account: account)
+
+      assert {:ok, _identity} = delete_identity(identity, subject)
+
+      group = Repo.preload(group, :memberships, force: true)
+      assert [membership] = group.memberships
+      assert membership.actor_id == actor.id
+      assert membership.group_id == group.id
     end
 
     test "deletes identity that belongs to another actor with manage permission", %{
@@ -2443,6 +2557,23 @@ defmodule Domain.AuthTest do
 
       expires_at = Repo.one(Domain.Flows.Flow).expires_at
       assert DateTime.diff(expires_at, DateTime.utc_now()) < 1
+    end
+
+    test "updates dynamic group memberships", %{
+      account: account,
+      provider: provider,
+      subject: subject
+    } do
+      actor = Fixtures.Actors.create_actor(account: account, provider: provider)
+      Fixtures.Auth.create_identity(account: account, provider: provider, actor: actor)
+
+      group = Fixtures.Actors.create_managed_group(account: account)
+
+      assert delete_identities_for(actor, subject) == :ok
+
+      group = Repo.preload(group, :memberships, force: true)
+      assert length(group.memberships) == 1
+      refute Enum.any?(group.memberships, &(&1.actor_id == actor.id))
     end
 
     test "does not remove identities that belong to another actor", %{

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -591,7 +591,7 @@ defmodule Domain.AuthTest do
         Fixtures.Auth.provider_attrs(
           adapter: :openid_connect,
           adapter_config: provider.adapter_config,
-          provisioner: :just_in_time
+          provisioner: :manual
         )
 
       assert {:error, changeset} = create_provider(account, attrs)
@@ -766,7 +766,7 @@ defmodule Domain.AuthTest do
     } do
       attrs =
         Fixtures.Auth.provider_attrs(
-          provisioner: :just_in_time,
+          provisioner: :manual,
           adapter: :foobar,
           adapter_config: %{
             client_id: "foo"

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -694,6 +694,18 @@ defmodule Domain.ResourcesTest do
       assert Enum.empty?(peek[resource2.id].items)
     end
 
+    test "preloads group providers", %{
+      account: account,
+      subject: subject
+    } do
+      resource = Fixtures.Resources.create_resource(account: account)
+      Fixtures.Policies.create_policy(account: account, resource: resource)
+
+      assert {:ok, peek} = peek_resource_actor_groups([resource], 3, subject)
+      assert [%Actors.Group{} = group] = peek[resource.id].items
+      assert Ecto.assoc_loaded?(group.provider)
+    end
+
     test "returns count of policies per resource and first LIMIT actors", %{
       account: account,
       subject: subject

--- a/elixir/apps/domain/test/support/fixtures/actors.ex
+++ b/elixir/apps/domain/test/support/fixtures/actors.ex
@@ -10,7 +10,11 @@ defmodule Domain.Fixtures.Actors do
   end
 
   def create_managed_group(attrs \\ %{}) do
-    attrs = group_attrs(attrs) |> Map.put(:type, :managed)
+    attrs =
+      attrs
+      |> group_attrs()
+      |> Map.put(:type, :managed)
+      |> Map.put_new(:membership_rules, [%{operator: true}])
 
     {account, attrs} =
       pop_assoc_fixture(attrs, :account, fn assoc_attrs ->
@@ -51,7 +55,10 @@ defmodule Domain.Fixtures.Actors do
       |> Actors.create_group(subject)
 
     if provider do
-      update!(group, provider_id: provider.id, provider_identifier: provider_identifier)
+      update!(group,
+        provider_id: provider.id,
+        provider_identifier: provider_identifier
+      )
     else
       group
     end

--- a/elixir/apps/domain/test/support/fixtures/actors.ex
+++ b/elixir/apps/domain/test/support/fixtures/actors.ex
@@ -4,8 +4,21 @@ defmodule Domain.Fixtures.Actors do
 
   def group_attrs(attrs \\ %{}) do
     Enum.into(attrs, %{
-      name: "group-#{unique_integer()}"
+      name: "group-#{unique_integer()}",
+      type: :static
     })
+  end
+
+  def create_managed_group(attrs \\ %{}) do
+    attrs = group_attrs(attrs) |> Map.put(:type, :managed)
+
+    {account, attrs} =
+      pop_assoc_fixture(attrs, :account, fn assoc_attrs ->
+        Fixtures.Accounts.create_account(assoc_attrs)
+      end)
+
+    {:ok, group} = Actors.create_managed_group(account, attrs)
+    group
   end
 
   def create_group(attrs \\ %{}) do

--- a/elixir/apps/domain/test/support/fixtures/auth.ex
+++ b/elixir/apps/domain/test/support/fixtures/auth.ex
@@ -97,7 +97,7 @@ defmodule Domain.Fixtures.Auth do
     attrs =
       %{
         adapter: :openid_connect,
-        provisioner: :just_in_time
+        provisioner: :manual
       }
       |> Map.merge(Enum.into(attrs, %{}))
       |> provider_attrs()

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -862,7 +862,7 @@ defmodule Web.CoreComponents do
 
   def created_by(%{schema: %{created_by: :system}} = assigns) do
     ~H"""
-    <.relative_datetime datetime={@schema.inserted_at} />
+    <.relative_datetime datetime={@schema.inserted_at} /> by system
     """
   end
 

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -880,13 +880,13 @@ defmodule Web.CoreComponents do
 
   def created_by(%{schema: %{created_by: :provider}} = assigns) do
     ~H"""
-    synced <.relative_datetime datetime={@schema.inserted_at} /> from
+    <.relative_datetime datetime={@schema.inserted_at} /> by
     <.link
       class="text-accent-500 hover:underline"
       navigate={Web.Settings.IdentityProviders.Components.view_provider(@account, @schema.provider)}
     >
       <%= @schema.provider.name %>
-    </.link>
+    </.link> sync
     """
   end
 
@@ -962,7 +962,7 @@ defmodule Web.CoreComponents do
           "rounded-l",
           "py-0.5 pl-2.5 pr-1.5",
           "text-neutral-800",
-          "bg-neutral-100",
+          "bg-neutral-200",
           "whitespace-nowrap"
         ]}
       >

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -33,7 +33,7 @@ defmodule Web.FormComponents do
   attr :type, :string,
     default: "text",
     values: ~w(checkbox color date datetime-local email file hidden month number password
-               range radio search select tel text textarea taglist time url week)
+               range radio search group_select select tel text textarea taglist time url week)
 
   attr :field, Phoenix.HTML.FormField,
     doc: "a form field struct retrieved from the form, for example: @form[:email]"
@@ -108,6 +108,30 @@ defmodule Web.FormComponents do
         />
         <%= @label %>
       </label>
+      <.error :for={msg <- @errors} data-validation-error-for={@name}><%= msg %></.error>
+    </div>
+    """
+  end
+
+  def input(%{type: "group_select"} = assigns) do
+    ~H"""
+    <div phx-feedback-for={@name}>
+      <.label for={@id}><%= @label %></.label>
+      <select id={@id} name={@name} class={~w[
+          bg-neutral-50 border border-neutral-300 text-neutral-900 text-sm rounded
+          block w-full p-2.5]} multiple={@multiple} {@rest}>
+        <option :if={@prompt} value=""><%= @prompt %></option>
+
+        <%= for {label, options} <- @options do %>
+          <%= if label == nil do %>
+            <%= Phoenix.HTML.Form.options_for_select(options, @value) %>
+          <% else %>
+            <optgroup label={label}>
+              <%= Phoenix.HTML.Form.options_for_select(options, @value) %>
+            </optgroup>
+          <% end %>
+        <% end %>
+      </select>
       <.error :for={msg <- @errors} data-validation-error-for={@name}><%= msg %></.error>
     </div>
     """

--- a/elixir/apps/web/lib/web/components/table_components.ex
+++ b/elixir/apps/web/lib/web/components/table_components.ex
@@ -136,7 +136,7 @@ defmodule Web.TableComponents do
           />
         </tbody>
       </table>
-      <div :if={Enum.empty?(@rows)}>
+      <div :if={Enum.empty?(@rows)} id={"#{@id}-empty"}>
         <%= render_slot(@empty) %>
       </div>
     </div>

--- a/elixir/apps/web/lib/web/live/actors/components.ex
+++ b/elixir/apps/web/lib/web/live/actors/components.ex
@@ -78,12 +78,12 @@ defmodule Web.Actors.Components do
     </div>
     <div :if={@groups != []}>
       <.input
-        type="select"
+        type="group_select"
         multiple={true}
         label="Groups"
         field={@form[:memberships]}
         value_id={fn membership -> membership.group_id end}
-        options={Enum.map(@groups, fn group -> {group.name, group.id} end)}
+        options={Web.Groups.Components.select_options(@groups)}
         placeholder="Groups"
       />
       <p class="mt-2 text-xs text-neutral-500">

--- a/elixir/apps/web/lib/web/live/actors/edit.ex
+++ b/elixir/apps/web/lib/web/live/actors/edit.ex
@@ -8,9 +8,9 @@ defmodule Web.Actors.Edit do
            Actors.fetch_actor_by_id(id, socket.assigns.subject, preload: [:memberships]),
          nil <- actor.deleted_at,
          {:ok, groups} <- Actors.list_groups(socket.assigns.subject, preload: [:provider]) do
-      changeset = Actors.change_actor(actor)
+      groups = Enum.filter(groups, &Actors.group_editable?/1)
 
-      groups = Enum.reject(groups, &Actors.group_synced?/1)
+      changeset = Actors.change_actor(actor)
 
       socket =
         assign(socket,

--- a/elixir/apps/web/lib/web/live/actors/edit.ex
+++ b/elixir/apps/web/lib/web/live/actors/edit.ex
@@ -7,7 +7,7 @@ defmodule Web.Actors.Edit do
     with {:ok, actor} <-
            Actors.fetch_actor_by_id(id, socket.assigns.subject, preload: [:memberships]),
          nil <- actor.deleted_at,
-         {:ok, groups} <- Actors.list_groups(socket.assigns.subject) do
+         {:ok, groups} <- Actors.list_groups(socket.assigns.subject, preload: [:provider]) do
       changeset = Actors.change_actor(actor)
 
       groups = Enum.reject(groups, &Actors.group_synced?/1)

--- a/elixir/apps/web/lib/web/live/actors/index.ex
+++ b/elixir/apps/web/lib/web/live/actors/index.ex
@@ -1,19 +1,16 @@
 defmodule Web.Actors.Index do
   use Web, :live_view
   import Web.Actors.Components
-  alias Domain.Auth
   alias Domain.Actors
 
   def mount(_params, _session, socket) do
     with {:ok, actors} <-
            Actors.list_actors(socket.assigns.subject, preload: [identities: :provider]),
-         {:ok, actor_groups} <- Actors.peek_actor_groups(actors, 3, socket.assigns.subject),
-         {:ok, providers} <- Auth.list_providers(socket.assigns.subject) do
+         {:ok, actor_groups} <- Actors.peek_actor_groups(actors, 3, socket.assigns.subject) do
       socket =
         assign(socket,
           actors: actors,
           actor_groups: actor_groups,
-          providers_by_id: Map.new(providers, &{&1.id, &1}),
           page_title: "Actors"
         )
 
@@ -63,10 +60,7 @@ defmodule Web.Actors.Index do
               </:empty>
 
               <:item :let={group}>
-                <.group
-                  account={@account}
-                  group={%{group | provider: Map.get(@providers_by_id, group.provider_id)}}
-                />
+                <.group account={@account} group={group} />
               </:item>
 
               <:tail :let={count}>

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
@@ -5,9 +5,9 @@ defmodule Web.Actors.ServiceAccounts.New do
 
   def mount(_params, _session, socket) do
     with {:ok, groups} <- Actors.list_groups(socket.assigns.subject) do
-      changeset = Actors.new_actor(%{type: :service_account})
+      groups = Enum.filter(groups, &Actors.group_editable?/1)
 
-      groups = Enum.reject(groups, &Actors.group_synced?/1)
+      changeset = Actors.new_actor(%{type: :service_account})
 
       socket =
         assign(socket,

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
@@ -4,7 +4,7 @@ defmodule Web.Actors.ServiceAccounts.New do
   alias Domain.Actors
 
   def mount(_params, _session, socket) do
-    with {:ok, groups} <- Actors.list_groups(socket.assigns.subject) do
+    with {:ok, groups} <- Actors.list_editable_groups(socket.assigns.subject, preload: :provider) do
       groups = Enum.filter(groups, &Actors.group_editable?/1)
 
       changeset = Actors.new_actor(%{type: :service_account})

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -167,22 +167,24 @@ defmodule Web.Actors.Show do
             <div class="flex justify-center text-center text-neutral-500 p-4">
               <div class="w-auto pb-4">
                 No authentication identities to display.
-                <.link
-                  :if={is_nil(@actor.deleted_at) and @actor.type == :service_account}
-                  class={[link_style()]}
-                  navigate={~p"/#{@account}/actors/service_accounts/#{@actor}/new_identity"}
-                >
-                  Create a token
-                </.link>
-                to authenticate this service account.
-                <.link
-                  :if={is_nil(@actor.deleted_at) and @actor.type != :service_account}
-                  class={[link_style()]}
-                  navigate={~p"/#{@account}/actors/users/#{@actor}/new_identity"}
-                >
-                  Create an identity
-                </.link>
-                to authenticate this user.
+                <span :if={is_nil(@actor.deleted_at) and @actor.type == :service_account}>
+                  <.link
+                    class={[link_style()]}
+                    navigate={~p"/#{@account}/actors/service_accounts/#{@actor}/new_identity"}
+                  >
+                    Create a token
+                  </.link>
+                  to authenticate this service account.
+                </span>
+                <span :if={is_nil(@actor.deleted_at) and @actor.type != :service_account}>
+                  <.link
+                    class={[link_style()]}
+                    navigate={~p"/#{@account}/actors/users/#{@actor}/new_identity"}
+                  >
+                    Create an identity
+                  </.link>
+                  to authenticate this user.
+                </span>
               </div>
             </div>
           </:empty>

--- a/elixir/apps/web/lib/web/live/actors/users/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new.ex
@@ -4,7 +4,7 @@ defmodule Web.Actors.Users.New do
   alias Domain.Actors
 
   def mount(_params, _session, socket) do
-    with {:ok, groups} <- Actors.list_groups(socket.assigns.subject) do
+    with {:ok, groups} <- Actors.list_editable_groups(socket.assigns.subject, preload: :provider) do
       changeset = Actors.new_actor()
 
       socket =

--- a/elixir/apps/web/lib/web/live/groups/components.ex
+++ b/elixir/apps/web/lib/web/live/groups/components.ex
@@ -17,12 +17,14 @@ defmodule Web.Groups.Components do
   defp options_index_and_label(group) do
     index =
       cond do
+        Actors.group_managed?(group) -> 1
         Actors.group_synced?(group) -> 9
         true -> 2
       end
 
     label =
       cond do
+        Actors.group_managed?(group) -> nil
         Actors.group_synced?(group) -> group.provider.name
         true -> nil
       end

--- a/elixir/apps/web/lib/web/live/groups/components.ex
+++ b/elixir/apps/web/lib/web/live/groups/components.ex
@@ -17,15 +17,15 @@ defmodule Web.Groups.Components do
   defp options_index_and_label(group) do
     index =
       cond do
-        Actors.group_managed?(group) -> 1
         Actors.group_synced?(group) -> 9
+        Actors.group_managed?(group) -> 1
         true -> 2
       end
 
     label =
       cond do
-        Actors.group_managed?(group) -> nil
         Actors.group_synced?(group) -> group.provider.name
+        Actors.group_managed?(group) -> nil
         true -> nil
       end
 

--- a/elixir/apps/web/lib/web/live/groups/edit.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit.ex
@@ -6,7 +6,7 @@ defmodule Web.Groups.Edit do
     with {:ok, group} <-
            Actors.fetch_group_by_id(id, socket.assigns.subject, preload: [:memberships]),
          nil <- group.deleted_at,
-         false <- Actors.group_synced?(group) do
+         true <- Actors.group_editable?(group) do
       changeset = Actors.change_group(group)
 
       socket =

--- a/elixir/apps/web/lib/web/live/groups/edit_actors.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit_actors.ex
@@ -7,7 +7,7 @@ defmodule Web.Groups.EditActors do
     with {:ok, group} <-
            Actors.fetch_group_by_id(id, socket.assigns.subject, preload: [:memberships]),
          nil <- group.deleted_at,
-         false <- Actors.group_synced?(group),
+         true <- Actors.group_editable?(group),
          {:ok, actors} <-
            Actors.list_actors(socket.assigns.subject, preload: [identities: :provider]) do
       current_member_ids = Enum.map(group.memberships, & &1.actor_id)

--- a/elixir/apps/web/lib/web/live/groups/index.ex
+++ b/elixir/apps/web/lib/web/live/groups/index.ex
@@ -94,7 +94,6 @@ defmodule Web.Groups.Index do
               </div>
             </:empty>
           </.table>
-          <!--<.paginator page={3} total_pages={100} collection_base_path={~p"/#{@account}/groups"} />-->
         </div>
       </:content>
     </.section>

--- a/elixir/apps/web/lib/web/live/groups/index.ex
+++ b/elixir/apps/web/lib/web/live/groups/index.ex
@@ -1,6 +1,5 @@
 defmodule Web.Groups.Index do
   use Web, :live_view
-  import Web.Groups.Components
   alias Domain.Actors
 
   def mount(_params, _session, socket) do
@@ -74,7 +73,7 @@ defmodule Web.Groups.Index do
               </.peek>
             </:col>
             <:col :let={group} label="SOURCE" sortable="false">
-              <.source account={@account} group={group} />
+              <.created_by account={@account} schema={group} />
             </:col>
             <:empty>
               <div class="flex justify-center text-center text-neutral-500 p-4">

--- a/elixir/apps/web/lib/web/live/groups/new.ex
+++ b/elixir/apps/web/lib/web/live/groups/new.ex
@@ -3,7 +3,7 @@ defmodule Web.Groups.New do
   alias Domain.Actors
 
   def mount(_params, _session, socket) do
-    changeset = Actors.new_group()
+    changeset = Actors.new_group(%{type: :static})
 
     {:ok, assign(socket, form: to_form(changeset), page_title: "New Group"),
      temporary_assigns: [form: %Phoenix.HTML.Form{}]}
@@ -22,6 +22,7 @@ defmodule Web.Groups.New do
       <:content>
         <div class="py-8 px-4 mx-auto max-w-2xl lg:py-16">
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
+            <.input type="hidden" field={@form[:type]} value="static" />
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <div>
                 <.input

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -1,6 +1,5 @@
 defmodule Web.Groups.Show do
   use Web, :live_view
-  import Web.Groups.Components
   import Web.Actors.Components
   alias Domain.Actors
 
@@ -43,16 +42,18 @@ defmodule Web.Groups.Show do
         </.edit_button>
       </:action>
       <:content>
+        <.flash :if={Actors.group_synced?(@group)} kind={:info}>
+          This group is synced from an external source and cannot be edited.
+        </.flash>
+
         <.vertical_table id="group">
           <.vertical_table_row>
             <:label>Name</:label>
             <:value><%= @group.name %></:value>
           </.vertical_table_row>
           <.vertical_table_row>
-            <:label>Source</:label>
-            <:value>
-              <.source account={@account} group={@group} />
-            </:value>
+            <:label>Created</:label>
+            <:value><.created_by account={@account} schema={@group} /></:value>
           </.vertical_table_row>
         </.vertical_table>
       </:content>
@@ -84,17 +85,14 @@ defmodule Web.Groups.Show do
             <div class="flex justify-center text-center text-neutral-500 p-4">
               <div :if={not Actors.group_synced?(@group)} class="w-auto">
                 <div class="pb-4">
-                  No actors in group
+                  There are no actors in this group.
                 </div>
                 <.edit_button
                   :if={is_nil(@group.deleted_at)}
-                  navigate={~p"/#{@account}/groups/#{@group}/edit"}
+                  navigate={~p"/#{@account}/groups/#{@group}/edit_actors"}
                 >
-                  Edit Group
+                  Edit Actors
                 </.edit_button>
-              </div>
-              <div :if={Actors.group_synced?(@group)} class="w-auto">
-                No actors in synced group
               </div>
             </div>
           </:empty>

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -35,13 +35,16 @@ defmodule Web.Groups.Show do
       </:title>
       <:action :if={is_nil(@group.deleted_at)}>
         <.edit_button
-          :if={not Actors.group_synced?(@group)}
+          :if={Actors.group_editable?(@group)}
           navigate={~p"/#{@account}/groups/#{@group}/edit"}
         >
           Edit Group
         </.edit_button>
       </:action>
       <:content>
+        <.flash :if={Actors.group_managed?(@group)} kind={:info}>
+          This group is managed by Firezone and cannot be edited.
+        </.flash>
         <.flash :if={Actors.group_synced?(@group)} kind={:info}>
           This group is synced from an external source and cannot be edited.
         </.flash>
@@ -63,7 +66,7 @@ defmodule Web.Groups.Show do
       <:title>Actors</:title>
       <:action :if={is_nil(@group.deleted_at)}>
         <.edit_button
-          :if={not Actors.group_synced?(@group)}
+          :if={not Actors.group_synced?(@group) and not Actors.group_managed?(@group)}
           navigate={~p"/#{@account}/groups/#{@group}/edit_actors"}
         >
           Edit Actors
@@ -88,7 +91,7 @@ defmodule Web.Groups.Show do
                   There are no actors in this group.
                 </div>
                 <.edit_button
-                  :if={is_nil(@group.deleted_at)}
+                  :if={not Actors.group_synced?(@group) and not Actors.group_managed?(@group)}
                   navigate={~p"/#{@account}/groups/#{@group}/edit_actors"}
                 >
                   Edit Actors
@@ -100,7 +103,7 @@ defmodule Web.Groups.Show do
       </:content>
     </.section>
 
-    <.danger_zone :if={is_nil(@group.deleted_at) and not Actors.group_synced?(@group)}>
+    <.danger_zone :if={is_nil(@group.deleted_at) and Actors.group_editable?(@group)}>
       <:action>
         <.delete_button
           phx-click="delete"

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -42,8 +42,24 @@ defmodule Web.Groups.Show do
         </.edit_button>
       </:action>
       <:content>
-        <.flash :if={Actors.group_managed?(@group)} kind={:info}>
+        <.flash
+          :if={
+            Actors.group_managed?(@group) and
+              not Enum.any?(@group.membership_rules, &(&1 == %Actors.MembershipRule{operator: true}))
+          }
+          kind={:info}
+        >
           This group is managed by Firezone and cannot be edited.
+        </.flash>
+        <.flash
+          :if={
+            Actors.group_managed?(@group) and
+              Enum.any?(@group.membership_rules, &(&1 == %Actors.MembershipRule{operator: true}))
+          }
+          kind={:info}
+        >
+          <p>This group is managed by Firezone and cannot be edited.</p>
+          <p>It will contain all actors with at least one authentication identity.</p>
         </.flash>
         <.flash :if={Actors.group_synced?(@group)} kind={:info}>
           This group is synced from an external source and cannot be edited.

--- a/elixir/apps/web/lib/web/live/policies/index.ex
+++ b/elixir/apps/web/lib/web/live/policies/index.ex
@@ -14,7 +14,7 @@ defmodule Web.Policies.Index do
   defp load_policies_with_assocs(socket) do
     with {:ok, policies} <-
            Policies.list_policies(socket.assigns.subject,
-             preload: [:actor_group, :resource]
+             preload: [actor_group: [:provider], resource: []]
            ) do
       {:ok, assign(socket, policies: policies)}
     end
@@ -41,11 +41,7 @@ defmodule Web.Policies.Index do
             </.link>
           </:col>
           <:col :let={policy} label="GROUP">
-            <.link class={link_style()} navigate={~p"/#{@account}/groups/#{policy.actor_group_id}"}>
-              <.badge>
-                <%= policy.actor_group.name %>
-              </.badge>
-            </.link>
+            <.group account={@account} group={policy.actor_group} />
           </:col>
           <:col :let={policy} label="RESOURCE">
             <.link class={link_style()} navigate={~p"/#{@account}/resources/#{policy.resource_id}"}>

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -5,7 +5,7 @@ defmodule Web.Policies.New do
   def mount(params, _session, socket) do
     with {:ok, resources} <-
            Resources.list_resources(socket.assigns.subject, preload: [:gateway_groups]),
-         {:ok, actor_groups} <- Actors.list_groups(socket.assigns.subject) do
+         {:ok, actor_groups} <- Actors.list_groups(socket.assigns.subject, preload: :provider) do
       form = to_form(Policies.new_policy(%{}, socket.assigns.subject))
 
       socket =
@@ -64,8 +64,8 @@ defmodule Web.Policies.New do
             <.input
               field={@form[:actor_group_id]}
               label="Group"
-              type="select"
-              options={Enum.map(@actor_groups, fn g -> [key: g.name, value: g.id] end)}
+              type="group_select"
+              options={Web.Groups.Components.select_options(@actor_groups)}
               value={@form[:actor_group_id].value}
               required
             />

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -6,7 +6,7 @@ defmodule Web.Policies.Show do
   def mount(%{"id" => id}, _session, socket) do
     with {:ok, policy} <-
            Policies.fetch_policy_by_id(id, socket.assigns.subject,
-             preload: [:actor_group, :resource, [created_by_identity: :actor]]
+             preload: [actor_group: [:provider], resource: [], created_by_identity: :actor]
            ),
          {:ok, flows} <-
            Flows.list_flows_for(policy, socket.assigns.subject,
@@ -83,11 +83,7 @@ defmodule Web.Policies.Show do
               Group
             </:label>
             <:value>
-              <.link navigate={~p"/#{@account}/groups/#{@policy.actor_group_id}"} class={link_style()}>
-                <.badge>
-                  <%= @policy.actor_group.name %>
-                </.badge>
-              </.link>
+              <.group account={@account} group={@policy.actor_group} />
               <span :if={not is_nil(@policy.actor_group.deleted_at)} class="text-red-600">
                 (deleted)
               </span>

--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -84,11 +84,7 @@ defmodule Web.Resources.Index do
                 </:empty>
 
                 <:item :let={group}>
-                  <.link class={link_style()} navigate={~p"/#{@account}/groups/#{group.id}"}>
-                    <.badge>
-                      <%= group.name %>
-                    </.badge>
-                  </.link>
+                  <.group account={@account} group={group} />
                 </:item>
 
                 <:tail :let={count}>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -117,14 +117,7 @@ defmodule Web.Resources.Show do
                   </:empty>
 
                   <:item :let={group}>
-                    <.link
-                      class={link_style()}
-                      navigate={~p"/#{@account}/groups/#{group.id}?#{@params}"}
-                    >
-                      <.badge>
-                        <%= group.name %>
-                      </.badge>
-                    </.link>
+                    <.group account={@account} group={group} />
                   </:item>
 
                   <:tail :let={count}>

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -173,14 +173,7 @@ defmodule Web.Sites.Show do
                 </:empty>
 
                 <:item :let={group}>
-                  <.link
-                    class={link_style()}
-                    navigate={~p"/#{@account}/groups/#{group.id}?site_id=#{@group}"}
-                  >
-                    <.badge>
-                      <%= group.name %>
-                    </.badge>
-                  </.link>
+                  <.group account={@account} group={group} />
                 </:item>
 
                 <:tail :let={count}>

--- a/elixir/apps/web/test/web/live/actors/show_test.exs
+++ b/elixir/apps/web/test/web/live/actors/show_test.exs
@@ -333,8 +333,7 @@ defmodule Web.Live.Actors.ShowTest do
         "#{synced_identity.provider.name} #{synced_identity.provider_identifier}",
         fn row ->
           refute row["actions"]
-          assert row["created"] =~ "synced"
-          assert row["created"] =~ "from #{synced_identity.provider.name}"
+          assert row["created"] =~ "by #{synced_identity.provider.name} sync"
           assert row["last signed in"] == "never"
         end
       )

--- a/elixir/apps/web/test/web/live/groups/edit_test.exs
+++ b/elixir/apps/web/test/web/live/groups/edit_test.exs
@@ -113,7 +113,9 @@ defmodule Web.Live.Groups.EditTest do
     group: group,
     conn: conn
   } do
-    attrs = Fixtures.Actors.group_attrs()
+    attrs =
+      Fixtures.Actors.group_attrs()
+      |> Map.delete(:type)
 
     {:ok, lv, _html} =
       conn
@@ -140,7 +142,10 @@ defmodule Web.Live.Groups.EditTest do
     group: group,
     conn: conn
   } do
-    attrs = Fixtures.Actors.group_attrs()
+    attrs =
+      Fixtures.Actors.group_attrs()
+      |> Map.delete(:type)
+
     Fixtures.Actors.create_group(name: attrs.name, account: account)
 
     {:ok, lv, _html} =
@@ -162,7 +167,9 @@ defmodule Web.Live.Groups.EditTest do
     group: group,
     conn: conn
   } do
-    attrs = Fixtures.Actors.group_attrs()
+    attrs =
+      Fixtures.Actors.group_attrs()
+      |> Map.delete(:type)
 
     {:ok, lv, _html} =
       conn

--- a/elixir/apps/web/test/web/live/groups/new_test.exs
+++ b/elixir/apps/web/test/web/live/groups/new_test.exs
@@ -57,7 +57,8 @@ defmodule Web.Live.Groups.NewTest do
     form = form(lv, "form")
 
     assert find_inputs(form) == [
-             "group[name]"
+             "group[name]",
+             "group[type]"
            ]
   end
 

--- a/elixir/apps/web/test/web/live/groups/show_test.exs
+++ b/elixir/apps/web/test/web/live/groups/show_test.exs
@@ -85,8 +85,8 @@ defmodule Web.Live.Groups.ShowTest do
       |> vertical_table_to_map()
 
     assert table["name"] == group.name
-    assert around_now?(table["source"])
-    assert table["source"] =~ "by #{actor.name}"
+    assert around_now?(table["created"])
+    assert table["created"] =~ "by #{actor.name}"
   end
 
   test "renders name of actor that created group", %{
@@ -112,7 +112,7 @@ defmodule Web.Live.Groups.ShowTest do
            |> element("#group")
            |> render()
            |> vertical_table_to_map()
-           |> Map.fetch!("source") =~ "by #{actor.name}"
+           |> Map.fetch!("created") =~ "by #{actor.name}"
   end
 
   test "renders provider that synced group", %{
@@ -141,7 +141,7 @@ defmodule Web.Live.Groups.ShowTest do
            |> element("#group")
            |> render()
            |> vertical_table_to_map()
-           |> Map.fetch!("source") =~ "Synced from #{provider.name} never"
+           |> Map.fetch!("created") =~ "by #{provider.name} sync"
   end
 
   test "renders group actors", %{
@@ -239,7 +239,7 @@ defmodule Web.Live.Groups.ShowTest do
       |> live(~p"/#{account}/groups/#{group}")
 
     assert lv
-           |> element("a", "Edit Actors")
+           |> element("#actors-empty a", "Edit Actors")
            |> render_click() ==
              {:error,
               {:live_redirect, %{to: ~p"/#{account}/groups/#{group}/edit_actors", kind: :push}}}


### PR DESCRIPTION
After this PR is merged a manual migration will be needed to upsert Everyone group to existing accounts.

Closes #2588 

*This PR also improves UX around groups:*

1. Group selection now shows their source in dropdowns: 
<img width="669" alt="Screenshot 2024-02-08 at 18 30 25" src="https://github.com/firezone/firezone/assets/1877644/accb5cf9-1c16-429b-a16f-e63bb0c7930f">

2. The same is done across other pages which will help in case there is a duplicate group name (eg. manual and synced one): 
<img width="766" alt="Screenshot 2024-02-08 at 18 31 59" src="https://github.com/firezone/firezone/assets/1877644/f3133ceb-fc9d-4f7a-bfe2-63f81f379c9a">
<img width="1728" alt="Screenshot 2024-02-08 at 18 34 04" src="https://github.com/firezone/firezone/assets/1877644/daa86c7e-8401-418d-b8e5-ddaff31a1834">
<img width="1728" alt="Screenshot 2024-02-08 at 18 34 22" src="https://github.com/firezone/firezone/assets/1877644/5c885d06-0b0d-4385-a06e-8e9c09b85535">
<img width="576" alt="Screenshot 2024-02-08 at 18 34 31" src="https://github.com/firezone/firezone/assets/1877644/86b2020e-7159-4800-a08e-cecf7b0b1798">


3. A bug was fixed and now we don't show synced groups whenever an actor is created: 
<img width="662" alt="Screenshot 2024-02-08 at 18 32 22" src="https://github.com/firezone/firezone/assets/1877644/f69efe85-d7ac-412a-b267-9094a8dd9426">

4. We provide reason why groups are not editable:
<img width="591" alt="Screenshot 2024-02-08 at 18 33 29" src="https://github.com/firezone/firezone/assets/1877644/1525d876-1aad-4a17-be38-6a39c4bc7908">
<img width="558" alt="Screenshot 2024-02-08 at 18 33 50" src="https://github.com/firezone/firezone/assets/1877644/92615b97-19a6-4bf9-804d-d0d16c6c2dfe">
