### PR TITLE
refactor(elixir): remove telemetry id generation (#5084)

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -289,11 +289,6 @@ RUN set -xe \
     && adduser -s /bin/sh -u 1001 -G root -h /app -S -D default \
     && chown -R 1001:0 /app
 
-# Add other directories firezone needs to run
-RUN set -xe \
-    && mkdir -p /var/firezone \
-    && chown -R 1001:0 /var/firezone
-
 WORKDIR /app
 
 ARG APPLICATION_NAME

--- a/elixir/rel/overlays/bin/bootstrap
+++ b/elixir/rel/overlays/bin/bootstrap
@@ -1,13 +1,3 @@
 #!/bin/sh
 
-mkdir -p /var/firezone
-
-setup_telemetry() {
-    [ -f /var/firezone/.tid ] || cat /proc/sys/kernel/random/uuid >/var/firezone/.tid
-    tid=$(cat /var/firezone/.tid)
-    export TELEMETRY_ID="$tid"
-}
-
-setup_telemetry
-
 cd -P -- "$(dirname -- "$0")" || exit 1


### PR DESCRIPTION
Feel free to correct me if I'm wrong but it seems the telemetry id is not longer used in Firezone 1.x
Removing this uuid generation would allow me to put the folder `/var/firezone` as readonly instead of mounting a
[volume](https://github.com/Intuinewin/helm-charts/blob/367a46a5c8fe2aa7d90d7539d6190bb660f45aed/firezone/values.yaml#L157) to allow firezone to write inside. The folder `/var/firezone` seems to be used only for this purpose

Maybe I should also remove
[this](https://github.com/firezone/firezone/blob/49a965a6867aef90952252b6a30b37d2660c1f15/elixir/Dockerfile#L293) ?

PS: I cannot find the contrib branch, but don't hesite to create it and change the target branch of this PR