### PR TITLE
Fix: Exclude legacy docs from kb search and vice versa

### DIFF
--- a/website/src/components/DocsSidebar/SearchForm.tsx
+++ b/website/src/components/DocsSidebar/SearchForm.tsx
@@ -2,6 +2,9 @@ import { DocSearch } from "@docsearch/react";
 import "@docsearch/css";
 
 export default function SearchForm() {
+  // Keep /docs search in /docs (pre-1.0), and exclude /kb (>= 1.0)
+  const excludePathRegex = new RegExp(/^\/kb/)
+
   return (
     <div className="pb-3 -ml-1 flex justify-start border-b border-neutral-200 ">
       <DocSearch
@@ -9,6 +12,15 @@ export default function SearchForm() {
         appId="XXPZ9QVGFB"
         apiKey="66664e8765e1645ea0b500acebb0b0c2"
         indexName="firezone"
+        transformItems={(items) => {
+          return items.filter((item) => {
+            if (item.url) {
+              const pathname = (new URL(item.url)).pathname
+              if (pathname.match(excludePathRegex)) return false
+            }
+            return true
+          })
+        }}
       />
     </div>
   );

--- a/website/src/components/KbSidebar/SearchForm.tsx
+++ b/website/src/components/KbSidebar/SearchForm.tsx
@@ -2,6 +2,9 @@ import { DocSearch } from "@docsearch/react";
 import "@docsearch/css";
 
 export default function SearchForm() {
+  // Keep /kb search in /kb (>= v1.0), and exclude /docs (pre-1.0)
+  const excludePathRegex = new RegExp(/^\/docs/)
+
   return (
     <div className="pb-3 -ml-1 flex justify-start border-b border-neutral-200 ">
       <DocSearch
@@ -9,6 +12,15 @@ export default function SearchForm() {
         appId="XXPZ9QVGFB"
         apiKey="66664e8765e1645ea0b500acebb0b0c2"
         indexName="firezone"
+        transformItems={(items) => {
+          return items.filter((item) => {
+            if (item.url) {
+              const pathname = (new URL(item.url)).pathname
+              if (pathname.match(excludePathRegex)) return false
+            }
+            return true
+          })
+        }}
       />
     </div>
   );


### PR DESCRIPTION
When you're searching in KB (v1.0) you don't really want the results from docs and vice versa. There may be a better way to do this on Algolia's side, but this is an easy fix for now.