### PR TITLE
chore(firezone-tunnel/android): revert regression from #4788

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -64,7 +64,23 @@ impl Device {
         }
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(target_os = "android")]
+    pub(crate) fn set_config(
+        &mut self,
+        config: &Interface,
+        dns_config: Vec<IpAddr>,
+        callbacks: &impl Callbacks,
+    ) -> Result<(), ConnlibError> {
+        self.tun = Some(Tun::new(config, dns_config, callbacks)?);
+
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
     pub(crate) fn set_config(
         &mut self,
         config: &Interface,
@@ -73,6 +89,7 @@ impl Device {
     ) -> Result<(), ConnlibError> {
         self.tun = Some(Tun::new(config, dns_config.clone(), callbacks)?);
 
+        // The actual values are ignored, this is just used as a `TunnelReady` signal
         callbacks.on_set_interface_config(config.ipv4, config.ipv6, dns_config);
 
         if let Some(waker) = self.waker.take() {


### PR DESCRIPTION
Closes #5086
I accidentally modified a function that's used in both Android and Linux, this PR splits it up into two functions

```[tasklist]
### Before merging
- [x] Check aarch64 deb still signs in (716320)
```