### PR TITLE
chore(relay): log all failed requests on warn

### DIFF
--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -315,11 +315,9 @@ where
 
             error_response.add_attribute(Nonce::new(new_nonce.to_string()).unwrap());
             error_response.add_attribute((*FIREZONE).clone());
-
-            tracing::debug!(target: "relay", "{} failed: {}", error_response.method(), error.reason_phrase());
-        } else {
-            tracing::warn!(target: "relay", "{} failed: {}", error_response.method(), error.reason_phrase());
         }
+
+        tracing::warn!(target: "relay", "{} failed: {}", error_response.method(), error.reason_phrase());
 
         self.send_message(error_response, sender);
     }


### PR DESCRIPTION
This was discussed with @AndrewDryga to allow us detecting potential attacks. Some amount of authentication failures are expected during normal operation because TURN has this system of nonces which can only be used a certain number of times.

Resolves: #4550.