### PR TITLE
chore(phoenix-channel): reset heartbeat on reconnect

### DIFF
--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -47,6 +47,10 @@ impl Heartbeat {
         }
     }
 
+    pub fn reset(&mut self) {
+        self.pending = None;
+    }
+
     pub fn poll(
         &mut self,
         cx: &mut Context,

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -289,6 +289,7 @@ where
                 State::Connecting(future) => match future.poll_unpin(cx) {
                     Poll::Ready(Ok(stream)) => {
                         self.reconnect_backoff.reset();
+                        self.heartbeat.reset();
                         self.state = State::Connected(stream);
 
                         let host = self.url.expose_secret().host();


### PR DESCRIPTION
Looking through the logs of https://github.com/firezone/firezone/issues/4348, I noticed that we would instantly reconnect to the portal due to a "missed heartbeat" if the connection was reset for any other error. That happens because the timer within `Heartbeat` was still active and would immediately fire was soon as we are connected.

To fix this, we introduce a `reset` method that gets called every time we establish a connection to the portal.