### PR TITLE
fix(connlib): fix tun device detection

### DIFF
--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -11,6 +11,7 @@ use libc::{
 use netlink_packet_route::RT_SCOPE_UNIVERSE;
 use parking_lot::Mutex;
 use rtnetlink::{new_connection, Error::NetlinkError, Handle};
+use std::ffi::CStr;
 use std::net::IpAddr;
 use std::path::Path;
 use std::task::{Context, Poll};
@@ -29,7 +30,7 @@ pub(crate) const SIOCGIFMTU: libc::c_ulong = libc::SIOCGIFMTU;
 
 const IFACE_NAME: &str = "tun-firezone";
 const TUNSETIFF: libc::c_ulong = 0x4004_54ca;
-const TUN_FILE: &[u8] = b"/dev/net/tun\0";
+const TUN_FILE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"/dev/net/tun\0") };
 const TUN_DEV_MAJOR: u32 = 10;
 const TUN_DEV_MINOR: u32 = 200;
 const RT_PROT_STATIC: u8 = 4;
@@ -242,7 +243,7 @@ fn set_non_blocking(fd: RawFd) -> Result<()> {
 }
 
 fn create_tun_device() -> Result<()> {
-    let path = Path::new(std::str::from_utf8(TUN_FILE).unwrap());
+    let path = Path::new(TUN_FILE.to_str().unwrap());
 
     if path.exists() {
         return Ok(());


### PR DESCRIPTION
There is a trailing `\0`.

```
2024-01-30T19:17:09.226708Z INFO init{user_agent="Alpine Linux/3.19.1 (x86_64;5.15.0-91-generic;) connlib/1.0.0" login_topic="gateway"}: phoenix_channel: Connected to portal, waiting for `init` message
2024-01-30T19:17:09.385022Z INFO init{user_agent="Alpine Linux/3.19.1 (x86_64;5.15.0-91-generic;) connlib/1.0.0" login_topic="gateway"}: phoenix_channel: Connected to portal
2024-01-30T19:17:09.391393Z WARN init{user_agent="Alpine Linux/3.19.1 (x86_64;5.15.0-91-generic;) connlib/1.0.0" login_topic="gateway"}: phoenix_channel: Failed to deserialize message {"event":"phx_close","ref":null,"topic":"gateway","payload":{}}: data did not match any variant of untagged enum Payload at line 1 column 63
2024-01-30T19:17:09.395673Z INFO init{user_agent="Alpine Linux/3.19.1 (x86_64;5.15.0-91-generic;) connlib/1.0.0" login_topic="gateway"}: phoenix_channel: Received init message from portal
2024-01-30T19:17:09.402470Z ERROR firezone_gateway: Failed to set interface: File exists (os error 17)
```