### PR TITLE
feat(connlib): report resource status to client

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1183,7 +1183,6 @@ dependencies = [
  "snownet",
  "swift-bridge",
  "tempfile",
- "test-strategy",
  "thiserror",
  "tokio",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1183,6 +1183,7 @@ dependencies = [
  "snownet",
  "swift-bridge",
  "tempfile",
+ "test-strategy",
  "thiserror",
  "tokio",
  "tracing",

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -4,8 +4,8 @@
 // ecosystem, so it's used here for consistency.
 
 use connlib_client_shared::{
-    file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error, LoginUrl, LoginUrlError,
-    ResourceDescription, Session, Sockets,
+    callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error,
+    LoginUrl, LoginUrlError, Session, Sockets,
 };
 use jni::{
     objects::{GlobalRef, JClass, JObject, JString, JValue},

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -2,8 +2,8 @@
 #![allow(clippy::unnecessary_cast, improper_ctypes, non_camel_case_types)]
 
 use connlib_client_shared::{
-    file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error, LoginUrl, ResourceDescription, Session,
-    Sockets,
+    file_logger, keypair, Callbacks, Callbacks::ResourceDescription, Cidrv4, Cidrv6, Error,
+    LoginUrl, Session, Sockets,
 };
 use secrecy::SecretString;
 use std::{

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::unnecessary_cast, improper_ctypes, non_camel_case_types)]
 
 use connlib_client_shared::{
-    file_logger, keypair, Callbacks, Callbacks::ResourceDescription, Cidrv4, Cidrv6, Error,
+    callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error,
     LoginUrl, Session, Sockets,
 };
 use secrecy::SecretString;

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -325,7 +325,6 @@ where
                 tracing::debug!(resource_id = %offline_resource, "Resource is offline");
 
                 self.tunnel.set_resource_offline(offline_resource);
-                self.tunnel.cleanup_connection(offline_resource);
             }
 
             ErrorReply::Disabled => {

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -321,6 +321,7 @@ where
 
                 tracing::debug!(resource_id = %offline_resource, "Resource is offline");
 
+                self.tunnel.offline_resource(offline_resource);
                 self.tunnel.cleanup_connection(offline_resource);
             }
 

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -269,7 +269,7 @@ where
                 gateway_id,
                 resource_id,
                 relays,
-                gateway_group_id,
+                site_id,
                 ..
             }) => {
                 let should_accept = self
@@ -285,7 +285,7 @@ where
                     resource_id,
                     gateway_id,
                     relays,
-                    gateway_group_id,
+                    site_id,
                 ) {
                     Ok(firezone_tunnel::Request::NewConnection(connection_request)) => {
                         // TODO: keep track for the response
@@ -324,7 +324,7 @@ where
 
                 tracing::debug!(resource_id = %offline_resource, "Resource is offline");
 
-                self.tunnel.offline_resource(offline_resource);
+                self.tunnel.set_resource_offline(offline_resource);
                 self.tunnel.cleanup_connection(offline_resource);
             }
 

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -269,6 +269,7 @@ where
                 gateway_id,
                 resource_id,
                 relays,
+                gateway_group_id,
                 ..
             }) => {
                 let should_accept = self
@@ -280,10 +281,12 @@ where
                     return;
                 }
 
-                match self
-                    .tunnel
-                    .create_or_reuse_connection(resource_id, gateway_id, relays)
-                {
+                match self.tunnel.create_or_reuse_connection(
+                    resource_id,
+                    gateway_id,
+                    relays,
+                    gateway_group_id,
+                ) {
                     Ok(firezone_tunnel::Request::NewConnection(connection_request)) => {
                         // TODO: keep track for the response
                         let _id = self.portal.send(

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -1,7 +1,7 @@
 //! Main connlib library for clients.
 pub use connlib_shared::messages::client::ResourceDescription;
 pub use connlib_shared::{
-    keypair, Callbacks, Cidrv4, Cidrv6, Error, LoginUrl, LoginUrlError, StaticSecret,
+    callbacks, keypair, Callbacks, Cidrv4, Cidrv6, Error, LoginUrl, LoginUrlError, StaticSecret,
 };
 pub use firezone_tunnel::Sockets;
 pub use tracing_appender::non_blocking::WorkerGuard;

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -103,7 +103,7 @@ mod test {
     use super::*;
     use chrono::DateTime;
     use connlib_shared::messages::{
-        client::{GatewayGroup, ResourceDescriptionCidr, ResourceDescriptionDns, Status},
+        client::{GatewayGroup, ResourceDescriptionCidr, ResourceDescriptionDns},
         DnsServer, IpDnsServer, Stun, Turn,
     };
     use phoenix_channel::{OutboundRequestId, PhoenixMessage};

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -101,8 +101,7 @@ mod test {
     use super::*;
     use chrono::DateTime;
     use connlib_shared::messages::{
-        client::ResourceDescriptionCidr,
-        client::{GatewayGroup, ResourceDescriptionDns},
+        client::{GatewayGroup, ResourceDescriptionCidr, ResourceDescriptionDns, Status},
         DnsServer, IpDnsServer, Stun, Turn,
     };
     use phoenix_channel::{OutboundRequestId, PhoenixMessage};
@@ -238,6 +237,7 @@ mod test {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
+                        status: Status::Unknown,
                     }),
                     ResourceDescription::Dns(ResourceDescriptionDns {
                         id: "03000143-e25e-45c7-aafb-144990e57dcd".parse().unwrap(),
@@ -248,6 +248,7 @@ mod test {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
+                        status: Status::Unknown,
                     }),
                 ],
                 relays: vec![],
@@ -311,6 +312,7 @@ mod test {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
+                        status: Status::Unknown,
                     }),
                     ResourceDescription::Dns(ResourceDescriptionDns {
                         id: "03000143-e25e-45c7-aafb-144990e57dcd".parse().unwrap(),
@@ -321,6 +323,7 @@ mod test {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
+                        status: Status::Unknown,
                     }),
                 ],
                 relays: vec![],

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -26,7 +26,8 @@ pub struct ConnectionDetails {
     pub resource_id: ResourceId,
     pub gateway_id: GatewayId,
     pub gateway_remote_ip: IpAddr,
-    pub gateway_group_id: SiteId,
+    #[serde(rename = "gateway_group_id")]
+    pub site_id: SiteId,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
@@ -103,7 +104,7 @@ mod test {
     use super::*;
     use chrono::DateTime;
     use connlib_shared::messages::{
-        client::{GatewayGroup, ResourceDescriptionCidr, ResourceDescriptionDns},
+        client::{ResourceDescriptionCidr, ResourceDescriptionDns, Site},
         DnsServer, IpDnsServer, Stun, Turn,
     };
     use phoenix_channel::{OutboundRequestId, PhoenixMessage};
@@ -235,7 +236,7 @@ mod test {
                         address: "172.172.0.0/16".parse().unwrap(),
                         name: "172.172.0.0/16".to_string(),
                         address_description: "cidr resource".to_string(),
-                        gateway_groups: vec![GatewayGroup {
+                        gateway_groups: vec![Site {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
@@ -245,7 +246,7 @@ mod test {
                         address: "gitlab.mycorp.com".to_string(),
                         name: "gitlab.mycorp.com".to_string(),
                         address_description: "dns resource".to_string(),
-                        gateway_groups: vec![GatewayGroup {
+                        sites: vec![Site {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
@@ -308,7 +309,7 @@ mod test {
                         address: "172.172.0.0/16".parse().unwrap(),
                         name: "172.172.0.0/16".to_string(),
                         address_description: "cidr resource".to_string(),
-                        gateway_groups: vec![GatewayGroup {
+                        gateway_groups: vec![Site {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
@@ -318,7 +319,7 @@ mod test {
                         address: "gitlab.mycorp.com".to_string(),
                         name: "gitlab.mycorp.com".to_string(),
                         address_description: "dns resource".to_string(),
-                        gateway_groups: vec![GatewayGroup {
+                        sites: vec![Site {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
@@ -537,7 +538,7 @@ mod test {
                 gateway_id: "73037362-715d-4a83-a749-f18eadd970e6".parse().unwrap(),
                 gateway_remote_ip: "172.28.0.1".parse().unwrap(),
                 resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
-                gateway_group_id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
+                site_id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                 relays: vec![
                     Relay::Stun(Stun {
                         id: "c9cb8892-e355-41e6-a882-b6d6c38beb66".parse().unwrap(),

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -236,7 +236,7 @@ mod test {
                         address: "172.172.0.0/16".parse().unwrap(),
                         name: "172.172.0.0/16".to_string(),
                         address_description: "cidr resource".to_string(),
-                        gateway_groups: vec![Site {
+                        sites: vec![Site {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
@@ -309,7 +309,7 @@ mod test {
                         address: "172.172.0.0/16".parse().unwrap(),
                         name: "172.172.0.0/16".to_string(),
                         address_description: "cidr resource".to_string(),
-                        gateway_groups: vec![Site {
+                        sites: vec![Site {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -1,6 +1,7 @@
 use connlib_shared::messages::{
-    client::ResourceDescription, GatewayId, GatewayResponse, Interface, Key, Relay, RelaysPresence,
-    RequestConnection, ResourceId, ReuseConnection,
+    client::{ResourceDescription, SiteId},
+    GatewayId, GatewayResponse, Interface, Key, Relay, RelaysPresence, RequestConnection,
+    ResourceId, ReuseConnection,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, net::IpAddr};
@@ -25,6 +26,7 @@ pub struct ConnectionDetails {
     pub resource_id: ResourceId,
     pub gateway_id: GatewayId,
     pub gateway_remote_ip: IpAddr,
+    pub gateway_group_id: SiteId,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
@@ -237,7 +239,6 @@ mod test {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
-                        status: Status::Unknown,
                     }),
                     ResourceDescription::Dns(ResourceDescriptionDns {
                         id: "03000143-e25e-45c7-aafb-144990e57dcd".parse().unwrap(),
@@ -248,7 +249,6 @@ mod test {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
-                        status: Status::Unknown,
                     }),
                 ],
                 relays: vec![],
@@ -312,7 +312,6 @@ mod test {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
-                        status: Status::Unknown,
                     }),
                     ResourceDescription::Dns(ResourceDescriptionDns {
                         id: "03000143-e25e-45c7-aafb-144990e57dcd".parse().unwrap(),
@@ -323,7 +322,6 @@ mod test {
                             name: "test".to_string(),
                             id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                         }],
-                        status: Status::Unknown,
                     }),
                 ],
                 relays: vec![],
@@ -539,6 +537,7 @@ mod test {
                 gateway_id: "73037362-715d-4a83-a749-f18eadd970e6".parse().unwrap(),
                 gateway_remote_ip: "172.28.0.1".parse().unwrap(),
                 resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
+                gateway_group_id: "bf56f32d-7b2c-4f5d-a784-788977d014a4".parse().unwrap(),
                 relays: vec![
                     Relay::Stun(Stun {
                         id: "c9cb8892-e355-41e6-a882-b6d6c38beb66".parse().unwrap(),
@@ -576,6 +575,7 @@ mod test {
                         "resource_id": "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3",
                         "gateway_id": "73037362-715d-4a83-a749-f18eadd970e6",
                         "gateway_remote_ip": "172.28.0.1",
+                        "gateway_group_id": "bf56f32d-7b2c-4f5d-a784-788977d014a4",
                         "relays": [
                             {
                                 "id": "c9cb8892-e355-41e6-a882-b6d6c38beb66",

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 mock = []
-proptest = ["dep:test-strategy", "dep:proptest", "dep:itertools"]
+proptest = ["dep:proptest", "dep:itertools"]
 
 [dependencies]
 anyhow = "1.0.82"
@@ -35,7 +35,6 @@ libc = "0.2"
 snownet = { workspace = true }
 phoenix-channel = { workspace = true }
 proptest = { version = "1.4.0", optional = true }
-test-strategy = { version = "0.3.1", optional = true }
 itertools = { version = "0.12", optional = true }
 
 # Needed for Android logging until tracing is working

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 mock = []
+proptest = ["dep:test-strategy", "dep:proptest"]
 
 [dependencies]
 anyhow = "1.0.82"
@@ -34,6 +35,7 @@ libc = "0.2"
 snownet = { workspace = true }
 phoenix-channel = { workspace = true }
 proptest = { version = "1.4.0", optional = true }
+test-strategy = { version = "0.3.1", optional = true }
 
 # Needed for Android logging until tracing is working
 log = "0.4"

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 mock = []
-proptest = ["dep:test-strategy", "dep:proptest"]
+proptest = ["dep:test-strategy", "dep:proptest", "dep:itertools"]
 
 [dependencies]
 anyhow = "1.0.82"
@@ -36,13 +36,14 @@ snownet = { workspace = true }
 phoenix-channel = { workspace = true }
 proptest = { version = "1.4.0", optional = true }
 test-strategy = { version = "0.3.1", optional = true }
+itertools = { version = "0.12", optional = true }
 
 # Needed for Android logging until tracing is working
 log = "0.4"
 
 [dev-dependencies]
-itertools = "0.12"
 tempfile = "3.10.1"
+itertools = "0.12"
 mutants = "0.0.3" # Needed to mark functions as exempt from `cargo-mutants` testing
 tokio = { version = "1.36", features = ["macros", "rt"] }
 

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use crate::messages::client::GatewayGroup;
+use crate::messages::client::Site;
 use crate::messages::ResourceId;
 
 // Avoids having to map types for Windows
@@ -57,20 +57,6 @@ pub enum ResourceDescription {
 }
 
 impl ResourceDescription {
-    pub fn with_status(
-        r: crate::messages::client::ResourceDescription,
-        status: Status,
-    ) -> ResourceDescription {
-        match r {
-            crate::messages::client::ResourceDescription::Dns(r) => {
-                ResourceDescription::Dns(ResourceDescriptionDns::with_status(r, status))
-            }
-            crate::messages::client::ResourceDescription::Cidr(r) => {
-                ResourceDescription::Cidr(ResourceDescriptionCidr::with_status(r, status))
-            }
-        }
-    }
-
     pub fn name(&self) -> &str {
         match self {
             ResourceDescription::Dns(r) => &r.name,
@@ -126,25 +112,9 @@ pub struct ResourceDescriptionDns {
     pub name: String,
 
     pub address_description: String,
-    pub gateway_groups: Vec<GatewayGroup>,
+    pub gateway_groups: Vec<Site>,
 
     pub status: Status,
-}
-
-impl ResourceDescriptionDns {
-    fn with_status(
-        r: crate::messages::client::ResourceDescriptionDns,
-        status: Status,
-    ) -> ResourceDescriptionDns {
-        ResourceDescriptionDns {
-            id: r.id,
-            address: r.address,
-            name: r.name,
-            address_description: r.address_description,
-            gateway_groups: r.gateway_groups,
-            status,
-        }
-    }
 }
 
 impl From<ResourceDescriptionDns> for crate::messages::client::ResourceDescriptionDns {
@@ -154,7 +124,7 @@ impl From<ResourceDescriptionDns> for crate::messages::client::ResourceDescripti
             address: r.address,
             address_description: r.address_description,
             name: r.name,
-            gateway_groups: r.gateway_groups,
+            sites: r.gateway_groups,
         }
     }
 }
@@ -172,25 +142,9 @@ pub struct ResourceDescriptionCidr {
     pub name: String,
 
     pub address_description: String,
-    pub gateway_groups: Vec<GatewayGroup>,
+    pub gateway_groups: Vec<Site>,
 
     pub status: Status,
-}
-
-impl ResourceDescriptionCidr {
-    fn with_status(
-        r: crate::messages::client::ResourceDescriptionCidr,
-        status: Status,
-    ) -> ResourceDescriptionCidr {
-        ResourceDescriptionCidr {
-            id: r.id,
-            address: r.address,
-            name: r.name,
-            address_description: r.address_description,
-            gateway_groups: r.gateway_groups,
-            status,
-        }
-    }
 }
 
 impl From<ResourceDescriptionCidr> for crate::messages::client::ResourceDescriptionCidr {

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -101,6 +101,19 @@ impl ResourceDescription {
     }
 }
 
+impl From<ResourceDescription> for crate::messages::client::ResourceDescription {
+    fn from(value: ResourceDescription) -> Self {
+        match value {
+            ResourceDescription::Dns(r) => {
+                crate::messages::client::ResourceDescription::Dns(r.into())
+            }
+            ResourceDescription::Cidr(r) => {
+                crate::messages::client::ResourceDescription::Cidr(r.into())
+            }
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub struct ResourceDescriptionDns {
     /// Resource's id.
@@ -130,6 +143,18 @@ impl ResourceDescriptionDns {
             address_description: r.address_description,
             gateway_groups: r.gateway_groups,
             status,
+        }
+    }
+}
+
+impl From<ResourceDescriptionDns> for crate::messages::client::ResourceDescriptionDns {
+    fn from(r: ResourceDescriptionDns) -> Self {
+        crate::messages::client::ResourceDescriptionDns {
+            id: r.id,
+            address: r.address,
+            address_description: r.address_description,
+            name: r.name,
+            gateway_groups: r.gateway_groups,
         }
     }
 }
@@ -164,6 +189,18 @@ impl ResourceDescriptionCidr {
             address_description: r.address_description,
             gateway_groups: r.gateway_groups,
             status,
+        }
+    }
+}
+
+impl From<ResourceDescriptionCidr> for crate::messages::client::ResourceDescriptionCidr {
+    fn from(r: ResourceDescriptionCidr) -> Self {
+        crate::messages::client::ResourceDescriptionCidr {
+            id: r.id,
+            address: r.address,
+            address_description: r.address_description,
+            name: r.name,
+            gateway_groups: r.gateway_groups,
         }
     }
 }

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -1,8 +1,10 @@
-use crate::messages::client::ResourceDescription;
-use ip_network::{Ipv4Network, Ipv6Network};
+use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use serde::Serialize;
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use crate::messages::client::GatewayGroup;
+use crate::messages::ResourceId;
 
 // Avoids having to map types for Windows
 type RawFd = i32;
@@ -35,6 +37,103 @@ impl From<Ipv6Network> for Cidrv6 {
         Self {
             address: value.network_address(),
             prefix: value.netmask(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Status {
+    Unknown,
+    Online,
+    Offline,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResourceDescription {
+    Dns(ResourceDescriptionDns),
+    Cidr(ResourceDescriptionCidr),
+}
+
+impl ResourceDescription {
+    pub fn with_status(
+        r: crate::messages::client::ResourceDescription,
+        status: Status,
+    ) -> ResourceDescription {
+        match r {
+            crate::messages::client::ResourceDescription::Dns(r) => {
+                ResourceDescription::Dns(ResourceDescriptionDns::with_status(r, status))
+            }
+            crate::messages::client::ResourceDescription::Cidr(r) => {
+                ResourceDescription::Cidr(ResourceDescriptionCidr::with_status(r, status))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash)]
+pub struct ResourceDescriptionDns {
+    /// Resource's id.
+    pub id: ResourceId,
+    /// Internal resource's domain name.
+    pub address: String,
+    /// Name of the resource.
+    ///
+    /// Used only for display.
+    pub name: String,
+
+    pub address_description: String,
+    pub gateway_groups: Vec<GatewayGroup>,
+
+    pub status: Status,
+}
+
+impl ResourceDescriptionDns {
+    fn with_status(
+        r: crate::messages::client::ResourceDescriptionDns,
+        status: Status,
+    ) -> ResourceDescriptionDns {
+        ResourceDescriptionDns {
+            id: r.id,
+            address: r.address,
+            name: r.name,
+            address_description: r.address_description,
+            gateway_groups: r.gateway_groups,
+            status,
+        }
+    }
+}
+
+/// Description of a resource that maps to a CIDR.
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ResourceDescriptionCidr {
+    /// Resource's id.
+    pub id: ResourceId,
+    /// CIDR that this resource points to.
+    pub address: IpNetwork,
+    /// Name of the resource.
+    ///
+    /// Used only for display.
+    pub name: String,
+
+    pub address_description: String,
+    pub gateway_groups: Vec<GatewayGroup>,
+
+    pub status: Status,
+}
+
+impl ResourceDescriptionCidr {
+    fn with_status(
+        r: crate::messages::client::ResourceDescriptionCidr,
+        status: Status,
+    ) -> ResourceDescriptionCidr {
+        ResourceDescriptionCidr {
+            id: r.id,
+            address: r.address,
+            name: r.name,
+            address_description: r.address_description,
+            gateway_groups: r.gateway_groups,
+            status,
         }
     }
 }

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -112,7 +112,7 @@ pub struct ResourceDescriptionDns {
     pub name: String,
 
     pub address_description: String,
-    pub gateway_groups: Vec<Site>,
+    pub sites: Vec<Site>,
 
     pub status: Status,
 }
@@ -124,7 +124,7 @@ impl From<ResourceDescriptionDns> for crate::messages::client::ResourceDescripti
             address: r.address,
             address_description: r.address_description,
             name: r.name,
-            sites: r.gateway_groups,
+            sites: r.sites,
         }
     }
 }
@@ -142,7 +142,7 @@ pub struct ResourceDescriptionCidr {
     pub name: String,
 
     pub address_description: String,
-    pub gateway_groups: Vec<Site>,
+    pub sites: Vec<Site>,
 
     pub status: Status,
 }
@@ -154,7 +154,7 @@ impl From<ResourceDescriptionCidr> for crate::messages::client::ResourceDescript
             address: r.address,
             address_description: r.address_description,
             name: r.name,
-            gateway_groups: r.gateway_groups,
+            sites: r.sites,
         }
     }
 }

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -3,7 +3,7 @@
 //! This includes types provided by external crates, i.e. [boringtun] to make sure that
 //! we are using the same version across our own crates.
 
-mod callbacks;
+pub mod callbacks;
 pub mod error;
 pub mod messages;
 

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -329,6 +329,7 @@ mod tests {
                 name: "test".to_string(),
                 id: "99ba0c1e-5189-4cfc-a4db-fd6cb1c937fd".parse().unwrap(),
             }],
+            status: super::client::Status::Unknown,
         })
     }
 

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -50,6 +50,13 @@ impl ClientId {
     }
 }
 
+impl GatewayId {
+    #[cfg(feature = "proptest")]
+    pub(crate) fn from_u128(v: u128) -> Self {
+        Self(Uuid::from_u128(v))
+    }
+}
+
 #[derive(Hash, Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub struct ClientId(Uuid);
 

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -322,7 +322,7 @@ mod tests {
 
     use super::{
         client::ResourceDescription,
-        client::{GatewayGroup, ResourceDescriptionDns},
+        client::{ResourceDescriptionDns, Site},
         ResourceId,
     };
 
@@ -332,7 +332,7 @@ mod tests {
             name: name.to_string(),
             address: "unused.example.com".to_string(),
             address_description: "test description".to_string(),
-            gateway_groups: vec![GatewayGroup {
+            sites: vec![Site {
                 name: "test".to_string(),
                 id: "99ba0c1e-5189-4cfc-a4db-fd6cb1c937fd".parse().unwrap(),
             }],

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -329,7 +329,6 @@ mod tests {
                 name: "test".to_string(),
                 id: "99ba0c1e-5189-4cfc-a4db-fd6cb1c937fd".parse().unwrap(),
             }],
-            status: super::client::Status::Unknown,
         })
     }
 

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -10,18 +10,15 @@ use super::ResourceId;
 
 // TODO: decide if we keep the same ResourceDescription message or we separate into a non-deserializable thing
 
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default,
+)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub enum Status {
+    #[default]
     Unknown,
     Online,
     Offline,
-}
-
-impl Default for Status {
-    fn default() -> Self {
-        Status::Unknown
-    }
 }
 
 /// Description of a resource that maps to a DNS record.

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -34,7 +34,7 @@ impl ResourceDescriptionDns {
             address: self.address,
             name: self.name,
             address_description: self.address_description,
-            gateway_groups: self.sites,
+            sites: self.sites,
             status,
         }
     }
@@ -53,7 +53,8 @@ pub struct ResourceDescriptionCidr {
     pub name: String,
 
     pub address_description: String,
-    pub gateway_groups: Vec<Site>,
+    #[serde(rename = "gateway_groups")]
+    pub sites: Vec<Site>,
 }
 
 impl ResourceDescriptionCidr {
@@ -63,7 +64,7 @@ impl ResourceDescriptionCidr {
             address: self.address,
             name: self.name,
             address_description: self.address_description,
-            gateway_groups: self.gateway_groups,
+            sites: self.sites,
             status,
         }
     }
@@ -108,10 +109,10 @@ impl ResourceDescription {
         }
     }
 
-    pub fn gateway_groups(&self) -> HashSet<&Site> {
+    pub fn sites(&self) -> HashSet<&Site> {
         match self {
             ResourceDescription::Dns(r) => HashSet::from_iter(r.sites.iter()),
-            ResourceDescription::Cidr(r) => HashSet::from_iter(r.gateway_groups.iter()),
+            ResourceDescription::Cidr(r) => HashSet::from_iter(r.sites.iter()),
         }
     }
 

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -10,17 +10,6 @@ use super::ResourceId;
 
 // TODO: decide if we keep the same ResourceDescription message or we separate into a non-deserializable thing
 
-#[derive(
-    Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default,
-)]
-#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
-pub enum Status {
-    #[default]
-    Unknown,
-    Online,
-    Offline,
-}
-
 /// Description of a resource that maps to a DNS record.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
 pub struct ResourceDescriptionDns {
@@ -35,9 +24,6 @@ pub struct ResourceDescriptionDns {
 
     pub address_description: String,
     pub gateway_groups: Vec<GatewayGroup>,
-
-    #[serde(default)]
-    pub status: Status,
 }
 
 /// Description of a resource that maps to a CIDR.
@@ -54,9 +40,6 @@ pub struct ResourceDescriptionCidr {
 
     pub address_description: String,
     pub gateway_groups: Vec<GatewayGroup>,
-
-    #[serde(default)]
-    pub status: Status,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -65,7 +48,7 @@ pub struct GatewayGroup {
     pub id: SiteId,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SiteId(Uuid);
 
 impl FromStr for SiteId {
@@ -130,20 +113,6 @@ impl ResourceDescription {
                 cidr_a.address != cidr_b.address
             }
             _ => true,
-        }
-    }
-
-    pub fn status_mut(&mut self) -> &mut Status {
-        match self {
-            ResourceDescription::Dns(r) => &mut r.status,
-            ResourceDescription::Cidr(r) => &mut r.status,
-        }
-    }
-
-    pub fn status(&self) -> Status {
-        match self {
-            ResourceDescription::Dns(r) => r.status,
-            ResourceDescription::Cidr(r) => r.status,
         }
     }
 }

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -8,8 +8,6 @@ use uuid::Uuid;
 
 use super::ResourceId;
 
-// TODO: decide if we keep the same ResourceDescription message or we separate into a non-deserializable thing
-
 /// Description of a resource that maps to a DNS record.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
 pub struct ResourceDescriptionDns {

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -1,6 +1,6 @@
 //! Client related messages that are needed within connlib
 
-use std::{borrow::Cow, collections::HashSet, str::FromStr};
+use std::{collections::HashSet, str::FromStr};
 
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
@@ -93,14 +93,6 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => &r.name,
             ResourceDescription::Cidr(r) => &r.name,
-        }
-    }
-
-    /// What the GUI clients should paste to the clipboard, e.g. `https://github.com/firezone`
-    pub fn pastable(&self) -> Cow<'_, str> {
-        match self {
-            ResourceDescription::Dns(r) => Cow::from(&r.address),
-            ResourceDescription::Cidr(r) => Cow::from(r.address.to_string()),
         }
     }
 

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -8,6 +8,22 @@ use uuid::Uuid;
 
 use super::ResourceId;
 
+// TODO: decide if we keep the same ResourceDescription message or we separate into a non-deserializable thing
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+pub enum Status {
+    Unknown,
+    Online,
+    Offline,
+}
+
+impl Default for Status {
+    fn default() -> Self {
+        Status::Unknown
+    }
+}
+
 /// Description of a resource that maps to a DNS record.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
 pub struct ResourceDescriptionDns {
@@ -22,6 +38,9 @@ pub struct ResourceDescriptionDns {
 
     pub address_description: String,
     pub gateway_groups: Vec<GatewayGroup>,
+
+    #[serde(default)]
+    pub status: Status,
 }
 
 /// Description of a resource that maps to a CIDR.
@@ -38,6 +57,9 @@ pub struct ResourceDescriptionCidr {
 
     pub address_description: String,
     pub gateway_groups: Vec<GatewayGroup>,
+
+    #[serde(default)]
+    pub status: Status,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -104,6 +126,13 @@ impl ResourceDescription {
                 cidr_a.address != cidr_b.address
             }
             _ => true,
+        }
+    }
+
+    pub fn status(&mut self) -> &mut Status {
+        match self {
+            ResourceDescription::Dns(r) => &mut r.status,
+            ResourceDescription::Cidr(r) => &mut r.status,
         }
     }
 }

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -1,6 +1,6 @@
 //! Client related messages that are needed within connlib
 
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, collections::HashSet, str::FromStr};
 
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
@@ -101,6 +101,13 @@ impl ResourceDescription {
         }
     }
 
+    pub fn gateway_groups(&self) -> HashSet<&GatewayGroup> {
+        match self {
+            ResourceDescription::Dns(r) => HashSet::from_iter(r.gateway_groups.iter()),
+            ResourceDescription::Cidr(r) => HashSet::from_iter(r.gateway_groups.iter()),
+        }
+    }
+
     /// What the GUI clients should show as the user-friendly display name, e.g. `Firezone GitHub`
     pub fn name(&self) -> &str {
         match self {
@@ -129,10 +136,17 @@ impl ResourceDescription {
         }
     }
 
-    pub fn status(&mut self) -> &mut Status {
+    pub fn status_mut(&mut self) -> &mut Status {
         match self {
             ResourceDescription::Dns(r) => &mut r.status,
             ResourceDescription::Cidr(r) => &mut r.status,
+        }
+    }
+
+    pub fn status(&self) -> Status {
+        match self {
+            ResourceDescription::Dns(r) => r.status,
+            ResourceDescription::Cidr(r) => r.status,
         }
     }
 }

--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -1,6 +1,6 @@
 use crate::messages::{
     client::ResourceDescriptionCidr,
-    client::{GatewayGroup, ResourceDescription, ResourceDescriptionDns, SiteId, Status},
+    client::{GatewayGroup, ResourceDescription, ResourceDescriptionDns, SiteId},
     ClientId, ResourceId,
 };
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
@@ -33,18 +33,16 @@ pub fn dns_resource_with_groups(
         resource_name(),
         dns_resource_address(),
         address_description(),
-        any::<Status>(),
     )
-        .prop_map(move |(id, name, address, address_description, status)| {
-            ResourceDescriptionDns {
+        .prop_map(
+            move |(id, name, address, address_description)| ResourceDescriptionDns {
                 id,
                 address,
                 name,
                 gateway_groups: gateway_groups.clone(),
                 address_description,
-                status,
-            }
-        })
+            },
+        )
 }
 
 pub fn cidr_resource_with_groups(
@@ -56,18 +54,16 @@ pub fn cidr_resource_with_groups(
         resource_name(),
         ip_network(host_mask_bits),
         address_description(),
-        any::<Status>(),
     )
-        .prop_map(move |(id, name, address, address_description, status)| {
-            ResourceDescriptionCidr {
+        .prop_map(
+            move |(id, name, address, address_description)| ResourceDescriptionCidr {
                 id,
                 address,
                 name,
                 gateway_groups: gateway_groups.clone(),
                 address_description,
-                status,
-            }
-        })
+            },
+        )
 }
 
 pub fn dns_resource() -> impl Strategy<Value = ResourceDescriptionDns> {

--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -12,43 +12,43 @@ use proptest::{
 };
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-// Generate resources sharing 1 gateway group
-pub fn resources_sharing_group() -> impl Strategy<Value = (Vec<ResourceDescription>, Site)> {
-    (collection::vec(sites(), 1..=100), site()).prop_flat_map(|(groups, g)| {
+// Generate resources sharing 1 site
+pub fn resources_sharing_site() -> impl Strategy<Value = (Vec<ResourceDescription>, Site)> {
+    (collection::vec(sites(), 1..=100), site()).prop_flat_map(|(sites, site)| {
         (
-            groups
+            sites
                 .iter()
-                .map(|gs| {
-                    let mut groups = gs.clone();
-                    groups.push(g.clone());
-                    resource(groups.clone())
+                .map(|sites| {
+                    let mut sites = sites.clone();
+                    sites.push(site.clone());
+                    resource(sites.clone())
                 })
                 .collect_vec(),
-            Just(g),
+            Just(site),
         )
     })
 }
 
-// Generate resources sharing all gateway groups
-pub fn resources_sharing_all_groups() -> impl Strategy<Value = Vec<ResourceDescription>> {
+// Generate resources sharing all sites
+pub fn resources_sharing_all_sites() -> impl Strategy<Value = Vec<ResourceDescription>> {
     sites().prop_flat_map(|sites| collection::vec(resource(sites), 1..=100))
 }
 
 pub fn resource(sites: Vec<Site>) -> impl Strategy<Value = ResourceDescription> {
     any::<bool>().prop_flat_map(move |is_dns| {
         if is_dns {
-            dns_resource_with_groups(sites.clone())
+            dns_resource_with_sites(sites.clone())
                 .prop_map(ResourceDescription::Dns)
                 .boxed()
         } else {
-            cidr_resource_with_groups(8, sites.clone())
+            cidr_resource_with_sites(8, sites.clone())
                 .prop_map(ResourceDescription::Cidr)
                 .boxed()
         }
     })
 }
 
-pub fn dns_resource_with_groups(sites: Vec<Site>) -> impl Strategy<Value = ResourceDescriptionDns> {
+pub fn dns_resource_with_sites(sites: Vec<Site>) -> impl Strategy<Value = ResourceDescriptionDns> {
     (
         resource_id(),
         resource_name(),
@@ -66,7 +66,7 @@ pub fn dns_resource_with_groups(sites: Vec<Site>) -> impl Strategy<Value = Resou
         )
 }
 
-pub fn cidr_resource_with_groups(
+pub fn cidr_resource_with_sites(
     host_mask_bits: usize,
     sites: Vec<Site>,
 ) -> impl Strategy<Value = ResourceDescriptionCidr> {
@@ -88,11 +88,11 @@ pub fn cidr_resource_with_groups(
 }
 
 pub fn dns_resource() -> impl Strategy<Value = ResourceDescriptionDns> {
-    sites().prop_flat_map(dns_resource_with_groups)
+    sites().prop_flat_map(dns_resource_with_sites)
 }
 
 pub fn cidr_resource(host_mask_bits: usize) -> impl Strategy<Value = ResourceDescriptionCidr> {
-    sites().prop_flat_map(move |sites| cidr_resource_with_groups(host_mask_bits, sites))
+    sites().prop_flat_map(move |sites| cidr_resource_with_sites(host_mask_bits, sites))
 }
 
 pub fn address_description() -> impl Strategy<Value = String> {

--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -1,6 +1,6 @@
 use crate::messages::{
     client::ResourceDescriptionCidr,
-    client::{GatewayGroup, ResourceDescriptionDns, SiteId},
+    client::{GatewayGroup, ResourceDescriptionDns, SiteId, Status},
     ClientId, ResourceId,
 };
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
@@ -18,16 +18,20 @@ pub fn dns_resource() -> impl Strategy<Value = ResourceDescriptionDns> {
         dns_resource_address(),
         gateway_groups(),
         address_description(),
+        any::<Status>(),
     )
-        .prop_map(|(id, name, address, gateway_groups, address_description)| {
-            ResourceDescriptionDns {
-                id,
-                address,
-                name,
-                gateway_groups,
-                address_description,
-            }
-        })
+        .prop_map(
+            |(id, name, address, gateway_groups, address_description, status)| {
+                ResourceDescriptionDns {
+                    id,
+                    address,
+                    name,
+                    gateway_groups,
+                    address_description,
+                    status,
+                }
+            },
+        )
 }
 
 pub fn cidr_resource(host_mask_bits: usize) -> impl Strategy<Value = ResourceDescriptionCidr> {
@@ -37,16 +41,20 @@ pub fn cidr_resource(host_mask_bits: usize) -> impl Strategy<Value = ResourceDes
         ip_network(host_mask_bits),
         gateway_groups(),
         address_description(),
+        any::<Status>(),
     )
-        .prop_map(|(id, name, address, gateway_groups, address_description)| {
-            ResourceDescriptionCidr {
-                id,
-                address,
-                name,
-                gateway_groups,
-                address_description,
-            }
-        })
+        .prop_map(
+            |(id, name, address, gateway_groups, address_description, status)| {
+                ResourceDescriptionCidr {
+                    id,
+                    address,
+                    name,
+                    gateway_groups,
+                    address_description,
+                    status,
+                }
+            },
+        )
 }
 
 pub fn address_description() -> impl Strategy<Value = String> {

--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -33,18 +33,18 @@ pub fn resources_sharing_group() -> impl Strategy<Value = (Vec<ResourceDescripti
 // Generate resources sharing all gateway groups
 pub fn resources_sharing_all_groups() -> impl Strategy<Value = Vec<ResourceDescription>> {
     gateway_groups()
-        .prop_flat_map(|gateway_groups| collection::vec(resource(gateway_groups.clone()), 1..=100))
+        .prop_flat_map(|gateway_groups| collection::vec(resource(gateway_groups), 1..=100))
 }
 
 pub fn resource(gateway_groups: Vec<GatewayGroup>) -> impl Strategy<Value = ResourceDescription> {
     any::<bool>().prop_flat_map(move |is_dns| {
         if is_dns {
             dns_resource_with_groups(gateway_groups.clone())
-                .prop_map(|r| ResourceDescription::Dns(r))
+                .prop_map(ResourceDescription::Dns)
                 .boxed()
         } else {
             cidr_resource_with_groups(8, gateway_groups.clone())
-                .prop_map(|r| ResourceDescription::Cidr(r))
+                .prop_map(ResourceDescription::Cidr)
                 .boxed()
         }
     })
@@ -92,7 +92,7 @@ pub fn cidr_resource_with_groups(
 }
 
 pub fn dns_resource() -> impl Strategy<Value = ResourceDescriptionDns> {
-    gateway_groups().prop_flat_map(|gateway_groups| dns_resource_with_groups(gateway_groups))
+    gateway_groups().prop_flat_map(dns_resource_with_groups)
 }
 
 pub fn cidr_resource(host_mask_bits: usize) -> impl Strategy<Value = ResourceDescriptionCidr> {

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -972,7 +972,7 @@ impl ClientState {
     pub(crate) fn add_resources(&mut self, resources: &[ResourceDescription]) {
         for resource_description in resources {
             if let Some(resource) = self.resource_ids.get(&resource_description.id()) {
-                if resource.has_different_address(&resource_description) {
+                if resource.has_different_address(resource_description) {
                     self.remove_resources(&[resource.id()]);
                 }
             }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -803,7 +803,7 @@ impl ClientState {
     }
 
     pub fn cleanup_connected_gateway(&mut self, gateway_id: &GatewayId) {
-        self.update_site_status_by_gateway(&gateway_id, Status::Unknown);
+        self.update_site_status_by_gateway(gateway_id, Status::Unknown);
         self.peers.remove(gateway_id);
         self.dns_resources_internal_ips.retain(|resource, _| {
             !self

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -179,6 +179,8 @@ where
     pub fn set_resource_offline(&mut self, id: ResourceId) {
         self.role_state.set_resource_offline(id);
 
+        self.role_state.on_connection_failed(id);
+
         self.callbacks
             .on_update_resources(self.role_state.resources());
     }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1499,8 +1499,13 @@ mod proptests {
         ]);
 
         assert_eq!(
-            hashset(client_state.resources().iter()),
-            hashset(&[
+            hashset(
+                client_state
+                    .resources()
+                    .into_iter()
+                    .map_into::<ResourceDescription>()
+            ),
+            hashset([
                 ResourceDescription::Cidr(resource1.clone()),
                 ResourceDescription::Dns(resource2.clone())
             ])
@@ -1509,8 +1514,13 @@ mod proptests {
         client_state.add_resources(&[ResourceDescription::Cidr(resource3.clone())]);
 
         assert_eq!(
-            hashset(client_state.resources().iter()),
-            hashset(&[
+            hashset(
+                client_state
+                    .resources()
+                    .into_iter()
+                    .map_into::<ResourceDescription>()
+            ),
+            hashset([
                 ResourceDescription::Cidr(resource1),
                 ResourceDescription::Dns(resource2),
                 ResourceDescription::Cidr(resource3)
@@ -1534,8 +1544,13 @@ mod proptests {
         client_state.add_resources(&[ResourceDescription::Cidr(updated_resource.clone())]);
 
         assert_eq!(
-            hashset(client_state.resources().iter()),
-            hashset(&[ResourceDescription::Cidr(updated_resource),])
+            hashset(
+                client_state
+                    .resources()
+                    .into_iter()
+                    .map_into::<ResourceDescription>()
+            ),
+            hashset([ResourceDescription::Cidr(updated_resource),])
         );
         assert_eq!(
             hashset(client_state.routes()),
@@ -1562,8 +1577,13 @@ mod proptests {
         client_state.add_resources(&[ResourceDescription::Cidr(dns_as_cidr_resource.clone())]);
 
         assert_eq!(
-            hashset(client_state.resources().iter()),
-            hashset(&[ResourceDescription::Cidr(dns_as_cidr_resource),])
+            hashset(
+                client_state
+                    .resources()
+                    .into_iter()
+                    .map_into::<ResourceDescription>()
+            ),
+            hashset([ResourceDescription::Cidr(dns_as_cidr_resource),])
         );
         assert_eq!(
             hashset(client_state.routes()),
@@ -1585,8 +1605,13 @@ mod proptests {
         client_state.remove_resources(&[dns_resource.id]);
 
         assert_eq!(
-            hashset(client_state.resources().iter()),
-            hashset(&[ResourceDescription::Cidr(cidr_resource.clone())])
+            hashset(
+                client_state
+                    .resources()
+                    .into_iter()
+                    .map_into::<ResourceDescription>()
+            ),
+            hashset([ResourceDescription::Cidr(cidr_resource.clone())])
         );
         assert_eq!(
             hashset(client_state.routes()),
@@ -1618,8 +1643,13 @@ mod proptests {
         ]);
 
         assert_eq!(
-            hashset(client_state.resources().iter()),
-            hashset(&[
+            hashset(
+                client_state
+                    .resources()
+                    .into_iter()
+                    .map_into::<ResourceDescription>()
+            ),
+            hashset([
                 ResourceDescription::Dns(dns_resource2),
                 ResourceDescription::Cidr(cidr_resource2.clone()),
             ])

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1668,11 +1668,11 @@ mod proptests {
 
     #[test_strategy::proptest]
     fn setting_gateway_online_sets_all_related_resources_online(
-        #[strategy(resources_sharing_group())] resource_config_online: (
+        #[strategy(resources_sharing_site())] resource_config_online: (
             Vec<ResourceDescription>,
             Site,
         ),
-        #[strategy(resources_sharing_group())] resource_config_unknown: (
+        #[strategy(resources_sharing_site())] resource_config_unknown: (
             Vec<ResourceDescription>,
             Site,
         ),
@@ -1704,7 +1704,7 @@ mod proptests {
 
     #[test_strategy::proptest]
     fn disconnecting_gateway_sets_related_resources_unknown(
-        #[strategy(resources_sharing_group())] resource_config: (Vec<ResourceDescription>, Site),
+        #[strategy(resources_sharing_site())] resource_config: (Vec<ResourceDescription>, Site),
         #[strategy(gateway_id())] first_resource_gateway_id: GatewayId,
     ) {
         let (resources, site) = resource_config;
@@ -1727,7 +1727,7 @@ mod proptests {
 
     #[test_strategy::proptest]
     fn setting_resource_offline_doesnt_set_all_related_resources_offline(
-        #[strategy(resources_sharing_group())] resource_config_online: (
+        #[strategy(resources_sharing_site())] resource_config_online: (
             Vec<ResourceDescription>,
             Site,
         ),
@@ -1750,7 +1750,7 @@ mod proptests {
 
     #[test_strategy::proptest]
     fn setting_resource_offline_set_all_resources_sharing_all_groups_offline(
-        #[strategy(resources_sharing_all_groups())] resources: Vec<ResourceDescription>,
+        #[strategy(resources_sharing_all_sites())] resources: Vec<ResourceDescription>,
     ) {
         let mut client_state = ClientState::for_test();
         client_state.add_resources(&resources);

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -119,6 +119,8 @@ where
             )? {
                 Poll::Ready(io::Input::Timeout(timeout)) => {
                     self.role_state.handle_timeout(timeout);
+                    self.callbacks
+                        .on_update_resources(self.role_state.resources());
                     continue;
                 }
                 Poll::Ready(io::Input::Device(packet)) => {

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -9,7 +9,7 @@ use crate::client::{
     Failure,
 };
 use anyhow::{bail, Context, Result};
-use connlib_client_shared::ResourceDescription;
+use connlib_client_shared::callbacks::ResourceDescription;
 use connlib_shared::messages::ResourceId;
 use secrecy::{ExposeSecret, SecretString};
 use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray_menu.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray_menu.rs
@@ -3,7 +3,7 @@
 //! "Notification Area" is Microsoft's official name instead of "System tray":
 //! <https://learn.microsoft.com/en-us/windows/win32/shell/notification-area?redirectedfrom=MSDN#notifications-and-the-notification-area>
 
-use connlib_client_shared::ResourceDescription;
+use connlib_client_shared::callbacks::ResourceDescription;
 use std::str::FromStr;
 use tauri::{CustomMenuItem, SystemTrayMenu, SystemTrayMenuItem, SystemTraySubmenu};
 

--- a/rust/gui-client/src-tauri/src/client/tunnel-wrapper/in_proc.rs
+++ b/rust/gui-client/src-tauri/src/client/tunnel-wrapper/in_proc.rs
@@ -10,8 +10,8 @@
 
 use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
-use connlib_client_shared::{ResourceDescription, Sockets};
-use connlib_shared::{keypair, LoginUrl};
+use connlib_client_shared::Sockets;
+use connlib_shared::{callbacks::ResourceDescription, keypair, LoginUrl};
 use secrecy::SecretString;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},

--- a/rust/gui-client/src-tauri/src/client/tunnel-wrapper/ipc.rs
+++ b/rust/gui-client/src-tauri/src/client/tunnel-wrapper/ipc.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
-use connlib_client_shared::{Callbacks, ResourceDescription};
+use connlib_client_shared::Callbacks;
+use connlib_shared::callbacks::ResourceDescription;
 use firezone_headless_client::{imp::sock_path, IpcClientMsg, IpcServerMsg};
 use futures::{SinkExt, StreamExt};
 use secrecy::{ExposeSecret, SecretString};

--- a/rust/headless-client/src/imp_linux.rs
+++ b/rust/headless-client/src/imp_linux.rs
@@ -3,9 +3,9 @@
 use super::{Cli, IpcClientMsg, IpcServerMsg, FIREZONE_GROUP, TOKEN_ENV_KEY};
 use anyhow::{bail, Context as _, Result};
 use clap::Parser;
-use connlib_client_shared::{file_logger, Callbacks, ResourceDescription, Sockets};
+use connlib_client_shared::{file_logger, Callbacks, Sockets};
 use connlib_shared::{
-    keypair,
+    callbacks, keypair,
     linux::{etc_resolv_conf, get_dns_control_from_env, DnsControlMethod},
     LoginUrl,
 };
@@ -240,7 +240,7 @@ impl Callbacks for CallbackHandlerIpc {
         None
     }
 
-    fn on_update_resources(&self, resources: Vec<ResourceDescription>) {
+    fn on_update_resources(&self, resources: Vec<callbacks::ResourceDescription>) {
         tracing::info!(?resources, "New resource list");
         self.cb_tx
             .try_send(IpcServerMsg::OnUpdateResources(resources))

--- a/rust/headless-client/src/imp_linux.rs
+++ b/rust/headless-client/src/imp_linux.rs
@@ -241,7 +241,7 @@ impl Callbacks for CallbackHandlerIpc {
     }
 
     fn on_update_resources(&self, resources: Vec<callbacks::ResourceDescription>) {
-        tracing::info!(?resources, "New resource list");
+        tracing::debug!(len = resources.len(), "New resource list");
         self.cb_tx
             .try_send(IpcServerMsg::OnUpdateResources(resources))
             .expect("Should be able to send OnUpdateResources");

--- a/rust/headless-client/src/imp_linux.rs
+++ b/rust/headless-client/src/imp_linux.rs
@@ -241,7 +241,7 @@ impl Callbacks for CallbackHandlerIpc {
     }
 
     fn on_update_resources(&self, resources: Vec<ResourceDescription>) {
-        tracing::info!(len = resources.len(), "New resource list");
+        tracing::info!(?resources, "New resource list");
         self.cb_tx
             .try_send(IpcServerMsg::OnUpdateResources(resources))
             .expect("Should be able to send OnUpdateResources");

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -11,10 +11,10 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use connlib_client_shared::{file_logger, keypair, Callbacks, LoginUrl, Session, Sockets};
-use connlib_shared::callbacks::{self, Status};
+use connlib_shared::callbacks;
 use firezone_cli_utils::setup_global_subscriber;
 use secrecy::SecretString;
-use std::{collections::HashMap, future, net::IpAddr, path::PathBuf, task::Poll};
+use std::{future, net::IpAddr, path::PathBuf, task::Poll};
 use tokio::sync::mpsc;
 
 use imp::default_token_path;

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -13,9 +13,10 @@ use clap::Parser;
 use connlib_client_shared::{
     file_logger, keypair, Callbacks, LoginUrl, ResourceDescription, Session, Sockets,
 };
+use connlib_shared::messages::client::Status;
 use firezone_cli_utils::setup_global_subscriber;
 use secrecy::SecretString;
-use std::{future, net::IpAddr, path::PathBuf, task::Poll};
+use std::{collections::HashMap, future, net::IpAddr, path::PathBuf, task::Poll};
 use tokio::sync::mpsc;
 
 use imp::default_token_path;
@@ -276,7 +277,12 @@ impl Callbacks for CallbackHandler {
 
     fn on_update_resources(&self, resources: Vec<connlib_client_shared::ResourceDescription>) {
         // See easily with `export RUST_LOG=firezone_headless_client=debug`
-        tracing::debug!(len = resources.len(), "Printing the resource list one time");
+
+        let status = resources
+            .iter()
+            .map(|r| (r.name(), r.status()))
+            .collect::<HashMap<&str, Status>>();
+        tracing::info!(?status, "Resource Status");
         for resource in &resources {
             tracing::debug!(?resource);
         }

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -273,10 +273,7 @@ impl Callbacks for CallbackHandler {
             .expect("should be able to tell the main thread that we disconnected");
     }
 
-    fn on_update_resources(
-        &self,
-        resources: Vec<connlib_client_shared::callbacks::ResourceDescription>,
-    ) {
+    fn on_update_resources(&self, resources: Vec<callbacks::ResourceDescription>) {
         // See easily with `export RUST_LOG=firezone_headless_client=debug`
         for resource in &resources {
             tracing::debug!(?resource);

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -278,12 +278,6 @@ impl Callbacks for CallbackHandler {
         resources: Vec<connlib_client_shared::callbacks::ResourceDescription>,
     ) {
         // See easily with `export RUST_LOG=firezone_headless_client=debug`
-
-        let status = resources
-            .iter()
-            .map(|r| (r.name(), r.status()))
-            .collect::<HashMap<&str, Status>>();
-        tracing::info!(?status, "Resource Status");
         for resource in &resources {
             tracing::debug!(?resource);
         }

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -10,10 +10,8 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use connlib_client_shared::{
-    file_logger, keypair, Callbacks, LoginUrl, ResourceDescription, Session, Sockets,
-};
-use connlib_shared::messages::client::Status;
+use connlib_client_shared::{file_logger, keypair, Callbacks, LoginUrl, Session, Sockets};
+use connlib_shared::callbacks::{self, Status};
 use firezone_cli_utils::setup_global_subscriber;
 use secrecy::SecretString;
 use std::{collections::HashMap, future, net::IpAddr, path::PathBuf, task::Poll};
@@ -134,7 +132,7 @@ pub enum IpcClientMsg {
 pub enum IpcServerMsg {
     Ok,
     OnDisconnect,
-    OnUpdateResources(Vec<ResourceDescription>),
+    OnUpdateResources(Vec<callbacks::ResourceDescription>),
     TunnelReady,
 }
 
@@ -275,7 +273,10 @@ impl Callbacks for CallbackHandler {
             .expect("should be able to tell the main thread that we disconnected");
     }
 
-    fn on_update_resources(&self, resources: Vec<connlib_client_shared::ResourceDescription>) {
+    fn on_update_resources(
+        &self,
+        resources: Vec<connlib_client_shared::callbacks::ResourceDescription>,
+    ) {
         // See easily with `export RUST_LOG=firezone_headless_client=debug`
 
         let status = resources


### PR DESCRIPTION
This PR introduces site's `Status`. That's used to report to the client the status, either, unknown, online or offline, mostly as a hint to users as what's wrong with a connection.

This are the criteria for an online or offline resource

* If all sites related to a resource are offline the resource is considered offline, since there's no gateway that can respond to that resource's connection
* If any site is online the resource is online, since that same peer can be used to reach that resource
* Any other case is unknown

Right now resources are single site so it doesn't matter too much but tracking online/offline per-site instead of per-gateway or resource seems like the better long-term solution.

The way to "find out" the site's status is:

* If a response to a connection details is offline, all sites related to that resource must be offline otherwise there would've been a gateway in the response
* At the point we connect to a gateway, the site that corresponds to that gateway must be online
* When a connection to a peer stops it's considered unknown again

Fixes #4738 