### PR TITLE
deps: use usptream `str0m`

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -25,9 +25,9 @@ jobs:
           - runs-on: ubuntu-22.04
             packages: # Intentionally blank as a package catch-all linter
           - runs-on: macos-13
-            packages: -p connlib-client-apple
+            packages: -p connlib-client-apple -p firezone-connection
           - runs-on: windows-2022
-            packages: -p connlib-client-shared -p firezone-windows-client
+            packages: -p connlib-client-shared -p firezone-windows-client -p firezone-connection
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
@@ -47,17 +47,17 @@ jobs:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         include:
           - runs-on: ubuntu-20.04
-            packages: -p firezone-linux-client -p firezone-gateway -p connlib-client-android
+            packages: -p firezone-linux-client -p firezone-gateway -p connlib-client-android -p firezone-connection
           - runs-on: ubuntu-22.04
-            packages: -p firezone-linux-client -p firezone-gateway -p connlib-client-android
+            packages: -p firezone-linux-client -p firezone-gateway -p connlib-client-android -p firezone-connection
           - runs-on: macos-12
-            packages: -p connlib-client-apple
+            packages: -p connlib-client-apple -p firezone-connection
           - runs-on: macos-13
-            packages: -p connlib-client-apple
+            packages: -p connlib-client-apple -p firezone-connection
           - runs-on: windows-2019
-            packages: -p firezone-windows-client -p connlib-client-shared
+            packages: -p firezone-windows-client -p connlib-client-shared -p firezone-connection
           - runs-on: windows-2022
-            packages: -p firezone-windows-client -p connlib-client-shared
+            packages: -p firezone-windows-client -p connlib-client-shared -p firezone-connection
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6076,13 +6076,13 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 [[package]]
 name = "str0m"
 version = "0.4.1"
-source = "git+https://github.com/thomaseizinger/str0m?branch=main#12575cab1c8c466cbf1e05b0b7459136eeaba8ed"
+source = "git+https://github.com/thomaseizinger/str0m?branch=feat/export-stunpacket#da94d074602eb236987b21976ab4c3a9826c6e9a"
 dependencies = [
  "combine",
  "crc",
+ "fastrand 2.0.1",
  "hmac",
  "once_cell",
- "rand 0.8.5",
  "sctp-proto",
  "serde",
  "sha-1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6076,7 +6076,7 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 [[package]]
 name = "str0m"
 version = "0.4.1"
-source = "git+https://github.com/thomaseizinger/str0m?branch=feat/export-stunpacket#da94d074602eb236987b21976ab4c3a9826c6e9a"
+source = "git+https://github.com/algesten/str0m?branch=main#e6fa6808dfcdac23e0d1f61d405f938035e4eaf9"
 dependencies = [
  "combine",
  "crc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,7 +27,7 @@ tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
 hickory-resolver = { version = "0.24", features = ["tokio-runtime"] }
 webrtc = "0.9"
-str0m = "0.4"
+str0m = { version = "0.4", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.9", features = ["serde"] }
 dns-lookup = "2.0"
@@ -48,7 +48,7 @@ phoenix-channel = { path = "phoenix-channel"}
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" } # Contains unreleased patches we need (bump of x25519-dalek)
 webrtc = { git = "https://github.com/firezone/webrtc", branch = "expose-new-endpoint" }
-str0m = { git = "https://github.com/thomaseizinger/str0m", branch = "main" }
+str0m = { git = "https://github.com/thomaseizinger/str0m", branch = "feat/export-stunpacket" }
 
 [profile.release]
 strip = true

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -48,7 +48,7 @@ phoenix-channel = { path = "phoenix-channel"}
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" } # Contains unreleased patches we need (bump of x25519-dalek)
 webrtc = { git = "https://github.com/firezone/webrtc", branch = "expose-new-endpoint" }
-str0m = { git = "https://github.com/thomaseizinger/str0m", branch = "feat/export-stunpacket" }
+str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 
 [profile.release]
 strip = true


### PR DESCRIPTION
All major upstream contributions to `str0m` have been merged, meaning we can now discontinue the dependency on the fork.