### PR TITLE
refactor(portal): Move actor groups to own table in actor show page

### DIFF
--- a/elixir/apps/domain/lib/domain/actors.ex
+++ b/elixir/apps/domain/lib/domain/actors.ex
@@ -49,8 +49,7 @@ defmodule Domain.Actors do
   def list_groups_for(%Actor{} = actor, %Auth.Subject{} = subject, opts \\ []) do
     with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_actors_permission()) do
       Group.Query.not_deleted()
-      |> Group.Query.with_joined_memberships()
-      |> Membership.Query.by_actor_id(actor.id)
+      |> Group.Query.by_actor_id(actor.id)
       |> Authorizer.for_subject(subject)
       |> Repo.list(Group.Query, opts)
     end

--- a/elixir/apps/domain/lib/domain/actors.ex
+++ b/elixir/apps/domain/lib/domain/actors.ex
@@ -46,6 +46,16 @@ defmodule Domain.Actors do
     end
   end
 
+  def list_groups_for(%Actor{} = actor, %Auth.Subject{} = subject, opts \\ []) do
+    with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_actors_permission()) do
+      Group.Query.not_deleted()
+      |> Group.Query.with_joined_memberships()
+      |> Membership.Query.by_actor_id(actor.id)
+      |> Authorizer.for_subject(subject)
+      |> Repo.list(Group.Query, opts)
+    end
+  end
+
   def all_groups!(%Auth.Subject{} = subject, opts \\ []) do
     {preload, _opts} = Keyword.pop(opts, :preload, [])
 

--- a/elixir/apps/domain/lib/domain/actors/group/query.ex
+++ b/elixir/apps/domain/lib/domain/actors/group/query.ex
@@ -42,6 +42,13 @@ defmodule Domain.Actors.Group.Query do
     where(queryable, [groups: groups], groups.account_id == ^account_id)
   end
 
+  def by_actor_id(queryable, actor_id) do
+    join(queryable, :left, [groups: groups], memberships in assoc(groups, :memberships),
+      as: :memberships
+    )
+    |> where([memberships: memberships], memberships.actor_id == ^actor_id)
+  end
+
   def by_provider_id(queryable, provider_id) do
     where(queryable, [groups: groups], groups.provider_id == ^provider_id)
   end

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -469,7 +469,7 @@ defmodule Web.Actors.Show do
           filters={@filters_by_table_id["groups"]}
           filter={@filter_form_by_table_id["groups"]}
           ordered_by={@order_by_table_id["groups"]}
-          metadata={@clients_metadata}
+          metadata={@groups_metadata}
         >
           <:col :let={group} label="NAME">
             <.link navigate={~p"/#{@account}/groups/#{group.id}"} class={[link_style()]}>

--- a/elixir/apps/web/test/web/live/actors/show_test.exs
+++ b/elixir/apps/web/test/web/live/actors/show_test.exs
@@ -222,6 +222,29 @@ defmodule Web.Live.Actors.ShowTest do
              "#{flow.gateway.group.name}-#{flow.gateway.name} (#{flow.gateway.last_seen_remote_ip})"
   end
 
+  test "renders groups table", %{
+    conn: conn
+  } do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+    group = Fixtures.Actors.create_group(account: account)
+    Fixtures.Actors.create_membership(account: account, actor: actor, group: group)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/actors/#{actor}")
+
+    [row] =
+      lv
+      |> element("#groups")
+      |> render()
+      |> table_to_map()
+
+    assert row["name"] == group.name
+  end
+
   describe "users" do
     setup do
       account = Fixtures.Accounts.create_account()
@@ -268,9 +291,6 @@ defmodule Web.Live.Actors.ShowTest do
       identity: identity,
       conn: conn
     } do
-      group = Fixtures.Actors.create_group(account: account)
-      Fixtures.Actors.create_membership(account: account, actor: actor, group: group)
-
       {:ok, lv, html} =
         conn
         |> authorize_conn(identity)
@@ -285,7 +305,6 @@ defmodule Web.Live.Actors.ShowTest do
         |> render()
         |> vertical_table_to_map()
 
-      assert table["groups"] == group.name
       assert table["name"] == actor.name
       assert table["role"] == "admin"
       assert around_now?(table["last signed in"])
@@ -779,9 +798,6 @@ defmodule Web.Live.Actors.ShowTest do
       identity: identity,
       conn: conn
     } do
-      group = Fixtures.Actors.create_group(account: account)
-      Fixtures.Actors.create_membership(account: account, actor: actor, group: group)
-
       {:ok, lv, html} =
         conn
         |> authorize_conn(identity)
@@ -793,7 +809,6 @@ defmodule Web.Live.Actors.ShowTest do
              |> element("#actor")
              |> render()
              |> vertical_table_to_map() == %{
-               "groups" => group.name,
                "last signed in" => "never",
                "name" => actor.name,
                "role" => "service account"


### PR DESCRIPTION
Why:

* When viewing an actor in the portal, all of the groups were listed in the top info table.  This works for a small number of groups, but becomes difficult to use when an actor is in a large number of groups. This commit moves that information to it's own `live_table` element so that it's easier to parse and can be paginated.