### PR TITLE
Fix: Correct typo in Terraform links

### DIFF
--- a/website/src/app/kb/use-cases/nat-gateway/readme.mdx
+++ b/website/src/app/kb/use-cases/nat-gateway/readme.mdx
@@ -23,7 +23,7 @@ Gateway and then out to the internet using its public IP address.
 
 <Alert color="info">
   See our our [Terraform
-  examples](https://www.github.com/firezone/firezone/tree/main/terrraform/examples)
+  examples](https://www.github.com/firezone/firezone/tree/main/terraform/examples)
   for a high availability example of this guide using Terraform on Google Cloud
   Platform.
 </Alert>

--- a/website/src/app/kb/use-cases/saas-app-access/readme.mdx
+++ b/website/src/app/kb/use-cases/saas-app-access/readme.mdx
@@ -30,7 +30,7 @@ into an **app connector** for SaaS applications that support IP allowlists.
 - One or more Gateways deployed within the Site in a NAT Gateway configuration.
   See [Route traffic through a public IP](/kb/use-cases/nat-gateway) for how to
   deploy a single NAT Gateway, or see our
-  [Terraform examples](https://www.github.com/firezone/firezone/tree/main/terrraform/examples)
+  [Terraform examples](https://www.github.com/firezone/firezone/tree/main/terraform/examples)
   for examples on how to automate deploying multiple Gateways to various cloud
   providers.
 

--- a/website/src/app/kb/use-cases/scale-vpc-access/readme.mdx
+++ b/website/src/app/kb/use-cases/scale-vpc-access/readme.mdx
@@ -32,7 +32,7 @@ balanced across multiple Gateways for high availability.
 
 <Alert color="info">
   See our [Terraform
-  examples](https://www.github.com/firezone/firezone/tree/main/terrraform/examples)
+  examples](https://www.github.com/firezone/firezone/tree/main/terraform/examples)
   for examples on how to automate deploying multiple Gateways to various cloud
   providers.
 </Alert>


### PR DESCRIPTION
Now with less one less 'r'