### PR TITLE
fix(connlib): reply with `SERVFAIL` on DNS query errors

### DIFF
--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -25,6 +25,7 @@ boringtun = { workspace = true }
 chrono = { workspace = true }
 futures-bounded = { workspace = true }
 hickory-resolver = { workspace = true, features = ["tokio-runtime"] }
+hickory-proto = { workspace = true }
 bimap = "0.6"
 socket2 = { version = "0.5" }
 snownet = { workspace = true }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -664,9 +664,9 @@ impl ClientState {
                     query.query,
                     hickory_proto::op::ResponseCode::ServFail,
                 )
-                .map(|p| p.into_immutable());
+                .into_immutable();
 
-                self.buffered_packets.extend(response);
+                self.buffered_packets.push_back(response);
                 return;
             }
         };

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -679,8 +679,7 @@ impl ClientState {
 
         let dns_reply = match response {
             Ok(Ok(response)) => match dns::build_response_from_resolve_result(query, response) {
-                Ok(Some(dns_reply)) => dns_reply,
-                Ok(None) => return,
+                Ok(dns_reply) => dns_reply,
                 Err(e) => make_error_reply(&e),
             },
             Ok(Err(timeout)) => make_error_reply(&timeout),

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -63,6 +63,16 @@ impl<'a> DnsQuery<'a> {
     }
 }
 
+impl Clone for DnsQuery<'static> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            record_type: self.record_type,
+            query: self.query.clone(),
+        }
+    }
+}
+
 struct DnsQueryParams {
     name: String,
     record_type: RecordType,

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -8,7 +8,7 @@ use domain::base::{
 };
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::proto::error::{ProtoError, ProtoErrorKind};
-use hickory_resolver::proto::op::{Message as TrustDnsMessage, MessageType};
+use hickory_resolver::proto::op::MessageType;
 use hickory_resolver::proto::rr::RecordType;
 use ip_packet::udp::UdpPacket;
 use ip_packet::Packet as _;
@@ -173,7 +173,7 @@ pub(crate) fn build_response_from_resolve_result(
     original_pkt: IpPacket<'_>,
     response: hickory_resolver::error::ResolveResult<Lookup>,
 ) -> Result<Option<IpPacket>, hickory_resolver::error::ResolveError> {
-    let Some(mut message) = as_dns_message(&original_pkt) else {
+    let Some(mut message) = original_pkt.as_dns() else {
         debug_assert!(false, "The original message should be a DNS query for us to ever call write_dns_lookup_response");
         return Ok(None);
     };
@@ -444,11 +444,6 @@ pub(crate) fn ips_of_resource<'a>(
 ) -> impl Iterator<Item = IpAddr> + 'a {
     ips.iter()
         .filter_map(move |(ip, r)| (r == resource).then_some(*ip))
-}
-
-pub(crate) fn as_dns_message(pkt: &IpPacket) -> Option<TrustDnsMessage> {
-    let datagram = pkt.as_udp()?;
-    TrustDnsMessage::from_vec(datagram.payload()).ok()
 }
 
 fn reverse_dns_addr(name: &str) -> Option<IpAddr> {

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -128,9 +128,11 @@ impl Io {
 
     pub fn perform_dns_query(&mut self, query: DnsQuery<'static>) -> Result<(), DnsQueryError> {
         let upstream = query.query.destination();
-        let Some(resolver) = self.upstream_dns_servers.get(&upstream).cloned() else {
-            return Err(DnsQueryError::UnknownServer);
-        };
+        let resolver = self
+            .upstream_dns_servers
+            .get(&upstream)
+            .cloned()
+            .expect("Only DNS queries to known upstream servers should be forwarded to `Io`");
 
         if self
             .forwarded_dns_queries
@@ -184,8 +186,6 @@ impl Io {
 
 #[derive(Debug, thiserror::Error)]
 pub enum DnsQueryError {
-    #[error("No upstream DNS server configured")]
-    UnknownServer,
     #[error("Too many ongoing DNS queries")]
     TooManyQueries,
 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -116,7 +116,9 @@ where
             }
 
             if let Some(dns_query) = self.role_state.poll_dns_queries() {
-                self.io.perform_dns_query(dns_query);
+                if let Err(e) = self.io.perform_dns_query(dns_query.clone()) {
+                    self.role_state.on_dns_result(dns_query, Err(e))
+                }
                 continue;
             }
 
@@ -161,7 +163,7 @@ where
                     continue;
                 }
                 Poll::Ready(io::Input::DnsResponse(query, response)) => {
-                    self.role_state.on_dns_result(query, response);
+                    self.role_state.on_dns_result(query, Ok(response));
                     continue;
                 }
                 Poll::Pending => {}

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -72,7 +72,7 @@ impl AllowRules {
                 .as_tcp()
                 .is_some_and(|p| self.tcp.contains(&p.get_destination())),
             IpNextHeaderProtocols::Udp => packet
-                .try_as_udp()
+                .as_udp()
                 .is_some_and(|p| self.udp.contains(&p.get_destination())),
             IpNextHeaderProtocols::Icmp | IpNextHeaderProtocols::Icmpv6 => self.icmp,
             _ => false,

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -72,7 +72,7 @@ impl AllowRules {
                 .as_tcp()
                 .is_some_and(|p| self.tcp.contains(&p.get_destination())),
             IpNextHeaderProtocols::Udp => packet
-                .as_udp()
+                .try_as_udp()
                 .is_some_and(|p| self.udp.contains(&p.get_destination())),
             IpNextHeaderProtocols::Icmp | IpNextHeaderProtocols::Icmpv6 => self.icmp,
             _ => false,

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -919,7 +919,7 @@ impl TunnelTest {
         {
             let packet = packet.to_owned().into_immutable();
 
-            if let Some(udp) = packet.as_udp() {
+            if let Some(udp) = packet.try_as_udp() {
                 if let Ok(message) = hickory_proto::op::Message::from_bytes(udp.payload()) {
                     debug_assert_eq!(
                         message.message_type(),
@@ -1270,7 +1270,7 @@ impl TunnelTest {
             return;
         };
 
-        if let Some(udp) = packet.as_udp() {
+        if let Some(udp) = packet.try_as_udp() {
             if udp.get_source() == 53 {
                 let mut message = hickory_proto::op::Message::from_bytes(udp.payload())
                     .expect("ip packets on port 53 to be DNS packets");
@@ -2463,8 +2463,8 @@ fn assert_correct_src_and_dst_udp_ports(
     client_sent_request: &IpPacket<'_>,
     client_received_reply: &IpPacket<'_>,
 ) {
-    let client_sent_request = client_sent_request.as_udp().expect("packet to be UDP");
-    let client_received_reply = client_received_reply.as_udp().expect("packet to be UDP");
+    let client_sent_request = client_sent_request.as_udp_debug_checked().unwrap();
+    let client_received_reply = client_received_reply.as_udp_debug_checked().unwrap();
 
     assert_eq!(
         client_sent_request.get_destination(),

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -1359,10 +1359,10 @@ impl TunnelTest {
 
         self.client.state.on_dns_result(
             query,
-            Ok(Ok(Lookup::new_with_max_ttl(
+            Ok(Ok(Ok(Lookup::new_with_max_ttl(
                 Query::query(name, record_type),
                 record_data,
-            ))),
+            )))),
         );
     }
 }

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -1075,7 +1075,7 @@ impl TunnelTest {
                 return ControlFlow::Break(());
             }
 
-            if let Some(response) = ip_packet::make::dns_response(packet, |name| {
+            if let Some(response) = ip_packet::make::dns_ok_response(packet, |name| {
                 global_dns_records
                     .get(&hickory_name_to_domain(name.clone()))
                     .cloned()

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -303,32 +303,30 @@ impl<'a> IpPacket<'a> {
         self.next_header() == IpNextHeaderProtocols::Tcp
     }
 
-    pub fn try_as_udp(&self) -> Option<UdpPacket> {
+    pub fn as_udp(&self) -> Option<UdpPacket> {
         self.is_udp()
             .then(|| UdpPacket::new(self.payload()))
             .flatten()
     }
 
-    pub fn as_udp_debug_checked(&self) -> Option<UdpPacket> {
-        debug_assert!(self.is_udp(), "Packet is not a UDP packet");
+    /// Unwrap this [`IpPacket`] as a [`UdpPacket`], panicking in case it is not.
+    pub fn unwrap_as_udp(&self) -> UdpPacket {
+        assert!(self.is_udp(), "Packet is not a UDP packet");
 
-        UdpPacket::new(self.payload())
+        UdpPacket::new(self.payload()).unwrap()
     }
 
-    /// View this [`IpPacket`] as a DNS message.
-    ///
-    /// This is a checked conversion, panicking in debug mode in case this packet is not a DNS message.
-    pub fn as_dns_debug_checked(&self) -> Option<hickory_proto::op::Message> {
-        let udp = self.as_udp_debug_checked()?;
+    /// Unwrap this [`IpPacket`] as a DNS message, panicking in case it is not.
+    pub fn unwrap_as_dns(&self) -> hickory_proto::op::Message {
+        let udp = self.unwrap_as_udp();
         let message = match hickory_proto::op::Message::from_vec(udp.payload()) {
             Ok(message) => message,
             Err(e) => {
-                debug_assert!(false, "Failed to parse UDP payload as DNS message: {e}");
-                return None;
+                panic!("Failed to parse UDP payload as DNS message: {e}");
             }
         };
 
-        Some(message)
+        message
     }
 
     pub fn as_tcp(&self) -> Option<TcpPacket> {

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -309,6 +309,13 @@ impl<'a> IpPacket<'a> {
             .flatten()
     }
 
+    pub fn as_dns(&self) -> Option<hickory_proto::op::Message> {
+        let udp = self.as_udp()?;
+        let message = hickory_proto::op::Message::from_vec(udp.payload()).ok()?;
+
+        Some(message)
+    }
+
     pub fn as_tcp(&self) -> Option<TcpPacket> {
         self.is_tcp()
             .then(|| TcpPacket::new(self.payload()))

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -165,6 +165,11 @@ impl<'a> MutableIpPacket<'a> {
             .flatten()
     }
 
+    /// Unwrap this [`IpPacket`] as a [`MutableUdpPacket`], panicking in case it is not.
+    pub fn unwrap_as_udp(&mut self) -> MutableUdpPacket {
+        self.as_udp().expect("Packet is not a UDP packet")
+    }
+
     pub fn as_tcp(&mut self) -> Option<MutableTcpPacket> {
         self.to_immutable()
             .is_tcp()
@@ -311,9 +316,7 @@ impl<'a> IpPacket<'a> {
 
     /// Unwrap this [`IpPacket`] as a [`UdpPacket`], panicking in case it is not.
     pub fn unwrap_as_udp(&self) -> UdpPacket {
-        assert!(self.is_udp(), "Packet is not a UDP packet");
-
-        UdpPacket::new(self.payload()).unwrap()
+        self.as_udp().expect("Packet is not a UDP packet")
     }
 
     /// Unwrap this [`IpPacket`] as a DNS message, panicking in case it is not.

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -230,7 +230,7 @@ pub fn dns_query(
     udp_packet(src.ip(), dst.ip(), src.port(), dst.port(), payload)
 }
 
-/// Makes a DNS response to the given DNS query packet, using a resolver callback
+/// Makes a DNS response to the given DNS query packet, using a resolver callback.
 pub fn dns_ok_response<I>(
     packet: IpPacket<'static>,
     resolve: impl Fn(&Name) -> I,
@@ -277,6 +277,7 @@ where
     )
 }
 
+/// Makes a DNS response to the given DNS query packet, using the given error code.
 pub fn dns_err_response(packet: IpPacket<'static>, code: ResponseCode) -> MutableIpPacket<'static> {
     let udp = packet.unwrap_as_udp();
     let query = packet.unwrap_as_dns();

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -230,6 +230,7 @@ pub fn dns_query(
     udp_packet(src.ip(), dst.ip(), src.port(), dst.port(), payload)
 }
 
+/// Makes a DNS response to the given DNS query packet, using a resolver callback
 pub fn dns_ok_response<I>(
     packet: IpPacket<'static>,
     resolve: impl Fn(&Name) -> I,

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -4,7 +4,6 @@ use crate::{IpPacket, MutableIpPacket};
 use hickory_proto::{
     op::{Message, Query},
     rr::{Name, RData, Record, RecordType},
-    serialize::binary::BinDecodable as _,
 };
 use pnet_packet::{
     ip::IpNextHeaderProtocol,
@@ -12,7 +11,6 @@ use pnet_packet::{
     ipv6::MutableIpv6Packet,
     tcp::{self, MutableTcpPacket},
     udp::{self, MutableUdpPacket},
-    Packet as _,
 };
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
@@ -239,8 +237,8 @@ pub fn dns_response<I>(
 where
     I: Iterator<Item = IpAddr>,
 {
-    let udp = packet.as_udp()?;
-    let mut query = Message::from_bytes(udp.payload()).ok()?;
+    let udp = packet.as_udp_debug_checked()?;
+    let mut query = packet.as_dns_debug_checked()?;
 
     let mut response = Message::new();
     response.set_id(query.id());


### PR DESCRIPTION
Currently, we simply drop a DNS query if we can't fulfill it. Because DNS is based on UDP which is unreliable, a downstream system will re-send a DNS query if it doesn't receive an answer within a certain timeout window.

Instead of dropping queries, we now reply with `SERVFAIL`, indicating to the client that we can't fulfill that DNS query. The intent is that this will stop any kind of automated retry-loop and surface an error to the user.

Related: #4800.