### PR TITLE
Apple: Add 'debug' to network extension name in debug configuration

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 				MARKETING_VERSION = 1.0.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lconnlib";
-				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).debug.network-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "$(IOS_NE_PROVISIONING_PROFILE_IDENTIFIER)";
@@ -671,7 +671,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/debug";
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-lconnlib";
-				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).debug.network-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "$(MACOS_NE_PROVISIONING_PROFILE_IDENTIFIER)";

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -89,7 +89,7 @@ public final class TunnelStore: ObservableObject {
       return
     }
     let tunnel = NETunnelProviderManager()
-    tunnel.localizedDescription = "Firezone"
+    tunnel.localizedDescription = NETunnelProviderManager.firezoneNetworkExtensionDescription()
     tunnel.protocolConfiguration = basicProviderProtocol()
     try await tunnel.saveToPreferences()
     logger.log("\(#function): Tunnel created")
@@ -501,7 +501,7 @@ extension NETunnelProviderManager {
       protocolConfiguration.serverAddress = "unknown-server"
     }
     if localizedDescription?.isEmpty ?? true {
-      localizedDescription = "Firezone"
+      localizedDescription = Self.firezoneNetworkExtensionDescription()
     }
   }
 
@@ -510,6 +510,14 @@ extension NETunnelProviderManager {
       Bundle.main.bundleIdentifier.map { "\($0).debug.network-extension" }
     #else
       Bundle.main.bundleIdentifier.map { "\($0).network-extension" }
+    #endif
+  }
+
+  static func firezoneNetworkExtensionDescription() -> String {
+    #if DEBUG
+      "Firezone (Debug)"
+    #else
+      "Firezone"
     #endif
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -140,9 +140,8 @@ public final class TunnelStore: ObservableObject {
 
   func basicProviderProtocol() -> NETunnelProviderProtocol {
     let protocolConfiguration = NETunnelProviderProtocol()
-    protocolConfiguration.providerBundleIdentifier = Bundle.main.bundleIdentifier.map {
-      "\($0).network-extension"
-    }
+    protocolConfiguration.providerBundleIdentifier =
+      NETunnelProviderManager.firezoneNetworkExtensionBundleIdentifier()
     protocolConfiguration.serverAddress = AdvancedSettings.defaultValue.apiURLString
     protocolConfiguration.providerConfiguration = [
       TunnelProviderKeys.keyConnlibLogFilter:
@@ -490,21 +489,27 @@ extension NETunnelProviderManager {
     // Ensure the tunnel config has required values populated, because
     // to even sign out, we need saveToPreferences() to succeed.
     if let protocolConfiguration = protocolConfiguration as? NETunnelProviderProtocol {
-      protocolConfiguration.providerBundleIdentifier = Bundle.main.bundleIdentifier.map {
-        "\($0).network-extension"
-      }
+      protocolConfiguration.providerBundleIdentifier =
+        Self.firezoneNetworkExtensionBundleIdentifier()
       if protocolConfiguration.serverAddress?.isEmpty ?? true {
         protocolConfiguration.serverAddress = "unknown-server"
       }
     } else {
       let protocolConfiguration = NETunnelProviderProtocol()
-      protocolConfiguration.providerBundleIdentifier = Bundle.main.bundleIdentifier.map {
-        "\($0).network-extension"
-      }
+      protocolConfiguration.providerBundleIdentifier =
+        Self.firezoneNetworkExtensionBundleIdentifier()
       protocolConfiguration.serverAddress = "unknown-server"
     }
     if localizedDescription?.isEmpty ?? true {
       localizedDescription = "Firezone"
     }
+  }
+
+  static func firezoneNetworkExtensionBundleIdentifier() -> String? {
+    #if DEBUG
+      Bundle.main.bundleIdentifier.map { "\($0).debug.network-extension" }
+    #else
+      Bundle.main.bundleIdentifier.map { "\($0).network-extension" }
+    #endif
   }
 }


### PR DESCRIPTION
Supersedes PR #3395.

When testing this, might have to remove the tunnel config in Settings.app before running this.