### PR TITLE
chore(ci): use output image from build for integration tests

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -295,7 +295,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       - name: Output image name
-        id: output
+        id: image-name
         run: echo "${{ matrix.name.image_name }}_image=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) }}${{ matrix.name.image_name }}" >> $GITHUB_ENV
 
   merge-docker-artifacts:

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -26,13 +26,13 @@ on:
     outputs:
       client_image:
         description: "The client image that was built"
-        value: ${{ jobs.data-plane.steps.image-name.outputs.client_image }}
+        value: ${{ jobs.data-plane.outputs.client_image }}
       relay_image:
         description: "The relay image that was built"
-        value: ${{ jobs.data-plane.steps.image-name.outputs.relay_image }}
+        value: ${{ jobs.data-plane.outputs.relay_image }}
       gateway_image:
         description: "The gateway image that was built"
-        value: ${{ jobs.data-plane.steps.image-name.outputs.gateway_image }}
+        value: ${{ jobs.data-plane.outputs.gateway_image }}
 
 env:
   # mark:automatic-version
@@ -181,6 +181,10 @@ jobs:
             image_name: snownet-tests
     env:
       BINARY_DEST_PATH: ${{ matrix.name.artifact }}-${{ matrix.arch.shortname }}
+    outputs:
+      client_image: ${{ steps.image-name.outputs.client_image }}
+      relay_image: ${{ steps.image-name.outputs.relay_image }}
+      gateway_image: ${{ steps.image-name.outputs.gateway_image }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -82,10 +82,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image_name: client
+          - image_name: api
             target: runtime
             build-args: |
-              APPLICATION_NAME=client
+              APPLICATION_NAME=api
           - image_name: web
             target: runtime
             build-args: |
@@ -93,7 +93,7 @@ jobs:
           - image_name: elixir
             target: compiler
             build-args: |
-              APPLICATION_NAME=client
+              APPLICATION_NAME=api
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -26,13 +26,13 @@ on:
     outputs:
       client_image:
         description: "The client image that was built"
-        value: ${{ steps.data-plane.outputs.client_image }}
+        value: ${{ jobs.data-plane.steps.image-name.outputs.client_image }}
       relay_image:
         description: "The relay image that was built"
-        value: ${{ steps.data-plane.outputs.relay_image }}
+        value: ${{ jobs.data-plane.steps.image-name.outputs.relay_image }}
       gateway_image:
         description: "The gateway image that was built"
-        value: ${{ steps.data-plane.outputs.gateway_image }}
+        value: ${{ jobs.data-plane.steps.image-name.outputs.gateway_image }}
 
 env:
   # mark:automatic-version

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -23,6 +23,16 @@ on:
         description: "The stage of the data plane component images to build"
         required: true
         type: string
+    outputs:
+      client_image:
+        description: "The client image that was built"
+        value: ${{ steps.data-plane.outputs.client_image }}
+      relay_image:
+        description: "The relay image that was built"
+        value: ${{ steps.data-plane.outputs.relay_image }}
+      gateway_image:
+        description: "The gateway image that was built"
+        value: ${{ steps.data-plane.outputs.gateway_image }}
 
 env:
   # mark:automatic-version
@@ -72,10 +82,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image_name: api
+          - image_name: client
             target: runtime
             build-args: |
-              APPLICATION_NAME=api
+              APPLICATION_NAME=client
           - image_name: web
             target: runtime
             build-args: |
@@ -83,7 +93,7 @@ jobs:
           - image_name: elixir
             target: compiler
             build-args: |
-              APPLICATION_NAME=api
+              APPLICATION_NAME=client
     steps:
       - uses: actions/checkout@v4
         with:
@@ -284,6 +294,9 @@ jobs:
           path: /tmp/digests/${{ matrix.name.image_name }}
           if-no-files-found: error
           retention-days: 1
+      - name: Output image name
+        id: output
+        run: echo "${{ matrix.name.image_name }}_image=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) }}${{ matrix.name.image_name }}" >> $GITHUB_ENV
 
   merge-docker-artifacts:
     name: merge-${{ matrix.image_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/_build_artifacts.yml
     secrets: inherit
     with:
-      image_prefix: ${{ (github.event_name == 'pull_request' && 'debug') || inputs.image_prefix }}
+      image_prefix: ${{ (github.event_name != 'workflow_call' && 'debug') || inputs.image_prefix }}
       profile: ${{ inputs.profile || 'debug' }}
       stage: ${{ inputs.stage || 'debug' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
     uses: ./.github/workflows/_integration_tests.yml
     needs: build-artifacts
     secrets: inherit
+    with:
+      gateway_image: ${{ needs.build-artifacts.outputs.gateway_image }}
+      client_image: ${{ needs.build-artifacts.outputs.client_image }}
+      relay_image: ${{ needs.build-artifacts.outputs.relay_image }}
 
   snownet-tests:
     needs: build-artifacts


### PR DESCRIPTION
In CI, images have `debug/`. In CD, they don't, so test them that way.