### PR TITLE
build(rust): Trigger warnings for unused crate dependencies

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -34,7 +34,9 @@ jobs:
           cargo doc --all-features --no-deps --document-private-items ${{ matrix.packages }}
         env:
           RUSTDOCFLAGS: "-D warnings"
-      - run: |
+      - env:
+          RUSTFLAGS: "-Wunused-crate-dependencies"
+        run: |
           cargo clippy --all-targets --all-features ${{ matrix.packages }} -- -D warnings
 
   test:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4425,12 +4425,10 @@ dependencies = [
 name = "phoenix-channel"
 version = "1.0.0"
 dependencies = [
- "anyhow",
  "backoff",
  "base64 0.22.0",
  "futures",
  "hex",
- "hostname",
  "libc",
  "rand_core 0.6.4",
  "secrecy",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4429,6 +4429,7 @@ dependencies = [
  "base64 0.22.0",
  "futures",
  "hex",
+ "hostname",
  "libc",
  "rand_core 0.6.4",
  "secrecy",

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -19,12 +19,10 @@ serde_json = "1.0.108"
 thiserror = "1.0.50"
 tokio = { version = "1.36.0", features = ["net", "time"] }
 backoff = "0.4.0"
-anyhow = "1"
 uuid = { version = "1.7", default-features = false, features = ["std", "v4"] }
 sha2 = "0.10.8"
 hex = "0.4"
 libc = "0.2"
-hostname = "0.3.1" # Hickory already depends on `hostname` so this isn't new
 
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["macros", "rt"] }

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -24,6 +24,9 @@ sha2 = "0.10.8"
 hex = "0.4"
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+hostname = "0.3.1" # Hickory already depends on `hostname` so this isn't new
+
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["macros", "rt"] }
 


### PR DESCRIPTION
After all of the time spent hunting down all of our `fstat` calls for #4377, it became clear that our dependency tree is somewhat convoluted and includes a few unused crates and features.

This is a first step to try to clean up some of those.

Refs #4403 