### PR TITLE
feat(relay): increase number of allowed requests per nonce

### DIFF
--- a/rust/relay/src/auth.rs
+++ b/rust/relay/src/auth.rs
@@ -65,7 +65,7 @@ pub struct Nonces {
 
 impl Nonces {
     /// How many requests a client can perform with the same nonce.
-    const NUM_REQUESTS: u64 = 10;
+    const NUM_REQUESTS: u64 = 100;
 
     pub fn add_new(&mut self, nonce: Uuid) {
         self.inner.insert(nonce, Self::NUM_REQUESTS);


### PR DESCRIPTION
In the relay's authentication scheme, each nonce is only valid for a certain number of requests. This guards against replay attacks.

Currently, this is set to 10 which means all requests after 10 will receive a "stale nonce" error. 10 turns out to be way to low and greatly delays the setup of channels and allocations which is always a burst of messages that end up incurring additional round trips because they all need to be re-sent with a new nonce.