### PR TITLE
chore: set same eol for all platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # Don't allow Git to mess up line endings, ever
 # https://github.com/actions/checkout/issues/135#issuecomment-613329879
-* -text
+* -text eol=lf


### PR DESCRIPTION
Kotlin's `spottlessApply` uses the EOL in this file, so it messes up all line endings if running it from windows without this change.

I don't see a down-side on standardizing this to something fixed for all platforms and since we're already using LF everywhere I think keeping it seems like the best.