### PR TITLE
fix(apple): Encapsulate Apple DNS dance to getSystemDefaultResolvers()

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -537,12 +537,12 @@ extension Adapter: CallbackHandlerDelegate {
     var resolvers: [String] = Resolv().getservers().map(Resolv.getnameinfo)
 
     // When the tunnel is up, we can only get the system's default resolvers
-    // by reading /etc/resolv.conf and matchDomains is set to a non-empty string.
+    // by reading /etc/resolv.conf when matchDomains is set to a non-empty string.
     // If matchDomains is an empty string, /etc/resolv.conf will contain connlib's
     // sentinel, which isn't helpful to us.
     // If networkSettings isn't initialized, this means we're setting up the tunnel,
-    // so we haven't overridden the system's default DNS resolver yet, and so we
-    // don't need to do this dance.
+    // so we haven't set matchDomains at all yet, and so we
+    // don't need to do this dance and can just read what's in /etc/resolv.conf.
     if let networkSettings = self.networkSettings {
       // async / await can't be used here because this is an FFI callback
       let semaphore = DispatchSemaphore(value: 0)

--- a/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
+++ b/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
@@ -27,11 +27,11 @@ public protocol CallbackHandlerDelegate: AnyObject {
   func onRemoveRoute(_: String)
   func onUpdateResources(resourceList: String)
   func onDisconnect(error: String?)
+  func getSystemDefaultResolvers() -> RustString
 }
 
 public class CallbackHandler {
   public weak var delegate: CallbackHandlerDelegate?
-  private var systemDefaultResolvers: [String] = []
   private let logger: AppLogger
 
   init(logger: AppLogger) {
@@ -95,20 +95,7 @@ public class CallbackHandler {
     delegate?.onDisconnect(error: optionalError)
   }
 
-  func setSystemDefaultResolvers(resolvers: [String]) {
-    logger.log(
-      "CallbackHandler.setSystemDefaultResolvers: \(resolvers)")
-    self.systemDefaultResolvers = resolvers
-  }
-
   func getSystemDefaultResolvers() -> RustString {
-    logger.log(
-      "CallbackHandler.getSystemDefaultResolvers: \(self.systemDefaultResolvers)"
-    )
-
-    return try! String(
-      decoding: JSONEncoder().encode(self.systemDefaultResolvers),
-      as: UTF8.self
-    ).intoRustString()
+    return delegate!.getSystemDefaultResolvers()
   }
 }


### PR DESCRIPTION
Before, we would cache the DNS resolvers from the system whenever the tunnel would disconnect temporarily, and then re-read them when it reconnected.

This breaks things when network switching. For example: if we go from the `Internet -> No Internet -> Internet` state because during `No Internet`, there are no system DNS resolvers.

Instead, the logic is simplified to one place: `getSystemDefaultResolvers()`

If the tunnel is already up (networkSettings is initialized), we temporarily change `matchedDomains` so that the OS writes the actual system resolvers to `/etc/resolv.conf` which we then read, save, and change back.