### PR TITLE
chore(ci): build docker dev images with `main`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,9 +23,7 @@ jobs:
     uses: ./.github/workflows/_build_artifacts.yml
     secrets: inherit
     with:
-      # See https://github.com/actions/runner/issues/2372
-      # mark:automatic-version
-      tag_name: "1.0.0"
+      tag_name: "${{ github.ref_name }}"
       image_prefix: "dev"
       stage: "debug"
       profile: "debug"


### PR DESCRIPTION
Fixes broken pulling of images for dev