### PR TITLE
chore(windows client): update `windows` and `windows-implement` deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,11 @@ updates:
           - tracing-stackdriver
         update-types:
           - minor
+      windows:
+        patterns:
+          - windows
+          - windows-implement
+          - windows-sys
   - package-ecosystem: gradle
     directory: rust/connlib/clients/android/connlib/
     schedule:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
  "url",
  "uuid",
  "windows 0.52.0",
- "windows-implement 0.52.0",
+ "windows-implement 0.53.0",
  "winreg 0.52.0",
  "wintun",
  "zip",
@@ -7417,6 +7417,17 @@ name = "windows-implement"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1168,7 +1168,7 @@ dependencies = [
  "tracing-appender",
  "url",
  "uuid",
- "windows 0.52.0",
+ "windows 0.54.0",
  "wintun",
 ]
 
@@ -1907,7 +1907,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "windows 0.52.0",
+ "windows 0.54.0",
  "windows-implement 0.52.0",
  "winreg 0.52.0",
  "wintun",
@@ -2012,7 +2012,7 @@ dependencies = [
  "tracing",
  "tracing-android",
  "uuid",
- "windows 0.52.0",
+ "windows 0.54.0",
  "wintun",
 ]
 
@@ -2848,7 +2848,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.10",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -7369,7 +7369,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-implement 0.52.0",
+ "windows-targets 0.52.3",
+]
+
+[[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-implement 0.53.0",
  "windows-interface",
  "windows-targets 0.52.3",
 ]
@@ -7403,6 +7413,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.3",
+]
+
+[[package]]
 name = "windows-implement"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7424,10 +7444,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-interface"
-version = "0.52.0"
+name = "windows-implement"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
+checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7439,6 +7470,15 @@ name = "windows-metadata"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee5e275231f07c6e240d14f34e1b635bf1faa1c76c57cfd59a5cdb9848e4278"
+
+[[package]]
+name = "windows-result"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
+dependencies = [
+ "windows-targets 0.52.3",
+]
 
 [[package]]
 name = "windows-sys"

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -66,7 +66,7 @@ wintun = "0.4.0"
 
 # Windows Win32 API
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.52.0"
+version = "0.54.0"
 features = [
   "Win32_Foundation",
 ]

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -56,7 +56,7 @@ wintun = "0.4.0"
 
 # Windows Win32 API
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.52.0"
+version = "0.54.0"
 features = [
   "Win32_Foundation",
   "Win32_NetworkManagement_IpHelper",

--- a/rust/connlib/tunnel/src/device_channel/tun_windows.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_windows.rs
@@ -158,7 +158,7 @@ impl Tun {
         let entry = self.forward_entry(route);
 
         // SAFETY: Windows shouldn't store the reference anywhere, it's just a way to pass lots of arguments at once. And no other thread sees this variable.
-        match unsafe { CreateIpForwardEntry2(&entry) } {
+        match unsafe { CreateIpForwardEntry2(&entry) }.ok() {
             Ok(()) => Ok(()),
             Err(e) if e.code().0 as u32 == DUPLICATE_ERR => {
                 tracing::debug!(%route, "Failed to add duplicate route, ignoring");
@@ -173,9 +173,7 @@ impl Tun {
         let entry = self.forward_entry(route);
 
         // SAFETY: Windows shouldn't store the reference anywhere, it's just a way to pass lots of arguments at once. And no other thread sees this variable.
-        unsafe {
-            DeleteIpForwardEntry2(&entry)?;
-        }
+        unsafe { DeleteIpForwardEntry2(&entry) }.ok()?;
         Ok(())
     }
 
@@ -299,7 +297,7 @@ fn set_iface_config(luid: wintun::NET_LUID_LH, mtu: u32) -> Result<()> {
         };
 
         // SAFETY: TODO
-        unsafe { GetIpInterfaceEntry(&mut row) }?;
+        unsafe { GetIpInterfaceEntry(&mut row) }.ok()?;
 
         // https://stackoverflow.com/questions/54857292/setipinterfaceentry-returns-error-invalid-parameter
         row.SitePrefixLength = 0;
@@ -308,7 +306,7 @@ fn set_iface_config(luid: wintun::NET_LUID_LH, mtu: u32) -> Result<()> {
         row.NlMtu = mtu;
 
         // SAFETY: TODO
-        unsafe { SetIpInterfaceEntry(&mut row) }?;
+        unsafe { SetIpInterfaceEntry(&mut row) }.ok()?;
     }
 
     // Set MTU for IPv6
@@ -320,7 +318,7 @@ fn set_iface_config(luid: wintun::NET_LUID_LH, mtu: u32) -> Result<()> {
         };
 
         // SAFETY: TODO
-        unsafe { GetIpInterfaceEntry(&mut row) }?;
+        unsafe { GetIpInterfaceEntry(&mut row) }.ok()?;
 
         // https://stackoverflow.com/questions/54857292/setipinterfaceentry-returns-error-invalid-parameter
         row.SitePrefixLength = 0;
@@ -329,7 +327,7 @@ fn set_iface_config(luid: wintun::NET_LUID_LH, mtu: u32) -> Result<()> {
         row.NlMtu = mtu;
 
         // SAFETY: TODO
-        unsafe { SetIpInterfaceEntry(&mut row) }?;
+        unsafe { SetIpInterfaceEntry(&mut row) }.ok()?;
     }
     Ok(())
 }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -64,7 +64,7 @@ winreg = "0.52.0"
 wintun = "0.4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
-version = "0.52.0"
+version = "0.54.0"
 features = [
   # For implementing COM interfaces
   "implement",

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -59,7 +59,7 @@ futures = "0.3.30"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 tauri-winrt-notification = "0.1.3"
-windows-implement = "0.52.0"
+windows-implement = "0.53.0"
 winreg = "0.52.0"
 wintun = "0.4.0"
 

--- a/rust/gui-client/src-tauri/src/client/network_changes/windows.rs
+++ b/rust/gui-client/src-tauri/src/client/network_changes/windows.rs
@@ -202,7 +202,8 @@ impl ComGuard {
     pub fn new() -> Result<Self, Error> {
         // SAFETY: Threading shouldn't be a problem since this is meant to initialize
         // COM per-thread anyway.
-        unsafe { Com::CoInitializeEx(None, Com::COINIT_MULTITHREADED) }.ok()
+        unsafe { Com::CoInitializeEx(None, Com::COINIT_MULTITHREADED) }
+            .ok()
             .map_err(Error::ComInitialize)?;
         Ok(Self {
             dropped: false,

--- a/rust/gui-client/src-tauri/src/client/network_changes/windows.rs
+++ b/rust/gui-client/src-tauri/src/client/network_changes/windows.rs
@@ -37,7 +37,7 @@ use anyhow::Result;
 use std::sync::Arc;
 use tokio::{runtime::Runtime, sync::Notify};
 use windows::{
-    core::{ComInterface, Result as WinResult, GUID},
+    core::{Interface, Result as WinResult, GUID},
     Win32::{
         Networking::NetworkListManager::{
             INetworkEvents, INetworkEvents_Impl, INetworkListManager, NetworkListManager,
@@ -202,7 +202,7 @@ impl ComGuard {
     pub fn new() -> Result<Self, Error> {
         // SAFETY: Threading shouldn't be a problem since this is meant to initialize
         // COM per-thread anyway.
-        unsafe { Com::CoInitializeEx(None, Com::COINIT_MULTITHREADED) }
+        unsafe { Com::CoInitializeEx(None, Com::COINIT_MULTITHREADED) }.ok()
             .map_err(Error::ComInitialize)?;
         Ok(Self {
             dropped: false,


### PR DESCRIPTION
Closes #3879 and #3902 

I re-created Cargo.lock, so it incidentally updated a bunch of other stuff. I can revert that file if it's a problem.

Had to search a bit for the breaking changes. Found here that they renamed `ComInterface`: https://github.com/microsoft/windows-rs/issues/2875#issuecomment-1962332067