### PR TITLE
fix(windows): vt100 seems to panic in CI, just print a warning instead

### DIFF
--- a/rust/windows-client/src-tauri/src/client/logging.rs
+++ b/rust/windows-client/src-tauri/src/client/logging.rs
@@ -45,7 +45,9 @@ pub(crate) fn setup(log_filter: &str) -> Result<Handles, Error> {
         .with(layer.with_filter(filter))
         .with(fmt::layer().with_filter(EnvFilter::from_str(log_filter)?));
     set_global_default(subscriber)?;
-    output_vt100::init();
+    if let Err(error) = output_vt100::try_init() {
+        tracing::warn!(?error, "Failed to init vt100 terminal colors");
+    }
     LogTracer::init()?;
     Ok(Handles {
         logger,


### PR DESCRIPTION
Fixes the Windows smoke test failing in CI currently.
The CI already has coloring enabled.