### PR TITLE
Add explicit sysctl flags for AWS gateway command

### DIFF
--- a/terraform/modules/aws/gateway/templates/cloud-init.yaml
+++ b/terraform/modules/aws/gateway/templates/cloud-init.yaml
@@ -20,7 +20,7 @@ write_files:
       TimeoutStartSec=0
       Restart=always
       ExecStartPre=/usr/bin/docker pull ${container_image}
-      ExecStart=/bin/sh -c 'docker run --rm --name=${container_name} --cap-add=NET_ADMIN --volume /etc/firezone --device="/dev/net/tun:/dev/net/tun" --env FIREZONE_NAME=$(hostname) --env FIREZONE_ID=$(echo $RANDOM$(hostname) | md5sum | head -c 20; echo;) --env-file="/etc/firezone-gateway/env" ${container_image}'
+      ExecStart=/bin/sh -c 'docker run --rm --name=${container_name} --cap-add=NET_ADMIN --volume /etc/firezone --sysctl net.ipv4.ip_forward=1 --sysctl net.ipv4.conf.all.src_valid_mark=1 --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 --sysctl net.ipv6.conf.default.forwarding=1 --device="/dev/net/tun:/dev/net/tun" --env FIREZONE_NAME=$(hostname) --env FIREZONE_ID=$(echo $RANDOM$(hostname) | md5sum | head -c 20; echo;) --env-file="/etc/firezone-gateway/env" ${container_image}'
       ExecStop=/usr/bin/docker stop gateway
       ExecStopPost=/usr/bin/docker rm gateway
 


### PR DESCRIPTION
Why:

* The previous command that was used to start the gateway running in AWS was not explicitly using any `sysctl` flags in the command.  This ended up causing issues with IPv6 in the container, even though the sysctl properties on the host were set as expected.  Adding the `sysctl` flags to the command allows the container to work as expected.