### PR TITLE
chore(linux-client): more debugging info during tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1946,6 +1946,7 @@ dependencies = [
  "dirs",
  "firezone-cli-utils",
  "futures",
+ "git-version",
  "humantime",
  "nix 0.28.0",
  "resolv-conf",

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 # This actually relies on many other features in Tokio, so this will probably
 # fail to build outside the workspace. <https://github.com/firezone/firezone/pull/4328#discussion_r1540342142>
 tokio = { version = "1.36.0", features = ["macros", "signal"] }
+tracing = { workspace = true }
 url = { version = "2.3.1", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -30,7 +31,6 @@ sd-notify = "0.4.1" # This is a pure Rust re-implementation, so it isn't vulnera
 serde_json = "1.0.115"
 secrecy = { workspace = true }
 tokio-util = { version = "0.7.10", features = ["codec"] }
-tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Firezone, Inc."]
 [dependencies]
 anyhow = { version = "1.0" }
 clap = { version = "4.5", features = ["derive",  "env"] }
+git-version = "0.3.9"
 humantime = "2.1"
 serde = { version = "1.0.197", features = ["derive"] }
 # This actually relies on many other features in Tokio, so this will probably

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -23,12 +23,26 @@ mod windows {
     pub async fn run() -> anyhow::Result<()> {
         let cli = super::Cli::parse();
         let _cmd = cli.command();
+        tracing::info!(git_version = crate::GIT_VERSION);
         Ok(())
     }
 }
 
 #[cfg(target_os = "windows")]
 pub use windows::run;
+
+/// Output of `git describe` at compile time
+/// e.g. `1.0.0-pre.4-20-ged5437c88-modified` where:
+///
+/// * `1.0.0-pre.4` is the most recent ancestor tag
+/// * `20` is the number of commits since then
+/// * `g` doesn't mean anything
+/// * `ed5437c88` is the Git commit hash
+/// * `-modified` is present if the working dir has any changes from that commit number
+pub const GIT_VERSION: &str = git_version::git_version!(
+    args = ["--always", "--dirty=-modified", "--tags"],
+    fallback = "unknown"
+);
 
 #[derive(clap::Parser)]
 #[command(author, version, about, long_about = None)]

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -34,6 +34,8 @@ pub async fn run() -> Result<()> {
     let (layer, _handle) = cli.log_dir.as_deref().map(file_logger::layer).unzip();
     setup_global_subscriber(layer);
 
+    tracing::info!(git_version = crate::GIT_VERSION);
+
     match cli.command() {
         Cmd::Auto => {
             if let Some(token) = token(&cli)? {

--- a/scripts/tests/linux-group.sh
+++ b/scripts/tests/linux-group.sh
@@ -8,6 +8,7 @@ source "./scripts/tests/lib.sh"
 BINARY_NAME=firezone-linux-client
 FZ_GROUP="firezone"
 SERVICE_NAME=firezone-client
+SERVICE_FILE="scripts/tests/systemd/$SERVICE_NAME.service"
 export RUST_LOG=info
 
 function print_debug_info {
@@ -21,7 +22,8 @@ docker compose exec client cat firezone-linux-client > "$BINARY_NAME"
 chmod u+x "$BINARY_NAME"
 sudo mv "$BINARY_NAME" "/usr/bin/$BINARY_NAME"
 
-sudo cp "scripts/tests/systemd/$SERVICE_NAME.service" /usr/lib/systemd/system/
+sudo cp "$SERVICE_FILE" /usr/lib/systemd/system/
+cat "$SERVICE_FILE"
 
 # The firezone group must exist before the daemon starts
 sudo groupadd "$FZ_GROUP"


### PR DESCRIPTION
https://firezonehq.slack.com/archives/C04HRQTFY0Z/p1713456449683199
https://github.com/firezone/firezone/actions/runs/8739378166/job/23985938732

The problem is probably because the compatibility tests are using the last manually published release, which was about a week ago.

So the systemd file is calling `firezone-headless-client` (or `firezone-linux-client`) with no args. On the new client this means "Auto-detect the token and either run standalone or run IPC service". On the old client this means "run standalone".

That causes `linux-group` to fail because the token isn't used for that test, which will cause standalone mode to bail out.