### PR TITLE
feat: automatically rejoin channel on portal after reconnect

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4612,6 +4612,7 @@ dependencies = [
 name = "phoenix-channel"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
  "backoff",
  "base64 0.21.7",
  "futures",

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -17,7 +17,7 @@ pub const PHOENIX_TOPIC: &str = "gateway";
 
 pub struct Eventloop {
     tunnel: Arc<Tunnel<CallbackHandler, GatewayState>>,
-    portal: PhoenixChannel<IngressMessages, EgressMessages>,
+    portal: PhoenixChannel<(), IngressMessages, EgressMessages>,
 
     // TODO: Strongly type request reference (currently `String`)
     connection_request_tasks:
@@ -31,7 +31,7 @@ pub struct Eventloop {
 impl Eventloop {
     pub(crate) fn new(
         tunnel: Arc<Tunnel<CallbackHandler, GatewayState>>,
-        portal: PhoenixChannel<IngressMessages, EgressMessages>,
+        portal: PhoenixChannel<(), IngressMessages, EgressMessages>,
     ) -> Self {
         Self {
             tunnel,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -234,6 +234,13 @@ impl Eventloop {
                     }
                     continue;
                 }
+                Poll::Ready(phoenix_channel::Event::InboundMessage {
+                    msg: IngressMessages::Init(_),
+                    ..
+                }) => {
+                    // TODO: Handle `init` message during operation.
+                    continue;
+                }
                 _ => {}
             }
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -82,7 +82,7 @@ async fn run(connect_url: Url, private_key: StaticSecret) -> Result<Infallible> 
     let tunnel: Arc<Tunnel<_, GatewayState>> =
         Arc::new(Tunnel::new(private_key, CallbackHandler).await?);
 
-    let (portal, init) = phoenix_channel::init::<InitGateway, _, _>(
+    let (portal, init) = phoenix_channel::init::<_, InitGateway, _, _>(
         Secret::new(SecureUrl::from_url(connect_url.clone())),
         get_user_agent(None),
         PHOENIX_TOPIC,

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -97,6 +97,7 @@ pub enum IngressMessages {
     RequestConnection(RequestConnection),
     AllowAccess(AllowAccess),
     IceCandidates(ClientIceCandidates),
+    Init(InitGateway),
 }
 
 /// A client's ice candidate message.

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -19,3 +19,4 @@ serde_json = "1.0.108"
 thiserror = "1.0.50"
 tokio = { version = "1.33.0", features = ["net", "time"] }
 backoff = "0.4.0"
+anyhow = "1"

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -71,7 +71,7 @@ where
         secret_url,
         user_agent,
         reconnect_backoff,
-    ); // No reconnection on `init`.
+    );
     channel.join(login_topic, payload);
 
     tracing::info!("Connected to portal, waiting for `init` message");

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -89,9 +89,6 @@ where
 
     let (channel, init_message) = loop {
         match future::poll_fn(|cx| channel.poll(cx)).await? {
-            Event::JoinedRoom { topic } if topic == login_topic => {
-                tracing::info!("Joined {login_topic} room on portal")
-            }
             Event::InboundMessage {
                 topic,
                 msg: InitMessage::Init(msg),
@@ -328,7 +325,7 @@ where
                                 return Poll::Ready(Ok(Event::InboundMessage {
                                     topic: message.topic,
                                     msg,
-                                }))
+                                }));
                             }
                             Some(reference) => {
                                 return Poll::Ready(Ok(Event::InboundReq {
@@ -355,6 +352,8 @@ where
                                 OutboundRequestId(message.reference.ok_or(Error::MissingReplyId)?);
 
                             if self.pending_join_requests.remove(&req_id) {
+                                tracing::info!("Joined {} room on portal", message.topic);
+
                                 // For `phx_join` requests, `reply` is empty so we can safely ignore it.
                                 return Poll::Ready(Ok(Event::JoinedRoom {
                                     topic: message.topic,


### PR DESCRIPTION
In https://github.com/firezone/firezone/pull/3364, we forgot to rejoin the channel on the portal. Additionally, I found a way to detect the disconnect even more quickly.