### PR TITLE
chore(deps): Link Package.resolved to where dependabot should find it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,7 +106,7 @@ updates:
           - com.google.firebase:firebase-analytics-ktx
 
   - package-ecosystem: swift
-    directory: swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
+    directory: swift/apple/FirezoneKit/
     schedule:
       interval: monthly
   - package-ecosystem: npm

--- a/swift/apple/FirezoneKit/Package.resolved
+++ b/swift/apple/FirezoneKit/Package.resolved
@@ -1,0 +1,1 @@
+../Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved


### PR DESCRIPTION
Dependabot isn't bumping our Swift packages. This is an attempt to resolve that by linking the "lockfile" into the directory where the associated Package.swift lives.

Unfortunately Dependabot's docs [aren't great](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#swift) on the subject.