### PR TITLE
connlib: make dns request in a new task without blocking peers

### DIFF
--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -2,6 +2,7 @@
 use base64::{DecodeError, DecodeSliceError};
 use boringtun::noise::errors::WireGuardError;
 use thiserror::Error;
+use tokio::task::JoinError;
 
 /// Unified Result type to use across connlib.
 pub type Result<T> = std::result::Result<T, ConnlibError>;
@@ -155,6 +156,8 @@ pub enum ConnlibError {
     TooManyConnectionRequests,
     #[error("Channel connection closed by portal")]
     ClosedByPortal,
+    #[error(transparent)]
+    JoinError(#[from] JoinError),
 }
 
 impl ConnlibError {


### PR DESCRIPTION
This required making `allow_access` `async` which is ugly, but we can fix it later like we did it with `set_peer_connection_request`, but doing this ASAP otherwise this would block the `peers_by_ip` struct and also block the executor a bunch of times and slow everything down.