### PR TITLE
test(gui-client): remove parts of the test scripts that are redundant

### DIFF
--- a/scripts/build/tauri-rename-ubuntu.sh
+++ b/scripts/build/tauri-rename-ubuntu.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-FZ_GROUP="firezone-client"
 SERVICE_NAME=firezone-client-ipc
 
 function debug_exit() {
@@ -33,8 +32,6 @@ make_hash "$BINARY_DEST_PATH.deb"
 # Test the deb package, since this script is the easiest place to get a release build
 DEB_PATH=$(realpath "$BINARY_DEST_PATH.deb")
 sudo apt-get install "$DEB_PATH"
-# Update users / groups
-sudo systemd-sysusers
 
 # Debug-print the files. The icons and both binaries should be in here
 dpkg --listfiles firezone-client-gui
@@ -47,6 +44,5 @@ stat /usr/share/icons/hicolor/512x512/apps/firezone-client-gui.png
 # knows its own name
 firezone-client-gui --help | grep "Usage: firezone-client-gui"
 
-# Try to start the IPC service
-sudo groupadd --force "$FZ_GROUP"
-sudo systemctl start "$SERVICE_NAME" || debug_exit
+# Make sure the IPC service is running
+systemctl status "$SERVICE_NAME" || debug_exit

--- a/scripts/build/tauri-rename-windows.sh
+++ b/scripts/build/tauri-rename-windows.sh
@@ -22,4 +22,5 @@ make_hash "$BINARY_DEST_PATH.pdb"
 msiexec //i "$BINARY_DEST_PATH.msi" //log install.log //qn
 # For debugging
 cat install.log
+# Make sure the IPC service is running
 sc query FirezoneClientIpcService | grep RUNNING


### PR DESCRIPTION
The post-install script does all this stuff now ﻿https://github.com/firezone/firezone/blob/63567b5b33a919e977a7eeaae99599661bfc58c4/rust/gui-client/src-tauri/deb_files/postinst#L9-L15

Ran into this while working on #5279