### PR TITLE
test(connlib): add `RoamClient` transition to state machine tests

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -157,6 +157,8 @@ where
                 remove_local_candidate(id, agent, &candidate, &mut self.pending_events)
             }
         }
+
+        debug_assert!(self.host_candidates.is_empty());
     }
 
     pub fn public_key(&self) -> PublicKey {
@@ -660,7 +662,9 @@ where
                 };
 
                 if allocation.handle_input(from, local, packet, now) {
-                    // Successfully handled the packet
+                    // Successfully handled the packet; ensure all new events are being handled.
+                    self.bindings_and_allocations_drain_events();
+
                     return ControlFlow::Break(());
                 }
 


### PR DESCRIPTION
Firezone needs to work seemlessly despite the user roaming networks. We can incorporate this property into our state machine tests with a `RoamClient` transition. This updates the client's IPv4 and IPv6 socket to a new pair.

In these tests, we treat all unhandled packets as a bug. Unfortunately, a client cannot immediately detect that it roamed networks (we use BINDING requests to all our relays for that). Prior to it detecting which interfaces are now available and which are gone, it may still send outdated srflx candidates to the gateway which will prompt the gateway to send packets to that endpoint. Thus, we have to add an exception to the "all unhandled packets are a bug"-check and simply discard packets to a client's old sockets.

Depends-On: #5080.
Depends-On: #5077.
Depends-On: #5079.
Depends-On: #5049.