### PR TITLE
refactor(connlib): remove concept of "allowed IPs" from `Peer`

### DIFF
--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -1,6 +1,5 @@
 //! Error module.
 use base64::DecodeError;
-use std::net::IpAddr;
 use thiserror::Error;
 
 /// Unified Result type to use across connlib.
@@ -78,8 +77,6 @@ pub enum ConnlibError {
 
     #[error(transparent)]
     Snownet(#[from] snownet::Error),
-    #[error("Detected non-allowed packet in channel from {0}")]
-    UnallowedPacket(IpAddr),
 
     // Error variants for `systemd-resolved` DNS control
     #[error("Failed to control system DNS with `resolvectl`")]

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -197,7 +197,7 @@ where
         expires_at: Option<DateTime<Utc>>,
         resource_addresses: Vec<IpNetwork>,
     ) {
-        let mut peer = ClientOnGateway::new(client_id, &ips);
+        let mut peer = ClientOnGateway::new(client_id);
 
         peer.add_resource(resource_addresses, resource, filters, expires_at);
 

--- a/rust/connlib/tunnel/src/peer_store.rs
+++ b/rust/connlib/tunnel/src/peer_store.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::net::IpAddr;
 
 use crate::peer::{ClientOnGateway, GatewayOnClient};
-use connlib_shared::messages::{ClientId, GatewayId, ResourceId};
+use connlib_shared::messages::{ClientId, GatewayId};
 use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 
@@ -17,22 +17,6 @@ impl<TId, P> Default for PeerStore<TId, P> {
         Self {
             id_by_ip: IpNetworkTable::new(),
             peer_by_id: HashMap::new(),
-        }
-    }
-}
-
-impl PeerStore<GatewayId, GatewayOnClient> {
-    pub(crate) fn add_ips_with_resource(
-        &mut self,
-        id: &GatewayId,
-        ips: &[IpNetwork],
-        resource: &ResourceId,
-    ) {
-        for ip in ips {
-            let Some(peer) = self.add_ip(id, ip) else {
-                continue;
-            };
-            peer.insert_id(ip, resource);
         }
     }
 }


### PR DESCRIPTION
In firezone, a wireguard tunnel between two nodes is always ephemeral. Thus, any packet coming out of a tunnel always comes from the same IP.

There is no need to double check that the packets do indeed come from the TUN device of the other peer. If the remote has the correct WG key to send us packets, we should accept them. Checking the IP does not give us any additional security benefit.