### PR TITLE
chore(deps): Dependabot fails at Swift, so let it try its best

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.swift
+++ b/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.swift
@@ -1,1 +1,0 @@
-../../../../FirezoneKit/Package.swift


### PR DESCRIPTION
Dependabot doesn't seem to consider the `Package.resolved` lockfile for updates, only Package.swift.

Dependabot security updates however flag us for outdated dependencies in `Package.resolved`.

There doesn't seem to be a good workaround, so revert back to previous behavior and update Package.resolved via Xcode until support gets better.