### PR TITLE
fix(firezone-tunnel): ignore our own sentinel DNS when updating list of system resolvers

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -67,7 +67,7 @@ where
             match self.rx.poll_recv(cx) {
                 Poll::Ready(Some(Command::Stop)) | Poll::Ready(None) => return Poll::Ready(Ok(())),
                 Poll::Ready(Some(Command::SetDns(dns))) => {
-                    if let Err(e) = self.tunnel.set_dns(dns) {
+                    if let Err(e) = self.tunnel.set_dns(&dns) {
                         tracing::warn!("Failed to update DNS: {e}");
                     }
                 }


### PR DESCRIPTION
Closes #4318.

Maybe this bug caused an issue I saw earlier with DNS timeouts? Could connlib be trying to recurse to itself?

We could also not parse it every time, the string parsing probably costs more than the RAM to store this range somewhere in the Tunnel struct.

I noticed this in the Windows client, which doesn't ignore the sentinels when reporting the resolvers, since the filtering is platform-independent.