### PR TITLE
chore(ci): .env not available in `with` shared workflow context

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,9 @@ jobs:
     uses: ./.github/workflows/_build_artifacts.yml
     secrets: inherit
     with:
-      tag_name: "${{ env.VERSION }}"
+      # See https://github.com/actions/runner/issues/2372
+      # mark:automatic-version
+      tag_name: "1.0.0"
       image_prefix: "dev"
       stage: "debug"
       profile: "debug"


### PR DESCRIPTION
Le sigh