### PR TITLE
feat(gateway): support for docker secrets

### DIFF
--- a/rust/docker-init.sh
+++ b/rust/docker-init.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -f "${FIREZONE_TOKEN}" ]; then
+    export FIREZONE_TOKEN=$(cat "${FIREZONE_TOKEN}")
+fi
+
 if [ "${FIREZONE_ENABLE_MASQUERADE}" = "1" ]; then
     IFACE="tun-firezone"
     # Enable masquerading for ethernet and wireless interfaces

--- a/rust/docker-init.sh
+++ b/rust/docker-init.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 if [ -f "${FIREZONE_TOKEN}" ]; then
-    export FIREZONE_TOKEN=$(cat "${FIREZONE_TOKEN}")
+    FIREZONE_TOKEN="$(cat "${FIREZONE_TOKEN}")"
+    export FIREZONE_TOKEN
 fi
 
 if [ "${FIREZONE_ENABLE_MASQUERADE}" = "1" ]; then


### PR DESCRIPTION
Addition to [#5031](https://github.com/firezone/firezone/pull/5031)
- Fixed SC2155 and SC2046 warnings in docker-init.sh from [static-analysis / global-linter](https://github.com/firezone/firezone/actions/runs/9160472530/job/25183196263?pr=5043#logs).