### PR TITLE
build(gui-client): disable AppImage bundling

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -34,7 +34,6 @@ jobs:
             upload-script: ../../scripts/build/tauri-upload-ubuntu.sh
             artifacts: |
               rust/gui-client/firezone-linux-gui-client-amd64
-              rust/gui-client/firezone-linux-gui-client_amd64.AppImage
               rust/gui-client/firezone-linux-gui-client_amd64.deb
           - runs-on: windows-2019
             binary-dest-path: firezone-windows-client

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -38,9 +38,8 @@ going on under the hood.
 pnpm build
 
 # Linux:
-# The release exe, AppImage with bundled WebView, and deb package are up in the workspace.
+# The release exe and deb package are up in the workspace.
 stat ../target/release/firezone
-stat ../target/release/bundle/appimage/*.AppImage
 stat ../target/release/bundle/deb/*.deb
 
 # Windows:

--- a/rust/gui-client/src-tauri/src/client/updates.rs
+++ b/rust/gui-client/src-tauri/src/client/updates.rs
@@ -65,11 +65,11 @@ const LATEST_RELEASE_API_URL: &str =
 /// <https://docs.github.com/en/rest/about-the-rest-api/api-versions?apiVersion=2022-11-28>
 const GITHUB_API_VERSION: &str = "2022-11-28";
 
-/// The name of the Windows MSI / Linux AppImage or deb asset.
+/// The name of the Windows MSI / Linux deb asset.
 ///
 /// These ultimately come from `cd.yml`, `git grep WCPYPXZF`
 #[cfg(target_os = "linux")]
-const ASSET_NAME: &str = "firezone-linux-gui-client_amd64.AppImage";
+const ASSET_NAME: &str = "firezone-linux-gui-client_amd64.deb";
 
 /// Unused - The Tauri client is not supported for macOS
 #[cfg(target_os = "macos")]
@@ -177,7 +177,7 @@ mod tests {
                 "url": "https://api.github.com/repos/firezone/firezone/releases/assets/147443613",
                 "id": 147443613,
                 "node_id": "RA_kwDOD12Hpc4Iyc-c",
-                "name": "firezone-linux-gui-client_amd64.AppImage",
+                "name": "firezone-linux-gui-client_amd64.deb",
                 "label": "",
                 "uploader": {
                     "login": "github-actions[bot]",
@@ -205,7 +205,7 @@ mod tests {
                 "download_count": 10,
                 "created_at": "2024-01-24T04:33:53Z",
                 "updated_at": "2024-01-24T04:33:53Z",
-                "browser_download_url": "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/firezone-linux-gui-client_amd64.AppImage"
+                "browser_download_url": "https://github.com/firezone/firezone/releases/download/1.0.0-pre.8/firezone-linux-gui-client_amd64.deb"
             },
             {
                 "url": "https://api.github.com/repos/firezone/firezone/releases/assets/147443612",

--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
     },
     "bundle": {
       "active": true,
-      "targets": ["appimage", "deb", "msi"],
+      "targets": ["deb", "msi"],
       "identifier": "dev.firezone.client",
       "icon": [
         "icons/32x32.png",

--- a/scripts/build/tauri-rename-ubuntu.sh
+++ b/scripts/build/tauri-rename-ubuntu.sh
@@ -2,13 +2,12 @@
 set -euo pipefail
 
 # For debugging
-ls ../target/release ../target/release/bundle/appimage ../target/release/bundle/deb
+ls ../target/release ../target/release/bundle/deb
 
 # Used for release artifact
 # In release mode the name comes from tauri.conf.json
-# Using a glob for the source, there will only be one exe, AppImage, and deb anyway
+# Using a glob for the source, there will only be one exe and one deb anyway
 cp ../target/release/firezone "$BINARY_DEST_PATH"-amd64
-cp ../target/release/bundle/appimage/*_amd64.AppImage "$BINARY_DEST_PATH"_amd64.AppImage
 cp ../target/release/bundle/deb/*_amd64.deb "$BINARY_DEST_PATH"_amd64.deb
 # TODO: Debug symbols for Linux
 
@@ -21,5 +20,4 @@ function make_hash() {
 # Debian calls it "amd64". Rust and Linux call it "x86_64". So whatever, it's
 # amd64 here. They're all the same.
 make_hash "$BINARY_DEST_PATH"-amd64
-make_hash "$BINARY_DEST_PATH"_amd64.AppImage
 make_hash "$BINARY_DEST_PATH"_amd64.deb

--- a/scripts/build/tauri-upload-ubuntu.sh
+++ b/scripts/build/tauri-upload-ubuntu.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 
 # This artifact name is tied to the update checker in `gui-client/src-tauri/src/client/updates.rs`
 gh release upload "$TAG_NAME" \
-    "$BINARY_DEST_PATH"_amd64.AppImage \
-    "$BINARY_DEST_PATH"_amd64.AppImage.sha256sum.txt \
     "$BINARY_DEST_PATH"_amd64.deb \
     "$BINARY_DEST_PATH"_amd64.deb.sha256sum.txt \
     --clobber \


### PR DESCRIPTION
AppImages won't work with process splitting. (#3713)

As far as I can tell, they just produce one binary. Internally they use FUSE or something to mount a squashfs image, but that image won't be able to hook into systemd and run with root permissions and everything. I don't think it's practical, and Tauri's AppImage bundling doesn't have the features for it.

Even their deb bundler doesn't have any way to specify a path for a daemon to be installed. The sidecar feature only seems intended for the GUI app to call, not anything else on the system.

(There is such a thing as installing AppImages, but I don't think it's worth pursuing - We should just do debs)