### PR TITLE
fix(connlib): reset pending DNS queries when exceeding limit

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -16,7 +16,6 @@ use ip_network_table::IpNetworkTable;
 use ip_packet::{IpPacket, MutableIpPacket, Packet as _};
 use itertools::Itertools;
 
-use crate::io::DnsQueryError;
 use crate::peer::GatewayOnClient;
 use crate::utils::{earliest, stun, turn};
 use crate::{ClientEvent, ClientTunnel};
@@ -673,13 +672,7 @@ impl ClientState {
     pub(crate) fn on_dns_result(
         &mut self,
         query: DnsQuery<'static>,
-        response: Result<
-            Result<
-                Result<hickory_resolver::lookup::Lookup, hickory_resolver::error::ResolveError>,
-                futures_bounded::Timeout,
-            >,
-            DnsQueryError,
-        >,
+        response: Result<hickory_resolver::lookup::Lookup, hickory_resolver::error::ResolveError>,
     ) {
         let query = query.query;
         let make_error_reply = {
@@ -699,12 +692,8 @@ impl ClientState {
             }
         };
 
-        let dns_reply = match response {
-            Ok(Ok(response)) => match dns::build_response_from_resolve_result(query, response) {
-                Ok(dns_reply) => dns_reply,
-                Err(e) => make_error_reply(&e),
-            },
-            Ok(Err(timeout)) => make_error_reply(&timeout),
+        let dns_reply = match dns::build_response_from_resolve_result(query, response) {
+            Ok(dns_reply) => dns_reply,
             Err(e) => make_error_reply(&e),
         };
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -116,9 +116,7 @@ where
             }
 
             if let Some(dns_query) = self.role_state.poll_dns_queries() {
-                if let Err(e) = self.io.perform_dns_query(dns_query.clone()) {
-                    self.role_state.on_dns_result(dns_query, Err(e))
-                }
+                self.io.perform_dns_query(dns_query.clone());
                 continue;
             }
 
@@ -163,7 +161,7 @@ where
                     continue;
                 }
                 Poll::Ready(io::Input::DnsResponse(query, response)) => {
-                    self.role_state.on_dns_result(query, Ok(response));
+                    self.role_state.on_dns_result(query, response);
                     continue;
                 }
                 Poll::Pending => {}

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -844,10 +844,10 @@ impl TunnelTest {
 
         self.client.state.on_dns_result(
             query,
-            Ok(Ok(Ok(Lookup::new_with_max_ttl(
+            Ok(Lookup::new_with_max_ttl(
                 Query::query(name, record_type),
                 record_data,
-            )))),
+            )),
         );
     }
 }


### PR DESCRIPTION
The DNS queries that we forward are all based on UDP which is an unreliable protocol. Thus, when we are faced with a burst of DNS requests, it doesn't really make sense to tail-drop (i.e. drop the newer) DNS query. Very likely, a newer DNS query is more relevant than an older one.

Instead of head-dropping a single one, we clear all our pending DNS queries. This gives us capacity for 100 new requests, allowing us to answer those as fast as possible.

I also discovered that reacting to the timeout from `futures_bounded` _should_ not be necessary because the timeout within hickory is always < 60s.