### PR TITLE
fix(portal): Increase group name max length

### DIFF
--- a/elixir/apps/domain/lib/domain/actors/group/changeset.ex
+++ b/elixir/apps/domain/lib/domain/actors/group/changeset.ex
@@ -57,7 +57,7 @@ defmodule Domain.Actors.Group.Changeset do
   defp changeset(changeset) do
     changeset
     |> trim_change(:name)
-    |> validate_length(:name, min: 1, max: 64)
+    |> validate_length(:name, min: 1, max: 255)
     |> unique_constraint(:name, name: :actor_groups_account_id_name_index)
   end
 

--- a/elixir/apps/domain/test/domain/actors_test.exs
+++ b/elixir/apps/domain/test/domain/actors_test.exs
@@ -1117,11 +1117,11 @@ defmodule Domain.ActorsTest do
     end
 
     test "returns error on invalid attrs", %{account: account} do
-      attrs = %{name: String.duplicate("A", 65)}
+      attrs = %{name: String.duplicate("A", 256)}
       assert {:error, changeset} = create_managed_group(account, attrs)
 
       assert errors_on(changeset) == %{
-               name: ["should be at most 64 character(s)"],
+               name: ["should be at most 255 character(s)"],
                membership_rules: ["can't be blank"]
              }
 
@@ -1178,11 +1178,11 @@ defmodule Domain.ActorsTest do
     end
 
     test "returns error on invalid attrs", %{account: account, subject: subject} do
-      attrs = %{name: String.duplicate("A", 65), type: :foo}
+      attrs = %{name: String.duplicate("A", 256), type: :foo}
       assert {:error, changeset} = create_group(attrs, subject)
 
       assert errors_on(changeset) == %{
-               name: ["should be at most 64 character(s)"],
+               name: ["should be at most 255 character(s)"],
                type: ["is invalid"]
              }
 
@@ -1315,9 +1315,9 @@ defmodule Domain.ActorsTest do
     test "returns error on invalid attrs", %{account: account, subject: subject} do
       group = Fixtures.Actors.create_group(account: account)
 
-      attrs = %{name: String.duplicate("A", 65)}
+      attrs = %{name: String.duplicate("A", 256)}
       assert {:error, changeset} = update_group(group, attrs, subject)
-      assert errors_on(changeset) == %{name: ["should be at most 64 character(s)"]}
+      assert errors_on(changeset) == %{name: ["should be at most 255 character(s)"]}
 
       Fixtures.Actors.create_group(account: account, name: "foo")
       attrs = %{name: "foo"}

--- a/elixir/apps/web/test/web/live/groups/edit_test.exs
+++ b/elixir/apps/web/test/web/live/groups/edit_test.exs
@@ -126,7 +126,7 @@ defmodule Web.Live.Groups.EditTest do
     |> form("form", group: attrs)
     |> validate_change(%{group: %{name: String.duplicate("a", 256)}}, fn form, _html ->
       assert form_validation_errors(form) == %{
-               "group[name]" => ["should be at most 64 character(s)"]
+               "group[name]" => ["should be at most 255 character(s)"]
              }
     end)
     |> validate_change(%{group: %{name: ""}}, fn form, _html ->

--- a/elixir/apps/web/test/web/live/groups/new_test.exs
+++ b/elixir/apps/web/test/web/live/groups/new_test.exs
@@ -78,7 +78,7 @@ defmodule Web.Live.Groups.NewTest do
     |> form("form", group: attrs)
     |> validate_change(%{group: %{name: String.duplicate("a", 256)}}, fn form, _html ->
       assert form_validation_errors(form) == %{
-               "group[name]" => ["should be at most 64 character(s)"]
+               "group[name]" => ["should be at most 255 character(s)"]
              }
     end)
     |> validate_change(%{group: %{name: ""}}, fn form, _html ->


### PR DESCRIPTION
Fixes https://firezonehq.slack.com/archives/C05JUKPT83T/p1710324078226719