### PR TITLE
chore(snownet): remove obsolete TODO

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -237,7 +237,6 @@ where
         // Next: If we can parse the message as a STUN message, cycle through all agents to check which one it is for.
         if let Ok(message) = StunMessage::parse(packet) {
             for agent in self.agents_mut() {
-                // TODO: `accepts_message` cannot demultiplexing multiple connections until https://github.com/algesten/str0m/pull/418 is merged.
                 if agent.accepts_message(&message) {
                     agent.handle_packet(
                         now,


### PR DESCRIPTION
This has been resolved and we are depending on the latest version.