### PR TITLE
feat(connlib): remove duplication from logs

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -271,7 +271,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "trace", skip(self, msg))]
     pub async fn handle_message(
         &mut self,
         msg: Messages,

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -112,7 +112,6 @@ fn sentinel_dns_mapping(dns: &[DnsServer]) -> BiMap<IpAddr, DnsServer> {
 }
 
 impl<CB: Callbacks + 'static> ControlPlane<CB> {
-    #[tracing::instrument(level = "trace", skip(self))]
     async fn init(
         &mut self,
         InitClient {

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -159,7 +159,6 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
     pub fn connect(
         &mut self,
         Connect {
@@ -191,7 +190,6 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
     pub fn add_resource(&self, resource_description: ResourceDescription) {
         if let Err(e) = self.tunnel.add_resource(resource_description) {
             tracing::error!(message = "Can't add resource", error = ?e);
@@ -203,7 +201,6 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
         // TODO
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
     fn connection_details(
         &self,
         ConnectionDetails {

--- a/rust/connlib/shared/src/control.rs
+++ b/rust/connlib/shared/src/control.rs
@@ -210,10 +210,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(handler))]
     async fn message_process(handler: &F, message: tungstenite::Message) -> Result<()> {
-        tracing::trace!("{message:?}");
-
         match message.into_text() {
             Ok(m_str) => match serde_json::from_str::<PhoenixMessage<I, R>>(&m_str) {
                 Ok(m) => match m.payload {

--- a/rust/connlib/shared/src/control.rs
+++ b/rust/connlib/shared/src/control.rs
@@ -123,7 +123,6 @@ where
     ///
     // TODO: this is not very elegant but it was the easiest way to do reset the exponential backoff for now
     /// Furthermore, it calls the given callback once it connects to the portal.
-    #[tracing::instrument(level = "trace", skip(self, after_connection_ends))]
     pub async fn start(
         &mut self,
         topics: Vec<String>,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -61,7 +61,6 @@ where
     ///
     /// Once added, when a packet for the resource is intercepted a new data channel will be created
     /// and packets will be wrapped with wireguard and sent through it.
-    #[tracing::instrument(level = "trace", skip(self))]
     pub fn add_resource(
         &self,
         resource_description: ResourceDescription,

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -76,7 +76,7 @@ where
     ///
     /// # Returns
     /// A [RequestConnection] that should be sent to the gateway through the control-plane.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "trace", skip_all, fields(%resource_id, %gateway_id))]
     pub async fn request_connection(
         self: &Arc<Self>,
         resource_id: ResourceId,

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -84,7 +84,7 @@ where
         relays: Vec<Relay>,
         reference: Option<Reference>,
     ) -> Result<Request> {
-        tracing::trace!(%gateway_id, %resource_id, "request_connection");
+        tracing::trace!("request_connection");
 
         let reference: usize = reference
             .ok_or(Error::InvalidReference)?


### PR DESCRIPTION
Currently, we log messages from the portal several times via different ways. For one, the message is included in the span via `tracing::instrument`. Then it is also logged on `trace!` level twice (this PR removes one of them). Plus, the fields of the `request_connection` span are not printed in a very human-readable way (bytes arrays). This makes the logs super noisy, see here for the latest run on `main`: https://github.com/firezone/firezone/actions/runs/7808301643/job/21298585685#step:13:13

Compare this with the logs from the run in this PR: https://github.com/firezone/firezone/actions/runs/7813774334/job/21313812863?pr=3596#step:13:13

Some of these improvements were made as part of debugging #3391. Extracting them here in a separate PR to reduce the diff of #3391.