### PR TITLE
chore(portal): Increase page size to maximum when using MS Graph API

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/api_client.ex
@@ -58,7 +58,8 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClient do
       |> URI.append_query(
         URI.encode_query(%{
           "$select" => Enum.join(@user_fields, ","),
-          "$filter" => "accountEnabled eq true"
+          "$filter" => "accountEnabled eq true",
+          "$top" => "999"
         })
       )
 
@@ -74,7 +75,8 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClient do
       URI.parse("#{endpoint}/v1.0/groups")
       |> URI.append_query(
         URI.encode_query(%{
-          "$select" => Enum.join(@group_fields, ",")
+          "$select" => Enum.join(@group_fields, ","),
+          "$top" => "999"
         })
       )
 
@@ -98,7 +100,8 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClient do
       URI.parse("#{endpoint}/v1.0/groups/#{group_id}/transitiveMembers/microsoft.graph.user")
       |> URI.append_query(
         URI.encode_query(%{
-          "$select" => Enum.join(@group_member_fields, ",")
+          "$select" => Enum.join(@group_member_fields, ","),
+          "$top" => "999"
         })
       )
 

--- a/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/api_client_test.exs
@@ -40,7 +40,8 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
                      userPrincipalName
                    ],
                    ","
-                 )
+                 ),
+               "$top" => "999"
              }
 
       assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer #{api_token}"]
@@ -72,7 +73,8 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       assert_receive {:bypass_request, conn}
 
       assert conn.params == %{
-               "$select" => "id,displayName"
+               "$select" => "id,displayName",
+               "$top" => "999"
              }
 
       assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer #{api_token}"]
@@ -104,7 +106,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       end
 
       assert_receive {:bypass_request, conn}
-      assert conn.params == %{"$select" => "id,accountEnabled"}
+      assert conn.params == %{"$select" => "id,accountEnabled", "$top" => "999"}
       assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer #{api_token}"]
     end
 


### PR DESCRIPTION
For very large accounts we will make 9x less requests, meaning less changes for timeout and no additional rountrips to the API.