### PR TITLE
chore(gui-client): remove incorrect DNS deactivation

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -267,7 +267,6 @@ pub(crate) fn run(cli: client::Cli) -> Result<(), Error> {
                         Ok(Ok(_)) => 0,
                     };
 
-                    cleanup();
                     tracing::info!(?exit_code);
                     app_handle.exit(exit_code);
                 });
@@ -308,13 +307,6 @@ pub(crate) fn run(cli: client::Cli) -> Result<(), Error> {
         }
     });
     Ok(())
-}
-
-/// Best-effort cleanup of things like DNS control before graceful exit
-fn cleanup() {
-    // Do this redundant deactivation because `Tun` will not automatically Drop before
-    // the process exits
-    connlib_shared::deactivate_dns_control().ok();
 }
 
 /// Runs a smoke test and then asks Controller to exit gracefully


### PR DESCRIPTION
This call always results in an error because the GUI runs unprivileged on both Linux and Windows now, so it can't control DNS or deactivate DNS control. The IPC service has taken over all that, so the GUI not only shouldn't do it, it can't do it.

<img width="568" alt="image" src="https://github.com/firezone/firezone/assets/13400041/ad1b861f-4f3e-453a-94b5-d6f21c9eb198">
