### PR TITLE
chore(connlib): split allowed_ips into ipv4 and ipv6 in `ClientOnGateway`

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -10,12 +10,11 @@ use connlib_shared::messages::{
     ResourceId,
 };
 use connlib_shared::{Callbacks, DomainName, Error, Result, StaticSecret};
-use ip_network::IpNetwork;
 use ip_packet::{IpPacket, MutableIpPacket};
 use secrecy::{ExposeSecret as _, Secret};
 use snownet::{RelaySocket, ServerNode};
 use std::collections::{HashSet, VecDeque};
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::{Duration, Instant};
 
 const PEERS_IPV4: &str = "100.64.0.0/11";
@@ -54,7 +53,8 @@ where
         key: Secret<Key>,
         offer: Offer,
         client: PublicKey,
-        ips: Vec<IpNetwork>,
+        ipv4: Ipv4Addr,
+        ipv6: Ipv6Addr,
         relays: Vec<Relay>,
         domain: Option<DomainName>,
         expires_at: Option<DateTime<Utc>>,
@@ -70,7 +70,8 @@ where
                 },
             },
             client,
-            ips,
+            ipv4,
+            ipv6,
             stun(&relays, |addr| self.io.sockets_ref().can_handle(addr)),
             turn(&relays),
             domain,
@@ -225,7 +226,8 @@ impl GatewayState {
         client_id: ClientId,
         offer: snownet::Offer,
         client: PublicKey,
-        ips: Vec<IpNetwork>,
+        ipv4: Ipv4Addr,
+        ipv6: Ipv6Addr,
         stun_servers: HashSet<SocketAddr>,
         turn_servers: HashSet<(RelayId, RelaySocket, String, String, String)>,
         domain: Option<DomainName>,
@@ -247,7 +249,7 @@ impl GatewayState {
             self.node
                 .accept_connection(client_id, offer, client, stun_servers, turn_servers, now);
 
-        let mut peer = ClientOnGateway::new(client_id, &ips);
+        let mut peer = ClientOnGateway::new(client_id, ipv4, ipv6);
 
         peer.add_resource(
             resource.addresses(),
@@ -256,7 +258,7 @@ impl GatewayState {
             expires_at,
         );
 
-        self.peers.insert(peer, &ips);
+        self.peers.insert(peer, &[ipv4.into(), ipv6.into()]);
 
         Ok(ConnectionAccepted {
             ice_parameters: Answer {

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -889,10 +889,8 @@ impl TunnelTest {
                                         },
                                     },
                                     self.client.state.public_key(),
-                                    vec![
-                                        self.client.tunnel_ip4.into(),
-                                        self.client.tunnel_ip6.into(),
-                                    ],
+                                    self.client.tunnel_ip4,
+                                    self.client.tunnel_ip6,
                                     HashSet::default(),
                                     HashSet::default(),
                                     new_connection.client_payload.domain,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -219,14 +219,13 @@ impl Eventloop {
             .inspect_err(|e| tracing::debug!(client = %req.client.id, reference = %req.reference, "DNS resolution timed out as part of connection request: {e}"))
             .unwrap_or_default();
 
-        let ips = req.client.peer.ips();
-
         match self.tunnel.accept(
             req.client.id,
             req.client.peer.preshared_key,
             req.client.payload.ice_parameters,
             PublicKey::from(req.client.peer.public_key.0),
-            ips,
+            req.client.peer.ipv4,
+            req.client.peer.ipv6,
             req.relays,
             req.client.payload.domain,
             req.expires_at,


### PR DESCRIPTION
To encode that clients always have both ipv4 and ipv6 and they are the only allowed source ips for any given client, into the type, we split those into their specific fields in the `ClientOnGateway` struct and update tests accordingly.

Furthermore, these will be used for the DNS refactor for ipv6-in-ipv4 and ipv4-in-ipv6 to set the source ip of outgoing packets, without having to do additional routing or mappings. There will be more notes on this on the corresponding PR #5049 .