### PR TITLE
refactor: move BUNDLE_ID since it won't be Windows-specific

### DIFF
--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -32,6 +32,21 @@ use url::Url;
 
 pub type Dname = domain::base::Dname<Vec<u8>>;
 
+/// Bundle ID / App ID that the client uses to distinguish itself from other programs on the system
+///
+/// e.g. In ProgramData and AppData we use this to name our subdirectories for configs and data,
+/// and Windows may use it to track things like the MSI installer, notification titles,
+/// deep link registration, etc.
+///
+/// This should be identical to the `tauri.bundle.identifier` over in `tauri.conf.json`,
+/// but sometimes I need to use this before Tauri has booted up, or in a place where
+/// getting the Tauri app handle would be awkward.
+///
+/// Luckily this is also the AppUserModelId that Windows uses to label notifications,
+/// so if your dev system has Firezone installed by MSI, the notifications will look right.
+/// <https://learn.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app>
+pub const BUNDLE_ID: &str = "dev.firezone.client";
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const LIB_NAME: &str = "connlib";
 

--- a/rust/connlib/shared/src/windows.rs
+++ b/rust/connlib/shared/src/windows.rs
@@ -4,21 +4,6 @@ use crate::Error;
 use known_folders::{get_known_folder_path, KnownFolder};
 use std::path::PathBuf;
 
-/// Bundle ID / App ID that we use to distinguish ourself from other programs on the system
-///
-/// e.g. In ProgramData and AppData we use this to name our subdirectories for configs and data,
-/// and Windows may use it to track things like the MSI installer, notification titles,
-/// deep link registration, etc.
-///
-/// This should be identical to the `tauri.bundle.identifier` over in `tauri.conf.json`,
-/// but sometimes I need to use this before Tauri has booted up, or in a place where
-/// getting the Tauri app handle would be awkward.
-///
-/// Luckily this is also the AppUserModelId that Windows uses to label notifications,
-/// so if your dev system has Firezone installed by MSI, the notifications will look right.
-/// <https://learn.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app>
-pub const BUNDLE_ID: &str = "dev.firezone.client";
-
 /// Returns e.g. `C:/Users/User/AppData/Local/dev.firezone.client
 ///
 /// This is where we can save config, logs, crash dumps, etc.
@@ -27,7 +12,7 @@ pub const BUNDLE_ID: &str = "dev.firezone.client";
 pub fn app_local_data_dir() -> Result<PathBuf, Error> {
     let path = get_known_folder_path(KnownFolder::LocalAppData)
         .ok_or(Error::CantFindLocalAppDataFolder)?
-        .join(BUNDLE_ID);
+        .join(crate::BUNDLE_ID);
     Ok(path)
 }
 

--- a/rust/windows-client/src-tauri/src/client/deep_link.rs
+++ b/rust/windows-client/src-tauri/src/client/deep_link.rs
@@ -2,7 +2,7 @@
 //! Based on reading some of the Windows code from <https://github.com/FabianLars/tauri-plugin-deep-link>, which is licensed "MIT OR Apache-2.0"
 
 use crate::client::auth::Response as AuthResponse;
-use connlib_shared::{control::SecureUrl, windows::BUNDLE_ID};
+use connlib_shared::{control::SecureUrl, BUNDLE_ID};
 use secrecy::{ExposeSecret, Secret, SecretString};
 use std::{ffi::c_void, io, path::Path, str::FromStr};
 use tokio::{io::AsyncReadExt, io::AsyncWriteExt, net::windows::named_pipe};

--- a/rust/windows-client/src-tauri/src/client/gui.rs
+++ b/rust/windows-client/src-tauri/src/client/gui.rs
@@ -11,7 +11,7 @@ use crate::client::{
 use anyhow::{anyhow, bail, Context, Result};
 use arc_swap::ArcSwap;
 use connlib_client_shared::{file_logger, ResourceDescription};
-use connlib_shared::{control::SecureUrl, messages::ResourceId, windows::BUNDLE_ID};
+use connlib_shared::{control::SecureUrl, messages::ResourceId, BUNDLE_ID};
 use secrecy::{ExposeSecret, Secret, SecretString};
 use std::{net::IpAddr, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 use system_tray_menu::Event as TrayMenuEvent;


### PR DESCRIPTION
It is still client-specific, but this was the closest place I could find in connlib to put it.
A hypothetical GUI / .deb / systemd-involved gateway would need to be "dev.firezone.gateway"