### PR TITLE
feat(macOS): Add resource and site details to macOS menu

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -7,7 +7,6 @@
 // This models resources that are displayed in the UI
 
 import Foundation
-import AppKit
 
 public struct Resource: Decodable, Identifiable {
   public let id: String
@@ -54,17 +53,6 @@ public enum ResourceStatus: String, Decodable {
       return "You're connected to a healthy Gateway in this Site."
     case .unknown:
       return "No connection has been attempted to Resources in this Site. Access a Resource to establish a Gateway connection."
-    }
-  }
-
-  public func toState() -> NSControl.StateValue {
-    switch self {
-    case .offline:
-      return .off
-    case .online:
-      return .on
-    case .unknown:
-      return .mixed
     }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -7,6 +7,7 @@
 // This models resources that are displayed in the UI
 
 import Foundation
+import AppKit
 
 public struct Resource: Decodable, Identifiable {
   public let id: String
@@ -32,10 +33,57 @@ public enum ResourceStatus: String, Decodable {
   case offline = "Offline"
   case online = "Online"
   case unknown = "Unknown"
+
+  public func toSiteStatus() -> String {
+    switch self {
+    case .offline:
+      return "All Gateways offline"
+    case .online:
+      return "Gateway connected"
+    case .unknown:
+      return "No activity"
+    }
+  }
+
+  // Longer explanation shown when hovering over the site status menu item
+  public func toSiteStatusTooltip() -> String {
+    switch self {
+    case .offline:
+      return "No healthy Gateways are online in this Site."
+    case .online:
+      return "You're connected to a healthy Gateway in this Site."
+    case .unknown:
+      return "No connection has been attempted to Resources in this Site. Access a Resource to establish a Gateway connection."
+    }
+  }
+
+  public func toState() -> NSControl.StateValue {
+    switch self {
+    case .offline:
+      return .off
+    case .online:
+      return .on
+    case .unknown:
+      return .mixed
+    }
+  }
 }
 
 public enum ResourceType: String, Decodable {
   case dns = "dns"
   case cidr = "cidr"
   case ip = "ip"
+}
+
+extension Resource: Equatable {
+  public static func == (lhs: Resource, rhs: Resource) -> Bool {
+    // Resources are the same if their members are the same
+    return lhs.id == rhs.id &&
+    lhs.name == rhs.name &&
+    lhs.address == rhs.address &&
+    lhs.addressDescription == rhs.addressDescription &&
+    lhs.sites == rhs.sites &&
+    lhs.type == rhs.type &&
+    lhs.status == rhs.status
+  }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Resource: Decodable, Identifiable {
+public struct Resource: Decodable, Identifiable, Equatable {
   public let id: String
   public var name: String
   public var address: String
@@ -61,17 +61,4 @@ public enum ResourceType: String, Decodable {
   case dns = "dns"
   case cidr = "cidr"
   case ip = "ip"
-}
-
-extension Resource: Equatable {
-  public static func == (lhs: Resource, rhs: Resource) -> Bool {
-    // Resources are the same if their members are the same
-    return lhs.id == rhs.id &&
-    lhs.name == rhs.name &&
-    lhs.address == rhs.address &&
-    lhs.addressDescription == rhs.addressDescription &&
-    lhs.sites == rhs.sites &&
-    lhs.type == rhs.type &&
-    lhs.status == rhs.status
-  }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Site.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Site.swift
@@ -7,18 +7,12 @@
 
 import Foundation
 
-public struct Site: Decodable, Identifiable {
+public struct Site: Decodable, Identifiable, Equatable {
   public let id: String
   public var name: String
 
   public init(id: String, name: String) {
     self.id = id
     self.name = name
-  }
-}
-
-extension Site: Equatable {
-  public static func == (lhs: Site, rhs: Site) -> Bool {
-    return lhs.id == rhs.id && lhs.name == rhs.name
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Site.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Site.swift
@@ -16,3 +16,9 @@ public struct Site: Decodable, Identifiable {
     self.name = name
   }
 }
+
+extension Site: Equatable {
+  public static func == (lhs: Site, rhs: Site) -> Bool {
+    return lhs.id == rhs.id && lhs.name == rhs.name
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -500,7 +500,7 @@ public final class MenuBar: NSObject {
       siteStatusItem.action = #selector(resourceValueTapped(_:))
       siteStatusItem.title = resource.status.toSiteStatus()
       siteStatusItem.toolTip = "\(resource.status.toSiteStatusTooltip()) (click to copy)"
-      siteStatusItem.state = resource.status.toState()
+      siteStatusItem.state = statusToState(status: resource.status)
       siteStatusItem.isEnabled = true
       siteStatusItem.target = self
       if let onImage = NSImage(named: NSImage.statusAvailableName),
@@ -533,6 +533,17 @@ public final class MenuBar: NSObject {
     let pasteBoard = NSPasteboard.general
     pasteBoard.clearContents()
     pasteBoard.writeObjects([string as NSString])
+  }
+
+  private func statusToState(status: ResourceStatus) -> NSControl.StateValue {
+    switch status {
+    case .offline:
+      return .off
+    case .online:
+      return .on
+    case .unknown:
+      return .mixed
+    }
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -42,26 +42,10 @@ public final class MenuBar: NSObject {
 
     if let button = statusItem.button {
       button.image = signedOutIcon
-      button.target = self
-      button.action = #selector(statusItemClicked)
     }
 
     createMenu()
     setupObservers()
-  }
-
-  @objc private func statusItemClicked() {
-    // Bring our app to the foreground.
-    // Prevents the "Window ordered front from a non-active application" warning, which
-    // can cause display issues with the menu.
-    NSApp.activate(ignoringOtherApps: true)
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-      guard let self = self, let button = self.statusItem.button else { return }
-      self.statusItem.menu = menu
-
-      // Simulate a click to open the menu
-      button.performClick(nil)
-    }
   }
 
   private func setupObservers() {
@@ -72,7 +56,9 @@ public final class MenuBar: NSObject {
 
         if status == .connected {
           model.store.beginUpdatingResources { data in
-            if let newResources = try? JSONDecoder().decode([Resource].self, from: data) {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            if let newResources = try? decoder.decode([Resource].self, from: data) {
               // Handle resource changes
               self.populateResourceMenu(newResources)
               self.handleTunnelStatusOrResourcesChanged(status: status, resources: newResources)
@@ -141,12 +127,45 @@ public final class MenuBar: NSObject {
     }
     return menuItem
   }()
+  private lazy var adminPortalMenuItem: NSMenuItem = {
+    let menuItem = createMenuItem(
+      menu,
+      title: "Admin Portal...",
+      action: #selector(adminPortalButtonTapped),
+      target: self
+    )
+    return menuItem
+  }()
+  private lazy var documentationMenuItem: NSMenuItem = {
+    let menuItem = createMenuItem(
+      menu,
+      title: "Documentation...",
+      action: #selector(documentationButtonTapped),
+      target: self
+    )
+    return menuItem
+  }()
+  private lazy var supportMenuItem = createMenuItem(
+    menu,
+    title: "Support...",
+    action: #selector(supportButtonTapped),
+    target: self
+  )
+  private lazy var helpMenuItem: NSMenuItem = {
+    let menuItem = NSMenuItem(title: "Help", action: nil, keyEquivalent: "")
+    let subMenu = NSMenu()
+    subMenu.addItem(documentationMenuItem)
+    subMenu.addItem(supportMenuItem)
+    menuItem.submenu = subMenu
+    return menuItem
+  }()
 
   private lazy var settingsMenuItem = createMenuItem(
     menu,
     title: "Settings",
     action: #selector(settingsButtonTapped),
-    target: nil
+    key: ",",
+    target: self
   )
   private lazy var quitMenuItem: NSMenuItem = {
     let menuItem = createMenuItem(
@@ -173,10 +192,14 @@ public final class MenuBar: NSObject {
     menu.addItem(resourcesSeparatorMenuItem)
 
     menu.addItem(aboutMenuItem)
+    menu.addItem(adminPortalMenuItem)
+    menu.addItem(helpMenuItem)
     menu.addItem(settingsMenuItem)
+    menu.addItem(NSMenuItem.separator())
     menu.addItem(quitMenuItem)
 
     menu.delegate = self
+    statusItem.menu = menu
   }
 
   private func createMenuItem(
@@ -197,6 +220,7 @@ public final class MenuBar: NSObject {
   }
 
   @objc private func signInButtonTapped() {
+    NSApp.activate(ignoringOtherApps: true)
     Task { await WebAuthSession.signIn(store: model.store) }
   }
 
@@ -210,7 +234,23 @@ public final class MenuBar: NSObject {
     AppViewModel.WindowDefinition.settings.openWindow()
   }
 
+  @objc private func adminPortalButtonTapped() {
+    let url = URL(string: model.store.settings.authBaseURL)!
+    NSWorkspace.shared.open(url)
+  }
+
+  @objc private func documentationButtonTapped() {
+    let url = URL(string: "https://www.firezone.dev/kb?utm_source=macos-client")!
+    NSWorkspace.shared.open(url)
+  }
+
+  @objc private func supportButtonTapped() {
+    let url = URL(string: "https://www.firezone.dev/support?utm_source=macos-client")!
+    NSWorkspace.shared.open(url)
+  }
+
   @objc private func aboutButtonTapped() {
+    NSApp.activate(ignoringOtherApps: true)
     NSApp.orderFrontStandardAboutPanel(self)
   }
 
@@ -357,13 +397,13 @@ public final class MenuBar: NSObject {
     // the menu contains other things besides resources, so update it in-place
     let diff = (newResources ?? []).difference(
       from: resources ?? [],
-      by: { $0.name == $1.name && $0.address == $1.address }
+      by: { $0 == $1 }
     )
     let index = menu.index(of: resourcesTitleMenuItem) + 1
     for change in diff {
       switch change {
       case .insert(let offset, let element, associatedWith: _):
-        let menuItem = createResourceMenuItem(title: element.name, submenuTitle: element.address)
+        let menuItem = createResourceMenuItem(resource: element)
         menu.insertItem(menuItem, at: index + offset)
       case .remove(let offset, element: _, associatedWith: _):
         menu.removeItem(at: index + offset)
@@ -371,26 +411,121 @@ public final class MenuBar: NSObject {
     }
   }
 
-  private func createResourceMenuItem(title: String, submenuTitle: String) -> NSMenuItem {
-    let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-
-    let subMenu = NSMenu()
-    let subMenuItem = NSMenuItem(
-      title: submenuTitle, action: #selector(resourceValueTapped(_:)), keyEquivalent: ""
-    )
-    subMenuItem.isEnabled = true
-    subMenuItem.target = self
-    subMenu.addItem(subMenuItem)
+  private func createResourceMenuItem(resource: Resource) -> NSMenuItem {
+    let item = NSMenuItem(title: resource.name, action: nil, keyEquivalent: "")
 
     item.isHidden = false
-    item.submenu = subMenu
+    item.submenu = createSubMenu(resource: resource)
 
     return item
+  }
+
+  private func createSubMenu(resource: Resource) -> NSMenu {
+    let subMenu = NSMenu()
+    let resourceAddressDescriptionItem = NSMenuItem()
+    let resourceSectionItem = NSMenuItem()
+    let resourceNameItem = NSMenuItem()
+    let resourceAddressItem = NSMenuItem()
+    let siteSectionItem = NSMenuItem()
+    let siteNameItem = NSMenuItem()
+    let siteStatusItem = NSMenuItem()
+
+
+    // AddressDescription first -- will be most common action
+    if let addressDescription = resource.addressDescription {
+      resourceAddressDescriptionItem.title = addressDescription
+
+      if let url = URL(string: addressDescription),
+         let _ = url.host {
+        // Looks like a URL, so allow opening it
+        resourceAddressDescriptionItem.action = #selector(resourceURLTapped(_:))
+        resourceAddressDescriptionItem.toolTip = "Click to open"
+
+        // TODO: Expose markdown support? Blocked by Tauri clients.
+        // Using Markdown here only to highlight the URL
+        resourceAddressDescriptionItem.attributedTitle = try? NSAttributedString(markdown: "**[\(addressDescription)](\(addressDescription))**")
+      } else {
+        resourceAddressDescriptionItem.attributedTitle = try? NSAttributedString(markdown: "**\(addressDescription)**")
+        resourceAddressDescriptionItem.action = #selector(resourceValueTapped(_:))
+        resourceAddressDescriptionItem.toolTip = "Click to copy"
+      }
+    } else {
+      // Show Address first if addressDescription is missing
+      resourceAddressDescriptionItem.title = resource.address
+      resourceAddressDescriptionItem.action = #selector(resourceValueTapped(_:))
+    }
+    resourceAddressDescriptionItem.isEnabled = true
+    resourceAddressDescriptionItem.target = self
+    subMenu.addItem(resourceAddressDescriptionItem)
+
+    subMenu.addItem(NSMenuItem.separator())
+
+    resourceSectionItem.title = "Resource"
+    resourceSectionItem.isEnabled = false
+    subMenu.addItem(resourceSectionItem)
+
+    // Resource name
+    resourceNameItem.action = #selector(resourceValueTapped(_:))
+    resourceNameItem.title = resource.name
+    resourceNameItem.toolTip = "Resource name (click to copy)"
+    resourceNameItem.isEnabled = true
+    resourceNameItem.target = self
+    subMenu.addItem(resourceNameItem)
+
+    // Resource address
+    resourceAddressItem.action = #selector(resourceValueTapped(_:))
+    resourceAddressItem.title = resource.address
+    resourceAddressItem.toolTip = "Resource address (click to copy)"
+    resourceAddressItem.isEnabled = true
+    resourceAddressItem.target = self
+    subMenu.addItem(resourceAddressItem)
+
+    // Site details
+    if let site = resource.sites.first {
+      subMenu.addItem(NSMenuItem.separator())
+
+      siteSectionItem.title = "Site"
+      siteSectionItem.isEnabled = false
+      subMenu.addItem(siteSectionItem)
+
+      // Site name
+      siteNameItem.title = site.name
+      siteNameItem.action = #selector(resourceValueTapped(_:))
+      siteNameItem.toolTip = "Site name (click to copy)"
+      siteNameItem.isEnabled = true
+      siteNameItem.target = self
+      subMenu.addItem(siteNameItem)
+
+      // Site status
+      siteStatusItem.action = #selector(resourceValueTapped(_:))
+      siteStatusItem.title = resource.status.toSiteStatus()
+      siteStatusItem.toolTip = "\(resource.status.toSiteStatusTooltip()) (click to copy)"
+      siteStatusItem.state = resource.status.toState()
+      siteStatusItem.isEnabled = true
+      siteStatusItem.target = self
+      if let onImage = NSImage(named: NSImage.statusAvailableName),
+         let offImage = NSImage(named: NSImage.statusUnavailableName),
+         let mixedImage = NSImage(named: NSImage.statusNoneName) {
+        siteStatusItem.onStateImage = onImage
+        siteStatusItem.offStateImage = offImage
+        siteStatusItem.mixedStateImage = mixedImage
+      }
+      subMenu.addItem(siteStatusItem)
+    }
+
+    return subMenu
   }
 
   @objc private func resourceValueTapped(_ sender: AnyObject?) {
     if let value = (sender as? NSMenuItem)?.title {
       copyToClipboard(value)
+    }
+  }
+
+  @objc private func resourceURLTapped(_ sender: AnyObject?) {
+    if let value = (sender as? NSMenuItem)?.title {
+      // URL has already been validated
+      NSWorkspace.shared.open(URL(string: value)!)
     }
   }
 
@@ -402,9 +537,16 @@ public final class MenuBar: NSObject {
 }
 
 extension MenuBar: NSMenuDelegate {
-  public func menuDidClose(_ menu: NSMenu) {
-    // Reset the menu so our custom action continues to work
-    statusItem.menu = nil
+}
+
+extension NSImage {
+  func resized(to newSize: NSSize) -> NSImage {
+    let newImage = NSImage(size: newSize)
+    newImage.lockFocus()
+    self.draw(in: NSRect(origin: .zero, size: newSize), from: NSRect(origin: .zero, size: self.size), operation: .copy, fraction: 1.0)
+    newImage.unlockFocus()
+    newImage.size = newSize
+    return newImage
   }
 }
 #endif


### PR DESCRIPTION
- Adds admin portal, docs, and support links to menu. The support link is a 404 for now, see firezone/gtm#249
- Adds more details including site online/offline status to submenu
- If the `address_description` field looks like a URL, open it on click. Otherwise, copy to clipboard
- Adds relevant tooltips

<img width="550" alt="Screenshot 2024-05-23 at 9 37 40 PM" src="https://github.com/firezone/firezone/assets/167144/cae4f6ce-e581-459c-82dd-032bf4ea4eb4">



<img width="481" alt="Screenshot 2024-05-23 at 9 54 51 PM" src="https://github.com/firezone/firezone/assets/167144/0f4eb80f-47f6-49a8-8830-ebfbdad7dd26">
<img width="577" alt="Screenshot 2024-05-23 at 9 54 38 PM" src="https://github.com/firezone/firezone/assets/167144/e93fefc8-3f55-45b2-9a69-cf885996a857">


Refs #3514 