### PR TITLE
chore(connlib): forward panics containing an owned string

### DIFF
--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -158,6 +158,10 @@ where
                     callbacks.on_disconnect(&Error::Panic(msg.to_string()));
                     return;
                 }
+                if let Some(msg) = panic.downcast_ref::<String>() {
+                    callbacks.on_disconnect(&Error::Panic(msg.to_string()));
+                    return;
+                }
 
                 callbacks.on_disconnect(&Error::PanicNonStringPayload);
             }


### PR DESCRIPTION
In Rust, `Result::unwrap()` produces a panic with an owned `String`. Currently, we only attempt to downcast to a `str` which means those errors show up as "panicked with a non-string payload" instead of the actual panic message.

Related: #4736.