### PR TITLE
fix(apple): spawn new thread for runtime to prevent it from being taken down

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -208,7 +208,9 @@ impl WrappedSession {
         )
         .map_err(|e| e.to_string())?;
 
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("connlib")
             .enable_all()
             .build()
             .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Using the current thread in apple was causing a crashloop, since connlib's thread was taken down by the network extension after `WrappedSession::connect` returned.

Now we force the runtime to create the thread to prevent it from being taken down.