### PR TITLE
build(connlib): suppress `clippy::unnecessary_cast` lint on aarch64 Linux

### DIFF
--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -188,6 +188,7 @@ fn kernel_version() -> Option<String> {
         return None;
     }
 
+    #[allow(clippy::unnecessary_cast)]
     let version: Vec<u8> = utsname
         .release
         .split(|c| *c == 0)

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -188,7 +188,10 @@ fn kernel_version() -> Option<String> {
         return None;
     }
 
-    #[allow(clippy::unnecessary_cast)]
+    #[cfg_attr(
+        all(target_os = "linux", target_arch = "aarch64"),
+        allow(clippy::unnecessary_cast)
+    )]
     let version: Vec<u8> = utsname
         .release
         .split(|c| *c == 0)


### PR DESCRIPTION
This took me 5 entire minutes at least to figure out:

`c_char` is...
- i8 on aarch64 Darwin: https://docs.rs/libc/latest/aarch64-apple-darwin/libc/type.c_char.html
- i8 on aarch64 Windows: https://docs.rs/libc/latest/aarch64-pc-windows-msvc/libc/type.c_char.html
- i8 on x86_64 Linux: https://docs.rs/libc/latest/libc/type.c_char.html
- i8 on x86_64 Windows: https://docs.rs/libc/latest/x86_64-pc-windows-msvc/libc/type.c_char.html
- **u8** on aarch64 Linux. Both GNU and musl: https://docs.rs/libc/latest/aarch64-unknown-linux-gnu/libc/type.c_char.html

It is also u8 on Android aarch64, but we don't run CI on that so I guess Clippy never hit it there.