### PR TITLE
feat(snownet): optimise which channels we bind

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -159,6 +159,12 @@ where
             agent.add_remote_candidate(candidate.clone());
         }
 
+        if candidate.kind() == CandidateKind::Host {
+            // Binding a TURN channel for host candidates does not make sense.
+            // They are only useful to circumvent restrictive NATs in which case we are either talking to another relay candidate or a server-reflexive address.
+            return;
+        };
+
         let last_now = self.last_now;
 
         // First, optimisatically try to bind the channel only on the same relay as the remote peer.


### PR DESCRIPTION
Currently, we bind a lot of TURN channels on our relays because we bind a channel to each candidate on each relay. With every node having usually 4 relays, that results in 16 channels per connection just for the relay candidates.

We can bring this down optimistically by first checking if the remote's candidate is a relay candidate and happens to be on a relay that we are also using. In that case, we only bind the channel on that one.

That should also improve latency when data needs to be relayed because we reduce the number of hops by 1 and don't send traffic between two relays.

Additionally, there is no reason to bind channels for host candidates.