### PR TITLE
test(integration): remove redundant `integration-test-` prefix

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -70,7 +70,7 @@ on:
 
 jobs:
   integration-tests:
-    name: integration-tests-${{ matrix.test }}
+    name: ${{ matrix.test }}
     runs-on: ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
They all have the same prefix anyway, and it uses up real estate in the CI page 

**After**
<img width="311" alt="image" src="https://github.com/firezone/firezone/assets/13400041/8028f9bf-5c13-4170-9e01-06bfd393751c">

**Before**
<img width="292" alt="image" src="https://github.com/firezone/firezone/assets/13400041/8cabf67e-6be2-4719-b06f-4a76cf5c8111">
