### PR TITLE
chore(deps): Link a Package.swift where dependabot expects to find it

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.swift
+++ b/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.swift
@@ -1,0 +1,1 @@
+../../../../FirezoneKit/Package.swift

--- a/swift/apple/FirezoneKit/Package.resolved
+++ b/swift/apple/FirezoneKit/Package.resolved
@@ -1,1 +1,0 @@
-../Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved


### PR DESCRIPTION
Looks like dependabot is expecting it in the same dir as the lockfile.