### PR TITLE
feat(connlib): support resource updates from the portal

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -166,8 +166,8 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    fn resource_deleted(&self, id: ResourceId) {
-        // TODO
+    fn resource_deleted(&mut self, id: ResourceId) {
+        self.tunnel.remove_resource(id);
     }
 
     fn connection_details(

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -231,6 +231,18 @@ impl ResourceDescription {
             ResourceDescription::Cidr(r) => Cow::from(r.address.to_string()),
         }
     }
+
+    pub fn different_address(&self, other: &ResourceDescription) -> bool {
+        match (self, other) {
+            (ResourceDescription::Dns(dns_a), ResourceDescription::Dns(dns_b)) => {
+                dns_a.address != dns_b.address
+            }
+            (ResourceDescription::Cidr(cidr_a), ResourceDescription::Cidr(cidr_b)) => {
+                cidr_a.address != cidr_b.address
+            }
+            _ => true,
+        }
+    }
 }
 
 /// Description of a resource that maps to a CIDR.

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -232,7 +232,7 @@ impl ResourceDescription {
         }
     }
 
-    pub fn different_address(&self, other: &ResourceDescription) -> bool {
+    pub fn has_different_address(&self, other: &ResourceDescription) -> bool {
         match (self, other) {
             (ResourceDescription::Dns(dns_a), ResourceDescription::Dns(dns_b)) => {
                 dns_a.address != dns_b.address

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -247,7 +247,7 @@ pub struct ClientState {
     pub resource_ids: HashMap<ResourceId, ResourceDescription>,
     pub deferred_dns_queries: HashMap<(DnsResource, Rtype), IpPacket<'static>>,
 
-    pub peers: PeerStore<GatewayId, PacketTransformClient>,
+    pub peers: PeerStore<GatewayId, PacketTransformClient, ResourceId>,
 
     forwarded_dns_queries: FuturesTupleSet<
         Result<hickory_resolver::lookup::Lookup, hickory_resolver::error::ResolveError>,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -59,14 +59,10 @@ where
         &mut self,
         resource_description: ResourceDescription,
     ) -> connlib_shared::Result<()> {
-        if self
-            .role_state
-            .resource_ids
-            .contains_key(&resource_description.id())
-        {
-            // TODO
-            tracing::info!("Resource updates aren't implemented yet");
-            return Ok(());
+        if let Some(resource) = self.role_state.resource_ids.get(&resource_description.id()) {
+            if address_changed(resource, &resource_description) {
+                self.remove_resource(resource.id());
+            }
         }
 
         match &resource_description {
@@ -812,5 +808,16 @@ impl Default for ClientState {
             dns_resolvers: Default::default(),
             buffered_packets: Default::default(),
         }
+    }
+}
+fn address_changed(resource_a: &ResourceDescription, resource_b: &ResourceDescription) -> bool {
+    match (resource_a, resource_b) {
+        (ResourceDescription::Dns(dns_a), ResourceDescription::Dns(dns_b)) => {
+            dns_a.address != dns_b.address
+        }
+        (ResourceDescription::Cidr(cidr_a), ResourceDescription::Cidr(cidr_b)) => {
+            cidr_a.address != cidr_b.address
+        }
+        _ => true,
     }
 }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -135,7 +135,7 @@ where
                 continue;
             }
 
-            // If the allowed_ips doesn't correspond to any resource anymorre we
+            // If the allowed_ips doesn't correspond to any resource anymore we
             // clean up any related translation.
             peer.transform
                 .translations

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -98,7 +98,7 @@ where
     pub fn remove_resource(&mut self, id: ResourceId) {
         if let Some(ResourceDescription::Cidr(resource)) = self.role_state.resource_ids.remove(&id)
         {
-            // Note: hopefuly the os doesn't coalece routes in a way that removing a more general route deletes the most specific
+            // Note: hopefully the os doesn't coalece routes in a way that removing a more general route deletes the most specific
             let _ = self.remove_route(resource.address).inspect_err(
                 |err| tracing::error!(%id, %resource.address, "failed to remove route: {err:?}"),
             );

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -60,7 +60,7 @@ where
         resource_description: ResourceDescription,
     ) -> connlib_shared::Result<()> {
         if let Some(resource) = self.role_state.resource_ids.get(&resource_description.id()) {
-            if resource.different_address(resource) {
+            if resource.has_different_address(resource) {
                 self.remove_resource(resource.id());
             }
         }

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -106,13 +106,12 @@ where
             &domain_response.as_ref().map(|d| d.domain.clone()),
         )?;
 
-        let mut peer: Peer<_, PacketTransformClient, _> = Peer::new(gateway_id, Default::default());
-        for ip in &ips {
-            peer.insert_id(ip, &resource_id)
-        }
-
+        let mut resource_ids = HashSet::new();
+        resource_ids.insert(resource_id);
+        let mut peer: Peer<_, PacketTransformClient, _> =
+            Peer::new(gateway_id, Default::default(), &ips, resource_ids);
         peer.transform.set_dns(self.role_state.dns_mapping());
-        self.role_state.peers.insert(peer);
+        self.role_state.peers.insert(peer, &[]);
 
         let peer_ips = if let Some(domain_response) = domain_response {
             self.dns_response(&resource_id, &domain_response, &gateway_id)?

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -106,7 +106,8 @@ where
             &domain_response.as_ref().map(|d| d.domain.clone()),
         )?;
 
-        let mut peer: Peer<_, PacketTransformClient> = Peer::new(gateway_id, Default::default());
+        let mut peer: Peer<_, PacketTransformClient, ResourceId> =
+            Peer::new(gateway_id, Default::default());
         for ip in &ips {
             peer.add_allowed_ip(*ip, resource_id);
         }

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -106,8 +106,11 @@ where
             &domain_response.as_ref().map(|d| d.domain.clone()),
         )?;
 
-        let mut peer: Peer<_, PacketTransformClient> =
-            Peer::new(ips.clone(), gateway_id, Default::default());
+        let mut peer: Peer<_, PacketTransformClient> = Peer::new(gateway_id, Default::default());
+        for ip in &ips {
+            peer.add_allowed_ip(*ip, resource_id);
+        }
+
         peer.transform.set_dns(self.role_state.dns_mapping());
         self.role_state.peers.insert(peer);
 
@@ -117,7 +120,9 @@ where
             ips
         };
 
-        self.role_state.peers.add_ips(&gateway_id, &peer_ips);
+        self.role_state
+            .peers
+            .add_ips(&gateway_id, &peer_ips, resource_id);
 
         Ok(())
     }
@@ -232,7 +237,9 @@ where
 
         let peer_ips = self.dns_response(&resource_id, &domain_response, &gateway_id)?;
 
-        self.role_state.peers.add_ips(&gateway_id, &peer_ips);
+        self.role_state
+            .peers
+            .add_ips(&gateway_id, &peer_ips, resource_id);
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -106,8 +106,7 @@ where
             &domain_response.as_ref().map(|d| d.domain.clone()),
         )?;
 
-        let mut resource_ids = HashSet::new();
-        resource_ids.insert(resource_id);
+        let resource_ids = HashSet::from([resource_id]);
         let mut peer: Peer<_, PacketTransformClient, _> =
             Peer::new(gateway_id, Default::default(), &ips, resource_ids);
         peer.transform.set_dns(self.role_state.dns_mapping());

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -167,7 +167,7 @@ where
     ) -> Result<()> {
         tracing::trace!(?ips, "new_data_channel_open");
 
-        let mut peer = Peer::new(ips.clone(), client_id, PacketTransformGateway::default());
+        let mut peer = Peer::new(client_id, PacketTransformGateway::default());
 
         for address in resource_addresses {
             peer.transform
@@ -175,7 +175,14 @@ where
         }
 
         self.role_state.peers.insert(peer);
-        self.role_state.peers.add_ips(&client_id, &ips);
+
+        // TODO: for gateways the association between ip and id should be treated a bit differently
+        let resource_id = match resource {
+            connlib_shared::messages::ResourceDescription::Dns(r) => r.id,
+            connlib_shared::messages::ResourceDescription::Cidr(r) => r.id,
+        };
+
+        self.role_state.peers.add_ips(&client_id, &ips, resource_id);
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -176,13 +176,7 @@ where
 
         self.role_state.peers.insert(peer);
 
-        // TODO: for gateways the association between ip and id should be treated a bit differently
-        let resource_id = match resource {
-            connlib_shared::messages::ResourceDescription::Dns(r) => r.id,
-            connlib_shared::messages::ResourceDescription::Cidr(r) => r.id,
-        };
-
-        self.role_state.peers.add_ips(&client_id, &ips, resource_id);
+        self.role_state.peers.add_ips(&client_id, &ips, ());
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -174,9 +174,15 @@ where
                 .add_resource(address, resource.clone(), expires_at);
         }
 
+        for ip in &ips {
+            peer.allowed_ips.insert(*ip, ());
+        }
+
         self.role_state.peers.insert(peer);
 
-        self.role_state.peers.add_ips(&client_id, &ips, ());
+        for ip in ips {
+            self.role_state.peers.add_ip(&client_id, &ip);
+        }
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/control_protocol/gateway.rs
+++ b/rust/connlib/tunnel/src/control_protocol/gateway.rs
@@ -167,22 +167,14 @@ where
     ) -> Result<()> {
         tracing::trace!(?ips, "new_data_channel_open");
 
-        let mut peer = Peer::new(client_id, PacketTransformGateway::default());
+        let mut peer = Peer::new(client_id, PacketTransformGateway::default(), &ips, ());
 
         for address in resource_addresses {
             peer.transform
                 .add_resource(address, resource.clone(), expires_at);
         }
 
-        for ip in &ips {
-            peer.allowed_ips.insert(*ip, ());
-        }
-
-        self.role_state.peers.insert(peer);
-
-        for ip in ips {
-            self.role_state.peers.add_ip(&client_id, &ip);
-        }
+        self.role_state.peers.insert(peer, &ips);
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -170,9 +170,9 @@ impl Device {
     pub(crate) fn remove_route(
         &mut self,
         route: IpNetwork,
-        callbacks: &impl Callbacks<Error = Error>,
+        _callbacks: &impl Callbacks<Error = Error>,
     ) -> Result<Option<Device>, Error> {
-        self.tun.remove_route(route, callbacks)?;
+        self.tun.remove_route(route)?;
         Ok(None)
     }
 

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -148,6 +148,34 @@ impl Device {
         }))
     }
 
+    #[cfg(target_family = "unix")]
+    pub(crate) fn remove_route(
+        &mut self,
+        route: IpNetwork,
+        callbacks: &impl Callbacks<Error = Error>,
+    ) -> Result<Option<Device>, Error> {
+        let Some(tun) = self.tun.remove_route(route, callbacks)? else {
+            return Ok(None);
+        };
+        let mtu = ioctl::interface_mtu_by_name(tun.name())?;
+
+        Ok(Some(Device {
+            mtu,
+            tun,
+            mtu_refreshed_at: Instant::now(),
+        }))
+    }
+
+    #[cfg(target_family = "windows")]
+    pub(crate) fn remove_route(
+        &mut self,
+        route: IpNetwork,
+        callbacks: &impl Callbacks<Error = Error>,
+    ) -> Result<Option<Device>, Error> {
+        self.tun.remove_route(route, callbacks)?;
+        Ok(None)
+    }
+
     #[cfg(target_family = "windows")]
     #[allow(unused_mut)]
     pub(crate) fn add_route(

--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -75,6 +75,21 @@ impl Tun {
             name,
         }))
     }
+
+    pub fn remove_route(
+        &self,
+        route: IpNetwork,
+        callbacks: &impl Callbacks<Error = Error>,
+    ) -> Result<Option<Self>> {
+        self.fd.close();
+        let fd = callbacks.on_remove_route(route)?.ok_or(Error::NoFd)?;
+        let name = unsafe { interface_name(fd)? };
+
+        Ok(Some(Tun {
+            fd: Closeable::new(AsyncFd::new(fd)?),
+            name,
+        }))
+    }
 }
 
 /// Retrieves the name of the interface pointed to by the provided file descriptor.

--- a/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
@@ -153,6 +153,16 @@ impl Tun {
         Ok(None)
     }
 
+    pub fn remove_route(
+        &self,
+        route: IpNetwork,
+        callbacks: &impl Callbacks<Error = Error>,
+    ) -> Result<Option<Self>> {
+        // This will always be None in macos
+        callbacks.on_remove_route(route)?;
+        Ok(None)
+    }
+
     pub fn name(&self) -> &str {
         self.name.as_str()
     }

--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -6,16 +6,16 @@ use connlib_shared::{
 use futures::TryStreamExt;
 use futures_util::future::BoxFuture;
 use futures_util::FutureExt;
-use ip_network::IpNetwork;
+use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use libc::{
     close, fcntl, makedev, mknod, open, F_GETFL, F_SETFL, IFF_MULTI_QUEUE, IFF_NO_PI, IFF_TUN,
     O_NONBLOCK, O_RDWR, S_IFCHR,
 };
 use netlink_packet_route::route::{RouteProtocol, RouteScope};
 use netlink_packet_route::rule::RuleAction;
-use rtnetlink::RuleAddRequest;
 use rtnetlink::{new_connection, Error::NetlinkError, Handle};
-use std::net::IpAddr;
+use rtnetlink::{RouteAddRequest, RuleAddRequest};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::Path;
 use std::task::{Context, Poll};
 use std::{
@@ -154,26 +154,9 @@ impl Tun {
                 .header
                 .index;
 
-            let req = handle
-                .route()
-                .add()
-                .output_interface(index)
-                .protocol(RouteProtocol::Static)
-                .scope(RouteScope::Universe)
-                .table_id(FIREZONE_TABLE);
             let res = match route {
-                IpNetwork::V4(ipnet) => {
-                    req.v4()
-                        .destination_prefix(ipnet.network_address(), ipnet.netmask())
-                        .execute()
-                        .await
-                }
-                IpNetwork::V6(ipnet) => {
-                    req.v6()
-                        .destination_prefix(ipnet.network_address(), ipnet.netmask())
-                        .execute()
-                        .await
-                }
+                IpNetwork::V4(ipnet) => make_route_v4(index, &handle, ipnet).execute().await,
+                IpNetwork::V6(ipnet) => make_route_v6(index, &handle, ipnet).execute().await,
             };
 
             match res {
@@ -181,6 +164,53 @@ impl Tun {
                 Err(NetlinkError(err)) if err.raw_code() == FILE_ALREADY_EXISTS => Ok(()),
                 // TODO: we should be able to surface this error and handle it depending on
                 // if any of the added routes succeeded.
+                Err(err) => {
+                    tracing::error!(%route, "failed to add route: {err:#?}");
+                    Ok(())
+                }
+            }
+        };
+
+        match self.worker.take() {
+            None => self.worker = Some(add_route_worker.boxed()),
+            Some(current_worker) => {
+                self.worker = Some(
+                    async move {
+                        current_worker.await?;
+                        add_route_worker.await?;
+
+                        Ok(())
+                    }
+                    .boxed(),
+                )
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn remove_route(&mut self, route: IpNetwork, _: &impl Callbacks) -> Result<Option<Self>> {
+        let handle = self.handle.clone();
+
+        let add_route_worker = async move {
+            let index = handle
+                .link()
+                .get()
+                .match_name(IFACE_NAME.to_string())
+                .execute()
+                .try_next()
+                .await?
+                .ok_or(Error::NoIface)?
+                .header
+                .index;
+
+            let message = match route {
+                IpNetwork::V4(ipnet) => make_route_v4(index, &handle, ipnet).message_mut().clone(),
+                IpNetwork::V6(ipnet) => make_route_v6(index, &handle, ipnet).message_mut().clone(),
+            };
+
+            match handle.route().del(message).execute().await {
+                Ok(_) => Ok(()),
                 Err(err) => {
                     tracing::error!(%route, "failed to add route: {err:#?}");
                     Ok(())
@@ -325,6 +355,28 @@ fn make_rule(handle: &Handle) -> RuleAddRequest {
         ));
 
     rule
+}
+
+fn make_route(idx: u32, handle: &Handle) -> RouteAddRequest {
+    handle
+        .route()
+        .add()
+        .output_interface(idx)
+        .protocol(RouteProtocol::Static)
+        .scope(RouteScope::Universe)
+        .table_id(FIREZONE_TABLE)
+}
+
+fn make_route_v4(idx: u32, handle: &Handle, route: Ipv4Network) -> RouteAddRequest<Ipv4Addr> {
+    make_route(idx, handle)
+        .v4()
+        .destination_prefix(route.network_address(), route.netmask())
+}
+
+fn make_route_v6(idx: u32, handle: &Handle, route: Ipv6Network) -> RouteAddRequest<Ipv6Addr> {
+    make_route(idx, handle)
+        .v6()
+        .destination_prefix(route.network_address(), route.netmask())
 }
 
 fn get_last_error() -> Error {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -285,7 +285,6 @@ where
     ) -> Poll<io::Result<()>>
     where
         TTransform: PacketTransform,
-        RId: Copy,
     {
         let received = match ready!(self.sockets.poll_recv_from(cx)) {
             Ok(received) => received,

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -277,14 +277,15 @@ where
     }
 
     // TODO: passing the peer_store looks weird, we can just remove ConnectionState and move everything into Tunnel, there's no Mutexes any longer that justify this separation
-    fn poll_sockets<TTransform>(
+    fn poll_sockets<TTransform, RId>(
         &mut self,
         device: &mut Device,
-        peer_store: &mut PeerStore<TId, TTransform>,
+        peer_store: &mut PeerStore<TId, TTransform, RId>,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<()>>
     where
         TTransform: PacketTransform,
+        RId: Copy,
     {
         let received = match ready!(self.sockets.poll_recv_from(cx)) {
             Ok(received) => received,

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -277,14 +277,15 @@ where
     }
 
     // TODO: passing the peer_store looks weird, we can just remove ConnectionState and move everything into Tunnel, there's no Mutexes any longer that justify this separation
-    fn poll_sockets<TTransform, RId>(
+    fn poll_sockets<TTransform, TResource>(
         &mut self,
         device: &mut Device,
-        peer_store: &mut PeerStore<TId, TTransform, RId>,
+        peer_store: &mut PeerStore<TId, TTransform, TResource>,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<()>>
     where
         TTransform: PacketTransform,
+        TResource: Clone,
     {
         let received = match ready!(self.sockets.poll_recv_from(cx)) {
             Ok(received) => received,

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -35,13 +35,10 @@ where
     TTransform: PacketTransform,
 {
     pub(crate) fn insert_id(&mut self, ip: &IpNetwork, id: &ResourceId) {
-        if let Some(resources) = self.allowed_ips.exact_match_mut(*ip) {
-            resources.insert(*id);
-        } else {
-            let mut resources = HashSet::new();
-            resources.insert(*id);
-            self.allowed_ips.insert(*ip, resources);
-        }
+        self.allowed_ips
+            .exact_match_mut(*ip)
+            .get_or_insert(&mut HashSet::new())
+            .insert(*id);
     }
 }
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -20,27 +20,26 @@ type ExpiryingResource = (ResourceDescription, Option<DateTime<Utc>>);
 // is 30 seconds. See resolvconf(5) timeout.
 const IDS_EXPIRE: std::time::Duration = std::time::Duration::from_secs(60);
 
-pub struct Peer<TId, TTransform, RId> {
-    pub allowed_ips: IpNetworkTable<RId>,
+pub struct Peer<TId, TTransform, TResource> {
+    // TODO: we should refactor this
+    // in the gateway-side this means that we are explicit about ()
+    // maybe duping the Peer struct is the way to go
+    pub allowed_ips: IpNetworkTable<TResource>,
     pub conn_id: TId,
     pub transform: TTransform,
 }
 
-impl<TId, TTransform, RId> Peer<TId, TTransform, RId>
+impl<TId, TTransform, TResource> Peer<TId, TTransform, TResource>
 where
     TId: Copy,
     TTransform: PacketTransform,
 {
-    pub(crate) fn new(conn_id: TId, transform: TTransform) -> Peer<TId, TTransform, RId> {
+    pub(crate) fn new(conn_id: TId, transform: TTransform) -> Peer<TId, TTransform, TResource> {
         Peer {
             allowed_ips: IpNetworkTable::new(),
             conn_id,
             transform,
         }
-    }
-
-    pub(crate) fn add_allowed_ip(&mut self, ip: IpNetwork, resource_id: RId) {
-        self.allowed_ips.insert(ip, resource_id);
     }
 
     fn is_allowed(&self, addr: IpAddr) -> bool {

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -35,10 +35,11 @@ where
     TTransform: PacketTransform,
 {
     pub(crate) fn insert_id(&mut self, ip: &IpNetwork, id: &ResourceId) {
-        self.allowed_ips
-            .exact_match_mut(*ip)
-            .get_or_insert(&mut HashSet::new())
-            .insert(*id);
+        if let Some(resources) = self.allowed_ips.exact_match_mut(*ip) {
+            resources.insert(*id);
+        } else {
+            self.allowed_ips.insert(*ip, HashSet::from([*id]));
+        }
     }
 }
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::time::Instant;
 
@@ -27,6 +27,22 @@ pub struct Peer<TId, TTransform, TResource> {
     pub allowed_ips: IpNetworkTable<TResource>,
     pub conn_id: TId,
     pub transform: TTransform,
+}
+
+impl<TId, TTransform> Peer<TId, TTransform, HashSet<ResourceId>>
+where
+    TId: Copy,
+    TTransform: PacketTransform,
+{
+    pub(crate) fn insert_id(&mut self, ip: &IpNetwork, id: &ResourceId) {
+        if let Some(resources) = self.allowed_ips.exact_match_mut(*ip) {
+            resources.insert(*id);
+        } else {
+            let mut resources = HashSet::new();
+            resources.insert(*id);
+            self.allowed_ips.insert(*ip, resources);
+        }
+    }
 }
 
 impl<TId, TTransform, TResource> Peer<TId, TTransform, TResource>

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -49,10 +49,21 @@ impl<TId, TTransform, TResource> Peer<TId, TTransform, TResource>
 where
     TId: Copy,
     TTransform: PacketTransform,
+    TResource: Clone,
 {
-    pub(crate) fn new(conn_id: TId, transform: TTransform) -> Peer<TId, TTransform, TResource> {
+    pub(crate) fn new(
+        conn_id: TId,
+        transform: TTransform,
+        ips: &[IpNetwork],
+        resource: TResource,
+    ) -> Peer<TId, TTransform, TResource> {
+        let mut allowed_ips = IpNetworkTable::new();
+        for ip in ips {
+            allowed_ips.insert(*ip, resource.clone());
+        }
+
         Peer {
-            allowed_ips: IpNetworkTable::new(),
+            allowed_ips,
             conn_id,
             transform,
         }

--- a/rust/connlib/tunnel/src/peer_store.rs
+++ b/rust/connlib/tunnel/src/peer_store.rs
@@ -60,8 +60,13 @@ where
     pub fn insert(
         &mut self,
         peer: Peer<TId, TTransform, TResource>,
+        ips: &[IpNetwork],
     ) -> Option<Peer<TId, TTransform, TResource>> {
         self.id_by_ip.retain(|_, &mut r_id| r_id != peer.conn_id);
+
+        for ip in ips {
+            self.add_ip(&peer.conn_id, &ip);
+        }
 
         self.peer_by_id.insert(peer.conn_id, peer)
     }

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -86,6 +86,12 @@ pub struct AllowAccess {
     pub reference: String,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct RejectAccess {
+    pub client_id: ClientId,
+    pub resource_id: ResourceId,
+}
+
 // These messages are the messages that can be received
 // either by a client or a gateway by the client.
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
@@ -93,6 +99,7 @@ pub struct AllowAccess {
 pub enum IngressMessages {
     RequestConnection(RequestConnection),
     AllowAccess(AllowAccess),
+    RejectAccess(RejectAccess),
     IceCandidates(ClientIceCandidates),
     Init(InitGateway),
 }


### PR DESCRIPTION
This PR doesn't yet provide support for the update of upstream DNS but it does provide support for all the other resources update messages.

 Should comply with the  description of issue #2022 but it doesn't respond to DNS upstream updates which is imply it should on the issue title