### PR TITLE
fix(headless-client): clean up and exit gracefully when `on_disconnect` called

### DIFF
--- a/rust/connlib/shared/src/linux/etc_resolv_conf.rs
+++ b/rust/connlib/shared/src/linux/etc_resolv_conf.rs
@@ -127,6 +127,7 @@ fn revert_at_paths(paths: &ResolvPaths) -> Result<()> {
     // Don't delete the backup file - If we lose power here, and the revert is rolled back,
     // we may want it. Filesystems are not atomic by default, and have weak ordering,
     // so we don't want to end up in a state where the backup is deleted and the revert was rolled back.
+    tracing::info!("Reverted resolv.conf file");
     Ok(())
 }
 

--- a/rust/connlib/tunnel/src/device_channel/tun_linux.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_linux.rs
@@ -67,6 +67,7 @@ impl Drop for Tun {
     fn drop(&mut self) {
         unsafe { close(self.fd.as_raw_fd()) };
         self.connection.abort();
+        tracing::debug!("Reverting DNS control...");
         if let Some(DnsControlMethod::EtcResolvConf) = self.dns_control_method {
             // TODO: Check that nobody else modified the file while we were running.
             etc_resolv_conf::revert().ok();

--- a/rust/headless-client/src/imp_linux.rs
+++ b/rust/headless-client/src/imp_linux.rs
@@ -200,11 +200,6 @@ fn run_standalone(cli: Cli, token: &SecretString) -> Result<()> {
     let mut sigint = tokio::signal::unix::signal(SignalKind::interrupt())?;
     let mut sighup = tokio::signal::unix::signal(SignalKind::hangup())?;
 
-    rt.spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        callback_handler.on_disconnect(&connlib_client_shared::Error::Other("fault injection"));
-    });
-
     let result = rt.block_on(async {
         future::poll_fn(|cx| loop {
             match on_disconnect_rx.poll_recv(cx) {

--- a/rust/headless-client/src/imp_linux.rs
+++ b/rust/headless-client/src/imp_linux.rs
@@ -190,7 +190,7 @@ fn run_standalone(cli: Cli, token: &SecretString) -> Result<()> {
         Sockets::new(),
         private_key,
         None,
-        callback_handler,
+        callback_handler.clone(),
         max_partition_time,
         rt.handle().clone(),
     );
@@ -199,6 +199,11 @@ fn run_standalone(cli: Cli, token: &SecretString) -> Result<()> {
 
     let mut sigint = tokio::signal::unix::signal(SignalKind::interrupt())?;
     let mut sighup = tokio::signal::unix::signal(SignalKind::hangup())?;
+
+    rt.spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        callback_handler.on_disconnect(&connlib_client_shared::Error::Other("fault injection"));
+    });
 
     let result = rt.block_on(async {
         future::poll_fn(|cx| loop {

--- a/rust/headless-client/src/imp_linux.rs
+++ b/rust/headless-client/src/imp_linux.rs
@@ -190,7 +190,7 @@ fn run_standalone(cli: Cli, token: &SecretString) -> Result<()> {
         Sockets::new(),
         private_key,
         None,
-        callback_handler.clone(),
+        callback_handler,
         max_partition_time,
         rt.handle().clone(),
     );

--- a/rust/headless-client/src/imp_linux.rs
+++ b/rust/headless-client/src/imp_linux.rs
@@ -190,7 +190,7 @@ fn run_standalone(cli: Cli, token: &SecretString) -> Result<()> {
         Sockets::new(),
         private_key,
         None,
-        callback_handler.clone(),
+        callback_handler,
         max_partition_time,
         rt.handle().clone(),
     );
@@ -199,11 +199,6 @@ fn run_standalone(cli: Cli, token: &SecretString) -> Result<()> {
 
     let mut sigint = tokio::signal::unix::signal(SignalKind::interrupt())?;
     let mut sighup = tokio::signal::unix::signal(SignalKind::hangup())?;
-
-    rt.spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        callback_handler.on_disconnect(&connlib_client_shared::Error::Other("fault injection"));
-    });
 
     let result = rt.block_on(async {
         future::poll_fn(|cx| loop {


### PR DESCRIPTION
Calling `std::process::exit` won't let the DNS deactivation code runs. For some control methods (systemd-resolved) this doesn't matter. For etc-resolvconf and Windows, we are responsible for cleaning up DNS.

```[tasklist]
- [x] Replicate the issue
- [x] Fix it
- [x] Remove the fault injection code
```

Closes #4784 