### PR TITLE
feat(snownet): automatically discover host candidates

### DIFF
--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -1,3 +1,5 @@
+//! A SANS-IO connectivity library for wireguard connections formed by ICE.
+
 mod allocation;
 mod channel_data;
 mod index;

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -123,9 +123,9 @@ where
 
     /// Add an address as a `host` candidate.
     ///
-    /// For most network topologies, [`snownet`] will automatically discover host candidates via the traffic to the configured STUN and TURN servers.
+    /// For most network topologies, [`snownet`](crate) will automatically discover host candidates via the traffic to the configured STUN and TURN servers.
     /// However, in topologies like the one below, we cannot discover that there is a more optimal link between BACKEND and DB.
-    /// For those situations, users need to manually add the address of the direct link in order for [`snownet`] to establish a connection.
+    /// For those situations, users need to manually add the address of the direct link in order for [`snownet`](crate) to establish a connection.
     ///
     /// ```no_run
     ///        ┌──────┐          ┌──────┐

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -127,7 +127,7 @@ where
     /// However, in topologies like the one below, we cannot discover that there is a more optimal link between BACKEND and DB.
     /// For those situations, users need to manually add the address of the direct link in order for [`snownet`](crate) to establish a connection.
     ///
-    /// ```no_run
+    /// ```ignore
     ///        ┌──────┐          ┌──────┐
     ///        │ STUN ├─┐      ┌─┤ TURN │
     ///        └──────┘ │      │ └──────┘

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -121,6 +121,35 @@ where
         })
     }
 
+    /// Add an address as a `host` candidate.
+    ///
+    /// For most network topologies, [`snownet`] will automatically discover host candidates via the traffic to the configured STUN and TURN servers.
+    /// However, in topologies like the one below, we cannot discover that there is a more optimal link between BACKEND and DB.
+    /// For those situations, users need to manually add the address of the direct link in order for [`snownet`] to establish a connection.
+    ///
+    /// ```norun
+    ///        ┌──────┐          ┌──────┐
+    ///        │ STUN ├─┐      ┌─┤ TURN │
+    ///        └──────┘ │      │ └──────┘
+    ///                 │      │
+    ///               ┌─┴──────┴─┐
+    ///      ┌────────┤   WAN    ├───────┐
+    ///      │        └──────────┘       │
+    /// ┌────┴─────┐                  ┌──┴───┐
+    /// │    FW    │                  │  FW  │
+    /// └────┬─────┘                  └──┬───┘
+    ///      │            ┌──┐           │
+    ///  ┌───┴─────┐      │  │         ┌─┴──┐
+    ///  │ BACKEND ├──────┤FW├─────────┤ DB │
+    ///  └─────────┘      │  │         └────┘
+    ///                   └──┘
+    /// ```
+    pub fn add_local_host_candidate(&mut self, address: SocketAddr) -> Result<(), Error> {
+        self.add_local_as_host_candidate(address)?;
+
+        Ok(())
+    }
+
     pub fn add_remote_candidate(&mut self, id: TId, candidate: String) {
         let candidate = match Candidate::from_sdp_string(&candidate) {
             Ok(c) => c,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -127,7 +127,7 @@ where
     /// However, in topologies like the one below, we cannot discover that there is a more optimal link between BACKEND and DB.
     /// For those situations, users need to manually add the address of the direct link in order for [`snownet`] to establish a connection.
     ///
-    /// ```norun
+    /// ```no_run
     ///        ┌──────┐          ┌──────┐
     ///        │ STUN ├─┐      ┌─┤ TURN │
     ///        └──────┘ │      │ └──────┘

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -49,7 +49,7 @@ pub struct Node<T, TId> {
     private_key: StaticSecret,
     index: IndexLfsr,
     rate_limiter: Arc<RateLimiter>,
-    local_interfaces: HashSet<SocketAddr>,
+    host_candidates: HashSet<Candidate>,
     buffered_transmits: VecDeque<Transmit<'static>>,
 
     next_rate_limiter_reset: Option<Instant>,
@@ -80,6 +80,8 @@ pub enum Error {
     UnmatchedPacket,
     #[error("Not connected")]
     NotConnected,
+    #[error("Invalid local address: {0}")]
+    BadLocalAddress(#[from] str0m::error::IceError),
 }
 
 impl<T, TId> Node<T, TId>
@@ -93,7 +95,7 @@ where
             marker: Default::default(),
             index: IndexLfsr::default(),
             rate_limiter: Arc::new(RateLimiter::new(public_key, HANDSHAKE_RATE_LIMIT)),
-            local_interfaces: HashSet::default(),
+            host_candidates: HashSet::default(),
             buffered_transmits: VecDeque::default(),
             next_rate_limiter_reset: None,
             negotiated_connections: HashMap::default(),
@@ -117,12 +119,6 @@ where
                 },
             )
         })
-    }
-
-    pub fn add_local_interface(&mut self, local_addr: SocketAddr) {
-        self.local_interfaces.insert(local_addr);
-
-        // TODO: Add host candidate to all existing connections here.
     }
 
     pub fn add_remote_candidate(&mut self, id: TId, candidate: String) {
@@ -165,6 +161,8 @@ where
         now: Instant,
         buffer: &'s mut [u8],
     ) -> Result<Option<(TId, IpPacket<'s>)>, Error> {
+        self.add_local_as_host_candidate(local)?;
+
         // First, check if a `StunBinding` wants the packet
         if let Some(binding) = self.bindings.get_mut(&from) {
             if binding.handle_input(from, local, packet, now) {
@@ -208,11 +206,6 @@ where
 
         // Next: If we can parse the message as a STUN message, cycle through all agents to check which one it is for.
         if let Ok(message) = StunMessage::parse(packet) {
-            // `str0m` panics if you feed it traffic from an interface it doesn't know about. (TODO: Fix upstream)
-            if !self.local_interfaces.contains(&local) {
-                return Err(Error::UnknownInterface);
-            }
-
             for agent in self.agents_mut() {
                 // TODO: `accepts_message` cannot demultiplexing multiple connections until https://github.com/algesten/str0m/pull/418 is merged.
                 if agent.accepts_message(&message) {
@@ -552,6 +545,40 @@ where
             last_seen: None,
         }
     }
+
+    /// Attempt to add the `local` address as a host candidate.
+    ///
+    /// Receiving traffic on a certain interface means we at least have a connection to a relay via this interface.
+    /// Thus, it is also a viable interface to attempt a connection to a gateway.
+    fn add_local_as_host_candidate(&mut self, local: SocketAddr) -> Result<(), Error> {
+        let host_candidate = Candidate::host(local, Protocol::Udp)?;
+
+        let is_new = self.host_candidates.insert(host_candidate.clone());
+
+        if !is_new {
+            return Ok(());
+        }
+
+        // TODO: This is duplicated with `agents_mut` but the borrow-checker doesn't allow us to de-duplicate :(
+        let initial_agents = self
+            .initial_connections
+            .iter_mut()
+            .map(|(id, c)| (*id, &mut c.agent));
+        let negotiated_agents = self
+            .negotiated_connections
+            .iter_mut()
+            .map(|(id, c)| (*id, &mut c.agent));
+
+        for (conn, agent) in initial_agents.chain(negotiated_agents) {
+            add_local_candidate(
+                conn,
+                agent,
+                host_candidate.clone(),
+                &mut self.pending_events,
+            );
+        }
+        Ok(())
+    }
 }
 
 impl<TId> Node<Client, TId>
@@ -766,21 +793,8 @@ where
         allowed_stun_servers: &HashSet<SocketAddr>,
         allowed_turn_servers: &HashSet<SocketAddr>,
     ) {
-        for local in self.local_interfaces.iter().copied() {
-            let candidate = match Candidate::host(local, Protocol::Udp) {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::debug!("Failed to generate host candidate from addr: {e}");
-                    continue;
-                }
-            };
-
-            add_local_candidate(
-                connection,
-                agent,
-                candidate.clone(),
-                &mut self.pending_events,
-            );
+        for candidate in self.host_candidates.iter().cloned() {
+            add_local_candidate(connection, agent, candidate, &mut self.pending_events);
         }
 
         for candidate in self.bindings.iter().filter_map(|(server, binding)| {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -127,7 +127,7 @@ where
     /// However, in topologies like the one below, we cannot discover that there is a more optimal link between BACKEND and DB.
     /// For those situations, users need to manually add the address of the direct link in order for [`snownet`](crate) to establish a connection.
     ///
-    /// ```ignore
+    /// ```text
     ///        ┌──────┐          ┌──────┐
     ///        │ STUN ├─┐      ┌─┤ TURN │
     ///        └──────┘ │      │ └──────┘

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -698,9 +698,6 @@ where
 {
     /// Accept a new connection indexed by the given ID.
     ///
-    /// The `local_server_socket` is the socket from which you are planning to send all required traffic to the (relay) servers.
-    /// It will be returned as part of [`Transmit`]'s `src` field.
-    ///
     /// Out of all configured STUN and TURN servers, the connection will only use the ones provided here.
     /// The returned [`Answer`] must be passed to the remote via a signalling channel.
     pub fn accept_connection(

--- a/rust/snownet-tests/docker-compose.lan.yml
+++ b/rust/snownet-tests/docker-compose.lan.yml
@@ -1,3 +1,7 @@
+# This test environment partitions has dialer and listener on the same subnet.
+# The relay acts only as a STUN server and sits in a different network.
+# This allows us to test that our automatic discovery of host candidates makes a local connection possible.
+
 version: "3.8"
 name: lan-integration-test
 
@@ -11,7 +15,6 @@ services:
       cache_from:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/connection-tests:main
     image: us-east1-docker.pkg.dev/firezone-staging/firezone/connection-tests:${VERSION:-main}
-    init: true
     environment:
       ROLE: "dialer"
     cap_add:
@@ -22,15 +25,32 @@ services:
       - |
         set -ex
 
-        export REDIS_HOST=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/containers/lan-integration-test-redis-1/json | jq -r '.NetworkSettings.Networks."lan-integration-test_app".IPAddress')
+        ROUTER_IP=$$(dig +short router)
+        INTERNET_SUBNET=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/networks/lan-integration-test_wan | jq -r '.IPAM.Config[0].Subnet')
+
+        ip route add $$INTERNET_SUBNET via $$ROUTER_IP dev eth0
+
+        export STUN_SERVER=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/containers/lan-integration-test-relay-1/json | jq -r '.NetworkSettings.Networks."lan-integration-test_wan".IPAddress')
+        export REDIS_HOST=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/containers/lan-integration-test-redis-1/json | jq -r '.NetworkSettings.Networks."lan-integration-test_wan".IPAddress')
 
         snownet-tests
     depends_on:
+      - router
       - redis
     networks:
-      - app
+      - lan
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  router:
+    init: true
+    build:
+      context: ./router
+    cap_add:
+      - NET_ADMIN
+    networks:
+      - lan
+      - wan
 
   listener:
     build:
@@ -44,31 +64,77 @@ services:
     init: true
     environment:
       ROLE: "listener"
-    cap_add:
-      - NET_ADMIN
     entrypoint: /bin/sh
     command:
       - -c
       - |
         set -ex
 
-        export REDIS_HOST=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/containers/lan-integration-test-redis-1/json | jq -r '.NetworkSettings.Networks."lan-integration-test_app".IPAddress')
+        ROUTER_IP=$$(dig +short router)
+        INTERNET_SUBNET=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/networks/lan-integration-test_wan | jq -r '.IPAM.Config[0].Subnet')
+
+        ip route add $$INTERNET_SUBNET via $$ROUTER_IP dev eth0
+
+        export STUN_SERVER=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/containers/lan-integration-test-relay-1/json | jq -r '.NetworkSettings.Networks."lan-integration-test_wan".IPAddress')
+        export REDIS_HOST=$$(curl --fail --silent --unix-socket /var/run/docker.sock http://localhost/containers/lan-integration-test-redis-1/json | jq -r '.NetworkSettings.Networks."lan-integration-test_wan".IPAddress')
 
         snownet-tests
+    cap_add:
+      - NET_ADMIN
     depends_on:
+      - router
       - redis
     networks:
-      - app
+      - lan
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  relay:
+    environment:
+      LOWEST_PORT: 55555
+      HIGHEST_PORT: 55666
+      RUST_LOG: "debug"
+      RUST_BACKTRACE: 1
+    build:
+      target: debug
+      context: ..
+      cache_from:
+        - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
+      args:
+        PACKAGE: firezone-relay
+    image: us-east1-docker.pkg.dev/firezone-staging/firezone/relay:${VERSION:-main}
+    init: true
+    healthcheck:
+      test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 5s
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        set -ex;
+        export PUBLIC_IP4_ADDR=$(ip -json addr show eth0 | jq '.[0].addr_info[0].local' -r)
+
+        firezone-relay
+    ports:
+      # XXX: Only 111 ports are used for local dev / testing because Docker Desktop
+      # allocates a userland proxy process for each forwarded port X_X.
+      #
+      # Large ranges here will bring your machine to its knees.
+      - "55555-55666:55555-55666/udp"
+      - 3478:3478/udp
+    networks:
+      - wan
 
   redis:
     image: "redis:7-alpine"
     healthcheck:
       test: ["CMD-SHELL", "echo 'ready';"]
     networks:
-      - app
+      - wan
 
 networks:
-  app:
-   # enable_ipv6: true Disable until we find a workaround for https://github.com/moby/moby/issues/41438.
+  lan:
+  wan:

--- a/rust/snownet-tests/src/main.rs
+++ b/rust/snownet-tests/src/main.rs
@@ -66,7 +66,6 @@ async fn main() -> Result<()> {
     let mut redis_connection = redis_client.get_multiplexed_async_connection().await?;
 
     let socket = UdpSocket::bind((listen_addr, 0)).await?;
-    let socket_addr = socket.local_addr()?;
     let private_key = StaticSecret::random_from_rng(rand::thread_rng());
     let public_key = PublicKey::from(&private_key);
 
@@ -77,7 +76,6 @@ async fn main() -> Result<()> {
     match role {
         Role::Dialer => {
             let mut pool = ClientNode::<u64>::new(private_key, Instant::now());
-            pool.add_local_interface(socket_addr);
 
             let offer = pool.new_connection(
                 1,
@@ -160,7 +158,6 @@ async fn main() -> Result<()> {
         }
         Role::Listener => {
             let mut pool = ServerNode::<u64>::new(private_key, Instant::now());
-            pool.add_local_interface(socket_addr);
 
             let offer = redis_connection
                 .blpop::<_, (String, wire::Offer)>("offers", 10.0)


### PR DESCRIPTION
I had an idea that is quite a big deal. Instead of manually discovering host candidates by iterating interfaces and adding all of them, we automatically generate host candidates every time we receive traffic on from a certain interface. Initially, you might think that this is a catch-22: How do we generate traffic without having host candidates? The answer is: relays!

When we initiate a new connection using `snownet`, we add a list of STUN and TURN servers. We will immediately attempt to talk to both of them, sending STUN bindings to the former and ALLOCATE requests to the latter. As the replies come in, we know, which interface they have been received on. That particular interface is an excellent `host` candidate because we've already proven connectivity to a STUN or TURN server. In fact, for hole-punching, we will need to send traffic via that same interface to reach the gateway (otherwise the `srflx` candidate won't work anyway).

There is only one "edge"-case in which this doesn't work: When you want to make a connection between a client and a gateway on the same subnet yet without connectivity to a relay. At that point, I'd argue that your network topology is broken anyway. If you can't talk to a relay, you probably also cannot talk to the portal, meaning the signaling protocol also doesn't work.