### PR TITLE
fix(portal): fix otlp exporter initialization

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -68,8 +68,8 @@ defmodule Firezone.MixProject do
         validate_compile_env: true,
         applications: [
           web: :permanent,
-          opentelemetry: :temporary,
-          opentelemetry_exporter: :permanent
+          opentelemetry_exporter: :permanent,
+          opentelemetry: :temporary
         ]
       ],
       api: [
@@ -77,8 +77,8 @@ defmodule Firezone.MixProject do
         validate_compile_env: true,
         applications: [
           api: :permanent,
-          opentelemetry: :temporary,
-          opentelemetry_exporter: :permanent
+          opentelemetry_exporter: :permanent,
+          opentelemetry: :temporary
         ]
       ]
     ]


### PR DESCRIPTION
This fixes the otlp exporter initialization.

```
=WARNING REPORT==== 24-Jan-2024::12:15:01.388842 ===
OTLP exporter failed to initialize with exception error:{badmatch,
{error,
inets_not_started}}
```

https://elixirforum.com/t/opentelemetry-exporter-failed-to-initialize-with-exception-inets-not-started/58133
https://github.com/open-telemetry/opentelemetry-erlang/discussions/625

