### PR TITLE
chore(connlib): ensure there are client_resources before trying to sample them in proptest

### DIFF
--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -355,11 +355,19 @@ impl ReferenceStateMachine for ReferenceState {
                 src.is_ipv4() == dst.is_ipv4() && src != dst
             }
             Transition::SendICMPPacketToIp4Resource { src, r_idx } => {
+                if state.client_resources.len().0 == 0 {
+                    return false;
+                }
+
                 let dst = state.sample_ipv4_cidr_resource_dst(r_idx);
 
                 src != &dst
             }
             Transition::SendICMPPacketToIp6Resource { src, r_idx } => {
+                if state.client_resources.len().1 == 0 {
+                    return false;
+                }
+
                 let dst = state.sample_ipv6_cidr_resource_dst(r_idx);
 
                 src != &dst


### PR DESCRIPTION
This came up while working on #4994 while writing the proptests I noticed that the precondition could panic since we don't have this check there and would cause shrinking to fail.

