### PR TITLE
refactor(connlib): unify handling of IP packets

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -18,12 +18,12 @@ mod tun;
 #[path = "device_channel/tun_android.rs"]
 mod tun;
 
-use crate::ip_packet::MutableIpPacket;
+use crate::ip_packet::{IpPacket, MutableIpPacket};
 use connlib_shared::error::ConnlibError;
 use connlib_shared::messages::Interface;
 use connlib_shared::{Callbacks, Error};
 use ip_network::IpNetwork;
-use std::borrow::Cow;
+use pnet_packet::Packet;
 use std::io;
 use std::net::IpAddr;
 use std::task::{Context, Poll};
@@ -174,33 +174,12 @@ impl Device {
         Ok(())
     }
 
-    pub fn write(&self, packet: Packet<'_>) -> io::Result<usize> {
-        tracing::trace!(target: "wire", action = "write", to = "device", bytes = %packet.len());
+    pub fn write(&self, packet: IpPacket<'_>) -> io::Result<usize> {
+        tracing::trace!(target: "wire", action = "write", to = "device", bytes = %packet.packet().len());
 
         match packet {
-            Packet::Ipv4(msg) => self.tun.write4(&msg),
-            Packet::Ipv6(msg) => self.tun.write6(&msg),
-        }
-    }
-}
-
-pub enum Packet<'a> {
-    Ipv4(Cow<'a, [u8]>),
-    Ipv6(Cow<'a, [u8]>),
-}
-
-impl<'a> Packet<'a> {
-    pub fn into_owned(self) -> Packet<'static> {
-        match self {
-            Packet::Ipv4(p) => Packet::Ipv4(Cow::Owned(p.into_owned())),
-            Packet::Ipv6(p) => Packet::Ipv6(Cow::Owned(p.into_owned())),
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        match self {
-            Packet::Ipv4(p) => p.len(),
-            Packet::Ipv6(p) => p.len(),
+            IpPacket::Ipv4Packet(msg) => self.tun.write4(msg.packet()),
+            IpPacket::Ipv6Packet(msg) => self.tun.write6(msg.packet()),
         }
     }
 }

--- a/rust/connlib/tunnel/src/ip_packet.rs
+++ b/rust/connlib/tunnel/src/ip_packet.rs
@@ -42,6 +42,14 @@ impl<'a> MutableIpPacket<'a> {
     }
 
     #[inline]
+    pub(crate) fn source(&self) -> IpAddr {
+        match self {
+            MutableIpPacket::MutableIpv4Packet(i) => i.get_source().into(),
+            MutableIpPacket::MutableIpv6Packet(i) => i.get_source().into(),
+        }
+    }
+
+    #[inline]
     pub(crate) fn destination(&self) -> IpAddr {
         match self {
             MutableIpPacket::MutableIpv4Packet(i) => i.get_destination().into(),
@@ -203,18 +211,16 @@ impl<'a> From<IpPacket<'a>> for snownet::IpPacket<'a> {
     }
 }
 
-impl<'a> IpPacket<'a> {
-    #[inline]
-    pub(crate) fn new(data: &mut [u8]) -> Option<IpPacket> {
-        let packet = match data[0] >> 4 {
-            4 => Ipv4Packet::new(data)?.into(),
-            6 => Ipv6Packet::new(data)?.into(),
-            _ => return None,
-        };
-
-        Some(packet)
+impl<'a> From<snownet::MutableIpPacket<'a>> for MutableIpPacket<'a> {
+    fn from(value: snownet::MutableIpPacket<'a>) -> Self {
+        match value {
+            snownet::MutableIpPacket::Ipv4(p) => Self::MutableIpv4Packet(p),
+            snownet::MutableIpPacket::Ipv6(p) => Self::MutableIpv6Packet(p),
+        }
     }
+}
 
+impl<'a> IpPacket<'a> {
     pub(crate) fn owned(data: Vec<u8>) -> Option<IpPacket<'static>> {
         let packet = match data[0] >> 4 {
             4 => Ipv4Packet::owned(data)?.into(),

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -329,10 +329,7 @@ where
                 continue;
             };
 
-            let packet_len = packet.packet().len();
-            let packet = match peer
-                .untransform(packet.source(), &mut self.write_buf.as_mut()[..packet_len])
-            {
+            let packet = match peer.untransform(packet.into()) {
                 Ok(packet) => packet,
                 Err(e) => {
                     tracing::warn!(%conn_id, %local, %from, "Failed to transform packet: {e}");
@@ -341,7 +338,7 @@ where
                 }
             };
 
-            device.write(packet)?;
+            device.write(packet.as_immutable())?;
         }
 
         Poll::Ready(Ok(()))

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -166,13 +166,13 @@ impl PacketTransform for PacketTransformGateway {
             return Err(Error::BadPacket);
         };
 
-        if self.resources.longest_match(dst).is_some() {
-            let packet = make_packet(packet, addr);
-            Ok((packet, *addr))
-        } else {
+        if self.resources.longest_match(dst).is_none() {
             tracing::warn!(%dst, "unallowed packet");
-            Err(Error::InvalidDst)
+            return Err(Error::InvalidDst);
         }
+
+        let packet = make_packet(packet, addr);
+        Ok((packet, *addr))
     }
 
     fn packet_transform<'a>(&mut self, packet: MutableIpPacket<'a>) -> Option<MutableIpPacket<'a>> {


### PR DESCRIPTION
Instead of converting back and forth between buffers, `device_channel::Packet` and `IpPacket`, we now use the same `IpPacket` type everywhere.