### PR TITLE
fix(portal): Fix bug in actor edit page preventing updates

### DIFF
--- a/elixir/apps/domain/lib/domain/actors/membership/query.ex
+++ b/elixir/apps/domain/lib/domain/actors/membership/query.ex
@@ -6,6 +6,12 @@ defmodule Domain.Actors.Membership.Query do
     from(memberships in Membership, as: :memberships)
   end
 
+  def only_editable_groups(queryable \\ all()) do
+    queryable
+    |> with_joined_groups()
+    |> where([groups: groups], is_nil(groups.provider_id) and groups.type == :static)
+  end
+
   def by_actor_id(queryable \\ all(), actor_id) do
     where(queryable, [memberships: memberships], memberships.actor_id == ^actor_id)
   end
@@ -40,12 +46,6 @@ defmodule Domain.Actors.Membership.Query do
     queryable
     |> with_joined_groups()
     |> where([groups: groups], groups.provider_id == ^provider_id)
-  end
-
-  def by_not_synced_group(queryable \\ all()) do
-    queryable
-    |> with_joined_groups()
-    |> where([groups: groups], is_nil(groups.provider_id))
   end
 
   def count_actors_by_group_id(queryable \\ all()) do

--- a/elixir/apps/web/lib/web/live/actors/edit.ex
+++ b/elixir/apps/web/lib/web/live/actors/edit.ex
@@ -13,10 +13,7 @@ defmodule Web.Actors.Edit do
            ) do
       # TODO: unify this and dropdowns for filters
       groups =
-        Actors.all_groups!(socket.assigns.subject,
-          preload: [:provider],
-          filter: [editable?: true]
-        )
+        Actors.all_editable_groups!(socket.assigns.subject, preload: [:provider])
 
       changeset = Actors.change_actor(actor)
 

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
@@ -5,10 +5,7 @@ defmodule Web.Actors.ServiceAccounts.New do
 
   def mount(_params, _session, socket) do
     groups =
-      Actors.all_groups!(socket.assigns.subject,
-        preload: :provider,
-        filter: [editable?: true]
-      )
+      Actors.all_editable_groups!(socket.assigns.subject, preload: :provider)
 
     changeset = Actors.new_actor(%{type: :service_account})
 

--- a/elixir/apps/web/lib/web/live/actors/users/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new.ex
@@ -5,10 +5,7 @@ defmodule Web.Actors.Users.New do
 
   def mount(_params, _session, socket) do
     groups =
-      Actors.all_groups!(socket.assigns.subject,
-        preload: :provider,
-        filter: [editable?: true]
-      )
+      Actors.all_editable_groups!(socket.assigns.subject, preload: :provider)
 
     changeset = Actors.new_actor()
 


### PR DESCRIPTION
Why:

* A bug was present in the actor edit page that prevented updating an actor due to managed and synced groups being sent as part of the form submission.  Along with that, if a user manually removed the managed group(s) from the form submission, the actor being edited would be removed from the managed group, which should not be allowed.

* There was also another small bug which prevent an admin actor from being updated at all if they were the only admin in the account.