### PR TITLE
chore(connlib): upsert relays from "init" message

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -179,6 +179,7 @@ where
             IngressMessages::Init(InitClient {
                 interface,
                 resources,
+                relays,
             }) => {
                 if let Err(e) = self.tunnel.set_new_interface_config(interface) {
                     tracing::warn!("Failed to set interface on tunnel: {e}");
@@ -187,6 +188,7 @@ where
 
                 tracing::info!("Firezone Started!");
                 let _ = self.tunnel.set_resources(resources);
+                self.tunnel.upsert_relays(relays)
             }
             IngressMessages::ResourceCreatedOrUpdated(resource) => {
                 let resource_id = resource.id();

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -10,6 +10,8 @@ pub struct InitClient {
     pub interface: Interface,
     #[serde(default)]
     pub resources: Vec<ResourceDescription>,
+    #[serde(default)]
+    pub relays: Vec<Relay>,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
@@ -198,6 +200,7 @@ mod test {
                         name: "gitlab.mycorp.com".to_string(),
                     }),
                 ],
+                relays: vec![],
             }),
             None,
         );
@@ -256,6 +259,7 @@ mod test {
                         name: "gitlab.mycorp.com".to_string(),
                     }),
                 ],
+                relays: vec![],
             }),
             None,
         );
@@ -306,6 +310,7 @@ mod test {
                     upstream_dns: vec![],
                 },
                 resources: vec![],
+                relays: vec![],
             }),
             None,
         );
@@ -339,6 +344,7 @@ mod test {
                     upstream_dns: vec![],
                 },
                 resources: vec![],
+                relays: vec![],
             }),
             None,
         );
@@ -372,6 +378,7 @@ mod test {
                     upstream_dns: vec![],
                 },
                 resources: vec![],
+                relays: vec![],
             }),
             None,
         );
@@ -405,6 +412,7 @@ mod test {
                     upstream_dns: vec![],
                 },
                 resources: vec![],
+                relays: vec![],
             }),
             None,
         );
@@ -462,18 +470,22 @@ mod test {
                 resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
                 relays: vec![
                     Relay::Stun(Stun {
+                        id: "c9cb8892-e355-41e6-a882-b6d6c38beb66".parse().unwrap(),
                         addr: "189.172.73.111:3478".parse().unwrap(),
                     }),
                     Relay::Turn(Turn {
+                        id: "6a7f3ba9-d9c4-4633-81ab-311276993fbd".parse().unwrap(),
                         expires_at: DateTime::from_timestamp(1686629954, 0).unwrap(),
                         addr: "189.172.73.111:3478".parse().unwrap(),
                         username: "1686629954:C7I74wXYFdFugMYM".to_string(),
                         password: "OXXRDJ7lJN1cm+4+2BWgL87CxDrvpVrn5j3fnJHye98".to_string(),
                     }),
                     Relay::Stun(Stun {
+                        id: "1ea93681-aeda-467f-9dca-219c06c18c3d".parse().unwrap(),
                         addr: "[::1]:3478".parse().unwrap(),
                     }),
                     Relay::Turn(Turn {
+                        id: "94209389-e18d-4453-a00d-2583ba857592".parse().unwrap(),
                         expires_at: DateTime::from_timestamp(1686629954, 0).unwrap(),
                         addr: "[::1]:3478".parse().unwrap(),
                         username: "1686629954:dpHxHfNfOhxPLfMG".to_string(),
@@ -495,10 +507,12 @@ mod test {
                         "gateway_remote_ip": "172.28.0.1",
                         "relays": [
                             {
+                                "id": "c9cb8892-e355-41e6-a882-b6d6c38beb66",
                                 "type":"stun",
                                 "addr": "189.172.73.111:3478"
                             },
                             {
+                                "id": "6a7f3ba9-d9c4-4633-81ab-311276993fbd",
                                 "expires_at": 1686629954,
                                 "password": "OXXRDJ7lJN1cm+4+2BWgL87CxDrvpVrn5j3fnJHye98",
                                 "type": "turn",
@@ -506,10 +520,12 @@ mod test {
                                 "username":"1686629954:C7I74wXYFdFugMYM"
                             },
                             {
+                                "id": "1ea93681-aeda-467f-9dca-219c06c18c3d",
                                 "type": "stun",
                                 "addr": "[::1]:3478"
                             },
                             {
+                                "id": "94209389-e18d-4453-a00d-2583ba857592",
                                 "expires_at": 1686629954,
                                 "password": "8Wtb+3YGxO6ia23JUeSEfZ2yFD6RhGLkbgZwqjebyKY",
                                 "type": "turn",

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -79,6 +79,12 @@ impl fmt::Display for GatewayId {
     }
 }
 
+impl fmt::Display for RelayId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// Represents a wireguard peer.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Peer {

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -18,8 +18,20 @@ use crate::Dname;
 
 #[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub struct GatewayId(Uuid);
+
 #[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ResourceId(Uuid);
+
+#[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RelayId(Uuid);
+
+impl FromStr for RelayId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(RelayId(Uuid::parse_str(s)?))
+    }
+}
 
 impl ResourceId {
     pub fn random() -> ResourceId {
@@ -364,6 +376,7 @@ pub enum Relay {
 /// Represent a TURN relay
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct Turn {
+    pub id: RelayId,
     //// Expire time of the username/password in unix millisecond timestamp UTC
     #[serde(with = "ts_seconds")]
     pub expires_at: DateTime<Utc>,
@@ -379,6 +392,8 @@ pub struct Turn {
 /// Stun kind of relay
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct Stun {
+    pub id: RelayId,
+
     /// Address for the relay
     pub addr: SocketAddr,
 }

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -145,11 +145,13 @@ where
     /// This will implicitly trigger a [`refresh`](Allocation::refresh) to ensure these credentials are valid.
     pub fn update_credentials(
         &mut self,
+        socket: SocketAddr,
         username: Username,
         password: &str,
         realm: Realm,
         now: Instant,
     ) {
+        self.server = socket;
         self.username = username;
         self.realm = realm;
         self.password = password.to_owned();
@@ -1095,6 +1097,7 @@ mod tests {
     const PEER2_IP6: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 20000);
 
     const RELAY: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3478);
+    const RELAY2: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 3478);
     const RELAY_ADDR_IP4: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9999);
     const RELAY_ADDR_IP6: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 9999);
 
@@ -1924,6 +1927,23 @@ mod tests {
         )
     }
 
+    #[test]
+    fn new_address_is_used_for_new_messages() {
+        let now = Instant::now();
+        let mut allocation = Allocation::for_test(now).with_allocate_response(&[RELAY_ADDR_IP4]);
+        let _drained_messages = iter::from_fn(|| allocation.poll_transmit()).collect::<Vec<_>>();
+
+        allocation.update_credentials(
+            RELAY2,
+            allocation.username.clone(),
+            &allocation.password.clone(),
+            allocation.realm.clone(),
+            now,
+        );
+
+        assert_eq!(allocation.poll_transmit().unwrap().dst, RELAY2)
+    }
+
     fn ch(peer: SocketAddr, now: Instant) -> Channel {
         Channel {
             peer,
@@ -2060,6 +2080,7 @@ mod tests {
 
         fn refresh_with_same_credentials(&mut self) {
             self.update_credentials(
+                self.server,
                 Username::new("foobar".to_owned()).unwrap(),
                 "baz",
                 Realm::new("firezone".to_owned()).unwrap(),

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -561,7 +561,7 @@ where
 
     /// Tries to handle the packet using one of our [`Allocation`]s.
     ///
-    /// This functions is in the hot-path of packet processing and thus must be as efficient as possible.
+    /// This function is in the hot-path of packet processing and thus must be as efficient as possible.
     /// Even look-ups in [`HashMap`]s and linear searches across small lists are expensive at this point.
     /// Thus, we use the first byte of the message as a heuristic for whether we should attempt to handle it here.
     ///

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -542,6 +542,7 @@ where
     /// Those are fully encrypted and thus any byte pattern may appear at the front of the packet.
     /// We can detect this by further checking the origin of the packet.
     #[must_use]
+    #[allow(clippy::type_complexity)]
     fn allocations_try_handle<'p>(
         &mut self,
         from: SocketAddr,
@@ -703,10 +704,6 @@ where
                 }
             }
         }
-    }
-
-    pub fn upsert_relays(&self, _: HashSet<(RId, SocketAddr, String, String, String)>) {
-        unimplemented!()
     }
 }
 
@@ -890,7 +887,7 @@ where
         }
     }
 
-    fn upsert_turn_servers(
+    pub fn upsert_turn_servers(
         &mut self,
         servers: &HashSet<(RId, SocketAddr, String, String, String)>,
         now: Instant,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -464,7 +464,7 @@ where
             };
 
             if let Some(existing) = self.allocations.get_mut(id) {
-                existing.update_credentials(username, password, realm, now); // TODO: Pass new address here.
+                existing.update_credentials(*server, username, password, realm, now);
                 continue;
             }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -6,7 +6,7 @@ use bimap::BiMap;
 use connlib_shared::error::{ConnlibError as Error, ConnlibError};
 use connlib_shared::messages::{
     Answer, ClientPayload, DnsServer, DomainResponse, GatewayId, Interface as InterfaceConfig,
-    IpDnsServer, Key, Offer, Relay, RequestConnection, ResourceDescription,
+    IpDnsServer, Key, Offer, Relay, RelayId, RequestConnection, ResourceDescription,
     ResourceDescriptionCidr, ResourceDescriptionDns, ResourceId, ReuseConnection,
 };
 use connlib_shared::{Callbacks, Dname, PublicKey, StaticSecret};
@@ -71,6 +71,11 @@ where
             .on_update_resources(self.role_state.resources());
 
         Ok(())
+    }
+
+    pub fn upsert_relays(&mut self, relays: Vec<Relay>) {
+        self.role_state
+            .upsert_relays(turn(&relays, |addr| self.io.sockets_ref().can_handle(addr)))
     }
 
     /// Adds a the given resource to the tunnel.
@@ -250,7 +255,7 @@ pub struct ClientState {
 
     pub peers: PeerStore<GatewayId, PacketTransformClient, HashSet<ResourceId>>,
 
-    node: ClientNode<GatewayId>,
+    node: ClientNode<GatewayId, RelayId>,
 
     pub ip_provider: IpProvider,
 
@@ -425,7 +430,7 @@ impl ClientState {
         resource_id: ResourceId,
         gateway_id: GatewayId,
         allowed_stun_servers: HashSet<SocketAddr>,
-        allowed_turn_servers: HashSet<(SocketAddr, String, String, String)>,
+        allowed_turn_servers: HashSet<(RelayId, SocketAddr, String, String, String)>,
     ) -> connlib_shared::Result<Request> {
         tracing::trace!("create_or_reuse_connection");
 
@@ -984,6 +989,10 @@ impl ClientState {
         self.set_dns_mapping(dns_mapping);
 
         true
+    }
+
+    fn upsert_relays(&self, relays: HashSet<(RelayId, SocketAddr, String, String, String)>) {
+        self.node.upsert_relays(relays);
     }
 }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -74,8 +74,10 @@ where
     }
 
     pub fn upsert_relays(&mut self, relays: Vec<Relay>) {
-        self.role_state
-            .upsert_relays(turn(&relays, |addr| self.io.sockets_ref().can_handle(addr)))
+        self.role_state.upsert_relays(
+            turn(&relays, |addr| self.io.sockets_ref().can_handle(addr)),
+            Instant::now(),
+        )
     }
 
     /// Adds a the given resource to the tunnel.
@@ -991,8 +993,12 @@ impl ClientState {
         true
     }
 
-    fn upsert_relays(&self, relays: HashSet<(RelayId, SocketAddr, String, String, String)>) {
-        self.node.upsert_relays(relays);
+    fn upsert_relays(
+        &mut self,
+        relays: HashSet<(RelayId, SocketAddr, String, String, String)>,
+        now: Instant,
+    ) {
+        self.node.upsert_turn_servers(&relays, now);
     }
 }
 

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -310,9 +310,10 @@ impl GatewayState {
     }
 
     pub(crate) fn upsert_relays(
-        &self,
+        &mut self,
         relays: HashSet<(RelayId, SocketAddr, String, String, String)>,
+        now: Instant,
     ) {
-        self.node.upsert_relays(relays)
+        self.node.upsert_turn_servers(&relays, now);
     }
 }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -7,7 +7,7 @@ use boringtun::x25519::PublicKey;
 use chrono::{DateTime, Utc};
 use connlib_shared::messages::{
     Answer, ClientId, ConnectionAccepted, DomainResponse, Interface as InterfaceConfig, Key, Offer,
-    Relay, ResolvedResourceDescriptionDns, ResourceDescription, ResourceId,
+    Relay, RelayId, ResolvedResourceDescriptionDns, ResourceDescription, ResourceId,
 };
 use connlib_shared::{Callbacks, Dname, Error, Result, StaticSecret};
 use ip_network::IpNetwork;
@@ -189,8 +189,7 @@ where
 
 pub struct GatewayState {
     pub peers: PeerStore<ClientId, PacketTransformGateway, ()>,
-    node: ServerNode<ClientId>,
-
+    node: ServerNode<ClientId, RelayId>,
     next_expiry_resources_check: Option<Instant>,
     buffered_events: VecDeque<GatewayEvent>,
 }
@@ -308,5 +307,12 @@ impl GatewayState {
 
     pub(crate) fn poll_event(&mut self) -> Option<GatewayEvent> {
         self.buffered_events.pop_front()
+    }
+
+    pub(crate) fn upsert_relays(
+        &self,
+        relays: HashSet<(RelayId, SocketAddr, String, String, String)>,
+    ) {
+        self.node.upsert_relays(relays)
     }
 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -5,7 +5,7 @@
 
 use boringtun::x25519::StaticSecret;
 use connlib_shared::{
-    messages::{ClientId, GatewayId, ResourceId, ReuseConnection},
+    messages::{ClientId, GatewayId, Relay, ResourceId, ReuseConnection},
     Callbacks, Result,
 };
 use io::Io;
@@ -18,6 +18,7 @@ use std::{
 pub use client::{ClientState, Request};
 pub use gateway::GatewayState;
 pub use sockets::Sockets;
+use utils::turn;
 
 mod client;
 mod device_channel;
@@ -169,6 +170,11 @@ where
             ip6_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
             device_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
         })
+    }
+
+    pub fn upsert_relays(&self, relays: Vec<Relay>) {
+        self.role_state
+            .upsert_relays(turn(&relays, |addr| self.io.sockets_ref().can_handle(addr)))
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Result<GatewayEvent>> {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -172,9 +172,11 @@ where
         })
     }
 
-    pub fn upsert_relays(&self, relays: Vec<Relay>) {
-        self.role_state
-            .upsert_relays(turn(&relays, |addr| self.io.sockets_ref().can_handle(addr)))
+    pub fn upsert_relays(&mut self, relays: Vec<Relay>) {
+        self.role_state.upsert_relays(
+            turn(&relays, |addr| self.io.sockets_ref().can_handle(addr)),
+            Instant::now(),
+        )
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Result<GatewayEvent>> {

--- a/rust/connlib/tunnel/src/utils.rs
+++ b/rust/connlib/tunnel/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::REALM;
-use connlib_shared::messages::Relay;
+use connlib_shared::messages::{Relay, RelayId};
 use std::{collections::HashSet, net::SocketAddr, time::Instant};
 
 pub fn stun(relays: &[Relay], predicate: impl Fn(&SocketAddr) -> bool) -> HashSet<SocketAddr> {
@@ -19,12 +19,13 @@ pub fn stun(relays: &[Relay], predicate: impl Fn(&SocketAddr) -> bool) -> HashSe
 pub fn turn(
     relays: &[Relay],
     predicate: impl Fn(&SocketAddr) -> bool,
-) -> HashSet<(SocketAddr, String, String, String)> {
+) -> HashSet<(RelayId, SocketAddr, String, String, String)> {
     relays
         .iter()
         .filter_map(|r| {
             if let Relay::Turn(r) = r {
                 Some((
+                    r.id,
                     r.addr,
                     r.username.clone(),
                     r.password.clone(),
@@ -34,7 +35,7 @@ pub fn turn(
                 None
             }
         })
-        .filter(|(socket, _, _, _)| predicate(socket))
+        .filter(|(_, socket, _, _, _)| predicate(socket))
         .collect()
 }
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -110,6 +110,7 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
     tunnel
         .set_interface(&init.interface)
         .context("Failed to set interface")?;
+    tunnel.upsert_relays(init.relays);
 
     let mut eventloop = Eventloop::new(tunnel, portal);
 

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -151,10 +151,12 @@ mod test {
                 },
                 "relays": [
                     {
+                        "id": "0bfc5e02-a093-423b-827b-002d7d2bb407",
                         "type": "stun",
                         "addr": "172.28.0.101:3478"
                     },
                     {
+                        "id": "0a133356-7a9e-4b9a-b413-0d95a5720fd8",
                         "type": "turn",
                         "username": "1719367575:ZQHcVGkdnfgGmcP1",
                         "password": "ZWYiBeFHOJyYq0mcwAXjRpcuXIJJpzWlOXVdxwttrWg",

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 pub struct InitGateway {
     pub interface: Interface,
     pub config: Config,
+    #[serde(default)]
+    pub relays: Vec<Relay>,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
@@ -178,6 +180,7 @@ mod test {
                 ipv4_masquerade_enabled: true,
                 ipv6_masquerade_enabled: true,
             },
+            relays: vec![],
         });
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
@@ -197,6 +200,7 @@ mod test {
                 ipv4_masquerade_enabled: true,
                 ipv6_masquerade_enabled: true,
             },
+            relays: vec![],
         });
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","irrelevant":"field","payload":{"more":"info","interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true,"ignored":"field"}}}"#;
@@ -216,6 +220,7 @@ mod test {
                 ipv4_masquerade_enabled: true,
                 ipv6_masquerade_enabled: true,
             },
+            relays: vec![],
         });
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":null,"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
@@ -235,6 +240,7 @@ mod test {
                 ipv4_masquerade_enabled: true,
                 ipv6_masquerade_enabled: true,
             },
+            relays: vec![],
         });
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":0.3,"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
@@ -254,6 +260,7 @@ mod test {
                 ipv4_masquerade_enabled: true,
                 ipv6_masquerade_enabled: true,
             },
+            relays: vec![],
         });
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":true,"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
@@ -273,6 +280,7 @@ mod test {
                 ipv4_masquerade_enabled: true,
                 ipv6_masquerade_enabled: true,
             },
+            relays: vec![],
         });
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":{"ignored":"field"},"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
@@ -292,6 +300,7 @@ mod test {
                 ipv4_masquerade_enabled: true,
                 ipv6_masquerade_enabled: true,
             },
+            relays: vec![],
         });
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":[true,false],"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;


### PR DESCRIPTION
This is another step towards #4548. The portal now includes a list of relays as part of the "init" message. Any time we receive an "init", we will now upsert those relays based on their ID. This requires us to change our internal bookkeeping of relays from indexing them by address to indexing by ID.

To ensure that this works correctly, the unit tests are rewritten to use the new `upsert_relays` API.