### PR TITLE
feat(docs): Show page last updated at for each doc page

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -39,3 +39,6 @@ public/sitemap-*.xml
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# generated timestamps
+timestamps.json

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "bash ./timestamps.sh",
     "build": "next build",
     "postbuild": "next-sitemap",
     "start": "next start",

--- a/website/src/app/kb/administer/backup-restore/page.tsx
+++ b/website/src/app/kb/administer/backup-restore/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Backup and Restore • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/administer/logs/page.tsx
+++ b/website/src/app/kb/administer/logs/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Viewing Logs • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/administer/troubleshooting/page.tsx
+++ b/website/src/app/kb/administer/troubleshooting/page.tsx
@@ -1,5 +1,6 @@
 import _Page from "./_page";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Troubleshooting Guide • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <_Page />;
+  return (
+    <>
+      <_Page />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/administer/upgrading/page.tsx
+++ b/website/src/app/kb/administer/upgrading/page.tsx
@@ -1,5 +1,6 @@
 import _Page from "./_page";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Upgrading • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <_Page />;
+  return (
+    <>
+      <_Page />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/administer/upgrading/readme.mdx
+++ b/website/src/app/kb/administer/upgrading/readme.mdx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { TabsItem, TabsGroup } from "@/components/DocsTabs";
 import Image from "next/image";
 import Alert from "@/components/DocsAlert";
+import SupportOptions from "@/components/SupportOptions";
 
 # Upgrading Gateways
 
@@ -88,3 +89,7 @@ upgraded will automatically reconnect to an available Gateway.
 
 Users may notice very brief interruptions to Resources for a few seconds as
 their Client reconnects to a healthy Gateway.
+
+---
+
+<SupportOptions />

--- a/website/src/app/kb/authenticate/directory-sync/page.tsx
+++ b/website/src/app/kb/authenticate/directory-sync/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Directory Sync • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/authenticate/email/page.tsx
+++ b/website/src/app/kb/authenticate/email/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Email Authentication • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/authenticate/entra/page.tsx
+++ b/website/src/app/kb/authenticate/entra/page.tsx
@@ -1,5 +1,6 @@
 import _Page from "./_page";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Microsoft Entra ID Authentication • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <_Page />;
+  return (
+    <>
+      <_Page />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/authenticate/google/page.tsx
+++ b/website/src/app/kb/authenticate/google/page.tsx
@@ -1,5 +1,6 @@
 import _Page from "./_page";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Google Workspace Authentication • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <_Page />;
+  return (
+    <>
+      <_Page />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/authenticate/oidc/fusion/page.tsx
+++ b/website/src/app/kb/authenticate/oidc/fusion/page.tsx
@@ -1,5 +1,6 @@
 import _Page from "./_page";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "FusionAuth • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <_Page />;
+  return (
+    <>
+      <_Page />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/authenticate/oidc/page.tsx
+++ b/website/src/app/kb/authenticate/oidc/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "OIDC Authentication • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/authenticate/okta/page.tsx
+++ b/website/src/app/kb/authenticate/okta/page.tsx
@@ -1,5 +1,6 @@
 import _Page from "./_page";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Okta Authentication • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <_Page />;
+  return (
+    <>
+      <_Page />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/authenticate/page.tsx
+++ b/website/src/app/kb/authenticate/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Authentication Overview • Firezone Docs",
@@ -8,5 +9,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/authenticate/service-accounts/page.tsx
+++ b/website/src/app/kb/authenticate/service-accounts/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Service Accounts • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/deploy/clients/page.tsx
+++ b/website/src/app/kb/deploy/clients/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Clients • Firezone Deploy Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/deploy/dns/page.tsx
+++ b/website/src/app/kb/deploy/dns/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Configure DNS • Firezone Deploy Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/deploy/gateways/page.tsx
+++ b/website/src/app/kb/deploy/gateways/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Gateways • Firezone Deploy Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/deploy/groups/page.tsx
+++ b/website/src/app/kb/deploy/groups/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Groups • Firezone Deploy Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/deploy/page.tsx
+++ b/website/src/app/kb/deploy/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import _Page from "./_page";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Deploy • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <_Page />;
+  return (
+    <>
+      <_Page />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/deploy/policies/page.tsx
+++ b/website/src/app/kb/deploy/policies/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Policies • Firezone Deploy Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/deploy/resources/page.tsx
+++ b/website/src/app/kb/deploy/resources/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Resources • Firezone Deploy Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/deploy/sites/page.tsx
+++ b/website/src/app/kb/deploy/sites/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Sites • Firezone Deploy Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/deploy/users/page.tsx
+++ b/website/src/app/kb/deploy/users/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Users • Firezone Deploy Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/page.tsx
+++ b/website/src/app/kb/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Firezone Docs • Home",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/quickstart/page.tsx
+++ b/website/src/app/kb/quickstart/page.tsx
@@ -1,5 +1,6 @@
 import _Page from "./_page";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Quickstart • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <_Page />;
+  return (
+    <>
+      <_Page />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/reference/glossary/page.tsx
+++ b/website/src/app/kb/reference/glossary/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import Content from "./readme.mdx";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Glossary • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/user-guides/android-client/page.tsx
+++ b/website/src/app/kb/user-guides/android-client/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Android Client • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/user-guides/ios-client/page.tsx
+++ b/website/src/app/kb/user-guides/ios-client/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Apple Clients • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/user-guides/linux-client/page.tsx
+++ b/website/src/app/kb/user-guides/linux-client/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Linux Client • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/user-guides/macos-client/page.tsx
+++ b/website/src/app/kb/user-guides/macos-client/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Apple Clients • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/user-guides/page.tsx
+++ b/website/src/app/kb/user-guides/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "User Guides • Firezone Docs",
@@ -8,5 +9,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/app/kb/user-guides/windows-client/page.tsx
+++ b/website/src/app/kb/user-guides/windows-client/page.tsx
@@ -1,5 +1,6 @@
 import Content from "./readme.mdx";
 import { Metadata } from "next";
+import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Windows Client • Firezone Docs",
@@ -7,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  return <Content />;
+  return (
+    <>
+      <Content />
+      <LastUpdated dirname={__dirname} />
+    </>
+  );
 }

--- a/website/src/components/LastUpdated/index.tsx
+++ b/website/src/components/LastUpdated/index.tsx
@@ -2,25 +2,24 @@ import fs from "fs";
 import path from "path";
 
 export default function LastUpdated({ dirname }: { dirname: string }) {
+  // timestamps.json was generated during build
+  const timestampsFile = path.resolve("timestamps.json");
+  const timestampsData = fs.readFileSync(timestampsFile, "utf-8");
+  const timestamps = JSON.parse(timestampsData);
+
   // Hack to get the path to the readme file
   const filePath = path.join(
-    process.cwd(),
     "src",
     dirname.split(".next/server")[1],
     "readme.mdx"
   );
 
-  if (fs.existsSync(filePath)) {
-    const stats = fs.statSync(filePath);
-    const lastUpdated = new Date(stats.mtime).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
+  const timestamp = timestamps[filePath];
 
+  if (timestamp) {
     return (
       <div className="flex justify-end text-sm text-gray-500">
-        Last updated: {lastUpdated}
+        Last updated: {timestamp}
       </div>
     );
   } else {

--- a/website/src/components/LastUpdated/index.tsx
+++ b/website/src/components/LastUpdated/index.tsx
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+
+export default function LastUpdated({ dirname }: { dirname: string }) {
+  // Hack to get the path to the readme file
+  const filePath = path.join(
+    process.cwd(),
+    "src",
+    dirname.split(".next/server")[1],
+    "readme.mdx"
+  );
+
+  if (fs.existsSync(filePath)) {
+    const stats = fs.statSync(filePath);
+    const lastUpdated = new Date(stats.mtime).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+
+    return (
+      <div className="flex justify-end text-sm text-gray-500">
+        Last updated: {lastUpdated}
+      </div>
+    );
+  } else {
+    return null;
+  }
+}

--- a/website/timestamps.sh
+++ b/website/timestamps.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+json_file="timestamps.json"
+rm -f "$json_file"
+
+# Get all mdx files
+find src -name "*.mdx" | while read -r f; do
+    # Get the last modified date
+    last_modified=$(git log -1 --format="%ad" --date=format:'%B %d, %Y' -- "$f")
+
+    if [ -s "$json_file" ]; then
+        echo ",\"$f\":\"$last_modified\"" >>"$json_file"
+    else
+        echo "{\"$f\":\"$last_modified\"" >"$json_file"
+    fi
+done
+
+# Close the JSON
+echo "}" >>"$json_file"


### PR DESCRIPTION
This was quite hairy. The best approach I came up with is to use `git`'s last modified date. But Vercel uses a shallow clone, so the file's modification date isn't preserved.

Luckily, I found an undocumented ENV var, `VERCEL_DEEP_CLONE` that fixes this when set to `true`.

Using this technique we can generate any file's modified timestamp and load it from a server component to render.

Fixes #3960 

<img width="321" alt="Screenshot 2024-04-10 at 11 11 49 PM" src="https://github.com/firezone/firezone/assets/167144/07fe89cd-d792-49ca-b25b-8472fa19de8b">
