### PR TITLE
ci(docker): skip cargo-chef to run faster

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -56,7 +56,6 @@ FROM rust as chef
 ARG CARGO_CHEF_VERSION
 RUN set -xe \
   && apk add --no-cache musl-dev  \
-  && cargo install cargo-chef --locked --version=${CARGO_CHEF_VERSION} \
   && rm -rf $CARGO_HOME/registry/
 
 ## See https://github.com/LukeMathWalker/cargo-chef/issues/231.
@@ -73,17 +72,17 @@ FROM chef as planner
 
 COPY . .
 
-ARG PACKAGE
-RUN cargo chef prepare --recipe-path recipe.json --bin ${PACKAGE}
+#ARG PACKAGE
+#RUN cargo chef prepare --recipe-path recipe.json --bin ${PACKAGE}
 
 # Build dependencies and application application
 FROM chef as builder
 
-COPY --from=planner /build/recipe.json .
+#COPY --from=planner /build/recipe.json .
 
 ARG PACKAGE
-RUN set -xe \
-  && cargo chef cook --recipe-path recipe.json --bin ${PACKAGE}
+#RUN set -xe \
+#  && cargo chef cook --recipe-path recipe.json --bin ${PACKAGE}
 
 COPY . .
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -27,17 +27,10 @@ FROM chef as planner
 
 COPY . .
 
-#ARG PACKAGE
-#RUN cargo chef prepare --recipe-path recipe.json --bin ${PACKAGE}
-
 # Build dependencies and application application
 FROM chef as builder
 
-#COPY --from=planner /build/recipe.json .
-
 ARG PACKAGE
-#RUN set -xe \
-#  && cargo chef cook --recipe-path recipe.json --bin ${PACKAGE}
 
 COPY . .
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,68 +1,8 @@
-# Global args to use in build commands
-ARG ALPINE_VERSION="3.19"
-ARG CARGO_CHEF_VERSION="0.1.62"
-ARG RUSTUP_VERSION="1.26.0"
-ARG RUSTUP_x86_DOWNLOAD_SHA256="7aa9e2a380a9958fc1fc426a3323209b2c86181c6816640979580f62ff7d48d4"
-ARG RUSTUP_aarch64_DOWNLOAD_SHA256="b1962dfc18e1fd47d01341e6897cace67cddfabf547ef394e8883939bd6e002e"
-ARG RUST_VERSION="1.74.1"
-
-FROM alpine:${ALPINE_VERSION} as rust
-
-# Important!  Update this no-op ENV variable when this Dockerfile
-# is updated with the current date. It will force refresh of all
-# of the base images and things like `apk add` won't be using
-# old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2024-02-22 \
-  LANG=C.UTF-8 \
-  TERM=xterm
-
-RUN set -xe \
-  # Upgrade Alpine and base packages
-  && apk --no-cache --update-cache --available upgrade \
-  # Install required deps
-  && apk add --no-cache --update-cache \
-  ca-certificates \
-  gcc
-
-ENV RUSTUP_HOME=/usr/local/rustup \
-  CARGO_HOME=/usr/local/cargo \
-  PATH=/usr/local/cargo/bin:$PATH
-
-ARG RUSTUP_VERSION
-ARG RUSTUP_x86_DOWNLOAD_SHA256
-ARG RUSTUP_aarch64_DOWNLOAD_SHA256
-ARG RUST_VERSION
-RUN set -eux; \
-  apkArch="$(apk --print-arch)"; \
-  case "$apkArch" in \
-  x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256=${RUSTUP_x86_DOWNLOAD_SHA256} ;; \
-  aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256=${RUSTUP_aarch64_DOWNLOAD_SHA256} ;; \
-  *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
-  esac; \
-  url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustArch}/rustup-init"; \
-  wget "$url"; \
-  echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
-  chmod +x rustup-init; \
-  ./rustup-init -y --no-modify-path --profile minimal --default-toolchain ${RUST_VERSION} --default-host ${rustArch}; \
-  rm rustup-init; \
-  chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-  rustup --version; \
-  cargo --version; \
-  rustc --version;
-
 # This image is used to prepare Cargo Chef which is used to cache dependencies
-FROM rust as chef
-
-ARG CARGO_CHEF_VERSION
-RUN set -xe \
-  && apk add --no-cache musl-dev  \
-  && rm -rf $CARGO_HOME/registry/
+FROM rust:1.74-alpine as chef
 
 ## See https://github.com/LukeMathWalker/cargo-chef/issues/231.
 COPY rust-toolchain.toml rust-toolchain.toml
-
-RUN set -xe \
-  && rustup show
 
 WORKDIR /build
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -73,7 +73,8 @@ FROM chef as planner
 
 COPY . .
 
-RUN cargo chef prepare --recipe-path recipe.json
+ARG PACKAGE
+RUN cargo chef prepare --recipe-path recipe.json --bin ${PACKAGE}
 
 # Build dependencies and application application
 FROM chef as builder

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,7 +1,20 @@
 ARG ALPINE_VERSION="3.19"
 
+FROM rust:1.74-alpine as rust
+
+RUN set -xe \
+  # Upgrade Alpine and base packages
+  && apk --no-cache --update-cache --available upgrade \
+  # Install required deps
+  && apk add --no-cache --update-cache \
+  ca-certificates \
+  gcc
+
 # This image is used to prepare Cargo Chef which is used to cache dependencies
-FROM rust:1.74-alpine as chef
+FROM rust as chef
+RUN set -xe \
+  && apk add --no-cache musl-dev \
+  && rm -rf $CARGO_HOME/registry/
 
 ## See https://github.com/LukeMathWalker/cargo-chef/issues/231.
 COPY rust-toolchain.toml rust-toolchain.toml

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,3 +1,5 @@
+ARG ALPINE_VERSION="3.19"
+
 # This image is used to prepare Cargo Chef which is used to cache dependencies
 FROM rust:1.74-alpine as chef
 


### PR DESCRIPTION
This definitely breaks something.

This runs CI in 10 minutes of wall time instead of 13 minutes. 
Cumulative runner time drops from 2h44m to 2h30m.

I noticed the Client image is also build `firezone-relay` https://github.com/firezone/firezone/actions/runs/8190285986/job/22396925402#step:7:1328

I tried to reconfigure `cargo-chef` to avoid this, but it was simpler to just remove cargo-chef entirely. Since the CI builds are always clean, I don't think the caching and cargo-chef steps do anything.

I also tried replacing the custom Alpine image with `rust:1.74-alpine`. This didn't affect runtime, but it makes the Dockerfile shorter.