### PR TITLE
test(snownet): migrate relays for both parties

### DIFF
--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -841,6 +841,11 @@ impl<R> TestNode<R> {
                 continue;
             }
 
+            if !other.local.contains(&dst) {
+                tracing::debug!(target: "router", %src, %dst, "Unknown destination");
+                continue;
+            }
+
             // Firewall allowed traffic, let's dispatch it.
             other.receive(dst, src, payload, now);
         }

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -210,9 +210,10 @@ fn migrate_connection_to_new_relay() {
         ),
     )];
     alice = alice.with_relays("alice", HashSet::from([1]), &mut relays, clock.now);
+    bob = bob.with_relays("bob", HashSet::from([1]), &mut relays, clock.now);
 
-    // Make some progress. (the fact that we only need 5 clock ticks means we are no relying on timeouts here)
-    for _ in 0..5 {
+    // Make some progress. (the fact that we only need 22 clock ticks means we are no relying on timeouts here (22 * 100ms = 2.2s))
+    for _ in 0..22 {
         progress(&mut alice, &mut bob, &mut relays, &firewall, &mut clock);
     }
 


### PR DESCRIPTION
In production, the portal will signal disconnected relays to both the client and the gateway. We should mimic this in the tests.

In #5283, we remove invalidation of candidates during the connection setup which breaks this roaming test due to "unhandled messages". We could ignore those but I'd prefer to setup the test such that we panic on unhandled messages instead and thus, this seems to be the better fix.