### PR TITLE
feat(snownet): log duration since intent after WG handshake completes

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -272,10 +272,10 @@ pub struct ClientState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct AwaitingConnectionDetails {
-    domain: Option<Dname>,
+pub(crate) struct AwaitingConnectionDetails {
+    pub domain: Option<Dname>,
     gateways: HashSet<GatewayId>,
-    last_intent_sent_at: Instant,
+    pub last_intent_sent_at: Instant,
 }
 
 impl ClientState {
@@ -352,15 +352,13 @@ impl ClientState {
         }
     }
 
-    pub(crate) fn get_awaiting_connection_domain(
+    pub(crate) fn get_awaiting_connection(
         &self,
         resource: &ResourceId,
-    ) -> Result<&Option<Dname>, ConnlibError> {
-        Ok(&self
-            .awaiting_connection
+    ) -> Result<&AwaitingConnectionDetails, ConnlibError> {
+        self.awaiting_connection
             .get(resource)
-            .ok_or(Error::UnexpectedConnectionDetails)?
-            .domain)
+            .ok_or(Error::UnexpectedConnectionDetails)
     }
 
     pub(crate) fn attempt_to_reuse_connection(
@@ -373,7 +371,7 @@ impl ClientState {
             .get(&resource)
             .ok_or(Error::UnknownResource)?;
 
-        let domain = self.get_awaiting_connection_domain(&resource)?.clone();
+        let domain = self.get_awaiting_connection(&resource)?.domain.clone();
 
         if self.is_connected_to(resource, &domain) {
             return Err(Error::UnexpectedConnectionDetails);

--- a/rust/connlib/tunnel/src/control_protocol/client.rs
+++ b/rust/connlib/tunnel/src/control_protocol/client.rs
@@ -68,9 +68,9 @@ where
             return Err(Error::PendingConnection);
         }
 
-        let domain = self
+        let awaiting_connection = self
             .role_state
-            .get_awaiting_connection_domain(&resource_id)?
+            .get_awaiting_connection(&resource_id)?
             .clone();
 
         let offer = self.connections_state.node.new_connection(
@@ -81,6 +81,8 @@ where
             turn(&relays, |addr| {
                 self.connections_state.sockets.can_handle(addr)
             }),
+            awaiting_connection.last_intent_sent_at,
+            Instant::now(),
         );
 
         Ok(Request::NewConnection(RequestConnection {
@@ -92,7 +94,7 @@ where
                     username: offer.credentials.username,
                     password: offer.credentials.password,
                 },
-                domain,
+                domain: awaiting_connection.domain,
             },
         }))
     }

--- a/rust/snownet-tests/src/main.rs
+++ b/rust/snownet-tests/src/main.rs
@@ -82,6 +82,8 @@ async fn main() -> Result<()> {
                 1,
                 stun_server.into_iter().collect(),
                 turn_server.into_iter().collect(),
+                Instant::now(),
+                Instant::now(),
             );
 
             redis_connection


### PR DESCRIPTION
Preceded by some refactoring, this PR adds a log line with a very important metric: Time since connection intent after WG handshake. This is the equivalent of time-to-first-byte, i.e. how long the user needs to wait to actually send their first application data after they've tried for the firs time (and generated an intent).