### PR TITLE
chore: remove markdownlint config files

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-    "MD002": false,
-    "MD013": {
-      "code_blocks": false,
-      "tables": false
-    }
-}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,4 +1,0 @@
-.docusaurus
-node_modules
-src
-static


### PR DESCRIPTION
I couldn't find any mention of a `markdownlint` tool anywhere in our repository via `rg --hidden markdownlint`. It doesn't seem to run in CI.