### PR TITLE
refactor(infra): Make relay and gateway logs sane on prod

### DIFF
--- a/terraform/environments/production/gateways.tf
+++ b/terraform/environments/production/gateways.tf
@@ -25,7 +25,7 @@ module "gateways" {
   image      = "gateway"
   image_tag  = var.image_tag
 
-  observability_log_level = "phoenix_channel=debug,firezone_gateway=trace,wire=trace,connlib_gateway_shared=trace,firezone_tunnel=trace,connlib_shared=trace,warn"
+  observability_log_level = "debug"
 
   application_name    = "gateway"
   application_version = replace(var.image_tag, ".", "-")

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -786,7 +786,7 @@ module "relays" {
   image      = "relay"
   image_tag  = var.image_tag
 
-  observability_log_level = "debug,hyper=off,h2=warn,tower=warn"
+  observability_log_level = "info,hyper=off,h2=warn,tower=warn"
 
   application_name    = "relay"
   application_version = replace(var.image_tag, ".", "-")

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -786,7 +786,7 @@ module "relays" {
   image      = "relay"
   image_tag  = var.image_tag
 
-  observability_log_level = "debug,firezone_relay=trace,hyper=off,h2=warn,tower=warn,wire=trace"
+  observability_log_level = "debug,hyper=off,h2=warn,tower=warn"
 
   application_name    = "relay"
   application_version = replace(var.image_tag, ".", "-")


### PR DESCRIPTION
`wire=trace` causes too much slow down.