### PR TITLE
chore(portal): Add billing.firezone.dev Stripe checkout domains

### DIFF
--- a/terraform/environments/production/dns.tf
+++ b/terraform/environments/production/dns.tf
@@ -388,6 +388,27 @@ resource "google_dns_record_set" "google-ext-dkim" {
   ]
 }
 
+# Stripe checkout pages
+resource "google_dns_record_set" "stripe-checkout" {
+  project      = module.google-cloud-project.project.project_id
+  managed_zone = module.google-cloud-dns.zone_name
+
+  type    = "CNAME"
+  name    = "billing.${module.google-cloud-dns.dns_name}"
+  rrdatas = ["hosted-checkout.stripecdn.com."]
+  ttl     = 300
+}
+
+resource "google_dns_record_set" "stripe-checkout-acme" {
+  project      = module.google-cloud-project.project.project_id
+  managed_zone = module.google-cloud-dns.zone_name
+
+  type    = "TXT"
+  name    = "_acme-challenge.billing.${module.google-cloud-dns.dns_name}"
+  rrdatas = ["YXH57351vMR9L5prjMoetmpktg1K65i6HkK0ZlLlF1g"]
+  ttl     = 300
+}
+
 # HubSpot
 resource "google_dns_record_set" "hubspot-domainkey1" {
   project      = module.google-cloud-project.project.project_id


### PR DESCRIPTION
Keeps the user inside the `firezone.dev` domain during checkout.

<img width="862" alt="Screenshot 2024-03-28 at 5 08 35 PM" src="https://github.com/firezone/firezone/assets/167144/538c2608-40ca-4e65-be24-18027d9cb4e9">
