### PR TITLE
fix(windows): Wrap deep link URLs in `SecureUrl`, don't log them

### DIFF
--- a/rust/windows-client/src-tauri/src/client/deep_link.rs
+++ b/rust/windows-client/src-tauri/src/client/deep_link.rs
@@ -172,7 +172,6 @@ impl Server {
 
         tracing::debug!("Server read");
         let s = String::from_utf8(bytes).map_err(Error::LinkNotUtf8)?;
-        tracing::info!("{}", s);
         let url = url::Url::parse(&s)?;
 
         Ok(url)

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -10,8 +10,8 @@ use crate::client::{
 use anyhow::{anyhow, bail, Context, Result};
 use arc_swap::ArcSwap;
 use connlib_client_shared::{file_logger, ResourceDescription};
-use connlib_shared::{messages::ResourceId, windows::BUNDLE_ID};
-use secrecy::{ExposeSecret, SecretString};
+use connlib_shared::{control::SecureUrl, messages::ResourceId, windows::BUNDLE_ID};
+use secrecy::{ExposeSecret, Secret, SecretString};
 use std::{net::IpAddr, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 use system_tray_menu::Event as TrayMenuEvent;
 use tauri::{Manager, SystemTray, SystemTrayEvent};
@@ -388,7 +388,7 @@ pub(crate) enum ControllerRequest {
         stem: PathBuf,
     },
     GetAdvancedSettings(oneshot::Sender<AdvancedSettings>),
-    SchemeRequest(url::Url),
+    SchemeRequest(Secret<SecureUrl>),
     SystemTrayMenu(TrayMenuEvent),
     TunnelReady,
     UpdateAvailable(client::updates::Release),
@@ -572,7 +572,7 @@ impl Controller {
         Ok(())
     }
 
-    async fn handle_deep_link(&mut self, url: &url::Url) -> Result<()> {
+    async fn handle_deep_link(&mut self, url: &Secret<SecureUrl>) -> Result<()> {
         let auth_response =
             client::deep_link::parse_auth_callback(url).context("Couldn't parse scheme request")?;
 

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -576,6 +576,7 @@ impl Controller {
         let auth_response =
             client::deep_link::parse_auth_callback(url).context("Couldn't parse scheme request")?;
 
+        tracing::info!("Got deep link");
         // Uses `std::fs`
         let token = self.auth.handle_response(auth_response)?;
         self.start_session(token)


### PR DESCRIPTION
Previously the whole URL was logged, which includes half of the secret token. Now it just says "Got deep link"