### PR TITLE
feat(connlib): filter out relays based on our locally created sockets

### DIFF
--- a/rust/connlib/tunnel/src/control_protocol.rs
+++ b/rust/connlib/tunnel/src/control_protocol.rs
@@ -40,7 +40,7 @@ fn insert_peers<TId: Copy, TTransform>(
     }
 }
 
-fn stun(relays: &[Relay]) -> HashSet<SocketAddr> {
+fn stun(relays: &[Relay], predicate: impl Fn(&SocketAddr) -> bool) -> HashSet<SocketAddr> {
     relays
         .iter()
         .filter_map(|r| {
@@ -50,10 +50,14 @@ fn stun(relays: &[Relay]) -> HashSet<SocketAddr> {
                 None
             }
         })
+        .filter(predicate)
         .collect()
 }
 
-fn turn(relays: &[Relay]) -> HashSet<(SocketAddr, String, String, String)> {
+fn turn(
+    relays: &[Relay],
+    predicate: impl Fn(&SocketAddr) -> bool,
+) -> HashSet<(SocketAddr, String, String, String)> {
     relays
         .iter()
         .filter_map(|r| {
@@ -68,5 +72,6 @@ fn turn(relays: &[Relay]) -> HashSet<(SocketAddr, String, String, String)> {
                 None
             }
         })
+        .filter(|(socket, _, _, _)| predicate(socket))
         .collect()
 }

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -72,12 +72,10 @@ where
             .get_awaiting_connection_domain(&resource_id)?
             .clone();
 
-        let mut stun_relays = stun(&relays);
-        stun_relays.extend(turn(&relays).iter().map(|r| r.0).collect::<HashSet<_>>());
         let offer =
             self.connections_state
                 .node
-                .new_connection(gateway_id, stun_relays, turn(&relays));
+                .new_connection(gateway_id, stun(&relays), turn(&relays));
 
         Ok(Request::NewConnection(RequestConnection {
             resource_id,

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -72,10 +72,15 @@ where
             .get_awaiting_connection_domain(&resource_id)?
             .clone();
 
-        let offer =
-            self.connections_state
-                .node
-                .new_connection(gateway_id, stun(&relays), turn(&relays));
+        let offer = self.connections_state.node.new_connection(
+            gateway_id,
+            stun(&relays, |addr| {
+                self.connections_state.sockets.can_handle(addr)
+            }),
+            turn(&relays, |addr| {
+                self.connections_state.sockets.can_handle(addr)
+            }),
+        );
 
         Ok(Request::NewConnection(RequestConnection {
             resource_id,

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -17,7 +17,7 @@ use connlib_shared::{
 use ip_network::IpNetwork;
 use secrecy::{ExposeSecret as _, Secret};
 use snownet::{Credentials, Server};
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 /// Description of a resource that maps to a DNS record which had its domain already resolved.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -75,8 +75,6 @@ where
             ResourceDescription::Cidr(ref cidr) => vec![cidr.address],
         };
 
-        let mut stun_servers: HashSet<_> = turn(&relays).iter().map(|r| r.0).collect();
-        stun_servers.extend(stun(&relays));
         let answer = self.connections_state.node.accept_connection(
             client,
             snownet::Offer {
@@ -87,7 +85,7 @@ where
                 },
             },
             gateway,
-            stun_servers,
+            stun(&relays),
             turn(&relays),
         );
 

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -85,8 +85,12 @@ where
                 },
             },
             gateway,
-            stun(&relays),
-            turn(&relays),
+            stun(&relays, |addr| {
+                self.connections_state.sockets.can_handle(addr)
+            }),
+            turn(&relays, |addr| {
+                self.connections_state.sockets.can_handle(addr)
+            }),
         );
 
         self.new_peer(

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -47,6 +47,13 @@ impl Sockets {
         })
     }
 
+    pub fn can_handle(&self, addr: &SocketAddr) -> bool {
+        match addr {
+            SocketAddr::V4(_) => self.socket_v4.is_some(),
+            SocketAddr::V6(_) => self.socket_v6.is_some(),
+        }
+    }
+
     #[cfg(target_os = "android")]
     pub fn ip4_socket_fd(&self) -> Option<std::os::fd::RawFd> {
         use std::os::fd::AsRawFd;


### PR DESCRIPTION
Currently, we will always try to reach all relays that we are given by the portal. That creates unnecessary warnings if we don't have connectivity for a certain IP version.

By filtering based on the IP version of our bound sockets, we can avoid these warnings in the logs.