### PR TITLE
fix(portal): don't confirm group selections if there aren't changes

### DIFF
--- a/elixir/apps/web/lib/web/live/actors/groups.ex
+++ b/elixir/apps/web/lib/web/live/actors/groups.ex
@@ -126,9 +126,14 @@ defmodule Web.Actors.EditGroups do
               </div>
             </:col>
           </.live_table>
-          <.button class="m-4" data-confirm={confirm_message(@added, @removed)} phx-click="submit">
-            Save
-          </.button>
+          <div class="flex justify-between items-center">
+            <p class="px-4 text-sm text-gray-500">
+              Note: Users will always belong to the <strong>Everyone</strong> group.
+            </p>
+            <.button class="m-4" data-confirm={confirm_message(@added, @removed)} phx-click="submit">
+              Save
+            </.button>
+          </div>
         </div>
       </:content>
     </.section>
@@ -218,7 +223,12 @@ defmodule Web.Actors.EditGroups do
     remove = if removed_names != [], do: "remove #{Enum.join(removed_names, ", ")}"
     change = [add, remove] |> Enum.reject(&is_nil/1) |> Enum.join(" and ")
 
-    "Are you sure you want to #{change}?"
+    if change == "" do
+      # Don't show confirmation message if no changes were made
+      nil
+    else
+      "Are you sure you want to #{change}?"
+    end
   end
 
   defp remove_non_editable_memberships(memberships, editable_groups) do

--- a/elixir/apps/web/lib/web/live/groups/edit_actors.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit_actors.ex
@@ -228,6 +228,11 @@ defmodule Web.Groups.EditActors do
     remove = if removed_names != [], do: "remove #{Enum.join(removed_names, ", ")}"
     change = [add, remove] |> Enum.reject(&is_nil/1) |> Enum.join(" and ")
 
-    "Are you sure you want to #{change}?"
+    if change == "" do
+      # Don't show confirmation message if no changes were made
+      nil
+    else
+      "Are you sure you want to #{change}?"
+    end
   end
 end


### PR DESCRIPTION
- Fixes #4937 (not worth adding complexity to the live table for this, so just added as a note in the bottom)
- Don't show confirmation dialog if no changes have been made

<img width="912" alt="Screenshot 2024-05-09 at 11 03 00 PM" src="https://github.com/firezone/firezone/assets/167144/47f1a76c-5f2a-4815-b0ff-7f1e68c785bf">
