### PR TITLE
refactor(phoenix-channel): reduce `Error` to fatal errors

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -3,7 +3,7 @@ use crate::messages::{
     EgressMessages, IngressMessages, RejectAccess, RequestConnection,
 };
 use crate::CallbackHandler;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use boringtun::x25519::PublicKey;
 use connlib_shared::{
     messages::{GatewayResponse, ResourceAccepted, ResourceDescription},
@@ -221,9 +221,6 @@ impl Eventloop {
                 }) => {
                     // TODO: Handle `init` message during operation.
                     continue;
-                }
-                Poll::Ready(phoenix_channel::Event::Disconnect(reason)) => {
-                    return Poll::Ready(Err(anyhow!("Disconnected by portal: {reason}")));
                 }
                 _ => {}
             }

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -398,16 +398,8 @@ where
                             continue;
                         }
                         Payload::Error(Empty {}) => {
-                            let Some(req_id) = message.reference else {
-                                tracing::warn!("Discarding reply because server omitted reference");
-                                continue;
-                            };
-
-                            return Poll::Ready(Ok(Event::ErrorResponse {
-                                topic: message.topic,
-                                req_id,
-                                reason: ErrorReply::Other,
-                            }));
+                            tracing::debug!(r#ref = ?message.reference, topic = &message.topic, "Received empty error response");
+                            continue;
                         }
                         Payload::Close(Empty {}) => {
                             self.reconnect_on_transient_error(Error::CloseMessage);

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -501,9 +501,6 @@ where
 
             // Priority 5: Handle portal messages
             match self.channel.as_mut().map(|c| c.poll(cx)) {
-                Some(Poll::Ready(Ok(Event::Disconnect(reason)))) => {
-                    return Poll::Ready(Err(anyhow!("Connection closed by portal: {reason}")));
-                }
                 Some(Poll::Ready(Err(Error::Serde(e)))) => {
                     tracing::warn!(target: "relay", "Failed to deserialize portal message: {e}");
                     continue; // This is not a hard-error, we can continue.

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -9,7 +9,7 @@ use futures::channel::mpsc;
 use futures::{future, FutureExt, SinkExt, StreamExt};
 use opentelemetry::{sdk, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
-use phoenix_channel::{Error, Event, PhoenixChannel, SecureUrl};
+use phoenix_channel::{Event, PhoenixChannel, SecureUrl};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use secrecy::{Secret, SecretString};
@@ -501,10 +501,6 @@ where
 
             // Priority 5: Handle portal messages
             match self.channel.as_mut().map(|c| c.poll(cx)) {
-                Some(Poll::Ready(Err(Error::Serde(e)))) => {
-                    tracing::warn!(target: "relay", "Failed to deserialize portal message: {e}");
-                    continue; // This is not a hard-error, we can continue.
-                }
                 Some(Poll::Ready(Err(e))) => {
                     return Poll::Ready(Err(anyhow!("Portal connection failed: {e}")));
                 }


### PR DESCRIPTION
As part of doing https://github.com/firezone/firezone/pull/3682, we noticed that the handling of errors up to the clients needs to differentiate between fatal errors that require clearing the token vs not.

Upon closer inspection of `phoenix_channel::Error`, it becomes obvious that the current design is not good here. In particular, we handle certain errors with retries internally but still expose those same errors.

To make this more obvious, we reduce the public `Error` to the variants that are actually fatal. Those can really only be three:

- HTTP client errors (those are by definition non-retryable)
- Token expired
- We have reached our max number of retries