### PR TITLE
fix: don't initialize relay with non-existent interface

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
   relay:
     environment:
       PUBLIC_IP4_ADDR: 172.28.0.101
-      PUBLIC_IP6_ADDR: fcff:3990:3990::101
+      # PUBLIC_IP6_ADDR: fcff:3990:3990::101
       LOWEST_PORT: 55555
       HIGHEST_PORT: 55666
       # Token for self-hosted Relay


### PR DESCRIPTION
In the `snownet` integration branch, we ran into some problems because we actually tried to use the IPv6 relay. This doesn't work though because the docker-compose doesn't provide an IPv6 socket to the container and thus the relay falsely registers with the portal as having an IPv6 address.

Internally, we only bind to a wildcard address (`0.0.0.0` and `::`) which unfortunately, doesn't seem to fail, even if we don't have an IPv6 interface.