### PR TITLE
ci(windows): publish Windows Client MSI

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -106,6 +106,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          TAG_NAME: ${{ needs.update-release-draft.outputs.tag_name }}
+          TAG_NAME: ${{ inputs.release_tag || env.VERSION }}
         shell: bash
         run: ${{ matrix.upload_script }}


### PR DESCRIPTION
I think this was just a small regression from the big CI refactor last week. `update-release-draft` doesn't exist in this file anymore.

Closes #4248 