### PR TITLE
fix(snownet): notify remote of invalidated relay candidate

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -514,7 +514,7 @@ where
                     .current_candidates()
                     .filter(|c| c.kind() == CandidateKind::Relayed)
                 {
-                    agent.invalidate_candidate(&candidate);
+                    remove_local_candidate(id, agent, &candidate, &mut self.pending_events);
                 }
             }
         }


### PR DESCRIPTION
When migrating to new relays, we need to notify the remote of our invalidated relay candidates and not just invalidate them locally.

Related: #5283.