### PR TITLE
docs: Fix docs code blocks with arrow

### DIFF
--- a/website/src/app/kb/authenticate/entra/readme.mdx
+++ b/website/src/app/kb/authenticate/entra/readme.mdx
@@ -41,7 +41,7 @@ Follow the steps below to setup the Entra ID connector.
 
 ### Step 1: Start the Entra ID provider setup in Firezone
 
-In your admin portal, go to `Settings` -> `Identity Providers` and click
+In your admin portal, go to `Settings -> Identity Providers` and click
 `Add Identity Provider`. Then, select `Microsoft Entra ID` from the list of
 identity providers.
 

--- a/website/src/app/kb/authenticate/oidc/readme.mdx
+++ b/website/src/app/kb/authenticate/oidc/readme.mdx
@@ -47,8 +47,9 @@ documentation for convenience:
 
 ## Setting up the universal OIDC connector
 
-To set up the universal OIDC connector, go to `Settings` -> `Identity Providers`
--> `Add Identity Provider` and select `OpenID Connect` as the identity provider.
+To set up the universal OIDC connector, go to
+`Settings -> Identity Providers -> Add Identity Provider` and select
+`OpenID Connect` as the identity provider.
 
 In general, you'll need three pieces of information to set up the connector:
 

--- a/website/src/app/kb/authenticate/okta/readme.mdx
+++ b/website/src/app/kb/authenticate/okta/readme.mdx
@@ -39,7 +39,7 @@ Follow the steps below to setup the Okta connector.
 
 ### Step 1: Start the Okta provider setup in Firezone
 
-In your admin portal, go to `Settings` -> `Identity Providers` and click
+In your admin portal, go to `Settings -> Identity Providers` and click
 `Add Identity Provider`. Then, select `Okta` from the list of identity
 providers.
 

--- a/website/src/app/kb/authenticate/service-accounts/readme.mdx
+++ b/website/src/app/kb/authenticate/service-accounts/readme.mdx
@@ -27,7 +27,7 @@ synced from your identity provider.
 
 ## Create a service account
 
-To create a service account, head to `Actors` -> `Add Actor` and select
+To create a service account, head to `Actors -> Add Actor` and select
 `Service Account` as the type.
 
 On the next screen, set an appropriate expiration date for the token.

--- a/website/src/app/kb/deploy/dns/readme.mdx
+++ b/website/src/app/kb/deploy/dns/readme.mdx
@@ -61,7 +61,7 @@ Upstream DNS in all Clients can be configured with the servers of your choosing
 so that all queries on Client devices will be forwarded to the servers you
 specify for all non-Firezone resources.
 
-Go to `Settings` -> `DNS` and enter IPv4 and/or IPv6 servers to use as fallback
+Go to `Settings -> DNS` and enter IPv4 and/or IPv6 servers to use as fallback
 resolvers. Firezone Clients will use these servers in the order they are defined
 for any query that doesn't match a Resource the user has access to.
 

--- a/website/src/app/kb/deploy/gateways/readme.mdx
+++ b/website/src/app/kb/deploy/gateways/readme.mdx
@@ -95,8 +95,8 @@ Deploying a single Gateway can be accomplished in the admin portal.
   rolling upgrades.
 </Alert>
 
-Go to `Sites` -> `<name of Site>` -> `Deploy a Gateway` and follow the prompts
-to deploy for your preferred environment. This will deploy a single Gateway.
+Go to `Sites -> <name of Site> -> Deploy a Gateway` and follow the prompts to
+deploy for your preferred environment. This will deploy a single Gateway.
 
 ## Deploy multiple Gateways
 


### PR DESCRIPTION
before

<img width="222" alt="Screenshot 2024-05-14 at 6 29 52 AM" src="https://github.com/firezone/firezone/assets/167144/a9308eca-b6ae-417c-a673-94c7ee8cdec6">

after

<img width="209" alt="Screenshot 2024-05-14 at 8 31 40 AM" src="https://github.com/firezone/firezone/assets/167144/1de92b63-8679-416a-9014-bf3593d141c4">
