### PR TITLE
ci(tauri): fix typo

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -108,4 +108,4 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           TAG_NAME: ${{ inputs.release_tag || env.VERSION }}
         shell: bash
-        run: ${{ matrix.upload_script }}
+        run: ${{ matrix.upload-script }}


### PR DESCRIPTION
You know what I want, when I'm waiting 15-60 minutes on a CI job?

I want a stringly-typed language

I want the compiler to do

as

little

work

as

possible

If there even _is_ a compile step. Cause I love waiting and squinting at underscores.