### PR TITLE
fix(relay): only unbind a channel if it is actually bound

### DIFF
--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -460,7 +460,7 @@ where
         for ((client, number), channel) in self
             .channels_by_client_and_number
             .iter_mut()
-            .filter(|(_, c)| c.is_expired(now))
+            .filter(|(_, c)| c.is_expired(now) && c.bound)
         {
             tracing::info!(target: "relay", channel = %number, %client, peer = %channel.peer_address, allocation = %channel.allocation, "Channel is now expired");
 


### PR DESCRIPTION
Currently, we are emitting the "Channel is now expired" message multiple times because we don't filter for the ones we have already unbound.