### PR TITLE
feat(portal): support for tls only smtp servers

### DIFF
--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -586,6 +586,7 @@ defmodule Domain.Config.Definitions do
     dump: fn map ->
       Dumper.keyword(map)
       |> Keyword.update(:tls_options, nil, &Dumper.dump_ssl_opts/1)
+      |> Keyword.update(:sockopts, nil, &Dumper.dump_ssl_opts/1)
     end
   )
 

--- a/elixir/apps/domain/lib/domain/config/dumper.ex
+++ b/elixir/apps/domain/lib/domain/config/dumper.ex
@@ -22,6 +22,7 @@ defmodule Domain.Config.Dumper do
   end
 
   defp map_values("verify", v), do: String.to_atom(v)
+  defp map_values("depth", v), do: v
   defp map_values("versions", v), do: Enum.map(v, &String.to_charlist/1)
   defp map_values("cacertfile", v), do: String.to_charlist(v)
   defp map_values("server_name_indication", v), do: String.to_charlist(v)


### PR DESCRIPTION
`tls_options` are only used for STARTTLS. To handle SMTP servers where SSL/TLS is enforced (i.e `ssl: "true"`), users must be able to provide custom `sockopts`

https://github.com/gen-smtp/gen_smtp/blob/da7893dbe5dc20f1d6137141a4ec49f910a7cef6/src/gen_smtp_client.erl#L853