### PR TITLE
ci(windows): fix unused deps static analysis

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -28,6 +28,11 @@ jobs:
       - uses: ./.github/actions/setup-rust
         id: setup-rust
       - uses: ./.github/actions/setup-tauri
+      - uses: taiki-e/install-action@cargo-udeps
+      - run: |
+          rustup install --no-self-update nightly-2024-03-26 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
+          cargo +nightly-2024-03-26 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
+        name: Check for unused dependencies
       - run: cargo fmt -- --check
       - run: cargo doc --all-features --no-deps --document-private-items ${{ steps.setup-rust.outputs.packages }}
         env:
@@ -37,12 +42,6 @@ jobs:
       - run: cargo clippy --all-targets --all-features ${{ steps.setup-rust.outputs.packages }} -- -D warnings
         name: "cargo clippy"
         shell: bash
-
-      - uses: taiki-e/install-action@cargo-udeps
-      - run: |
-          rustup install nightly-2024-03-26 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
-          cargo +nightly-2024-03-26 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
-        name: Check for unused dependencies
 
   test:
     name: test-${{ matrix.runs-on }}


### PR DESCRIPTION
Fixes these type of errors: https://github.com/firezone/firezone/actions/runs/8973627864/job/24644251114

Using `--no-self-update` as recommended here: https://github.com/rust-lang/rustup/issues/2415#issuecomment-658752121

Probably was a regression introduced by a version bump in the Github runner's Rustup or something

