### PR TITLE
chore(windows): bump Rust to handle CVE-2024-24576

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Keep synced with `Dockerfile`
-channel = "1.77.1"
+channel = "1.77.2"


### PR DESCRIPTION
https://blog.rust-lang.org/2024/04/09/cve-2024-24576.html

The Dockerfile just specifies 1.77 so it should automatically update, probably.

Closes #4566