### PR TITLE
chore(connlib): make `GatewayState::encapsulate` pure

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -150,6 +150,7 @@ impl GatewayState {
     pub(crate) fn encapsulate<'s>(
         &'s mut self,
         packet: MutableIpPacket<'_>,
+        now: Instant,
     ) -> Option<snownet::Transmit<'s>> {
         let dest = packet.destination();
 
@@ -157,7 +158,7 @@ impl GatewayState {
 
         let transmit = self
             .node
-            .encapsulate(peer.id(), packet.as_immutable(), Instant::now())
+            .encapsulate(peer.id(), packet.as_immutable(), now)
             .inspect_err(|e| tracing::debug!("Failed to encapsulate: {e}"))
             .ok()??;
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -207,7 +207,10 @@ where
                     continue;
                 }
                 Poll::Ready(io::Input::Device(packet)) => {
-                    let Some(transmit) = self.role_state.encapsulate(packet) else {
+                    let Some(transmit) = self
+                        .role_state
+                        .encapsulate(packet, std::time::Instant::now())
+                    else {
                         continue;
                     };
 


### PR DESCRIPTION
All functions on `GatewayState` and `ClientState` should be pure to allow testing via property-based tests where we control all inputs, including time.