### PR TITLE
feat(phoenix-channel): remove concept of "inbound requests"

### DIFF
--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -330,20 +330,12 @@ where
                     };
 
                     match message.payload {
-                        Payload::Message(msg) => match message.reference {
-                            None => {
-                                return Poll::Ready(Ok(Event::InboundMessage {
-                                    topic: message.topic,
-                                    msg,
-                                }));
-                            }
-                            Some(reference) => {
-                                return Poll::Ready(Ok(Event::InboundReq {
-                                    req_id: InboundRequestId(reference),
-                                    req: msg,
-                                }))
-                            }
-                        },
+                        Payload::Message(msg) => {
+                            return Poll::Ready(Ok(Event::InboundMessage {
+                                topic: message.topic,
+                                msg,
+                            }))
+                        }
                         Payload::Reply(Reply::Error { reason }) => {
                             return Poll::Ready(Ok(Event::ErrorResponse {
                                 topic: message.topic,
@@ -514,11 +506,6 @@ pub enum Event<TInboundMsg, TOutboundRes> {
     InboundMessage {
         topic: String,
         msg: TInboundMsg,
-    },
-    /// The server sent us a request and is expecting a response.
-    InboundReq {
-        req_id: InboundRequestId,
-        req: TInboundMsg,
     },
     Disconnect(String),
 }

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -523,9 +523,7 @@ where
                     tracing::debug!(target: "relay", "Heartbeat sent to portal");
                     continue;
                 }
-                Some(Poll::Ready(Ok(
-                    Event::InboundMessage { msg: (), .. } | Event::InboundReq { req: (), .. },
-                )))
+                Some(Poll::Ready(Ok(Event::InboundMessage { msg: (), .. })))
                 | Some(Poll::Pending)
                 | None => {}
             }


### PR DESCRIPTION
We don't have a concept of "inbound requests", at least not natively in the phoenix channel JSON format. Thus, we don't need to match on `ref` for incoming messages.

Extracted out of: #3682.