### PR TITLE
refactor(gui-client): keep the IPC connection up all the time, even when signed out

### DIFF
--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -76,6 +76,7 @@ pub(crate) fn system_resolvers() -> Result<Vec<IpAddr>> {
 ///
 /// Parameters:
 /// - `dns_config_string`: Comma-separated IP addresses of DNS servers, e.g. "1.1.1.1,8.8.8.8"
+#[tracing::instrument]
 pub(crate) fn activate(dns_config: &[IpAddr]) -> Result<()> {
     let dns_config_string = dns_config
         .iter()

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -499,6 +499,7 @@ async fn handle_ipc_client(stream: platform::IpcStream) -> Result<()> {
             IpcClientMsg::Disconnect => {
                 if let Some(connlib) = connlib.take() {
                     connlib.disconnect();
+                    dns_control::deactivate()?;
                 }
             }
             IpcClientMsg::Reconnect => connlib.as_mut().context("No connlib session")?.reconnect(),


### PR DESCRIPTION
Refs #5042 (Need IPC to be always-on to change settings even if we can't sign in)
Refs #5026 (Having the IPC service obey log levels from the GUI will make it easier to debug this)

```[tasklist]
### Before merging
- [ ] Fix smoke tests, need to run the IPC service on Linux + Windows
```