### PR TITLE
chore(ci): Configure rustc to use sccache

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
     - if: ${{ inputs.sccache_enabled == 'true' }}
       uses: mozilla-actions/sccache-action@v0.0.4
-    - if: ${{ inputs.sccache_enabled }}
+    - if: ${{ inputs.sccache_enabled == 'true' }}
       run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
       shell: bash
     - name: Extract Rust version


### PR DESCRIPTION
Due to the counter-intuitive way input variables work, `sccache` may not have been used during the Rust compilation steps.

refs #3456 