### PR TITLE
chore(connlib): fix echo request and reply packets

### DIFF
--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -349,14 +349,14 @@ impl<'a> IcmpPacket<'a> {
         match self {
             IcmpPacket::Ipv4(v4) if matches!(v4.get_icmp_type(), icmp::IcmpTypes::EchoRequest) => {
                 Some(IcmpEchoRequest::Ipv4(
-                    icmp::echo_request::EchoRequestPacket::new(v4.payload())?,
+                    icmp::echo_request::EchoRequestPacket::new(v4.packet())?,
                 ))
             }
             IcmpPacket::Ipv6(v6)
                 if matches!(v6.get_icmpv6_type(), icmpv6::Icmpv6Types::EchoRequest) =>
             {
                 Some(IcmpEchoRequest::Ipv6(
-                    icmpv6::echo_request::EchoRequestPacket::new(v6.payload())?,
+                    icmpv6::echo_request::EchoRequestPacket::new(v6.packet())?,
                 ))
             }
             IcmpPacket::Ipv4(_) | IcmpPacket::Ipv6(_) => None,
@@ -367,14 +367,14 @@ impl<'a> IcmpPacket<'a> {
         match self {
             IcmpPacket::Ipv4(v4) if matches!(v4.get_icmp_type(), icmp::IcmpTypes::EchoReply) => {
                 Some(IcmpEchoReply::Ipv4(icmp::echo_reply::EchoReplyPacket::new(
-                    v4.payload(),
+                    v4.packet(),
                 )?))
             }
             IcmpPacket::Ipv6(v6)
                 if matches!(v6.get_icmpv6_type(), icmpv6::Icmpv6Types::EchoReply) =>
             {
                 Some(IcmpEchoReply::Ipv6(
-                    icmpv6::echo_reply::EchoReplyPacket::new(v6.payload())?,
+                    icmpv6::echo_reply::EchoReplyPacket::new(v6.packet())?,
                 ))
             }
             IcmpPacket::Ipv4(_) | IcmpPacket::Ipv6(_) => None,

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -77,7 +77,7 @@ fn icmp_packet(
             icmp_packet.set_checksum(0);
 
             let mut echo_request_packet =
-                MutableEchoRequestPacket::new(icmp_packet.payload_mut()).unwrap();
+                MutableEchoRequestPacket::new(icmp_packet.packet_mut()).unwrap();
             echo_request_packet.set_sequence_number(seq);
             echo_request_packet.set_identifier(identifier);
             echo_request_packet.set_checksum(crate::util::checksum(
@@ -115,13 +115,13 @@ fn icmp_packet(
             }
 
             let mut echo_request_packet =
-                MutableEchoRequestPacket::new(icmp_packet.payload_mut()).unwrap();
+                MutableEchoRequestPacket::new(icmp_packet.packet_mut()).unwrap();
             echo_request_packet.set_identifier(identifier);
             echo_request_packet.set_sequence_number(seq);
             echo_request_packet.set_checksum(0);
 
             let checksum = crate::icmpv6::checksum(&icmp_packet.to_immutable(), &src, &dst);
-            MutableEchoRequestPacket::new(icmp_packet.payload_mut())
+            MutableEchoRequestPacket::new(icmp_packet.packet_mut())
                 .unwrap()
                 .set_checksum(checksum);
 


### PR DESCRIPTION
When creating an echo request or reply packet using pnet it uses the whole packet since the identifier and sequence is part of the icmp header not the payload.

Those fields aren't accessible unless the packet is converted to an echo request or reply because the interpretation of that header field depends on the specific type of packet.