### PR TITLE
fix(windows-client): package name should be "Firezone" not "firezone-client-gui"

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Sign the MSI
         if: ${{ runner.os == 'Windows' }}
         shell: bash
-        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/firezone-client-gui_${{ env.VERSION }}_x64_en-US.msi
+        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ matrix.rename-script }}

--- a/rust/gui-client/src-tauri/tauri.windows.conf.json
+++ b/rust/gui-client/src-tauri/tauri.windows.conf.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "beforeBundleCommand": "bash -c '../../scripts/build/sign.sh ../target/release/firezone-client-gui.exe'"
+    "beforeBundleCommand": "bash -c '../../scripts/build/sign.sh ../target/release/Firezone.exe'"
   },
   "package": {
     "productName": "Firezone"

--- a/rust/gui-client/src-tauri/tauri.windows.conf.json
+++ b/rust/gui-client/src-tauri/tauri.windows.conf.json
@@ -1,5 +1,8 @@
 {
   "build": {
     "beforeBundleCommand": "bash -c '../../scripts/build/sign.sh ../target/release/firezone-client-gui.exe'"
+  },
+  "package": {
+    "productName": "Firezone"
   }
 }

--- a/scripts/build/tauri-rename-windows.sh
+++ b/scripts/build/tauri-rename-windows.sh
@@ -6,7 +6,7 @@ ls ../target/release ../target/release/bundle/msi
 
 # Used for release artifact
 # In release mode the name comes from tauri.conf.json
-cp ../target/release/firezone-client-gui.exe "$BINARY_DEST_PATH.exe"
+cp ../target/release/Firezone.exe "$BINARY_DEST_PATH.exe"
 cp ../target/release/bundle/msi/*.msi "$BINARY_DEST_PATH.msi"
 cp ../target/release/firezone_gui_client.pdb "$BINARY_DEST_PATH.pdb"
 


### PR DESCRIPTION
Closes #4813 

After PR, the installer, UAC dialog, and notifications all say "Firezone" again

<img width="494" alt="image" src="https://github.com/firezone/firezone/assets/13400041/69a4fe0b-78fa-4945-b17f-625e68ac09db">
