### PR TITLE
feat(phoenix-channel): automatically reconnect based on provided `ExponentialBackoff`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,7 @@ services:
       test: ["CMD-SHELL", "ip link | grep tun-firezone"]
     environment:
       FIREZONE_TOKEN: ".SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkMjI3NDU2MGItZTk3Yi00NWU0LThiMzQtNjc5Yzc2MTdlOThkbQAAADhPMDJMN1VTMkozVklOT01QUjlKNklMODhRSVFQNlVPOEFRVk82VTVJUEwwVkpDMjJKR0gwPT09PW4GAF3gLBONAWIAAVGA.DCT0Qv80qzF5OQ6CccLKXPLgzC3Rzx5DqzDAh9mWAww"
-      RUST_LOG: firezone_gateway=trace,wire=trace,connlib_gateway_shared=trace,firezone_tunnel=trace,connlib_shared=trace,warn
+      RUST_LOG: firezone_gateway=trace,wire=trace,connlib_gateway_shared=trace,firezone_tunnel=trace,connlib_shared=trace,phoenix_channel=debug,warn
       FIREZONE_ENABLE_MASQUERADE: 1
       FIREZONE_API_URL: ws://api:8081
       FIREZONE_ID: 4694E56C-7643-4A15-9DF3-638E5B05F570

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2060,6 +2060,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum 0.7.4",
+ "backoff",
  "base64 0.21.7",
  "bytecodec",
  "bytes",
@@ -4609,6 +4610,7 @@ dependencies = [
 name = "phoenix-channel"
 version = "1.0.0"
 dependencies = [
+ "backoff",
  "base64 0.21.7",
  "futures",
  "rand_core 0.6.4",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,6 +31,7 @@ str0m = { version = "0.4", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.9", features = ["serde"] }
 dns-lookup = "2.0"
+tokio-tungstenite = "0.21"
 
 connlib-client-android = { path = "connlib/clients/android"}
 connlib-client-apple = { path = "connlib/clients/apple"}

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -3,10 +3,11 @@ use crate::messages::{
     EgressMessages, IngressMessages,
 };
 use crate::CallbackHandler;
-use anyhow::{anyhow, Result};
-use connlib_shared::messages::{ClientId, GatewayResponse};
+use anyhow::Result;
+use connlib_shared::messages::{ClientId, GatewayResponse, ResourceAccepted};
 use connlib_shared::Error;
 use firezone_tunnel::{Event, GatewayState, Tunnel};
+use phoenix_channel::PhoenixChannel;
 use std::convert::Infallible;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -16,13 +17,13 @@ pub const PHOENIX_TOPIC: &str = "gateway";
 
 pub struct Eventloop {
     tunnel: Arc<Tunnel<CallbackHandler, GatewayState>>,
-    portal: tokio::sync::mpsc::Receiver<IngressMessages>,
-    portal_sender: tokio::sync::mpsc::Sender<EgressMessages>,
+    portal: PhoenixChannel<IngressMessages, EgressMessages>,
 
     // TODO: Strongly type request reference (currently `String`)
     connection_request_tasks:
         futures_bounded::FuturesMap<(ClientId, String), Result<GatewayResponse, Error>>,
     add_ice_candidate_tasks: futures_bounded::FuturesSet<Result<(), Error>>,
+    allow_access_tasks: futures_bounded::FuturesMap<String, Option<ResourceAccepted>>,
 
     print_stats_timer: tokio::time::Interval,
 }
@@ -30,13 +31,11 @@ pub struct Eventloop {
 impl Eventloop {
     pub(crate) fn new(
         tunnel: Arc<Tunnel<CallbackHandler, GatewayState>>,
-        portal: tokio::sync::mpsc::Receiver<IngressMessages>,
-        portal_sender: tokio::sync::mpsc::Sender<EgressMessages>,
+        portal: PhoenixChannel<IngressMessages, EgressMessages>,
     ) -> Self {
         Self {
             tunnel,
             portal,
-            portal_sender,
 
             // TODO: Pick sane values for timeouts and size.
             connection_request_tasks: futures_bounded::FuturesMap::new(
@@ -45,6 +44,7 @@ impl Eventloop {
             ),
             add_ice_candidate_tasks: futures_bounded::FuturesSet::new(Duration::from_secs(60), 100),
             print_stats_timer: tokio::time::interval(Duration::from_secs(10)),
+            allow_access_tasks: futures_bounded::FuturesMap::new(Duration::from_secs(60), 100),
         }
     }
 }
@@ -60,17 +60,14 @@ impl Eventloop {
                 }) => {
                     tracing::debug!(%client, %candidate, "Sending ICE candidate to client");
 
-                    let sender = self.portal_sender.clone();
-                    tokio::spawn(async move {
-                        sender
-                            .send(EgressMessages::BroadcastIceCandidates(
-                                BroadcastClientIceCandidates {
-                                    client_ids: vec![client],
-                                    candidates: vec![candidate],
-                                },
-                            ))
-                            .await
-                    });
+                    self.portal.send(
+                        PHOENIX_TOPIC,
+                        EgressMessages::BroadcastIceCandidates(BroadcastClientIceCandidates {
+                            client_ids: vec![client],
+                            candidates: vec![candidate],
+                        }),
+                    );
+
                     continue;
                 }
                 Poll::Ready(Event::ConnectionIntent { .. }) => {
@@ -84,15 +81,13 @@ impl Eventloop {
                 Poll::Ready(((client, reference), Ok(Ok(gateway_payload)))) => {
                     tracing::debug!(%client, %reference, "Connection is ready");
 
-                    let sender = self.portal_sender.clone();
-                    tokio::spawn(async move {
-                        sender
-                            .send(EgressMessages::ConnectionReady(ConnectionReady {
-                                reference,
-                                gateway_payload,
-                            }))
-                            .await
-                    });
+                    self.portal.send(
+                        PHOENIX_TOPIC,
+                        EgressMessages::ConnectionReady(ConnectionReady {
+                            reference,
+                            gateway_payload,
+                        }),
+                    );
 
                     // TODO: If outbound request fails, cleanup connection.
                     continue;
@@ -108,6 +103,30 @@ impl Eventloop {
                         %client,
                         %reference,
                         "Failed to establish connection: {:#}", anyhow::Error::new(e)
+                    );
+                    continue;
+                }
+                Poll::Pending => {}
+            }
+
+            match self.allow_access_tasks.poll_unpin(cx) {
+                Poll::Ready((reference, Ok(Some(res)))) => {
+                    self.portal.send(
+                        PHOENIX_TOPIC,
+                        EgressMessages::ConnectionReady(ConnectionReady {
+                            reference,
+                            gateway_payload: GatewayResponse::ResourceAccepted(res),
+                        }),
+                    );
+                    continue;
+                }
+                Poll::Ready((_, Ok(None))) => {
+                    continue;
+                }
+                Poll::Ready((reference, Err(e))) => {
+                    tracing::debug!(
+                        %reference,
+                        "Failed to allow access: {:#}", anyhow::Error::new(e)
                     );
                     continue;
                 }
@@ -130,8 +149,11 @@ impl Eventloop {
                 Poll::Pending => {}
             }
 
-            match self.portal.poll_recv(cx) {
-                Poll::Ready(Some(IngressMessages::RequestConnection(req))) => {
+            match self.portal.poll(cx)? {
+                Poll::Ready(phoenix_channel::Event::InboundMessage {
+                    msg: IngressMessages::RequestConnection(req),
+                    ..
+                }) => {
                     let tunnel = Arc::clone(&self.tunnel);
 
                     match self.connection_request_tasks.try_push(
@@ -160,39 +182,42 @@ impl Eventloop {
                     };
                     continue;
                 }
-                Poll::Ready(Some(IngressMessages::AllowAccess(AllowAccess {
-                    client_id,
-                    resource,
-                    expires_at,
-                    payload,
-                    reference,
-                }))) => {
+                Poll::Ready(phoenix_channel::Event::InboundMessage {
+                    msg:
+                        IngressMessages::AllowAccess(AllowAccess {
+                            client_id,
+                            resource,
+                            expires_at,
+                            payload,
+                            reference,
+                        }),
+                    ..
+                }) => {
                     tracing::debug!(client = %client_id, resource = %resource.id(), expires = ?expires_at.map(|e| e.to_rfc3339()), "Allowing access to resource");
 
                     let tunnel = Arc::clone(&self.tunnel);
-                    let sender = self.portal_sender.clone();
-                    tokio::spawn(async move {
-                        if let Some(res) = tunnel
-                            .allow_access(resource, client_id, expires_at, payload)
-                            .await
-                        {
-                            if let Err(e) = sender
-                                .send(EgressMessages::ConnectionReady(ConnectionReady {
-                                    reference,
-                                    gateway_payload: GatewayResponse::ResourceAccepted(res),
-                                }))
+
+                    if self
+                        .allow_access_tasks
+                        .try_push(reference, async move {
+                            tunnel
+                                .allow_access(resource, client_id, expires_at, payload)
                                 .await
-                            {
-                                tracing::warn!("Error while sending gateway response: {e:#?}");
-                            }
-                        }
-                    });
+                        })
+                        .is_err()
+                    {
+                        tracing::warn!("Too many allow access requests, dropping existing one");
+                    }
                     continue;
                 }
-                Poll::Ready(Some(IngressMessages::IceCandidates(ClientIceCandidates {
-                    client_id,
-                    candidates,
-                }))) => {
+                Poll::Ready(phoenix_channel::Event::InboundMessage {
+                    msg:
+                        IngressMessages::IceCandidates(ClientIceCandidates {
+                            client_id,
+                            candidates,
+                        }),
+                    ..
+                }) => {
                     for candidate in candidates {
                         tracing::debug!(client = %client_id, %candidate, "Adding ICE candidate from client");
 
@@ -208,10 +233,6 @@ impl Eventloop {
                         }
                     }
                     continue;
-                }
-                // if we dropped the sender it means that there was an unrecoverable error
-                Poll::Ready(None) => {
-                    return Poll::Ready(Err(anyhow!("portal connection completely dropped")));
                 }
                 _ => {}
             }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -1,16 +1,14 @@
 use crate::eventloop::{Eventloop, PHOENIX_TOPIC};
 use crate::messages::InitGateway;
 use anyhow::{Context, Result};
-use backoff::backoff::Backoff;
-use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
+use backoff::ExponentialBackoffBuilder;
 use boringtun::x25519::StaticSecret;
 use clap::Parser;
 use connlib_shared::{get_user_agent, login_url, Callbacks, Mode};
 use firezone_cli_utils::{setup_global_subscriber, CommonArgs};
 use firezone_tunnel::{GatewayState, Tunnel};
 use futures::{future, TryFutureExt};
-use messages::{EgressMessages, IngressMessages};
-use phoenix_channel::{PhoenixChannel, SecureUrl};
+use phoenix_channel::SecureUrl;
 use secrecy::{Secret, SecretString};
 use std::convert::Infallible;
 use std::path::Path;
@@ -18,7 +16,6 @@ use std::pin::pin;
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 use tokio::signal::ctrl_c;
-use tokio_tungstenite::tungstenite;
 use tracing_subscriber::layer;
 use url::Url;
 use uuid::Uuid;
@@ -84,127 +81,29 @@ async fn get_firezone_id(env_id: Option<String>) -> Result<String> {
 async fn run(connect_url: Url, private_key: StaticSecret) -> Result<Infallible> {
     let tunnel: Arc<Tunnel<_, GatewayState>> =
         Arc::new(Tunnel::new(private_key, CallbackHandler).await?);
-    let mut exponential_backoff = ExponentialBackoffBuilder::default()
-        .with_max_elapsed_time(None)
-        .build();
 
-    let (portal, init) = connect_to_portal(&mut exponential_backoff, &connect_url).await?;
-
-    exponential_backoff.reset();
+    let (portal, init) = phoenix_channel::init::<InitGateway, _, _>(
+        Secret::new(SecureUrl::from_url(connect_url.clone())),
+        get_user_agent(None),
+        PHOENIX_TOPIC,
+        (),
+        ExponentialBackoffBuilder::default()
+            .with_max_elapsed_time(None)
+            .build(),
+    )
+    .await??;
 
     tunnel
         .set_interface(&init.interface)
         .context("Failed to set interface")?;
 
-    let (portal_tx, portal_rx) = tokio::sync::mpsc::channel(1_000);
-    let (portal_sender_tx, portal_sender_rx) = tokio::sync::mpsc::channel(1_000);
-    let portal_task = tokio::spawn(async move {
-        portal_loop(
-            portal,
-            portal_tx,
-            portal_sender_rx,
-            exponential_backoff,
-            connect_url,
-        )
+    let mut eventloop = Eventloop::new(tunnel, portal);
+
+    future::poll_fn(|cx| eventloop.poll(cx))
         .await
-        .context("Connection to portal failed")
-    });
+        .context("Eventloop failed")?;
 
-    let mut eventloop = Eventloop::new(tunnel, portal_rx, portal_sender_tx);
-
-    let eventloop_task = tokio::spawn(async move {
-        future::poll_fn(|cx| eventloop.poll(cx))
-            .await
-            .context("Eventloop failed")
-    });
-
-    let res = future::try_select(portal_task, eventloop_task)
-        .await
-        .map_err(|e| e.factor_first().0)?;
-    res.factor_first().0?;
-
-    unreachable!("should never exit without error");
-}
-
-async fn portal_loop(
-    mut portal: PhoenixChannel<IngressMessages, EgressMessages>,
-    tx: tokio::sync::mpsc::Sender<IngressMessages>,
-    mut rx: tokio::sync::mpsc::Receiver<EgressMessages>,
-    mut exponential_backoff: ExponentialBackoff,
-    connect_url: Url,
-) -> Result<Infallible> {
-    loop {
-        handle_portal_messages(portal, tx.clone(), &mut rx).await?;
-        (portal, _) = connect_to_portal(&mut exponential_backoff, &connect_url).await?;
-        exponential_backoff.reset();
-    }
-}
-
-async fn handle_portal_messages(
-    mut portal: PhoenixChannel<IngressMessages, EgressMessages>,
-    tx: tokio::sync::mpsc::Sender<IngressMessages>,
-    rx: &mut tokio::sync::mpsc::Receiver<EgressMessages>,
-) -> Result<()> {
-    loop {
-        tokio::select! {
-            result = future::poll_fn(|cx| portal.poll(cx)) => {
-                match result {
-                    Ok(phoenix_channel::Event::InboundMessage { topic: _, msg }) => {
-                        tx.send(msg).await?;
-                    }
-                    Err(e) => {
-                        client_errors(e.into())?;
-                        return Ok(());
-                    }
-                    _ => {}
-                }
-            }
-            message = rx.recv() => {
-                portal.send(PHOENIX_TOPIC, message);
-            }
-        }
-    }
-}
-
-async fn connect_to_portal(
-    exponential_backoff: &mut ExponentialBackoff,
-    connect_url: &Url,
-) -> Result<(PhoenixChannel<IngressMessages, EgressMessages>, InitGateway)> {
-    loop {
-        let result = phoenix_channel::init::<InitGateway, _, _>(
-            Secret::new(SecureUrl::from_url(connect_url.clone())),
-            get_user_agent(None),
-            PHOENIX_TOPIC,
-            (),
-        )
-        .await;
-
-        if let Ok(Ok((portal, init))) = result {
-            tracing::debug!("connected to portal");
-            return Ok((portal, init));
-        }
-
-        if let Err(e) = result {
-            client_errors(e.into())?;
-        }
-
-        let Some(next_backoff) = exponential_backoff.next_backoff() else {
-            panic!("exponential backoff should never end");
-        };
-
-        tracing::debug!(retrying_in=?next_backoff, "portal disconnected");
-        tokio::time::sleep(next_backoff).await;
-    }
-}
-
-/// Keep HTTP errors as is convert all other errors to Ok, used to find out if we should keep retrying connection.
-fn client_errors(e: anyhow::Error) -> Result<()> {
-    // As per HTTP spec, retrying client-errors without modifying the request is pointless. Thus we abort the backoff.
-    if e.chain().any(is_client_error) {
-        return Err(e);
-    }
-
-    Ok(())
+    unreachable!()
 }
 
 #[derive(Clone)]
@@ -222,43 +121,4 @@ struct Cli {
     /// Identifier generated by the portal to identify and display the device.
     #[arg(short = 'i', long, env = "FIREZONE_ID")]
     pub firezone_id: Option<String>,
-}
-
-/// Checks whether the given [`std::error::Error`] is in-fact an HTTP error with a 4xx status code.
-fn is_client_error(e: &(dyn std::error::Error + 'static)) -> bool {
-    let Some(tungstenite::Error::Http(r)) = e.downcast_ref() else {
-        return false;
-    };
-
-    r.status().is_client_error()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use anyhow::anyhow;
-
-    #[test]
-    fn filters_client_error() {
-        let thrown_error =
-            anyhow::Error::new(phoenix_channel::Error::WebSocket(tungstenite::Error::Http(
-                tungstenite::http::Response::builder()
-                    .status(400)
-                    .body(None)
-                    .unwrap(),
-            )));
-
-        let converted_error = client_errors(thrown_error);
-
-        assert!(converted_error.is_err());
-    }
-
-    #[test]
-    fn ok_for_non_client_error() {
-        let thrown_error = anyhow!("normal error");
-
-        let converted_error = client_errors(thrown_error);
-
-        assert!(converted_error.is_ok());
-    }
 }

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 secrecy = { workspace = true }
-tokio-tungstenite = { version = "0.21.0", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 futures = "0.3.29"
 base64 = "0.21.7"
 serde = { version = "1.0.190", features = ["derive"] }
@@ -18,3 +18,4 @@ url = "2.4.1"
 serde_json = "1.0.108"
 thiserror = "1.0.50"
 tokio = { version = "1.33.0", features = ["net", "time"] }
+backoff = "0.4.0"

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -50,7 +50,7 @@ enum State {
 ///
 /// The provided URL must contain a host.
 /// Additionally, you must already provide any query parameters required for authentication.
-#[tracing::instrument(level = "debug", skip(payload, secret_url))]
+#[tracing::instrument(level = "debug", skip(payload, secret_url, reconnect_backoff))]
 #[allow(clippy::type_complexity)]
 pub async fn init<TInitM, TInboundMsg, TOutboundRes>(
     secret_url: Secret<SecureUrl>,
@@ -246,7 +246,7 @@ where
                         let secret_url = self.secret_url.clone();
                         let user_agent = self.user_agent.clone();
 
-                        tracing::debug!(?backoff, "Reconnecting to portal");
+                        tracing::debug!(?backoff, max_elapsed_time = ?self.reconnect_backoff.max_elapsed_time, "Reconnecting to portal");
 
                         self.state = State::Connecting(Box::pin(async move {
                             tokio::time::sleep(backoff).await;

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -1,13 +1,16 @@
 use std::collections::HashSet;
 use std::{fmt, future, marker::PhantomData, time::Duration};
 
+use backoff::backoff::Backoff;
+use backoff::ExponentialBackoff;
 use base64::Engine;
+use futures::future::BoxFuture;
 use futures::{FutureExt, SinkExt, StreamExt};
 use rand_core::{OsRng, RngCore};
-use secrecy::Secret;
+use secrecy::{CloneableSecret, Secret};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use tokio::net::TcpStream;
 use tokio::time::Instant;
 use tokio_tungstenite::{
@@ -22,7 +25,7 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 // TODO: Refactor this PhoenixChannel to be compatible with the needs of the client and gateway
 // See https://github.com/firezone/firezone/issues/2158
 pub struct PhoenixChannel<TInboundMsg, TOutboundRes> {
-    stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    state: State,
     pending_messages: Vec<Message>,
     next_request_id: u64,
 
@@ -31,6 +34,16 @@ pub struct PhoenixChannel<TInboundMsg, TOutboundRes> {
     _phantom: PhantomData<(TInboundMsg, TOutboundRes)>,
 
     pending_join_requests: HashSet<OutboundRequestId>,
+
+    // Stored here to allow re-connecting.
+    secret_url: Secret<SecureUrl>,
+    user_agent: String,
+    reconnect_backoff: ExponentialBackoff,
+}
+
+enum State {
+    Connected(WebSocketStream<MaybeTlsStream<TcpStream>>),
+    Connecting(BoxFuture<'static, Result<WebSocketStream<MaybeTlsStream<TcpStream>>, Error>>),
 }
 
 /// Creates a new [PhoenixChannel] to the given endpoint and waits for an `init` message.
@@ -44,6 +57,7 @@ pub async fn init<TInitM, TInboundMsg, TOutboundRes>(
     user_agent: String,
     login_topic: &'static str,
     payload: impl Serialize,
+    reconnect_backoff: ExponentialBackoff,
 ) -> Result<
     Result<(PhoenixChannel<TInboundMsg, TOutboundRes>, TInitM), UnexpectedEventDuringInit>,
     Error,
@@ -53,8 +67,11 @@ where
     TInboundMsg: DeserializeOwned,
     TOutboundRes: DeserializeOwned,
 {
-    let mut channel =
-        PhoenixChannel::<InitMessage<TInitM>, ()>::connect(secret_url, user_agent).await?;
+    let mut channel = PhoenixChannel::<InitMessage<TInitM>, ()>::connect(
+        secret_url,
+        user_agent,
+        reconnect_backoff,
+    ); // No reconnection on `init`.
     channel.join(login_topic, payload);
 
     tracing::info!("Connected to portal, waiting for `init` message");
@@ -120,6 +137,7 @@ impl fmt::Display for InboundRequestId {
     }
 }
 
+#[derive(Clone)]
 pub struct SecureUrl {
     inner: Url,
 }
@@ -129,6 +147,8 @@ impl SecureUrl {
         Self { inner: url }
     }
 }
+
+impl CloneableSecret for SecureUrl {}
 
 impl secrecy::Zeroize for SecureUrl {
     fn zeroize(&mut self) {
@@ -146,21 +166,26 @@ where
     ///
     /// The provided URL must contain a host.
     /// Additionally, you must already provide any query parameters required for authentication.
-    pub async fn connect(secret_url: Secret<SecureUrl>, user_agent: String) -> Result<Self, Error> {
-        tracing::info!("Trying to connect to the portal...");
+    pub fn connect(
+        secret_url: Secret<SecureUrl>,
+        user_agent: String,
+        reconnect_backoff: ExponentialBackoff,
+    ) -> Self {
+        Self {
+            reconnect_backoff,
+            secret_url: secret_url.clone(),
+            user_agent: user_agent.clone(),
+            state: State::Connecting(Box::pin(async move {
+                let (stream, _) = connect_async(make_request(secret_url, user_agent)?).await?;
 
-        let (stream, _) = connect_async(make_request(secret_url, user_agent)?).await?;
-
-        tracing::info!("Successfully connected to portal");
-
-        Ok(Self {
-            stream,
+                Ok(stream)
+            })),
             pending_messages: vec![],
             _phantom: PhantomData,
             next_request_id: 0,
             next_heartbeat: Box::pin(tokio::time::sleep(HEARTBEAT_INTERVAL)),
             pending_join_requests: Default::default(),
-        })
+        }
     }
 
     /// Join the provided room.
@@ -182,101 +207,173 @@ where
         cx: &mut Context,
     ) -> Poll<Result<Event<TInboundMsg, TOutboundRes>, Error>> {
         loop {
+            // First, check if we are connected.
+            let stream = match &mut self.state {
+                State::Connected(stream) => stream,
+                State::Connecting(future) => match ready!(future.poll_unpin(cx)) {
+                    Ok(stream) => {
+                        self.reconnect_backoff.reset();
+                        self.state = State::Connected(stream);
+
+                        tracing::info!("Connected to portal");
+
+                        continue;
+                    }
+                    Err(e) => {
+                        if let Error::WebSocket(tokio_tungstenite::tungstenite::Error::Http(r)) = &e
+                        {
+                            let status = r.status();
+
+                            if status.is_client_error() {
+                                let body = r
+                                    .body()
+                                    .as_deref()
+                                    .map(String::from_utf8_lossy)
+                                    .unwrap_or_default();
+
+                                tracing::warn!(
+                                    "Fatal client error ({status}) in portal connection: {body}"
+                                );
+
+                                return Poll::Ready(Err(e));
+                            }
+                        };
+
+                        let Some(backoff) = self.reconnect_backoff.next_backoff() else {
+                            tracing::warn!("Reconnect backoff expired");
+                            return Poll::Ready(Err(e));
+                        };
+                        let secret_url = self.secret_url.clone();
+                        let user_agent = self.user_agent.clone();
+
+                        tracing::debug!(?backoff, "Reconnecting to portal");
+
+                        self.state = State::Connecting(Box::pin(async move {
+                            tokio::time::sleep(backoff).await;
+
+                            let (stream, _) =
+                                connect_async(make_request(secret_url, user_agent)?).await?;
+
+                            Ok(stream)
+                        }));
+                        continue;
+                    }
+                },
+            };
+
             // Priority 1: Keep local buffers small and send pending messages.
-            if self.stream.poll_ready_unpin(cx).is_ready() {
+            if stream.poll_ready_unpin(cx).is_ready() {
                 if let Some(message) = self.pending_messages.pop() {
-                    self.stream.start_send_unpin(message)?;
+                    match stream.start_send_unpin(message) {
+                        Ok(()) => {}
+                        Err(e) => {
+                            self.reconnect_on_transient_error(e);
+                        }
+                    }
                     continue;
                 }
             }
 
             // Priority 2: Handle incoming messages.
-            if let Poll::Ready(Some(message)) = self.stream.poll_next_unpin(cx)? {
-                let Ok(text) = message.into_text() else {
-                    tracing::warn!("Received non-text message from portal");
-                    continue;
-                };
-
-                tracing::trace!("Received message from portal: {text}");
-
-                let message = match serde_json::from_str::<PhoenixMessage<TInboundMsg, TOutboundRes>>(
-                    &text,
-                ) {
-                    Ok(m) => m,
-                    Err(e) => {
-                        tracing::warn!("Failed to deserialize message {text}: {e}");
+            match stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(message))) => {
+                    let Ok(text) = message.into_text() else {
+                        tracing::warn!("Received non-text message from portal");
                         continue;
-                    }
-                };
+                    };
 
-                match message.payload {
-                    Payload::Message(msg) => match message.reference {
-                        None => {
-                            return Poll::Ready(Ok(Event::InboundMessage {
-                                topic: message.topic,
-                                msg,
-                            }))
-                        }
-                        Some(reference) => {
-                            return Poll::Ready(Ok(Event::InboundReq {
-                                req_id: InboundRequestId(reference),
-                                req: msg,
-                            }))
-                        }
-                    },
-                    Payload::Reply(ReplyMessage::PhxReply(PhxReply::Error(ErrorInfo::Reason(
-                        reason,
-                    )))) => {
-                        return Poll::Ready(Ok(Event::ErrorResponse {
-                            topic: message.topic,
-                            req_id: OutboundRequestId(
-                                message.reference.ok_or(Error::MissingReplyId)?,
-                            ),
-                            reason,
-                        }));
-                    }
-                    Payload::Reply(ReplyMessage::PhxReply(PhxReply::Ok(OkReply::Message(
-                        reply,
-                    )))) => {
-                        let req_id =
-                            OutboundRequestId(message.reference.ok_or(Error::MissingReplyId)?);
+                    tracing::trace!("Received message from portal: {text}");
 
-                        if self.pending_join_requests.remove(&req_id) {
-                            // For `phx_join` requests, `reply` is empty so we can safely ignore it.
-                            return Poll::Ready(Ok(Event::JoinedRoom {
+                    let message = match serde_json::from_str::<
+                        PhoenixMessage<TInboundMsg, TOutboundRes>,
+                    >(&text)
+                    {
+                        Ok(m) => m,
+                        Err(e) => {
+                            tracing::warn!("Failed to deserialize message {text}: {e}");
+                            continue;
+                        }
+                    };
+
+                    match message.payload {
+                        Payload::Message(msg) => match message.reference {
+                            None => {
+                                return Poll::Ready(Ok(Event::InboundMessage {
+                                    topic: message.topic,
+                                    msg,
+                                }))
+                            }
+                            Some(reference) => {
+                                return Poll::Ready(Ok(Event::InboundReq {
+                                    req_id: InboundRequestId(reference),
+                                    req: msg,
+                                }))
+                            }
+                        },
+                        Payload::Reply(ReplyMessage::PhxReply(PhxReply::Error(
+                            ErrorInfo::Reason(reason),
+                        ))) => {
+                            return Poll::Ready(Ok(Event::ErrorResponse {
                                 topic: message.topic,
+                                req_id: OutboundRequestId(
+                                    message.reference.ok_or(Error::MissingReplyId)?,
+                                ),
+                                reason,
                             }));
                         }
+                        Payload::Reply(ReplyMessage::PhxReply(PhxReply::Ok(OkReply::Message(
+                            reply,
+                        )))) => {
+                            let req_id =
+                                OutboundRequestId(message.reference.ok_or(Error::MissingReplyId)?);
 
-                        return Poll::Ready(Ok(Event::SuccessResponse {
-                            topic: message.topic,
-                            req_id,
-                            res: reply,
-                        }));
-                    }
-                    Payload::Reply(ReplyMessage::PhxReply(PhxReply::Error(ErrorInfo::Offline))) => {
-                        tracing::warn!(
-                            "Received offline error for request {:?}",
-                            message.reference
-                        );
-                        continue;
-                    }
-                    Payload::Reply(ReplyMessage::PhxReply(PhxReply::Ok(OkReply::NoMessage(
-                        Empty {},
-                    )))) => {
-                        tracing::trace!("Received empty reply for request {:?}", message.reference);
-                        continue;
-                    }
-                    Payload::Reply(ReplyMessage::PhxError(Empty {})) => {
-                        return Poll::Ready(Ok(Event::ErrorResponse {
-                            topic: message.topic,
-                            req_id: OutboundRequestId(
-                                message.reference.ok_or(Error::MissingReplyId)?,
-                            ),
-                            reason: "unknown error (bad event?)".to_owned(),
-                        }))
+                            if self.pending_join_requests.remove(&req_id) {
+                                // For `phx_join` requests, `reply` is empty so we can safely ignore it.
+                                return Poll::Ready(Ok(Event::JoinedRoom {
+                                    topic: message.topic,
+                                }));
+                            }
+
+                            return Poll::Ready(Ok(Event::SuccessResponse {
+                                topic: message.topic,
+                                req_id,
+                                res: reply,
+                            }));
+                        }
+                        Payload::Reply(ReplyMessage::PhxReply(PhxReply::Error(
+                            ErrorInfo::Offline,
+                        ))) => {
+                            tracing::warn!(
+                                "Received offline error for request {:?}",
+                                message.reference
+                            );
+                            continue;
+                        }
+                        Payload::Reply(ReplyMessage::PhxReply(PhxReply::Ok(
+                            OkReply::NoMessage(Empty {}),
+                        ))) => {
+                            tracing::trace!(
+                                "Received empty reply for request {:?}",
+                                message.reference
+                            );
+                            continue;
+                        }
+                        Payload::Reply(ReplyMessage::PhxError(Empty {})) => {
+                            return Poll::Ready(Ok(Event::ErrorResponse {
+                                topic: message.topic,
+                                req_id: OutboundRequestId(
+                                    message.reference.ok_or(Error::MissingReplyId)?,
+                                ),
+                                reason: "unknown error (bad event?)".to_owned(),
+                            }))
+                        }
                     }
                 }
+                Poll::Ready(Some(Err(e))) => {
+                    self.reconnect_on_transient_error(e);
+                    continue;
+                }
+                _ => (),
             }
 
             // Priority 3: Handle heartbeats.
@@ -290,12 +387,26 @@ where
             }
 
             // Priority 4: Flush out.
-            if self.stream.poll_flush_unpin(cx)?.is_ready() {
-                tracing::trace!("Flushed websocket")
+            match stream.poll_flush_unpin(cx) {
+                Poll::Ready(Ok(())) => {
+                    tracing::trace!("Flushed websocket");
+                }
+                Poll::Ready(Err(e)) => {
+                    self.reconnect_on_transient_error(e);
+                    continue;
+                }
+                Poll::Pending => {}
             }
 
             return Poll::Pending;
         }
+    }
+
+    /// Sets the channels state to [`State::Connecting`] with the given error.
+    ///
+    /// The [`PhoenixChannel::poll`] function will handle the reconnect if appropriate for the given error.
+    fn reconnect_on_transient_error(&mut self, e: tokio_tungstenite::tungstenite::Error) {
+        self.state = State::Connecting(future::ready(Err(Error::WebSocket(e))).boxed())
     }
 
     fn send_message(
@@ -326,12 +437,15 @@ where
         self,
     ) -> PhoenixChannel<TInboundMsgNew, TOutboundResNew> {
         PhoenixChannel {
-            stream: self.stream,
+            state: self.state,
             pending_messages: self.pending_messages,
             next_request_id: self.next_request_id,
             next_heartbeat: self.next_heartbeat,
             _phantom: PhantomData,
             pending_join_requests: self.pending_join_requests,
+            secret_url: self.secret_url,
+            user_agent: self.user_agent,
+            reconnect_backoff: self.reconnect_backoff,
         }
     }
 }

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1.0.190", features = ["derive"] }
 trackable = "1.3.0"
 socket2 = "0.5.5"
 axum = { version = "0.7.3", default-features = false, features = ["http1", "tokio"] }
+backoff = "0.4"
 
 [dev-dependencies]
 webrtc = { workspace = true }

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, Context, Result};
+use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use firezone_relay::{
     AddressFamily, Allocation, AllocationId, Command, IpStack, Server, Sleep, SocketAddrExt,
@@ -272,6 +273,9 @@ async fn connect_to_portal(
         JoinMessage {
             stamp_secret: stamp_secret.expose_secret().to_string(),
         },
+        ExponentialBackoffBuilder::default()
+            .with_max_elapsed_time(None)
+            .build(),
     )
     .await??;
 


### PR DESCRIPTION
Currently, only the gateway has a reconnect logic for (transient) errors when connecting to the portal. Instead of duplicating this for the relay, I moved the reconnect state machine to `phoenix-channel`. This means the relay now automatically gets it too and in the future, the clients will also benefit from it.

As a nice benefit, this also greatly simplifies the gateway's `Eventloop` and removes a bunch of cruft with channels.

Resolves: #2915.