### PR TITLE
refactor(connlib): allow commands to be sent to eventloop

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -43,7 +43,7 @@ mod ffi {
             callback_handler: CallbackHandler,
         ) -> Result<WrappedSession, String>;
 
-        fn disconnect(&mut self);
+        fn disconnect(self);
     }
 
     extern "Swift" {
@@ -217,7 +217,7 @@ impl WrappedSession {
         Ok(Self(session))
     }
 
-    fn disconnect(&mut self) {
+    fn disconnect(self) {
         self.0.disconnect()
     }
 }

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -102,9 +102,12 @@ pub enum ConnlibError {
     /// A panic occurred.
     #[error("Panicked: {0}")]
     Panic(String),
+    /// The task was cancelled
+    #[error("The task was cancelled")]
+    Cancelled,
     /// A panic occurred with a non-string payload.
     #[error("Panicked with a non-string payload")]
-    PanicNonStringPayload(Option<String>),
+    PanicNonStringPayload,
     /// Received connection details that might be stale
     #[error("Unexpected connection details")]
     UnexpectedConnectionDetails,
@@ -176,8 +179,8 @@ pub enum ConnlibError {
     #[error("Failed to control system DNS with `resolvectl`")]
     ResolvectlFailed,
 
-    #[error("connection to the portal failed")]
-    PortalConnectionFailed,
+    #[error("connection to the portal failed: {0}")]
+    PortalConnectionFailed(phoenix_channel::Error),
 }
 
 impl ConnlibError {

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -100,10 +100,10 @@ pub enum ConnlibError {
     #[error("No MTU found")]
     NoMtu,
     /// A panic occurred.
-    #[error("Panicked: {0}")]
+    #[error("Connlib panicked: {0}")]
     Panic(String),
     /// The task was cancelled
-    #[error("The task was cancelled")]
+    #[error("Connlib task was cancelled")]
     Cancelled,
     /// A panic occurred with a non-string payload.
     #[error("Panicked with a non-string payload")]

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -729,7 +729,7 @@ impl Controller {
     fn sign_out(&mut self) -> Result<()> {
         self.auth.sign_out()?;
         self.tunnel_ready = false;
-        if let Some(mut session) = self.session.take() {
+        if let Some(session) = self.session.take() {
             tracing::debug!("disconnecting connlib");
             // This is redundant if the token is expired, in that case
             // connlib already disconnected itself.

--- a/rust/linux-client/src/main.rs
+++ b/rust/linux-client/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
         public_key.to_bytes(),
     )?;
 
-    let mut session =
+    let session =
         Session::connect(login, private_key, None, callbacks, max_partition_time).unwrap();
 
     block_on_ctrl_c();

--- a/rust/linux-client/src/main.rs
+++ b/rust/linux-client/src/main.rs
@@ -83,8 +83,9 @@ impl Callbacks for CallbackHandler {
     }
 
     fn on_disconnect(&self, error: &connlib_client_shared::Error) -> Result<(), Self::Error> {
-        tracing::error!(?error, "Disconnected");
-        Ok(())
+        tracing::error!("Disconnected: {error}");
+
+        std::process::exit(1);
     }
 
     fn roll_log_file(&self) -> Option<PathBuf> {


### PR DESCRIPTION
This refactors `Session` to allow for commands to be sent to the `Eventloop`. Currently, we only send a `Stop` command. With #3429, we will add more commands like refreshing and updating the DNS servers.