### PR TITLE
fix(android): Load library before starting tunnel only

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/presentation/MainActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/presentation/MainActivity.kt
@@ -8,17 +8,12 @@ import dev.firezone.android.R
 
 @AndroidEntryPoint
 internal class MainActivity : AppCompatActivity(R.layout.activity_main) {
-    // fail fast if the native library is not loaded
-    companion object {
-        init {
-            System.loadLibrary("connlib")
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
     }
 
     @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {}
+    override fun onBackPressed() {
+        super.onBackPressed()
+    }
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -178,6 +178,7 @@ class TunnelService : VpnService() {
             } else if (config.token != null) {
                 onTunnelStateUpdate(Tunnel.State.Connecting)
                 updateStatusNotification("Status: Connecting...")
+                System.loadLibrary("connlib")
 
                 sessionPtr =
                     TunnelSession.connect(


### PR DESCRIPTION
When AlwaysOnVpn is configured, the tunnel can run without MainActivity, so the library is never loaded.

Fixes #3532 