### PR TITLE
ci(gui-client): hide the Linux GUI deb since it's not ready yet

### DIFF
--- a/scripts/build/tauri-upload-ubuntu.sh
+++ b/scripts/build/tauri-upload-ubuntu.sh
@@ -3,8 +3,10 @@
 set -euo pipefail
 
 # This artifact name is tied to the update checker in `gui-client/src-tauri/src/client/updates.rs`
-gh release upload "$TAG_NAME" \
-    "$BINARY_DEST_PATH"_amd64.deb \
-    "$BINARY_DEST_PATH"_amd64.deb.sha256sum.txt \
-    --clobber \
-    --repo "$REPOSITORY"
+# Before publishing the deb re-check this checklist: <https://github.com/firezone/firezone/issues/3884>
+
+#gh release upload "$TAG_NAME" \
+#    "$BINARY_DEST_PATH"_amd64.deb \
+#    "$BINARY_DEST_PATH"_amd64.deb.sha256sum.txt \
+#    --clobber \
+#    --repo "$REPOSITORY"

--- a/scripts/build/tauri-upload-windows.sh
+++ b/scripts/build/tauri-upload-windows.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 # This artifact name is tied to the update checker in `gui-client/src-tauri/src/client/updates.rs`
+# So we can't put the version number in it until we stop using Github for update checks.
 gh release upload "$TAG_NAME" \
     "$BINARY_DEST_PATH"-x64.msi \
     "$BINARY_DEST_PATH"-x64.msi.sha256sum.txt \


### PR DESCRIPTION
It's still in the CI artifacts for easy testing, but there's no point letting users see it since it's in the middle of the process split re-architect