### PR TITLE
fix(snownet): generate candidates only after we accept the ICE answer

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -666,13 +666,6 @@ where
         let mut agent = IceAgent::new();
         agent.set_controlling(true);
 
-        self.seed_agent_with_local_candidates(
-            id,
-            &mut agent,
-            &allowed_stun_servers,
-            &allowed_turn_servers,
-        );
-
         let session_key = Secret::new(random());
         let ice_creds = agent.local_credentials();
 
@@ -713,6 +706,13 @@ where
             ufrag: answer.credentials.username,
             pass: answer.credentials.password,
         });
+
+        self.seed_agent_with_local_candidates(
+            id,
+            &mut agent,
+            &initial.stun_servers,
+            &initial.turn_servers,
+        );
 
         let connection = self.init_connection(
             agent,

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -56,15 +56,11 @@ fn only_generate_candidate_event_after_answer() {
 
     let offer = alice.new_connection(1, HashSet::new(), HashSet::new());
 
-    while let Some(event) = alice.poll_event() {
-        assert!(!matches!(
-            event,
-            Event::SignalIceCandidate {
-                connection: _,
-                candidate: _
-            }
-        ));
-    }
+    assert_eq!(
+        alice.poll_event(),
+        None,
+        "no event to be emitted before accepting the answer"
+    );
 
     let answer =
         bob.accept_connection(1, offer, alice.public_key(), HashSet::new(), HashSet::new());

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -67,9 +67,7 @@ fn only_generate_candidate_event_after_answer() {
 
     alice.accept_answer(1, bob.public_key(), answer);
 
-    let mut events = iter::from_fn(|| alice.poll_event());
-
-    assert!(events.any(|ev| ev
+    assert!(iter::from_fn(|| alice.poll_event()).any(|ev| ev
         == Event::SignalIceCandidate {
             connection: 1,
             candidate: Candidate::host(local_candidate, Protocol::Udp)

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -2,6 +2,7 @@ use boringtun::x25519::StaticSecret;
 use snownet::{ClientNode, Event, ServerNode};
 use std::{
     collections::HashSet,
+    iter,
     net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     time::{Duration, Instant},
 };
@@ -70,12 +71,9 @@ fn only_generate_candidate_event_after_answer() {
 
     alice.accept_answer(1, bob.public_key(), answer);
 
-    let mut events = Vec::new();
-    while let Some(event) = alice.poll_event() {
-        events.push(event);
-    }
+    let mut events = iter::from_fn(|| alice.poll_event());
 
-    assert!(events.into_iter().any(|ev| ev
+    assert!(events.any(|ev| ev
         == Event::SignalIceCandidate {
             connection: 1,
             candidate: Candidate::host(local_candidate, Protocol::Udp)


### PR DESCRIPTION
This is done to delay the candidate generation after the gateway has already received the request.

Since we already know the candidates in most cases, an optimization in the future to reduce the number of round-trips to the gateway we can add the candidates to the request connection message.