### PR TITLE
fix(portal): fix email sent flash when using oidc

### DIFF
--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -573,7 +573,7 @@ defmodule Web.Actors.Show do
 
     socket =
       socket
-      |> put_flash(:info, "Welcome email sent to #{identity.provider_identifier}")
+      |> put_flash(:info, "Welcome email sent to #{get_identity_email(identity)}")
 
     {:noreply, socket}
   end


### PR DESCRIPTION
For oidc users, `provider_identifier` is an id and not the email of the user.