### PR TITLE
chore: remove test lib bash sourcing from customer-run scripts

### DIFF
--- a/scripts/gateway-docker-upgrade.sh
+++ b/scripts/gateway-docker-upgrade.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "./scripts/tests/lib.sh"
+set -euo pipefail
 
 TARGET_IMAGE="ghcr.io/firezone/gateway:1"
 

--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "./scripts/tests/lib.sh"
+set -euo pipefail
 
 hostname=$(hostname)
 FIREZONE_NAME=${FIREZONE_NAME:-$hostname}


### PR DESCRIPTION
Didn't catch this in code review. These are run on customer's systems and can't possibly source our shared script.