### PR TITLE
chore(ci): Use target-specific cache when cross building

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -201,8 +201,8 @@ jobs:
           targets: ${{ matrix.arch.target }}
           # Cross doesn't support scccache without a lot of work
           cache_backend: github
-          # Cache needs to be scoped per OS version
-          key: ubuntu-22.04-${{ runner.arch }}
+          # Cache needs to be scoped per OS version and target since cross seems to clobber the cache
+          key: ubuntu-22.04-${{ matrix.arch.target }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cross


### PR DESCRIPTION
I suspect the cache is being saved from cross builds, so this PR further isolates the cross cache per target.

https://github.com/firezone/firezone/actions/runs/8564714747/job/23471683253?pr=4517