### PR TITLE
refactor(connlib): use selectors to randomly pick values

### DIFF
--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -4,7 +4,7 @@ use connlib_shared::DomainName;
 use ip_packet::IpPacket;
 use pretty_assertions::assert_eq;
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
+    collections::{hash_map::Entry, BTreeMap, HashMap, HashSet, VecDeque},
     net::IpAddr,
 };
 
@@ -173,7 +173,7 @@ fn assert_destination_is_cdir_resource(
 
 fn assert_destination_is_dns_resource(
     gateway_received_request: &IpPacket<'_>,
-    global_dns_records: &HashMap<DomainName, HashSet<IpAddr>>,
+    global_dns_records: &BTreeMap<DomainName, HashSet<IpAddr>>,
     expected_resource: &DomainName,
 ) {
     let actual_destination = gateway_received_request.destination();

--- a/rust/connlib/tunnel/src/tests/sim_portal.rs
+++ b/rust/connlib/tunnel/src/tests/sim_portal.rs
@@ -3,7 +3,7 @@ use connlib_shared::messages::{
     ClientId, GatewayId, RelayId, ResourceId,
 };
 use ip_network_table::IpNetworkTable;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 /// Stub implementation of the portal.
 ///
@@ -30,7 +30,7 @@ impl SimPortal {
         resource: ResourceId,
         _connected_gateway_ids: HashSet<GatewayId>,
         client_cidr_resources: &IpNetworkTable<ResourceDescriptionCidr>,
-        client_dns_resources: &HashMap<ResourceId, ResourceDescriptionDns>,
+        client_dns_resources: &BTreeMap<ResourceId, ResourceDescriptionDns>,
     ) -> (GatewayId, SiteId) {
         // TODO: Should we somehow vary how many gateways we connect to?
         // TODO: Should we somehow pick, which site to use?

--- a/rust/connlib/tunnel/src/tests/strategies.rs
+++ b/rust/connlib/tunnel/src/tests/strategies.rs
@@ -1,7 +1,7 @@
 use connlib_shared::{messages::DnsServer, proptest::domain_name, DomainName};
 use proptest::{collection, prelude::*};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
@@ -53,8 +53,8 @@ pub(crate) fn system_dns_servers() -> impl Strategy<Value = Vec<IpAddr>> {
     collection::vec(any::<IpAddr>(), 1..4) // Always need at least 1 system DNS server. TODO: Should we test what happens if we don't?
 }
 
-pub(crate) fn global_dns_records() -> impl Strategy<Value = HashMap<DomainName, HashSet<IpAddr>>> {
-    collection::hash_map(
+pub(crate) fn global_dns_records() -> impl Strategy<Value = BTreeMap<DomainName, HashSet<IpAddr>>> {
+    collection::btree_map(
         domain_name(2..4).prop_map(|d| d.parse().unwrap()),
         collection::hash_set(any::<IpAddr>(), 1..6),
         0..15,

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -28,6 +28,7 @@ use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
 use rand::{rngs::StdRng, SeedableRng as _};
 use secrecy::ExposeSecret as _;
 use snownet::Transmit;
+use std::collections::{BTreeMap, BTreeSet};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::{IpAddr, SocketAddr},
@@ -346,7 +347,7 @@ impl TunnelTest {
     }
 
     /// Returns the _effective_ DNS servers that connlib is using.
-    fn effective_dns_servers(&self) -> HashSet<SocketAddr> {
+    fn effective_dns_servers(&self) -> BTreeSet<SocketAddr> {
         self.client_dns_by_sentinel
             .right_values()
             .copied()
@@ -452,7 +453,7 @@ impl TunnelTest {
         transmit: Transmit,
         sending_socket: Option<SocketAddr>,
         buffered_transmits: &mut VecDeque<(Transmit<'static>, Option<SocketAddr>)>,
-        global_dns_records: &HashMap<DomainName, HashSet<IpAddr>>,
+        global_dns_records: &BTreeMap<DomainName, HashSet<IpAddr>>,
     ) {
         let dst = transmit.dst;
         let payload = &transmit.payload;
@@ -533,7 +534,7 @@ impl TunnelTest {
         src: SocketAddr,
         payload: &[u8],
         buffered_transmits: &mut VecDeque<(Transmit<'static>, Option<SocketAddr>)>,
-        global_dns_records: &HashMap<DomainName, HashSet<IpAddr>>,
+        global_dns_records: &BTreeMap<DomainName, HashSet<IpAddr>>,
     ) -> ControlFlow<()> {
         let mut buffer = [0u8; 2000];
 
@@ -586,8 +587,8 @@ impl TunnelTest {
         src: ClientId,
         event: ClientEvent,
         client_cidr_resources: &IpNetworkTable<ResourceDescriptionCidr>,
-        client_dns_resource: &HashMap<ResourceId, ResourceDescriptionDns>,
-        global_dns_records: &HashMap<DomainName, HashSet<IpAddr>>,
+        client_dns_resource: &BTreeMap<ResourceId, ResourceDescriptionDns>,
+        global_dns_records: &BTreeMap<DomainName, HashSet<IpAddr>>,
     ) {
         match event {
             ClientEvent::NewIceCandidate { candidate, .. } => self.gateway.span.in_scope(|| {
@@ -854,7 +855,7 @@ impl TunnelTest {
 
 fn map_client_resource_to_gateway_resource(
     client_cidr_resources: &IpNetworkTable<ResourceDescriptionCidr>,
-    client_dns_resources: &HashMap<ResourceId, ResourceDescriptionDns>,
+    client_dns_resources: &BTreeMap<ResourceId, ResourceDescriptionDns>,
     resolved_ips: Vec<IpNetwork>,
     resource_id: ResourceId,
 ) -> gateway::ResourceDescription<gateway::ResolvedResourceDescriptionDns> {


### PR DESCRIPTION
Reading through more of the `proptest` library, I came across the `Selector` concept. It is more generic than the `sample::Index` and allows us to directly pick from anything that is an `IntoIterator`.

This greatly simplifies a lot of the code in `tunnel_test`. In order (pun intended) to make things deterministic, we migrate all maps and sets to `BTreeMap`s and `BTreeSets` which have a deterministic ordering of their contents, thus avoiding additional sorting.