### PR TITLE
fix(relay): clear channel bindings when allocation is deleted

### DIFF
--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -525,7 +525,7 @@ where
 
             if self.stats_log_interval.poll_tick(cx).is_ready() {
                 let num_allocations = self.server.num_allocations();
-                let num_channels = self.server.num_channels();
+                let num_channels = self.server.num_active_channels();
 
                 let bytes_relayed_since_last_tick =
                     self.server.num_relayed_bytes() - self.last_num_bytes_relayed;

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -215,8 +215,11 @@ where
         self.allocations.len()
     }
 
-    pub fn num_channels(&self) -> usize {
-        self.channels_by_client_and_number.len()
+    pub fn num_active_channels(&self) -> usize {
+        self.channels_by_client_and_number
+            .iter()
+            .filter(|(_, c)| c.bound)
+            .count()
     }
 
     /// Process the bytes received from a client.

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -880,6 +880,35 @@ where
 
         let port = allocation.port;
 
+        self.channels_by_client_and_number
+            .retain(|(cl, number), c| {
+                if c.allocation != port {
+                    return true;
+                }
+
+                debug_assert_eq!(cl, &client, "internal state to be consistent");
+
+                let peer = c.peer_address;
+
+                let existing = self
+                    .channel_numbers_by_client_and_peer
+                    .remove(&(client, peer));
+                debug_assert_eq!(existing, Some(*number), "internal state to be consistent");
+
+                let existing = self
+                    .channel_and_client_by_port_and_peer
+                    .remove(&(port, peer));
+                debug_assert_eq!(
+                    existing,
+                    Some((client, *number)),
+                    "internal state to be consistent"
+                );
+
+                tracing::info!(%peer, %number, "Deleted channel binding");
+
+                false
+            });
+
         self.allocations_up_down_counter.add(-1, &[]);
         self.pending_commands.push_back(Command::FreeAllocation {
             port,


### PR DESCRIPTION
As suspected, there was a bug in the relay where channel bindings were not cleared if the client freed the allocation early by sending a REFRESH request with a lifetime of 0.

Resolves: #4588.