### PR TITLE
ci: Add tag name to build-dev-images

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/_build_artifacts.yml
     secrets: inherit
     with:
+      tag_name: "${{ env.VERSION }}"
       image_prefix: "dev"
       stage: "debug"
       profile: "debug"


### PR DESCRIPTION
dev images don't uses releases and shouldn't rely on release-drafter, instead following the `VERSION` that's set in CI.

Fixes https://github.com/firezone/firezone/actions/runs/8696082974