### PR TITLE
fix(website): Fix script load errors and warnings

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -37,6 +37,19 @@ const nextConfig = {
   experimental: {
     typedRoutes: true,
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Permissions-Policy",
+            value: "browsing-topics=()",
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return redirects;
   },

--- a/website/src/components/Analytics/index.tsx
+++ b/website/src/components/Analytics/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, Suspense } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useMixpanel } from "react-mixpanel-browser";
 import { HubSpotSubmittedFormData } from "./types";
@@ -58,7 +58,7 @@ export function Mixpanel() {
     };
   }, [pathname, searchParams, mixpanel]);
 
-  return null;
+  return <Suspense />;
 }
 
 export function GoogleAds() {

--- a/website/src/components/Analytics/index.tsx
+++ b/website/src/components/Analytics/index.tsx
@@ -1,0 +1,152 @@
+"use client";
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useMixpanel } from "react-mixpanel-browser";
+import { HubSpotSubmittedFormData } from "./types";
+
+export function Mixpanel() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const mixpanel = useMixpanel();
+
+  useEffect(() => {
+    if (!pathname) return;
+    if (!mixpanel) return;
+
+    let url = window.origin + pathname;
+    if (searchParams.toString()) {
+      url = url + `?${searchParams.toString()}`;
+    }
+    mixpanel.track("$mp_web_page_view", {
+      $current_url: url,
+    });
+
+    const handleMessage = (event: MessageEvent) => {
+      if (
+        event.data.type === "hsFormCallback" &&
+        event.data.eventName === "onFormSubmitted"
+      ) {
+        const formData: HubSpotSubmittedFormData = event.data.data;
+        if (!formData || !formData.formGuid || !formData.submissionValues) {
+          console.error("Missing form data:", formData);
+          return;
+        }
+
+        if (
+          formData.submissionValues.email &&
+          formData.submissionValues.firstname &&
+          formData.submissionValues.lastname
+        ) {
+          mixpanel.people.set({
+            $email: formData.submissionValues.email,
+            $first_name: formData.submissionValues.firstname,
+            $last_name: formData.submissionValues.lastname,
+          });
+
+          mixpanel.track("HubSpot Form Submitted", {
+            formId: formData.formGuid,
+            conversionId: formData.conversionId,
+          });
+        }
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [pathname, searchParams, mixpanel]);
+
+  return null;
+}
+
+export function GoogleAds() {
+  const trackingId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (
+        event.data.type === "hsFormCallback" &&
+        event.data.eventName === "onFormSubmitted"
+      ) {
+        const formData: HubSpotSubmittedFormData = event.data.data;
+        if (!formData || !formData.formGuid || !formData.submissionValues) {
+          console.error("Missing form data:", formData);
+          return;
+        }
+
+        const callback = function () {
+          return;
+        };
+
+        (window as any).gtag("event", "conversion", {
+          send_to: `${trackingId}/1wX_CNmzg7MZEPyK3OA9`,
+          value: Number(formData.submissionValues["0-2/numberofemployees"]) * 5,
+          currency: "USD",
+          event_callback: callback,
+        });
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [trackingId]);
+
+  return null;
+}
+
+export function LinkedInInsights() {
+  const linkedInPartnerId = process.env.NEXT_PUBLIC_LINKEDIN_PARTNER_ID;
+
+  useEffect(() => {
+    const winAny = window as any;
+    winAny._linkedin_data_partner_ids = winAny._linkedin_data_partner_ids || [];
+    winAny._linkedin_data_partner_ids.push(linkedInPartnerId);
+
+    const initializeLintrk = () => {
+      if (winAny.lintrk) return;
+
+      winAny.lintrk = function (a: any, b: any) {
+        (winAny.lintrk.q = winAny.lintrk.q || []).push([a, b]);
+      };
+
+      const s = document.getElementsByTagName("script")[0];
+      const b = document.createElement("script");
+      b.type = "text/javascript";
+      b.async = true;
+      b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+      if (s && s.parentNode) {
+        s.parentNode.insertBefore(b, s);
+      }
+    };
+
+    initializeLintrk();
+
+    const handleMessage = (event: MessageEvent) => {
+      if (
+        event.data.type === "hsFormCallback" &&
+        event.data.eventName === "onFormSubmitted"
+      ) {
+        const formData: HubSpotSubmittedFormData = event.data.data;
+        if (!formData || !formData.formGuid || !formData.submissionValues) {
+          console.error("Missing form data:", formData);
+          return;
+        }
+
+        (window as any).lintrk("track", { conversion_id: 16519956 });
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [linkedInPartnerId]);
+
+  return null;
+}

--- a/website/src/components/Analytics/index.tsx
+++ b/website/src/components/Analytics/index.tsx
@@ -4,7 +4,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { useMixpanel } from "react-mixpanel-browser";
 import { HubSpotSubmittedFormData } from "./types";
 
-export function Mixpanel() {
+function _Mixpanel() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const mixpanel = useMixpanel();
@@ -58,7 +58,15 @@ export function Mixpanel() {
     };
   }, [pathname, searchParams, mixpanel]);
 
-  return <Suspense />;
+  return null;
+}
+
+export function Mixpanel() {
+  return (
+    <Suspense>
+      <_Mixpanel />
+    </Suspense>
+  );
 }
 
 export function GoogleAds() {

--- a/website/src/components/Analytics/types.ts
+++ b/website/src/components/Analytics/types.ts
@@ -1,0 +1,10 @@
+export interface HubSpotSubmittedFormData {
+  type: string;
+  eventName: string;
+  redirectUrl: string;
+  conversionId: string;
+  formGuid: string;
+  submissionValues: {
+    [key: string]: string;
+  };
+}

--- a/website/src/components/Providers/index.jsx
+++ b/website/src/components/Providers/index.jsx
@@ -1,16 +1,21 @@
 "use client";
 import { MixpanelProvider } from "react-mixpanel-browser";
 import { HubspotProvider } from "next-hubspot";
-import { GoogleAnalytics } from '@next/third-parties/google';
+import { GoogleAnalytics } from "@next/third-parties/google";
 
 export default function Provider({ children }) {
-  const token = process.env.NODE_ENV == "development" ? "313bdddc66b911f4afeb2c3242a78113" : "b0ab1d66424a27555ed45a27a4fd0cd2";
+  const mpToken = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
+  const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
   const host = "https://t.firez.one";
 
   return (
-    <MixpanelProvider token={token} config={{ api_host: host, record_sessions_percent: 5 }}>
+    <>
+      <MixpanelProvider
+        token={mpToken}
+        config={{ api_host: host, record_sessions_percent: 5 }}
+      />
       <HubspotProvider>{children}</HubspotProvider>
-      <GoogleAnalytics gaId="AW-16577398140" />
-    </MixpanelProvider>
+      <GoogleAnalytics gaId />
+    </>
   );
 }

--- a/website/src/components/RootLayout/index.tsx
+++ b/website/src/components/RootLayout/index.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { Metadata } from "next";
 import Link from "next/link";
 
@@ -14,172 +13,14 @@ const source_sans_3 = Source_Sans_3({
   weight: ["200", "300", "400", "500", "600", "700", "800", "900"],
 });
 import { HiArrowLongRight } from "react-icons/hi2";
-import { useMixpanel } from "react-mixpanel-browser";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, Suspense } from "react";
+import { Mixpanel, GoogleAds, LinkedInInsights } from "@/components/Analytics";
 
 export const metadata: Metadata = {
   title: "WireGuard® for Enterprise • Firezone",
   description: "Open-source, zero-trust access platform built on WireGuard®",
 };
-
-interface HubSpotSubmittedFormData {
-  type: string;
-  eventName: string;
-  redirectUrl: string;
-  conversionId: string;
-  formGuid: string;
-  submissionValues: {
-    [key: string]: string;
-  };
-}
-
-function Mixpanel() {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const mixpanel = useMixpanel();
-
-  useEffect(() => {
-    if (!pathname) return;
-    if (!mixpanel) return;
-
-    let url = window.origin + pathname;
-    if (searchParams.toString()) {
-      url = url + `?${searchParams.toString()}`;
-    }
-    mixpanel.track("$mp_web_page_view", {
-      $current_url: url,
-    });
-
-    const handleMessage = (event: MessageEvent) => {
-      if (
-        event.data.type === "hsFormCallback" &&
-        event.data.eventName === "onFormSubmitted"
-      ) {
-        const formData: HubSpotSubmittedFormData = event.data.data;
-        if (!formData || !formData.formGuid || !formData.submissionValues) {
-          console.error("Missing form data:", formData);
-          return;
-        }
-
-        if (
-          formData.submissionValues.email &&
-          formData.submissionValues.firstname &&
-          formData.submissionValues.lastname
-        ) {
-          mixpanel.people.set({
-            $email: formData.submissionValues.email,
-            $first_name: formData.submissionValues.firstname,
-            $last_name: formData.submissionValues.lastname,
-          });
-
-          mixpanel.track("HubSpot Form Submitted", {
-            formId: formData.formGuid,
-            conversionId: formData.conversionId,
-          });
-        }
-      }
-    };
-
-    window.addEventListener("message", handleMessage);
-
-    return () => {
-      window.removeEventListener("message", handleMessage);
-    };
-  }, [pathname, searchParams, mixpanel]);
-
-  return null;
-}
-
-function GoogleAds() {
-  const trackingId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
-
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (
-        event.data.type === "hsFormCallback" &&
-        event.data.eventName === "onFormSubmitted"
-      ) {
-        const formData: HubSpotSubmittedFormData = event.data.data;
-        if (!formData || !formData.formGuid || !formData.submissionValues) {
-          console.error("Missing form data:", formData);
-          return;
-        }
-
-        const callback = function () {
-          return;
-        };
-
-        (window as any).gtag("event", "conversion", {
-          send_to: `${trackingId}/1wX_CNmzg7MZEPyK3OA9`,
-          value: Number(formData.submissionValues["0-2/numberofemployees"]) * 5,
-          currency: "USD",
-          event_callback: callback,
-        });
-      }
-    };
-
-    window.addEventListener("message", handleMessage);
-
-    return () => {
-      window.removeEventListener("message", handleMessage);
-    };
-  }, [trackingId]);
-
-  return null;
-}
-
-function LinkedInInsights() {
-  const linkedInPartnerId = process.env.NEXT_PUBLIC_LINKEDIN_PARTNER_ID;
-
-  useEffect(() => {
-    const winAny = window as any;
-    winAny._linkedin_data_partner_ids = winAny._linkedin_data_partner_ids || [];
-    winAny._linkedin_data_partner_ids.push(linkedInPartnerId);
-
-    const initializeLintrk = () => {
-      if (winAny.lintrk) return;
-
-      winAny.lintrk = function (a: any, b: any) {
-        (winAny.lintrk.q = winAny.lintrk.q || []).push([a, b]);
-      };
-
-      const s = document.getElementsByTagName("script")[0];
-      const b = document.createElement("script");
-      b.type = "text/javascript";
-      b.async = true;
-      b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
-      if (s && s.parentNode) {
-        s.parentNode.insertBefore(b, s);
-      }
-    };
-
-    initializeLintrk();
-
-    const handleMessage = (event: MessageEvent) => {
-      if (
-        event.data.type === "hsFormCallback" &&
-        event.data.eventName === "onFormSubmitted"
-      ) {
-        const formData: HubSpotSubmittedFormData = event.data.data;
-        if (!formData || !formData.formGuid || !formData.submissionValues) {
-          console.error("Missing form data:", formData);
-          return;
-        }
-
-        (window as any).lintrk("track", { conversion_id: 16519956 });
-      }
-    };
-
-    window.addEventListener("message", handleMessage);
-
-    return () => {
-      window.removeEventListener("message", handleMessage);
-    };
-  }, [linkedInPartnerId]);
-
-  return null;
-}
 
 export default function RootLayout({
   children,
@@ -194,8 +35,6 @@ export default function RootLayout({
       />
       <Suspense>
         <Mixpanel />
-        <GoogleAds />
-        <LinkedInInsights />
       </Suspense>
       <body className={source_sans_3.className}>
         <Banner active={false}>
@@ -229,6 +68,8 @@ export default function RootLayout({
           defer
           src="//js.hs-scripts.com/23723443.js"
         />
+        <GoogleAds />
+        <LinkedInInsights />
       </body>
     </html>
   );

--- a/website/src/components/RootLayout/index.tsx
+++ b/website/src/components/RootLayout/index.tsx
@@ -33,9 +33,6 @@ export default function RootLayout({
         type="text/javascript"
         src="https://app.termly.io/resource-blocker/c4df1a31-22d9-4000-82e6-a86cbec0bba0?autoBlock=on"
       />
-      <Suspense>
-        <Mixpanel />
-      </Suspense>
       <body className={source_sans_3.className}>
         <Banner active={false}>
           <p className="mx-auto text-center">
@@ -68,6 +65,7 @@ export default function RootLayout({
           defer
           src="//js.hs-scripts.com/23723443.js"
         />
+        <Mixpanel />
         <GoogleAds />
         <LinkedInInsights />
       </body>

--- a/website/src/components/RootLayout/index.tsx
+++ b/website/src/components/RootLayout/index.tsx
@@ -14,7 +14,6 @@ const source_sans_3 = Source_Sans_3({
 });
 import { HiArrowLongRight } from "react-icons/hi2";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect, Suspense } from "react";
 import { Mixpanel, GoogleAds, LinkedInInsights } from "@/components/Analytics";
 
 export const metadata: Metadata = {

--- a/website/src/components/RootLayout/index.tsx
+++ b/website/src/components/RootLayout/index.tsx
@@ -32,6 +32,7 @@ export default function RootLayout({
         type="text/javascript"
         src="https://app.termly.io/resource-blocker/c4df1a31-22d9-4000-82e6-a86cbec0bba0?autoBlock=on"
       />
+      <Mixpanel />
       <body className={source_sans_3.className}>
         <Banner active={false}>
           <p className="mx-auto text-center">
@@ -64,7 +65,6 @@ export default function RootLayout({
           defer
           src="//js.hs-scripts.com/23723443.js"
         />
-        <Mixpanel />
         <GoogleAds />
         <LinkedInInsights />
       </body>

--- a/website/src/components/RootLayout/index.tsx
+++ b/website/src/components/RootLayout/index.tsx
@@ -92,8 +92,7 @@ function Mixpanel() {
 }
 
 function GoogleAds() {
-  const trackingId =
-    process.env.NODE_ENV == "development" ? null : "AW-16577398140";
+  const trackingId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
@@ -112,7 +111,7 @@ function GoogleAds() {
         };
 
         (window as any).gtag("event", "conversion", {
-          send_to: "AW-16577398140/1wX_CNmzg7MZEPyK3OA9",
+          send_to: `${trackingId}/1wX_CNmzg7MZEPyK3OA9`,
           value: Number(formData.submissionValues["0-2/numberofemployees"]) * 5,
           currency: "USD",
           event_callback: callback,
@@ -131,7 +130,7 @@ function GoogleAds() {
 }
 
 function LinkedInInsights() {
-  const linkedInPartnerId = "6200852";
+  const linkedInPartnerId = process.env.NEXT_PUBLIC_LINKEDIN_PARTNER_ID;
 
   useEffect(() => {
     const winAny = window as any;
@@ -189,7 +188,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <Script src="https://app.termly.io/resource-blocker/c4df1a31-22d9-4000-82e6-a86cbec0bba0?autoBlock=off" />
+      <Script
+        type="text/javascript"
+        src="https://app.termly.io/resource-blocker/c4df1a31-22d9-4000-82e6-a86cbec0bba0?autoBlock=on"
+      />
       <Suspense>
         <Mixpanel />
         <GoogleAds />

--- a/website/src/components/RootNavbar/index.tsx
+++ b/website/src/components/RootNavbar/index.tsx
@@ -54,13 +54,14 @@ export default function RootNavbar() {
               />
             </Link>
             <Link href="/">
-              <Image
-                width={150}
-                height={150}
-                src="/images/logo-text.svg"
-                className="hidden lg:flex w-32 sm:w-40 ml-2 mr-2 sm:mr-5"
-                alt="Firezone Logo"
-              />
+              <span className="hidden lg:flex w-32 sm:w-40 ml-2 mr-2 sm:mr-5">
+                <Image
+                  width={150}
+                  height={150}
+                  src="/images/logo-text.svg"
+                  alt="Firezone Logo"
+                />
+              </span>
             </Link>
             <span className="p-2"></span>
             <button


### PR DESCRIPTION
A [Suspense boundary](https://react.dev/errors/419?invariant=419) error from one of the tracking scripts is breaking any server-side rendering, causing the entire website to switch to client rendering mode, which means the full site bundle (multiple MB) needs to be downloaded before first paint.

Unfortunately it doesn't happen in dev mode. This is a first attempt to clean up some of the tracking vars to see if that fixes it.

refs firezone/gtm#268



# NOTE

You'll need to add `.env.local` in `website/` with these env vars since this PR uses the `NEXT_PUBLIC_` env var naming scheme to make sure the production ones are available in the production client bundle.

```
NEXT_PUBLIC_MIXPANEL_ID=313bdddc66b911f4afeb2c3242a78113
NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=
NEXT_PUBLIC_LINKEDIN_PARTNER_ID=6200852
```