### PR TITLE
revert: Revert removal of GitHub link in the navbar

### DIFF
--- a/website/src/components/Buttons/index.tsx
+++ b/website/src/components/Buttons/index.tsx
@@ -6,7 +6,7 @@ export function SignUpButton() {
     <Link href="https://app.firezone.dev/sign_up">
       <button
         type="button"
-        className="text-white bg-accent-450 hover:bg-accent-700 font-semibold hover:font-bold tracking-tight rounded duration-0 hover:scale-105 transition transform text-sm px-5 py-2.5 "
+        className="text-xs px-3 py-1.5 lg:text-sm lg:px-5 lg:py-2.5 text-white bg-accent-450 hover:bg-accent-700 font-semibold hover:font-bold tracking-tight rounded duration-0 hover:scale-105 transition transform"
       >
         Sign up
       </button>
@@ -19,7 +19,7 @@ export function RequestDemoButton() {
     <Link href="/contact/sales">
       <button
         type="button"
-        className="text-primary-450 bg-white hover:bg-neutral-50 border border-1 border-primary-450 hover:border-2 hover:font-bold font-semibold tracking-tight rounded duration-0 hover:scale-105 transition transform text-sm px-5 py-2.5 "
+        className="text-xs px-3 py-1.5 lg:text-sm lg:px-5 lg:py-2.5 text-primary-450 bg-white hover:bg-neutral-50 border border-1 border-primary-450 hover:border-2 hover:font-bold font-semibold tracking-tight rounded duration-0 hover:scale-105 transition transform"
       >
         Request demo
       </button>

--- a/website/src/components/RootNavbar/index.tsx
+++ b/website/src/components/RootNavbar/index.tsx
@@ -49,7 +49,7 @@ export default function RootNavbar() {
                 width={150}
                 height={150}
                 src="/images/logo-main.svg"
-                className="md:hidden w-9 ml-2 flex"
+                className="lg:hidden w-9 ml-2 flex"
                 alt="Firezone Logo"
               />
             </Link>
@@ -58,7 +58,7 @@ export default function RootNavbar() {
                 width={150}
                 height={150}
                 src="/images/logo-text.svg"
-                className="hidden md:flex w-32 sm:w-40 ml-2 mr-2 sm:mr-5"
+                className="hidden lg:flex w-32 sm:w-40 ml-2 mr-2 sm:mr-5"
                 alt="Firezone Logo"
               />
             </Link>
@@ -178,7 +178,7 @@ export default function RootNavbar() {
               Pricing
             </Link>
           </div>
-          <div className="hidden md:flex space-x-2.5 items-center lg:order-2 mr-2">
+          <div className="hidden sm:flex space-x-2.5 items-center sm:order-2 mr-2">
             <Link
               href="https://github.com/firezone/firezone"
               aria-label="GitHub Repository"

--- a/website/src/components/RootNavbar/index.tsx
+++ b/website/src/components/RootNavbar/index.tsx
@@ -179,6 +179,18 @@ export default function RootNavbar() {
             </Link>
           </div>
           <div className="hidden md:flex space-x-2.5 items-center lg:order-2 mr-2">
+            <Link
+              href="https://github.com/firezone/firezone"
+              aria-label="GitHub Repository"
+            >
+              <Image
+                alt="Github Repo stars"
+                height={50}
+                width={100}
+                className=""
+                src="https://img.shields.io/github/stars/firezone/firezone?label=Stars&amp;style=social"
+              />
+            </Link>
             <RequestDemoButton />
             <SignUpButton />
           </div>


### PR DESCRIPTION
I was able to fixing spacing / sizing to get the GitHub link in there. It is still one our main CTAs.
<img width="700" alt="Screenshot 2024-04-22 at 8 30 36 AM" src="https://github.com/firezone/firezone/assets/167144/44703d82-e0b6-4db8-8c69-0950ff81bc3c">
