### PR TITLE
fix(android): Allow bypassing AlwaysOn VPN

### DIFF
--- a/kotlin/android/.gitignore
+++ b/kotlin/android/.gitignore
@@ -65,8 +65,9 @@ replay_pid*
 # Covers files to be ignored for android development using Android Studio.
 
 # Built application files
-*.ap_
-*.aab
+**/*.ap_
+**/*.aab
+app/release
 
 # Files for the ART/Dalvik VM
 *.dex

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -46,7 +46,8 @@ android {
 
     defaultConfig {
         applicationId = "dev.firezone.android"
-        minSdk = 30
+        // Android 8
+        minSdk = 26
         targetSdk = 33
         versionCode = (System.currentTimeMillis() / 1000 / 10).toInt()
         // mark:automatic-version

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -252,7 +252,11 @@ class TunnelService : VpnService() {
                 allowFamily(OsConstants.AF_INET6)
                 // Allow traffic to bypass the VPN interface when Always-on VPN is enabled.
                 allowBypass()
-                setMetered(false) // Inherit the metered status from the underlying networks.
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    setMetered(false) // Inherit the metered status from the underlying networks.
+                }
+
                 setUnderlyingNetworks(null) // Use all available networks.
 
                 addAddress(tunnel.config.tunnelAddressIPv4, 32)

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -250,8 +250,10 @@ class TunnelService : VpnService() {
             activeTunnel?.let { tunnel ->
                 allowFamily(OsConstants.AF_INET)
                 allowFamily(OsConstants.AF_INET6)
-                setMetered(false); // Inherit the metered status from the underlying networks.
-                setUnderlyingNetworks(null); // Use all available networks.
+                // Allow traffic to bypass the VPN interface when Always-on VPN is enabled.
+                allowBypass()
+                setMetered(false) // Inherit the metered status from the underlying networks.
+                setUnderlyingNetworks(null) // Use all available networks.
 
                 addAddress(tunnel.config.tunnelAddressIPv4, 32)
                 addAddress(tunnel.config.tunnelAddressIPv6, 128)

--- a/website/src/app/blog/jan-2024-product-update/readme.mdx
+++ b/website/src/app/blog/jan-2024-product-update/readme.mdx
@@ -38,7 +38,7 @@ To beta test 1.0, you'll need one of the following:
 
 - Apple silicon or Intel Mac running **macOS 12** or later
 - iPhone or iPad running **iOS/iPadOS 15** or later
-- Android phone, tablet, or ChromeOS device running **Android 11** or later
+- Android phone, tablet, or ChromeOS device running **Android 8** or later
 
 If you qualify for beta testing, we'll add you to a dedicated Slack channel for
 feedback and support and provide further instructions for downloading clients

--- a/website/src/app/kb/user-guides/android-client/readme.mdx
+++ b/website/src/app/kb/user-guides/android-client/readme.mdx
@@ -5,7 +5,7 @@ Google Play Store.
 
 ## Prerequisites
 
-- Android / ChromeOS 11 or higher (third party OSes like LineageOS or GrapheneOS
+- ChromeOS / Android 8 or higher (third party OSes like LineageOS or GrapheneOS
   may work too but are **not** supported)
 - Google Chrome browser installed
 


### PR DESCRIPTION
When AlwaysOnVPN is enabled, it's [possible for apps to be blocked](https://developer.android.com/develop/connectivity/vpn#bypass_vpn) because their traffic gets full-routed through connlib, while we expect to only selectively add routes.

This PR fixes things so that AlwaysOn behaves like normal VPN mode.

Fixes https://firezonehq.slack.com/archives/C06F51698RK/p1706816373989109?thread_ts=1706813494.509349&cid=C06F51698RK