### PR TITLE
fix(ci): Sleep a bit before checking path

### DIFF
--- a/elixir/apps/web/test/support/acceptance_case.ex
+++ b/elixir/apps/web/test/support/acceptance_case.ex
@@ -198,6 +198,8 @@ defmodule Web.AcceptanceCase do
   end
 
   def assert_path(session, path) do
+    # Occasionally the path is not updated immediately after the page body
+    Process.sleep(10)
     assert current_path(session) == path
     session
   end


### PR DESCRIPTION
It's possible for the page body to be updated slightly before the path, so sleep a few ms to fix the race condition.

https://github.com/firezone/firezone/actions/runs/7997620660/job/21842436816?pr=3728#step:21:1399