### PR TITLE
refactor(connlib): unify peer storage

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1922,7 +1922,6 @@ name = "firezone-tunnel"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "arc-swap",
  "async-trait",
  "bimap",
  "boringtun",
@@ -1942,7 +1941,6 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "parking_lot",
  "pnet_packet",
  "quinn-udp",
  "rand_core 0.6.4",

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -311,10 +311,6 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
         Ok(())
     }
 
-    pub async fn stats_event(&mut self) {
-        tracing::debug!(target: "tunnel_state", stats = ?self.tunnel.stats());
-    }
-
     pub async fn request_log_upload_url(&mut self) {
         tracing::info!("Requesting log upload URL from portal");
 

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -185,7 +185,6 @@ where
                 let runtime_stopper = runtime_stopper.clone();
                 let callbacks = callbacks.clone();
                 async move {
-                let mut log_stats_interval = tokio::time::interval(Duration::from_secs(10));
                 let mut upload_logs_interval = upload_interval();
                 loop {
                     tokio::select! {
@@ -201,7 +200,6 @@ where
                             }
                         },
                         event = poll_fn(|cx| control_plane.tunnel.poll_next_event(cx)) => control_plane.handle_tunnel_event(event).await,
-                        _ = log_stats_interval.tick() => control_plane.stats_event().await,
                         _ = upload_logs_interval.tick() => control_plane.request_log_upload_url().await,
                         else => break
                     }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -14,7 +14,6 @@ serde = { version = "1.0", default-features = false, features = ["derive", "std"
 futures =  { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
 futures-util =  { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }
 tracing = { workspace = true }
-parking_lot = { version = "0.12", default-features = false }
 bytes = { version = "1.4", default-features = false, features = ["std"] }
 itertools = { version = "0.12", default-features = false, features = ["use_std"] }
 connlib-shared = { workspace = true }
@@ -27,7 +26,6 @@ chrono = { workspace = true }
 pnet_packet = { version = "0.34" }
 futures-bounded = { workspace = true }
 hickory-resolver = { workspace = true, features = ["tokio-runtime"] }
-arc-swap = "1.6.0"
 bimap = "0.6"
 resolv-conf = "0.7.0"
 socket2 = { version = "0.5" }

--- a/rust/connlib/tunnel/src/control_protocol.rs
+++ b/rust/connlib/tunnel/src/control_protocol.rs
@@ -1,13 +1,11 @@
-use ip_network::IpNetwork;
-use ip_network_table::IpNetworkTable;
-use std::{collections::HashSet, fmt, hash::Hash, net::SocketAddr, sync::Arc};
+use std::{collections::HashSet, fmt, hash::Hash, net::SocketAddr};
 
 use connlib_shared::{
     messages::{Relay, RequestConnection, ReuseConnection},
     Callbacks,
 };
 
-use crate::{peer::Peer, Tunnel, REALM};
+use crate::{Tunnel, REALM};
 
 mod client;
 pub mod gateway;
@@ -18,7 +16,7 @@ pub enum Request {
     ReuseConnection(ReuseConnection),
 }
 
-impl<CB, TRoleState, TRole, TId, TTransform> Tunnel<CB, TRoleState, TRole, TId, TTransform>
+impl<CB, TRoleState, TRole, TId> Tunnel<CB, TRoleState, TRole, TId>
 where
     CB: Callbacks + 'static,
     TId: Eq + Hash + Copy + fmt::Display,
@@ -27,16 +25,6 @@ where
         self.connections_state
             .node
             .add_remote_candidate(conn_id, ice_candidate);
-    }
-}
-
-fn insert_peers<TId: Copy, TTransform>(
-    peers_by_ip: &mut IpNetworkTable<Arc<Peer<TId, TTransform>>>,
-    ips: &Vec<IpNetwork>,
-    peer: Arc<Peer<TId, TTransform>>,
-) {
-    for ip in ips {
-        peers_by_ip.insert(*ip, peer.clone());
     }
 }
 

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, net::IpAddr, sync::Arc};
+use std::{collections::HashSet, net::IpAddr};
 
 use boringtun::x25519::PublicKey;
 use connlib_shared::{
@@ -23,9 +23,7 @@ use crate::{
 };
 use crate::{peer::Peer, ClientState, Error, Request, Result, Tunnel};
 
-use super::insert_peers;
-
-impl<CB> Tunnel<CB, ClientState, Client, GatewayId, PacketTransformClient>
+impl<CB> Tunnel<CB, ClientState, Client, GatewayId>
 where
     CB: Callbacks + 'static,
 {
@@ -108,24 +106,18 @@ where
             &domain_response.as_ref().map(|d| d.domain.clone()),
         )?;
 
-        let peer = Arc::new(Peer::new(ips.clone(), gateway_id, Default::default()));
+        let mut peer: Peer<_, PacketTransformClient> =
+            Peer::new(ips.clone(), gateway_id, Default::default());
+        peer.transform.set_dns(self.role_state.dns_mapping());
+        self.role_state.peers.insert(peer);
 
         let peer_ips = if let Some(domain_response) = domain_response {
-            self.dns_response(&resource_id, &domain_response, &peer)?
+            self.dns_response(&resource_id, &domain_response, &gateway_id)?
         } else {
             ips
         };
 
-        peer.transform.set_dns(self.role_state.dns_mapping());
-
-        // cleaning up old state
-        self.role_state
-            .peers_by_ip
-            .retain(|_, p| p.conn_id != gateway_id);
-        self.connections_state
-            .peers_by_id
-            .insert(gateway_id, Arc::clone(&peer));
-        insert_peers(&mut self.role_state.peers_by_ip, &peer_ips, peer);
+        self.role_state.peers.add_ips(&gateway_id, &peer_ips);
 
         Ok(())
     }
@@ -168,8 +160,14 @@ where
         &mut self,
         resource_id: &ResourceId,
         domain_response: &DomainResponse,
-        peer: &Peer<GatewayId, PacketTransformClient>,
+        peer_id: &GatewayId,
     ) -> Result<Vec<IpNetwork>> {
+        let peer = self
+            .role_state
+            .peers
+            .get_mut(peer_id)
+            .ok_or(Error::ControlProtocolError)?;
+
         let resource_description = self
             .role_state
             .resource_ids
@@ -199,9 +197,6 @@ where
             .insert(resource_description.clone(), addrs.clone());
 
         let ips: Vec<IpNetwork> = addrs.iter().copied().map(Into::into).collect();
-        for ip in &ips {
-            peer.add_allowed_ip(*ip);
-        }
 
         if let Some(device) = self.device.as_ref() {
             send_dns_answer(
@@ -235,17 +230,10 @@ where
             .gateway_by_resource(&resource_id)
             .ok_or(Error::UnknownResource)?;
 
-        let Some(peer) = self
-            .role_state
-            .peers_by_ip
-            .iter_mut()
-            .find_map(|(_, p)| (p.conn_id == gateway_id).then_some(p.clone()))
-        else {
-            return Err(Error::ControlProtocolError);
-        };
+        let peer_ips = self.dns_response(&resource_id, &domain_response, &gateway_id)?;
 
-        let peer_ips = self.dns_response(&resource_id, &domain_response, &peer)?;
-        insert_peers(&mut self.role_state.peers_by_ip, &peer_ips, peer);
+        self.role_state.peers.add_ips(&gateway_id, &peer_ips);
+
         Ok(())
     }
 }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -1,21 +1,20 @@
-use crate::device_channel::Device;
-use crate::ip_packet::MutableIpPacket;
-use crate::peer::{PacketTransformGateway, Peer};
-use crate::{peer_by_ip, Tunnel};
-use connlib_shared::messages::{ClientId, Interface as InterfaceConfig};
-use connlib_shared::Callbacks;
-use ip_network_table::IpNetworkTable;
-use itertools::Itertools;
-use snownet::Server;
-use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 use std::time::Duration;
+
+use crate::device_channel::Device;
+use crate::ip_packet::MutableIpPacket;
+use crate::peer::PacketTransformGateway;
+use crate::peer_store::PeerStore;
+use crate::Tunnel;
+use connlib_shared::messages::{ClientId, Interface as InterfaceConfig};
+use connlib_shared::Callbacks;
+use snownet::Server;
 use tokio::time::{interval, Interval, MissedTickBehavior};
 
 const PEERS_IPV4: &str = "100.64.0.0/11";
 const PEERS_IPV6: &str = "fd00:2021:1111::/107";
 
-impl<CB> Tunnel<CB, GatewayState, Server, ClientId, PacketTransformGateway>
+impl<CB> Tunnel<CB, GatewayState, Server, ClientId>
 where
     CB: Callbacks + 'static,
 {
@@ -38,16 +37,14 @@ where
     }
 
     /// Clean up a connection to a resource.
-    pub fn cleanup_connection(&mut self, id: ClientId) {
-        self.connections_state.peers_by_id.remove(&id);
-        self.role_state.peers_by_ip.retain(|_, p| p.conn_id != id);
+    pub fn cleanup_connection(&mut self, id: &ClientId) {
+        self.role_state.peers.remove(id);
     }
 }
 
 /// [`Tunnel`] state specific to gateways.
 pub struct GatewayState {
-    #[allow(clippy::type_complexity)]
-    pub peers_by_ip: IpNetworkTable<Arc<Peer<ClientId, PacketTransformGateway>>>,
+    pub peers: PeerStore<ClientId, PacketTransformGateway>,
     expire_interval: Interval,
 }
 
@@ -58,29 +55,23 @@ impl GatewayState {
     ) -> Option<(ClientId, MutableIpPacket<'a>)> {
         let dest = packet.destination();
 
-        let peer = peer_by_ip(&self.peers_by_ip, dest)?;
+        let peer = self.peers.peer_by_ip_mut(dest)?;
         let packet = peer.transform(packet)?;
 
         Some((peer.conn_id, packet))
     }
 
-    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Vec<ClientId>> {
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         ready!(self.expire_interval.poll_tick(cx));
-        Poll::Ready(self.expire_resources().collect_vec())
+        self.expire_resources();
+        Poll::Ready(())
     }
 
-    fn expire_resources(&self) -> impl Iterator<Item = ClientId> + '_ {
-        self.peers_by_ip
-            .iter()
-            .unique_by(|(_, p)| p.conn_id)
-            .for_each(|(_, p)| p.transform.expire_resources());
-        self.peers_by_ip.iter().filter_map(|(_, p)| {
-            if p.transform.is_emptied() {
-                Some(p.conn_id)
-            } else {
-                None
-            }
-        })
+    fn expire_resources(&mut self) {
+        self.peers
+            .iter_mut()
+            .for_each(|p| p.transform.expire_resources());
+        self.peers.retain(|_, p| !p.transform.is_emptied());
     }
 }
 
@@ -89,7 +80,7 @@ impl Default for GatewayState {
         let mut expire_interval = interval(Duration::from_secs(1));
         expire_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Self {
-            peers_by_ip: IpNetworkTable::new(),
+            peers: Default::default(),
             expire_interval,
         }
     }

--- a/rust/connlib/tunnel/src/peer_store.rs
+++ b/rust/connlib/tunnel/src/peer_store.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::net::IpAddr;
+
+use crate::peer::{PacketTransform, Peer};
+use ip_network::IpNetwork;
+use ip_network_table::IpNetworkTable;
+
+pub struct PeerStore<TId, TTransform> {
+    id_by_ip: IpNetworkTable<TId>,
+    peer_by_id: HashMap<TId, Peer<TId, TTransform>>,
+}
+
+impl<T, U> Default for PeerStore<T, U> {
+    fn default() -> Self {
+        Self {
+            id_by_ip: IpNetworkTable::new(),
+            peer_by_id: HashMap::new(),
+        }
+    }
+}
+
+impl<TId, TTransform> PeerStore<TId, TTransform>
+where
+    TId: Hash + Eq + Clone + Copy,
+    TTransform: PacketTransform,
+{
+    pub fn retain(&mut self, f: impl Fn(&TId, &mut Peer<TId, TTransform>) -> bool) {
+        self.peer_by_id.retain(f);
+        self.id_by_ip
+            .retain(|_, id| self.peer_by_id.contains_key(id));
+    }
+
+    pub fn add_ips(&mut self, id: &TId, ips: &[IpNetwork]) -> Option<&Peer<TId, TTransform>> {
+        let peer = self.peer_by_id.get_mut(id)?;
+
+        for ip in ips {
+            self.id_by_ip.insert(*ip, peer.conn_id);
+            peer.add_allowed_ip(*ip);
+        }
+
+        Some(peer)
+    }
+
+    pub fn insert(&mut self, peer: Peer<TId, TTransform>) -> Option<Peer<TId, TTransform>> {
+        self.id_by_ip.retain(|_, &mut r_id| r_id != peer.conn_id);
+
+        self.peer_by_id.insert(peer.conn_id, peer)
+    }
+
+    pub fn remove(&mut self, id: &TId) -> Option<Peer<TId, TTransform>> {
+        self.id_by_ip.retain(|_, r_id| r_id != id);
+        self.peer_by_id.remove(id)
+    }
+
+    pub fn exact_match(&self, ip: IpNetwork) -> Option<&Peer<TId, TTransform>> {
+        let ip = self.id_by_ip.exact_match(ip)?;
+        self.peer_by_id.get(ip)
+    }
+
+    pub fn get(&self, id: &TId) -> Option<&Peer<TId, TTransform>> {
+        self.peer_by_id.get(id)
+    }
+
+    pub fn get_mut(&mut self, id: &TId) -> Option<&mut Peer<TId, TTransform>> {
+        self.peer_by_id.get_mut(id)
+    }
+
+    pub fn peer_by_ip(&self, ip: IpAddr) -> Option<&Peer<TId, TTransform>> {
+        let (_, id) = self.id_by_ip.longest_match(ip)?;
+        self.peer_by_id.get(id)
+    }
+
+    pub fn peer_by_ip_mut(&mut self, ip: IpAddr) -> Option<&mut Peer<TId, TTransform>> {
+        let (_, id) = self.id_by_ip.longest_match(ip)?;
+        self.peer_by_id.get_mut(id)
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Peer<TId, TTransform>> {
+        self.peer_by_id.values_mut()
+    }
+
+    pub fn iter(&mut self) -> impl Iterator<Item = &Peer<TId, TTransform>> {
+        self.peer_by_id.values()
+    }
+}

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -29,7 +29,6 @@ pub struct Eventloop {
         Result<ResourceDescription<ResolvedResourceDescriptionDns>>,
         Either<RequestConnection, AllowAccess>,
     >,
-    print_stats_timer: tokio::time::Interval,
 }
 
 impl Eventloop {
@@ -41,7 +40,6 @@ impl Eventloop {
             tunnel,
             portal,
             resolve_tasks: futures_bounded::FuturesTupleSet::new(Duration::from_secs(60), 100),
-            print_stats_timer: tokio::time::interval(Duration::from_secs(10)),
         }
     }
 }
@@ -104,7 +102,7 @@ impl Eventloop {
                         Err(e) => {
                             let client = req.client.id;
 
-                            self.tunnel.cleanup_connection(client);
+                            self.tunnel.cleanup_connection(&client);
                             tracing::debug!(%client, "Connection request failed: {:#}", anyhow::Error::new(e));
 
                             continue;
@@ -214,11 +212,6 @@ impl Eventloop {
                     return Poll::Ready(Err(anyhow!("Disconnected by portal: {reason}")));
                 }
                 _ => {}
-            }
-
-            if self.print_stats_timer.poll_tick(cx).is_ready() {
-                tracing::debug!(target: "tunnel_state", stats = ?self.tunnel.stats());
-                continue;
             }
 
             return Poll::Pending;


### PR DESCRIPTION
Now that we have `&mut` access everywhere in the tunnel, the remaining shared-memory and locks are in how we store peers. To resolve this, we introduce a new `PeerStore` that allows us to look up peers by IP and by ID.