### PR TITLE
ci(gui-client): remove unused bare exe from CI artifacts

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -34,8 +34,6 @@ jobs:
             rename-script: ../../scripts/build/tauri-rename-ubuntu.sh
             upload-script: ../../scripts/build/tauri-upload-ubuntu.sh
             # mark:automatic-version
-            exe-artifact: rust/gui-client/firezone-client-gui-linux_1.0.6_x86_64
-            # mark:automatic-version
             syms-artifact: rust/gui-client/firezone-client-gui-linux_1.0.6_x86_64.dwp
             # mark:automatic-version
             pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.0.6_x86_64.deb
@@ -44,8 +42,6 @@ jobs:
             binary-dest-path: firezone-client-gui-windows_1.0.6_x86_64
             rename-script: ../../scripts/build/tauri-rename-windows.sh
             upload-script: ../../scripts/build/tauri-upload-windows.sh
-            # mark:automatic-version
-            exe-artifact: rust/gui-client/firezone-client-gui-windows_1.0.6_x86_64.exe
             # mark:automatic-version
             syms-artifact: rust/gui-client/firezone-client-gui-windows_1.0.6_x86_64.pdb
             # mark:automatic-version
@@ -89,13 +85,6 @@ jobs:
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ matrix.rename-script }}
-      - name: Upload exe
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.binary-dest-path }}-exe
-          path: |
-            ${{ matrix.exe-artifact }}
-          if-no-files-found: error
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Closes #5268 

With the IPC service, the bare exe isn't useful, just the MSI and deb are used even for testing