### PR TITLE
ci(gui-client): enable unit test for gui-client on Ubuntu 20.04

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -50,7 +50,8 @@ jobs:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         include:
           - runs-on: ubuntu-20.04
-            packages: -p firezone-relay -p firezone-linux-client -p firezone-gateway -p connlib-client-android -p snownet
+            packages: -p firezone-gui-client -p firezone-relay -p firezone-linux-client -p firezone-gateway -p connlib-client-android -p snownet
+            # GUI client doesn't build on 22.04 yet <https://github.com/firezone/firezone/issues/3699>
           - runs-on: ubuntu-22.04
             packages: -p firezone-relay -p firezone-linux-client -p firezone-gateway -p connlib-client-android -p snownet
           - runs-on: macos-12


### PR DESCRIPTION
There's no tests in there yet, but this will make them run once added