### PR TITLE
chore(relay): make profiling in release build possible

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -82,3 +82,7 @@ strip = "none"
 debug = "full"
 split-debuginfo = "packed"
 strip = "none"
+
+# Override build settings for the relay, so we can capture flamegraphs
+[profile.release.package.firezone-relay]
+debug = "full"

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -60,8 +60,6 @@ struct Args {
     #[arg(env = "FIREZONE_NAME")]
     name: Option<String>,
     /// A seed to use for all randomness operations.
-    ///
-    /// Only available in debug builds.
     #[arg(long, env, hide = true)]
     rng_seed: Option<u64>,
 
@@ -286,7 +284,6 @@ struct JoinMessage {
     stamp_secret: String,
 }
 
-#[cfg(debug_assertions)]
 fn make_rng(seed: Option<u64>) -> StdRng {
     let Some(seed) = seed else {
         return StdRng::from_entropy();
@@ -295,15 +292,6 @@ fn make_rng(seed: Option<u64>) -> StdRng {
     tracing::info!(target: "relay", "Seeding RNG from '{seed}'");
 
     StdRng::seed_from_u64(seed)
-}
-
-#[cfg(not(debug_assertions))]
-fn make_rng(seed: Option<u64>) -> StdRng {
-    if seed.is_some() {
-        tracing::debug!(target: "relay", "Ignoring rng-seed because we are running in release mode");
-    }
-
-    StdRng::from_entropy()
 }
 
 struct Eventloop<R> {


### PR DESCRIPTION
Currently, controlling the RNG seed is gated for debug builds only. This makes profiling the release build impossible because we cannot generate credentials upfront.

Additionally, for flamegraphs to be useful, we need to enable debug symbols for the relay.