### PR TITLE
fix(android): prevent null pointer segfault on 32-bit platforms

### DIFF
--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -111,8 +111,8 @@ impl ioctl::Request<GetInterfaceNamePayload> {
 #[repr(C)]
 struct GetInterfaceNamePayload {
     // Fixes a nasty alignment bug on 32-bit architectures on Android.
-    // Essentially, the compiler will optimize out the `name` field in the Request struct
-    // if the ioctl payload is not aligned to 32 bytes.
+    // The `name` field in `ioctl::Request` is only 16 bytes long and accessing it causes a NPE without this alignment.
+    // Why? Not sure. It seems to only happen in release mode which hints at an optimisation issue.
     alignment: [std::ffi::c_uchar; 16],
 }
 

--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -109,7 +109,12 @@ impl ioctl::Request<GetInterfaceNamePayload> {
 
 #[derive(Default)]
 #[repr(C)]
-struct GetInterfaceNamePayload;
+struct GetInterfaceNamePayload {
+    // Fixes a nasty alignment bug on 32-bit architectures on Android.
+    // Essentially, the compiler will optimize out the `name` field in the Request struct
+    // if the ioctl payload is not aligned to 32 bytes.
+    alignment: [std::ffi::c_uchar; 16],
+}
 
 /// Read from the given file descriptor in the buffer.
 fn read(fd: RawFd, dst: &mut [u8]) -> io::Result<usize> {


### PR DESCRIPTION
Without this alignment, accessing the `name` field reliably produces a segfault:

```
Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x1d in tid 13835 (Thread-7), pid 13757 (irezone.android)
```

Interestingly, this only happens in release builds on 32-bit platforms. Logging the returned name fixes it too which hints at some kind of optimisation issue. Adding a padding is the most reliable fix.

Fixes: #3637.