### PR TITLE
feat(relay): improve logging and error handling

### DIFF
--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -475,7 +475,7 @@ where
             if let Poll::Ready(Some((data, sender, allocation))) =
                 self.relay_data_receiver.poll_next_unpin(cx)
             {
-                self.server.handle_relay_input(&data, sender, allocation);
+                self.server.handle_peer_traffic(&data, sender, allocation);
                 continue; // Handle potentially new commands.
             }
 

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -433,7 +433,6 @@ where
     /// Handle a TURN allocate request.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc8656#name-receiving-an-allocate-reque> for details.
-    #[tracing::instrument(skip(self, request, now), fields(%sender, effective_lifetime = ?request.effective_lifetime().lifetime()), level = "error")]
     fn handle_allocate_request(
         &mut self,
         request: Allocate,
@@ -531,12 +530,14 @@ where
                 target: "relay",
                 first_relay_address = field::display(first_relay_address),
                 second_relay_address = field::display(second_relay_addr),
+                lifetime = field::debug(effective_lifetime.lifetime()),
                 "Created new allocation",
             )
         } else {
             tracing::info!(
                 target: "relay",
                 first_relay_address = field::display(first_relay_address),
+                lifetime = field::debug(effective_lifetime.lifetime()),
                 "Created new allocation",
             )
         }

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -619,6 +619,8 @@ where
 
         // Check that our allocation can handle the requested peer addr.
         if !allocation.can_relay_to(peer_address) {
+            tracing::error!(target: "relay", "Allocation cannot relay to peer");
+
             return Err(error_response(PeerAddressFamilyMismatch, &request));
         }
 

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -524,6 +524,8 @@ where
         }
         self.send_message(message, sender);
 
+        Span::current().record("allocation", display(&allocation.id));
+
         if let Some(second_relay_addr) = maybe_second_relay_addr {
             tracing::info!(
                 target: "relay",

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -89,7 +89,7 @@ pub enum Command {
     },
     /// Listen for traffic on the provided port [AddressFamily].
     ///
-    /// Any incoming data should be handed to the [`Server`] via [`Server::handle_relay_input`].
+    /// Any incoming data should be handed to the [`Server`] via [`Server::handle_peer_traffic`].
     /// A single allocation can reference one of either [AddressFamily]s or both.
     /// Only the combination of [AllocationId] and [AddressFamily] is unique.
     CreateAllocation {

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -619,7 +619,7 @@ where
 
         // Check that our allocation can handle the requested peer addr.
         if !allocation.can_relay_to(peer_address) {
-            tracing::error!(target: "relay", "Allocation cannot relay to peer");
+            tracing::warn!(target: "relay", "Allocation cannot relay to peer");
 
             return Err(error_response(PeerAddressFamilyMismatch, &request));
         }
@@ -627,7 +627,7 @@ where
         // Ensure the same address isn't already bound to a different channel.
         if let Some(number) = self.channel_numbers_by_peer.get(&peer_address) {
             if number != &requested_channel {
-                tracing::error!(target: "relay", existing_channel = %number, "Peer is already bound to another channel");
+                tracing::warn!(target: "relay", existing_channel = %number, "Peer is already bound to another channel");
 
                 return Err(error_response(BadRequest, &request));
             }
@@ -639,7 +639,7 @@ where
             .get_mut(&(sender, requested_channel))
         {
             if channel.peer_address != peer_address {
-                tracing::error!(target: "relay", existing_peer = %channel.peer_address, "Channel is already bound to a different peer");
+                tracing::warn!(target: "relay", existing_peer = %channel.peer_address, "Channel is already bound to a different peer");
 
                 return Err(error_response(BadRequest, &request));
             }

--- a/rust/relay/tests/regression.rs
+++ b/rust/relay/tests/regression.rs
@@ -453,7 +453,7 @@ impl TestServer {
             }
             Input::Peer(peer, data, port) => {
                 self.server
-                    .handle_relay_input(&data, peer, self.id_to_port[&port]);
+                    .handle_peer_traffic(&data, peer, self.id_to_port[&port]);
             }
         }
 


### PR DESCRIPTION
By changing around how the fields are recorded in the tracing spans and what the functions are called, the logs now align nicely:

Before:

```
[  relay] 2024-01-25T02:01:00.103279Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.103448Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.103627Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.103774Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.103955Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.104119Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.104303Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.104456Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.104650Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.104825Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.105015Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.105165Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.105332Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.105534Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.105739Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.105934Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.106155Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.106343Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.106534Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.106671Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.106838Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.106987Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.107148Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.107289Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.107496Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.107662Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.107846Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.108003Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.108189Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.108340Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.108529Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.108665Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.108835Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.109006Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.109193Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.109363Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.109563Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.109733Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.109919Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.110058Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.110228Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.110360Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.110510Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.110628Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.110773Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.110904Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.111049Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.111199Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.111359Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.111540Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.111735Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.111884Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.112064Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.112246Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.112422Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.112577Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.112754Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.112933Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.113109Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.113254Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.113421Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:55880}:handle_channel_data_message{sender=127.0.0.1:55880 channel=16384 recipient=127.0.0.1:37062}: relay: Relaying 32 bytes
[  relay] 2024-01-25T02:01:00.113658Z DEBUG Eventloop::poll:handle_relay_input{sender=127.0.0.1:37062 allocation_id=AID-1 recipient=127.0.0.1:55880 channel=16384}: relay: Relaying 32 bytes
```

Now:

```
[  relay] 2024-01-25T01:57:42.045265Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.045393Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.045543Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.045676Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.045792Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.045918Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.046060Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.046190Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.046302Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.046410Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.046547Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.046964Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.047100Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.047219Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.047365Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.047497Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.047613Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.047732Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.047863Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.048212Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.048342Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.048460Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.048601Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.049029Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.049167Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.049292Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.049434Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.049549Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.049660Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.049787Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.049927Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.050095Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.050219Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.050688Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.050891Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.051046Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.051159Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.051300Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.051462Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.051618Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.051726Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.051884Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.052130Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.052344Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.052466Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.052631Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.052775Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.052941Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.053065Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.053224Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.053367Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.053527Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.053665Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.053826Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.053972Z DEBUG Eventloop::poll:handle_peer_traffic{sender=127.0.0.1:45679 allocation_id=AID-1 recipient=127.0.0.1:49137 channel=16384}: relay: Relaying 32 bytes
[  relay] 2024-01-25T01:57:42.054127Z DEBUG Eventloop::poll:handle_client_input{sender=127.0.0.1:49137 allocation_id=AID-1 recipient=127.0.0.1:45679 channel=16384}: relay: Relaying 32 bytes
```