### PR TITLE
refactor(connlib): remove `Option<RawFd>` return value from `Callbacks`

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -8,7 +8,6 @@ use connlib_client_shared::{
 use secrecy::SecretString;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    os::fd::RawFd,
     path::PathBuf,
     sync::Arc,
     time::Duration,
@@ -107,28 +106,20 @@ impl Callbacks for CallbackHandler {
         tunnel_address_v4: Ipv4Addr,
         tunnel_address_v6: Ipv6Addr,
         dns_addresses: Vec<IpAddr>,
-    ) -> Option<RawFd> {
+    ) {
         self.inner.on_set_interface_config(
             tunnel_address_v4.to_string(),
             tunnel_address_v6.to_string(),
             serde_json::to_string(&dns_addresses)
                 .expect("developer error: a list of ips should always be serializable"),
         );
-
-        None
     }
 
-    fn on_update_routes(
-        &self,
-        route_list_4: Vec<Cidrv4>,
-        route_list_6: Vec<Cidrv6>,
-    ) -> Option<RawFd> {
+    fn on_update_routes(&self, route_list_4: Vec<Cidrv4>, route_list_6: Vec<Cidrv6>) {
         self.inner.on_update_routes(
             serde_json::to_string(&route_list_4).unwrap(),
             serde_json::to_string(&route_list_6).unwrap(),
         );
-
-        None
     }
 
     fn on_update_resources(&self, resource_list: Vec<ResourceDescription>) {

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -10,7 +10,7 @@ use connlib_shared::{
     messages::{ConnectionAccepted, GatewayResponse, ResourceAccepted, ResourceId},
     Callbacks,
 };
-use firezone_tunnel::ClientTunnel;
+use firezone_tunnel::{ClientTunnel, Tun};
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
 use std::{
     collections::HashMap,
@@ -32,6 +32,7 @@ pub enum Command {
     Stop,
     Reconnect,
     SetDns(Vec<IpAddr>),
+    SetTun(Tun),
 }
 
 impl<C: Callbacks> Eventloop<C> {
@@ -62,6 +63,7 @@ where
                         tracing::warn!("Failed to update DNS: {e}");
                     }
                 }
+                Poll::Ready(Some(Command::SetTun(tun))) => self.tunnel.set_tun(tun),
                 Poll::Ready(Some(Command::Reconnect)) => {
                     self.portal.reconnect();
                     if let Err(e) = self.tunnel.reconnect() {

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -3,16 +3,21 @@ pub use connlib_shared::messages::ResourceDescription;
 pub use connlib_shared::{
     keypair, Callbacks, Cidrv4, Cidrv6, Error, LoginUrl, LoginUrlError, StaticSecret,
 };
+pub use eventloop::Eventloop;
 pub use firezone_tunnel::Sockets;
+pub use firezone_tunnel::Tun;
 pub use tracing_appender::non_blocking::WorkerGuard;
 
 use backoff::ExponentialBackoffBuilder;
 use connlib_shared::get_user_agent;
-use firezone_tunnel::{ClientTunnel, Tun};
+use eventloop::Command;
+use firezone_tunnel::ClientTunnel;
 use phoenix_channel::PhoenixChannel;
+use secrecy::Secret;
 use std::net::IpAddr;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::task::JoinHandle;
 
 mod eventloop;
 pub mod file_logger;
@@ -20,14 +25,10 @@ mod messages;
 
 const PHOENIX_TOPIC: &str = "client";
 
-use eventloop::Command;
-pub use eventloop::Eventloop;
-use secrecy::Secret;
-use tokio::task::JoinHandle;
-
 /// A session is the entry-point for connlib, maintains the runtime and the tunnel.
 ///
 /// A session is created using [Session::connect], then to stop a session we use [Session::disconnect].
+#[derive(Clone)]
 pub struct Session {
     channel: tokio::sync::mpsc::UnboundedSender<Command>,
 }

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -8,7 +8,7 @@ pub use tracing_appender::non_blocking::WorkerGuard;
 
 use backoff::ExponentialBackoffBuilder;
 use connlib_shared::get_user_agent;
-use firezone_tunnel::ClientTunnel;
+use firezone_tunnel::{ClientTunnel, Tun};
 use phoenix_channel::PhoenixChannel;
 use std::net::IpAddr;
 use std::time::Duration;
@@ -93,6 +93,11 @@ impl Session {
     /// The implementation is idempotent; calling it with the same set of servers is safe.
     pub fn set_dns(&self, new_dns: Vec<IpAddr>) {
         let _ = self.channel.send(Command::SetDns(new_dns));
+    }
+
+    /// Sets a new TUN device for this [`Session`].
+    pub fn set_tun(&self, new_tun: Tun) {
+        let _ = self.channel.send(Command::SetTun(new_tun));
     }
 
     /// Disconnect a [`Session`].

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -4,9 +4,6 @@ use serde::Serialize;
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-// Avoids having to map types for Windows
-type RawFd = i32;
-
 #[derive(Serialize, Clone, Copy, Debug)]
 /// Identical to `ip_network::Ipv4Network` except we implement `Serialize` on the Rust side and the equivalent of `Deserialize` on the Swift / Kotlin side to avoid manually serializing and deserializing.
 pub struct Cidrv4 {
@@ -42,17 +39,10 @@ impl From<Ipv6Network> for Cidrv6 {
 /// Traits that will be used by connlib to callback the client upper layers.
 pub trait Callbacks: Clone + Send + Sync {
     /// Called when the tunnel address is set.
-    ///
-    /// This should return a new `fd` if there is one.
-    /// (Only happens on android for now)
-    fn on_set_interface_config(&self, _: Ipv4Addr, _: Ipv6Addr, _: Vec<IpAddr>) -> Option<RawFd> {
-        None
-    }
+    fn on_set_interface_config(&self, _: Ipv4Addr, _: Ipv6Addr, _: Vec<IpAddr>) {}
 
     /// Called when the route list changes.
-    fn on_update_routes(&self, _: Vec<Cidrv4>, _: Vec<Cidrv6>) -> Option<RawFd> {
-        None
-    }
+    fn on_update_routes(&self, _: Vec<Cidrv4>, _: Vec<Cidrv6>) {}
 
     /// Called when the resource list changes.
     fn on_update_resources(&self, _: Vec<ResourceDescription>) {}

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -16,7 +16,7 @@ use ip_network_table::IpNetworkTable;
 use itertools::Itertools;
 
 use crate::utils::{earliest, stun, turn};
-use crate::{ClientEvent, ClientTunnel};
+use crate::{ClientEvent, ClientTunnel, Tun};
 use secrecy::{ExposeSecret as _, Secret};
 use snownet::ClientNode;
 use std::collections::hash_map::Entry;
@@ -122,6 +122,10 @@ where
         };
 
         Ok(())
+    }
+
+    pub fn set_tun(&mut self, tun: Tun) {
+        self.io.device_mut().set_tun(tun);
     }
 
     #[tracing::instrument(level = "trace", skip(self))]

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -35,7 +35,8 @@ use std::io;
 use std::net::IpAddr;
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
-use tun::Tun;
+
+pub use tun::Tun;
 
 pub struct Device {
     mtu: usize,
@@ -67,6 +68,14 @@ impl Device {
             mtu: 1_280,
             waker: None,
             mtu_refreshed_at: Instant::now(),
+        }
+    }
+
+    pub(crate) fn set_tun(&mut self, tun: Tun) {
+        self.tun = Some(tun);
+
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
         }
     }
 

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -79,7 +79,19 @@ impl Device {
         }
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(target_os = "android")]
+    pub(crate) fn set_config(
+        &mut self,
+        config: &Interface,
+        dns_config: Vec<IpAddr>,
+        callbacks: &impl Callbacks,
+    ) -> Result<(), ConnlibError> {
+        callbacks.on_set_interface_config(config.ipv4, config.ipv6, dns_config);
+
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
     pub(crate) fn set_config(
         &mut self,
         config: &Interface,

--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -56,21 +56,10 @@ impl Tun {
         routes: HashSet<IpNetwork>,
         callbacks: &impl Callbacks,
     ) -> Result<()> {
-        let fd = callbacks.on_update_routes(
+        callbacks.on_update_routes(
             routes.iter().copied().filter_map(ipv4).collect(),
             routes.iter().copied().filter_map(ipv6).collect(),
         );
-
-        Ok(())
-    }
-
-    // SAFETY: must be called with a valid file descriptor
-    unsafe fn replace_fd(&mut self, fd: RawFd) -> Result<()> {
-        if self.fd.as_raw_fd() != fd {
-            unsafe { libc::close(self.fd.as_raw_fd()) };
-            self.fd = AsyncFd::new(fd)?;
-            self.name = interface_name(fd)?;
-        }
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -1,8 +1,7 @@
 use super::utils;
 use crate::device_channel::{ioctl, ipv4, ipv6};
-use connlib_shared::{messages::Interface as InterfaceConfig, Callbacks, Error, Result};
+use connlib_shared::{Callbacks, Result};
 use ip_network::IpNetwork;
-use std::net::IpAddr;
 use std::task::{Context, Poll};
 use std::{
     collections::HashSet,
@@ -61,6 +60,8 @@ impl Tun {
             routes.iter().copied().filter_map(ipv4).collect(),
             routes.iter().copied().filter_map(ipv6).collect(),
         );
+
+        Ok(())
     }
 
     // SAFETY: must be called with a valid file descriptor

--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -14,7 +14,7 @@ use tokio::io::unix::AsyncFd;
 pub(crate) const SIOCGIFMTU: libc::c_ulong = libc::SIOCGIFMTU;
 
 #[derive(Debug)]
-pub(crate) struct Tun {
+pub struct Tun {
     fd: AsyncFd<RawFd>,
     name: String,
 }

--- a/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_darwin.rs
@@ -21,7 +21,7 @@ const CTL_NAME: &[u8] = b"com.apple.net.utun_control";
 pub(crate) const SIOCGIFMTU: u64 = 0x0000_0000_c020_6933;
 
 #[derive(Debug)]
-pub(crate) struct Tun {
+pub struct Tun {
     name: String,
     fd: AsyncFd<RawFd>,
 }

--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -106,7 +106,7 @@ impl Tun {
     ///
     /// This will eventually disappear once updating of routes and interface config no longer happens within `firezone-tunnel`.
     /// At that point, `firezone-tunnel` will interact with a `Stream + Sink` of `IpPacket` and the corresponding implementation of it will sit in the client-crates.
-    pub fn with_fd(_: RawFd) -> Self {
+    pub fn with_fd(_: RawFd) -> Result<Self> {
         unimplemented!("This API should never be called on Linux.")
     }
 

--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -102,6 +102,14 @@ impl Tun {
         utils::poll_raw_fd(&self.fd, |fd| read(fd, buf), cx)
     }
 
+    /// Stub implementation of the `with_fd` constructor that exists only for Android.
+    ///
+    /// This will eventually disappear once updating of routes and interface config no longer happens within `firezone-tunnel`.
+    /// At that point, `firezone-tunnel` will interact with a `Stream + Sink` of `IpPacket` and the corresponding implementation of it will sit in the client-crates.
+    pub fn with_fd(_: RawFd) -> Self {
+        unimplemented!("This API should never be called on Linux.")
+    }
+
     pub fn new(
         config: &InterfaceConfig,
         dns_config: Vec<IpAddr>,

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 pub use client::{ClientState, Request};
+pub use device_channel::Tun;
 pub use gateway::GatewayState;
 pub use sockets::Sockets;
 

--- a/rust/gui-client/src-tauri/src/client/tunnel-wrapper/in_proc.rs
+++ b/rust/gui-client/src-tauri/src/client/tunnel-wrapper/in_proc.rs
@@ -98,12 +98,11 @@ impl connlib_client_shared::Callbacks for CallbackHandler {
             .expect("controller channel failed");
     }
 
-    fn on_set_interface_config(&self, _: Ipv4Addr, _: Ipv6Addr, _: Vec<IpAddr>) -> Option<i32> {
+    fn on_set_interface_config(&self, _: Ipv4Addr, _: Ipv6Addr, _: Vec<IpAddr>) {
         tracing::info!("on_set_interface_config");
         self.ctlr_tx
             .try_send(ControllerRequest::TunnelReady)
             .expect("controller channel failed");
-        None
     }
 
     fn on_update_resources(&self, resources: Vec<ResourceDescription>) {


### PR DESCRIPTION
This represents a more minimal version of #4159 where we for now only change the Android-related code, making this a much smaller change.

The idea is that, instead of setting the new file descriptor based on the return value from the callback, it is the responsibility of the `connlib-client-android` glue code to construct a new `Tun` device and set it on the `Tunnel` using a new command.

Related: #4473.