### PR TITLE
chore(website): Clarify billing cycle a bit more

### DIFF
--- a/website/src/app/pricing/_page.tsx
+++ b/website/src/app/pricing/_page.tsx
@@ -371,8 +371,8 @@ export default function _Page() {
             <p>When will I be billed?</p>
           </blockquote>
           <p className="mb-8">
-            The Team plan is billed when you start service, and then monthly
-            thereafter. Enterprise plans are billed annually.
+            The Team plan is billed monthly on the same day you start service
+            until canceled. Enterprise plans are billed annually.
           </p>
 
           <a id="payment-methods" className="pt-8"></a>

--- a/website/src/components/FAQ/readme.mdx
+++ b/website/src/components/FAQ/readme.mdx
@@ -180,8 +180,8 @@ group at a fine-grained Resource level.
 #### How do you charge for Firezone?
 
 Firezone charges per user — visit our [pricing page](/pricing) for more
-information. Accounts on the Team plan are billed when they start service and
-then monthly thereafter. Enterprise plans are billed annually. Team and
+information. Accounts on the Team plan are billed monthly on the same day you
+start service until canceled. Enterprise plans are billed annually. Team and
 Enterprise plans can be paid via credit card, ACH, or wire transfer. Firezone
 does not require a credit card to get started.
 


### PR DESCRIPTION
This is explained better on the Stripe pages

<img width="630" alt="Screenshot 2024-04-08 at 8 44 46 AM" src="https://github.com/firezone/firezone/assets/167144/9c337ed5-851e-4bda-bdb1-486d361a5d9e">
<img width="508" alt="Screenshot 2024-04-08 at 8 44 41 AM" src="https://github.com/firezone/firezone/assets/167144/c5985e6f-98ca-4031-9bb2-cfaec431178b">
