### PR TITLE
fix(portal): Add provider icon to identity/group badges

### DIFF
--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -349,7 +349,9 @@ end
 
 {:ok, eng_group} = Actors.create_group(%{name: "Engineering", type: :static}, admin_subject)
 {:ok, finance_group} = Actors.create_group(%{name: "Finance", type: :static}, admin_subject)
-{:ok, synced_group} = Actors.create_group(%{name: "Synced Group with long name", type: :static}, admin_subject)
+
+{:ok, synced_group} =
+  Actors.create_group(%{name: "Synced Group with long name", type: :static}, admin_subject)
 
 for group <- [eng_group, finance_group, synced_group] do
   IO.puts("  Name: #{group.name}  ID: #{group.id}")

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -349,7 +349,7 @@ end
 
 {:ok, eng_group} = Actors.create_group(%{name: "Engineering", type: :static}, admin_subject)
 {:ok, finance_group} = Actors.create_group(%{name: "Finance", type: :static}, admin_subject)
-{:ok, synced_group} = Actors.create_group(%{name: "Synced Group", type: :static}, admin_subject)
+{:ok, synced_group} = Actors.create_group(%{name: "Synced Group with long name", type: :static}, admin_subject)
 
 for group <- [eng_group, finance_group, synced_group] do
   IO.puts("  Name: #{group.name}  ID: #{group.id}")

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -844,19 +844,22 @@ defmodule Web.CoreComponents do
         class={~w[
           text-xs
           rounded-l
-          py-0.5 pl-2.5 pr-1.5
-          text-neutral-800
-          bg-neutral-200
+          py-0.5 px-1.5
+          text-neutral-900
+          bg-neutral-50
+          border-neutral-100
+          border
         ]}
       >
-        <%= @identity.provider.name %>
+        <.provider_icon adapter={@identity.provider.adapter} class="h-3.5 w-3.5" />
       </.link>
-      <span class={[
-        "text-xs",
-        "rounded-r",
-        "mr-2 py-0.5 pl-1.5 pr-2.5",
-        "text-neutral-800",
-        "bg-neutral-100"
+      <span class={~w[
+        flex items-center
+        text-xs
+        rounded-r
+        mr-2 py-0.5 pl-1.5 pr-2.5
+        text-neutral-900
+        bg-neutral-100
       ]}>
         <%= get_identity_email(@identity) %>
       </span>
@@ -890,34 +893,34 @@ defmodule Web.CoreComponents do
 
   def group(assigns) do
     ~H"""
-    <span class="inline-block whitespace-nowrap mr-2" data-group-id={@group.id}>
+    <span class="flex inline-flex" data-group-id={@group.id}>
       <.link
         :if={Actors.group_synced?(@group)}
         navigate={Web.Settings.IdentityProviders.Components.view_provider(@account, @group.provider)}
         data-provider-id={@group.provider_id}
         title={@group.provider.adapter}
-        class={[
-          "text-xs",
-          "rounded-l",
-          "py-0.5 pl-2.5 pr-1.5",
-          "text-neutral-800",
-          "bg-neutral-200",
-          "whitespace-nowrap"
+        class={~w[
+          text-xs
+          rounded-l
+          py-0.5 px-1.5
+          text-neutral-900
+          bg-neutral-50
+          border-neutral-100
+          border
+          whitespace-nowrap
         ]}
       >
-        <%= @group.provider.name %>
+        <.provider_icon adapter={@group.provider.adapter} class="h-3.5 w-3.5" />
       </.link>
-      <.link
-        navigate={~p"/#{@account}/groups/#{@group}"}
-        class={[
-          "text-xs",
-          if(Actors.group_synced?(@group), do: "rounded-r pl-1.5 pr-2.5", else: "rounded px-1.5"),
-          "py-0.5",
-          "text-neutral-800",
-          "bg-neutral-100",
-          "whitespace-nowrap"
-        ]}
-      >
+      <.link navigate={~p"/#{@account}/groups/#{@group}"} class={~w[
+          flex items-center
+          text-xs
+          #{if(Actors.group_synced?(@group), do: "rounded-r pl-1.5 pr-2.5", else: "rounded px-1.5")}
+          py-0.5
+          text-neutral-800
+          bg-neutral-100
+          whitespace-nowrap
+        ]}>
         <%= @group.name %>
       </.link>
     </span>
@@ -1103,6 +1106,18 @@ defmodule Web.CoreComponents do
   def provider_icon(%{adapter: :okta} = assigns) do
     ~H"""
     <img src={~p"/images/okta-logo.svg"} alt="Okta Logo" {@rest} />
+    """
+  end
+
+  def provider_icon(%{adapter: :email} = assigns) do
+    ~H"""
+    <.icon name="hero-envelope" {@rest} />
+    """
+  end
+
+  def provider_icon(%{adapter: :userpass} = assigns) do
+    ~H"""
+    <.icon name="hero-key" {@rest} />
     """
   end
 

--- a/elixir/apps/web/lib/web/live/actors/index.ex
+++ b/elixir/apps/web/lib/web/live/actors/index.ex
@@ -72,7 +72,7 @@ defmodule Web.Actors.Index do
           </:col>
 
           <:col :let={actor} label="identifiers">
-            <div class="flex flex-wrap gap-y-2">
+            <div class="flex flex-wrap gap-y-1">
               <.identity_identifier
                 :for={identity <- actor.identities}
                 account={@account}
@@ -88,7 +88,9 @@ defmodule Web.Actors.Index do
               </:empty>
 
               <:item :let={group}>
-                <.group account={@account} group={group} />
+                <div class="flex flex-wrap gap-y-1 mr-1">
+                  <.group account={@account} group={group} />
+                </div>
               </:item>
 
               <:tail :let={count}>

--- a/elixir/apps/web/lib/web/live/actors/index.ex
+++ b/elixir/apps/web/lib/web/live/actors/index.ex
@@ -72,7 +72,7 @@ defmodule Web.Actors.Index do
           </:col>
 
           <:col :let={actor} label="identifiers">
-            <div class="flex flex-wrap gap-y-1">
+            <div class="flex flex-wrap gap-y-2">
               <.identity_identifier
                 :for={identity <- actor.identities}
                 account={@account}
@@ -88,7 +88,7 @@ defmodule Web.Actors.Index do
               </:empty>
 
               <:item :let={group}>
-                <div class="flex flex-wrap gap-y-1 mr-1">
+                <div class="flex flex-wrap gap-y-2 mr-2">
                   <.group account={@account} group={group} />
                 </div>
               </:item>

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -154,11 +154,13 @@ defmodule Web.Groups.Show do
             <.actor_name_and_role account={@account} actor={actor} />
           </:col>
           <:col :let={actor} label="IDENTITIES">
-            <.identity_identifier
-              :for={identity <- actor.identities}
-              account={@account}
-              identity={identity}
-            />
+            <span class="flex items-center">
+              <.identity_identifier
+                :for={identity <- actor.identities}
+                account={@account}
+                identity={identity}
+              />
+            </span>
           </:col>
           <:empty>
             <div class="flex justify-center text-center text-neutral-500 p-4">

--- a/elixir/apps/web/lib/web/live/policies/index.ex
+++ b/elixir/apps/web/lib/web/live/policies/index.ex
@@ -70,7 +70,9 @@ defmodule Web.Policies.Index do
             </.link>
           </:col>
           <:col :let={policy} label="GROUP">
-            <.group account={@account} group={policy.actor_group} />
+            <span class="flex items-center">
+              <.group account={@account} group={policy.actor_group} />
+            </span>
           </:col>
           <:col :let={policy} label="RESOURCE">
             <.link class={link_style()} navigate={~p"/#{@account}/resources/#{policy.resource_id}"}>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -95,7 +95,11 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
             </.vertical_table_row>
             <.vertical_table_row>
               <:label>Type</:label>
-              <:value>OpenID Connect</:value>
+              <:value>
+                <span class="flex items-center gap-x-1">
+                  <.provider_icon adapter={@provider.adapter} class="w-3.5 h-3.5" /> OpenID Connect
+                </span>
+              </:value>
             </.vertical_table_row>
             <.vertical_table_row>
               <:label>Response Type</:label>

--- a/elixir/apps/web/test/web/live/actors/show_test.exs
+++ b/elixir/apps/web/test/web/live/actors/show_test.exs
@@ -346,7 +346,7 @@ defmodule Web.Live.Actors.ShowTest do
       |> table_to_map()
       |> with_table_row(
         "identity",
-        "#{admin_identity.provider.name} #{admin_identity.provider_identifier}",
+        "#{admin_identity.provider_identifier}",
         fn row ->
           assert row["actions"] =~ "Delete"
           assert around_now?(row["last signed in"])
@@ -355,7 +355,7 @@ defmodule Web.Live.Actors.ShowTest do
       )
       |> with_table_row(
         "identity",
-        "#{invited_identity.provider.name} #{invited_identity.provider_identifier}",
+        "#{invited_identity.provider_identifier}",
         fn row ->
           assert row["actions"] =~ "Delete"
           assert row["created"] =~ "by #{actor.name}"
@@ -364,7 +364,7 @@ defmodule Web.Live.Actors.ShowTest do
       )
       |> with_table_row(
         "identity",
-        "#{synced_identity.provider.name} #{synced_identity.provider_identifier}",
+        "#{synced_identity.provider_identifier}",
         fn row ->
           refute row["actions"]
           assert row["created"] =~ "by #{synced_identity.provider.name} sync"

--- a/elixir/apps/web/test/web/live/groups/edit_actors_test.exs
+++ b/elixir/apps/web/test/web/live/groups/edit_actors_test.exs
@@ -113,7 +113,6 @@ defmodule Web.Live.Groups.EditActorsTest do
     end)
     |> with_table_row("actor", "#{admin_actor.name} (admin)", fn row ->
       for(identity <- admin_actor.identities) do
-        assert row["identities"] =~ identity.provider.name
         assert row["identities"] =~ identity.provider_identifier
       end
 
@@ -156,7 +155,6 @@ defmodule Web.Live.Groups.EditActorsTest do
       assert row["actor"] == "#{actor.name} (admin)"
 
       for identity <- actor.identities do
-        assert row["identities"] =~ identity.provider.name
         assert row["identities"] =~ identity.provider_identifier
       end
 


### PR DESCRIPTION
- Makes the group badges a little easier on the eyes, and reduces their size to improve layout flow a bit. Allows to more quickly identity provider adapters at-a-glance.
- Fix group badge wrapping so that long group names don't flow into the next table cell

Fixes #4905 



<img width="1209" alt="Screenshot 2024-05-10 at 7 24 59 AM" src="https://github.com/firezone/firezone/assets/167144/fba4190a-af0a-464a-b3b1-9e98505c59fb">

