### PR TITLE
chore(snownet): free memory of allocation without valid credentials

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -62,6 +62,11 @@ pub struct Allocation<RId> {
 
     last_now: Instant,
 
+    credentials: Option<Credentials>,
+}
+
+#[derive(Debug, Clone)]
+struct Credentials {
     username: Username,
     password: String,
     realm: Realm,
@@ -114,10 +119,12 @@ where
             buffered_transmits: Default::default(),
             events: Default::default(),
             sent_requests: Default::default(),
-            username,
-            password,
-            realm,
-            nonce: Default::default(),
+            credentials: Some(Credentials {
+                username,
+                password,
+                realm,
+                nonce: Default::default(),
+            }),
             allocation_lifetime: Default::default(),
             channel_bindings: Default::default(),
             last_now: now,
@@ -152,9 +159,12 @@ where
         now: Instant,
     ) {
         self.server = socket;
-        self.username = username;
-        self.realm = realm;
-        self.password = password.to_owned();
+        self.credentials = Some(Credentials {
+            username,
+            realm,
+            password: password.to_owned(),
+            nonce: None,
+        });
 
         self.refresh(now);
     }
@@ -226,6 +236,7 @@ where
                     "Invalid credentials, refusing to re-authenticate {}",
                     original_request.method()
                 );
+                self.credentials = None;
                 self.invalidate_allocation();
 
                 return true;
@@ -233,13 +244,17 @@ where
 
             // Check if we need to re-authenticate the original request
             if error.code() == Unauthorized::CODEPOINT || error.code() == StaleNonce::CODEPOINT {
-                if let Some(nonce) = message.get_attribute::<Nonce>() {
-                    self.nonce = Some(nonce.clone());
+                let Some(Credentials { nonce, realm, .. }) = &mut self.credentials else {
+                    return true;
+                };
+
+                if let Some(new_nonce) = message.get_attribute::<Nonce>() {
+                    let _ = nonce.insert(new_nonce.clone());
                 };
 
                 if let Some(offered_realm) = message.get_attribute::<Realm>() {
-                    if offered_realm != &self.realm {
-                        tracing::warn!(allowed_realm = %self.realm.text(), server_realm = %offered_realm.text(), "Refusing to authenticate with server");
+                    if offered_realm != realm {
+                        tracing::warn!(allowed_realm = %realm.text(), server_realm = %offered_realm.text(), "Refusing to authenticate with server");
                         return true; // We still handled our message correctly.
                     }
                 };
@@ -692,7 +707,11 @@ where
         no_allocation && nothing_in_flight && nothing_buffered && waiting_on_nothing
     }
 
-    fn authenticate(&self, message: Message<Attribute>) -> Message<Attribute> {
+    fn authenticate(
+        &self,
+        message: Message<Attribute>,
+        credentials: &Credentials,
+    ) -> Message<Attribute> {
         let attributes = message
             .attributes()
             .filter(|a| !matches!(a, Attribute::Nonce(_)))
@@ -701,10 +720,10 @@ where
             .filter(|a| !matches!(a, Attribute::Username(_)))
             .cloned()
             .chain([
-                Attribute::Username(self.username.clone()),
-                Attribute::Realm(self.realm.clone()),
+                Attribute::Username(credentials.username.clone()),
+                Attribute::Realm(credentials.realm.clone()),
             ])
-            .chain(self.nonce.clone().map(Attribute::Nonce));
+            .chain(credentials.nonce.clone().map(Attribute::Nonce));
 
         let transaction_id = TransactionId::new(random());
         let mut message = Message::new(MessageClass::Request, message.method(), transaction_id);
@@ -715,9 +734,9 @@ where
 
         let message_integrity = MessageIntegrity::new_long_term_credential(
             &message,
-            &self.username,
-            &self.realm,
-            &self.password,
+            &credentials.username,
+            &credentials.realm,
+            &credentials.password,
         )
         .expect("signing never fails");
 
@@ -736,7 +755,15 @@ where
             return false;
         };
 
-        let authenticated_message = self.authenticate(message);
+        let Some(credentials) = &self.credentials else {
+            tracing::debug!(
+                "Unable to queue {} because we don't have credentials",
+                message.method()
+            );
+            return false;
+        };
+
+        let authenticated_message = self.authenticate(message, credentials);
         let id = authenticated_message.transaction_id();
 
         self.sent_requests
@@ -1903,7 +1930,8 @@ mod tests {
         let mut allocation =
             Allocation::for_test(now).with_allocate_response(&[RELAY_ADDR_IP4, RELAY_ADDR_IP6]);
         let _drained_events = iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>();
-        allocation.nonce = Some(Nonce::new("nonce1".to_owned()).unwrap()); // Assume we had a nonce.
+        allocation.credentials.as_mut().unwrap().nonce =
+            Some(Nonce::new("nonce1".to_owned()).unwrap()); // Assume we had a nonce.
 
         let now = now + Duration::from_secs(1);
         allocation.refresh(now);
@@ -1933,11 +1961,13 @@ mod tests {
         let mut allocation = Allocation::for_test(now).with_allocate_response(&[RELAY_ADDR_IP4]);
         let _drained_messages = iter::from_fn(|| allocation.poll_transmit()).collect::<Vec<_>>();
 
+        let existing_credentials = allocation.credentials.clone().unwrap();
+
         allocation.update_credentials(
             RELAY2,
-            allocation.username.clone(),
-            &allocation.password.clone(),
-            allocation.realm.clone(),
+            existing_credentials.username,
+            &existing_credentials.password,
+            existing_credentials.realm,
             now,
         );
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -422,6 +422,15 @@ where
             self.next_rate_limiter_reset = Some(now + Duration::from_secs(1));
         }
 
+        self.allocations.retain(|id, allocation| {
+            if allocation.can_be_freed() {
+                tracing::info!(%id, "Freeing memory of allocation");
+
+                return false;
+            }
+
+            true
+        });
         self.connections.remove_failed(&mut self.pending_events);
     }
 


### PR DESCRIPTION
In https://github.com/firezone/firezone/pull/4537, we fixed a bug that made an `Allocation` busy-loop with invalid credentials. There is no point in keeping invalid credentials around so with this PR, we are clearing the credentials and free the memory associated with this `Allocation`.

This is another safe-guard to prevent these kind of busy-loops and also reduces the memory footprint of very long-running services.