### PR TITLE
fix(snownet): don't log addresses twice

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -162,7 +162,7 @@ impl Allocation {
         self.authenticate_and_queue(make_refresh_request());
     }
 
-    #[tracing::instrument(level = "debug", skip(self, packet, now), fields(relay = %self.server, id, method, class, rtt))]
+    #[tracing::instrument(level = "debug", skip_all, fields(relay = %self.server, id, method, class, rtt))]
     pub fn handle_input(
         &mut self,
         from: SocketAddr,


### PR DESCRIPTION
The `from` address is already logged as part of the `decapsulate` span in the `Node`. The `local` address isn't that interesting thus noise most of the time.