### PR TITLE
feat(devops): Add Trisha to staging GCP

### DIFF
--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -4,7 +4,8 @@ locals {
     "bmanifold@firezone.dev",
     "gabriel@firezone.dev",
     "jamil@firezone.dev",
-    "thomas@firezone.dev"
+    "thomas@firezone.dev",
+    "trish@firezone.dev"
   ]
 
   demo_access = []


### PR DESCRIPTION
Adds Trisha as a staging env owner so she can view / debug client logs and related staging GCP infrastructure.