### PR TITLE
fix(snownet): properly handle dual-stack relays

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -2160,6 +2160,28 @@ mod tests {
     }
 
     #[test]
+    fn new_address_sends_binding_requests() {
+        let now = Instant::now();
+        let mut allocation = Allocation::for_test_ip4(now)
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4]);
+        let _drained_messages = iter::from_fn(|| allocation.poll_transmit()).collect::<Vec<_>>();
+
+        let existing_credentials = allocation.credentials.clone().unwrap();
+
+        allocation.update_credentials(
+            RelaySocket::V6(RELAY_V6),
+            existing_credentials.username,
+            &existing_credentials.password,
+            existing_credentials.realm,
+            now,
+        );
+
+        let message = allocation.next_message().unwrap();
+        assert_eq!(message.method(), BINDING)
+    }
+
+    #[test]
     fn relay_socket_matches_v4_socket() {
         let socket = RelaySocket::V4(RELAY_V4);
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -485,7 +485,7 @@ impl Allocation {
         packet: &'p [u8],
         now: Instant,
     ) -> Option<(SocketAddr, &'p [u8], Socket)> {
-        if Some(from) != self.active_socket {
+        if from != self.active_socket? {
             return None;
         }
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -551,10 +551,12 @@ impl Allocation {
     pub fn encode_to_borrowed_transmit<'b>(
         &self,
         peer: SocketAddr,
-        packet_len: usize,
         buffer: &'b mut [u8],
         now: Instant,
     ) -> Option<Transmit<'b>> {
+        let buffer_len = buffer.len();
+        let packet_len = buffer_len - 4;
+
         let channel_number = self.channel_bindings.channel_to_peer(peer, now)?;
         let total_length = crate::channel_data::encode_header_to_slice(
             &mut buffer[..4],

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -294,9 +294,8 @@ impl Allocation {
 
         self.update_now(now);
 
-        match self.active_socket {
-            None if !self.server.matches(from) => return false,
-            Some(_) | None => {}
+        if !self.server.matches(from) {
+            return false;
         }
 
         let Ok(Ok(message)) = decode(packet) else {

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -420,6 +420,8 @@ impl Allocation {
 
                 // If the socket isn't set yet, use the `original_dst` as the primary socket.
                 self.active_socket = Some(original_dst);
+                // Make an allocation using the chosen socket.
+                self.authenticate_and_queue(make_allocate_request(), None);
             }
             ALLOCATE => {
                 let Some(lifetime) = message.get_attribute::<Lifetime>().map(|l| l.lifetime())

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1451,7 +1451,7 @@ mod tests {
             "no messages to be sent if we don't have an allocation"
         );
 
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4]),
             Instant::now(),
         );
@@ -1468,7 +1468,7 @@ mod tests {
         allocation.bind_channel(PEER2_IP4, Instant::now());
 
         let channel_bind_msg = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &encode(channel_bind_success(&channel_bind_msg)),
             Instant::now(),
         );
@@ -1503,7 +1503,7 @@ mod tests {
 
         let channel_bind_msg = allocation.next_message().unwrap();
 
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &encode(channel_bind_bad_request(&channel_bind_msg)),
             Instant::now(),
         );
@@ -1526,7 +1526,7 @@ mod tests {
         allocation.bind_channel(PEER2_IP4, Instant::now());
 
         let channel_bind_msg = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &encode(channel_bind_success(&channel_bind_msg)),
             Instant::now(),
         );
@@ -1599,7 +1599,7 @@ mod tests {
         );
 
         // Allocation succeeds but only for IPv4
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4]),
             Instant::now(),
         );
@@ -1639,7 +1639,7 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &stale_nonce_response(&allocate, Nonce::new("nonce2".to_owned()).unwrap()),
             Instant::now(),
         );
@@ -1660,7 +1660,8 @@ mod tests {
 
         // Attempt to authenticate without a nonce
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(&unauthorized_response(&allocate, "nonce1"), Instant::now());
+        allocation
+            .handle_test_input_ip4(&unauthorized_response(&allocate, "nonce1"), Instant::now());
 
         let allocate = allocation.next_message().unwrap();
         assert_eq!(
@@ -1669,7 +1670,8 @@ mod tests {
             "expect next message to include nonce from error response"
         );
 
-        allocation.handle_test_input(&unauthorized_response(&allocate, "nonce2"), Instant::now());
+        allocation
+            .handle_test_input_ip4(&unauthorized_response(&allocate, "nonce2"), Instant::now());
 
         assert!(
             allocation.next_message().is_none(),
@@ -1682,7 +1684,7 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4]),
             Instant::now(),
         );
@@ -1710,7 +1712,7 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4]),
             Instant::now(),
         );
@@ -1729,7 +1731,7 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
             Instant::now(),
         );
@@ -1738,7 +1740,7 @@ mod tests {
         allocation.refresh_with_same_credentials();
 
         let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input(&failed_refresh(&refresh), Instant::now());
+        allocation.handle_test_input_ip4(&failed_refresh(&refresh), Instant::now());
 
         assert_eq!(
             allocation.poll_event(),
@@ -1765,14 +1767,14 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
             Instant::now(),
         );
 
         allocation.bind_channel(PEER2_IP4, Instant::now());
         let channel_bind_msg = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &encode(channel_bind_success(&channel_bind_msg)),
             Instant::now(),
         );
@@ -1783,7 +1785,7 @@ mod tests {
         allocation.refresh_with_same_credentials();
 
         let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input(&failed_refresh(&refresh), Instant::now());
+        allocation.handle_test_input_ip4(&failed_refresh(&refresh), Instant::now());
 
         let msg = allocation.encode_to_owned_transmit(PEER2_IP4, b"foobar", Instant::now());
         assert!(msg.is_none(), "expect to no longer have a channel to peer");
@@ -1806,7 +1808,7 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
             Instant::now(),
         );
@@ -1814,7 +1816,7 @@ mod tests {
         allocation.refresh_with_same_credentials();
 
         let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input(&failed_refresh(&refresh), Instant::now());
+        allocation.handle_test_input_ip4(&failed_refresh(&refresh), Instant::now());
 
         let allocate = allocation.next_message().unwrap();
         assert_eq!(allocate.method(), ALLOCATE);
@@ -1828,7 +1830,7 @@ mod tests {
 
         let received_at = Instant::now();
 
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
             received_at,
         );
@@ -1846,7 +1848,7 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
             Instant::now(),
         );
@@ -1863,7 +1865,7 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
             Instant::now(),
         );
@@ -1871,10 +1873,10 @@ mod tests {
         allocation.advance_to_next_timeout();
 
         let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input(&failed_refresh(&refresh), Instant::now());
+        allocation.handle_test_input_ip4(&failed_refresh(&refresh), Instant::now());
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(&server_error(&allocate), Instant::now()); // These ones are not retried.
+        allocation.handle_test_input_ip4(&server_error(&allocate), Instant::now()); // These ones are not retried.
 
         assert_eq!(allocation.poll_timeout(), None);
     }
@@ -1884,7 +1886,7 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(&server_error(&allocate), Instant::now());
+        allocation.handle_test_input_ip4(&server_error(&allocate), Instant::now());
 
         allocation.refresh_with_same_credentials();
 
@@ -1899,12 +1901,12 @@ mod tests {
         allocation.bind_channel(PEER1, Instant::now());
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(&server_error(&allocate), Instant::now()); // This should clear the buffered channel bindings.
+        allocation.handle_test_input_ip4(&server_error(&allocate), Instant::now()); // This should clear the buffered channel bindings.
 
         allocation.refresh_with_same_credentials();
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
             Instant::now(),
         );
@@ -1921,7 +1923,7 @@ mod tests {
         allocation.bind_channel(PEER1, Instant::now());
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4]),
             Instant::now(),
         );
@@ -1941,7 +1943,7 @@ mod tests {
         allocation.bind_channel(PEER2_IP4, Instant::now());
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(
+        allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4]),
             Instant::now(),
         );
@@ -1995,7 +1997,7 @@ mod tests {
         let mut allocation = Allocation::for_test_ip4(Instant::now());
 
         let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input(&server_error(&allocate), Instant::now()); // This should clear the buffered channel bindings.
+        allocation.handle_test_input_ip4(&server_error(&allocate), Instant::now()); // This should clear the buffered channel bindings.
 
         assert!(allocation.is_suspended())
     }
@@ -2008,7 +2010,7 @@ mod tests {
         // Make an allocation
         {
             let allocate = allocation.next_message().unwrap();
-            allocation.handle_test_input(
+            allocation.handle_test_input_ip4(
                 &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
                 start,
             );
@@ -2054,7 +2056,7 @@ mod tests {
         // Make an allocation
         {
             let allocate = allocation.next_message().unwrap();
-            allocation.handle_test_input(
+            allocation.handle_test_input_ip4(
                 &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
                 start,
             );
@@ -2090,7 +2092,7 @@ mod tests {
         // If the relay is restarted, our current credentials will be invalid. Simulate with an "unauthorized" response".
         let now = now + Duration::from_secs(1);
         let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input(&unauthorized_response(&refresh, "nonce2"), now);
+        allocation.handle_test_input_ip4(&unauthorized_response(&refresh, "nonce2"), now);
 
         assert!(
             allocation.next_message().is_none(),
@@ -2282,14 +2284,14 @@ mod tests {
 
         fn with_binding_response(mut self, srflx_addr: SocketAddr) -> Self {
             let binding = self.next_message().unwrap();
-            self.handle_test_input(&binding_response(&binding, srflx_addr), Instant::now());
+            self.handle_test_input_ip4(&binding_response(&binding, srflx_addr), Instant::now());
 
             self
         }
 
         fn with_allocate_response(mut self, relay_addrs: &[SocketAddr]) -> Self {
             let allocate = self.next_message().unwrap();
-            self.handle_test_input(&allocate_response(&allocate, relay_addrs), Instant::now());
+            self.handle_test_input_ip4(&allocate_response(&allocate, relay_addrs), Instant::now());
 
             self
         }
@@ -2301,7 +2303,7 @@ mod tests {
         }
 
         /// Wrapper around `handle_input` that always sets `RELAY` and `PEER1`.
-        fn handle_test_input(&mut self, packet: &[u8], now: Instant) -> bool {
+        fn handle_test_input_ip4(&mut self, packet: &[u8], now: Instant) -> bool {
             self.handle_input(RELAY_V4.into(), PEER1, packet, now)
         }
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -243,6 +243,7 @@ impl Allocation {
             password: password.to_owned(),
             nonce: None,
         });
+        // TODO: Clear `socket`?
 
         self.refresh(now);
     }
@@ -262,12 +263,14 @@ impl Allocation {
         if self.is_suspended() {
             tracing::debug!("Attempting to make a new allocation");
 
+            // TODO: Send binding requests instead?
             self.authenticate_and_queue(make_allocate_request(), None);
             return;
         }
 
         tracing::debug!("Refreshing allocation");
 
+        // TODO: Send binding requests?
         self.authenticate_and_queue(make_refresh_request(), None);
     }
 
@@ -743,6 +746,8 @@ impl Allocation {
         self.channel_bindings.clear();
         self.allocation_lifetime = None;
         self.sent_requests.clear();
+
+        // TODO: Invalidate `server`?
     }
 
     /// Checks whether the given socket is part of this allocation.

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1440,7 +1440,7 @@ mod tests {
 
     #[test]
     fn buffer_channel_bind_requests_until_we_have_allocation() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         assert_eq!(allocate.method(), ALLOCATE);
@@ -1462,8 +1462,9 @@ mod tests {
 
     #[test]
     fn does_not_relay_to_with_unbound_channel() {
-        let mut allocation =
-            Allocation::for_test(Instant::now()).with_allocate_response(&[RELAY_ADDR_IP4]);
+        let mut allocation = Allocation::for_test(Instant::now())
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
 
         let channel_bind_msg = allocation.next_message().unwrap();
@@ -1483,8 +1484,9 @@ mod tests {
 
     #[test]
     fn does_relay_to_with_bound_channel() {
-        let mut allocation =
-            Allocation::for_test(Instant::now()).with_allocate_response(&[RELAY_ADDR_IP4]);
+        let mut allocation = Allocation::for_test(Instant::now())
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
 
         let message = allocation.encode_to_owned_transmit(PEER2_IP4, b"foobar", Instant::now());
@@ -1494,8 +1496,9 @@ mod tests {
 
     #[test]
     fn failed_channel_binding_removes_state() {
-        let mut allocation =
-            Allocation::for_test(Instant::now()).with_allocate_response(&[RELAY_ADDR_IP4]);
+        let mut allocation = Allocation::for_test(Instant::now())
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
 
         let channel_bind_msg = allocation.next_message().unwrap();
@@ -1517,8 +1520,9 @@ mod tests {
 
     #[test]
     fn rebinding_existing_channel_send_no_message() {
-        let mut allocation =
-            Allocation::for_test(Instant::now()).with_allocate_response(&[RELAY_ADDR_IP4]);
+        let mut allocation = Allocation::for_test(Instant::now())
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
 
         let channel_bind_msg = allocation.next_message().unwrap();
@@ -1558,8 +1562,9 @@ mod tests {
 
     #[test]
     fn given_no_ip6_allocation_does_not_attempt_to_bind_channel_to_ip6_address() {
-        let mut allocation =
-            Allocation::for_test(Instant::now()).with_allocate_response(&[RELAY_ADDR_IP4]);
+        let mut allocation = Allocation::for_test(Instant::now())
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4]);
 
         allocation.bind_channel(PEER2_IP6, Instant::now());
         let next_msg = allocation.next_message();
@@ -1569,8 +1574,9 @@ mod tests {
 
     #[test]
     fn given_no_ip4_allocation_does_not_attempt_to_bind_channel_to_ip4_address() {
-        let mut allocation =
-            Allocation::for_test(Instant::now()).with_allocate_response(&[RELAY_ADDR_IP6]);
+        let mut allocation = Allocation::for_test(Instant::now())
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP6]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
 
         let next_msg = allocation.next_message();
@@ -1579,7 +1585,7 @@ mod tests {
 
     #[test]
     fn given_only_ip4_allocation_when_binding_channel_to_ip6_does_not_emit_buffered_binding() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         // Attempt to allocate
         let allocate = allocation.next_message().unwrap();
@@ -1604,7 +1610,7 @@ mod tests {
 
     #[test]
     fn initial_allocate_has_username_realm_and_message_integrity_set() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
 
@@ -1621,7 +1627,7 @@ mod tests {
 
     #[test]
     fn initial_allocate_is_missing_nonce() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
 
@@ -1630,7 +1636,7 @@ mod tests {
 
     #[test]
     fn upon_stale_nonce_reauthorizes_using_new_nonce() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1650,7 +1656,7 @@ mod tests {
 
     #[test]
     fn given_a_request_with_nonce_and_we_are_unauthorized_dont_retry() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         // Attempt to authenticate without a nonce
         let allocate = allocation.next_message().unwrap();
@@ -1673,7 +1679,7 @@ mod tests {
 
     #[test]
     fn returns_new_candidates_on_successful_allocation() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1701,7 +1707,7 @@ mod tests {
 
     #[test]
     fn calling_refresh_with_same_credentials_will_trigger_refresh() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1720,7 +1726,7 @@ mod tests {
 
     #[test]
     fn failed_refresh_will_invalidate_relay_candiates() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1756,7 +1762,7 @@ mod tests {
 
     #[test]
     fn failed_refresh_clears_all_channel_bindings() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1785,7 +1791,7 @@ mod tests {
 
     #[test]
     fn refresh_does_nothing_if_we_dont_have_an_allocation_yet() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let _allocate = allocation.next_message().unwrap();
 
@@ -1797,7 +1803,7 @@ mod tests {
 
     #[test]
     fn failed_refresh_attempts_to_make_new_allocation() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1816,7 +1822,7 @@ mod tests {
 
     #[test]
     fn allocation_is_refreshed_after_half_its_lifetime() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
 
@@ -1837,7 +1843,7 @@ mod tests {
 
     #[test]
     fn allocation_is_refreshed_only_once() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1854,7 +1860,7 @@ mod tests {
 
     #[test]
     fn failed_refresh_resets_allocation_lifetime() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1875,7 +1881,7 @@ mod tests {
 
     #[test]
     fn when_refreshed_with_no_allocation_after_failed_response_tries_to_allocate() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(&server_error(&allocate), Instant::now());
@@ -1888,7 +1894,7 @@ mod tests {
 
     #[test]
     fn failed_allocation_clears_buffered_channel_bindings() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         allocation.bind_channel(PEER1, Instant::now());
 
@@ -1909,7 +1915,7 @@ mod tests {
 
     #[test]
     fn dont_buffer_channel_bindings_twice() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         allocation.bind_channel(PEER1, Instant::now());
         allocation.bind_channel(PEER1, Instant::now());
@@ -1929,7 +1935,7 @@ mod tests {
 
     #[test]
     fn buffered_channel_bindings_to_different_peers_work() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
 
         allocation.bind_channel(PEER1, Instant::now());
         allocation.bind_channel(PEER2_IP4, Instant::now());
@@ -1952,8 +1958,9 @@ mod tests {
 
     #[test]
     fn dont_send_channel_binding_if_inflight() {
-        let mut allocation =
-            Allocation::for_test(Instant::now()).with_allocate_response(&[RELAY_ADDR_IP4]);
+        let mut allocation = Allocation::for_test(Instant::now())
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4]);
 
         allocation.bind_channel(PEER1, Instant::now());
 
@@ -1967,8 +1974,9 @@ mod tests {
 
     #[test]
     fn send_channel_binding_to_second_peer_if_inflight_for_other() {
-        let mut allocation =
-            Allocation::for_test(Instant::now()).with_allocate_response(&[RELAY_ADDR_IP4]);
+        let mut allocation = Allocation::for_test(Instant::now())
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4]);
 
         allocation.bind_channel(PEER1, Instant::now());
 
@@ -1995,7 +2003,7 @@ mod tests {
     #[test]
     fn timed_out_refresh_requests_invalid_candidates() {
         let start = Instant::now();
-        let mut allocation = Allocation::for_test(start);
+        let mut allocation = Allocation::for_test(start).with_binding_response(PEER1);
 
         // Make an allocation
         {
@@ -2041,7 +2049,7 @@ mod tests {
     #[test]
     fn expires_allocation_invalidates_candidaets() {
         let start = Instant::now();
-        let mut allocation = Allocation::for_test(start);
+        let mut allocation = Allocation::for_test(start).with_binding_response(PEER1);
 
         // Make an allocation
         {
@@ -2069,8 +2077,9 @@ mod tests {
     #[test]
     fn invalid_credentials_invalidates_existing_allocation() {
         let now = Instant::now();
-        let mut allocation =
-            Allocation::for_test(now).with_allocate_response(&[RELAY_ADDR_IP4, RELAY_ADDR_IP6]);
+        let mut allocation = Allocation::for_test(now)
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4, RELAY_ADDR_IP6]);
         let _drained_events = iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>();
         allocation.credentials.as_mut().unwrap().nonce =
             Some(Nonce::new("nonce1".to_owned()).unwrap()); // Assume we had a nonce.
@@ -2101,7 +2110,9 @@ mod tests {
     #[test]
     fn new_address_is_used_for_new_messages() {
         let now = Instant::now();
-        let mut allocation = Allocation::for_test(now).with_allocate_response(&[RELAY_ADDR_IP4]);
+        let mut allocation = Allocation::for_test(now)
+            .with_binding_response(PEER1)
+            .with_allocate_response(&[RELAY_ADDR_IP4]);
         let _drained_messages = iter::from_fn(|| allocation.poll_transmit()).collect::<Vec<_>>();
 
         let existing_credentials = allocation.credentials.clone().unwrap();
@@ -2172,6 +2183,17 @@ mod tests {
         }
 
         message.add_attribute(Lifetime::new(ALLOCATION_LIFETIME).unwrap());
+
+        encode(message)
+    }
+
+    fn binding_response(request: &Message<Attribute>, srflx_addr: SocketAddr) -> Vec<u8> {
+        let mut message = Message::new(
+            MessageClass::SuccessResponse,
+            BINDING,
+            request.transaction_id(),
+        );
+        message.add_attribute(XorMappedAddress::new(srflx_addr));
 
         encode(message)
     }
@@ -2256,6 +2278,13 @@ mod tests {
                 Realm::new("firezone".to_owned()).unwrap(),
                 start,
             )
+        }
+
+        fn with_binding_response(mut self, srflx_addr: SocketAddr) -> Self {
+            let binding = self.next_message().unwrap();
+            self.handle_test_input(&binding_response(&binding, srflx_addr), Instant::now());
+
+            self
         }
 
         fn with_allocate_response(mut self, relay_addrs: &[SocketAddr]) -> Self {

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -282,7 +282,6 @@ impl Allocation {
 
         tracing::debug!("Refreshing allocation");
 
-        // TODO: Send binding requests?
         self.authenticate_and_queue(make_refresh_request(), None);
     }
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -2159,7 +2159,20 @@ mod tests {
 
     #[test]
     fn first_binding_response_sets_socket_to_use() {
-        todo!()
+        let now = Instant::now();
+        let mut allocation = Allocation::for_test_dual(now);
+
+        let _ = allocation.next_message().unwrap(); // Discard the first one.
+
+        let binding = allocation.next_message().unwrap();
+        allocation.handle_input(
+            RELAY_V6.into(),
+            PEER2_IP6,
+            &binding_response(&binding, PEER2_IP6),
+            now,
+        );
+
+        assert_eq!(allocation.poll_transmit().unwrap().dst, RELAY_V6.into());
     }
 
     #[test]

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -195,18 +195,18 @@ impl Allocation {
         };
 
         if let Some(v4) = server.as_v4() {
-            allocation.buffered_transmits.push_back(Transmit {
-                src: None,
-                dst: (*v4).into(),
-                payload: encode(make_binding_request()).into(),
-            })
+            let backoff = allocation
+                .backoff
+                .next_backoff()
+                .expect("to have backoff on startup");
+            allocation.queue((*v4).into(), make_binding_request(), backoff);
         }
         if let Some(v6) = server.as_v6() {
-            allocation.buffered_transmits.push_back(Transmit {
-                src: None,
-                dst: (*v6).into(),
-                payload: encode(make_binding_request()).into(),
-            })
+            let backoff = allocation
+                .backoff
+                .next_backoff()
+                .expect("to have backoff on startup");
+            allocation.queue((*v6).into(), make_binding_request(), backoff);
         }
 
         allocation

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -763,8 +763,8 @@ impl Allocation {
         is_ip4 || is_ip6
     }
 
-    pub fn server(&self) -> Option<SocketAddr> {
-        self.active_socket
+    pub fn server(&self) -> RelaySocket {
+        self.server
     }
 
     pub fn ip4_socket(&self) -> Option<Socket> {

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1440,7 +1440,7 @@ mod tests {
 
     #[test]
     fn buffer_channel_bind_requests_until_we_have_allocation() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         assert_eq!(allocate.method(), ALLOCATE);
@@ -1462,7 +1462,7 @@ mod tests {
 
     #[test]
     fn does_not_relay_to_with_unbound_channel() {
-        let mut allocation = Allocation::for_test(Instant::now())
+        let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
@@ -1484,7 +1484,7 @@ mod tests {
 
     #[test]
     fn does_relay_to_with_bound_channel() {
-        let mut allocation = Allocation::for_test(Instant::now())
+        let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
@@ -1496,7 +1496,7 @@ mod tests {
 
     #[test]
     fn failed_channel_binding_removes_state() {
-        let mut allocation = Allocation::for_test(Instant::now())
+        let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
@@ -1520,7 +1520,7 @@ mod tests {
 
     #[test]
     fn rebinding_existing_channel_send_no_message() {
-        let mut allocation = Allocation::for_test(Instant::now())
+        let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
@@ -1540,7 +1540,7 @@ mod tests {
     #[test]
     fn retries_requests_using_backoff_and_gives_up_eventually() {
         let start = Instant::now();
-        let mut allocation = Allocation::for_test(start);
+        let mut allocation = Allocation::for_test_ip4(start);
 
         let mut expected_backoffs = VecDeque::from(backoff::steps(start));
 
@@ -1562,7 +1562,7 @@ mod tests {
 
     #[test]
     fn given_no_ip6_allocation_does_not_attempt_to_bind_channel_to_ip6_address() {
-        let mut allocation = Allocation::for_test(Instant::now())
+        let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);
 
@@ -1574,7 +1574,7 @@ mod tests {
 
     #[test]
     fn given_no_ip4_allocation_does_not_attempt_to_bind_channel_to_ip4_address() {
-        let mut allocation = Allocation::for_test(Instant::now())
+        let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP6]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
@@ -1585,7 +1585,7 @@ mod tests {
 
     #[test]
     fn given_only_ip4_allocation_when_binding_channel_to_ip6_does_not_emit_buffered_binding() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         // Attempt to allocate
         let allocate = allocation.next_message().unwrap();
@@ -1610,7 +1610,7 @@ mod tests {
 
     #[test]
     fn initial_allocate_has_username_realm_and_message_integrity_set() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
 
@@ -1627,7 +1627,7 @@ mod tests {
 
     #[test]
     fn initial_allocate_is_missing_nonce() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
 
@@ -1636,7 +1636,7 @@ mod tests {
 
     #[test]
     fn upon_stale_nonce_reauthorizes_using_new_nonce() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1656,7 +1656,7 @@ mod tests {
 
     #[test]
     fn given_a_request_with_nonce_and_we_are_unauthorized_dont_retry() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         // Attempt to authenticate without a nonce
         let allocate = allocation.next_message().unwrap();
@@ -1679,7 +1679,7 @@ mod tests {
 
     #[test]
     fn returns_new_candidates_on_successful_allocation() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1707,7 +1707,7 @@ mod tests {
 
     #[test]
     fn calling_refresh_with_same_credentials_will_trigger_refresh() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1726,7 +1726,7 @@ mod tests {
 
     #[test]
     fn failed_refresh_will_invalidate_relay_candiates() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1762,7 +1762,7 @@ mod tests {
 
     #[test]
     fn failed_refresh_clears_all_channel_bindings() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1791,7 +1791,7 @@ mod tests {
 
     #[test]
     fn refresh_does_nothing_if_we_dont_have_an_allocation_yet() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let _allocate = allocation.next_message().unwrap();
 
@@ -1803,7 +1803,7 @@ mod tests {
 
     #[test]
     fn failed_refresh_attempts_to_make_new_allocation() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1822,7 +1822,7 @@ mod tests {
 
     #[test]
     fn allocation_is_refreshed_after_half_its_lifetime() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
 
@@ -1843,7 +1843,7 @@ mod tests {
 
     #[test]
     fn allocation_is_refreshed_only_once() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1860,7 +1860,7 @@ mod tests {
 
     #[test]
     fn failed_refresh_resets_allocation_lifetime() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(
@@ -1881,7 +1881,7 @@ mod tests {
 
     #[test]
     fn when_refreshed_with_no_allocation_after_failed_response_tries_to_allocate() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(&server_error(&allocate), Instant::now());
@@ -1894,7 +1894,7 @@ mod tests {
 
     #[test]
     fn failed_allocation_clears_buffered_channel_bindings() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         allocation.bind_channel(PEER1, Instant::now());
 
@@ -1915,7 +1915,7 @@ mod tests {
 
     #[test]
     fn dont_buffer_channel_bindings_twice() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         allocation.bind_channel(PEER1, Instant::now());
         allocation.bind_channel(PEER1, Instant::now());
@@ -1935,7 +1935,7 @@ mod tests {
 
     #[test]
     fn buffered_channel_bindings_to_different_peers_work() {
-        let mut allocation = Allocation::for_test(Instant::now()).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
         allocation.bind_channel(PEER1, Instant::now());
         allocation.bind_channel(PEER2_IP4, Instant::now());
@@ -1958,7 +1958,7 @@ mod tests {
 
     #[test]
     fn dont_send_channel_binding_if_inflight() {
-        let mut allocation = Allocation::for_test(Instant::now())
+        let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);
 
@@ -1974,7 +1974,7 @@ mod tests {
 
     #[test]
     fn send_channel_binding_to_second_peer_if_inflight_for_other() {
-        let mut allocation = Allocation::for_test(Instant::now())
+        let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);
 
@@ -1992,7 +1992,7 @@ mod tests {
 
     #[test]
     fn failed_allocation_is_suspended() {
-        let mut allocation = Allocation::for_test(Instant::now());
+        let mut allocation = Allocation::for_test_ip4(Instant::now());
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input(&server_error(&allocate), Instant::now()); // This should clear the buffered channel bindings.
@@ -2003,7 +2003,7 @@ mod tests {
     #[test]
     fn timed_out_refresh_requests_invalid_candidates() {
         let start = Instant::now();
-        let mut allocation = Allocation::for_test(start).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(start).with_binding_response(PEER1);
 
         // Make an allocation
         {
@@ -2049,7 +2049,7 @@ mod tests {
     #[test]
     fn expires_allocation_invalidates_candidaets() {
         let start = Instant::now();
-        let mut allocation = Allocation::for_test(start).with_binding_response(PEER1);
+        let mut allocation = Allocation::for_test_ip4(start).with_binding_response(PEER1);
 
         // Make an allocation
         {
@@ -2077,7 +2077,7 @@ mod tests {
     #[test]
     fn invalid_credentials_invalidates_existing_allocation() {
         let now = Instant::now();
-        let mut allocation = Allocation::for_test(now)
+        let mut allocation = Allocation::for_test_ip4(now)
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4, RELAY_ADDR_IP6]);
         let _drained_events = iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>();
@@ -2110,7 +2110,7 @@ mod tests {
     #[test]
     fn new_address_is_used_for_new_messages() {
         let now = Instant::now();
-        let mut allocation = Allocation::for_test(now)
+        let mut allocation = Allocation::for_test_ip4(now)
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);
         let _drained_messages = iter::from_fn(|| allocation.poll_transmit()).collect::<Vec<_>>();
@@ -2130,7 +2130,7 @@ mod tests {
 
     #[test]
     fn allocation_is_not_freed_on_startup() {
-        let allocation = Allocation::for_test(Instant::now());
+        let allocation = Allocation::for_test_ip4(Instant::now());
 
         assert!(!allocation.can_be_freed());
     }
@@ -2270,7 +2270,7 @@ mod tests {
     }
 
     impl Allocation {
-        fn for_test(start: Instant) -> Self {
+        fn for_test_ip4(start: Instant) -> Self {
             Allocation::new(
                 RelaySocket::V4(RELAY_V4),
                 Username::new("foobar".to_owned()).unwrap(),

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -548,13 +548,16 @@ impl Allocation {
     pub fn encode_to_slice(
         &self,
         peer: SocketAddr,
-        packet: &[u8],
-        header: &mut [u8],
+        packet_len: usize,
+        buffer: &mut [u8],
         now: Instant,
     ) -> Option<usize> {
         let channel_number = self.channel_bindings.channel_to_peer(peer, now)?;
-        let total_length =
-            crate::channel_data::encode_header_to_slice(header, channel_number, packet);
+        let total_length = crate::channel_data::encode_header_to_slice(
+            &mut buffer[..4],
+            channel_number,
+            packet_len,
+        );
 
         Some(total_length)
     }

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -2149,12 +2149,29 @@ mod tests {
 
     #[test]
     fn relay_socket_matches_v4_socket() {
-        todo!()
+        let socket = RelaySocket::V4(RELAY_V4);
+
+        assert!(socket.matches(SocketAddr::V4(RELAY_V4)));
+        assert!(!socket.matches(SocketAddr::V6(RELAY_V6)));
     }
 
     #[test]
     fn relay_socket_matches_v6_socket() {
-        todo!()
+        let socket = RelaySocket::V6(RELAY_V6);
+
+        assert!(socket.matches(SocketAddr::V6(RELAY_V6)));
+        assert!(!socket.matches(SocketAddr::V4(RELAY_V4)));
+    }
+
+    #[test]
+    fn relay_socket_matches_dual_socket() {
+        let socket = RelaySocket::Dual {
+            v4: RELAY_V4,
+            v6: RELAY_V6,
+        };
+
+        assert!(socket.matches(SocketAddr::V4(RELAY_V4)));
+        assert!(socket.matches(SocketAddr::V6(RELAY_V6)));
     }
 
     #[test]

--- a/rust/connlib/snownet/src/channel_data.rs
+++ b/rust/connlib/snownet/src/channel_data.rs
@@ -47,9 +47,8 @@ pub fn encode(channel: u16, data: &[u8]) -> Vec<u8> {
 /// Encode the channel data header (number + length) to the given slice.
 ///
 /// Returns the total length of the packet (i.e. the encoded header + data).
-pub fn encode_header_to_slice(mut slice: &mut [u8], channel: u16, data: &[u8]) -> usize {
+pub fn encode_header_to_slice(mut slice: &mut [u8], channel: u16, payload_length: usize) -> usize {
     assert_eq!(slice.len(), HEADER_LEN);
-    let payload_length = data.len();
 
     debug_assert!(channel > 0x400);
     debug_assert!(channel < 0x7FFF);

--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -10,6 +10,7 @@ mod stats;
 mod stun_binding;
 mod utils;
 
+pub use allocation::RelaySocket;
 pub use node::{
     Answer, Client, ClientNode, Credentials, Error, Event, Node, Offer, Server, ServerNode,
     Transmit,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -360,20 +360,17 @@ where
                     tracing::warn!(%relay, "No allocation");
                     return Ok(None);
                 };
-                let Some(total_length) =
-                    allocation.encode_to_slice(peer, packet_len, self.buffer.as_mut(), now)
-                else {
+                let Some(transmit) = allocation.encode_to_borrowed_transmit(
+                    peer,
+                    packet_len,
+                    self.buffer.as_mut(),
+                    now,
+                ) else {
                     tracing::warn!(%peer, "No channel");
                     return Ok(None);
                 };
 
-                let channel_data_packet = &self.buffer[..total_length];
-
-                Ok(Some(Transmit {
-                    src: None,
-                    dst: allocation.server(),
-                    payload: Cow::Borrowed(channel_data_packet),
-                }))
+                Ok(Some(transmit))
             }
         }
     }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1216,7 +1216,7 @@ pub enum Event<TId> {
     ConnectionFailed(TId),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Transmit<'a> {
     /// The local interface from which this packet should be sent.
     ///

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -360,12 +360,10 @@ where
                     tracing::warn!(%relay, "No allocation");
                     return Ok(None);
                 };
-                let Some(transmit) = allocation.encode_to_borrowed_transmit(
-                    peer,
-                    packet_len,
-                    self.buffer.as_mut(),
-                    now,
-                ) else {
+                let packet = &mut self.buffer.as_mut()[..packet_end];
+
+                let Some(transmit) = allocation.encode_to_borrowed_transmit(peer, packet, now)
+                else {
                     tracing::warn!(%peer, "No channel");
                     return Ok(None);
                 };

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -640,7 +640,7 @@ where
                 let Some(allocation) = self
                     .allocations
                     .values_mut()
-                    .find(|a| a.server().is_some_and(|s| s == from))
+                    .find(|a| a.server().matches(from))
                 else {
                     // False-positive, continue processing packet elsewhere
                     return ControlFlow::Continue((from, packet, None));
@@ -660,7 +660,7 @@ where
                 let Some(allocation) = self
                     .allocations
                     .values_mut()
-                    .find(|a| a.server().is_some_and(|s| s == from))
+                    .find(|a| a.server().matches(from))
                 else {
                     // False-positive, continue processing packet elsewhere
                     return ControlFlow::Continue((from, packet, None));

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -550,20 +550,7 @@ impl TestRelay {
         other: &mut TestNode,
         now: Instant,
     ) {
-        if self
-            .listen_addr
-            .as_v4()
-            .is_some_and(|v4| SocketAddr::V4(*v4) == dst)
-        {
-            self.handle_client_input(payload, ClientSocket::new(sender), other, now);
-            return;
-        }
-
-        if self
-            .listen_addr
-            .as_v6()
-            .is_some_and(|v6| SocketAddr::V6(*v6) == dst)
-        {
+        if self.listen_addr.matches(dst) {
             self.handle_client_input(payload, ClientSocket::new(sender), other, now);
             return;
         }

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -332,32 +332,6 @@ fn only_generate_candidate_event_after_answer() {
         }));
 }
 
-#[test]
-fn second_connection_with_same_relay_reuses_allocation() {
-    let mut alice = ClientNode::new(StaticSecret::random_from_rng(rand::thread_rng()));
-    _ = alice.new_connection(
-        1,
-        HashSet::new(),
-        HashSet::from([relay(1, "user1", "pass1", "realm1")]),
-        Instant::now(),
-        Instant::now(),
-    );
-
-    let transmit = alice.poll_transmit().unwrap();
-    assert_eq!(transmit.dst, RELAY_V4.into());
-    assert!(alice.poll_transmit().is_none());
-
-    let _ = alice.new_connection(
-        2,
-        HashSet::new(),
-        HashSet::from([relay(1, "user1", "pass1", "realm1")]),
-        Instant::now(),
-        Instant::now(),
-    );
-
-    assert!(alice.poll_transmit().is_none());
-}
-
 fn setup_tracing() -> tracing::subscriber::DefaultGuard {
     tracing_subscriber::fmt()
         .with_test_writer()
@@ -390,21 +364,6 @@ fn send_offer(
     )
 }
 
-fn relay(
-    id: u64,
-    username: &str,
-    pass: &str,
-    realm: &str,
-) -> (u64, RelaySocket, String, String, String) {
-    (
-        id,
-        RelaySocket::V4(RELAY_V4),
-        username.to_owned(),
-        pass.to_owned(),
-        realm.to_owned(),
-    )
-}
-
 fn host(socket: &str) -> String {
     Candidate::host(s(socket), Protocol::Udp)
         .unwrap()
@@ -418,8 +377,6 @@ fn s(socket: &str) -> SocketAddr {
 fn ip(ip: &str) -> IpAddr {
     ip.parse().unwrap()
 }
-
-const RELAY_V4: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 10000);
 
 // Heavily inspired by https://github.com/algesten/str0m/blob/7ed5143381cf095f7074689cc254b8c9e50d25c5/src/ice/mod.rs#L547-L647.
 struct TestNode {

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -2,7 +2,7 @@ use boringtun::x25519::{PublicKey, StaticSecret};
 use firezone_relay::{AddressFamily, AllocationPort, ClientSocket, IpStack, PeerSocket};
 use ip_packet::*;
 use rand::rngs::OsRng;
-use snownet::{Answer, ClientNode, Event, ServerNode, Transmit};
+use snownet::{Answer, ClientNode, Event, RelaySocket, ServerNode, Transmit};
 use std::{
     collections::{HashSet, VecDeque},
     iter,
@@ -55,7 +55,10 @@ fn smoke_relayed() {
 
     let mut relays = [(
         1,
-        TestRelay::new(IpAddr::V4(Ipv4Addr::LOCALHOST), debug_span!("Roger")),
+        TestRelay::new(
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3478),
+            debug_span!("Roger"),
+        ),
     )];
     let mut alice = TestNode::new(debug_span!("Alice"), alice, "1.1.1.1:80").with_relays(
         HashSet::default(),
@@ -100,7 +103,10 @@ fn reconnect_discovers_new_interface() {
 
     let mut relays = [(
         1,
-        TestRelay::new(IpAddr::V4(Ipv4Addr::LOCALHOST), debug_span!("Roger")),
+        TestRelay::new(
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3478),
+            debug_span!("Roger"),
+        ),
     )];
     let mut alice = TestNode::new(debug_span!("Alice"), alice, "1.1.1.1:80").with_relays(
         HashSet::default(),
@@ -160,7 +166,10 @@ fn migrate_connection_to_new_relay() {
 
     let mut relays = [(
         1,
-        TestRelay::new(IpAddr::V4(Ipv4Addr::LOCALHOST), debug_span!("Roger")),
+        TestRelay::new(
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3478),
+            debug_span!("Roger"),
+        ),
     )];
     let mut alice = TestNode::new(debug_span!("Alice"), alice, "1.1.1.1:80").with_relays(
         HashSet::default(),
@@ -187,7 +196,13 @@ fn migrate_connection_to_new_relay() {
     }
 
     // Swap out the relays. "Roger" is being removed (ID 1) and "Robert" is being added (ID 2).
-    let mut relays = [(2, TestRelay::new(ip("10.0.0.1"), debug_span!("Robert")))];
+    let mut relays = [(
+        2,
+        TestRelay::new(
+            SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 3478),
+            debug_span!("Robert"),
+        ),
+    )];
     alice = alice.with_relays(HashSet::from([1]), &mut relays, clock.now);
 
     // Make some progress. (the fact that we only need 5 clock ticks means we are no relying on timeouts here)
@@ -329,7 +344,7 @@ fn second_connection_with_same_relay_reuses_allocation() {
     );
 
     let transmit = alice.poll_transmit().unwrap();
-    assert_eq!(transmit.dst, RELAY);
+    assert_eq!(transmit.dst, RELAY_V4.into());
     assert!(alice.poll_transmit().is_none());
 
     let _ = alice.new_connection(
@@ -380,10 +395,10 @@ fn relay(
     username: &str,
     pass: &str,
     realm: &str,
-) -> (u64, SocketAddr, String, String, String) {
+) -> (u64, RelaySocket, String, String, String) {
     (
         id,
-        RELAY,
+        RelaySocket::V4(RELAY_V4),
         username.to_owned(),
         pass.to_owned(),
         realm.to_owned(),
@@ -404,7 +419,7 @@ fn ip(ip: &str) -> IpAddr {
     ip.parse().unwrap()
 }
 
-const RELAY: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 10000));
+const RELAY_V4: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 10000);
 
 // Heavily inspired by https://github.com/algesten/str0m/blob/7ed5143381cf095f7074689cc254b8c9e50d25c5/src/ice/mod.rs#L547-L647.
 struct TestNode {
@@ -424,7 +439,7 @@ struct TestNode {
 
 struct TestRelay {
     inner: firezone_relay::Server<OsRng>,
-    listen_addr: SocketAddr,
+    listen_addr: RelaySocket,
     span: Span,
 
     allocations: HashSet<(AddressFamily, AllocationPort)>,
@@ -482,12 +497,13 @@ impl Firewall {
 }
 
 impl TestRelay {
-    fn new(local: IpAddr, span: Span) -> Self {
-        let inner = firezone_relay::Server::new(IpStack::from(local), OsRng, 49152, 65535);
+    fn new(local: impl Into<RelaySocket>, span: Span) -> Self {
+        let local = local.into();
+        let inner = firezone_relay::Server::new(to_ip_stack(local), OsRng, 49152, 65535);
 
         Self {
             inner,
-            listen_addr: SocketAddr::from((local, 3478)),
+            listen_addr: local,
             span,
             allocations: HashSet::default(),
             buffer: vec![0u8; (1 << 16) - 1],
@@ -495,15 +511,35 @@ impl TestRelay {
     }
 
     fn wants(&self, dst: SocketAddr) -> bool {
-        self.listen_addr == dst
-            || self.allocations.contains(&match dst {
-                SocketAddr::V4(_) => (AddressFamily::V4, AllocationPort::new(dst.port())),
-                SocketAddr::V6(_) => (AddressFamily::V6, AllocationPort::new(dst.port())),
-            })
+        let is_v4_ctrl = self
+            .listen_addr
+            .as_v4()
+            .is_some_and(|v4| SocketAddr::V4(*v4) == dst);
+        let is_v6_ctrl = self
+            .listen_addr
+            .as_v6()
+            .is_some_and(|v6| SocketAddr::V6(*v6) == dst);
+        let is_allocation = self.allocations.contains(&match dst {
+            SocketAddr::V4(_) => (AddressFamily::V4, AllocationPort::new(dst.port())),
+            SocketAddr::V6(_) => (AddressFamily::V6, AllocationPort::new(dst.port())),
+        });
+
+        is_v4_ctrl || is_v6_ctrl || is_allocation
     }
 
-    fn ip(&self) -> IpAddr {
-        self.listen_addr.ip()
+    fn matching_listen_socket(&self, other: SocketAddr) -> Option<SocketAddr> {
+        match other {
+            SocketAddr::V4(_) => Some(SocketAddr::V4(*self.listen_addr.as_v4()?)),
+            SocketAddr::V6(_) => Some(SocketAddr::V6(*self.listen_addr.as_v6()?)),
+        }
+    }
+
+    fn ip4(&self) -> Option<IpAddr> {
+        self.listen_addr.as_v4().map(|s| IpAddr::V4(*s.ip()))
+    }
+
+    fn ip6(&self) -> Option<IpAddr> {
+        self.listen_addr.as_v6().map(|s| IpAddr::V6(*s.ip()))
     }
 
     fn handle_packet(
@@ -514,7 +550,20 @@ impl TestRelay {
         other: &mut TestNode,
         now: Instant,
     ) {
-        if dst == self.listen_addr {
+        if self
+            .listen_addr
+            .as_v4()
+            .is_some_and(|v4| SocketAddr::V4(*v4) == dst)
+        {
+            self.handle_client_input(payload, ClientSocket::new(sender), other, now);
+            return;
+        }
+
+        if self
+            .listen_addr
+            .as_v6()
+            .is_some_and(|v6| SocketAddr::V6(*v6) == dst)
+        {
             self.handle_client_input(payload, ClientSocket::new(sender), other, now);
             return;
         }
@@ -541,11 +590,31 @@ impl TestRelay {
         {
             let payload = &payload[4..];
 
-            // The `src` of the relayed packet is the relay itself _from_ the allocated port.
-            let src = SocketAddr::new(self.ip(), port.value());
-
             // The `dst` of the relayed packet is what TURN calls a "peer".
             let dst = peer.into_socket();
+
+            // The `src_ip` is the relay's IP
+            let src_ip = match dst {
+                SocketAddr::V4(_) => {
+                    assert!(
+                        self.allocations.contains(&(AddressFamily::V4, port)),
+                        "IPv4 allocation to be present if we want to send to an IPv4 socket"
+                    );
+
+                    self.ip4().expect("listen on IPv4 if we have an allocation")
+                }
+                SocketAddr::V6(_) => {
+                    assert!(
+                        self.allocations.contains(&(AddressFamily::V6, port)),
+                        "IPv6 allocation to be present if we want to send to an IPv6 socket"
+                    );
+
+                    self.ip6().expect("listen on IPv6 if we have an allocation")
+                }
+            };
+
+            // The `src` of the relayed packet is the relay itself _from_ the allocated port.
+            let src = SocketAddr::new(src_ip, port.value());
 
             // Check if we need to relay to ourselves (from one allocation to another)
             if self.wants(dst) {
@@ -582,9 +651,11 @@ impl TestRelay {
             );
             self.buffer[4..full_length].copy_from_slice(payload);
 
+            let receiving_socket = client.into_socket();
+            let sending_socket = self.matching_listen_socket(receiving_socket).unwrap();
             receiver.receive(
-                client.into_socket(),
-                self.listen_addr,
+                receiving_socket,
+                sending_socket,
                 &self.buffer[..full_length],
                 now,
             );
@@ -596,13 +667,15 @@ impl TestRelay {
             match command {
                 firezone_relay::Command::SendMessage { payload, recipient } => {
                     let recipient = recipient.into_socket();
+                    let sending_socket = self.matching_listen_socket(recipient).unwrap();
+
                     if a1.local.contains(&recipient) {
-                        a1.receive(recipient, self.listen_addr, &payload, now);
+                        a1.receive(recipient, sending_socket, &payload, now);
                         continue;
                     }
 
                     if a2.local.contains(&recipient) {
-                        a2.receive(recipient, self.listen_addr, &payload, now);
+                        a2.receive(recipient, sending_socket, &payload, now);
                         continue;
                     }
 
@@ -630,6 +703,17 @@ impl TestRelay {
             firezone_relay::auth::generate_password(self.inner.auth_secret(), expiry, username);
 
         (format!("{secs}:{username}"), password)
+    }
+}
+
+fn to_ip_stack(socket: RelaySocket) -> IpStack {
+    match socket {
+        RelaySocket::V4(v4) => IpStack::Ip4(*v4.ip()),
+        RelaySocket::V6(v6) => IpStack::Ip6(*v6.ip()),
+        RelaySocket::Dual { v4, v6 } => IpStack::Dual {
+            ip4: *v4.ip(),
+            ip6: *v6.ip(),
+        },
     }
 }
 
@@ -764,7 +848,7 @@ impl EitherNode {
     fn update_relays(
         &mut self,
         to_remove: HashSet<u64>,
-        to_add: &HashSet<(u64, SocketAddr, String, String, String)>,
+        to_add: &HashSet<(u64, RelaySocket, String, String, String)>,
         now: Instant,
     ) {
         match self {

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -12,7 +12,7 @@ use connlib_shared::{Callbacks, Dname, Error, Result, StaticSecret};
 use ip_network::IpNetwork;
 use ip_packet::{IpPacket, MutableIpPacket};
 use secrecy::{ExposeSecret as _, Secret};
-use snownet::ServerNode;
+use snownet::{RelaySocket, ServerNode};
 use std::collections::{HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
@@ -85,7 +85,7 @@ where
             },
             client,
             stun(&relays, |addr| self.io.sockets_ref().can_handle(addr)),
-            turn(&relays, |addr| self.io.sockets_ref().can_handle(addr)),
+            turn(&relays),
             Instant::now(),
         );
 
@@ -321,7 +321,7 @@ impl GatewayState {
     pub(crate) fn update_relays(
         &mut self,
         to_remove: HashSet<RelayId>,
-        to_add: HashSet<(RelayId, SocketAddr, String, String, String)>,
+        to_add: HashSet<(RelayId, RelaySocket, String, String, String)>,
         now: Instant,
     ) {
         self.node.update_relays(to_remove, &to_add, now);

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -175,11 +175,8 @@ where
     }
 
     pub fn update_relays(&mut self, to_remove: HashSet<RelayId>, to_add: Vec<Relay>) {
-        self.role_state.update_relays(
-            to_remove,
-            turn(&to_add, |addr| self.io.sockets_ref().can_handle(addr)),
-            Instant::now(),
-        )
+        self.role_state
+            .update_relays(to_remove, turn(&to_add), Instant::now())
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<Result<GatewayEvent>> {

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -112,17 +112,17 @@ impl Sockets {
 
     pub fn try_send(&mut self, transmit: quinn_udp::Transmit) -> io::Result<()> {
         match transmit.destination {
-            SocketAddr::V4(_) => {
+            SocketAddr::V4(dst) => {
                 let socket = self.socket_v4.as_mut().ok_or(io::Error::new(
                     io::ErrorKind::NotConnected,
-                    "no IPv4 socket",
+                    format!("failed send packet to {dst}: no IPv4 socket"),
                 ))?;
                 socket.send(transmit);
             }
-            SocketAddr::V6(_) => {
+            SocketAddr::V6(dst) => {
                 let socket = self.socket_v6.as_mut().ok_or(io::Error::new(
                     io::ErrorKind::NotConnected,
-                    "no IPv6 socket",
+                    format!("failed send packet to {dst}: no IPv6 socket"),
                 ))?;
                 socket.send(transmit);
             }

--- a/rust/connlib/tunnel/src/utils.rs
+++ b/rust/connlib/tunnel/src/utils.rs
@@ -1,5 +1,7 @@
 use crate::REALM;
 use connlib_shared::messages::{Relay, RelayId};
+use itertools::Itertools;
+use snownet::RelaySocket;
 use std::{collections::HashSet, net::SocketAddr, time::Instant};
 
 pub fn stun(relays: &[Relay], predicate: impl Fn(&SocketAddr) -> bool) -> HashSet<SocketAddr> {
@@ -16,17 +18,17 @@ pub fn stun(relays: &[Relay], predicate: impl Fn(&SocketAddr) -> bool) -> HashSe
         .collect()
 }
 
-pub fn turn(
-    relays: &[Relay],
-    predicate: impl Fn(&SocketAddr) -> bool,
-) -> HashSet<(RelayId, SocketAddr, String, String, String)> {
+pub fn turn(relays: &[Relay]) -> HashSet<(RelayId, RelaySocket, String, String, String)> {
     relays
         .iter()
         .filter_map(|r| {
             if let Relay::Turn(r) = r {
                 Some((
                     r.id,
-                    r.addr,
+                    match r.addr {
+                        SocketAddr::V4(v4) => RelaySocket::V4(v4),
+                        SocketAddr::V6(v6) => RelaySocket::V6(v6),
+                    },
                     r.username.clone(),
                     r.password.clone(),
                     REALM.to_string(),
@@ -35,7 +37,36 @@ pub fn turn(
                 None
             }
         })
-        .filter(|(_, socket, _, _, _)| predicate(socket))
+        .group_by(|(id, _, _, _, _)| *id)
+        .into_iter()
+        .filter_map(|(_, grouped)| {
+            grouped.reduce(
+                |(_, current_socket, _, _, _), (id, socket, username, password, realm)| {
+                    let new_socket = match (current_socket, socket) {
+                        (RelaySocket::V4(v4), RelaySocket::V6(v6)) => RelaySocket::Dual { v4, v6 },
+                        (RelaySocket::V6(v6), RelaySocket::V4(v4)) => RelaySocket::Dual { v4, v6 },
+                        (_, dual @ RelaySocket::Dual { .. })
+                        | (dual @ RelaySocket::Dual { .. }, _) => {
+                            tracing::warn!(%id, "Duplicate addresses for relay");
+
+                            dual
+                        }
+                        (v4 @ RelaySocket::V4(_), _) => {
+                            tracing::warn!(%id, "Duplicate IPv4 address for relay");
+
+                            v4
+                        }
+                        (v6 @ RelaySocket::V6(_), _) => {
+                            tracing::warn!(%id, "Duplicate IPv6 address for relay");
+
+                            v6
+                        }
+                    };
+
+                    (id, new_socket, username, password, realm)
+                },
+            )
+        })
         .collect()
 }
 

--- a/rust/snownet-tests/src/main.rs
+++ b/rust/snownet-tests/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
     future::poll_fn,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     str::FromStr,
     task::{Context, Poll},
     time::Instant,
@@ -13,7 +13,7 @@ use ip_packet::IpPacket;
 use pnet_packet::{ip::IpNextHeaderProtocols, ipv4::Ipv4Packet};
 use redis::{aio::MultiplexedConnection, AsyncCommands};
 use secrecy::{ExposeSecret as _, Secret};
-use snownet::{Answer, ClientNode, Credentials, Node, Offer, ServerNode};
+use snownet::{Answer, ClientNode, Credentials, Node, Offer, RelaySocket, ServerNode};
 use tokio::{io::ReadBuf, net::UdpSocket};
 use tracing_subscriber::EnvFilter;
 
@@ -48,13 +48,13 @@ async fn main() -> Result<()> {
         .map(|ip| SocketAddr::new(ip, 3478));
     let turn_server = std::env::var("TURN_SERVER")
         .ok()
-        .map(|a| a.parse::<IpAddr>())
+        .map(|a| a.parse::<Ipv4Addr>())
         .transpose()
         .context("Failed to parse `TURNERVER`")?
         .map(|ip| {
             (
                 1,
-                SocketAddr::new(ip, 3478),
+                RelaySocket::V4(SocketAddrV4::new(ip, 3478)),
                 "2000000000:client".to_owned(), // TODO: Use different credentials per role.
                 "+Qou8TSjw9q3JMnWET7MbFsQh/agwz/LURhpfX7a0hE".to_owned(),
                 "firezone".to_owned(),


### PR DESCRIPTION
Currently, the portal returns us a flat list of relays where each entry only has a single address. But, our relays can operate in dual-stack mode, meaning that they listen on IPv4 and IPv6 at the same time. Thus, for a relay that is in dual-stack mode, this list will contain two entries with the same relay ID, one for each address.

This wasn't really a problem until #4567 where we started indexing relays by ID. As a result, a relay that operates in dual-stack mode is now only reachable either under its IPv4 or IPv6 address. Which one wins is non-deterministic due to the sorting behaviour of `HashMap`s and the order that the list is returned from the portal.

For the TURN protocol, clients are indexed by their 3-tuple (IP, port, protocol) which means a client talking to a relay over IPv4 is a different client than one talking over IPv6. Thus, treating the same relay as two different relays has additional consequences: It means we allocate a pair of IPv4 & IPv6 addresses for each one, resulting in up to 4 relay candidates per relay.

Both of these problems are solved in this PR.

1. Upon deserializing the list of relays from the portal, we group them by ID and parse the addresses into a `RelaySocket`. This structure is the equivalent of `IpStack` on the relay end and represents an enum with 3 different values:
	- `V4`: Only an IPv4 address is known.
	- `V6`: Only an IPv6 address is known.
	- `Dual`: Both an IPv4 and an IPv6 address is known.
2. Instead of creating two `Allocation`s (one per address), we now initialize an `Allocation` with this `RelaySocket`.
3. We let the `Allocation` figure out, which socket to use. Let's look into how we do that.

Previously, the first action of an `Allocation` was to send an `ALLOCATE` request. A naive approach would be to simply send an `ALLOCATE` request to both IPs. In case the client / gateway has a properly configured IPv4 and IPv6 address, both of these will succeed! Which one should we pick?

To avoid this problem, we don't send an `ALLOCATE` but a `BINDING` request instead. `BINDING` requests don't have side-effects and just returned the observed address (this is commonly known as STUN). Once the responses for the `BINDING` requests come back, we can deterministically chose a socket to use for sending an `ALLOCATE` request. In particular, we just pick the response that comes back first! A successful `BINDING` request means the network path is working so we can also just it for `ALLOCATE`. In case both requests are answered, we record both responses as server-reflexive candidates.

Lastly, one final change with this PR is that we stop filtering the relays returned by the portal based on the sockets that we have locally. When a client roams, we may experience any combination of available network interfaces (dual stack, IPv4 only and IPv6 only). Thus, it is important that we always attempt to reach all relays over all network paths and simply give up if we don't receive a response. Pre-filtering relays based on the sockets that we currently have may leave us without relays if we e.g. roam from an IPv4-only to and IPv6-only network. A consequence of this design is that we might see a few more warnings in the code in case the client's / gateway's interface doesn't support a particular IP version. The warnings read something like:

```
2024-04-23T07:09:05.209212Z  WARN connlib_client_shared::eventloop: Tunnel error: failed send packet to 35.197.175.154:3478: no IPv4 socket
```

Resolves: #4726.