### PR TITLE
chore(ux): Add sync time hint help to idp show

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -83,6 +83,14 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
           Reconnect
         </.button>
       </:action>
+      <:help>
+        Directory sync is enabled for this provider. Users, groups, and organizational units will
+        be synced every 10 minutes on average, but could take longer for very large organizations.
+        <.website_link href="/kb/authenticate/directory-sync">
+          Read more
+        </.website_link>
+        about directory sync.
+      </:help>
       <:content>
         <.header>
           <:title>Details</:title>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -83,6 +83,14 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
           Reconnect
         </.button>
       </:action>
+      <:help>
+        Directory sync is enabled for this provider. Users and groups will be synced every 10
+        minutes on average, but could take longer for very large organizations.
+        <.website_link href="/kb/authenticate/directory-sync">
+          Read more
+        </.website_link>
+        about directory sync.
+      </:help>
       <:content>
         <.header>
           <:title>Details</:title>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -81,6 +81,14 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
           Reconnect
         </.button>
       </:action>
+      <:help>
+        Directory sync is enabled for this provider. Users and groups will be synced every 10
+        minutes on average, but could take longer for very large organizations.
+        <.website_link href="/kb/authenticate/directory-sync">
+          Read more
+        </.website_link>
+        about directory sync.
+      </:help>
       <:content>
         <.header>
           <:title>Details</:title>


### PR DESCRIPTION
Adds help text to IdP show page to communicate a little more about how the sync works and also link to the relevant docs.

Fixes #5025 