### PR TITLE
feat(clients): don't write log files as JSON

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1147,7 +1147,6 @@ dependencies = [
  "tracing",
  "tracing-android",
  "tracing-appender",
- "tracing-stackdriver",
  "tracing-subscriber",
  "url",
 ]

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -14,7 +14,6 @@ secrecy = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-appender = { version = "0.2.2" }
-tracing-stackdriver = { version = "0.10.0" }
 async-trait = { version = "0.1", default-features = false }
 connlib-shared = { workspace = true }
 firezone-tunnel = { workspace = true }

--- a/rust/connlib/clients/shared/src/file_logger.rs
+++ b/rust/connlib/clients/shared/src/file_logger.rs
@@ -32,7 +32,9 @@ where
     T: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
 {
     let (appender, handle) = new_appender(log_dir.to_path_buf());
-    let layer = tracing_stackdriver::layer().with_writer(appender).boxed();
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(appender)
+        .boxed();
 
     // Return the guard so that the caller maintains a handle to it. Otherwise,
     // we have to wait for tracing_appender to flush the logs before exiting.


### PR DESCRIPTION
Currently, all clients write their log files as JSON. This was useful when we were uploading them automatically. This was however removed in https://github.com/firezone/firezone/pull/4390. JSON-formatted logs are really hard to read.

With this PR, we use the regular `fmt` layer which is better suitable for humans.