### PR TITLE
chore(deps): Don't create duplicate dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,25 +41,20 @@ updates:
           - windows-implement
           - windows-sys
   - package-ecosystem: gradle
-    directory: kotlin/android/
+    directory: kotlin/android/app/
     schedule:
       interval: monthly
-    groups:
-      com.squareup.moshi:
-        patterns:
-          - com.squareup.moshi.*
-      com.android:
-        patterns:
-          - com.android.*
     ignore:
       # Depends on JDK version which is bundled with Android Studio (JDK 17)
       - dependency-name: org.jetbrains.kotlin:kotlin-gradle-plugin
       - dependency-name: org.jetbrains.kotlin.android
-  - package-ecosystem: gradle
-    directory: kotlin/android/app/
-    schedule:
-      interval: monthly
     groups:
+      com.android:
+        patterns:
+          - com.android.*
+      com.squareup.moshi:
+        patterns:
+          - com.squareup.moshi.*
       AndroidX:
         patterns:
           - androidx.core:core-ktx

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,7 @@ updates:
           - windows-implement
           - windows-sys
   - package-ecosystem: gradle
-    directory: kotlin/android/app/
+    directory: kotlin/android
     schedule:
       interval: monthly
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,7 @@ updates:
           - windows-implement
           - windows-sys
   - package-ecosystem: gradle
-    directory: kotlin/android
+    directory: kotlin/android/
     schedule:
       interval: monthly
     ignore:


### PR DESCRIPTION
It looks like Dependabot's path search is recursive, so it was pulling in dependencies for both the project-wide and app-wide folders.