### PR TITLE
feat(snownet): always force a handshake when we change the socket

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -417,13 +417,11 @@ where
 
                             conn.invalidate_candiates();
 
+                            tracing::info!(%id, "Sending wireguard handshake");
+                            self.buffered_transmits
+                                .extend(conn.force_handshake(&mut self.allocations, self.last_now));
+
                             if is_first_connection {
-                                tracing::info!(%id, "Starting wireguard handshake");
-
-                                self.buffered_transmits.extend(
-                                    conn.force_handshake(&mut self.allocations, self.last_now),
-                                );
-
                                 return Some(Event::ConnectionEstablished(id));
                             }
                         }


### PR DESCRIPTION
Some local testing identified that we might lose the first packet if we switch the sockets too quickly, i.e. upgrade from a relayed one to a direct one initially. To mitigate having to wait for the wireguard timeout here, let's force a handshake every time we switch to a new socket.