### PR TITLE
fix(connlib): Enable ansi colors for the windows client debug console

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2156,6 +2156,7 @@ dependencies = [
  "known-folders",
  "minidumper",
  "native-dialog",
+ "output_vt100",
  "rand 0.8.5",
  "reqwest",
  "ring 0.17.7",
@@ -4382,6 +4383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
 dependencies = [
  "log",
+ "winapi",
+]
+
+[[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
  "winapi",
 ]
 

--- a/rust/windows-client/src-tauri/Cargo.toml
+++ b/rust/windows-client/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ windows-implement = "0.52.0"
 sadness-generator = "0.5.0"
 bincode = "1.3.3"
 native-dialog = "0.7.0"
+output_vt100 = "0.1"
 
 # These dependencies are locked behind `cfg(windows)` because they either can't compile at all on Linux, or they need native dependencies like glib that are difficult to get. Try not to add more here.
 

--- a/rust/windows-client/src-tauri/src/client/logging.rs
+++ b/rust/windows-client/src-tauri/src/client/logging.rs
@@ -41,12 +41,11 @@ pub(crate) fn setup(log_filter: &str) -> Result<Handles, Error> {
     let (layer, logger) = file_logger::layer(&log_path);
     let filter = EnvFilter::from_str(log_filter)?;
     let (filter, reloader) = reload::Layer::new(filter);
-    let subscriber = Registry::default().with(layer.with_filter(filter)).with(
-        fmt::layer()
-            .with_ansi(false)
-            .with_filter(EnvFilter::from_str(log_filter)?),
-    );
+    let subscriber = Registry::default()
+        .with(layer.with_filter(filter))
+        .with(fmt::layer().with_filter(EnvFilter::from_str(log_filter)?));
     set_global_default(subscriber)?;
+    output_vt100::init();
     LogTracer::init()?;
     Ok(Handles {
         logger,

--- a/rust/windows-client/src-tauri/src/client/logging.rs
+++ b/rust/windows-client/src-tauri/src/client/logging.rs
@@ -41,9 +41,11 @@ pub(crate) fn setup(log_filter: &str) -> Result<Handles, Error> {
     let (layer, logger) = file_logger::layer(&log_path);
     let filter = EnvFilter::from_str(log_filter)?;
     let (filter, reloader) = reload::Layer::new(filter);
-    let subscriber = Registry::default()
-        .with(layer.with_filter(filter))
-        .with(fmt::layer().with_filter(EnvFilter::from_str(log_filter)?));
+    let subscriber = Registry::default().with(layer.with_filter(filter)).with(
+        fmt::layer()
+            .with_ansi(false)
+            .with_filter(EnvFilter::from_str(log_filter)?),
+    );
     set_global_default(subscriber)?;
     LogTracer::init()?;
     Ok(Handles {


### PR DESCRIPTION
This adds colors to the debug console in the windows client

![image](https://github.com/firezone/firezone/assets/3310803/dfb5b119-9db3-40b8-acf9-3485a2268597)