### PR TITLE
feat(snownet): send `BINDING` on cold-start of `Allocation`

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -629,7 +629,7 @@ where
         let handled = binding.handle_input(from, local, packet, now);
 
         if !handled {
-            tracing::debug!("Packet was a STUN message but not accepted");
+            return ControlFlow::Continue(()); // The packet might be for an `Allocation` that we have on the same server.
         }
 
         ControlFlow::Break(())

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -89,8 +89,10 @@ fn second_connection_with_same_relay_reuses_allocation() {
         HashSet::from([relay("user1", "pass1", "realm1")]),
     );
 
-    let transmit = alice.poll_transmit().unwrap();
-    assert_eq!(transmit.dst, RELAY);
+    let transmit1 = alice.poll_transmit().unwrap();
+    let transmit2 = alice.poll_transmit().unwrap();
+    assert_eq!(transmit1.dst, RELAY);
+    assert_eq!(transmit2.dst, RELAY);
     assert!(alice.poll_transmit().is_none());
 
     let _ = alice.new_connection(


### PR DESCRIPTION
When we are about to use a relay for the first time, the initial request will fail because we don't yet have a nonce to include in request. Thus, it takes 2 RTTs until we learn our server-reflexive address which is a very useful candidate.

Hence, we treat each TURN server also as a STUN server which should improve the discovery of our server-reflexive candidates.