### PR TITLE
chore(ci): Bump CI tool versions

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -84,7 +84,7 @@ jobs:
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
           # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.12.0
+            image=moby/buildkit:v0.13
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
@@ -258,7 +258,7 @@ jobs:
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
           # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.12.0
+            image=moby/buildkit:v0.13
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -84,7 +84,7 @@ jobs:
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
           # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.13
+            image=moby/buildkit:v0.13.2
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
@@ -258,7 +258,7 @@ jobs:
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
           # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.13
+            image=moby/buildkit:v0.13.2
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     services:
       postgres:
-        image: postgres:15.2
+        image: postgres:15.5
         ports:
           - 5432:5432
         env:
@@ -130,7 +130,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     services:
       postgres:
-        image: postgres:15.2
+        image: postgres:15.5
         ports:
           - 5432:5432
         env:
@@ -184,7 +184,7 @@ jobs:
         MIX_TEST_PARTITION: [1]
     services:
       postgres:
-        image: postgres:15.2
+        image: postgres:15.5
         ports:
           - 5432:5432
         env:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,12 +1,12 @@
 # These are used for the dev environment.
 # This should match the versions used in the built product.
-nodejs 18.19.0
+nodejs 20.14.0
 elixir 1.16.2-otp-26
 erlang 26.2.2
-terraform 1.7.5
+terraform 1.8.5
 
 # Used for static analysis
-python 3.11.7
+python 3.11.9
 
 # Used to lint Bash scripts
 shellcheck 0.9.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Dependencies
   postgres:
-    image: postgres:15.2
+    image: postgres:15.5
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:

--- a/terraform/environments/production/versions.tf
+++ b/terraform/environments/production/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.7.5"
+  required_version = "1.8.5"
 
   required_providers {
     random = {

--- a/terraform/environments/staging/versions.tf
+++ b/terraform/environments/staging/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.7.5"
+  required_version = "1.8.5"
 
   required_providers {
     random = {


### PR DESCRIPTION
Bumps the tool versions that fall through the Dependabot cracks.