### PR TITLE
refactor(connlib): don't start a runtime as part of `Session`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1116,6 +1116,7 @@ dependencies = [
  "secrecy",
  "serde_json",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-android",
  "tracing-appender",
@@ -1135,6 +1136,7 @@ dependencies = [
  "serde_json",
  "swift-bridge",
  "swift-bridge-build",
+ "tokio",
  "tracing",
  "tracing-appender",
  "tracing-oslog",
@@ -1987,6 +1989,7 @@ dependencies = [
  "resolv-conf",
  "secrecy",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -902,12 +902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,16 +1415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
-dependencies = [
- "nix 0.28.0",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,7 +1865,6 @@ name = "firezone-cli-utils"
 version = "1.0.0"
 dependencies = [
  "clap",
- "ctrlc",
  "ip_network",
  "tracing",
  "tracing-log",
@@ -3847,18 +3830,6 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "cfg_aliases",
  "libc",
 ]
 

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4"
 serde_json = "1"
 thiserror = "1"
 url = "2.4.0"
+tokio = { version = "1.36", default-features = false, features = ["rt"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-android = "0.2"

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -13,7 +13,7 @@ use jni::{
     JNIEnv, JavaVM,
 };
 use secrecy::SecretString;
-use std::{net::IpAddr, path::Path};
+use std::{io, net::IpAddr, path::Path};
 use std::{
     net::{Ipv4Addr, Ipv6Addr},
     os::fd::RawFd,
@@ -21,6 +21,7 @@ use std::{
 };
 use std::{sync::OnceLock, time::Duration};
 use thiserror::Error;
+use tokio::runtime::Runtime;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
@@ -358,6 +359,8 @@ enum ConnectError {
     ConnectFailed(#[from] Error),
     #[error(transparent)]
     InvalidLoginUrl(#[from] LoginUrlError<url::ParseError>),
+    #[error("Unable to create tokio runtime: {0}")]
+    UnableToCreateRuntime(#[from] io::Error),
 }
 
 macro_rules! string_from_jstring {
@@ -386,7 +389,7 @@ fn connect(
     log_dir: JString,
     log_filter: JString,
     callback_handler: GlobalRef,
-) -> Result<Session, ConnectError> {
+) -> Result<SessionWrapper, ConnectError> {
     let api_url = string_from_jstring!(env, api_url);
     let secret = SecretString::from(string_from_jstring!(env, token));
     let device_id = string_from_jstring!(env, device_id);
@@ -412,15 +415,23 @@ fn connect(
         public_key.to_bytes(),
     )?;
 
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
     let session = Session::connect(
         login,
         private_key,
         Some(os_version),
         callback_handler,
         Some(MAX_PARTITION_TIME),
+        runtime.handle().clone(),
     )?;
 
-    Ok(session)
+    Ok(SessionWrapper {
+        inner: session,
+        runtime,
+    })
 }
 
 /// # Safety
@@ -439,7 +450,7 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_co
     log_dir: JString,
     log_filter: JString,
     callback_handler: JObject,
-) -> *const Session {
+) -> *const SessionWrapper {
     let Ok(callback_handler) = env.new_global_ref(callback_handler) else {
         return std::ptr::null();
     };
@@ -470,6 +481,13 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_co
     Box::into_raw(Box::new(session))
 }
 
+pub struct SessionWrapper {
+    inner: Session,
+
+    #[allow(dead_code)] // Only here so we don't drop the memory early.
+    runtime: Runtime,
+}
+
 /// # Safety
 /// Pointers must be valid
 #[allow(non_snake_case)]
@@ -477,9 +495,9 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_co
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_disconnect(
     mut env: JNIEnv,
     _: JClass,
-    session: *mut Session,
+    session: *mut SessionWrapper,
 ) {
     catch_and_throw(&mut env, |_| {
-        Box::from_raw(session).disconnect();
+        Box::from_raw(session).inner.disconnect();
     });
 }

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -24,6 +24,7 @@ tracing-oslog = { git = "https://github.com/Absolucy/tracing-oslog", branch = "m
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 url = "2.5.0"
+tokio = { version = "1.36", default-features = false, features = ["rt"] }
 
 [lib]
 name = "connlib"

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -211,6 +211,7 @@ impl WrappedSession {
                 handle: init_logging(log_dir.into(), log_filter),
             },
             Some(MAX_PARTITION_TIME),
+            tokio::runtime::Handle::current(), // `swift-bridge` already starts a runtime
         )
         .map_err(|err| err.to_string())?;
 

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -54,12 +54,6 @@ impl Session {
         max_partition_time: Option<Duration>,
         handle: tokio::runtime::Handle,
     ) -> connlib_shared::Result<Self> {
-        // TODO: We could use tokio::runtime::current() to get the current runtime
-        // which could work with swift-rust that already runs a runtime. But IDK if that will work
-        // in all platforms, a couple of new threads shouldn't bother none.
-        // Big question here however is how do we get the result? We could block here await the result and spawn a new task.
-        // but then platforms should know that this function is blocking.
-
         let callbacks = CallbackErrorFacade(callbacks);
         let (tx, rx) = tokio::sync::mpsc::channel(1);
 

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -33,19 +33,9 @@ pub struct Session {
 }
 
 impl Session {
-    /// Starts a session in the background.
+    /// Creates a new [`Session`].
     ///
-    /// This will:
-    /// 1. Create and start a tokio runtime
-    /// 2. Connect to the control plane to the portal
-    /// 3. Start the tunnel in the background and forward control plane messages to it.
-    ///
-    /// The generic parameter `CB` should implement all the handlers and that's how errors will be surfaced.
-    ///
-    /// On a fatal error you should call `[Session::disconnect]` and start a new one.
-    ///
-    /// * `device_id` - The cleartext device ID. connlib will obscure this with a hash internally.
-    // TODO: token should be something like SecretString but we need to think about FFI compatibility
+    /// This connects to the portal a specified using [`LoginUrl`] and creates a wireguard tunnel using the provided private key.
     pub fn connect<CB: Callbacks + 'static>(
         url: LoginUrl,
         private_key: StaticSecret,

--- a/rust/firezone-cli-utils/Cargo.toml
+++ b/rust/firezone-cli-utils/Cargo.toml
@@ -13,4 +13,3 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing = { workspace = true }
 tracing-log = "0.2"
 clap = { version = "4.5", features = ["derive",  "env"] }
-ctrlc  = "3.4"

--- a/rust/firezone-cli-utils/src/lib.rs
+++ b/rust/firezone-cli-utils/src/lib.rs
@@ -5,13 +5,6 @@ use tracing_subscriber::{
 };
 use url::Url;
 
-pub fn block_on_ctrl_c() {
-    let (tx, rx) = std::sync::mpsc::channel();
-    ctrlc::set_handler(move || tx.send(()).expect("Could not send stop signal on channel."))
-        .expect("Error setting Ctrl-C handler");
-    rx.recv().expect("Could not receive ctrl-c signal");
-}
-
 pub fn setup_global_subscriber<L>(additional_layer: L)
 where
     L: Layer<Registry> + Send + Sync,

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -557,6 +557,7 @@ impl Controller {
             None,
             callback_handler.clone(),
             Some(MAX_PARTITION_TIME),
+            tokio::runtime::Handle::current(),
         )?;
 
         self.session = Some(Session {

--- a/rust/linux-client/Cargo.toml
+++ b/rust/linux-client/Cargo.toml
@@ -20,3 +20,4 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 humantime = "2.1"
 resolv-conf = "0.7.0"
 thiserror = "1.0.57"
+tokio = { version = "1.36", default-features = false, features = ["rt", "macros"] }

--- a/rust/linux-client/Cargo.toml
+++ b/rust/linux-client/Cargo.toml
@@ -20,4 +20,4 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 humantime = "2.1"
 resolv-conf = "0.7.0"
 thiserror = "1.0.57"
-tokio = { version = "1.36", default-features = false, features = ["rt", "macros"] }
+tokio = { version = "1.36", default-features = false, features = ["rt", "macros", "signal"] }


### PR DESCRIPTION
Currently, each use of `Session` creates its own `Runtime`. That is unnecessary because some platforms already have a tokio runtime running. Instead of creating another one, we simply ask the caller to provide us with a `Handle` to an existing tokio runtime. For Android and iOS we spawn a new single-threaded runtime to satisfy this new requirement.