### PR TITLE
refactor(apple): Remove Client-side retry logic in favor of letting the error take effect

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/TunnelShutdownEvent.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/TunnelShutdownEvent.swift
@@ -20,8 +20,6 @@ public struct TunnelShutdownEvent: Codable, CustomStringConvertible {
     case connlibDisconnected
     case badTunnelConfiguration
     case tokenNotFound
-    case networkSettingsApplyFailure
-    case invalidAdapterState
 
     public var description: String {
       switch self {
@@ -30,8 +28,6 @@ public struct TunnelShutdownEvent: Codable, CustomStringConvertible {
       case .connlibDisconnected: return "connlib disconnected"
       case .badTunnelConfiguration: return "bad tunnel configuration"
       case .tokenNotFound: return "token not found"
-      case .networkSettingsApplyFailure: return "network settings apply failure"
-      case .invalidAdapterState: return "invalid adapter state"
       }
     }
 
@@ -40,13 +36,9 @@ public struct TunnelShutdownEvent: Codable, CustomStringConvertible {
       case .stopped(let reason):
         if reason == .userInitiated {
           return .signoutImmediatelySilently
-        } else if reason == .userLogout || reason == .userSwitch {
-          return .doNothing
         } else {
-          return .retryThenSignout
+          return .doNothing
         }
-      case .networkSettingsApplyFailure, .invalidAdapterState:
-        return .retryThenSignout
       case .connlibConnectFailure, .connlibDisconnected,
         .badTunnelConfiguration, .tokenNotFound:
         return .signoutImmediately
@@ -58,7 +50,6 @@ public struct TunnelShutdownEvent: Codable, CustomStringConvertible {
     case doNothing
     case signoutImmediately
     case signoutImmediatelySilently
-    case retryThenSignout
   }
 
   public let reason: TunnelShutdownEvent.Reason

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -129,9 +129,7 @@ class Adapter {
 
       self.logger.log("Adapter.start")
       guard case .stoppedTunnel = self.state else {
-        packetTunnelProvider?.handleTunnelShutdown(
-          dueTo: .invalidAdapterState,
-          errorMessage: "Adapter is in invalid state")
+        logger.error("\(#function): Invalid Adapter state")
         completionHandler(.invalidState)
         return
       }
@@ -433,9 +431,7 @@ extension Adapter: CallbackHandlerDelegate {
       networkSettings.setMatchDomains([""])
       networkSettings.apply(on: packetTunnelProvider, logger: self.logger) { error in
         if let error = error {
-          self.packetTunnelProvider?.handleTunnelShutdown(
-            dueTo: .networkSettingsApplyFailure,
-            errorMessage: error.localizedDescription)
+          self.logger.error("\(#function): \(error)")
           onStarted?(AdapterError.setNetworkSettings(error))
           self.state = .stoppedTunnel
         } else {


### PR DESCRIPTION
Currently we retry starting the tunnel based on why it disconnected. This has happened for example if the stored token is invalid and we don't clear it, causing a connect -> disconnect loop that causes the UI to glitch every second.

Instead, we just let it fail, and log the error, or maybe even crash. This PR makes that more noisy so (1) we know about it, and (2) the app enters a valid state (signed out) more quickly.

Fixes #4138 