### PR TITLE
fix(android): delete log zip on finish and on create

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -30,6 +30,7 @@ internal class SettingsActivity : AppCompatActivity() {
         setupStateObservers()
 
         viewModel.populateFieldsFromConfig()
+        viewModel.deleteLogZip(this@SettingsActivity)
     }
 
     private fun setupViews() {
@@ -79,6 +80,13 @@ internal class SettingsActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.onViewResume(this@SettingsActivity)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        if (isFinishing) {
+            viewModel.deleteLogZip(this@SettingsActivity)
+        }
     }
 
     private inner class SettingsPagerAdapter(activity: FragmentActivity) :

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsViewModel.kt
@@ -61,8 +61,6 @@ internal class SettingsViewModel
             val directory = File(context.cacheDir.absolutePath + "/logs")
             val totalSize = directory.walkTopDown().filter { it.isFile }.map { it.length() }.sum()
 
-            deleteLogZip(context)
-
             _uiState.value =
                 _uiState.value.copy(
                     logSizeBytes = totalSize,
@@ -161,6 +159,13 @@ internal class SettingsViewModel
             )
         }
 
+        fun deleteLogZip(context: Context) {
+            val zipFile = File(getLogZipPath(context))
+            if (zipFile.exists()) {
+                zipFile.delete()
+            }
+        }
+
         private suspend fun zipFolder(
             sourceFolder: File,
             zipFile: File,
@@ -184,13 +189,6 @@ internal class SettingsViewModel
         }.catch { e ->
             emit(Result.failure(e))
         }.flowOn(Dispatchers.IO)
-
-        private fun deleteLogZip(context: Context) {
-            val zipFile = File(getLogZipPath(context))
-            if (zipFile.exists()) {
-                zipFile.delete()
-            }
-        }
 
         private fun getLogZipPath(context: Context) = "${context.cacheDir.absolutePath}/connlib-logs.zip"
 


### PR DESCRIPTION
When deleting the log zip on resume, the file can be deleted before the email client has a chance to attach it. This causes a race condition where the attachment will sometimes fail to attach when sharing.