### PR TITLE
fix(ux): Use icon sizes consistent with text size

### DIFF
--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -744,17 +744,20 @@ defmodule Web.CoreComponents do
     assigns = assign_new(assigns, :relative_to, fn -> DateTime.utc_now() end)
 
     ~H"""
-    <.badge
-      type={if @schema.online?, do: "success", else: "danger"}
-      title={
-        if @schema.last_seen_at,
-          do:
-            "Last connected #{Cldr.DateTime.Relative.to_string!(@schema.last_seen_at, Web.CLDR, relative_to: @relative_to)}",
-          else: "Never connected"
-      }
-    >
-      <%= if @schema.online?, do: "Online", else: "Offline" %>
-    </.badge>
+    <span class="flex items-center">
+      <.ping_icon color={if @schema.online?, do: "success", else: "danger"} />
+      <span
+        class="ml-2.5"
+        title={
+          if @schema.last_seen_at,
+            do:
+              "Last connected #{Cldr.DateTime.Relative.to_string!(@schema.last_seen_at, Web.CLDR, relative_to: @relative_to)}",
+            else: "Never connected"
+        }
+      >
+        <%= if @schema.online?, do: "Online", else: "Offline" %>
+      </span>
+    </span>
     """
   end
 
@@ -1066,6 +1069,35 @@ defmodule Web.CoreComponents do
       </div>
     </div>
     """
+  end
+
+  @doc """
+  Render an animated status indicator dot.
+  """
+
+  attr :color, :string, default: "info"
+
+  def ping_icon(assigns) do
+    ~H"""
+    <span class="relative flex h-2.5 w-2.5">
+      <span class={~w[
+        animate-ping absolute inline-flex
+        h-full w-full rounded-full opacity-50
+        #{ping_icon_color(@color) |> elem(1)}]}></span>
+      <span class={~w[
+        relative inline-flex rounded-full h-2.5 w-2.5
+        #{ping_icon_color(@color) |> elem(0)}]}></span>
+    </span>
+    """
+  end
+
+  defp ping_icon_color(color) do
+    case color do
+      "info" -> {"bg-accent-500", "bg-accent-400"}
+      "success" -> {"bg-green-500", "bg-green-400"}
+      "warning" -> {"bg-orange-500", "bg-orange-400"}
+      "danger" -> {"bg-red-500", "bg-red-400"}
+    end
   end
 
   @doc """

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -581,11 +581,11 @@ defmodule Web.FormComponents do
     }
 
     spacing = %{
-      "xs" => "px-2 py-1",
-      "sm" => "px-3 py-2",
-      "md" => "px-4 py-2",
-      "lg" => "px-5 py-3",
-      "xl" => "px-6 py-3.5"
+      "xs" => "px-1.5 py-1",
+      "sm" => "px-2 py-2",
+      "md" => "px-3 py-2",
+      "lg" => "px-4 py-3",
+      "xl" => "px-5 py-3.5"
     }
 
     [text[size], spacing[size]]
@@ -594,18 +594,18 @@ defmodule Web.FormComponents do
   defp icon_size(size) do
     icon_size = %{
       "xs" => "w-3 h-3",
-      "sm" => "w-3.5 h-3.5",
-      "md" => "w-4 h-4",
-      "lg" => "w-5 h-5",
-      "xl" => "w-6 h-6"
+      "sm" => "w-3 h-3",
+      "md" => "w-3.5 h-3.5",
+      "lg" => "w-4 h-4",
+      "xl" => "w-5 h-5"
     }
 
     spacing = %{
       "xs" => "mr-1",
-      "sm" => "mr-2",
-      "md" => "mr-3",
-      "lg" => "mr-4",
-      "xl" => "mr-5"
+      "sm" => "mr-1.5",
+      "md" => "mr-2",
+      "lg" => "mr-3",
+      "xl" => "mr-4"
     }
 
     [icon_size[size], spacing[size]]

--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -81,18 +81,19 @@
   </.sidebar_item_group>
 
   <:bottom>
-    <div class="absolute bottom-0 left-0 justify-left p-4 space-x-4 w-full lg:flex bg-white z-20">
+    <div class="absolute bottom-0 left-0 p-4 space-x-4">
       <a
         target="_blank"
         href="https://www.firezone.dev/kb?utm_source=product"
-        class="text-neutral-700 hover:text-neutral-900 lg:hidden"
+        class="text-neutral-700 hover:text-neutral-900 hover:underline lg:hidden"
       >
         Docs
       </a>
       <a
         target="_blank"
         href="https://firezone.statuspage.io"
-        class="text-neutral-700 hover:text-neutral-900 lg:hidden"
+        title="Firezone Platform Status"
+        class="text-neutral-700 hover:text-neutral-900 hover:underline lg:hidden"
       >
         Status
       </a>

--- a/elixir/apps/web/lib/web/components/navigation_components.ex
+++ b/elixir/apps/web/lib/web/components/navigation_components.ex
@@ -33,14 +33,14 @@ defmodule Web.NavigationComponents do
           <a
             target="_blank"
             href="https://www.firezone.dev/kb?utm_source=product"
-            class="mr-6 mt-1 text-neutral-700 hover:text-neutral-900 lg:ml-2 hidden lg:block"
+            class="mr-6 mt-1 text-neutral-700 hover:text-neutral-900 hover:underline lg:ml-2 hidden lg:block"
           >
             Docs
           </a>
           <a
             target="_blank"
             href="https://firezone.statuspage.io"
-            class="mr-6 mt-1 text-neutral-700 hover:text-neutral-900 lg:ml-2 hidden lg:block"
+            class="mr-6 mt-1 text-neutral-700 hover:text-neutral-900 hover:underline lg:ml-2 hidden lg:block"
           >
             Status
           </a>
@@ -153,25 +153,26 @@ defmodule Web.NavigationComponents do
   attr :navigate, :string, required: true
   slot :inner_block, required: true
   attr :current_path, :string, required: true
-  attr :active_class, :string, required: false, default: "bg-neutral-100"
+
+  attr :active_class, :string,
+    required: false,
+    default: "bg-neutral-50 text-neutral-800 font-medium"
 
   def sidebar_item(assigns) do
     ~H"""
     <li>
       <.link navigate={@navigate} class={~w[
       flex items-center p-2
-      text-base text-neutral-900
+      text-base
       rounded
       #{sidebar_item_active?(@current_path, @navigate) && @active_class}
-      hover:bg-neutral-100
-      group]}>
+      text-neutral-700
+      hover:bg-neutral-100 hover:text-neutral-900
+      ]}>
         <.icon name={@icon} class={~w[
-          w-6 h-6
-          text-neutral-700
-          transition duration-75
-          group-hover:text-neutral-900
+          w-5 h-5
         ]} />
-        <span class="ml-3"><%= render_slot(@inner_block) %></span>
+        <span class="ml-3 text-lg"><%= render_slot(@inner_block) %></span>
       </.link>
     </li>
     """
@@ -186,7 +187,10 @@ defmodule Web.NavigationComponents do
   attr :id, :string, required: true, doc: "ID of the nav group container"
   attr :icon, :string, required: true
   attr :current_path, :string, required: true
-  attr :active_class, :string, required: false, default: "bg-neutral-100"
+
+  attr :active_class, :string,
+    required: false,
+    default: "bg-neutral-50 text-neutral-800 font-medium"
 
   slot :name, required: true
 
@@ -207,31 +211,27 @@ defmodule Web.NavigationComponents do
       <button
         type="button"
         class={~w[
-          flex items-center p-2 w-full group rounded
-          text-base text-neutral-900
+          flex items-center p-2 w-full rounded
+          text-lg text-neutral-700
           transition duration-75
-          hover:bg-neutral-100]}
+          hover:bg-neutral-100 hover:text-neutral-900]}
         aria-controls={"dropdown-#{@id}"}
         data-collapse-toggle={"dropdown-#{@id}"}
         aria-hidden={@dropdown_hidden}
       >
         <.icon name={@icon} class={~w[
-          w-6 h-6 text-neutral-800
-          transition duration-75
-          group-hover:text-neutral-900]} />
+          w-5 h-5 text-neutral-700]} />
         <span class="flex-1 ml-3 text-left whitespace-nowrap"><%= render_slot(@name) %></span>
         <.icon name="hero-chevron-down-solid" class={~w[
-          w-6 h-6 text-neutral-500
-          transition duration-75
-          group-hover:text-neutral-900]} />
+          w-5 h-5 text-neutral-700]} />
       </button>
       <ul id={"dropdown-#{@id}"} class={if @dropdown_hidden, do: "hidden", else: ""}>
         <li :for={item <- @item}>
           <.link navigate={item.navigate} class={~w[
-              flex items-center p-2 pl-11 w-full group rounded
-              text-base text-neutral-900
+              flex items-center p-2 pl-10 w-full group rounded
+              text-lg text-neutral-700
               #{String.starts_with?(@current_path, item.navigate) && @active_class}
-              transition duration-75
+              hover:text-neutral-900
               hover:bg-neutral-100]}>
             <%= render_slot(item) %>
           </.link>
@@ -260,7 +260,7 @@ defmodule Web.NavigationComponents do
             navigate={if @account, do: ~p"/#{@account}", else: @home_path}
             class="inline-flex items-center text-neutral-700 hover:text-neutral-900"
           >
-            <.icon name="hero-home-solid" class="w-4 h-4 mr-2" /> Home
+            <.icon name="hero-home-solid" class="w-3.5 h-3.5 mr-2" /> Home
           </.link>
 
           <%= render_slot(@inner_block) %>
@@ -280,7 +280,7 @@ defmodule Web.NavigationComponents do
     ~H"""
     <li class="inline-flex items-center">
       <div class="flex items-center text-neutral-700">
-        <.icon name="hero-chevron-right-solid" class="w-6 h-6" />
+        <.icon name="hero-chevron-right-solid" class="w-3.5 h-3.5" />
         <.link
           :if={not is_nil(@path)}
           navigate={@path}

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -238,6 +238,7 @@ defmodule Web.Actors.Show do
               :if={identity_has_email?(identity)}
               size="xs"
               title="Send Welcome Email"
+              style="info"
               icon="hero-envelope"
               phx-click="send_welcome_email"
               phx-value-id={identity.id}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
@@ -4,7 +4,7 @@ defmodule Web.Settings.IdentityProviders.Components do
   def status(%{provider: %{deleted_at: deleted_at}} = assigns) when not is_nil(deleted_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-neutral-500 rounded-full"></span>
+      <.ping_icon color="info" />
       <span class="ml-3">
         Deleted
       </span>
@@ -29,7 +29,7 @@ defmodule Web.Settings.IdentityProviders.Components do
 
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
+      <.ping_icon color="danger" />
       <span class="ml-3">
         No refresh token provided by IdP and access token expires on
         <.datetime datetime={@expires_at} /> UTC
@@ -50,7 +50,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
+      <.ping_icon color="danger" />
       <span class="ml-3">
         Provisioning
         <span :if={@provider.adapter_state["status"]}>
@@ -85,7 +85,7 @@ defmodule Web.Settings.IdentityProviders.Components do
 
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
+      <.ping_icon color="danger" />
       <span class="ml-3">
         No refresh token provided by IdP and access token expires on
         <.datetime datetime={@expires_at} /> UTC
@@ -106,7 +106,7 @@ defmodule Web.Settings.IdentityProviders.Components do
       when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
+      <.ping_icon color="danger" />
       <span class="ml-3">
         Provisioning
         <span :if={@provider.adapter_state["status"]}>
@@ -141,7 +141,7 @@ defmodule Web.Settings.IdentityProviders.Components do
 
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
+      <.ping_icon color="danger" />
       <span class="ml-3">
         No refresh token provided by IdP and access token expires on
         <.datetime datetime={@expires_at} /> UTC
@@ -162,8 +162,8 @@ defmodule Web.Settings.IdentityProviders.Components do
       when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
-      <span class="ml-3">
+      <.ping_icon color="danger" />
+      <span class="ml-2.5">
         Provisioning
         <span :if={@provider.adapter_state["status"]}>
           <.button
@@ -192,8 +192,8 @@ defmodule Web.Settings.IdentityProviders.Components do
       when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
-      <span class="ml-3">
+      <.ping_icon color="danger" />
+      <span class="ml-2.5">
         Provisioning
         <span :if={@provider.adapter_state["status"]}>
           <.button
@@ -213,8 +213,8 @@ defmodule Web.Settings.IdentityProviders.Components do
   def status(%{provider: %{disabled_at: disabled_at}} = assigns) when not is_nil(disabled_at) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-neutral-500 rounded-full"></span>
-      <span class="ml-3">
+      <.ping_icon color="info" />
+      <span class="ml-2.5">
         Disabled
       </span>
     </div>
@@ -224,8 +224,8 @@ defmodule Web.Settings.IdentityProviders.Components do
   def status(assigns) do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-green-500 rounded-full"></span>
-      <span class="ml-3">
+      <.ping_icon color="success" />
+      <span class="ml-2.5">
         Active
       </span>
     </div>
@@ -258,13 +258,11 @@ defmodule Web.Settings.IdentityProviders.Components do
   def sync_status(%{provider: %{provisioner: :custom}} = assigns) do
     ~H"""
     <div :if={not is_nil(@provider.last_synced_at)} class="flex items-center">
-      <span class={[
-        "w-3 h-3 rounded-full",
-        @provider.last_syncs_failed > 3 or (not is_nil(@provider.sync_disabled_at) && "bg-red-500") ||
-          "bg-green-500"
-      ]}>
-      </span>
-      <span class="ml-3">
+      <.ping_icon color={
+        @provider.last_syncs_failed > 3 or (not is_nil(@provider.sync_disabled_at) && "danger") ||
+          "success"
+      } />
+      <span class="ml-2.5">
         Synced
         <.link
           navigate={~p"/#{@account}/actors?#{%{"actors_filter[provider_id]" => @provider.id}}"}
@@ -292,8 +290,8 @@ defmodule Web.Settings.IdentityProviders.Components do
       </span>
     </div>
     <div :if={is_nil(@provider.last_synced_at)} class="flex items-center">
-      <span class="w-3 h-3 bg-red-500 rounded-full"></span>
-      <span class="ml-3">
+      <.ping_icon color="danger" />
+      <span class="ml-2.5">
         Never synced
       </span>
     </div>
@@ -304,8 +302,8 @@ defmodule Web.Settings.IdentityProviders.Components do
       when provisioner in [:just_in_time, :manual] do
     ~H"""
     <div class="flex items-center">
-      <span class="w-3 h-3 bg-green-500 rounded-full"></span>
-      <span class="ml-3">
+      <.ping_icon color="success" />
+      <span class="ml-2.5">
         Created
         <.link
           navigate={~p"/#{@account}/actors?#{%{"actors_filter[provider_id]" => @provider.id}}"}

--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -117,10 +117,12 @@ defmodule Web.Sites.Index do
             peek = %{count: length(gateways), items: Enum.take(gateways, 5)} %>
             <.peek peek={peek}>
               <:empty>
-                <.icon
-                  name="hero-exclamation-triangle"
-                  class="inline-block w-5 h-5 mr-1 text-red-500"
-                /> None
+                <span class="justify flex items-center">
+                  <.icon
+                    name="hero-exclamation-triangle-solid"
+                    class="inline-block w-3.5 h-3.5 mr-1 text-red-500"
+                  /> None
+                </span>
               </:empty>
 
               <:separator>

--- a/elixir/apps/web/test/web/live/sidebar_test.exs
+++ b/elixir/apps/web/test/web/live/sidebar_test.exs
@@ -38,7 +38,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/actors")
-    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/actors']")
+    assert item = Floki.find(html, "a.bg-neutral-50[href='/#{account.slug}/actors']")
     assert String.trim(Floki.text(item)) == "Actors"
   end
 
@@ -48,7 +48,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/groups")
-    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/groups']")
+    assert item = Floki.find(html, "a.bg-neutral-50[href='/#{account.slug}/groups']")
     assert String.trim(Floki.text(item)) == "Groups"
   end
 
@@ -58,7 +58,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/clients")
-    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/clients']")
+    assert item = Floki.find(html, "a.bg-neutral-50[href='/#{account.slug}/clients']")
     assert String.trim(Floki.text(item)) == "Clients"
   end
 
@@ -68,7 +68,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/sites")
-    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/sites']")
+    assert item = Floki.find(html, "a.bg-neutral-50[href='/#{account.slug}/sites']")
     assert String.trim(Floki.text(item)) == "Sites"
   end
 
@@ -78,7 +78,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/relay_groups")
-    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/relay_groups']")
+    assert item = Floki.find(html, "a.bg-neutral-50[href='/#{account.slug}/relay_groups']")
     assert String.trim(Floki.text(item)) == "Relays"
   end
 
@@ -88,7 +88,7 @@ defmodule Web.SidebarTest do
   #   conn: conn
   # } do
   #   {:ok, _lv, html} = conn |> authorize_conn(identity) |> live( ~p"/#{account}/resources")
-  #   assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/resources']")
+  #   assert item = Floki.find(html, "a.bg-neutral-50[href='/#{account.slug}/resources']")
   #   assert String.trim(Floki.text(item)) == "Resources"
   # end
 
@@ -98,7 +98,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/policies")
-    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/policies']")
+    assert item = Floki.find(html, "a.bg-neutral-50[href='/#{account.slug}/policies']")
     assert String.trim(Floki.text(item)) == "Policies"
   end
 
@@ -108,7 +108,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/settings/account")
-    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/settings/account']")
+    assert item = Floki.find(html, "a.bg-neutral-50[href='/#{account.slug}/settings/account']")
     assert String.trim(Floki.text(item)) == "Account"
   end
 
@@ -123,7 +123,7 @@ defmodule Web.SidebarTest do
     assert item =
              Floki.find(
                html,
-               "a.bg-neutral-100[href='/#{account.slug}/settings/identity_providers']"
+               "a.bg-neutral-50[href='/#{account.slug}/settings/identity_providers']"
              )
 
     assert String.trim(Floki.text(item)) == "Identity Providers"
@@ -143,7 +143,7 @@ defmodule Web.SidebarTest do
     assert item =
              Floki.find(
                html,
-               "a.bg-neutral-100[href='/#{account.slug}/settings/identity_providers']"
+               "a.bg-neutral-50[href='/#{account.slug}/settings/identity_providers']"
              )
 
     assert String.trim(Floki.text(item)) == "Identity Providers"
@@ -155,7 +155,7 @@ defmodule Web.SidebarTest do
     conn: conn
   } do
     {:ok, _lv, html} = conn |> authorize_conn(identity) |> live(~p"/#{account}/settings/dns")
-    assert item = Floki.find(html, "a.bg-neutral-100[href='/#{account.slug}/settings/dns']")
+    assert item = Floki.find(html, "a.bg-neutral-50[href='/#{account.slug}/settings/dns']")
     assert String.trim(Floki.text(item)) == "DNS"
   end
 end


### PR DESCRIPTION
Fixes #5229 

<img width="303" alt="Screenshot 2024-06-05 at 9 54 29 AM" src="https://github.com/firezone/firezone/assets/167144/b234ba01-b0e2-4d6b-ab49-48f90933f4de">
<img width="282" alt="Screenshot 2024-06-05 at 9 54 24 AM" src="https://github.com/firezone/firezone/assets/167144/126b35d6-ba39-45a0-b828-48ea50f450f5">
