### PR TITLE
chore(connlib): update dependency after merged PR

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6721,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "tracing-oslog"
 version = "0.1.2"
-source = "git+https://github.com/sbag13/tracing-oslog?rev=0f82b8051c65de86191e1350afc7a26d5c670c29#0f82b8051c65de86191e1350afc7a26d5c670c29"
+source = "git+https://github.com/Absolucy/tracing-oslog?branch=main#2207764b7edd3a5c059f4c3e8837fe72127067f9"
 dependencies = [
  "bindgen",
  "cc",

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -20,8 +20,7 @@ swift-bridge = { workspace = true }
 connlib-client-shared = { workspace = true }
 serde_json = "1"
 tracing = { workspace = true }
-# TODO: https://github.com/Absolucy/tracing-oslog/pull/9
-tracing-oslog = { git = "https://github.com/sbag13/tracing-oslog", rev = "0f82b8051c65de86191e1350afc7a26d5c670c29" }
+tracing-oslog = { git = "https://github.com/Absolucy/tracing-oslog", branch = "main" } # Waiting for a release.
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 


### PR DESCRIPTION
The linked PR got merged, so we can now depend on the upstream repository.