### PR TITLE
fix(snownet): don't try to re-authorize forever

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1328,10 +1328,7 @@ mod tests {
 
         // Attempt to authenticate without a nonce
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
-            &unauthorized_response(&allocate, Some(Nonce::new("nonce1".to_owned()).unwrap())),
-            Instant::now(),
-        );
+        allocation.handle_test_input(&unauthorized_response(&allocate, "nonce1"), Instant::now());
 
         let allocate = allocation.next_message().unwrap();
         assert_eq!(
@@ -1340,10 +1337,7 @@ mod tests {
             "expect next message to include nonce from error response"
         );
 
-        allocation.handle_test_input(
-            &unauthorized_response(&allocate, Some(Nonce::new("nonce2".to_owned()).unwrap())),
-            Instant::now(),
-        );
+        allocation.handle_test_input(&unauthorized_response(&allocate, "nonce2"), Instant::now());
 
         assert!(
             allocation.next_message().is_none(),
@@ -1378,7 +1372,7 @@ mod tests {
         encode(message)
     }
 
-    fn unauthorized_response(request: &Message<Attribute>, nonce: Option<Nonce>) -> Vec<u8> {
+    fn unauthorized_response(request: &Message<Attribute>, nonce: &str) -> Vec<u8> {
         let mut message = Message::new(
             MessageClass::ErrorResponse,
             request.method(),
@@ -1386,10 +1380,7 @@ mod tests {
         );
         message.add_attribute(ErrorCode::from(Unauthorized));
         message.add_attribute(Realm::new("firezone".to_owned()).unwrap());
-
-        if let Some(nonce) = nonce {
-            message.add_attribute(nonce)
-        }
+        message.add_attribute(Nonce::new(nonce.to_owned()).unwrap());
 
         encode(message)
     }


### PR DESCRIPTION
If we receive a 401 or a 438, we should re-authenticate the request with the new nonce sent from the server. Except if we had sent a nonce and receive a 401, then it means our credentials are completely invalid and retrying to authenticate will not solve it.