### PR TITLE
refactor(windows): fix cancellation-safety when listening for network events

### DIFF
--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ tauri = { version = "1.6", features = [ "dialog", "shell-open-api", "system-tray
 tauri-runtime = "0.14.2"
 tauri-utils = "1.5.3"
 thiserror = { version = "1.0", default-features = false }
-tokio = { version = "1.36.0", features = ["time"] }
+tokio = { version = "1.36.0", features = ["signal", "time"] }
 tracing = { workspace = true }
 tracing-log = "0.2"
 tracing-panic = "0.1.1"

--- a/rust/gui-client/src-tauri/src/client/network_changes/windows.rs
+++ b/rust/gui-client/src-tauri/src/client/network_changes/windows.rs
@@ -107,7 +107,7 @@ pub(crate) fn run_debug() -> Result<()> {
 
     rt.block_on(async move {
         loop {
-            tokio::select!{
+            tokio::select! {
                 _r = tokio::signal::ctrl_c() => break,
                 () = com_worker.notified() => {},
             };
@@ -351,9 +351,7 @@ impl<'a> Listener<'a> {
             _com: com,
         };
 
-        let cb = Callback {
-            tx: tx.clone(),
-        };
+        let cb = Callback { tx: tx.clone() };
 
         let callbacks: INetworkEvents = cb.into();
 


### PR DESCRIPTION
Not sure if this is a fix or a refactor.

Closes #4226 