### PR TITLE
fix(windows): CSS nit

### DIFF
--- a/rust/windows-client/src/settings.html
+++ b/rust/windows-client/src/settings.html
@@ -9,7 +9,7 @@
     <script type="module" src="settings.js" defer></script>
   </head>
 
-  <body class="bg-netural-100 text-neutral-900">
+  <body class="bg-neutral-100 text-neutral-900">
     <div class="container mx-auto">
       <div class="mb-4 border-b border-neutral-300">
         <ul
@@ -48,7 +48,7 @@
       </div>
       <div id="tab-content">
         <div
-          class="hidden p-4 rounded-lg bg-neutral-50"
+          class="hidden p-4 rounded-lg bg-transparent"
           id="advanced"
           role="tabpanel"
           aria-labelledby="advanced-tab"

--- a/rust/windows-client/src/settings.html
+++ b/rust/windows-client/src/settings.html
@@ -48,7 +48,7 @@
       </div>
       <div id="tab-content">
         <div
-          class="hidden p-4 rounded-lg bg-transparent"
+          class="hidden p-4 rounded-lg"
           id="advanced"
           role="tabpanel"
           aria-labelledby="advanced-tab"


### PR DESCRIPTION
Before this change, some of the background was (252, 252, 252) (#fcfcfc, bg-neutral-50) and some was #ffffff white

![image](https://github.com/firezone/firezone/assets/13400041/ebfd0488-2ee7-4790-85d2-dee86edbe272)

After this change, all the background is (248, 247, 247) (#f8f7f7, bg-neutral-100)

![image](https://github.com/firezone/firezone/assets/13400041/22185728-aa1b-4f45-a888-74a8a4120a8d)

"Before" with exaggerated contrast: 
![image](https://github.com/firezone/firezone/assets/13400041/de63471b-48cd-4073-936b-bf5a0df888c8)
