### PR TITLE
chore(connlib): move `wire` trace logs to `Socket`

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -12,7 +12,6 @@ use device_channel::Device;
 use futures_util::{future::BoxFuture, task::AtomicWaker, FutureExt};
 use peer::PacketTransform;
 use peer_store::PeerStore;
-use pnet_packet::Packet;
 use snownet::{Node, Server};
 use sockets::{Received, Sockets};
 use std::{
@@ -324,8 +323,6 @@ where
                     continue;
                 }
             };
-
-            tracing::trace!(target: "wire", %local, %from, bytes = %packet.packet().len(), "read new packet");
 
             let Some(peer) = peer_store.get_mut(&conn_id) else {
                 tracing::error!(%conn_id, %local, %from, "Couldn't find connection");


### PR DESCRIPTION
This further improves consistency in when we emit these logs. Previously, the `wire` trace would also log packets that we failed to send (so never actually hit the wire) and would omit packets that we handled internally within `snownet`.

To implement this consistently, I ended up merging the two iterators for IPv4 and IPv6 packets which is a nice addition because it means we always empty both sockets and don't prioritize IPv4 over IPv6.