### PR TITLE
refactor(connlib): remove unnecessary `Serialize` derive

### DIFF
--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -24,7 +24,7 @@ pub struct ConfigUpdate {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct RemoveResource(pub ResourceId);
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct ConnectionDetails {
     pub relays: Vec<Relay>,
     pub resource_id: ResourceId,
@@ -86,7 +86,7 @@ pub struct GatewayIceCandidates {
 }
 
 /// The replies that can arrive from the channel by a client
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum ReplyMessages {

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -270,7 +270,7 @@ pub struct Interface {
 }
 
 /// A single relay
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Relay {
     /// STUN type of relay
@@ -280,7 +280,7 @@ pub enum Relay {
 }
 
 /// Represent a TURN relay
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct Turn {
     //// Expire time of the username/password in unix millisecond timestamp UTC
     #[serde(with = "ts_seconds")]
@@ -295,7 +295,7 @@ pub struct Turn {
 }
 
 /// Stun kind of relay
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct Stun {
     /// URI for the relay
     pub uri: String,

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -40,7 +40,7 @@ impl PartialEq for Client {
 
 impl Eq for Client {}
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct RequestConnection {
     pub actor: Actor,
     pub relays: Vec<Relay>,
@@ -89,7 +89,7 @@ pub struct AllowAccess {
 
 // These messages are the messages that can be received
 // either by a client or a gateway by the client.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 // TODO: We will need to re-visit webrtc-rs
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
These messages are only deserialized, never serialized. The `derive` can thus be removed.

Extracted from: #3391.