### PR TITLE
ci: upgrade iperf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,22 +284,16 @@ jobs:
           cat /tmp/iperf3results/tcp_server2client.json | jq -r '"tcp_server2client_sum_sent_bits_per_second=" + (.end.sum_sent.bits_per_second|tostring)' >> "$GITHUB_OUTPUT"
           cat /tmp/iperf3results/tcp_server2client.json | jq -r '"tcp_server2client_sum_sent_retransmits=" + (.end.sum_sent.retransmits|tostring)' >> "$GITHUB_OUTPUT"
 
-          docker compose restart iperf3
-
           docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 -O 1 -c 172.20.0.110 --json' >> /tmp/iperf3results/tcp_client2server.json
           cat /tmp/iperf3results/tcp_client2server.json | jq -r '"tcp_client2server_sum_received_bits_per_second=" + (.end.sum_received.bits_per_second|tostring)' >> "$GITHUB_OUTPUT"
           cat /tmp/iperf3results/tcp_client2server.json | jq -r '"tcp_client2server_sum_sent_bits_per_second=" + (.end.sum_sent.bits_per_second|tostring)' >> "$GITHUB_OUTPUT"
           cat /tmp/iperf3results/tcp_client2server.json | jq -r '"tcp_client2server_sum_sent_retransmits=" + (.end.sum_sent.retransmits|tostring)' >> "$GITHUB_OUTPUT"
-
-          docker compose restart iperf3
 
           # Note: birtate is reduced to be 250M but what we actually want to test for is 1G once we flesh out some bugs
           docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 -O 1 -u -b 250M -R -c 172.20.0.110 --json' >> /tmp/iperf3results/udp_server2client.json
           cat /tmp/iperf3results/udp_server2client.json | jq -r '"udp_server2client_sum_bits_per_second=" + (.end.sum.bits_per_second|tostring)' >> "$GITHUB_OUTPUT"
           cat /tmp/iperf3results/udp_server2client.json | jq -r '"udp_server2client_sum_jitter_ms=" + (.end.sum.jitter_ms|tostring)' >> "$GITHUB_OUTPUT"
           cat /tmp/iperf3results/udp_server2client.json | jq -r '"udp_server2client_sum_lost_percent=" + (.end.sum.lost_percent|tostring)' >> "$GITHUB_OUTPUT"
-
-          docker compose restart iperf3
 
           # Note: birtate is reduced to be 250M but what we actually want to test for is 1G once we flesh out some bugs
           docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 -O 1 -u -b 250M -c 172.20.0.110 --json' >> /tmp/iperf3results/udp_client2server.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,10 +189,8 @@ services:
         ipv4_address: 172.21.0.100
 
   iperf3:
-    image: networkstatic/iperf3
-    healthcheck:
-      test: ["CMD-SHELL", "iperf3 -k 1 -c 127.0.0.1 || exit 1"]
-    command: -s
+    image: mlabbe/iperf3
+    command: -s -V
     networks:
       resources:
         ipv4_address: 172.20.0.110


### PR DESCRIPTION
Whilst debugging the performance tests in #3391, I found that we are using a 4 year old version of `iperf` for the server. This, plus restarting the server inbetween the performance runs resulted in flaky tests. I am not sure how we arrived at #3303 but [this](https://github.com/firezone/firezone/actions/runs/7926579022?pr=3391) CI run succeeded with a big matrix using the newer iperf server and without the restarts.