### PR TITLE
ci(windows): Upload Windows debug symbols

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -106,9 +106,11 @@ jobs:
           # In release mode the name comes from tauri.conf.json
           cp "../target/release/Firezone.exe" "${{ env.BINARY_DEST_PATH }}-x64.exe"
           cp "../target/release/bundle/msi/*.msi" "${{ env.BINARY_DEST_PATH }}-x64.msi"
+          cp "../target/release/firezone_windows_client.pdb" "${{ env.BINARY_DEST_PATH }}-x64.pdb"
 
           Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.exe -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.exe.sha256sum.txt
           Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.msi -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.msi.sha256sum.txt
+          Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.pdb -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.pdb.sha256sum.txt
 
           # This might catch regressions in #3384, depending how CI runners
           # handle exit codes
@@ -127,6 +129,13 @@ jobs:
           path: |
             ${{ github.workspace }}/rust/windows-client/windows-client-x64.msi
             ${{ github.workspace }}/rust/windows-client/windows-client-x64.msi.sha256sum.txt
+      - name: Save Windows debug symbols
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-client-x64-msi
+          path: |
+            ${{ github.workspace }}/rust/windows-client/windows-client-x64.pdb
+            ${{ github.workspace }}/rust/windows-client/windows-client-x64.pdb.sha256sum.txt
 
   smoke-test-relay:
     runs-on: ubuntu-22.04

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Save Windows debug symbols
         uses: actions/upload-artifact@v4
         with:
-          name: windows-client-x64-msi
+          name: windows-client-x64-pdb
           path: |
             ${{ github.workspace }}/rust/windows-client/windows-client-x64.pdb
             ${{ github.workspace }}/rust/windows-client/windows-client-x64.pdb.sha256sum.txt

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -271,11 +271,9 @@ jobs:
           # This should match 'build-tauri' in _rust.yml
           cp "../target/release/Firezone.exe" "${{ env.BINARY_DEST_PATH }}-x64.exe"
           cp "../target/release/bundle/msi/*.msi" "${{ env.BINARY_DEST_PATH }}-x64.msi"
-          cp "../target/release/firezone_windows_client.pdb" "${{ env.BINARY_DEST_PATH }}-x64.pdb"
 
           Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.exe -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.exe.sha256sum.txt
           Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.msi -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.msi.sha256sum.txt
-          Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.pdb -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.pdb.sha256sum.txt
       - name: Upload Release Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -285,8 +283,6 @@ jobs:
             ${{ env.BINARY_DEST_PATH }}-x64.exe.sha256sum.txt `
             ${{ env.BINARY_DEST_PATH }}-x64.msi `
             ${{ env.BINARY_DEST_PATH }}-x64.msi.sha256sum.txt `
-            ${{ env.BINARY_DEST_PATH }}-x64.pdb `
-            ${{ env.BINARY_DEST_PATH }}-x64.pdb.sha256sum.txt `
             --clobber `
             --repo ${{ github.repository }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -262,6 +262,8 @@ jobs:
       - uses: ./.github/actions/setup-node
       - name: Build release binaries
         run: |
+          # Build Windows Tauri GUI
+
           pnpm install
           pnpm build
 
@@ -269,9 +271,11 @@ jobs:
           # This should match 'build-tauri' in _rust.yml
           cp "../target/release/Firezone.exe" "${{ env.BINARY_DEST_PATH }}-x64.exe"
           cp "../target/release/bundle/msi/*.msi" "${{ env.BINARY_DEST_PATH }}-x64.msi"
+          cp "../target/release/firezone_windows_client.pdb" "${{ env.BINARY_DEST_PATH }}-x64.pdb"
 
           Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.exe -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.exe.sha256sum.txt
           Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.msi -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.msi.sha256sum.txt
+          Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.pdb -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.pdb.sha256sum.txt
       - name: Upload Release Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -281,6 +285,8 @@ jobs:
             ${{ env.BINARY_DEST_PATH }}-x64.exe.sha256sum.txt `
             ${{ env.BINARY_DEST_PATH }}-x64.msi `
             ${{ env.BINARY_DEST_PATH }}-x64.msi.sha256sum.txt `
+            ${{ env.BINARY_DEST_PATH }}-x64.pdb `
+            ${{ env.BINARY_DEST_PATH }}-x64.pdb.sha256sum.txt `
             --clobber `
             --repo ${{ github.repository }}
 

--- a/rust/windows-client/src-tauri/src/client/crash_handling.rs
+++ b/rust/windows-client/src-tauri/src/client/crash_handling.rs
@@ -3,6 +3,15 @@
 //! Mostly copied from <https://github.com/EmbarkStudios/crash-handling/blob/main/minidumper/examples/diskwrite.rs>
 //!
 //! TODO: Capture crash dumps on panic.
+//!
+//! To get human-usable stack traces out of a dump, do this:
+//! (Copied from <https://github.com/firezone/firezone/issues/3111#issuecomment-1887975171>)
+//!
+//! - Get the pdb corresponding to the client exe
+//! - `cargo install dump_syms`
+//! - Use dump_syms to convert the pdb to a syms file
+//! - Compile `minidump-stackwalk` with PR 891 merged
+//! - `minidump-stackwalker --symbols-path firezone.syms crash.dmp`
 
 use crate::client::settings::app_local_data_dir;
 use anyhow::{anyhow, bail, Context, Result};


### PR DESCRIPTION
Closes #3450 

I was able to get stacktraces from a crash generated inside my VM. It picked out the correct line in gui.rs where the crash was triggered.

![image](https://github.com/firezone/firezone/assets/13400041/1fc521a1-059c-489b-b9b8-506570a4df0f)

![image](https://github.com/firezone/firezone/assets/13400041/17e4bdd9-cd2a-477a-821a-ab23e61eadf7)

