### PR TITLE
refactor(connlib-client-shared): Use builder pattern for `Session::connect`

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -5,7 +5,7 @@
 
 use connlib_client_shared::{
     callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error,
-    LoginUrl, LoginUrlError, Session, Sockets,
+    LoginUrl, LoginUrlError, Session, SessionBuilder, Sockets,
 };
 use jni::{
     objects::{GlobalRef, JClass, JObject, JString, JValue},
@@ -376,15 +376,16 @@ fn connect(
         }
     });
 
-    let session = Session::connect(
-        login,
-        sockets,
-        private_key,
-        Some(os_version),
-        callback_handler,
-        Some(MAX_PARTITION_TIME),
-        runtime.handle().clone(),
-    );
+    let session = SessionBuilder::default()
+        .max_partition_time(MAX_PARTITION_TIME)
+        .os_version_override(os_version)
+        .sockets(sockets)
+        .build(
+            login,
+            private_key,
+            callback_handler,
+            runtime.handle().clone(),
+        );
 
     Ok(SessionWrapper {
         inner: session,

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -3,7 +3,7 @@
 
 use connlib_client_shared::{
     callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error,
-    LoginUrl, Session, Sockets,
+    LoginUrl, Session, SessionBuilder,
 };
 use secrecy::SecretString;
 use std::{
@@ -191,17 +191,17 @@ impl WrappedSession {
             .build()
             .map_err(|e| e.to_string())?;
 
-        let session = Session::connect(
-            login,
-            Sockets::new(),
-            private_key,
-            os_version_override,
-            CallbackHandler {
-                inner: Arc::new(callback_handler),
-            },
-            Some(MAX_PARTITION_TIME),
-            runtime.handle().clone(),
-        );
+        let session = SessionBuilder::default()
+            .max_partition_time(MAX_PARTITION_TIME)
+            .os_version_override(os_version_override)
+            .build(
+                login,
+                private_key,
+                CallbackHandler {
+                    inner: Arc::new(callback_handler),
+                },
+                runtime.handle().clone(),
+            );
 
         Ok(Self {
             inner: session,

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -33,45 +33,29 @@ pub struct Session {
 }
 
 // Tried `derive_builder` for this but couldn't make it do what we need
-pub struct SessionBuilder<CB> {
-    url: LoginUrl,
-    private_key: StaticSecret,
-    callbacks: CB,
-    handle: tokio::runtime::Handle,
-
+#[derive(Default)]
+pub struct SessionBuilder {
     sockets: Option<Sockets>,
     os_version_override: Option<String>,
     max_partition_time: Option<Duration>,
 }
 
-impl<CB: Callbacks + 'static> SessionBuilder<CB> {
-    pub fn new(
+impl SessionBuilder {
+    pub fn build<CB: Callbacks + 'static>(
+        self,
         url: LoginUrl,
         private_key: StaticSecret,
         callbacks: CB,
         handle: tokio::runtime::Handle,
-    ) -> Self {
-        Self {
-            url,
-            private_key,
-            callbacks,
-            handle,
-
-            sockets: None,
-            os_version_override: None,
-            max_partition_time: None,
-        }
-    }
-
-    pub fn build(self) -> Session {
+    ) -> Session {
         Session::connect(
-            self.url,
+            url,
             self.sockets.unwrap_or_default(),
-            self.private_key,
+            private_key,
             self.os_version_override,
-            self.callbacks,
+            callbacks,
             self.max_partition_time,
-            self.handle,
+            handle,
         )
     }
 

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -66,7 +66,7 @@ impl<CB: Callbacks + 'static> SessionBuilder<CB> {
     pub fn build(self) -> Session {
         Session::connect(
             self.url,
-            self.sockets.unwrap_or_else(|| Sockets::new()),
+            self.sockets.unwrap_or_default(),
             self.private_key,
             self.os_version_override,
             self.callbacks,

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -10,7 +10,7 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use connlib_client_shared::{file_logger, keypair, Callbacks, LoginUrl, Session, Sockets};
+use connlib_client_shared::{file_logger, keypair, Callbacks, LoginUrl, SessionBuilder};
 use connlib_shared::callbacks;
 use firezone_cli_utils::setup_global_subscriber;
 use secrecy::SecretString;
@@ -205,15 +205,9 @@ pub fn run_only_headless_client() -> Result<()> {
     let callback_handler = CallbackHandler { on_disconnect_tx };
 
     platform::setup_before_connlib()?;
-    let session = Session::connect(
-        login,
-        Sockets::new(),
-        private_key,
-        None,
-        callback_handler,
-        max_partition_time,
-        rt.handle().clone(),
-    );
+    let session = SessionBuilder::default()
+        .max_partition_time(max_partition_time)
+        .build(login, private_key, callback_handler, rt.handle().clone());
     // TODO: this should be added dynamically
     session.set_dns(platform::system_resolvers().unwrap_or_default());
 

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -3,7 +3,7 @@
 use super::{Cli, IpcClientMsg, IpcServerMsg, FIREZONE_GROUP, TOKEN_ENV_KEY};
 use anyhow::{bail, Context as _, Result};
 use clap::Parser;
-use connlib_client_shared::{file_logger, Callbacks};
+use connlib_client_shared::{file_logger, Callbacks, SessionBuilder};
 use connlib_shared::{
     callbacks, keypair,
     linux::{etc_resolv_conf, get_dns_control_from_env, DnsControlMethod},
@@ -300,11 +300,11 @@ async fn handle_ipc_client(cli: &Cli, stream: UnixStream) -> Result<()> {
                 )?;
 
                 connlib = Some(
-                    connlib_client_shared::SessionBuilder::default()
+                    SessionBuilder::default()
                         .max_partition_time(
                             cli.max_partition_time
                                 .map(|t| t.into())
-                                .or(Some(std::time::Duration::from_secs(60 * 60 * 24 * 30))),
+                                .unwrap_or(std::time::Duration::from_secs(60 * 60 * 24 * 30)),
                         )
                         .build(
                             login,

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -300,18 +300,18 @@ async fn handle_ipc_client(cli: &Cli, stream: UnixStream) -> Result<()> {
                 )?;
 
                 connlib = Some(
-                    connlib_client_shared::SessionBuilder::new(
-                        login,
-                        private_key,
-                        callback_handler.clone(),
-                        tokio::runtime::Handle::try_current()?,
-                    )
-                    .max_partition_time(
-                        cli.max_partition_time
-                            .map(|t| t.into())
-                            .or(Some(std::time::Duration::from_secs(60 * 60 * 24 * 30))),
-                    )
-                    .build(),
+                    connlib_client_shared::SessionBuilder::default()
+                        .max_partition_time(
+                            cli.max_partition_time
+                                .map(|t| t.into())
+                                .or(Some(std::time::Duration::from_secs(60 * 60 * 24 * 30))),
+                        )
+                        .build(
+                            login,
+                            private_key,
+                            callback_handler.clone(),
+                            tokio::runtime::Handle::try_current()?,
+                        ),
                 );
             }
             IpcClientMsg::Disconnect => {


### PR DESCRIPTION
Closes #2986 

Needed because #5075 will add an 8th parameter, which Clippy says is too many, and that parameter (DNS control method) is only needed on Linux.

Other than that the payoff is not big. Fortunately the risk is also low.

I tried `derive_builder` but it doesn't seem like a good match for this use case, it doesn't handle `Option<T>` exactly the way I wanted.

I was going to let it be opt-in but once that 8th parameter is added, the existing `Session::connect` function would also have 8 parameters, and that ended up influencing the design of the `SessionBuilder` anyway.