### PR TITLE
fix(snownet): don't try to allocate a new channel if we already have one

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -355,6 +355,11 @@ impl Allocation {
     // }
 
     pub fn bind_channel(&mut self, peer: SocketAddr, now: Instant) {
+        if self.channel_bindings.channel_to_peer(peer, now).is_some() {
+            tracing::debug!(relay = %self.server, %peer, "Already got a channel");
+            return;
+        }
+
         let Some(channel) = self.channel_bindings.new_channel_to_peer(peer, now) else {
             tracing::warn!(relay = %self.server, "All channels are exhausted");
             return;


### PR DESCRIPTION
Currently, we always try to allocate a channel when the user calls `bind_channel`. This is a problem if we try to re-connect to a peer. The channel binding will still be active so `bind_channel` needs to be a no-op.

Resolves: #3475.