### PR TITLE
fix(snownet): don't use unbound channels for relaying

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -688,7 +688,7 @@ impl Channel {
     ///
     /// In case the channel is older than its lifetime (10 minutes), this returns false because the relay will have de-allocated the channel.
     fn connected_to_peer(&self, peer: SocketAddr, now: Instant) -> bool {
-        self.peer == peer && self.age(now) < Self::CHANNEL_LIFETIME
+        self.peer == peer && self.age(now) < Self::CHANNEL_LIFETIME && self.bound
     }
 
     fn can_rebind(&self, now: Instant) -> bool {


### PR DESCRIPTION
Currently, the `bound` flag is not considered when attempting to relay data. This isn't actively harmful because the relay will drop them but it causes warnings in the logs. This PR adds a check to make sure we only try to relay data via channels that are bound. Additionally, we now handle failed channel bind requests by clearing the local state.