### PR TITLE
feat(windows): add CLI flag to test a clickable update notification

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2167,6 +2167,7 @@ dependencies = [
  "tauri-build",
  "tauri-runtime",
  "tauri-utils",
+ "tauri-winrt-notification",
  "thiserror",
  "tokio",
  "tracing",
@@ -3658,19 +3659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
-name = "mac-notification-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fca4d74ff9dbaac16a01b924bc3693fa2bba0862c2c633abc73f9a8ea21f64"
-dependencies = [
- "cc",
- "dirs-next",
- "objc-foundation",
- "objc_id",
- "time",
-]
-
-[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4051,19 +4039,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "notify-rust"
-version = "4.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827c5edfa80235ded4ab3fe8e9dc619b4f866ef16fe9b1c6b8a7f8692c0f2226"
-dependencies = [
- "log",
- "mac-notification-sys",
- "serde",
- "tauri-winrt-notification",
- "zbus",
 ]
 
 [[package]]
@@ -6533,7 +6508,6 @@ dependencies = [
  "heck 0.4.1",
  "http 0.2.11",
  "ignore",
- "notify-rust",
  "objc",
  "once_cell",
  "open",

--- a/rust/connlib/shared/src/windows.rs
+++ b/rust/connlib/shared/src/windows.rs
@@ -13,6 +13,10 @@ use std::path::PathBuf;
 /// This should be identical to the `tauri.bundle.identifier` over in `tauri.conf.json`,
 /// but sometimes I need to use this before Tauri has booted up, or in a place where
 /// getting the Tauri app handle would be awkward.
+///
+/// Luckily this is also the AppUserModelId that Windows uses to label notifications,
+/// so if your dev system has Firezone installed by MSI, the notifications will look right.
+/// <https://learn.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app>
 pub const BUNDLE_ID: &str = "dev.firezone.client";
 
 /// Returns e.g. `C:/Users/User/AppData/Local/dev.firezone.client

--- a/rust/windows-client/src-tauri/Cargo.toml
+++ b/rust/windows-client/src-tauri/Cargo.toml
@@ -52,9 +52,10 @@ native-dialog = "0.7.0"
 
 [target.'cfg(windows)'.dependencies]
 # Tauri works fine on Linux, but it requires a lot of build-time deps like glib and gdk, so I've blocked it out for now.
-tauri = { version = "1.5", features = [ "dialog", "notification", "shell-open-api", "system-tray" ] }
+tauri = { version = "1.5", features = [ "dialog", "shell-open-api", "system-tray" ] }
 tauri-runtime = "0.14.2"
 tauri-utils = "1.5.1"
+tauri-winrt-notification = "0.1.3"
 winreg = "0.52.0"
 wintun = "0.4.0"
 

--- a/rust/windows-client/src-tauri/src/client.rs
+++ b/rust/windows-client/src-tauri/src/client.rs
@@ -124,6 +124,9 @@ fn run_gui(cli: Cli) -> Result<()> {
     Ok(result?)
 }
 
+/// The debug / test flags like `crash_on_purpose` and `test_update_notification`
+/// don't propagate when we use `RunAs` to elevate ourselves. So those must be run
+/// from an admin terminal, or with "Run as administrator" in the right-click menu.
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -102,12 +102,6 @@ pub(crate) fn run(cli: client::Cli) -> Result<(), Error> {
     tracing::info!("started log");
     tracing::info!("GIT_VERSION = {}", crate::client::GIT_VERSION);
 
-    let client::Cli {
-        command: _,
-        crash_on_purpose,
-        inject_faults,
-    } = cli;
-
     // Need to keep this alive so crashes will be handled. Dropping detaches it.
     let _crash_handler = match client::crash_handling::attach_handler() {
         Ok(x) => Some(x),
@@ -123,7 +117,7 @@ pub(crate) fn run(cli: client::Cli) -> Result<(), Error> {
     let rt = tokio::runtime::Runtime::new().map_err(Error::TokioRuntimeNew)?;
     let _guard = rt.enter();
 
-    if crash_on_purpose {
+    if cli.crash_on_purpose {
         tokio::spawn(async {
             let delay = 10;
             tracing::info!("Will crash on purpose in {delay} seconds to test crash handling.");
@@ -150,7 +144,7 @@ pub(crate) fn run(cli: client::Cli) -> Result<(), Error> {
 
     let managed = Managed {
         ctlr_tx: ctlr_tx.clone(),
-        inject_faults,
+        inject_faults: cli.inject_faults,
     };
 
     let tray = SystemTray::new().with_menu(system_tray_menu::signed_out());

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -70,7 +70,7 @@ pub(crate) enum Error {
 }
 
 /// Runs the Tauri GUI and returns on exit or unrecoverable error
-pub(crate) fn run(params: client::GuiParams) -> Result<(), Error> {
+pub(crate) fn run(cli: client::Cli) -> Result<(), Error> {
     let advanced_settings = settings::load_advanced_settings().unwrap_or_default();
 
     // If the log filter is unparsable, show an error and use the default
@@ -102,11 +102,11 @@ pub(crate) fn run(params: client::GuiParams) -> Result<(), Error> {
     tracing::info!("started log");
     tracing::info!("GIT_VERSION = {}", crate::client::GIT_VERSION);
 
-    let client::GuiParams {
+    let client::Cli {
+        command: _,
         crash_on_purpose,
-        flag_elevated: _,
         inject_faults,
-    } = params;
+    } = cli;
 
     // Need to keep this alive so crashes will be handled. Dropping detaches it.
     let _crash_handler = match client::crash_handling::attach_handler() {

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -689,10 +689,12 @@ fn show_notification(title: &str, body: &str) -> Result<(), Error> {
 /// click signal.
 ///
 /// I've seen this reported by people using Powershell, C#, etc., so I think it might
-/// be a Windows bug:
+/// be a Windows bug?
 /// - <https://superuser.com/questions/1488763/windows-10-notifications-not-activating-the-associated-app-when-clicking-on-it>
 /// - <https://stackoverflow.com/questions/65835196/windows-toast-notification-com-not-working>
 /// - <https://answers.microsoft.com/en-us/windows/forum/all/notifications-not-activating-the-associated-app/7a3b31b0-3a20-4426-9c88-c6e3f2ac62c6>
+///
+/// Firefox doesn't have this problem. Maybe they're using a different API.
 fn show_clickable_notification(
     title: &str,
     body: &str,

--- a/rust/windows-client/src-tauri/src/client/gui/system_tray_menu.rs
+++ b/rust/windows-client/src-tauri/src/client/gui/system_tray_menu.rs
@@ -1,3 +1,8 @@
+//! Code for the Windows notification area
+//!
+//! "Notification Area" is Microsoft's official name instead of "System tray":
+//! <https://learn.microsoft.com/en-us/windows/win32/shell/notification-area?redirectedfrom=MSDN#notifications-and-the-notification-area>
+
 use connlib_client_shared::ResourceDescription;
 use std::str::FromStr;
 use tauri::{CustomMenuItem, SystemTrayMenu, SystemTrayMenuItem, SystemTraySubmenu};


### PR DESCRIPTION
Looks a little odd in the Windows Server VM cause of the minimal desktop environment, but it does open the browser, same as the "Sign In" button
![image](https://github.com/firezone/firezone/assets/13400041/772b755d-8291-44c4-9cb9-d0dca5c98f8e)
