### PR TITLE
refactor(connlib): fail tunnel in case the device gets closed

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -71,7 +71,7 @@ impl Device {
         &mut self,
         buf: &'b mut [u8],
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<Option<MutableIpPacket<'b>>>> {
+    ) -> Poll<io::Result<MutableIpPacket<'b>>> {
         use pnet_packet::Packet as _;
 
         if self.mtu_refreshed_at.elapsed() > Duration::from_secs(30) {
@@ -81,7 +81,10 @@ impl Device {
         let n = std::task::ready!(self.tun.poll_read(&mut buf[..self.mtu()], cx))?;
 
         if n == 0 {
-            return Poll::Ready(Ok(None));
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "device is closed",
+            )));
         }
 
         let packet = MutableIpPacket::new(&mut buf[..n]).ok_or_else(|| {
@@ -93,7 +96,7 @@ impl Device {
 
         tracing::trace!(target: "wire", action = "read", from = "device", dest = %packet.destination(), bytes = %packet.packet().len());
 
-        Poll::Ready(Ok(Some(packet)))
+        Poll::Ready(Ok(packet))
     }
 
     #[cfg(target_family = "windows")]
@@ -101,7 +104,7 @@ impl Device {
         &self,
         buf: &'b mut [u8],
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<Option<MutableIpPacket<'b>>>> {
+    ) -> Poll<io::Result<MutableIpPacket<'b>>> {
         use pnet_packet::Packet as _;
 
         if self.mtu_refreshed_at.elapsed() > Duration::from_secs(30) {
@@ -111,7 +114,10 @@ impl Device {
         let n = std::task::ready!(self.tun.poll_read(&mut buf[..self.mtu()], cx))?;
 
         if n == 0 {
-            return Poll::Ready(Ok(None));
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "device is closed",
+            )));
         }
 
         let packet = MutableIpPacket::new(&mut buf[..n]).ok_or_else(|| {
@@ -123,7 +129,7 @@ impl Device {
 
         tracing::trace!(target: "wire", action = "read", from = "device", dest = %packet.destination(), bytes = %packet.packet().len());
 
-        Poll::Ready(Ok(Some(packet)))
+        Poll::Ready(Ok(packet))
     }
 
     pub(crate) fn mtu(&self) -> usize {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -106,7 +106,7 @@ where
         ready!(self.connections_state.sockets.poll_send_ready(cx))?; // Ensure socket is ready before we read from device.
 
         match device.poll_read(&mut self.read_buf, cx)? {
-            Poll::Ready(Some(packet)) => {
+            Poll::Ready(packet) => {
                 let Some((peer_id, packet)) = self.role_state.encapsulate(packet, Instant::now())
                 else {
                     cx.waker().wake_by_ref();
@@ -116,13 +116,6 @@ where
                 self.connections_state.send(peer_id, packet.as_immutable());
 
                 cx.waker().wake_by_ref();
-            }
-            Poll::Ready(None) => {
-                tracing::info!("Device stopped");
-                self.device = None;
-
-                self.no_device_waker.register(cx.waker());
-                return Poll::Pending;
             }
             Poll::Pending => {}
         }
@@ -170,7 +163,7 @@ where
         ready!(self.connections_state.sockets.poll_send_ready(cx))?; // Ensure socket is ready before we read from device.
 
         match device.poll_read(&mut self.read_buf, cx)? {
-            Poll::Ready(Some(packet)) => {
+            Poll::Ready(packet) => {
                 let Some((peer_id, packet)) = self.role_state.encapsulate(packet) else {
                     cx.waker().wake_by_ref();
                     return Poll::Pending;
@@ -179,13 +172,6 @@ where
                 self.connections_state.send(peer_id, packet.as_immutable());
 
                 cx.waker().wake_by_ref();
-            }
-            Poll::Ready(None) => {
-                tracing::info!("Device stopped");
-                self.device = None;
-
-                self.no_device_waker.register(cx.waker());
-                return Poll::Pending;
             }
             Poll::Pending => {
                 // device not ready for reading, moving on ..


### PR DESCRIPTION
Currently, we have some duplication between client and gateway in how we handle a closed TUN device (i.e. reading a 0-length packet). Previously, we would just deactivate the tunnel as we can't do anything when the device is gone. I don't think that is actually helpful. Instead, we should fail the tunnel if the device gets closed, similar to any other IO error on the device.\

This reduces duplication between the two eventloops.