### PR TITLE
chore(android): upgrade hilt to 2.51

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -174,9 +174,9 @@ dependencies {
     implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
 
     // Hilt
-    implementation("com.google.dagger:hilt-android:2.50")
+    implementation("com.google.dagger:hilt-android:2.51")
     kapt("androidx.hilt:hilt-compiler:1.2.0")
-    kapt("com.google.dagger:hilt-android-compiler:2.50")
+    kapt("com.google.dagger:hilt-android-compiler:2.51")
 
     // Retrofit 2
     implementation("com.squareup.retrofit2:retrofit:2.9.0")

--- a/kotlin/android/build.gradle.kts
+++ b/kotlin/android/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.8.22" apply false
     id("com.android.application") version "8.3.0" apply false
     id("com.google.firebase.appdistribution") version "4.2.0" apply false
-    id("com.google.dagger.hilt.android") version "2.50" apply false
+    id("com.google.dagger.hilt.android") version "2.51" apply false
     id("com.google.gms.google-services") version "4.4.1" apply false
     id("org.mozilla.rust-android-gradle.rust-android") version "0.9.3" apply false
     id("com.google.firebase.crashlytics") version "2.9.9" apply false


### PR DESCRIPTION
The error I was getting was:

```error
java.lang.RuntimeException: Cannot create an instance of class dev.firezone.android.features.splash.ui.SplashViewModel
Caused by: java.lang.NoSuchMethodException: dev.firezone.android.features.splash.ui.SplashViewModel.<init> []
```

I'm not sure how hilt works, but I saw a package for the hilt compiler that was version 2.50. After upgrading that, the crash stopped happening. My best guess is that the compiler needs to be on the same version, otherwise it doesn't work?