### PR TITLE
build(rust): Use Rust base image and bump to 1.77

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,59 +1,8 @@
-# Global args to use in build commands
-ARG ALPINE_VERSION="3.19"
+ARG ALPINE_VERSION=3.19
 ARG CARGO_CHEF_VERSION="0.1.62"
-ARG RUSTUP_VERSION="1.26.0"
-ARG RUSTUP_x86_DOWNLOAD_SHA256="7aa9e2a380a9958fc1fc426a3323209b2c86181c6816640979580f62ff7d48d4"
-ARG RUSTUP_aarch64_DOWNLOAD_SHA256="b1962dfc18e1fd47d01341e6897cace67cddfabf547ef394e8883939bd6e002e"
-# Keep synced with `rust-toolchain.toml`
-ARG RUST_VERSION="1.76.0"
-
-# TODO: Document why we don't use `rust:1.76.0-alpine` here
-FROM alpine:${ALPINE_VERSION} as rust
-
-# Important!  Update this no-op ENV variable when this Dockerfile
-# is updated with the current date. It will force refresh of all
-# of the base images and things like `apk add` won't be using
-# old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2024-02-22 \
-  LANG=C.UTF-8 \
-  TERM=xterm
-
-RUN set -xe \
-  # Upgrade Alpine and base packages
-  && apk --no-cache --update-cache --available upgrade \
-  # Install required deps
-  && apk add --no-cache --update-cache \
-  ca-certificates \
-  gcc
-
-ENV RUSTUP_HOME=/usr/local/rustup \
-  CARGO_HOME=/usr/local/cargo \
-  PATH=/usr/local/cargo/bin:$PATH
-
-ARG RUSTUP_VERSION
-ARG RUSTUP_x86_DOWNLOAD_SHA256
-ARG RUSTUP_aarch64_DOWNLOAD_SHA256
-ARG RUST_VERSION
-RUN set -eux; \
-  apkArch="$(apk --print-arch)"; \
-  case "$apkArch" in \
-  x86_64) rustArch='x86_64-unknown-linux-musl'; rustupSha256=${RUSTUP_x86_DOWNLOAD_SHA256} ;; \
-  aarch64) rustArch='aarch64-unknown-linux-musl'; rustupSha256=${RUSTUP_aarch64_DOWNLOAD_SHA256} ;; \
-  *) echo >&2 "unsupported architecture: $apkArch"; exit 1 ;; \
-  esac; \
-  url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustArch}/rustup-init"; \
-  wget "$url"; \
-  echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
-  chmod +x rustup-init; \
-  ./rustup-init -y --no-modify-path --profile minimal --default-toolchain ${RUST_VERSION} --default-host ${rustArch}; \
-  rm rustup-init; \
-  chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-  rustup --version; \
-  cargo --version; \
-  rustc --version;
 
 # This image is used to prepare Cargo Chef which is used to cache dependencies
-FROM rust as chef
+FROM rust:1.77-alpine${ALPINE_VERSION} as chef
 
 ARG CARGO_CHEF_VERSION
 RUN set -xe \

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -121,9 +121,7 @@ where
 
         let (addresses, resource_id) = match &resource {
             ResourceDescription::Dns(r) => {
-                let Some(domain) = domain.clone() else {
-                    return None;
-                };
+                let domain = domain.clone()?;
 
                 if !crate::dns::is_subdomain(&domain, &r.domain) {
                     return None;

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Keep synced with `Dockerfile`
-channel = "1.76.0"
+channel = "1.77.1"


### PR DESCRIPTION
These customizations were from before we used `cargo cross` for all architectures in CI.

1.77.1 has been tested to work with the following clients:

- [x] Apple
- [x] Android
- [x] Windows

