### PR TITLE
chore(Android): use SCHEDULE_EXACT_ALARM vs USE_EXACT_ALARM permission to avoid play store warning

### DIFF
--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <queries>
         <intent>


### PR DESCRIPTION
<img width="863" alt="Screenshot 2024-04-23 at 11 21 56 PM" src="https://github.com/firezone/firezone/assets/167144/db14f59c-4026-4025-82ba-abf8e4ec2614">
