### PR TITLE
test(connlib): make use of `check_invariants` function

### DIFF
--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -14,7 +14,7 @@ use std::{
 ///     - For CIDR resources, that is the actual CIDR resource IP.
 ///     - For DNS resources, the IP must match one of the resolved IPs for the domain.
 /// 3. For DNS resources, the mapping of proxy IP to actual resource IP must be stable.
-pub(crate) fn assert_icmp_packets_properties(state: &mut TunnelTest, ref_state: &ReferenceState) {
+pub(crate) fn assert_icmp_packets_properties(state: &TunnelTest, ref_state: &ReferenceState) {
     let unexpected_icmp_replies = find_unexpected_entries(
         &ref_state.expected_icmp_handshakes,
         &state.client_received_icmp_replies,

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -229,16 +229,21 @@ impl StateMachineTest for TunnelTest {
         state.advance(ref_state, &mut buffered_transmits);
         assert!(buffered_transmits.is_empty()); // Sanity check to ensure we handled all packets.
 
+        state
+    }
+
+    fn check_invariants(
+        state: &Self::SystemUnderTest,
+        ref_state: &<Self::Reference as ReferenceStateMachine>::State,
+    ) {
         // Assert our properties: Check that our actual state is equivalent to our expectation (the reference state).
-        assert_icmp_packets_properties(&mut state, ref_state);
-        assert_dns_packets_properties(&state, ref_state);
+        assert_icmp_packets_properties(state, ref_state);
+        assert_dns_packets_properties(state, ref_state);
         assert_eq!(
             state.effective_dns_servers(),
             ref_state.expected_dns_servers(),
             "Effective DNS servers should match either system or upstream DNS"
         );
-
-        state
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -135,12 +135,7 @@ impl StateMachineTest for TunnelTest {
         this
     }
 
-    /// Apply a generated state transition to our system under test and assert against the reference state machine.
-    ///
-    /// This is equivalent to "arrange - act - assert" of a regular test:
-    /// 1. We start out in a certain state (arrange)
-    /// 2. We apply a [`Transition`] (act)
-    /// 3. We assert against the reference state (assert)
+    /// Apply a generated state transition to our system under test.
     fn apply(
         mut state: Self::SystemUnderTest,
         ref_state: &<Self::Reference as ReferenceStateMachine>::State,
@@ -232,6 +227,7 @@ impl StateMachineTest for TunnelTest {
         state
     }
 
+    // Assert against the reference state machine.
     fn check_invariants(
         state: &Self::SystemUnderTest,
         ref_state: &<Self::Reference as ReferenceStateMachine>::State,


### PR DESCRIPTION
Previously, we asserted at the end of `TunnelTest::apply`. `proptest-state-machine` offers a dedicated function for checking invariants which only gives you a regular reference. That is a good thing to enforce as we don't want our assertions to change state.