### PR TITLE
fix(connlib): only update the interface when setting dns if the effective dns changed

### DIFF
--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -297,7 +297,7 @@ pub struct ResourceDescriptionCidr {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
 #[serde(tag = "protocol", rename_all = "snake_case")]
 pub enum DnsServer {
     IpPort(IpDnsServer),
@@ -328,7 +328,7 @@ where
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct IpDnsServer {
     pub address: SocketAddr,
 }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -168,7 +168,7 @@ where
     /// Updates the system's dns
     pub fn set_dns(&mut self, new_dns: Vec<IpAddr>) -> connlib_shared::Result<()> {
         // We store the sentinel dns both in the config and in the system's resolvers
-        // but once calculated the dns mapping those are ignored.
+        // but when we calculate the dns mapping, those are ignored.
         self.role_state.update_system_resolvers(new_dns);
 
         let dns_changed = self.update_dns_mapping();


### PR DESCRIPTION
Supersedes #4320, closes #4318

Updates the interface if effective dns have changed.

Fixes a bug where we could set upstream_dns to have sentinel dns

Adds corresponding unit tests.