### PR TITLE
chore(snownet): improve logs on blocked STUN traffic

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -740,11 +740,6 @@ impl Allocation {
             return Some(FreeReason::AuthenticationError);
         }
 
-        debug_assert!(
-            pending_work,
-            "Expect a reason for why we don't have any pending work"
-        );
-
         None
     }
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -451,15 +451,15 @@ where
             self.next_rate_limiter_reset = Some(now + Duration::from_secs(1));
         }
 
-        self.allocations.retain(|id, allocation| {
-            if allocation.can_be_freed() {
-                tracing::info!(%id, "Freeing memory of allocation");
+        self.allocations
+            .retain(|id, allocation| match allocation.can_be_freed() {
+                Some(e) => {
+                    tracing::info!(%id, "Disconnecting from relay; {e}");
 
-                return false;
-            }
-
-            true
-        });
+                    false
+                }
+                None => true,
+            });
         self.connections.remove_failed(&mut self.pending_events);
     }
 


### PR DESCRIPTION
Detecting blocked STUN traffic is somewhat tricky. What we can observe is not receiving any responses from a relay (neither on IPv4 nor IPv6). Once an `Allocation` gives up retrying requests with a relay (after 60s), we now de-allocate the `Allocation` and print the following message:

> INFO snownet::node: Disconnecting from relay; no response received. Is STUN blocked? id=613f68ac-483e-4e9d-bf87-457fd7223bf6

I chose to go with the wording of "disconnecting from relay" as sysdamins likely don't have any clue of what an "Allocation" is. The error message is specific to a relay though so it could also be emitted if a relay is down for > 60s or not responding for whatever reason.

Resolves: #5281.