### PR TITLE
refactor(linux-client): rename `daemon` subcommand to `ipc-service`

### DIFF
--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -80,7 +80,7 @@ impl Cli {
 #[derive(clap::Subcommand, Clone, Copy)]
 enum Cmd {
     /// Listen for IPC connections and act as a privileged tunnel process for a GUI client
-    Daemon,
+    IpcService,
     /// Act as a CLI-only Client, don't listen for IPC connections
     Standalone,
 }

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -29,7 +29,7 @@ pub async fn run() -> Result<()> {
     setup_global_subscriber(layer);
 
     match cli.command() {
-        Cmd::Daemon => run_daemon(cli).await,
+        Cmd::IpcService => run_daemon(cli).await,
         Cmd::Standalone => run_standalone(cli).await,
     }
 }


### PR DESCRIPTION
Closes #4655

This should be more clear since "daemon", like "tunnel", could mean a variety of things. The IPC thing is the distinct part for this subcommand, and I didn't want to call it "server" and confuse it with a web server. "service" hopefully evokes "systemd service" and "Windows service", something that provides a service locally.

If not it could always be something longer