### PR TITLE
ci: add timeout to cache download from GitHub

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -40,6 +40,9 @@ runs:
         save-if: ${{ github.ref_name == 'main' }}
         key: ${{ runner.os }}-${{ inputs.targets }}
         workspaces: ./rust
+      # Download from GitHub actions can sometimes fail and it has a very long default timeout.
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
     # Common to either cache backend
     - name: Extract Rust version


### PR DESCRIPTION
GitHub actions cache download sometimes gets stuck. See https://github.com/firezone/firezone/actions/runs/8335503938/job/22811115560. In my experience with `rust-libp2p`, this can be fixed using an explicit timeout.

See https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cache-segment-restore-timeout.