### PR TITLE
feat(apple): UI notification for reauth

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -29,7 +29,7 @@ struct FirezoneApp: App {
         StateObject(
           wrappedValue: AskPermissionViewModel(
             tunnelStore: appStore.tunnelStore,
-            notificationDecisionHelper: SessionNotificationHelper(logger: appStore.logger, authStore: appStore.authStore)
+            sessionNotificationHelper: SessionNotificationHelper(logger: appStore.logger, authStore: appStore.authStore)
           )
         )
       appDelegate.appStore = appStore

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -29,7 +29,7 @@ struct FirezoneApp: App {
         StateObject(
           wrappedValue: AskPermissionViewModel(
             tunnelStore: appStore.tunnelStore,
-            notificationDecisionHelper: NotificationDecisionHelper(logger: appStore.logger)
+            notificationDecisionHelper: NotificationDecisionHelper(logger: appStore.logger, authStore: appStore.authStore)
           )
         )
       appDelegate.appStore = appStore

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -26,7 +26,12 @@ struct FirezoneApp: App {
 
     #if os(macOS)
       self._askPermissionViewModel =
-        StateObject(wrappedValue: AskPermissionViewModel(tunnelStore: appStore.tunnelStore))
+        StateObject(
+          wrappedValue: AskPermissionViewModel(
+            tunnelStore: appStore.tunnelStore,
+            notificationDecisionHelper: NotificationDecisionHelper(logger: appStore.logger)
+          )
+        )
       appDelegate.appStore = appStore
     #elseif os(iOS)
       self._appViewModel =

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -29,7 +29,7 @@ struct FirezoneApp: App {
         StateObject(
           wrappedValue: AskPermissionViewModel(
             tunnelStore: appStore.tunnelStore,
-            notificationDecisionHelper: NotificationDecisionHelper(logger: appStore.logger, authStore: appStore.authStore)
+            notificationDecisionHelper: SessionNotificationHelper(logger: appStore.logger, authStore: appStore.authStore)
           )
         )
       appDelegate.appStore = appStore

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 @MainActor
 public final class AskPermissionViewModel: ObservableObject {
   public var tunnelStore: TunnelStore
-  private var notificationDecisionHelper: NotificationDecisionHelper
+  private var notificationDecisionHelper: SessionNotificationHelper
 
   private var cancellables: Set<AnyCancellable> = []
 
@@ -29,7 +29,7 @@ public final class AskPermissionViewModel: ObservableObject {
 
   @Published var needsNotificationDecision = false
 
-  public init(tunnelStore: TunnelStore, notificationDecisionHelper: NotificationDecisionHelper) {
+  public init(tunnelStore: TunnelStore, notificationDecisionHelper: SessionNotificationHelper) {
     self.tunnelStore = tunnelStore
     self.notificationDecisionHelper = notificationDecisionHelper
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 @MainActor
 public final class AskPermissionViewModel: ObservableObject {
   public var tunnelStore: TunnelStore
-  private var notificationDecisionHelper: SessionNotificationHelper
+  private var sessionNotificationHelper: SessionNotificationHelper
 
   private var cancellables: Set<AnyCancellable> = []
 
@@ -29,9 +29,9 @@ public final class AskPermissionViewModel: ObservableObject {
 
   @Published var needsNotificationDecision = false
 
-  public init(tunnelStore: TunnelStore, notificationDecisionHelper: SessionNotificationHelper) {
+  public init(tunnelStore: TunnelStore, sessionNotificationHelper: SessionNotificationHelper) {
     self.tunnelStore = tunnelStore
-    self.notificationDecisionHelper = notificationDecisionHelper
+    self.sessionNotificationHelper = sessionNotificationHelper
 
     tunnelStore.$tunnelAuthStatus
       .filter { $0.isInitialized }
@@ -50,7 +50,7 @@ public final class AskPermissionViewModel: ObservableObject {
       }
       .store(in: &cancellables)
 
-    notificationDecisionHelper.$notificationDecision
+    sessionNotificationHelper.$notificationDecision
       .filter { $0.isInitialized }
       .sink { [weak self] notificationDecision in
         guard let self = self else { return }
@@ -85,7 +85,7 @@ public final class AskPermissionViewModel: ObservableObject {
 
   #if os(iOS)
     func grantNotificationButtonTapped() {
-      self.notificationDecisionHelper.askUserForNotificationPermissions()
+      self.sessionNotificationHelper.askUserForNotificationPermissions()
     }
   #endif
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
@@ -149,7 +149,7 @@ public struct AskPermissionView: View {
             .multilineTextAlignment(.center)
           #elseif os(iOS)
             Text(
-              "After tapping on the above button, tap on 'Allow' when prompted."
+              "After tapping the above button, tap 'Allow' when prompted."
             )
             .font(.caption)
             .multilineTextAlignment(.center)
@@ -157,7 +157,7 @@ public struct AskPermissionView: View {
         } else if $model.needsNotificationDecision.wrappedValue {
           #if os(iOS)
             Text(
-              "Firezone requires your permission to show local notifications whenever you become signed out of your account."
+              "Firezone requires your permission to show local notifications when you need to sign in again."
             )
             .font(.body)
             .multilineTextAlignment(.center)
@@ -174,7 +174,7 @@ public struct AskPermissionView: View {
             Spacer()
               .frame(maxHeight: 20)
             Text(
-              "After tapping on the above button, tap on 'Allow' when prompted."
+              "After tapping the above button, tap 'Allow' when prompted."
             )
             .font(.caption)
             .multilineTextAlignment(.center)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
@@ -128,6 +128,10 @@ public struct AskPermissionView: View {
             )
             .font(.body)
             .multilineTextAlignment(.center)
+            .padding(EdgeInsets(top: 0, leading: 5, bottom: 0, trailing: 5))
+            Spacer()
+            Image(systemName: "network.badge.shield.half.filled")
+              .imageScale(.large)
           #endif
           Spacer()
           Button("Grant VPN Permission") {
@@ -157,6 +161,10 @@ public struct AskPermissionView: View {
             )
             .font(.body)
             .multilineTextAlignment(.center)
+            .padding(EdgeInsets(top: 0, leading: 5, bottom: 0, trailing: 5))
+            Spacer()
+            Image(systemName: "bell")
+              .imageScale(.large)
             Spacer()
             Button("Grant Notification Permission") {
               model.grantNotificationButtonTapped()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
@@ -40,7 +40,7 @@ import SwiftUINavigationCore
     }
 
     private let appStore: AppStore
-    private let notificationDecisionHelper: SessionNotificationHelper
+    private let sessionNotificationHelper: SessionNotificationHelper
 
     let settingsViewModel: SettingsViewModel
     @Published var isSettingsSheetPresented = false
@@ -49,8 +49,8 @@ import SwiftUINavigationCore
       self.appStore = appStore
       self.settingsViewModel = appStore.settingsViewModel
 
-      let notificationDecisionHelper = SessionNotificationHelper(logger: appStore.logger, authStore: appStore.authStore)
-      self.notificationDecisionHelper = notificationDecisionHelper
+      let sessionNotificationHelper = SessionNotificationHelper(logger: appStore.logger, authStore: appStore.authStore)
+      self.sessionNotificationHelper = sessionNotificationHelper
 
       appStore.objectWillChange
         .receive(on: mainQueue)
@@ -59,7 +59,7 @@ import SwiftUINavigationCore
 
       Publishers.CombineLatest(
         appStore.authStore.$loginStatus,
-        notificationDecisionHelper.$notificationDecision
+        sessionNotificationHelper.$notificationDecision
       )
       .receive(on: mainQueue)
       .sink(receiveValue: { [weak self] loginStatus, notificationDecision in
@@ -73,7 +73,7 @@ import SwiftUINavigationCore
           self.state = .needsPermission(
             AskPermissionViewModel(
               tunnelStore: self.appStore.tunnelStore,
-              notificationDecisionHelper: self.notificationDecisionHelper
+              sessionNotificationHelper: self.sessionNotificationHelper
             )
           )
         case (.signedOut, .determined):

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
@@ -40,6 +40,7 @@ import SwiftUINavigationCore
     }
 
     private let appStore: AppStore
+    private let notificationDecisionHelper: NotificationDecisionHelper
 
     let settingsViewModel: SettingsViewModel
     @Published var isSettingsSheetPresented = false
@@ -48,32 +49,40 @@ import SwiftUINavigationCore
       self.appStore = appStore
       self.settingsViewModel = appStore.settingsViewModel
 
+      let notificationDecisionHelper = NotificationDecisionHelper(logger: appStore.logger)
+      self.notificationDecisionHelper = notificationDecisionHelper
+
       appStore.objectWillChange
         .receive(on: mainQueue)
         .sink { [weak self] in self?.objectWillChange.send() }
         .store(in: &cancellables)
 
-      appStore.authStore.$loginStatus
-        .receive(on: mainQueue)
-        .sink(receiveValue: { [weak self] loginStatus in
-          guard let self else {
-            return
-          }
-
-          switch loginStatus {
-          case .signedIn:
-            self.state = .authenticated(MainViewModel(appStore: self.appStore))
-          case .signedOut:
-            self.state = .unauthenticated(AuthViewModel(authStore: self.appStore.authStore))
-          case .needsTunnelCreationPermission:
-            self.state = .needsPermission(
-              AskPermissionViewModel(tunnelStore: self.appStore.tunnelStore)
+      Publishers.CombineLatest(
+        appStore.authStore.$loginStatus,
+        notificationDecisionHelper.$notificationDecision
+      )
+      .receive(on: mainQueue)
+      .sink(receiveValue: { [weak self] loginStatus, notificationDecision in
+        guard let self else {
+          return
+        }
+        switch (loginStatus, notificationDecision) {
+        case (.uninitialized, _), (_, .uninitialized):
+          self.state = .uninitialized
+        case (.needsTunnelCreationPermission, _), (_, .notDetermined):
+          self.state = .needsPermission(
+            AskPermissionViewModel(
+              tunnelStore: self.appStore.tunnelStore,
+              notificationDecisionHelper: self.notificationDecisionHelper
             )
-          case .uninitialized:
-            self.state = .uninitialized
-          }
-        })
-        .store(in: &cancellables)
+          )
+        case (.signedOut, .determined):
+          self.state = .unauthenticated(AuthViewModel(authStore: self.appStore.authStore))
+        case (.signedIn, .determined):
+          self.state = .authenticated(MainViewModel(appStore: self.appStore))
+        }
+      })
+      .store(in: &cancellables)
     }
 
     func settingsButtonTapped() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
@@ -40,7 +40,7 @@ import SwiftUINavigationCore
     }
 
     private let appStore: AppStore
-    private let notificationDecisionHelper: NotificationDecisionHelper
+    private let notificationDecisionHelper: SessionNotificationHelper
 
     let settingsViewModel: SettingsViewModel
     @Published var isSettingsSheetPresented = false
@@ -49,7 +49,7 @@ import SwiftUINavigationCore
       self.appStore = appStore
       self.settingsViewModel = appStore.settingsViewModel
 
-      let notificationDecisionHelper = NotificationDecisionHelper(logger: appStore.logger, authStore: appStore.authStore)
+      let notificationDecisionHelper = SessionNotificationHelper(logger: appStore.logger, authStore: appStore.authStore)
       self.notificationDecisionHelper = notificationDecisionHelper
 
       appStore.objectWillChange

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
@@ -49,7 +49,7 @@ import SwiftUINavigationCore
       self.appStore = appStore
       self.settingsViewModel = appStore.settingsViewModel
 
-      let notificationDecisionHelper = NotificationDecisionHelper(logger: appStore.logger)
+      let notificationDecisionHelper = NotificationDecisionHelper(logger: appStore.logger, authStore: appStore.authStore)
       self.notificationDecisionHelper = notificationDecisionHelper
 
       appStore.objectWillChange

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/NotificationDecisionHelper.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/NotificationDecisionHelper.swift
@@ -1,0 +1,73 @@
+//
+//  NotificationDecisionHelper.swift
+//  (c) 2024 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Foundation
+import UserNotifications
+
+public class NotificationDecisionHelper {
+
+  enum NotificationDecision {
+    case uninitialized
+    case notDetermined
+    case determined(isNotificationAllowed: Bool)
+
+    var isInitialized: Bool {
+      switch self {
+      case .uninitialized: return false
+      default: return true
+      }
+    }
+  }
+
+  private let logger: AppLogger
+
+  @Published var notificationDecision: NotificationDecision = .uninitialized {
+    didSet {
+      self.logger.log(
+        "NotificationDecisionHelper: notificationDecision changed to \(notificationDecision)"
+      )
+    }
+  }
+
+  init(logger: AppLogger) {
+
+    self.logger = logger
+
+    #if os(iOS)
+      UNUserNotificationCenter.current().getNotificationSettings { notificationSettings in
+        self.logger.log(
+          "NotificationDecisionHelper: getNotificationSettings returned. authorizationStatus is \(notificationSettings.authorizationStatus)"
+        )
+        switch notificationSettings.authorizationStatus {
+        case .notDetermined:
+          self.notificationDecision = .notDetermined
+        case .authorized:
+          self.notificationDecision = .determined(isNotificationAllowed: true)
+        case .denied:
+          self.notificationDecision = .determined(isNotificationAllowed: false)
+        default:
+          break
+        }
+      }
+    #endif
+  }
+
+  func askUserForNotificationPermissions() {
+    guard case .notDetermined = self.notificationDecision else { return }
+    let notificationCenter = UNUserNotificationCenter.current()
+    notificationCenter.requestAuthorization(options: [.sound, .alert]) { isAuthorized, error in
+      self.logger.log(
+        "NotificationDecisionHelper.askUserForNotificationPermissions: isAuthorized = \(isAuthorized)"
+      )
+      if let error = error {
+        self.logger.log(
+          "NotificationDecisionHelper.askUserForNotificationPermissions: Error: \(error)"
+        )
+      }
+      self.notificationDecision = .determined(isNotificationAllowed: isAuthorized)
+    }
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/NotificationDecisionHelper.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/NotificationDecisionHelper.swift
@@ -7,6 +7,9 @@
 import Foundation
 import UserNotifications
 
+// NotificationDecisionHelper helps with iOS local notifications.
+// It doesn't do anything in macOS.
+
 public class NotificationDecisionHelper {
 
   enum NotificationDecision {
@@ -32,7 +35,7 @@ public class NotificationDecisionHelper {
     }
   }
 
-  init(logger: AppLogger) {
+  public init(logger: AppLogger) {
 
     self.logger = logger
 
@@ -55,19 +58,21 @@ public class NotificationDecisionHelper {
     #endif
   }
 
-  func askUserForNotificationPermissions() {
-    guard case .notDetermined = self.notificationDecision else { return }
-    let notificationCenter = UNUserNotificationCenter.current()
-    notificationCenter.requestAuthorization(options: [.sound, .alert]) { isAuthorized, error in
-      self.logger.log(
-        "NotificationDecisionHelper.askUserForNotificationPermissions: isAuthorized = \(isAuthorized)"
-      )
-      if let error = error {
+  #if os(iOS)
+    func askUserForNotificationPermissions() {
+      guard case .notDetermined = self.notificationDecision else { return }
+      let notificationCenter = UNUserNotificationCenter.current()
+      notificationCenter.requestAuthorization(options: [.sound, .alert]) { isAuthorized, error in
         self.logger.log(
-          "NotificationDecisionHelper.askUserForNotificationPermissions: Error: \(error)"
+          "NotificationDecisionHelper.askUserForNotificationPermissions: isAuthorized = \(isAuthorized)"
         )
+        if let error = error {
+          self.logger.log(
+            "NotificationDecisionHelper.askUserForNotificationPermissions: Error: \(error)"
+          )
+        }
+        self.notificationDecision = .determined(isNotificationAllowed: isAuthorized)
       }
-      self.notificationDecision = .determined(isNotificationAllowed: isAuthorized)
     }
-  }
+  #endif
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SessionNotificationHelper.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SessionNotificationHelper.swift
@@ -15,8 +15,9 @@ import UserNotifications
 #endif
 
 
-// NotificationDecisionHelper helps with iOS local notifications.
-// It doesn't do anything in macOS.
+// SessionNotificationHelper helps with showing iOS local notifications
+// when the session ends.
+// In macOS, it helps with showing an alert when the session ends.
 
 public enum NotificationIndentifier: String {
   case sessionEndedNotificationCategory

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SessionNotificationHelper.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SessionNotificationHelper.swift
@@ -46,7 +46,7 @@ public class SessionNotificationHelper: NSObject {
   @Published var notificationDecision: NotificationDecision = .uninitialized {
     didSet {
       self.logger.log(
-        "NotificationDecisionHelper: notificationDecision changed to \(notificationDecision)"
+        "SessionNotificationHelper: notificationDecision changed to \(notificationDecision)"
       )
     }
   }
@@ -81,7 +81,7 @@ public class SessionNotificationHelper: NSObject {
       notificationCenter.setNotificationCategories([certificateExpiryCategory])
       notificationCenter.getNotificationSettings { notificationSettings in
         self.logger.log(
-          "NotificationDecisionHelper: getNotificationSettings returned. authorizationStatus is \(notificationSettings.authorizationStatus)"
+          "SessionNotificationHelper: getNotificationSettings returned. authorizationStatus is \(notificationSettings.authorizationStatus)"
         )
         switch notificationSettings.authorizationStatus {
         case .notDetermined:
@@ -103,11 +103,11 @@ public class SessionNotificationHelper: NSObject {
       let notificationCenter = UNUserNotificationCenter.current()
       notificationCenter.requestAuthorization(options: [.sound, .alert]) { isAuthorized, error in
         self.logger.log(
-          "NotificationDecisionHelper.askUserForNotificationPermissions: isAuthorized = \(isAuthorized)"
+          "SessionNotificationHelper.askUserForNotificationPermissions: isAuthorized = \(isAuthorized)"
         )
         if let error = error {
           self.logger.log(
-            "NotificationDecisionHelper.askUserForNotificationPermissions: Error: \(error)"
+            "SessionNotificationHelper.askUserForNotificationPermissions: Error: \(error)"
           )
         }
         self.notificationDecision = .determined(isNotificationAllowed: isAuthorized)
@@ -154,7 +154,7 @@ public class SessionNotificationHelper: NSObject {
       NSApp.activate(ignoringOtherApps: true)
       let response = alert.runModal()
       if response == NSApplication.ModalResponse.alertFirstButtonReturn {
-        logger.log("NotificationDecisionHelper: \(#function): 'Sign In' clicked in notification")
+        logger.log("SessionNotificationHelper: \(#function): 'Sign In' clicked in notification")
         Task {
           do {
             try await authStore.signIn()
@@ -170,7 +170,7 @@ public class SessionNotificationHelper: NSObject {
 #if os(iOS)
   extension SessionNotificationHelper: UNUserNotificationCenterDelegate {
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-      self.logger.log("NotificationDecisionHelper: \(#function): 'Sign In' clicked in notification")
+      self.logger.log("SessionNotificationHelper: \(#function): 'Sign In' clicked in notification")
       let actionId = response.actionIdentifier
       let categoryId = response.notification.request.content.categoryIdentifier
       if categoryId == NotificationIndentifier.sessionEndedNotificationCategory.rawValue,

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SessionNotificationHelper.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SessionNotificationHelper.swift
@@ -1,5 +1,5 @@
 //
-//  NotificationDecisionHelper.swift
+//  SessionNotificationHelper.swift
 //  (c) 2024 Firezone, Inc.
 //  LICENSE: Apache-2.0
 //
@@ -16,7 +16,7 @@ public enum NotificationIndentifier: String {
   case dismissNotificationAction
 }
 
-public class NotificationDecisionHelper: NSObject {
+public class SessionNotificationHelper: NSObject {
 
   enum NotificationDecision {
     case uninitialized
@@ -107,7 +107,7 @@ public class NotificationDecisionHelper: NSObject {
   #endif
 }
 
-extension NotificationDecisionHelper: UNUserNotificationCenterDelegate {
+extension SessionNotificationHelper: UNUserNotificationCenterDelegate {
   public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
     self.logger.log("NotificationDecisionHelper: \(#function): 'Sign In' clicked in notification")
       let actionId = response.actionIdentifier

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/TunnelShutdownEvent.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/TunnelShutdownEvent.swift
@@ -39,7 +39,7 @@ public struct TunnelShutdownEvent: Codable, CustomStringConvertible {
       switch self {
       case .stopped(let reason):
         if reason == .userInitiated {
-          return .signoutImmediately
+          return .signoutImmediatelySilently
         } else if reason == .userLogout || reason == .userSwitch {
           return .doNothing
         } else {
@@ -57,6 +57,7 @@ public struct TunnelShutdownEvent: Codable, CustomStringConvertible {
   public enum Action {
     case doNothing
     case signoutImmediately
+    case signoutImmediatelySilently
     case retryThenSignout
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AppStore.swift
@@ -66,7 +66,7 @@ public final class AppStore: ObservableObject {
   public let settingsViewModel: SettingsViewModel
 
   private var cancellables: Set<AnyCancellable> = []
-  let logger: AppLogger
+  public let logger: AppLogger
 
   public init() {
     let logger = AppLogger(process: .app, folderURL: SharedAccess.appLogFolderURL)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -209,6 +209,10 @@ public final class AuthStore: ObservableObject {
         #if os(macOS)
           SessionNotificationHelper.showSignedOutAlertmacOS(logger: self.logger, authStore: self)
         #endif
+      case .signoutImmediatelySilently:
+        Task {
+          await self.signOut()
+        }
       case .retryThenSignout:
         self.retryStartTunnel()
       case .doNothing:

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -10,6 +10,10 @@ import Foundation
 import NetworkExtension
 import OSLog
 
+#if os(macOS)
+  import AppKit
+#endif
+
 @MainActor
 public final class AuthStore: ObservableObject {
   enum LoginStatus: CustomStringConvertible {
@@ -202,6 +206,9 @@ public final class AuthStore: ObservableObject {
         Task {
           await self.signOut()
         }
+        #if os(macOS)
+          self.showSignedOutAlertmacOS()
+        #endif
       case .retryThenSignout:
         self.retryStartTunnel()
       case .doNothing:
@@ -230,8 +237,21 @@ public final class AuthStore: ObservableObject {
       Task {
         await self.signOut()
       }
+      #if os(macOS)
+        self.showSignedOutAlertmacOS()
+      #endif
     }
   }
+
+  #if os(macOS)
+    private func showSignedOutAlertmacOS() {
+      let alert = NSAlert()
+      alert.messageText = "Your Firezone session has ended"
+      alert.informativeText = "Please sign in again to reconnect"
+      NSApp.activate(ignoringOtherApps: true)
+      alert.runModal()
+    }
+  #endif
 
   private func handleLoginStatusChanged() {
     logger.log("\(#function): Login status: \(self.loginStatus)")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -207,7 +207,7 @@ public final class AuthStore: ObservableObject {
           await self.signOut()
         }
         #if os(macOS)
-          self.showSignedOutAlertmacOS()
+          SessionNotificationHelper.showSignedOutAlertmacOS(logger: self.logger, authStore: self)
         #endif
       case .retryThenSignout:
         self.retryStartTunnel()
@@ -238,31 +238,10 @@ public final class AuthStore: ObservableObject {
         await self.signOut()
       }
       #if os(macOS)
-        self.showSignedOutAlertmacOS()
+        SessionNotificationHelper.showSignedOutAlertmacOS(logger: self.logger, authStore: self)
       #endif
     }
   }
-
-  #if os(macOS)
-    private func showSignedOutAlertmacOS() {
-      let alert = NSAlert()
-      alert.messageText = "Your Firezone session has ended"
-      alert.informativeText = "Please sign in again to reconnect"
-      alert.addButton(withTitle: "Sign In")
-      alert.addButton(withTitle: "Cancel")
-      NSApp.activate(ignoringOtherApps: true)
-      let response = alert.runModal()
-      if response == NSApplication.ModalResponse.alertFirstButtonReturn {
-        Task {
-          do {
-            try await self.signIn()
-          } catch {
-            self.logger.error("Error signing in: \(error)")
-          }
-        }
-      }
-    }
-  #endif
 
   private func handleLoginStatusChanged() {
     logger.log("\(#function): Login status: \(self.loginStatus)")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/AuthStore.swift
@@ -248,8 +248,19 @@ public final class AuthStore: ObservableObject {
       let alert = NSAlert()
       alert.messageText = "Your Firezone session has ended"
       alert.informativeText = "Please sign in again to reconnect"
+      alert.addButton(withTitle: "Sign In")
+      alert.addButton(withTitle: "Cancel")
       NSApp.activate(ignoringOtherApps: true)
-      alert.runModal()
+      let response = alert.runModal()
+      if response == NSApplication.ModalResponse.alertFirstButtonReturn {
+        Task {
+          do {
+            try await self.signIn()
+          } catch {
+            self.logger.error("Error signing in: \(error)")
+          }
+        }
+      }
     }
   #endif
 

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -7,7 +7,6 @@
 import Dependencies
 import FirezoneKit
 import NetworkExtension
-import UserNotifications
 import os
 
 enum PacketTunnelProviderError: Error {
@@ -113,37 +112,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     #if os(iOS)
       if reason.action == .signoutImmediately {
-        UNUserNotificationCenter.current().getNotificationSettings { notificationSettings in
-          if notificationSettings.authorizationStatus == .authorized {
-            self.logger.log(
-              "Notifications are allowed. Alert style is \(notificationSettings.alertStyle.rawValue)"
-            )
-            self.showSignedOutNotificationiOS()
-          }
-        }
+        SessionNotificationHelper.showSignedOutNotificationiOS(logger: self.logger)
       }
     #endif
   }
-
-  #if os(iOS)
-    func showSignedOutNotificationiOS() {
-      let content = UNMutableNotificationContent()
-      content.title = "Your Firezone session has ended"
-      content.body = "Please sign in again to reconnect"
-      content.categoryIdentifier = NotificationIndentifier.sessionEndedNotificationCategory.rawValue
-      let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
-      let request = UNNotificationRequest(
-        identifier: "FirezoneTunnelShutdown", content: content, trigger: trigger
-      )
-      UNUserNotificationCenter.current().add(request) { error in
-        if let error = error {
-          self.logger.error("showSignedOutNotificationiOS: Error requesting notification: \(error)")
-        } else {
-          self.logger.error("showSignedOutNotificationiOS: Successfully requested notification")
-        }
-      }
-    }
-  #endif
 }
 
 extension NEProviderStopReason: CustomStringConvertible {

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -130,6 +130,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       let content = UNMutableNotificationContent()
       content.title = "Your Firezone session has ended"
       content.body = "Please sign in again to reconnect"
+      content.categoryIdentifier = NotificationIndentifier.sessionEndedNotificationCategory.rawValue
       let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
       let request = UNNotificationRequest(
         identifier: "FirezoneTunnelShutdown", content: content, trigger: trigger


### PR DESCRIPTION
This PR shows an alert (macOS) / local notification (iOS) when the user is signed out because of a tunnel error.

Fixes the apple part of #3329.