### PR TITLE
refactor(connlib): implement new FFI guidelines

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -470,7 +470,7 @@ pub struct SessionWrapper {
 }
 
 impl SessionWrapper {
-    fn reconnect(&self, env: &mut JNIEnv) -> Result<(), CallbackError> {
+    fn reconnect(&self) -> Result<(), CallbackError> {
         let sockets = Sockets::new()?;
 
         if let Some(ip4_socket) = sockets.ip4_socket_fd() {
@@ -532,7 +532,7 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_re
     _: JClass,
     session: *const SessionWrapper,
 ) {
-    if let Err(e) = (*session).reconnect(&mut env) {
+    if let Err(e) = (*session).reconnect() {
         throw(&mut env, "java/lang/Exception", e.to_string());
     }
 }

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -3,6 +3,7 @@
 
 use connlib_client_shared::{
     file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error, LoginUrl, ResourceDescription, Session,
+    Sockets,
 };
 use secrecy::SecretString;
 use std::{
@@ -204,6 +205,7 @@ impl WrappedSession {
 
         let session = Session::connect(
             login,
+            Sockets::new().map_err(|err| err.to_string())?,
             private_key,
             os_version_override,
             CallbackHandler {

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -10,7 +10,7 @@ use connlib_shared::{
     messages::{ConnectionAccepted, GatewayResponse, ResourceAccepted, ResourceId},
     Callbacks,
 };
-use firezone_tunnel::ClientTunnel;
+use firezone_tunnel::{ClientTunnel, Sockets};
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
 use std::{
     collections::HashMap,
@@ -37,7 +37,7 @@ pub struct Eventloop<C: Callbacks> {
 /// Commands that can be sent to the [`Eventloop`].
 pub enum Command {
     Stop,
-    Reconnect,
+    Reconnect(Sockets),
     SetDns(Vec<IpAddr>),
 }
 
@@ -71,9 +71,9 @@ where
                         tracing::warn!("Failed to update DNS: {e}");
                     }
                 }
-                Poll::Ready(Some(Command::Reconnect)) => {
+                Poll::Ready(Some(Command::Reconnect(sockets))) => {
                     self.portal.reconnect();
-                    self.tunnel.reconnect();
+                    self.tunnel.reconnect(sockets);
 
                     continue;
                 }

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -18,7 +18,7 @@ use std::{
     net::IpAddr,
     path::PathBuf,
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::Duration,
 };
 use tokio::time::{Interval, MissedTickBehavior};
 use url::Url;
@@ -66,7 +66,11 @@ where
         loop {
             match self.rx.poll_recv(cx) {
                 Poll::Ready(Some(Command::Stop)) | Poll::Ready(None) => return Poll::Ready(Ok(())),
-                Poll::Ready(Some(Command::SetDns(dns))) => self.tunnel.set_dns(dns, Instant::now()),
+                Poll::Ready(Some(Command::SetDns(dns))) => {
+                    if let Err(e) = self.tunnel.set_dns(dns) {
+                        tracing::warn!("Failed to update DNS: {e}");
+                    }
+                }
                 Poll::Ready(Some(Command::Reconnect)) => {
                     self.portal.reconnect();
                     self.tunnel.reconnect();

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -73,8 +73,8 @@ impl Session {
     ///
     /// In case of destructive network state changes, i.e. the user switched from wifi to cellular,
     /// reconnect allows connlib to re-establish connections faster because we don't have to wait for timeouts first.
-    pub fn reconnect(&self) {
-        let _ = self.channel.send(Command::Reconnect);
+    pub fn reconnect(&self, sockets: Sockets) {
+        let _ = self.channel.send(Command::Reconnect(sockets));
     }
 
     pub fn set_dns(&self, new_dns: Vec<IpAddr>) {

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -73,10 +73,6 @@ pub trait Callbacks: Clone + Send + Sync {
         std::process::exit(0);
     }
 
-    /// Protects the socket file descriptor from routing loops.
-    #[cfg(target_os = "android")]
-    fn protect_file_descriptor(&self, file_descriptor: std::os::fd::RawFd);
-
     fn roll_log_file(&self) -> Option<PathBuf> {
         None
     }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -115,6 +115,10 @@ impl Io {
         &self.sockets
     }
 
+    pub(crate) fn set_sockets(&mut self, sockets: Sockets) {
+        self.sockets = sockets;
+    }
+
     pub fn set_upstream_dns_servers(
         &mut self,
         dns_servers: impl IntoIterator<Item = (IpAddr, DnsServer)>,

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -43,17 +43,17 @@ pub enum Input<'a, I> {
 }
 
 impl Io {
-    pub fn new() -> io::Result<Self> {
-        Ok(Self {
+    pub fn new(sockets: Sockets) -> Self {
+        Self {
             device: Device::new(),
             timeout: None,
-            sockets: Sockets::new()?,
+            sockets,
             upstream_dns_servers: HashMap::default(),
             forwarded_dns_queries: FuturesTupleSet::new(
                 Duration::from_secs(60),
                 DNS_QUERIES_QUEUE_SIZE,
             ),
-        })
+        }
     }
 
     pub fn poll<'b>(

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -76,23 +76,8 @@ where
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Result<ClientEvent>> {
         loop {
-            match self.role_state.poll_event() {
-                Some(client::Event::SignalIceCandidate { conn_id, candidate }) => {
-                    return Poll::Ready(Ok(ClientEvent::SignalIceCandidate { conn_id, candidate }))
-                }
-                Some(client::Event::ConnectionIntent {
-                    resource,
-                    connected_gateway_ids,
-                }) => {
-                    return Poll::Ready(Ok(ClientEvent::ConnectionIntent {
-                        resource,
-                        connected_gateway_ids,
-                    }))
-                }
-                Some(client::Event::RefreshResources { connections }) => {
-                    return Poll::Ready(Ok(ClientEvent::RefreshResources { connections }))
-                }
-                None => {}
+            if let Some(e) = self.role_state.poll_event() {
+                return Poll::Ready(Ok(e));
             }
 
             if let Some(packet) = self.role_state.poll_packets() {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
 
 pub use client::{ClientState, Request};
 pub use gateway::GatewayState;
+use sockets::Sockets;
 
 mod client;
 mod device_channel;
@@ -223,20 +224,20 @@ fn new_io<CB>(callbacks: &CB) -> Result<Io>
 where
     CB: Callbacks,
 {
-    let io = Io::new()?;
+    let sockets = Sockets::new()?;
 
     // TODO: Eventually, this should move into the `connlib-client-android` crate.
     #[cfg(target_os = "android")]
     {
-        if let Some(ip4_socket) = io.sockets_ref().ip4_socket_fd() {
+        if let Some(ip4_socket) = sockets.ip4_socket_fd() {
             callbacks.protect_file_descriptor(ip4_socket);
         }
-        if let Some(ip6_socket) = io.sockets_ref().ip6_socket_fd() {
+        if let Some(ip6_socket) = sockets.ip6_socket_fd() {
             callbacks.protect_file_descriptor(ip6_socket);
         }
     }
 
-    Ok(io)
+    Ok(Io::new(sockets))
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -77,10 +77,6 @@ where
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Result<ClientEvent>> {
         loop {
             match self.role_state.poll_event() {
-                Some(client::Event::RefreshInterface) => {
-                    self.update_interface()?;
-                    continue;
-                }
                 Some(client::Event::SignalIceCandidate { conn_id, candidate }) => {
                     return Poll::Ready(Ok(ClientEvent::SignalIceCandidate { conn_id, candidate }))
                 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -71,8 +71,9 @@ where
         }
     }
 
-    pub fn reconnect(&mut self) {
+    pub fn reconnect(&mut self, sockets: Sockets) {
         self.role_state.reconnect(Instant::now());
+        self.io.set_sockets(sockets);
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Result<ClientEvent>> {

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -52,14 +52,12 @@ impl Sockets {
         }
     }
 
-    #[cfg(target_os = "android")]
     pub fn ip4_socket_fd(&self) -> Option<std::os::fd::RawFd> {
         use std::os::fd::AsRawFd;
 
         self.socket_v4.as_ref().map(|s| s.socket.as_raw_fd())
     }
 
-    #[cfg(target_os = "android")]
     pub fn ip6_socket_fd(&self) -> Option<std::os::fd::RawFd> {
         use std::os::fd::AsRawFd;
 

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -52,12 +52,14 @@ impl Sockets {
         }
     }
 
+    #[cfg(unix)]
     pub fn ip4_socket_fd(&self) -> Option<std::os::fd::RawFd> {
         use std::os::fd::AsRawFd;
 
         self.socket_v4.as_ref().map(|s| s.socket.as_raw_fd())
     }
 
+    #[cfg(unix)]
     pub fn ip6_socket_fd(&self) -> Option<std::os::fd::RawFd> {
         use std::os::fd::AsRawFd;
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -5,7 +5,7 @@ use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use connlib_shared::{get_user_agent, keypair, Callbacks, LoginUrl, StaticSecret};
 use firezone_cli_utils::{setup_global_subscriber, CommonArgs};
-use firezone_tunnel::GatewayTunnel;
+use firezone_tunnel::{GatewayTunnel, Sockets};
 use futures::{future, TryFutureExt};
 use secrecy::{Secret, SecretString};
 use std::convert::Infallible;
@@ -91,7 +91,7 @@ async fn get_firezone_id(env_id: Option<String>) -> Result<String> {
 }
 
 async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
-    let mut tunnel = GatewayTunnel::new(private_key, CallbackHandler)?;
+    let mut tunnel = GatewayTunnel::new(private_key, Sockets::new()?, CallbackHandler);
 
     let (portal, init) = phoenix_channel::init::<_, InitGateway, _, _>(
         Secret::new(login),

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -10,7 +10,7 @@ use crate::client::{
 };
 use anyhow::{bail, Context, Result};
 use arc_swap::ArcSwap;
-use connlib_client_shared::{file_logger, ResourceDescription};
+use connlib_client_shared::{file_logger, ResourceDescription, Sockets};
 use connlib_shared::{keypair, messages::ResourceId, LoginUrl, BUNDLE_ID};
 use secrecy::{ExposeSecret, SecretString};
 use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
@@ -534,6 +534,7 @@ impl Controller {
         )?;
         let connlib = connlib_client_shared::Session::connect(
             login,
+            Sockets::new()?,
             private_key,
             None,
             callback_handler.clone(),

--- a/rust/linux-client/src/main.rs
+++ b/rust/linux-client/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use connlib_client_shared::{file_logger, Callbacks, Session};
+use connlib_client_shared::{file_logger, Callbacks, Session, Sockets};
 use connlib_shared::{
     keypair,
     linux::{etc_resolv_conf, get_dns_control_from_env, DnsControlMethod},
@@ -38,6 +38,7 @@ async fn main() -> Result<()> {
 
     let session = Session::connect(
         login,
+        Sockets::new()?,
         private_key,
         None,
         callbacks.clone(),

--- a/rust/linux-client/src/main.rs
+++ b/rust/linux-client/src/main.rs
@@ -56,19 +56,19 @@ async fn main() -> Result<()> {
         if sigint.poll_recv(cx).is_ready() {
             tracing::debug!("Received SIGINT");
 
-            return Poll::Ready(());
+            return Poll::Ready(std::io::Result::Ok(()));
         }
 
         if sighup.poll_recv(cx).is_ready() {
             tracing::debug!("Received SIGHUP");
 
-            session.reconnect();
+            session.reconnect(Sockets::new()?);
             continue;
         }
 
         return Poll::Pending;
     })
-    .await;
+    .await?;
 
     session.disconnect();
 


### PR DESCRIPTION
This updates connlib to follow the new guidelines described in #4262. I only made the bare-minimum changes to the clients. With these changes `reconnect` should only be called when the network interface actually changed, meaning clients have to be updated to reflect that.