### PR TITLE
chore(apple): Fix tunnelStore state bug = .invalid

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/TunnelStore.swift
@@ -101,6 +101,12 @@ public final class TunnelStore: ObservableObject {
       if self.status == .disconnected {
         try await start()
       }
+
+      // If no tunnel configuration was found, update state to
+      // prompt user to create one.
+      if manager == nil {
+        status = .invalid
+      }
     }
   }
 

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -30,7 +30,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       do {
         var token = options?["token"] as? String
         let keychain = Keychain()
-        var tokenRef = await keychain.search()
+        let tokenRef = await keychain.search()
 
         if let token = token {
           // 1. If we're passed a token, save it to keychain
@@ -38,7 +38,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
           // Apple recommends updating Keychain items in place if possible
           // In reality this won't happen unless there's some kind of race condition
           // because we would have deleted the item upon sign out.
-          if let ref = tokenRef {
+          if tokenRef != nil {
             try await keychain.update(token: token)
           } else {
             try await keychain.add(token: token)


### PR DESCRIPTION
Fixes an issue caused by the order of PRs getting merged...


I would prefer keeping the number of PRs lower for Apple until we can get some tests in to prevent semantic/developer bugs.