### PR TITLE
chore(website): Add sign in to navbar

### DIFF
--- a/website/src/components/RootNavbar/index.tsx
+++ b/website/src/components/RootNavbar/index.tsx
@@ -195,6 +195,13 @@ export default function RootNavbar() {
             </Link>
             <SignUpButton />
             <RequestDemoButton />
+            <ActionLink
+              href="https://app.firezone.dev/"
+              className="hover:underline hidden sm:inline-flex sm:text-sm md:text-base"
+              size="ml-1 mr-1 w-5 h-5"
+            >
+              Sign in
+            </ActionLink>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
Back by customer request, sign in from website navbar. Witnessed a couple customers fumble around trying to sign in after entering `firezone.dev` in their navbar.