### PR TITLE
chore(rust): lint against redundant `async`

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -56,6 +56,7 @@ clippy.dbg_macro = "warn"
 clippy.print_stdout = "warn"
 clippy.print_stderr = "warn"
 clippy.unnecessary_wraps = "warn"
+clippy.unused_async = "warn"
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }

--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -285,7 +285,7 @@ async fn set_iface_config(
         Some(DnsControlMethod::EtcResolvConf) => etc_resolv_conf::configure(&dns_config)
             .await
             .map_err(Error::ResolvConf)?,
-        Some(DnsControlMethod::NetworkManager) => configure_network_manager(&dns_config).await?,
+        Some(DnsControlMethod::NetworkManager) => configure_network_manager(&dns_config)?,
         Some(DnsControlMethod::Systemd) => configure_systemd_resolved(&dns_config).await?,
     }
 
@@ -450,7 +450,7 @@ impl ioctl::Request<SetTunFlagsPayload> {
     }
 }
 
-async fn configure_network_manager(_dns_config: &[IpAddr]) -> Result<()> {
+fn configure_network_manager(_dns_config: &[IpAddr]) -> Result<()> {
     Err(Error::Other(
         "DNS control with NetworkManager is not implemented yet",
     ))

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -548,7 +548,7 @@ impl Controller {
         Ok(())
     }
 
-    async fn handle_deep_link(&mut self, url: &SecretString) -> Result<()> {
+    fn handle_deep_link(&mut self, url: &SecretString) -> Result<()> {
         let auth_response =
             client::deep_link::parse_auth_callback(url).context("Couldn't parse scheme request")?;
 
@@ -587,7 +587,6 @@ impl Controller {
             }
             Req::SchemeRequest(url) => self
                 .handle_deep_link(&url)
-                .await
                 .context("Couldn't handle deep link")?,
             Req::SignIn | Req::SystemTrayMenu(TrayMenuEvent::SignIn) => {
                 if let Some(req) = self.auth.start_sign_in()? {

--- a/rust/gui-client/src-tauri/src/client/logging.rs
+++ b/rust/gui-client/src-tauri/src/client/logging.rs
@@ -79,9 +79,7 @@ pub(crate) async fn clear_logs(managed: tauri::State<'_, Managed>) -> StdResult<
 
 #[tauri::command]
 pub(crate) async fn export_logs(managed: tauri::State<'_, Managed>) -> StdResult<(), String> {
-    export_logs_inner(managed.ctlr_tx.clone())
-        .await
-        .map_err(|e| e.to_string())
+    export_logs_inner(managed.ctlr_tx.clone()).map_err(|e| e.to_string())
 }
 
 #[derive(Clone, Default, Serialize)]
@@ -110,7 +108,7 @@ pub(crate) async fn clear_logs_inner(managed: &Managed) -> Result<()> {
 }
 
 /// Pops up the "Save File" dialog
-pub(crate) async fn export_logs_inner(ctlr_tx: CtlrTx) -> Result<()> {
+pub(crate) fn export_logs_inner(ctlr_tx: CtlrTx) -> Result<()> {
     let now = chrono::Local::now();
     let datetime_string = now.format("%Y_%m_%d-%H-%M");
     let stem = PathBuf::from(format!("connlib-{datetime_string}"));

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -99,7 +99,7 @@ enum LogFormat {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
-    setup_tracing(&args).await?;
+    setup_tracing(&args)?;
 
     let public_addr = match (args.public_ip4_addr, args.public_ip6_addr) {
         (Some(ip4), Some(ip6)) => IpStack::Dual { ip4, ip6 },
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
 /// ## Integration with OTLP
 ///
 /// If the user has specified [`TraceCollector::Otlp`], we will set up an OTLP-exporter that connects to an OTLP collector specified at `Args.otlp_grpc_endpoint`.
-async fn setup_tracing(args: &Args) -> Result<()> {
+fn setup_tracing(args: &Args) -> Result<()> {
     // Use `tracing_core` directly for the temp logger because that one does not initialize a `log` logger.
     // A `log` Logger cannot be unset once set, so we can't use that for our temp logger during the setup.
     let temp_logger_guard = tracing_core::dispatcher::set_default(


### PR DESCRIPTION
I came across a redundant `async` within the relay code and thought: "Hey, I know there is a lint against this, let's turn it on".