### PR TITLE
docs(client): add support options (Discord, email, etc.) to all Client docs

### DIFF
--- a/website/src/app/kb/user-guides/android-client/readme.mdx
+++ b/website/src/app/kb/user-guides/android-client/readme.mdx
@@ -1,3 +1,5 @@
+import SupportOptions from "@/components/SupportOptions";
+
 # Android Client
 
 Firezone supports Android and ChromeOS with a native client available in the
@@ -21,3 +23,5 @@ Updates for the Android client are handled through the Google Play Store.
 Consult the
 [Play Store documentation](https://support.google.com/googleplay/answer/113412?hl=en)
 for more information on how to update apps on your device.
+
+<SupportOptions />

--- a/website/src/app/kb/user-guides/ios-client/readme.mdx
+++ b/website/src/app/kb/user-guides/ios-client/readme.mdx
@@ -1,3 +1,5 @@
+import SupportOptions from "@/components/SupportOptions";
+
 # iOS Client
 
 Firezone supports iOS with a native clients available in the iOS App Store. The
@@ -17,3 +19,5 @@ the Apple App Store.
 Updates for the Apple clients are handled through the Apple App Store. Consult
 [Apple's documentation](https://support.apple.com/guide/iphone/update-apps-iph98709f167/17.0/ios/17.0)
 for more information on how to update apps on your device.
+
+<SupportOptions />

--- a/website/src/app/kb/user-guides/linux-client/readme.mdx
+++ b/website/src/app/kb/user-guides/linux-client/readme.mdx
@@ -1,4 +1,5 @@
 import Alert from "@/components/DocsAlert";
+import SupportOptions from "@/components/SupportOptions";
 
 # Linux Client
 
@@ -155,3 +156,5 @@ client.
 1. Download a newer binary from one of the [links above](#installation).
 1. Replace the existing binary with the new one.
 1. Start the Client with the same environment variables as before.
+
+<SupportOptions />

--- a/website/src/app/kb/user-guides/macos-client/readme.mdx
+++ b/website/src/app/kb/user-guides/macos-client/readme.mdx
@@ -1,3 +1,5 @@
+import SupportOptions from "@/components/SupportOptions";
+
 # macOS Client
 
 Firezone supports macOS with a native client available in the macOS App Store.
@@ -32,3 +34,5 @@ for more information on how to update apps on your device.
   disabled completely or uninstalled to prevent these issues. See
   [this thread](https://discourse.firez.one/t/firezone-app-on-macos/682) for
   more information.
+
+<SupportOptions />

--- a/website/src/app/kb/user-guides/windows-client/readme.mdx
+++ b/website/src/app/kb/user-guides/windows-client/readme.mdx
@@ -1,3 +1,5 @@
+import SupportOptions from "@/components/SupportOptions";
+
 # Windows Client
 
 Firezone supports Microsoft Windows with a native client for the x86-64
@@ -37,3 +39,5 @@ resolution. See
 [this guide](/kb/administer/troubleshooting#some-browsers-break-dns-routing) to
 disable DNS-over-HTTPS if you're experiencing issues connecting to DNS Resources
 within your browser.
+
+<SupportOptions />


### PR DESCRIPTION
Extracted from #4965, it was mixed in there