### PR TITLE
refactor(windows): set absolute paths for logs and wintun.dll

### DIFF
--- a/rust/windows-client/src-tauri/src/client/debug_commands.rs
+++ b/rust/windows-client/src-tauri/src/client/debug_commands.rs
@@ -46,8 +46,8 @@ fn hostname() -> Result<()> {
 fn wintun() -> Result<()> {
     tracing_subscriber::fmt::init();
     let path = crate::client::wintun_install::dll_path()?;
-    unsafe { wintun::load_from_path(path) }?;
-    tracing::info!("Loaded wintun from {path}.");
+    unsafe { wintun::load_from_path(&path) }?;
+    tracing::info!(?path, "Loaded wintun.dll");
 
     Ok(())
 }

--- a/rust/windows-client/src-tauri/src/client/debug_commands.rs
+++ b/rust/windows-client/src-tauri/src/client/debug_commands.rs
@@ -42,13 +42,12 @@ fn hostname() -> Result<()> {
     Ok(())
 }
 
+/// Try to load wintun.dll and throw an error if it's not in the right place
 fn wintun() -> Result<()> {
     tracing_subscriber::fmt::init();
+    let path = crate::client::wintun_install::dll_path()?;
+    unsafe { wintun::load_from_path(path) }?;
+    tracing::info!("Loaded wintun from somewhere.");
 
-    if client::elevation::check()? {
-        tracing::info!("Elevated");
-    } else {
-        tracing::warn!("Not elevated")
-    }
     Ok(())
 }

--- a/rust/windows-client/src-tauri/src/client/debug_commands.rs
+++ b/rust/windows-client/src-tauri/src/client/debug_commands.rs
@@ -47,7 +47,7 @@ fn wintun() -> Result<()> {
     tracing_subscriber::fmt::init();
     let path = crate::client::wintun_install::dll_path()?;
     unsafe { wintun::load_from_path(path) }?;
-    tracing::info!("Loaded wintun from somewhere.");
+    tracing::info!("Loaded wintun from {path}.");
 
     Ok(())
 }

--- a/rust/windows-client/src-tauri/src/client/elevation.rs
+++ b/rust/windows-client/src-tauri/src/client/elevation.rs
@@ -20,15 +20,15 @@ pub(crate) fn check() -> Result<bool, Error> {
     const TUNNEL_UUID: &str = "72228ef4-cb84-4ca5-a4e6-3f8636e75757";
     const TUNNEL_NAME: &str = "Firezone Elevation Check";
 
-    match wintun_install::ensure_dll() {
-        Ok(_) => {}
+    let path = match wintun_install::ensure_dll() {
+        Ok(x) => x,
         Err(wintun_install::Error::PermissionDenied) => return Ok(false),
         Err(e) => return Err(Error::DllInstall(e)),
-    }
+    };
 
     // The unsafe is here because we're loading a DLL from disk and it has arbitrary C code in it.
     // TODO: As a defense, we could verify the hash before loading it. This would protect against accidental corruption, but not against attacks. (Because of TOCTOU)
-    let wintun = unsafe { wintun::load_from_path("./wintun.dll") }.map_err(|_| Error::DllLoad)?;
+    let wintun = unsafe { wintun::load_from_path(path) }.map_err(|_| Error::DllLoad)?;
     let uuid = uuid::Uuid::from_str(TUNNEL_UUID).map_err(|_| Error::Uuid)?;
 
     // Wintun hides the exact Windows error, so let's assume the only way Adapter::create can fail is if we're not elevated.

--- a/rust/windows-client/src-tauri/src/client/wintun_install.rs
+++ b/rust/windows-client/src-tauri/src/client/wintun_install.rs
@@ -21,6 +21,8 @@ pub(crate) enum Error {
     CantFindLocalAppData,
     #[error("create_dir_all failed")]
     CreateDirAll,
+    #[error("Computed DLL path is invalid")]
+    DllPathInvalid,
     #[error("permission denied")]
     PermissionDenied,
     #[error("platform not supported")]
@@ -36,7 +38,9 @@ pub(crate) fn ensure_dll() -> Result<PathBuf, Error> {
     let dll_bytes = get_dll_bytes().ok_or(Error::PlatformNotSupported)?;
 
     let path = dll_path()?;
-    std::fs::create_dir_all(path.parent()).map_err(|_| Error::CreateDirAll)?;
+    // The DLL path should always have a parent
+    let dir = path.parent().ok_or(Error::DllPathInvalid)?;
+    std::fs::create_dir_all(dir).map_err(|_| Error::CreateDirAll)?;
     tracing::info!(?path, "wintun.dll path");
 
     // This hash check is not meant to protect against attacks. It only lets us skip redundant disk writes, and it updates the DLL if needed.

--- a/rust/windows-client/src-tauri/src/client/wintun_install.rs
+++ b/rust/windows-client/src-tauri/src/client/wintun_install.rs
@@ -36,7 +36,7 @@ pub(crate) fn ensure_dll() -> Result<PathBuf, Error> {
     let dll_bytes = get_dll_bytes().ok_or(Error::PlatformNotSupported)?;
 
     let path = dll_path()?;
-    std::fs::create_dir_all(path.with_file_name("")).map_err(|_| Error::CreateDirAll)?;
+    std::fs::create_dir_all(path.parent()).map_err(|_| Error::CreateDirAll)?;
     tracing::info!(?path, "wintun.dll path");
 
     // This hash check is not meant to protect against attacks. It only lets us skip redundant disk writes, and it updates the DLL if needed.

--- a/rust/windows-client/src-tauri/src/client/wintun_install.rs
+++ b/rust/windows-client/src-tauri/src/client/wintun_install.rs
@@ -1,10 +1,11 @@
 //! "Installs" wintun.dll at runtime by copying it into whatever folder the exe is in
 
+use crate::client::settings::app_local_data_dir;
 use ring::digest;
 use std::{
     fs,
     io::{self, Read},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 struct DllBytes {
@@ -16,8 +17,10 @@ struct DllBytes {
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
-    #[error("current exe path unknown")]
-    CurrentExePathUnknown,
+    #[error("Can't find %LOCALAPPDATA%")]
+    CantFindLocalAppData,
+    #[error("create_dir_all failed")]
+    CreateDirAll,
     #[error("permission denied")]
     PermissionDenied,
     #[error("platform not supported")]
@@ -26,20 +29,15 @@ pub(crate) enum Error {
     WriteFailed(io::Error),
 }
 
-/// Installs the DLL alongside the current exe, if needed
-/// The reason not to do it in the current working dir is that deep links may launch
-/// with a current working dir of `C:\Windows\System32`
-/// The reason not to do it in AppData is that learning our AppData path before Tauri
-/// setup is difficult.
-/// The reason not to do it in `C:\Program Files` is that running in portable mode
-/// is useful for development, even though it's not supported for production.
-pub(crate) fn ensure_dll() -> Result<(), Error> {
+/// Installs the DLL in %LOCALAPPDATA% and returns the DLL's absolute path
+///
+/// e.g. `C:\Users\User\AppData\Local\dev.firezone.client\data\wintun.dll`
+pub(crate) fn ensure_dll() -> Result<PathBuf, Error> {
     let dll_bytes = get_dll_bytes().ok_or(Error::PlatformNotSupported)?;
 
-    let path = tauri_utils::platform::current_exe()
-        .map_err(|_| Error::CurrentExePathUnknown)?
-        .with_file_name("wintun.dll");
-    tracing::debug!("wintun.dll path = {path:?}");
+    let path = dll_path()?;
+    std::fs::create_dir_all(path.with_file_name("")).map_err(|_| Error::CreateDirAll)?;
+    tracing::info!(?path, "wintun.dll path");
 
     // This hash check is not meant to protect against attacks. It only lets us skip redundant disk writes, and it updates the DLL if needed.
     if !dll_already_exists(&path, &dll_bytes) {
@@ -48,7 +46,18 @@ pub(crate) fn ensure_dll() -> Result<(), Error> {
             _ => Error::WriteFailed(e),
         })?;
     }
-    Ok(())
+    Ok(path)
+}
+
+/// Returns the absolute path where the DLL should be
+///
+/// e.g. `C:\Users\User\AppData\Local\dev.firezone.client\data\wintun.dll`
+pub(crate) fn dll_path() -> Result<PathBuf, Error> {
+    let path = app_local_data_dir()
+        .ok_or_else(|| Error::CantFindLocalAppData)?
+        .join("data")
+        .join("wintun.dll");
+    Ok(path)
 }
 
 fn dll_already_exists(path: &Path, dll_bytes: &DllBytes) -> bool {


### PR DESCRIPTION
This is part of fixing #3425 

Until now I changed the app's working directory into our %LOCALAPPDATA% folder and then used relative paths.

But this causes two problems:
- Passing `.\wintun.dll` when loading the DLL can cause Windows to search for the DLL. We don't want it to search, we want to put the DLL in one place and make sure it uses that, since that's the version we'll be updating
- It means I've been using the app's current working dir as de-facto global mutable state

The reason I could not fix it sooner is that it needed the bundle ID to be available before Tauri starts.