### PR TITLE
fix(snownet): replace `Allocation` if credentials to relay change

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -131,6 +131,10 @@ impl Allocation {
         .flatten()
     }
 
+    pub fn uses_credentials(&self, username: &str, password: &str, realm: &str) -> bool {
+        self.username.name() == username && self.password == password && self.realm.text() == realm
+    }
+
     #[tracing::instrument(level = "debug", skip(self, packet, now), fields(relay = %self.server, id, method, class, rtt))]
     pub fn handle_input(
         &mut self,

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -48,6 +48,7 @@ fn reinitialize_allocation_if_credentials_for_relay_differ() {
     // Expect to send another message to the "new" relay
     let transmit = alice.poll_transmit().unwrap();
     assert_eq!(transmit.dst, RELAY);
+    assert_eq!(&transmit.payload[..2], [0x0, 0x3]); // `ALLOCATE` is 0x0003: https://www.rfc-editor.org/rfc/rfc8656#name-stun-methods
     assert!(alice.poll_transmit().is_none());
 }
 

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -30,12 +30,7 @@ fn reinitialize_allocation_if_credentials_for_relay_differ() {
     let _ = alice.new_connection(
         1,
         HashSet::new(),
-        HashSet::from([(
-            RELAY,
-            "user1".to_owned(),
-            "pass1".to_owned(),
-            "realm".to_owned(),
-        )]),
+        HashSet::from([relay("user1", "pass1", "realm1")]),
     );
 
     let transmit = alice.poll_transmit().unwrap();
@@ -43,15 +38,11 @@ fn reinitialize_allocation_if_credentials_for_relay_differ() {
     assert!(alice.poll_transmit().is_none());
 
     // Make another connection, using the same relay but different credentials (happens when the relay restarts)
+
     let _ = alice.new_connection(
-        1,
+        2,
         HashSet::new(),
-        HashSet::from([(
-            RELAY,
-            "user2".to_owned(),
-            "pass2".to_owned(),
-            "realm".to_owned(),
-        )]),
+        HashSet::from([relay("user2", "pass2", "realm1")]),
     );
 
     // Expect to send another message to the "new" relay
@@ -70,12 +61,7 @@ fn second_connection_with_same_relay_reuses_allocation() {
     let _ = alice.new_connection(
         1,
         HashSet::new(),
-        HashSet::from([(
-            RELAY,
-            "user1".to_owned(),
-            "pass1".to_owned(),
-            "realm".to_owned(),
-        )]),
+        HashSet::from([relay("user1", "pass1", "realm1")]),
     );
 
     let transmit = alice.poll_transmit().unwrap();
@@ -83,17 +69,21 @@ fn second_connection_with_same_relay_reuses_allocation() {
     assert!(alice.poll_transmit().is_none());
 
     let _ = alice.new_connection(
-        1,
+        2,
         HashSet::new(),
-        HashSet::from([(
-            RELAY,
-            "user1".to_owned(),
-            "pass1".to_owned(),
-            "realm".to_owned(),
-        )]),
+        HashSet::from([relay("user1", "pass1", "realm1")]),
     );
 
     assert!(alice.poll_transmit().is_none());
+}
+
+fn relay(username: &str, pass: &str, realm: &str) -> (SocketAddr, String, String, String) {
+    (
+        RELAY,
+        username.to_owned(),
+        pass.to_owned(),
+        realm.to_owned(),
+    )
 }
 
 const RELAY: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 10000));

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -2,6 +2,7 @@ use boringtun::x25519::StaticSecret;
 use snownet::{ClientNode, Event};
 use std::{
     collections::HashSet,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     time::{Duration, Instant},
 };
 
@@ -17,3 +18,82 @@ fn connection_times_out_after_10_seconds() {
 
     assert_eq!(alice.poll_event().unwrap(), Event::ConnectionFailed(1));
 }
+
+#[test]
+fn reinitialize_allocation_if_credentials_for_relay_differ() {
+    let mut alice = ClientNode::<u64>::new(
+        StaticSecret::random_from_rng(rand::thread_rng()),
+        Instant::now(),
+    );
+
+    // Make a new connection that uses RELAY with initial set of credentials
+    let _ = alice.new_connection(
+        1,
+        HashSet::new(),
+        HashSet::from([(
+            RELAY,
+            "user1".to_owned(),
+            "pass1".to_owned(),
+            "realm".to_owned(),
+        )]),
+    );
+
+    let transmit = alice.poll_transmit().unwrap();
+    assert_eq!(transmit.dst, RELAY);
+    assert!(alice.poll_transmit().is_none());
+
+    // Make another connection, using the same relay but different credentials (happens when the relay restarts)
+    let _ = alice.new_connection(
+        1,
+        HashSet::new(),
+        HashSet::from([(
+            RELAY,
+            "user2".to_owned(),
+            "pass2".to_owned(),
+            "realm".to_owned(),
+        )]),
+    );
+
+    // Expect to send another message to the "new" relay
+    let transmit = alice.poll_transmit().unwrap();
+    assert_eq!(transmit.dst, RELAY);
+    assert!(alice.poll_transmit().is_none());
+}
+
+#[test]
+fn second_connection_with_same_relay_reuses_allocation() {
+    let mut alice = ClientNode::<u64>::new(
+        StaticSecret::random_from_rng(rand::thread_rng()),
+        Instant::now(),
+    );
+
+    let _ = alice.new_connection(
+        1,
+        HashSet::new(),
+        HashSet::from([(
+            RELAY,
+            "user1".to_owned(),
+            "pass1".to_owned(),
+            "realm".to_owned(),
+        )]),
+    );
+
+    let transmit = alice.poll_transmit().unwrap();
+    assert_eq!(transmit.dst, RELAY);
+    assert!(alice.poll_transmit().is_none());
+
+    let _ = alice.new_connection(
+        1,
+        HashSet::new(),
+        HashSet::from([(
+            RELAY,
+            "user1".to_owned(),
+            "pass1".to_owned(),
+            "realm".to_owned(),
+        )]),
+    );
+
+    assert!(alice.poll_transmit().is_none());
+}
+
+const RELAY: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 10000));


### PR DESCRIPTION
When a relay restarts, its credentials change but the socket we use to connect to it might not. Because we upsert `Allocation`s within a `snownet::Node` based on the socket, such a change is currently not picked up.

Instead, we now check whether an existing allocation uses the same credentials and if it doesn't we throw the old one away and use the new one instead.