### PR TITLE
feat(connection): add a very basic connection timeout

### DIFF
--- a/rust/connlib/connection/src/pool.rs
+++ b/rust/connlib/connection/src/pool.rs
@@ -446,6 +446,19 @@ where
             self.rate_limiter.reset_count();
             self.next_rate_limiter_reset = Some(now + Duration::from_secs(1));
         }
+
+        let stale_connections = self
+            .initial_connections
+            .iter()
+            .filter_map(|(id, conn)| {
+                (now.duration_since(conn.created_at) >= Duration::from_secs(10)).then_some(*id)
+            })
+            .collect::<Vec<_>>();
+
+        for conn in stale_connections {
+            self.initial_connections.remove(&conn);
+            self.pending_events.push_back(Event::ConnectionFailed(conn));
+        }
     }
 
     /// Returns buffered data that needs to be sent on the socket.
@@ -566,6 +579,7 @@ where
                 session_key,
                 stun_servers: allowed_stun_servers,
                 turn_servers: allowed_turn_servers,
+                created_at: self.last_now,
             },
         );
 
@@ -936,6 +950,8 @@ struct InitialConnection {
     session_key: Secret<[u8; 32]>,
     stun_servers: HashSet<SocketAddr>,
     turn_servers: HashSet<SocketAddr>,
+
+    created_at: Instant,
 }
 
 struct Connection {

--- a/rust/connlib/connection/src/pool.rs
+++ b/rust/connlib/connection/src/pool.rs
@@ -889,6 +889,7 @@ pub struct Credentials {
     pub password: String,
 }
 
+#[derive(Debug, PartialEq)]
 pub enum Event<TId> {
     /// Signal the ICE candidate to the remote via the signalling channel.
     ///

--- a/rust/connlib/connection/tests/lib.rs
+++ b/rust/connlib/connection/tests/lib.rs
@@ -1,0 +1,19 @@
+use boringtun::x25519::StaticSecret;
+use firezone_connection::{ClientConnectionPool, Event};
+use std::{
+    collections::HashSet,
+    time::{Duration, Instant},
+};
+
+#[test]
+fn connection_times_out_after_10_seconds() {
+    let start = Instant::now();
+
+    let mut alice =
+        ClientConnectionPool::<u64>::new(StaticSecret::random_from_rng(rand::thread_rng()), start);
+
+    let _ = alice.new_connection(1, HashSet::new(), HashSet::new());
+    alice.handle_timeout(start + Duration::from_secs(10));
+
+    assert_eq!(alice.poll_event().unwrap(), Event::ConnectionFailed(1));
+}


### PR DESCRIPTION
Adds a very basic connection timeout in case there is never a follow-up with an `Answer`. This is mostly to prevent memory-leaks. I am also hoping that we can add much more unit-tests in the same manner.