### PR TITLE
feat(portal): allow multiple relays with same ip but different port

### DIFF
--- a/elixir/apps/domain/lib/domain/relays/relay/changeset.ex
+++ b/elixir/apps/domain/lib/domain/relays/relay/changeset.ex
@@ -23,12 +23,13 @@ defmodule Domain.Relays.Relay.Changeset do
                               updated_at]a
 
   def upsert_conflict_target(%{account_id: nil}) do
-    {:unsafe_fragment, ~s/(COALESCE(ipv4, ipv6)) WHERE deleted_at IS NULL AND account_id IS NULL/}
+    {:unsafe_fragment,
+     ~s/(COALESCE(ipv4, ipv6), port) WHERE deleted_at IS NULL AND account_id IS NULL/}
   end
 
   def upsert_conflict_target(%{account_id: _account_id}) do
     {:unsafe_fragment,
-     ~s/(account_id, COALESCE(ipv4, ipv6)) WHERE deleted_at IS NULL AND account_id IS NOT NULL/}
+     ~s/(account_id, COALESCE(ipv4, ipv6), port) WHERE deleted_at IS NULL AND account_id IS NOT NULL/}
   end
 
   def upsert_on_conflict, do: {:replace, @conflict_replace_fields}
@@ -41,8 +42,10 @@ defmodule Domain.Relays.Relay.Changeset do
     |> validate_number(:port, greater_than_or_equal_to: 1, less_than_or_equal_to: 65_535)
     |> unique_constraint(:ipv4, name: :relays_unique_address_index)
     |> unique_constraint(:ipv6, name: :relays_unique_address_index)
+    |> unique_constraint(:port, name: :relays_unique_address_index)
     |> unique_constraint(:ipv4, name: :global_relays_unique_address_index)
     |> unique_constraint(:ipv6, name: :global_relays_unique_address_index)
+    |> unique_constraint(:port, name: :global_relays_unique_address_index)
     |> put_change(:last_seen_at, DateTime.utc_now())
     |> put_change(:last_seen_user_agent, context.user_agent)
     |> put_change(:last_seen_remote_ip, context.remote_ip)

--- a/elixir/apps/domain/priv/repo/migrations/20240605231610_add_port_to_relay_indexes.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20240605231610_add_port_to_relay_indexes.exs
@@ -1,0 +1,20 @@
+defmodule Domain.Repo.Migrations.AddPortToRelayIndexes do
+  use Ecto.Migration
+
+  def change do
+    execute("DROP INDEX relays_unique_address_index")
+    execute("DROP INDEX global_relays_unique_address_index")
+
+    execute("""
+    CREATE UNIQUE INDEX relays_unique_address_index
+    ON relays (account_id, COALESCE(ipv4, ipv6), port)
+    WHERE deleted_at IS NULL AND account_id IS NOT NULL
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX global_relays_unique_address_index
+    ON relays (COALESCE(ipv4, ipv6), port)
+    WHERE deleted_at IS NULL AND account_id IS NULL
+    """)
+  end
+end

--- a/elixir/apps/domain/test/domain/relays_test.exs
+++ b/elixir/apps/domain/test/domain/relays_test.exs
@@ -950,6 +950,41 @@ defmodule Domain.RelaysTest do
 
       assert Repo.aggregate(Domain.Network.Address, :count) == 0
     end
+
+    test "creates multiple relays when only port changes", %{
+      account: account,
+      group: group
+    } do
+      ipv4 = Domain.Fixture.unique_ipv4()
+      ipv6 = Domain.Fixture.unique_ipv6()
+      first_port = Domain.Fixture.unique_integer()
+      second_port = Domain.Fixture.unique_integer()
+
+      first_relay =
+        Fixtures.Relays.create_relay(
+          ipv4: ipv4,
+          ipv6: ipv6,
+          port: first_port,
+          account: account,
+          group: group
+        )
+
+      second_relay =
+        Fixtures.Relays.create_relay(
+          ipv4: ipv4,
+          ipv6: ipv6,
+          port: second_port,
+          account: account,
+          group: group
+        )
+
+      assert first_relay.ipv4 == second_relay.ipv4
+      assert first_relay.ipv6 == second_relay.ipv6
+      assert first_relay.port == first_port
+      assert second_relay.port == second_port
+
+      assert Repo.aggregate(Relays.Relay, :count, :id) == 2
+    end
   end
 
   describe "delete_relay/2" do


### PR DESCRIPTION
Following https://github.com/firezone/firezone/pull/5130

A relay with the same IPs as an existing relay but a different port should be considered a new relay.