### PR TITLE
feat(connlib): reduce stack size usage

### DIFF
--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -62,11 +62,7 @@ impl Session {
         let callbacks = CallbackErrorFacade(callbacks);
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
-        // In android we get an stack-overflow due to tokio
-        // taking too much of the stack-space:
-        // See: https://github.com/firezone/firezone/issues/2227
         let runtime = tokio::runtime::Builder::new_multi_thread()
-            .thread_stack_size(3 * 1024 * 1024)
             .enable_all()
             .build()?;
         {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -107,7 +107,7 @@ where
 
         ready!(self.connections_state.sockets.poll_send_ready(cx))?; // Ensure socket is ready before we read from device.
 
-        match self.device.poll_read(&mut self.read_buf, cx)? {
+        match self.device.poll_read(self.read_buf.as_mut(), cx)? {
             Poll::Ready(packet) => {
                 let Some((peer_id, packet)) = self.role_state.encapsulate(packet, Instant::now())
                 else {
@@ -165,7 +165,7 @@ where
 
         ready!(self.connections_state.sockets.poll_send_ready(cx))?; // Ensure socket is ready before we read from device.
 
-        match self.device.poll_read(&mut self.read_buf, cx)? {
+        match self.device.poll_read(self.read_buf.as_mut(), cx)? {
             Poll::Ready(packet) => {
                 let Some((peer_id, packet)) = self.role_state.encapsulate(packet) else {
                     cx.waker().wake_by_ref();
@@ -222,7 +222,7 @@ where
             callbacks,
             role_state: Default::default(),
             connections_state,
-            read_buf: [0u8; MAX_UDP_SIZE],
+            read_buf: Box::new([0u8; MAX_UDP_SIZE]),
         })
     }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -64,7 +64,7 @@ pub struct Tunnel<CB: Callbacks, TRoleState, TRole, TId> {
 
     connections_state: ConnectionState<TRole, TId>,
 
-    read_buf: [u8; MAX_UDP_SIZE],
+    read_buf: Box<[u8; MAX_UDP_SIZE]>,
 }
 
 impl<CB> Tunnel<CB, ClientState, snownet::Client, GatewayId>


### PR DESCRIPTION
With the use of `snownet`, we now have explicit control over how we read and write messages to sockets. As such, we can make the remaining stack-allocated buffer heap-allocated and remove the increased stack-size on our tokio worker threads.