### PR TITLE
refactor(portal): Remove assertions in sign-in success acceptance tests

### DIFF
--- a/elixir/apps/web/test/web/acceptance/auth/email_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/email_test.exs
@@ -57,8 +57,6 @@ defmodule Web.Acceptance.SignIn.EmailTest do
 
     session
     |> email_login_flow(account, identity.provider_identifier, redirect_params)
-    |> assert_el(Query.text("Sign in successful"))
-    |> assert_path(~p"/#{account}/sign_in/success")
     |> assert_el(Query.text("Client redirected"))
     |> assert_path(~p"/handle_client_sign_in_callback")
 
@@ -112,8 +110,6 @@ defmodule Web.Acceptance.SignIn.EmailTest do
     # And then to a client
     session
     |> email_login_flow(account, identity.provider_identifier, redirect_params)
-    |> assert_el(Query.text("Sign in successful"))
-    |> assert_path(~p"/#{account}/sign_in/success")
     |> assert_el(Query.text("Client redirected"))
     |> assert_path(~p"/handle_client_sign_in_callback")
 


### PR DESCRIPTION
Why:

* The extra assertions added to the sign-in success acceptance tests do not behave as reliably as needed.  The assertions being removed were checking an intermediate step of the sign-in success redirect process, so the test should not be fundamentally changed by removing them.  We'll just be checking the final state rather than the intermediate state and the final state.