### PR TITLE
chore(windows): Sign internal exe using beforeBundleCommand

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -131,12 +131,6 @@ jobs:
     env:
       BINARY_DEST_PATH: ${{ matrix.binary-dest-path }}
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
-      AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
-      VERSION: "1.0.0"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -148,16 +142,8 @@ jobs:
       - uses: ./.github/actions/setup-tauri
       - name: Install pnpm deps
         run: pnpm install
-      - name: Install AzureSignTool
-        if: ${{ runner.os == 'Windows' }}
-        shell: bash
-        run: dotnet tool install --global AzureSignTool
       - name: Build release exe and MSI
         run: pnpm build
-      - name: Sign the MSI
-        if: ${{ runner.os == 'Windows' }}
-        shell: bash
-        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ matrix.rename-script }}

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -131,6 +131,12 @@ jobs:
     env:
       BINARY_DEST_PATH: ${{ matrix.binary-dest-path }}
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
+      AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
+      VERSION: "1.0.0"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -142,8 +148,16 @@ jobs:
       - uses: ./.github/actions/setup-tauri
       - name: Install pnpm deps
         run: pnpm install
+      - name: Install AzureSignTool
+        if: ${{ runner.os == 'Windows' }}
+        shell: bash
+        run: dotnet tool install --global AzureSignTool
       - name: Build release exe and MSI
         run: pnpm build
+      - name: Sign the MSI
+        if: ${{ runner.os == 'Windows' }}
+        shell: bash
+        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ matrix.rename-script }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -261,6 +261,11 @@ jobs:
     env:
       BINARY_DEST_PATH: ${{ matrix.binary-dest-path }}
       CONNLIB_LOG_UPLOAD_INTERVAL_SECS: 300
+      AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -272,24 +277,21 @@ jobs:
       - uses: ./.github/actions/setup-tauri
       - name: Install pnpm deps
         run: pnpm install
-      - name: Build release exe and MSI
-        run: pnpm build
       - name: Install AzureSignTool
         if: ${{ runner.os == 'Windows' }}
         shell: bash
         run: dotnet tool install --global AzureSignTool
-      - name: Sign the release exe and MSI
+      - name: Build release exe and MSI
+        run: pnpm build
+      # We need to sign the exe inside the MSI. Currently
+      # we do this in a "beforeBundleCommand" hook in tauri.windows.conf.json.
+      # But this will soon be natively supported in Tauri.
+      # TODO: Use Tauri's native MSI signing with support for EV certs
+      # See https://github.com/tauri-apps/tauri/pull/8718
+      - name: Sign the MSI
         if: ${{ runner.os == 'Windows' }}
-        env:
-          AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
         shell: bash
-        run: |
-          ../../scripts/build/sign.sh ../target/release/Firezone.exe
-          ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.VERSION }}_x64_en-US.msi
+        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ matrix.rename-script }}

--- a/rust/gui-client/src-tauri/tauri.windows.conf.json
+++ b/rust/gui-client/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,5 @@
+{
+  "build": {
+    "beforeBundleCommand": "bash -c '../../scripts/build/sign.sh ../target/release/Firezone.exe'"
+  }
+}

--- a/scripts/build/sign.sh
+++ b/scripts/build/sign.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 if ! command -v AzureSignTool &>/dev/null; then
     echo "AzureSignTool not installed. Signing will be skipped."
+    exit
 fi
 
 AzureSignTool sign \

--- a/scripts/build/sign.sh
+++ b/scripts/build/sign.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! command -v AzureSignTool &>/dev/null; then
+    echo "AzureSignTool not installed. Signing will be skipped."
+fi
+
 AzureSignTool sign \
     --azure-key-vault-url "$AZURE_KEY_VAULT_URI" \
     --azure-key-vault-client-id "$AZURE_CLIENT_ID" \


### PR DESCRIPTION
Refs #3230 

It looks like we need to sign the internal exe before it gets bundled too. We can use `beforeBundleCommand` to do so.

Soon, Tauri should have native support for this exact scenario: https://github.com/tauri-apps/tauri/pull/8718