### PR TITLE
feat(elixir): allow migrations bypass on startup

### DIFF
--- a/elixir/rel/overlays/bin/server
+++ b/elixir/rel/overlays/bin/server
@@ -1,5 +1,7 @@
 #!/bin/sh
 set -e
 . "$(dirname -- "$0")/bootstrap"
-./migrate
+if [ "${SKIP_DB_MIGRATIONS}" != "1" ]; then
+    ./migrate
+fi
 exec ./"$APPLICATION_NAME" start


### PR DESCRIPTION
~~I've not tested that yet but~~ it would be nice to have an option to bypass db migrations in order to improve the startup time.
