### PR TITLE
fix(portal): Update site deletion modal message

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -264,7 +264,7 @@ defmodule Web.Sites.Show do
       <:action>
         <.delete_button
           phx-click="delete"
-          data-confirm="Are you sure want to delete this gateway group and disconnect all it's gateways?"
+          data-confirm="Are you sure want to delete this Site and disconnect all it's Gateways?"
         >
           Delete Site
         </.delete_button>

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -264,7 +264,7 @@ defmodule Web.Sites.Show do
       <:action>
         <.delete_button
           phx-click="delete"
-          data-confirm="Are you sure want to delete this Site and disconnect all it's Gateways?"
+          data-confirm="Are you sure you want to delete this Site and disconnect all its Gateways?"
         >
           Delete Site
         </.delete_button>


### PR DESCRIPTION
Why:

* Deleting a Site from the show page would prompt the user with a message about Gateway Groups.