### PR TITLE
feat(portal): Broadcast relays presence updates to the client and return them in init

### DIFF
--- a/elixir/apps/api/lib/api/client/views/gateway_group.ex
+++ b/elixir/apps/api/lib/api/client/views/gateway_group.ex
@@ -8,8 +8,7 @@ defmodule API.Client.Views.GatewayGroup do
   def render(%Gateways.Group{} = gateway_group) do
     %{
       id: gateway_group.id,
-      name: gateway_group.name,
-      routing: gateway_group.routing
+      name: gateway_group.name
     }
   end
 end

--- a/elixir/apps/api/lib/api/client/views/relay.ex
+++ b/elixir/apps/api/lib/api/client/views/relay.ex
@@ -1,7 +1,7 @@
 defmodule API.Client.Views.Relay do
   alias Domain.Relays
 
-  def render_many(relays, expires_at, stun_or_turn) do
+  def render_many(relays, expires_at, stun_or_turn \\ :turn) do
     Enum.flat_map(relays, &render(&1, expires_at, stun_or_turn))
   end
 
@@ -23,6 +23,7 @@ defmodule API.Client.Views.Relay do
   defp maybe_render(%Relays.Relay{} = relay, _expires_at, address, :stun) do
     [
       %{
+        id: relay.id,
         type: :stun,
         addr: "#{format_address(address)}:#{relay.port}"
       }
@@ -38,6 +39,7 @@ defmodule API.Client.Views.Relay do
 
     [
       %{
+        id: relay.id,
         type: :turn,
         addr: "#{format_address(address)}:#{relay.port}",
         username: username,

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -201,10 +201,7 @@ defmodule API.Gateway.Channel do
       resource = Resources.fetch_resource_by_id!(resource_id)
       :ok = Resources.subscribe_to_events_for_resource(resource_id)
 
-      {relay_hosting_type, relay_connection_type} =
-        Gateways.relay_strategy([socket.assigns.gateway_group])
-
-      {:ok, relays} = Relays.all_connected_relays_for_resource(resource, relay_hosting_type)
+      {:ok, relays} = Relays.all_connected_relays_for_account(socket.assigns.subject.account)
 
       opentelemetry_headers = :otel_propagator_text_map.inject([])
       ref = encode_ref(socket, channel_pid, socket_ref, resource_id, opentelemetry_headers)
@@ -213,7 +210,7 @@ defmodule API.Gateway.Channel do
         ref: ref,
         flow_id: flow_id,
         actor: Views.Actor.render(client.actor),
-        relays: Views.Relay.render_many(relays, authorization_expires_at, relay_connection_type),
+        relays: Views.Relay.render_many(relays, authorization_expires_at),
         resource: Views.Resource.render(resource),
         client: Views.Client.render(client, payload, preshared_key),
         expires_at: DateTime.to_unix(authorization_expires_at, :second)

--- a/elixir/apps/api/lib/api/gateway/views/relay.ex
+++ b/elixir/apps/api/lib/api/gateway/views/relay.ex
@@ -1,5 +1,5 @@
 defmodule API.Gateway.Views.Relay do
   def render_many(relays, expires_at) do
-    Enum.flat_map(relays, &API.Client.Views.Relay.render(&1, expires_at, :turn))
+    API.Client.Views.Relay.render_many(relays, expires_at)
   end
 end

--- a/elixir/apps/api/lib/api/gateway/views/relay.ex
+++ b/elixir/apps/api/lib/api/gateway/views/relay.ex
@@ -1,5 +1,5 @@
 defmodule API.Gateway.Views.Relay do
-  def render_many(relays, expires_at, conn_type) do
-    Enum.flat_map(relays, &API.Client.Views.Relay.render(&1, expires_at, conn_type))
+  def render_many(relays, expires_at) do
+    Enum.flat_map(relays, &API.Client.Views.Relay.render(&1, expires_at, :turn))
   end
 end

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -308,34 +308,6 @@ defmodule API.Client.ChannelTest do
     end
   end
 
-  describe "handle_info/2 for relays presence" do
-    test "sends left relay id and new relays" do
-      # relay = Fixtures.Relays.create_relay(account: account)
-
-      # spawn(fn ->
-      #   stamp_secret = Ecto.UUID.generate()
-      #   :ok = Domain.Relays.connect_relay(relay, stamp_secret)
-      # end)
-
-      # assert_push "init", %{relays: relays}
-
-      # assert length(relays) == 1
-      # assert List.first(relays).id == relay.id
-
-      # relay2 = Fixtures.Relays.create_relay(account: account)
-
-      # spawn(fn ->
-      #   stamp_secret = Ecto.UUID.generate()
-      #   :ok = Domain.Relays.connect_relay(relay2, stamp_secret)
-      # end)
-
-      # assert_push "relays_presence", %{left: [relay.id], relays: relays}
-
-      # assert length(relays) == 1
-      # assert List.first(relays).id == relay2.id
-    end
-  end
-
   describe "handle_info/2 :config_changed" do
     test "sends updated configuration", %{
       account: account,

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -168,8 +168,14 @@ defmodule API.Client.ChannelTest do
       cidr_resource: cidr_resource,
       ip_resource: ip_resource
     } do
-      assert_push "init", %{resources: resources, interface: interface}
+      assert_push "init", %{
+        resources: resources,
+        interface: interface,
+        relays: relays
+      }
+
       assert length(resources) == 3
+      assert length(relays) == 0
 
       assert %{
                id: dns_resource.id,
@@ -180,8 +186,7 @@ defmodule API.Client.ChannelTest do
                gateway_groups: [
                  %{
                    id: gateway_group.id,
-                   name: gateway_group.name,
-                   routing: gateway_group.routing
+                   name: gateway_group.name
                  }
                ]
              } in resources
@@ -195,8 +200,7 @@ defmodule API.Client.ChannelTest do
                gateway_groups: [
                  %{
                    id: gateway_group.id,
-                   name: gateway_group.name,
-                   routing: gateway_group.routing
+                   name: gateway_group.name
                  }
                ]
              } in resources
@@ -210,8 +214,7 @@ defmodule API.Client.ChannelTest do
                gateway_groups: [
                  %{
                    id: gateway_group.id,
-                   name: gateway_group.name,
-                   routing: gateway_group.routing
+                   name: gateway_group.name
                  }
                ]
              } in resources
@@ -244,6 +247,46 @@ defmodule API.Client.ChannelTest do
       assert_push "resource_created_or_updated", %{}
     end
 
+    test "subscribes for relays presence", %{client: client, subject: subject} do
+      relay_group = Fixtures.Relays.create_global_group()
+      relay = Fixtures.Relays.create_relay(group: relay_group)
+      stamp_secret = Ecto.UUID.generate()
+      :ok = Domain.Relays.connect_relay(relay, stamp_secret)
+
+      API.Client.Socket
+      |> socket("client:#{client.id}", %{
+        opentelemetry_ctx: OpenTelemetry.Ctx.new(),
+        opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test"),
+        client: client,
+        subject: subject
+      })
+      |> subscribe_and_join(API.Client.Channel, "client")
+
+      assert_push "init", %{relays: [relay_view1, relay_view2]}
+      assert relay_view1.id == relay.id
+      assert relay_view2.id == relay.id
+
+      assert %{
+               addr: _,
+               expires_at: _,
+               id: _,
+               password: _,
+               type: _,
+               username: _
+             } = relay_view1
+
+      Domain.Relays.Presence.untrack(self(), "presences:relays:#{relay.id}", relay.id)
+
+      assert_push "relay_offline", %{
+        offline_relay_ids: [relay_id],
+        online_relays: [relay_view1, relay_view2]
+      }
+
+      assert relay_view1.id == relay.id
+      assert relay_view2.id == relay.id
+      assert relay_id == relay.id
+    end
+
     test "subscribes for membership/policy access events", %{
       actor: actor,
       subject: subject
@@ -262,6 +305,34 @@ defmodule API.Client.ChannelTest do
       {:ok, _resource} = Domain.Policies.disable_policy(dns_resource_policy, subject)
       assert_push "resource_deleted", _payload
       refute_push "resource_created_or_updated", _payload
+    end
+  end
+
+  describe "handle_info/2 for relays presence" do
+    test "sends left relay id and new relays" do
+      # relay = Fixtures.Relays.create_relay(account: account)
+
+      # spawn(fn ->
+      #   stamp_secret = Ecto.UUID.generate()
+      #   :ok = Domain.Relays.connect_relay(relay, stamp_secret)
+      # end)
+
+      # assert_push "init", %{relays: relays}
+
+      # assert length(relays) == 1
+      # assert List.first(relays).id == relay.id
+
+      # relay2 = Fixtures.Relays.create_relay(account: account)
+
+      # spawn(fn ->
+      #   stamp_secret = Ecto.UUID.generate()
+      #   :ok = Domain.Relays.connect_relay(relay2, stamp_secret)
+      # end)
+
+      # assert_push "relays_presence", %{left: [relay.id], relays: relays}
+
+      # assert length(relays) == 1
+      # assert List.first(relays).id == relay2.id
     end
   end
 
@@ -352,7 +423,7 @@ defmodule API.Client.ChannelTest do
                address: resource.address,
                address_description: resource.address_description,
                gateway_groups: [
-                 %{id: gateway_group.id, name: gateway_group.name, routing: gateway_group.routing}
+                 %{id: gateway_group.id, name: gateway_group.name}
                ]
              }
     end
@@ -430,7 +501,7 @@ defmodule API.Client.ChannelTest do
                address: resource.address,
                address_description: resource.address_description,
                gateway_groups: [
-                 %{id: gateway_group.id, name: gateway_group.name, routing: gateway_group.routing}
+                 %{id: gateway_group.id, name: gateway_group.name}
                ]
              }
     end
@@ -496,7 +567,7 @@ defmodule API.Client.ChannelTest do
                address: resource.address,
                address_description: resource.address_description,
                gateway_groups: [
-                 %{id: gateway_group.id, name: gateway_group.name, routing: gateway_group.routing}
+                 %{id: gateway_group.id, name: gateway_group.name}
                ]
              }
     end
@@ -595,13 +666,11 @@ defmodule API.Client.ChannelTest do
       assert_reply ref, :error, %{reason: :offline}
     end
 
-    test "returns online gateway and relays connected to the resource", %{
-      account: account,
+    test "returns online gateway and global relays connected to the resource", %{
       dns_resource: resource,
       gateway: gateway,
       socket: socket
     } do
-      # Online Relay
       global_relay_group = Fixtures.Relays.create_global_group()
 
       global_relay =
@@ -611,15 +680,9 @@ defmodule API.Client.ChannelTest do
           last_seen_remote_ip_location_lon: -120
         )
 
-      # Creating this Relay to verify it doesn't get returned when :managed routing option is selected
-      relay = Fixtures.Relays.create_relay(account: account)
       stamp_secret = Ecto.UUID.generate()
-      :ok = Domain.Relays.connect_relay(relay, stamp_secret)
+      :ok = Domain.Relays.connect_relay(global_relay, stamp_secret)
 
-      stamp_secret_global = Ecto.UUID.generate()
-      :ok = Domain.Relays.connect_relay(global_relay, stamp_secret_global)
-
-      # Online Gateway
       :ok = Domain.Gateways.connect_gateway(gateway)
 
       ref = push(socket, "prepare_connection", %{"resource_id" => resource.id})
@@ -640,6 +703,7 @@ defmodule API.Client.ChannelTest do
 
       assert [
                %{
+                 id: _,
                  type: :turn,
                  expires_at: expires_at_unix,
                  password: password1,
@@ -647,6 +711,7 @@ defmodule API.Client.ChannelTest do
                  addr: ^ipv4_turn_uri
                },
                %{
+                 id: _,
                  type: :turn,
                  expires_at: expires_at_unix,
                  password: password2,
@@ -672,7 +737,7 @@ defmodule API.Client.ChannelTest do
       actor_group: actor_group
     } do
       # Gateway setup
-      gateway_group = Fixtures.Gateways.create_group(account: account, routing: :self_hosted)
+      gateway_group = Fixtures.Gateways.create_group(account: account)
       gateway = Fixtures.Gateways.create_gateway(account: account, group: gateway_group)
       :ok = Domain.Gateways.connect_gateway(gateway)
 
@@ -689,20 +754,6 @@ defmodule API.Client.ChannelTest do
         resource: resource
       )
 
-      # Global Relay setup
-      global_relay_group = Fixtures.Relays.create_global_group()
-
-      global_relay =
-        Fixtures.Relays.create_relay(
-          group: global_relay_group,
-          last_seen_remote_ip_location_lat: 37,
-          last_seen_remote_ip_location_lon: -120
-        )
-
-      stamp_secret_global = Ecto.UUID.generate()
-      :ok = Domain.Relays.connect_relay(global_relay, stamp_secret_global)
-
-      # Self-hosted Relay setup
       relay = Fixtures.Relays.create_relay(account: account)
       stamp_secret = Ecto.UUID.generate()
       :ok = Domain.Relays.connect_relay(relay, stamp_secret)
@@ -751,77 +802,6 @@ defmodule API.Client.ChannelTest do
       assert expires_at == socket_expires_at
 
       assert is_binary(salt)
-    end
-
-    test "returns online gateway and stun-only relay URLs connected to the resource", %{
-      account: account,
-      socket: socket,
-      actor_group: actor_group
-    } do
-      # Gateway setup
-      gateway_group = Fixtures.Gateways.create_group(account: account, routing: :stun_only)
-      gateway = Fixtures.Gateways.create_gateway(account: account, group: gateway_group)
-      :ok = Domain.Gateways.connect_gateway(gateway)
-
-      # Resource setup
-      resource =
-        Fixtures.Resources.create_resource(
-          account: account,
-          connections: [%{gateway_group_id: gateway_group.id}]
-        )
-
-      Fixtures.Policies.create_policy(
-        account: account,
-        actor_group: actor_group,
-        resource: resource
-      )
-
-      # Global Relay setup
-      global_relay_group = Fixtures.Relays.create_global_group()
-
-      global_relay =
-        Fixtures.Relays.create_relay(
-          group: global_relay_group,
-          last_seen_remote_ip_location_lat: 37,
-          last_seen_remote_ip_location_lon: -120
-        )
-
-      stamp_secret_global = Ecto.UUID.generate()
-      :ok = Domain.Relays.connect_relay(global_relay, stamp_secret_global)
-
-      # Self-hosted Relay setup
-      relay = Fixtures.Relays.create_relay(account: account)
-      stamp_secret = Ecto.UUID.generate()
-      :ok = Domain.Relays.connect_relay(relay, stamp_secret)
-
-      ref = push(socket, "prepare_connection", %{"resource_id" => resource.id})
-      resource_id = resource.id
-
-      assert_reply ref, :ok, %{
-        relays: relays,
-        gateway_id: gateway_id,
-        gateway_remote_ip: gateway_last_seen_remote_ip,
-        resource_id: ^resource_id
-      }
-
-      assert length(relays) == 2
-
-      assert gateway_id == gateway.id
-      assert gateway_last_seen_remote_ip == gateway.last_seen_remote_ip
-
-      ipv4_turn_uri = "#{global_relay.ipv4}:#{global_relay.port}"
-      ipv6_turn_uri = "[#{global_relay.ipv6}]:#{global_relay.port}"
-
-      assert [
-               %{
-                 type: :stun,
-                 addr: ^ipv4_turn_uri
-               },
-               %{
-                 type: :stun,
-                 addr: ^ipv6_turn_uri
-               }
-             ] = relays
     end
 
     test "works with service accounts", %{

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -19,7 +19,6 @@ defmodule API.Gateway.ChannelTest do
     {:ok, _, socket} =
       API.Gateway.Socket
       |> socket("gateway:#{gateway.id}", %{
-        subject: subject,
         gateway: gateway,
         gateway_group: gateway_group,
         opentelemetry_ctx: OpenTelemetry.Ctx.new(),

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -19,6 +19,7 @@ defmodule API.Gateway.ChannelTest do
     {:ok, _, socket} =
       API.Gateway.Socket
       |> socket("gateway:#{gateway.id}", %{
+        subject: subject,
         gateway: gateway,
         gateway_group: gateway_group,
         opentelemetry_ctx: OpenTelemetry.Ctx.new(),
@@ -393,10 +394,11 @@ defmodule API.Gateway.ChannelTest do
 
     test "pushes request_connection message with self-hosted relays", %{
       account: account,
+      subject: subject,
       client: client,
       relay: relay
     } do
-      gateway_group = Fixtures.Gateways.create_group(%{account: account, routing: "self_hosted"})
+      gateway_group = Fixtures.Gateways.create_group(%{account: account})
       gateway = Fixtures.Gateways.create_gateway(account: account, group: gateway_group)
 
       resource =
@@ -408,6 +410,7 @@ defmodule API.Gateway.ChannelTest do
       {:ok, _, socket} =
         API.Gateway.Socket
         |> socket("gateway:#{gateway.id}", %{
+          subject: subject,
           gateway: gateway,
           gateway_group: gateway_group,
           opentelemetry_ctx: OpenTelemetry.Ctx.new(),
@@ -472,102 +475,6 @@ defmodule API.Gateway.ChannelTest do
       assert username_expires_at_unix == to_string(DateTime.to_unix(expires_at, :second))
       assert DateTime.from_unix!(expires_at_unix) == DateTime.truncate(expires_at, :second)
       assert is_binary(username_salt)
-
-      assert payload.resource == %{
-               address: resource.address,
-               id: resource.id,
-               name: resource.name,
-               type: :dns,
-               filters: [
-                 %{protocol: :tcp, port_range_end: 80, port_range_start: 80},
-                 %{protocol: :tcp, port_range_end: 433, port_range_start: 433},
-                 %{protocol: :udp, port_range_start: 100, port_range_end: 200}
-               ]
-             }
-
-      assert payload.client == %{
-               id: client.id,
-               peer: %{
-                 ipv4: client.ipv4,
-                 ipv6: client.ipv6,
-                 persistent_keepalive: 25,
-                 preshared_key: preshared_key,
-                 public_key: client.public_key
-               },
-               payload: client_payload
-             }
-
-      assert DateTime.from_unix!(payload.expires_at) == DateTime.truncate(expires_at, :second)
-    end
-
-    test "pushes request_connection message with stun-only relay URLs", %{
-      account: account,
-      client: client,
-      global_relay: relay
-    } do
-      gateway_group = Fixtures.Gateways.create_group(%{account: account, routing: "stun_only"})
-      gateway = Fixtures.Gateways.create_gateway(account: account, group: gateway_group)
-
-      resource =
-        Fixtures.Resources.create_resource(
-          account: account,
-          connections: [%{gateway_group_id: gateway_group.id}]
-        )
-
-      {:ok, _, socket} =
-        API.Gateway.Socket
-        |> socket("gateway:#{gateway.id}", %{
-          gateway: gateway,
-          gateway_group: gateway_group,
-          opentelemetry_ctx: OpenTelemetry.Ctx.new(),
-          opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test")
-        })
-        |> subscribe_and_join(API.Gateway.Channel, "gateway")
-
-      channel_pid = self()
-      socket_ref = make_ref()
-      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
-      preshared_key = "PSK"
-      client_payload = "RTC_SD"
-      flow_id = Ecto.UUID.generate()
-
-      otel_ctx = {OpenTelemetry.Ctx.new(), OpenTelemetry.Tracer.start_span("connect")}
-
-      stamp_secret = Ecto.UUID.generate()
-      :ok = Domain.Relays.connect_relay(relay, stamp_secret)
-
-      send(
-        socket.channel_pid,
-        {:request_connection, {channel_pid, socket_ref},
-         %{
-           client_id: client.id,
-           resource_id: resource.id,
-           flow_id: flow_id,
-           authorization_expires_at: expires_at,
-           client_payload: client_payload,
-           client_preshared_key: preshared_key
-         }, otel_ctx}
-      )
-
-      assert_push "request_connection", payload
-
-      assert is_binary(payload.ref)
-      assert payload.flow_id == flow_id
-      assert payload.actor == %{id: client.actor_id}
-
-      ipv4_turn_uri = "#{relay.ipv4}:#{relay.port}"
-      ipv6_turn_uri = "[#{relay.ipv6}]:#{relay.port}"
-
-      assert [
-               %{
-                 type: :stun,
-                 addr: ^ipv4_turn_uri
-               },
-               %{
-                 type: :stun,
-                 addr: ^ipv6_turn_uri
-               }
-             ] = payload.relays
 
       assert payload.resource == %{
                address: resource.address,

--- a/elixir/apps/domain/lib/domain/gateways.ex
+++ b/elixir/apps/domain/lib/domain/gateways.ex
@@ -82,8 +82,7 @@ defmodule Domain.Gateways do
           group
           |> Repo.preload(:account)
           |> Group.Changeset.update(attrs, subject)
-        end,
-        after_commit: &disconnect_gateways_in_group/1
+        end
       )
     end
   end
@@ -365,29 +364,6 @@ defmodule Domain.Gateways do
     |> case do
       [] -> load_balance_gateways({lat, lon}, gateways)
       preferred_gateways -> load_balance_gateways({lat, lon}, preferred_gateways)
-    end
-  end
-
-  # Finds the most strict routing strategy for a given list of gateway groups.
-  def relay_strategy(gateway_groups) when is_list(gateway_groups) do
-    strictness = [
-      stun_only: 3,
-      self_hosted: 2,
-      managed: 1
-    ]
-
-    gateway_groups
-    |> Enum.max_by(fn %{routing: routing} ->
-      Keyword.fetch!(strictness, routing)
-    end)
-    |> relay_strategy_mapping()
-  end
-
-  defp relay_strategy_mapping(%Group{} = group) do
-    case group.routing do
-      :stun_only -> {:managed, :stun}
-      :self_hosted -> {:self_hosted, :turn}
-      :managed -> {:managed, :turn}
     end
   end
 

--- a/elixir/apps/domain/lib/domain/gateways/group.ex
+++ b/elixir/apps/domain/lib/domain/gateways/group.ex
@@ -3,7 +3,6 @@ defmodule Domain.Gateways.Group do
 
   schema "gateway_groups" do
     field :name, :string
-    field :routing, Ecto.Enum, values: ~w[managed self_hosted stun_only]a
 
     belongs_to :account, Domain.Accounts.Account
     has_many :gateways, Domain.Gateways.Gateway, foreign_key: :group_id, where: [deleted_at: nil]

--- a/elixir/apps/domain/lib/domain/gateways/group/changeset.ex
+++ b/elixir/apps/domain/lib/domain/gateways/group/changeset.ex
@@ -3,7 +3,7 @@ defmodule Domain.Gateways.Group.Changeset do
   alias Domain.{Auth, Accounts}
   alias Domain.Gateways
 
-  @fields ~w[name routing]a
+  @fields ~w[name]a
 
   def create(%Accounts.Account{} = account, attrs, %Auth.Subject{} = subject) do
     %Gateways.Group{account: account}

--- a/elixir/apps/domain/lib/domain/relays.ex
+++ b/elixir/apps/domain/lib/domain/relays.ex
@@ -231,12 +231,16 @@ defmodule Domain.Relays do
   end
 
   def all_connected_relays_for_account(%Accounts.Account{} = account) do
+    all_connected_relays_for_account(account.id)
+  end
+
+  def all_connected_relays_for_account(account_id) do
     connected_global_relays =
       global_groups_presence_topic()
       |> Presence.list()
 
     connected_account_relays =
-      account_presence_topic(account.id)
+      account_presence_topic(account_id)
       |> Presence.list()
 
     connected_relays = Map.merge(connected_global_relays, connected_account_relays)
@@ -245,7 +249,7 @@ defmodule Domain.Relays do
     relays =
       Relay.Query.not_deleted()
       |> Relay.Query.by_ids(connected_relay_ids)
-      |> Relay.Query.global_or_by_account_id(account.id)
+      |> Relay.Query.global_or_by_account_id(account_id)
       |> Relay.Query.prefer_global()
       |> Repo.all()
       |> Enum.map(fn relay ->

--- a/elixir/apps/domain/lib/domain/relays.ex
+++ b/elixir/apps/domain/lib/domain/relays.ex
@@ -1,7 +1,7 @@
 defmodule Domain.Relays do
   use Supervisor
   alias Domain.{Repo, Auth, Geo, PubSub}
-  alias Domain.{Accounts, Resources, Tokens}
+  alias Domain.{Accounts, Tokens}
   alias Domain.Relays.{Authorizer, Relay, Group, Presence}
 
   def start_link(opts) do
@@ -230,32 +230,23 @@ defmodule Domain.Relays do
     end)
   end
 
-  def all_connected_relays_for_resource(%Resources.Resource{} = _resource, :managed) do
-    connected_relays =
+  def all_connected_relays_for_account(%Accounts.Account{} = account) do
+    connected_global_relays =
       global_groups_presence_topic()
       |> Presence.list()
 
-    filter = &Relay.Query.public(&1)
-    list_relays_for_resource(connected_relays, filter)
-  end
-
-  def all_connected_relays_for_resource(%Resources.Resource{} = resource, :self_hosted) do
-    connected_relays =
-      resource.account_id
-      |> account_presence_topic()
+    connected_account_relays =
+      account_presence_topic(account.id)
       |> Presence.list()
 
-    filter = &Relay.Query.by_account_id(&1, resource.account_id)
-    list_relays_for_resource(connected_relays, filter)
-  end
-
-  defp list_relays_for_resource(connected_relays, filter) do
+    connected_relays = Map.merge(connected_global_relays, connected_account_relays)
     connected_relay_ids = Map.keys(connected_relays)
 
     relays =
       Relay.Query.not_deleted()
       |> Relay.Query.by_ids(connected_relay_ids)
-      |> filter.()
+      |> Relay.Query.global_or_by_account_id(account.id)
+      |> Relay.Query.prefer_global()
       |> Repo.all()
       |> Enum.map(fn relay ->
         %{metas: metas} = Map.get(connected_relays, relay.id)
@@ -345,10 +336,11 @@ defmodule Domain.Relays do
     with {:ok, _} <-
            Presence.track(self(), group_presence_topic(relay.group_id), relay.id, %{}),
          {:ok, _} <-
-           Presence.track(self(), presence_topic(relay), relay.id, %{
+           Presence.track(self(), account_or_global_presence_topic(relay), relay.id, %{
              online_at: System.system_time(:second),
              secret: secret
-           }) do
+           }),
+         {:ok, _} <- Presence.track(self(), presence_topic(relay), relay.id, %{}) do
       :ok = PubSub.subscribe(relay_topic(relay))
       :ok = PubSub.subscribe(group_topic(relay.group_id))
       :ok = PubSub.subscribe(account_topic(relay.account_id))
@@ -358,10 +350,13 @@ defmodule Domain.Relays do
 
   ### Presence
 
-  defp presence_topic(%Relay{account_id: nil}),
+  defp presence_topic(relay_or_id),
+    do: "presences:#{relay_topic(relay_or_id)}"
+
+  defp account_or_global_presence_topic(%Relay{account_id: nil}),
     do: global_groups_presence_topic()
 
-  defp presence_topic(%Relay{account_id: account_id}),
+  defp account_or_global_presence_topic(%Relay{account_id: account_id}),
     do: account_presence_topic(account_id)
 
   def global_groups_presence_topic,
@@ -385,6 +380,10 @@ defmodule Domain.Relays do
 
   defp group_topic(%Group{} = group), do: group_topic(group.id)
   defp group_topic(group_id), do: "group_relays:#{group_id}"
+
+  def subscribe_to_relay_presence(relay_or_id) do
+    PubSub.subscribe(presence_topic(relay_or_id))
+  end
 
   def subscribe_to_relays_presence_in_account(%Accounts.Account{} = account) do
     PubSub.subscribe(global_groups_presence_topic())

--- a/elixir/apps/domain/lib/domain/relays/relay/query.ex
+++ b/elixir/apps/domain/lib/domain/relays/relay/query.ex
@@ -38,7 +38,7 @@ defmodule Domain.Relays.Relay.Query do
     )
   end
 
-  def public_or_by_account_id(queryable, account_id) do
+  def global_or_by_account_id(queryable, account_id) do
     where(
       queryable,
       [relays: relays],
@@ -46,12 +46,8 @@ defmodule Domain.Relays.Relay.Query do
     )
   end
 
-  def global_or_by_account_id(queryable, account_id) do
-    where(
-      queryable,
-      [relays: relays],
-      relays.account_id == ^account_id or is_nil(relays.account_id)
-    )
+  def prefer_global(queryable) do
+    order_by(queryable, [relays: relays], asc_nulls_first: relays.account_id)
   end
 
   def returning_not_deleted(queryable) do

--- a/elixir/apps/domain/priv/repo/migrations/20240412001352_delete_gateway_groups_routing.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20240412001352_delete_gateway_groups_routing.exs
@@ -1,0 +1,9 @@
+defmodule Domain.Repo.Migrations.DeleteGatewayGroupsRouting do
+  use Ecto.Migration
+
+  def change do
+    alter table(:gateway_groups) do
+      remove(:routing, :string)
+    end
+  end
+end

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -523,7 +523,7 @@ IO.puts("")
 gateway_group =
   account
   |> Gateways.Group.Changeset.create(
-    %{name: "mycro-aws-gws", routing: "managed", tokens: [%{}]},
+    %{name: "mycro-aws-gws", tokens: [%{}]},
     admin_subject
   )
   |> Repo.insert!()

--- a/elixir/apps/domain/test/domain/relays_test.exs
+++ b/elixir/apps/domain/test/domain/relays_test.exs
@@ -1197,5 +1197,15 @@ defmodule Domain.RelaysTest do
 
       assert_receive "disconnect"
     end
+
+    test "subscribes to relay presence", %{account: account} do
+      relay = Fixtures.Relays.create_relay(account: account)
+      :ok = subscribe_to_relay_presence(relay)
+
+      assert connect_relay(relay, "foo") == :ok
+
+      relay_id = relay.id
+      assert_receive %Phoenix.Socket.Broadcast{topic: "presences:relays:" <> ^relay_id}
+    end
   end
 end

--- a/elixir/apps/domain/test/domain/relays_test.exs
+++ b/elixir/apps/domain/test/domain/relays_test.exs
@@ -695,29 +695,19 @@ defmodule Domain.RelaysTest do
     end
   end
 
-  describe "all_connected_relays_for_resource/2" do
-    test "returns empty list when there are no managed relays online", %{account: account} do
-      resource = Fixtures.Resources.create_resource(account: account)
-      group = Fixtures.Relays.create_global_group()
+  describe "all_connected_relays_for_account/1" do
+    test "returns empty list when there are no relays online", %{account: account} do
+      # managed
+      global_group = Fixtures.Relays.create_global_group()
+      Fixtures.Relays.create_relay(account: account, group: global_group)
 
-      Fixtures.Relays.create_relay(account: account, group: group)
-
-      assert all_connected_relays_for_resource(resource, :managed) == {:ok, []}
-    end
-
-    test "returns empty list when there are no self-hosted relays online", %{account: account} do
-      resource = Fixtures.Resources.create_resource(account: account)
-
+      # self hosted
       Fixtures.Relays.create_relay(account: account)
 
-      Fixtures.Relays.create_relay(account: account)
-      |> Fixtures.Relays.delete_relay()
-
-      assert all_connected_relays_for_resource(resource, :self_hosted) == {:ok, []}
+      assert all_connected_relays_for_account(account) == {:ok, []}
     end
 
     test "returns list of connected account relays", %{account: account} do
-      resource = Fixtures.Resources.create_resource(account: account)
       relay1 = Fixtures.Relays.create_relay(account: account)
       relay2 = Fixtures.Relays.create_relay(account: account)
       stamp_secret = Ecto.UUID.generate()
@@ -725,21 +715,20 @@ defmodule Domain.RelaysTest do
       assert connect_relay(relay1, stamp_secret) == :ok
       assert connect_relay(relay2, stamp_secret) == :ok
 
-      assert {:ok, connected_relays} = all_connected_relays_for_resource(resource, :self_hosted)
+      assert {:ok, connected_relays} = all_connected_relays_for_account(account)
 
       assert Enum.all?(connected_relays, &(&1.stamp_secret == stamp_secret))
       assert Enum.sort(Enum.map(connected_relays, & &1.id)) == Enum.sort([relay1.id, relay2.id])
     end
 
     test "returns list of connected global relays", %{account: account} do
-      resource = Fixtures.Resources.create_resource(account: account)
       group = Fixtures.Relays.create_global_group()
       relay = Fixtures.Relays.create_relay(account: account, group: group)
       stamp_secret = Ecto.UUID.generate()
 
       assert connect_relay(relay, stamp_secret) == :ok
 
-      assert {:ok, [connected_relay]} = all_connected_relays_for_resource(resource, :managed)
+      assert {:ok, [connected_relay]} = all_connected_relays_for_account(account)
 
       assert connected_relay.id == relay.id
       assert connected_relay.stamp_secret == stamp_secret

--- a/elixir/apps/domain/test/support/fixtures/gateways.ex
+++ b/elixir/apps/domain/test/support/fixtures/gateways.ex
@@ -4,8 +4,7 @@ defmodule Domain.Fixtures.Gateways do
 
   def group_attrs(attrs \\ %{}) do
     Enum.into(attrs, %{
-      name: "group-#{unique_integer()}",
-      routing: "managed"
+      name: "group-#{unique_integer()}"
     })
   end
 

--- a/elixir/apps/web/lib/web/live/sites/edit.ex
+++ b/elixir/apps/web/lib/web/live/sites/edit.ex
@@ -39,7 +39,6 @@ defmodule Web.Sites.Edit do
       <:content>
         <div class="py-8 px-4 mx-auto max-w-2xl lg:py-16">
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
-            <.input type="hidden" field={@form[:routing]} value="managed" />
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <.input label="Name" field={@form[:name]} placeholder="Name of this Site" required />
             </div>

--- a/elixir/apps/web/lib/web/live/sites/new.ex
+++ b/elixir/apps/web/lib/web/live/sites/new.ex
@@ -23,7 +23,6 @@ defmodule Web.Sites.New do
         <.flash kind={:error} flash={@flash} />
         <div class="py-8 px-4 mx-auto max-w-2xl lg:py-16">
           <.form for={@form} phx-change={:change} phx-submit={:submit}>
-            <.input type="hidden" field={@form[:routing]} value="managed" />
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
               <.input label="Name" field={@form[:name]} placeholder="Name of this Site" required />
             </div>

--- a/elixir/apps/web/test/web/live/sites/edit_test.exs
+++ b/elixir/apps/web/test/web/live/sites/edit_test.exs
@@ -79,8 +79,7 @@ defmodule Web.Live.Sites.EditTest do
     form = form(lv, "form")
 
     assert find_inputs(form) == [
-             "group[name]",
-             "group[routing]"
+             "group[name]"
            ]
   end
 

--- a/elixir/apps/web/test/web/live/sites/new_test.exs
+++ b/elixir/apps/web/test/web/live/sites/new_test.exs
@@ -57,8 +57,7 @@ defmodule Web.Live.Sites.NewTest do
     form = form(lv, "form")
 
     assert find_inputs(form) == [
-             "group[name]",
-             "group[routing]"
+             "group[name]"
            ]
   end
 


### PR DESCRIPTION
`relays` will be removed from `prepare_connection` in a few weeks after we release a version that reads them from `init` message. Keep in mind technically `relays` list can be empty, it would be nice if clients would log an error or show it in such cases.