### PR TITLE
chore(relay): allow domains in `--otel-grpc-endpoint`

### DIFF
--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -635,16 +635,20 @@ mod tests {
         assert!(!is_healthy)
     }
 
+    // Regression tests to ensure we can parse sockets as well as domains for the otlp-grpc endpoint.
     #[test]
-    fn parse_args_otlp_grpc_endpoint() {
-        let result = Args::try_parse_from(["relay", "--otlp-grpc-endpoint", "127.0.0.1:4317"]);
-        assert!(
-            result.is_ok_and(|args| args.otlp_grpc_endpoint == Some("127.0.0.1:4317".to_string()))
-        );
+    fn args_can_parse_otlp_endpoint_from_socket() {
+        let args =
+            Args::try_parse_from(["relay", "--otlp-grpc-endpoint", "127.0.0.1:4317"]).unwrap();
 
-        let result = Args::try_parse_from(["relay", "--otlp-grpc-endpoint", "localhost:4317"]);
-        assert!(
-            result.is_ok_and(|args| args.otlp_grpc_endpoint == Some("localhost:4317".to_string()))
-        );
+        assert_eq!(args.otlp_grpc_endpoint.unwrap(), "127.0.0.1:4317");
+    }
+
+    #[test]
+    fn args_can_parse_otlp_endpoint_from_domain() {
+        let args =
+            Args::try_parse_from(["relay", "--otlp-grpc-endpoint", "localhost:4317"]).unwrap();
+
+        assert_eq!(args.otlp_grpc_endpoint.unwrap(), "localhost:4317");
     }
 }

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -638,9 +638,13 @@ mod tests {
     #[test]
     fn parse_args_otlp_grpc_endpoint() {
         let result = Args::try_parse_from(&["relay", "--otlp-grpc-endpoint", "127.0.0.1:4317"]);
-        assert!(result.is_ok_and(|args| args.otlp_grpc_endpoint == Some("127.0.0.1:4317".to_string())));
+        assert!(
+            result.is_ok_and(|args| args.otlp_grpc_endpoint == Some("127.0.0.1:4317".to_string()))
+        );
 
         let result = Args::try_parse_from(&["relay", "--otlp-grpc-endpoint", "localhost:4317"]);
-        assert!(result.is_ok_and(|args| args.otlp_grpc_endpoint == Some("localhost:4317".to_string())));
+        assert!(
+            result.is_ok_and(|args| args.otlp_grpc_endpoint == Some("localhost:4317".to_string()))
+        );
     }
 }

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -637,12 +637,12 @@ mod tests {
 
     #[test]
     fn parse_args_otlp_grpc_endpoint() {
-        let result = Args::try_parse_from(&["relay", "--otlp-grpc-endpoint", "127.0.0.1:4317"]);
+        let result = Args::try_parse_from(["relay", "--otlp-grpc-endpoint", "127.0.0.1:4317"]);
         assert!(
             result.is_ok_and(|args| args.otlp_grpc_endpoint == Some("127.0.0.1:4317".to_string()))
         );
 
-        let result = Args::try_parse_from(&["relay", "--otlp-grpc-endpoint", "localhost:4317"]);
+        let result = Args::try_parse_from(["relay", "--otlp-grpc-endpoint", "localhost:4317"]);
         assert!(
             result.is_ok_and(|args| args.otlp_grpc_endpoint == Some("localhost:4317".to_string()))
         );


### PR DESCRIPTION
Replaces #4932.