### PR TITLE
Remove assertions in sign-in success acceptance tests

### DIFF
--- a/elixir/apps/web/test/web/acceptance/auth/openid_connect_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/openid_connect_test.exs
@@ -187,8 +187,6 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
     |> visit(~p"/#{account}?#{redirect_params}")
     |> assert_el(Query.text("Sign in to #{account.name}"))
     |> click(Query.link("Sign in with Vault"))
-    |> assert_el(Query.text("Sign in successful"))
-    |> assert_path(~p"/#{account}/sign_in/success")
     |> assert_el(Query.text("Client redirected"))
     |> assert_path(~p"/handle_client_sign_in_callback")
 
@@ -242,8 +240,6 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
     |> assert_el(Query.text("Sign in to #{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
-    |> assert_el(Query.text("Sign in successful"))
-    |> assert_path(~p"/#{account}/sign_in/success")
     |> assert_el(Query.text("Client redirected"))
     |> assert_path(~p"/handle_client_sign_in_callback")
 

--- a/elixir/apps/web/test/web/acceptance/auth/userpass_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/userpass_test.exs
@@ -167,8 +167,6 @@ defmodule Web.Acceptance.Auth.UserPassTest do
 
     session
     |> password_login_flow(account, identity.provider_identifier, password, redirect_params)
-    |> assert_el(Query.text("Sign in successful"))
-    |> assert_path(~p"/#{account}/sign_in/success")
     |> assert_el(Query.text("Client redirected"))
     |> assert_path(~p"/handle_client_sign_in_callback")
 
@@ -232,8 +230,6 @@ defmodule Web.Acceptance.Auth.UserPassTest do
     # And then to a client
     session
     |> password_login_flow(account, identity.provider_identifier, password, redirect_params)
-    |> assert_el(Query.text("Sign in successful"))
-    |> assert_path(~p"/#{account}/sign_in/success")
     |> assert_el(Query.text("Client redirected"))
     |> assert_path(~p"/handle_client_sign_in_callback")
 


### PR DESCRIPTION
Why:

* The extra assertions added to the sign-in success acceptance tests do not behave as reliably as needed. The assertions being removed were checking an intermediate step of the sign-in success redirect process, so the test should not be fundamentally changed by removing them. We'll just be checking the final state rather than the intermediate state and the final state.  The previous commit removing these assertions was only done on the email signin tests.  This commit updates the userpass and openid_connect tests