### PR TITLE
fix(gateway): expire resources

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -8,6 +8,9 @@ use ip_network_table::IpNetworkTable;
 use itertools::Itertools;
 use snownet::Server;
 use std::sync::Arc;
+use std::task::{ready, Context, Poll};
+use std::time::Duration;
+use tokio::time::{interval, Interval, MissedTickBehavior};
 
 const PEERS_IPV4: &str = "100.64.0.0/11";
 const PEERS_IPV6: &str = "fd00:2021:1111::/107";
@@ -45,6 +48,7 @@ where
 pub struct GatewayState {
     #[allow(clippy::type_complexity)]
     pub peers_by_ip: IpNetworkTable<Arc<Peer<ClientId, PacketTransformGateway>>>,
+    expire_interval: Interval,
 }
 
 impl GatewayState {
@@ -60,7 +64,12 @@ impl GatewayState {
         Some((peer.conn_id, packet))
     }
 
-    pub fn expire_resources(&mut self) -> impl Iterator<Item = ClientId> + '_ {
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<impl Iterator<Item = ClientId> + '_> {
+        ready!(self.expire_interval.poll_tick(cx));
+        Poll::Ready(self.expire_resources())
+    }
+
+    fn expire_resources(&self) -> impl Iterator<Item = ClientId> + '_ {
         self.peers_by_ip
             .iter()
             .unique_by(|(_, p)| p.conn_id)
@@ -77,8 +86,11 @@ impl GatewayState {
 
 impl Default for GatewayState {
     fn default() -> Self {
+        let mut expire_interval = interval(Duration::from_secs(1));
+        expire_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Self {
             peers_by_ip: IpNetworkTable::new(),
+            expire_interval,
         }
     }
 }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -64,9 +64,9 @@ impl GatewayState {
         Some((peer.conn_id, packet))
     }
 
-    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<impl Iterator<Item = ClientId> + '_> {
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Vec<ClientId>> {
         ready!(self.expire_interval.poll_tick(cx));
-        Poll::Ready(self.expire_resources())
+        Poll::Ready(self.expire_resources().collect_vec())
     }
 
     fn expire_resources(&self) -> impl Iterator<Item = ClientId> + '_ {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -134,6 +134,16 @@ where
     CB: Callbacks + 'static,
 {
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Result<Event<ClientId>>> {
+        match self.role_state.poll(cx) {
+            Poll::Ready(ids) => {
+                for id in ids {
+                    self.connections_state.peers_by_id.remove(&id);
+                }
+                cx.waker().wake_by_ref();
+            }
+            Poll::Pending => {}
+        }
+
         let Some(device) = self.device.as_mut() else {
             self.no_device_waker.register(cx.waker());
             return Poll::Pending;

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -136,10 +136,10 @@ where
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Result<Event<ClientId>>> {
         match self.role_state.poll(cx) {
             Poll::Ready(ids) => {
-                for id in ids {
-                    self.connections_state.peers_by_id.remove(&id);
-                }
                 cx.waker().wake_by_ref();
+                for id in ids {
+                    self.cleanup_connection(id);
+                }
             }
             Poll::Pending => {}
         }


### PR DESCRIPTION
I forgot to actually call the expire resources function after the refactor 🤦 

This will be much cleaned up in a PR that I'm working on to eliminate the `peers_by_id`/`peers_by_ip` maps. 

In the mean time let's merge this asap since the gateway not expiring resources is a security hole.

