### PR TITLE
refactor(apple): Use AppleArchive not Zipfiles for log export

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -80,15 +80,6 @@
         "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
         "version" : "1.1.1"
       }
-    },
-    {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation.git",
-      "state" : {
-        "revision" : "b979e8b52c7ae7f3f39fa0182e738e9e7257eb78",
-        "version" : "0.9.18"
-      }
     }
   ],
   "version" : 2

--- a/swift/apple/FirezoneKit/Package.swift
+++ b/swift/apple/FirezoneKit/Package.swift
@@ -15,7 +15,6 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "1.0.0"),
-    .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0")),
   ],
   targets: [
     .target(
@@ -24,7 +23,6 @@ let package = Package(
         .product(name: "SwiftUINavigation", package: "swiftui-navigation"),
         .product(name: "SwiftUINavigationCore", package: "swiftui-navigation"),
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "ZIPFoundation", package: "ZIPFoundation"),
       ]
     ),
     .testTarget(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogCompressor.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogCompressor.swift
@@ -1,0 +1,103 @@
+//
+//  LogCompressor.swift
+//
+//
+//  Created by Jamil Bou Kheir on 3/28/24.
+//
+
+import AppleArchive
+import Foundation
+import System
+
+struct LogCompressor {
+  private let logger: AppLogger
+  private let destinationURL: URL?
+  let fileName: String
+
+  init(logger: AppLogger, destinationURL: URL? = nil) {
+    let dateFormatter = ISO8601DateFormatter()
+    dateFormatter.formatOptions = [.withFullDate, .withTime, .withTimeZone]
+    let timeStampString = dateFormatter.string(from: Date())
+    self.fileName = "firezone_logs_\(timeStampString).aar"
+    self.logger = logger
+    self.destinationURL = destinationURL
+  }
+
+  public func compressFolder(destinationURL: URL? = nil) async throws {
+    try await compressFolderReturningURL(destinationURL: destinationURL)
+  }
+
+  @discardableResult
+  public func compressFolderReturningURL(destinationURL: URL? = nil) async throws -> URL? {
+    guard let logFilesFolderURL = SharedAccess.logFolderURL,
+      let logFilesFolderPath = FilePath(logFilesFolderURL)
+    else {
+      throw SettingsViewError.logFolderIsUnavailable
+    }
+
+    let fileManager = FileManager.default
+    let fileURL =
+      destinationURL
+      ?? fileManager.temporaryDirectory.appendingPathComponent(fileName)
+
+    // Remove logfile if it happens to exist
+    if fileManager.fileExists(atPath: fileURL.path) {
+      try fileManager.removeItem(at: fileURL)
+    }
+
+    // Create the file stream to write the compressed file
+    guard let filePath = FilePath(fileURL),
+      let writeFileStream = ArchiveByteStream.fileStream(
+        path: filePath,
+        mode: .writeOnly,
+        options: [.create],
+        permissions: FilePermissions(rawValue: 0o644))
+    else {
+      logger.error("\(#function): Couldn't create the file stream")
+      return nil
+    }
+    defer {
+      try? writeFileStream.close()
+    }
+
+    // Create the compression stream
+    guard
+      let compressStream = ArchiveByteStream.compressionStream(
+        using: .lzfse,
+        writingTo: writeFileStream)
+    else {
+      logger.error("\(#function): Couldn't create the compression stream")
+      return nil
+    }
+    defer {
+      try? compressStream.close()
+    }
+
+    // Create the encoding stream
+    guard let encodeStream = ArchiveStream.encodeStream(writingTo: compressStream) else {
+      logger.error("\(#function): Couldn't create encoding stream")
+      return nil
+    }
+    defer {
+      try? encodeStream.close()
+    }
+
+    // Define header keys
+    guard let keySet = ArchiveHeader.FieldKeySet("TYP,PAT,LNK,DEV,DAT,UID,GID,MOD,FLG,MTM,BTM,CTM")
+    else {
+      logger.error("\(#function): Couldn't define header keys")
+      return nil
+    }
+
+    do {
+      try encodeStream.writeDirectoryContents(
+        archiveFrom: logFilesFolderPath,
+        keySet: keySet)
+    } catch {
+      logger.error("Write directory contents failed.")
+      return nil
+    }
+
+    return fileURL
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogCompressor.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogCompressor.swift
@@ -41,9 +41,7 @@ struct LogCompressor {
       ?? fileManager.temporaryDirectory.appendingPathComponent(fileName)
 
     // Remove logfile if it happens to exist
-    if fileManager.fileExists(atPath: fileURL.path) {
-      try fileManager.removeItem(at: fileURL)
-    }
+    try? fileManager.removeItem(at: fileURL)
 
     // Create the file stream to write the compressed file
     guard let filePath = FilePath(fileURL),


### PR DESCRIPTION
We were using an external library to compress the log folder on Apple, when Apple has native APIs for such things. The external library also doesn't have a good security track record, so this work was prioritized for GA.

Default compression level I'm seeing is about 30:1, whereas the previous Zip compression level seemed to be disabled.

Fixes #4377 
Fixes #4362 