### PR TITLE
chore(relay): parse `init` message

### DIFF
--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -265,6 +265,12 @@ fn env_filter() -> EnvFilter {
         .from_env_lossy()
 }
 
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "event", content = "payload")]
+enum IngressMessage {
+    Init(Init),
+}
+
 #[derive(serde::Deserialize, Debug)]
 struct Init {}
 
@@ -289,7 +295,7 @@ struct Eventloop<R> {
     sockets: Sockets,
 
     server: Server<R>,
-    channel: Option<PhoenixChannel<JoinMessage, (), ()>>,
+    channel: Option<PhoenixChannel<JoinMessage, IngressMessage, ()>>,
     sleep: Sleep,
 
     sigterm: unix::Signal,
@@ -309,7 +315,7 @@ where
 {
     fn new(
         server: Server<R>,
-        channel: Option<PhoenixChannel<JoinMessage, (), ()>>,
+        channel: Option<PhoenixChannel<JoinMessage, IngressMessage, ()>>,
         public_address: IpStack,
         last_heartbeat_sent: Arc<Mutex<Option<Instant>>>,
     ) -> Result<Self> {
@@ -536,7 +542,7 @@ where
         }
     }
 
-    fn handle_portal_event(&mut self, event: phoenix_channel::Event<(), ()>) {
+    fn handle_portal_event(&mut self, event: phoenix_channel::Event<IngressMessage, ()>) {
         match event {
             Event::SuccessResponse { res: (), .. } => {}
             Event::JoinedRoom { topic } => {
@@ -549,7 +555,10 @@ where
                 tracing::debug!(target: "relay", "Heartbeat sent to portal");
                 *self.last_heartbeat_sent.lock().unwrap() = Some(Instant::now());
             }
-            Event::InboundMessage { msg: (), .. } => {}
+            Event::InboundMessage {
+                msg: IngressMessage::Init(Init {}),
+                ..
+            } => {}
             Event::Closed => {
                 self.channel = None;
             }


### PR DESCRIPTION
Actually parsing this got lost as part of introducing graceful shutdown where we re-ordered when to connect to the portal. This removes a warning from the logs which might otherwise be misleading of a problem.