### PR TITLE
chore(gui-client): remove unused env var

### DIFF
--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -9,7 +9,6 @@ LOGS_PATH="$HOME/.cache/$BUNDLE_ID/data/logs"
 DUMP_PATH="$LOGS_PATH/last_crash.dmp"
 SETTINGS_PATH="$HOME/.config/$BUNDLE_ID/config/advanced_settings.json"
 
-export FIREZONE_DISABLE_SYSTRAY=true
 PACKAGE=firezone-gui-client
 export RUST_LOG=firezone_gui_client=debug,warn
 export WEBKIT_DISABLE_COMPOSITING_MODE=1


### PR DESCRIPTION
Must have been a hack to run the smoke test in CI, and was never actually hooked up.