### PR TITLE
chore(portal): Fix policy creation for conditions disabled; tweak design

### DIFF
--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -195,7 +195,7 @@ defmodule Web.FormComponents do
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div phx-feedback-for={@name}>
-      <.label for={@id}><%= @label %></.label>
+      <.label :if={@label} for={@id}><%= @label %></.label>
       <input
         :if={@rest[:disabled] in [true, "true"] and not is_nil(@value)}
         type="hidden"
@@ -227,7 +227,7 @@ defmodule Web.FormComponents do
   def input(%{type: "textarea"} = assigns) do
     ~H"""
     <div phx-feedback-for={@name}>
-      <.label for={@id}><%= @label %></.label>
+      <.label :if={@label} for={@id}><%= @label %></.label>
       <textarea
         id={@id}
         name={@name}
@@ -263,7 +263,7 @@ defmodule Web.FormComponents do
   def input(%{type: "readonly"} = assigns) do
     ~H"""
     <div>
-      <.label><%= @label %></.label>
+      <.label :if={@label}><%= @label %></.label>
       <div class="border border-solid rounded p-2 text-sm text-neutral-500">
         <%= assigns.value %>
       </div>
@@ -285,7 +285,7 @@ defmodule Web.FormComponents do
   def input(%{type: "text", prefix: prefix} = assigns) when not is_nil(prefix) do
     ~H"""
     <div phx-feedback-for={@name} class={@inline_errors && "flex flex-row items-center"}>
-      <.label :if={not is_nil(@label)} for={@id}><%= @label %></.label>
+      <.label :if={@label} for={@id}><%= @label %></.label>
       <div class={[
         "flex",
         "text-sm text-neutral-900 bg-neutral-50",
@@ -329,7 +329,7 @@ defmodule Web.FormComponents do
   def input(assigns) do
     ~H"""
     <div phx-feedback-for={@name} class={@inline_errors && "flex flex-row items-center"}>
-      <.label :if={not is_nil(@label)} for={@id}><%= @label %></.label>
+      <.label :if={@label} for={@id}><%= @label %></.label>
       <input
         type={@type}
         name={@name}

--- a/elixir/apps/web/lib/web/live/policies/components.ex
+++ b/elixir/apps/web/lib/web/live/policies/components.ex
@@ -12,7 +12,7 @@ defmodule Web.Policies.Components do
     {"U", "Sunday"}
   ]
 
-  attr :policy, :map, required: true
+  attr(:policy, :map, required: true)
 
   def policy_name(assigns) do
     ~H"<%= @policy.actor_group.name %> → <%= @policy.resource.name %>"
@@ -285,11 +285,19 @@ defmodule Web.Policies.Components do
             to: "#policy_conditions_remote_ip_location_region_condition"
           )
           |> JS.toggle_class("bg-neutral-50")
+          |> JS.toggle_class("hero-chevron-down",
+            to: "#policy_conditions_remote_ip_location_region_chevron"
+          )
+          |> JS.toggle_class("hero-chevron-up",
+            to: "#policy_conditions_remote_ip_location_region_chevron"
+          )
         }
       >
         <legend class="flex justify-between items-center text-neutral-700">
           Client location
-          <.icon id="policy_conditions_remote_ip_location_region_chevron" name="hero-bars-3" />
+          <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
+          <.icon id="policy_conditions_remote_ip_location_region_chevron" name="hero-chevron-down" class="w-5 h-5" />
+        </span>
         </legend>
       </div>
 
@@ -358,10 +366,19 @@ defmodule Web.Policies.Components do
             to: "#policy_conditions_remote_ip_condition"
           )
           |> JS.toggle_class("bg-neutral-50")
+          |> JS.toggle_class("hero-chevron-down",
+            to: "#policy_conditions_remote_ip_chevron"
+          )
+          |> JS.toggle_class("hero-chevron-up",
+            to: "#policy_conditions_remote_ip_chevron"
+          )
         }
       >
         <legend class="flex justify-between items-center text-neutral-700">
-          IP address <.icon id="policy_conditions_remote_ip_chevron" name="hero-bars-3" />
+          IP address
+          <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
+            <.icon id="policy_conditions_remote_ip_chevron" name="hero-chevron-down" class="w-5 h-5" />
+          </span>
         </legend>
       </div>
 
@@ -430,11 +447,19 @@ defmodule Web.Policies.Components do
             to: "#policy_conditions_provider_id_condition"
           )
           |> JS.toggle_class("bg-neutral-50")
+          |> JS.toggle_class("hero-chevron-down",
+            to: "#policy_conditions_provider_id_chevron"
+          )
+          |> JS.toggle_class("hero-chevron-up",
+            to: "#policy_conditions_provider_id_chevron"
+          )
         }
       >
         <legend class="flex justify-between items-center text-neutral-700">
           Authentication Provider
-          <.icon id="policy_conditions_provider_id_chevron" name="hero-bars-3" />
+          <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
+          <.icon id="policy_conditions_provider_id_chevron" name="hero-chevron-down" class="w-5 h-5" />
+        </span>
         </legend>
       </div>
 
@@ -513,11 +538,19 @@ defmodule Web.Policies.Components do
             to: "#policy_conditions_current_utc_datetime_condition"
           )
           |> JS.toggle_class("bg-neutral-50")
+          |> JS.toggle_class("hero-chevron-down",
+            to: "#policy_conditions_current_utc_datetime_chevron"
+          )
+          |> JS.toggle_class("hero-chevron-up",
+            to: "#policy_conditions_current_utc_datetime_chevron"
+          )
         }
       >
         <legend class="flex justify-between items-center text-neutral-700">
           Current time
-          <.icon id="policy_conditions_current_utc_datetime_chevron" name="hero-bars-3" />
+          <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
+          <.icon id="policy_conditions_current_utc_datetime_chevron" name="hero-chevron-down" class="w-5 h-5" />
+        </span>
         </legend>
       </div>
 

--- a/elixir/apps/web/lib/web/live/policies/components.ex
+++ b/elixir/apps/web/lib/web/live/policies/components.ex
@@ -296,8 +296,12 @@ defmodule Web.Policies.Components do
         <legend class="flex justify-between items-center text-neutral-700">
           Client location
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
-          <.icon id="policy_conditions_remote_ip_location_region_chevron" name="hero-chevron-down" class="w-5 h-5" />
-        </span>
+            <.icon
+              id="policy_conditions_remote_ip_location_region_chevron"
+              name="hero-chevron-down"
+              class="w-5 h-5"
+            />
+          </span>
         </legend>
       </div>
 
@@ -458,8 +462,12 @@ defmodule Web.Policies.Components do
         <legend class="flex justify-between items-center text-neutral-700">
           Authentication Provider
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
-          <.icon id="policy_conditions_provider_id_chevron" name="hero-chevron-down" class="w-5 h-5" />
-        </span>
+            <.icon
+              id="policy_conditions_provider_id_chevron"
+              name="hero-chevron-down"
+              class="w-5 h-5"
+            />
+          </span>
         </legend>
       </div>
 
@@ -549,8 +557,12 @@ defmodule Web.Policies.Components do
         <legend class="flex justify-between items-center text-neutral-700">
           Current time
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
-          <.icon id="policy_conditions_current_utc_datetime_chevron" name="hero-chevron-down" class="w-5 h-5" />
-        </span>
+            <.icon
+              id="policy_conditions_current_utc_datetime_chevron"
+              name="hero-chevron-down"
+              class="w-5 h-5"
+            />
+          </span>
         </legend>
       </div>
 

--- a/elixir/apps/web/lib/web/live/policies/components.ex
+++ b/elixir/apps/web/lib/web/live/policies/components.ex
@@ -232,9 +232,9 @@ defmodule Web.Policies.Components do
       end)
 
     ~H"""
-    <fieldset class="flex flex-col gap-2">
+    <fieldset class="flex flex-col gap-2 mt-4">
       <div class="flex items-center justify-between">
-        <legend class="text-lg mb-4">Conditions</legend>
+        <legend class="text-xl mb-2">Conditions</legend>
         <%= if @policy_conditions_enabled? == false do %>
           <.link navigate={~p"/#{@account}/settings/billing"} class="text-sm text-primary-500">
             <.badge type="primary" title="Feature available on a higher pricing plan">
@@ -244,28 +244,30 @@ defmodule Web.Policies.Components do
         <% end %>
       </div>
 
-      <.remote_ip_location_region_condition_form
-        form={@form}
-        disabled={@policy_conditions_enabled? == false}
-      />
-      <.remote_ip_condition_form form={@form} disabled={@policy_conditions_enabled? == false} />
-      <.provider_id_condition_form
-        form={@form}
-        providers={@providers}
-        disabled={@policy_conditions_enabled? == false}
-      />
-      <.current_utc_datetime_condition_form
-        form={@form}
-        timezone={@timezone}
-        disabled={@policy_conditions_enabled? == false}
-      />
+      <div class={@policy_conditions_enabled? == false && "opacity-50"}>
+        <.remote_ip_location_region_condition_form
+          form={@form}
+          disabled={@policy_conditions_enabled? == false}
+        />
+        <.remote_ip_condition_form form={@form} disabled={@policy_conditions_enabled? == false} />
+        <.provider_id_condition_form
+          form={@form}
+          providers={@providers}
+          disabled={@policy_conditions_enabled? == false}
+        />
+        <.current_utc_datetime_condition_form
+          form={@form}
+          timezone={@timezone}
+          disabled={@policy_conditions_enabled? == false}
+        />
+      </div>
     </fieldset>
     """
   end
 
   defp remote_ip_location_region_condition_form(assigns) do
     ~H"""
-    <fieldset class="mb-2">
+    <fieldset class="mb-4">
       <% condition_form = find_condition_form(@form[:conditions], :remote_ip_location_region) %>
 
       <.input
@@ -277,64 +279,60 @@ defmodule Web.Policies.Components do
       />
 
       <div
-        class="cursor-pointer"
+        class="hover:bg-neutral-100 cursor-pointer border border-neutral-200 shadow-b rounded-t px-4 py-2"
         phx-click={
           JS.toggle_class("hidden",
             to: "#policy_conditions_remote_ip_location_region_condition"
           )
-          |> JS.toggle_class("hero-chevron-down",
-            to: "#policy_conditions_remote_ip_location_region_chevron"
-          )
-          |> JS.toggle_class("hero-chevron-up",
-            to: "#policy_conditions_remote_ip_location_region_chevron"
-          )
+          |> JS.toggle_class("bg-neutral-50")
         }
       >
-        <legend>
-          <.icon id="policy_conditions_remote_ip_location_region_chevron" name="hero-chevron-down" />
+        <legend class="flex justify-between items-center text-neutral-700">
           Client location
+          <.icon id="policy_conditions_remote_ip_location_region_chevron" name="hero-bars-3" />
         </legend>
-
-        <p class="text-sm text-neutral-500 mb-2">
-          Restrict access based on the location of the Client.
-        </p>
       </div>
 
       <div
         id="policy_conditions_remote_ip_location_region_condition"
         class={[
-          "grid gap-2 sm:grid-cols-5 sm:gap-4",
+          "p-4 border-neutral-200 border-l border-r border-b rounded-b",
           condition_values_empty?(condition_form) && "hidden"
         ]}
       >
-        <.input
-          type="select"
-          name="policy[conditions][remote_ip_location_region][operator]"
-          id="policy_conditions_remote_ip_location_region_operator"
-          field={condition_form[:operator]}
-          disabled={@disabled}
-          options={condition_operator_options(:remote_ip_location_region)}
-          value={get_in(condition_form, [:operator, Access.key!(:value)])}
-        />
+        <p class="text-sm text-neutral-500 mb-2">
+          Restrict access based on the location of the Client.
+        </p>
+        <div class="grid gap-2 sm:grid-cols-5 sm:gap-4">
+          <.input
+            type="select"
+            name="policy[conditions][remote_ip_location_region][operator]"
+            id="policy_conditions_remote_ip_location_region_operator"
+            field={condition_form[:operator]}
+            disabled={@disabled}
+            options={condition_operator_options(:remote_ip_location_region)}
+            value={get_in(condition_form, [:operator, Access.key!(:value)])}
+          />
 
-        <%= for {value, index} <- Enum.with_index((condition_form[:values] && condition_form[:values].value || []) ++ [nil]) do %>
-          <div :if={index > 0} class="text-right mt-3 text-sm text-neutral-900">
-            or
-          </div>
+          <%= for {value, index} <- Enum.with_index((condition_form[:values] && condition_form[:values].value || []) ++ [nil]) do %>
+            <div :if={index > 0} class="text-right mt-3 text-sm text-neutral-900">
+              or
+            </div>
 
-          <div class="col-span-4">
-            <.input
-              type="select"
-              field={condition_form[:values]}
-              name="policy[conditions][remote_ip_location_region][values][]"
-              id={"policy_conditions_remote_ip_location_region_values_#{index}"}
-              options={[{"Select Country", nil}] ++ Domain.Geo.all_country_options!()}
-              disabled={@disabled}
-              value_index={index}
-              value={value}
-            />
-          </div>
-        <% end %>
+            <div class="col-span-4">
+              <.input
+                type="select"
+                field={condition_form[:values]}
+                name="policy[conditions][remote_ip_location_region][values][]"
+                id={"policy_conditions_remote_ip_location_region_values_#{index}"}
+                options={[{"Select Country", nil}] ++ Domain.Geo.all_country_options!()}
+                disabled={@disabled}
+                value_index={index}
+                value={value}
+              />
+            </div>
+          <% end %>
+        </div>
       </div>
     </fieldset>
     """
@@ -342,7 +340,7 @@ defmodule Web.Policies.Components do
 
   defp remote_ip_condition_form(assigns) do
     ~H"""
-    <fieldset class="mb-2">
+    <fieldset class="mb-4">
       <% condition_form = find_condition_form(@form[:conditions], :remote_ip) %>
 
       <.input
@@ -354,64 +352,59 @@ defmodule Web.Policies.Components do
       />
 
       <div
-        class="cursor-pointer"
+        class="hover:bg-neutral-100 cursor-pointer border border-neutral-200 shadow-b rounded-t px-4 py-2"
         phx-click={
           JS.toggle_class("hidden",
             to: "#policy_conditions_remote_ip_condition"
           )
-          |> JS.toggle_class("hero-chevron-down",
-            to: "#policy_conditions_remote_ip_chevron"
-          )
-          |> JS.toggle_class("hero-chevron-up",
-            to: "#policy_conditions_remote_ip_chevron"
-          )
+          |> JS.toggle_class("bg-neutral-50")
         }
       >
-        <legend>
-          <.icon id="policy_conditions_remote_ip_chevron" name="hero-chevron-down" class="w-5 h-5" />
-          IP address
+        <legend class="flex justify-between items-center text-neutral-700">
+          IP address <.icon id="policy_conditions_remote_ip_chevron" name="hero-bars-3" />
         </legend>
-
-        <p class="text-sm text-neutral-500 mb-2">
-          Restrict access based on the Client's IP address or CIDR range.
-        </p>
       </div>
 
       <div
         id="policy_conditions_remote_ip_condition"
         class={[
-          "grid gap-2 sm:grid-cols-5 sm:gap-4",
+          "p-4 border-neutral-200 border-l border-r border-b rounded-b",
           condition_values_empty?(condition_form) && "hidden"
         ]}
       >
-        <.input
-          type="select"
-          name="policy[conditions][remote_ip][operator]"
-          id="policy_conditions_remote_ip_operator"
-          field={condition_form[:operator]}
-          options={condition_operator_options(:remote_ip)}
-          disabled={@disabled}
-          value={get_in(condition_form, [:operator, Access.key!(:value)])}
-        />
+        <p class="text-sm text-neutral-500 mb-2">
+          Restrict access based on the Client's IP address or CIDR range.
+        </p>
+        <div class="grid gap-2 sm:grid-cols-5 sm:gap-4">
+          <.input
+            type="select"
+            name="policy[conditions][remote_ip][operator]"
+            id="policy_conditions_remote_ip_operator"
+            field={condition_form[:operator]}
+            disabled={@disabled}
+            options={condition_operator_options(:remote_ip)}
+            value={get_in(condition_form, [:operator, Access.key!(:value)])}
+          />
 
-        <%= for {value, index} <- Enum.with_index((condition_form[:values] && condition_form[:values].value || []) ++ [nil]) do %>
-          <div :if={index > 0} class="text-right mt-3 text-sm text-neutral-900">
-            or
-          </div>
+          <%= for {value, index} <- Enum.with_index((condition_form[:values] && condition_form[:values].value || []) ++ [nil]) do %>
+            <div :if={index > 0} class="text-right mt-3 text-sm text-neutral-900">
+              or
+            </div>
 
-          <div class="col-span-4">
-            <.input
-              type="text"
-              field={condition_form[:values]}
-              name="policy[conditions][remote_ip][values][]"
-              id={"policy_conditions_remote_ip_values_#{index}"}
-              placeholder="E.g. 189.172.0.0/24 or 10.10.10.1"
-              disabled={@disabled}
-              value_index={index}
-              value={value}
-            />
-          </div>
-        <% end %>
+            <div class="col-span-4">
+              <.input
+                type="text"
+                field={condition_form[:values]}
+                name="policy[conditions][remote_ip][values][]"
+                id={"policy_conditions_remote_ip_values_#{index}"}
+                placeholder="E.g. 189.172.0.0/24 or 10.10.10.1"
+                disabled={@disabled}
+                value_index={index}
+                value={value}
+              />
+            </div>
+          <% end %>
+        </div>
       </div>
     </fieldset>
     """
@@ -419,7 +412,7 @@ defmodule Web.Policies.Components do
 
   defp provider_id_condition_form(assigns) do
     ~H"""
-    <fieldset class="mb-2">
+    <fieldset class="mb-4">
       <% condition_form = find_condition_form(@form[:conditions], :provider_id) %>
 
       <.input
@@ -431,64 +424,60 @@ defmodule Web.Policies.Components do
       />
 
       <div
-        class="cursor-pointer"
+        class="hover:bg-neutral-100 cursor-pointer border border-neutral-200 shadow-b rounded-t px-4 py-2"
         phx-click={
           JS.toggle_class("hidden",
             to: "#policy_conditions_provider_id_condition"
           )
-          |> JS.toggle_class("hero-chevron-down",
-            to: "#policy_conditions_provider_id_chevron"
-          )
-          |> JS.toggle_class("hero-chevron-up",
-            to: "#policy_conditions_provider_id_chevron"
-          )
+          |> JS.toggle_class("bg-neutral-50")
         }
       >
-        <legend>
-          <.icon id="policy_conditions_provider_id_chevron" name="hero-chevron-down" class="w-5 h-5" />
+        <legend class="flex justify-between items-center text-neutral-700">
           Authentication Provider
+          <.icon id="policy_conditions_provider_id_chevron" name="hero-bars-3" />
         </legend>
-
-        <p class="text-sm text-neutral-500 mb-2">
-          Restrict access based on the identity provider that was used to sign in.
-        </p>
       </div>
 
       <div
         id="policy_conditions_provider_id_condition"
         class={[
-          "grid gap-2 sm:grid-cols-5 sm:gap-4",
+          "p-4 border-neutral-200 border-l border-r border-b rounded-b",
           condition_values_empty?(condition_form) && "hidden"
         ]}
       >
-        <.input
-          type="select"
-          name="policy[conditions][provider_id][operator]"
-          id="policy_conditions_provider_id_operator"
-          field={condition_form[:operator]}
-          options={condition_operator_options(:provider_id)}
-          disabled={@disabled}
-          value={get_in(condition_form, [:operator, Access.key!(:value)])}
-        />
+        <p class="text-sm text-neutral-500 mb-2">
+          Restrict access based on the identity provider that was used to sign in.
+        </p>
+        <div class="grid gap-2 sm:grid-cols-5 sm:gap-4">
+          <.input
+            type="select"
+            name="policy[conditions][provider_id][operator]"
+            id="policy_conditions_provider_id_operator"
+            field={condition_form[:operator]}
+            disabled={@disabled}
+            options={condition_operator_options(:provider_id)}
+            value={get_in(condition_form, [:operator, Access.key!(:value)])}
+          />
 
-        <%= for {value, index} <- Enum.with_index((condition_form[:values] && condition_form[:values].value || []) ++ [nil]) do %>
-          <div :if={index > 0} class="text-right mt-3 text-sm text-neutral-900">
-            or
-          </div>
+          <%= for {value, index} <- Enum.with_index((condition_form[:values] && condition_form[:values].value || []) ++ [nil]) do %>
+            <div :if={index > 0} class="text-right mt-3 text-sm text-neutral-900">
+              or
+            </div>
 
-          <div class="col-span-4">
-            <.input
-              type="select"
-              field={condition_form[:values]}
-              name="policy[conditions][provider_id][values][]"
-              id={"policy_conditions_provider_id_values_#{index}"}
-              options={[{"Select Provider", nil}] ++ Enum.map(@providers, &{&1.name, &1.id})}
-              disabled={@disabled}
-              value_index={index}
-              value={value}
-            />
-          </div>
-        <% end %>
+            <div class="col-span-4">
+              <.input
+                type="select"
+                field={condition_form[:values]}
+                name="policy[conditions][provider_id][values][]"
+                id={"policy_conditions_provider_id_values_#{index}"}
+                options={[{"Select Provider", nil}] ++ Enum.map(@providers, &{&1.name, &1.id})}
+                disabled={@disabled}
+                value_index={index}
+                value={value}
+              />
+            </div>
+          <% end %>
+        </div>
       </div>
     </fieldset>
     """
@@ -498,7 +487,7 @@ defmodule Web.Policies.Components do
     assigns = assign_new(assigns, :days_of_week, fn -> @days_of_week end)
 
     ~H"""
-    <fieldset>
+    <fieldset class="mb-2">
       <% condition_form = find_condition_form(@form[:conditions], :current_utc_datetime) %>
 
       <.input
@@ -518,57 +507,50 @@ defmodule Web.Policies.Components do
       />
 
       <div
-        class="cursor-pointer"
+        class="hover:bg-neutral-100 cursor-pointer border border-neutral-200 shadow-b rounded-t px-4 py-2"
         phx-click={
           JS.toggle_class("hidden",
             to: "#policy_conditions_current_utc_datetime_condition"
           )
-          |> JS.toggle_class("hero-chevron-down",
-            to: "#policy_conditions_current_utc_datetime_chevron"
-          )
-          |> JS.toggle_class("hero-chevron-up",
-            to: "#policy_conditions_current_utc_datetime_chevron"
-          )
+          |> JS.toggle_class("bg-neutral-50")
         }
       >
-        <legend>
-          <.icon
-            id="policy_conditions_current_utc_datetime_chevron"
-            name="hero-chevron-down"
-            class="w-5 h-5"
-          /> Current time
+        <legend class="flex justify-between items-center text-neutral-700">
+          Current time
+          <.icon id="policy_conditions_current_utc_datetime_chevron" name="hero-bars-3" />
         </legend>
-
-        <p class="text-sm text-neutral-500 mb-2">
-          Restrict access based on the current time of the day in 24hr format. Multiple time ranges per day are supported.
-        </p>
       </div>
 
       <div
         id="policy_conditions_current_utc_datetime_condition"
         class={[
-          "space-y-2",
+          "p-4 border-neutral-200 border-l border-r border-b rounded-b",
           condition_values_empty?(condition_form) && "hidden"
         ]}
       >
-        <.input
-          type="select"
-          label="Timezone"
-          name="policy[conditions][current_utc_datetime][timezone]"
-          id="policy_conditions_current_utc_datetime_timezone"
-          field={condition_form[:timezone]}
-          options={Tzdata.zone_list()}
-          disabled={@disabled}
-          value={condition_form[:timezone].value || @timezone}
-        />
-
+        <p class="text-sm text-neutral-500 mb-2">
+          Restrict access based on the current time of the day in 24hr format. Multiple time ranges per day are supported.
+        </p>
         <div class="space-y-2">
-          <.current_utc_datetime_condition_day_input
-            :for={{code, _name} <- @days_of_week}
+          <.input
+            type="select"
+            label="Timezone"
+            name="policy[conditions][current_utc_datetime][timezone]"
+            id="policy_conditions_current_utc_datetime_timezone"
+            field={condition_form[:timezone]}
+            options={Tzdata.zone_list()}
             disabled={@disabled}
-            condition_form={condition_form}
-            day={code}
+            value={condition_form[:timezone].value || @timezone}
           />
+
+          <div class="space-y-2">
+            <.current_utc_datetime_condition_day_input
+              :for={{code, _name} <- @days_of_week}
+              disabled={@disabled}
+              condition_form={condition_form}
+              day={code}
+            />
+          </div>
         </div>
       </div>
     </fieldset>

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -138,7 +138,7 @@ defmodule Web.Policies.New do
       if Domain.Accounts.policy_conditions_enabled?(socket.assigns.account) do
         params
       else
-        Map.delete(params, "conditions")
+        Map.put(params, "conditions", [])
       end
 
     with {:ok, policy} <- Policies.create_policy(params, socket.assigns.subject) do

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -39,7 +39,7 @@ defmodule Web.Policies.New do
       </:title>
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto lg:py-16">
-          <h2 class="mb-4 text-xl text-neutral-900">Define a Policy</h2>
+          <h2 class="mb-4 text-xl text-neutral-900">Details</h2>
           <div
             :if={@actor_groups == []}
             class={[
@@ -133,6 +133,13 @@ defmodule Web.Policies.New do
       params
       |> put_default_params(socket)
       |> map_condition_params(empty_values: :drop)
+
+    params =
+      if Domain.Accounts.policy_conditions_enabled?(socket.assigns.account) do
+        params
+      else
+        Map.delete(params, "conditions")
+      end
 
     with {:ok, policy} <- Policies.create_policy(params, socket.assigns.subject) do
       if site_id = socket.assigns.params["site_id"] do

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -138,7 +138,7 @@ defmodule Web.Policies.New do
       if Domain.Accounts.policy_conditions_enabled?(socket.assigns.account) do
         params
       else
-        Map.put(params, "conditions", [])
+        Map.delete(params, "conditions")
       end
 
     with {:ok, policy} <- Policies.create_policy(params, socket.assigns.subject) do

--- a/elixir/apps/web/test/web/live/policies/new_test.exs
+++ b/elixir/apps/web/test/web/live/policies/new_test.exs
@@ -405,35 +405,10 @@ defmodule Web.Live.Policies.NewTest do
     attrs = %{
       actor_group_id: group.id,
       conditions: %{
-        current_utc_datetime: %{
-          property: "current_utc_datetime",
-          operator: "is_in_day_of_week_time_ranges",
-          timezone: "US/Pacific",
-          values: %{
-            M: "true",
-            T: "",
-            W: "true",
-            R: "",
-            F: "",
-            S: "10:00:00-15:00:00",
-            U: "23:00:00-23:59:59"
-          }
-        },
-        provider_id: %{
-          property: "provider_id",
-          operator: "is_in",
-          values: [identity.provider_id]
-        },
-        remote_ip: %{
-          property: "remote_ip",
-          operator: "is_not_in_cidr",
-          values: ["0.0.0.0/0"]
-        },
-        remote_ip_location_region: %{
-          property: "remote_ip_location_region",
-          operator: "is_in",
-          values: ["US"]
-        }
+        current_utc_datetime: %{},
+        provider_id: %{},
+        remote_ip: %{},
+        remote_ip_location_region: %{}
       }
     }
 

--- a/elixir/apps/web/test/web/live/policies/new_test.exs
+++ b/elixir/apps/web/test/web/live/policies/new_test.exs
@@ -392,9 +392,15 @@ defmodule Web.Live.Policies.NewTest do
     identity: identity,
     conn: conn
   } do
+    account =
+      Fixtures.Accounts.update_account(account,
+        features: %{
+          policy_conditions: false
+        }
+      )
+
     group = Fixtures.Actors.create_group(account: account)
     resource = Fixtures.Resources.create_resource(account: account)
-    Domain.Config.put_env_override(:policy_conditions, false)
 
     attrs = %{
       actor_group_id: group.id,


### PR DESCRIPTION
- Fixes policy creation when `policy_conditions` is disabled
- Updates design so that items are a little more aligned and text has more / consistent spacing around.


https://github.com/firezone/firezone/assets/167144/b9c29110-ae1c-4841-b999-a0da022f4a38



Test is failing though. Before sinking more time into this I wanted to open this PR to get @AndrewDryga's input.