### PR TITLE
chore(snownet): reduce log levels

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -950,7 +950,7 @@ impl ChannelBindings {
 
         channel.set_confirmed(now);
 
-        tracing::info!(channel = %c, peer = %channel.peer, "Bound channel");
+        tracing::debug!(channel = %c, peer = %channel.peer, "Bound channel");
 
         true
     }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1339,7 +1339,7 @@ impl Connection {
             // Payload should be sent from a "remote socket", let's wrap it in a channel data message!
             let Some(channel_data) = allocation.encode_to_vec(dst, &packet, now) else {
                 // Unlikely edge-case, drop the packet and continue.
-                tracing::debug!(%relay, peer = %dst, "Dropping packet because allocation does not offer a channel to peer");
+                tracing::trace!(%relay, peer = %dst, "Dropping packet because allocation does not offer a channel to peer");
                 continue;
             };
 


### PR DESCRIPTION
Both of these happen quite often and aren't really of concern for day-to-day operation. Binding a new channel is still a state change but after using the clients for a bit, it seems that it is not an important enough state change to actually tell the user about (which I assume will likely log on `INFO`).

Similarly, dropping a packet because we don't have a channel happens more often now because we've optimised, which addresses we bind channels to.