### PR TITLE
chore: unbreak CI after force-push

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.5.0"
-source = "git+https://github.com/conectado/quinn?branch=main#86e25140452bdd56e3be2d05ed7b79ad09b88faa"
+source = "git+https://github.com/firezone/quinn?branch=main#2e312721a5c751af6c7d45ac4227b68f92554581"
 dependencies = [
  "bytes",
  "libc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,7 +52,7 @@ str0m = { git = "https://github.com/firezone/str0m", branch = "reduce-ice-timeou
 
 [patch."https://github.com/quinn-rs/quinn"]
 # waiting for https://github.com/quinn-rs/quinn/pull/1758
-quinn-udp = { git = "https://github.com/conectado/quinn", branch = "main" }
+quinn-udp = { git = "https://github.com/firezone/quinn", branch = "main" }
 
 [profile.release]
 strip = true


### PR DESCRIPTION
https://github.com/quinn-rs/quinn/pull/1758 was force-pushed which is currently blocking CI. I've made a fork in the `firezone` org that doesn't have any open PRs so it won't get changed.