### PR TITLE
fix(portal): Use info button style for buttons that change form elements and don't submit

### DIFF
--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -436,7 +436,7 @@ defmodule Web.FormComponents do
   def button(assigns) do
     ~H"""
     <button type={@type} class={button_style(@style) ++ button_size(@size) ++ [@class]} {@rest}>
-      <.icon :if={@icon} name={@icon} class="h-3.5 w-3.5 mr-2" />
+      <.icon :if={@icon} name={@icon} class={icon_size(@size)} />
       <%= render_slot(@inner_block) %>
     </button>
     """
@@ -589,5 +589,25 @@ defmodule Web.FormComponents do
     }
 
     [text[size], spacing[size]]
+  end
+
+  defp icon_size(size) do
+    icon_size = %{
+      "xs" => "w-3 h-3",
+      "sm" => "w-3.5 h-3.5",
+      "md" => "w-4 h-4",
+      "lg" => "w-5 h-5",
+      "xl" => "w-6 h-6"
+    }
+
+    spacing = %{
+      "xs" => "mr-1",
+      "sm" => "mr-2",
+      "md" => "mr-3",
+      "lg" => "mr-4",
+      "xl" => "mr-5"
+    }
+
+    [icon_size[size], spacing[size]]
   end
 end

--- a/elixir/apps/web/lib/web/live/actors/groups.ex
+++ b/elixir/apps/web/lib/web/live/actors/groups.ex
@@ -110,20 +110,24 @@ defmodule Web.Actors.EditGroups do
                 <.button
                   :if={member?(@current_group_ids, group, @added, @removed)}
                   size="xs"
+                  style="info"
+                  icon="hero-minus"
                   phx-click={:remove_group}
                   phx-value-id={group.id}
                   phx-value-name={group.name}
                 >
-                  <.icon name="hero-minus" class="h-3.5 w-3.5 mr-2" /> Remove
+                  Remove
                 </.button>
                 <.button
                   :if={not member?(@current_group_ids, group, @added, @removed)}
                   size="xs"
+                  style="info"
+                  icon="hero-plus"
                   phx-click={:add_group}
                   phx-value-id={group.id}
                   phx-value-name={group.name}
                 >
-                  <.icon name="hero-plus" class="h-3.5 w-3.5 mr-2" /> Add
+                  Add
                 </.button>
               </div>
             </:col>

--- a/elixir/apps/web/lib/web/live/groups/edit_actors.ex
+++ b/elixir/apps/web/lib/web/live/groups/edit_actors.ex
@@ -108,29 +108,37 @@ defmodule Web.Groups.EditActors do
               />
             </:col>
             <:col :let={actor} label="IDENTITIES">
-              <.identity_identifier
-                :for={identity <- actor.identities}
-                account={@account}
-                identity={identity}
-              />
+              <span class="flex flex-wrap gap-y-2">
+                <.identity_identifier
+                  :for={identity <- actor.identities}
+                  account={@account}
+                  identity={identity}
+                />
+              </span>
             </:col>
             <:col :let={actor} class="w-1/6">
-              <.button
-                :if={member?(@current_member_ids, actor, @added, @removed)}
-                size="xs"
-                phx-click={:remove_actor}
-                phx-value-id={actor.id}
-              >
-                <.icon name="hero-minus" class="h-3.5 w-3.5 mr-2" /> Remove
-              </.button>
-              <.button
-                :if={not member?(@current_member_ids, actor, @added, @removed)}
-                size="xs"
-                phx-click={:add_actor}
-                phx-value-id={actor.id}
-              >
-                <.icon name="hero-plus" class="h-3.5 w-3.5 mr-2" /> Add
-              </.button>
+              <span class="flex justify-end">
+                <.button
+                  :if={member?(@current_member_ids, actor, @added, @removed)}
+                  style="info"
+                  size="xs"
+                  icon="hero-minus"
+                  phx-click={:remove_actor}
+                  phx-value-id={actor.id}
+                >
+                  Remove
+                </.button>
+                <.button
+                  :if={not member?(@current_member_ids, actor, @added, @removed)}
+                  style="info"
+                  size="xs"
+                  icon="hero-plus"
+                  phx-click={:add_actor}
+                  phx-value-id={actor.id}
+                >
+                  Add
+                </.button>
+              </span>
             </:col>
           </.live_table>
 


### PR DESCRIPTION
Why:

I've been on two live support calls now where the user didn't realize the simply clicking the "Add" button didn't save the Group memberships form, so they were confused why their user wasn't in the group, and why their client couldn't access the Resources they were trying to access.

- The color of the "Add/Remove" buttons are changed to make the Save button at the bottom stand out a little more.
- Tidies up a couple other minor issues found while implementing this.

# Before
<img width="910" alt="Screenshot 2024-05-11 at 6 26 23 PM" src="https://github.com/firezone/firezone/assets/167144/d2bdba74-6dba-4904-a13b-faeba3e0b0d0">



# After
<img width="902" alt="Screenshot 2024-05-11 at 6 25 15 PM" src="https://github.com/firezone/firezone/assets/167144/2adf937c-4dd0-4d51-a7d3-a73e764e3493">
