### PR TITLE
test(linux-client): temporarily disable failing linux-group integration test

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -106,7 +106,7 @@ jobs:
           direct-download-roaming-network,
           dns-failsafe, # Uses the default DNS control method
           dns-nm,
-          linux-group,  # Stub, doesn't run Firezone code yet
+          # linux-group,  # Stub, doesn't run Firezone code yet. Broken too, see <https://github.com/firezone/firezone/issues/4669>
           relay-graceful-shutdown,
           relayed-curl-api-down,
           relayed-curl-api-restart,


### PR DESCRIPTION
Refs #4669. That issue will be for fixing and re-enabling the test.

This is only needed for Linux IPC which isn't in production yet, so it's easier to disable first and debug second