### PR TITLE
fix(gui-client): fix some papercuts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -249,6 +249,7 @@ jobs:
       fail-fast: false
       # The matrix is 1x1 to match the style of build-push-linux-release-artifacts
       # In the future we could try to cross-compile aarch64-windows here.
+      # Match with `updates.rs` in gui-client, `git grep WCPYPXZF`
       matrix:
         include:
           - runs-on: ubuntu-20.04

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -1,13 +1,21 @@
-# windows-client
+# gui-client
 
-This crate houses a Windows GUI client.
+This crate houses a GUI client for Linux and Windows.
 
-## Setup
+## Setup (Ubuntu)
 
-This is the minimal toolchain needed to compile natively for x86_64 Windows:
+To compile natively for x86_64 Linux:
 
-1. [Install rustup](https://win.rustup.rs/x86_64) for Windows.
-1. Install [pnpm](https://pnpm.io/installation) for your platform.
+1. [Install rustup](https://rustup.rs/)
+1. Install [pnpm](https://pnpm.io/installation)
+1. `sudo apt-get install at-spi2-core gcc libwebkit2gtk-4.0-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev pkg-config xvfb`
+
+## Setup (Windows)
+
+To compile natively for x86_64 Windows:
+
+1. [Install rustup](https://rustup.rs/)
+1. Install [pnpm](https://pnpm.io/installation)
 
 ### Recommended IDE Setup
 
@@ -25,10 +33,17 @@ and css is compiled properly before bundling the application.
 See the [`package.json`](./package.json) script for more details as to what's
 going on under the hood.
 
-```powershell
+```bash
 # Builds a release exe
 pnpm build
 
+# Linux:
+# The release exe, AppImage with bundled WebView, and deb package are up in the workspace.
+stat ../target/release/firezone
+stat ../target/release/bundle/appimage/*.AppImage
+stat ../target/release/bundle/deb/*.deb
+
+# Windows:
 # The release exe and MSI installer should be up in the workspace.
 # The exe can run without being installed
 stat ../target/release/Firezone.exe
@@ -55,6 +70,8 @@ The app's config and logs will be stored at
 `C:\Users\$USER\AppData\Local\dev.firezone.client`.
 
 ## Platform support
+
+Ubuntu 20.04 and newer is supported.
 
 Tauri says it should work on Windows 10, Version 1803 and up. Older versions may
 work if you

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -609,7 +609,7 @@ impl Controller {
                     // but if you already got in, don't make me sign in all over again."
                     //
                     // Also, by amazing coincidence, it doesn't work in Tauri anyway.
-                    // We'd have to re-use the `sign_out` ID to make it work.
+                    // We'd have to reuse the `sign_out` ID to make it work.
                     tracing::info!("This can never happen. Tauri doesn't pass us a system tray event if the menu no longer has any item with that ID.");
                 } else {
                     tracing::info!("Calling `sign_out` to cancel sign-in");

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -183,6 +183,7 @@ pub(crate) fn run(cli: &client::Cli) -> Result<(), Error> {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event.event() {
                 // Keep the frontend running but just hide this webview
                 // Per https://tauri.app/v1/guides/features/system-tray/#preventing-the-app-from-closing
+                // Closing the window fully seems to deallocate it or something.
 
                 event.window().hide().unwrap();
                 api.prevent_close();
@@ -201,6 +202,7 @@ pub(crate) fn run(cli: &client::Cli) -> Result<(), Error> {
         .system_tray(tray)
         .on_system_tray_event(|app, event| {
             if let SystemTrayEvent::MenuItemClick { id, .. } = event {
+                tracing::debug!(?id, "SystemTrayEvent::MenuItemClick");
                 let event = match TrayMenuEvent::from_str(&id) {
                     Ok(x) => x,
                     Err(e) => {
@@ -599,12 +601,23 @@ impl Controller {
                 .handle_deep_link(&url)
                 .await
                 .context("Couldn't handle deep link")?,
+            Req::SystemTrayMenu(TrayMenuEvent::CancelSignIn) => {
+                if self.session.is_some() {
+                    // If the user opened the menu, then sign-in completed, then they
+                    // click "cancel sign in", don't sign out - They can click Sign Out
+                    // if they want to sign out. "Cancel" may mean "Give up waiting,
+                    // but if you already got in, don't make me sign in all over again."
+                    //
+                    // Also, by amazing coincidence, it doesn't work in Tauri anyway.
+                    // We'd have to re-use the `sign_out` ID to make it work.
+                    tracing::info!("This can never happen. Tauri doesn't pass us a system tray event if the menu no longer has any item with that ID.");
+                } else {
+                    tracing::info!("Calling `sign_out` to cancel sign-in");
+                    self.sign_out()?;
+                }
+            }
             Req::SystemTrayMenu(TrayMenuEvent::ToggleWindow(window)) => {
                 self.toggle_window(window)?
-            }
-            Req::SystemTrayMenu(TrayMenuEvent::CancelSignIn | TrayMenuEvent::SignOut) => {
-                tracing::info!("User signed out or canceled sign-in");
-                self.sign_out()?;
             }
             Req::SystemTrayMenu(TrayMenuEvent::Resource { id }) => self
                 .copy_resource(&id)
@@ -619,6 +632,10 @@ impl Controller {
                         None,
                     )?;
                 }
+            }
+            Req::SystemTrayMenu(TrayMenuEvent::SignOut) => {
+                tracing::info!("User asked to sign out");
+                self.sign_out()?;
             }
             Req::SystemTrayMenu(TrayMenuEvent::Quit) => {
                 bail!("Impossible error: `Quit` should be handled before this")
@@ -705,7 +722,7 @@ impl Controller {
         } else {
             // Might just be because we got a double sign-out or
             // the user canceled the sign-in or something innocent.
-            tracing::warn!("tried to sign out but there's no session");
+            tracing::info!("Tried to sign out but there's no session, cancelled sign-in");
         }
         self.refresh_system_tray_menu()?;
         Ok(())
@@ -722,12 +739,8 @@ impl Controller {
             .get_window(id)
             .ok_or_else(|| anyhow!("getting handle to `{id}` window"))?;
 
-        if win.is_visible()? {
-            // If we close the window here, we can't re-open it, we'd have to fully re-create it. Not needed for MVP - We agreed 100 MB is fine for the GUI client.
-            win.hide()?;
-        } else {
-            win.show()?;
-        }
+        win.show()?;
+        win.unminimize()?;
         Ok(())
     }
 }

--- a/rust/gui-client/src-tauri/src/client/logging.rs
+++ b/rust/gui-client/src-tauri/src/client/logging.rs
@@ -50,7 +50,7 @@ pub(crate) fn setup(log_filter: &str) -> Result<Handles, Error> {
     if let Err(error) = output_vt100::try_init() {
         tracing::warn!(
             ?error,
-            "Failed to init vt100 terminal colors (expected in CI)"
+            "Failed to init vt100 terminal colors (expected in release builds and in CI)"
         );
     }
     LogTracer::init()?;

--- a/rust/gui-client/src-tauri/src/client/updates.rs
+++ b/rust/gui-client/src-tauri/src/client/updates.rs
@@ -170,10 +170,10 @@ mod tests {
         "published_at": "2024-01-24T04:34:44Z",
         "assets": [
             {
-                "url": "https://api.github.com/repos/firezone/firezone/releases/assets/147443612",
-                "id": 147443612,
+                "url": "https://api.github.com/repos/firezone/firezone/releases/assets/147443613",
+                "id": 147443613,
                 "node_id": "RA_kwDOD12Hpc4Iyc-c",
-                "name": "firezone-gui-client-windows-x64.msi",
+                "name": "firezone-linux-gui-client_amd64.AppImage",
                 "label": "",
                 "uploader": {
                     "login": "github-actions[bot]",
@@ -201,15 +201,53 @@ mod tests {
                 "download_count": 10,
                 "created_at": "2024-01-24T04:33:53Z",
                 "updated_at": "2024-01-24T04:33:53Z",
-                "browser_download_url": "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/firezone-gui-client-windows-x64.msi"
+                "browser_download_url": "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/firezone-linux-gui-client_amd64.AppImage"
+            },
+            {
+                "url": "https://api.github.com/repos/firezone/firezone/releases/assets/147443612",
+                "id": 147443612,
+                "node_id": "RA_kwDOD12Hpc4Iyc-c",
+                "name": "firezone-windows-client-x64.msi",
+                "label": "",
+                "uploader": {
+                    "login": "github-actions[bot]",
+                    "id": 41898282,
+                    "node_id": "MDM6Qm90NDE4OTgyODI=",
+                    "avatar_url": "https://avatars.githubusercontent.com/in/15368?v=4",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/github-actions%5Bbot%5D",
+                    "html_url": "https://github.com/apps/github-actions",
+                    "followers_url": "https://api.github.com/users/github-actions%5Bbot%5D/followers",
+                    "following_url": "https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/github-actions%5Bbot%5D/subscriptions",
+                    "organizations_url": "https://api.github.com/users/github-actions%5Bbot%5D/orgs",
+                    "repos_url": "https://api.github.com/users/github-actions%5Bbot%5D/repos",
+                    "events_url": "https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/github-actions%5Bbot%5D/received_events",
+                    "type": "Bot",
+                    "site_admin": false
+                },
+                "content_type": "application/octet-stream",
+                "state": "uploaded",
+                "size": 8376320,
+                "download_count": 10,
+                "created_at": "2024-01-24T04:33:53Z",
+                "updated_at": "2024-01-24T04:33:53Z",
+                "browser_download_url": "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/firezone-windows-client-x64.msi"
             }
         ]
     }"#;
 
     #[test]
     fn test() {
+        let asset_name = super::ASSET_NAME;
         let release = super::Release::from_str(RELEASES_LATEST_JSON).unwrap();
-        assert_eq!(release.browser_download_url.to_string(), "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/firezone-gui-client-windows-x64.msi");
+        let expected_url = format!(
+            "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/{asset_name}"
+        );
+        assert_eq!(release.browser_download_url.to_string(), expected_url);
         assert_eq!(release.tag_name.to_string(), "1.0.0-pre.8");
 
         assert!(

--- a/rust/gui-client/src-tauri/src/client/updates.rs
+++ b/rust/gui-client/src-tauri/src/client/updates.rs
@@ -23,7 +23,7 @@ impl Release {
         let ReleaseDetails { assets, tag_name } = serde_json::from_str(s)?;
         let asset = assets
             .into_iter()
-            .find(|asset| asset.name == MSI_ASSET_NAME)
+            .find(|asset| asset.name == ASSET_NAME)
             .ok_or(Error::NoSuchAsset)?;
 
         Ok(Release {
@@ -51,7 +51,7 @@ pub(crate) enum Error {
     HttpStatus(reqwest::StatusCode),
     #[error(transparent)]
     JsonParse(#[from] serde_json::Error),
-    #[error("No such asset `{MSI_ASSET_NAME}` in the latest release")]
+    #[error("No such asset `{ASSET_NAME}` in the latest release")]
     NoSuchAsset,
     #[error("Our own semver in the exe is invalid, this should be impossible")]
     OurVersionIsInvalid(semver::Error),
@@ -67,9 +67,12 @@ const GITHUB_API_VERSION: &str = "2022-11-28";
 
 /// The name of the Windows MSI asset.
 ///
-/// This ultimately comes from `cd.yml`
-// TODO: Remove 'windows'
-const MSI_ASSET_NAME: &str = "firezone-gui-client-windows-x64.msi";
+/// This ultimately comes from `cd.yml`, `git grep WCPYPXZF`
+#[cfg(target_os = "linux")]
+const ASSET_NAME: &str = "firezone-linux-gui-client_amd64.AppImage";
+
+#[cfg(target_os = "windows")]
+const ASSET_NAME: &str = "firezone-windows-client-x64.msi";
 
 /// Returns the latest release, even if ours is already newer
 pub(crate) async fn check() -> Result<Release, Error> {


### PR DESCRIPTION
Fixes various small issues, including some of the issues in #3768:

- Clicking "About" or "Settings" no longer toggles a window between visible and hidden, it always shows and un-minimizes the window. So if it's minimized, it won't vanish, it will appear
- Log message for vt100 failure is clearer
- The "cancel sign-in" race was coincidentally already working as intended, but the code and comments are clarified.
- Fix the asset name used to check for auto-updates (this cannot be end-to-end tested until we cut a new release of the clients on Github, not just a draft release)
- Fix README to include Ubuntu instructions