### PR TITLE
refactor(ci): extract `setup-tauri` action and generalize Windows builds

### DIFF
--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -1,34 +1,30 @@
 # From https://tauri.app/v1/guides/getting-started/prerequisites
 name: "Setup Tauri"
 description: "Sets up the dependencies for building and testing Tauri apps"
-inputs:
-  target_os:
-    description: "`windows` or `linux` like in Rust"
-    required: true
 runs:
   using: "composite"
   steps:
     - name: Apt-get update
-      if: ${{ inputs.target_os == 'linux' }}
+      if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get update
       shell: bash
     - name: Install Tauri build deps
-      if: ${{ inputs.target_os == 'linux' }}
+      if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get install libwebkit2gtk-4.0-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
       shell: bash
     - name: Install gnome-keyring
-      if: ${{ inputs.target_os == 'linux' }}
+      if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get install gnome-keyring
       shell: bash
       # This is only needed if we'll launch the Tauri GUI, so it's redundant for clippy / test
       # This is what the Tauri CI tests use
       # <https://github.com/tauri-apps/tauri/blob/3fb414b61ad7cfce67751230826fddfb39effec5/.github/workflows/bench.yml#L74>
     - name: Install Tauri runtime deps
-      if: ${{ inputs.target_os == 'linux' }}
+      if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get install at-spi2-core xvfb
       shell: bash
     - name: Download WebView2 bootstrapper
-      if: ${{ inputs.target_os == 'windows' }}
+      if: ${{ runner.os == 'Windows' }}
       # This is the "Evergreen" bootstrapper from Microsoft
       # <https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH#download>
       # Unfortunately, this makes the test non-deterministic.
@@ -36,7 +32,7 @@ runs:
       run: Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/p/?LinkId=2124703 -OutFile WebView2Installer.exe
       shell: pwsh
     - name: Install WebView2
-      if: ${{ inputs.target_os == 'windows' }}
+      if: ${{ runner.os == 'Windows' }}
       # This downloads about 200 MB and takes about 5 minutes on my VM
       # So we could fault in WebView2 from the client exe without the MSI if we needed.
       # Currently the MSI does this and it's a little janky.

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -1,0 +1,44 @@
+# From https://tauri.app/v1/guides/getting-started/prerequisites
+name: "Setup Tauri"
+description: "Sets up the dependencies for building and testing Tauri apps"
+inputs:
+  target_os:
+    description: "`windows` or `linux` like in Rust"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Apt-get update
+      if: ${{ inputs.target_os == 'linux' }}
+      run: sudo apt-get update
+      shell: bash
+    - name: Install Tauri build deps
+      if: ${{ inputs.target_os == 'linux' }}
+      run: sudo apt-get install libwebkit2gtk-4.0-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      shell: bash
+    - name: Install gnome-keyring
+      if: ${{ inputs.target_os == 'linux' }}
+      run: sudo apt-get install gnome-keyring
+      shell: bash
+      # This is only needed if we'll launch the Tauri GUI, so it's redundant for clippy / test
+      # This is what the Tauri CI tests use
+      # <https://github.com/tauri-apps/tauri/blob/3fb414b61ad7cfce67751230826fddfb39effec5/.github/workflows/bench.yml#L74>
+    - name: Install Tauri runtime deps
+      if: ${{ inputs.target_os == 'linux' }}
+      run: sudo apt-get install at-spi2-core xvfb
+      shell: bash
+    - name: Download WebView2 bootstrapper
+      if: ${{ inputs.target_os == 'windows' }}
+      # This is the "Evergreen" bootstrapper from Microsoft
+      # <https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH#download>
+      # Unfortunately, this makes the test non-deterministic.
+      # Controlling the version would be difficult.
+      run: Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/p/?LinkId=2124703 -OutFile WebView2Installer.exe
+      shell: pwsh
+    - name: Install WebView2
+      if: ${{ inputs.target_os == 'windows' }}
+      # This downloads about 200 MB and takes about 5 minutes on my VM
+      # So we could fault in WebView2 from the client exe without the MSI if we needed.
+      # Currently the MSI does this and it's a little janky.
+      run: Start-Process WebView2Installer.exe -ArgumentList "/install" -Wait
+      shell: pwsh

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -115,7 +115,7 @@ jobs:
 
   # This should be identical to `build-push-windows-release-artifacts` in `cd.yml` except for the Github permissions, needs tag, and uploading step
   build-gui:
-    name: build-gui-${{ runner.os }}
+    name: build-gui-${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -159,7 +159,7 @@ jobs:
           - runs-on: windows-2019
             target_os: windows
     env:
-      BINARY_DEST_PATH: ${{ env.ARTIFACT }}
+      BINARY_DEST_PATH: firezone-windows-client
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -25,14 +25,20 @@ jobs:
         include:
           - runs-on: ubuntu-22.04
             packages: # Intentionally blank as a package catch-all linter
+            target_os: linux
           - runs-on: macos-14
             packages: -p connlib-client-apple -p snownet
+            target_os: macos
           - runs-on: windows-2022
             packages: -p connlib-client-shared -p firezone-windows-client -p snownet
+            target_os: windows
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/setup-tauri
+        with:
+          target_os: ${{ matrix.target_os }}
       - run: cargo fmt -- --check
       - run: |
           cargo doc --all-features --no-deps --document-private-items ${{ matrix.packages }}
@@ -50,29 +56,56 @@ jobs:
         include:
           - runs-on: ubuntu-20.04
             packages: -p firezone-linux-client -p firezone-gateway -p connlib-client-android -p snownet
+            target_os: linux
           - runs-on: ubuntu-22.04
             packages: -p firezone-linux-client -p firezone-gateway -p connlib-client-android -p snownet
+            target_os: linux
           - runs-on: macos-12
             packages: -p connlib-client-apple -p snownet
+            target_os: macos
           - runs-on: macos-13
             packages: -p connlib-client-apple -p snownet
+            target_os: macos
           - runs-on: macos-14
             packages: -p connlib-client-apple -p snownet
+            target_os: macos
           - runs-on: windows-2019
             packages: -p firezone-windows-client -p connlib-client-shared -p snownet
+            target_os: windows
           - runs-on: windows-2022
             packages: -p firezone-windows-client -p connlib-client-shared -p snownet
+            target_os: windows
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/setup-tauri
+        with:
+          target_os: ${{ matrix.target_os }}
       - run: cargo test --all-features ${{ matrix.packages }}
 
   # Runs the Windows client smoke test, built in debug mode. We can't run it in release
   # mode because of a known issue: <https://github.com/firezone/firezone/blob/456e044f882c2bb314e19cc44c0d19c5ad817b7c/rust/windows-client/src-tauri/src/client.rs#L162-L164>
   windows-smoke-test:
-    name: windows-smoke-test
-    runs-on: windows-2019
+    name: windows-smoke-test-${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            target_os: linux
+          # Broken on 22.04 <https://github.com/firezone/firezone/issues/3699>
+          #- runs-on: ubuntu-22.04
+          #  target: x86_64-unknown-linux-gnu
+          #  target_os: linux
+          - runs-on: windows-2019
+            target: x86_64-pc-windows-msvc
+            target_os: windows
+          - runs-on: windows-2022
+            target: x86_64-pc-windows-msvc
+            target_os: windows
+    runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
         working-directory: ./rust/windows-client
@@ -86,18 +119,9 @@ jobs:
           node-version: '20'
       - uses: ./.github/actions/setup-rust
         with:
-          targets: x86_64-pc-windows-msvc
-        # This is the "Evergreen" bootstrapper from Microsoft
-        # <https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH#download>
-        # Unfortunately, this makes the test non-deterministic.
-        # Controlling the version would be difficult.
-      - name: Download WebView2 bootstrapper
-        run: Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/p/?LinkId=2124703 -OutFile WebView2Installer.exe
-        # This downloads about 200 MB and takes about 5 minutes on my VM
-        # So we could fault in WebView2 from the client exe without the MSI if we needed.
-        # Currently the MSI does this and it's a little janky.
-      - name: Install WebView2
-        run: Start-Process WebView2Installer.exe -ArgumentList "/install" -Wait
+      - uses: ./.github/actions/setup-tauri
+        with:
+          target_os: ${{ matrix.target_os }}
       - name: pnpm install
         run: |
           pnpm install
@@ -139,7 +163,10 @@ jobs:
           node-version: '20'
       - uses: ./.github/actions/setup-rust
         with:
-          targets: x86_64-pc-windows-msvc
+          targets: ${{ matrix.target }}
+      - uses: ./.github/actions/setup-tauri
+        with:
+        target_os: ${{ matrix.target_os }}
       - name: Install pnpm deps
         run: pnpm install
       - name: Build release exe and MSI
@@ -159,14 +186,15 @@ jobs:
           # This might catch regressions in #3384, depending how CI runners
           # handle exit codes
           git diff --exit-code
-      - name: Save Windows client
+      - name: Save GUI client
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}-x64
           path: |
             ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.exe
             ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.exe.sha256sum.txt
-      - name: Save Windows installer
+      - name: Save Windows MSI installer
+        if: ${{ matrix.target_os == 'windows' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}-x64-msi
@@ -174,6 +202,7 @@ jobs:
             ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.msi
             ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.msi.sha256sum.txt
       - name: Save Windows debug symbols
+        if: ${{ matrix.target_os == 'windows' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}-x64-pdb

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -119,6 +119,7 @@ jobs:
           node-version: '20'
       - uses: ./.github/actions/setup-rust
         with:
+          targets: ${{ matrix.target }}
       - uses: ./.github/actions/setup-tauri
         with:
           target_os: ${{ matrix.target_os }}

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -166,7 +166,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: ./.github/actions/setup-tauri
         with:
-        target_os: ${{ matrix.target_os }}
+          target_os: ${{ matrix.target_os }}
       - name: Install pnpm deps
         run: pnpm install
       - name: Build release exe and MSI

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -92,9 +92,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-20.04
-            target: x86_64-unknown-linux-gnu
-            target_os: linux
+          # Awaiting another PR to generalize the smoke test for Ubuntu
+          #- runs-on: ubuntu-20.04
+          #  target: x86_64-unknown-linux-gnu
+          #  target_os: linux
           # Broken on 22.04 <https://github.com/firezone/firezone/issues/3699>
           #- runs-on: ubuntu-22.04
           #  target: x86_64-unknown-linux-gnu

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -25,20 +25,15 @@ jobs:
         include:
           - runs-on: ubuntu-22.04
             packages: # Intentionally blank as a package catch-all linter
-            target_os: linux
           - runs-on: macos-14
             packages: -p connlib-client-apple -p snownet
-            target_os: macos
           - runs-on: windows-2022
             packages: -p connlib-client-shared -p firezone-windows-client -p snownet
-            target_os: windows
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri
-        with:
-          target_os: ${{ matrix.target_os }}
       - run: cargo fmt -- --check
       - run: |
           cargo doc --all-features --no-deps --document-private-items ${{ matrix.packages }}
@@ -56,32 +51,23 @@ jobs:
         include:
           - runs-on: ubuntu-20.04
             packages: -p firezone-linux-client -p firezone-gateway -p connlib-client-android -p snownet
-            target_os: linux
           - runs-on: ubuntu-22.04
             packages: -p firezone-linux-client -p firezone-gateway -p connlib-client-android -p snownet
-            target_os: linux
           - runs-on: macos-12
             packages: -p connlib-client-apple -p snownet
-            target_os: macos
           - runs-on: macos-13
             packages: -p connlib-client-apple -p snownet
-            target_os: macos
           - runs-on: macos-14
             packages: -p connlib-client-apple -p snownet
-            target_os: macos
           - runs-on: windows-2019
             packages: -p firezone-windows-client -p connlib-client-shared -p snownet
-            target_os: windows
           - runs-on: windows-2022
             packages: -p firezone-windows-client -p connlib-client-shared -p snownet
-            target_os: windows
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri
-        with:
-          target_os: ${{ matrix.target_os }}
       - run: cargo test --all-features ${{ matrix.packages }}
 
   # Runs the Windows client smoke test, built in debug mode. We can't run it in release
@@ -94,18 +80,10 @@ jobs:
         include:
           # Awaiting another PR to generalize the smoke test for Ubuntu
           #- runs-on: ubuntu-20.04
-          #  target: x86_64-unknown-linux-gnu
-          #  target_os: linux
           # Broken on 22.04 <https://github.com/firezone/firezone/issues/3699>
           #- runs-on: ubuntu-22.04
-          #  target: x86_64-unknown-linux-gnu
-          #  target_os: linux
           - runs-on: windows-2019
-            target: x86_64-pc-windows-msvc
-            target_os: windows
           - runs-on: windows-2022
-            target: x86_64-pc-windows-msvc
-            target_os: windows
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
@@ -119,11 +97,7 @@ jobs:
         with:
           node-version: '20'
       - uses: ./.github/actions/setup-rust
-        with:
-          targets: ${{ matrix.target }}
       - uses: ./.github/actions/setup-tauri
-        with:
-          target_os: ${{ matrix.target_os }}
       - name: pnpm install
         run: |
           pnpm install
@@ -141,7 +115,7 @@ jobs:
 
   # This should be identical to `build-push-windows-release-artifacts` in `cd.yml` except for the Github permissions, needs tag, and uploading step
   build-gui:
-    name: build-gui-${{ matrix.target_os }}
+    name: build-gui-${{ runner.os }}
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
@@ -155,9 +129,7 @@ jobs:
           - windows-2019
         include:
           # - runs-on: ubuntu-20.04
-          #   target_os: linux
           - runs-on: windows-2019
-            target_os: windows
     env:
       BINARY_DEST_PATH: firezone-windows-client
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
@@ -168,8 +140,6 @@ jobs:
           node-version: '20'
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri
-        with:
-          target_os: ${{ matrix.target_os }}
       - name: Install pnpm deps
         run: pnpm install
       - name: Build release exe and MSI
@@ -197,7 +167,7 @@ jobs:
             ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.exe
             ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.exe.sha256sum.txt
       - name: Save Windows MSI installer
-        if: ${{ matrix.target_os == 'windows' }}
+        if: ${{ runner.os == 'Windows' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BINARY_DEST_PATH }}-x64-msi
@@ -205,7 +175,7 @@ jobs:
             ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.msi
             ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.msi.sha256sum.txt
       - name: Save Windows debug symbols
-        if: ${{ matrix.target_os == 'windows' }}
+        if: ${{ runner.os == 'Windows' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BINARY_DEST_PATH }}-x64-pdb

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -141,8 +141,8 @@ jobs:
 
   # This should be identical to `build-push-windows-release-artifacts` in `cd.yml` except for the Github permissions, needs tag, and uploading step
   build-tauri:
-    name: build-tauri-${{ matrix.name }}
-    runs-on: windows-2019
+    name: build-tauri-${{ matrix.name }}-${{ matrix.target_os }}
+    runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
         working-directory: ./rust/windows-client
@@ -155,6 +155,8 @@ jobs:
           - package: firezone-windows-client
             artifact: firezone-windows-client
             name: windows-client
+          - runs-on: windows-2019
+            target_os: windows
     env:
       BINARY_DEST_PATH: ${{ matrix.artifact }}
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
@@ -164,8 +166,6 @@ jobs:
         with:
           node-version: '20'
       - uses: ./.github/actions/setup-rust
-        with:
-          targets: ${{ matrix.target }}
       - uses: ./.github/actions/setup-tauri
         with:
           target_os: ${{ matrix.target_os }}

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -141,24 +141,25 @@ jobs:
 
   # This should be identical to `build-push-windows-release-artifacts` in `cd.yml` except for the Github permissions, needs tag, and uploading step
   build-tauri:
-    name: build-tauri-${{ matrix.name }}-${{ matrix.target_os }}
+    name: build-tauri-${{ matrix.target_os }}
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
         working-directory: ./rust/windows-client
     strategy:
       fail-fast: false
-      # The matrix is 1x1 to match the style of build-push-linux-release-artifacts
-      # In the future we could try to cross-compile aarch64-windows here.
       matrix:
+        runs-on:
+          # TODO
+          # - ubuntu-20.04
+          - windows-2019
         include:
-          - package: firezone-windows-client
-            artifact: firezone-windows-client
-            name: windows-client
+          # - runs-on: ubuntu-20.04
+          #   target_os: linux
           - runs-on: windows-2019
             target_os: windows
     env:
-      BINARY_DEST_PATH: ${{ matrix.artifact }}
+      BINARY_DEST_PATH: ${{ env.ARTIFACT }}
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
     steps:
       - uses: actions/checkout@v4
@@ -191,23 +192,23 @@ jobs:
       - name: Save GUI client
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}-x64
+          name: ${{ env.BINARY_DEST_PATH }}-x64
           path: |
-            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.exe
-            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.exe.sha256sum.txt
+            ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.exe
+            ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.exe.sha256sum.txt
       - name: Save Windows MSI installer
         if: ${{ matrix.target_os == 'windows' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}-x64-msi
+          name: ${{ env.BINARY_DEST_PATH }}-x64-msi
           path: |
-            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.msi
-            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.msi.sha256sum.txt
+            ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.msi
+            ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.msi.sha256sum.txt
       - name: Save Windows debug symbols
         if: ${{ matrix.target_os == 'windows' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}-x64-pdb
+          name: ${{ env.BINARY_DEST_PATH }}-x64-pdb
           path: |
-            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.pdb
-            ${{ github.workspace }}/rust/windows-client/${{ matrix.artifact }}-x64.pdb.sha256sum.txt
+            ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.pdb
+            ${{ github.workspace }}/rust/windows-client/${{ env.BINARY_DEST_PATH }}-x64.pdb.sha256sum.txt

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -86,8 +86,8 @@ jobs:
 
   # Runs the Windows client smoke test, built in debug mode. We can't run it in release
   # mode because of a known issue: <https://github.com/firezone/firezone/blob/456e044f882c2bb314e19cc44c0d19c5ad817b7c/rust/windows-client/src-tauri/src/client.rs#L162-L164>
-  windows-smoke-test:
-    name: windows-smoke-test-${{ matrix.runs-on }}
+  gui-smoke-test:
+    name: gui-smoke-test-${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -140,8 +140,8 @@ jobs:
         run: bash scripts/crash-handling-smoke-test.bash
 
   # This should be identical to `build-push-windows-release-artifacts` in `cd.yml` except for the Github permissions, needs tag, and uploading step
-  build-tauri:
-    name: build-tauri-${{ matrix.target_os }}
+  build-gui:
+    name: build-gui-${{ matrix.target_os }}
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:

--- a/rust/windows-client/src-tauri/src/main.rs
+++ b/rust/windows-client/src-tauri/src/main.rs
@@ -10,7 +10,7 @@ fn main() -> anyhow::Result<()> {
 #[cfg(target_family = "unix")]
 mod client {
     pub(crate) fn run() -> anyhow::Result<()> {
-        panic!("The Windows client does not compile on non-Windows platforms");
+        println!("The Windows client does not compile on non-Windows platforms yet");
     }
 }
 

--- a/rust/windows-client/src-tauri/src/main.rs
+++ b/rust/windows-client/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ fn main() -> anyhow::Result<()> {
 mod client {
     pub(crate) fn run() -> anyhow::Result<()> {
         println!("The Windows client does not compile on non-Windows platforms yet");
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This prevents duplication for different Tauri jobs like building the release packages vs testing a debug build with mock keyring.

```[tasklist]
- [ ] Fix branch protection rules for changed tests
```