### PR TITLE
ci(windows): fix warning about CONNLIB_LOG_UPLOAD_INTERVAL_SECS

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -77,7 +77,8 @@ jobs:
       run:
         working-directory: ./rust/windows-client
     env:
-      RUST_LOG: firezone_windows_client=info
+      CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
+      # The Windows client ignores RUST_LOG because it uses a settings file instead
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -125,6 +126,7 @@ jobs:
             artifact: windows-client
     env:
       BINARY_DEST_PATH: ${{ matrix.artifact }}
+      CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -254,6 +254,7 @@ jobs:
             artifact: windows-client
     env:
       BINARY_DEST_PATH: ${{ matrix.name.artifact }}
+      CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust


### PR DESCRIPTION
It was bugging me a little. Before:
![image](https://github.com/firezone/firezone/assets/13400041/bc0a03cc-ef47-4b68-b33c-f671eddc78e9)

After (with jq pretty-printing)
![image](https://github.com/firezone/firezone/assets/13400041/faf7ebac-0dc0-4e93-8349-653e57e6eeda)
