### PR TITLE
fix(ux): Remove some padding around vertical_table

### DIFF
--- a/elixir/apps/web/lib/web/components/table_components.ex
+++ b/elixir/apps/web/lib/web/components/table_components.ex
@@ -324,14 +324,14 @@ defmodule Web.TableComponents do
       <th
         scope="row"
         class={[
-          "text-right px-2 py-3 font-medium text-neutral-900 whitespace-nowrap",
+          "text-right px-4 py-3 font-medium text-neutral-900 whitespace-nowrap",
           "bg-neutral-50 w-1/5",
           @label_class
         ]}
       >
         <%= render_slot(@label) %>
       </th>
-      <td class={["px-2 py-3", @value_class]}>
+      <td class={["px-4 py-3", @value_class]}>
         <%= render_slot(@value) %>
       </td>
     </tr>

--- a/elixir/apps/web/lib/web/components/table_components.ex
+++ b/elixir/apps/web/lib/web/components/table_components.ex
@@ -324,14 +324,14 @@ defmodule Web.TableComponents do
       <th
         scope="row"
         class={[
-          "text-right px-6 py-4 font-medium text-neutral-900 whitespace-nowrap",
+          "text-right px-2 py-3 font-medium text-neutral-900 whitespace-nowrap",
           "bg-neutral-50 w-1/5",
           @label_class
         ]}
       >
         <%= render_slot(@label) %>
       </th>
-      <td class={["px-6 py-4", @value_class]}>
+      <td class={["px-2 py-3", @value_class]}>
         <%= render_slot(@value) %>
       </td>
     </tr>


### PR DESCRIPTION
# Before

<img width="616" alt="Screenshot 2024-06-05 at 2 08 20 PM" src="https://github.com/firezone/firezone/assets/167144/90935c5e-3e19-499c-afdc-764280b8a306">


# After
<img width="522" alt="Screenshot 2024-06-05 at 2 11 58 PM" src="https://github.com/firezone/firezone/assets/167144/8e22b64f-6169-4e98-9408-d796f690f3c8">

Fixes #5228