### PR TITLE
feat(snownet): remove wireguard keep-alives

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/thomaseizinger/boringtun?branch=feat/expose-last-seen#6fd54c027e6b78192a02de3e77d00552ec36968d"
+source = "git+https://github.com/cloudflare/boringtun?branch=master#f672bb6c1e1e371240a8d151f15854687eb740bb"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,7 +47,7 @@ firezone-tunnel = { path = "connlib/tunnel"}
 phoenix-channel = { path = "phoenix-channel"}
 
 [patch.crates-io]
-boringtun = { git = "https://github.com/thomaseizinger/boringtun", branch = "feat/expose-last-seen" }
+boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }
 webrtc = { git = "https://github.com/firezone/webrtc", branch = "expose-new-endpoint" }
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 

--- a/rust/connlib/snownet/src/info.rs
+++ b/rust/connlib/snownet/src/info.rs
@@ -1,62 +1,7 @@
-use crate::node::WIREGUARD_KEEP_ALIVE;
 use std::time::Instant;
 
 #[derive(Debug)]
 pub struct ConnectionInfo {
-    pub last_seen: Option<Instant>,
-
     /// When this instance of [`ConnectionInfo`] was created.
     pub generated_at: Instant,
-}
-
-impl ConnectionInfo {
-    pub fn missed_keep_alives(&self) -> u64 {
-        let Some(last_seen) = self.last_seen else {
-            return 0;
-        };
-
-        let duration = self.generated_at.duration_since(last_seen);
-
-        duration.as_secs() / WIREGUARD_KEEP_ALIVE as u64
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::Duration;
-
-    #[test]
-    fn no_missed_keep_alives_on_none() {
-        let info = info(None);
-
-        let missed_keep_alives = info.missed_keep_alives();
-
-        assert_eq!(missed_keep_alives, 0);
-    }
-
-    #[test]
-    fn more_than_5_sec_one_missed_keep_alive() {
-        let info = info(Some(Instant::now() - Duration::from_secs(6)));
-
-        let missed_keep_alives = info.missed_keep_alives();
-
-        assert_eq!(missed_keep_alives, 1);
-    }
-
-    #[test]
-    fn more_than_10_sec_two_missed_keep_alives() {
-        let info = info(Some(Instant::now() - Duration::from_secs(11)));
-
-        let missed_keep_alives = info.missed_keep_alives();
-
-        assert_eq!(missed_keep_alives, 2);
-    }
-
-    fn info(last_seen: Option<Instant>) -> ConnectionInfo {
-        ConnectionInfo {
-            last_seen,
-            generated_at: Instant::now(),
-        }
-    }
 }


### PR DESCRIPTION
`str0m` sends its own STUN keep-alives and @conectado has already removed the logic that uses the wireguard keep-alives to detect stale connections in https://github.com/firezone/firezone/commit/8234529cdf0bad59a4d40e6b9d17933808b322a7 as part of the integration of `snownet`.

We don't need two keep-alive mechanisms at once.