### PR TITLE
refactor(apple): Don't log error if calling stop on stopped tunnel

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -115,10 +115,7 @@ public final class Store: ObservableObject {
 
   func stop(clearToken: Bool = false) {
     guard [.connected, .connecting, .reasserting].contains(status)
-    else {
-      Log.app.error("\(#function): Can't stop from state: \(status)")
-      return
-    }
+    else { return }
 
     tunnelManager.stop(clearToken: clearToken)
   }


### PR DESCRIPTION
This can happen on app start, but it's not an error or interesting state we care about.