### PR TITLE
chore(devops): Add client monitor VM

### DIFF
--- a/terraform/environments/staging/demo.tf
+++ b/terraform/environments/staging/demo.tf
@@ -67,7 +67,12 @@ resource "google_compute_instance" "demo" {
     && sudo systemctl start docker \
     && sudo docker run -d --restart always --name=httpbin -p 80:80 kennethreitz/httpbin \
     && echo ${module.metabase.internal_ip} metabase.fz >> /etc/hosts \
-    && echo 127.0.0.1 host.firezone.local >> /etc/hosts
+    && echo 127.0.0.1 host.firezone.local >> /etc/hosts \
+    && curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh \
+    && sudo bash add-google-cloud-ops-agent-repo.sh \
+    && sudo apt-get update \
+    && sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install google-cloud-ops-agent
+
 EOT
 
   allow_stopping_for_update = true

--- a/terraform/environments/staging/monitor.tf
+++ b/terraform/environments/staging/monitor.tf
@@ -1,0 +1,91 @@
+# Deploy our Firezone monitor instance
+
+locals {
+  client_monitor_region = local.region
+  client_monitor_zone   = local.availability_zone
+}
+
+module "client_monitor" {
+  source     = "../../modules/google-cloud/apps/client-monitor"
+  project_id = module.google-cloud-project.project.project_id
+
+  compute_network    = module.google-cloud-vpc.id
+  compute_subnetwork = google_compute_subnetwork.apps.self_link
+
+  compute_instance_type              = "f1-micro"
+  compute_region                     = local.client_monitor_region
+  compute_instance_availability_zone = local.client_monitor_zone
+
+  container_registry = module.google-artifact-registry.url
+
+  firezone_client_id = "gcp-client-monitor-main"
+  firezone_api_url   = "wss://api.firez.one"
+  firezone_token     = var.firezone_client_token
+
+  image_repo = module.google-artifact-registry.repo
+  image      = "client"
+  image_tag  = var.image_tag
+
+  application_name = "client-monitor"
+
+  application_environment_variables = []
+
+  health_check = {
+    name     = "health"
+    protocol = "TCP"
+    port     = 3000
+
+    initial_delay_sec = 60
+
+    check_interval_sec  = 15
+    timeout_sec         = 10
+    healthy_threshold   = 1
+    unhealthy_threshold = 3
+
+    http_health_check = {
+      request_path = "/healthz"
+    }
+  }
+}
+
+# Allow outbound traffic
+resource "google_compute_firewall" "client-monitor-egress-ipv4" {
+  project = module.google-cloud-project.project.project_id
+
+  name      = "client-monitor-egress-ipv4"
+  network   = module.google-cloud-vpc.id
+  direction = "EGRESS"
+
+  target_tags        = module.client_monitor.target_tags
+  destination_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "all"
+  }
+}
+
+resource "google_compute_firewall" "client-monitor-ssh-ipv4" {
+  project = module.google-cloud-project.project.project_id
+
+  name    = "client-monitor-ssh-ipv4"
+  network = module.google-cloud-vpc.id
+
+  allow {
+    protocol = "tcp"
+    ports    = [22]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = [22]
+  }
+
+  allow {
+    protocol = "sctp"
+    ports    = [22]
+  }
+
+  # Only allows connections using IAP
+  source_ranges = local.iap_ipv4_ranges
+  target_tags   = module.client_monitor.target_tags
+}

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -349,7 +349,7 @@ module "domain" {
   source     = "../../modules/google-cloud/apps/elixir"
   project_id = module.google-cloud-project.project.project_id
 
-  compute_instance_type               = "n1-standard-2"
+  compute_instance_type               = "n1-standard-1"
   compute_instance_region             = local.region
   compute_instance_availability_zones = ["${local.region}-d"]
 

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -51,3 +51,8 @@ variable "stripe_webhook_signing_secret" {
 variable "stripe_default_price_id" {
   type = string
 }
+
+variable "firezone_client_token" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/modules/google-cloud/apps/client-monitor/iam.tf
+++ b/terraform/modules/google-cloud/apps/client-monitor/iam.tf
@@ -1,0 +1,54 @@
+
+# Create IAM role for the application instances
+resource "google_service_account" "application" {
+  project = var.project_id
+
+  account_id   = "app-${local.application_name}"
+  display_name = "${local.application_name} app"
+  description  = "Service account for ${local.application_name} application instances."
+}
+
+## Allow fluentbit to injest logs
+resource "google_project_iam_member" "logs" {
+  project = var.project_id
+
+  role = "roles/logging.logWriter"
+
+  member = "serviceAccount:${google_service_account.application.email}"
+}
+
+## Allow reporting application errors
+resource "google_project_iam_member" "errors" {
+  project = var.project_id
+
+  role = "roles/errorreporting.writer"
+
+  member = "serviceAccount:${google_service_account.application.email}"
+}
+
+## Allow reporting metrics
+resource "google_project_iam_member" "metrics" {
+  project = var.project_id
+
+  role = "roles/monitoring.metricWriter"
+
+  member = "serviceAccount:${google_service_account.application.email}"
+}
+
+## Allow reporting metrics
+resource "google_project_iam_member" "service_management" {
+  project = var.project_id
+
+  role = "roles/servicemanagement.reporter"
+
+  member = "serviceAccount:${google_service_account.application.email}"
+}
+
+## Allow appending traces
+resource "google_project_iam_member" "cloudtrace" {
+  project = var.project_id
+
+  role = "roles/cloudtrace.agent"
+
+  member = "serviceAccount:${google_service_account.application.email}"
+}

--- a/terraform/modules/google-cloud/apps/client-monitor/main.tf
+++ b/terraform/modules/google-cloud/apps/client-monitor/main.tf
@@ -101,7 +101,6 @@ resource "google_compute_instance" "client_monitor" {
     enable_vtpm                 = true
   }
 
-  # us-east1-docker.pkg.dev/firezone-staging/firezone/client:1.0.0-3e457fbd3c9252ba4c5b7a7cc943bceae8c3c827
   metadata = {
     user-data = templatefile("${path.module}/templates/cloud-init.yaml", {
       client_container_image    = "${var.container_registry}/${var.image_repo}/${var.image}:${var.image_tag}"

--- a/terraform/modules/google-cloud/apps/client-monitor/outputs.tf
+++ b/terraform/modules/google-cloud/apps/client-monitor/outputs.tf
@@ -1,0 +1,15 @@
+output "service_account" {
+  value = google_service_account.application
+}
+
+output "target_tags" {
+  value = local.application_tags
+}
+
+output "instance" {
+  value = google_compute_instance.client_monitor
+}
+
+output "internal_ip" {
+  value = google_compute_address.client_monitor.address
+}

--- a/terraform/modules/google-cloud/apps/client-monitor/services.tf
+++ b/terraform/modules/google-cloud/apps/client-monitor/services.tf
@@ -1,0 +1,83 @@
+resource "google_project_service" "compute" {
+  project = var.project_id
+  service = "compute.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "pubsub" {
+  project = var.project_id
+  service = "pubsub.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "bigquery" {
+  project = var.project_id
+  service = "bigquery.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "container" {
+  project = var.project_id
+  service = "container.googleapis.com"
+
+  depends_on = [
+    google_project_service.compute,
+    google_project_service.pubsub,
+    google_project_service.bigquery,
+  ]
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "stackdriver" {
+  project = var.project_id
+  service = "stackdriver.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "logging" {
+  project = var.project_id
+  service = "logging.googleapis.com"
+
+  disable_on_destroy = false
+
+  depends_on = [google_project_service.stackdriver]
+}
+
+resource "google_project_service" "monitoring" {
+  project = var.project_id
+  service = "monitoring.googleapis.com"
+
+  disable_on_destroy = false
+
+  depends_on = [google_project_service.stackdriver]
+}
+
+resource "google_project_service" "cloudprofiler" {
+  project = var.project_id
+  service = "cloudprofiler.googleapis.com"
+
+  disable_on_destroy = false
+
+  depends_on = [google_project_service.stackdriver]
+}
+
+resource "google_project_service" "cloudtrace" {
+  project = var.project_id
+  service = "cloudtrace.googleapis.com"
+
+  disable_on_destroy = false
+
+  depends_on = [google_project_service.stackdriver]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = var.project_id
+  service = "servicenetworking.googleapis.com"
+
+  disable_on_destroy = false
+}

--- a/terraform/modules/google-cloud/apps/client-monitor/templates/cloud-init.yaml
+++ b/terraform/modules/google-cloud/apps/client-monitor/templates/cloud-init.yaml
@@ -73,7 +73,9 @@ write_files:
     owner: root
     content: |
       * * * * * root /usr/local/bin/firezone-monitor/tunnel.sh 2>&1 >> /var/log/firezone_monitor/tunnel.log
-      */2 * * * * root /usr/local/bin/firezone-monitor/ping.sh 10.0.32.100 2>&1 >> /var/log/firezone_monitor/ping.log
+      */2 * * * * root /usr/local/bin/firezone-monitor/ping.sh 10.0.32.100 2>&1 >> /var/log/firezone_monitor/ping_internal.log
+      */2 * * * * root /usr/local/bin/firezone-monitor/ping.sh 8.8.4.4 2>&1 >> /var/log/firezone_monitor/ping_google_dns_ipv4.log
+      */2 * * * * root /usr/local/bin/firezone-monitor/ping6.sh 2001:4860:4860::8844 2>&1 >> /var/log/firezone_monitor/ping_google_dns_ipv6.log
       */10 * * * * root /usr/local/bin/firezone-monitor/iperf.sh 10.0.32.101 2>&1 >> /var/log/firezone_monitor/iperf.log
 
   - path: /usr/local/bin/firezone-monitor/common.sh
@@ -137,7 +139,38 @@ write_files:
 
       run_test() {
         log "Test output:"
-        ping -c 10 -W 5 "$PING_HOST"
+        ping -4 -c 10 -W 5 -I "tun-firezone" "$PING_HOST"
+      }
+
+      main() {
+        log "Start Firezone Monitor Test: $TEST_NAME"
+        check_tunnel
+        run_test
+      }
+
+      finish() {
+        log "Finish Firezone Monitor Test: $TEST_NAME"
+      }
+
+      trap finish EXIT
+      main
+
+  - path: /usr/local/bin/firezone-monitor/ping6.sh
+    permissions: "0555"
+    owner: root
+    content: |
+      #!/bin/bash
+
+      set -euo pipefail
+
+      source $(dirname "$0")/common.sh
+
+      TEST_NAME="ping6"
+      PING_HOST=$1
+
+      run_test() {
+        log "Test output:"
+        ping -6 -c 10 -W 5 -I "tun-firezone" "$PING_HOST"
       }
 
       main() {

--- a/terraform/modules/google-cloud/apps/client-monitor/templates/cloud-init.yaml
+++ b/terraform/modules/google-cloud/apps/client-monitor/templates/cloud-init.yaml
@@ -1,0 +1,208 @@
+#cloud-config
+
+write_files:
+  - path: /etc/dev.firezone.client/token
+    content: ${firezone_token}
+    permissions: "0600"
+    owner: root
+
+  - path: /etc/systemd/system/firezone.service
+    owner: root
+    content: |
+      [Unit]
+      Description=Firezone Client
+
+      [Service]
+      AmbientCapabilities=CAP_NET_ADMIN
+      CapabilityBoundingSet=CAP_CHOWN CAP_NET_ADMIN
+      DeviceAllow=/dev/net/tun
+      LockPersonality=true
+      MemoryDenyWriteExecute=true
+      NoNewPrivileges=true
+      PrivateMounts=true
+      PrivateTmp=true
+      PrivateUsers=false
+      ProcSubset=pid
+      ProtectClock=true
+      ProtectControlGroups=true
+      ProtectHome=true
+      ProtectHostname=true
+      ProtectKernelLogs=true
+      ProtectKernelModules=true
+      ProtectKernelTunables=true
+      ProtectProc=invisible
+      ProtectSystem=full
+      RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_UNIX
+      RestrictNamespaces=true
+      RestrictRealtime=true
+      RestrictSUIDSGID=true
+      StateDirectory=dev.firezone.client
+      SystemCallArchitectures=native
+      SystemCallFilter=@aio @basic-io @file-system @io-event @ipc @network-io @signal @system-service
+      UMask=077
+
+      Environment="FIREZONE_API_URL=${firezone_api_url}"
+      Environment="FIREZONE_DNS_CONTROL=systemd-resolved"
+      Environment="FIREZONE_ID=${firezone_client_id}"
+      Environment="RUST_LOG=${firezone_client_log_level}"
+      Environment="LOG_DIR=/var/log/firezone"
+
+      ExecStart=/usr/local/bin/firezone-linux-client standalone
+      Type=notify
+      User=root
+
+      [Install]
+      WantedBy=default.target
+
+  - path: /etc/google-cloud-ops-agent/config.yaml
+    permissions: "0644"
+    owner: root
+    content: |
+      logging:
+        receivers:
+          firezone_monitor:
+            type: files
+            include_paths:
+            - /var/log/firezone_monitor/*.log
+        service:
+          pipelines:
+            firezone_monitor_pipeline:
+              receivers: [firezone_monitor]
+
+  - path: /etc/cron.d/firezone_monitor
+    owner: root
+    content: |
+      * * * * * root /usr/local/bin/firezone-monitor/tunnel.sh 2>&1 >> /var/log/firezone_monitor/tunnel.log
+      */2 * * * * root /usr/local/bin/firezone-monitor/ping.sh 10.0.32.100 2>&1 >> /var/log/firezone_monitor/ping.log
+      */10 * * * * root /usr/local/bin/firezone-monitor/iperf.sh 10.0.32.101 2>&1 >> /var/log/firezone_monitor/iperf.log
+
+  - path: /usr/local/bin/firezone-monitor/common.sh
+    permissions: "0555"
+    owner: root
+    content: |
+      #!/bin/bash
+
+      log() {
+        local timestamp=$(date "+%Y/%m/%d-%H:%M:%S")
+        echo "$timestamp >> $1"
+      }
+
+      check_tunnel() {
+        log "Checking tunnel state"
+
+        if $(ip address show tun-firezone > /dev/null 2>&1) ; then
+          log "Firezone Tunnel is running"
+        else
+          log "Firezone Monitor Test ERROR: Firezone tunnel is not running"
+          exit 1
+        fi
+      }
+
+  - path: /usr/local/bin/firezone-monitor/tunnel.sh
+    permissions: "0555"
+    owner: root
+    content: |
+      #!/bin/bash
+
+      set -euo pipefail
+
+      source $(dirname "$0")/common.sh
+
+      TEST_NAME="tunnel"
+
+      main() {
+        log "Start Firezone Monitor Test: $TEST_NAME"
+        check_tunnel
+      }
+
+      finish() {
+        log "Finish Firezone Monitor Test: $TEST_NAME"
+      }
+
+      trap finish EXIT
+      main
+
+  - path: /usr/local/bin/firezone-monitor/ping.sh
+    permissions: "0555"
+    owner: root
+    content: |
+      #!/bin/bash
+
+      set -euo pipefail
+
+      source $(dirname "$0")/common.sh
+
+      TEST_NAME="ping"
+      PING_HOST=$1
+
+      run_test() {
+        log "Test output:"
+        ping -c 10 -W 5 "$PING_HOST"
+      }
+
+      main() {
+        log "Start Firezone Monitor Test: $TEST_NAME"
+        check_tunnel
+        run_test
+      }
+
+      finish() {
+        log "Finish Firezone Monitor Test: $TEST_NAME"
+      }
+
+      trap finish EXIT
+      main
+
+  - path: /usr/local/bin/firezone-monitor/iperf.sh
+    permissions: "0555"
+    owner: root
+    content: |
+      #!/bin/bash
+
+      set -euo pipefail
+
+      source $(dirname "$0")/common.sh
+
+      TEST_NAME="iperf"
+      IPERF_HOST=$1
+      TIMEOUT=5000
+
+      run_test() {
+        log "Test output:"
+        iperf3 -c $IPERF_HOST -R --connect-timeout $TIMEOUT
+      }
+
+      main() {
+        log "Start Firezone Monitor Test: $TEST_NAME"
+        check_tunnel
+        run_test
+      }
+
+      finish() {
+        log "Finish Firezone Monitor Test: $TEST_NAME"
+      }
+
+      trap finish EXIT
+      main
+
+runcmd:
+  - sudo mkdir -m 0755 -p /var/log/firezone_monitor
+  - sudo apt update -y
+  - sudo apt install -y apt-transport-https ca-certificates curl software-properties-common iperf3
+  - sudo install -m 0755 -d /etc/apt/keyrings
+  - 'sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc'
+  - sudo chmod a+r /etc/apt/keyrings/docker.asc
+  - 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null'
+  - sudo apt-get update
+  - sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  - sudo systemctl enable --now docker.service
+  - sudo systemctl enable --now containerd.service
+  - curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+  - sudo bash add-google-cloud-ops-agent-repo.sh
+  - sudo apt-get update
+  - 'sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install google-cloud-ops-agent'
+  - sudo docker pull ${client_container_image}
+  - sudo docker create --name fz-client ${client_container_image}
+  - 'sudo docker cp fz-client:/bin/firezone-linux-client /usr/local/bin/firezone-linux-client'
+  - sudo docker rm -v fz-client
+  - sudo systemctl enable --now firezone.service

--- a/terraform/modules/google-cloud/apps/client-monitor/variables.tf
+++ b/terraform/modules/google-cloud/apps/client-monitor/variables.tf
@@ -1,0 +1,163 @@
+variable "project_id" {
+  type        = string
+  description = "ID of a Google Cloud Project"
+}
+
+################################################################################
+## Compute
+################################################################################
+
+variable "compute_network" {
+  type = string
+}
+
+variable "compute_subnetwork" {
+  type = string
+}
+
+variable "compute_region" {
+  type = string
+}
+
+variable "compute_instance_availability_zone" {
+  type        = string
+  description = "List of zones in the region defined in `compute_region` where replicas should be deployed."
+}
+
+variable "compute_instance_type" {
+  type = string
+}
+
+################################################################################
+## Container Registry
+################################################################################
+
+variable "container_registry" {
+  type        = string
+  nullable    = false
+  description = "Container registry URL to pull the image from."
+}
+
+###############################################################################
+# Container Image
+###############################################################################
+
+variable "image_repo" {
+  type     = string
+  nullable = false
+
+  description = "Repo of a container image used to deploy the application."
+}
+
+variable "image" {
+  type     = string
+  nullable = false
+
+  description = "Container image used to deploy the application."
+}
+
+variable "image_tag" {
+  type     = string
+  nullable = false
+
+  description = "Container image used to deploy the application."
+}
+
+################################################################################
+## Application
+################################################################################
+
+variable "application_name" {
+  type     = string
+  nullable = true
+  default  = null
+
+  description = "Name of the application. Defaults to value of `var.image_name` with `_` replaced to `-`."
+}
+
+variable "application_version" {
+  type     = string
+  nullable = true
+  default  = null
+
+  description = "Version of the application. Defaults to value of `var.image_tag`."
+}
+
+variable "application_labels" {
+  type     = map(string)
+  nullable = false
+  default  = {}
+
+  description = "Labels to add to all created by this module resources."
+}
+
+variable "health_check" {
+  type = object({
+    name     = string
+    protocol = string
+    port     = number
+
+    initial_delay_sec   = number
+    check_interval_sec  = optional(number)
+    timeout_sec         = optional(number)
+    healthy_threshold   = optional(number)
+    unhealthy_threshold = optional(number)
+
+    http_health_check = optional(object({
+      host         = optional(string)
+      request_path = optional(string)
+      port         = optional(string)
+      response     = optional(string)
+    }))
+  })
+
+  nullable = false
+
+  description = "Health check which will be used for auto healing policy."
+}
+
+variable "application_environment_variables" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+
+  nullable = false
+  default  = []
+
+  description = "List of environment variables to set for the application."
+}
+
+################################################################################
+## Firezone Client
+################################################################################
+
+variable "firezone_api_url" {
+  type     = string
+  nullable = false
+  default  = "wss://api.firez.one"
+
+  description = "URL the firezone client will connect to"
+}
+
+variable "firezone_client_id" {
+  type     = string
+  nullable = false
+  default  = ""
+
+  description = ""
+}
+
+variable "firezone_token" {
+  type    = string
+  default = ""
+
+  description = "Firezone token to allow client to connect to portal"
+}
+
+variable "firezone_client_log_level" {
+  type    = string
+  default = "debug"
+
+  description = "Firezone client Rust log level"
+}

--- a/terraform/modules/google-cloud/apps/gateway-region-instance-group/main.tf
+++ b/terraform/modules/google-cloud/apps/gateway-region-instance-group/main.tf
@@ -108,7 +108,7 @@ resource "google_compute_instance_template" "application" {
 
       content {
         network_tier = "PREMIUM"
-        # Ephimerical IP address
+        # Ephemeral IP address
       }
     }
 
@@ -117,7 +117,7 @@ resource "google_compute_instance_template" "application" {
 
       content {
         network_tier = "PREMIUM"
-        # Ephimerical IP address
+        # Ephemeral IP address
       }
     }
   }

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -187,12 +187,12 @@ resource "google_compute_instance_template" "application" {
 
     ipv6_access_config {
       network_tier = "PREMIUM"
-      # Ephimerical IP address
+      # Ephemeral IP address
     }
 
     access_config {
       network_tier = "PREMIUM"
-      # Ephimerical IP address
+      # Ephemeral IP address
     }
   }
 


### PR DESCRIPTION
Why:

* The client-monitor VM can serve multiple purposes, but for now it will
      act as a soak test for the latest client to allow longer term testing
      of the client before pushing out a new release.
      
 Fixes #4506 