### PR TITLE
fix(connlib): set the real packet length before putting it into the device

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -331,15 +331,17 @@ where
             return Poll::Pending;
         };
 
-        let packet = match peer.untransform(packet.source(), self.write_buf.as_mut()) {
-            Ok(packet) => packet,
-            Err(e) => {
-                tracing::warn!(%conn_id, %local, %from, "Failed to transform packet: {e}");
+        let packet_len = packet.packet().len();
+        let packet =
+            match peer.untransform(packet.source(), &mut self.write_buf.as_mut()[..packet_len]) {
+                Ok(packet) => packet,
+                Err(e) => {
+                    tracing::warn!(%conn_id, %local, %from, "Failed to transform packet: {e}");
 
-                cx.waker().wake_by_ref();
-                return Poll::Pending;
-            }
-        };
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+            };
 
         Poll::Ready(packet)
     }


### PR DESCRIPTION
This was fixed at some point in the feature branch but was lost to time.

This is preventing macos from working(and might be causing some issues in other platforms)