### PR TITLE
chore(relay): Reduce staging log level to avoid loss of connectivity

### DIFF
--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -52,7 +52,7 @@ module "relays" {
   image      = "relay"
   image_tag  = var.image_tag
 
-  observability_log_level = "debug,firezone_relay=trace,hyper=off,h2=warn,tower=warn,wire=trace"
+  observability_log_level = "debug,firezone_relay=debug,hyper=off,h2=warn,tower=warn,wire=debug"
 
   application_name    = "relay"
   application_version = replace(var.image_tag, ".", "-")


### PR DESCRIPTION
`trace` logs are debilitating to the Relay, as it logs for each seen packet. This reduces the level to `debug` so that the staging Relays are more closely aligned with the `production` ones.

Ideally, `staging` should have the Relay configuration as `production`, perhaps after GA.

```
Accepted connection from 172.17.0.2, port 60804
[  5] local 192.168.1.249 port 5201 connected to 172.17.0.2 port 60805
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec   149 KBytes  1.22 Mbits/sec                  
[  5]   1.00-2.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   2.00-3.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   3.00-4.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   4.00-5.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   5.00-6.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   6.00-7.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   7.00-8.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   8.00-9.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   9.00-10.00  sec  0.00 Bytes  0.00 bits/sec                  
[  5]  10.00-11.00  sec  0.00 Bytes  0.00 bits/sec                  
[  5]  11.00-12.00  sec  0.00 Bytes  0.00 bits/sec                  
[  5]  12.00-13.00  sec  0.00 Bytes  0.00 bits/sec                  
[  5]  13.00-14.00  sec  0.00 Bytes  0.00 bits/sec                  
[  5]  14.00-15.00  sec  0.00 Bytes  0.00 bits/sec                  
[  5]  15.00-16.00  sec  0.00 Bytes  0.00 bits/sec                  
[  5]  16.00-17.00  sec  0.00 Bytes  0.00 bits/sec                  
[  5]  17.00-18.00  sec   271 KBytes  2.22 Mbits/sec                  
[  5]  18.00-19.00  sec   470 KBytes  3.85 Mbits/sec                  
[  5]  19.00-20.00  sec   508 KBytes  4.17 Mbits/sec                  
[  5]  20.00-21.00  sec   584 KBytes  4.78 Mbits/sec                  
[  5]  21.00-22.00  sec   501 KBytes  4.11 Mbits/sec                  
[  5]  22.00-23.00  sec   480 KBytes  3.93 Mbits/sec                  
[  5]  23.00-24.00  sec   535 KBytes  4.38 Mbits/sec                  
[  5]  24.00-25.00  sec   514 KBytes  4.21 Mbits/sec                  
[  5]  25.00-26.00  sec   495 KBytes  4.06 Mbits/sec                  
[  5]  26.00-27.00  sec   518 KBytes  4.24 Mbits/sec                  
[  5]  27.00-28.00  sec   499 KBytes  4.09 Mbits/sec                  
[  5]  28.00-29.00  sec   408 KBytes  3.34 Mbits/sec                  
[  5]  29.00-30.00  sec   490 KBytes  4.02 Mbits/sec                  
[  5]  30.00-30.03  sec  18.0 KBytes  4.99 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-30.03  sec  6.29 MBytes  1.76 Mbits/sec                  receiver
-----------------------------------------------------------
Server listening on 5201
-----------------------------------------------------------
```