### PR TITLE
fix(connlib): resource filter deserialization

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -153,6 +153,12 @@ where
         None
     }
 
+    pub fn update_resource(&mut self, resource: ResourceDescription) {
+        for peer in self.role_state.peers.iter_mut() {
+            peer.update_resource(&resource);
+        }
+    }
+
     #[tracing::instrument(level = "debug", skip_all, fields(%resource, %client))]
     pub fn remove_access(&mut self, client: &ClientId, resource: &ResourceId) {
         let Some(peer) = self.role_state.peers.get_mut(client) else {

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -216,6 +216,19 @@ impl ClientOnGateway {
         self.recalculate_filters();
     }
 
+    // Note: we only allow updating filters and names
+    // but names updates have no effect on the gateway
+    pub(crate) fn update_resource(
+        &mut self,
+        resource: &connlib_shared::messages::gateway::ResourceDescription,
+    ) {
+        let Some(old_resource) = self.resources.get_mut(&resource.id()) else {
+            return;
+        };
+        old_resource.filters = resource.filters();
+        self.recalculate_filters();
+    }
+
     // Call this after any resources change
     //
     // This recalculate the ip-table rules, this allows us to remove and add resources and keep the allow-list correct

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -192,6 +192,12 @@ impl Eventloop {
             } => {
                 // TODO: Handle `init` message during operation.
             }
+            phoenix_channel::Event::InboundMessage {
+                msg: IngressMessages::ResourceUpdated(resource_description),
+                ..
+            } => {
+                self.tunnel.update_resource(resource_description);
+            }
             phoenix_channel::Event::ErrorResponse { topic, req_id, res } => {
                 tracing::warn!(%topic, %req_id, "Request failed: {res:?}");
             }

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -116,6 +116,9 @@ pub struct ConnectionReady {
 #[cfg(test)]
 mod test {
     use super::*;
+    use connlib_shared::messages::gateway::Filter;
+    use connlib_shared::messages::gateway::PortRange;
+    use connlib_shared::messages::gateway::ResourceDescriptionDns;
     use connlib_shared::messages::Turn;
     use phoenix_channel::InitMessage;
     use phoenix_channel::PhoenixMessage;
@@ -329,6 +332,26 @@ mod test {
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":[true,false],"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
         let ingress_message = serde_json::from_str::<InitMessage<InitGateway>>(message).unwrap();
+        assert_eq!(m, ingress_message);
+    }
+
+    #[test]
+    fn resource_updated() {
+        let message = r#"{"event":"resource_updated","ref":null,"topic":"gateway","payload":{"id":"57f9ebbb-21d5-4f9f-bf86-b25122fc7a43","name":"?.httpbin","type":"dns","address":"?.httpbin","filters":[{"protocol":"icmp"},{"protocol":"tcp"}]}}"#;
+        let m =
+            IngressMessages::ResourceUpdated(ResourceDescription::Dns(ResourceDescriptionDns {
+                id: "57f9ebbb-21d5-4f9f-bf86-b25122fc7a43".parse().unwrap(),
+                address: "?.httpbin".to_string(),
+                name: "?.httpbin".to_string(),
+                filters: vec![
+                    Filter::Icmp,
+                    Filter::Tcp(PortRange {
+                        port_range_end: 65535,
+                        port_range_start: 0,
+                    }),
+                ],
+            }));
+        let ingress_message = serde_json::from_str::<IngressMessages>(message).unwrap();
         assert_eq!(m, ingress_message);
     }
 

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -75,6 +75,7 @@ pub enum IngressMessages {
     InvalidateIceCandidates(ClientIceCandidates),
     Init(InitGateway),
     RelaysPresence(RelaysPresence),
+    ResourceUpdated(ResourceDescription),
 }
 
 /// A client's ice candidate message.


### PR DESCRIPTION
There was an error on how resource filters were deserialized in the gateway:

* we always assumed that there would be the ports included but the portal sends no port down when the "all" range is allowed
* also we didn't support the resource_updated message, this fixes it, and resources allow-list can be changes in-flight