### PR TITLE
chore(infra): Add EC2 instance connect and remove bastion host

### DIFF
--- a/terraform/environments/staging/aws.tf
+++ b/terraform/environments/staging/aws.tf
@@ -265,24 +265,6 @@ module "sg_allow_subnet_ingress" {
   ]
 }
 
-module "sg_allow_ssh_ingress" {
-  source = "terraform-aws-modules/security-group/aws"
-
-  name        = "allow SSH ingress from the internet"
-  description = "Security group to allow SSH ingress from the internet"
-  vpc_id      = module.vpc.vpc_id
-
-  ingress_with_cidr_blocks = [
-    {
-      from_port   = 22
-      to_port     = 22
-      protocol    = "tcp"
-      description = "SSH access from the internet"
-      cidr_blocks = "0.0.0.0/0"
-    }
-  ]
-}
-
 ################################################################################
 # SSH Keys
 ################################################################################


### PR DESCRIPTION
Why:

* As part of the SOC2 process, rather than having a bastion host to connect to EC2 instances in our AWS infra, this PR removes the bastion host and replaces it with an EC2 instance connect endpoint.  This will allow SSH connections to use AWS IAM credentials rather than static SSH keys.

Closes #5215 