### PR TITLE
chore(gui-client): support cargo-mutants

### DIFF
--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -30,7 +30,7 @@ mod wintun_install;
 /// * `ed5437c88` is the Git commit hash
 /// * `-modified` is present if the working dir has any changes from that commit number
 pub const GIT_VERSION: &str =
-    git_version::git_version!(args = ["--always", "--dirty=-modified", "--tags"]);
+    git_version::git_version!(args = ["--always", "--dirty=-modified", "--tags"], fallback = "unknown");
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -29,8 +29,10 @@ mod wintun_install;
 /// * `g` doesn't mean anything
 /// * `ed5437c88` is the Git commit hash
 /// * `-modified` is present if the working dir has any changes from that commit number
-pub const GIT_VERSION: &str =
-    git_version::git_version!(args = ["--always", "--dirty=-modified", "--tags"], fallback = "unknown");
+pub const GIT_VERSION: &str = git_version::git_version!(
+    args = ["--always", "--dirty=-modified", "--tags"],
+    fallback = "unknown"
+);
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {


### PR DESCRIPTION
`git_version` gets confused when `cargo-mutants` compiles it outside the Git tree