### PR TITLE
chore(ci): Add debug/ and perf/ prefix to some images

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -4,7 +4,11 @@ on:
   workflow_call:
     inputs:
       image_prefix:
-        description: "The prefix to prepend to the image name to prevent SHA conflicts"
+        description: |
+          The prefix to prepend to the image name to prevent SHA conflicts.
+          * Use "debug" to build debug binaries inside debug stage images + with debug tooling installed.
+          * Use "perf" to build release binaries inside debug stage images + with debug tooling installed.
+          * Leave blank to build release binaries inside release stage images.
         required: false
         type: string
       sha:

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -236,7 +236,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format("{0}/", inputs.image_prefix) }}${{ matrix.name.image_name }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) }}${{ matrix.name.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -266,7 +266,7 @@ jobs:
             type=registry,ref=${{ steps.login.outputs.registry }}/cache/${{ matrix.name.image_name }}:${{ env.CACHE_TAG }},mode=max
           target: ${{ inputs.stage }}
           outputs:
-            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format("{0}/", inputs.image_prefix) }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
+            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |
           mkdir -p /tmp/digests/${{ matrix.name.image_name }}
@@ -276,7 +276,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.image_prefix && format("{0}-", inputs.image_prefix) }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
+          name: ${{ inputs.image_prefix && format('{0}-', inputs.image_prefix) }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
           path: /tmp/digests/${{ matrix.name.image_name }}
           if-no-files-found: error
           retention-days: 1
@@ -305,7 +305,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ inputs.image_prefix && format("{0}-", inputs.image_prefix) }}${{ matrix.image_name }}-${{ inputs.sha }}-digest-*
+          pattern: ${{ inputs.image_prefix && format('{0}-', inputs.image_prefix) }}${{ matrix.image_name }}-${{ inputs.sha }}-digest-*
           merge-multiple: true
           path: /tmp/digests/${{ matrix.image_name }}
       - name: Display structure of downloaded artifacts
@@ -325,7 +325,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format("{0}/", inputs.image_prefix) }}${{ matrix.image_name }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) }}${{ matrix.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -337,7 +337,7 @@ jobs:
         working-directory: /tmp/digests/${{ matrix.image_name }}
         run: |
           tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format("{0}/", inputs.image_prefix) }}${{ matrix.image_name }}@sha256:%s ' *)
+          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) }}${{ matrix.image_name }}@sha256:%s ' *)
           echo "$sources"
           docker buildx imagetools create $tags $sources
           docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) }}${{ matrix.image_name }}"

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -3,8 +3,8 @@ run-name: Triggered from ${{ github.event_name }} by ${{ github.actor }}
 on:
   workflow_call:
     inputs:
-      image_suffix:
-        description: "The suffix to append to the image name to prevent SHA conflicts"
+      image_prefix:
+        description: "The prefix to prepend to the image name to prevent SHA conflicts"
         required: false
         type: string
       sha:
@@ -236,7 +236,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ matrix.name.image_name }}${{ inputs.image_suffix }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.name.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -266,7 +266,7 @@ jobs:
             type=registry,ref=${{ steps.login.outputs.registry }}/cache/${{ matrix.name.image_name }}:${{ env.CACHE_TAG }},mode=max
           target: ${{ inputs.stage }}
           outputs:
-            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ matrix.name.image_name }}${{ inputs.image_suffix }},push-by-digest=true,name-canonical=true,push=true
+            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |
           mkdir -p /tmp/digests/${{ matrix.name.image_name }}
@@ -276,7 +276,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ matrix.name.image_name }}${{ inputs.image_suffix }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
+          name: ${{ inputs.image_prefix }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
           path: /tmp/digests/${{ matrix.name.image_name }}
           if-no-files-found: error
           retention-days: 1
@@ -305,7 +305,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ matrix.image_name }}${{ inputs.image_suffix }}-${{ inputs.sha }}-digest-*
+          pattern: ${{ inputs.image_prefix }}${{ matrix.image_name }}-${{ inputs.sha }}-digest-*
           merge-multiple: true
           path: /tmp/digests/${{ matrix.image_name }}
       - name: Display structure of downloaded artifacts
@@ -325,7 +325,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}${{ inputs.image_suffix }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -337,7 +337,7 @@ jobs:
         working-directory: /tmp/digests/${{ matrix.image_name }}
         run: |
           tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}${{ inputs.image_suffix }}@sha256:%s ' *)
+          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.image_name }}@sha256:%s ' *)
           echo "$sources"
           docker buildx imagetools create $tags $sources
-          docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}${{ inputs.image_suffix }}"
+          docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.image_name }}"

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -236,7 +236,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.name.image_name }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format("{0}/", inputs.image_prefix) }}${{ matrix.name.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -266,7 +266,7 @@ jobs:
             type=registry,ref=${{ steps.login.outputs.registry }}/cache/${{ matrix.name.image_name }}:${{ env.CACHE_TAG }},mode=max
           target: ${{ inputs.stage }}
           outputs:
-            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
+            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format("{0}/", inputs.image_prefix) }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |
           mkdir -p /tmp/digests/${{ matrix.name.image_name }}
@@ -276,7 +276,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.image_prefix && inputs.image_prefix + '-' }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
+          name: ${{ inputs.image_prefix && format("{0}-", inputs.image_prefix) }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
           path: /tmp/digests/${{ matrix.name.image_name }}
           if-no-files-found: error
           retention-days: 1
@@ -305,7 +305,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ inputs.image_prefix && inputs.image_prefix + '-' }}${{ matrix.image_name }}-${{ inputs.sha }}-digest-*
+          pattern: ${{ inputs.image_prefix && format("{0}-", inputs.image_prefix) }}${{ matrix.image_name }}-${{ inputs.sha }}-digest-*
           merge-multiple: true
           path: /tmp/digests/${{ matrix.image_name }}
       - name: Display structure of downloaded artifacts
@@ -325,7 +325,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.image_name }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format("{0}/", inputs.image_prefix) }}${{ matrix.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -337,7 +337,7 @@ jobs:
         working-directory: /tmp/digests/${{ matrix.image_name }}
         run: |
           tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.image_name }}@sha256:%s ' *)
+          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format("{0}/", inputs.image_prefix) }}${{ matrix.image_name }}@sha256:%s ' *)
           echo "$sources"
           docker buildx imagetools create $tags $sources
-          docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.image_name }}"
+          docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) }}${{ matrix.image_name }}"

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -236,7 +236,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.name.image_name }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.name.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -266,7 +266,7 @@ jobs:
             type=registry,ref=${{ steps.login.outputs.registry }}/cache/${{ matrix.name.image_name }}:${{ env.CACHE_TAG }},mode=max
           target: ${{ inputs.stage }}
           outputs:
-            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
+            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |
           mkdir -p /tmp/digests/${{ matrix.name.image_name }}
@@ -276,7 +276,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.image_prefix }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
+          name: ${{ inputs.image_prefix && inputs.image_prefix + '-' }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
           path: /tmp/digests/${{ matrix.name.image_name }}
           if-no-files-found: error
           retention-days: 1
@@ -305,7 +305,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ inputs.image_prefix }}${{ matrix.image_name }}-${{ inputs.sha }}-digest-*
+          pattern: ${{ inputs.image_prefix && inputs.image_prefix + '-' }}${{ matrix.image_name }}-${{ inputs.sha }}-digest-*
           merge-multiple: true
           path: /tmp/digests/${{ matrix.image_name }}
       - name: Display structure of downloaded artifacts
@@ -325,7 +325,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.image_name }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -337,7 +337,7 @@ jobs:
         working-directory: /tmp/digests/${{ matrix.image_name }}
         run: |
           tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.image_name }}@sha256:%s ' *)
+          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.image_name }}@sha256:%s ' *)
           echo "$sources"
           docker buildx imagetools create $tags $sources
-          docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix }}${{ matrix.image_name }}"
+          docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && inputs.image_prefix + '/' }}${{ matrix.image_name }}"

--- a/.github/workflows/_deploy_production.yml
+++ b/.github/workflows/_deploy_production.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Pull and push images
         run: |
           set -xe
-          IMAGES=(relay api gateway web)
+          IMAGES=(client relay gateway api web)
           MAJOR_VERSION="${VERSION%%.*}"
           MAJOR_MINOR_VERSION="${VERSION%.*}"
 

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -30,7 +30,7 @@ on:
       relay_image:
         required: false
         type: string
-        default: 'us-east1-docker.pkg.dev/firezone-staging/firezone/relay'
+        default: 'us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay'
       relay_tag:
         required: false
         type: string
@@ -38,7 +38,7 @@ on:
       gateway_image:
         required: false
         type: string
-        default: 'us-east1-docker.pkg.dev/firezone-staging/firezone/gateway'
+        default: 'us-east1-docker.pkg.dev/firezone-staging/firezone/debug/gateway'
       gateway_tag:
         required: false
         type: string
@@ -46,7 +46,7 @@ on:
       client_image:
         required: false
         type: string
-        default: 'us-east1-docker.pkg.dev/firezone-staging/firezone/client'
+        default: 'us-east1-docker.pkg.dev/firezone-staging/firezone/debug/client'
       client_tag:
         required: false
         type: string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Run docker-compose.${{ matrix.name }}.yml test
         run: |
           sudo sysctl -w vm.overcommit_memory=1
-          timeout 600 docker compose -f rust/snownet-tests/docker-compose.${{ matrix.name }}.yml up --no-build --exit-code-from dialer --abort-on-container-exit
+          timeout 600 docker compose -f rust/snownet-tests/docker-compose.${{ matrix.name }}.yml up --exit-code-from dialer --abort-on-container-exit
 
   compatibility-tests:
     # Don't run compatibility tests when called from cd.yml on `main` because

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       image_prefix:
-        description: 'The prefix for the image name, e.g. "debug", "perf" or "release"'
+        description: 'The prefix for the image name, "debug" or "perf"'
         required: false
         type: string
       stage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Run docker-compose.${{ matrix.name }}.yml test
         run: |
           sudo sysctl -w vm.overcommit_memory=1
-          timeout 600 docker compose -f rust/snownet-tests/docker-compose.${{ matrix.name }}.yml up --exit-code-from dialer --abort-on-container-exit
+          timeout 600 docker compose -f rust/snownet-tests/docker-compose.${{ matrix.name }}.yml up --no-build --exit-code-from dialer --abort-on-container-exit
 
   compatibility-tests:
     # Don't run compatibility tests when called from cd.yml on `main` because
@@ -136,17 +136,17 @@ jobs:
       id-token: write
       pull-requests: write
     env:
-      API_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/api-perf'
+      API_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/api'
       API_TAG: ${{ matrix.sha }}
-      WEB_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/web-perf'
+      WEB_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/web'
       WEB_TAG: ${{ matrix.sha }}
-      ELIXIR_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/elixir-perf'
+      ELIXIR_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/elixir'
       ELIXIR_TAG: ${{ matrix.sha }}
-      GATEWAY_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/gateway-perf'
+      GATEWAY_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/perf/gateway'
       GATEWAY_TAG: ${{ matrix.sha }}
-      CLIENT_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/client-perf'
+      CLIENT_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/perf/client'
       CLIENT_TAG: ${{ matrix.sha }}
-      RELAY_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/relay-perf'
+      RELAY_IMAGE: 'us-east1-docker.pkg.dev/firezone-staging/firezone/perf/relay'
       RELAY_TAG: ${{ matrix.sha }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/_build_artifacts.yml
     secrets: inherit
     with:
-      image_prefix: ${{ inputs.image_prefix || 'debug/' }}
+      image_prefix: ${{ inputs.image_prefix || 'debug' }}
       profile: ${{ inputs.profile || 'debug' }}
       stage: ${{ inputs.stage || 'debug' }}
 
@@ -59,7 +59,7 @@ jobs:
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha }}
-      image_prefix: 'perf/'
+      image_prefix: 'perf'
       profile: 'release'
       stage: 'debug'
 
@@ -69,7 +69,7 @@ jobs:
     secrets: inherit
     with:
       sha: ${{ github.sha }}
-      image_prefix: 'perf/'
+      image_prefix: 'perf'
       profile: 'release'
       stage: 'debug'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     types: [checks_requested]
   workflow_call:
     inputs:
+      image_prefix:
+        description: 'The prefix for the image name, e.g. "debug", "perf" or "release"'
+        required: false
+        type: string
       stage:
         required: true
         type: string
@@ -45,6 +49,7 @@ jobs:
     uses: ./.github/workflows/_build_artifacts.yml
     secrets: inherit
     with:
+      image_prefix: ${{ inputs.image_prefix || 'debug/' }}
       profile: ${{ inputs.profile || 'debug' }}
       stage: ${{ inputs.stage || 'debug' }}
 
@@ -54,7 +59,7 @@ jobs:
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha }}
-      image_suffix: '-perf'
+      image_prefix: 'perf/'
       profile: 'release'
       stage: 'debug'
 
@@ -64,7 +69,7 @@ jobs:
     secrets: inherit
     with:
       sha: ${{ github.sha }}
-      image_suffix: '-perf'
+      image_prefix: 'perf/'
       profile: 'release'
       stage: 'debug'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,10 +183,10 @@ jobs:
 
           # Start services in the same order each time for the tests
           docker compose up -d iperf3
-          docker compose up -d api web
-          docker compose up -d relay
-          docker compose up -d gateway
-          docker compose up -d client
+          docker compose up -d api web --no-build
+          docker compose up -d relay --no-build
+          docker compose up -d gateway --no-build
+          docker compose up -d client --no-build
       - name: 'Performance test: ${{ matrix.test_name }}'
         timeout-minutes: 5
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
-          project: firezone-staging
+          project: firezone-prod
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/client:main
       args:
         PACKAGE: firezone-linux-client
-    image: ${CLIENT_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/client}:${CLIENT_TAG:-main}
+    image: ${CLIENT_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/client}:${CLIENT_TAG:-main}
     cap_add:
       - NET_ADMIN
     sysctls:
@@ -153,7 +153,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/gateway:main
       args:
         PACKAGE: firezone-gateway
-    image: ${GATEWAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/gateway}:${GATEWAY_TAG:-main}
+    image: ${GATEWAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/gateway}:${GATEWAY_TAG:-main}
     cap_add:
       - NET_ADMIN
     sysctls:
@@ -219,7 +219,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/relay}:${RELAY_TAG:-main}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-main}
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 10s

--- a/rust/snownet-tests/docker-compose.lan.yml
+++ b/rust/snownet-tests/docker-compose.lan.yml
@@ -14,7 +14,7 @@ services:
         PACKAGE: snownet-tests
       cache_from:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/snownet-tests:main
-    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/snownet-tests}:${SNOWNET_TAG:-main}
+    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/snownet-tests}:${SNOWNET_TAG:-main}
     environment:
       ROLE: "dialer"
     cap_add:
@@ -60,7 +60,7 @@ services:
         PACKAGE: snownet-tests
       cache_from:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/snownet-tests:main
-    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/snownet-tests}:${SNOWNET_TAG:-main}
+    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/snownet-tests}:${SNOWNET_TAG:-main}
     init: true
     environment:
       ROLE: "listener"
@@ -102,7 +102,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/relay}:${RELAY_TAG:-main}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-main}
     init: true
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]

--- a/rust/snownet-tests/docker-compose.wan-hp.yml
+++ b/rust/snownet-tests/docker-compose.wan-hp.yml
@@ -13,7 +13,7 @@ services:
         PACKAGE: snownet-tests
       cache_from:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/snownet-tests:main
-    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/snownet-tests}:${SNOWNET_TAG:-main}
+    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/snownet-tests}:${SNOWNET_TAG:-main}
     environment:
       ROLE: "dialer"
     cap_add:
@@ -59,7 +59,7 @@ services:
         PACKAGE: snownet-tests
       cache_from:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/snownet-tests:main
-    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/snownet-tests}:${SNOWNET_TAG:-main}
+    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/snownet-tests}:${SNOWNET_TAG:-main}
     init: true
     environment:
       ROLE: "listener"
@@ -111,7 +111,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/relay}:${RELAY_TAG:-main}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-main}
     init: true
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]

--- a/rust/snownet-tests/docker-compose.wan-relay.yml
+++ b/rust/snownet-tests/docker-compose.wan-relay.yml
@@ -13,7 +13,7 @@ services:
         PACKAGE: snownet-tests
       cache_from:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/snownet-tests:main
-    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/snownet-tests}:${SNOWNET_TAG:-main}
+    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/snownet-tests}:${SNOWNET_TAG:-main}
     environment:
       ROLE: "dialer"
     cap_add:
@@ -61,7 +61,7 @@ services:
         PACKAGE: snownet-tests
       cache_from:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/snownet-tests:main
-    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/snownet-tests}:${SNOWNET_TAG:-main}
+    image: ${SNOWNET_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/snownet-tests}:${SNOWNET_TAG:-main}
     init: true
     environment:
       ROLE: "listener"
@@ -116,7 +116,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/relay}:${RELAY_TAG:-main}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-main}
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 20s

--- a/scripts/tests/dns-etc-resolvconf.sh
+++ b/scripts/tests/dns-etc-resolvconf.sh
@@ -22,7 +22,7 @@ function gateway() {
 }
 
 # Re-up the gateway since a local dev setup may run this back-to-back
-docker compose up -d gateway
+docker compose up -d gateway --no-build
 
 echo "# check original resolv.conf"
 client sh -c "cat /etc/resolv.conf.before-firezone"


### PR DESCRIPTION
Followup from #4100:


- Add `perf/relay` and `debug/relay` etc data plane images in `firezone-staging`.
- The `perf` images are `debug` stage images and have tooling installed, but use release binaries.
- The `debug` images are `debug` binaries inside `debug` images
- `firezone-prod` contains only release binaries -- these image names haven't changed