### PR TITLE
fix(connection): buffer channel bindings until we have an allocation

### DIFF
--- a/rust/connlib/connection/src/allocation.rs
+++ b/rust/connlib/connection/src/allocation.rs
@@ -339,7 +339,7 @@ impl Allocation {
         let msg = make_channel_bind_request(peer, channel);
 
         if !self.has_allocation() {
-            tracing::debug!("No allocation yet, buffering channel binding");
+            tracing::debug!(relay = %self.server, %peer, "No allocation yet, buffering channel binding");
 
             self.buffered_channel_bindings.push_back(msg);
             return;


### PR DESCRIPTION
Previously, there was a race condition where we would try to bind a channel despite not yet have made an allocation on the relay.