### PR TITLE
feat(snownet): return `MutableIpPacket` from `decapsulate`

### DIFF
--- a/rust/connlib/snownet/src/ip_packet.rs
+++ b/rust/connlib/snownet/src/ip_packet.rs
@@ -1,12 +1,17 @@
 use std::net::IpAddr;
 
-use pnet_packet::{ip::IpNextHeaderProtocols, ipv4::Ipv4Packet, ipv6::Ipv6Packet, Packet};
+use pnet_packet::{
+    ip::IpNextHeaderProtocols,
+    ipv4::{Ipv4Packet, MutableIpv4Packet},
+    ipv6::{Ipv6Packet, MutableIpv6Packet},
+    Packet,
+};
 
 macro_rules! for_both {
     ($this:ident, |$name:ident| $body:expr) => {
         match $this {
-            IpPacket::Ipv4($name) => $body,
-            IpPacket::Ipv6($name) => $body,
+            Self::Ipv4($name) => $body,
+            Self::Ipv6($name) => $body,
         }
     };
 }
@@ -15,6 +20,45 @@ macro_rules! for_both {
 pub enum IpPacket<'a> {
     Ipv4(Ipv4Packet<'a>),
     Ipv6(Ipv6Packet<'a>),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum MutableIpPacket<'a> {
+    Ipv4(MutableIpv4Packet<'a>),
+    Ipv6(MutableIpv6Packet<'a>),
+}
+
+impl<'a> MutableIpPacket<'a> {
+    pub fn new(buf: &'a mut [u8]) -> Option<Self> {
+        match buf[0] >> 4 {
+            4 => Some(MutableIpPacket::Ipv4(MutableIpv4Packet::new(buf)?)),
+            6 => Some(MutableIpPacket::Ipv6(MutableIpv6Packet::new(buf)?)),
+            _ => None,
+        }
+    }
+
+    pub fn to_owned(&self) -> MutableIpPacket<'static> {
+        match self {
+            MutableIpPacket::Ipv4(i) => MutableIpv4Packet::owned(i.packet().to_vec())
+                .expect("owned packet is still valid")
+                .into(),
+            MutableIpPacket::Ipv6(i) => MutableIpv6Packet::owned(i.packet().to_vec())
+                .expect("owned packet is still valid")
+                .into(),
+        }
+    }
+
+    pub fn to_immutable(&self) -> IpPacket {
+        for_both!(self, |i| i.to_immutable().into())
+    }
+
+    pub fn source(&self) -> IpAddr {
+        for_both!(self, |i| i.get_source().into())
+    }
+
+    pub fn destination(&self) -> IpAddr {
+        for_both!(self, |i| i.get_destination().into())
+    }
 }
 
 impl<'a> IpPacket<'a> {
@@ -70,6 +114,28 @@ impl<'a> From<Ipv6Packet<'a>> for IpPacket<'a> {
     }
 }
 
+impl<'a> From<MutableIpv4Packet<'a>> for MutableIpPacket<'a> {
+    fn from(value: MutableIpv4Packet<'a>) -> Self {
+        Self::Ipv4(value)
+    }
+}
+
+impl<'a> From<MutableIpv6Packet<'a>> for MutableIpPacket<'a> {
+    fn from(value: MutableIpv6Packet<'a>) -> Self {
+        Self::Ipv6(value)
+    }
+}
+
+impl pnet_packet::Packet for MutableIpPacket<'_> {
+    fn packet(&self) -> &[u8] {
+        for_both!(self, |i| i.packet())
+    }
+
+    fn payload(&self) -> &[u8] {
+        for_both!(self, |i| i.payload())
+    }
+}
+
 impl pnet_packet::Packet for IpPacket<'_> {
     fn packet(&self) -> &[u8] {
         for_both!(self, |i| i.packet())
@@ -77,5 +143,15 @@ impl pnet_packet::Packet for IpPacket<'_> {
 
     fn payload(&self) -> &[u8] {
         for_both!(self, |i| i.payload())
+    }
+}
+
+impl pnet_packet::MutablePacket for MutableIpPacket<'_> {
+    fn packet_mut(&mut self) -> &mut [u8] {
+        for_both!(self, |i| i.packet_mut())
+    }
+
+    fn payload_mut(&mut self) -> &mut [u8] {
+        for_both!(self, |i| i.payload_mut())
     }
 }

--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -9,5 +9,5 @@ mod node;
 mod stun_binding;
 
 pub use info::ConnectionInfo;
-pub use ip_packet::IpPacket;
+pub use ip_packet::{IpPacket, MutableIpPacket};
 pub use node::{Answer, ClientNode, Credentials, Error, Event, Node, Offer, ServerNode, Transmit};

--- a/rust/snownet-tests/src/main.rs
+++ b/rust/snownet-tests/src/main.rs
@@ -428,7 +428,7 @@ impl<T> Eventloop<T> {
             )? {
                 return Poll::Ready(Ok(Event::Incoming {
                     conn,
-                    packet: packet.to_owned(),
+                    packet: packet.to_immutable().to_owned(),
                 }));
             }
 


### PR DESCRIPTION
The user is already passing us a mutable buffer so we might as well give them a `MutableIpPacket` to allow them to further mutate it.

Extracted out of #3391.