### PR TITLE
feat(portal): Add API Client UI

### DIFF
--- a/elixir/apps/domain/lib/domain/accounts/features.ex
+++ b/elixir/apps/domain/lib/domain/accounts/features.ex
@@ -8,5 +8,6 @@ defmodule Domain.Accounts.Features do
     field :traffic_filters, :boolean
     field :self_hosted_relays, :boolean
     field :idp_sync, :boolean
+    field :rest_api, :boolean
   end
 end

--- a/elixir/apps/domain/lib/domain/accounts/features/changeset.ex
+++ b/elixir/apps/domain/lib/domain/accounts/features/changeset.ex
@@ -2,7 +2,7 @@ defmodule Domain.Accounts.Features.Changeset do
   use Domain, :changeset
   alias Domain.Accounts.Features
 
-  @fields ~w[flow_activities multi_site_resources traffic_filters self_hosted_relays idp_sync]a
+  @fields ~w[flow_activities multi_site_resources traffic_filters self_hosted_relays idp_sync rest_api]a
 
   def changeset(features \\ %Features{}, attrs) do
     features

--- a/elixir/apps/domain/lib/domain/actors.ex
+++ b/elixir/apps/domain/lib/domain/actors.ex
@@ -379,15 +379,6 @@ defmodule Domain.Actors do
     end
   end
 
-  def list_actors_by_type(%Auth.Subject{} = subject, type, opts \\ []) do
-    with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_actors_permission()) do
-      Actor.Query.not_deleted()
-      |> Actor.Query.by_type(type)
-      |> Authorizer.for_subject(subject)
-      |> Repo.list(Actor.Query, opts)
-    end
-  end
-
   def new_actor(attrs \\ %{memberships: []}) do
     Actor.Changeset.create(attrs)
   end

--- a/elixir/apps/domain/lib/domain/actors.ex
+++ b/elixir/apps/domain/lib/domain/actors.ex
@@ -380,16 +380,11 @@ defmodule Domain.Actors do
   end
 
   def list_actors_by_type(%Auth.Subject{} = subject, type, opts \\ []) do
-    {preload, _opts} = Keyword.pop(opts, :preload, [])
-
     with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_actors_permission()) do
-      {:ok, actors} =
-        Actor.Query.not_deleted()
-        |> Actor.Query.by_type(type)
-        |> Authorizer.for_subject(subject)
-        |> Repo.list()
-
-      {:ok, Repo.preload(actors, preload)}
+      Actor.Query.not_deleted()
+      |> Actor.Query.by_type(type)
+      |> Authorizer.for_subject(subject)
+      |> Repo.list(Actor.Query, opts)
     end
   end
 

--- a/elixir/apps/domain/lib/domain/auth.ex
+++ b/elixir/apps/domain/lib/domain/auth.ex
@@ -730,6 +730,7 @@ defmodule Domain.Auth do
          {:ok, subject} <- build_subject(token, context) do
       {:ok, subject}
     else
+      {:error, :actor_not_active} -> {:error, :unauthorized}
       {:error, :invalid_or_expired_token} -> {:error, :unauthorized}
       {:error, :invalid_remote_ip} -> {:error, :unauthorized}
       {:error, :invalid_user_agent} -> {:error, :unauthorized}

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -598,4 +598,9 @@ defmodule Domain.Config.Definitions do
   Boolean flag to turn Multi-Site resources functionality on/off for all accounts.
   """
   defconfig(:feature_multi_site_resources_enabled, :boolean, default: false)
+
+  @doc """
+  Boolean flag to turn API Client UI functionality on/off for all accounts.
+  """
+  defconfig(:feature_api_client_ui_enabled, :boolean, default: false)
 end

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -602,5 +602,5 @@ defmodule Domain.Config.Definitions do
   @doc """
   Boolean flag to turn API Client UI functionality on/off for all accounts.
   """
-  defconfig(:feature_api_client_ui_enabled, :boolean, default: false)
+  defconfig(:feature_rest_api_enabled, :boolean, default: false)
 end

--- a/elixir/apps/domain/lib/domain/tokens.ex
+++ b/elixir/apps/domain/lib/domain/tokens.ex
@@ -54,14 +54,6 @@ defmodule Domain.Tokens do
     end
   end
 
-  def list_tokens_by_type(type, %Auth.Subject{} = subject, opts \\ []) do
-    with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_tokens_permission()) do
-      Token.Query.not_deleted()
-      |> Token.Query.by_type(type)
-      |> list_tokens(subject, opts)
-    end
-  end
-
   defp list_tokens(queryable, subject, opts) do
     queryable
     |> Authorizer.for_subject(subject)

--- a/elixir/apps/domain/lib/domain/tokens.ex
+++ b/elixir/apps/domain/lib/domain/tokens.ex
@@ -54,6 +54,13 @@ defmodule Domain.Tokens do
     end
   end
 
+  def list_tokens_by_type(type, %Auth.Subject{} = subject, opts \\ []) do
+    with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_tokens_permission()) do
+      Token.Query.by_type(type)
+      |> list_tokens(subject, opts)
+    end
+  end
+
   defp list_tokens(queryable, subject, opts) do
     queryable
     |> Authorizer.for_subject(subject)

--- a/elixir/apps/domain/lib/domain/tokens.ex
+++ b/elixir/apps/domain/lib/domain/tokens.ex
@@ -56,7 +56,8 @@ defmodule Domain.Tokens do
 
   def list_tokens_by_type(type, %Auth.Subject{} = subject, opts \\ []) do
     with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_tokens_permission()) do
-      Token.Query.by_type(type)
+      Token.Query.not_deleted()
+      |> Token.Query.by_type(type)
       |> list_tokens(subject, opts)
     end
   end

--- a/elixir/apps/domain/lib/domain/tokens/token/query.ex
+++ b/elixir/apps/domain/lib/domain/tokens/token/query.ex
@@ -92,4 +92,26 @@ defmodule Domain.Tokens.Token.Query do
       {:tokens, :asc, :inserted_at},
       {:tokens, :asc, :id}
     ]
+
+  @impl Domain.Repo.Query
+  def filters,
+    do: [
+      %Domain.Repo.Filter{
+        name: :type,
+        type: :string,
+        values: [
+          {"API Client", "api_client"},
+          {"Browser", "browser"},
+          {"Client", "client"},
+          {"Email", "email"},
+          {"Gateway Group", "gateway_group"},
+          {"Relay Group", "relay_group"}
+        ],
+        fun: &filter_by_type/2
+      }
+    ]
+
+  def filter_by_type(queryable, type) do
+    {queryable, dynamic([tokens: tokens], tokens.type == ^type)}
+  end
 end

--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -72,6 +72,7 @@
       Identity Providers
     </:item>
     <:item navigate={~p"/#{@account}/settings/dns"}>DNS</:item>
+    <:item navigate={~p"/#{@account}/settings/api_clients"}>API Clients</:item>
   </.sidebar_item_group>
 
   <:bottom>

--- a/elixir/apps/web/lib/web/live/settings/api_clients/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/components.ex
@@ -8,7 +8,15 @@ defmodule Web.Settings.ApiClients.Components do
   def api_client_form(assigns) do
     ~H"""
     <div>
-      <.input label="Name" field={@form[:name]} placeholder="Name for API client" required />
+      <.input
+        label="Name"
+        field={@form[:name]}
+        placeholder="E.g. 'GitHub Actions' or 'Terraform'"
+        required
+      />
+      <p class="mt-2 text-xs text-neutral-500">
+        Describe what this API client will be used for. This can be changed later if needed.
+      </p>
     </div>
     """
   end

--- a/elixir/apps/web/lib/web/live/settings/api_clients/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/components.ex
@@ -1,0 +1,56 @@
+defmodule Web.Settings.ApiClients.Components do
+  use Web, :component_library
+
+  attr :type, :atom, required: true
+  attr :form, :any, required: true
+  attr :subject, :any, required: true
+
+  def api_client_form(assigns) do
+    ~H"""
+    <div>
+      <.input label="Name" field={@form[:name]} placeholder="Name for API client" required />
+    </div>
+    """
+  end
+
+  attr :form, :any, required: true
+
+  def api_token_form(assigns) do
+    ~H"""
+    <div>
+      <.input label="Name" field={@form[:name]} placeholder="Name for this token (optional)" />
+    </div>
+
+    <div>
+      <.input
+        label="Expires At"
+        type="date"
+        field={@form[:expires_at]}
+        value={Date.utc_today() |> Date.add(365)}
+        placeholder="When the token should auto-expire"
+        required
+      />
+    </div>
+    """
+  end
+
+  attr :encoded_token, :string, required: true
+  attr :account, :any, required: true
+  attr :actor, :any, required: true
+
+  def api_token_reveal(assigns) do
+    ~H"""
+    <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
+      <div class="text-xl mb-2">
+        Your API token (will be shown only once):
+      </div>
+
+      <.code_block id="code-api-token" class="w-full mw-1/2 rounded" phx-no-format><%= @encoded_token %></.code_block>
+
+      <.button icon="hero-arrow-uturn-left" navigate={~p"/#{@account}/settings/api_clients/#{@actor}"}>
+        Back to API Client
+      </.button>
+    </div>
+    """
+  end
+end

--- a/elixir/apps/web/lib/web/live/settings/api_clients/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/edit.ex
@@ -4,7 +4,7 @@ defmodule Web.Settings.ApiClients.Edit do
   alias Domain.Actors
 
   def mount(%{"id" => id}, _session, socket) do
-    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+    unless Domain.Config.global_feature_enabled?(:rest_api),
       do: raise(Web.LiveErrors.NotFoundError)
 
     with {:ok, actor} <- Actors.fetch_actor_by_id(id, socket.assigns.subject, preload: []),

--- a/elixir/apps/web/lib/web/live/settings/api_clients/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/edit.ex
@@ -1,0 +1,94 @@
+defmodule Web.Settings.ApiClients.Edit do
+  use Web, :live_view
+  import Web.Settings.ApiClients.Components
+  alias Domain.Actors
+
+  def mount(%{"id" => id}, _session, socket) do
+    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+      do: raise(Web.LiveErrors.NotFoundError)
+
+    with {:ok, actor} <- Actors.fetch_actor_by_id(id, socket.assigns.subject, preload: []),
+         nil <- actor.deleted_at do
+      changeset = Actors.change_actor(actor)
+
+      socket =
+        assign(socket,
+          actor: actor,
+          form: to_form(changeset),
+          page_title: "Edit #{actor.name}"
+        )
+
+      {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
+    else
+      _other -> raise Web.LiveErrors.NotFoundError
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs account={@account}>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients"}>API Clients</.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients/#{@actor}"}>
+        <%= @actor.name %>
+      </.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients/#{@actor}/edit"}>Edit</.breadcrumb>
+    </.breadcrumbs>
+
+    <.section>
+      <:title><%= @page_title %></:title>
+      <:content>
+        <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
+          <h2 class="mb-4 text-xl text-neutral-900">
+            Edit API Client
+          </h2>
+          <.flash kind={:error} flash={@flash} />
+          <.form for={@form} phx-change={:change} phx-submit={:submit}>
+            <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
+              <.api_client_form form={@form} type={:api_client} subject={@subject} />
+            </div>
+            <.submit_button>
+              Update
+            </.submit_button>
+          </.form>
+        </div>
+      </:content>
+    </.section>
+    """
+  end
+
+  def handle_event("change", %{"actor" => attrs}, socket) do
+    attrs =
+      attrs
+      |> Map.put("type", :api_client)
+
+    changeset =
+      Actors.change_actor(socket.assigns.actor, attrs)
+      |> Map.put(:action, :insert)
+
+    {:noreply, assign(socket, form: to_form(changeset))}
+  end
+
+  def handle_event("submit", %{"actor" => attrs}, socket) do
+    attrs =
+      attrs
+      |> Map.put("type", :api_client)
+
+    with {:ok, actor} <- Actors.update_actor(socket.assigns.actor, attrs, socket.assigns.subject) do
+      socket =
+        push_navigate(socket, to: ~p"/#{socket.assigns.account}/settings/api_clients/#{actor}")
+
+      {:noreply, socket}
+    else
+      {:error, :unauthorized} ->
+        {:noreply,
+         put_flash(socket, :error, "You don't have permissions to perform this action.")}
+
+      {:error, {:unauthorized, _context}} ->
+        {:noreply,
+         put_flash(socket, :error, "You don't have permissions to perform this action.")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+end

--- a/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
@@ -3,7 +3,7 @@ defmodule Web.Settings.ApiClients.Index do
   alias Domain.Actors
 
   def mount(_params, _session, socket) do
-    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+    unless Domain.Config.global_feature_enabled?(:rest_api),
       do: raise(Web.LiveErrors.NotFoundError)
 
     socket =

--- a/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
@@ -36,8 +36,7 @@ defmodule Web.Settings.ApiClients.Index do
       socket =
         assign(socket,
           actors: actors,
-          actors_metadata: actors_metadata,
-          page_title: "API Clients"
+          actors_metadata: actors_metadata
         )
 
       {:ok, socket}

--- a/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
@@ -31,8 +31,13 @@ defmodule Web.Settings.ApiClients.Index do
   end
 
   def handle_api_clients_update!(socket, list_opts) do
+    list_opts =
+      Keyword.update(list_opts, :filter, [], fn filters ->
+        Keyword.put(filters, :type, "api_client")
+      end)
+
     with {:ok, actors, actors_metadata} <-
-           Actors.list_actors_by_type(socket.assigns.subject, :api_client, list_opts) do
+           Actors.list_actors(socket.assigns.subject, list_opts) do
       socket =
         assign(socket,
           actors: actors,

--- a/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
@@ -15,9 +15,11 @@ defmodule Web.Settings.ApiClients.Index do
           {:actors, :name},
           {:actors, :status}
         ],
+        enforce_filters: [
+          {:type, "api_client"}
+        ],
         hide_filters: [
-          :provider_id,
-          :type
+          :provider_id
         ],
         callback: &handle_api_clients_update!/2
       )
@@ -31,11 +33,6 @@ defmodule Web.Settings.ApiClients.Index do
   end
 
   def handle_api_clients_update!(socket, list_opts) do
-    list_opts =
-      Keyword.update(list_opts, :filter, [], fn filters ->
-        Keyword.put(filters, :type, "api_client")
-      end)
-
     with {:ok, actors, actors_metadata} <-
            Actors.list_actors(socket.assigns.subject, list_opts) do
       socket =

--- a/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
@@ -1,0 +1,75 @@
+defmodule Web.Settings.ApiClients.Index do
+  use Web, :live_view
+  alias Domain.{Actors, Tokens}
+
+  def mount(_params, _session, socket) do
+    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+      do: raise(Web.LiveErrors.NotFoundError)
+
+    with {:ok, actors} <- Actors.list_actors_by_type(socket.assigns.subject, :api_client),
+         {:ok, tokens} <- Tokens.list_tokens_by_type(:api_client, socket.assigns.subject) do
+      token_count =
+        Enum.reduce(tokens, %{}, fn %{actor_id: actor_id}, acc ->
+          Map.update(acc, actor_id, 1, &(&1 + 1))
+        end)
+
+      socket =
+        assign(socket,
+          actors: actors,
+          token_count: token_count,
+          page_title: "API Clients"
+        )
+
+      {:ok, socket}
+    else
+      {:error, _reason} -> raise Web.LiveErrors.NotFoundError
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs account={@account}>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients"}><%= @page_title %></.breadcrumb>
+    </.breadcrumbs>
+
+    <.section>
+      <:title><%= @page_title %></:title>
+
+      <:action>
+        <.add_button navigate={~p"/#{@account}/settings/api_clients/new"}>
+          Add API Client
+        </.add_button>
+      </:action>
+      <:content>
+        <.table id="actors" rows={@actors} row_id={&"api-client-#{&1.id}"}>
+          <:col :let={actor} label="name" sortable="false">
+            <.link navigate={~p"/#{@account}/settings/api_clients/#{actor}"} class={link_style()}>
+              <%= actor.name %>
+            </.link>
+          </:col>
+          <:col :let={actor} label="status" sortable="false">
+            <%= status(actor) %>
+          </:col>
+          <:col :let={actor} label="tokens" sortable="false">
+            <%= Map.get(@token_count, actor.id, 0) %>
+          </:col>
+          <:col :let={actor} label="created at" sortable="false">
+            <%= Cldr.DateTime.Formatter.date(actor.inserted_at, 1, "en", Web.CLDR, []) %>
+          </:col>
+          <:empty>
+            <div class="flex justify-center text-center text-neutral-500 p-4">
+              <div class="w-auto pb-4">
+                No API Clients to display.
+              </div>
+            </div>
+          </:empty>
+        </.table>
+      </:content>
+    </.section>
+    """
+  end
+
+  defp status(actor) do
+    if Actors.actor_active?(actor), do: "Active", else: "Disabled"
+  end
+end

--- a/elixir/apps/web/lib/web/live/settings/api_clients/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/new.ex
@@ -1,0 +1,82 @@
+defmodule Web.Settings.ApiClients.New do
+  use Web, :live_view
+  import Web.Settings.ApiClients.Components
+  alias Domain.Actors
+
+  def mount(_params, _session, socket) do
+    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+      do: raise(Web.LiveErrors.NotFoundError)
+
+    changeset = Actors.new_actor(%{type: :api_client})
+
+    socket =
+      assign(socket,
+        form: to_form(changeset),
+        page_title: "New API Client"
+      )
+
+    {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs account={@account}>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients"}>API Clients</.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients/new"}>Add</.breadcrumb>
+    </.breadcrumbs>
+
+    <.section>
+      <:title><%= @page_title %></:title>
+      <:content>
+        <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
+          <h2 class="mb-4 text-xl text-neutral-900">
+            Create API Client
+          </h2>
+          <.flash kind={:error} flash={@flash} />
+          <.form for={@form} phx-change={:change} phx-submit={:submit}>
+            <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
+              <.api_client_form form={@form} type={:api_client} subject={@subject} />
+            </div>
+            <.submit_button>
+              Create
+            </.submit_button>
+          </.form>
+        </div>
+      </:content>
+    </.section>
+    """
+  end
+
+  def handle_event("change", %{"actor" => attrs}, socket) do
+    changeset =
+      attrs
+      |> Map.put("type", :api_client)
+      |> Actors.new_actor()
+      |> Map.put(:action, :insert)
+
+    {:noreply, assign(socket, form: to_form(changeset))}
+  end
+
+  def handle_event("submit", %{"actor" => attrs}, socket) do
+    attrs =
+      attrs
+      |> Map.put("type", :api_client)
+
+    with {:ok, actor} <-
+           Actors.create_actor(
+             socket.assigns.account,
+             attrs,
+             socket.assigns.subject
+           ) do
+      socket =
+        push_navigate(socket,
+          to: ~p"/#{socket.assigns.account}/settings/api_clients/#{actor}/new_token"
+        )
+
+      {:noreply, socket}
+    else
+      {:error, changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+end

--- a/elixir/apps/web/lib/web/live/settings/api_clients/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/new.ex
@@ -4,7 +4,7 @@ defmodule Web.Settings.ApiClients.New do
   alias Domain.Actors
 
   def mount(_params, _session, socket) do
-    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+    unless Domain.Config.global_feature_enabled?(:rest_api),
       do: raise(Web.LiveErrors.NotFoundError)
 
     changeset = Actors.new_actor(%{type: :api_client})

--- a/elixir/apps/web/lib/web/live/settings/api_clients/new_token.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/new_token.ex
@@ -1,0 +1,99 @@
+defmodule Web.Settings.ApiClients.NewToken do
+  use Web, :live_view
+  import Web.Settings.ApiClients.Components
+  alias Domain.{Auth, Actors, Tokens}
+
+  def mount(%{"id" => id}, _session, socket) do
+    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+      do: raise(Web.LiveErrors.NotFoundError)
+
+    with {:ok, %{type: :api_client} = actor} <-
+           Actors.fetch_actor_by_id(id, socket.assigns.subject) do
+      changeset = Tokens.Token.Changeset.create(%{})
+
+      socket =
+        assign(socket,
+          actor: actor,
+          encoded_token: nil,
+          form: to_form(changeset),
+          page_title: "Create API Token"
+        )
+
+      {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
+    else
+      _other -> raise Web.LiveErrors.NotFoundError
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs account={@account}>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients"}>API Clients</.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients/#{@actor}"}>
+        <%= @actor.name %>
+      </.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients/#{@actor}/new_token"}>
+        Add Token
+      </.breadcrumb>
+    </.breadcrumbs>
+
+    <.section>
+      <:title><%= @page_title %></:title>
+      <:content>
+        <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
+          <div :if={is_nil(@encoded_token)}>
+            <h2 class="mb-4 text-xl text-neutral-900">Create Token</h2>
+            <.flash kind={:error} flash={@flash} />
+            <.form for={@form} phx-change={:change} phx-submit={:submit}>
+              <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
+                <.api_token_form form={@form} />
+              </div>
+              <.submit_button>
+                Create
+              </.submit_button>
+            </.form>
+          </div>
+
+          <div :if={not is_nil(@encoded_token)} class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
+            <.api_token_reveal encoded_token={@encoded_token} account={@account} actor={@actor} />
+          </div>
+        </div>
+      </:content>
+    </.section>
+    """
+  end
+
+  def handle_event("change", %{"token" => attrs}, socket) do
+    attrs = map_expires_at(attrs)
+
+    changeset =
+      Tokens.Token.Changeset.create(attrs)
+      |> Map.put(:action, :insert)
+
+    {:noreply, assign(socket, form: to_form(changeset))}
+  end
+
+  def handle_event("submit", %{"token" => attrs}, socket) do
+    attrs = map_expires_at(attrs)
+
+    with {:ok, encoded_token} <-
+           Auth.create_api_client_token(
+             socket.assigns.actor,
+             attrs,
+             socket.assigns.subject
+           ) do
+      {:noreply, assign(socket, encoded_token: encoded_token)}
+    else
+      {:error, changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp map_expires_at(attrs) do
+    Map.update(attrs, "expires_at", nil, fn
+      nil -> nil
+      "" -> ""
+      value -> "#{value}T00:00:00.000000Z"
+    end)
+  end
+end

--- a/elixir/apps/web/lib/web/live/settings/api_clients/new_token.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/new_token.ex
@@ -4,7 +4,7 @@ defmodule Web.Settings.ApiClients.NewToken do
   alias Domain.{Auth, Actors, Tokens}
 
   def mount(%{"id" => id}, _session, socket) do
-    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+    unless Domain.Config.global_feature_enabled?(:rest_api),
       do: raise(Web.LiveErrors.NotFoundError)
 
     with {:ok, %{type: :api_client} = actor} <-

--- a/elixir/apps/web/lib/web/live/settings/api_clients/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/show.ex
@@ -1,0 +1,214 @@
+defmodule Web.Settings.ApiClients.Show do
+  use Web, :live_view
+  alias Domain.{Actors, Tokens}
+
+  def mount(%{"id" => id}, _session, socket) do
+    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+      do: raise(Web.LiveErrors.NotFoundError)
+
+    with {:ok, actor} <-
+           Actors.fetch_actor_by_id(id, socket.assigns.subject, preload: []),
+         {:ok, tokens} <-
+           Tokens.list_tokens_for(actor, socket.assigns.subject, preload: :created_by_identity) do
+      socket =
+        assign(
+          socket,
+          actor: actor,
+          tokens: tokens,
+          page_title: "API Client #{actor.name}"
+        )
+
+      {:ok, socket}
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs account={@account}>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients"}>API Clients</.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/settings/api_clients/#{@actor}"}>
+        <%= @actor.name %>
+      </.breadcrumb>
+    </.breadcrumbs>
+
+    <.section>
+      <:title>
+        API Client: <span class="font-medium"><%= @actor.name %></span>
+        <span :if={Actors.actor_deleted?(@actor)} class="text-red-600">(deleted)</span>
+      </:title>
+      <:action :if={is_nil(@actor.deleted_at)}>
+        <.edit_button navigate={~p"/#{@account}/settings/api_clients/#{@actor}/edit"}>
+          Edit API Client
+        </.edit_button>
+      </:action>
+      <:action :if={Actors.actor_active?(@actor)}>
+        <.button
+          style="warning"
+          icon="hero-lock-closed"
+          phx-click="disable"
+          data-confirm="Are you sure want to disable this API Client and revoke all its tokens?"
+        >
+          Disable API Client
+        </.button>
+      </:action>
+      <:action :if={is_nil(@actor.deleted_at) and Actors.actor_disabled?(@actor)}>
+        <.button
+          style="warning"
+          icon="hero-lock-open"
+          phx-click="enable"
+          data-confirm="Are you sure want to enable this API Client?"
+        >
+          Enable API Client
+        </.button>
+      </:action>
+      <:content flash={@flash}>
+        <.vertical_table id="api-client">
+          <.vertical_table_row>
+            <:label>Name</:label>
+            <:value><%= @actor.name %></:value>
+          </.vertical_table_row>
+
+          <.vertical_table_row>
+            <:label>Created</:label>
+            <:value>
+              <%= Cldr.DateTime.Formatter.date(@actor.inserted_at, 1, "en", Web.CLDR, []) %>
+            </:value>
+          </.vertical_table_row>
+        </.vertical_table>
+      </:content>
+    </.section>
+
+    <.section>
+      <:title>API Tokens</:title>
+
+      <:action :if={Actors.actor_active?(@actor) and @actor.type == :api_client}>
+        <.add_button
+          :if={@actor.type == :api_client}
+          navigate={~p"/#{@account}/settings/api_clients/#{@actor}/new_token"}
+        >
+          Create Token
+        </.add_button>
+      </:action>
+
+      <:action :if={Actors.actor_active?(@actor)}>
+        <.delete_button
+          phx-click="revoke_all_tokens"
+          data-confirm="Are you sure you want to revoke all tokens for this API client?"
+        >
+          Revoke All
+        </.delete_button>
+      </:action>
+
+      <:content>
+        <.table id="tokens" rows={@tokens} row_id={&"api-client-token-#{&1.id}"}>
+          <:col :let={token} label="name" sortable="false">
+            <%= token.name %>
+          </:col>
+          <:col :let={token} label="expires at" sortable="false">
+            <%= Cldr.DateTime.Formatter.date(token.expires_at, 1, "en", Web.CLDR, []) %>
+          </:col>
+          <:col :let={token} label="created by" sortable="false">
+            <%= token.created_by_identity.provider_identifier %>
+          </:col>
+          <:col :let={token} label="last seen at" sortable="false">
+            <.relative_datetime datetime={token.last_seen_at} />
+          </:col>
+          <:action :let={token}>
+            <.delete_button
+              phx-click="revoke_token"
+              data-confirm="Are you sure you want to revoke this token?"
+              phx-value-id={token.id}
+              class={[
+                "block w-full py-2 px-4 hover:bg-gray-100"
+              ]}
+            >
+              Revoke
+            </.delete_button>
+          </:action>
+          <:empty>
+            <div class="flex justify-center text-center text-neutral-500 p-4">
+              <div class="w-auto pb-4">
+                No API tokens to display.
+              </div>
+            </div>
+          </:empty>
+        </.table>
+      </:content>
+    </.section>
+
+    <.danger_zone :if={is_nil(@actor.deleted_at)}>
+      <:action>
+        <.delete_button
+          phx-click="delete"
+          data-confirm="Are you sure want to delete this API Client along with all associated tokens?"
+        >
+          Delete API Client
+        </.delete_button>
+      </:action>
+    </.danger_zone>
+    """
+  end
+
+  def handle_event("disable", _params, socket) do
+    with {:ok, actor} <- Actors.disable_actor(socket.assigns.actor, socket.assigns.subject),
+         {:ok, tokens} <-
+           Tokens.list_tokens_for(actor, socket.assigns.subject, preload: :created_by_identity) do
+      socket =
+        socket
+        |> put_flash(:info, "API Client was disabled.")
+        |> assign(actor: actor, tokens: tokens)
+
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("enable", _params, socket) do
+    {:ok, actor} = Actors.enable_actor(socket.assigns.actor, socket.assigns.subject)
+
+    socket =
+      socket
+      |> put_flash(:info, "API Client was enabled.")
+      |> assign(actor: actor)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("revoke_all_tokens", _params, socket) do
+    {:ok, deleted_tokens} = Tokens.delete_tokens_for(socket.assigns.actor, socket.assigns.subject)
+
+    {:ok, tokens} =
+      Tokens.list_tokens_for(socket.assigns.actor, socket.assigns.subject,
+        preload: :created_by_identity
+      )
+
+    socket =
+      socket
+      |> put_flash(:info, "#{length(deleted_tokens)} token(s) were revoked.")
+      |> assign(tokens: tokens)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("revoke_token", %{"id" => id}, socket) do
+    {:ok, token} = Tokens.fetch_token_by_id(id, socket.assigns.subject)
+    {:ok, _token} = Tokens.delete_token(token, socket.assigns.subject)
+
+    {:ok, tokens} =
+      Tokens.list_tokens_for(socket.assigns.actor, socket.assigns.subject,
+        preload: :created_by_identity
+      )
+
+    socket =
+      socket
+      |> put_flash(:info, "Token was revoked.")
+      |> assign(tokens: tokens)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("delete", _params, socket) do
+    with {:ok, _actor} <- Actors.delete_actor(socket.assigns.actor, socket.assigns.subject) do
+      {:noreply, push_navigate(socket, to: ~p"/#{socket.assigns.account}/settings/api_clients")}
+    end
+  end
+end

--- a/elixir/apps/web/lib/web/live/settings/api_clients/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/show.ex
@@ -3,7 +3,7 @@ defmodule Web.Settings.ApiClients.Show do
   alias Domain.{Actors, Tokens}
 
   def mount(%{"id" => id}, _session, socket) do
-    unless Domain.Config.global_feature_enabled?(:api_client_ui),
+    unless Domain.Config.global_feature_enabled?(:rest_api),
       do: raise(Web.LiveErrors.NotFoundError)
 
     with {:ok, actor} <- Actors.fetch_actor_by_id(id, socket.assigns.subject, preload: []) do

--- a/elixir/apps/web/lib/web/router.ex
+++ b/elixir/apps/web/lib/web/router.ex
@@ -212,6 +212,14 @@ defmodule Web.Router do
 
         live "/billing", Billing
 
+        scope "/api_clients", ApiClients do
+          live "/", Index
+          live "/new", New
+          live "/:id/new_token", NewToken
+          live "/:id", Show
+          live "/:id/edit", Edit
+        end
+
         scope "/identity_providers", IdentityProviders do
           live "/", Index
           live "/new", New

--- a/elixir/apps/web/test/web/live/actors/edit_test.exs
+++ b/elixir/apps/web/test/web/live/actors/edit_test.exs
@@ -268,7 +268,7 @@ defmodule Web.Live.Actors.EditTest do
                  }}}
     end
 
-    test "renders not found error when gateway is deleted", %{
+    test "renders not found error when actor is deleted", %{
       account: account,
       actor: actor,
       identity: identity,

--- a/elixir/apps/web/test/web/live/settings/api_clients/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/api_clients/edit_test.exs
@@ -1,0 +1,155 @@
+defmodule Web.Live.Settings.ApiClients.EditTest do
+  use Web.ConnCase, async: true
+
+  setup do
+    account = Fixtures.Accounts.create_account()
+    api_client = Fixtures.Actors.create_actor(type: :api_client, account: account)
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(actor: actor, account: account)
+
+    %{
+      account: account,
+      actor: actor,
+      identity: identity,
+      api_client: api_client
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{
+    account: account,
+    api_client: api_client,
+    conn: conn
+  } do
+    path = ~p"/#{account}/settings/api_clients/#{api_client}/edit"
+
+    assert live(conn, path) ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}?#{%{redirect_to: path}}",
+                 flash: %{"error" => "You must sign in to access this page."}
+               }}}
+  end
+
+  test "renders not found error when API Client is deleted", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    api_client = Fixtures.Actors.delete(api_client)
+
+    assert_raise Web.LiveErrors.NotFoundError, fn ->
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/edit")
+    end
+  end
+
+  test "renders breadcrumbs item", %{
+    account: account,
+    identity: identity,
+    api_client: api_client,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/edit")
+
+    assert item = Floki.find(html, "[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "API Clients"
+    assert breadcrumbs =~ api_client.name
+    assert breadcrumbs =~ "Edit"
+  end
+
+  test "renders form", %{
+    account: account,
+    identity: identity,
+    api_client: api_client,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/edit")
+
+    form = form(lv, "form")
+
+    assert find_inputs(form) == [
+             "actor[name]"
+           ]
+  end
+
+  test "renders changeset errors on input change", %{
+    account: account,
+    identity: identity,
+    api_client: api_client,
+    conn: conn
+  } do
+    attrs = Fixtures.Actors.actor_attrs() |> Map.take([:name])
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/edit")
+
+    lv
+    |> form("form", actor: attrs)
+    |> validate_change(%{actor: %{name: String.duplicate("a", 555)}}, fn form, _html ->
+      assert form_validation_errors(form) == %{
+               "actor[name]" => ["should be at most 512 character(s)"]
+             }
+    end)
+    |> validate_change(%{actor: %{name: ""}}, fn form, _html ->
+      assert form_validation_errors(form) == %{
+               "actor[name]" => ["can't be blank"]
+             }
+    end)
+  end
+
+  test "renders changeset errors on submit", %{
+    account: account,
+    identity: identity,
+    api_client: api_client,
+    conn: conn
+  } do
+    attrs = %{name: String.duplicate("a", 555)}
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/edit")
+
+    assert lv
+           |> form("form", actor: attrs)
+           |> render_submit()
+           |> form_validation_errors() == %{
+             "actor[name]" => ["should be at most 512 character(s)"]
+           }
+  end
+
+  test "updates an api client on valid attrs", %{
+    account: account,
+    identity: identity,
+    api_client: api_client,
+    conn: conn
+  } do
+    attrs = %{name: Fixtures.Actors.actor_attrs().name}
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/edit")
+
+    lv
+    |> form("form", actor: attrs)
+    |> render_submit()
+
+    assert_redirected(lv, ~p"/#{account}/settings/api_clients/#{api_client}")
+
+    assert actor = Repo.get_by(Domain.Actors.Actor, id: api_client.id)
+    assert actor.name == attrs.name
+  end
+end

--- a/elixir/apps/web/test/web/live/settings/api_clients/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/api_clients/index_test.exs
@@ -1,0 +1,98 @@
+defmodule Web.Live.Settings.ApiClients.IndexTest do
+  use Web.ConnCase, async: true
+
+  setup do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(account: account, actor: [type: :account_admin_user])
+    api_client = Fixtures.Actors.create_actor(type: :api_client, account: account)
+
+    %{
+      account: account,
+      actor: actor,
+      identity: identity,
+      api_client: api_client
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{account: account, conn: conn} do
+    path = ~p"/#{account}/settings/api_clients"
+
+    assert live(conn, path) ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}?#{%{redirect_to: path}}",
+                 flash: %{"error" => "You must sign in to access this page."}
+               }}}
+  end
+
+  test "renders breadcrumbs item", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients")
+
+    assert item = Floki.find(html, "[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "API Clients"
+  end
+
+  test "renders add api client button", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients")
+
+    assert button = Floki.find(html, "a[href='/#{account.slug}/settings/api_clients/new']")
+    assert Floki.text(button) =~ "Add API Client"
+  end
+
+  test "renders table with multiple api clients", %{
+    account: account,
+    identity: identity,
+    api_client: api_client,
+    conn: conn
+  } do
+    api_client_2 = Fixtures.Actors.create_actor(type: :api_client, account: account)
+    api_client_3 = Fixtures.Actors.create_actor(type: :api_client, account: account)
+
+    Fixtures.Actors.disable(api_client_2)
+    Fixtures.Tokens.create_api_client_token(account: account, actor: api_client_3)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients")
+
+    rows =
+      lv
+      |> element("#actors")
+      |> render()
+      |> table_to_map()
+
+    assert length(rows) == 3
+
+    rows
+    |> with_table_row("name", api_client.name, fn row ->
+      assert row["status"] =~ "Active"
+      assert row["tokens"] == "0"
+    end)
+    |> with_table_row("name", api_client_2.name, fn row ->
+      assert row["status"] =~ "Disabled"
+      assert row["tokens"] == "0"
+    end)
+    |> with_table_row("name", api_client_3.name, fn row ->
+      assert row["status"] =~ "Active"
+      assert row["tokens"] == "1"
+    end)
+  end
+end

--- a/elixir/apps/web/test/web/live/settings/api_clients/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/api_clients/index_test.exs
@@ -84,15 +84,12 @@ defmodule Web.Live.Settings.ApiClients.IndexTest do
     rows
     |> with_table_row("name", api_client.name, fn row ->
       assert row["status"] =~ "Active"
-      assert row["tokens"] == "0"
     end)
     |> with_table_row("name", api_client_2.name, fn row ->
       assert row["status"] =~ "Disabled"
-      assert row["tokens"] == "0"
     end)
     |> with_table_row("name", api_client_3.name, fn row ->
       assert row["status"] =~ "Active"
-      assert row["tokens"] == "1"
     end)
   end
 end

--- a/elixir/apps/web/test/web/live/settings/api_clients/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/api_clients/new_test.exs
@@ -1,0 +1,123 @@
+defmodule Web.Live.Settings.ApiClient.NewTest do
+  use Web.ConnCase, async: true
+
+  setup do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+
+    %{
+      account: account,
+      actor: actor,
+      identity: identity
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{
+    account: account,
+    conn: conn
+  } do
+    path = ~p"/#{account}/settings/api_clients/new"
+
+    assert live(conn, path) ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}?#{%{redirect_to: path}}",
+                 flash: %{"error" => "You must sign in to access this page."}
+               }}}
+  end
+
+  test "renders breadcrumbs item", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/new")
+
+    assert item = Floki.find(html, "[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "API Clients"
+    assert breadcrumbs =~ "Add"
+  end
+
+  test "renders form", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/new")
+
+    form = form(lv, "form")
+
+    assert find_inputs(form) == ["actor[name]"]
+  end
+
+  test "renders changeset errors on input change", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    attrs = Fixtures.Actors.actor_attrs() |> Map.take([:name])
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/new")
+
+    lv
+    |> form("form", actor: attrs)
+    |> validate_change(%{actor: %{name: String.duplicate("a", 555)}}, fn form, _html ->
+      assert form_validation_errors(form) == %{
+               "actor[name]" => ["should be at most 512 character(s)"]
+             }
+    end)
+  end
+
+  test "renders changeset errors on submit", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/new")
+
+    assert lv
+           |> form("form", actor: %{})
+           |> render_submit()
+           |> form_validation_errors() == %{
+             "actor[name]" => ["can't be blank"]
+           }
+  end
+
+  test "creates a new actor on valid attrs", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    attrs = %{
+      name: Fixtures.Actors.actor_attrs().name
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/new")
+
+    lv
+    |> form("form", actor: attrs)
+    |> render_submit()
+
+    assert api_client = Repo.get_by(Domain.Actors.Actor, name: attrs.name)
+
+    assert_redirect(lv, ~p"/#{account}/settings/api_clients/#{api_client}/new_token")
+  end
+end

--- a/elixir/apps/web/test/web/live/settings/api_clients/new_token_test.exs
+++ b/elixir/apps/web/test/web/live/settings/api_clients/new_token_test.exs
@@ -1,0 +1,155 @@
+defmodule Web.Live.Settings.ApiClient.NewTokenTest do
+  use Web.ConnCase, async: true
+
+  setup do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+    api_client = Fixtures.Actors.create_actor(type: :api_client, account: account)
+
+    %{
+      account: account,
+      actor: actor,
+      identity: identity,
+      api_client: api_client
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{
+    account: account,
+    api_client: api_client,
+    conn: conn
+  } do
+    path = ~p"/#{account}/settings/api_clients/#{api_client}/new_token"
+
+    assert live(conn, path) ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}?#{%{redirect_to: path}}",
+                 flash: %{"error" => "You must sign in to access this page."}
+               }}}
+  end
+
+  test "renders breadcrumbs item", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/new_token")
+
+    assert item = Floki.find(html, "[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "API Clients"
+    assert breadcrumbs =~ api_client.name
+    assert breadcrumbs =~ "Add Token"
+  end
+
+  test "renders form", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/new_token")
+
+    assert lv
+           |> form("form")
+           |> find_inputs() == [
+             "token[expires_at]",
+             "token[name]"
+           ]
+  end
+
+  test "renders changeset errors on input change", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/new_token")
+
+    lv
+    |> form("form", identity: %{})
+    |> validate_change(
+      %{token: %{expires_at: "1991-01-01"}},
+      fn form, _html ->
+        assert %{
+                 "token[expires_at]" => ["must be greater than" <> _]
+               } = form_validation_errors(form)
+      end
+    )
+  end
+
+  test "renders changeset errors on submit", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    attrs = %{expires_at: "1991-01-01"}
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/new_token")
+
+    html =
+      lv
+      |> form("form", token: attrs)
+      |> render_submit()
+
+    assert %{
+             "token[expires_at]" => ["must be greater than" <> _]
+           } = form_validation_errors(html)
+  end
+
+  test "creates a new token on valid attrs", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    expires_at = Date.utc_today() |> Date.add(3)
+
+    attrs = %{
+      name: Fixtures.Actors.actor_attrs().name,
+      expires_at: Date.to_iso8601(expires_at)
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}/new_token")
+
+    html =
+      lv
+      |> form("form", token: attrs)
+      |> render_submit()
+
+    assert html =~ "Your API token (will be shown only once)"
+
+    assert Floki.find(html, "code")
+           |> element_to_text()
+           |> String.trim()
+           |> String.first() == "."
+
+    lv
+    |> element("a", "Back to API Client")
+    |> render_click()
+
+    {path, _flash} = assert_redirect(lv)
+
+    assert path =~ ~p"/#{account}/settings/api_clients/#{api_client}"
+  end
+end

--- a/elixir/apps/web/test/web/live/settings/api_clients/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/api_clients/show_test.exs
@@ -1,0 +1,275 @@
+defmodule Web.Live.Settings.ApiClients.ShowTest do
+  use Web.ConnCase, async: true
+
+  setup do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(account: account, actor: [type: :account_admin_user])
+    api_client = Fixtures.Actors.create_actor(type: :api_client, account: account)
+
+    %{
+      account: account,
+      actor: actor,
+      identity: identity,
+      api_client: api_client
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{conn: conn} do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :api_client, account: account)
+
+    path = ~p"/#{account}/settings/api_clients/#{actor}"
+
+    assert live(conn, path) ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}?#{%{redirect_to: path}}",
+                 flash: %{"error" => "You must sign in to access this page."}
+               }}}
+  end
+
+  test "renders deleted actor without action buttons", %{conn: conn} do
+    account = Fixtures.Accounts.create_account()
+
+    api_client =
+      Fixtures.Actors.create_actor(type: :api_client, account: account)
+      |> Fixtures.Actors.delete()
+
+    auth_actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    auth_identity = Fixtures.Auth.create_identity(account: account, actor: auth_actor)
+
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(auth_identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    assert html =~ "(deleted)"
+    assert active_buttons(html) == []
+  end
+
+  test "renders breadcrumbs item", %{conn: conn} do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+    api_client = Fixtures.Actors.create_actor(type: :api_client, account: account)
+
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    assert item = Floki.find(html, "[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "API Clients"
+    assert breadcrumbs =~ api_client.name
+  end
+
+  test "renders api client details", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    assert html =~ "API Client"
+
+    expected_date = Cldr.DateTime.Formatter.date(api_client.inserted_at, 1, "en", Web.CLDR, [])
+
+    assert lv
+           |> element("#api-client")
+           |> render()
+           |> vertical_table_to_map() == %{
+             "name" => api_client.name,
+             "created" => expected_date
+           }
+  end
+
+  test "allows creating tokens", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    lv
+    |> element("a:first-child", "Create Token")
+    |> render_click()
+
+    assert_redirect(lv, ~p"/#{account}/settings/api_clients/#{api_client}/new_token")
+  end
+
+  test "allows editing api clients", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    assert lv
+           |> element("a", "Edit API Client")
+           |> render_click() ==
+             {:error,
+              {:live_redirect,
+               %{to: ~p"/#{account}/settings/api_clients/#{api_client}/edit", kind: :push}}}
+  end
+
+  test "allows deleting actors", %{
+    account: account,
+    identity: identity,
+    api_client: api_client,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    lv
+    |> element("button", "Delete API Client")
+    |> render_click()
+
+    assert_redirect(lv, ~p"/#{account}/settings/api_clients")
+
+    assert Repo.get(Domain.Actors.Actor, api_client.id).deleted_at
+  end
+
+  test "allows disabling api clients", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    refute has_element?(lv, "button", "Enable API Client")
+
+    assert lv
+           |> element("button", "Disable API Client")
+           |> render_click()
+           |> Floki.find(".flash-info")
+           |> element_to_text() =~ "API Client was disabled."
+
+    assert Repo.get(Domain.Actors.Actor, api_client.id).disabled_at
+  end
+
+  test "allows enabling api clients", %{
+    account: account,
+    api_client: api_client,
+    identity: identity,
+    conn: conn
+  } do
+    api_client = Fixtures.Actors.disable(api_client)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    refute has_element?(lv, "button", "Disable API Client")
+
+    assert lv
+           |> element("button", "Enable API Client")
+           |> render_click()
+           |> Floki.find(".flash-info")
+           |> element_to_text() =~ "API Client was enabled."
+
+    refute Repo.get(Domain.Actors.Actor, api_client.id).disabled_at
+  end
+
+  test "renders api client tokens", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    api_client = Fixtures.Actors.create_actor(type: :api_client, account: account)
+    token = Fixtures.Tokens.create_api_client_token(account: account, actor: api_client)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    [row1] =
+      lv
+      |> element("#tokens")
+      |> render()
+      |> table_to_map()
+
+    assert row1["name"] == token.name
+    assert row1["expires at"]
+    assert row1["last seen at"] == "never"
+    assert row1["actions"] == "Revoke"
+  end
+
+  test "allows revoking tokens", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    api_client = Fixtures.Actors.create_actor(type: :api_client, account: account)
+    token = Fixtures.Tokens.create_api_client_token(account: account, actor: api_client)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    assert lv
+           |> element("td button", "Revoke")
+           |> render_click()
+
+    assert lv
+           |> element("#tokens")
+           |> render()
+           |> table_to_map() == []
+
+    assert Repo.get_by(Domain.Tokens.Token, id: token.id).deleted_at
+  end
+
+  test "allows revoking all tokens", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    api_client = Fixtures.Actors.create_actor(type: :api_client, account: account)
+    token = Fixtures.Tokens.create_api_client_token(account: account, actor: api_client)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/api_clients/#{api_client}")
+
+    assert lv
+           |> element("#tokens")
+           |> render()
+           |> table_to_map() != []
+
+    assert lv
+           |> element("button", "Revoke All")
+           |> render_click()
+
+    assert lv
+           |> element("#tokens")
+           |> render()
+           |> table_to_map() == []
+
+    assert Repo.get_by(Domain.Tokens.Token, id: token.id).deleted_at
+  end
+end

--- a/elixir/apps/web/test/web/live/settings/api_clients/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/api_clients/show_test.exs
@@ -214,7 +214,7 @@ defmodule Web.Live.Settings.ApiClients.ShowTest do
 
     assert row1["name"] == token.name
     assert row1["expires at"]
-    assert row1["last seen at"] == "never"
+    assert row1["last used"] == "never"
     assert row1["actions"] == "Revoke"
   end
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -85,7 +85,8 @@ config :domain, :enabled_features,
   sign_up: true,
   flow_activities: true,
   self_hosted_relays: true,
-  multi_site_resources: true
+  multi_site_resources: true,
+  api_client_ui: true
 
 config :domain, sign_up_whitelisted_domains: []
 

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -86,7 +86,7 @@ config :domain, :enabled_features,
   flow_activities: true,
   self_hosted_relays: true,
   multi_site_resources: true,
-  api_client_ui: true
+  rest_api: true
 
 config :domain, sign_up_whitelisted_domains: []
 

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -60,7 +60,7 @@ if config_env() == :prod do
     flow_activities: compile_config!(:feature_flow_activities_enabled),
     self_hosted_relays: compile_config!(:feature_self_hosted_relays_enabled),
     multi_site_resources: compile_config!(:feature_multi_site_resources_enabled),
-    api_client_ui: compile_config!(:feature_api_client_ui_enabled)
+    rest_api: compile_config!(:feature_rest_api_enabled)
 
   config :domain, sign_up_whitelisted_domains: compile_config!(:sign_up_whitelisted_domains)
 

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -59,7 +59,8 @@ if config_env() == :prod do
     sign_up: compile_config!(:feature_sign_up_enabled),
     flow_activities: compile_config!(:feature_flow_activities_enabled),
     self_hosted_relays: compile_config!(:feature_self_hosted_relays_enabled),
-    multi_site_resources: compile_config!(:feature_multi_site_resources_enabled)
+    multi_site_resources: compile_config!(:feature_multi_site_resources_enabled),
+    api_client_ui: compile_config!(:feature_api_client_ui_enabled)
 
   config :domain, sign_up_whitelisted_domains: compile_config!(:sign_up_whitelisted_domains)
 

--- a/terraform/environments/production/portal.tf
+++ b/terraform/environments/production/portal.tf
@@ -351,7 +351,7 @@ locals {
       value = true
     },
     {
-      name  = "FEATURE_API_CLIENT_UI_ENABLED"
+      name  = "FEATURE_REST_API_ENABLED"
       value = false
     }
   ]

--- a/terraform/environments/production/portal.tf
+++ b/terraform/environments/production/portal.tf
@@ -350,6 +350,10 @@ locals {
       name  = "FEATURE_SIGN_UP_ENABLED"
       value = true
     },
+    {
+      name  = "FEATURE_API_CLIENT_UI_ENABLED"
+      value = false
+    }
   ]
 }
 

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -339,7 +339,7 @@ locals {
       value = "firezone.dev,firez.one"
     },
     {
-      name  = "FEATURE_API_CLIENT_UI_ENABLED"
+      name  = "FEATURE_REST_API_ENABLED"
       value = true
     }
   ]

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -338,6 +338,10 @@ locals {
       name  = "SIGN_UP_WHITELISTED_DOMAINS"
       value = "firezone.dev,firez.one"
     },
+    {
+      name  = "FEATURE_API_CLIENT_UI_ENABLED"
+      value = true
+    }
   ]
 }
 


### PR DESCRIPTION
Why:

* As work on the portal REST API has begun, there was a need to easily provision API tokens to allow testing of the new API endpoints being created.  Adding the API Client UI allows for this to be done very easily and will also be used once the API is ready to be consumed by customers.

Closes #2368 