### PR TITLE
chore(connlib): make device buffers smaller

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -70,7 +70,8 @@ pub struct Tunnel<CB: Callbacks, TRoleState> {
     ip4_read_buf: Box<[u8; MAX_UDP_SIZE]>,
     ip6_read_buf: Box<[u8; MAX_UDP_SIZE]>,
 
-    write_buf: Box<[u8; MTU]>,
+    // We need an extra 16 bytes on top of the MTU for write_buf since boringtun copies the extra AEAD tag before decrypting it
+    write_buf: Box<[u8; MTU + 16]>,
     device_read_buf: Box<[u8; MTU]>,
 }
 
@@ -87,7 +88,7 @@ where
             io: Io::new(sockets)?,
             callbacks,
             role_state: ClientState::new(private_key),
-            write_buf: Box::new([0u8; MTU]),
+            write_buf: Box::new([0u8; MTU + 16]),
             ip4_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
             ip6_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
             device_read_buf: Box::new([0u8; MTU]),
@@ -183,7 +184,7 @@ where
             io: Io::new(sockets)?,
             callbacks,
             role_state: GatewayState::new(private_key),
-            write_buf: Box::new([0u8; MTU]),
+            write_buf: Box::new([0u8; MTU + 16]),
             ip4_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
             ip6_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
             device_read_buf: Box::new([0u8; MTU]),


### PR DESCRIPTION
Since we expect a fixed MTU size, we can encode this in the size of the buffers for the device, we will never read or write more than the 1280 MTU we expect.

Note that the `write_buf` needs an extra 16 bytes for the aead tag that boringtun will copy over.