### PR TITLE
chore: set rust log level to info for gateways and client

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -167,20 +167,7 @@ defmodule Web.Sites.NewToken do
       {"FIREZONE_ID", Ecto.UUID.generate()},
       {"FIREZONE_TOKEN", encoded_token},
       api_url_override,
-      {"RUST_LOG",
-       Enum.join(
-         [
-           "firezone_gateway=info",
-           "firezone_tunnel=info",
-           "connlib_shared=info",
-           "tunnel_state=info",
-           "phoenix_channel=info",
-           "str0m=info",
-           "snownet=info",
-           "warn"
-         ],
-         ","
-       )}
+      {"RUST_LOG", "info"}
     ]
     |> Enum.reject(&is_nil/1)
   end

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -175,9 +175,8 @@ defmodule Web.Sites.NewToken do
            "connlib_shared=info",
            "tunnel_state=info",
            "phoenix_channel=info",
-           "boringtun=info",
            "str0m=info",
-           "snownet=debug",
+           "snownet=info",
            "warn"
          ],
          ","

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -127,7 +127,7 @@ android {
                 "String",
                 "LOG_FILTER",
                 "\"connlib_client_android=info,firezone_tunnel=info,phoenix_channel=info,connlib_shared=info," +
-                    "boringtun=info,snownet=info,str0m=info,connlib_client_shared=info,warn\"",
+                    "snownet=info,str0m=info,connlib_client_shared=info,warn\"",
             )
             firebaseAppDistribution {
                 serviceCredentialsFile = System.getenv("FIREBASE_CREDENTIALS_PATH")

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -123,12 +123,7 @@ android {
 
             buildConfigField("String", "AUTH_BASE_URL", "\"https://app.firezone.dev\"")
             buildConfigField("String", "API_URL", "\"wss://api.firezone.dev\"")
-            buildConfigField(
-                "String",
-                "LOG_FILTER",
-                "\"connlib_client_android=info,firezone_tunnel=info,phoenix_channel=info,connlib_shared=info," +
-                    "snownet=info,str0m=info,connlib_client_shared=info,warn\"",
-            )
+            buildConfigField("String", "LOG_FILTER", "\"info\"")
             firebaseAppDistribution {
                 serviceCredentialsFile = System.getenv("FIREBASE_CREDENTIALS_PATH")
                 artifactType = "AAB"

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -118,13 +118,6 @@ pub enum ConnlibError {
     /// Any parse error
     #[error("parse error")]
     ParseError,
-    /// DNS lookup error
-    #[error("Error with the DNS fallback lookup")]
-    DNSFallback(#[from] hickory_resolver::error::ResolveError),
-    #[error("Error with the DNS fallback lookup")]
-    DNSFallbackKind(#[from] hickory_resolver::error::ResolveErrorKind),
-    #[error("DNS proto error")]
-    DnsProtoError(#[from] hickory_resolver::proto::error::ProtoError),
     /// Connection is still being stablished, retry later
     #[error("Pending connection")]
     PendingConnection,

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -118,7 +118,7 @@ pub enum ConnlibError {
     /// Any parse error
     #[error("parse error")]
     ParseError,
-    /// Connection is still being stablished, retry later
+    /// Connection is still being established, retry later
     #[error("Pending connection")]
     PendingConnection,
     #[error(transparent)]

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -828,13 +828,14 @@ impl ClientState {
             .map(|(_, res)| res.id)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn update_system_resolvers(&mut self, new_dns: Vec<IpAddr>) -> bool {
         if !dns_updated(&self.system_resolvers, &new_dns) {
             tracing::debug!("Updated dns called but no change to system's resolver");
             return false;
         }
 
-        tracing::info!("Found new system resolvers: {new_dns:?}");
+        tracing::info!("Found new system resolvers");
         self.system_resolvers = new_dns;
 
         true

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -1,6 +1,5 @@
 use crate::client::DnsResource;
 use crate::ip_packet::{to_dns, IpPacket, MutableIpPacket};
-use connlib_shared::error::ConnlibError;
 use connlib_shared::messages::{DnsServer, ResourceDescriptionDns};
 use connlib_shared::Dname;
 use domain::base::RelativeDname;
@@ -157,7 +156,7 @@ pub(crate) fn create_local_answer<'a>(
 pub(crate) fn build_response_from_resolve_result(
     original_pkt: IpPacket<'_>,
     response: hickory_resolver::error::ResolveResult<Lookup>,
-) -> Result<Option<IpPacket>, ConnlibError> {
+) -> Result<Option<IpPacket>, hickory_resolver::error::ResolveError> {
     let Some(mut message) = as_dns_message(&original_pkt) else {
         debug_assert!(false, "The original message should be a DNS query for us to ever call write_dns_lookup_response");
         return Ok(None);

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -78,8 +78,9 @@ impl Io {
                             self.device.write(packet)?;
                         }
                         Ok(None) => {}
-                        Err(e) => {
-                            tracing::warn!("Failed to build DNS response from lookup result: {e}");
+                        Err(_) => {
+                            // The error might contain sensitive information therefore we ignore it
+                            tracing::warn!("Failed to build DNS response from lookup result");
                         }
                     }
 

--- a/scripts/tests/systemd/firezone-client.service
+++ b/scripts/tests/systemd/firezone-client.service
@@ -8,7 +8,7 @@ Environment="FIREZONE_API_URL=ws://localhost:8081"
 Environment="FIREZONE_DNS_CONTROL=systemd-resolved"
 Environment="FIREZONE_ID=D0455FDE-8F65-4960-A778-B934E4E85A5F"
 Environment="FIREZONE_TOKEN=n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAGUmu74wBYgABUYA.UN3vSLLcAMkHeEh5VHumPOutkuue8JA6wlxM9JxJEPE"
-Environment="RUST_LOG=firezone_linux_client=info,connlib_client_shared=info,firezone_tunnel=info,connlib_shared=info,snownet=info,str0m=info,warn"
+Environment="RUST_LOG=info"
 
 ExecStart=firezone-linux-client
 Type=notify

--- a/scripts/tests/systemd/firezone-client.service
+++ b/scripts/tests/systemd/firezone-client.service
@@ -8,7 +8,7 @@ Environment="FIREZONE_API_URL=ws://localhost:8081"
 Environment="FIREZONE_DNS_CONTROL=systemd-resolved"
 Environment="FIREZONE_ID=D0455FDE-8F65-4960-A778-B934E4E85A5F"
 Environment="FIREZONE_TOKEN=n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAGUmu74wBYgABUYA.UN3vSLLcAMkHeEh5VHumPOutkuue8JA6wlxM9JxJEPE"
-Environment="RUST_LOG=firezone_linux_client=trace,connlib_client_shared=trace,firezone_tunnel=trace,connlib_shared=trace,boringtun=debug,snownet=debug,str0m=info,warn"
+Environment="RUST_LOG=firezone_linux_client=info,connlib_client_shared=info,firezone_tunnel=info,connlib_shared=info,snownet=info,str0m=info,warn"
 
 ExecStart=firezone-linux-client
 Type=notify

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -37,9 +37,8 @@ struct AdvancedSettings: Equatable {
       AdvancedSettings(
         authBaseURLString: "https://app.firezone.dev/",
         apiURLString: "wss://api.firezone.dev/",
-        connlibLogFilterString:
-          "firezone_tunnel=info,connlib_shared=info,phoenix_channel=info,connlib_client_shared=info,snownet=info,str0m=info,warn"
-      )
+        connlibLogFilterString: "info"
+    )
     #endif
   }()
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -38,7 +38,7 @@ struct AdvancedSettings: Equatable {
         authBaseURLString: "https://app.firezone.dev/",
         apiURLString: "wss://api.firezone.dev/",
         connlibLogFilterString:
-          "firezone_tunnel=info,connlib_shared=info,phoenix_channel=info,connlib_client_shared=info,boringtun=info,snownet=info,str0m=info,warn"
+          "firezone_tunnel=info,connlib_shared=info,phoenix_channel=info,connlib_client_shared=info,snownet=info,str0m=info,warn"
       )
     #endif
   }()


### PR DESCRIPTION
- [x] Updated log level string for client and gateways to info or higher
- [x] Update logs to hide DNS information

I also removed `hickory_resolve` errors which could contain sensitive info from our general error and hide the logs that specifically relates to them.

@bmanifold double checking that the log levels in the gateway's `*.tf` files are just used for our own gateways.

Also, the relays still have `debug`, since only we see that I think that makes sense but double checking with @jamilbk 

Fixes: #3618.