### PR TITLE
ci: Only build debug images for `linux/amd64`

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -132,6 +132,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Exclude debug builds for non-amd64 targets since they won't be used,
+        # and trying to nodejs inside cross-platform containers has issues.
+        # See https://github.com/nodejs/docker-node/issues/1946
+        # Syntax is weird because https://github.com/actions/runner/issues/1512
+        exclude:
+          - {stage: debug, arch: {platform: linux/arm/v7}}
+          - {stage: debug, arch: {platform: linux/arm64}}
+
+        stage:
+          - ${{ inputs.stage }}
         arch:
           - target: x86_64-unknown-linux-musl
             shortname: x64
@@ -196,7 +206,7 @@ jobs:
           # Used for Docker images
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}
       - name: Upload Release Assets
-        if: ${{ inputs.profile == 'release' && inputs.stage == 'release' && (matrix.name.image_name == 'gateway' || matrix.name.image_name == 'client') }}
+        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && (matrix.name.image_name == 'gateway' || matrix.name.image_name == 'client') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -249,7 +259,7 @@ jobs:
           REF="${{ github.ref_name }}"
           CACHE_TAG="${REF//\//-}"
           echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
-      - name: Build and push Docker images by digest
+      - name: Build Docker images
         id: build
         uses: docker/build-push-action@v5
         with:
@@ -263,7 +273,7 @@ jobs:
             type=registry,ref=${{ steps.login.outputs.registry }}/cache/${{ matrix.name.image_name }}:main
           cache-to: |
             type=registry,ref=${{ steps.login.outputs.registry }}/cache/${{ matrix.name.image_name }}:${{ env.CACHE_TAG }},mode=max
-          target: ${{ inputs.stage }}
+          target: ${{ matrix.stage }}
           outputs:
             type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -132,16 +132,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Exclude debug builds for non-amd64 targets since they won't be used,
-        # and trying to nodejs inside cross-platform containers has issues.
-        # See https://github.com/nodejs/docker-node/issues/1946
-        # Syntax is weird because https://github.com/actions/runner/issues/1512
-        exclude:
-          - {stage: debug, arch: {platform: linux/arm/v7}}
-          - {stage: debug, arch: {platform: linux/arm64}}
-
+        # Copy input vars to matrix vars to conditionally exclude them
+        image_prefix:
+          - ${{ inputs.image_prefix }}
         stage:
           - ${{ inputs.stage }}
+
+        # Syntax is weird because https://github.com/actions/runner/issues/1512
+        exclude:
+          # Exclude debug builds for non-amd64 targets since they won't be used.
+          - {stage: debug, arch: {platform: linux/arm/v7}}
+          - {stage: debug, arch: {platform: linux/arm64}}
+          # Exclude snownet-tests and http-test-server from perf image builds
+          - {image_prefix: perf, name: {package: snownet-tests}}
+          - {image_prefix: perf, name: {package: http-test-server}}
+
         arch:
           - target: x86_64-unknown-linux-musl
             shortname: x64
@@ -245,7 +250,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) || '' }}${{ matrix.name.image_name }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -275,7 +280,7 @@ jobs:
             type=registry,ref=${{ steps.login.outputs.registry }}/cache/${{ matrix.name.image_name }}:${{ env.CACHE_TAG }},mode=max
           target: ${{ matrix.stage }}
           outputs:
-            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
+            type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |
           mkdir -p /tmp/digests/${{ matrix.name.image_name }}
@@ -285,13 +290,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.image_prefix && format('{0}-', inputs.image_prefix) || '' }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
+          name: ${{ matrix.image_prefix && format('{0}-', matrix.image_prefix) || '' }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
           path: /tmp/digests/${{ matrix.name.image_name }}
           if-no-files-found: error
           retention-days: 1
       - name: Output image name
         id: image-name
-        run: echo "${{ matrix.name.image_name }}_image=${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) || '' }}${{ matrix.name.image_name }}" >> $GITHUB_OUTPUT
+        run: echo "${{ matrix.name.image_name }}_image=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }}" >> $GITHUB_OUTPUT
 
   merge-docker-artifacts:
     name: merge-${{ matrix.image_name }}
@@ -301,6 +306,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Copy input vars to matrix vars to conditionally exclude them
+        image_prefix:
+          - ${{ inputs.image_prefix }}
+
+        # Exclude snownet-tests and http-test-server from perf image builds
+        exclude:
+          - {image_prefix: perf, image_name: snownet-tests}
+          - {image_prefix: perf, image_name: http-test-server}
+
         image_name:
           - relay
           - gateway
@@ -318,7 +332,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ inputs.image_prefix && format('{0}-', inputs.image_prefix) || '' }}${{ matrix.image_name }}-${{ inputs.sha }}-digest-*
+          pattern: ${{ matrix.image_prefix && format('{0}-', matrix.image_prefix) || '' }}${{ matrix.image_name }}-${{ inputs.sha }}-digest-*
           merge-multiple: true
           path: /tmp/digests/${{ matrix.image_name }}
       - name: Display structure of downloaded artifacts
@@ -338,7 +352,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images:
-            ${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) || '' }}${{ matrix.image_name }}
+            ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image_name }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ inputs.sha }}
@@ -350,7 +364,7 @@ jobs:
         working-directory: /tmp/digests/${{ matrix.image_name }}
         run: |
           tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) || '' }}${{ matrix.image_name }}@sha256:%s ' *)
+          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image_name }}@sha256:%s ' *)
           echo "$sources"
           docker buildx imagetools create $tags $sources
-          docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ inputs.image_prefix && format('{0}/', inputs.image_prefix) || '' }}${{ matrix.image_name }}"
+          docker buildx imagetools inspect "${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image_name }}"


### PR DESCRIPTION
refs #4602 

- Removes `debug` stage building of `arm` and `arm64` binaries and images (PRs only) -- these just get thrown away since we only test in CI with `amd64`
- Removes `perf` builds for snownet-tests and http-test-server
- `base-base*` jobs are expected to fail since these changes haven't hit `main` yet
- 
This changes our required checks, so after approval I'll need to update those.
