### PR TITLE
fix: let Tauri know about hiDPI icons

### DIFF
--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -22,6 +22,9 @@
       "targets": ["appimage", "deb", "msi"],
       "identifier": "dev.firezone.client",
       "icon": [
+        "icons/32x32.png",
+        "icons/128x128.png",
+        "icons/128x128@2x.png",
         "icons/firezone.ico",
         "icons/Square107x107Logo.png",
         "icons/Square142x142Logo.png",


### PR DESCRIPTION
Untested guess, refs #3999

Looks like we generated a 2x PNG but didn't tell Tauri about it, maybe it'll know what to do if it's added to tauri.conf.json.