### PR TITLE
feat(connection): allocate IPv6 address

### DIFF
--- a/rust/connlib/connection/src/allocation.rs
+++ b/rust/connlib/connection/src/allocation.rs
@@ -466,7 +466,9 @@ fn make_allocate_request() -> Message<Attribute> {
     );
 
     message.add_attribute(RequestedTransport::new(17));
-    // message.add_attribute(AdditionalAddressFamily::new(AddressFamily::V6)); TODO: Request IPv6 binding.
+    message.add_attribute(AdditionalAddressFamily::new(
+        stun_codec::rfc8656::attributes::AddressFamily::V6,
+    ));
 
     message
 }
@@ -475,7 +477,9 @@ fn make_refresh_request() -> Message<Attribute> {
     let mut message = Message::new(MessageClass::Request, REFRESH, TransactionId::new(random()));
 
     message.add_attribute(RequestedTransport::new(17));
-    // message.add_attribute(AdditionalAddressFamily::new(AddressFamily::V6)); TODO: Request IPv6 binding.
+    message.add_attribute(AdditionalAddressFamily::new(
+        stun_codec::rfc8656::attributes::AddressFamily::V6,
+    ));
 
     message
 }


### PR DESCRIPTION
Resolve the two TODOs mentioned in the code. As part of #3399, we correctly are handling different combinations of available sockets and requested addresses in the relay more gracefully. In particular, we return whatever addresses we could allocate and only fail if we couldn't allocate any at all.

The `Allocation` struct will extract whatever allocated addresses are present in the response. Thus, it is safe for us to **always** request both, an IPv4 and IPv6 address. A relay that only operates on one of them will just return that one address.

Resolves: #3406.