### PR TITLE
ci: assert that nothing busy loops after the perf tests

### DIFF
--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -33,3 +33,26 @@ function client_nslookup() {
     # `tee` here copies stdout to stderr
     client timeout 30 sh -c "nslookup $1 | tee >(cat 1>&2) | tail -n +4"
 }
+
+function assert_equals() {
+    local expected="$1"
+    local actual="$2"
+
+    if [[ "$expected" != "$actual" ]]; then
+        echo "Expected $expected but got $actual"
+        exit 1
+    fi
+}
+
+function process_state() {
+    local process_name="$1"
+
+    ps -C "$process_name" -o state=
+}
+
+function assert_process_state {
+    local process_name="$1"
+    local expected_state="$2"
+
+    assert_equals "$(process_state "$process_name")" "$expected_state"
+}

--- a/scripts/tests/perf/direct-tcp-client2server.sh
+++ b/scripts/tests/perf/direct-tcp-client2server.sh
@@ -5,3 +5,6 @@ set -euox pipefail
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
+
+assert_process_state "firezone-gateway" "S"
+assert_process_state "firezone-linux-client" "S"

--- a/scripts/tests/perf/direct-tcp-client2server.sh
+++ b/scripts/tests/perf/direct-tcp-client2server.sh
@@ -2,6 +2,8 @@
 
 set -euox pipefail
 
+source "./scripts/tests/lib.sh"
+
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"

--- a/scripts/tests/perf/direct-tcp-server2client.sh
+++ b/scripts/tests/perf/direct-tcp-server2client.sh
@@ -2,6 +2,8 @@
 
 set -euox pipefail
 
+source "./scripts/tests/lib.sh"
+
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --reverse \
   --client 172.20.0.110 \

--- a/scripts/tests/perf/direct-tcp-server2client.sh
+++ b/scripts/tests/perf/direct-tcp-server2client.sh
@@ -6,3 +6,6 @@ docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --reverse \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
+
+assert_process_state "firezone-gateway" "S"
+assert_process_state "firezone-linux-client" "S"

--- a/scripts/tests/perf/direct-udp-client2server.sh
+++ b/scripts/tests/perf/direct-udp-client2server.sh
@@ -2,6 +2,8 @@
 
 set -euox pipefail
 
+source "./scripts/tests/lib.sh"
+
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --udp \
   --bandwidth 50M \

--- a/scripts/tests/perf/direct-udp-client2server.sh
+++ b/scripts/tests/perf/direct-udp-client2server.sh
@@ -7,3 +7,6 @@ docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --bandwidth 50M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
+
+assert_process_state "firezone-gateway" "S"
+assert_process_state "firezone-linux-client" "S"

--- a/scripts/tests/perf/direct-udp-server2client.sh
+++ b/scripts/tests/perf/direct-udp-server2client.sh
@@ -2,6 +2,8 @@
 
 set -euox pipefail
 
+source "./scripts/tests/lib.sh"
+
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --reverse \
   --udp \

--- a/scripts/tests/perf/direct-udp-server2client.sh
+++ b/scripts/tests/perf/direct-udp-server2client.sh
@@ -8,3 +8,6 @@ docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --bandwidth 50M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
+
+assert_process_state "firezone-gateway" "S"
+assert_process_state "firezone-linux-client" "S"

--- a/scripts/tests/perf/relayed-tcp-client2server.sh
+++ b/scripts/tests/perf/relayed-tcp-client2server.sh
@@ -8,3 +8,7 @@ install_iptables_drop_rules
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
+
+assert_process_state "firezone-relay" "S"
+assert_process_state "firezone-gateway" "S"
+assert_process_state "firezone-linux-client" "S"

--- a/scripts/tests/perf/relayed-tcp-server2client.sh
+++ b/scripts/tests/perf/relayed-tcp-server2client.sh
@@ -9,3 +9,7 @@ docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --reverse \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
+
+assert_process_state "firezone-relay" "S"
+assert_process_state "firezone-gateway" "S"
+assert_process_state "firezone-linux-client" "S"

--- a/scripts/tests/perf/relayed-udp-client2server.sh
+++ b/scripts/tests/perf/relayed-udp-client2server.sh
@@ -10,3 +10,7 @@ docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --bandwidth 50M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
+
+assert_process_state "firezone-relay" "S"
+assert_process_state "firezone-gateway" "S"
+assert_process_state "firezone-linux-client" "S"

--- a/scripts/tests/perf/relayed-udp-server2client.sh
+++ b/scripts/tests/perf/relayed-udp-server2client.sh
@@ -11,3 +11,7 @@ docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --bandwidth 50M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
+
+assert_process_state "firezone-relay" "S"
+assert_process_state "firezone-gateway" "S"
+assert_process_state "firezone-linux-client" "S"


### PR DESCRIPTION
The clients, gateway and relay all employ an internal design that is based on an eventloop. This gives us a lot of control in how various IO components interact with each other. Great control also comes with a source of bugs, the latest of which made the relay busy-loop once it started relaying some traffic.

Eventloops are notoriously hard to unit-test because they compose various IO bits together. Instead of writing unit tests, we can go and assert the process state after the performance tests. Those generate a fair bit of load on all our components but after that, they should suspend.

The most effective tests survive even large refactorings and for that, they need to be coded against a stable API / property. Asserting that the process sleeps when it is idle from an application PoV is such a property.

Related: #4511.