### PR TITLE
chore(firezone-tunnel): Remove unused `SIOCGIFMTU` in tun_android

### DIFF
--- a/rust/connlib/tunnel/src/device_channel/tun_android.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_android.rs
@@ -11,8 +11,6 @@ use std::{
 };
 use tokio::io::unix::AsyncFd;
 
-pub(crate) const SIOCGIFMTU: libc::c_ulong = libc::SIOCGIFMTU;
-
 #[derive(Debug)]
 pub(crate) struct Tun {
     fd: AsyncFd<RawFd>,


### PR DESCRIPTION
https://github.com/firezone/firezone/actions/runs/8821060629/job/24216095183?pr=4178#step:9:2150