### PR TITLE
chore(gui-client): set `author` key in the Cargo.toml manifest

### DIFF
--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -5,6 +5,7 @@ version = "1.0.0"
 description = "Firezone"
 edition = "2021"
 default-run = "firezone-gui-client"
+authors = ["Firezone, Inc."]
 
 [build-dependencies]
 anyhow = { version = "1.0" }


### PR DESCRIPTION
This fixes a warning about the `Maintainer` field in the deb being empty, when you install it