### PR TITLE
chore(android): Remove i686 android target

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
-          targets: armv7-linux-androideabi aarch64-linux-android x86_64-linux-android i686-linux-android
+          targets: armv7-linux-androideabi aarch64-linux-android x86_64-linux-android
       - uses: actions/setup-java@v4
         with:
           distribution: temurin

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -170,7 +170,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           sccache_enabled: false
-          targets: armv7-linux-androideabi aarch64-linux-android x86_64-linux-android i686-linux-android
+          targets: armv7-linux-androideabi aarch64-linux-android x86_64-linux-android
       - uses: actions/setup-java@v4
         with:
           distribution: oracle

--- a/kotlin/android/README.md
+++ b/kotlin/android/README.md
@@ -49,7 +49,6 @@ locally.
    aarch64-linux-android
    arm-linux-androideabi
    armv7-linux-androideabi
-   i686-linux-android
    x86_64-linux-android
    ```
 
@@ -58,7 +57,7 @@ locally.
    `/rust/rust-toolchain.toml` file), then run:
 
    ```
-   rustup target add aarch64-linux-android arm-linux-androideabi armv7-linux-androideabi i686-linux-android x86_64-linux-android
+   rustup target add aarch64-linux-android arm-linux-androideabi armv7-linux-androideabi x86_64-linux-android
    ```
 
 1. Perform a test build: `./gradlew assembleDebug`.

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -217,7 +217,7 @@ cargo {
     verbose = true
     module = "../../../rust/connlib/clients/android"
     libname = "connlib"
-    targets = listOf("arm", "arm64", "x86_64", "x86")
+    targets = listOf("arm", "arm64", "x86_64")
     targetDirectory = "../../../rust/target"
 }
 


### PR DESCRIPTION
This increases our app bundle size with no real benefit. ~~I'm also encountering an issue where the `x86` shared library is being loaded instead of the appropriate x86_64 one, causing a crash.~~ Edit: The crash appears to be coming from somewhere else, still investigating. Still it would be good to remove this as the Rust dependency in the Android build is built serially.