### PR TITLE
refactor(gui-client): move `known_dirs` module into `headless-client`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1949,6 +1949,7 @@ dependencies = [
  "clap",
  "connlib-client-shared",
  "connlib-shared",
+ "dirs",
  "firezone-cli-utils",
  "futures",
  "git-version",

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ connlib-client-shared = { workspace = true }
 connlib-shared = { workspace = true }
 crash-handler = "0.6.1"
 firezone-headless-client = { path = "../../headless-client" }
+futures = { version = "0.3", default-features = false }
 git-version = "0.3.9"
 hex = "0.4.3"
 # Same crate Hickory uses
@@ -53,18 +54,12 @@ zip = { version = "0.6.6", features = ["deflate", "time"], default-features = fa
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dirs = "5.0.1"
-# Used for infinite `pending` on not-yet-implemented functions
-futures = "0.3.30"
 nix = { version =  "0.28.0", features = ["user"] }
 tokio-util = { version = "0.7.10", features = ["codec"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-dirs = "5.0.1"
-# Used for infinite `pending` on not-implemented functions
-futures = "0.3.30"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-futures = { version = "0.3", default-features = false }
 tauri-winrt-notification = "0.2.0"
 windows-core = "0.56.0"
 windows-implement = "0.56.0"

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -10,7 +10,6 @@ mod debug_commands;
 mod deep_link;
 mod elevation;
 mod gui;
-mod known_dirs;
 mod logging;
 mod network_changes;
 mod resolvers;

--- a/rust/gui-client/src-tauri/src/client/auth.rs
+++ b/rust/gui-client/src-tauri/src/client/auth.rs
@@ -1,6 +1,6 @@
 //! Fulfills <https://github.com/firezone/firezone/issues/2823>
 
-use crate::client::known_dirs;
+use firezone_headless_client::known_dirs;
 use rand::{thread_rng, RngCore};
 use secrecy::{ExposeSecret, SecretString};
 use std::path::PathBuf;

--- a/rust/gui-client/src-tauri/src/client/crash_handling.rs
+++ b/rust/gui-client/src-tauri/src/client/crash_handling.rs
@@ -12,9 +12,9 @@
 //! - Use dump_syms to convert the pdb to a syms file
 //! - `minidump-stackwalk --symbols-path firezone.syms crash.dmp`
 
-use crate::client::known_dirs;
 use anyhow::{anyhow, bail, Context, Result};
 use crash_handler::CrashHandler;
+use firezone_headless_client::known_dirs;
 use std::{fs::File, io::Write, path::PathBuf};
 
 /// Attaches a crash handler to the client process

--- a/rust/gui-client/src-tauri/src/client/deep_link/linux.rs
+++ b/rust/gui-client/src-tauri/src/client/deep_link/linux.rs
@@ -1,5 +1,5 @@
-use crate::client::known_dirs;
 use anyhow::{bail, Context, Result};
+use firezone_headless_client::known_dirs;
 use secrecy::{ExposeSecret, Secret};
 use std::{path::PathBuf, process::Command};
 use tokio::{

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -755,7 +755,8 @@ async fn run_controller(
     logging_handles: client::logging::Handles,
     advanced_settings: AdvancedSettings,
 ) -> Result<()> {
-    let session_dir = crate::client::known_dirs::session().context("Couldn't find session dir")?;
+    let session_dir =
+        firezone_headless_client::known_dirs::session().context("Couldn't find session dir")?;
     let ran_before_path = session_dir.join("ran_before.txt");
     if !tokio::fs::try_exists(&ran_before_path).await? {
         let win = app

--- a/rust/gui-client/src-tauri/src/client/logging.rs
+++ b/rust/gui-client/src-tauri/src/client/logging.rs
@@ -1,11 +1,9 @@
 //! Everything for logging to files, zipping up the files for export, and counting the files
 
-use crate::client::{
-    gui::{ControllerRequest, CtlrTx, Managed},
-    known_dirs,
-};
+use crate::client::gui::{ControllerRequest, CtlrTx, Managed};
 use anyhow::{bail, Context, Result};
 use connlib_client_shared::file_logger;
+use firezone_headless_client::known_dirs;
 use serde::Serialize;
 use std::{
     fs, io,

--- a/rust/gui-client/src-tauri/src/client/settings.rs
+++ b/rust/gui-client/src-tauri/src/client/settings.rs
@@ -1,11 +1,9 @@
 //! Everything related to the Settings window, including
 //! advanced settings and code for manipulating diagnostic logs.
 
-use crate::client::{
-    gui::{self, ControllerRequest, Managed},
-    known_dirs,
-};
+use crate::client::gui::{self, ControllerRequest, Managed};
 use anyhow::{Context, Result};
+use firezone_headless_client::known_dirs;
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, time::Duration};
 use tokio::sync::oneshot;

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -25,11 +25,15 @@ tracing = { workspace = true }
 url = { version = "2.3.1", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+dirs = "5.0.1"
 futures = "0.3.30"
 nix = { version =  "0.28.0", features = ["fs", "user"] }
 resolv-conf = "0.7.0"
 sd-notify = "0.4.1" # This is a pure Rust re-implementation, so it isn't vulnerable to CVE-2024-3094
 tokio-util = { version = "0.7.10", features = ["codec"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+dirs = "5.0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 ipconfig = "0.3.2"

--- a/rust/headless-client/src/known_dirs.rs
+++ b/rust/headless-client/src/known_dirs.rs
@@ -7,7 +7,7 @@
 //!
 //! I wanted the ProgramData folder on Windows, which `dirs` alone doesn't provide.
 
-pub(crate) use imp::{logs, runtime, session, settings};
+pub use imp::{logs, runtime, session, settings};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod imp {
@@ -18,14 +18,14 @@ mod imp {
     ///
     /// Logs are considered cache because they're not configs and it's technically okay
     /// if the system / user deletes them to free up space
-    pub(crate) fn logs() -> Option<PathBuf> {
+    pub fn logs() -> Option<PathBuf> {
         Some(dirs::cache_dir()?.join(BUNDLE_ID).join("data").join("logs"))
     }
 
     /// e.g. `/run/user/1000/dev.firezone.client/data`
     ///
     /// Crash handler socket and other temp files go here
-    pub(crate) fn runtime() -> Option<PathBuf> {
+    pub fn runtime() -> Option<PathBuf> {
         Some(dirs::runtime_dir()?.join(BUNDLE_ID).join("data"))
     }
 
@@ -34,14 +34,14 @@ mod imp {
     /// Things like actor name are stored here because they're kind of config,
     /// the system / user should not delete them to free up space, but they're not
     /// really config since the program will rewrite them automatically to persist sessions.
-    pub(crate) fn session() -> Option<PathBuf> {
+    pub fn session() -> Option<PathBuf> {
         Some(dirs::data_local_dir()?.join(BUNDLE_ID).join("data"))
     }
 
     /// e.g. `/home/alice/.config/dev.firezone.client/config`
     ///
     /// See connlib docs for details
-    pub(crate) fn settings() -> Option<PathBuf> {
+    pub fn settings() -> Option<PathBuf> {
         Some(dirs::config_local_dir()?.join(BUNDLE_ID).join("config"))
     }
 }
@@ -53,7 +53,7 @@ mod imp {
     /// e.g. `C:\Users\Alice\AppData\Local\dev.firezone.client\data\logs`
     ///
     /// See connlib docs for details
-    pub(crate) fn logs() -> Option<PathBuf> {
+    pub fn logs() -> Option<PathBuf> {
         Some(
             connlib_shared::windows::app_local_data_dir()
                 .ok()?
@@ -65,7 +65,7 @@ mod imp {
     /// e.g. `C:\Users\Alice\AppData\Local\dev.firezone.client\data`
     ///
     /// Crash handler socket and other temp files go here
-    pub(crate) fn runtime() -> Option<PathBuf> {
+    pub fn runtime() -> Option<PathBuf> {
         Some(
             connlib_shared::windows::app_local_data_dir()
                 .ok()?
@@ -76,7 +76,7 @@ mod imp {
     /// e.g. `C:\Users\Alice\AppData\Local\dev.firezone.client\data`
     ///
     /// Things like actor name go here
-    pub(crate) fn session() -> Option<PathBuf> {
+    pub fn session() -> Option<PathBuf> {
         Some(
             connlib_shared::windows::app_local_data_dir()
                 .ok()?
@@ -87,7 +87,7 @@ mod imp {
     /// e.g. `C:\Users\Alice\AppData\Local\dev.firezone.client\config`
     ///
     /// See connlib docs for details
-    pub(crate) fn settings() -> Option<PathBuf> {
+    pub fn settings() -> Option<PathBuf> {
         Some(
             connlib_shared::windows::app_local_data_dir()
                 .ok()?

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -20,6 +20,8 @@ use tokio::sync::mpsc;
 
 use imp::default_token_path;
 
+pub mod known_dirs;
+
 #[cfg(target_os = "linux")]
 pub mod imp_linux;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
This should make it easier for the IPC services on both Linux and Windows to write logs to well-known dirs that the GUI can read for exporting zips.