### PR TITLE
fix(snownet): make TURN channel bindings more reliable

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1765,6 +1765,21 @@ mod tests {
     }
 
     #[test]
+    fn dont_send_channel_binding_if_inflight() {
+        let mut allocation =
+            Allocation::for_test(Instant::now()).with_allocate_response(&[RELAY_ADDR_IP4]);
+
+        allocation.bind_channel(PEER1, Instant::now());
+
+        let channel_bind = allocation.next_message().unwrap();
+        assert_eq!(channel_bind.method(), CHANNEL_BIND);
+
+        allocation.bind_channel(PEER1, Instant::now());
+
+        assert!(allocation.next_message().is_none());
+    }
+
+    #[test]
     fn failed_allocation_is_suspended() {
         let mut allocation = Allocation::for_test(Instant::now());
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -17,7 +17,6 @@ use stun_codec::{
     rfc5389::{
         attributes::{ErrorCode, MessageIntegrity, Nonce, Realm, Username, XorMappedAddress},
         errors::{StaleNonce, Unauthorized},
-        methods::BINDING,
     },
     rfc5766::{
         attributes::{

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1745,6 +1745,26 @@ mod tests {
     }
 
     #[test]
+    fn dont_buffer_channel_bindings_twice() {
+        let mut allocation = Allocation::for_test(Instant::now());
+
+        allocation.bind_channel(PEER1, Instant::now());
+        allocation.bind_channel(PEER1, Instant::now());
+
+        let allocate = allocation.next_message().unwrap();
+        allocation.handle_test_input(
+            &allocate_response(&allocate, &[RELAY_ADDR_IP4]),
+            Instant::now(),
+        );
+
+        let channel_bind = allocation.next_message().unwrap();
+        let next_msg = allocation.next_message();
+
+        assert_eq!(channel_bind.method(), CHANNEL_BIND);
+        assert!(next_msg.is_none());
+    }
+
+    #[test]
     fn failed_allocation_is_suspended() {
         let mut allocation = Allocation::for_test(Instant::now());
 


### PR DESCRIPTION
Previously, we would only bind channels for _established_ connections. This caused a problem if we'd get the other parties candidates before the offer response. Additionally, we'd often send multiple channel bindings for the same peer which caused additional warnings in the logs.