### PR TITLE
refactor(snownet): introduce `CandidateEvent`

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1360,6 +1360,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn returns_new_candidates_on_successful_allocation() {
+        let mut allocation = Allocation::for_test(Instant::now());
+
+        let allocate = allocation.next_message().unwrap();
+        allocation.handle_test_input(
+            &allocate_response(&allocate, &[RELAY_ADDR_IP4]),
+            Instant::now(),
+        );
+
+        let next_event = allocation.poll_event();
+        assert_eq!(
+            next_event,
+            Some(CandidateEvent::New(
+                Candidate::server_reflexive(PEER1, PEER1, Protocol::Udp).unwrap()
+            ))
+        );
+        let next_event = allocation.poll_event();
+        assert_eq!(
+            next_event,
+            Some(CandidateEvent::New(
+                Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()
+            ))
+        );
+        let next_event = allocation.poll_event();
+        assert_eq!(next_event, None);
+    }
+
     fn ch(peer: SocketAddr, now: Instant) -> Channel {
         Channel {
             peer,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -376,13 +376,6 @@ where
                         &mut self.pending_events,
                     );
                 }
-                CandidateEvent::Expired(candidate) => {
-                    for (_, agent) in self.connections.agents_mut() {
-                        agent.invalidate_candidate(&candidate);
-
-                        // TODO: Perform ICE restart here in case candidate was the active one?
-                    }
-                }
             }
         }
 
@@ -1069,8 +1062,6 @@ impl<'a> Transmit<'a> {
 #[derive(Debug, PartialEq)]
 pub(crate) enum CandidateEvent {
     New(Candidate),
-    #[allow(dead_code)]
-    Expired(Candidate),
 }
 
 struct InitialConnection {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1069,6 +1069,7 @@ impl<'a> Transmit<'a> {
 #[derive(Debug, PartialEq)]
 pub(crate) enum CandidateEvent {
     New(Candidate),
+    #[allow(dead_code)]
     Expired(Candidate),
 }
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -377,10 +377,15 @@ where
                     );
                 }
                 CandidateEvent::Expired(candidate) => {
-                    tracing::info!("Candiate expired: {}", candidate.to_sdp_string());
+                    for (_, agent) in self.connections.agents_mut() {
+                        agent.invalidate_candidate(&candidate);
+
+                        // TODO: Perform ICE restart here in case candidate was the active one?
+                    }
                 }
             }
         }
+
         let mut failed_connections = vec![];
 
         for (id, conn) in self.connections.iter_established_mut() {

--- a/rust/connlib/snownet/src/stun_binding.rs
+++ b/rust/connlib/snownet/src/stun_binding.rs
@@ -106,7 +106,7 @@ impl StunBinding {
         match self.last_candidate.take() {
             Some(candidate) if candidate != new_candidate => {
                 tracing::info!(current = %candidate, new = %new_candidate, "Updating server-reflexive candidate");
-                self.events.push_back(CandidateEvent::Expired(candidate));
+                // self.events.push_back(CandidateEvent::Expired(candidate)); TODO: Is this a good idea? Just because on STUN server says so doesn't necessarily mean the server-reflexive address is completely invalid? Not sure...
             }
             None => {
                 tracing::info!(new = %new_candidate, "New server-reflexive candidate");


### PR DESCRIPTION
Candidates, especially relay candidates can become invalid. For example, a relay might be shut down, change its credentials or now be unreachable due to network changes. In order to signal these changes in network connections to a `snownet::Node`, we introduce a `CandidateEvent`.

Right now, `CandidateEvent` does not yet have an `Invalid` variant because it would be dead code (it is not yet emitted by anything). This PR is just the scaffolding to make that easier to introduce later.