### PR TITLE
chore(gui-client): disable the Welcome screen only after the first sign-in

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -500,10 +500,7 @@ impl Controller {
         };
 
         let api_url = self.advanced_settings.api_url.clone();
-        tracing::info!(
-            api_url = api_url.to_string(),
-            "Starting connlib..."
-        );
+        tracing::info!(api_url = api_url.to_string(), "Starting connlib...");
 
         let mut connlib = ipc::Client::connect(
             api_url.as_str(),

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -502,7 +502,7 @@ impl Controller {
         let api_url = self.advanced_settings.api_url.clone();
         tracing::info!(
             api_url = api_url.to_string(),
-            "Calling connlib Session::connect"
+            "Starting connlib..."
         );
 
         let mut connlib = ipc::Client::connect(
@@ -523,6 +523,7 @@ impl Controller {
         });
         self.refresh_system_tray_menu()?;
 
+        ran_before::set().await?;
         Ok(())
     }
 
@@ -554,7 +555,6 @@ impl Controller {
         self.start_session(token)
             .await
             .context("Couldn't start connlib session")?;
-        ran_before::set().await?;
         Ok(())
     }
 

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -743,16 +743,9 @@ async fn run_controller(
     logging_handles: client::logging::Handles,
     advanced_settings: AdvancedSettings,
 ) -> Result<()> {
-    if !ran_before::get().await? {
-        let win = app
-            .get_window("welcome")
-            .context("Couldn't get handle to Welcome window")?;
-        win.show()?;
-    }
-
     let mut controller = Controller {
         advanced_settings,
-        app,
+        app: app.clone(),
         auth: client::auth::Auth::new(),
         ctlr_tx,
         session: None,
@@ -773,6 +766,13 @@ async fn run_controller(
             .context("Failed to restart session during app start")?;
     } else {
         tracing::info!("No token / actor_name on disk, starting in signed-out state");
+    }
+
+    if !ran_before::get().await? {
+        let win = app
+            .get_window("welcome")
+            .context("Couldn't get handle to Welcome window")?;
+        win.show()?;
     }
 
     let mut have_internet =

--- a/rust/gui-client/src-tauri/src/client/gui/ran_before.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/ran_before.rs
@@ -1,0 +1,29 @@
+//! Controls an on-disk flag indicating whether the user has signed in before
+
+use anyhow::{Context as _, Result};
+use std::path::PathBuf;
+use tokio::fs;
+
+/// Returns true if the flag is set
+pub(crate) async fn get() -> Result<bool> {
+    Ok(fs::try_exists(path()?).await?)
+}
+
+/// Sets the flag to true
+pub(crate) async fn set() -> Result<()> {
+    let path = path()?;
+    fs::create_dir_all(
+        path.parent()
+            .context("ran_before path should have a parent dir")?,
+    )
+    .await?;
+    fs::write(&path, &[]).await?;
+    debug_assert!(get().await?);
+    Ok(())
+}
+
+fn path() -> Result<PathBuf> {
+    let session_dir =
+        firezone_headless_client::known_dirs::session().context("Couldn't find session dir")?;
+    Ok(session_dir.join("ran_before.txt"))
+}

--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -58,7 +58,8 @@ function smoke_test() {
     bash -c "stat \"${LOGS_PATH}/\"connlib*log"
     stat "$SETTINGS_PATH"
     # stat "$DEVICE_ID_PATH"
-    stat "$RAN_BEFORE_PATH"
+    # `ran_before` is now only written after a successful sign-in
+    stat "$RAN_BEFORE_PATH" && exit 1
 
     # Run the test again and make sure the device ID is not changed
     run_fz_gui --no-deep-links smoke-test
@@ -74,7 +75,7 @@ function smoke_test() {
     rm -rf "$LOGS_PATH"
     rm "$SETTINGS_PATH"
     # rm "$DEVICE_ID_PATH"
-    rm "$RAN_BEFORE_PATH"
+    rm -f "$RAN_BEFORE_PATH"
 }
 
 function crash_test() {


### PR DESCRIPTION
Closes #5015.

This way if the user opens and closes the GUI without doing anything, the Welcome screen still appears until they successfully sign in. Previously the `ran_before` flag was set after the first GUI startup.

Tested on Windows once.