### PR TITLE
feat(portal): enable welcome email sending on manually provisionned oidc users

### DIFF
--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -877,7 +877,8 @@ defmodule Web.CoreComponents do
   end
 
   def identity_has_email?(identity) do
-    not is_nil(provider_email(identity)) or identity.provider.adapter == :email
+    not is_nil(provider_email(identity)) or identity.provider.adapter == :email or
+      identity.provider_identifier =~ "@"
   end
 
   defp provider_email(identity) do

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -572,7 +572,7 @@ defmodule Web.Actors.Show do
 
     socket =
       socket
-      |> put_flash(:info, "Welcome email sent to #{identity.provider_identifier}")
+      |> put_flash(:info, "Welcome email sent to #{get_identity_email(identity)}")
 
     {:noreply, socket}
   end


### PR DESCRIPTION
Currently we can only send a welcome email to oidc users who have already logged in once. For manually provisionned oidc users, we can't. This PR aims to solve this issue