### PR TITLE
fix(apple): Fix menu display and activation

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -212,7 +212,6 @@ public final class MenuBar: NSObject {
   }
 
   @objc private func aboutButtonTapped() {
-    NSApp.activate(ignoringOtherApps: true)
     NSApp.orderFrontStandardAboutPanel(self)
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -34,8 +34,6 @@ public final class MenuBar: NSObject {
   private var connectingAnimationImageIndex: Int = 0
   private var connectingAnimationTimer: Timer?
 
-  private lazy var menu = NSMenu()
-
   public init(model: SessionViewModel) {
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     self.model = model
@@ -66,23 +64,6 @@ public final class MenuBar: NSObject {
     }
   }
 
-  private func createMenu() {
-    menu.addItem(signInMenuItem)
-    menu.addItem(signOutMenuItem)
-    menu.addItem(NSMenuItem.separator())
-
-    menu.addItem(resourcesTitleMenuItem)
-    menu.addItem(resourcesUnavailableMenuItem)
-    menu.addItem(resourcesUnavailableReasonMenuItem)
-    menu.addItem(resourcesSeparatorMenuItem)
-
-    menu.addItem(aboutMenuItem)
-    menu.addItem(settingsMenuItem)
-    menu.addItem(quitMenuItem)
-
-    menu.delegate = self
-  }
-
   private func setupObservers() {
     model.store.$status
       .receive(on: DispatchQueue.main)
@@ -111,6 +92,7 @@ public final class MenuBar: NSObject {
       }).store(in: &cancellables)
   }
 
+  private lazy var menu = NSMenu()
 
   private lazy var signInMenuItem = createMenuItem(
     menu,
@@ -179,6 +161,23 @@ public final class MenuBar: NSObject {
     }
     return menuItem
   }()
+
+  private func createMenu() {
+    menu.addItem(signInMenuItem)
+    menu.addItem(signOutMenuItem)
+    menu.addItem(NSMenuItem.separator())
+
+    menu.addItem(resourcesTitleMenuItem)
+    menu.addItem(resourcesUnavailableMenuItem)
+    menu.addItem(resourcesUnavailableReasonMenuItem)
+    menu.addItem(resourcesSeparatorMenuItem)
+
+    menu.addItem(aboutMenuItem)
+    menu.addItem(settingsMenuItem)
+    menu.addItem(quitMenuItem)
+
+    menu.delegate = self
+  }
 
   private func createMenuItem(
     _: NSMenu,


### PR DESCRIPTION
When the menu was clicked, the system would show it without activating the app. This meant that other actions launched from the menu like `Sign in` could sometimes happen without their respective window coming to the foreground.

To fix it, we need more control over how the menu is displayed. So we add a click handler and open the menu manually. Note that to do this, we need to ensure `statusItem.menu = nil` otherwise the system will default to showing the menu for us, and not firing our handler.

fixes #4818 