### PR TITLE
refactor(connlib): only store `ResourceId` in `Peer`

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -11,10 +11,9 @@ use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 use pnet_packet::Packet;
 
-use crate::gateway::ResourceDescription;
 use crate::ip_packet::MutableIpPacket;
 
-type ExpiryingResource = (ResourceDescription, Option<DateTime<Utc>>);
+type ExpiryingResource = (ResourceId, Option<DateTime<Utc>>);
 
 // The max time a dns request can be configured to live in resolvconf
 // is 30 seconds. See resolvconf(5) timeout.
@@ -149,16 +148,13 @@ impl PacketTransformGateway {
     }
 
     pub(crate) fn remove_resource(&mut self, resource: &ResourceId) {
-        self.resources.retain(|_, (r, _)| match r {
-            connlib_shared::messages::ResourceDescription::Dns(r) => r.id != *resource,
-            connlib_shared::messages::ResourceDescription::Cidr(r) => r.id != *resource,
-        })
+        self.resources.retain(|_, (r, _)| r != resource)
     }
 
     pub(crate) fn add_resource(
         &mut self,
         ip: IpNetwork,
-        resource: ResourceDescription,
+        resource: ResourceId,
         expires_at: Option<DateTime<Utc>>,
     ) {
         self.resources.insert(ip, (resource, expires_at));


### PR DESCRIPTION
In order to track the allowed resources, we only need to track the ID, not the entire resource. This avoids duplicating information about resources.