### PR TITLE
deps: point to correct hash of str0m fork

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2835,7 +2835,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.10",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5735,7 +5735,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.4.1"
-source = "git+https://github.com/firezone/str0m?branch=reduce-ice-timeout#9acce01e215e98c790832f28ed4c2c7b38d34b37"
+source = "git+https://github.com/firezone/str0m?branch=reduce-ice-timeout#fd192d65695b466b0bac1d9577b589e563f476aa"
 dependencies = [
  "combine",
  "crc",


### PR DESCRIPTION
I accidentally force-pushed to the branch that we depend on in our str0m fork.