### PR TITLE
test(connlib): add transition for removing CIDR & DNS resources

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1112,7 +1112,7 @@ impl ClientState {
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(?ids))]
-    fn remove_resources(&mut self, ids: &[ResourceId]) {
+    pub(crate) fn remove_resources(&mut self, ids: &[ResourceId]) {
         for id in ids {
             self.awaiting_connection.remove(id);
             self.dns_resources_internal_ips

--- a/rust/connlib/tunnel/src/tests/sim_node.rs
+++ b/rust/connlib/tunnel/src/tests/sim_node.rs
@@ -1,7 +1,9 @@
 use super::sim_relay::SimRelay;
 use crate::{ClientState, GatewayState};
 use connlib_shared::{
-    messages::{client::ResourceDescription, ClientId, DnsServer, GatewayId, Interface},
+    messages::{
+        client::ResourceDescription, ClientId, DnsServer, GatewayId, Interface, ResourceId,
+    },
     StaticSecret,
 };
 use ip_network::{Ipv4Network, Ipv6Network};
@@ -102,6 +104,12 @@ impl SimNode<ClientId, ClientState> {
     pub(crate) fn add_resource(&mut self, resource: ResourceDescription) {
         self.span.in_scope(|| {
             self.state.add_resources(&[resource]);
+        })
+    }
+
+    pub(crate) fn remove_resource(&mut self, resource: ResourceId) {
+        self.span.in_scope(|| {
+            self.state.remove_resources(&[resource]);
         })
     }
 }

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -147,11 +147,12 @@ impl StateMachineTest for TunnelTest {
         // Act: Apply the transition
         match transition {
             Transition::AddCidrResource(r) => {
-                state.client.add_resource(ResourceDescription::Cidr(r));
+                state.client.add_resource(ResourceDescription::Cidr(r))
             }
             Transition::AddDnsResource { resource, .. } => state
                 .client
                 .add_resource(ResourceDescription::Dns(resource)),
+            Transition::RemoveResource(id) => state.client.remove_resource(id),
             Transition::SendICMPPacketToNonResourceIp {
                 src,
                 dst,

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -2,7 +2,7 @@ use super::strategies::*;
 use connlib_shared::{
     messages::{
         client::{ResourceDescriptionCidr, ResourceDescriptionDns},
-        DnsServer,
+        DnsServer, ResourceId,
     },
     proptest::*,
     DomainName,
@@ -69,6 +69,9 @@ pub(crate) enum Transition {
 
     /// Advance time by this many milliseconds.
     Tick { millis: u64 },
+
+    /// Remove a resource from the client.
+    RemoveResource(ResourceId),
 }
 
 pub(crate) fn ping_random_ip<I>(


### PR DESCRIPTION
Removing resources in the middle of a session is part of connlib's functionality and should be tested as part of `tunnel_test`.