### PR TITLE
chore(rust): enforce no wildcard matching

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -57,7 +57,7 @@ clippy.print_stdout = "warn"
 clippy.print_stderr = "warn"
 clippy.unnecessary_wraps = "warn"
 clippy.unused_async = "warn"
-clippy.wildcard_enum_match_arm = "warn"
+clippy.wildcard_enum_match_arm = "warn" # Ensures we match on all combinations of `Poll`, preventing errenous suspensions.
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -57,7 +57,7 @@ clippy.print_stdout = "warn"
 clippy.print_stderr = "warn"
 clippy.unnecessary_wraps = "warn"
 clippy.unused_async = "warn"
-clippy.wildcard_enum_match_arm = "warn" # Ensures we match on all combinations of `Poll`, preventing errenous suspensions.
+clippy.wildcard_enum_match_arm = "warn" # Ensures we match on all combinations of `Poll`, preventing erroneous suspensions.
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -57,6 +57,7 @@ clippy.print_stdout = "warn"
 clippy.print_stderr = "warn"
 clippy.unnecessary_wraps = "warn"
 clippy.unused_async = "warn"
+clippy.wildcard_enum_match_arm = "warn"
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -174,6 +174,7 @@ impl ConnlibError {
 #[cfg(target_os = "linux")]
 impl From<rtnetlink::Error> for ConnlibError {
     fn from(err: rtnetlink::Error) -> Self {
+        #[allow(clippy::wildcard_enum_match_arm)]
         match err {
             rtnetlink::Error::NetlinkError(err) => Self::NetlinkErrorIo(err.to_io()),
             err => Self::NetlinkError(err),

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1416,7 +1416,9 @@ impl Connection {
                 TunnResult::WriteToNetwork(b) => {
                     transmits.extend(make_owned_transmit(peer_socket, b, allocations, now));
                 }
-                _ => panic!("Unexpected result from update_timers"),
+                TunnResult::WriteToTunnelV4(..) | TunnResult::WriteToTunnelV6(..) => {
+                    panic!("Unexpected result from update_timers")
+                }
             };
         }
 
@@ -1476,7 +1478,7 @@ impl Connection {
                         self.force_handshake(allocations, transmits, now);
                     }
                 }
-                _ => {}
+                IceAgentEvent::IceRestart(_) | IceAgentEvent::IceConnectionStateChange(_) => {}
             }
         }
 

--- a/rust/connlib/snownet/src/stun_binding.rs
+++ b/rust/connlib/snownet/src/stun_binding.rs
@@ -80,8 +80,11 @@ impl StunBinding {
 
         let transaction_id = message.transaction_id();
 
-        if !matches!(self.state, State::SentRequest { id, .. } if id == transaction_id) {
-            return false;
+        match self.state {
+            State::SentRequest { id, .. } if id == transaction_id => {}
+            State::SentRequest { .. } | State::ReceivedResponse { .. } | State::Failed => {
+                return false
+            }
         }
 
         self.state = State::ReceivedResponse { at: now };

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -130,6 +130,8 @@ pub(crate) fn create_local_answer<'a>(
     let message = to_dns(&datagram).unwrap();
     let question = message.first_question().unwrap();
     let qtype = question.qtype();
+
+    #[allow(clippy::wildcard_enum_match_arm)]
     let resource = match qtype {
         Rtype::A => RecordData::A(
             ips.iter()
@@ -349,6 +351,7 @@ fn resource_from_question<N: ToDname>(
     let name = ToDname::to_vec(question.qname());
     let qtype = question.qtype();
 
+    #[allow(clippy::wildcard_enum_match_arm)]
     match qtype {
         Rtype::A => {
             let Some(description) = get_description(&name, dns_resources) else {

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -122,6 +122,7 @@ fn run_gui(cli: Cli) -> Result<()> {
 }
 
 fn show_error_dialog(error: &gui::Error) -> Result<()> {
+    #[allow(clippy::wildcard_enum_match_arm)]
     let error_msg = match error {
         // TODO: Update this URL
         gui::Error::WebViewNotInstalled => "Firezone cannot start because WebView2 is not installed. Follow the instructions at <https://www.firezone.dev/kb/user-guides/windows-client>.".to_string(),

--- a/rust/gui-client/src-tauri/src/client/auth.rs
+++ b/rust/gui-client/src-tauri/src/client/auth.rs
@@ -117,7 +117,7 @@ impl Auth {
     pub fn session(&self) -> Option<&Session> {
         match &self.state {
             State::SignedIn(x) => Some(x),
-            _ => None,
+            State::NeedResponse(_) | State::SignedOut => None,
         }
     }
 
@@ -189,7 +189,7 @@ impl Auth {
     pub fn token(&self) -> Result<Option<SecretString>> {
         match self.state {
             State::SignedIn(_) => {}
-            _ => return Ok(None),
+            State::NeedResponse(_) | State::SignedOut => return Ok(None),
         }
 
         Ok(self
@@ -225,7 +225,7 @@ impl Auth {
     pub fn ongoing_request(&self) -> Result<&Request> {
         match &self.state {
             State::NeedResponse(x) => Ok(x),
-            _ => Err(Error::NoInflightRequest),
+            State::SignedIn(_) | State::SignedOut => Err(Error::NoInflightRequest),
         }
     }
 }

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -313,6 +313,7 @@ pub(crate) fn run(cli: client::Cli) -> Result<(), Error> {
         Ok(x) => x,
         Err(error) => {
             tracing::error!(?error, "Failed to build Tauri app instance");
+            #[allow(clippy::wildcard_enum_match_arm)]
             match error {
                 tauri::Error::Runtime(tauri_runtime::Error::CreateWebview(_)) => {
                     return Err(Error::WebViewNotInstalled);
@@ -819,6 +820,8 @@ async fn run_controller(
                 let Some(req) = req else {
                     break;
                 };
+
+                #[allow(clippy::wildcard_enum_match_arm)]
                 match req {
                     // SAFETY: Crashing is unsafe
                     Req::Fail(Failure::Crash) => {

--- a/rust/gui-client/src-tauri/src/client/wintun_install.rs
+++ b/rust/gui-client/src-tauri/src/client/wintun_install.rs
@@ -47,9 +47,12 @@ pub(crate) fn ensure_dll() -> Result<PathBuf, Error> {
     // This hash check is not meant to protect against attacks. It only lets us skip redundant disk writes, and it updates the DLL if needed.
     // `tun_windows.rs` in connlib, and `elevation.rs`, rely on thia.
     if !dll_already_exists(&path, &dll_bytes) {
-        fs::write(&path, dll_bytes.bytes).map_err(|e| match e.kind() {
-            io::ErrorKind::PermissionDenied => Error::PermissionDenied,
-            _ => Error::WriteFailed(e),
+        fs::write(&path, dll_bytes.bytes).map_err(|e| {
+            #[allow(clippy::wildcard_enum_match_arm)]
+            match e.kind() {
+                io::ErrorKind::PermissionDenied => Error::PermissionDenied,
+                _ => Error::WriteFailed(e),
+            }
         })?;
     }
     Ok(path)

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -850,7 +850,7 @@ where
         let response_class = match class {
             MessageClass::SuccessResponse => "success",
             MessageClass::ErrorResponse => "error",
-            _ => return,
+            MessageClass::Indication | MessageClass::Request => return,
         };
         let message_type = match method {
             BINDING => "binding",


### PR DESCRIPTION
A wildcard match was the underlying bug fixed in #4486. Despite being a bit annoying in some cases, I think it is worth having this lint turned on to ensure we don't wildcard match in situations where it can have bad consequences, like `poll` functions.