### PR TITLE
chore(ip-packet): model ICMP packets

### DIFF
--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -736,7 +736,7 @@ impl<R> TestNode<R> {
             .in_scope(|| {
                 self.node.encapsulate(
                     id,
-                    ip_packet::make::icmp_request_packet(src, dst).to_immutable(),
+                    ip_packet::make::icmp_request_packet(src, dst, 1, 0).to_immutable(),
                     now,
                 )
             })

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -539,7 +539,7 @@ mod proptests {
             let packet = match protocol {
                 Protocol::Tcp { dport } => tcp_packet(src, dest, sport, *dport, payload.clone()),
                 Protocol::Udp { dport } => udp_packet(src, dest, sport, *dport, payload.clone()),
-                Protocol::Icmp => icmp_request_packet(src, dest),
+                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
             };
             assert!(peer.ensure_allowed(&packet).is_ok());
         }
@@ -577,7 +577,7 @@ mod proptests {
                         Protocol::Udp { dport } => {
                             udp_packet(*src, dest, sport, dport, payload.clone())
                         }
-                        Protocol::Icmp => icmp_request_packet(*src, dest),
+                        Protocol::Icmp => icmp_request_packet(*src, dest, 1, 0),
                     };
                     assert!(peer.ensure_allowed(&packet).is_ok());
                 }
@@ -629,7 +629,7 @@ mod proptests {
                         Protocol::Udp { dport } => {
                             udp_packet(*src, dest, sport, dport, payload.clone())
                         }
-                        Protocol::Icmp => icmp_request_packet(*src, dest),
+                        Protocol::Icmp => icmp_request_packet(*src, dest, 1, 0),
                     };
                     assert!(peer.ensure_allowed(&packet).is_ok());
                 }
@@ -646,7 +646,7 @@ mod proptests {
                         Protocol::Udp { dport } => {
                             udp_packet(*src, dest, sport, dport, payload.clone())
                         }
-                        Protocol::Icmp => icmp_request_packet(*src, dest),
+                        Protocol::Icmp => icmp_request_packet(*src, dest, 1, 0),
                     };
                     assert!(peer.ensure_allowed(&packet).is_ok());
                 }
@@ -682,7 +682,7 @@ mod proptests {
             let packet = match protocol {
                 Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload.clone()),
                 Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload.clone()),
-                Protocol::Icmp => icmp_request_packet(src, dest),
+                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
             };
 
             assert!(peer.ensure_allowed(&packet).is_ok());
@@ -705,7 +705,7 @@ mod proptests {
         let packet = match protocol {
             Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload),
             Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload),
-            Protocol::Icmp => icmp_request_packet(src, dest),
+            Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
         };
 
         peer.add_resource(vec![resource_addr], resource_id, filters, None);
@@ -738,13 +738,13 @@ mod proptests {
         let packet_allowed = match protocol_allowed {
             Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload.clone()),
             Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload.clone()),
-            Protocol::Icmp => icmp_request_packet(src, dest),
+            Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
         };
 
         let packet_rejected = match protocol_removed {
             Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload),
             Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload),
-            Protocol::Icmp => icmp_request_packet(src, dest),
+            Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
         };
 
         peer.add_resource(

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -20,7 +20,9 @@ pub fn icmp_request_packet(
 }
 
 pub fn icmp_response_packet(packet: IpPacket<'static>) -> MutableIpPacket<'static> {
-    let icmp = packet.as_icmp().expect("IP packet should be an ICMP packet");
+    let icmp = packet
+        .as_icmp()
+        .expect("IP packet should be an ICMP packet");
     let echo_request = icmp.as_echo_request().expect("to be ICMP echo request");
 
     icmp_packet(

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -1,5 +1,6 @@
 //! Factory module for making all kinds of packets.
 
+use crate::{IpPacket, MutableIpPacket};
 use pnet_packet::{
     ip::IpNextHeaderProtocol,
     ipv4::MutableIpv4Packet,
@@ -7,16 +8,28 @@ use pnet_packet::{
     tcp::{self, MutableTcpPacket},
     udp::{self, MutableUdpPacket},
 };
-
-use crate::MutableIpPacket;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-pub fn icmp_request_packet(src: IpAddr, dst: IpAddr) -> MutableIpPacket<'static> {
-    icmp_packet(src, dst, 1, 0, IcmpKind::Request)
+pub fn icmp_request_packet(
+    src: IpAddr,
+    dst: impl Into<IpAddr>,
+    seq: u16,
+    identifier: u16,
+) -> MutableIpPacket<'static> {
+    icmp_packet(src, dst.into(), seq, identifier, IcmpKind::Request)
 }
 
-pub fn icmp_response_packet(src: IpAddr, dst: IpAddr) -> MutableIpPacket<'static> {
-    icmp_packet(src, dst, 1, 0, IcmpKind::Response)
+pub fn icmp_response_packet(packet: IpPacket<'static>) -> MutableIpPacket<'static> {
+    let icmp = packet.as_icmp().expect("to be ICMP packet");
+    let echo_request = icmp.as_echo_request().expect("to be ICMP echo request");
+
+    icmp_packet(
+        packet.destination(),
+        packet.source(),
+        echo_request.sequence(),
+        echo_request.identifier(),
+        IcmpKind::Response,
+    )
 }
 
 enum IcmpKind {

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -20,7 +20,7 @@ pub fn icmp_request_packet(
 }
 
 pub fn icmp_response_packet(packet: IpPacket<'static>) -> MutableIpPacket<'static> {
-    let icmp = packet.as_icmp().expect("to be ICMP packet");
+    let icmp = packet.as_icmp().expect("IP packet should be an ICMP packet");
     let echo_request = icmp.as_echo_request().expect("to be ICMP echo request");
 
     icmp_packet(


### PR DESCRIPTION
An `IpPacket` may contain an ICMP or ICMPv6 packet. To extract metadata like the sequence number of identifier from it, we need to be able to parse an `IpPacket`'s payload into the appropriate packets.

Extracted out of #5083.