### PR TITLE
fix(relay): update tests for current values

### DIFF
--- a/rust/relay/src/auth.rs
+++ b/rust/relay/src/auth.rs
@@ -242,13 +242,13 @@ mod tests {
     }
 
     #[test]
-    fn nonces_are_valid_for_10_requests() {
+    fn nonces_are_valid_for_100_requests() {
         let mut nonces = Nonces::default();
         let nonce = Uuid::new_v4();
 
         nonces.add_new(nonce);
 
-        for _ in 0..10 {
+        for _ in 0..100 {
             nonces.handle_nonce_used(nonce).unwrap();
         }
 


### PR DESCRIPTION
In #3726 this value was increased but the test didn't reflect that.

I've not the slightest idea how this is passing on CI. It isn't locally. 

Now I have an Idea, relay tests aren't run on CI.