### PR TITLE
chore(connlib): Make request ioctl mutable

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -167,11 +167,11 @@ mod ioctl {
 
     pub(crate) fn interface_mtu_by_name(name: &str) -> Result<usize, ConnlibError> {
         let socket = Socket::ip4()?;
-        let request = Request::<GetInterfaceMtuPayload>::new(name)?;
+        let mut request = Request::<GetInterfaceMtuPayload>::new(name)?;
 
         // Safety: The file descriptor is open.
         unsafe {
-            exec(socket.fd, SIOCGIFMTU, &request)?;
+            exec(socket.fd, SIOCGIFMTU, &mut request)?;
         }
 
         Ok(request.payload.mtu as usize)
@@ -185,7 +185,7 @@ mod ioctl {
     pub(crate) unsafe fn exec<P>(
         fd: RawFd,
         code: libc::c_ulong,
-        req: &Request<P>,
+        req: &mut Request<P>,
     ) -> Result<(), ConnlibError> {
         let ret = unsafe { libc::ioctl(fd, code as _, req) };
 

--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -84,9 +84,9 @@ impl Tun {
 /// The file descriptor must be open.
 unsafe fn interface_name(fd: RawFd) -> Result<String> {
     const TUNGETIFF: libc::c_ulong = 0x800454d2;
-    let request = ioctl::Request::<GetInterfaceNamePayload>::new();
+    let mut request = ioctl::Request::<GetInterfaceNamePayload>::new();
 
-    ioctl::exec(fd, TUNGETIFF, &request)?;
+    ioctl::exec(fd, TUNGETIFF, &mut request)?;
 
     Ok(request.name().to_string())
 }
@@ -139,7 +139,7 @@ impl Closeable {
     fn new(fd: AsyncFd<RawFd>) -> Self {
         Self {
             closed: AtomicBool::new(false),
-            fd: fd,
+            fd,
         }
     }
 

--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -105,7 +105,11 @@ impl Tun {
 
         // Safety: We just opened the file descriptor.
         unsafe {
-            ioctl::exec(fd, TUNSETIFF, &ioctl::Request::<SetTunFlagsPayload>::new())?;
+            ioctl::exec(
+                fd,
+                TUNSETIFF,
+                &mut ioctl::Request::<SetTunFlagsPayload>::new(),
+            )?;
         }
 
         set_non_blocking(fd)?;


### PR DESCRIPTION
Technically, the data held by the ioctl request is changing, so make them mutable.