### PR TITLE
chore(gui-client/linux): fix notifications

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1923,7 +1923,7 @@ dependencies = [
  "tauri-build",
  "tauri-runtime",
  "tauri-utils",
- "tauri-winrt-notification",
+ "tauri-winrt-notification 0.2.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -3487,6 +3487,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fca4d74ff9dbaac16a01b924bc3693fa2bba0862c2c633abc73f9a8ea21f64"
+dependencies = [
+ "cc",
+ "dirs-next",
+ "objc-foundation",
+ "objc_id",
+ "time",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,6 +3889,19 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827c5edfa80235ded4ab3fe8e9dc619b4f866ef16fe9b1c6b8a7f8692c0f2226"
+dependencies = [
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification 0.1.3",
+ "zbus",
 ]
 
 [[package]]
@@ -6116,6 +6142,8 @@ dependencies = [
  "heck 0.4.1",
  "http 0.2.12",
  "ignore",
+ "nix 0.26.4",
+ "notify-rust",
  "objc",
  "once_cell",
  "open",
@@ -6283,6 +6311,16 @@ checksum = "5993dc129e544393574288923d1ec447c857f3f644187f4fbf7d9a875fbfc4fb"
 dependencies = [
  "embed-resource",
  "toml 0.7.8",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006851c9ccefa3c38a7646b8cec804bb429def3da10497bfa977179869c3e8e2"
+dependencies = [
+ "quick-xml 0.30.0",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -7361,6 +7399,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+dependencies = [
+ "windows-core 0.51.1",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
@@ -7397,6 +7445,15 @@ checksum = "68003dbd0e38abc0fb85b939240f4bce37c43a5981d3df37ccbaaa981b47cb41"
 dependencies = [
  "windows-metadata",
  "windows-tokens",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = { version = "1.0.22", features = ["serde"] }
 subtle = "2.5.0"
-tauri = { version = "1.6", features = [ "dialog", "shell-open-api", "system-tray" ] }
+tauri = { version = "1.6", features = [ "dialog", "notification", "shell-open-api", "system-tray" ] }
 tauri-runtime = "0.14.2"
 tauri-utils = "1.5.3"
 thiserror = { version = "1.0", default-features = false }

--- a/rust/gui-client/src-tauri/src/client/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/os_linux.rs
@@ -1,7 +1,7 @@
-use super::{ControllerRequest, CtlrTx, Error};
+use super::{ControllerRequest, CtlrTx};
 use anyhow::Result;
 use secrecy::{ExposeSecret, SecretString};
-use tauri::Manager;
+use tauri::{api::notification::Notification, Manager};
 
 /// Open a URL in the user's default browser
 pub(crate) fn open_url(app: &tauri::AppHandle, url: &SecretString) -> Result<()> {
@@ -10,8 +10,11 @@ pub(crate) fn open_url(app: &tauri::AppHandle, url: &SecretString) -> Result<()>
 }
 
 /// Show a notification in the bottom right of the screen
-pub(crate) fn show_notification(_title: &str, _body: &str) -> Result<(), Error> {
-    // TODO
+pub(crate) fn show_notification(title: &str, body: &str) -> Result<()> {
+    Notification::new(connlib_shared::BUNDLE_ID)
+        .title(title)
+        .body(body)
+        .show()?;
     Ok(())
 }
 
@@ -21,7 +24,8 @@ pub(crate) fn show_clickable_notification(
     _body: &str,
     _tx: CtlrTx,
     _req: ControllerRequest,
-) -> Result<(), Error> {
-    // TODO
+) -> Result<()> {
+    // TODO: Tauri doesn't seem to have clickable notifications on Linux.
+    // No indication if it'll be in 2.x or if there's a good third-party replacement
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/client/gui/os_macos.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/os_macos.rs
@@ -1,5 +1,5 @@
 //! This file is a stub only to do Tauri UI dev natively on a Mac.
-use super::{ControllerRequest, CtlrTx, Error};
+use super::{ControllerRequest, CtlrTx};
 use anyhow::Result;
 use secrecy::SecretString;
 
@@ -8,7 +8,7 @@ pub(crate) fn open_url(_app: &tauri::AppHandle, _url: &SecretString) -> Result<(
 }
 
 /// Show a notification in the bottom right of the screen
-pub(crate) fn show_notification(_title: &str, _body: &str) -> Result<(), Error> {
+pub(crate) fn show_notification(_title: &str, _body: &str) -> Result<()> {
     unimplemented!()
 }
 
@@ -18,6 +18,6 @@ pub(crate) fn show_clickable_notification(
     _body: &str,
     _tx: CtlrTx,
     _req: ControllerRequest,
-) -> Result<(), Error> {
+) -> Result<()> {
     unimplemented!()
 }


### PR DESCRIPTION
The clickable "Firezone 1.x is ready to download" notification still isn't there. Tauri doesn't seem to have cross-platform clickable notifications.