### PR TITLE
fix(portal): remove typo in manual command var

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -247,7 +247,7 @@ defmodule Web.Sites.NewToken do
 
   defp manual_command(env) do
     """
-    #{Enum.map_join(env, "\n", fn {key, value} -> "#{key}=#{value}" end)})
+    #{Enum.map_join(env, "\n", fn {key, value} -> "#{key}=#{value}" end)}
     """
   end
 


### PR DESCRIPTION
This breaks copy-pasting the token from the Deploy Gateway page:

<img width="341" alt="Screenshot 2024-04-13 at 2 59 08 PM" src="https://github.com/firezone/firezone/assets/167144/1cb6bc9e-e2ae-476b-85ac-7d0e1b635945">
