### PR TITLE
fix(connlib): set socket to IPv6 only before binding address

### DIFF
--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -214,13 +214,13 @@ fn make_socket(addr: impl Into<SocketAddr>) -> Result<std::net::UdpSocket> {
         socket.set_mark(crate::FIREZONE_MARK)?;
     }
 
-    socket.set_nonblocking(true)?;
-    socket.bind(&addr)?;
-
     // Note: for AF_INET sockets IPV6_V6ONLY is not a valid flag
     if addr.is_ipv6() {
         socket.set_only_v6(true)?;
     }
+
+    socket.set_nonblocking(true)?;
+    socket.bind(&addr)?;
 
     Ok(socket.into())
 }


### PR DESCRIPTION
Binding the IPv6 socket would always fail because we do it _after_ the IPv4 socket. However, without setting the socket to `IP6_ONLY`, binding the unspecified IPv6 address (`::`) also wants to bind to IPv4 (depending on the kernel settings). To avoid this, we need to first configure the socket properly and then bind it to the given address.