### PR TITLE
Add lifecycle block to AWS TF gateway module

### DIFF
--- a/terraform/modules/aws/gateway/main.tf
+++ b/terraform/modules/aws/gateway/main.tf
@@ -48,5 +48,9 @@ resource "aws_instance" "this" {
     volume_size = 20
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = merge({ "Name" = var.name }, var.instance_tags, var.tags)
 }


### PR DESCRIPTION
Adding a lifecycle block to the AWS Gateway module as a way to reduce the the amount of downtime between deployments of a gateway.