### PR TITLE
feat(apple): In resources list, tapping on a list item shows a 'Copy Address' menu

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Features/MainView.swift
@@ -124,21 +124,21 @@ import SwiftUI
               Text("No resources")
             } else {
               ForEach(self.model.orderedResources) { resource in
-                HStack {
-                  Text(resource.name)
-                  Spacer()
-                  Text(resource.location)
-                    .foregroundColor(.secondary)
-                  Button(
-                    role: .none,
-                    action: { self.copyResourceTapped(resource) },
-                    label: {
-                      Label("", systemImage: "doc.on.doc")
-                        .symbolRenderingMode(.monochrome)
-                        .foregroundColor(.secondary)
-                    }
-                  )
-                }
+                Menu(content: {
+                  Button {
+                    self.copyResourceTapped(resource)
+                  } label: {
+                    Label("Copy Address", systemImage: "doc.on.doc")
+                  }
+                }, label : {
+                  HStack {
+                    Text(resource.name)
+                      .foregroundColor(.primary)
+                    Spacer()
+                    Text(resource.location)
+                      .foregroundColor(.secondary)
+                  }
+                })
               }
             }
           }


### PR DESCRIPTION
Previousy, tapping on a resource list item in iOS copied the resource address.

In this PR, tapping on a resource list item in iOS shows a menu with "Copy Address", tapping on which copies the resource address.

Fixes #3998.