### PR TITLE
refactor(apple): Add padding to Logo image

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AskPermissionView.swift
@@ -82,6 +82,9 @@ public struct AskPermissionView: View {
       content: {
         Spacer()
         Image("LogoText")
+          .resizable()
+          .scaledToFit()
+          .padding(.horizontal, 10)
         Spacer()
         if $model.needsTunnelPermission.wrappedValue {
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AuthView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/AuthView.swift
@@ -41,6 +41,9 @@ struct AuthView: View {
       content: {
         Spacer()
         Image("LogoText")
+          .resizable()
+          .scaledToFit()
+          .padding(.horizontal, 10)
         Spacer()
         Button("Sign in") {
           Task {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
@@ -101,7 +101,10 @@ import SwiftUINavigationCore
         Group {
           switch model.state {
           case .uninitialized:
-            Image("LogoText")
+            Image("LogoText")          
+              .resizable()
+              .scaledToFit()
+              .padding(.horizontal, 10)
           case .needsPermission(let model):
             AskPermissionView(model: model)
           case .unauthenticated(let model):

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/WelcomeView.swift
@@ -101,7 +101,7 @@ import SwiftUINavigationCore
         Group {
           switch model.state {
           case .uninitialized:
-            Image("LogoText")          
+            Image("LogoText")
               .resizable()
               .scaledToFit()
               .padding(.horizontal, 10)


### PR DESCRIPTION
Fixes the logo image so that there's a little bit of horizontal padding.




![IMG_0062](https://github.com/firezone/firezone/assets/167144/75d437d6-63bc-447a-9baf-bd236892c7b5)
