### PR TITLE
fix(android): spawn dedicated thread for connlib

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -415,7 +415,9 @@ fn connect(
         public_key.to_bytes(),
     )?;
 
-    let runtime = tokio::runtime::Builder::new_current_thread()
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .thread_name("connlib")
         .enable_all()
         .build()?;
 


### PR DESCRIPTION
Same as https://github.com/firezone/firezone/pull/4141 but for Android.