### PR TITLE
chore(phoenix-channel): don't log message on deserialisation error

### DIFF
--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -418,7 +418,7 @@ where
                             continue;
                         }
                         Err(e) => {
-                            tracing::warn!("Failed to deserialize message {message}: {e}");
+                            tracing::warn!("Failed to deserialize message: {e}");
                             continue;
                         }
                     };


### PR DESCRIPTION
To see the offending message, we now need to turn on `wire=trace` logs.

Resolves: #4650.