### PR TITLE
refactor(connlib): No longer replacing `Device` in the `Tunnel` and android fixes to `Tun` struct

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -218,15 +218,10 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn add_route(&mut self, route: IpNetwork) -> connlib_shared::Result<()> {
         let callbacks = self.callbacks().clone();
-        let maybe_new_device = self
-            .device
+        self.device
             .as_mut()
             .ok_or(Error::ControlProtocolError)?
             .add_route(route, &callbacks)?;
-
-        if let Some(new_device) = maybe_new_device {
-            self.device = Some(new_device);
-        }
 
         Ok(())
     }
@@ -234,15 +229,10 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn remove_route(&mut self, route: IpNetwork) -> connlib_shared::Result<()> {
         let callbacks = self.callbacks().clone();
-        let maybe_new_device = self
-            .device
+        self.device
             .as_mut()
             .ok_or(Error::ControlProtocolError)?
             .remove_route(route, &callbacks)?;
-
-        if let Some(new_device) = maybe_new_device {
-            self.device = Some(new_device);
-        }
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -140,60 +140,22 @@ impl Device {
         self.tun.name()
     }
 
-    #[cfg(target_family = "unix")]
-    pub(crate) fn add_route(
-        &mut self,
-        route: IpNetwork,
-        callbacks: &impl Callbacks<Error = Error>,
-    ) -> Result<Option<Device>, Error> {
-        let Some(tun) = self.tun.add_route(route, callbacks)? else {
-            return Ok(None);
-        };
-        let mtu = ioctl::interface_mtu_by_name(tun.name())?;
-
-        Ok(Some(Device {
-            mtu,
-            tun,
-            mtu_refreshed_at: Instant::now(),
-        }))
-    }
-
-    #[cfg(target_family = "unix")]
     pub(crate) fn remove_route(
         &mut self,
         route: IpNetwork,
         callbacks: &impl Callbacks<Error = Error>,
     ) -> Result<Option<Device>, Error> {
-        let Some(tun) = self.tun.remove_route(route, callbacks)? else {
-            return Ok(None);
-        };
-        let mtu = ioctl::interface_mtu_by_name(tun.name())?;
-
-        Ok(Some(Device {
-            mtu,
-            tun,
-            mtu_refreshed_at: Instant::now(),
-        }))
-    }
-
-    #[cfg(target_family = "windows")]
-    pub(crate) fn remove_route(
-        &mut self,
-        route: IpNetwork,
-        _callbacks: &impl Callbacks<Error = Error>,
-    ) -> Result<Option<Device>, Error> {
-        self.tun.remove_route(route)?;
+        self.tun.remove_route(route, callbacks)?;
         Ok(None)
     }
 
-    #[cfg(target_family = "windows")]
     #[allow(unused_mut)]
     pub(crate) fn add_route(
         &mut self,
         route: IpNetwork,
-        _: &impl Callbacks<Error = Error>,
+        callbacks: &impl Callbacks<Error = Error>,
     ) -> Result<Option<Device>, Error> {
-        self.tun.add_route(route)?;
+        self.tun.add_route(route, callbacks)?;
         Ok(None)
     }
 

--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -67,6 +67,8 @@ impl Tun {
             self.fd = AsyncFd::new(fd)?;
             self.name = interface_name(fd)?;
         }
+
+        Ok(())
     }
 
     pub fn add_route(

--- a/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
@@ -147,20 +147,20 @@ impl Tun {
         &self,
         route: IpNetwork,
         callbacks: &impl Callbacks<Error = Error>,
-    ) -> Result<Option<Self>> {
+    ) -> Result<()> {
         // This will always be None in macos
         callbacks.on_add_route(route)?;
-        Ok(None)
+        Ok(())
     }
 
     pub fn remove_route(
         &self,
         route: IpNetwork,
         callbacks: &impl Callbacks<Error = Error>,
-    ) -> Result<Option<Self>> {
+    ) -> Result<()> {
         // This will always be None in macos
         callbacks.on_remove_route(route)?;
-        Ok(None)
+        Ok(())
     }
 
     pub fn name(&self) -> &str {

--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -140,7 +140,7 @@ impl Tun {
         })
     }
 
-    pub fn add_route(&mut self, route: IpNetwork, _: &impl Callbacks) -> Result<Option<Self>> {
+    pub fn add_route(&mut self, route: IpNetwork, _: &impl Callbacks) -> Result<()> {
         let handle = self.handle.clone();
 
         let add_route_worker = async move {
@@ -187,10 +187,10 @@ impl Tun {
             }
         }
 
-        Ok(None)
+        Ok(())
     }
 
-    pub fn remove_route(&mut self, route: IpNetwork, _: &impl Callbacks) -> Result<Option<Self>> {
+    pub fn remove_route(&mut self, route: IpNetwork, _: &impl Callbacks) -> Result<()> {
         let handle = self.handle.clone();
 
         let add_route_worker = async move {
@@ -234,7 +234,7 @@ impl Tun {
             }
         }
 
-        Ok(None)
+        Ok(())
     }
 
     pub fn name(&self) -> &str {

--- a/rust/connlib/tunnel/src/device_channel/tun_windows.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_windows.rs
@@ -154,7 +154,11 @@ impl Tun {
     }
 
     // It's okay if this blocks until the route is added in the OS.
-    pub fn add_route(&self, route: IpNetwork) -> Result<()> {
+    pub fn add_route(
+        &self,
+        route: IpNetwork,
+        _: &impl connlib_shared::Callbacks<Error = connlib_shared::Error>,
+    ) -> Result<()> {
         const DUPLICATE_ERR: u32 = 0x80071392;
         let entry = self.forward_entry(route);
 
@@ -170,7 +174,11 @@ impl Tun {
     }
 
     // It's okay if this blocks until the route is added in the OS.
-    pub fn remove_route(&self, route: IpNetwork) -> Result<()> {
+    pub fn remove_route(
+        &self,
+        route: IpNetwork,
+        _: &impl connlib_shared::Callbacks<Error = connlib_shared::Error>,
+    ) -> Result<()> {
         let entry = self.forward_entry(route);
 
         // SAFETY: Windows shouldn't store the reference anywhere, it's just a way to pass lots of arguments at once. And no other thread sees this variable.


### PR DESCRIPTION
This PR does the following:

* Remove `Closeable` struct for andorid's tun file descriptor
* Make `add_route` and `remove_route` mutate tun device so android can mutate file descriptor and no longer have upper layers replacing `Device`
* Fix a bug where android closed still used file descriptor if `add_route` and `remove_route` returned the same