### PR TITLE
feat(phoenix-channel): fail on missing heartbeat after 5s

### DIFF
--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -78,7 +78,7 @@ pub struct MissedLastHeartbeat {}
 mod tests {
     use super::*;
     use futures::future::Either;
-    use std::{future::poll_fn, pin::pin, time::Instant};
+    use std::{future::poll_fn, time::Instant};
 
     const INTERVAL: Duration = Duration::from_millis(30);
     const TIMEOUT: Duration = Duration::from_millis(5);

--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -99,6 +99,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ignores_other_ids() {
+        let mut heartbeat = Heartbeat::new(Duration::from_millis(10));
+
+        let _ = poll_fn(|cx| heartbeat.poll(cx)).await;
+        heartbeat.set_id(OutboundRequestId::for_test(1));
+
+        heartbeat.maybe_handle_reply(OutboundRequestId::for_test(2));
+
+        let result = poll_fn(|cx| heartbeat.poll(cx)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn succeeds_if_response_is_provided_inbetween_polls() {
         let mut heartbeat = Heartbeat::new(Duration::from_millis(10));
 

--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -17,16 +17,14 @@ pub struct Heartbeat {
 
 impl Heartbeat {
     pub fn maybe_handle_reply(&mut self, id: OutboundRequestId) -> bool {
-        let Some(pending) = self.id.take() else {
-            return false;
-        };
+        match self.id.as_ref() {
+            Some(pending) if pending == &id => {
+                self.id = None;
 
-        if pending != id {
-            return false;
+                true
+            }
+            _ => false,
         }
-
-        self.id = None;
-        true
     }
 
     pub fn set_id(&mut self, id: OutboundRequestId) {

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -23,6 +23,8 @@ use tokio_tungstenite::{
 };
 
 pub use login_url::{LoginUrl, LoginUrlError};
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
 // TODO: Refactor this PhoenixChannel to be compatible with the needs of the client and gateway
 // See https://github.com/firezone/firezone/issues/2158
@@ -30,7 +32,7 @@ pub struct PhoenixChannel<TInitReq, TInboundMsg, TOutboundRes> {
     state: State,
     waker: Option<Waker>,
     pending_messages: VecDeque<String>,
-    next_request_id: u64,
+    next_request_id: Arc<AtomicU64>,
 
     heartbeat: Heartbeat,
 
@@ -217,6 +219,8 @@ where
         init_req: TInitReq,
         reconnect_backoff: ExponentialBackoff,
     ) -> Self {
+        let next_request_id = Arc::new(AtomicU64::new(0));
+
         Self {
             reconnect_backoff,
             url: url.clone(),
@@ -231,8 +235,8 @@ where
             waker: None,
             pending_messages: Default::default(),
             _phantom: PhantomData,
-            next_request_id: 0,
-            heartbeat: Default::default(),
+            heartbeat: Heartbeat::new(heartbeat::INTERVAL, next_request_id.clone()),
+            next_request_id,
             pending_join_requests: Default::default(),
             login,
             init_req: init_req.clone(),
@@ -448,10 +452,9 @@ where
 
             // Priority 3: Handle heartbeats.
             match self.heartbeat.poll(cx) {
-                Poll::Ready(Ok(msg)) => {
-                    let (id, msg) = self.make_message("phoenix", msg);
-                    self.pending_messages.push_back(msg);
-                    self.heartbeat.set_id(id);
+                Poll::Ready(Ok((id, msg))) => {
+                    self.pending_messages
+                        .push_back(serialize_msg("phoenix", msg, id.copy()));
 
                     return Poll::Ready(Ok(Event::HeartbeatSent));
                 }
@@ -493,19 +496,15 @@ where
         let request_id = self.fetch_add_request_id();
 
         // We don't care about the reply type when serializing
-        let msg = serde_json::to_string(&PhoenixMessage::<_, ()>::new_message(
-            topic,
-            payload,
-            Some(request_id.copy()),
-        ))
-        .expect("we should always be able to serialize a join topic message");
+        let msg = serialize_msg(topic, payload, request_id.copy());
 
         (request_id, msg)
     }
 
     fn fetch_add_request_id(&mut self) -> OutboundRequestId {
-        let next_id = self.next_request_id;
-        self.next_request_id += 1;
+        let next_id = self
+            .next_request_id
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
         OutboundRequestId(next_id)
     }
@@ -684,6 +683,19 @@ fn make_request(url: Secret<LoginUrl>, user_agent: String) -> Request {
 enum EgressControlMessage<T> {
     PhxJoin(T),
     Heartbeat(Empty),
+}
+
+fn serialize_msg(
+    topic: impl Into<String>,
+    payload: impl Serialize,
+    request_id: OutboundRequestId,
+) -> String {
+    serde_json::to_string(&PhoenixMessage::<_, ()>::new_message(
+        topic,
+        payload,
+        Some(request_id),
+    ))
+    .expect("we should always be able to serialize a join topic message")
 }
 
 #[cfg(test)]

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -452,9 +452,12 @@ where
 
             // Priority 3: Handle heartbeats.
             match self.heartbeat.poll(cx) {
-                Poll::Ready(Ok((id, msg))) => {
-                    self.pending_messages
-                        .push_back(serialize_msg("phoenix", msg, id.copy()));
+                Poll::Ready(Ok(id)) => {
+                    self.pending_messages.push_back(serialize_msg(
+                        "phoenix",
+                        EgressControlMessage::<()>::Heartbeat(Empty {}),
+                        id.copy(),
+                    ));
 
                     return Poll::Ready(Ok(Event::HeartbeatSent));
                 }

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -235,7 +235,11 @@ where
             waker: None,
             pending_messages: Default::default(),
             _phantom: PhantomData,
-            heartbeat: Heartbeat::new(heartbeat::INTERVAL, next_request_id.clone()),
+            heartbeat: Heartbeat::new(
+                heartbeat::INTERVAL,
+                heartbeat::TIMEOUT,
+                next_request_id.clone(),
+            ),
             next_request_id,
             pending_join_requests: Default::default(),
             login,


### PR DESCRIPTION
This PR fixes a bug and adds a missing feature to `phoenix-channel`.

1. Previously, we used to erroneously reset the heartbeat state on all sorts of empty replies, not just the specific one from the heartbeat.
2. We only failed on missing heartbeats when it was time to send the next one.

With this PR, we correct the first bug and add a dedicated timeout of 5s for the heartbeat reply.