### PR TITLE
ci: Only run release_drafter on workflow_call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
     secrets: inherit
 
   update-release-draft:
-    if: github.event_name == 'workflow_call'
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -57,6 +56,7 @@ jobs:
             config_name: release-drafter-gui-client.yml
     steps:
       - uses: release-drafter/release-drafter@v6
+        if: github.event_name == 'workflow_call'
         id: update-release-draft
         with:
           config-name: ${{ matrix.config_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     secrets: inherit
 
   update-release-draft:
+    if: github.event_name == 'workflow_call'
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fixes https://github.com/firezone/firezone/actions/runs/9471306551/job/26094229731?pr=5325#step:2:22