### PR TITLE
refactor(headless-client): use Tokio codec instead of hand-rolled length-delimited codec

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1944,6 +1944,7 @@ dependencies = [
  "connlib-shared",
  "dirs",
  "firezone-cli-utils",
+ "futures",
  "humantime",
  "nix 0.28.0",
  "resolv-conf",
@@ -1951,6 +1952,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
 ]

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -95,11 +95,10 @@ mod test {
     use super::*;
     use chrono::DateTime;
     use connlib_shared::messages::{
-        DnsServer, Interface, IpDnsServer, Relay, ResourceDescription, ResourceDescriptionCidr,
+        DnsServer, IpDnsServer, ResourceDescriptionCidr,
         ResourceDescriptionDns, Stun, Turn,
     };
     use phoenix_channel::PhoenixMessage;
-    use std::collections::HashSet;
 
     // TODO: request_connection tests
 

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -95,8 +95,7 @@ mod test {
     use super::*;
     use chrono::DateTime;
     use connlib_shared::messages::{
-        DnsServer, IpDnsServer, ResourceDescriptionCidr,
-        ResourceDescriptionDns, Stun, Turn,
+        DnsServer, IpDnsServer, ResourceDescriptionCidr, ResourceDescriptionDns, Stun, Turn,
     };
     use phoenix_channel::PhoenixMessage;
 

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -26,6 +26,7 @@ impl ResourceId {
         ResourceId(Uuid::new_v4())
     }
 
+    #[cfg(feature = "proptest")]
     pub(crate) fn from_u128(v: u128) -> Self {
         Self(Uuid::from_u128(v))
     }

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -10,14 +10,11 @@ authors = ["Firezone, Inc."]
 [dependencies]
 anyhow = { version = "1.0" }
 clap = { version = "4.5", features = ["derive",  "env"] }
-futures = "0.3.30"
 humantime = "2.1"
 serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.115"
 # This actually relies on many other features in Tokio, so this will probably
 # fail to build outside the workspace. <https://github.com/firezone/firezone/pull/4328#discussion_r1540342142>
 tokio = { version = "1.36.0", features = ["macros", "signal"] }
-tokio-util = { version = "0.7.10", features = ["codec"] }
 url = { version = "2.3.1", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -25,9 +22,12 @@ connlib-client-shared = { workspace = true }
 connlib-shared = { workspace = true }
 dirs = "5.0.1"
 firezone-cli-utils = { workspace = true }
+futures = "0.3.30"
 nix = { version =  "0.28.0", features = ["user"] }
 resolv-conf = "0.7.0"
 secrecy = { workspace = true }
+serde_json = "1.0.115"
+tokio-util = { version = "0.7.10", features = ["codec"] }
 tracing = { workspace = true }
 
 [lints]

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -10,12 +10,14 @@ authors = ["Firezone, Inc."]
 [dependencies]
 anyhow = { version = "1.0" }
 clap = { version = "4.5", features = ["derive",  "env"] }
+futures = "0.3.30"
 humantime = "2.1"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
 # This actually relies on many other features in Tokio, so this will probably
 # fail to build outside the workspace. <https://github.com/firezone/firezone/pull/4328#discussion_r1540342142>
 tokio = { version = "1.36.0", features = ["macros", "signal"] }
+tokio-util = { version = "0.7.10", features = ["codec"] }
 url = { version = "2.3.1", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -18,7 +18,6 @@ pub use linux::run;
 
 #[cfg(target_os = "windows")]
 mod windows {
-    use anyhow::Result;
     use clap::Parser;
 
     pub async fn run() -> anyhow::Result<()> {

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -8,10 +8,7 @@
 //! Tauri deb bundler to pick it up easily.
 //! Otherwise we would just make it a normal binary crate.
 
-use anyhow::Result;
-use serde::Serialize;
 use std::path::PathBuf;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -21,6 +18,7 @@ pub use linux::run;
 
 #[cfg(target_os = "windows")]
 mod windows {
+    use anyhow::Result;
     use clap::Parser;
 
     pub async fn run() -> anyhow::Result<()> {
@@ -73,61 +71,4 @@ struct Cli {
     /// it's down. Accepts human times. e.g. "5m" or "1h" or "30d".
     #[arg(short, long, env = "MAX_PARTITION_TIME")]
     max_partition_time: Option<humantime::Duration>,
-}
-
-// Copied from <https://github.com/firezone/subzone>
-
-/// Reads a message from an async reader, with a 32-bit LE length prefix
-// Dead on Windows temporarily
-#[allow(dead_code)]
-async fn read_ipc_msg<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>> {
-    let mut len_buf = [0u8; 4];
-    reader.read_exact(&mut len_buf).await?;
-    let len = u32::from_le_bytes(len_buf);
-    let len = usize::try_from(len)?;
-    let mut buf = vec![0u8; len];
-    reader.read_exact(&mut buf).await?;
-    Ok(buf)
-}
-
-/// Encodes a message as JSON and writes it to an async writer, with a 32-bit LE length prefix
-///
-/// TODO: Why does this one take `T` and `read_ipc_msg` doesn't?
-// Dead on Windows temporarily
-#[allow(dead_code)]
-async fn write_ipc_msg<W: AsyncWrite + Unpin, T: Serialize>(writer: &mut W, msg: &T) -> Result<()> {
-    let buf = serde_json::to_string(msg)?;
-    let len = u32::try_from(buf.len())?.to_le_bytes();
-    writer.write_all(&len).await?;
-    writer.write_all(buf.as_bytes()).await?;
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(target_os = "windows")]
-    mod windows {
-        use crate::{read_ipc_msg, write_ipc_msg};
-
-        const MESSAGE_ONE: &str = "message one";
-
-        #[tokio::test]
-        async fn ipc_windows() {
-            // Round-trip a message to avoid dead code warnings
-            let mut buffer = vec![];
-
-            write_ipc_msg(&mut buffer, &MESSAGE_ONE.to_string())
-                .await
-                .unwrap();
-
-            let mut cursor = std::io::Cursor::new(buffer);
-            let v = read_ipc_msg(&mut cursor).await.unwrap();
-            let s = String::from_utf8(v).unwrap();
-            let decoded: String = serde_json::from_str(&s).unwrap();
-            assert_eq!(decoded, MESSAGE_ONE);
-
-            // TODO: Windows process splitting
-            // <https://github.com/firezone/firezone/issues/3712>
-        }
-    }
 }

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -224,8 +224,7 @@ async fn handle_ipc_client(mut stream: IpcStream) -> Result<()> {
         .await
         .context("Error while reading IPC message")?
         .context("IPC stream empty")?;
-    let s = String::from_utf8(v.to_vec())?;
-    let decoded: String = serde_json::from_str(&s)?;
+    let decoded: String = serde_json::from_slice(&v)?;
 
     tracing::debug!(?decoded, "Received message");
     stream.send("OK".to_string().into()).await?;
@@ -271,8 +270,7 @@ mod tests {
                 .await
                 .expect("Error while reading IPC message")
                 .expect("IPC stream empty");
-            let s = String::from_utf8(v.to_vec()).unwrap();
-            let decoded: String = serde_json::from_str(&s).unwrap();
+            let decoded: String = serde_json::from_slice(&v).unwrap();
             assert_eq!(MESSAGE_ONE, decoded);
 
             let v = stream
@@ -280,8 +278,7 @@ mod tests {
                 .await
                 .expect("Error while reading IPC message")
                 .expect("IPC stream empty");
-            let s = String::from_utf8(v.to_vec()).unwrap();
-            let decoded: String = serde_json::from_str(&s).unwrap();
+            let decoded: String = serde_json::from_slice(&v).unwrap();
             assert_eq!(MESSAGE_TWO, decoded);
         });
 


### PR DESCRIPTION
The ongoing yak shave towards #3713

Closes #4514 and saves about 30 lines of code, thanks for the suggestion Thomas