### PR TITLE
fix(windows): move crash dumps into logs dir so they get exported in the zip, closes #3263

### DIFF
--- a/rust/windows-client/src-tauri/src/client.rs
+++ b/rust/windows-client/src-tauri/src/client.rs
@@ -50,10 +50,6 @@ pub(crate) struct GuiParams {
     inject_faults: bool,
 }
 
-/// Newtype for our per-user directory in AppData, e.g.
-/// `C:/Users/$USER/AppData/Local/dev.firezone.client`
-pub(crate) struct AppLocalDataDir(std::path::PathBuf);
-
 // Hides Powershell's console on Windows
 // <https://stackoverflow.com/questions/59692146/is-it-possible-to-use-the-standard-library-to-spawn-a-process-without-showing-th#60958956>
 const CREATE_NO_WINDOW: u32 = 0x08000000;

--- a/rust/windows-client/src-tauri/src/client/crash_handling.rs
+++ b/rust/windows-client/src-tauri/src/client/crash_handling.rs
@@ -4,9 +4,8 @@
 //!
 //! TODO: Capture crash dumps on panic.
 
-use crate::client::BUNDLE_ID;
+use crate::client::settings::app_local_data_dir;
 use anyhow::{anyhow, bail, Context};
-use known_folders::{get_known_folder_path, KnownFolder};
 use std::{fs::File, io::Write, path::PathBuf};
 
 const SOCKET_NAME: &str = "dev.firezone.client.crash_handler";
@@ -104,10 +103,10 @@ impl minidumper::ServerHandler for Handler {
     /// Called when a crash has been received and a backing file needs to be
     /// created to store it.
     fn create_minidump_file(&self) -> Result<(File, PathBuf), std::io::Error> {
-        let dump_path = get_known_folder_path(KnownFolder::ProgramData)
-            .expect("should be able to find C:/ProgramData")
-            .join(BUNDLE_ID)
-            .join("dumps")
+        let dump_path = app_local_data_dir()
+            .expect("app_local_data_dir() failed")
+            .join("data")
+            .join("logs")
             .join("last_crash.dmp");
 
         if let Some(dir) = dump_path.parent() {


### PR DESCRIPTION
![image](https://github.com/firezone/firezone/assets/13400041/0fffa284-4c37-4b35-a0cf-841442246c66)

![image](https://github.com/firezone/firezone/assets/13400041/2d275cba-5d1f-4289-9214-05804f4477c6)

Screenshots taken on 33737b3a38f7
I also refactored some of the related code.