### PR TITLE
chore(phoenix-channel): remove stray `dbg`

### DIFF
--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -38,7 +38,7 @@ impl Heartbeat {
 
     pub fn maybe_handle_reply(&mut self, id: OutboundRequestId) -> bool {
         match self.pending.as_ref() {
-            Some((pending, timeout)) if pending == &id && !dbg!(timeout.is_elapsed()) => {
+            Some((pending, timeout)) if pending == &id && !timeout.is_elapsed() => {
                 self.pending = None;
 
                 true


### PR DESCRIPTION
This was introduced in #4296 and I'm guessing it shouldn't be there because we are standardized on `tracing::*` and this goes straight to stderr, can't be filtered out, etc.