### PR TITLE
docs(gui-client): add instructions for auto-start

### DIFF
--- a/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
@@ -41,7 +41,7 @@ sudo usermod -aG firezone-client "$USER"
 reboot
 ```
 
-To auto-start the GUI when you log in, run these commands:
+To auto-start the Client when you log in, run these commands:
 
 ```bash
 mkdir -p "$HOME/.config/autostart"

--- a/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
@@ -41,6 +41,13 @@ sudo usermod -aG firezone-client "$USER"
 reboot
 ```
 
+To auto-start the GUI when you log in, run these commands:
+
+```bash
+mkdir -p "$HOME/.config/autostart"
+ln -s /usr/share/applications/firezone-client-gui.desktop "$HOME/.config/autostart"
+```
+
 ## Usage
 
 ### Signing in
@@ -105,6 +112,7 @@ To export your logs as a zip archive, or clear your log directory:
 
 1. Quit `firezone-client-gui` if it's running.
 1. Remove the package: `sudo apt-get remove firezone-client-gui`
+1. Remove the auto-start link: `rm --force "$HOME/.config/autostart/firezone-client-gui.desktop"`
 
 ## Troubleshooting
 

--- a/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
@@ -112,7 +112,8 @@ To export your logs as a zip archive, or clear your log directory:
 
 1. Quit `firezone-client-gui` if it's running.
 1. Remove the package: `sudo apt-get remove firezone-client-gui`
-1. Remove the auto-start link: `rm --force "$HOME/.config/autostart/firezone-client-gui.desktop"`
+1. Remove the auto-start link:
+   `rm --force "$HOME/.config/autostart/firezone-client-gui.desktop"`
 
 ## Troubleshooting
 

--- a/website/src/app/kb/user-guides/windows-client/readme.mdx
+++ b/website/src/app/kb/user-guides/windows-client/readme.mdx
@@ -22,7 +22,8 @@ direct link below:
 
 After downloading, run the `.msi` to install the Firezone GUI Client.
 
-To auto-start the Client when you log in, copy the "Firezone" shortcut from your desktop to `%APPDATA%/Microsoft/Windows/Start Menu/Programs/Startup/`
+To auto-start the Client when you log in, copy the "Firezone" shortcut from your
+desktop to `%APPDATA%/Microsoft/Windows/Start Menu/Programs/Startup/`
 
 ## Usage
 
@@ -90,7 +91,8 @@ To export your logs as a zip archive, or clear your log directory:
 
 ## Uninstalling
 
-1. Delete the "Firezone" shortcut from `%APPDATA%/Microsoft/Windows/Start Menu/Programs/Startup/`
+1. Delete the "Firezone" shortcut from
+   `%APPDATA%/Microsoft/Windows/Start Menu/Programs/Startup/`
 1. Quit Firezone.
 1. Open the Start Menu. Search for `Add or remove programs` and open it.
 1. In the `Add or remove programs` dialog, search for `Firezone`.

--- a/website/src/app/kb/user-guides/windows-client/readme.mdx
+++ b/website/src/app/kb/user-guides/windows-client/readme.mdx
@@ -22,6 +22,8 @@ direct link below:
 
 After downloading, run the `.msi` to install the Firezone GUI Client.
 
+To auto-start the Client when you log in, copy the "Firezone" shortcut from your desktop to `%APPDATA%/Microsoft/Windows/Start Menu/Programs/Startup/`
+
 ## Usage
 
 ### Signing in
@@ -88,6 +90,7 @@ To export your logs as a zip archive, or clear your log directory:
 
 ## Uninstalling
 
+1. Delete the "Firezone" shortcut from `%APPDATA%/Microsoft/Windows/Start Menu/Programs/Startup/`
 1. Quit Firezone.
 1. Open the Start Menu. Search for `Add or remove programs` and open it.
 1. In the `Add or remove programs` dialog, search for `Firezone`.


### PR DESCRIPTION
Refs #5118

I did it for Windows, too. Putting the shortcut in `%APPDATA%` like this only makes it auto-start for the current user. Twingate appears to put it under `%PROGRAMDATA%`, which causes it to auto-start for all users. We could also use the registry if creating shortcuts programmatically on Windows is difficult.

I tested these on an Ubuntu 22.04 aarch64 VM and the Windows 11 dev laptop.