### PR TITLE
feat(devops): Add CoreDNS to AWS TF

### DIFF
--- a/terraform/environments/staging/aws.tf
+++ b/terraform/environments/staging/aws.tf
@@ -168,6 +168,28 @@ module "aws_gateway" {
   tags = local.tags
 }
 
+module "aws_coredns" {
+  source = "../../modules/aws/coredns"
+
+  ami  = data.aws_ami.ubuntu.id
+  name = "coredns - ${local.environment}"
+
+  associate_public_ip_address = false
+  instance_type               = "t3.micro"
+  key_name                    = local.ssh_keypair_name
+  subnet_id                   = element(module.vpc.private_subnets, 0)
+  private_ip                  = cidrhost(element(module.vpc.private_subnets_cidr_blocks, 0), 10)
+
+  application_name = "coredns"
+
+  vpc_security_group_ids = [
+    module.sg_allow_all_egress.security_group_id,
+    module.sg_allow_subnet_ingress.security_group_id
+  ]
+
+  tags = local.tags
+}
+
 ################################################################################
 # Security Groups
 ################################################################################

--- a/terraform/environments/staging/aws.tf
+++ b/terraform/environments/staging/aws.tf
@@ -182,6 +182,21 @@ module "aws_coredns" {
 
   application_name = "coredns"
 
+  dns_records = [
+    {
+      name  = "gateway",
+      value = module.aws_gateway.private_ip
+    },
+    {
+      name  = "httpbin",
+      value = module.aws_httpbin.private_ip
+    },
+    {
+      name  = "iperf",
+      value = module.aws_iperf.private_ip
+    },
+  ]
+
   vpc_security_group_ids = [
     module.sg_allow_all_egress.security_group_id,
     module.sg_allow_subnet_ingress.security_group_id

--- a/terraform/modules/aws/coredns/main.tf
+++ b/terraform/modules/aws/coredns/main.tf
@@ -1,7 +1,3 @@
-locals {
-  environment_variables = concat([], var.application_environment_variables)
-}
-
 resource "aws_instance" "this" {
   ami                         = var.ami
   instance_type               = var.instance_type
@@ -13,10 +9,10 @@ resource "aws_instance" "this" {
   key_name                    = var.key_name
 
   user_data = templatefile("${path.module}/templates/cloud-init.yaml", {
-    container_name        = "coredns"
-    container_image       = "coredns/coredns"
-    host_ip               = var.private_ip
-    container_environment = local.environment_variables
+    container_name  = "coredns"
+    container_image = "coredns/coredns"
+    host_ip         = var.private_ip
+    dns_records     = concat([{ name = "coredns", value = var.private_ip }], var.dns_records)
   })
 
   root_block_device {

--- a/terraform/modules/aws/coredns/main.tf
+++ b/terraform/modules/aws/coredns/main.tf
@@ -1,0 +1,28 @@
+locals {
+  environment_variables = concat([], var.application_environment_variables)
+}
+
+resource "aws_instance" "this" {
+  ami                         = var.ami
+  instance_type               = var.instance_type
+  monitoring                  = var.monitoring
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = var.vpc_security_group_ids
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = var.private_ip
+  key_name                    = var.key_name
+
+  user_data = templatefile("${path.module}/templates/cloud-init.yaml", {
+    container_name        = "coredns"
+    container_image       = "coredns/coredns"
+    host_ip               = var.private_ip
+    container_environment = local.environment_variables
+  })
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 15
+  }
+
+  tags = merge({ "Name" = var.name }, var.instance_tags, var.tags)
+}

--- a/terraform/modules/aws/coredns/outputs.tf
+++ b/terraform/modules/aws/coredns/outputs.tf
@@ -1,0 +1,55 @@
+output "id" {
+  description = "The ID of the instance"
+  value = try(
+    aws_instance.this.id,
+    null,
+  )
+}
+
+output "arn" {
+  description = "The ARN of the instance"
+  value = try(
+    aws_instance.this.arn,
+    null,
+  )
+}
+
+output "instance_state" {
+  description = "The state of the instance"
+  value = try(
+    aws_instance.this.instance_state,
+    null,
+  )
+}
+
+output "primary_network_interface_id" {
+  description = "The ID of the instance's primary network interface"
+  value = try(
+    aws_instance.this.primary_network_interface_id,
+    null,
+  )
+}
+
+output "public_ip" {
+  description = "The public IP address assigned to the instance, if applicable. NOTE: If you are using an aws_eip with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached"
+  value = try(
+    aws_instance.this.public_ip,
+    null,
+  )
+}
+
+output "private_ip" {
+  description = "The private IP address assigned to the instance"
+  value = try(
+    aws_instance.this.private_ip,
+    null,
+  )
+}
+
+output "ipv6_addresses" {
+  description = "The IPv6 address assigned to the instance, if applicable"
+  value = try(
+    aws_instance.this.ipv6_addresses,
+    [],
+  )
+}

--- a/terraform/modules/aws/coredns/templates/cloud-init.yaml
+++ b/terraform/modules/aws/coredns/templates/cloud-init.yaml
@@ -31,8 +31,9 @@ write_files:
                       1h         ; Minimum TTL (1 hour)
                   )
 
-      httpbin     IN A     10.0.32.101
-      iperf       IN A     10.0.32.102
+      %{ for record in dns_records ~}
+      ${record.name}     IN A     ${record.value}
+      %{ endfor ~}
 
   - path: /etc/systemd/system/coredns.service
     permissions: "0644"
@@ -62,4 +63,5 @@ runcmd:
   - sudo systemctl stop docker
   - sudo systemctl start docker
   - sudo systemctl daemon-reload
+  - sudo sed -r -i 's/^\s*(.* IN A .*)$/\1/' /etc/coredns/db.firezone.internal
   - sudo systemctl start coredns.service

--- a/terraform/modules/aws/coredns/templates/cloud-init.yaml
+++ b/terraform/modules/aws/coredns/templates/cloud-init.yaml
@@ -1,0 +1,65 @@
+#cloud-config
+
+write_files:
+  - path: /etc/coredns/Corefile
+    permissions: "0644"
+    owner: root
+    content: |
+      .:53 {
+        forward . 1.1.1.1 9.9.9.9
+        log
+        errors
+      }
+
+      firezone.internal:53 {
+        file /etc/coredns/db.firezone.internal
+        log
+        errors
+      }
+
+  - path: /etc/coredns/db.firezone.internal
+    permissions: "0644"
+    owner: root
+    content: |
+      $ORIGIN firezone.internal.
+      $TTL 1h
+      @   IN SOA   ns1.firezone.internal. admin.firezone.internal. (
+                      2024010501 ; Serial
+                      1h         ; Refresh (1 hour)
+                      10m        ; Retry (10 minutes)
+                      7d         ; Expire (7 days)
+                      1h         ; Minimum TTL (1 hour)
+                  )
+
+      httpbin     IN A     10.0.32.101
+      iperf       IN A     10.0.32.102
+
+  - path: /etc/systemd/system/coredns.service
+    permissions: "0644"
+    owner: root
+    content: |
+      [Unit]
+      Description=Start a CoreDNS container
+
+      [Service]
+      TimeoutStartSec=0
+      Restart=always
+      ExecStartPre=/usr/bin/docker pull ${container_image}
+      ExecStart=/bin/sh -c 'docker run --name=${container_name} -p ${host_ip}:53:53 -p ${host_ip}:53:53/udp -v /etc/coredns:/etc/coredns --restart=unless-stopped --pull=always ${container_image} -conf /etc/coredns/Corefile'
+      ExecStop=/usr/bin/docker stop coredns
+      ExecStopPost=/usr/bin/docker rm coredns
+
+runcmd:
+  - sudo apt-get update
+  - sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  - sudo apt-get update
+  - sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+  - echo '{"experimental":true,"ip6tables":true,"ipv6":true,"fixed-cidr-v6":"fd00::/80"}' | sudo tee -a /etc/docker/daemon.json
+  - sudo usermod -aG docker ubuntu
+  - sudo systemctl enable docker
+  - sudo systemctl stop docker
+  - sudo systemctl start docker
+  - sudo systemctl daemon-reload
+  - sudo systemctl start coredns.service

--- a/terraform/modules/aws/coredns/variables.tf
+++ b/terraform/modules/aws/coredns/variables.tf
@@ -15,15 +15,6 @@ variable "api_url" {
   default     = null
 }
 
-variable "application_environment_variables" {
-  description = "List of environment variables to set for all application containers."
-  type = list(object({
-    name  = string
-    value = string
-  }))
-  default  = []
-  nullable = false
-}
 
 variable "application_name" {
   description = "Name of the application. Defaults to value of `var.image_name` with `_` replaced to `-`."
@@ -43,6 +34,16 @@ variable "associate_public_ip_address" {
   description = "Whether to associate a public IP address with an instance in a VPC"
   type        = bool
   default     = true
+}
+
+variable "dns_records" {
+  description = "List of DNS records to set for CoreDNS."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default  = []
+  nullable = false
 }
 
 variable "instance_type" {

--- a/terraform/modules/aws/coredns/variables.tf
+++ b/terraform/modules/aws/coredns/variables.tf
@@ -1,0 +1,126 @@
+variable "ami" {
+  description = "AMI ID for the EC2 instance"
+  type        = string
+  default     = "ami-0b2a9065573b0a9c9" # Ubuntu 22.04 in us-east-1
+
+  validation {
+    condition     = length(var.ami) > 4 && substr(var.ami, 0, 4) == "ami-"
+    error_message = "Please provide a valid value for variable AMI."
+  }
+}
+
+variable "api_url" {
+  description = "URL of the control plane endpoint."
+  type        = string
+  default     = null
+}
+
+variable "application_environment_variables" {
+  description = "List of environment variables to set for all application containers."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default  = []
+  nullable = false
+}
+
+variable "application_name" {
+  description = "Name of the application. Defaults to value of `var.image_name` with `_` replaced to `-`."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "application_version" {
+  description = "Version of the application. Defaults to value of `var.image_tag`."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "associate_public_ip_address" {
+  description = "Whether to associate a public IP address with an instance in a VPC"
+  type        = bool
+  default     = true
+}
+
+variable "instance_type" {
+  description = "The type of instance to start"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "instance_tags" {
+  description = "Additional tags for the instance"
+  type        = map(string)
+  default     = {}
+}
+
+variable "ipv6_addresses" {
+  description = "Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface"
+  type        = list(string)
+  default     = null
+}
+
+variable "key_name" {
+  description = "Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource"
+  type        = string
+  default     = null
+}
+
+variable "monitoring" {
+  description = "If true, the launched EC2 instance will have detailed monitoring enabled"
+  type        = bool
+  default     = null
+}
+
+variable "name" {
+  description = "Name to be used on EC2 instance created"
+  type        = string
+  default     = ""
+}
+
+variable "observability_log_level" {
+  description = "Sets RUST_LOG environment variable which applications should use to configure Rust Logger. Default: 'info'."
+  type        = string
+  nullable    = false
+  default     = "info"
+
+}
+
+variable "private_ip" {
+  description = "Private IP address to associate with the instance in a VPC"
+  type        = string
+  default     = null
+}
+
+variable "root_block_device" {
+  description = "Customize details about the root block device of the instance. See Block Devices below for details"
+  type        = list(any)
+  default     = []
+}
+
+variable "subnet_id" {
+  description = "The VPC Subnet ID to launch in"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource"
+  type        = map(string)
+  default     = {}
+}
+
+variable "token" {
+  description = "Portal token to use for authentication."
+  type        = string
+  default     = null
+}
+
+variable "vpc_security_group_ids" {
+  description = "A list of security group IDs to associate with"
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
Why:

* The CoreDNS server that had been running in AWS was not yet ported over to use the new AWS Terraform in the mono repo.