### PR TITLE
refactor: remove `on_tunnel_ready` callback and switch Windows to `on_set_interface_config`

### DIFF
--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -50,11 +50,6 @@ pub trait Callbacks: Clone + Send + Sync {
         None
     }
 
-    /// Called when the tunnel is connected.
-    fn on_tunnel_ready(&self) {
-        tracing::trace!("tunnel_connected");
-    }
-
     /// Called when the route list changes.
     fn on_update_routes(&self, _: Vec<Cidrv4>, _: Vec<Cidrv6>) -> Option<RawFd> {
         None

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -145,8 +145,6 @@ where
             .set_routes(self.role_state.routes().collect(), &self.callbacks)?;
         let name = self.io.device_mut().name().to_owned();
 
-        self.callbacks.on_tunnel_ready();
-
         tracing::debug!(ip4 = %config.ipv4, ip6 = %config.ipv6, %name, "TUN device initialized");
 
         Ok(())

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -121,13 +121,15 @@ impl Device {
         &mut self,
         config: &Interface,
         dns_config: Vec<IpAddr>,
-        _: &impl Callbacks,
+        callbacks: &impl Callbacks,
     ) -> Result<(), ConnlibError> {
         if self.tun.is_none() {
             self.tun = Some(Tun::new()?);
         }
 
         self.tun.as_ref().unwrap().set_config(config, &dns_config)?;
+
+        callbacks.on_set_interface_config(config.ipv4, config.ipv6, dns_config);
 
         if let Some(waker) = self.waker.take() {
             waker.wake();

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -15,7 +15,13 @@ use arc_swap::ArcSwap;
 use connlib_client_shared::{file_logger, ResourceDescription, Sockets};
 use connlib_shared::{keypair, messages::ResourceId, LoginUrl, BUNDLE_ID};
 use secrecy::{ExposeSecret, SecretString};
-use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 use system_tray_menu::Event as TrayMenuEvent;
 use tauri::{Manager, SystemTray, SystemTrayEvent};
 use tokio::sync::{mpsc, oneshot, Notify};
@@ -463,11 +469,12 @@ impl connlib_client_shared::Callbacks for CallbackHandler {
             .expect("controller channel failed");
     }
 
-    fn on_tunnel_ready(&self) {
-        tracing::info!("on_tunnel_ready");
+    fn on_set_interface_config(&self, _: Ipv4Addr, _: Ipv6Addr, _: Vec<IpAddr>) -> Option<i32> {
+        tracing::info!("on_set_interface_config");
         self.ctlr_tx
             .try_send(ControllerRequest::TunnelReady)
             .expect("controller channel failed");
+        None
     }
 
     fn on_update_resources(&self, resources: Vec<ResourceDescription>) {


### PR DESCRIPTION
Closes #4305 

The two callbacks fire within 1 ms of each other so I figure they're basically the same. If it's firing too early I can fix that after GA.