### PR TITLE
refactor(portal): Update actor group selection in portal

### DIFF
--- a/elixir/apps/domain/lib/domain/actors.ex
+++ b/elixir/apps/domain/lib/domain/actors.ex
@@ -74,6 +74,15 @@ defmodule Domain.Actors do
     |> Repo.preload(preload)
   end
 
+  def list_editable_groups(%Auth.Subject{} = subject, opts \\ []) do
+    with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_actors_permission()) do
+      Group.Query.not_deleted()
+      |> Group.Query.editable()
+      |> Authorizer.for_subject(subject)
+      |> Repo.list(Group.Query, opts)
+    end
+  end
+
   def peek_group_actors(groups, limit, %Auth.Subject{} = subject) do
     with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_actors_permission()) do
       ids = groups |> Enum.map(& &1.id) |> Enum.uniq()

--- a/elixir/apps/web/lib/web/live/actors/components.ex
+++ b/elixir/apps/web/lib/web/live/actors/components.ex
@@ -45,7 +45,6 @@ defmodule Web.Actors.Components do
 
   attr :type, :atom, required: true
   attr :actor, :any, default: %Actors.Actor{memberships: [], last_synced_at: nil}, required: false
-  attr :groups, :any, required: true
   attr :form, :any, required: true
   attr :subject, :any, required: true
 
@@ -76,29 +75,7 @@ defmodule Web.Actors.Components do
         required
       />
     </div>
-    <div :if={@groups != []}>
-      <.input
-        type="group_select"
-        multiple={true}
-        label="Groups"
-        field={@form[:memberships]}
-        value_id={fn membership -> membership.group_id end}
-        options={Web.Groups.Components.select_options(@groups)}
-        placeholder="Groups"
-      />
-      <p class="mt-2 text-xs text-neutral-500">
-        Hold <kbd>Ctrl</kbd> (or <kbd>Command</kbd> on Mac) to select or unselect multiple groups.
-      </p>
-    </div>
     """
-  end
-
-  def map_actor_form_memberships_attr(attrs) do
-    Map.update(attrs, "memberships", [], fn group_ids ->
-      Enum.map(group_ids, fn group_id ->
-        %{group_id: group_id}
-      end)
-    end)
   end
 
   attr :form, :any, required: true

--- a/elixir/apps/web/lib/web/live/actors/edit.ex
+++ b/elixir/apps/web/lib/web/live/actors/edit.ex
@@ -11,17 +11,12 @@ defmodule Web.Actors.Edit do
                deleted?: false
              ]
            ) do
-      # TODO: unify this and dropdowns for filters
-      groups =
-        Actors.all_editable_groups!(socket.assigns.subject, preload: [:provider])
-
       changeset = Actors.change_actor(actor)
 
       socket =
         assign(socket,
           page_title: "Edit #{actor.name}",
           actor: actor,
-          groups: groups,
           form: to_form(changeset)
         )
 
@@ -53,13 +48,7 @@ defmodule Web.Actors.Edit do
           <.flash kind={:error} flash={@flash} />
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
-              <.actor_form
-                form={@form}
-                type={@actor.type}
-                actor={@actor}
-                groups={@groups}
-                subject={@subject}
-              />
+              <.actor_form form={@form} type={@actor.type} actor={@actor} subject={@subject} />
             </div>
             <.submit_button>Save</.submit_button>
           </.form>
@@ -70,8 +59,6 @@ defmodule Web.Actors.Edit do
   end
 
   def handle_event("change", %{"actor" => attrs}, socket) do
-    attrs = map_actor_form_memberships_attr(attrs)
-
     changeset =
       Actors.change_actor(socket.assigns.actor, attrs)
       |> Map.put(:action, :insert)
@@ -80,8 +67,6 @@ defmodule Web.Actors.Edit do
   end
 
   def handle_event("submit", %{"actor" => attrs}, socket) do
-    attrs = map_actor_form_memberships_attr(attrs)
-
     with {:ok, actor} <- Actors.update_actor(socket.assigns.actor, attrs, socket.assigns.subject) do
       socket = push_navigate(socket, to: ~p"/#{socket.assigns.account}/actors/#{actor}")
       {:noreply, socket}

--- a/elixir/apps/web/lib/web/live/actors/groups.ex
+++ b/elixir/apps/web/lib/web/live/actors/groups.ex
@@ -1,4 +1,4 @@
-defmodule Web.Actors.Groups do
+defmodule Web.Actors.EditGroups do
   use Web, :live_view
   alias Domain.Actors
 
@@ -57,7 +57,7 @@ defmodule Web.Actors.Groups do
       <.breadcrumb path={~p"/#{@account}/actors/#{@actor}"}>
         <%= @actor.name %>
       </.breadcrumb>
-      <.breadcrumb path={~p"/#{@account}/actors/#{@actor}/groups"}>
+      <.breadcrumb path={~p"/#{@account}/actors/#{@actor}/edit_groups"}>
         Group Memberships
       </.breadcrumb>
     </.breadcrumbs>
@@ -186,12 +186,10 @@ defmodule Web.Actors.Groups do
       {:noreply, socket}
     else
       {:error, :unauthorized} ->
-        {:noreply,
-         put_flash(socket, :error, "You don't have permissions to perform this action.")}
+        {:noreply, put_flash(socket, :error, "You don't have permission to perform this action.")}
 
       {:error, {:unauthorized, _context}} ->
-        {:noreply,
-         put_flash(socket, :error, "You don't have permissions to perform this action.")}
+        {:noreply, put_flash(socket, :error, "You don't have permission to perform this action.")}
     end
   end
 
@@ -224,9 +222,6 @@ defmodule Web.Actors.Groups do
   end
 
   defp remove_non_editable_memberships(memberships, editable_groups) do
-    # Memberships :: List of membership structs
-    # Groups :: List of group structs
-
     editable_group_ids =
       editable_groups
       |> Enum.map(& &1.id)

--- a/elixir/apps/web/lib/web/live/actors/groups.ex
+++ b/elixir/apps/web/lib/web/live/actors/groups.ex
@@ -1,0 +1,247 @@
+defmodule Web.Actors.Groups do
+  use Web, :live_view
+  alias Domain.Actors
+
+  def mount(%{"id" => id}, _session, socket) do
+    with {:ok, actor} <-
+           Actors.fetch_actor_by_id(id, socket.assigns.subject,
+             preload: [:memberships],
+             filter: [
+               deleted?: false
+             ]
+           ) do
+      current_group_ids = Enum.map(actor.memberships, & &1.group_id)
+
+      socket =
+        socket
+        |> assign(
+          actor: actor,
+          current_group_ids: current_group_ids,
+          added: %{},
+          removed: %{}
+        )
+        |> assign_live_table("groups",
+          query_module: Actors.Group.Query,
+          sortable_fields: [],
+          hide_filters: [:provider_id],
+          limit: 5,
+          callback: &handle_groups_update!/2
+        )
+
+      {:ok, socket}
+    else
+      _other -> raise Web.LiveErrors.NotFoundError
+    end
+  end
+
+  def handle_params(params, uri, socket) do
+    socket = handle_live_tables_params(socket, params, uri)
+    {:noreply, socket}
+  end
+
+  def handle_groups_update!(socket, list_opts) do
+    with {:ok, groups, metadata} <-
+           Actors.list_editable_groups(socket.assigns.subject, list_opts) do
+      {:ok,
+       assign(socket,
+         groups: groups,
+         groups_metadata: metadata
+       )}
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs account={@account}>
+      <.breadcrumb path={~p"/#{@account}/actors"}>Actors</.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/actors/#{@actor}"}>
+        <%= @actor.name %>
+      </.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/actors/#{@actor}/groups"}>
+        Group Memberships
+      </.breadcrumb>
+    </.breadcrumbs>
+    <.section>
+      <:title>
+        Group Memberships: <%= @actor.name %>
+      </:title>
+      <:help>
+        Add or remove Groups for a given Actor.
+      </:help>
+      <:content>
+        <div class="max-w-xl px-4 py-8 mx-auto lg:py-16">
+          <.flash kind={:error} flash={@flash} />
+          <.live_table
+            id="groups"
+            rows={@groups}
+            row_id={&"group-#{&1.id}"}
+            filters={@filters_by_table_id["groups"]}
+            filter={@filter_form_by_table_id["groups"]}
+            ordered_by={@order_by_table_id["groups"]}
+            metadata={@groups_metadata}
+          >
+            <:col :let={group} label="GROUP">
+              <.icon
+                :if={removed?(group, @removed)}
+                name="hero-minus"
+                class="h-3.5 w-3.5 mr-2 text-red-500"
+              />
+              <.icon
+                :if={added?(group, @added)}
+                name="hero-plus"
+                class="h-3.5 w-3.5 mr-2 text-green-500"
+              />
+
+              <.link
+                navigate={~p"/#{@account}/groups/#{group}"}
+                class={
+                  cond do
+                    removed?(group, @removed) -> ["text-red-500"]
+                    added?(group, @added) -> ["text-green-500"]
+                    true -> []
+                  end ++ ["text-accent-500", "hover:underline"]
+                }
+              >
+                <%= group.name %>
+              </.link>
+            </:col>
+            <:col :let={group}>
+              <div class="flex justify-end">
+                <.button
+                  :if={member?(@current_group_ids, group, @added, @removed)}
+                  phx-click={:remove_group}
+                  phx-value-id={group.id}
+                  phx-value-name={group.name}
+                >
+                  <.icon name="hero-minus" class="h-3.5 w-3.5 mr-2" /> Remove
+                </.button>
+                <.button
+                  :if={not member?(@current_group_ids, group, @added, @removed)}
+                  phx-click={:add_group}
+                  phx-value-id={group.id}
+                  phx-value-name={group.name}
+                >
+                  <.icon name="hero-plus" class="h-3.5 w-3.5 mr-2" /> Add
+                </.button>
+              </div>
+            </:col>
+          </.live_table>
+          <.button class="m-4" data-confirm={confirm_message(@added, @removed)} phx-click="submit">
+            Save
+          </.button>
+        </div>
+      </:content>
+    </.section>
+    """
+  end
+
+  def handle_event(event, params, socket) when event in ["paginate", "order_by", "filter"],
+    do: handle_live_table_event(event, params, socket)
+
+  def handle_event("add_group", %{"id" => id, "name" => name}, socket) do
+    if id in socket.assigns.current_group_ids do
+      removed = Map.delete(socket.assigns.removed, id)
+      {:noreply, assign(socket, removed: removed)}
+    else
+      added = Map.put(socket.assigns.added, id, name)
+      removed = Map.delete(socket.assigns.removed, id)
+      {:noreply, assign(socket, added: added, removed: removed)}
+    end
+  end
+
+  def handle_event("remove_group", %{"id" => id, "name" => name}, socket) do
+    if id in socket.assigns.current_group_ids do
+      added = Map.delete(socket.assigns.added, id)
+      removed = Map.put(socket.assigns.removed, id, name)
+      {:noreply, assign(socket, added: added, removed: removed)}
+    else
+      added = Map.delete(socket.assigns.added, id)
+      {:noreply, assign(socket, added: added)}
+    end
+  end
+
+  def handle_event("submit", _params, socket) do
+    filtered_memberships =
+      socket.assigns.actor.memberships
+      |> remove_non_editable_memberships(socket.assigns.groups)
+      |> Enum.flat_map(fn membership ->
+        if Map.has_key?(socket.assigns.removed, membership.group_id) do
+          []
+        else
+          [Map.from_struct(membership)]
+        end
+      end)
+
+    new_memberships =
+      Enum.map(socket.assigns.added, fn
+        {id, _name} -> %{group_id: id}
+      end)
+
+    attrs =
+      %{memberships: filtered_memberships ++ new_memberships}
+      |> map_actor_memberships_attr()
+
+    with {:ok, actor} <- Actors.update_actor(socket.assigns.actor, attrs, socket.assigns.subject) do
+      socket = push_navigate(socket, to: ~p"/#{socket.assigns.account}/actors/#{actor}")
+      {:noreply, socket}
+    else
+      {:error, :unauthorized} ->
+        {:noreply,
+         put_flash(socket, :error, "You don't have permissions to perform this action.")}
+
+      {:error, {:unauthorized, _context}} ->
+        {:noreply,
+         put_flash(socket, :error, "You don't have permissions to perform this action.")}
+    end
+  end
+
+  defp member?(current_group_ids, group, added, removed) do
+    if group.id in current_group_ids do
+      not Map.has_key?(removed, group.id)
+    else
+      Map.has_key?(added, group.id)
+    end
+  end
+
+  defp removed?(group, removed) do
+    Map.has_key?(removed, group.id)
+  end
+
+  defp added?(group, added) do
+    Map.has_key?(added, group.id)
+  end
+
+  # TODO: this should be replaced by a new state of a form which will render impact of a change
+  defp confirm_message(added, removed) do
+    added_names = Enum.map(added, fn {_id, name} -> name end)
+    removed_names = Enum.map(removed, fn {_id, name} -> name end)
+
+    add = if added_names != [], do: "add #{Enum.join(added_names, ", ")}"
+    remove = if removed_names != [], do: "remove #{Enum.join(removed_names, ", ")}"
+    change = [add, remove] |> Enum.reject(&is_nil/1) |> Enum.join(" and ")
+
+    "Are you sure you want to #{change}?"
+  end
+
+  defp remove_non_editable_memberships(memberships, editable_groups) do
+    # Memberships :: List of membership structs
+    # Groups :: List of group structs
+
+    editable_group_ids =
+      editable_groups
+      |> Enum.map(& &1.id)
+      |> MapSet.new()
+
+    Enum.filter(memberships, fn membership ->
+      MapSet.member?(editable_group_ids, membership.group_id)
+    end)
+  end
+
+  defp map_actor_memberships_attr(attrs) do
+    Map.update(attrs, :memberships, [], fn memberships ->
+      Enum.map(memberships, fn membership ->
+        %{group_id: membership.group_id}
+      end)
+    end)
+  end
+end

--- a/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/service_accounts/new.ex
@@ -4,14 +4,10 @@ defmodule Web.Actors.ServiceAccounts.New do
   alias Domain.Actors
 
   def mount(_params, _session, socket) do
-    groups =
-      Actors.all_editable_groups!(socket.assigns.subject, preload: :provider)
-
     changeset = Actors.new_actor(%{type: :service_account})
 
     socket =
       assign(socket,
-        groups: groups,
         form: to_form(changeset),
         page_title: "New Service Account"
       )
@@ -39,7 +35,7 @@ defmodule Web.Actors.ServiceAccounts.New do
           <.flash kind={:error} flash={@flash} />
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
-              <.actor_form form={@form} type={:service_account} groups={@groups} subject={@subject} />
+              <.actor_form form={@form} type={:service_account} subject={@subject} />
             </div>
             <.submit_button>
               Create
@@ -54,7 +50,6 @@ defmodule Web.Actors.ServiceAccounts.New do
   def handle_event("change", %{"actor" => attrs}, socket) do
     changeset =
       attrs
-      |> map_actor_form_memberships_attr()
       |> Map.put("type", :service_account)
       |> Actors.new_actor()
       |> Map.put(:action, :insert)
@@ -66,7 +61,6 @@ defmodule Web.Actors.ServiceAccounts.New do
     attrs =
       attrs
       |> Map.put("type", :service_account)
-      |> map_actor_form_memberships_attr()
 
     with {:ok, actor} <-
            Actors.create_actor(

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -462,7 +462,7 @@ defmodule Web.Actors.Show do
       <:title>Groups</:title>
 
       <:action>
-        <.edit_button navigate={~p"/#{@account}/actors/#{@actor}/groups"}>
+        <.edit_button navigate={~p"/#{@account}/actors/#{@actor}/edit_groups"}>
           Edit Groups
         </.edit_button>
       </:action>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -461,6 +461,12 @@ defmodule Web.Actors.Show do
     <.section>
       <:title>Groups</:title>
 
+      <:action>
+        <.edit_button navigate={~p"/#{@account}/actors/#{@actor}/groups"}>
+          Edit Groups
+        </.edit_button>
+      </:action>
+
       <:content>
         <.live_table
           id="groups"

--- a/elixir/apps/web/lib/web/live/actors/users/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new.ex
@@ -63,7 +63,8 @@ defmodule Web.Actors.Users.New do
            ) do
       socket =
         push_navigate(socket,
-          to: ~p"/#{socket.assigns.account}/actors/users/#{actor}/new_identity"
+          to:
+            ~p"/#{socket.assigns.account}/actors/users/#{actor}/new_identity?next_step=edit_groups"
         )
 
       {:noreply, socket}

--- a/elixir/apps/web/lib/web/live/actors/users/new.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new.ex
@@ -4,14 +4,10 @@ defmodule Web.Actors.Users.New do
   alias Domain.Actors
 
   def mount(_params, _session, socket) do
-    groups =
-      Actors.all_editable_groups!(socket.assigns.subject, preload: :provider)
-
     changeset = Actors.new_actor()
 
     socket =
       assign(socket,
-        groups: groups,
         form: to_form(changeset),
         page_title: "New User"
       )
@@ -37,7 +33,7 @@ defmodule Web.Actors.Users.New do
           <.flash kind={:error} flash={@flash} />
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
-              <.actor_form form={@form} type={:user} groups={@groups} subject={@subject} />
+              <.actor_form form={@form} type={:user} subject={@subject} />
             </div>
             <.submit_button>
               Create
@@ -52,7 +48,6 @@ defmodule Web.Actors.Users.New do
   def handle_event("change", %{"actor" => attrs}, socket) do
     changeset =
       attrs
-      |> map_memberships_attr()
       |> Actors.new_actor()
       |> Map.put(:action, :insert)
 
@@ -60,8 +55,6 @@ defmodule Web.Actors.Users.New do
   end
 
   def handle_event("submit", %{"actor" => attrs}, socket) do
-    attrs = map_memberships_attr(attrs)
-
     with {:ok, actor} <-
            Actors.create_actor(
              socket.assigns.account,
@@ -94,13 +87,5 @@ defmodule Web.Actors.Users.New do
       {:error, changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
     end
-  end
-
-  defp map_memberships_attr(attrs) do
-    Map.update(attrs, "memberships", [], fn group_ids ->
-      Enum.map(group_ids, fn group_id ->
-        %{group_id: group_id}
-      end)
-    end)
   end
 end

--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -115,7 +115,7 @@ defmodule Web.Actors.Users.NewIdentity do
 
       socket =
         push_navigate(socket,
-          to: ~p"/#{socket.assigns.account}/actors/#{socket.assigns.actor}/groups"
+          to: ~p"/#{socket.assigns.account}/actors/#{socket.assigns.actor}/edit_groups"
         )
 
       {:noreply, socket}

--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -3,7 +3,7 @@ defmodule Web.Actors.Users.NewIdentity do
   import Web.Actors.Components
   alias Domain.{Auth, Actors}
 
-  def mount(%{"id" => id}, _session, socket) do
+  def mount(%{"id" => id} = params, _session, socket) do
     with {:ok, actor} <-
            Actors.fetch_actor_by_id(id, socket.assigns.subject,
              preload: [:memberships],
@@ -29,7 +29,8 @@ defmodule Web.Actors.Users.NewIdentity do
           providers: providers,
           provider: provider,
           form: to_form(changeset),
-          page_title: "New User Identity"
+          page_title: "New User Identity",
+          next_step: Map.get(params, "next_step")
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
@@ -113,15 +114,19 @@ defmodule Web.Actors.Users.NewIdentity do
         |> Web.Mailer.deliver()
       end
 
-      socket =
-        push_navigate(socket,
-          to: ~p"/#{socket.assigns.account}/actors/#{socket.assigns.actor}/edit_groups"
-        )
+      socket = push_navigate(socket, to: next_path(socket))
 
       {:noreply, socket}
     else
       {:error, changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp next_path(socket) do
+    case socket.assigns.next_step do
+      "edit_groups" -> ~p"/#{socket.assigns.account}/actors/#{socket.assigns.actor}/edit_groups"
+      _ -> ~p"/#{socket.assigns.account}/actors/#{socket.assigns.actor}"
     end
   end
 end

--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -114,7 +114,9 @@ defmodule Web.Actors.Users.NewIdentity do
       end
 
       socket =
-        push_navigate(socket, to: ~p"/#{socket.assigns.account}/actors/#{socket.assigns.actor}")
+        push_navigate(socket,
+          to: ~p"/#{socket.assigns.account}/actors/#{socket.assigns.actor}/groups"
+        )
 
       {:noreply, socket}
     else

--- a/elixir/apps/web/lib/web/router.ex
+++ b/elixir/apps/web/lib/web/router.ex
@@ -140,7 +140,7 @@ defmodule Web.Router do
         end
 
         live "/:id/edit", Edit
-        live "/:id/groups", Groups
+        live "/:id/edit_groups", EditGroups
       end
 
       scope "/groups", Groups do

--- a/elixir/apps/web/lib/web/router.ex
+++ b/elixir/apps/web/lib/web/router.ex
@@ -140,6 +140,7 @@ defmodule Web.Router do
         end
 
         live "/:id/edit", Edit
+        live "/:id/groups", Groups
       end
 
       scope "/groups", Groups do

--- a/elixir/apps/web/test/web/live/actors/edit_test.exs
+++ b/elixir/apps/web/test/web/live/actors/edit_test.exs
@@ -81,20 +81,7 @@ defmodule Web.Live.Actors.EditTest do
                "actor[type]"
              ]
 
-      Fixtures.Actors.create_group(account: account)
-
-      {:ok, lv, _html} =
-        conn
-        |> authorize_conn(identity)
-        |> live(~p"/#{account}/actors/#{actor}/edit")
-
-      form = form(lv, "form")
-
-      assert find_inputs(form) == [
-               "actor[memberships][]",
-               "actor[name]",
-               "actor[type]"
-             ]
+      # Verify synced actor edit form does not allow editing the "name" field
 
       Fixtures.Actors.update(actor, last_synced_at: DateTime.utc_now())
 
@@ -106,7 +93,6 @@ defmodule Web.Live.Actors.EditTest do
       form = form(lv, "form")
 
       assert find_inputs(form) == [
-               "actor[memberships][]",
                "actor[type]"
              ]
     end
@@ -184,31 +170,8 @@ defmodule Web.Live.Actors.EditTest do
       actor: actor,
       conn: conn
     } do
-      managed_group = Fixtures.Actors.create_managed_group(account: account)
-
-      {provider, _bypass} =
-        Fixtures.Auth.start_and_create_google_workspace_provider(account: account)
-
-      synced_group = Fixtures.Actors.create_group(account: account)
-
-      synced_group
-      |> Ecto.Changeset.change(
-        created_by: :provider,
-        provider_id: provider.id,
-        provider_identifier: Ecto.UUID.generate()
-      )
-      |> Repo.update!()
-
-      Fixtures.Actors.create_membership(actor: actor, group: synced_group)
-
-      group1 = Fixtures.Actors.create_group(account: account)
-      Fixtures.Actors.create_membership(actor: actor, group: group1)
-
-      group2 = Fixtures.Actors.create_group(account: account)
-
       attrs = %{
-        name: Fixtures.Actors.actor_attrs().name,
-        memberships: [group2.id]
+        name: Fixtures.Actors.actor_attrs().name
       }
 
       {:ok, lv, _html} =
@@ -222,15 +185,9 @@ defmodule Web.Live.Actors.EditTest do
 
       assert_redirected(lv, ~p"/#{account}/actors/#{actor}")
 
-      expected_group_ids = [managed_group.id, synced_group.id, group2.id]
-
-      assert actor = Repo.get_by(Domain.Actors.Actor, id: actor.id) |> Repo.preload(:memberships)
-      assert actor.name == attrs.name
-      assert length(actor.memberships) == length(expected_group_ids)
-
-      Enum.each(actor.memberships, fn membership ->
-        assert membership.group_id in expected_group_ids
-      end)
+      assert updated_actor = Repo.get_by(Domain.Actors.Actor, id: actor.id)
+      assert updated_actor.name == attrs.name
+      assert updated_actor.name != actor.name
     end
   end
 
@@ -317,20 +274,6 @@ defmodule Web.Live.Actors.EditTest do
       assert find_inputs(form) == [
                "actor[name]"
              ]
-
-      Fixtures.Actors.create_group(account: account)
-
-      {:ok, lv, _html} =
-        conn
-        |> authorize_conn(identity)
-        |> live(~p"/#{account}/actors/#{actor}/edit")
-
-      form = form(lv, "form")
-
-      assert find_inputs(form) == [
-               "actor[memberships][]",
-               "actor[name]"
-             ]
     end
 
     test "renders changeset errors on input change", %{
@@ -387,14 +330,8 @@ defmodule Web.Live.Actors.EditTest do
       actor: actor,
       conn: conn
     } do
-      group1 = Fixtures.Actors.create_group(account: account)
-      Fixtures.Actors.create_membership(actor: actor, group: group1)
-
-      group2 = Fixtures.Actors.create_group(account: account)
-
       attrs = %{
-        name: Fixtures.Actors.actor_attrs().name,
-        memberships: [group2.id]
+        name: Fixtures.Actors.actor_attrs().name
       }
 
       {:ok, lv, _html} =
@@ -408,10 +345,11 @@ defmodule Web.Live.Actors.EditTest do
 
       assert_redirected(lv, ~p"/#{account}/actors/#{actor}")
 
-      assert actor = Repo.get_by(Domain.Actors.Actor, id: actor.id) |> Repo.preload(:memberships)
-      assert actor.name == attrs.name
-      assert [%{group_id: group_id}] = actor.memberships
-      assert group_id == group2.id
+      assert updated_actor =
+               Repo.get_by(Domain.Actors.Actor, id: actor.id) |> Repo.preload(:memberships)
+
+      assert updated_actor.name == attrs.name
+      assert updated_actor.name != actor.name
     end
   end
 end

--- a/elixir/apps/web/test/web/live/actors/groups_test.exs
+++ b/elixir/apps/web/test/web/live/actors/groups_test.exs
@@ -1,0 +1,193 @@
+defmodule Web.Live.Actors.GroupsTest do
+  use Web.ConnCase, async: true
+
+  setup do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+
+    %{
+      account: account,
+      actor: actor,
+      identity: identity
+    }
+  end
+
+  test "redirects to sign in page for unauthorized user", %{
+    account: account,
+    actor: actor,
+    conn: conn
+  } do
+    path = ~p"/#{account}/actors/#{actor}/groups"
+
+    assert live(conn, path) ==
+             {:error,
+              {:redirect,
+               %{
+                 to: ~p"/#{account}?#{%{redirect_to: path}}",
+                 flash: %{"error" => "You must sign in to access this page."}
+               }}}
+  end
+
+  test "renders not found error when actor is deleted", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    actor =
+      Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+      |> Fixtures.Actors.delete()
+
+    assert_raise Web.LiveErrors.NotFoundError, fn ->
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/actors/#{actor}/groups")
+    end
+  end
+
+  test "renders breadcrumbs item", %{
+    account: account,
+    identity: identity,
+    actor: actor,
+    conn: conn
+  } do
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/actors/#{actor}/groups")
+
+    assert item = Floki.find(html, "[aria-label='Breadcrumb']")
+    breadcrumbs = String.trim(Floki.text(item))
+    assert breadcrumbs =~ "Actors"
+    assert breadcrumbs =~ actor.name
+    assert breadcrumbs =~ "Group Memberships"
+  end
+
+  test "renders table with all groups", %{
+    account: account,
+    actor: actor,
+    identity: identity,
+    conn: conn
+  } do
+    group1 = Fixtures.Actors.create_group(account: account)
+    group2 = Fixtures.Actors.create_group(account: account)
+    group3 = Fixtures.Actors.create_group(account: account)
+    Fixtures.Actors.create_managed_group(account: account)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/actors/#{actor}/groups")
+
+    lv
+    |> element("#groups")
+    |> render()
+    |> table_to_map()
+    |> tap(fn rows ->
+      assert length(rows) == 3
+    end)
+    |> with_table_row("group", "#{group1.name}", fn row ->
+      assert row["group"] == group1.name
+      assert row[""] == "Add"
+    end)
+    |> with_table_row("group", "#{group2.name}", fn row ->
+      assert row["group"] == group2.name
+      assert row[""] == "Add"
+    end)
+    |> with_table_row("group", "#{group3.name}", fn row ->
+      assert row["group"] == group3.name
+      assert row[""] == "Add"
+    end)
+  end
+
+  test "changes rows status on add/remove clicks", %{
+    account: account,
+    actor: actor,
+    identity: identity,
+    conn: conn
+  } do
+    group = Fixtures.Actors.create_group(account: account)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/actors/#{actor}/groups")
+
+    lv
+    |> tap(fn lv ->
+      rows =
+        lv
+        |> element("#groups")
+        |> render()
+        |> table_to_map()
+
+      assert [row] = rows
+      assert row["group"] == "#{group.name}"
+      assert row[""] == "Add"
+    end)
+    |> tap(fn lv ->
+      [row] =
+        lv
+        |> element("tr button", "Add")
+        |> render_click()
+        |> Floki.find("#groups")
+        |> table_to_map()
+
+      assert row[""] == "Remove"
+    end)
+    |> tap(fn lv ->
+      [row] =
+        lv
+        |> element("tr button", "Remove")
+        |> render_click()
+        |> Floki.find("#groups")
+        |> table_to_map()
+
+      assert row[""] == "Add"
+    end)
+  end
+
+  test "changes actors on submit", %{
+    account: account,
+    actor: actor,
+    identity: identity,
+    conn: conn
+  } do
+    group1 = Fixtures.Actors.create_group(account: account)
+    group2 = Fixtures.Actors.create_group(account: account)
+    group3 = Fixtures.Actors.create_group(account: account)
+
+    Fixtures.Actors.create_membership(group: group1, actor: actor)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/actors/#{actor}/groups")
+
+    lv
+    |> element("#group-#{group1.id} button", "Remove")
+    |> render_click()
+
+    lv
+    |> element("#group-#{group2.id} button", "Add")
+    |> render_click()
+
+    lv
+    |> element("#group-#{group3.id} button", "Add")
+    |> render_click()
+
+    lv
+    |> element("button", "Save")
+    |> render_click()
+
+    assert_redirected(lv, ~p"/#{account}/actors/#{actor}")
+
+    actor = Repo.preload(actor, :groups, force: true)
+
+    actor_group_ids = Enum.map(actor.groups, & &1.id)
+    assert length(actor_group_ids) == 2
+    assert group1.id not in actor_group_ids
+    assert group2.id in actor_group_ids
+    assert group3.id in actor_group_ids
+  end
+end

--- a/elixir/apps/web/test/web/live/actors/groups_test.exs
+++ b/elixir/apps/web/test/web/live/actors/groups_test.exs
@@ -18,7 +18,7 @@ defmodule Web.Live.Actors.GroupsTest do
     actor: actor,
     conn: conn
   } do
-    path = ~p"/#{account}/actors/#{actor}/groups"
+    path = ~p"/#{account}/actors/#{actor}/edit_groups"
 
     assert live(conn, path) ==
              {:error,
@@ -41,7 +41,7 @@ defmodule Web.Live.Actors.GroupsTest do
     assert_raise Web.LiveErrors.NotFoundError, fn ->
       conn
       |> authorize_conn(identity)
-      |> live(~p"/#{account}/actors/#{actor}/groups")
+      |> live(~p"/#{account}/actors/#{actor}/edit_groups")
     end
   end
 
@@ -54,7 +54,7 @@ defmodule Web.Live.Actors.GroupsTest do
     {:ok, _lv, html} =
       conn
       |> authorize_conn(identity)
-      |> live(~p"/#{account}/actors/#{actor}/groups")
+      |> live(~p"/#{account}/actors/#{actor}/edit_groups")
 
     assert item = Floki.find(html, "[aria-label='Breadcrumb']")
     breadcrumbs = String.trim(Floki.text(item))
@@ -77,7 +77,7 @@ defmodule Web.Live.Actors.GroupsTest do
     {:ok, lv, _html} =
       conn
       |> authorize_conn(identity)
-      |> live(~p"/#{account}/actors/#{actor}/groups")
+      |> live(~p"/#{account}/actors/#{actor}/edit_groups")
 
     lv
     |> element("#groups")
@@ -111,7 +111,7 @@ defmodule Web.Live.Actors.GroupsTest do
     {:ok, lv, _html} =
       conn
       |> authorize_conn(identity)
-      |> live(~p"/#{account}/actors/#{actor}/groups")
+      |> live(~p"/#{account}/actors/#{actor}/edit_groups")
 
     lv
     |> tap(fn lv ->
@@ -162,7 +162,7 @@ defmodule Web.Live.Actors.GroupsTest do
     {:ok, lv, _html} =
       conn
       |> authorize_conn(identity)
-      |> live(~p"/#{account}/actors/#{actor}/groups")
+      |> live(~p"/#{account}/actors/#{actor}/edit_groups")
 
     lv
     |> element("#group-#{group1.id} button", "Remove")

--- a/elixir/apps/web/test/web/live/actors/service_accounts/new_test.exs
+++ b/elixir/apps/web/test/web/live/actors/service_accounts/new_test.exs
@@ -63,20 +63,6 @@ defmodule Web.Live.Actors.ServiceAccount.NewTest do
     assert find_inputs(form) == [
              "actor[name]"
            ]
-
-    Fixtures.Actors.create_group(account: account)
-
-    {:ok, lv, _html} =
-      conn
-      |> authorize_conn(identity)
-      |> live(~p"/#{account}/actors/service_accounts/new")
-
-    form = form(lv, "form")
-
-    assert find_inputs(form) == [
-             "actor[memberships][]",
-             "actor[name]"
-           ]
   end
 
   test "renders changeset errors on input change", %{
@@ -152,18 +138,11 @@ defmodule Web.Live.Actors.ServiceAccount.NewTest do
 
   test "creates a new actor on valid attrs", %{
     account: account,
-    actor: actor,
     identity: identity,
     conn: conn
   } do
-    group1 = Fixtures.Actors.create_group(account: account)
-    Fixtures.Actors.create_membership(actor: actor, group: group1)
-
-    group2 = Fixtures.Actors.create_group(account: account)
-
     attrs = %{
-      name: Fixtures.Actors.actor_attrs().name,
-      memberships: [group1.id, group2.id]
+      name: Fixtures.Actors.actor_attrs().name
     }
 
     {:ok, lv, _html} =
@@ -176,6 +155,7 @@ defmodule Web.Live.Actors.ServiceAccount.NewTest do
     |> render_submit()
 
     assert actor = Repo.get_by(Domain.Actors.Actor, name: attrs.name)
+    assert actor.type == :service_account
 
     assert_redirect(lv, ~p"/#{account}/actors/service_accounts/#{actor}/new_identity")
   end

--- a/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
+++ b/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
@@ -193,7 +193,7 @@ defmodule Web.Live.Actors.User.NewIdentityTest do
     assert identity =
              Repo.get_by(Domain.Auth.Identity, provider_identifier: attrs.provider_identifier)
 
-    assert_redirect(lv, ~p"/#{account}/actors/#{identity.actor_id}/groups")
+    assert_redirect(lv, ~p"/#{account}/actors/#{identity.actor_id}/edit_groups")
 
     assert_email_sent(fn email ->
       assert email.text_body =~ account.slug

--- a/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
+++ b/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
@@ -193,7 +193,7 @@ defmodule Web.Live.Actors.User.NewIdentityTest do
     assert identity =
              Repo.get_by(Domain.Auth.Identity, provider_identifier: attrs.provider_identifier)
 
-    assert_redirect(lv, ~p"/#{account}/actors/#{identity.actor_id}")
+    assert_redirect(lv, ~p"/#{account}/actors/#{identity.actor_id}/groups")
 
     assert_email_sent(fn email ->
       assert email.text_body =~ account.slug

--- a/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
+++ b/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
@@ -168,7 +168,7 @@ defmodule Web.Live.Actors.User.NewIdentityTest do
            }
   end
 
-  test "creates a new actor on valid attrs", %{
+  test "creates a new identity on valid attrs when next_step not set", %{
     account: account,
     actor: actor,
     identity: identity,
@@ -185,6 +185,38 @@ defmodule Web.Live.Actors.User.NewIdentityTest do
       conn
       |> authorize_conn(identity)
       |> live(~p"/#{account}/actors/users/#{actor}/new_identity")
+
+    lv
+    |> form("form", identity: attrs)
+    |> render_submit()
+
+    assert identity =
+             Repo.get_by(Domain.Auth.Identity, provider_identifier: attrs.provider_identifier)
+
+    assert_redirect(lv, ~p"/#{account}/actors/#{identity.actor_id}")
+
+    assert_email_sent(fn email ->
+      assert email.text_body =~ account.slug
+    end)
+  end
+
+  test "creates a new identity on valid attrs when next_step is set", %{
+    account: account,
+    actor: actor,
+    identity: identity,
+    conn: conn
+  } do
+    email_addr = Fixtures.Auth.email()
+
+    attrs = %{
+      provider_identifier: email_addr,
+      provider_identifier_confirmation: email_addr
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/actors/users/#{actor}/new_identity?next_step=edit_groups")
 
     lv
     |> form("form", identity: attrs)

--- a/elixir/apps/web/test/web/live/actors/users/new_test.exs
+++ b/elixir/apps/web/test/web/live/actors/users/new_test.exs
@@ -162,7 +162,10 @@ defmodule Web.Live.Actors.User.NewTest do
     assert new_admin_actor = Repo.get_by(Domain.Actors.Actor, name: attrs.name)
     assert new_admin_actor.type == :account_admin_user
 
-    assert_redirect(lv, ~p"/#{account}/actors/users/#{new_admin_actor}/new_identity")
+    assert_redirect(
+      lv,
+      ~p"/#{account}/actors/users/#{new_admin_actor}/new_identity?next_step=edit_groups"
+    )
 
     # Create non-admin actor
 
@@ -183,6 +186,9 @@ defmodule Web.Live.Actors.User.NewTest do
     assert new_actor = Repo.get_by(Domain.Actors.Actor, name: attrs.name)
     assert new_actor.type == :account_user
 
-    assert_redirect(lv, ~p"/#{account}/actors/users/#{new_actor}/new_identity")
+    assert_redirect(
+      lv,
+      ~p"/#{account}/actors/users/#{new_actor}/new_identity?next_step=edit_groups"
+    )
   end
 end


### PR DESCRIPTION
Why:

* When creating or editing an actor, the previous form had a multi-select input that would list all groups in the account.  In order to select or deselect groups, you would need to hold down ctrl or cmd on the keyboard and click a given group.  This worked when there were a very small number of groups, but if an account had a moderate number of groups it became very difficult.  Along with that, it was also easy to accidentally forget to hold down ctrl/cmd and click a group, which would clear all previously selected groups.  This commit moves the group selection out from the new/edit actor pages and creates a new actor group edit page that allows a user to search for groups as well as making it easy to select which group should be added or removed.

Fixes #4372 

<img width="1008" alt="Screenshot 2024-04-03 at 1 37 25 AM" src="https://github.com/firezone/firezone/assets/2646332/bca9163b-bbaf-49ef-b3b9-8c6770e8c307">