### PR TITLE
ci(windows): hide bare Windows exe from releases page

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -267,18 +267,14 @@ jobs:
 
           # Used for release artifact
           # This should match 'build-tauri' in _rust.yml
-          cp "../target/release/Firezone.exe" "${{ env.BINARY_DEST_PATH }}-x64.exe"
           cp "../target/release/bundle/msi/*.msi" "${{ env.BINARY_DEST_PATH }}-x64.msi"
 
-          Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.exe -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.exe.sha256sum.txt
           Get-FileHash ${{ env.BINARY_DEST_PATH }}-x64.msi -Algorithm SHA256 | Select-Object Hash > ${{ env.BINARY_DEST_PATH }}-x64.msi.sha256sum.txt
       - name: Upload Release Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ needs.update-release-draft.outputs.tag_name }} `
-            ${{ env.BINARY_DEST_PATH }}-x64.exe `
-            ${{ env.BINARY_DEST_PATH }}-x64.exe.sha256sum.txt `
             ${{ env.BINARY_DEST_PATH }}-x64.msi `
             ${{ env.BINARY_DEST_PATH }}-x64.msi.sha256sum.txt `
             --clobber `


### PR DESCRIPTION
The MSI is needed to install WebView2, otherwise the exe will crash, per #3451 .

We don't have any manual way to install WebView2, and the MSI also makes sure the exe goes into Program Files as it should, so I don't think users will need the bare exe.

It'll still be produced in CI runs for devs / superusers to look at if they really need.