### PR TITLE
test(connlib): increase buffer sizes

### DIFF
--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -1038,7 +1038,7 @@ impl TunnelTest {
         src: SocketAddr,
         payload: &[u8],
     ) -> ControlFlow<()> {
-        let mut buffer = [0u8; 200]; // In these tests, we only send ICMP packets which are very small.
+        let mut buffer = [0u8; 2000];
 
         if !self.client.wants(dst) {
             return ControlFlow::Continue(());
@@ -1063,7 +1063,7 @@ impl TunnelTest {
         buffered_transmits: &mut VecDeque<(Transmit<'static>, Option<SocketAddr>)>,
         global_dns_records: &HashMap<DomainName, HashSet<IpAddr>>,
     ) -> ControlFlow<()> {
-        let mut buffer = [0u8; 200]; // In these tests, we only send ICMP packets which are very small.
+        let mut buffer = [0u8; 2000];
 
         if !self.gateway.wants(dst) {
             return ControlFlow::Continue(());


### PR DESCRIPTION
In case an upstream DNS server is a resource, we need to not only send an ICMP packet through the tunnel but also DNS queries. These can be larger than 200 bytes which currently breaks the test because we only give it a buffer of 200 bytes.