### PR TITLE
refactor(connlib): replace intent timer with explicit throttling

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -41,7 +41,6 @@ pub struct ControlPlane<CB: Callbacks> {
     pub tunnel_init: bool,
 
     pub next_request_id: usize,
-
     pub sent_connection_intents: SentConnectionIntents,
 }
 

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -485,3 +485,39 @@ async fn upload(path: PathBuf, url: Url) -> io::Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discards_old_connection_intent() {
+        let mut intents = SentConnectionIntents::default();
+
+        let resource = ResourceId::random();
+
+        intents.register_new_intent(1, resource);
+        intents.register_new_intent(2, resource);
+
+        let should_accept = intents.handle_connection_details_received(1, resource);
+
+        assert!(!should_accept);
+    }
+
+    #[test]
+    fn allows_unrelated_intents() {
+        let mut intents = SentConnectionIntents::default();
+
+        let resource1 = ResourceId::random();
+        let resource2 = ResourceId::random();
+
+        intents.register_new_intent(1, resource1);
+        intents.register_new_intent(2, resource2);
+
+        let should_accept_1 = intents.handle_connection_details_received(1, resource1);
+        let should_accept_2 = intents.handle_connection_details_received(2, resource2);
+
+        assert!(should_accept_1);
+        assert!(should_accept_2);
+    }
+}

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -346,7 +346,7 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
                     .clone()
                     .send_with_ref(
                         EgressMessages::PrepareConnection {
-                            resource_id: resource.id(),
+                            resource_id: resource,
                             connected_gateway_ids,
                         },
                         reference,

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -12,7 +12,6 @@ use messages::IngressMessages;
 use messages::Messages;
 use messages::ReplyMessages;
 use secrecy::{Secret, SecretString};
-use std::collections::HashMap;
 use std::future::poll_fn;
 use std::time::Duration;
 use tokio::time::{Interval, MissedTickBehavior};
@@ -181,7 +180,7 @@ where
                 phoenix_channel: connection.sender_with_topic("client".to_owned()),
                 tunnel_init: false,
                 next_request_id: 0,
-                last_connection_intent_request: HashMap::default(),
+                sent_connection_intents: Default::default(),
             };
 
             tokio::spawn({

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -12,6 +12,7 @@ use messages::IngressMessages;
 use messages::Messages;
 use messages::ReplyMessages;
 use secrecy::{Secret, SecretString};
+use std::collections::HashMap;
 use std::future::poll_fn;
 use std::time::Duration;
 use tokio::time::{Interval, MissedTickBehavior};
@@ -180,7 +181,7 @@ where
                 phoenix_channel: connection.sender_with_topic("client".to_owned()),
                 tunnel_init: false,
                 next_request_id: 0,
-                last_connection_intent_request: 0,
+                last_connection_intent_request: HashMap::default(),
             };
 
             tokio::spawn({

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -179,6 +179,8 @@ where
                 tunnel,
                 phoenix_channel: connection.sender_with_topic("client".to_owned()),
                 tunnel_init: false,
+                next_request_id: 0,
+                last_connection_intent_request: 0,
             };
 
             tokio::spawn({

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -20,6 +20,12 @@ use crate::Dname;
 pub struct GatewayId(Uuid);
 #[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ResourceId(Uuid);
+
+impl ResourceId {
+    pub fn random() -> ResourceId {
+        ResourceId(Uuid::new_v4())
+    }
+}
 #[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub struct ClientId(Uuid);
 #[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -531,14 +531,6 @@ impl ClientState {
         self.dns_mapping.clone()
     }
 
-    fn is_awaiting_connection_to_cidr(&self, destination: IpAddr) -> bool {
-        let Some(resource) = self.get_cidr_resource_by_destination(destination) else {
-            return false;
-        };
-
-        self.awaiting_connection.contains_key(&resource)
-    }
-
     fn is_connected_to(&self, resource: ResourceId, domain: &Option<Dname>) -> bool {
         let Some(resource) = self.resource_ids.get(&resource) else {
             return false;

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -515,7 +515,7 @@ impl ClientState {
         };
 
         self.buffered_events.push_back(Event::ConnectionIntent {
-            resource: resource.clone(),
+            resource: resource.id(),
             connected_gateway_ids: gateways,
             reference,
         });

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -435,7 +435,9 @@ impl ClientState {
         self.gateway_awaiting_connection_timers.remove(gateway);
     }
 
-    pub fn on_connection_intent_dns(&mut self, resource: &DnsResource, now: Instant) {
+    fn on_connection_intent_dns(&mut self, resource: &DnsResource, now: Instant) {
+        tracing::trace!(address = %resource.address, "resource_connection_intent");
+
         self.on_connection_intent_to_resource(resource.id, Some(resource.address.clone()), now)
     }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -274,7 +274,6 @@ pub struct ClientState {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AwaitingConnectionDetails {
-    response_received: bool,
     domain: Option<Dname>,
     gateways: HashSet<GatewayId>,
     last_intent_sent_at: Instant,
@@ -381,12 +380,9 @@ impl ClientState {
             return Err(Error::UnexpectedConnectionDetails);
         }
 
-        let details = self
-            .awaiting_connection
+        self.awaiting_connection
             .get_mut(&resource)
             .ok_or(Error::UnexpectedConnectionDetails)?;
-
-        details.response_received = true;
 
         if self.gateway_awaiting_connection.contains(&gateway) {
             self.awaiting_connection.remove(&resource);
@@ -493,7 +489,6 @@ impl ClientState {
             }
             Entry::Vacant(vacant) => {
                 vacant.insert(AwaitingConnectionDetails {
-                    response_received: false,
                     domain: None,
                     gateways: gateways.clone(),
                     last_intent_sent_at: now,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -436,7 +436,7 @@ impl ClientState {
     }
 
     pub fn on_connection_intent_dns(&mut self, resource: &DnsResource, now: Instant) {
-        self.on_connection_intent_to_resource(resource.id, now)
+        self.on_connection_intent_to_resource(resource.id, Some(resource.address.clone()), now)
     }
 
     fn on_connection_intent_ip(&mut self, destination: IpAddr, now: Instant) {
@@ -454,10 +454,15 @@ impl ClientState {
             return;
         };
 
-        self.on_connection_intent_to_resource(resource_id, now)
+        self.on_connection_intent_to_resource(resource_id, None, now)
     }
 
-    fn on_connection_intent_to_resource(&mut self, resource: ResourceId, now: Instant) {
+    fn on_connection_intent_to_resource(
+        &mut self,
+        resource: ResourceId,
+        domain: Option<Dname>,
+        now: Instant,
+    ) {
         debug_assert!(self.resource_ids.contains_key(&resource));
 
         let gateways = self
@@ -477,7 +482,7 @@ impl ClientState {
             }
             Entry::Vacant(vacant) => {
                 vacant.insert(AwaitingConnectionDetails {
-                    domain: None,
+                    domain,
                     gateways: gateways.clone(),
                     last_intent_sent_at: now,
                 });

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -276,7 +276,7 @@ pub struct ClientState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AwaitingConnectionDetails {
+struct AwaitingConnectionDetails {
     total_attemps: usize,
     response_received: bool,
     domain: Option<Dname>,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -435,15 +435,7 @@ impl ClientState {
         self.gateway_awaiting_connection_timers.remove(gateway);
     }
 
-    fn is_awaiting_connection_to_dns(&self, resource: &DnsResource) -> bool {
-        self.awaiting_connection.contains_key(&resource.id)
-    }
-
     pub fn on_connection_intent_dns(&mut self, resource: &DnsResource, now: Instant) {
-        if self.is_awaiting_connection_to_dns(resource) {
-            return;
-        }
-
         self.on_connection_intent_to_resource(resource.id, now)
     }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -448,10 +448,6 @@ impl ClientState {
     }
 
     fn on_connection_intent_ip(&mut self, destination: IpAddr, now: Instant) {
-        if self.is_awaiting_connection_to_cidr(destination) {
-            return;
-        }
-
         tracing::trace!(resource_ip = %destination, "resource_connection_intent");
 
         let Some(resource_id) = self.get_cidr_resource_by_destination(destination) else {

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -480,10 +480,7 @@ impl ClientState {
     }
 
     fn on_connection_intent_to_resource(&mut self, resource: ResourceId, now: Instant) {
-        let resource = self
-            .resource_ids
-            .get(&resource)
-            .expect("inconsistent internal state");
+        debug_assert!(self.resource_ids.contains_key(&resource));
 
         let gateways = self
             .gateway_awaiting_connection
@@ -492,7 +489,7 @@ impl ClientState {
             .copied()
             .collect::<HashSet<_>>();
 
-        let reference = match self.awaiting_connection.entry(resource.id()) {
+        let reference = match self.awaiting_connection.entry(resource) {
             Entry::Occupied(mut occupied) => {
                 if now.duration_since(occupied.get().last_intent_sent_at) < Duration::from_secs(2) {
                     return;
@@ -515,7 +512,7 @@ impl ClientState {
         };
 
         self.buffered_events.push_back(Event::ConnectionIntent {
-            resource: resource.id(),
+            resource,
             connected_gateway_ids: gateways,
             reference,
         });

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -502,7 +502,7 @@ impl ClientState {
 
         tracing::trace!(resource_ip = %destination, "resource_connection_intent");
 
-        let Some(resource) = self.get_cidr_resource_by_destination(destination) else {
+        let Some(resource_id) = self.get_cidr_resource_by_destination(destination) else {
             if let Some(resource) = self
                 .dns_resources_internal_ips
                 .iter()
@@ -515,8 +515,6 @@ impl ClientState {
         };
 
         const MAX_SIGNAL_CONNECTION_DELAY: Duration = Duration::from_secs(2);
-
-        let resource_id = resource.id();
 
         let gateways = self
             .gateway_awaiting_connection
@@ -592,7 +590,7 @@ impl ClientState {
             return false;
         };
 
-        self.awaiting_connection.contains_key(&resource.id())
+        self.awaiting_connection.contains_key(&resource)
     }
 
     fn is_connected_to(&self, resource: ResourceId, domain: &Option<Dname>) -> bool {
@@ -638,10 +636,10 @@ impl ClientState {
         });
     }
 
-    fn get_cidr_resource_by_destination(&self, destination: IpAddr) -> Option<ResourceDescription> {
+    fn get_cidr_resource_by_destination(&self, destination: IpAddr) -> Option<ResourceId> {
         self.cidr_resources
             .longest_match(destination)
-            .map(|(_, res)| ResourceDescription::Cidr(res.clone()))
+            .map(|(_, res)| res.id)
     }
 
     fn add_pending_dns_query(&mut self, query: DnsQuery) {

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -2,7 +2,6 @@ use std::{collections::HashSet, net::IpAddr};
 
 use boringtun::x25519::PublicKey;
 use connlib_shared::{
-    control::Reference,
     messages::{
         Answer, ClientPayload, DomainResponse, GatewayId, Key, Offer, Relay, RequestConnection,
         ResourceDescription, ResourceId,
@@ -44,18 +43,12 @@ where
         resource_id: ResourceId,
         gateway_id: GatewayId,
         relays: Vec<Relay>,
-        reference: Option<Reference>,
     ) -> Result<Request> {
         tracing::trace!("request_connection");
 
-        let reference: usize = reference
-            .ok_or(Error::InvalidReference)?
-            .parse()
-            .map_err(|_| Error::InvalidReference)?;
-
-        if let Some(connection) =
-            self.role_state
-                .attempt_to_reuse_connection(resource_id, gateway_id, reference)?
+        if let Some(connection) = self
+            .role_state
+            .attempt_to_reuse_connection(resource_id, gateway_id)?
         {
             // TODO: now we send reuse connections before connection is established but after
             // response is offered.

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -5,7 +5,7 @@
 
 use boringtun::x25519::StaticSecret;
 use connlib_shared::{
-    messages::{ClientId, GatewayId, ResourceDescription, ReuseConnection},
+    messages::{ClientId, GatewayId, ResourceId, ReuseConnection},
     CallbackErrorFacade, Callbacks, Error, Result,
 };
 use device_channel::Device;
@@ -392,7 +392,7 @@ pub enum Event<TId> {
         candidate: String,
     },
     ConnectionIntent {
-        resource: ResourceDescription,
+        resource: ResourceId,
         connected_gateway_ids: HashSet<GatewayId>,
         reference: usize,
     },

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -107,7 +107,8 @@ where
 
         match device.poll_read(&mut self.read_buf, cx)? {
             Poll::Ready(Some(packet)) => {
-                let Some((peer_id, packet)) = self.role_state.encapsulate(packet) else {
+                let Some((peer_id, packet)) = self.role_state.encapsulate(packet, Instant::now())
+                else {
                     cx.waker().wake_by_ref();
                     return Poll::Pending;
                 };

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -394,7 +394,6 @@ pub enum Event<TId> {
     ConnectionIntent {
         resource: ResourceId,
         connected_gateway_ids: HashSet<GatewayId>,
-        reference: usize,
     },
     RefreshResources {
         connections: Vec<ReuseConnection>,


### PR DESCRIPTION
The reference that is specified as part of the connection intent fulfills one particular purpose: To avoid accepting connection details for a "stale" intent, i.e. a previous one that we sent for the same resource.

With the move to `phoenix-channel` in #3682, we can no longer specify the reference explicitly. Instead, sending a message to the portal gives us an `OutboundRequestId`.

To make the transition in #3682 easier, we emulate this behaviour here temporarily in the `ControlPlane` of the clients.