### PR TITLE
chore(gui-client): fix macOS clippy warning, clean up error types

### DIFF
--- a/rust/gui-client/src-tauri/src/client/deep_link.rs
+++ b/rust/gui-client/src-tauri/src/client/deep_link.rs
@@ -20,10 +20,11 @@ mod imp;
 #[path = "deep_link/windows.rs"]
 mod imp;
 
-// TODO: Replace this all for `anyhow`.
 #[cfg_attr(target_os = "linux", allow(dead_code))]
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    // This one is not `anyhow` since we catch it in the caller
     #[error("named pipe server couldn't start listening, we are probably the second instance")]
     CantListen,
     #[error(transparent)]

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -66,23 +66,13 @@ impl Managed {
 }
 
 // TODO: Replace with `anyhow` gradually per <https://github.com/firezone/firezone/pull/3546#discussion_r1477114789>
-#[cfg_attr(target_os = "linux", allow(dead_code))]
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
-    #[error(r#"Couldn't show clickable notification titled "{0}""#)]
-    ClickableNotification(String),
     #[error("Deep-link module error: {0}")]
     DeepLink(#[from] deep_link::Error),
-    #[error("Can't show log filter error dialog: {0}")]
-    LogFilterErrorDialog(native_dialog::Error),
     #[error("Logging module error: {0}")]
     Logging(#[from] logging::Error),
-    #[error(r#"Couldn't show notification titled "{0}""#)]
-    Notification(String),
-    #[error(transparent)]
-    Tauri(#[from] tauri::Error),
-    #[error("tokio::runtime::Runtime::new failed: {0}")]
-    TokioRuntimeNew(std::io::Error),
 
     // `client.rs` provides a more user-friendly message when showing the error dialog box
     #[error("WebViewNotInstalled")]
@@ -110,7 +100,7 @@ pub(crate) fn run(cli: &client::Cli) -> Result<(), Error> {
                     )
                     .set_type(native_dialog::MessageType::Error)
                     .show_alert()
-                    .map_err(Error::LogFilterErrorDialog)?;
+                    .context("Can't show log filter error dialog")?;
 
                 AdvancedSettings {
                     log_filter: AdvancedSettings::default().log_filter,
@@ -138,7 +128,7 @@ pub(crate) fn run(cli: &client::Cli) -> Result<(), Error> {
     };
 
     // Needed for the deep link server
-    let rt = tokio::runtime::Runtime::new().map_err(Error::TokioRuntimeNew)?;
+    let rt = tokio::runtime::Runtime::new().context("Couldn't start Tokio runtime")?;
     let _guard = rt.enter();
 
     let (ctlr_tx, ctlr_rx) = mpsc::channel(5);
@@ -295,7 +285,7 @@ pub(crate) fn run(cli: &client::Cli) -> Result<(), Error> {
                 tauri::Error::Runtime(tauri_runtime::Error::CreateWebview(_)) => {
                     return Err(Error::WebViewNotInstalled);
                 }
-                error => Err(error)?,
+                error => Err(anyhow::Error::from(error).context("Tauri error"))?,
             }
         }
     };

--- a/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
@@ -1,5 +1,5 @@
-use super::{ControllerRequest, CtlrTx, Error};
-use anyhow::Result;
+use super::{ControllerRequest, CtlrTx};
+use anyhow::{Context, Result};
 use connlib_shared::BUNDLE_ID;
 use secrecy::{ExposeSecret, SecretString};
 use tauri::Manager;

--- a/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
@@ -17,14 +17,14 @@ pub(crate) fn open_url(app: &tauri::AppHandle, url: &SecretString) -> Result<()>
 ///
 /// TODO: Warn about silent failure if the AppID is not installed:
 /// <https://github.com/tauri-apps/winrt-notification/issues/17#issuecomment-1988715694>
-pub(crate) fn show_notification(title: &str, body: &str) -> Result<(), Error> {
+pub(crate) fn show_notification(title: &str, body: &str) -> Result<()> {
     tracing::debug!(?title, ?body, "show_notification");
 
     tauri_winrt_notification::Toast::new(BUNDLE_ID)
         .title(title)
         .text1(body)
         .show()
-        .map_err(|_| Error::Notification(title.to_string()))?;
+        .context("Couldn't show notification")?;
 
     Ok(())
 }
@@ -50,7 +50,7 @@ pub(crate) fn show_clickable_notification(
     body: &str,
     tx: CtlrTx,
     req: ControllerRequest,
-) -> Result<(), Error> {
+) -> Result<()> {
     // For some reason `on_activated` is FnMut
     let mut req = Some(req);
 
@@ -70,6 +70,6 @@ pub(crate) fn show_clickable_notification(
             Ok(())
         })
         .show()
-        .map_err(|_| Error::ClickableNotification(title.to_string()))?;
+        .context("Couldn't show clickable notification")?;
     Ok(())
 }


### PR DESCRIPTION
Fixes the compile warning in macOS for the `version-check` CI job.

Removes some error variants that were never matched on, folding them into `anyhow::Error`s