### PR TITLE
feat(snownet): timeout connections if we don't receive a candidate within 10s

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5650,6 +5650,7 @@ dependencies = [
  "stun_codec",
  "thiserror",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -20,3 +20,4 @@ bytes = "1.4.0"
 once_cell = "1.17.1"
 backoff = "0.4.0"
 hex = "0.4.0"
+tracing-subscriber = { workspace = true }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -35,6 +35,9 @@ use tracing::{field, Span};
 // Note: Taken from boringtun
 const HANDSHAKE_RATE_LIMIT: u64 = 100;
 
+/// How long we will at most wait for a candidate from the remote.
+const CANDIDATE_TIMEOUT: Duration = Duration::from_secs(10);
+
 const MAX_UDP_SIZE: usize = (1 << 16) - 1;
 
 /// Manages a set of wireguard connections for a server.
@@ -469,16 +472,20 @@ where
         self.last_now = now;
 
         let mut expired_connections = vec![];
+        let mut no_candidates_received = vec![];
 
         for (id, c) in self.connections.iter_established_mut() {
             match c.handle_timeout(now, &mut self.allocations) {
                 Ok(Some(transmit)) => {
                     self.buffered_transmits.push_back(transmit);
                 }
-                Err(WireGuardError::ConnectionExpired) => {
+                Err(ConnectionError::Wireguard(WireGuardError::ConnectionExpired)) => {
                     expired_connections.push(id);
                 }
-                Err(e) => {
+                Err(ConnectionError::CandidateTimeout) => {
+                    no_candidates_received.push(id);
+                }
+                Err(ConnectionError::Wireguard(e)) => {
                     tracing::warn!(%id, ?e);
                 }
                 _ => {}
@@ -487,6 +494,13 @@ where
 
         for conn in expired_connections {
             tracing::info!(id = %conn, "Connection failed (wireguard tunnel expired)");
+
+            self.connections.established.remove(&conn);
+            self.pending_events.push_back(Event::ConnectionFailed(conn))
+        }
+
+        for conn in no_candidates_received {
+            tracing::info!(id = %conn, "Connection failed (no candidates received)");
 
             self.connections.established.remove(&conn);
             self.pending_events.push_back(Event::ConnectionFailed(conn))
@@ -560,6 +574,7 @@ where
         key: [u8; 32],
         allowed_stun_servers: HashSet<SocketAddr>,
         allowed_turn_servers: HashSet<SocketAddr>,
+        now: Instant,
     ) -> Connection {
         agent.handle_timeout(self.last_now);
 
@@ -584,6 +599,7 @@ where
             peer_socket: None,
             possible_sockets: HashSet::default(),
             stats: Default::default(),
+            signalling_completed_at: now,
         }
     }
 
@@ -873,6 +889,7 @@ where
             *initial.session_key.expose_secret(),
             initial.stun_servers,
             initial.turn_servers,
+            now,
         );
 
         let existing = self.connections.established.insert(id, connection);
@@ -900,6 +917,7 @@ where
         remote: PublicKey,
         allowed_stun_servers: HashSet<SocketAddr>,
         allowed_turn_servers: HashSet<(SocketAddr, String, String, String)>,
+        now: Instant,
     ) -> Answer {
         debug_assert!(
             !self.connections.initial.contains_key(&id),
@@ -945,6 +963,7 @@ where
             *offer.session_key.expose_secret(),
             allowed_stun_servers,
             allowed_turn_servers,
+            now,
         );
         let existing = self.connections.established.insert(id, connection);
 
@@ -1287,6 +1306,8 @@ struct Connection {
     turn_servers: HashSet<SocketAddr>,
 
     stats: ConnectionStats,
+
+    signalling_completed_at: Instant,
 }
 
 /// The socket of the peer we are connected to.
@@ -1354,8 +1375,17 @@ impl Connection {
     fn poll_timeout(&mut self) -> Option<Instant> {
         let agent_timeout = self.agent.poll_timeout();
         let next_wg_timer = Some(self.next_timer_update);
+        let candidate_timeout = self.candidate_timeout();
 
-        earliest(agent_timeout, next_wg_timer)
+        earliest(agent_timeout, earliest(next_wg_timer, candidate_timeout))
+    }
+
+    fn candidate_timeout(&self) -> Option<Instant> {
+        if !self.agent.remote_candidates().is_empty() {
+            return None;
+        }
+
+        Some(self.signalling_completed_at + CANDIDATE_TIMEOUT)
     }
 
     #[must_use]
@@ -1407,8 +1437,15 @@ impl Connection {
         &mut self,
         now: Instant,
         allocations: &mut HashMap<SocketAddr, Allocation>,
-    ) -> Result<Option<Transmit<'static>>, WireGuardError> {
+    ) -> Result<Option<Transmit<'static>>, ConnectionError> {
         self.agent.handle_timeout(now);
+
+        if self
+            .candidate_timeout()
+            .is_some_and(|timeout| now >= timeout)
+        {
+            return Err(ConnectionError::CandidateTimeout);
+        }
 
         // TODO: `boringtun` is impure because it calls `Instant::now`.
 
@@ -1429,7 +1466,7 @@ impl Connection {
 
             match self.tunnel.update_timers(&mut buf) {
                 TunnResult::Done => {}
-                TunnResult::Err(e) => return Err(e),
+                TunnResult::Err(e) => return Err(ConnectionError::Wireguard(e)),
                 TunnResult::WriteToNetwork(b) => {
                     let Some(transmit) = self.encapsulate(b, allocations, now) else {
                         return Ok(None);
@@ -1523,4 +1560,10 @@ impl Connection {
             .iter()
             .find(|c| c.addr() == source)
     }
+}
+
+#[derive(Debug)]
+enum ConnectionError {
+    Wireguard(WireGuardError),
+    CandidateTimeout,
 }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -862,6 +862,11 @@ where
         params
     }
 
+    /// Whether we have sent an [`Offer`] for this connection and are currently expecting an [`Answer`].
+    pub fn is_expecting_answer(&self, id: TId) -> bool {
+        self.connections.initial.contains_key(&id)
+    }
+
     /// Accept an [`Answer`] from the remote for a connection previously created via [`Node::new_connection`].
     #[tracing::instrument(level = "info", skip_all, fields(%id))]
     pub fn accept_answer(&mut self, id: TId, remote: PublicKey, answer: Answer, now: Instant) {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -848,7 +848,7 @@ where
 
     /// Accept an [`Answer`] from the remote for a connection previously created via [`Node::new_connection`].
     #[tracing::instrument(level = "info", skip_all, fields(%id))]
-    pub fn accept_answer(&mut self, id: TId, remote: PublicKey, answer: Answer) {
+    pub fn accept_answer(&mut self, id: TId, remote: PublicKey, answer: Answer, now: Instant) {
         let Some(initial) = self.connections.initial.remove(&id) else {
             tracing::debug!("No initial connection state, ignoring answer"); // This can happen if the connection setup timed out.
             return;

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -9,11 +9,10 @@ use std::{
 use str0m::{net::Protocol, Candidate};
 
 #[test]
-fn connection_times_out_after_10_seconds() {
+fn connection_times_out_after_20_seconds() {
     let start = Instant::now();
 
-    let mut alice =
-        ClientNode::<u64>::new(StaticSecret::random_from_rng(rand::thread_rng()), start);
+    let (mut alice, _) = alice_and_bob(start);
 
     let _ = alice.new_connection(1, HashSet::new(), HashSet::new());
     alice.handle_timeout(start + Duration::from_secs(20));
@@ -25,9 +24,7 @@ fn connection_times_out_after_10_seconds() {
 fn answer_after_stale_connection_does_not_panic() {
     let start = Instant::now();
 
-    let mut alice =
-        ClientNode::<u64>::new(StaticSecret::random_from_rng(rand::thread_rng()), start);
-    let mut bob = ServerNode::<u64>::new(StaticSecret::random_from_rng(rand::thread_rng()), start);
+    let (mut alice, mut bob) = alice_and_bob(start);
 
     let offer = alice.new_connection(1, HashSet::new(), HashSet::new());
     let answer =
@@ -100,6 +97,13 @@ fn second_connection_with_same_relay_reuses_allocation() {
     );
 
     assert!(alice.poll_transmit().is_none());
+}
+
+fn alice_and_bob(start: Instant) -> (ClientNode<u64>, ServerNode<u64>) {
+    let alice = ClientNode::<u64>::new(StaticSecret::random_from_rng(rand::thread_rng()), start);
+    let bob = ServerNode::<u64>::new(StaticSecret::random_from_rng(rand::thread_rng()), start);
+
+    (alice, bob)
 }
 
 fn relay(username: &str, pass: &str, realm: &str) -> (SocketAddr, String, String, String) {

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -1,5 +1,5 @@
 use boringtun::x25519::StaticSecret;
-use snownet::{ClientNode, Event, ServerNode};
+use snownet::{Answer, ClientNode, Event, ServerNode};
 use std::{
     collections::HashSet,
     iter,
@@ -21,18 +21,55 @@ fn connection_times_out_after_20_seconds() {
 }
 
 #[test]
+fn connection_without_candidates_times_out_after_10_seconds() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+
+    let start = Instant::now();
+
+    let (mut alice, mut bob) = alice_and_bob(start);
+    let answer = send_offer(&mut alice, &mut bob);
+
+    let accepted_at = start + Duration::from_secs(1);
+    alice.accept_answer(1, bob.public_key(), answer, accepted_at);
+
+    alice.handle_timeout(accepted_at + Duration::from_secs(10));
+
+    assert_eq!(alice.poll_event().unwrap(), Event::ConnectionFailed(1));
+}
+
+#[test]
+fn connection_with_candidates_does_not_time_out_after_10_seconds() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+
+    let start = Instant::now();
+
+    let (mut alice, mut bob) = alice_and_bob(start);
+    let answer = send_offer(&mut alice, &mut bob);
+
+    let accepted_at = start + Duration::from_secs(1);
+    alice.accept_answer(1, bob.public_key(), answer, accepted_at);
+    alice.add_local_host_candidate(s("10.0.0.2:4444")).unwrap();
+    alice.add_remote_candidate(1, host("10.0.0.1:4444"));
+
+    alice.handle_timeout(accepted_at + Duration::from_secs(10));
+
+    let any_failed =
+        iter::from_fn(|| alice.poll_event()).any(|e| matches!(e, Event::ConnectionFailed(_)));
+
+    assert!(!any_failed);
+}
+
+#[test]
 fn answer_after_stale_connection_does_not_panic() {
     let start = Instant::now();
 
     let (mut alice, mut bob) = alice_and_bob(start);
+    let answer = send_offer(&mut alice, &mut bob);
 
-    let offer = alice.new_connection(1, HashSet::new(), HashSet::new());
-    let answer =
-        bob.accept_connection(1, offer, alice.public_key(), HashSet::new(), HashSet::new());
+    let now = start + Duration::from_secs(10);
+    alice.handle_timeout(now);
 
-    alice.handle_timeout(start + Duration::from_secs(10));
-
-    alice.accept_answer(1, bob.public_key(), answer);
+    alice.accept_answer(1, bob.public_key(), answer, now + Duration::from_secs(1));
 }
 
 #[test]
@@ -62,7 +99,7 @@ fn only_generate_candidate_event_after_answer() {
     let answer =
         bob.accept_connection(1, offer, alice.public_key(), HashSet::new(), HashSet::new());
 
-    alice.accept_answer(1, bob.public_key(), answer);
+    alice.accept_answer(1, bob.public_key(), answer, Instant::now());
 
     assert!(iter::from_fn(|| alice.poll_event()).any(|ev| ev
         == Event::SignalIceCandidate {
@@ -106,6 +143,12 @@ fn alice_and_bob(start: Instant) -> (ClientNode<u64>, ServerNode<u64>) {
     (alice, bob)
 }
 
+fn send_offer(alice: &mut ClientNode<u64>, bob: &mut ServerNode<u64>) -> Answer {
+    let offer = alice.new_connection(1, HashSet::new(), HashSet::new());
+
+    bob.accept_connection(1, offer, alice.public_key(), HashSet::new(), HashSet::new())
+}
+
 fn relay(username: &str, pass: &str, realm: &str) -> (SocketAddr, String, String, String) {
     (
         RELAY,
@@ -113,6 +156,16 @@ fn relay(username: &str, pass: &str, realm: &str) -> (SocketAddr, String, String
         pass.to_owned(),
         realm.to_owned(),
     )
+}
+
+fn host(socket: &str) -> String {
+    Candidate::host(s(socket), Protocol::Udp)
+        .unwrap()
+        .to_sdp_string()
+}
+
+fn s(socket: &str) -> SocketAddr {
+    socket.parse().unwrap()
 }
 
 const RELAY: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 10000));

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -64,6 +64,10 @@ where
             return Ok(Request::ReuseConnection(connection));
         }
 
+        if self.connections_state.node.is_expecting_answer(gateway_id) {
+            return Err(Error::PendingConnection);
+        }
+
         let domain = self
             .role_state
             .get_awaiting_connection_domain(&resource_id)?

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -101,7 +101,6 @@ where
     ) -> Result<()> {
         let ips = self.role_state.create_peer_config_for_new_connection(
             resource_id,
-            gateway_id,
             &domain_response.as_ref().map(|d| d.domain.clone()),
         )?;
 

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, net::IpAddr};
+use std::{collections::HashSet, net::IpAddr, time::Instant};
 
 use boringtun::x25519::PublicKey;
 use connlib_shared::{
@@ -151,6 +151,7 @@ where
                     password: rtc_ice_params.password,
                 },
             },
+            Instant::now(),
         );
 
         self.new_peer(resource_id, gateway_id, domain_response)?;

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -335,10 +335,12 @@ where
     }
 
     fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Event<TId>> {
-        if let Poll::Ready(instant) = self.connection_pool_timeout.poll_unpin(cx) {
-            self.node.handle_timeout(instant);
-            if let Some(timeout) = self.node.poll_timeout() {
-                self.connection_pool_timeout = sleep_until(timeout).boxed();
+        if let Poll::Ready(prev_timeout) = self.connection_pool_timeout.poll_unpin(cx) {
+            self.node.handle_timeout(prev_timeout);
+            if let Some(new_timeout) = self.node.poll_timeout() {
+                debug_assert_ne!(prev_timeout, new_timeout, "Timer busy loop!");
+
+                self.connection_pool_timeout = sleep_until(new_timeout).boxed();
             }
 
             cx.waker().wake_by_ref();

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -335,6 +335,15 @@ where
     }
 
     fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Event<TId>> {
+        if let Poll::Ready(instant) = self.connection_pool_timeout.poll_unpin(cx) {
+            self.node.handle_timeout(instant);
+            if let Some(timeout) = self.node.poll_timeout() {
+                self.connection_pool_timeout = sleep_until(timeout).boxed();
+            }
+
+            cx.waker().wake_by_ref();
+        }
+
         if self.stats_timer.poll_tick(cx).is_ready() {
             let (node_stats, conn_stats) = self.node.stats();
 
@@ -371,15 +380,6 @@ where
                 return Poll::Ready(Event::StopPeer(id));
             }
             _ => {}
-        }
-
-        if let Poll::Ready(instant) = self.connection_pool_timeout.poll_unpin(cx) {
-            self.node.handle_timeout(instant);
-            if let Some(timeout) = self.node.poll_timeout() {
-                self.connection_pool_timeout = sleep_until(timeout).boxed();
-            }
-
-            cx.waker().wake_by_ref();
         }
 
         Poll::Pending

--- a/rust/snownet-tests/src/main.rs
+++ b/rust/snownet-tests/src/main.rs
@@ -112,6 +112,7 @@ async fn main() -> Result<()> {
                         password: answer.password,
                     },
                 },
+                Instant::now(),
             );
 
             let rx = spawn_candidate_task(redis_connection.clone(), "listener_candidates");

--- a/rust/snownet-tests/src/main.rs
+++ b/rust/snownet-tests/src/main.rs
@@ -179,6 +179,7 @@ async fn main() -> Result<()> {
                 offer.public_key.into(),
                 stun_server.into_iter().collect(),
                 turn_server.into_iter().collect(),
+                Instant::now(),
             );
 
             redis_connection

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -51,7 +51,7 @@
           };
 
           devShell = pkgs.mkShell {
-            packages = [ pkgs.cargo-tauri ];
+            packages = [ pkgs.cargo-tauri pkgs.iptables ];
             buildInputs = [
               (pkgs.rust-bin.fromRustupToolchainFile ../../rust/rust-toolchain.toml)
             ] ++ packages;


### PR DESCRIPTION
Previously, we had a dedicated timer for this within the tunnel implementation. Now that we have control over the internals of our connection via `snownet`, we can timeout the connection if we don't receive a candidate from the remote within 10s.