### PR TITLE
refactor(connlib): move `Node` into `{Client,Gateway}State`

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -376,13 +376,6 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                     }
                 });
             }
-            Ok(firezone_tunnel::Event::StopPeer(_)) => {
-                // This should never bubbled up
-                // TODO: we might want to segregate events further
-            }
-            Ok(firezone_tunnel::Event::SendPacket(_)) => {
-                unimplemented!("Handled internally");
-            }
             Err(e) => {
                 tracing::error!("Tunnel failed: {e:#?}");
             }

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -7,7 +7,7 @@ use backoff::{backoff::Backoff, ExponentialBackoffBuilder};
 use connlib_shared::control::SecureUrl;
 use connlib_shared::{control::PhoenixChannel, login_url, CallbackErrorFacade, Mode, Result};
 use control::ControlPlane;
-use firezone_tunnel::Tunnel;
+use firezone_tunnel::ClientTunnel;
 use messages::IngressMessages;
 use messages::Messages;
 use messages::ReplyMessages;
@@ -170,7 +170,7 @@ where
             });
 
             let tunnel = fatal_error!(
-                Tunnel::new(private_key, callbacks.clone()),
+                ClientTunnel::new(private_key, callbacks.clone()),
                 runtime_stopper,
                 &callbacks
             );

--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -13,7 +13,4 @@ mod utils;
 
 pub use info::ConnectionInfo;
 pub use ip_packet::{IpPacket, MutableIpPacket};
-pub use node::{
-    Answer, Client, ClientNode, Credentials, Error, Event, Node, Offer, Server, ServerNode,
-    Transmit,
-};
+pub use node::{Answer, ClientNode, Credentials, Error, Event, Node, Offer, ServerNode, Transmit};

--- a/rust/connlib/tunnel/src/control_protocol.rs
+++ b/rust/connlib/tunnel/src/control_protocol.rs
@@ -1,13 +1,10 @@
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
-use std::{collections::HashSet, fmt, hash::Hash, net::SocketAddr, sync::Arc};
+use std::{collections::HashSet, net::SocketAddr, sync::Arc};
 
-use connlib_shared::{
-    messages::{Relay, RequestConnection, ReuseConnection},
-    Callbacks,
-};
+use connlib_shared::messages::{Relay, RequestConnection, ReuseConnection};
 
-use crate::{peer::Peer, Tunnel, REALM};
+use crate::{peer::Peer, REALM};
 
 mod client;
 pub mod gateway;
@@ -16,18 +13,6 @@ pub mod gateway;
 pub enum Request {
     NewConnection(RequestConnection),
     ReuseConnection(ReuseConnection),
-}
-
-impl<CB, TRoleState, TRole, TId, TTransform> Tunnel<CB, TRoleState, TRole, TId, TTransform>
-where
-    CB: Callbacks + 'static,
-    TId: Eq + Hash + Copy + fmt::Display,
-{
-    pub fn add_ice_candidate(&mut self, conn_id: TId, ice_candidate: String) {
-        self.connections_state
-            .node
-            .add_remote_candidate(conn_id, ice_candidate);
-    }
 }
 
 fn insert_peers<TId: Copy, TTransform>(

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -129,11 +129,11 @@ impl GatewayState {
         Some(packet)
     }
 
-    pub fn poll_transmit(&mut self) -> Option<snownet::Transmit> {
+    pub(crate) fn poll_transmit(&mut self) -> Option<snownet::Transmit> {
         self.node.poll_transmit()
     }
 
-    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+    pub(crate) fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         loop {
             if let Poll::Ready(instant) = self.node_timeout.poll_unpin(cx) {
                 self.node.handle_timeout(instant);
@@ -173,7 +173,7 @@ impl GatewayState {
 }
 
 impl GatewayState {
-    pub fn new(private_key: StaticSecret) -> Self {
+    pub(crate) fn new(private_key: StaticSecret) -> Self {
         let mut expire_interval = interval(Duration::from_secs(1));
         expire_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Self {

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -1,21 +1,27 @@
-use crate::device_channel::Device;
+use crate::device_channel::{Device, Packet};
 use crate::ip_packet::MutableIpPacket;
 use crate::peer::{PacketTransformGateway, Peer};
-use crate::{peer_by_ip, Tunnel};
+use crate::sockets::Received;
+use crate::{peer_by_ip, sleep_until, Tunnel};
+use boringtun::x25519::StaticSecret;
 use connlib_shared::messages::{ClientId, Interface as InterfaceConfig};
 use connlib_shared::Callbacks;
+use futures_util::future::BoxFuture;
+use futures_util::FutureExt;
 use ip_network_table::IpNetworkTable;
 use itertools::Itertools;
-use snownet::Server;
+use pnet_packet::Packet as _;
+use snownet::{ServerNode, Transmit};
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::task::{ready, Context, Poll};
-use std::time::Duration;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 use tokio::time::{interval, Interval, MissedTickBehavior};
 
 const PEERS_IPV4: &str = "100.64.0.0/11";
 const PEERS_IPV6: &str = "fd00:2021:1111::/107";
 
-impl<CB> Tunnel<CB, GatewayState, Server, ClientId, PacketTransformGateway>
+impl<CB> Tunnel<CB, GatewayState>
 where
     CB: Callbacks + 'static,
 {
@@ -39,7 +45,7 @@ where
 
     /// Clean up a connection to a resource.
     pub fn cleanup_connection(&mut self, id: ClientId) {
-        self.connections_state.peers_by_id.remove(&id);
+        self.role_state.peers_by_id.remove(&id);
         self.role_state.peers_by_ip.retain(|_, p| p.conn_id != id);
     }
 }
@@ -49,24 +55,106 @@ pub struct GatewayState {
     #[allow(clippy::type_complexity)]
     pub peers_by_ip: IpNetworkTable<Arc<Peer<ClientId, PacketTransformGateway>>>,
     expire_interval: Interval,
+
+    pub node: ServerNode<ClientId>,
+    pub peers_by_id: HashMap<ClientId, Arc<Peer<ClientId, PacketTransformGateway>>>,
+    node_timeout: BoxFuture<'static, std::time::Instant>,
 }
 
 impl GatewayState {
-    pub(crate) fn encapsulate<'a>(
-        &mut self,
-        packet: MutableIpPacket<'a>,
-    ) -> Option<(ClientId, MutableIpPacket<'a>)> {
+    pub(crate) fn encapsulate<'s>(
+        &'s mut self,
+        packet: MutableIpPacket<'_>,
+    ) -> Option<Transmit<'s>> {
         let dest = packet.destination();
 
         let peer = peer_by_ip(&self.peers_by_ip, dest)?;
         let packet = peer.transform(packet)?;
 
-        Some((peer.conn_id, packet))
+        let transmit = self
+            .node
+            .encapsulate(peer.conn_id, packet.as_immutable().into())
+            .inspect_err(
+                |e| tracing::warn!(peer = %peer.conn_id, "Failed to encapsulate packet: {e}"),
+            )
+            .ok()??;
+
+        Some(transmit)
     }
 
-    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Vec<ClientId>> {
-        ready!(self.expire_interval.poll_tick(cx));
-        Poll::Ready(self.expire_resources().collect_vec())
+    pub(crate) fn decapsulate<'b>(
+        &mut self,
+        received: Received<'_>,
+        buf: &'b mut [u8],
+    ) -> Option<Packet<'b>> {
+        let Received {
+            local,
+            from,
+            packet,
+        } = received;
+
+        let (conn_id, packet) = match self.node.decapsulate(
+            local,
+            from,
+            packet.as_ref(),
+            std::time::Instant::now(),
+            buf,
+        ) {
+            Ok(packet) => packet?,
+            Err(e) => {
+                tracing::warn!(%local, %from, num_bytes = %packet.len(), "Failed to decapsulate incoming packet: {e}");
+
+                return None;
+            }
+        };
+
+        tracing::trace!(target: "wire", %local, %from, bytes = %packet.packet().len(), "read new packet");
+
+        let Some(peer) = self.peers_by_id.get(&conn_id) else {
+            tracing::error!(%conn_id, %local, %from, "Couldn't find connection");
+
+            return None;
+        };
+
+        let packet_len = packet.packet().len();
+        let packet = match peer.untransform(packet.source(), &mut buf[..packet_len]) {
+            Ok(packet) => packet,
+            Err(e) => {
+                tracing::warn!(%conn_id, %local, %from, "Failed to transform packet: {e}");
+
+                return None;
+            }
+        };
+
+        Some(packet)
+    }
+
+    pub fn poll_transmit(&mut self) -> Option<snownet::Transmit> {
+        self.node.poll_transmit()
+    }
+
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        loop {
+            if let Poll::Ready(instant) = self.node_timeout.poll_unpin(cx) {
+                self.node.handle_timeout(instant);
+                if let Some(timeout) = self.node.poll_timeout() {
+                    self.node_timeout = sleep_until(timeout).boxed();
+                }
+
+                continue;
+            }
+
+            if self.expire_interval.poll_tick(cx).is_ready() {
+                for id in self.expire_resources().collect::<Vec<_>>() {
+                    self.peers_by_id.remove(&id);
+                    self.peers_by_ip.retain(|_, p| p.conn_id != id);
+                }
+
+                continue;
+            }
+
+            return Poll::Pending;
+        }
     }
 
     fn expire_resources(&self) -> impl Iterator<Item = ClientId> + '_ {
@@ -84,13 +172,16 @@ impl GatewayState {
     }
 }
 
-impl Default for GatewayState {
-    fn default() -> Self {
+impl GatewayState {
+    pub fn new(private_key: StaticSecret) -> Self {
         let mut expire_interval = interval(Duration::from_secs(1));
         expire_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Self {
             peers_by_ip: IpNetworkTable::new(),
             expire_interval,
+            node: ServerNode::new(private_key, Instant::now()),
+            peers_by_id: Default::default(),
+            node_timeout: sleep_until(Instant::now()).boxed(),
         }
     }
 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -4,14 +4,17 @@
 //! [Tunnel] is the main entry-point for this crate.
 
 use boringtun::x25519::StaticSecret;
+use client::ClientState;
 use connlib_shared::{
     messages::{ClientId, GatewayId, ResourceDescription, ReuseConnection},
     CallbackErrorFacade, Callbacks, Error, Result,
 };
 use device_channel::Device;
 use futures_util::task::AtomicWaker;
+use gateway::GatewayState;
 use ip_network_table::IpNetworkTable;
 use peer::{Peer, PeerStats};
+use sockets::Sockets;
 use std::{
     collections::{HashMap, HashSet},
     net::IpAddr,
@@ -20,10 +23,7 @@ use std::{
     time::Instant,
 };
 
-pub use client::ClientState;
 pub use control_protocol::{gateway::ResolvedResourceDescriptionDns, Request};
-pub use gateway::GatewayState;
-use sockets::Sockets;
 
 mod client;
 mod control_protocol;

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -68,19 +68,19 @@ impl Sockets {
         self.socket_v6.as_ref().map(|s| s.socket.as_raw_fd())
     }
 
-    pub fn poll_send_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        if let Some(socket) = self.socket_v4.as_mut() {
+    pub fn poll_send_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if let Some(socket) = self.socket_v4.as_ref() {
             ready!(socket.poll_send_ready(cx))?;
         }
 
-        if let Some(socket) = self.socket_v6.as_mut() {
+        if let Some(socket) = self.socket_v6.as_ref() {
             ready!(socket.poll_send_ready(cx))?;
         }
 
         Poll::Ready(Ok(()))
     }
 
-    pub fn try_send(&mut self, transmit: &Transmit) -> Result<usize> {
+    pub fn try_send(&self, transmit: &Transmit) -> Result<usize> {
         tracing::trace!(target: "wire", action = "write", to = %transmit.dst, src = ?transmit.src, bytes = %transmit.payload.len());
 
         match transmit.dst {
@@ -194,7 +194,7 @@ impl<const N: usize> Socket<N> {
         }
     }
 
-    fn poll_send_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_send_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.socket.poll_send_ready(cx)
     }
 


### PR DESCRIPTION
This introduces some duplication within `ClientState` and `Gateway` state but it greatly simplifies the `Tunnel` as a result.