### PR TITLE
fix(snownet): invalidate host candidates on reconnect

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5809,7 +5809,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.5.0"
-source = "git+https://github.com/firezone/str0m?branch=main#1a69339a76ea21fa526d7a90893e3549e0281e0f"
+source = "git+https://github.com/firezone/str0m?branch=main#44b616945145033ade739f30cdce004728011619"
 dependencies = [
  "combine",
  "crc",

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -484,7 +484,11 @@ impl Allocation {
     }
 
     pub fn poll_event(&mut self) -> Option<CandidateEvent> {
-        self.events.pop_front()
+        let next_event = self.events.pop_front()?;
+
+        tracing::debug!(?next_event);
+
+        Some(next_event)
     }
 
     pub fn poll_transmit(&mut self) -> Option<Transmit<'static>> {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -151,6 +151,12 @@ where
         for allocation in self.allocations.values_mut() {
             allocation.refresh(now);
         }
+
+        for candidate in self.host_candidates.drain() {
+            for (id, agent) in self.connections.agents_mut() {
+                remove_local_candidate(id, agent, &candidate, &mut self.pending_events)
+            }
+        }
     }
 
     pub fn public_key(&self) -> PublicKey {


### PR DESCRIPTION
As part of testing #4750, @jamilbk ran into an interesting but unrelated bug. Currently, we never invalidate host candidates. However, because we rebind our sockets, we get new ports and thus our old host candidates are always invalid. Thus, if you have a setup where your gateway and client are on the same subnet they end up settling on a host-host connection. If the client then roams to a different network, we get a new srflx IP but because we don't invalidate the host candidate, we run into an ICE timeout and never switch over the connection.

We actually have a unit test for this but it wasn't caught because of a bug in str0m (https://github.com/algesten/str0m/pull/504): Candidates with the same IP but different kind were incorrectly invalidated. In our test, we don't have a NAT and thus host == srflx candidate. Thus, in the roaming test, we invalidated the host candidate based on the new srflx candidate which made the connection migration work.

With the patch included, the reconnect unit test actually fails to send the packet, confirming this theory. By invalidating all host candidates on `reconnect`, we fix this bug.