### PR TITLE
chore(relay): change `run_smoke_test.sh` to use `/usr/bin/env`

### DIFF
--- a/rust/relay/run_smoke_test.sh
+++ b/rust/relay/run_smoke_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo build --package firezone-relay --bin firezone-relay --example client --example gateway


### PR DESCRIPTION
On systems like NixOS, there is no `/bin/bash` because they heavily rely on lookups in `$PATH`. `/usr/bin/env` does such a lookup and will use the first `bash` executable it finds to run the script.