### PR TITLE
fix(ci): Use default NDK on GH runners

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -7,6 +7,12 @@ permissions:
   contents: 'read'
   id-token: 'write'
 
+# https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+# Not having these causes flaky CI builds with "Missing NDK"
+env:
+  ANDROID_NDK: /usr/local/lib/android/sdk/ndk/26.1.10909125
+  ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/26.1.10909125
+
 jobs:
   static-analysis:
     # Android SDK tools hardware accel is available only on Linux runners

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -7,12 +7,6 @@ permissions:
   contents: 'read'
   id-token: 'write'
 
-# https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
-# Not having these causes flaky CI builds with "Missing NDK"
-env:
-  ANDROID_NDK: /usr/local/lib/android/sdk/ndk/26.1.10909125
-  ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/26.1.10909125
-
 jobs:
   static-analysis:
     # Android SDK tools hardware accel is available only on Linux runners

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -44,7 +44,10 @@ android {
 
     namespace = "dev.firezone.android"
     compileSdk = 34
-    ndkVersion = "26.1.10909125"
+
+    // Life is easier if we just match the default NDK on the Ubuntu 22.04 runners
+    // https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#android
+    ndkVersion = "25.2.9519653"
 
     defaultConfig {
         applicationId = "dev.firezone.android"


### PR DESCRIPTION
This should fix the flaky kotlin builds if the NDK is actually installed.