### PR TITLE
refactor(connlib): move functionality onto `ClientState`

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -565,13 +565,10 @@ impl ClientState {
         self.dns_resources_internal_ips
             .insert(resource_description.clone(), addrs.clone());
 
-        let ips: Vec<IpNetwork> = addrs.iter().copied().map(Into::into).collect();
-
         send_dns_answer(self, Rtype::Aaaa, &resource_description, &addrs);
-
         send_dns_answer(self, Rtype::A, &resource_description, &addrs);
 
-        Ok(ips)
+        Ok(addrs.iter().copied().map(Into::into).collect())
     }
 
     /// Attempt to handle the given packet as a DNS packet.

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -516,9 +516,11 @@ impl ClientState {
             return Err(Error::UnexpectedConnectionDetails);
         }
 
-        self.awaiting_connection
-            .get_mut(&resource_id)
-            .ok_or(Error::UnexpectedConnectionDetails)?;
+        let awaiting_connection = self
+            .awaiting_connection
+            .get(&resource_id)
+            .ok_or(Error::UnexpectedConnectionDetails)?
+            .clone();
 
         self.resources_gateways.insert(resource_id, gateway_id);
 
@@ -526,8 +528,6 @@ impl ClientState {
             if self.node.is_expecting_answer(gateway_id) {
                 return Err(Error::PendingConnection);
             }
-
-            let awaiting_connection = self.get_awaiting_connection(&resource_id)?.clone();
 
             let offer = self.node.new_connection(
                 gateway_id,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -279,18 +279,8 @@ where
         resource_id: ResourceId,
         domain_response: DomainResponse,
     ) -> connlib_shared::Result<()> {
-        let gateway_id = self
-            .role_state
-            .gateway_by_resource(&resource_id)
-            .ok_or(Error::UnknownResource)?;
-
-        let peer_ips = self
-            .role_state
-            .dns_response(&resource_id, &domain_response, &gateway_id)?;
-
         self.role_state
-            .peers
-            .add_ips_with_resource(&gateway_id, &peer_ips, &resource_id);
+            .received_domain_parameters(resource_id, domain_response)?;
 
         Ok(())
     }
@@ -564,6 +554,23 @@ impl ClientState {
                 domain: awaiting_connection.domain,
             },
         }));
+    }
+
+    fn received_domain_parameters(
+        &mut self,
+        resource_id: ResourceId,
+        domain_response: DomainResponse,
+    ) -> connlib_shared::Result<()> {
+        let gateway_id = self
+            .gateway_by_resource(&resource_id)
+            .ok_or(Error::UnknownResource)?;
+
+        let peer_ips = self.dns_response(&resource_id, &domain_response, &gateway_id)?;
+
+        self.peers
+            .add_ips_with_resource(&gateway_id, &peer_ips, &resource_id);
+
+        Ok(())
     }
 
     fn dns_response(

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -297,20 +297,15 @@ where
     /// Called when a response to [ClientTunnel::request_connection] is ready.
     ///
     /// Once this is called, if everything goes fine, a new tunnel should be started between the 2 peers.
-    #[tracing::instrument(level = "trace", skip(self, gateway_public_key, resource_id))]
     pub fn received_offer_response(
         &mut self,
         resource_id: ResourceId,
-        rtc_ice_params: Answer,
+        answer: Answer,
         domain_response: Option<DomainResponse>,
         gateway_public_key: PublicKey,
     ) -> connlib_shared::Result<()> {
-        self.role_state.accept_answer(
-            rtc_ice_params,
-            resource_id,
-            gateway_public_key,
-            domain_response,
-        )?;
+        self.role_state
+            .accept_answer(answer, resource_id, gateway_public_key, domain_response)?;
 
         Ok(())
     }
@@ -486,6 +481,7 @@ impl ClientState {
         Some(packet.into_immutable())
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(%resource_id))]
     fn accept_answer(
         &mut self,
         answer: Answer,


### PR DESCRIPTION
With the move to SANS-IO, we will be able to write deterministic unit tests for the tunnel logic. To actually do that, `ClientState` and `GatewayState` need to encapsulate all the logic that we want to test.

This PR does some minor refactoring on the functions on `ClientTunnel` and moves several of them onto `ClientState`. It doesn't touch `add_resources` and `remove_resource` because those depend on #4156.