### PR TITLE
chore(portal): normal weight for helptext

### DIFF
--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -226,7 +226,7 @@ defmodule Web.CoreComponents do
           </div>
         </div>
       </div>
-      <p :for={help <- @help} class="font-light pt-3 text-neutral-500">
+      <p :for={help <- @help} class="pt-3 text-neutral-500">
         <%= render_slot(help) %>
       </p>
     </div>

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -226,7 +226,7 @@ defmodule Web.CoreComponents do
           </div>
         </div>
       </div>
-      <p :for={help <- @help} class="pt-3 text-neutral-500">
+      <p :for={help <- @help} class="pt-3 text-neutral-400">
         <%= render_slot(help) %>
       </p>
     </div>


### PR DESCRIPTION
FF is ok but on Chrome it's a bit hard to read:

<img width="451" alt="Screenshot 2024-04-10 at 6 51 19 AM" src="https://github.com/firezone/firezone/assets/167144/3f152c4f-2903-4c26-b20e-5f239d39c28e">

`font-normal text-neutral-400`

<img width="518" alt="Screenshot 2024-04-10 at 6 56 57 AM" src="https://github.com/firezone/firezone/assets/167144/c8d8dc59-b69b-468c-b9cb-d70c622a938f">
