### PR TITLE
hotfix(connlib): ignore remove remote candidate message

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -538,8 +538,9 @@ impl ClientState {
         self.node.add_remote_candidate(conn_id, ice_candidate, now);
     }
 
-    pub fn remove_ice_candidate(&mut self, conn_id: GatewayId, ice_candidate: String) {
-        self.node.remove_remote_candidate(conn_id, ice_candidate);
+    pub fn remove_ice_candidate(&mut self, _: GatewayId, _: String) {
+        // TODO
+        // self.node.remove_remote_candidate(conn_id, ice_candidate);
     }
 
     #[tracing::instrument(level = "trace", skip_all, fields(%resource_id))]

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -214,8 +214,9 @@ impl GatewayState {
         self.node.add_remote_candidate(conn_id, ice_candidate, now);
     }
 
-    pub fn remove_ice_candidate(&mut self, conn_id: ClientId, ice_candidate: String) {
-        self.node.remove_remote_candidate(conn_id, ice_candidate);
+    pub fn remove_ice_candidate(&mut self, _: ClientId, _: String) {
+        // TODO
+        // self.node.remove_remote_candidate(conn_id, ice_candidate);
     }
 
     /// Accept a connection request from a client.


### PR DESCRIPTION
This is more of a heuristic fix rather than a definitive one, this seems to fix the bug but a better fix would be to get #5283 right but it doesn't work right now