### PR TITLE
refactor(firezone_tunnel): allow cargo-mutants to pick up the `tun` impls

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -2,16 +2,19 @@
 #![cfg_attr(target_family = "windows", allow(dead_code))] // TODO: Remove when windows is fully implemented.
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-#[path = "device_channel/tun_darwin.rs"]
-mod tun;
+mod tun_darwin;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use tun_darwin as tun;
 
 #[cfg(target_os = "linux")]
-#[path = "device_channel/tun_linux.rs"]
-mod tun;
+mod tun_linux;
+#[cfg(target_os = "linux")]
+use tun_linux as tun;
 
-#[cfg(target_family = "windows")]
-#[path = "device_channel/tun_windows.rs"]
-mod tun;
+#[cfg(target_os = "windows")]
+mod tun_windows;
+#[cfg(target_os = "windows")]
+use tun_windows as tun;
 
 // TODO: Android and linux are nearly identical; use a common tunnel module?
 #[cfg(target_os = "android")]

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -24,6 +24,7 @@ use tun_windows as tun;
 #[path = "device_channel/tun_android.rs"]
 mod tun;
 
+#[cfg(target_family = "unix")]
 mod utils;
 
 use crate::ip_packet::MutableIpPacket;

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::module_inception)]
 #![cfg_attr(target_family = "windows", allow(dead_code))] // TODO: Remove when windows is fully implemented.
 
+#[cfg(target_os = "linux")]
+mod etc_resolv_conf;
+
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod tun_darwin;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -20,6 +23,8 @@ use tun_windows as tun;
 #[cfg(target_os = "android")]
 #[path = "device_channel/tun_android.rs"]
 mod tun;
+
+mod utils;
 
 use crate::ip_packet::MutableIpPacket;
 use connlib_shared::error::ConnlibError;

--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -1,3 +1,4 @@
+use super::utils;
 use crate::device_channel::ioctl;
 use connlib_shared::{messages::Interface as InterfaceConfig, Callbacks, Error, Result};
 use ip_network::IpNetwork;
@@ -9,8 +10,6 @@ use std::{
     os::fd::{AsRawFd, RawFd},
 };
 use tokio::io::unix::AsyncFd;
-
-mod utils;
 
 pub(crate) const SIOCGIFMTU: libc::c_ulong = libc::SIOCGIFMTU;
 

--- a/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
@@ -1,3 +1,4 @@
+use super::utils;
 use connlib_shared::{messages::Interface as InterfaceConfig, Callbacks, Error, Result};
 use ip_network::IpNetwork;
 use libc::{
@@ -13,8 +14,6 @@ use std::{
     os::fd::{AsRawFd, RawFd},
 };
 use tokio::io::unix::AsyncFd;
-
-mod utils;
 
 const CTL_NAME: &[u8] = b"com.apple.net.utun_control";
 /// `libc` for darwin doesn't define this constant so we declare it here.

--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -1,3 +1,4 @@
+use super::{etc_resolv_conf, utils};
 use crate::device_channel::ioctl;
 use crate::FIREZONE_MARK;
 use connlib_shared::{
@@ -27,9 +28,6 @@ use std::{
     },
 };
 use tokio::io::unix::AsyncFd;
-
-mod etc_resolv_conf;
-mod utils;
 
 pub(crate) const SIOCGIFMTU: libc::c_ulong = libc::SIOCGIFMTU;
 

--- a/rust/connlib/tunnel/src/device_channel/utils.rs
+++ b/rust/connlib/tunnel/src/device_channel/utils.rs
@@ -3,7 +3,6 @@ use std::os::fd::{AsRawFd, RawFd};
 use std::task::{Context, Poll};
 use tokio::io::Ready;
 
-#[cfg(target_family = "unix")]
 pub fn poll_raw_fd(
     fd: &tokio::io::unix::AsyncFd<RawFd>,
     mut read: impl FnMut(RawFd) -> io::Result<usize>,


### PR DESCRIPTION
cargo-mutants uses its own code parser that doesn't understand `cfg` or some nuances of Rust, so it couldn't find `tun_windows.rs` without this patch.

I also changed `target_family` to `target_os` here to make Windows consistent with other platforms. Research indicates that `target_os = "windows"` and `target_family = "windows"` are the same thing:
https://stackoverflow.com/a/76480973

This is part of a small yak shave to write unit tests for `tun_windows.rs`, since it's not covered by integration tests.