### PR TITLE
chore(ci): Use explicit images for hotfix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,9 @@ jobs:
           timeout 600 docker compose -f rust/snownet-tests/docker-compose.${{ matrix.name }}.yml up --exit-code-from dialer --abort-on-container-exit
 
   compatibility-tests:
-    # Don't run compatibility tests when called from cd.yml on `main` because
+    # Don't run compatibility tests when called from hotfix.yml or publish.yml on `main` because
     # it'll be red if there was a breaking change we're tring to publish,
-    # and the publish workflow checks for main to be green.
+    # and the deploy_production workflow checks for main to be green.
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     uses: ./.github/workflows/_integration_tests.yml
     needs: build-artifacts

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,5 +1,5 @@
 name: Hotfix Production
-run-name: Triggered by ${{ github.actor }}
+run-name: Triggered by ${{ github.actor }} on ${{ github.event_name }}
 on:
   workflow_dispatch:
     inputs:
@@ -21,9 +21,11 @@ jobs:
     uses: ./.github/workflows/_integration_tests.yml
     secrets: inherit
     with:
+      relay_image: 'us-east1-docker.pkg.dev/firezone-staging/firezone/relay'
       gateway_image: "ghcr.io/firezone/gateway"
       gateway_tag: "latest"
       # FIXME: Uncomment this after the next release -- the
+      client_image: 'us-east1-docker.pkg.dev/firezone-staging/firezone/client'
       # client will be published then.
       # client_tag: "latest"
 


### PR DESCRIPTION
Hotfix calls integrations tests separately, so we need to explicitly define the images for it to use.