### PR TITLE
fix: Slow DNS lookups on (at least) Windows by updating to `main` of Hickory

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2605,8 +2605,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 [[package]]
 name = "hickory-proto"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
+source = "git+https://github.com/hickory-dns/hickory-dns?branch=main#a3669bd80f3f7b97f0c301c15f1cba6368d97b63"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2615,7 +2614,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 0.4.0",
+ "idna",
  "ipnet",
  "once_cell",
  "rand 0.8.5",
@@ -2629,8 +2628,7 @@ dependencies = [
 [[package]]
 name = "hickory-resolver"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+source = "git+https://github.com/hickory-dns/hickory-dns?branch=main#a3669bd80f3f7b97f0c301c15f1cba6368d97b63"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2902,16 +2900,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -6898,7 +6886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2605,7 +2605,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 [[package]]
 name = "hickory-proto"
 version = "0.24.0"
-source = "git+https://github.com/hickory-dns/hickory-dns?branch=main#a3669bd80f3f7b97f0c301c15f1cba6368d97b63"
+source = "git+https://github.com/hickory-dns/hickory-dns?rev=a3669bd80f3f7b97f0c301c15f1cba6368d97b63#a3669bd80f3f7b97f0c301c15f1cba6368d97b63"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "hickory-resolver"
 version = "0.24.0"
-source = "git+https://github.com/hickory-dns/hickory-dns?branch=main#a3669bd80f3f7b97f0c301c15f1cba6368d97b63"
+source = "git+https://github.com/hickory-dns/hickory-dns?rev=a3669bd80f3f7b97f0c301c15f1cba6368d97b63#a3669bd80f3f7b97f0c301c15f1cba6368d97b63"
 dependencies = [
  "cfg-if",
  "futures-util",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ backoff = { version = "0.4", features = ["tokio"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
-hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", branch="main", features = ["tokio-runtime"] }
+hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev="a3669bd80f3f7b97f0c301c15f1cba6368d97b63", features = ["tokio-runtime"] }
 str0m = { version = "0.4", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.9", features = ["serde"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ backoff = { version = "0.4", features = ["tokio"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
-hickory-resolver = { version = "0.24", features = ["tokio-runtime"] }
+hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", branch="main", features = ["tokio-runtime"] }
 str0m = { version = "0.4", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.9", features = ["serde"] }


### PR DESCRIPTION
```[tasklist]
- [x] Maybe pick a rev for Hickory so even if Cargo.lock is rebuilt we don't advance unless we want to
- [ ] Maybe ask them politely to cut a release with this patch since it helps us
```

Tested on my Windows laptop and it reduces `nslookup` times for resources and non-resources (can't remember which way was which) from something like 10 and 2 seconds to 0.25 and 0.33 seconds, which is great. 

Hickory's patch got merged into main around Jan 5th but they haven't cut a release since then, so this PR changes us to use Hickory's main branch instead of crates.io: https://github.com/hickory-dns/hickory-dns/issues/2081