### PR TITLE
refactor: Reduce log levels for production releases to avoid filling customer's…

### DIFF
--- a/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
@@ -240,12 +240,12 @@ defmodule Web.RelayGroups.NewToken do
       {"RUST_LOG",
        Enum.join(
          [
-           "firezone_relay=trace",
-           "firezone_tunnel=trace",
-           "connlib_shared=trace",
-           "tunnel_state=trace",
-           "phoenix_channel=debug",
-           "snownet=debug",
+           "firezone_relay=info",
+           "firezone_tunnel=info",
+           "connlib_shared=info",
+           "tunnel_state=info",
+           "phoenix_channel=info",
+           "snownet=info",
            "str0m=info",
            "warn"
          ],

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -82,8 +82,8 @@ android {
             buildConfigField(
                 "String",
                 "LOG_FILTER",
-                "\"connlib_client_android=debug,firezone_tunnel=debug,phoenix_channel=debug,connlib_shared=debug," +
-                    "boringtun=debug,snownet=debug,str0m=info,connlib_client_shared=debug,warn\"",
+                "\"connlib_client_android=debug,firezone_tunnel=trace,phoenix_channel=debug,connlib_shared=debug," +
+                    "boringtun=debug,snownet=debug,str0m=debug,connlib_client_shared=debug,info\"",
             )
         }
 
@@ -126,8 +126,8 @@ android {
             buildConfigField(
                 "String",
                 "LOG_FILTER",
-                "\"connlib_client_android=info,firezone_tunnel=debug,phoenix_channel=info,connlib_shared=info," +
-                    "boringtun=debug,snownet=debug,str0m=info,connlib_client_shared=info,warn\"",
+                "\"connlib_client_android=info,firezone_tunnel=info,phoenix_channel=info,connlib_shared=info," +
+                    "boringtun=info,snownet=info,str0m=info,connlib_client_shared=info,warn\"",
             )
             firebaseAppDistribution {
                 serviceCredentialsFile = System.getenv("FIREBASE_CREDENTIALS_PATH")

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -256,7 +256,7 @@ where
             write_buf: Box::new([0; MAX_UDP_SIZE]),
             connection_pool_timeout: sleep_until(std::time::Instant::now()).boxed(),
             sockets: Sockets::new()?,
-            stats_timer: tokio::time::interval(Duration::from_secs(10)),
+            stats_timer: tokio::time::interval(Duration::from_secs(60)),
         })
     }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -352,10 +352,10 @@ where
         if self.stats_timer.poll_tick(cx).is_ready() {
             let (node_stats, conn_stats) = self.node.stats();
 
-            tracing::info!(target: "connlib::stats", "{node_stats:?}");
+            tracing::debug!(target: "connlib::stats", "{node_stats:?}");
 
             for (id, stats) in conn_stats {
-                tracing::info!(target: "connlib::stats", %id, "{stats:?}");
+                tracing::debug!(target: "connlib::stats", %id, "{stats:?}");
             }
 
             cx.waker().wake_by_ref();

--- a/rust/gui-client/src-tauri/src/client/settings.rs
+++ b/rust/gui-client/src-tauri/src/client/settings.rs
@@ -24,7 +24,7 @@ impl Default for AdvancedSettings {
         Self {
             auth_base_url: Url::parse("https://app.firez.one").unwrap(),
             api_url: Url::parse("wss://api.firez.one").unwrap(),
-            log_filter: "firezone_gui_client=debug,firezone_tunnel=debug,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,boringtun=debug,snownet=debug,str0m=info,warn".to_string(),
+            log_filter: "firezone_gui_client=debug,firezone_tunnel=trace,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,boringtun=debug,snownet=debug,str0m=info,info".to_string(),
         }
     }
 }
@@ -35,7 +35,7 @@ impl Default for AdvancedSettings {
         Self {
             auth_base_url: Url::parse("https://app.firezone.dev").unwrap(),
             api_url: Url::parse("wss://api.firezone.dev").unwrap(),
-            log_filter: "firezone_gui_client=info,firezone_tunnel=debug,phoenix_channel=info,connlib_shared=info,connlib_client_shared=info,boringtun=debug,snownet=debug,str0m=info,warn".to_string(),
+            log_filter: "firezone_gui_client=info,firezone_tunnel=info,phoenix_channel=info,connlib_shared=info,connlib_client_shared=info,boringtun=info,snownet=info,str0m=info,warn".to_string(),
         }
     }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -31,15 +31,15 @@ struct AdvancedSettings: Equatable {
         authBaseURLString: "https://app.firez.one/",
         apiURLString: "wss://api.firez.one/",
         connlibLogFilterString:
-          "connlib_client_apple=debug,firezone_tunnel=trace,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,warn"
+          "connlib_client_apple=debug,firezone_tunnel=trace,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,info"
       )
     #else
       AdvancedSettings(
         authBaseURLString: "https://app.firezone.dev/",
         apiURLString: "wss://api.firezone.dev/",
         connlibLogFilterString:
-          "connlib_client_apple=info,firezone_tunnel=trace,"
-          + "connlib_shared=info,phoenix_channel=info,connlib_client_shared=info,boringtun=debug,snownet=debug,str0m=info,firezone_tunnel=debug,warn"
+          "connlib_client_apple=info,firezone_tunnel=info,"
+          + "connlib_shared=info,phoenix_channel=info,connlib_client_shared=info,boringtun=info,snownet=info,str0m=info,firezone_tunnel=info,warn"
       )
     #endif
   }()


### PR DESCRIPTION
Tuning the logging down a bit on our production releases. Prevents gathering data we don't need to be gathering and prevents filling up drive space with debug logs.

refs #3618 