### PR TITLE
feat(relay): allow channel bindings to IPv6 addresses

### DIFF
--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -1027,9 +1027,18 @@ impl Channel {
 }
 
 impl Allocation {
+    /// Checks whether this [`Allocation`] can relay to the given address.
+    ///
+    /// This is called in the context of a channel binding with the requested peer address.
+    /// We can only relay to the address if the allocation supports the same version of the IP protocol.
     fn can_relay_to(&self, addr: SocketAddr) -> bool {
-        // Currently, we only support IPv4, thus any IPv6 address is invalid.
-        addr.is_ipv4()
+        match addr {
+            SocketAddr::V4(_) => self.first_relay_addr.is_ipv4(), // If we have an IPv4 address, it is in `first_relay_addr`, no need to check `second_relay_addr`.
+            SocketAddr::V6(_) => {
+                self.first_relay_addr.is_ipv6()
+                    || self.second_relay_addr.is_some_and(|a| a.is_ipv6())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Previously, we still had a hard-coded rule in the relay that would not allow us to relay to an IPv6 peer. We can remove that and properly check this based on the allocated addresses.

Resolves: #3405.