### PR TITLE
deps: update to latest upstream version of `str0m`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5625,9 +5625,9 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514eb06a3f6b1f119b6a00a9a87afac072894817d3283b0d36adc8f8a135886a"
+checksum = "8f64cef148d3295c730c3cb340b0b252a4d570b1c7d4bf0808f88540b0a888bc"
 dependencies = [
  "bytes",
  "crc",
@@ -6161,7 +6161,7 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 [[package]]
 name = "str0m"
 version = "0.4.1"
-source = "git+https://github.com/thomaseizinger/str0m?branch=feat/base-is-host-for-srflx#86a5851874802244c3cff00754ea1c5e71badee1"
+source = "git+https://github.com/algesten/str0m?branch=main#18f56ebf6266c8df5d9dcf9699695e59b717d30a"
 dependencies = [
  "combine",
  "crc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -49,7 +49,7 @@ phoenix-channel = { path = "phoenix-channel"}
 [patch.crates-io]
 boringtun = { git = "https://github.com/thomaseizinger/boringtun", branch = "feat/expose-last-seen" }
 webrtc = { git = "https://github.com/firezone/webrtc", branch = "expose-new-endpoint" }
-str0m = { git = "https://github.com/thomaseizinger/str0m", branch = "feat/base-is-host-for-srflx" }
+str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Necessary contributions have (once again) been merged so we can switch back to the upstream repo again! :)