### PR TITLE
chore(snownet): improve logs in `Allocation`

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -391,6 +391,7 @@ impl Allocation {
         Some((peer, payload, socket))
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(relay = %self.server))]
     pub fn handle_timeout(&mut self, now: Instant) {
         self.update_now(now);
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -438,6 +438,9 @@ impl Allocation {
             .channels_to_refresh(now, |number| {
                 self.channel_binding_in_flight_by_number(number)
             })
+            .inspect(|(number, peer)| {
+                tracing::debug!(%number, %peer, "Channel is due for a refresh");
+            })
             .map(|(number, peer)| make_channel_bind_request(peer, number))
             .collect::<Vec<_>>(); // Need to allocate here to satisfy borrow-checker. Number of channel refresh messages should be small so this shouldn't be a big impact.
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -691,7 +691,7 @@ impl Allocation {
     /// Returns: Whether we actually queued a message.
     fn authenticate_and_queue(&mut self, message: Message<Attribute>) -> bool {
         let Some(backoff) = self.backoff.next_backoff() else {
-            tracing::warn!(
+            tracing::debug!(
                 "Unable to queue {} because we've exceeded our backoffs",
                 message.method()
             );

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -399,6 +399,8 @@ impl Allocation {
             .allocation_expires_at()
             .is_some_and(|expires_at| now >= expires_at)
         {
+            tracing::debug!("Allocation is expired");
+
             self.invalidate_allocation();
         }
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -114,8 +114,6 @@ impl Allocation {
             backoff: backoff::new(now, REQUEST_TIMEOUT),
         };
 
-        tracing::debug!(%server, "Requesting new allocation");
-
         allocation.authenticate_and_queue(make_allocate_request());
 
         allocation

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -156,7 +156,7 @@ impl Allocation {
         self.authenticate_and_queue(make_refresh_request());
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(relay = %self.server, id, method, class, rtt))]
+    #[tracing::instrument(level = "debug", skip_all, fields(id, method, class, rtt))]
     pub fn handle_input(
         &mut self,
         from: SocketAddr,


### PR DESCRIPTION
This adds a few logs that I noticed could be helpful after looking at some logs shared by a customer. Most importantly, we now log everything in `handle_timeout` in the scope of the relay's IP, meaning we can differentiate them from each other.