### PR TITLE
fix(windows): Take the default button shade darker a notch

### DIFF
--- a/rust/windows-client/src/settings.html
+++ b/rust/windows-client/src/settings.html
@@ -105,7 +105,7 @@
               <button
                 id="reset-advanced-settings-btn"
                 type="button"
-                class="bg-neutral-200 text-neutral-900 hover:bg-neutral-300 font-medium rounded text-sm w-full sm:w-auto px-5 py-2.5 text-center"
+                class="bg-neutral-300 border-neutral-400 border text-neutral-900 hover:bg-neutral-400 font-medium rounded text-sm w-full sm:w-auto px-5 py-2.5 text-center"
               >
                 Reset to Defaults
               </button>
@@ -133,7 +133,7 @@
             <button
               id="export-logs-btn"
               type="button"
-              class="mr-4 inline-flex items-center bg-neutral-200 text-neutral-900 hover:bg-neutral-300 font-medium rounded text-sm px-5 py-2.5 text-center"
+              class="mr-4 inline-flex items-center border border-neutral-400 bg-neutral-300 text-neutral-900 hover:bg-neutral-400 font-medium rounded text-sm px-5 py-2.5 text-center"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -155,7 +155,7 @@
             <button
               id="clear-logs-btn"
               type="button"
-              class="inline-flex items-center bg-neutral-200 text-neutral-900 hover:bg-neutral-300 font-medium rounded text-sm px-5 py-2.5 text-center"
+              class="inline-flex items-center border border-neutral-400 bg-neutral-300 text-neutral-900 hover:bg-neutral-400 font-medium rounded text-sm px-5 py-2.5 text-center"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<img width="688" alt="Screenshot 2024-01-31 at 11 16 11 AM" src="https://github.com/firezone/firezone/assets/167144/891af931-9ff5-4975-8222-027e081e7ae6">
<img width="679" alt="Screenshot 2024-01-31 at 11 16 22 AM" src="https://github.com/firezone/firezone/assets/167144/f84f886a-f7d9-428b-9199-3214a3002682">
