### PR TITLE
fix(connlib): filters for resoruces with multiple ips

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -133,9 +133,12 @@ where
 
         let peer = self.role_state.peers.get_mut(&client)?;
 
-        for address in resource.addresses() {
-            peer.add_resource(address, resource.id(), resource.filters(), expires_at);
-        }
+        peer.add_resource(
+            resource.addresses(),
+            resource.id(),
+            resource.filters(),
+            expires_at,
+        );
 
         tracing::info!(%client, resource = %resource.id(), expires = ?expires_at.map(|e| e.to_rfc3339()), "Allowing access to resource");
 
@@ -196,9 +199,7 @@ where
     ) {
         let mut peer = ClientOnGateway::new(client_id, &ips);
 
-        for address in resource_addresses {
-            peer.add_resource(address, resource, filters.clone(), expires_at);
-        }
+        peer.add_resource(resource_addresses, resource, filters.clone(), expires_at);
 
         self.role_state.peers.insert(peer, &ips);
     }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -199,7 +199,7 @@ where
     ) {
         let mut peer = ClientOnGateway::new(client_id, &ips);
 
-        peer.add_resource(resource_addresses, resource, filters.clone(), expires_at);
+        peer.add_resource(resource_addresses, resource, filters, expires_at);
 
         self.role_state.peers.insert(peer, &ips);
     }

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -543,7 +543,7 @@ mod proptests {
             &src.clone().into_iter().map(Into::into).collect_vec(),
         );
 
-        peer.add_resource(resource_addr, resource_id, filters.clone(), None);
+        peer.add_resource(resource_addr, resource_id, filters, None);
 
         for dest in dest {
             for src in &src {


### PR DESCRIPTION
Fixes a bug, wherein a resource with multiple ip, would get a single allowed ip since each time `add_resource` was called it was replacing the previous one.

For the fix we add all the resource ips with a single call, and then use those multiple ips to calculate the filters.

The edge-case here is if there are 2 DNS resources with some overlapping ips but some not overlapping: In that case, overlapping ips would get both filters non-overlapping would only get those corresponding to its ips.

Note that only dns resources can get multiple ips for now.