### PR TITLE
docs(apple-client): update Client user guides

### DIFF
--- a/website/src/app/kb/user-guides/ios-client/page.tsx
+++ b/website/src/app/kb/user-guides/ios-client/page.tsx
@@ -4,7 +4,7 @@ import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "iOS Client • Firezone Docs",
-  description: "Firezone Documentation",
+  description: "How to install and use the Firezone iOS Client.",
 };
 
 export default function Page() {

--- a/website/src/app/kb/user-guides/ios-client/readme.mdx
+++ b/website/src/app/kb/user-guides/ios-client/readme.mdx
@@ -7,17 +7,95 @@ iOS app also works for iPad.
 
 ## Prerequisites
 
-- iOS 15 or higher
+- **iOS 15** or higher
 
 ## Installation
 
-[Download the client](https://apps.apple.com/us/app/firezone/id6443661826) from
-the Apple App Store.
+1. [Download the client](https://apps.apple.com/us/app/firezone/id6443661826)
+   from the Apple App Store.
+1. Tap `Open`. The Firezone welcome screen will appear.
+1. Tap `Grant VPN Permission`. iOS will show a dialog saying,
+   `"Firezone" Would Like to Add VPN Configurations`.
+1. Tap `Allow` and allow the permission using your passcode, FaceID, or TouchID.
+   Firezone will then ask for notification permission.
+1. Tap `Grant Notification Permission`. iOS will show a dialog saying,
+   `"Firezone" Would Like to Send You Notifications`.
+1. Tap `Allow`. Firezone will show a `Sign in` button.
 
-### Upgrading
+## Usage
+
+### Signing in
+
+1. Tap `Sign in`. iOS will show a dialog saying,
+   `"Firezone" Wants to Use "firezone.dev" to Sign In`.
+1. Tap `Continue`. Firezone will open a sign-in page.
+1. Select your account and sign in. Firezone will show your username and
+   Resources.
+
+### Accessing a Resource
+
+When Firezone is signed in, web browsers and other programs will automatically
+use it to securely connect to Resources.
+
+To copy-paste the address of a Resource:
+
+1. Tap on the Resource.
+1. Tap `Copy Address`.
+1. Long-press your browser's URL bar and tap `Paste and Go`
+
+### Quitting
+
+1. Open the `Settings` app.
+1. Tap `VPN` to turn the VPN switch off.
+
+When Firezone is not running, you can't access private Resources, and the phone
+will use its normal DNS and Internet behavior.
+
+If you were signed in, then you will still be signed in the next time you start
+Firezone.
+
+### Signing out
+
+1. Open the Firezone app.
+1. At the top, under `AUTHENTICATION`, tap `Sign Out`.
+
+When you're signed out, you can't access private Resources, and the phone will
+use its normal DNS and Internet behavior.
+
+## Upgrading
 
 Updates for the Apple clients are handled through the Apple App Store. Consult
 [Apple's documentation](https://support.apple.com/guide/iphone/update-apps-iph98709f167/17.0/ios/17.0)
 for more information on how to update apps on your device.
+
+## Diagnostic logs
+
+Firezone writes log files to the phone's memory. These logs stay on the phone
+and are not transmitted anywhere. If you find a bug, you can send us an `.aar`
+archive of your logs to help us fix the bug.
+
+To export or clear your logs:
+
+1. Open the Firezone app.
+1. In the upper-right corner, tap the gear icon.
+1. In the bottom-right corner, tap `Diagnostic Logs`.
+1. Tap `Export Logs` or `Clear Log Directory`.
+
+## Uninstalling
+
+1. On the phone's home screen, long-press the Firezone app icon.
+1. Tap `Remove App`.
+1. Tap `Delete App`. iOS will show a dialog saying,
+   `Delete "Firezone"? Deleting this app will also delete its data`.
+1. Tap `Delete`.
+
+## Troubleshooting
+
+We will add troubleshooting steps here in the future.
+
+## Known issues
+
+- If another VPN app is running on the system, Firezone will not work.
+  [#4733](https://github.com/firezone/firezone/issues/4733)
 
 <SupportOptions />

--- a/website/src/app/kb/user-guides/linux-gui-client/page.tsx
+++ b/website/src/app/kb/user-guides/linux-gui-client/page.tsx
@@ -4,7 +4,7 @@ import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Linux GUI Client • Firezone Docs",
-  description: "How to install and use the Firezone Linux GUI client.",
+  description: "How to install and use the Firezone Linux GUI Client.",
 };
 
 export default function Page() {

--- a/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
@@ -62,7 +62,7 @@ ln -s /usr/share/applications/firezone-client-gui.desktop "$HOME/.config/autosta
 1. Unlock your desktop's keyring, or create one if needed. Most desktops,
    including GNOME, encrypt the keyring with your login password, so your
    Firezone token is encrypted at rest.
-1. When you see the `Firezone connected` notification, the tunnel is ready.
+1. When you see the `Firezone connected` notification, Firezone is running.
 
 The Welcome screen only appears during your first sign-in. After that, you can
 click on the Firezone icon in the system tray to open the tray menu and sign in.
@@ -72,7 +72,7 @@ click on the Firezone icon in the system tray to open the tray menu and sign in.
 When Firezone is signed in, web browsers and other programs will automatically
 use it to securely connect to Resources.
 
-To copy-paste the address of a Resource you have access to:
+To copy-paste the address of a Resource:
 
 1. Click on the Firezone tray icon to open the menu.
 1. Open a Resource's submenu and click on its address to copy it.
@@ -83,9 +83,10 @@ To copy-paste the address of a Resource you have access to:
 1. Click on the Firezone tray icon to open the menu.
 1. Click `Disconnect and Quit` or `Quit`.
 
-The tunnel is now stopped.
+When Firezone is not running, you can't access private Resources, and the
+computer will use its normal DNS and Internet behavior.
 
-If you were signed in, the tunnel will restart automatically next time you open
+If you were signed in, then you will still be signed in the next time you start
 Firezone.
 
 ### Signing out
@@ -93,10 +94,8 @@ Firezone.
 1. Click on the Firezone tray icon to open the menu.
 1. Click `Sign out`.
 
-The tunnel is now stopped.
-
-When you're signed out, Resources will be inaccessible and your system will use
-its normal DNS and Internet behavior.
+When you're signed out, you can't access private Resources, and the computer
+will use its normal DNS and Internet behavior.
 
 ## Upgrading
 
@@ -110,22 +109,22 @@ its normal DNS and Internet behavior.
 ## Diagnostic logs
 
 Firezone writes log files to disk. These logs stay on your computer and are not
-transmitted anywhere. If you encounter a bug, sending us a `.zip` archive of
-your logs may help us fix the bug.
+transmitted anywhere. If you find a bug, you can send us a `.zip` archive of
+your logs to help us fix the bug.
 
-To export your logs as a `.zip` archive, or clear your log directory:
+To export or clear your logs:
 
-1. Click on the Firezone tray icon to open the menu.
+1. Click on the Firezone tray icon.
 1. Click `Settings`.
 1. Click `Diagnostic Logs`.
 1. Click `Export Logs` or `Clear Log Directory`.
 
 ## Uninstalling
 
-1. Quit `firezone-client-gui` if it's running.
-1. Remove the package: `sudo apt-get remove firezone-client-gui`
 1. Remove the auto-start link:
    `rm --force "$HOME/.config/autostart/firezone-client-gui.desktop"`
+1. Quit `firezone-client-gui` if it's running.
+1. Remove the package: `sudo apt-get remove firezone-client-gui`
 
 ## Troubleshooting
 
@@ -181,9 +180,10 @@ sudo systemctl restart firezone-client-ipc
 
 ## Known issues
 
-- Web browsers that use DNS-over-HTTPS by default may not work with Firezone.
-  See
-  [this guide](/kb/administer/troubleshooting#some-browsers-break-dns-routing)
+- **DNS Resources**: Web browsers that enable "Secure DNS" or DNS-over-HTTPS by
+  default may interfere with DNS resolution because they force all DNS traffic
+  through the browser's configured resolvers. See
+  [Administer / Troubleshooting / Some browsers break DNS routing](/kb/administer/troubleshooting#some-browsers-break-dns-routing)
   to disable DNS-over-HTTPS if you're experiencing issues connecting to DNS
   Resources within your browser.
 - After clearing diagnostic logs, no more logs are written until the GUI and

--- a/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
@@ -76,21 +76,32 @@ To copy-paste the address of a Resource you have access to:
 
 1. Click on the Firezone tray icon to open the menu.
 1. Open a Resource's submenu and click on its address to copy it.
+1. Paste the address into your browser's URL bar and press Enter.
 
 ### Quitting
 
-When you quit the Firezone GUI, your token is still stored on the disk, so it
-will sign in automatically next time you open the GUI.
+1. Click on the Firezone tray icon to open the menu.
+1. Click `Disconnect and Quit` or `Quit`.
+
+The tunnel is now stopped.
+
+If you were signed in, the tunnel will restart automatically next time you open
+Firezone.
 
 ### Signing out
 
 1. Click on the Firezone tray icon to open the menu.
 1. Click `Sign out`.
 
-The tunnel is now stopped until you sign in again.
+The tunnel is now stopped.
+
+When you're signed out, Resources will be inaccessible and your system will use
+its normal DNS and Internet behavior.
 
 ## Upgrading
 
+1. Download the latest `.deb` installer package from
+   ["Installation"](#installation) above.
 1. Quit `firezone-client-gui` if it's running.
 1. Install the new package:
    `sudo apt-get install ./firezone-client-gui-linux_<VERSION>_<ARCH>.deb`
@@ -99,14 +110,15 @@ The tunnel is now stopped until you sign in again.
 ## Diagnostic logs
 
 Firezone writes log files to disk. These logs stay on your computer and are not
-transmitted anywhere. If you encounter a bug, sending us a zip archive of your
-logs may help us fix the bug.
+transmitted anywhere. If you encounter a bug, sending us a `.zip` archive of
+your logs may help us fix the bug.
 
-To export your logs as a zip archive, or clear your log directory:
+To export your logs as a `.zip` archive, or clear your log directory:
 
 1. Click on the Firezone tray icon to open the menu.
 1. Click `Settings`.
 1. Click `Diagnostic Logs`.
+1. Click `Export Logs` or `Clear Log Directory`.
 
 ## Uninstalling
 

--- a/website/src/app/kb/user-guides/macos-client/page.tsx
+++ b/website/src/app/kb/user-guides/macos-client/page.tsx
@@ -4,7 +4,7 @@ import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "macOS Client • Firezone Docs",
-  description: "Firezone Documentation",
+  description: "How to install and use the Firezone macOS Client.",
 };
 
 export default function Page() {

--- a/website/src/app/kb/user-guides/macos-client/readme.mdx
+++ b/website/src/app/kb/user-guides/macos-client/readme.mdx
@@ -14,8 +14,8 @@ Firezone supports macOS with a native client available in the macOS App Store.
 1. [Download the Client](https://apps.apple.com/us/app/firezone/id6443661826)
    from the Apple App Store.
 1. Click `Open` in the App Store. The `Welcome to Firezone` window will open.
-1. Click `Grant VPN Permission`. macOS will show a dialog,
-   `"Firezone" Would Like to Add VPN Configurations`
+1. Click `Grant VPN Permission`. macOS will show a dialog saying,
+   `"Firezone" Would Like to Add VPN Configurations`.
 1. Click `Allow`.
 
 ## Usage
@@ -23,7 +23,7 @@ Firezone supports macOS with a native client available in the macOS App Store.
 ### Signing in
 
 1. In the menu bar, click the crossed-out Firezone icon and click `Sign In`.
-   macOS will show a dialog,
+   macOS will show a dialog saying,
    `“Firezone” Wants to Use “firezone.dev” to Sign In`.
 1. Click `Continue`. Firezone will open a sign-in page.
 1. Select your account and sign in. The Firezone icon should no longer be
@@ -34,31 +34,30 @@ Firezone supports macOS with a native client available in the macOS App Store.
 When Firezone is signed in, web browsers and other programs will automatically
 use it to securely connect to Resources.
 
-To copy-paste the address of a Resource you have access to:
+To copy-paste the address of a Resource:
 
 1. In the menu bar, click the Firezone icon to open the status menu.
 1. Open a Resource's submenu and click on its address to copy it.
-1. Paste the address into your browser's URL bar and press Enter.
+1. Paste the address into your browser's URL bar and press Return.
 
 ### Quitting
 
 1. In the menu bar, click on the Firezone icon to open the status menu.
 1. Click `Disconnect and Quit` or `Quit`.
 
-The tunnel is now stopped. If you were signed in, the tunnel will restart
-automatically next time you open Firezone.
+When Firezone is not running, you can't access private Resources, and the
+computer will use its normal DNS and Internet behavior.
 
-The tunnel will be stopped until you sign in again.
+If you were signed in, then you will still be signed in the next time you start
+Firezone.
 
 ### Signing out
 
 1. In the menu bar, Click on the Firezone icon to open the status menu.
 1. Click `Sign out`.
 
-The tunnel is now stopped.
-
-When you're signed out, Resources will be inaccessible and your system will use
-its normal DNS and Internet behavior.
+When you're signed out, you can't access private Resources, and the computer
+will use its normal DNS and Internet behavior.
 
 ## Upgrading
 
@@ -69,14 +68,14 @@ for more information.
 ## Diagnostic logs
 
 Firezone writes log files to disk. These logs stay on your computer and are not
-transmitted anywhere. If you encounter a bug, sending us an `.aar` archive of
-your logs may help us fix the bug.
+transmitted anywhere. If you find a bug, you can send us a `.aar` archive of
+your logs to help us fix the bug.
 
-To export your logs as an `.aar` archive, or clear your log directory:
+To export or clear your logs:
 
 1. In the menu bar, click on the Firezone icon to open the status menu.
-1. Click "Settings".
-1. Click "Diagnostic Logs".
+1. Click `Settings`.
+1. Click `Diagnostic Logs`.
 1. Click `Export Logs` or `Clear Log Directory`.
 
 ## Uninstalling
@@ -94,7 +93,7 @@ information.
 
 ### Check if Firezone is controlling DNS
 
-1. Open the `Terminal` app.
+1. Open the Terminal app.
 1. Run `dig firezone.dev` and look for a line starting with `;; SERVER:`.
 
 If the Firezone is controlling the system's DNS, then the server will be

--- a/website/src/app/kb/user-guides/macos-client/readme.mdx
+++ b/website/src/app/kb/user-guides/macos-client/readme.mdx
@@ -6,33 +6,130 @@ Firezone supports macOS with a native client available in the macOS App Store.
 
 ## Prerequisites
 
-- macOS 12 or higher
-- Intel or Apple silicon Mac
+- **macOS 12** or higher
+- **Intel x86-64 or Apple Silicon** CPU architecture
 
 ## Installation
 
-[Download the client](https://apps.apple.com/us/app/firezone/id6443661826) from
-the Apple App Store.
+1. [Download the Client](https://apps.apple.com/us/app/firezone/id6443661826)
+   from the Apple App Store.
+1. Click `Open` in the App Store. The `Welcome to Firezone` window will open.
+1. Click `Grant VPN Permission`. macOS will show a dialog,
+   `"Firezone" Would Like to Add VPN Configurations`
+1. Click `Allow`.
 
-### Upgrading
+## Usage
 
-Updates for the Apple clients are handled through the Apple App Store. Consult
-[Apple's documentation](https://support.apple.com/guide/app-store/update-apps-fir9b01adda3/3.0/mac/14.0)
-for more information on how to update apps on your device.
+### Signing in
+
+1. In the menu bar, click the crossed-out Firezone icon and click `Sign In`.
+   macOS will show a dialog,
+   `“Firezone” Wants to Use “firezone.dev” to Sign In`.
+1. Click `Continue`. Firezone will open a sign-in page.
+1. Select your account and sign in. The Firezone icon should no longer be
+   crossed out.
+
+### Accessing a Resource
+
+When Firezone is signed in, web browsers and other programs will automatically
+use it to securely connect to Resources.
+
+To copy-paste the address of a Resource you have access to:
+
+1. In the menu bar, click the Firezone icon to open the status menu.
+1. Open a Resource's submenu and click on its address to copy it.
+1. Paste the address into your browser's URL bar and press Enter.
+
+### Quitting
+
+1. In the menu bar, click on the Firezone icon to open the status menu.
+1. Click `Disconnect and Quit` or `Quit`.
+
+The tunnel is now stopped. If you were signed in, the tunnel will restart
+automatically next time you open Firezone.
+
+The tunnel will be stopped until you sign in again.
+
+### Signing out
+
+1. In the menu bar, Click on the Firezone icon to open the status menu.
+1. Click `Sign out`.
+
+The tunnel is now stopped.
+
+When you're signed out, Resources will be inaccessible and your system will use
+its normal DNS and Internet behavior.
+
+## Upgrading
+
+Use the App Store to update the Firezone Apple Client. See Apple's documentation
+["Use the App Store to update apps on Mac"](https://support.apple.com/guide/app-store/update-apps-fir9b01adda3/3.0/mac/14.0)
+for more information.
+
+## Diagnostic logs
+
+Firezone writes log files to disk. These logs stay on your computer and are not
+transmitted anywhere. If you encounter a bug, sending us an `.aar` archive of
+your logs may help us fix the bug.
+
+To export your logs as an `.aar` archive, or clear your log directory:
+
+1. In the menu bar, click on the Firezone icon to open the status menu.
+1. Click "Settings".
+1. Click "Diagnostic Logs".
+1. Click `Export Logs` or `Clear Log Directory`.
+
+## Uninstalling
+
+1. Quit the Firezone Client.
+1. Open Launchpad and find Firezone.
+1. Press and hold the `Option` key, and click on the "X" button on the Firezone
+   icon.
+
+See Apple's documentation
+["Uninstall apps on your Mac"](https://support.apple.com/en-us/102610) for more
+information.
+
+## Troubleshooting
+
+### Check if Firezone is controlling DNS
+
+1. Open the `Terminal` app.
+1. Run `dig firezone.dev` and look for a line starting with `;; SERVER:`.
+
+If the Firezone is controlling the system's DNS, then the server will be
+`100.100.111.1` or some other IP in the `100.100.111.0/24` range or
+`fd00:2021:1111:8000:100:100:111:0/120` range.
+
+Firezone Split DNS:
+
+```text
+;; SERVER: 100.100.111.1#53(100.100.111.1)
+;; WHEN: Thu May 30 00:00:00 UTC 2024
+;; MSG SIZE  rcvd: 57
+```
+
+Normal system DNS:
+
+```text
+;; SERVER: fe80::96a6:7eff:fe78:edb7%15#53(fe80::96a6:7eff:fe78:edb7%15)
+;; WHEN: Thu May 30 00:00:00 UTC 2024
+;; MSG SIZE  rcvd: 57
+```
 
 ## Known issues
 
 - **DNS Resources**: Web browsers that enable "Secure DNS" or DNS-over-HTTPS by
   default may interfere with DNS resolution because they force all DNS traffic
   through the browser's configured resolvers. See
-  [this guide](/kb/administer/troubleshooting#some-browsers-break-dns-routing)
+  [Administer / Troubleshooting / Some browsers break DNS routing](/kb/administer/troubleshooting#some-browsers-break-dns-routing)
   to disable DNS-over-HTTPS if you're experiencing issues connecting to DNS
   Resources within your browser.
 - **Cloudflare WARP client conflicts with other VPN apps**: The Cloudflare WARP
   client may interfere with Firezone's ability to initialize its tunnel
   interface or resolve DNS resources. Ensure the Cloudflare WARP client is
   disabled completely or uninstalled to prevent these issues. See
-  [this thread](https://discourse.firez.one/t/firezone-app-on-macos/682) for
-  more information.
+  [this thread on our forum](https://discourse.firez.one/t/firezone-app-on-macos/682)
+  for more information.
 
 <SupportOptions />

--- a/website/src/app/kb/user-guides/windows-client/page.tsx
+++ b/website/src/app/kb/user-guides/windows-client/page.tsx
@@ -4,7 +4,7 @@ import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Windows Client • Firezone Docs",
-  description: "How to install and use the Firezone Windows client.",
+  description: "How to install and use the Firezone Windows Client.",
 };
 
 export default function Page() {

--- a/website/src/app/kb/user-guides/windows-client/readme.mdx
+++ b/website/src/app/kb/user-guides/windows-client/readme.mdx
@@ -49,45 +49,52 @@ To copy-paste the address of a Resource you have access to:
 
 1. Right-click on the Firezone tray icon to open the menu.
 1. Open a Resource's submenu and click on its address to copy it.
-
-Then you can paste the address into your browser's URL bar and press Enter.
-
-### Signing out
-
-1. Right-click on the Firezone tray icon to open the menu.
-1. Click `Sign out`.
-
-when you're signed out, Resources will be inaccessible and your system will use
-its normal DNS and Internet behavior.
+1. Paste the address into your browser's URL bar and press Enter.
 
 ### Quitting
 
 1. Right-click on the Firezone tray icon to open the menu.
 1. Click `Disconnect and Quit` or `Quit`.
 
-The tunnel is now stopped. If you were signed in, the tunnel will restart
-automatically next time you open Firezone.
+The tunnel is now stopped.
 
-The tunnel is now stopped until you sign in again.
+If you were signed in, the tunnel will restart automatically next time you open
+Firezone.
+
+### Signing out
+
+1. Right-click on the Firezone tray icon to open the menu.
+1. Click `Sign out`.
+
+The tunnel is now stopped.
+
+When you're signed out, Resources will be inaccessible and your system will use
+its normal DNS and Internet behavior.
 
 ## Upgrading
 
 The Windows Client will automatically check for updates on launch and prompt you
-to upgrade when a new version is available. Simply download the latest `.msi`
-installer package above, quit the GUI, and install the new MSI over the existing
-version.
+to upgrade when a new version is available.
+
+To upgrade:
+
+1. Download the latest `.msi` installer package from
+   ["Installation"](#installation) above.
+1. Quit the Client
+1. Install the new `.msi`
 
 ## Diagnostic logs
 
 Firezone writes log files to disk. These logs stay on your computer and are not
-transmitted anywhere. If you encounter a bug, sending us a zip archive of your
-logs may help us fix the bug.
+transmitted anywhere. If you encounter a bug, sending us a `.zip` archive of
+your logs may help us fix the bug.
 
-To export your logs as a zip archive, or clear your log directory:
+To export your logs as a `.zip` archive, or clear your log directory:
 
 1. Right-click on the Firezone tray icon to open the menu.
 1. Click "Settings".
 1. Click "Diagnostic Logs".
+1. Click `Export Logs` or `Clear Log Directory`.
 
 ## Uninstalling
 

--- a/website/src/app/kb/user-guides/windows-client/readme.mdx
+++ b/website/src/app/kb/user-guides/windows-client/readme.mdx
@@ -7,7 +7,7 @@ to authenticate with your identity provider interactively.
 
 ## Prerequisites
 
-- Windows **10** or higher
+- **Windows 10** or higher
 - **x86-64** CPU
 - [**WebView2**](https://developer.microsoft.com/en-us/microsoft-edge/webview2/)
   (The installer will install this automatically if needed)
@@ -35,17 +35,17 @@ desktop to `%APPDATA%/Microsoft/Windows/Start Menu/Programs/Startup/`
 1. Sign in using your account slug and identity provider.
 1. If your browser asks whether it should open Firezone links, check
    `Always allow` and open the link.
-1. When you see the "Firezone connected" notification, the tunnel is ready.
+1. When you see the `Firezone connected` notification, Firezone is running.
 
-The Welcome screen only appears for your first sign-in. After that, you can use
-the tray menu to sign in.
+The Welcome screen only appears during your first sign-in. After that, you can
+click on the Firezone icon in the system tray to open the tray menu and sign in.
 
 ### Accessing a Resource
 
 When Firezone is signed in, web browsers and other programs will automatically
 use it to securely connect to Resources.
 
-To copy-paste the address of a Resource you have access to:
+To copy-paste the address of a Resource:
 
 1. Right-click on the Firezone tray icon to open the menu.
 1. Open a Resource's submenu and click on its address to copy it.
@@ -56,9 +56,10 @@ To copy-paste the address of a Resource you have access to:
 1. Right-click on the Firezone tray icon to open the menu.
 1. Click `Disconnect and Quit` or `Quit`.
 
-The tunnel is now stopped.
+When Firezone is not running, you can't access private Resources, and the
+computer will use its normal DNS and Internet behavior.
 
-If you were signed in, the tunnel will restart automatically next time you open
+If you were signed in, then you will still be signed in the next time you start
 Firezone.
 
 ### Signing out
@@ -66,10 +67,8 @@ Firezone.
 1. Right-click on the Firezone tray icon to open the menu.
 1. Click `Sign out`.
 
-The tunnel is now stopped.
-
-When you're signed out, Resources will be inaccessible and your system will use
-its normal DNS and Internet behavior.
+When you're signed out, you can't access private Resources, and the computer
+will use its normal DNS and Internet behavior.
 
 ## Upgrading
 
@@ -86,14 +85,14 @@ To upgrade:
 ## Diagnostic logs
 
 Firezone writes log files to disk. These logs stay on your computer and are not
-transmitted anywhere. If you encounter a bug, sending us a `.zip` archive of
-your logs may help us fix the bug.
+transmitted anywhere. If you find a bug, you can send us a `.zip` archive of
+your logs to help us fix the bug.
 
-To export your logs as a `.zip` archive, or clear your log directory:
+To export or clear your logs:
 
-1. Right-click on the Firezone tray icon to open the menu.
-1. Click "Settings".
-1. Click "Diagnostic Logs".
+1. Right-click on the Firezone tray icon.
+1. Click `Settings`.
+1. Click `Diagnostic Logs`.
 1. Click `Export Logs` or `Clear Log Directory`.
 
 ## Uninstalling
@@ -157,9 +156,10 @@ Get-DnsClientNrptRule | where Comment -eq firezone-fd0020211111 | foreach { Remo
 
 ## Known issues
 
-- Web browsers that use DNS-over-HTTPS by default may not work with Firezone.
-  See
-  [this guide](/kb/administer/troubleshooting#some-browsers-break-dns-routing)
+- **DNS Resources**: Web browsers that enable "Secure DNS" or DNS-over-HTTPS by
+  default may interfere with DNS resolution because they force all DNS traffic
+  through the browser's configured resolvers. See
+  [Administer / Troubleshooting / Some browsers break DNS routing](/kb/administer/troubleshooting#some-browsers-break-dns-routing)
   to disable DNS-over-HTTPS if you're experiencing issues connecting to DNS
   Resources within your browser.
 - Firezone does not register itself with Windows as a VPN


### PR DESCRIPTION
Closes #4999 
Closes #5000

Applied these changes:
- Tried to make the link texts more descriptive in case, for any reason, someone prints them onto paper. (this happened on another project)
- Synced up wording between Linux, macOS, and Windows
- Added a DNS troubleshooting section just to match Linux and Windows
- Always put file extensions in code blocks, e.g. `.aar`, `.deb`, `.msi`, `.zip`
- In other Client guides, continue switching to active voice and using shorter words / fewer words where possible.
- Use `Firezone` instead of `the tunnel`.
- Make page descriptions consistent with each other

```[tasklist]
- [ ] ~~Should the uninstall instructions include purging configs and logs?~~
- [ ] ~~Add screenshots for UI items that are stable (like the tray icons)~~
- [ ] ~~Is it "Quit", "Stopped", or "Closed"? Or "Not running" I want to make statements about what happens when Firezone is not running, and "when Firezone has quit" is awkward.~~
- [ ] ~~Decide if "your phone" and "your computer" is better than "the phone" and "the computer"~~
```