### PR TITLE
ci(windows): add 'firezone' to the MSI names

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -123,9 +123,9 @@ jobs:
       matrix:
         include:
           - package: firezone-windows-client
-            artifact: windows-client
+            artifact: firezone-windows-client
     env:
-      BINARY_DEST_PATH: ${{ matrix.artifact }}
+      BINARY_DEST_PATH: firezone-${{ matrix.artifact }}
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -155,24 +155,24 @@ jobs:
       - name: Save Windows client
         uses: actions/upload-artifact@v4
         with:
-          name: windows-client-x64
+          name: ${{ matrix.artifact }}-x64
           path: |
-            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.exe
-            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.exe.sha256sum.txt
+            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.exe
+            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.exe.sha256sum.txt
       - name: Save Windows installer
         uses: actions/upload-artifact@v4
         with:
-          name: windows-client-x64-msi
+          name: ${{ matrix.artifact }}-x64-msi
           path: |
-            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.msi
-            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.msi.sha256sum.txt
+            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.msi
+            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.msi.sha256sum.txt
       - name: Save Windows debug symbols
         uses: actions/upload-artifact@v4
         with:
-          name: windows-client-x64-pdb
+          name: ${{ matrix.artifact }}-x64-pdb
           path: |
-            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.pdb
-            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.pdb.sha256sum.txt
+            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.pdb
+            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.pdb.sha256sum.txt
 
   smoke-test-relay:
     runs-on: ubuntu-22.04

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -157,22 +157,22 @@ jobs:
         with:
           name: windows-client-x64
           path: |
-            ${{ github.workspace }}/rust/windows-client/windows-client-x64.exe
-            ${{ github.workspace }}/rust/windows-client/windows-client-x64.exe.sha256sum.txt
+            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.exe
+            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.exe.sha256sum.txt
       - name: Save Windows installer
         uses: actions/upload-artifact@v4
         with:
           name: windows-client-x64-msi
           path: |
-            ${{ github.workspace }}/rust/windows-client/windows-client-x64.msi
-            ${{ github.workspace }}/rust/windows-client/windows-client-x64.msi.sha256sum.txt
+            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.msi
+            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.msi.sha256sum.txt
       - name: Save Windows debug symbols
         uses: actions/upload-artifact@v4
         with:
           name: windows-client-x64-pdb
           path: |
-            ${{ github.workspace }}/rust/windows-client/windows-client-x64.pdb
-            ${{ github.workspace }}/rust/windows-client/windows-client-x64.pdb.sha256sum.txt
+            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.pdb
+            ${{ github.workspace }}/rust/windows-client/firezone-windows-client-x64.pdb.sha256sum.txt
 
   smoke-test-relay:
     runs-on: ubuntu-22.04

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -111,7 +111,7 @@ jobs:
 
   # This should be identical to `build-push-windows-release-artifacts` in `cd.yml` except for the Github permissions, needs tag, and uploading step
   build-tauri:
-    name: build-tauri-${{ matrix.artifact }}
+    name: build-tauri-${{ matrix.name }}
     runs-on: windows-2019
     defaults:
       run:
@@ -124,6 +124,7 @@ jobs:
         include:
           - package: firezone-windows-client
             artifact: firezone-windows-client
+            name: windows-client
     env:
       BINARY_DEST_PATH: ${{ matrix.artifact }}
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -125,7 +125,7 @@ jobs:
           - package: firezone-windows-client
             artifact: firezone-windows-client
     env:
-      BINARY_DEST_PATH: firezone-${{ matrix.artifact }}
+      BINARY_DEST_PATH: ${{ matrix.artifact }}
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -133,12 +133,12 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           targets: x86_64-pc-windows-msvc
-      - name: Build release binaries
+      - name: Install pnpm deps
+        run: pnpm install
+      - name: Build release exe and MSI
+        run: pnpm build
+      - name: Compute SHA256 and rename
         run: |
-          # Build Windows Tauri GUI
-          pnpm install
-          pnpm build
-
           # Used for release artifact
           # In release mode the name comes from tauri.conf.json
           cp "../target/release/Firezone.exe" "${{ env.BINARY_DEST_PATH }}-x64.exe"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -261,13 +261,12 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
       - uses: ./.github/actions/setup-node
-      - name: Build release binaries
+      - name: Install pnpm deps
+        run: pnpm install
+      - name: Build release exe and MSI
+        run: pnpm build
+      - name: Compute SHA256 and rename
         run: |
-          # Build Windows Tauri GUI
-
-          pnpm install
-          pnpm build
-
           # Used for release artifact
           # This should match 'build-tauri' in _rust.yml
           cp "../target/release/bundle/msi/*.msi" "${{ env.BINARY_DEST_PATH }}-x64.msi"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -253,7 +253,7 @@ jobs:
           - package: firezone-windows-client
             artifact: windows-client
     env:
-      BINARY_DEST_PATH: ${{ matrix.name.artifact }}
+      BINARY_DEST_PATH: firezone-${{ matrix.name.artifact }}
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
     steps:
       - uses: actions/checkout@v4

--- a/rust/windows-client/src-tauri/src/client/updates.rs
+++ b/rust/windows-client/src-tauri/src/client/updates.rs
@@ -114,7 +114,7 @@ struct ReleaseDetails {
 #[derive(serde::Deserialize)]
 struct Asset {
     browser_download_url: Url,
-    /// Name of the asset, e.g. `windows-client-x64.msi`
+    /// Name of the asset, e.g. `firezone-windows-client-x64.msi`
     name: String,
 }
 
@@ -168,7 +168,7 @@ mod tests {
                 "url": "https://api.github.com/repos/firezone/firezone/releases/assets/147443612",
                 "id": 147443612,
                 "node_id": "RA_kwDOD12Hpc4Iyc-c",
-                "name": "windows-client-x64.msi",
+                "name": "firezone-windows-client-x64.msi",
                 "label": "",
                 "uploader": {
                     "login": "github-actions[bot]",
@@ -196,7 +196,7 @@ mod tests {
                 "download_count": 10,
                 "created_at": "2024-01-24T04:33:53Z",
                 "updated_at": "2024-01-24T04:33:53Z",
-                "browser_download_url": "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/windows-client-x64.msi"
+                "browser_download_url": "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/firezone-windows-client-x64.msi"
             }
         ]
     }"#;
@@ -204,7 +204,7 @@ mod tests {
     #[test]
     fn test() {
         let release = super::Release::from_str(RELEASES_LATEST_JSON).unwrap();
-        assert_eq!(release.browser_download_url.to_string(), "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/windows-client-x64.msi");
+        assert_eq!(release.browser_download_url.to_string(), "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/firezone-windows-client-x64.msi");
         assert_eq!(release.tag_name.to_string(), "1.0.0-pre.8");
 
         assert!(

--- a/rust/windows-client/src-tauri/src/client/updates.rs
+++ b/rust/windows-client/src-tauri/src/client/updates.rs
@@ -68,7 +68,7 @@ const GITHUB_API_VERSION: &str = "2022-11-28";
 /// The name of the Windows MSI asset.
 ///
 /// This ultimately comes from `cd.yml`
-const MSI_ASSET_NAME: &str = "windows-client-x64.msi";
+const MSI_ASSET_NAME: &str = "firezone-windows-client-x64.msi";
 
 /// Returns the latest release, even if ours is already newer
 pub(crate) async fn check() -> Result<Release, Error> {


### PR DESCRIPTION
Since `windows-client-x64.msi` could be any other product.

I also split up the build steps similar to how the smoke test does.