### PR TITLE
refactor(snownet): be more explicit about dispatching messages

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -72,7 +72,7 @@ pub struct Allocation {
 ///
 /// Note that any combination of IP versions is possible here.
 /// We might have allocated an IPv6 address on a TURN server that we are talking to IPv4 and vice versa.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Socket {
     /// The server this socket was allocated on.
     server: SocketAddr,

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -54,9 +54,6 @@ pub struct Allocation {
     backoff: ExponentialBackoff,
     sent_requests: HashMap<TransactionId, (Message<Attribute>, Instant, Duration)>,
 
-    /// When we time out requests, we remember the last [`TransactionId`]s to be able to recognize them in case they do arrive later.
-    timed_out_requests: RingBuffer<TransactionId>,
-
     channel_bindings: ChannelBindings,
     buffered_channel_bindings: RingBuffer<SocketAddr>,
 
@@ -115,7 +112,6 @@ impl Allocation {
             last_now: now,
             buffered_channel_bindings: RingBuffer::new(100),
             backoff: backoff::new(now, REQUEST_TIMEOUT),
-            timed_out_requests: RingBuffer::new(100),
         };
 
         tracing::debug!(%server, "Requesting new allocation");
@@ -185,14 +181,6 @@ impl Allocation {
         Span::current().record("id", field::debug(transaction_id));
         Span::current().record("method", field::display(message.method()));
         Span::current().record("class", field::display(message.class()));
-
-        if self.timed_out_requests.remove(&transaction_id) {
-            tracing::debug!(
-                ?transaction_id,
-                "Received response to timed-out request, ignoring"
-            );
-            return true;
-        }
 
         let Some((original_request, sent_at, _)) = self.sent_requests.remove(&transaction_id)
         else {
@@ -426,8 +414,6 @@ impl Allocation {
                 .expect("ID is from list");
 
             tracing::debug!(id = ?request.transaction_id(), method = %request.method(), "Request timed out, re-sending");
-
-            self.timed_out_requests.push(request.transaction_id());
 
             self.authenticate_and_queue(request);
         }
@@ -1864,26 +1850,6 @@ mod tests {
                 CandidateEvent::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp).unwrap()),
             ]
         )
-    }
-
-    #[test]
-    fn timed_out_request_is_recognised() {
-        let start = Instant::now();
-        let mut allocation = Allocation::for_test(start);
-
-        let allocate = allocation.next_message().unwrap();
-
-        allocation.advance_to_next_timeout();
-        let allocate_retry = allocation.next_message().unwrap();
-        assert_eq!(allocate_retry.method(), ALLOCATE);
-
-        let handled = allocation.handle_test_input(
-            &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
-            start + Duration::from_secs(5),
-        );
-
-        assert!(allocation.poll_event().is_none());
-        assert!(handled);
     }
 
     fn ch(peer: SocketAddr, now: Instant) -> Channel {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -602,7 +602,7 @@ where
         let handled = binding.handle_input(from, local, packet, now);
 
         if !handled {
-            tracing::debug!("Packet was destined for binding but no longer accepted");
+            tracing::debug!("Packet was a STUN message but not accepted");
         }
 
         ControlFlow::Break(())

--- a/rust/connlib/snownet/src/ringbuffer.rs
+++ b/rust/connlib/snownet/src/ringbuffer.rs
@@ -18,12 +18,6 @@ impl<T: PartialEq> RingBuffer<T> {
         self.buffer.push(item);
     }
 
-    pub fn remove(&mut self, item: &T) -> bool {
-        let initial_len = self.buffer.len();
-        self.buffer.retain(|x| x != item);
-        initial_len != self.buffer.len()
-    }
-
     pub fn pop(&mut self) -> Option<T> {
         self.buffer.pop()
     }
@@ -66,28 +60,5 @@ mod tests {
         buffer.push(3);
 
         assert_eq!(buffer.inner(), &[2, 3]);
-    }
-
-    #[test]
-    fn test_remove_existing_item() {
-        let mut buffer = RingBuffer::new(3);
-
-        buffer.push(1);
-        buffer.push(2);
-        buffer.push(3);
-
-        assert!(buffer.remove(&2));
-        assert_eq!(buffer.inner(), &[1, 3]);
-    }
-
-    #[test]
-    fn test_remove_non_existing_item() {
-        let mut buffer = RingBuffer::new(2);
-
-        buffer.push(1);
-        buffer.push(2);
-
-        assert!(!buffer.remove(&3));
-        assert_eq!(buffer.inner(), &[1, 2]);
     }
 }


### PR DESCRIPTION
As part of handling an incoming packet, `snownet` has to go through several steps:

1. The packet might be a control message from a STUN server, we handle that first.
2. The packet might from a TURN server, which could either be a control message or a channel-data message.
    The former should be handled directly where as the latter needs to unpacked and passed along further.
3. Once potentially unpacked, the packet could be a STUN message for an ICE agent of one of our connections.
4. Lastly, the packet might be a wireguard payload from one of our connections.

Previously, we handled all of that in one big function which resulted in us sometimes "falling through" to the next branch when we didn't want that. For example, if a message is from a TURN server's address, it MUST be a control or channel data message but it can never be a wireguard packet. In certain circumstances, we don't detect that though. For example, if a channel is not yet bound, we refuse to decapsulate the message which results in us incorrectly passing on the message to later stages.

We refactor the handling into individual functions and explicitly signal to the upper layer using `ControlFlow`, whether we should continue or abort.

As an added benefit, this allows us to remove the "memory" of timed-out control messages in `StunBinding` and `Allocation`.