### PR TITLE
wip: re-architect how we initialize the TUN device

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1104,6 +1104,7 @@ name = "connlib-client-android"
 version = "1.0.0"
 dependencies = [
  "connlib-client-shared",
+ "firezone-tunnel",
  "ip_network",
  "jni 0.21.1",
  "log",
@@ -1124,6 +1125,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "connlib-client-shared",
+ "firezone-tunnel",
  "ip_network",
  "libc",
  "secrecy",
@@ -1969,8 +1971,13 @@ dependencies = [
  "connlib-client-shared",
  "connlib-shared",
  "firezone-cli-utils",
+ "firezone-tunnel",
  "humantime",
+ "netlink-packet-core",
+ "netlink-packet-route",
  "resolv-conf",
+ "rtnetlink",
+ "sd-notify",
  "secrecy",
  "thiserror",
  "tokio",

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1"
 thiserror = "1"
 url = "2.4.0"
 tokio = { version = "1.36", default-features = false, features = ["rt"] }
+firezone-tunnel = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-android = "0.2"

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 url = "2.5.0"
 tokio = { version = "1.36", default-features = false, features = ["rt"] }
+firezone-tunnel = { workspace = true }
 
 [lib]
 name = "connlib"

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -4,10 +4,10 @@
 use connlib_client_shared::{
     file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error, LoginUrl, ResourceDescription, Session,
 };
+use firezone_tunnel::Tun;
 use secrecy::SecretString;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    os::fd::RawFd,
     path::PathBuf,
     sync::Arc,
     time::Duration,
@@ -94,6 +94,7 @@ pub struct CallbackHandler {
     // recount. Instead, we just wrap it in an `Arc`.
     inner: Arc<ffi::CallbackHandler>,
     handle: file_logger::Handle,
+    new_tun_sender: tokio::sync::mpsc::Sender<Tun>,
 }
 
 impl Callbacks for CallbackHandler {
@@ -102,32 +103,33 @@ impl Callbacks for CallbackHandler {
         tunnel_address_v4: Ipv4Addr,
         tunnel_address_v6: Ipv6Addr,
         dns_addresses: Vec<IpAddr>,
-    ) -> Option<RawFd> {
+    ) {
+        let tun = match Tun::new() {
+            Ok(tun) => tun,
+            Err(e) => {
+                tracing::error!("Failed to create TUN device");
+                return;
+            }
+        };
+
         self.inner.on_set_interface_config(
             tunnel_address_v4.to_string(),
             tunnel_address_v6.to_string(),
             serde_json::to_string(&dns_addresses)
                 .expect("developer error: a list of ips should always be serializable"),
         );
-
-        None
+        let _ = self.new_tun_sender.try_send(tun);
     }
 
     fn on_tunnel_ready(&self) {
         self.inner.on_tunnel_ready();
     }
 
-    fn on_update_routes(
-        &self,
-        route_list_4: Vec<Cidrv4>,
-        route_list_6: Vec<Cidrv6>,
-    ) -> Option<RawFd> {
+    fn on_update_routes(&self, route_list_4: Vec<Cidrv4>, route_list_6: Vec<Cidrv6>) {
         self.inner.on_update_routes(
             serde_json::to_string(&route_list_4).unwrap(),
             serde_json::to_string(&route_list_6).unwrap(),
         );
-
-        None
     }
 
     fn on_update_resources(&self, resource_list: Vec<ResourceDescription>) {
@@ -193,6 +195,8 @@ impl WrappedSession {
         let handle = init_logging(log_dir.into(), log_filter).map_err(|e| e.to_string())?;
         let secret = SecretString::from(token);
 
+        let (new_tun_sender, mut new_tun_receiver) = tokio::sync::mpsc::channel(1);
+
         let (private_key, public_key) = keypair();
         let login = LoginUrl::client(
             api_url.as_str(),
@@ -217,11 +221,21 @@ impl WrappedSession {
             CallbackHandler {
                 inner: Arc::new(callback_handler),
                 handle,
+                new_tun_sender,
             },
             Some(MAX_PARTITION_TIME),
             runtime.handle().clone(),
         )
         .map_err(|err| err.to_string())?;
+
+        {
+            let mut session = session.clone();
+            tokio::spawn(async move {
+                while let Some(tun) = new_tun_receiver.recv().await {
+                    session.update_tun(tun);
+                }
+            });
+        }
 
         Ok(Self {
             inner: session,

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -7,7 +7,7 @@ pub use tracing_appender::non_blocking::WorkerGuard;
 
 use backoff::ExponentialBackoffBuilder;
 use connlib_shared::get_user_agent;
-use firezone_tunnel::ClientTunnel;
+use firezone_tunnel::{ClientTunnel, Tun};
 use phoenix_channel::PhoenixChannel;
 use std::time::Duration;
 
@@ -25,6 +25,7 @@ use tokio::task::JoinHandle;
 /// A session is the entry-point for connlib, maintains the runtime and the tunnel.
 ///
 /// A session is created using [Session::connect], then to stop a session we use [Session::disconnect].
+#[derive(Clone)]
 pub struct Session {
     channel: tokio::sync::mpsc::Sender<Command>,
 }
@@ -70,6 +71,10 @@ impl Session {
     /// reconnect allows connlib to re-establish connections faster because we don't have to wait for timeouts first.
     pub fn reconnect(&mut self) {
         let _ = self.channel.try_send(Command::Reconnect);
+    }
+
+    pub fn update_tun(&mut self, tun: Tun) {
+        let _ = self.channel.try_send(Command::Update(tun));
     }
 
     /// Disconnect a [`Session`].

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -5,9 +5,6 @@ use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
 
-// Avoids having to map types for Windows
-type RawFd = i32;
-
 #[derive(Serialize, Clone, Copy, Debug)]
 /// Identical to `ip_network::Ipv4Network` except we implement `Serialize` on the Rust side and the equivalent of `Deserialize` on the Swift / Kotlin side to avoid manually serializing and deserializing.
 pub struct Cidrv4 {
@@ -42,13 +39,10 @@ impl From<Ipv6Network> for Cidrv6 {
 
 /// Traits that will be used by connlib to callback the client upper layers.
 pub trait Callbacks: Clone + Send + Sync {
-    /// Called when the tunnel address is set.
+    /// Called when the tunnel's TUN device configuration is updated.
     ///
-    /// This should return a new `fd` if there is one.
-    /// (Only happens on android for now)
-    fn on_set_interface_config(&self, _: Ipv4Addr, _: Ipv6Addr, _: Vec<IpAddr>) -> Option<RawFd> {
-        None
-    }
+    /// Implementations may need to re-initialize the [`Tun`] device as a result.
+    fn on_set_interface_config(&self, _: Ipv4Addr, _: Ipv6Addr, _: Vec<IpAddr>) {}
 
     /// Called when the tunnel is connected.
     fn on_tunnel_ready(&self) {
@@ -56,9 +50,7 @@ pub trait Callbacks: Clone + Send + Sync {
     }
 
     /// Called when the route list changes.
-    fn on_update_routes(&self, _: Vec<Cidrv4>, _: Vec<Cidrv6>) -> Option<RawFd> {
-        None
-    }
+    fn on_update_routes(&self, _: Vec<Cidrv4>, _: Vec<Cidrv6>) {}
 
     /// Called when the resource list changes.
     fn on_update_resources(&self, _: Vec<ResourceDescription>) {}

--- a/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
@@ -70,11 +70,7 @@ impl Tun {
         }
     }
 
-    pub fn new(
-        config: &InterfaceConfig,
-        dns_config: Vec<IpAddr>,
-        callbacks: &impl Callbacks,
-    ) -> Result<Self> {
+    pub fn new() -> Result<Self> {
         let mut info = ctl_info {
             ctl_id: 0,
             ctl_name: [0; 96],
@@ -131,8 +127,6 @@ impl Tun {
             }
 
             if addr.sc_id == info.ctl_id {
-                callbacks.on_set_interface_config(config.ipv4, config.ipv6, dns_config);
-
                 set_non_blocking(fd)?;
 
                 return Ok(Self {
@@ -145,15 +139,15 @@ impl Tun {
         Err(get_last_error())
     }
 
-    pub fn set_routes(&self, routes: HashSet<IpNetwork>, callbacks: &impl Callbacks) -> Result<()> {
-        // This will always be None in macos
-        callbacks.on_update_routes(
-            routes.iter().copied().filter_map(ipv4).collect(),
-            routes.iter().copied().filter_map(ipv6).collect(),
-        );
+    // pub fn set_routes(&self, routes: HashSet<IpNetwork>, callbacks: &impl Callbacks) -> Result<()> {
+    //     // This will always be None in macos
+    //     callbacks.on_update_routes(
+    //         routes.iter().copied().filter_map(ipv4).collect(),
+    //         routes.iter().copied().filter_map(ipv6).collect(),
+    //     );
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     pub fn name(&self) -> &str {
         self.name.as_str()

--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -1,29 +1,14 @@
 use crate::device_channel::ioctl;
-use crate::FIREZONE_MARK;
-use connlib_shared::{
-    linux::{etc_resolv_conf, DnsControlMethod},
-    messages::Interface as InterfaceConfig,
-    Callbacks, Error, Result,
-};
-use futures::TryStreamExt;
-use futures_util::future::BoxFuture;
-use futures_util::FutureExt;
-use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
+use connlib_shared::{Error, Result};
 use libc::{
     close, fcntl, makedev, mknod, open, F_GETFL, F_SETFL, IFF_MULTI_QUEUE, IFF_NO_PI, IFF_TUN,
     O_NONBLOCK, O_RDWR, S_IFCHR,
 };
-use netlink_packet_route::route::{RouteProtocol, RouteScope};
-use netlink_packet_route::rule::RuleAction;
-use rtnetlink::{new_connection, Error::NetlinkError, Handle};
-use rtnetlink::{RouteAddRequest, RuleAddRequest};
-use std::collections::HashSet;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::Path;
 use std::task::{Context, Poll};
 use std::{
     ffi::CStr,
-    fmt, fs, io,
+    fs, io,
     os::{
         fd::{AsRawFd, RawFd},
         unix::fs::PermissionsExt,
@@ -34,46 +19,23 @@ use tokio::io::unix::AsyncFd;
 mod utils;
 
 pub(crate) const SIOCGIFMTU: libc::c_ulong = libc::SIOCGIFMTU;
-
-const IFACE_NAME: &str = "tun-firezone";
 const TUNSETIFF: libc::c_ulong = 0x4004_54ca;
 const TUN_DEV_MAJOR: u32 = 10;
 const TUN_DEV_MINOR: u32 = 200;
-const DEFAULT_MTU: u32 = 1280;
-const FILE_ALREADY_EXISTS: i32 = -17;
-const FIREZONE_TABLE: u32 = 0x2021_fd00;
 
 // Safety: We know that this is a valid C string.
 const TUN_FILE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"/dev/net/tun\0") };
 
+#[derive(Debug)]
 pub struct Tun {
-    handle: Handle,
-    connection: tokio::task::JoinHandle<()>,
-    dns_control_method: Option<DnsControlMethod>,
+    // dns_control_method: Option<DnsControlMethod>,
     fd: AsyncFd<RawFd>,
-
-    worker: Option<BoxFuture<'static, Result<()>>>,
-    routes: HashSet<IpNetwork>,
-}
-
-impl fmt::Debug for Tun {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Tun")
-            .field("handle", &self.handle)
-            .field("connection", &self.connection)
-            .field("fd", &self.fd)
-            .finish_non_exhaustive()
-    }
+    name: String,
 }
 
 impl Drop for Tun {
     fn drop(&mut self) {
         unsafe { close(self.fd.as_raw_fd()) };
-        self.connection.abort();
-        if let Some(DnsControlMethod::EtcResolvConf) = self.dns_control_method {
-            // TODO: Check that nobody else modified the file while we were running.
-            etc_resolv_conf::revert().ok();
-        }
     }
 }
 
@@ -87,35 +49,23 @@ impl Tun {
     }
 
     pub fn poll_read(&mut self, buf: &mut [u8], cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
-        if let Some(worker) = self.worker.as_mut() {
-            match worker.poll_unpin(cx) {
-                Poll::Ready(Ok(())) => {
-                    self.worker = None;
-                }
-                Poll::Ready(Err(e)) => {
-                    self.worker = None;
-                    return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, e)));
-                }
-                Poll::Pending => return Poll::Pending,
-            }
-        }
+        // if let Some(worker) = self.worker.as_mut() {
+        //     match worker.poll_unpin(cx) {
+        //         Poll::Ready(Ok(())) => {
+        //             self.worker = None;
+        //         }
+        //         Poll::Ready(Err(e)) => {
+        //             self.worker = None;
+        //             return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, e)));
+        //         }
+        //         Poll::Pending => return Poll::Pending,
+        //     }
+        // }
 
         utils::poll_raw_fd(&self.fd, |fd| read(fd, buf), cx)
     }
 
-    pub fn new(
-        config: &InterfaceConfig,
-        dns_config: Vec<IpAddr>,
-        _: &impl Callbacks,
-    ) -> Result<Self> {
-        tracing::debug!(?dns_config);
-
-        // TODO: Tech debt: <https://github.com/firezone/firezone/issues/3636>
-        // TODO: Gateways shouldn't set up DNS, right? Only clients?
-        // TODO: Move this configuration up to the client
-        let dns_control_method = connlib_shared::linux::get_dns_control_from_env();
-        tracing::info!(?dns_control_method);
-
+    pub fn new(name: &str) -> Result<Self> {
         create_tun_device()?;
 
         let fd = match unsafe { open(TUN_FILE.as_ptr() as _, O_RDWR) } {
@@ -128,224 +78,71 @@ impl Tun {
             ioctl::exec(
                 fd,
                 TUNSETIFF,
-                &mut ioctl::Request::<SetTunFlagsPayload>::new(),
+                &mut ioctl::Request::<SetTunFlagsPayload>::new(name),
             )?;
         }
 
         set_non_blocking(fd)?;
 
-        let (connection, handle, _) = new_connection()?;
-        let join_handle = tokio::spawn(connection);
-
         Ok(Self {
-            handle: handle.clone(),
-            connection: join_handle,
-            dns_control_method: dns_control_method.clone(),
+            name: name.to_owned(),
             fd: AsyncFd::new(fd)?,
-            worker: Some(
-                set_iface_config(
-                    config.clone(),
-                    dns_config,
-                    handle,
-                    dns_control_method.clone(),
-                )
-                .boxed(),
-            ),
-            routes: HashSet::new(),
         })
     }
 
-    pub fn set_routes(&mut self, new_routes: HashSet<IpNetwork>, _: &impl Callbacks) -> Result<()> {
-        if new_routes == self.routes {
-            return Ok(());
-        }
+    // pub fn set_routes(&mut self, new_routes: HashSet<IpNetwork>, _: &impl Callbacks) -> Result<()> {
+    //     if new_routes == self.routes {
+    //         return Ok(());
+    //     }
 
-        let handle = self.handle.clone();
-        let current_routes = self.routes.clone();
-        self.routes = new_routes.clone();
+    //     let handle = self.handle.clone();
+    //     let current_routes = self.routes.clone();
+    //     self.routes = new_routes.clone();
 
-        let set_routes_worker = async move {
-            let index = handle
-                .link()
-                .get()
-                .match_name(IFACE_NAME.to_string())
-                .execute()
-                .try_next()
-                .await?
-                .ok_or(Error::NoIface)?
-                .header
-                .index;
+    //     let set_routes_worker = async move {
+    //         let index = handle
+    //             .link()
+    //             .get()
+    //             .match_name(IFACE_NAME.to_string())
+    //             .execute()
+    //             .try_next()
+    //             .await?
+    //             .ok_or(Error::NoIface)?
+    //             .header
+    //             .index;
 
-            for route in new_routes.difference(&current_routes) {
-                add_route(route, index, &handle).await;
-            }
+    //         for route in new_routes.difference(&current_routes) {
+    //             add_route(route, index, &handle).await;
+    //         }
 
-            for route in current_routes.difference(&new_routes) {
-                delete_route(route, index, &handle).await;
-            }
+    //         for route in current_routes.difference(&new_routes) {
+    //             delete_route(route, index, &handle).await;
+    //         }
 
-            Ok(())
-        };
+    //         Ok(())
+    //     };
 
-        match self.worker.take() {
-            None => self.worker = Some(set_routes_worker.boxed()),
-            Some(current_worker) => {
-                self.worker = Some(
-                    async move {
-                        current_worker.await?;
-                        set_routes_worker.await?;
+    //     // match self.worker.take() {
+    //     //     None => self.worker = Some(set_routes_worker.boxed()),
+    //     //     Some(current_worker) => {
+    //     //         self.worker = Some(
+    //     //             async move {
+    //     //                 current_worker.await?;
+    //     //                 set_routes_worker.await?;
 
-                        Ok(())
-                    }
-                    .boxed(),
-                )
-            }
-        }
+    //     //                 Ok(())
+    //     //             }
+    //     //             .boxed(),
+    //     //         )
+    //     //     }
+    //     // }
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     pub fn name(&self) -> &str {
-        IFACE_NAME
+        &self.name
     }
-}
-
-#[tracing::instrument(level = "trace", skip(handle))]
-async fn set_iface_config(
-    config: InterfaceConfig,
-    dns_config: Vec<IpAddr>,
-    handle: Handle,
-    dns_control_method: Option<DnsControlMethod>,
-) -> Result<()> {
-    let index = handle
-        .link()
-        .get()
-        .match_name(IFACE_NAME.to_string())
-        .execute()
-        .try_next()
-        .await?
-        .ok_or(Error::NoIface)?
-        .header
-        .index;
-
-    let ips = handle
-        .address()
-        .get()
-        .set_link_index_filter(index)
-        .execute();
-
-    ips.try_for_each(|ip| handle.address().del(ip).execute())
-        .await?;
-
-    handle.link().set(index).mtu(DEFAULT_MTU).execute().await?;
-
-    let res_v4 = handle
-        .address()
-        .add(index, config.ipv4.into(), 32)
-        .execute()
-        .await;
-    let res_v6 = handle
-        .address()
-        .add(index, config.ipv6.into(), 128)
-        .execute()
-        .await;
-
-    handle.link().set(index).up().execute().await?;
-
-    if res_v4.is_ok() {
-        if let Err(e) = make_rule(&handle).v4().execute().await {
-            if !matches!(&e, NetlinkError(err) if err.raw_code() == FILE_ALREADY_EXISTS) {
-                tracing::warn!(
-                    "Couldn't add ip rule for ipv4: {e:?}, ipv4 packets won't be routed"
-                );
-            }
-            // TODO: Be smarter about this
-        } else {
-            tracing::debug!("Successfully created ip rule for ipv4");
-        }
-    }
-
-    if res_v6.is_ok() {
-        if let Err(e) = make_rule(&handle).v6().execute().await {
-            if !matches!(&e, NetlinkError(err) if err.raw_code() == FILE_ALREADY_EXISTS) {
-                tracing::warn!(
-                    "Couldn't add ip rule for ipv6: {e:?}, ipv6 packets won't be routed"
-                );
-            }
-            // TODO: Be smarter about this
-        } else {
-            tracing::debug!("Successfully created ip rule for ipv6");
-        }
-    }
-
-    res_v4.or(res_v6)?;
-
-    match dns_control_method {
-        None => {}
-        Some(DnsControlMethod::EtcResolvConf) => etc_resolv_conf::configure(&dns_config)
-            .await
-            .map_err(Error::ResolvConf)?,
-        Some(DnsControlMethod::NetworkManager) => configure_network_manager(&dns_config).await?,
-        Some(DnsControlMethod::Systemd) => configure_systemd_resolved(&dns_config).await?,
-    }
-
-    // TODO: Having this inside the library is definitely wrong. I think `set_iface_config`
-    // needs to return before `new` returns, so that the `on_tunnel_ready` callback
-    // happens after the IP address and DNS are set up. Then we can call `sd_notify`
-    // inside `on_tunnel_ready` in the client.
-    //
-    // `sd_notify::notify` is always safe to call, it silently returns `Ok(())`
-    // if we aren't running as a systemd service.
-    if let Err(error) = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]) {
-        // Nothing we can do about it
-        tracing::warn!(?error, "Failed to notify systemd that we're ready");
-    }
-
-    Ok(())
-}
-
-fn make_rule(handle: &Handle) -> RuleAddRequest {
-    let mut rule = handle
-        .rule()
-        .add()
-        .fw_mark(FIREZONE_MARK)
-        .table_id(FIREZONE_TABLE)
-        .action(RuleAction::ToTable);
-
-    rule.message_mut()
-        .header
-        .flags
-        .push(netlink_packet_route::rule::RuleFlag::Invert);
-
-    rule.message_mut()
-        .attributes
-        .push(netlink_packet_route::rule::RuleAttribute::Protocol(
-            RouteProtocol::Kernel,
-        ));
-
-    rule
-}
-
-fn make_route(idx: u32, handle: &Handle) -> RouteAddRequest {
-    handle
-        .route()
-        .add()
-        .output_interface(idx)
-        .protocol(RouteProtocol::Static)
-        .scope(RouteScope::Universe)
-        .table_id(FIREZONE_TABLE)
-}
-
-fn make_route_v4(idx: u32, handle: &Handle, route: Ipv4Network) -> RouteAddRequest<Ipv4Addr> {
-    make_route(idx, handle)
-        .v4()
-        .destination_prefix(route.network_address(), route.netmask())
-}
-
-fn make_route_v6(idx: u32, handle: &Handle, route: Ipv6Network) -> RouteAddRequest<Ipv6Addr> {
-    make_route(idx, handle)
-        .v6()
-        .destination_prefix(route.network_address(), route.netmask())
 }
 
 fn get_last_error() -> Error {
@@ -405,37 +202,9 @@ fn write(fd: RawFd, buf: &[u8]) -> io::Result<usize> {
     }
 }
 
-async fn add_route(route: &IpNetwork, idx: u32, handle: &Handle) {
-    let res = match route {
-        IpNetwork::V4(ipnet) => make_route_v4(idx, handle, *ipnet).execute().await,
-        IpNetwork::V6(ipnet) => make_route_v6(idx, handle, *ipnet).execute().await,
-    };
-
-    match res {
-        Ok(_) => {}
-        Err(NetlinkError(err)) if err.raw_code() == FILE_ALREADY_EXISTS => {}
-        // TODO: we should be able to surface this error and handle it depending on
-        // if any of the added routes succeeded.
-        Err(err) => {
-            tracing::error!(%route, "failed to add route: {err}");
-        }
-    }
-}
-
-async fn delete_route(route: &IpNetwork, idx: u32, handle: &Handle) {
-    let message = match route {
-        IpNetwork::V4(ipnet) => make_route_v4(idx, handle, *ipnet).message_mut().clone(),
-        IpNetwork::V6(ipnet) => make_route_v6(idx, handle, *ipnet).message_mut().clone(),
-    };
-
-    if let Err(err) = handle.route().del(message).execute().await {
-        tracing::error!(%route, "failed to add route: {err:#?}");
-    }
-}
-
 impl ioctl::Request<SetTunFlagsPayload> {
-    fn new() -> Self {
-        let name_as_bytes = IFACE_NAME.as_bytes();
+    fn new(name: &str) -> Self {
+        let name_as_bytes = name.as_bytes();
         debug_assert!(name_as_bytes.len() < libc::IF_NAMESIZE);
 
         let mut name = [0u8; libc::IF_NAMESIZE];
@@ -448,40 +217,6 @@ impl ioctl::Request<SetTunFlagsPayload> {
             },
         }
     }
-}
-
-async fn configure_network_manager(_dns_config: &[IpAddr]) -> Result<()> {
-    Err(Error::Other(
-        "DNS control with NetworkManager is not implemented yet",
-    ))
-}
-
-async fn configure_systemd_resolved(dns_config: &[IpAddr]) -> Result<()> {
-    let status = tokio::process::Command::new("resolvectl")
-        .arg("dns")
-        .arg(IFACE_NAME)
-        .args(dns_config.iter().map(ToString::to_string))
-        .status()
-        .await
-        .map_err(|_| Error::ResolvectlFailed)?;
-    if !status.success() {
-        return Err(Error::ResolvectlFailed);
-    }
-
-    let status = tokio::process::Command::new("resolvectl")
-        .arg("domain")
-        .arg(IFACE_NAME)
-        .arg("~.")
-        .status()
-        .await
-        .map_err(|_| Error::ResolvectlFailed)?;
-    if !status.success() {
-        return Err(Error::ResolvectlFailed);
-    }
-
-    tracing::info!(?dns_config, "Configured DNS sentinels with `resolvectl`");
-
-    Ok(())
 }
 
 #[repr(C)]

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -13,7 +13,7 @@ use connlib_shared::{Callbacks, Dname, Error, Result, StaticSecret};
 use ip_network::IpNetwork;
 use secrecy::{ExposeSecret as _, Secret};
 use snownet::ServerNode;
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
@@ -47,14 +47,14 @@ where
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn set_interface(&mut self, config: &InterfaceConfig) -> connlib_shared::Result<()> {
         // Note: the dns fallback strategy is irrelevant for gateways
-        let callbacks = self.callbacks.clone();
-        self.io
-            .device_mut()
-            .initialize(config, vec![], &callbacks)?;
-        self.io.device_mut().set_routes(
-            HashSet::from([PEERS_IPV4.parse().unwrap(), PEERS_IPV6.parse().unwrap()]),
-            &callbacks,
-        )?;
+        // let callbacks = self.callbacks.clone();
+        // self.io
+        //     .device_mut()
+        //     .initialize(config, vec![], &callbacks)?;
+        // self.io.device_mut().set_routes(
+        //     HashSet::from([PEERS_IPV4.parse().unwrap(), PEERS_IPV6.parse().unwrap()]),
+        //     &callbacks,
+        // )?;
 
         let name = self.io.device_mut().name().to_owned();
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 pub use client::{ClientState, Request};
+pub use device_channel::Tun;
 pub use gateway::{GatewayState, ResolvedResourceDescriptionDns};
 
 mod client;

--- a/rust/linux-client/Cargo.toml
+++ b/rust/linux-client/Cargo.toml
@@ -21,3 +21,8 @@ humantime = "2.1"
 resolv-conf = "0.7.0"
 thiserror = "1.0.57"
 tokio = { version = "1.36", default-features = false, features = ["rt", "macros", "signal"] }
+netlink-packet-route = { version = "0.19", default-features = false }
+netlink-packet-core = { version = "0.7", default-features = false }
+rtnetlink = { workspace = true }
+firezone-tunnel = { workspace = true }
+sd-notify = "0.4.1"


### PR DESCRIPTION
Currently, the callbacks for initializing and updating the TUN device create a lot of back-and-forth control flow that is hard to follow. This PR presents the cornerstones of a different design that I deem simpler to understand.

The key differences are:

- `Tunnel` has an `update_tun` function that allows setting a new TUN device. Essentially `Tun` is now just an `AsyncRead + AsyncWrite` so that could be further abstracted. I think that would be good because we end up with less conditional dependencies.
- All platforms now use the callbacks to update the state about the device and routes. Receiving a callback for `on_set_interface_config` means the portal has given us new IPs. We set those IPs on the TUN device in a platform-specific way. For example, for Linux, this means talking to `netlink`, for Android and iOS/MacOS, this means forwarding to the main app.
- The devices are initialized in a platform-specific way. For Linux, iOS and MacOS, we can initialize it right away as part of booting up the `Session`. For Android, we have to wait for the file-descriptor from the first callback.
- I haven't looked closely at Windows yet but it also seems like we can initialize it right away there.