### PR TITLE
fix(snownet): properly cleanup connections before adding a new one

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -644,6 +644,8 @@ where
         allowed_stun_servers: HashSet<SocketAddr>,
         allowed_turn_servers: HashSet<(SocketAddr, String, String, String)>,
     ) -> Offer {
+        self.negotiated_connections.remove(&id);
+
         self.upsert_stun_servers(&allowed_stun_servers);
         self.upsert_turn_servers(&allowed_turn_servers);
 


### PR DESCRIPTION
This was causing some problems in my tests with connlib, when the client re-created the connection and recieved the candidates before the offer response, this *seems* like it made the client hang waiting for the connection to happen, without failing it.

I couldn't find out why exactly the hang happens since it seems like the remote candidates are added to the new connection and stun packets are directed to the new connection, so it may be unrelated but I think it's still right to clean this hashmap up.