### PR TITLE
fix(gateway): Detect executables with 'ELF' string

### DIFF
--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -75,7 +75,7 @@ if [ ! -e /usr/local/bin/firezone-gateway ]; then
   # See https://www.github.com/firezone/firezone/releases for available binaries
   curl -fsSL ${FIREZONE_ARTIFACT_URL}/${FIREZONE_VERSION}/\$arch -o /tmp/firezone-gateway
 
-  if file /tmp/firezone-gateway | grep -q "executable"; then
+  if file /tmp/firezone-gateway | grep -q "ELF"; then
     mv /tmp/firezone-gateway /usr/local/bin/firezone-gateway
   else
     echo "/tmp/firezone-gateway is not an executable!"


### PR DESCRIPTION
On some older systems (CentOS 7), `file gateway` will produce this:

```
firezone-gateway: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, stripped
```

`ELF` is a much more reliable means of detecting the file is a binary executable.