### PR TITLE
ci(windows): time out the WebView2 install after 5 minutes

### DIFF
--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -45,7 +45,7 @@ runs:
       #
       # Also sometimes it never finishes. This appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935
       run: |
-        $process = Start-Process WebView2Installer.exe -PassThru -ArgumentList "/install" -Wait `
+        $process = Start-Process WebView2Installer.exe -PassThru -ArgumentList "/install" `
         if (!$process.WaitForExit(300 * 1000)) { `
             throw "Process timed out" `
         }

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -3,7 +3,6 @@ name: "Setup Tauri"
 description: "Sets up the dependencies for building and testing Tauri apps"
 runs:
   using: "composite"
-  timeout-minutes: 5 # Appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935
   steps:
     - name: Apt-get update
       if: ${{ runner.os == 'Linux' }}
@@ -43,5 +42,11 @@ runs:
       # This downloads about 200 MB and takes about 5 minutes on my VM
       # So we could fault in WebView2 from the client exe without the MSI if we needed.
       # Currently the MSI does this and it's a little janky.
-      run: Start-Process WebView2Installer.exe -ArgumentList "/install" -Wait
+      #
+      # Also sometimes it never finishes. This appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935
+      run: |
+        $process = Start-Process WebView2Installer.exe -ArgumentList "/install" -Wait `
+        if (!$process.WaitForExit(300 * 1000)) { `
+            throw "Process timed out" `
+        }
       shell: pwsh

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -25,6 +25,7 @@ runs:
       shell: bash
     - uses: actions/cache@v4
       if: ${{ runner.os == 'Windows' }}
+      timeout-minutes: 5 # Appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935
       id: cache-webview2-installer
       with:
         path: WebView2Installer.exe

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -42,11 +42,5 @@ runs:
       # This downloads about 200 MB and takes about 5 minutes on my VM
       # So we could fault in WebView2 from the client exe without the MSI if we needed.
       # Currently the MSI does this and it's a little janky.
-      #
-      # Also sometimes it never finishes. This appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935
-      run: |
-        $process = Start-Process WebView2Installer.exe -PassThru -ArgumentList "/install" `
-        if (!$process.WaitForExit(300 * 1000)) { `
-            throw "Process timed out" `
-        }
+      run: Start-Process WebView2Installer.exe -ArgumentList "/install" -Wait
       shell: pwsh

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -45,7 +45,7 @@ runs:
       #
       # Also sometimes it never finishes. This appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935
       run: |
-        $process = Start-Process WebView2Installer.exe -ArgumentList "/install" -Wait `
+        $process = Start-Process WebView2Installer.exe -PassThru -ArgumentList "/install" -Wait `
         if (!$process.WaitForExit(300 * 1000)) { `
             throw "Process timed out" `
         }

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -25,7 +25,6 @@ runs:
       shell: bash
     - uses: actions/cache@v4
       if: ${{ runner.os == 'Windows' }}
-      timeout-minutes: 5 # Appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935
       id: cache-webview2-installer
       with:
         path: WebView2Installer.exe
@@ -45,3 +44,4 @@ runs:
       # Currently the MSI does this and it's a little janky.
       run: Start-Process WebView2Installer.exe -ArgumentList "/install" -Wait
       shell: pwsh
+      timeout-minutes: 5 # Appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -3,6 +3,7 @@ name: "Setup Tauri"
 description: "Sets up the dependencies for building and testing Tauri apps"
 runs:
   using: "composite"
+  timeout-minutes: 5 # Appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935
   steps:
     - name: Apt-get update
       if: ${{ runner.os == 'Linux' }}
@@ -44,4 +45,3 @@ runs:
       # Currently the MSI does this and it's a little janky.
       run: Start-Process WebView2Installer.exe -ArgumentList "/install" -Wait
       shell: pwsh
-      timeout-minutes: 5 # Appears to be an issue with WebView. https://github.com/firezone/firezone/pull/4935

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         id: setup-rust
       - uses: ./.github/actions/setup-tauri
+        timeout-minutes: 5
       - uses: taiki-e/install-action@cargo-udeps
       - run: |
           rustup install --no-self-update nightly-2024-03-26 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
@@ -63,6 +64,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         id: setup-rust
       - uses: ./.github/actions/setup-tauri
+        timeout-minutes: 5
       - run: cargo test --all-features ${{ steps.setup-rust.outputs.packages }} -- --include-ignored
         env:
           # <https://github.com/rust-lang/cargo/issues/5999>
@@ -100,6 +102,7 @@ jobs:
           # Cache needs to be scoped per OS version
           key: ${{ matrix.runs-on }}-${{ runner.arch }}
       - uses: ./.github/actions/setup-tauri
+        timeout-minutes: 5
       - name: pnpm install
         run: |
           pnpm install
@@ -130,6 +133,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri
+        timeout-minutes: 5
       - run: scripts/tests/${{ matrix.test }}.sh
         name: "test script"
         shell: bash

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -66,6 +66,7 @@ jobs:
           # Cache needs to be scoped per OS version
           key: ${{ matrix.runs-on }}-${{ runner.arch }}
       - uses: ./.github/actions/setup-tauri
+        timeout-minutes: 5
       - name: Install pnpm deps
         run: pnpm install
       - name: Install AzureSignTool


### PR DESCRIPTION
It typically takes about 1 minute to run in CI. We don't have any leads on fixing this issue, and it may be a regression in a recent release of WebView2. https://github.com/firezone/firezone/pull/4935