### PR TITLE
chore(gui-client): fix doc comment

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -1,7 +1,7 @@
 //! The Tauri-based GUI Client for Windows and Linux
 //!
 //! Most of this Client is stubbed out with panics on macOS.
-//! The real macOS Client is in `firezone/swift`
+//! The real macOS Client is in `swift/apple`
 
 // TODO: `git grep` for unwraps before 1.0, especially this gui module <https://github.com/firezone/firezone/issues/3521>
 

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -1,5 +1,7 @@
-//! The Tauri GUI for Windows
-//! This is not checked or compiled on other platforms.
+//! The Tauri-based GUI Client for Windows and Linux
+//!
+//! Most of this Client is stubbed out with panics on macOS.
+//! The real macOS Client is in `firezone/swift`
 
 // TODO: `git grep` for unwraps before 1.0, especially this gui module <https://github.com/firezone/firezone/issues/3521>
 


### PR DESCRIPTION
The Tauri client is for both Windows and Linux, though it's not released on Linux yet.