### PR TITLE
feat(windows): log `have_internet` changes and API base URL at INFO level

### DIFF
--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -431,8 +431,13 @@ impl Controller {
             resources: Default::default(),
         };
 
+        let api_url = self.advanced_settings.api_url.clone();
+        tracing::info!(
+            api_url = api_url.to_string(),
+            "Calling connlib Session::connect"
+        );
         let connlib = connlib_client_shared::Session::connect(
-            self.advanced_settings.api_url.clone(),
+            api_url,
             token,
             self.device_id.clone(),
             None, // `get_host_name` over in connlib gets the system's name automatically
@@ -573,7 +578,7 @@ async fn run_controller(
     .context("couldn't create Controller")?;
 
     let mut have_internet = network_changes::check_internet()?;
-    tracing::debug!(?have_internet);
+    tracing::info!(?have_internet);
 
     let mut com_worker = network_changes::Worker::new()?;
 
@@ -587,7 +592,7 @@ async fn run_controller(
                 if new_have_internet != have_internet {
                     have_internet = new_have_internet;
                     // TODO: Stop / start / restart connlib as needed here
-                    tracing::debug!(?have_internet);
+                    tracing::info!(?have_internet);
                 }
             },
             req = rx.recv() => {


### PR DESCRIPTION
API URL, e.g. `wss://api.firezone.dev/`

Closes #3536 

![image](https://github.com/firezone/firezone/assets/13400041/1ea4b481-0e2c-4a77-bf1d-7c7c46b4d68c)
