### PR TITLE
chore(apple): Remove connlib_client_apple log filters because they have no effect

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -31,15 +31,14 @@ struct AdvancedSettings: Equatable {
         authBaseURLString: "https://app.firez.one/",
         apiURLString: "wss://api.firez.one/",
         connlibLogFilterString:
-          "connlib_client_apple=debug,firezone_tunnel=trace,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,info"
+          "firezone_tunnel=trace,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,str0m=info,debug"
       )
     #else
       AdvancedSettings(
         authBaseURLString: "https://app.firezone.dev/",
         apiURLString: "wss://api.firezone.dev/",
         connlibLogFilterString:
-          "connlib_client_apple=info,firezone_tunnel=info,"
-          + "connlib_shared=info,phoenix_channel=info,connlib_client_shared=info,boringtun=info,snownet=info,str0m=info,firezone_tunnel=info,warn"
+          "firezone_tunnel=info,connlib_shared=info,phoenix_channel=info,connlib_client_shared=info,boringtun=info,snownet=info,str0m=info,warn"
       )
     #endif
   }()


### PR DESCRIPTION
Discovered that tracing doesn't respect the `connlib_client_apple` log filter, which makes it a bit confusing when logging debug in the Apple FFI module.

Removing to prevent further casualties.

Extracted out of #4133 