### PR TITLE
chore(snownet): add unit-test for relayed connection

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5641,6 +5641,7 @@ dependencies = [
  "boringtun",
  "bytecodec",
  "bytes",
+ "firezone-relay",
  "hex",
  "once_cell",
  "pnet_packet",

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -21,6 +21,7 @@ hex = "0.4.0"
 
 [dev-dependencies]
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
+firezone-relay = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -626,10 +626,9 @@ fn progress(
         let payload = &trans.payload;
         let Some(src) = trans.src else {
             // `src` not set? Must client-facing traffic for the relay.
+            assert_eq!(trans.dst.port(), 3478);
 
             if let Some(relay) = r {
-                assert_eq!(trans.dst.port(), 3478);
-
                 relay.handle_client_input(payload, ClientSocket::new(f.local), f, t);
             }
 

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -284,7 +284,7 @@ struct Clock {
 impl Clock {
     fn new() -> Self {
         let now = Instant::now();
-        let tick_rate = Duration::from_millis(10);
+        let tick_rate = Duration::from_millis(100);
         let one_hour = Duration::from_secs(60) * 60;
 
         Self {

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -646,14 +646,14 @@ fn progress(
         (a1, a2)
     };
 
-    t.progress_count += 1;
+    f.progress_count += 1;
 
-    while let Some(v) = t.span.in_scope(|| t.node.poll_event()) {
+    while let Some(v) = f.span.in_scope(|| f.node.poll_event()) {
         match v {
             Event::SignalIceCandidate {
                 connection,
                 candidate,
-            } => f
+            } => t
                 .node
                 .add_remote_candidate(connection, candidate, clock.now),
             Event::ConnectionEstablished(_) => {}

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -385,11 +385,7 @@ impl TestRelay {
             .span
             .in_scope(|| self.inner.handle_peer_traffic(payload, peer, port))
         {
-            assert_eq!(
-                client.into_socket(),
-                receiver.local,
-                "only relays to the other party"
-            );
+            assert_eq!(client.into_socket(), receiver.local); // We will relay to `receiver`, ensure that this is where the data should go.
 
             let mut msg = vec![0u8; payload.len() + 4];
             msg[4..].copy_from_slice(payload);

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -274,6 +274,7 @@ struct Firewall {
 }
 
 struct Clock {
+    start: Instant,
     now: Instant,
 
     tick_rate: Duration,
@@ -287,6 +288,7 @@ impl Clock {
         let one_hour = Duration::from_secs(60) * 60;
 
         Self {
+            start: now,
             now,
             tick_rate,
             max_time: now + one_hour,
@@ -295,6 +297,12 @@ impl Clock {
 
     fn tick(&mut self) {
         self.now += self.tick_rate;
+
+        let elapsed = self.now.duration_since(self.start);
+
+        if elapsed.as_millis() % 60_000 == 0 {
+            tracing::info!("Time since start: {elapsed:?}")
+        }
 
         if self.now >= self.max_time {
             panic!("Time exceeded")

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -497,7 +497,7 @@ fn progress(a1: &mut TestNode, a2: &mut TestNode, mut r: Option<&mut TestRelay>)
                 }
                 firezone_relay::Command::CreateAllocation { .. }
                 | firezone_relay::Command::FreeAllocation { .. } => {
-                    // We ignore these because in our test this always succeeds.
+                    // We ignore these because in our test we don't perform any IO.
                 }
             }
 

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -305,8 +305,6 @@ impl TestRelay {
                 return;
             }
 
-            let buffer = receiver.buffer.as_mut();
-
             if let Some((_, packet)) = receiver
                 .span
                 .in_scope(|| {
@@ -315,7 +313,7 @@ impl TestRelay {
                         SocketAddr::from((self.listen_addr.ip(), port.value())),
                         payload,
                         receiver.time,
-                        buffer,
+                        receiver.buffer.as_mut(),
                     )
                 })
                 .unwrap()
@@ -381,8 +379,6 @@ impl TestRelay {
                         panic!("Relay generated traffic for unknown client")
                     };
 
-                    let buffer = recipient.buffer.as_mut();
-
                     if let Some((_, packet)) = recipient
                         .span
                         .in_scope(|| {
@@ -391,7 +387,7 @@ impl TestRelay {
                                 self.listen_addr,
                                 &payload,
                                 recipient.time,
-                                buffer,
+                                recipient.buffer.as_mut(),
                             )
                         })
                         .unwrap()

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -377,7 +377,7 @@ impl TestRelay {
             let dst = peer.into_socket();
 
             // Check if we need to relay to ourselves (from one allocation to another)
-            if dst.ip() == self.ip() {
+            if self.wants(dst) {
                 // When relaying to ourselves, we become our own peer.
                 let peer_socket = PeerSocket::new(src);
                 // The allocation that the data is arriving on is the `dst`'s port.

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -608,11 +608,7 @@ impl TestNode {
         firewall: &Firewall,
         now: Instant,
     ) {
-        while let Some(trans) = self
-            .span
-            .in_scope(|| self.node.poll_transmit())
-            .map(|trans| trans.into_owned())
-        {
+        while let Some(trans) = self.span.in_scope(|| self.node.poll_transmit()) {
             let payload = &trans.payload;
             let dst = trans.dst;
 

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -274,17 +274,30 @@ struct Firewall {
 
 struct Clock {
     now: Instant,
+
+    tick_rate: Duration,
+    max_time: Instant,
 }
 
 impl Clock {
     fn new() -> Self {
+        let now = Instant::now();
+        let tick_rate = Duration::from_millis(10);
+        let one_hour = Duration::from_secs(60) * 60;
+
         Self {
-            now: Instant::now(),
+            now,
+            tick_rate,
+            max_time: now + one_hour,
         }
     }
 
     fn tick(&mut self) {
-        self.now += Duration::from_millis(10);
+        self.now += self.tick_rate;
+
+        if self.now >= self.max_time {
+            panic!("Time exceeded")
+        }
     }
 }
 
@@ -634,9 +647,6 @@ fn progress(
     };
 
     t.progress_count += 1;
-    if t.progress_count > 100 {
-        panic!("Test looped more than 100 times");
-    }
 
     while let Some(v) = t.span.in_scope(|| t.node.poll_event()) {
         match v {

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -710,6 +710,12 @@ fn progress(
         }
     }
 
+    if let Some(timeout) = t.node.poll_timeout() {
+        if clock.now >= timeout {
+            t.span.in_scope(|| t.node.handle_timeout(clock.now));
+        }
+    }
+
     if let Some(relay) = r {
         if let Some(timeout) = relay.inner.poll_timeout() {
             if clock.now >= timeout {

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -50,7 +50,9 @@ fn smoke_relayed() {
     let relay = TestRelay::new(IpAddr::V4(Ipv4Addr::LOCALHOST), debug_span!("Roger"));
     let mut alice: TestNode = TestNode::new(debug_span!("Alice"), alice, "1.1.1.1:80");
     let mut bob = TestNode::new(debug_span!("Bob"), bob, "2.2.2.2:80");
-    let firewall = Firewall::default().with_block_rule("1.1.1.1:80", "2.2.2.2:80");
+    let firewall = Firewall::default()
+        .with_block_rule("1.1.1.1:80", "2.2.2.2:80")
+        .with_block_rule("2.2.2.2:80", "1.1.1.1:80");
     let mut clock = Clock::new();
 
     let mut relays = [relay];

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -627,13 +627,14 @@ fn progress(
         .in_scope(|| f.node.poll_transmit())
         .map(|t| t.into_owned())
     {
+        let payload = &trans.payload;
         let Some(src) = trans.src else {
             // `src` not set? Must client-facing traffic for the relay.
 
             if let Some(relay) = r {
                 assert_eq!(trans.dst.port(), 3478);
 
-                relay.handle_client_input(&trans.payload, ClientSocket::new(f.local), f, t);
+                relay.handle_client_input(payload, ClientSocket::new(f.local), f, t);
             }
 
             return;
@@ -644,7 +645,7 @@ fn progress(
         if let Some(relay) = r {
             if dst.ip() == relay.listen_addr.ip() {
                 relay.handle_peer_traffic(
-                    &trans.payload,
+                    payload,
                     PeerSocket::new(f.local),
                     AllocationPort::new(dst.port()),
                     f,
@@ -666,7 +667,7 @@ fn progress(
             .span
             .in_scope(|| {
                 t.node
-                    .decapsulate(dst, src, &trans.payload, t.time, t.buffer.as_mut())
+                    .decapsulate(dst, src, payload, t.time, t.buffer.as_mut())
             })
             .unwrap()
         {

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -1,5 +1,5 @@
 use boringtun::x25519::{PublicKey, StaticSecret};
-use firezone_relay::{AllocationPort, ChannelData, ClientSocket, IpStack, PeerSocket};
+use firezone_relay::{AllocationPort, ClientSocket, IpStack, PeerSocket};
 use rand::rngs::OsRng;
 use snownet::{Answer, ClientNode, Event, MutableIpPacket, ServerNode, Transmit};
 use std::{
@@ -287,9 +287,7 @@ impl TestRelay {
                 sender.time,
             )
         }) {
-            let payload = ChannelData::parse(&trans.payload)
-                .expect("valid ChannelData if we should relay it")
-                .data();
+            let payload = &trans.payload[4..];
 
             // Check if we need to relay to ourselves (from one allocation to another)
             if peer.into_socket().ip() == self.listen_addr.ip() {

--- a/rust/relay/src/lib.rs
+++ b/rust/relay/src/lib.rs
@@ -1,8 +1,8 @@
-mod auth;
 mod net_ext;
 mod server;
 mod sleep;
 
+pub mod auth;
 #[cfg(feature = "proptest")]
 pub mod proptest;
 pub mod sockets;
@@ -17,7 +17,7 @@ pub use stun_codec::rfc8656::attributes::AddressFamily;
 
 use std::{
     fmt,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
 };
 
 /// Describes the IP stack of a relay server.
@@ -42,6 +42,15 @@ impl IpStack {
             IpStack::Ip4(_) => None,
             IpStack::Ip6(ip6) => Some(ip6),
             IpStack::Dual { ip6, .. } => Some(ip6),
+        }
+    }
+}
+
+impl From<IpAddr> for IpStack {
+    fn from(value: IpAddr) -> Self {
+        match value {
+            IpAddr::V4(inner) => IpStack::Ip4(inner),
+            IpAddr::V6(inner) => IpStack::Ip6(inner),
         }
     }
 }

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -337,8 +337,6 @@ where
         sender: PeerSocket,
         allocation: AllocationPort,
     ) -> Option<(ClientSocket, ChannelNumber)> {
-        tracing::trace!(target: "wire", num_bytes = %msg.len());
-
         let Some((client, channel_number)) = self
             .channel_and_client_by_port_and_peer
             .get(&(allocation, sender))
@@ -352,6 +350,8 @@ where
 
         self.data_relayed_counter.add(msg.len() as u64, &[]);
         self.data_relayed += msg.len() as u64;
+
+        tracing::trace!(target: "wire", num_bytes = %msg.len());
 
         Some((*client, *channel_number))
     }


### PR DESCRIPTION
This PR adds a unit-test to `snownet` that exercises all code paths that are required for a relayed connection to work. This includes:

- Nodes make an allocation with real credentials, nonces etc
- Nodes exchange their ICE candidates
- Nodes bind data channels on the relay
- str0m performs ICE over these data channels
- Nodes handshake a wireguard tunnel on the nominated socket

I consider this a baseline. Once merged, I want to attempt writing a test in #4568 that asserts migration of a connection to a new relay without the connection expiring. At some point, we can even go further and move these tests to `firezone-tunnel` and unit-test even more things like connection intents etc.