### PR TITLE
docs: Add sidebar sections

### DIFF
--- a/website/src/components/KbSidebar/Collapse.tsx
+++ b/website/src/components/KbSidebar/Collapse.tsx
@@ -26,15 +26,15 @@ export default function Collapse({
         onClick={() => setExpandedState(!expandedState)}
       >
         <span
-          className="uppercase ml-3 flex-1 text-left whitespace-nowrap font-semibold text-neutral-800"
+          className="ml-3 flex-1 text-left whitespace-nowrap font-medium text-neutral-800"
           sidebar-toggle-item="true"
         >
           {label}
         </span>
         {expandedState ? (
-          <HiChevronDown sidebar-toggle-item="true" className="w-4 h-4" />
+          <HiChevronDown sidebar-toggle-item="true" className="w-4 h-4 mr-2" />
         ) : (
-          <HiChevronRight sidebar-toggle-item="true" className="w-4 h-4" />
+          <HiChevronRight sidebar-toggle-item="true" className="w-4 h-4 mr-2" />
         )}
       </button>
       <ul

--- a/website/src/components/KbSidebar/index.tsx
+++ b/website/src/components/KbSidebar/index.tsx
@@ -22,13 +22,16 @@ export default function KbSidebar() {
       className="sticky left-0 top-0 flex-none z-40 w-64 overflow-y-auto h-[calc(100vh-20px)] pt-20 transition-transform -translate-x-full bg-white border-r border-neutral-200 md:translate-x-0"
     >
       <SearchForm />
-      <div className="mt-5 bg-white pr-3">
+      <div className="mt-5 bg-white">
         <ul className="space-y-2 font-medium">
           <li>
             <Item topLevel href="/kb" label="Overview" />
           </li>
           <li>
             <Item topLevel href="/kb/quickstart" label="Quickstart" />
+          </li>
+          <li className="ml-3 pt-3 border-t border-neutral-200 uppercase font-bold text-neutral-800">
+            Get started
           </li>
           <li>
             <Collapse expanded={p.startsWith("/kb/deploy")} label="Deploy">
@@ -113,6 +116,9 @@ export default function KbSidebar() {
               </li>
             </Collapse>
           </li>
+          <li className="ml-3 pt-3 border-t border-neutral-200 uppercase font-bold text-neutral-800">
+            Use Firezone
+          </li>
           <li>
             <Collapse
               expanded={p.startsWith("/kb/administer")}
@@ -187,37 +193,6 @@ export default function KbSidebar() {
           </li>
           <li>
             <Collapse
-              expanded={p.startsWith("/kb/architecture")}
-              label="Architecture"
-            >
-              <li>
-                <Item href="/kb/architecture" label="Overview" />
-              </li>
-              <li>
-                <Item
-                  href="/kb/architecture/core-components"
-                  label="Core components"
-                />
-              </li>
-              <li>
-                <Item href="/kb/architecture/tech-stack" label="Tech stack" />
-              </li>
-              <li>
-                <Item
-                  href="/kb/architecture/critical-sequences"
-                  label="Critical sequences"
-                />
-              </li>
-              <li>
-                <Item
-                  href="/kb/architecture/security-controls"
-                  label="Security controls"
-                />
-              </li>
-            </Collapse>
-          </li>
-          <li>
-            <Collapse
               expanded={p.startsWith("/kb/use-cases")}
               label="Use cases"
             >
@@ -270,6 +245,40 @@ export default function KbSidebar() {
                 <Item
                   href="/kb/use-cases/web-app-access"
                   label="Access a private web app"
+                />
+              </li>
+            </Collapse>
+          </li>
+          <li className="ml-3 pt-3 border-t border-neutral-200 uppercase font-bold text-neutral-800">
+            Learn more
+          </li>
+          <li>
+            <Collapse
+              expanded={p.startsWith("/kb/architecture")}
+              label="Architecture"
+            >
+              <li>
+                <Item href="/kb/architecture" label="Overview" />
+              </li>
+              <li>
+                <Item
+                  href="/kb/architecture/core-components"
+                  label="Core components"
+                />
+              </li>
+              <li>
+                <Item href="/kb/architecture/tech-stack" label="Tech stack" />
+              </li>
+              <li>
+                <Item
+                  href="/kb/architecture/critical-sequences"
+                  label="Critical sequences"
+                />
+              </li>
+              <li>
+                <Item
+                  href="/kb/architecture/security-controls"
+                  label="Security controls"
                 />
               </li>
             </Collapse>


### PR DESCRIPTION
Why: to make docs a tad easier to navigate at-a-glance

# Before

<img width="1616" alt="Screenshot 2024-05-11 at 7 03 55 PM" src="https://github.com/firezone/firezone/assets/167144/152d24cd-e9bd-4d30-adc5-2430fb844268">


# After

<img width="1616" alt="Screenshot 2024-05-11 at 7 03 23 PM" src="https://github.com/firezone/firezone/assets/167144/3896140d-39c6-463c-bac4-db02cb2c0379">
