### PR TITLE
refactor(ci): Use curl for connectivity tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,11 +185,11 @@ jobs:
       fail-fast: false
       matrix:
         test: [
-          direct-ping-portal-restart,
-          relayed-ping-portal-restart,
-          direct-ping-portal-down,
-          relayed-ping-portal-down,
-          direct-ping-portal-relay-down,
+          direct-curl-portal-restart,
+          relayed-curl-portal-restart,
+          direct-curl-portal-down,
+          relayed-curl-portal-down,
+          direct-curl-portal-relay-down,
           dns-etc-resolvconf,
           dns-nm,
           systemd/dns-systemd-resolved,

--- a/scripts/tests/direct-curl-portal-down.sh
+++ b/scripts/tests/direct-curl-portal-down.sh
@@ -4,10 +4,10 @@ set -e
 
 source "./scripts/tests/lib.sh"
 
-client_ping_resource
+client_curl_resource
 
 docker compose stop api relay # Stop portal & relay
 
 sleep 5 # Wait for client to disconnect
 
-client_ping_resource
+client_curl_resource

--- a/scripts/tests/direct-curl-portal-relay-down.sh
+++ b/scripts/tests/direct-curl-portal-relay-down.sh
@@ -4,10 +4,10 @@ set -e
 
 source "./scripts/tests/lib.sh"
 
-client_ping_resource
+client_curl_resource
 
 docker compose stop api # Stop portal
 
 sleep 5 # Wait for client to disconnect
 
-client_ping_resource
+client_curl_resource

--- a/scripts/tests/direct-curl-portal-restart.sh
+++ b/scripts/tests/direct-curl-portal-restart.sh
@@ -4,10 +4,10 @@ set -e
 
 source "./scripts/tests/lib.sh"
 
-client_ping_resource
+client_curl_resource
 
 docker compose restart api # Restart portal
 
 sleep 5 # Wait for client to reconnect
 
-client_ping_resource
+client_curl_resource

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -10,6 +10,6 @@ function remove_iptables_drop_rules() {
     sudo iptables -D FORWARD -s 172.28.0.105 -d 172.28.0.100 -j DROP
 }
 
-function client_ping_resource() {
+function client_curl_resource() {
     docker compose exec -it client curl --fail -i 172.20.0.100
 }

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -11,5 +11,5 @@ function remove_iptables_drop_rules() {
 }
 
 function client_ping_resource() {
-    docker compose exec -it client timeout 60 sh -c 'until ping -W 1 -c 10 172.20.0.100 &>/dev/null; do true; done'
+    docker compose exec -it client curl --fail -i 172.20.0.100
 }

--- a/scripts/tests/relayed-curl-portal-down.sh
+++ b/scripts/tests/relayed-curl-portal-down.sh
@@ -7,10 +7,10 @@ source "./scripts/tests/lib.sh"
 install_iptables_drop_rules
 trap remove_iptables_drop_rules EXIT # Cleanup after us
 
-client_ping_resource
+client_curl_resource
 
-docker compose restart api # Restart portal
+docker compose stop api # Stop portal
 
-sleep 5 # Wait for client to reconnect
+sleep 5 # Wait for client to disconnect
 
-client_ping_resource
+client_curl_resource

--- a/scripts/tests/relayed-curl-portal-restart.sh
+++ b/scripts/tests/relayed-curl-portal-restart.sh
@@ -7,10 +7,10 @@ source "./scripts/tests/lib.sh"
 install_iptables_drop_rules
 trap remove_iptables_drop_rules EXIT # Cleanup after us
 
-client_ping_resource
+client_curl_resource
 
-docker compose stop api # Stop portal
+docker compose restart api # Restart portal
 
-sleep 5 # Wait for client to disconnect
+sleep 5 # Wait for client to reconnect
 
-client_ping_resource
+client_curl_resource


### PR DESCRIPTION
It would be good to run tests with a TCP protocol like `http` to catch things like MTU and port issues.