### PR TITLE
chore(portal): Remove duplicated "Users" billing row

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/billing.ex
+++ b/elixir/apps/web/lib/web/live/settings/billing.ex
@@ -97,21 +97,6 @@ defmodule Web.Settings.Billing do
                 <%= @users_count %> used
               </span>
               / <%= @account.limits.users_count %> allowed
-            </:value>
-          </.vertical_table_row>
-
-          <.vertical_table_row :if={not is_nil(@account.limits.monthly_active_users_count)}>
-            <:label>
-              <p>Users</p>
-            </:label>
-            <:value>
-              <span class={[
-                not is_nil(@active_users_count) and
-                  @active_users_count > @account.limits.monthly_active_users_count && "text-red-500"
-              ]}>
-                <%= @active_users_count %> used
-              </span>
-              / <%= @account.limits.monthly_active_users_count %> allowed
               <p class="text-xs">Includes both admins and regular users.</p>
             </:value>
           </.vertical_table_row>

--- a/elixir/apps/web/test/web/live/settings/billing_test.exs
+++ b/elixir/apps/web/test/web/live/settings/billing_test.exs
@@ -77,7 +77,6 @@ defmodule Web.Live.Settings.BillingTest do
     assert rows["billing email"] =~ account.metadata.stripe.billing_email
     assert rows["current plan"] =~ account.metadata.stripe.product_name
     assert rows["users"] =~ "1 used / 200 allowed"
-    assert rows["seats"] =~ "0 used / 100 allowed"
     assert rows["sites"] =~ "0 used / 10 allowed"
     assert rows["admins"] =~ "1 used / 2 allowed"
 


### PR DESCRIPTION
This removes the duplicate Users section (formerly "Seats")