### PR TITLE
chore: Revert "fix(ci): Publish images even for hotfixes"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,6 @@ jobs:
           done
 
   deploy-production:
-    # Only run from main or release so we never deploy old code against a newer DB schema
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     needs: push-images-to-production-artifacts
     runs-on: ubuntu-22.04
@@ -125,9 +124,7 @@ jobs:
             "Apply Run from GitHub Actions CI ${{ inputs.tag || github.sha }}"
 
   publish-images-to-ghcr:
-    # Run on release, or when deploying to production without a release to ensure the same images
-    # are available in the GitHub Container Registry as the ones deployed to production
-    if: ${{ github.event_name == 'release' || (github.ref == 'refs/heads/main' && inputs.foolproof == true) }}
+    if: ${{ github.event_name == 'release' }}
     needs: deploy-production
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
Reverts firezone/firezone#3897

The gateway binary published on the releases page still isn't updated with this fix, so going to revert to implement a more long-term solution.