### PR TITLE
test(connlib): reduce number of sites to 3

### DIFF
--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -100,7 +100,7 @@ pub fn address_description() -> impl Strategy<Value = String> {
 }
 
 pub fn sites() -> impl Strategy<Value = Vec<Site>> {
-    collection::vec(site(), 1..=10)
+    collection::vec(site(), 1..=3)
 }
 
 pub fn site() -> impl Strategy<Value = Site> {


### PR DESCRIPTION
Generating up to 10 can be quite verbose in the output. I think 3 should also be enough to hit all codepaths that need to deal with more than 1.