### PR TITLE
chore(gui-client/linux): poll for DNS changes every 5 seconds

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -824,7 +824,7 @@ async fn run_controller(
             resolvers = dns_listener.notified() => {
                 let resolvers = resolvers?;
                 if let Some(session) = controller.session.as_mut() {
-                    tracing::debug!("New DNS resolvers, calling `Session::set_dns`");
+                    tracing::debug!(?resolvers, "New DNS resolvers, calling `Session::set_dns`");
                     session.connlib.set_dns(resolvers).await?;
                 }
             },

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -821,11 +821,11 @@ async fn run_controller(
                     }
                 }
             },
-            r = dns_listener.notified() => {
-                r?;
+            resolvers = dns_listener.notified() => {
+                let resolvers = resolvers?;
                 if let Some(session) = controller.session.as_mut() {
                     tracing::debug!("New DNS resolvers, calling `Session::set_dns`");
-                    session.connlib.set_dns(client::resolvers::get().unwrap_or_default()).await?;
+                    session.connlib.set_dns(resolvers).await?;
                 }
             },
             req = rx.recv() => {

--- a/rust/gui-client/src-tauri/src/client/network_changes/linux.rs
+++ b/rust/gui-client/src-tauri/src/client/network_changes/linux.rs
@@ -19,26 +19,22 @@ pub(crate) fn check_internet() -> Result<bool> {
     Ok(true)
 }
 
-pub(crate) struct Worker {
-    interval: Interval,
-}
+pub(crate) struct Worker {}
 
 impl Worker {
     pub(crate) fn new() -> Result<Self> {
-        Ok(Self {
-            interval: create_interval(),
-        })
+        Ok(Self {})
     }
 
     pub(crate) fn close(&mut self) -> Result<()> {
         Ok(())
     }
 
+    /// Not implemented on Linux
+    ///
+    /// On Windows this returns when we gain or lose Internet.
     pub(crate) async fn notified(&mut self) {
-        loop {
-            self.interval.tick().await;
-            tracing::trace!("Checking for network changes");
-        }
+        futures::future::pending().await
     }
 }
 

--- a/rust/gui-client/src-tauri/src/client/network_changes/linux.rs
+++ b/rust/gui-client/src-tauri/src/client/network_changes/linux.rs
@@ -1,6 +1,7 @@
 //! Not implemented for Linux yet
 
 use anyhow::Result;
+use tokio::time::Interval;
 
 pub(crate) fn run_dns_debug() -> Result<()> {
     tracing::warn!("network_changes not implemented yet on Linux");
@@ -17,29 +18,49 @@ pub(crate) fn check_internet() -> Result<bool> {
     Ok(true)
 }
 
-pub(crate) struct Worker {}
+pub(crate) struct Worker {
+    interval: Interval,
+}
 
 impl Worker {
     pub(crate) fn new() -> Result<Self> {
-        Ok(Self {})
+        Ok(Self {
+            interval: create_interval(),
+        })
     }
 
     pub(crate) fn close(&mut self) -> Result<()> {
         Ok(())
     }
 
-    pub(crate) async fn notified(&self) {
-        futures::future::pending().await
+    pub(crate) async fn notified(&mut self) {
+        loop {
+            self.interval.tick().await;
+            tracing::debug!("Checking for network changes");
+        }
     }
 }
 
-pub(crate) struct DnsListener {}
+pub(crate) struct DnsListener {
+    interval: Interval,
+}
 
 impl DnsListener {
     pub(crate) fn new() -> Result<Self> {
-        Ok(Self {})
+        Ok(Self {
+            interval: create_interval(),
+        })
     }
     pub(crate) async fn notified(&mut self) -> Result<()> {
-        futures::future::pending().await
+        loop {
+            self.interval.tick().await;
+            tracing::debug!("Checking for DNS changes");
+        }
     }
+}
+
+fn create_interval() -> Interval {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    interval
 }

--- a/rust/gui-client/src-tauri/src/client/network_changes/windows.rs
+++ b/rust/gui-client/src-tauri/src/client/network_changes/windows.rs
@@ -65,6 +65,7 @@
 //! Raymond Chen also explains it on his blog: <https://devblogs.microsoft.com/oldnewthing/20191125-00/?p=103135>
 
 use anyhow::Result;
+use std::net::IpAddr;
 use tokio::{runtime::Runtime, sync::mpsc};
 use windows::{
     core::{Interface, Result as WinResult, GUID},
@@ -572,7 +573,7 @@ mod async_dns {
         /// This is `&mut self` because calling `register_callback` twice
         /// before the callback fires would cause a resource leak.
         /// Cancel-safety: Yes. <https://docs.rs/tokio/latest/tokio/macro.select.html#cancellation-safety>
-        pub(crate) async fn notified(&mut self) -> Result<()> {
+        pub(crate) async fn notified(&mut self) -> Result<Vec<IpAddr>> {
             // We use a particular order here because I initially assumed
             // `RegNotifyChangeKeyValue` has a gap in this sequence:
             // - RegNotifyChangeKeyValue
@@ -593,7 +594,7 @@ mod async_dns {
             self.register_callback()
                 .context("`register_callback` failed")?;
 
-            Ok(())
+            Ok(crate::client::resolvers::get().unwrap_or_default())
         }
 
         // Be careful with this, if you register twice before the callback fires,


### PR DESCRIPTION
Closes #4819

There is a way to get them async with D-Bus. We can invest time in that if we want. Polling works for now, it's just gonna be a slight battery waste on laptops.