### PR TITLE
chore(gui-client): log update URL if fetching the version number fails

### DIFF
--- a/rust/gui-client/src-tauri/src/client/updates.rs
+++ b/rust/gui-client/src-tauri/src/client/updates.rs
@@ -35,7 +35,8 @@ pub(crate) async fn check() -> Result<Release> {
         .head(update_url.clone())
         .header("User-Agent", user_agent)
         .send()
-        .await.context("Couldn't fetch from update URL `{update_url}`")?;
+        .await
+        .context("Couldn't fetch from update URL `{update_url}`")?;
     let status = response.status();
     if status != reqwest::StatusCode::TEMPORARY_REDIRECT {
         anyhow::bail!("HTTP status: {status} from update URL `{update_url}`");

--- a/rust/gui-client/src-tauri/src/client/updates.rs
+++ b/rust/gui-client/src-tauri/src/client/updates.rs
@@ -27,18 +27,18 @@ pub(crate) async fn check() -> Result<Release> {
     // We used to send this to Github, couldn't hurt to send it to our own site, too
     let user_agent = format!("Firezone Client/{:?} ({os}; {arch})", current_version());
 
-    let mut latest_url = url::Url::parse("https://www.firezone.dev")
+    let mut update_url = url::Url::parse("https://www.firezone.dev")
         .context("Impossible: Hard-coded URL should always be parsable")?;
-    latest_url.set_path(&format!("/dl/firezone-client-gui-{os}/latest/{arch}"));
+    update_url.set_path(&format!("/dl/firezone-client-gui-{os}/latest/{arch}"));
 
     let response = client
-        .head(latest_url)
+        .head(update_url.clone())
         .header("User-Agent", user_agent)
         .send()
-        .await?;
+        .await.context("Couldn't fetch from update URL `{update_url}`")?;
     let status = response.status();
     if status != reqwest::StatusCode::TEMPORARY_REDIRECT {
-        anyhow::bail!("HTTP status: {status}");
+        anyhow::bail!("HTTP status: {status} from update URL `{update_url}`");
     }
     let download_url = response
         .headers()


### PR DESCRIPTION
Closes #5155

I keep seeing these in my debug Clients and I just want to make sure the URL it's using is correct.

e.g.

```
2024-05-29T18:10:14.131542Z ERROR firezone_gui_client::client::gui: Error in check_for_updates error=Error in client::updates::check

Caused by:
    HTTP status: 404 Not Found from update URL `https://www.firezone.dev/dl/firezone-client-gui-windows/latest/aarch64`
```