### PR TITLE
feat(snownet): minimize delay when roaming

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2926,7 +2926,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.10",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5804,7 +5804,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.4.1"
-source = "git+https://github.com/firezone/str0m?branch=main#5da11ebbceee63997ab6b34d089f107e78d575b3"
+source = "git+https://github.com/firezone/str0m?branch=main#ffb4e4f54936c9745cb2a884be05ba4265af41dc"
 dependencies = [
  "combine",
  "crc",

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -756,8 +756,9 @@ fn update_candidate(
 ) {
     match (maybe_new, &maybe_current) {
         (Some(new), Some(current)) if &new != current => {
-            *maybe_current = Some(new.clone());
-            events.push_back(CandidateEvent::New(new));
+            events.push_back(CandidateEvent::New(new.clone()));
+            events.push_back(CandidateEvent::Invalid(current.clone()));
+            *maybe_current = Some(new);
         }
         (Some(new), None) => {
             *maybe_current = Some(new.clone());

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -731,6 +731,7 @@ where
 
         let mut agent = IceAgent::new();
         agent.set_controlling(true);
+        agent.set_max_candidate_pairs(300);
 
         let session_key = Secret::new(random());
         let ice_creds = agent.local_credentials();


### PR DESCRIPTION
Currently, we need to wait for the timeout of the current candidate pair during `reconnect` before we nominate a new one. To speed this up, we can preemptively invalidate candidates we have previously discovered via our `Allocation`s, i.e. relay candidates and srflx candidates.