### PR TITLE
ci: bootstrap browser test harness if missing

### DIFF
--- a/scripts/tests/direct-browser-relay-restart.sh
+++ b/scripts/tests/direct-browser-relay-restart.sh
@@ -5,6 +5,7 @@ HTTPBIN=http://dns.httpbin
 
 docker compose stop relay-2
 
+bootstrap_browser_test_harness
 start_chromium
 
 echo "# Make sure webpage is loaded once"

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -13,7 +13,7 @@ function client() {
 function bootstrap_browser_test_harness() {
     client which chromium-browser || (
         client apk add --no-cache nodejs npm chromium &&
-            docker compose cp ./scripts/tests/browser/* client:/bin &&
+            docker compose cp ./scripts/tests/browser client:/bin &&
             client npm install --prefix /bin
     )
 }

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -13,7 +13,7 @@ function client() {
 function bootstrap_browser_test_harness() {
     client which chromium-browser || (
         client apk add --no-cache nodejs npm chromium &&
-            docker compose cp ./scripts/tests/browser client:/bin &&
+            docker compose cp ./scripts/tests/browser/. client:/bin &&
             client npm install --prefix /bin
     )
 }

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -8,6 +8,16 @@ function client() {
     docker compose exec -it client "$@"
 }
 
+# Release images (by design) don't include our browser test harness,
+# so install it here if it's not already present.
+function bootstrap_browser_test_harness() {
+    client which chromium-browser || (
+        client apk add --no-cache nodejs npm chromium &&
+            docker compose cp ./scripts/tests/browser/* client:/bin &&
+            client npm install --prefix /bin
+    )
+}
+
 function start_chromium() {
     docker compose exec -d -it client chromium-browser --headless --no-sandbox --remote-debugging-port=$CHROMIUM_PORT
 }
@@ -88,7 +98,7 @@ function create_token_file {
     sudo mkdir "$CONFIG_DIR"
     sudo touch "$TOKEN_PATH"
     sudo chmod 600 "$TOKEN_PATH"
-    echo "n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAGUmu74wBYgABUYA.UN3vSLLcAMkHeEh5VHumPOutkuue8JA6wlxM9JxJEPE" | sudo tee "$TOKEN_PATH" > /dev/null
+    echo "n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAGUmu74wBYgABUYA.UN3vSLLcAMkHeEh5VHumPOutkuue8JA6wlxM9JxJEPE" | sudo tee "$TOKEN_PATH" >/dev/null
 
     # Also put it in `token.txt` for backwards compat, until pull #4666 merges and is
     # cut into a release.

--- a/scripts/tests/relayed-browser-relay-restart.sh
+++ b/scripts/tests/relayed-browser-relay-restart.sh
@@ -6,6 +6,7 @@ HTTPBIN=http://dns.httpbin
 docker compose stop relay-2
 
 install_iptables_drop_rules
+bootstrap_browser_test_harness
 start_chromium
 
 echo "# Make sure webpage is loaded once"


### PR DESCRIPTION
Should be a less brittle fix to the problem of testing release images for `compat-tests` with the browser harness.