### PR TITLE
chore(ci): update Node to 20 in the Windows CI jobs

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v3
       with:
         version: 8
     - uses: actions/setup-node@v4

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -82,6 +82,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
+        with:
+          node-version: '20'
       - uses: ./.github/actions/setup-rust
         with:
           targets: x86_64-pc-windows-msvc
@@ -130,6 +132,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
+        with:
+          node-version: '20'
       - uses: ./.github/actions/setup-rust
         with:
           targets: x86_64-pc-windows-msvc


### PR DESCRIPTION
Fixes warnings for using pnpm for the Windows smoke test and release build