### PR TITLE
chore: make rtnetlink versions explicit

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3663,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9ccdfabb457e05c7c61e66eb39262a204fbb376c53968b5e52dce15b423fc5"
+checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5014,9 +5014,9 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5bbb61e037711ff30a3657ec537285b2e1ecb5427e4365d275164f0928c884"
+checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
 dependencies = [
  "futures",
  "log",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,7 +31,7 @@ futures-bounded = "0.2.1"
 domain = { version = "0.9", features = ["serde"] }
 dns-lookup = "2.0"
 tokio-tungstenite = "0.21"
-rtnetlink = { version = "0.14", default-features = false, features = ["tokio_socket"] }
+rtnetlink = { version = "=0.14.0", default-features = false, features = ["tokio_socket"] }
 
 connlib-client-android = { path = "connlib/clients/android"}
 connlib-client-apple = { path = "connlib/clients/apple"}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,7 +31,7 @@ futures-bounded = "0.2.1"
 domain = { version = "0.9", features = ["serde"] }
 dns-lookup = "2.0"
 tokio-tungstenite = "0.21"
-rtnetlink = { version = "=0.14.0", default-features = false, features = ["tokio_socket"] }
+rtnetlink = { version = "0.14.1", default-features = false, features = ["tokio_socket"] }
 
 connlib-client-android = { path = "connlib/clients/android"}
 connlib-client-apple = { path = "connlib/clients/apple"}

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -45,7 +45,7 @@ tempfile = "3.10.0"
 
 # Linux tunnel dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
-netlink-packet-route = { version = "=0.18.1", default-features = false }
+netlink-packet-route = { version = "0.19", default-features = false }
 netlink-packet-core = { version = "0.7", default-features = false }
 rtnetlink = { workspace = true }
 sd-notify = "0.4.1"

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -45,7 +45,7 @@ tempfile = "3.10.0"
 
 # Linux tunnel dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
-netlink-packet-route = { version = "0.18", default-features = false }
+netlink-packet-route = { version = "=0.18.1", default-features = false }
 netlink-packet-core = { version = "0.7", default-features = false }
 rtnetlink = { workspace = true }
 sd-notify = "0.4.1"


### PR DESCRIPTION
If I do `rm Cargo.lock && cargo check --all` then I get errors about rtnetlink.

![image](https://github.com/firezone/firezone/assets/13400041/c1eeff84-d65c-403d-9b33-24e00168ba36)

Dependabot tried to update these a couple weeks ago in #3558 and it had some conflicts, so I'm just making the old versions explicit so that redoing the lockfile won't break anything.

This is because I got into a weird state with the new `dirs` dependency for Linux where I removed it from Cargo.toml, but it was still in the lockfile or something, so the program built even though it should not have. And then when I tried to rebuild Cargo.lock I got these errors about rtnetlink.