### PR TITLE
refactor(connlib): Disable log uploading until UI flows can be built in the clients to opt in

### DIFF
--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -438,38 +438,41 @@ impl<CB: Callbacks + 'static> ControlPlane<CB> {
     }
 }
 
-async fn upload(path: PathBuf, url: Url) -> io::Result<()> {
-    tracing::info!(path = %path.display(), %url, "Uploading log file");
+async fn upload(_path: PathBuf, _url: Url) -> io::Result<()> {
+    // TODO: Log uploads are disabled by default for GA until we expose a way to opt in
+    // to the user. See https://github.com/firezone/firezone/issues/3910
 
-    let file = tokio::fs::File::open(&path).await?;
-
-    let response = reqwest::Client::new()
-        .put(url)
-        .header(CONTENT_TYPE, "text/plain")
-        .header(CONTENT_ENCODING, "gzip")
-        .body(reqwest::Body::wrap_stream(FramedRead::new(
-            GzipEncoder::new(BufReader::new(file)),
-            BytesCodec::default(),
-        )))
-        .send()
-        .await
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-
-    let status_code = response.status();
-
-    if !status_code.is_success() {
-        let body = response
-            .text()
-            .await
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-
-        tracing::warn!(%body, %status_code, "Failed to upload logs");
-
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            "portal returned non-successful exit code",
-        ));
-    }
+    // tracing::info!(path = %path.display(), %url, "Uploading log file");
+    //
+    // let file = tokio::fs::File::open(&path).await?;
+    //
+    // let response = reqwest::Client::new()
+    //     .put(url)
+    //     .header(CONTENT_TYPE, "text/plain")
+    //     .header(CONTENT_ENCODING, "gzip")
+    //     .body(reqwest::Body::wrap_stream(FramedRead::new(
+    //         GzipEncoder::new(BufReader::new(file)),
+    //         BytesCodec::default(),
+    //     )))
+    //     .send()
+    //     .await
+    //     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    //
+    // let status_code = response.status();
+    //
+    // if !status_code.is_success() {
+    //     let body = response
+    //         .text()
+    //         .await
+    //         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    //
+    //     tracing::warn!(%body, %status_code, "Failed to upload logs");
+    //
+    //     return Err(io::Error::new(
+    //         io::ErrorKind::Other,
+    //         "portal returned non-successful exit code",
+    //     ));
+    // }
 
     Ok(())
 }

--- a/rust/connlib/clients/shared/src/control.rs
+++ b/rust/connlib/clients/shared/src/control.rs
@@ -1,4 +1,3 @@
-use async_compression::tokio::bufread::GzipEncoder;
 use bimap::BiMap;
 use connlib_shared::control::{ChannelError, ErrorReply};
 use connlib_shared::messages::{DnsServer, GatewayResponse, IpDnsServer};
@@ -9,6 +8,13 @@ use std::io;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
+
+// TODO: These are used in the `upload` function, which is currently disabled.
+// See the comment there for more information.
+// use async_compression::tokio::bufread::GzipEncoder;
+// use tokio_util::codec::{BytesCodec, FramedRead};
+// use reqwest::header::{CONTENT_ENCODING, CONTENT_TYPE};
+// use tokio::io::BufReader;
 
 use crate::messages::{
     BroadcastGatewayIceCandidates, Connect, ConnectionDetails, EgressMessages,
@@ -23,10 +29,7 @@ use connlib_shared::{
 };
 
 use firezone_tunnel::Request;
-use reqwest::header::{CONTENT_ENCODING, CONTENT_TYPE};
 use std::collections::HashMap;
-use tokio::io::BufReader;
-use tokio_util::codec::{BytesCodec, FramedRead};
 use url::Url;
 
 const DNS_PORT: u16 = 53;

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -279,7 +279,12 @@ fn upload_interval() -> Interval {
 ///
 /// If not present or parsing as u64 fails, we fall back to a default interval of 5 minutes.
 fn upload_interval_duration_from_env_or_default() -> Duration {
-    const DEFAULT: Duration = Duration::from_secs(60 * 5);
+    // TODO: Log uploads are disabled by default for GA until we expose a way to opt in
+    // to the user. See https://github.com/firezone/firezone/issues/3910
+    //
+    // Until then, we set the default rollover interval to something really high
+    // to avoid breaking existing clients that may have this variable set.
+    const DEFAULT: Duration = Duration::from_secs(u64::MAX);
 
     let Some(interval) = option_env!("CONNLIB_LOG_UPLOAD_INTERVAL_SECS") else {
         tracing::warn!(interval = ?DEFAULT, "Env variable `CONNLIB_LOG_UPLOAD_INTERVAL_SECS` was not set during compile-time, falling back to default");

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -279,7 +279,7 @@ fn upload_interval() -> Interval {
 ///
 /// If not present or parsing as u64 fails, we fall back to a default interval of 5 minutes.
 fn upload_interval_duration_from_env_or_default() -> Duration {
-    const DEFAULT: Duration = Duration::from_secs(5 * 60);
+    const DEFAULT: Duration = Duration::from_secs(60 * 5);
 
     let Some(interval) = option_env!("CONNLIB_LOG_UPLOAD_INTERVAL_SECS") else {
         tracing::warn!(interval = ?DEFAULT, "Env variable `CONNLIB_LOG_UPLOAD_INTERVAL_SECS` was not set during compile-time, falling back to default");

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -279,12 +279,7 @@ fn upload_interval() -> Interval {
 ///
 /// If not present or parsing as u64 fails, we fall back to a default interval of 5 minutes.
 fn upload_interval_duration_from_env_or_default() -> Duration {
-    // TODO: Log uploads are disabled by default for GA until we expose a way to opt in
-    // to the user. See https://github.com/firezone/firezone/issues/3910
-    //
-    // Until then, we set the default rollover interval to something really high
-    // to avoid breaking existing clients that may have this variable set.
-    const DEFAULT: Duration = Duration::from_secs(u64::MAX);
+    const DEFAULT: Duration = Duration::from_secs(5 * 60);
 
     let Some(interval) = option_env!("CONNLIB_LOG_UPLOAD_INTERVAL_SECS") else {
         tracing::warn!(interval = ?DEFAULT, "Env variable `CONNLIB_LOG_UPLOAD_INTERVAL_SECS` was not set during compile-time, falling back to default");


### PR DESCRIPTION
Making a minimal PR to get the app shipped. A better method of configuring this (or removing it altogether if deemed unnecessary) is coming in #3910 