### PR TITLE
fix(windows-client): remove spurious "Connected to Firezone" notifications

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -638,16 +638,14 @@ impl Controller {
                 bail!("Impossible error: `Quit` should be handled before this")
             }
             Req::TunnelReady => {
-                let was_already_ready = self.tunnel_ready;
-                self.tunnel_ready = true;
-                self.refresh_system_tray_menu()?;
-
-                if !was_already_ready {
+                if !self.tunnel_ready {
                     os::show_notification(
                         "Firezone connected",
                         "You are now signed in and able to access resources.",
                     )?;
                 }
+                self.tunnel_ready = true;
+                self.refresh_system_tray_menu()?;
             }
             Req::UpdateAvailable(release) => {
                 let title = format!("Firezone {} available for download", release.tag_name);

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -642,7 +642,7 @@ impl Controller {
                 self.tunnel_ready = true;
                 self.refresh_system_tray_menu()?;
 
-                if ! was_already_ready {
+                if !was_already_ready {
                     os::show_notification(
                         "Firezone connected",
                         "You are now signed in and able to access resources.",

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -638,13 +638,16 @@ impl Controller {
                 bail!("Impossible error: `Quit` should be handled before this")
             }
             Req::TunnelReady => {
+                let was_already_ready = self.tunnel_ready;
                 self.tunnel_ready = true;
                 self.refresh_system_tray_menu()?;
 
-                os::show_notification(
-                    "Firezone connected",
-                    "You are now signed in and able to access resources.",
-                )?;
+                if ! was_already_ready {
+                    os::show_notification(
+                        "Firezone connected",
+                        "You are now signed in and able to access resources.",
+                    )?;
+                }
             }
             Req::UpdateAvailable(release) => {
                 let title = format!("Firezone {} available for download", release.tag_name);


### PR DESCRIPTION
Closes #4385

```[tasklist]
### Manual test cases (f2c8f47b3 passed)
- [x] Given there is no token on disk, when you start the app, then there is no notification
- [x] Given there is a token on disk, when you start the app and it signs in, then there is 1 notification
- [x] Given the app is signed out, when you sign in, then there is 1 notification (test this in a sign-out-sign-in cycle)
- [x] Given the app is signed in, when you sign out, then there is no notification
- [x] Given the app is signed in, when you change Wi-Fi networks, then there is no notification
```

This will work on Linux once the Linux GUI comes up