### PR TITLE
fix(devops): Fix typo in AWS bastion host TF

### DIFF
--- a/terraform/modules/aws/bastion/main.tf
+++ b/terraform/modules/aws/bastion/main.tf
@@ -5,6 +5,7 @@ resource "aws_instance" "this" {
   subnet_id                   = var.subnet_id
   vpc_security_group_ids      = var.vpc_security_group_ids
   associate_public_ip_address = var.associate_public_ip_address
+  user_data_replace_on_change = true
 
   key_name  = var.key_name
   user_data = file("${path.module}/scripts/setup.sh")

--- a/terraform/modules/aws/bastion/scripts/setup.sh
+++ b/terraform/modules/aws/bastion/scripts/setup.sh
@@ -30,5 +30,5 @@ sudo cp $UPGRADE_CONF_FILE /tmp/unattended-upgrades.conf
 sudo sed -i 's/\/\/\(\s*"\${distro_id}:\${distro_codename}-updates";\)/  \1/' "${UPGRADE_CONF_FILE}"
 sudo sed -i 's/\/\/\(Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";\)/\1/' "${UPGRADE_CONF_FILE}"
 sudo sed -i 's/\/\/\(Unattended-Upgrade::Automatic-Reboot \)"false";/\1 "true";/' "${UPGRADE_CONF_FILE}"
-sudo sed -i 's/\/\/\(Unattended-Upgrade::Automatic-Reboot-Time \)"02:00";/\1 "07:00;"/' "${UPGRADE_CONF_FILE}"
+sudo sed -i 's/\/\/\(Unattended-Upgrade::Automatic-Reboot-Time \)"02:00";/\1 "07:00";/' "${UPGRADE_CONF_FILE}"
 sudo sed -i 's/\/\/\(Unattended-Upgrade::Automatic-Reboot-WithUsers "true";\)/\1/' "${UPGRADE_CONF_FILE}"

--- a/terraform/modules/aws/coredns/main.tf
+++ b/terraform/modules/aws/coredns/main.tf
@@ -7,6 +7,7 @@ resource "aws_instance" "this" {
   associate_public_ip_address = var.associate_public_ip_address
   private_ip                  = var.private_ip
   key_name                    = var.key_name
+  user_data_replace_on_change = true
 
   user_data = templatefile("${path.module}/templates/cloud-init.yaml", {
     container_name  = "coredns"

--- a/terraform/modules/aws/httpbin/main.tf
+++ b/terraform/modules/aws/httpbin/main.tf
@@ -6,6 +6,7 @@ resource "aws_instance" "this" {
   vpc_security_group_ids      = var.vpc_security_group_ids
   associate_public_ip_address = var.associate_public_ip_address
   private_ip                  = var.private_ip
+  user_data_replace_on_change = true
 
   key_name  = var.key_name
   user_data = file("${path.module}/scripts/setup.sh")

--- a/terraform/modules/aws/iperf/main.tf
+++ b/terraform/modules/aws/iperf/main.tf
@@ -6,6 +6,7 @@ resource "aws_instance" "this" {
   vpc_security_group_ids      = var.vpc_security_group_ids
   associate_public_ip_address = var.associate_public_ip_address
   private_ip                  = var.private_ip
+  user_data_replace_on_change = true
 
   key_name  = var.key_name
   user_data = file("${path.module}/scripts/setup.sh")

--- a/terraform/modules/aws/nat/main.tf
+++ b/terraform/modules/aws/nat/main.tf
@@ -6,6 +6,7 @@ resource "aws_instance" "this" {
   vpc_security_group_ids      = var.vpc_security_group_ids
   associate_public_ip_address = var.associate_public_ip_address
   source_dest_check           = false
+  user_data_replace_on_change = true
 
   key_name  = var.key_name
   user_data = file("${path.module}/scripts/setup.sh")


### PR DESCRIPTION
* Small typo in AWS bastion host was preventing unattended upgrades.
* Update all AWS modules to recreate the EC2 instance if the `user_data` is ever changed.