### PR TITLE
chore: add nix scripts

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake ./scripts/nix/flake.nix

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ npm-debug.log
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
 
+# Ignore local `direnv` cache
 .direnv

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ npm-debug.log
 
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
+
+.direnv

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -179,6 +179,10 @@ If using asdf, simply run `asdf install` from the project root.
 This is used to run static analysis checks during [pre-commit](#pre-commit) and
 for any local, non-Docker development or testing.
 
+### nix Setup
+
+If you are using Nix, see [scripts/nix/README](scripts/nix/README.md).
+
 ### Pre-commit
 
 We use [pre-commit](https://pre-commit.com) to catch any static analysis issues

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -181,7 +181,7 @@ for any local, non-Docker development or testing.
 
 ### nix Setup
 
-If you are using Nix, see [scripts/nix/README](scripts/nix/README.md).
+If you are using Nix, see [scripts/nix/README](../scripts/nix/README.md).
 
 ### Pre-commit
 

--- a/scripts/nix/README.md
+++ b/scripts/nix/README.md
@@ -1,0 +1,5 @@
+# Nix tooling
+
+To use the dev-shell specified in this repository, simply run `nix develop`.
+
+There is also an `.envrc` file at the repository root, meaning if you have `direnv` installed and hooked up for your shell, `nix develop` will be run automatically as soon as you enter the repository.

--- a/scripts/nix/flake.lock
+++ b/scripts/nix/flake.lock
@@ -1,0 +1,162 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1698420672,
+        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708847675,
+        "narHash": "sha256-RUZ7KEs/a4EzRELYDGnRB6i7M1Izii3JD/LyzH0c6Tg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2a34566b67bef34c551f204063faeecc444ae9da",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1708831307,
+        "narHash": "sha256-0iL/DuGjiUeck1zEaL+aIe2WvA3/cVhp/SlmTcOZXH4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1706487304,
+        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1708913568,
+        "narHash": "sha256-76PGANC2ADf0h7fe0w2nWpfdGN+bemFs2rvW2EdU/ZY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "cbdf3e5bb205ff2ca165fe661fbd6d885cbd0106",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -1,0 +1,40 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-23.11";
+    naersk.url = "github:nix-community/naersk";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... } @ inputs:
+    flake-utils.lib.eachDefaultSystem
+      (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (import rust-overlay) ];
+          };
+          naersk = pkgs.callPackage inputs.naersk { };
+          nativeBuildInputs = with pkgs; [ pkg-config glibc gtk3 gtk4 webkitgtk libsoup atk ];
+        in
+
+        {
+
+          packages.firezone-linux-client = naersk.buildPackage {
+            name = "foo";
+            src = ../../rust/linux-client;
+          };
+
+          devShell = pkgs.mkShell {
+            buildInputs = [
+              (pkgs.rust-bin.fromRustupToolchainFile ../../rust/rust-toolchain.toml)
+            ];
+            inherit nativeBuildInputs;
+            name = "rust-env";
+            src = ../../rust;
+          };
+        }
+
+      );
+}

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -27,6 +27,7 @@
           };
 
           devShell = pkgs.mkShell {
+            packages = [ pkgs.cargo-tauri ];
             buildInputs = [
               (pkgs.rust-bin.fromRustupToolchainFile ../../rust/rust-toolchain.toml)
             ];

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -16,7 +16,31 @@
             overlays = [ (import rust-overlay) ];
           };
           naersk = pkgs.callPackage inputs.naersk { };
-          nativeBuildInputs = with pkgs; [ pkg-config glibc gtk3 gtk4 webkitgtk libsoup atk ];
+
+          libraries = with pkgs;[
+            webkitgtk
+            gtk3
+            cairo
+            gdk-pixbuf
+            glib
+            dbus
+            openssl_3
+            librsvg
+          ];
+
+          packages = with pkgs; [
+            curl
+            wget
+            pkg-config
+            dbus
+            openssl_3
+            glib
+            gtk3
+            libsoup
+            webkitgtk
+            librsvg
+            libappindicator-gtk3
+          ];
         in
 
         {
@@ -30,10 +54,14 @@
             packages = [ pkgs.cargo-tauri ];
             buildInputs = [
               (pkgs.rust-bin.fromRustupToolchainFile ../../rust/rust-toolchain.toml)
-            ];
-            inherit nativeBuildInputs;
+            ] ++ packages;
             name = "rust-env";
             src = ../../rust;
+            shellHook =
+              ''
+                export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath libraries}:$LD_LIBRARY_PATH
+                export XDG_DATA_DIRS=${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS
+              '';
           };
         }
 


### PR DESCRIPTION
Some recent changes to the Rust part of the codebase made it quite difficult to locally build the project due to tauri's heavy dependencies on WebKitGTK and other native libraries.

I tried working around this on my local (nix) machine and found it quite difficult. The cleanest way here is to make use of what Nix calls "devshells" which give you an environment specifically for hacking on your project.

Unfortunately, these files need to be tracked in version control and cannot be ignored (at least I've not found a way to do that). Given that we already have a lot of clutter in our repository, I put them under `scripts/nix`.

They are generally useful. I also added a `.envrc` file which automatically launches the dev-shell. As a result, you have a shell ready to go with all your dependencies as soon as you `cd` into our repository (assuming you use `direnv` and it is hooked up with your shell).

I didn't really want to have any of my local setup leak into the repo because I think apart from me and @conectado, nobody is using nix, thus I hope this minimal footprint is an okay compromise.