### PR TITLE
refactor(docs): Refactor KbSideBar to more accurately reflect content

### DIFF
--- a/website/src/app/kb/authenticate/directory-sync/readme.mdx
+++ b/website/src/app/kb/authenticate/directory-sync/readme.mdx
@@ -4,7 +4,7 @@ import SupportOptions from "@/components/SupportOptions";
 
 <PlanBadge plans={["enterprise"]}>
 
-# Directory sync
+# How Directory Sync Works
 
 </PlanBadge>
 

--- a/website/src/app/kb/authenticate/entra/readme.mdx
+++ b/website/src/app/kb/authenticate/entra/readme.mdx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 <PlanBadge plans={["enterprise"]}>
 
-# SSO with Microsoft Entra ID
+# SSO + Sync with Microsoft Entra ID
 
 </PlanBadge>
 

--- a/website/src/app/kb/authenticate/google/readme.mdx
+++ b/website/src/app/kb/authenticate/google/readme.mdx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 <PlanBadge plans={["enterprise"]}>
 
-# SSO with Google Workspace
+# SSO + Sync with Google Workspace
 
 </PlanBadge>
 
@@ -299,7 +299,7 @@ prompts you.
   />
 </Link>
 
-If you get successfully redirected back to your Firezone admin dashboard,
-you're done! Your Google Workspace connector is now successfully configured.
-The first sync will occur within about 10 minutes. After that, users will be
-able to authenticate to Firezone using their Google Workspace accounts.
+If you get successfully redirected back to your Firezone admin dashboard, you're
+done! Your Google Workspace connector is now successfully configured. The first
+sync will occur within about 10 minutes. After that, users will be able to
+authenticate to Firezone using their Google Workspace accounts.

--- a/website/src/app/kb/authenticate/okta/readme.mdx
+++ b/website/src/app/kb/authenticate/okta/readme.mdx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 <PlanBadge plans={["enterprise"]}>
 
-# SSO with Okta
+# SSO + Sync with Okta
 
 </PlanBadge>
 

--- a/website/src/app/kb/deploy/clients/readme.mdx
+++ b/website/src/app/kb/deploy/clients/readme.mdx
@@ -4,7 +4,7 @@ import PlanBadge from "@/components/PlanBadge";
 
 <PlanBadge plans={["starter", "team", "enterprise"]}>
 
-# Install Clients
+# Distribute Clients
 
 </PlanBadge>
 
@@ -12,7 +12,7 @@ Firezone provides native clients for all major platforms. Use these clients on
 end-user devices, servers, and any other machine that needs access to your
 protected Resources.
 
-## User installation
+## Installation
 
 See our [end-user instructions](/kb/user-guides/) for basic installation and
 usage instructions for the Firezone Client that are appropriate for all Firezone

--- a/website/src/app/kb/readme.mdx
+++ b/website/src/app/kb/readme.mdx
@@ -28,9 +28,9 @@ Use the links below to get started.
   start syncing users and groups.
 - [Administer](/kb/administer): Everything related to typical, day-to-day
   management of your deployment.
-- [User guides](/kb/user-guides): Instructions you can pass along to Firezone
-  end-users, such as installing Clients, using them, and related troubleshooting
-  tips.
+- [End-user guides](/kb/user-guides): Instructions you can pass along to
+  Firezone end-users, such as installing Clients, using them, and related
+  troubleshooting tips.
 - [FAQ](/kb/reference/faq): Frequently asked questions we've collected over
   time.
 

--- a/website/src/app/kb/user-guides/readme.mdx
+++ b/website/src/app/kb/user-guides/readme.mdx
@@ -5,27 +5,25 @@ import {
   LinuxIcon,
 } from "@/components/Icons";
 
-# User Guides
-
-Guides for common end-user workflows in Firezone.
+# Install Clients
 
 Visit the appropriate page below for download instructions and more for your
 platform.
 
 <div class="mt-20 flex justify-between text-center space-x-5">
-  <AndroidIcon size={10} href="/kb/user-guides/android-client">
-    <p>Android client</p>
-  </AndroidIcon>
   <AppleIcon size={10} href="/kb/user-guides/macos-client">
-    <p>macOS client</p>
-  </AppleIcon>
-  <AppleIcon size={10} href="/kb/user-guides/ios-client">
-    <p>iOS client</p>
+    <p>macOS</p>
   </AppleIcon>
   <WindowsIcon size={10} href="/kb/user-guides/windows-client">
-    <p>Windows client</p>
+    <p>Windows</p>
   </WindowsIcon>
+  <AndroidIcon size={10} href="/kb/user-guides/android-client">
+    <p>Android & ChromeOS</p>
+  </AndroidIcon>
+  <AppleIcon size={10} href="/kb/user-guides/ios-client">
+    <p>iOS</p>
+  </AppleIcon>
   <LinuxIcon size={10} href="/kb/user-guides/linux-client">
-    <p>Linux client</p>
+    <p>Linux</p>
   </LinuxIcon>
 </div>

--- a/website/src/components/KbSidebar/index.tsx
+++ b/website/src/components/KbSidebar/index.tsx
@@ -54,7 +54,7 @@ export default function KbSidebar() {
                 <Item href="/kb/deploy/policies" label="Policies" />
               </li>
               <li>
-                <Item href="/kb/deploy/clients" label="Clients" />
+                <Item href="/kb/deploy/clients" label="Distribute Clients" />
               </li>
               <li>
                 <Item href="/kb/deploy/dns" label="Configure DNS" />
@@ -83,22 +83,27 @@ export default function KbSidebar() {
                 />
               </li>
               <li>
-                <Item href="/kb/authenticate/google" label="Google Workspace" />
+                <Item
+                  href="/kb/authenticate/directory-sync"
+                  label="SSO + directory sync"
+                />
               </li>
               <li>
                 <Item
+                  nested
+                  href="/kb/authenticate/google"
+                  label="Google Workspace"
+                />
+              </li>
+              <li>
+                <Item
+                  nested
                   href="/kb/authenticate/entra"
                   label="Microsoft Entra ID"
                 />
               </li>
               <li>
-                <Item href="/kb/authenticate/okta" label="Okta" />
-              </li>
-              <li>
-                <Item
-                  href="/kb/authenticate/directory-sync"
-                  label="Directory sync"
-                />
+                <Item nested href="/kb/authenticate/okta" label="Okta" />
               </li>
               <li>
                 <Item
@@ -142,36 +147,40 @@ export default function KbSidebar() {
           <li>
             <Collapse
               expanded={p.startsWith("/kb/user-guides")}
-              label="User guides"
+              label="End-user guides"
             >
               <li>
-                <Item href="/kb/user-guides" label="Overview" />
+                <Item href="/kb/user-guides" label="Install Clients" />
               </li>
               <li>
                 <Item
+                  nested
                   href="/kb/user-guides/macos-client"
-                  label="macOS client"
+                  label="macOS"
                 />
               </li>
               <li>
-                <Item href="/kb/user-guides/ios-client" label="iOS client" />
+                <Item nested href="/kb/user-guides/ios-client" label="iOS" />
               </li>
               <li>
                 <Item
+                  nested
                   href="/kb/user-guides/windows-client"
-                  label="Windows client"
+                  label="Windows"
                 />
               </li>
               <li>
                 <Item
+                  nested
                   href="/kb/user-guides/android-client"
-                  label="Android / ChromeOS client"
+                  label="Android & ChromeOS"
                 />
               </li>
               <li>
                 <Item
+                  nested
                   href="/kb/user-guides/linux-client"
-                  label="Linux client"
+                  label="Linux"
                 />
               </li>
             </Collapse>


### PR DESCRIPTION
"User-Guides" isn't a great name. "End-user guides" is a tiny bit better -- the goal for this was to have something an admin could distribute to their end-users during onboarding.

Also I tried to clarify that only SSO+sync requires the Enterprise tier for Google/Okta/Entra