### PR TITLE
feat(portal): Add sign up override in portal

### DIFF
--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -557,7 +557,14 @@ defmodule Domain.Config.Definitions do
   String of comma separated email domains allowed to signup regardless of signup enabled state.
   If signups are enabled, this list is ignored.
   """
-  defconfig(:sign_up_allow_list, :string, default: "")
+  defconfig(:sign_up_allowed_domains, :string,
+    changeset: fn changeset, key ->
+      changeset
+      |> Domain.Validator.validate_does_not_contain(key, " ", message: "cannot contain spaces")
+      |> Domain.Validator.validate_does_not_contain(key, ",,")
+    end,
+    default: ""
+  )
 
   ##############################################
   ## Feature Flags

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -550,6 +550,16 @@ defmodule Domain.Config.Definitions do
   defconfig(:api_url_override, :string, default: nil)
 
   ##############################################
+  ## Sign Up
+  ##############################################
+
+  @doc """
+  String of comma separated email domains allowed to signup regardless of signup enabled state.
+  If signups are enabled, this list is ignored.
+  """
+  defconfig(:sign_up_allow_list, :string, default: "")
+
+  ##############################################
   ## Feature Flags
   ##
   ## If feature is disabled globally it won't be available for any account,

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -550,23 +550,6 @@ defmodule Domain.Config.Definitions do
   defconfig(:api_url_override, :string, default: nil)
 
   ##############################################
-  ## Sign Up
-  ##############################################
-
-  @doc """
-  String of comma separated email domains allowed to signup regardless of signup enabled state.
-  If signups are enabled, this list is ignored.
-  """
-  defconfig(:sign_up_always_allowed_domains, {:array, ",", :string},
-    changeset: fn changeset, key ->
-      changeset
-      |> Ecto.Changeset.validate_required(key)
-      |> Domain.Validator.validate_fqdn(key)
-    end,
-    default: []
-  )
-
-  ##############################################
   ## Feature Flags
   ##
   ## If feature is disabled globally it won't be available for any account,
@@ -578,6 +561,18 @@ defmodule Domain.Config.Definitions do
   Boolean flag to turn Sign-ups on/off for all accounts.
   """
   defconfig(:feature_sign_up_enabled, :boolean, default: true)
+
+  @doc """
+  List of email domains allowed to signup from. Leave empty to allow signing up from any domain.
+  """
+  defconfig(:sign_up_whitelisted_domains, {:array, ",", :string},
+    default: [],
+    changeset: fn changeset, key ->
+      changeset
+      |> Ecto.Changeset.validate_required(key)
+      |> Domain.Repo.Changeset.validate_fqdn(key)
+    end
+  )
 
   @doc """
   Boolean flag to turn IdP sync on/off for all accounts.

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -557,13 +557,13 @@ defmodule Domain.Config.Definitions do
   String of comma separated email domains allowed to signup regardless of signup enabled state.
   If signups are enabled, this list is ignored.
   """
-  defconfig(:sign_up_allowed_domains, :string,
+  defconfig(:sign_up_always_allowed_domains, {:array, ",", :string},
     changeset: fn changeset, key ->
       changeset
-      |> Domain.Validator.validate_does_not_contain(key, " ", message: "cannot contain spaces")
-      |> Domain.Validator.validate_does_not_contain(key, ",,")
+      |> Ecto.Changeset.validate_required(key)
+      |> Domain.Validator.validate_fqdn(key)
     end,
-    default: ""
+    default: []
   )
 
   ##############################################

--- a/elixir/apps/domain/test/support/fixtures/auth.ex
+++ b/elixir/apps/domain/test/support/fixtures/auth.ex
@@ -5,7 +5,7 @@ defmodule Domain.Fixtures.Auth do
   def user_password, do: "Hello w0rld!"
   def remote_ip, do: {100, 64, 100, 58}
   def user_agent, do: "iOS/12.5 (iPhone) connlib/0.7.412"
-  def email, do: "user-#{unique_integer()}@example.com"
+  def email(domain \\ "example.com"), do: "user-#{unique_integer()}@#{domain}"
 
   def random_provider_identifier(%Domain.Auth.Provider{adapter: :email, name: name}) do
     "user-#{unique_integer()}@#{String.downcase(name)}.com"

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -34,18 +34,13 @@ defmodule Web.SignUp do
       )
     end
 
-    defp validate_email_allowed(changeset, sign_up_enabled, allowed_domains) do
+    defp validate_email_allowed(changeset, true, _allowed_domains), do: changeset
+
+    defp validate_email_allowed(changeset, _sign_up_enabled, allowed_domains) do
       Ecto.Changeset.validate_change(changeset, :email, fn :email, email ->
-        cond do
-          sign_up_enabled ->
-            []
-
-          email_allowed?(email, allowed_domains) ->
-            []
-
-          true ->
-            [email: "email domain is not allowed at this time"]
-        end
+        if email_allowed?(email, allowed_domains),
+          do: [],
+          else: [email: "email domain is not allowed at this time"]
       end)
     end
 
@@ -73,10 +68,8 @@ defmodule Web.SignUp do
       )
 
     allowed_domains =
-      Domain.Config.get_env(:domain, :sign_up_allow_list)
-      |> String.split(",")
-      |> Enum.map(&String.trim/1)
-      |> Enum.reject(&(&1 == ""))
+      Domain.Config.get_env(:domain, :sign_up_allowed_domains)
+      |> String.split(",", trim: true)
 
     socket =
       assign(socket,

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -50,7 +50,7 @@ defmodule Web.SignUp do
     end
 
     defp email_allowed?(email, allowed_domains) do
-      with [_, domain] <- String.split(email, "@", part: 2) do
+      with [_, domain] <- String.split(email, "@", parts: 2) do
         Enum.member?(allowed_domains, domain)
       else
         _ -> false

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -56,6 +56,8 @@ defmodule Web.SignUp do
   def mount(_params, _session, socket) do
     user_agent = Phoenix.LiveView.get_connect_info(socket, :user_agent)
     real_ip = Web.Auth.real_ip(socket)
+    sign_up_enabled = Config.sign_up_enabled?()
+    allowed_domains = Domain.Config.get_env(:domain, :sign_up_always_allowed_domains)
 
     changeset =
       Registration.changeset(
@@ -63,13 +65,9 @@ defmodule Web.SignUp do
           account: %{slug: "placeholder"},
           actor: %{type: :account_admin_user}
         },
-        true,
-        []
+        sign_up_enabled,
+        allowed_domains
       )
-
-    allowed_domains =
-      Domain.Config.get_env(:domain, :sign_up_allowed_domains)
-      |> String.split(",", trim: true)
 
     socket =
       assign(socket,
@@ -78,8 +76,8 @@ defmodule Web.SignUp do
         provider: nil,
         user_agent: user_agent,
         real_ip: real_ip,
-        sign_up_enabled?: Config.sign_up_enabled?(),
-        show_form?: Config.sign_up_enabled?() or allowed_domains != [],
+        sign_up_enabled?: sign_up_enabled,
+        show_form?: sign_up_enabled or allowed_domains != [],
         allowed_domains: allowed_domains,
         account_name_changed?: false,
         actor_name_changed?: false,

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -74,9 +74,9 @@ defmodule Web.SignUp do
 
     allowed_domains =
       Domain.Config.get_env(:domain, :sign_up_allow_list)
-      |> String.trim()
-      |> String.split(",", trim: true)
+      |> String.split(",")
       |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
 
     socket =
       assign(socket,

--- a/elixir/apps/web/test/web/live/sign_up_test.exs
+++ b/elixir/apps/web/test/web/live/sign_up_test.exs
@@ -71,7 +71,7 @@ defmodule Web.Live.SignUpTest do
   test "allows override to create new account and send a welcome email", %{conn: conn} do
     Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
     Domain.Config.feature_flag_override(:sign_up, false)
-    Domain.Config.put_env_override(:sign_up_allow_list, "example.com")
+    Domain.Config.put_env_override(:sign_up_allowed_domains, "example.com")
 
     account_name = "FooBar"
 
@@ -124,7 +124,7 @@ defmodule Web.Live.SignUpTest do
   test "prevents unauthorized email from creating new account", %{conn: conn} do
     Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
     Domain.Config.feature_flag_override(:sign_up, false)
-    Domain.Config.put_env_override(:sign_up_allow_list, "firezone.dev")
+    Domain.Config.put_env_override(:sign_up_allowed_domains, "firezone.dev")
 
     account_name = "FooBar"
 
@@ -210,7 +210,7 @@ defmodule Web.Live.SignUpTest do
 
   test "renders sign up disabled message", %{conn: conn} do
     Domain.Config.feature_flag_override(:sign_up, false)
-    Domain.Config.put_env_override(:sign_up_allow_list, "")
+    Domain.Config.put_env_override(:sign_up_allowed_domains, "")
 
     {:ok, _lv, html} = live(conn, ~p"/sign_up")
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -87,7 +87,7 @@ config :domain, :enabled_features,
   self_hosted_relays: true,
   multi_site_resources: true
 
-config :domain, sign_up_allowed_domains: "firezone.dev"
+config :domain, sign_up_always_allowed_domains: []
 
 config :domain, docker_registry: "us-east1-docker.pkg.dev/firezone-staging/firezone"
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -87,7 +87,7 @@ config :domain, :enabled_features,
   self_hosted_relays: true,
   multi_site_resources: true
 
-config :domain, sign_up_allow_list: "firezone.dev"
+config :domain, sign_up_allowed_domains: "firezone.dev"
 
 config :domain, docker_registry: "us-east1-docker.pkg.dev/firezone-staging/firezone"
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -87,7 +87,7 @@ config :domain, :enabled_features,
   self_hosted_relays: true,
   multi_site_resources: true
 
-config :domain, sign_up_always_allowed_domains: []
+config :domain, sign_up_whitelisted_domains: []
 
 config :domain, docker_registry: "us-east1-docker.pkg.dev/firezone-staging/firezone"
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -87,6 +87,8 @@ config :domain, :enabled_features,
   self_hosted_relays: true,
   multi_site_resources: true
 
+config :domain, sign_up_allow_list: "firezone.dev"
+
 config :domain, docker_registry: "us-east1-docker.pkg.dev/firezone-staging/firezone"
 
 config :domain, outbound_email_adapter_configured?: false

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -61,7 +61,7 @@ if config_env() == :prod do
     self_hosted_relays: compile_config!(:feature_self_hosted_relays_enabled),
     multi_site_resources: compile_config!(:feature_multi_site_resources_enabled)
 
-  config :domain, sign_up_always_allowed_domains: compile_config!(:sign_up_always_allowed_domains)
+  config :domain, sign_up_whitelisted_domains: compile_config!(:sign_up_whitelisted_domains)
 
   config :domain, docker_registry: compile_config!(:docker_registry)
 

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -61,6 +61,8 @@ if config_env() == :prod do
     self_hosted_relays: compile_config!(:feature_self_hosted_relays_enabled),
     multi_site_resources: compile_config!(:feature_multi_site_resources_enabled)
 
+  config :domain, sign_up_always_allowed_domains: compile_config!(:sign_up_always_allowed_domains)
+
   config :domain, docker_registry: compile_config!(:docker_registry)
 
   config :domain, outbound_email_adapter_configured?: !!compile_config!(:outbound_email_adapter)

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -28,6 +28,8 @@ config :domain, Domain.GoogleCloudPlatform,
   project_id: "fz-test",
   service_account_email: "foo@iam.example.com"
 
+config :domain, sign_up_always_allowed_domains: []
+
 ###############################
 ##### Web #####################
 ###############################

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -28,8 +28,6 @@ config :domain, Domain.GoogleCloudPlatform,
   project_id: "fz-test",
   service_account_email: "foo@iam.example.com"
 
-config :domain, sign_up_always_allowed_domains: []
-
 ###############################
 ##### Web #####################
 ###############################

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -331,8 +331,13 @@ locals {
     },
     {
       name  = "FEATURE_SIGN_UP_ENABLED"
-      value = false
-    }
+      value = true
+    },
+    # Sign Up
+    {
+      name  = "SIGN_UP_ALLOWED_DOMAINS"
+      value = "firezone.dev,firez.one"
+    },
   ]
 }
 

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -335,7 +335,7 @@ locals {
     },
     # Sign Up
     {
-      name  = "SIGN_UP_ALLOWED_DOMAINS"
+      name  = "SIGN_UP_WHITELISTED_DOMAINS"
       value = "firezone.dev,firez.one"
     },
   ]


### PR DESCRIPTION
Why:

* In order to allow easy testing of billing / Stripe integration, the staging environment needs to allow members of the Firezone team access to create new accounts, while disallowing the general public to create accounts.  The account creation override functionality allows for multiple domains to be set by ENV variable by passing a comma separated string of domains.