### PR TITLE
feat(android): use Android ShareSheet for sharing logs

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -118,7 +118,7 @@ internal class SettingsViewModel
 
                 zipFolder(sourceFolder, zipFile).collect()
 
-                val shareIntent =
+                val sendIntent =
                     Intent(Intent.ACTION_SEND).apply {
                         putExtra(
                             Intent.EXTRA_SUBJECT,
@@ -142,6 +142,7 @@ internal class SettingsViewModel
                         flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
                         data = fileURI
                     }
+                val shareIntent = Intent.createChooser(sendIntent, null)
                 context.startActivity(shareIntent)
             }
         }


### PR DESCRIPTION
Fixes #3545 

![sharesheet](https://github.com/firezone/firezone/assets/5115126/dce8cbea-14c4-4feb-8cda-7ed4c0de20b5)
