### PR TITLE
refactor(snownet): only send relay candidates if hole-punching fails

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -444,12 +444,15 @@ where
     #[allow(clippy::too_many_arguments)]
     fn init_connection(
         &mut self,
+        id: TId,
         mut agent: IceAgent,
         remote: PublicKey,
         key: [u8; 32],
         intent_sent_at: Instant,
         now: Instant,
     ) -> Connection {
+        self.seed_agent_with_local_candidates(id, &mut agent);
+
         agent.handle_timeout(now);
 
         /// We set a Wireguard keep-alive to ensure the WG session doesn't timeout on an idle connection.
@@ -756,9 +759,8 @@ where
             pass: answer.credentials.password,
         });
 
-        self.seed_agent_with_local_candidates(id, &mut agent);
-
         let connection = self.init_connection(
+            id,
             agent,
             remote,
             *initial.session_key.expose_secret(),
@@ -819,9 +821,8 @@ where
             },
         };
 
-        self.seed_agent_with_local_candidates(id, &mut agent);
-
         let connection = self.init_connection(
+            id,
             agent,
             remote,
             *offer.session_key.expose_secret(),

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -888,24 +888,17 @@ where
     }
 
     fn seed_agent_with_local_candidates(&mut self, connection: TId, agent: &mut IceAgent) {
-        for candidate in self
+        let binding_candidates = self
             .bindings
             .values()
-            .filter_map(|binding| binding.candidate())
-        {
-            add_local_candidate(
-                connection,
-                agent,
-                candidate.clone(),
-                &mut self.pending_events,
-            );
-        }
+            .flat_map(|binding| binding.candidate());
 
-        for candidate in self
+        let allocation_candidates = self
             .allocations
             .values()
-            .flat_map(|allocation| allocation.current_candidates())
-        {
+            .flat_map(|allocation| allocation.current_candidates());
+
+        for candidate in binding_candidates.chain(allocation_candidates) {
             add_local_candidate(
                 connection,
                 agent,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1017,16 +1017,12 @@ fn add_local_candidate_to_all<TId>(
 ) where
     TId: Copy + fmt::Display,
 {
-    let initial_connections = connections
-        .initial
-        .iter_mut()
-        .map(|(id, c)| (*id, &mut c.agent));
     let established_connections = connections
         .established
         .iter_mut()
         .map(|(id, c)| (*id, &mut c.agent));
 
-    for (id, agent) in initial_connections.chain(established_connections) {
+    for (id, agent) in established_connections {
         let _span = info_span!("connection", %id).entered();
 
         add_local_candidate(id, agent, candidate.clone(), pending_events);

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1236,7 +1236,7 @@ impl Connection {
                 continue;
             }
 
-            add_local_candidate(id, &mut self.agent, candidate.clone(), pending_events)
+            add_local_candidate(id, &mut self.agent, candidate, pending_events)
         }
     }
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -451,6 +451,10 @@ where
         intent_sent_at: Instant,
         now: Instant,
     ) -> Connection {
+        for candidate in self.host_candidates.iter().cloned() {
+            add_local_candidate(id, &mut agent, candidate, &mut self.pending_events);
+        }
+
         self.seed_agent_with_local_candidates(id, &mut agent);
 
         agent.handle_timeout(now);
@@ -884,10 +888,6 @@ where
     }
 
     fn seed_agent_with_local_candidates(&mut self, connection: TId, agent: &mut IceAgent) {
-        for candidate in self.host_candidates.iter().cloned() {
-            add_local_candidate(connection, agent, candidate, &mut self.pending_events);
-        }
-
         for candidate in self
             .bindings
             .values()

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1376,6 +1376,8 @@ impl Connection {
                     source,
                     ..
                 } => {
+                    self.fallback_relay_candidates.clear();
+
                     let candidate = self
                         .local_candidate(source)
                         .expect("to only nominate existing candidates");


### PR DESCRIPTION
Previously, we used to send all candidates as soon as we discover them. Whilst that may appear great for initial connectivity, it is fairly wasteful on both ends of the connection. In almost all cases, we are able to hole-punch a connection making the exchange of most candidates and the resulting binding of channels completely unnecessary.

To achieve this, we wait for 2 seconds before signaling relay candidates to the other party. In case we nominate a socket within those two seconds, we discard all those relay candidates because they are unnecessary.

Resolves: #4164.