### PR TITLE
refactor(client-tunnel): remove redundant main

### DIFF
--- a/rust/client-tunnel/src/main.rs
+++ b/rust/client-tunnel/src/main.rs
@@ -1,4 +1,0 @@
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    firezone_client_tunnel::run().await
-}


### PR DESCRIPTION
`client-tunnel` is a library used by `linux-client` and `gui-client` and doesn't need its own main.