### PR TITLE
chore(ci): auto-label based on PR title

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,28 @@
 name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
+autolabeler:
+  - label: "kind/feature"
+    title:
+      - "/^feat/i"
+  - label: "kind/bug"
+    title:
+      - "/^fix/i"
+      - "/^bug/i"
+  - label: "kind/refactor"
+    title:
+      - "/^refactor/i"
+  - label: "kind/chore"
+    title:
+      - "/^chore/i"
+  - label: "kind/docs"
+    title:
+      - "/^docs/i"
+  - label: "kind/security"
+    title:
+      - "/^security/i"
+  - label: "dependencies"
+    title:
+      - "/^deps/i"
 categories:
   - title: "✨ Features"
     labels:
@@ -14,7 +37,6 @@ categories:
       - "dependencies"
   - title: "📝 Documentation"
     label: "kind/docs"
-
   - title: "🔐 Security"
     label: "kind/security"
 exclude-labels:

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -7,16 +7,25 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check PR title
-        if: ${{
-          github.event.pull_request
-          && !startsWith(github.event.pull_request.title, "feat")
-          && !startsWith(github.event.pull_request.title, "fix")
-          && !startsWith(github.event.pull_request.title, "refactor")
-          && !startsWith(github.event.pull_request.title, "chore")
-          && !startsWith(github.event.pull_request.title, "docs")
-          && !startsWith(github.event.pull_request.title, "security")
-          && !startsWith(github.event.pull_request.title, "deps") }}
-        run: echo "Invalid PR title ${{ github.event.pull_request.title }}. Must be one of: feat, fix, refactor, chore, docs, security, deps" && exit 1
+        if: ${{ github.event.pull_request }}
+        env:
+          VALID_PREFIXES: |
+            feat
+            fix
+            refactor
+            chore
+            docs
+            security
+            deps
+        run: |
+          for prefix in $VALID_PREFIXES; do
+            if [[ "${{ github.event.pull_request.title }}" == "$prefix"* ]]; then
+              echo "PR title ${{ github.event.pull_request.title }} is valid"
+              exit 0
+            fi
+          done
+          echo "Invalid PR title ${{ github.event.pull_request.title }}. Must be one of: feat, fix, refactor, chore, docs, security, deps"
+          exit 1
   version-check:
     runs-on: macos-14
     steps:

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -3,29 +3,16 @@ on:
   workflow_call:
 
 jobs:
-  pr-title-check:
+  pr-lint:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: read
     steps:
-      - name: Check PR title
-        if: ${{ github.event.pull_request }}
+      - uses: amannn/action-semantic-pull-request@v5
         env:
-          VALID_PREFIXES: |
-            feat
-            fix
-            refactor
-            chore
-            docs
-            security
-            deps
-        run: |
-          for prefix in $VALID_PREFIXES; do
-            if [[ "${{ github.event.pull_request.title }}" == "$prefix"* ]]; then
-              echo "PR title '${{ github.event.pull_request.title }}' is valid"
-              exit 0
-            fi
-          done
-          echo "Invalid PR title ${{ github.event.pull_request.title }}. Must be one of: feat, fix, refactor, chore, docs, security, deps"
-          exit 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   version-check:
     runs-on: macos-14
     steps:

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           for prefix in $VALID_PREFIXES; do
             if [[ "${{ github.event.pull_request.title }}" == "$prefix"* ]]; then
-              echo "PR title ${{ github.event.pull_request.title }} is valid"
+              echo "PR title '${{ github.event.pull_request.title }}' is valid"
               exit 0
             fi
           done

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -3,6 +3,20 @@ on:
   workflow_call:
 
 jobs:
+  pr-title-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check PR title
+        if: ${{
+          github.event.pull_request
+          && !startsWith(github.event.pull_request.title, "feat")
+          && !startsWith(github.event.pull_request.title, "fix")
+          && !startsWith(github.event.pull_request.title, "refactor")
+          && !startsWith(github.event.pull_request.title, "chore")
+          && !startsWith(github.event.pull_request.title, "docs")
+          && !startsWith(github.event.pull_request.title, "security")
+          && !startsWith(github.event.pull_request.title, "deps") }}
+        run: echo "Invalid PR title ${{ github.event.pull_request.title }}. Must be one of: feat, fix, refactor, chore, docs, security, deps" && exit 1
   version-check:
     runs-on: macos-14
     steps:


### PR DESCRIPTION
- Auto-labels PRs based on PR title so that they're automatically categorized when generating the Changelog.
- Enforce ConventionalCommit-style PR titles so they can be easily categorized in the changelog