### PR TITLE
chore(ci): fix `debug_exit` in the flaky systemd DNS test

### DIFF
--- a/scripts/tests/systemd/dns-systemd-resolved.sh
+++ b/scripts/tests/systemd/dns-systemd-resolved.sh
@@ -9,8 +9,8 @@ SERVICE_NAME=firezone-client-headless
 debug_exit() {
     echo "Bailing out. Waiting a couple seconds for things to settle..."
     sleep 5
-    resolvectl dns tun-firezone
-    systemctl status "$SERVICE_NAME"
+    resolvectl dns tun-firezone || true
+    systemctl status "$SERVICE_NAME" || true
     exit 1
 }
 


### PR DESCRIPTION
If these fail we shouldn't bail out since we're already bailing out and we need them to continue for debug output.

Refs #4921 