### PR TITLE
build(connlib): Enable lto for release profile

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -64,6 +64,13 @@ tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdr
 [profile.release]
 strip = true
 
+# Full link-time optimization. Reduces binaries by up to 3x on some platforms.
+lto = "fat"
+
+# Increases the compiler's ability to produce smaller, optimized code
+# at the expense of compilation time
+codegen-units = 1
+
 # Override build settings just for the GUI client, so we get a pdb/dwp
 # Cargo ignores profile settings if they're not in the workspace's Cargo.toml
 [profile.dev.package.firezone-gui-client]


### PR DESCRIPTION
What it costs in build time will probably save us many times over in bandwidth fees. Seeing a 3x reduction in binary size on apple with LTO = "fat".


### `lto = false`

```
-rw-r--r--@    1 jamil  staff  50673800 Mar 29 16:42 libconnlib.a
```

### `lto = "thin"`

```
-rw-r--r--@    1 jamil  staff  26407568 Mar 29 17:32 libconnlib.a
```

### `lto = "fat"`

```
-rw-r--r--@    1 jamil  staff  15592728 Mar 29 17:18 libconnlib.a
```