### PR TITLE
fix(connection): only emit `Transmit.src` that correspond to local sockets

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6081,7 +6081,7 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 [[package]]
 name = "str0m"
 version = "0.4.1"
-source = "git+https://github.com/algesten/str0m?branch=main#30ba27e4fb683d45559e5a821c0c2c084e02463a"
+source = "git+https://github.com/thomaseizinger/str0m?branch=feat/base-is-host-for-srflx#86a5851874802244c3cff00754ea1c5e71badee1"
 dependencies = [
  "combine",
  "crc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -49,7 +49,7 @@ phoenix-channel = { path = "phoenix-channel"}
 [patch.crates-io]
 boringtun = { git = "https://github.com/thomaseizinger/boringtun", branch = "feat/expose-last-seen" }
 webrtc = { git = "https://github.com/firezone/webrtc", branch = "expose-new-endpoint" }
-str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
+str0m = { git = "https://github.com/thomaseizinger/str0m", branch = "feat/base-is-host-for-srflx" }
 
 [profile.release]
 strip = true

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -941,6 +941,7 @@ mod tests {
 
         allocation.handle_input(
             RELAY,
+            PEER1,
             &encode(allocate_response(message.transaction_id())),
             Instant::now(),
         );

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -89,7 +89,13 @@ impl Allocation {
         .flatten()
     }
 
-    pub fn handle_input(&mut self, from: SocketAddr, packet: &[u8], now: Instant) -> bool {
+    pub fn handle_input(
+        &mut self,
+        from: SocketAddr,
+        local: SocketAddr,
+        packet: &[u8],
+        now: Instant,
+    ) -> bool {
         if Some(now) > self.last_now {
             self.last_now = Some(now);
         }
@@ -167,7 +173,9 @@ impl Allocation {
                     return true;
                 };
 
-                let maybe_srflx_candidate = message.attributes().find_map(srflx_candidate);
+                let maybe_srflx_candidate = message
+                    .attributes()
+                    .find_map(|addr| srflx_candidate(local, addr));
                 let maybe_ip4_relay_candidate = message
                     .attributes()
                     .find_map(relay_candidate(|s| s.is_ipv4()));
@@ -497,13 +505,13 @@ fn make_channel_bind_request(target: SocketAddr, channel: u16) -> Message<Attrib
     message
 }
 
-fn srflx_candidate(attr: &Attribute) -> Option<Candidate> {
+fn srflx_candidate(local: SocketAddr, attr: &Attribute) -> Option<Candidate> {
     let addr = match attr {
         Attribute::XorMappedAddress(a) => a.address(),
         _ => return None,
     };
 
-    let new_candidate = match Candidate::server_reflexive(addr, Protocol::Udp) {
+    let new_candidate = match Candidate::server_reflexive(addr, local, Protocol::Udp) {
         Ok(c) => c,
         Err(e) => {
             tracing::debug!("Observed address is not a valid candidate: {e}");

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -167,7 +167,7 @@ where
     ) -> Result<Option<(TId, IpPacket<'s>)>, Error> {
         // First, check if a `StunBinding` wants the packet
         if let Some(binding) = self.bindings.get_mut(&from) {
-            if binding.handle_input(from, packet, now) {
+            if binding.handle_input(from, local, packet, now) {
                 // If it handled the packet, drain its events to ensure we update the candidates of all connections.
                 drain_and_add_candidates(
                     from,
@@ -182,7 +182,7 @@ where
 
         // Next, check if an `Allocation` wants the packet
         if let Some(allocation) = self.allocations.get_mut(&from) {
-            if allocation.handle_input(from, packet, now) {
+            if allocation.handle_input(from, local, packet, now) {
                 // If it handled the packet, drain its events to ensure we update the candidates of all connections.
                 drain_and_add_candidates(
                     from,

--- a/rust/connlib/snownet/src/stun_binding.rs
+++ b/rust/connlib/snownet/src/stun_binding.rs
@@ -42,7 +42,13 @@ impl StunBinding {
         self.last_candidate.clone()
     }
 
-    pub fn handle_input(&mut self, from: SocketAddr, packet: &[u8], now: Instant) -> bool {
+    pub fn handle_input(
+        &mut self,
+        from: SocketAddr,
+        local: SocketAddr,
+        packet: &[u8],
+        now: Instant,
+    ) -> bool {
         self.last_now = Some(now); // TODO: Do we need to do any other updates here?
 
         if from != self.server {
@@ -72,13 +78,14 @@ impl StunBinding {
 
         let observed_address = mapped_address.address();
 
-        let new_candidate = match Candidate::server_reflexive(observed_address, Protocol::Udp) {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::debug!("Observed address is not a valid candidate: {e}");
-                return true; // We still handled the packet correctly.
-            }
-        };
+        let new_candidate =
+            match Candidate::server_reflexive(observed_address, local, Protocol::Udp) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::debug!("Observed address is not a valid candidate: {e}");
+                    return true; // We still handled the packet correctly.
+                }
+            };
 
         match &self.last_candidate {
             Some(candidate) if candidate != &new_candidate => {
@@ -143,9 +150,10 @@ impl StunBinding {
     }
 
     #[cfg(test)]
-    fn set_received_at(&mut self, address: SocketAddr, now: Instant) {
+    fn set_received_at(&mut self, address: SocketAddr, local: SocketAddr, now: Instant) {
         self.last_now = Some(now);
-        self.last_candidate = Some(Candidate::server_reflexive(address, Protocol::Udp).unwrap());
+        self.last_candidate =
+            Some(Candidate::server_reflexive(address, local, Protocol::Udp).unwrap());
         self.state = State::ReceivedResponse { at: now };
     }
 }
@@ -251,8 +259,12 @@ mod tests {
         let request = stun_binding.poll_transmit().unwrap();
         let response = generate_stun_response(request, MAPPED_ADDRESS);
 
-        let handled =
-            stun_binding.handle_input(SERVER1, &response, start + Duration::from_millis(200));
+        let handled = stun_binding.handle_input(
+            SERVER1,
+            MAPPED_ADDRESS,
+            &response,
+            start + Duration::from_millis(200),
+        );
         assert!(handled);
 
         let candidate = stun_binding.poll_candidate().unwrap();
@@ -265,7 +277,7 @@ mod tests {
         let start = Instant::now();
 
         let mut stun_binding = StunBinding::new(SERVER1);
-        stun_binding.set_received_at(MAPPED_ADDRESS, start);
+        stun_binding.set_received_at(MAPPED_ADDRESS, MAPPED_ADDRESS, start);
         assert!(stun_binding.poll_transmit().is_none());
 
         stun_binding.handle_timeout(start + Duration::from_secs(5 * 60));
@@ -283,8 +295,12 @@ mod tests {
         let request = stun_binding.poll_transmit().unwrap();
         let response = generate_stun_response(request, MAPPED_ADDRESS);
 
-        let handled =
-            stun_binding.handle_input(SERVER2, &response, start + Duration::from_millis(200));
+        let handled = stun_binding.handle_input(
+            SERVER2,
+            MAPPED_ADDRESS,
+            &response,
+            start + Duration::from_millis(200),
+        );
 
         assert!(!handled);
         assert!(stun_binding.poll_candidate().is_none());

--- a/rust/snownet-tests/src/main.rs
+++ b/rust/snownet-tests/src/main.rs
@@ -371,6 +371,10 @@ impl<T> Eventloop<T> {
         while let Some(transmit) = self.pool.poll_transmit() {
             tracing::trace!(target = "wire::out", to = %transmit.dst, packet = %hex::encode(&transmit.payload));
 
+            if let Some(src) = transmit.src {
+                assert_eq!(src, self.socket.local_addr()?);
+            }
+
             self.socket.try_send_to(&transmit.payload, transmit.dst)?;
         }
 


### PR DESCRIPTION
It turns out that we need to do some post-processing of the `Transmit.source` attribute from `str0m`. In its current state, `str0m` may also set that to a server-reflexive address which is **not** a local socket. There is a longer discussion around this here: https://github.com/algesten/str0m/issues/453.

This depends on an unmerged PR in `str0m`: https://github.com/algesten/str0m/pull/455.