### PR TITLE
refactor(connlib): only call `onDisconnect` for unrecoverable errors

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -156,16 +156,6 @@ class TunnelService : VpnService() {
                 }.toTypedArray()
             }
 
-            // Something called disconnect() already, so assume it was user or system initiated.
-            override fun onDisconnect(): Boolean {
-                Log.d(TAG, "onDisconnect")
-                Firebase.crashlytics.log("onDisconnect")
-
-                shutdown()
-
-                return true
-            }
-
             // Unexpected disconnect, most likely a 401. Clear the token and initiate a stop of the
             // service.
             override fun onDisconnect(error: String): Boolean {
@@ -211,6 +201,8 @@ class TunnelService : VpnService() {
         connlibSessionPtr!!.let {
             ConnlibSession.disconnect(it)
         }
+
+        shutdown()
     }
 
     private fun shutdown() {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/callback/ConnlibCallback.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/callback/ConnlibCallback.kt
@@ -25,8 +25,6 @@ interface ConnlibCallback {
     // The JNI doesn't support nullable types, so we need two method signatures
     fun onDisconnect(error: String): Boolean
 
-    fun onDisconnect(): Boolean
-
     fun getSystemDefaultResolvers(): Array<ByteArray>
 
     fun protectFileDescriptor(fileDescriptor: Int)

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -481,6 +481,6 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_di
     session: *mut Session<CallbackHandler>,
 ) {
     catch_and_throw(&mut env, |_| {
-        Box::from_raw(session).disconnect(None);
+        Box::from_raw(session).disconnect();
     });
 }

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -269,10 +269,10 @@ impl Callbacks for CallbackHandler {
         })
     }
 
-    fn on_disconnect(&self, error: Option<&Error>) -> Result<(), Self::Error> {
+    fn on_disconnect(&self, error: &Error) -> Result<(), Self::Error> {
         self.env(|mut env| {
             let error = env
-                .new_string(serde_json::to_string(&error.map(ToString::to_string))?)
+                .new_string(serde_json::to_string(&error.to_string())?)
                 .map_err(|source| CallbackError::NewStringFailed {
                     name: "error",
                     source,

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -136,9 +136,8 @@ impl Callbacks for CallbackHandler {
         Ok(())
     }
 
-    fn on_disconnect(&self, error: Option<&Error>) -> Result<(), Self::Error> {
-        self.inner
-            .on_disconnect(error.map(ToString::to_string).unwrap_or_default());
+    fn on_disconnect(&self, error: &Error) -> Result<(), Self::Error> {
+        self.inner.on_disconnect(error.to_string());
         Ok(())
     }
 

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -210,6 +210,6 @@ impl WrappedSession {
     }
 
     fn disconnect(&mut self) {
-        self.0.disconnect(None)
+        self.0.disconnect()
     }
 }

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -264,7 +264,9 @@ where
             tracing::error!("Couldn't stop runtime: {err}");
         }
 
-        let _ = callbacks.on_disconnect(error.as_ref());
+        if let Some(error) = error {
+            let _ = callbacks.on_disconnect(&error);
+        }
     }
 
     /// Cleanup a [Session].

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -271,8 +271,10 @@ where
     ///
     /// For now this just drops the runtime, which should drop all pending tasks.
     /// Further cleanup should be done here. (Otherwise we can just drop [Session]).
-    pub fn disconnect(&mut self, error: Option<Error>) {
-        Self::disconnect_inner(self.runtime_stopper.clone(), &self.callbacks, error)
+    pub fn disconnect(&mut self) {
+        if let Err(err) = self.runtime_stopper.try_send(StopRuntime) {
+            tracing::error!("Couldn't stop runtime: {err}");
+        }
     }
 }
 

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -58,7 +58,7 @@ pub trait Callbacks: Clone + Send + Sync {
     ///
     /// If the tunnel disconnected due to a fatal error, `error` is the error
     /// that caused the disconnect.
-    fn on_disconnect(&self, error: Option<&crate::Error>) -> Result<(), Self::Error> {
+    fn on_disconnect(&self, error: &crate::Error) -> Result<(), Self::Error> {
         tracing::error!(error = ?error, "tunnel_disconnected");
         // Note that we can't panic here, since we already hooked the panic to this function.
         std::process::exit(0);

--- a/rust/connlib/shared/src/callbacks_error_facade.rs
+++ b/rust/connlib/shared/src/callbacks_error_facade.rs
@@ -73,7 +73,7 @@ impl<CB: Callbacks> Callbacks for CallbackErrorFacade<CB> {
         result
     }
 
-    fn on_disconnect(&self, error: Option<&Error>) -> Result<()> {
+    fn on_disconnect(&self, error: &Error) -> Result<()> {
         if let Err(err) = self.0.on_disconnect(error) {
             tracing::error!(?err, "`on_disconnect` failed");
         }

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -602,7 +602,7 @@ impl Controller {
                 if let Some(mut session) = self.session.take() {
                     tracing::info!("disconnecting connlib");
                     // This is probably redundant since connlib shuts itself down if it's disconnected.
-                    session.connlib.disconnect(None);
+                    session.connlib.disconnect();
                 }
                 self.refresh_system_tray_menu()?;
             }
@@ -751,7 +751,7 @@ impl Controller {
             tracing::debug!("disconnecting connlib");
             // This is redundant if the token is expired, in that case
             // connlib already disconnected itself.
-            session.connlib.disconnect(None);
+            session.connlib.disconnect();
         } else {
             // Might just be because we got a double sign-out or
             // the user canceled the sign-in or something innocent.

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -415,7 +415,7 @@ fn handle_system_tray_event(app: &tauri::AppHandle, event: TrayMenuEvent) -> Res
 pub(crate) enum ControllerRequest {
     /// The GUI wants us to use these settings in-memory, they've already been saved to disk
     ApplySettings(AdvancedSettings),
-    DisconnectedTokenExpired,
+    Disconnected,
     /// The same as the arguments to `client::logging::export_logs_to`
     ExportLogs {
         path: PathBuf,
@@ -453,7 +453,7 @@ impl connlib_client_shared::Callbacks for CallbackHandler {
     fn on_disconnect(&self, error: &connlib_client_shared::Error) -> Result<(), Self::Error> {
         tracing::debug!("on_disconnect {error:?}");
         self.ctlr_tx
-            .try_send(ControllerRequest::DisconnectedTokenExpired)?;
+            .try_send(ControllerRequest::Disconnected)?;
         Ok(())
     }
 
@@ -587,8 +587,8 @@ impl Controller {
                     "Applied new settings. Log level will take effect at next app start."
                 );
             }
-            Req::DisconnectedTokenExpired => {
-                tracing::info!("Token expired");
+            Req::Disconnected => {
+                tracing::info!("Disconnected by connlib");
                 self.sign_out()?;
                 os::show_notification(
                     "Firezone disconnected",

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -451,10 +451,7 @@ enum CallbackError {
 impl connlib_client_shared::Callbacks for CallbackHandler {
     type Error = CallbackError;
 
-    fn on_disconnect(
-        &self,
-        error: Option<&connlib_client_shared::Error>,
-    ) -> Result<(), Self::Error> {
+    fn on_disconnect(&self, error: &connlib_client_shared::Error) -> Result<(), Self::Error> {
         tracing::debug!("on_disconnect {error:?}");
         self.ctlr_tx.try_send(match error {
             Some(connlib_client_shared::Error::ClosedByPortal) => {

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -452,8 +452,7 @@ impl connlib_client_shared::Callbacks for CallbackHandler {
 
     fn on_disconnect(&self, error: &connlib_client_shared::Error) -> Result<(), Self::Error> {
         tracing::debug!("on_disconnect {error:?}");
-        self.ctlr_tx
-            .try_send(ControllerRequest::Disconnected)?;
+        self.ctlr_tx.try_send(ControllerRequest::Disconnected)?;
         Ok(())
     }
 

--- a/rust/linux-client/src/main.rs
+++ b/rust/linux-client/src/main.rs
@@ -71,10 +71,7 @@ impl Callbacks for CallbackHandler {
         Ok(Some(default_resolvers))
     }
 
-    fn on_disconnect(
-        &self,
-        error: Option<&connlib_client_shared::Error>,
-    ) -> Result<(), Self::Error> {
+    fn on_disconnect(&self, error: &connlib_client_shared::Error) -> Result<(), Self::Error> {
         tracing::error!(?error, "Disconnected");
         Ok(())
     }

--- a/rust/linux-client/src/main.rs
+++ b/rust/linux-client/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> Result<()> {
         etc_resolv_conf::unconfigure_dns()?;
     }
 
-    session.disconnect(None);
+    session.disconnect();
     Ok(())
 }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -190,24 +190,19 @@ class Adapter {
         break
       case .tunnelReady(let session):
         self.logger.log("Adapter.stop: Shutting down connlib")
-        self.state = .stoppingTunnel(session: session, onStopped: completionHandler)
         session.disconnect()
+        self.state = .stoppedTunnel
+        completionHandler()
       case .startingTunnel(let session, let onStarted):
         self.logger.log("Adapter.stop: Shutting down connlib before tunnel ready")
-        self.state = .stoppingTunnel(
-          session: session,
-          onStopped: {
-            onStarted?(AdapterError.stoppedByRequestWhileStarting)
-            completionHandler()
-          })
         session.disconnect()
+        self.state = .stoppedTunnel
+        onStarted?(AdapterError.stoppedByRequestWhileStarting)
+        completionHandler()
       case .stoppingTunnelTemporarily(let session, let onStopped):
-        self.state = .stoppingTunnel(
-          session: session,
-          onStopped: {
-            onStopped?()
-            completionHandler()
-          })
+        self.state = .stoppedTunnel
+        onStopped?()
+        completionHandler()
       case .stoppedTunnelTemporarily:
         self.state = .stoppedTunnel
         completionHandler()
@@ -515,46 +510,31 @@ extension Adapter: CallbackHandlerDelegate {
     }
   }
 
-  public func onDisconnect(error: String?) {
+  public func onDisconnect(error: String) {
     workQueue.async { [weak self] in
       guard let self = self else { return }
 
-      self.logger.log("Adapter.onDisconnect: \(error ?? "No error")")
-      if let errorMessage = error {
-        self.logger.error(
-          "Connlib disconnected with unrecoverable error: \(errorMessage)")
-        switch self.state {
-        case .stoppingTunnel(session: _, let onStopped):
-          onStopped?()
-          self.state = .stoppedTunnel
-        case .stoppingTunnelTemporarily(session: _, let onStopped):
-          onStopped?()
-          self.state = .stoppedTunnel
-        case .stoppedTunnel:
-          // This should not happen
-          break
-        case .stoppedTunnelTemporarily:
-          self.state = .stoppedTunnel
-        default:
-          packetTunnelProvider?.handleTunnelShutdown(
-            dueTo: .connlibDisconnected,
-            errorMessage: errorMessage)
-          self.packetTunnelProvider?.cancelTunnelWithError(
-            AdapterError.connlibFatalError(errorMessage))
-          self.state = .stoppedTunnel
-        }
-      } else {
-        self.logger.log("Connlib disconnected")
-        switch self.state {
-        case .stoppingTunnel(session: _, let onStopped):
-          onStopped?()
-          self.state = .stoppedTunnel
-        case .stoppingTunnelTemporarily(session: _, let onStopped):
-          onStopped?()
-          self.state = .stoppedTunnelTemporarily
-        default:
-          self.state = .stoppedTunnel
-        }
+      self.logger.error(
+        "Connlib disconnected with unrecoverable error: \(error)")
+      switch self.state {
+      case .stoppingTunnel(session: _, let onStopped):
+        onStopped?()
+        self.state = .stoppedTunnel
+      case .stoppingTunnelTemporarily(session: _, let onStopped):
+        onStopped?()
+        self.state = .stoppedTunnel
+      case .stoppedTunnel:
+        // This should not happen
+        break
+      case .stoppedTunnelTemporarily:
+        self.state = .stoppedTunnel
+      default:
+        packetTunnelProvider?.handleTunnelShutdown(
+          dueTo: .connlibDisconnected,
+          errorMessage: error)
+        self.packetTunnelProvider?.cancelTunnelWithError(
+          AdapterError.connlibFatalError(error))
+        self.state = .stoppedTunnel
       }
     }
   }

--- a/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
+++ b/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
@@ -26,7 +26,7 @@ public protocol CallbackHandlerDelegate: AnyObject {
   func onAddRoute(_: String)
   func onRemoveRoute(_: String)
   func onUpdateResources(resourceList: String)
-  func onDisconnect(error: String?)
+  func onDisconnect(error: String)
 }
 
 public class CallbackHandler {
@@ -86,13 +86,9 @@ public class CallbackHandler {
   }
 
   func onDisconnect(error: RustString) {
-    logger.log("CallbackHandler.onDisconnect: \(error.toString())")
     let error = error.toString()
-    var optionalError = Optional.some(error)
-    if error.isEmpty {
-      optionalError = Optional.none
-    }
-    delegate?.onDisconnect(error: optionalError)
+    logger.log("CallbackHandler.onDisconnect: \(error)")
+    delegate?.onDisconnect(error: error)
   }
 
   func setSystemDefaultResolvers(resolvers: [String]) {


### PR DESCRIPTION
Previously, we called `onDisconnect` in two kinds of situations:

- With an error when we wanted the clients to clear the token
- Without an error when the token was still valid (i.e. after a call to `disconnect` from the clients)

This is unnecessarily redundant. Firezone is designed to **not** have a state of "signed in but disconnected". Thus, every time connlib calls `disconnect`, we should clear the token and sign the user out.

At present, we only do this for errors with the control plane. Errors in the actual tunnel are only logged and we continue trying to use the tunnel. There are errors in the tunnel where we should also give up (i.e. TUN device gone, fatal IO error, etc). At present, those are not yet bubbled up but we will at some point. Once we have https://github.com/firezone/firezone/pull/3682, it will be much easier to create a type-safe contract that ensures we only disconnect on fatal errors.