### PR TITLE
refactor(ci): use the same test framework for headless client and IPC service

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri
-      - run: ../scripts/tests/${{ matrix.test }}.sh
+      - run: scripts/tests/${{ matrix.test }}.sh
         name: "test script"
         shell: bash
         working-directory: ./

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -129,9 +129,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
-      - run: cargo build -p firezone-headless-client
-        name: "cargo build"
-        shell: bash
       - run: scripts/tests/${{ matrix.test }}.sh
         name: "test script"
         shell: bash

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -132,4 +132,4 @@ jobs:
       - run: scripts/tests/${{ matrix.test }}.sh
         name: "test script"
         shell: bash
-        working-directory: ./
+        working-directory: rust

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -129,6 +129,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/setup-tauri
       - run: ../scripts/tests/${{ matrix.test }}.sh
         name: "test script"
         shell: bash

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -133,4 +133,4 @@ jobs:
       - run: ../scripts/tests/${{ matrix.test }}.sh
         name: "test script"
         shell: bash
-        working-directory: rust
+        working-directory: ./

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -129,7 +129,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
-      - run: scripts/tests/${{ matrix.test }}.sh
+      - run: ../scripts/tests/${{ matrix.test }}.sh
         name: "test script"
         shell: bash
         working-directory: rust

--- a/scripts/build/tauri-rename-ubuntu.sh
+++ b/scripts/build/tauri-rename-ubuntu.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
+FZ_GROUP="firezone-client"
+SERVICE_NAME=firezone-client-ipc
+
+function debug_exit() {
+    systemctl status "$SERVICE_NAME"
+    exit 1
+}
+
 # For debugging
 ls ../target/release ../target/release/bundle/deb
 
@@ -40,5 +48,5 @@ stat /usr/share/icons/hicolor/512x512/apps/firezone-client-gui.png
 firezone-client-gui --help | grep "Usage: firezone-client-gui"
 
 # Try to start the IPC service
-sudo groupadd --force firezone-client
-sudo systemctl start firezone-client-ipc || systemctl status firezone-client-ipc
+sudo groupadd --force "$FZ_GROUP"
+sudo systemctl start "SERVICE_NAME" || debug_exit

--- a/scripts/build/tauri-rename-ubuntu.sh
+++ b/scripts/build/tauri-rename-ubuntu.sh
@@ -49,4 +49,4 @@ firezone-client-gui --help | grep "Usage: firezone-client-gui"
 
 # Try to start the IPC service
 sudo groupadd --force "$FZ_GROUP"
-sudo systemctl start "SERVICE_NAME" || debug_exit
+sudo systemctl start "$SERVICE_NAME" || debug_exit

--- a/scripts/tests/linux-group.sh
+++ b/scripts/tests/linux-group.sh
@@ -11,8 +11,10 @@ SERVICE_NAME=firezone-client-ipc
 SOCKET=/run/dev.firezone.client/ipc.sock
 export RUST_LOG=info
 
+cargo build --bin "$BINARY_NAME"
+
 # Copy the Linux Client out of the build dir
-sudo cp "rust/target/debug/firezone-headless-client" "/usr/bin/$BINARY_NAME"
+sudo cp "rust/target/debug/$BINARY_NAME" "/usr/bin/$BINARY_NAME"
 
 # Set up the systemd service
 sudo cp "rust/gui-client/src-tauri/deb_files/$SERVICE_NAME.service" /usr/lib/systemd/system/

--- a/scripts/tests/linux-group.sh
+++ b/scripts/tests/linux-group.sh
@@ -3,7 +3,7 @@
 # The integration tests call this to test security for Linux IPC.
 # Only users in the `firezone` group should be able to control the privileged tunnel process.
 
-source "../scripts/tests/lib.sh"
+source "./scripts/tests/lib.sh"
 
 BINARY_NAME=firezone-client-ipc
 FZ_GROUP="firezone-client"
@@ -11,7 +11,9 @@ SERVICE_NAME=firezone-client-ipc
 SOCKET=/run/dev.firezone.client/ipc.sock
 export RUST_LOG=info
 
+cd rust || exit 1
 cargo build --bin "$BINARY_NAME"
+cd ..
 
 # Copy the Linux Client out of the build dir
 sudo cp "rust/target/debug/$BINARY_NAME" "/usr/bin/$BINARY_NAME"

--- a/scripts/tests/linux-group.sh
+++ b/scripts/tests/linux-group.sh
@@ -3,7 +3,7 @@
 # The integration tests call this to test security for Linux IPC.
 # Only users in the `firezone` group should be able to control the privileged tunnel process.
 
-source "./scripts/tests/lib.sh"
+source "../scripts/tests/lib.sh"
 
 BINARY_NAME=firezone-client-ipc
 FZ_GROUP="firezone-client"

--- a/scripts/tests/token-path.sh
+++ b/scripts/tests/token-path.sh
@@ -2,11 +2,13 @@
 
 source "./scripts/tests/lib.sh"
 
-BINARY_NAME=firezone-linux-client
+BINARY_NAME=firezone-headless-client
 TOKEN="n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAGUmu74wBYgABUYA.UN3vSLLcAMkHeEh5VHumPOutkuue8JA6wlxM9JxJEPE"
 TOKEN_PATH="token"
 
-sudo cp "rust/target/debug/firezone-headless-client" "/usr/bin/$BINARY_NAME"
+cargo build -p "$BINARY_NAME"
+
+sudo cp "rust/target/debug/$BINARY_NAME" "/usr/bin/$BINARY_NAME"
 
 # Fails because there's no token yet
 sudo "$BINARY_NAME" --check standalone && exit 1

--- a/scripts/tests/token-path.sh
+++ b/scripts/tests/token-path.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
-source "../scripts/tests/lib.sh"
+source "./scripts/tests/lib.sh"
 
 BINARY_NAME=firezone-headless-client
 TOKEN="n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAGUmu74wBYgABUYA.UN3vSLLcAMkHeEh5VHumPOutkuue8JA6wlxM9JxJEPE"
 TOKEN_PATH="token"
 
+cd rust || exit 1
 cargo build -p "$BINARY_NAME"
+cd ..
 
 sudo cp "rust/target/debug/$BINARY_NAME" "/usr/bin/$BINARY_NAME"
 

--- a/scripts/tests/token-path.sh
+++ b/scripts/tests/token-path.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "./scripts/tests/lib.sh"
+source "../scripts/tests/lib.sh"
 
 BINARY_NAME=firezone-headless-client
 TOKEN="n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAGUmu74wBYgABUYA.UN3vSLLcAMkHeEh5VHumPOutkuue8JA6wlxM9JxJEPE"


### PR DESCRIPTION
This will fix an issue with `linux-group` and `token-path` that happens when I try to split up the binaries.

```[tasklist]
### Before merging
- [x] Fix linux-group. That stub-ipc-client command doesn't even exist anymore
```