### PR TITLE
chore(relay): fail health-check with 400 on being partitioned for > 15min

### DIFF
--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -54,7 +54,10 @@ async fn try_main() -> Result<()> {
 
     let ctrl_c = pin!(ctrl_c().map_err(anyhow::Error::new));
 
-    tokio::spawn(http_health_check::serve(cli.health_check.health_check_addr));
+    tokio::spawn(http_health_check::serve(
+        cli.health_check.health_check_addr,
+        || true,
+    ));
 
     match future::try_select(task, ctrl_c)
         .await

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -27,6 +27,8 @@ const STATS_LOG_INTERVAL: Duration = Duration::from_secs(10);
 
 const TURN_PORT: u16 = 3478;
 
+const MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 15);
+
 #[derive(Parser, Debug)]
 struct Args {
     /// The public (i.e. internet-reachable) IPv4 address of the relay server.
@@ -272,7 +274,7 @@ async fn connect_to_portal(
             stamp_secret: stamp_secret.expose_secret().to_string(),
         },
         ExponentialBackoffBuilder::default()
-            .with_max_elapsed_time(None)
+            .with_max_elapsed_time(Some(MAX_PARTITION_TIME))
             .build(),
     )
     .await??;

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -135,6 +135,7 @@ async fn main() -> Result<()> {
 
     tokio::spawn(http_health_check::serve(
         args.health_check.health_check_addr,
+        || true,
     ));
 
     tracing::info!(target: "relay", "Listening for incoming traffic on UDP port {TURN_PORT}");

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -118,6 +118,11 @@ async fn main() -> Result<()> {
         args.highest_port,
     );
 
+    tokio::spawn(http_health_check::serve(
+        args.health_check.health_check_addr,
+        || true,
+    ));
+
     let channel = if let Some(token) = args.token.as_ref() {
         let base_url = args.api_url.clone();
         let stamp_secret = server.auth_secret();
@@ -134,11 +139,6 @@ async fn main() -> Result<()> {
     };
 
     let mut eventloop = Eventloop::new(server, channel, public_addr)?;
-
-    tokio::spawn(http_health_check::serve(
-        args.health_check.health_check_addr,
-        || true,
-    ));
 
     tracing::info!(target: "relay", "Listening for incoming traffic on UDP port {TURN_PORT}");
 


### PR DESCRIPTION
During the latest relay outage, we failed to send heartbeats to the portal because we were busy-looping and never got to handle messages or timers for the portal.

To mitigate this or similar bugs, we update an `Instant` every time we send a heartbeat to the portal. In case we are actually network-partitioned, this will cause the health-check to fail after 15 minutes. This value is the same as the partition timeout for the portal connection itself[^1]. Very likely, we will never see a relay being shutdown because of a failing health check in this case as it would have already shut itself down.

An exception to this are bugs in the eventloop where we fail to interact with the portal at all.

Resolves: #4510.

[^1]: Previously, this was unlimited.