### PR TITLE
chore(ci): Cancel stale jobs when new code is pushed

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -34,6 +34,11 @@ on:
         description: "The gateway image that was built"
         value: ${{ jobs.data-plane.outputs.gateway_image }}
 
+# Cancel old workflow runs if new code is pushed
+concurrency:
+  group: "ci-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 env:
   # mark:automatic-version
   VERSION: "1.0.0"

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -2,6 +2,11 @@ name: Elixir
 on:
   workflow_call:
 
+# Cancel old workflow runs if new code is pushed
+concurrency:
+  group: "ci-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   unit-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -3,6 +3,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# Cancel old workflow runs if new code is pushed
+concurrency:
+  group: "ci-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 permissions:
   contents: 'read'
   id-token: 'write'

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -2,6 +2,11 @@ name: Rust
 on:
   workflow_call:
 
+# Cancel old workflow runs if new code is pushed
+concurrency:
+  group: "ci-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: ./rust

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -2,6 +2,11 @@ name: Static Analysis
 on:
   workflow_call:
 
+# Cancel old workflow runs if new code is pushed
+concurrency:
+  group: "ci-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   pr-lint:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -3,6 +3,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# Cancel old workflow runs if new code is pushed
+concurrency:
+  group: "ci-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     name: build-${{ matrix.sdk }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -12,6 +12,11 @@ permissions:
   contents: write
   id-token: write
 
+# Cancel old workflow runs if new code is pushed
+concurrency:
+  group: "ci-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 env:
   # mark:automatic-version
   VERSION: "1.0.0"


### PR DESCRIPTION
Fixes some issues seen recently where `workflow_call` jobs keep running when new commits are pushed to PR.

https://github.com/firezone/firezone/actions/runs/8475521370