### PR TITLE
feat(snownet): refresh allocation upon each new connection

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -526,6 +526,10 @@ impl Allocation {
     }
 
     pub fn refresh(&mut self) {
+        if !self.has_allocation() {
+            return;
+        }
+
         self.authenticate_and_queue(make_refresh_request());
     }
 
@@ -1493,6 +1497,18 @@ mod tests {
 
         let msg = allocation.encode_to_vec(PEER2_IP4, b"foobar", Instant::now());
         assert!(msg.is_none(), "expect to no longer have a channel to peer");
+    }
+
+    #[test]
+    fn refresh_does_nothing_if_we_dont_have_an_allocation_yet() {
+        let mut allocation = Allocation::for_test(Instant::now());
+
+        let _allocate = allocation.next_message().unwrap();
+
+        allocation.refresh();
+
+        let next_msg = allocation.next_message();
+        assert!(next_msg.is_none())
     }
 
     fn ch(peer: SocketAddr, now: Instant) -> Channel {

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -218,11 +218,11 @@ impl Allocation {
                 }
                 REFRESH => {
                     if let Some(candidate) = self.ip4_allocation.take() {
-                        self.events.push_back(CandidateEvent::Expired(candidate))
+                        self.events.push_back(CandidateEvent::Invalid(candidate))
                     }
 
                     if let Some(candidate) = self.ip6_allocation.take() {
-                        self.events.push_back(CandidateEvent::Expired(candidate))
+                        self.events.push_back(CandidateEvent::Invalid(candidate))
                     }
 
                     self.channel_bindings.clear();
@@ -1431,7 +1431,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_refresh_will_expire_relay_candiates() {
+    fn failed_refresh_will_invalidate_relay_candiates() {
         let mut allocation = Allocation::for_test(Instant::now());
 
         let allocate = allocation.next_message().unwrap();
@@ -1448,13 +1448,13 @@ mod tests {
 
         assert_eq!(
             allocation.poll_event(),
-            Some(CandidateEvent::Expired(
+            Some(CandidateEvent::Invalid(
                 Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()
             ))
         );
         assert_eq!(
             allocation.poll_event(),
-            Some(CandidateEvent::Expired(
+            Some(CandidateEvent::Invalid(
                 Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp).unwrap()
             ))
         );

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -515,7 +515,9 @@ impl Allocation {
         })
     }
 
-    pub fn refresh(&self) {}
+    pub fn refresh(&mut self) {
+        self.authenticate_and_queue(make_refresh_request());
+    }
 
     fn has_allocation(&self) -> bool {
         self.ip4_allocation.is_some() || self.ip6_allocation.is_some()

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -792,12 +792,12 @@ where
 
     fn upsert_turn_servers(&mut self, servers: &HashSet<(SocketAddr, String, String, String)>) {
         for (server, username, password, realm) in servers {
-            if self
-                .allocations
-                .get(server)
-                .is_some_and(|a| a.uses_credentials(username, password, realm))
-            {
-                continue;
+            if let Some(existing) = self.allocations.get_mut(server) {
+                if existing.uses_credentials(username, password, realm) {
+                    existing.refresh();
+
+                    continue;
+                }
             }
 
             let Ok(username) = Username::new(username.to_owned()) else {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -376,7 +376,7 @@ where
                         &mut self.pending_events,
                     );
                 }
-                CandidateEvent::Expired(_) => {
+                CandidateEvent::Invalid(_) => {
                     // TODO: Handle expired candidates. Invalidate on ICE agent? ICE restart?
                 }
             }
@@ -1075,7 +1075,7 @@ impl<'a> Transmit<'a> {
 #[derive(Debug, PartialEq)]
 pub(crate) enum CandidateEvent {
     New(Candidate),
-    Expired(Candidate),
+    Invalid(Candidate),
 }
 
 struct InitialConnection {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -376,6 +376,9 @@ where
                         &mut self.pending_events,
                     );
                 }
+                CandidateEvent::Expired(_) => {
+                    // TODO: Handle expired candidates. Invalidate on ICE agent? ICE restart?
+                }
             }
         }
 
@@ -1072,6 +1075,7 @@ impl<'a> Transmit<'a> {
 #[derive(Debug, PartialEq)]
 pub(crate) enum CandidateEvent {
     New(Candidate),
+    Expired(Candidate),
 }
 
 struct InitialConnection {


### PR DESCRIPTION
Currently, a `REFRESH` for an allocation is only triggered after half its lifetime (which defaults to 10 minutes). A refresh is the only way for us to check whether an allocation is still active. If the relay restarted or the allocation was somehow invalidated otherwise, attempting to refresh it will fail.

By triggering a refresh for each allocation every time we get a new connection, we immediately check whether that allocation (and thus its candidates) are still valid. What to do with invalidated candidates is left to a future iteration.