### PR TITLE
chore(phoenix-channel): reduce noise in logs

### DIFF
--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -52,7 +52,6 @@ enum State {
 ///
 /// The provided URL must contain a host.
 /// Additionally, you must already provide any query parameters required for authentication.
-#[tracing::instrument(level = "debug", skip(payload, secret_url, reconnect_backoff))]
 #[allow(clippy::type_complexity)]
 pub async fn init<TInitReq, TInitRes, TInboundMsg, TOutboundRes>(
     secret_url: Secret<SecureUrl>,
@@ -83,8 +82,6 @@ where
         payload,
         reconnect_backoff,
     );
-
-    tracing::info!("Connected to portal, waiting for `init` message");
 
     let (channel, init_message) = loop {
         match future::poll_fn(|cx| channel.poll(cx)).await? {


### PR DESCRIPTION
The span around the `init` function doesn't actually add anything useful. We always use the `PhoenixChannel` only in a particular component, e.g. the relay will always log in using the `relay` topic etc. Thus, when looking at the relay's logs, this `login_topic` will simply say "relay" which is something we know by looking at the source code.

Additionally, the "Connected to portal, waiting for `init` message" line is no longer true. Connecting to the portal has been moved into the internal state machine, which now causes two similar logs to be printed:

```
gateway-1  | 2024-03-05T04:45:29.671736Z  INFO init{user_agent="Alpine Linux/3.19.1 (x86_64;6.6.16;) connlib/1.0.0" login_topic="gateway"}: phoenix_channel: Connected to portal, waiting for `init` message
gateway-1  | 2024-03-05T04:45:29.685338Z  INFO init{user_agent="Alpine Linux/3.19.1 (x86_64;6.6.16;) connlib/1.0.0" login_topic="gateway"}: phoenix_channel: Connected to portal host=api
```

Note that the first one is lying because we simply constructed the state machine but haven't connected to anything yet.