### PR TITLE
chore(portal): Add users limit and use it as default limit for accounts

### DIFF
--- a/elixir/apps/domain/lib/domain/accounts/limits.ex
+++ b/elixir/apps/domain/lib/domain/accounts/limits.ex
@@ -3,6 +3,7 @@ defmodule Domain.Accounts.Limits do
 
   @primary_key false
   embedded_schema do
+    field :users_count, :integer
     field :monthly_active_users_count, :integer
     field :service_accounts_count, :integer
     field :gateway_groups_count, :integer

--- a/elixir/apps/domain/lib/domain/accounts/limits/changeset.ex
+++ b/elixir/apps/domain/lib/domain/accounts/limits/changeset.ex
@@ -2,11 +2,16 @@ defmodule Domain.Accounts.Limits.Changeset do
   use Domain, :changeset
   alias Domain.Accounts.Limits
 
-  @fields ~w[monthly_active_users_count service_accounts_count gateway_groups_count account_admin_users_count]a
+  @fields ~w[users_count
+             monthly_active_users_count
+             service_accounts_count
+             gateway_groups_count
+             account_admin_users_count]a
 
   def changeset(limits \\ %Limits{}, attrs) do
     limits
     |> cast(attrs, @fields)
+    |> validate_number(:users_count, greater_than_or_equal_to: 0)
     |> validate_number(:monthly_active_users_count, greater_than_or_equal_to: 0)
     |> validate_number(:service_accounts_count, greater_than_or_equal_to: 0)
     |> validate_number(:gateway_groups_count, greater_than_or_equal_to: 0)

--- a/elixir/apps/domain/lib/domain/actors.ex
+++ b/elixir/apps/domain/lib/domain/actors.ex
@@ -312,6 +312,13 @@ defmodule Domain.Actors do
 
   # Actors
 
+  def count_users_for_account(%Accounts.Account{} = account) do
+    Actor.Query.not_disabled()
+    |> Actor.Query.by_account_id(account.id)
+    |> Actor.Query.by_type({:in, [:account_admin_user, :account_user]})
+    |> Repo.aggregate(:count)
+  end
+
   def count_account_admin_users_for_account(%Accounts.Account{} = account) do
     Actor.Query.not_disabled()
     |> Actor.Query.by_account_id(account.id)

--- a/elixir/apps/domain/lib/domain/actors/actor/query.ex
+++ b/elixir/apps/domain/lib/domain/actors/actor/query.ex
@@ -30,6 +30,10 @@ defmodule Domain.Actors.Actor.Query do
     where(queryable, [actors: actors], actors.account_id == ^account_id)
   end
 
+  def by_type(queryable, {:in, types}) do
+    where(queryable, [actors: actors], actors.type in ^types)
+  end
+
   def by_type(queryable, type) do
     where(queryable, [actors: actors], actors.type == ^type)
   end

--- a/elixir/apps/domain/lib/domain/billing.ex
+++ b/elixir/apps/domain/lib/domain/billing.ex
@@ -54,13 +54,11 @@ defmodule Domain.Billing do
       not Accounts.account_active?(account) ->
         false
 
-      not is_nil(account.limits.monthly_active_users_count) and
-          active_users_count >= account.limits.monthly_active_users_count ->
-        false
+      not is_nil(account.limits.monthly_active_users_count) ->
+        active_users_count < account.limits.monthly_active_users_count
 
-      not is_nil(account.limits.users_count) and
-          users_count >= account.limits.users_count ->
-        false
+      not is_nil(account.limits.users_count) ->
+        users_count < account.limits.users_count
 
       true ->
         true

--- a/elixir/apps/domain/lib/domain/billing/event_handler.ex
+++ b/elixir/apps/domain/lib/domain/billing/event_handler.ex
@@ -354,12 +354,9 @@ defmodule Domain.Billing.EventHandler do
       end)
       |> Enum.into(%{})
 
-    {monthly_active_users_count, features_and_limits} =
-      Map.pop(features_and_limits, "monthly_active_users_count", quantity)
-
+    {users_count, features_and_limits} = Map.pop(features_and_limits, "users_count", quantity)
     {limits, features} = Map.split(features_and_limits, limit_fields)
-
-    limits = Map.merge(limits, %{"monthly_active_users_count" => monthly_active_users_count})
+    limits = Map.merge(limits, %{"users_count" => users_count})
 
     %{
       features: features,

--- a/elixir/apps/domain/lib/domain/billing/jobs.ex
+++ b/elixir/apps/domain/lib/domain/billing/jobs.ex
@@ -7,6 +7,7 @@ defmodule Domain.Billing.Jobs do
     |> Enum.each(fn account ->
       if Billing.enabled?() and Billing.account_provisioned?(account) do
         []
+        |> check_users_limit(account)
         |> check_seats_limit(account)
         |> check_service_accounts_limit(account)
         |> check_gateway_groups_limit(account)
@@ -39,6 +40,16 @@ defmodule Domain.Billing.Jobs do
         :ok
       end
     end)
+  end
+
+  defp check_users_limit(limits_exceeded, account) do
+    users_count = Actors.count_users_for_account(account)
+
+    if Billing.users_limit_exceeded?(account, users_count) do
+      limits_exceeded ++ ["users"]
+    else
+      limits_exceeded
+    end
   end
 
   defp check_seats_limit(limits_exceeded, account) do

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -45,6 +45,7 @@ account =
       }
     },
     limits: %{
+      users_count: 15,
       monthly_active_users_count: 10,
       service_accounts_count: 10,
       gateway_groups_count: 3,

--- a/elixir/apps/domain/test/domain/actors_test.exs
+++ b/elixir/apps/domain/test/domain/actors_test.exs
@@ -1947,6 +1947,41 @@ defmodule Domain.ActorsTest do
     end
   end
 
+  describe "count_users_for_account/1" do
+    test "returns 0 when actors are in another account", %{} do
+      account = Fixtures.Accounts.create_account()
+      Fixtures.Actors.create_actor(type: :account_admin_user)
+
+      assert count_users_for_account(account) == 0
+    end
+
+    test "returns count of account users" do
+      account = Fixtures.Accounts.create_account()
+      Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+      Fixtures.Actors.create_actor(type: :account_user, account: account)
+
+      assert count_users_for_account(account) == 2
+    end
+
+    test "does not count disabled" do
+      account = Fixtures.Accounts.create_account()
+
+      Fixtures.Actors.create_actor(type: :account_user, account: account)
+      |> Fixtures.Actors.disable()
+
+      assert count_users_for_account(account) == 0
+    end
+
+    test "does not count deleted" do
+      account = Fixtures.Accounts.create_account()
+
+      Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+      |> Fixtures.Actors.delete()
+
+      assert count_users_for_account(account) == 0
+    end
+  end
+
   describe "count_account_admin_users_for_account/1" do
     test "returns 0 when actors are in another account", %{} do
       account = Fixtures.Accounts.create_account()

--- a/elixir/apps/domain/test/domain/billing/jobs_test.exs
+++ b/elixir/apps/domain/test/domain/billing/jobs_test.exs
@@ -47,6 +47,7 @@ defmodule Domain.Billing.JobsTest do
 
       Domain.Accounts.update_account(account, %{
         limits: %{
+          users_count: 1,
           monthly_active_users_count: 1,
           service_accounts_count: 1,
           gateway_groups_count: 1,
@@ -59,6 +60,7 @@ defmodule Domain.Billing.JobsTest do
       account = Repo.get!(Domain.Accounts.Account, account.id)
 
       assert account.warning =~ "You have exceeded the following limits:"
+      assert account.warning =~ "users"
       assert account.warning =~ "monthly active users"
       assert account.warning =~ "service accounts"
       assert account.warning =~ "sites"

--- a/elixir/apps/domain/test/domain/billing_test.exs
+++ b/elixir/apps/domain/test/domain/billing_test.exs
@@ -63,7 +63,7 @@ defmodule Domain.BillingTest do
       assert users_limit_exceeded?(account, 11) == true
     end
 
-    test "returns true when seats limit is not set", %{account: account} do
+    test "returns false when seats limit is not set", %{account: account} do
       assert users_limit_exceeded?(account, 0) == false
     end
   end
@@ -87,7 +87,7 @@ defmodule Domain.BillingTest do
       assert seats_limit_exceeded?(account, 11) == true
     end
 
-    test "returns true when seats limit is not set", %{account: account} do
+    test "returns false when seats limit is not set", %{account: account} do
       assert seats_limit_exceeded?(account, 0) == false
     end
   end
@@ -147,7 +147,7 @@ defmodule Domain.BillingTest do
       assert can_create_users?(account) == false
     end
 
-    test "returns true when seats limit is not set", %{account: account} do
+    test "returns false when seats limit is not set", %{account: account} do
       assert can_create_users?(account) == true
     end
   end

--- a/elixir/apps/web/lib/web/live/settings/billing.ex
+++ b/elixir/apps/web/lib/web/live/settings/billing.ex
@@ -7,6 +7,7 @@ defmodule Web.Settings.Billing do
     if Billing.account_provisioned?(socket.assigns.account) do
       admins_count = Actors.count_account_admin_users_for_account(socket.assigns.account)
       service_accounts_count = Actors.count_service_accounts_for_account(socket.assigns.account)
+      users_count = Actors.count_users_for_account(socket.assigns.account)
       active_users_count = Clients.count_1m_active_users_for_account(socket.assigns.account)
       gateway_groups_count = Gateways.count_groups_for_account(socket.assigns.account)
 
@@ -15,6 +16,7 @@ defmodule Web.Settings.Billing do
           page_title: "Billing",
           error: nil,
           admins_count: admins_count,
+          users_count: users_count,
           active_users_count: active_users_count,
           service_accounts_count: service_accounts_count,
           gateway_groups_count: gateway_groups_count
@@ -83,6 +85,21 @@ defmodule Web.Settings.Billing do
             </:value>
           </.vertical_table_row>
 
+          <.vertical_table_row :if={not is_nil(@account.limits.users_count)}>
+            <:label>
+              <p>Users</p>
+            </:label>
+            <:value>
+              <span class={[
+                not is_nil(@users_count) and
+                  @users_count > @account.limits.users_count && "text-red-500"
+              ]}>
+                <%= @users_count %> used
+              </span>
+              / <%= @account.limits.users_count %> allowed
+            </:value>
+          </.vertical_table_row>
+
           <.vertical_table_row :if={not is_nil(@account.limits.monthly_active_users_count)}>
             <:label>
               <p>Seats</p>
@@ -111,7 +128,6 @@ defmodule Web.Settings.Billing do
                 <%= @service_accounts_count %> used
               </span>
               / <%= @account.limits.service_accounts_count %> allowed
-              <p class="text-xs">users with at least one device signed-in within last month</p>
             </:value>
           </.vertical_table_row>
 

--- a/elixir/apps/web/test/web/live/settings/billing_test.exs
+++ b/elixir/apps/web/test/web/live/settings/billing_test.exs
@@ -18,7 +18,8 @@ defmodule Web.Live.Settings.BillingTest do
           monthly_active_users_count: 100,
           service_accounts_count: 100,
           gateway_groups_count: 10,
-          account_admin_users_count: 2
+          account_admin_users_count: 2,
+          users_count: 200
         }
       )
 
@@ -75,6 +76,7 @@ defmodule Web.Live.Settings.BillingTest do
 
     assert rows["billing email"] =~ account.metadata.stripe.billing_email
     assert rows["current plan"] =~ account.metadata.stripe.product_name
+    assert rows["users"] =~ "1 used / 200 allowed"
     assert rows["seats"] =~ "0 used / 100 allowed"
     assert rows["sites"] =~ "0 used / 10 allowed"
     assert rows["admins"] =~ "1 used / 2 allowed"


### PR DESCRIPTION
A manual migration will be needed (run `Domain.Ops.sync_pricing_plans()`) to sync the limits for all the accounts.