### PR TITLE
chore(android): prevent from calling setDns and reconnect redundantly

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
@@ -2,16 +2,30 @@
 import android.net.ConnectivityManager
 import android.net.LinkProperties
 import android.net.Network
+import android.util.Log
 import com.google.gson.Gson
 import dev.firezone.android.tunnel.ConnlibSession
+import java.net.InetAddress
 
 class NetworkMonitor(private val connlibSessionPtr: Long) : ConnectivityManager.NetworkCallback() {
+    private var lastNetwork: Network? = null
+    private var lastDns: List<InetAddress>? = null
+
     override fun onLinkPropertiesChanged(
         network: Network,
         linkProperties: LinkProperties,
     ) {
-        ConnlibSession.setDns(connlibSessionPtr, Gson().toJson(linkProperties.dnsServers))
-        ConnlibSession.reconnect(connlibSessionPtr)
+        Log.d("NetworkMonitor", "OnLinkPropertiesChanged: $network: $linkProperties")
+
+        if (lastDns != linkProperties.dnsServers) {
+            lastDns = linkProperties.dnsServers
+            ConnlibSession.setDns(connlibSessionPtr, Gson().toJson(linkProperties.dnsServers))
+        }
+
+        if (lastNetwork != network) {
+            lastNetwork = network
+            ConnlibSession.reconnect(connlibSessionPtr)
+        }
         super.onLinkPropertiesChanged(network, linkProperties)
     }
 }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -843,6 +843,7 @@ impl ClientState {
             return;
         }
 
+        tracing::info!("Found new system resolvers: {new_dns:?}");
         self.next_system_resolver_refresh = Some(now + std::time::Duration::from_millis(500));
         self.system_resolvers = new_dns;
     }
@@ -923,6 +924,7 @@ impl ClientState {
     }
 
     pub(crate) fn reconnect(&mut self, now: Instant) {
+        tracing::info!("Network change detected, refreshing connections");
         self.node.reconnect(now)
     }
 


### PR DESCRIPTION
Related to changes in #4263