### PR TITLE
fix(portal): Hide API clients sidebar link in UI when feature disabled

### DIFF
--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -28,7 +28,8 @@ account
     multi_site_resources: true,
     traffic_filters: true,
     self_hosted_relays: true,
-    idp_sync: true
+    idp_sync: true,
+    rest_api: true
   }
 )
 |> Repo.update!()

--- a/elixir/apps/domain/test/support/fixtures/accounts.ex
+++ b/elixir/apps/domain/test/support/fixtures/accounts.ex
@@ -21,7 +21,8 @@ defmodule Domain.Fixtures.Accounts do
         multi_site_resources: true,
         traffic_filters: true,
         self_hosted_relays: true,
-        idp_sync: true
+        idp_sync: true,
+        rest_api: true
       },
       limits: %{
         monthly_active_users_count: 100

--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -72,7 +72,12 @@
       Identity Providers
     </:item>
     <:item navigate={~p"/#{@account}/settings/dns"}>DNS</:item>
-    <:item navigate={~p"/#{@account}/settings/api_clients"}>API Clients</:item>
+    <:item
+      :if={Domain.Accounts.rest_api_enabled?(@account)}
+      navigate={~p"/#{@account}/settings/api_clients"}
+    >
+      API Clients
+    </:item>
   </.sidebar_item_group>
 
   <:bottom>

--- a/elixir/apps/web/test/web/live/settings/api_clients/index_test.exs
+++ b/elixir/apps/web/test/web/live/settings/api_clients/index_test.exs
@@ -27,6 +27,21 @@ defmodule Web.Live.Settings.ApiClients.IndexTest do
                }}}
   end
 
+  test "does not display API clients link when feature disabled", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    Domain.Config.feature_flag_override(:rest_api, false)
+
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/sites")
+
+    assert Floki.find(html, "a[href=\"/#{account.slug}/settings/api_clients\"]") == []
+  end
+
   test "renders breadcrumbs item", %{
     account: account,
     identity: identity,


### PR DESCRIPTION
The sidebar was missing a conditional check when displaying the API Clients link.  This was only a bug in the sidebar UI as visiting the actual API clients URL path showed a `404` as expected when the REST API feature was disabled.