### PR TITLE
fix(windows): Show "Signing in..." menu during auto-sign-in

### DIFF
--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -421,6 +421,7 @@ impl Controller {
             callback_handler,
             connlib,
         });
+        self.refresh_system_tray_menu()?;
 
         Ok(())
     }


### PR DESCRIPTION
closes #3403 

Given the token is saved on disk, when we start Firezone, then the menu will show "Signing in..." while connlib connects.