### PR TITLE
ci(rust): compile tests with optimistions

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -72,6 +72,7 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
           RUST_BACKTRACE: full
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
+          CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise proptests take forever.
         name: "cargo test"
         shell: bash
 


### PR DESCRIPTION
With an increased number of tests that make use of `proptest`, executing `cargo test` (almost 6 minutes on `main` currently: https://github.com/firezone/firezone/actions/runs/9278428694/job/25529425068#step:5:1407). By compiling them with optimisations, we can drastically cut down the execution time with only little penality in compilation speed as those should be cached in CI.