### PR TITLE
fix(apple): Don't crash on tunnel save if the configuration has been removed

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -57,7 +57,6 @@
         .receive(on: mainQueue)
         .sink { [weak self] status in
           guard let self = self else { return }
-          self.logger.log("\(#function): status changed: \(status)")
           self.updateStatusItemIcon()
           self.handleTunnelStatusChanged()
           self.handleMenuVisibilityOrStatusChanged()


### PR DESCRIPTION
- Handles an edge case where we would crash if the tunnel configuration was removed in the middle of saving Settings.
- Handles an edge case where our tunnel configuration may have been changed by the system -- if it was disabled, we disconnect.