### PR TITLE
ci: make output of `cargo test` smaller

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -70,7 +70,6 @@ jobs:
           # <https://github.com/rust-lang/cargo/issues/5999>
           # Needed to create tunnel interfaces in unit tests
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
-          RUST_BACKTRACE: full
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise proptests take forever.
         name: "cargo test"

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -45,9 +45,6 @@ use tracing_subscriber::{util::SubscriberInitExt as _, EnvFilter};
 
 proptest_state_machine::prop_state_machine! {
     #![proptest_config(Config {
-        // Enable verbose mode to make the state machine test print the
-        // transitions for each case.
-        verbose: 1,
         cases: 1000,
         .. Config::default()
     })]


### PR DESCRIPTION
When the `tunnel_test` fails, it generates a lot of output because it keeps printing the backtrace over and over. This makes it difficult to access the input seed to the test. Copying this seed into a local environment is the first step in debugging this, at which point the backtrace can be enabled locally.

We also disable the `verbose: 1` config option. Users can always set that using the `PROPTEST_VERBOSE` env variable.