### PR TITLE
chore(website): Use 'User' not 'Seat' when referring to pricing

### DIFF
--- a/website/src/app/pricing/_page.tsx
+++ b/website/src/app/pricing/_page.tsx
@@ -124,7 +124,7 @@ export default function _Page() {
               <span className="h-full">
                 <span className="text-sm text-neutral-700 inline-block align-bottom ml-1 mb-1">
                   {" "}
-                  per seat / month
+                  per user / month
                   {annual && ", $50 billed annually"}
                 </span>
               </span>

--- a/website/src/app/pricing/plan_table.tsx
+++ b/website/src/app/pricing/plan_table.tsx
@@ -51,7 +51,7 @@ export default function PlanTable() {
               role="tooltip"
               className="text-wrap absolute z-10 invisible inline-block px-3 py-2 text-xs font-medium text-white transition-opacity duration-100 bg-neutral-900 rounded shadow-sm opacity-90 tooltip"
             >
-              Human operators and end-users of your Firezone account
+              Includes both admins and end-users of your Firezone account
               <div className="tooltip-arrow" data-popper-arrow></div>
             </div>
           </td>

--- a/website/src/components/FAQ/readme.mdx
+++ b/website/src/components/FAQ/readme.mdx
@@ -177,7 +177,7 @@ group at a fine-grained Resource level.
 
 #### How do you charge for Firezone?
 
-Firezone charges per seat — visit our [pricing page](/pricing) for more
+Firezone charges per user — visit our [pricing page](/pricing) for more
 information. Accounts are billed when they start service, or at the beginning of
 each billing cycle. Enterprise plans are billed quarterly or annually, and can
 be paid via credit card, ACH, or wire transfer. Firezone does not require a


### PR DESCRIPTION
This will also need to be updated in #4414

This will prevent further confusion, since we use `User` in the table below this.

Fixes #4477 