### PR TITLE
test(windows client): Add stack trace printing to smoke test

### DIFF
--- a/rust/gui-client/src-tauri/src/client/crash_handling.rs
+++ b/rust/gui-client/src-tauri/src/client/crash_handling.rs
@@ -8,10 +8,9 @@
 //! (Copied from <https://github.com/firezone/firezone/issues/3111#issuecomment-1887975171>)
 //!
 //! - Get the pdb corresponding to the client exe
-//! - `cargo install dump_syms`
+//! - `cargo install --locked dump_syms minidump-stackwalk`
 //! - Use dump_syms to convert the pdb to a syms file
-//! - Compile `minidump-stackwalk` with PR 891 merged
-//! - `minidump-stackwalker --symbols-path firezone.syms crash.dmp`
+//! - `minidump-stackwalk --symbols-path firezone.syms crash.dmp`
 
 use crate::client::known_dirs;
 use anyhow::{anyhow, bail, Context, Result};

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -37,18 +37,20 @@ function crash_test() {
 
     # Fail if the crash file wasn't written
     stat "$DUMP_PATH"
-    rm "$DUMP_PATH"
 }
 
 function get_stacktrace() {
-    ls ../target/debug
     # Per `crash_handling.rs`
     SYMS_PATH="../target/debug/firezone-gui-client.syms"
     cargo install --locked dump_syms minidump-stackwalk
     dump_syms ../target/debug/firezone_gui_client.pdb ../target/debug/firezone-gui-client.exe --output "$SYMS_PATH"
+    ls ../target/debug
     minidump-stackwalk --symbols-path "$SYMS_PATH" "$DUMP_PATH"
 }
 
 smoke_test
 crash_test
 get_stacktrace
+
+# Clean up
+rm "$DUMP_PATH"

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -7,33 +7,48 @@ BUNDLE_ID="dev.firezone.client"
 DUMP_PATH="$LOCALAPPDATA/$BUNDLE_ID/data/logs/last_crash.dmp"
 PACKAGE=firezone-gui-client
 
+# This prevents a `shellcheck` lint warning about using an unset CamelCase var
 if [[ -z "$ProgramData" ]]; then
     echo "The env var \$ProgramData should be set to \`C:\ProgramData\` or similar"
     exit 1
 fi
 
-# Make sure the files we want to check don't exist on the system yet
-stat "$LOCALAPPDATA/$BUNDLE_ID" && exit 1
-stat "$ProgramData/$BUNDLE_ID" && exit 1
+function smoke_test() {
+    # Make sure the files we want to check don't exist on the system yet
+    stat "$LOCALAPPDATA/$BUNDLE_ID" && exit 1
+    stat "$ProgramData/$BUNDLE_ID" && exit 1
 
-# Run the smoke test normally
-cargo run -p "$PACKAGE" -- smoke-test
+    # Run the smoke test normally
+    cargo run -p "$PACKAGE" -- smoke-test
 
-# Make sure the files were written in the right paths
-stat "$LOCALAPPDATA/$BUNDLE_ID/config/advanced_settings.json"
-stat "$LOCALAPPDATA/$BUNDLE_ID/data/logs/"connlib*log
-stat "$LOCALAPPDATA/$BUNDLE_ID/data/wintun.dll"
-stat "$ProgramData/$BUNDLE_ID/config/device_id.json"
+    # Make sure the files were written in the right paths
+    stat "$LOCALAPPDATA/$BUNDLE_ID/config/advanced_settings.json"
+    stat "$LOCALAPPDATA/$BUNDLE_ID/data/logs/"connlib*log
+    stat "$LOCALAPPDATA/$BUNDLE_ID/data/wintun.dll"
+    stat "$ProgramData/$BUNDLE_ID/config/device_id.json"
+}
 
-# Delete the crash file if present
-rm -f "$DUMP_PATH"
+function crash_test() {
+    # Delete the crash file if present
+    rm -f "$DUMP_PATH"
 
-# Fail if it returns success, this is supposed to crash
-cargo run -p "$PACKAGE" -- --crash && exit 1
+    # Fail if it returns success, this is supposed to crash
+    cargo run -p "$PACKAGE" -- --crash && exit 1
 
-# Fail if the crash file wasn't written
-stat "$DUMP_PATH"
-rm "$DUMP_PATH"
+    # Fail if the crash file wasn't written
+    stat "$DUMP_PATH"
+    rm "$DUMP_PATH"
+}
 
-# I'm not sure if the last command is handled specially, so explicitly exit with 0
-exit 0
+function get_stacktrace() {
+    ls ../target/debug
+    # Per `crash_handling.rs`
+    SYMS_PATH="../target/debug/firezone-gui-client.syms"
+    cargo install --locked dump_syms minidump-stackwalk
+    dump_syms ../target/debug/firezone_gui_client.pdb ../target/debug/firezone-gui-client.exe --output "$SYMS_PATH"
+    minidump-stackwalk --symbols-path "$SYMS_PATH" "$DUMP_PATH"
+}
+
+smoke_test
+crash_test
+get_stacktrace


### PR DESCRIPTION
Closes #3798 

- After the crash test, the Windows smoke test runs `minidump-stackwalk` to print a stack trace: https://github.com/firezone/firezone/actions/runs/8100801373/job/22139592883#step:11:770
- This acts as runnable documentation for getting stack traces on Windows, and it should flunk the test if anything in the crash handling to stack trace pipeline is broken
- I also updated the comment in the code since the minidump PR I was waiting on was put into their newest release