### PR TITLE
fix: Use correct component versions by overriding from FIREZONE_PACKAGE_VERSION

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -163,9 +163,9 @@ jobs:
             artifact: firezone-gateway
             image_name: gateway
             # mark:next-gateway-version
-            version: 1.1.0
+            version: 1.0.7
             # mark:next-gateway-version
-            release_name: gateway-1.1.0
+            release_name: gateway-1.0.7
           - package: snownet-tests
             artifact: snownet-tests
             image_name: snownet-tests
@@ -343,7 +343,7 @@ jobs:
           - name: relay
           - name: gateway
             # mark:next-gateway-version
-            version: 1.1.0
+            version: 1.0.7
           - name: client
             # mark:next-client-version
             version: 1.0.6

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -204,7 +204,6 @@ jobs:
 
           # Override version by setting it inside cross container if it's provided
           ${{ matrix.name.version && format('CROSS_CONTAINER_OPTS="--env FIREZONE_PACKAGE_VERSION={0}"', matrix.name.version) }} \
-            FIREZONE_PACKAGE_NAME="${{ matrix.name.package }}" \
             cross build $PROFILE -p ${{ matrix.name.package }} --target ${{ matrix.arch.target }}
 
           # Used for Docker images

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -204,6 +204,7 @@ jobs:
 
           # Override version by setting it inside cross container if it's provided
           ${{ matrix.name.version && format('CROSS_CONTAINER_OPTS="--env FIREZONE_PACKAGE_VERSION={0}"', matrix.name.version) }} \
+            FIREZONE_PACKAGE_NAME="${{ matrix.name.package }}" \
             cross build $PROFILE -p ${{ matrix.name.package }} --target ${{ matrix.arch.target }}
 
           # Used for Docker images

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -202,7 +202,9 @@ jobs:
             PROFILE=""
           fi
 
-          cross build $PROFILE -p ${{ matrix.name.package }} --target ${{ matrix.arch.target }}
+          # Override version by setting it inside cross container if it's provided
+          ${{ matrix.name.version && format('CROSS_CONTAINER_OPTS="--env FIREZONE_PACKAGE_VERSION={0}"', matrix.name.version) }} \
+            cross build $PROFILE -p ${{ matrix.name.package }} --target ${{ matrix.arch.target }}
 
           # Used for Docker images
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           # mark:next-android-version
           FIREZONE_PACKAGE_VERSION: 1.0.4
+          FIREZONE_PACKAGE_NAME: android
           KEYSTORE_BASE64: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_PASSWORD }}
           KEYSTORE_KEY_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_KEY_PASSWORD }}

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -52,7 +52,6 @@ jobs:
         env:
           # mark:next-android-version
           FIREZONE_PACKAGE_VERSION: 1.0.4
-          FIREZONE_PACKAGE_NAME: android
           KEYSTORE_BASE64: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_PASSWORD }}
           KEYSTORE_KEY_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_KEY_PASSWORD }}

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -50,6 +50,8 @@ jobs:
       - run: touch local.properties
       - name: Bundle and sign release
         env:
+          # mark:next-android-version
+          FIREZONE_PACKAGE_VERSION: 1.0.4
           KEYSTORE_BASE64: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_PASSWORD }}
           KEYSTORE_KEY_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_KEY_PASSWORD }}

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -95,6 +95,8 @@ jobs:
           ONLY_ACTIVE_ARCH: no
           # Needed because `productbuild` doesn't support picking this up automatically like Xcode does
           INSTALLER_CODE_SIGN_IDENTITY: "3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
+          # mark:next-apple-version
+          FIREZONE_PACKAGE_VERSION: 1.0.5
         run: |
           # Use the same Xcode version as development
           sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -14,13 +14,11 @@ jobs:
           - sdk: macosx
             runs-on: macos-14
             platform: macOS
-            firezone-package-name: macos
             xcode: '15.2'
             destination: platform=macOS
           - sdk: iphoneos
             runs-on: macos-14
             platform: iOS
-            firezone-package-name: ios
             xcode: '15.2'
             destination: generic/platform=iOS
     permissions:
@@ -99,7 +97,6 @@ jobs:
           INSTALLER_CODE_SIGN_IDENTITY: "3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
           # mark:next-apple-version
           FIREZONE_PACKAGE_VERSION: 1.0.5
-          FIREZONE_PACKAGE_NAME: ${{ matrix.firezone-package-name }}
         run: |
           # Use the same Xcode version as development
           sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -14,11 +14,13 @@ jobs:
           - sdk: macosx
             runs-on: macos-14
             platform: macOS
+            firezone-package-name: macos
             xcode: '15.2'
             destination: platform=macOS
           - sdk: iphoneos
             runs-on: macos-14
             platform: iOS
+            firezone-package-name: ios
             xcode: '15.2'
             destination: generic/platform=iOS
     permissions:
@@ -97,6 +99,7 @@ jobs:
           INSTALLER_CODE_SIGN_IDENTITY: "3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
           # mark:next-apple-version
           FIREZONE_PACKAGE_VERSION: 1.0.5
+          FIREZONE_PACKAGE_NAME: ${{ matrix.firezone-package-name }}
         run: |
           # Use the same Xcode version as development
           sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -33,7 +33,6 @@ jobs:
             syms-artifact: rust/gui-client/firezone-client-gui-linux_1.0.7_x86_64.dwp
             # mark:next-gui-version
             pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.0.7_x86_64.deb
-            firezone-package-name: linux-gui
           - runs-on: windows-2019
             # mark:next-gui-version
             binary-dest-path: firezone-client-gui-windows_1.0.7_x86_64
@@ -43,7 +42,6 @@ jobs:
             syms-artifact: rust/gui-client/firezone-client-gui-windows_1.0.7_x86_64.pdb
             # mark:next-gui-version
             pkg-artifact: rust/gui-client/firezone-client-gui-windows_1.0.7_x86_64.msi
-            firezone-package-name: windows-gui
     env:
       BINARY_DEST_PATH: ${{ matrix.binary-dest-path }}
       AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
@@ -53,7 +51,6 @@ jobs:
       AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
       # mark:next-gui-version
       FIREZONE_PACKAGE_VERSION: 1.0.7
-      FIREZONE_PACKAGE_NAME: ${{ matrix.firezone-package-name }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -49,6 +49,8 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
+      # mark:next-gui-version
+      FIREZONE_PACKAGE_VERSION: 1.0.7
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -33,6 +33,7 @@ jobs:
             syms-artifact: rust/gui-client/firezone-client-gui-linux_1.0.7_x86_64.dwp
             # mark:next-gui-version
             pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.0.7_x86_64.deb
+            firezone-package-name: linux-gui
           - runs-on: windows-2019
             # mark:next-gui-version
             binary-dest-path: firezone-client-gui-windows_1.0.7_x86_64
@@ -42,6 +43,7 @@ jobs:
             syms-artifact: rust/gui-client/firezone-client-gui-windows_1.0.7_x86_64.pdb
             # mark:next-gui-version
             pkg-artifact: rust/gui-client/firezone-client-gui-windows_1.0.7_x86_64.msi
+            firezone-package-name: windows-gui
     env:
       BINARY_DEST_PATH: ${{ matrix.binary-dest-path }}
       AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
@@ -51,6 +53,7 @@ jobs:
       AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
       # mark:next-gui-version
       FIREZONE_PACKAGE_VERSION: 1.0.7
+      FIREZONE_PACKAGE_NAME: ${{ matrix.firezone-package-name }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         include:
           # mark:next-gateway-version
-          - release_name: gateway-1.1.0
+          - release_name: gateway-1.0.7
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
           - release_name: headless-client-1.0.7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
           if [[ "${{ github.event.release.name }}" =~ gateway* ]]; then
             image=gateway
             # mark:next-gateway-version
-            VERSION="1.1.0"
+            VERSION="1.0.7"
           elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
             image=client
             # mark:next-headless-version

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gateway"
-version = "1.1.0"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "connlib-client-android"
-version = "1.0.6"
+version = "1.0.4"
 dependencies = [
  "connlib-client-shared",
  "ip_network",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "connlib-client-apple"
-version = "1.0.6"
+version = "1.0.5"
 dependencies = [
  "connlib-client-shared",
  "ip_network",

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "connlib-client-android"
 # mark:next-android-version
-version = "1.0.6"
+version = "1.0.4"
 edition = "2021"
 
 [lib]

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "connlib-client-apple"
 # mark:next-apple-version
-version = "1.0.6"
+version = "1.0.5"
 edition = "2021"
 
 [features]

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -46,6 +46,7 @@ for var in $(env | awk -F= '{print $1}'); do
         [[ "$var" != "ACTIONS_RUNTIME_TOKEN" ]] &&
         [[ "$var" != "CARGO_INCREMENTAL" ]] &&
         [[ "$var" != "CARGO_TERM_COLOR" ]] &&
+        [[ "$var" != "FIREZONE_PACKAGE_VERSION" ]] &&
         [[ "$var" != "CONNLIB_TARGET_DIR" ]]; then
         unset "$var"
     fi

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -46,7 +46,6 @@ for var in $(env | awk -F= '{print $1}'); do
         [[ "$var" != "ACTIONS_RUNTIME_TOKEN" ]] &&
         [[ "$var" != "CARGO_INCREMENTAL" ]] &&
         [[ "$var" != "CARGO_TERM_COLOR" ]] &&
-        [[ "$var" != "FIREZONE_PACKAGE_NAME" ]] &&
         [[ "$var" != "FIREZONE_PACKAGE_VERSION" ]] &&
         [[ "$var" != "CONNLIB_TARGET_DIR" ]]; then
         unset "$var"

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -46,6 +46,7 @@ for var in $(env | awk -F= '{print $1}'); do
         [[ "$var" != "ACTIONS_RUNTIME_TOKEN" ]] &&
         [[ "$var" != "CARGO_INCREMENTAL" ]] &&
         [[ "$var" != "CARGO_TERM_COLOR" ]] &&
+        [[ "$var" != "FIREZONE_PACKAGE_NAME" ]] &&
         [[ "$var" != "FIREZONE_PACKAGE_VERSION" ]] &&
         [[ "$var" != "CONNLIB_TARGET_DIR" ]]; then
         unset "$var"

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -42,6 +42,8 @@ pub const BUNDLE_ID: &str = "dev.firezone.client";
 
 pub const DEFAULT_MTU: u32 = 1280;
 
+const LIB_NAME: &str = "connlib";
+
 pub fn keypair() -> (StaticSecret, PublicKey) {
     let private_key = StaticSecret::random_from_rng(OsRng);
     let public_key = PublicKey::from(&private_key);
@@ -65,10 +67,9 @@ pub fn get_user_agent(os_version_override: Option<String>) -> String {
 
     let os_version = os_version_override.unwrap_or(info.version().to_string());
     let additional_info = additional_info();
-
-    let name = option_env!("FIREZONE_PACKAGE_NAME").unwrap_or(env!("CARGO_PKG_NAME"));
-    let version = option_env!("FIREZONE_PACKAGE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
-    format!("{os_type}/{os_version}{additional_info}{name}/{version}")
+    let version = option_env!("FIREZONE_PACKAGE_VERSION").unwrap_or("development");
+    let lib_name = LIB_NAME;
+    format!("{os_type}/{os_version}{additional_info}{lib_name}/{version}")
 }
 
 fn additional_info() -> String {

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -42,8 +42,7 @@ pub const BUNDLE_ID: &str = "dev.firezone.client";
 
 pub const DEFAULT_MTU: u32 = 1280;
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-const LIB_NAME: &str = "connlib";
+const LIB_NAME: &str = env!("CARGO_PRIMARY_PACKAGE");
 
 pub fn keypair() -> (StaticSecret, PublicKey) {
     let private_key = StaticSecret::random_from_rng(OsRng);
@@ -68,7 +67,7 @@ pub fn get_user_agent(os_version_override: Option<String>) -> String {
 
     let os_version = os_version_override.unwrap_or(info.version().to_string());
     let additional_info = additional_info();
-    let lib_version = VERSION;
+    let lib_version = option_env!("FIREZONE_PACKAGE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
     let lib_name = LIB_NAME;
     format!("{os_type}/{os_version}{additional_info}{lib_name}/{lib_version}")
 }

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -42,8 +42,6 @@ pub const BUNDLE_ID: &str = "dev.firezone.client";
 
 pub const DEFAULT_MTU: u32 = 1280;
 
-const LIB_NAME: &str = env!("CARGO_PRIMARY_PACKAGE");
-
 pub fn keypair() -> (StaticSecret, PublicKey) {
     let private_key = StaticSecret::random_from_rng(OsRng);
     let public_key = PublicKey::from(&private_key);
@@ -67,9 +65,10 @@ pub fn get_user_agent(os_version_override: Option<String>) -> String {
 
     let os_version = os_version_override.unwrap_or(info.version().to_string());
     let additional_info = additional_info();
-    let lib_version = option_env!("FIREZONE_PACKAGE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
-    let lib_name = LIB_NAME;
-    format!("{os_type}/{os_version}{additional_info}{lib_name}/{lib_version}")
+
+    let name = option_env!("FIREZONE_PACKAGE_NAME").unwrap_or(env!("CARGO_PKG_NAME"));
+    let version = option_env!("FIREZONE_PACKAGE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+    format!("{os_type}/{os_version}{additional_info}{name}/{version}")
 }
 
 fn additional_info() -> String {

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gateway"
 # mark:next-gateway-version
-version = "1.1.0"
+version = "1.0.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -37,11 +37,17 @@ endif
 
 apple-version:
 	@find website -name "redirects.js" -exec sed $(SEDARG) -e '/mark:current-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(current-apple-version)/g;}' {} \;
+	@find .github -type f -exec sed $(SEDARG) -e '/mark:next-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(next-apple-version)/g;}' {} \;
 	@find swift -type f -name "project.pbxproj" -exec sed $(SEDARG) -e 's/MARKETING_VERSION = .*;/MARKETING_VERSION = $(next-apple-version);/' {} \;
+	@find rust -path rust/gui-client/node_modules -prune -o -name "Cargo.toml" -exec sed $(SEDARG) -e '/mark:next-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(next-apple-version)/;}' {} \;
+	@cd rust && cargo update --workspace
 
 android-version:
 	@find website -name "redirects.js" -exec sed $(SEDARG) -e '/mark:current-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(current-android-version)/g;}' {} \;
+	@find .github -type f -exec sed $(SEDARG) -e '/mark:next-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(next-android-version)/g;}' {} \;
 	@find kotlin -type f -name "*.gradle.kts" -exec sed $(SEDARG) -e '/mark:next-android-version/{n;s/versionName =.*/versionName = "$(next-android-version)"/;}' {} \;
+	@find rust -path rust/gui-client/node_modules -prune -o -name "Cargo.toml" -exec sed $(SEDARG) -e '/mark:next-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(next-android-version)/;}' {} \;
+	@cd rust && cargo update --workspace
 
 gateway-version:
 	@find website -name "redirects.js" -exec sed $(SEDARG) -e '/mark:current-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(current-gateway-version)/g;}' {} \;

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -22,7 +22,7 @@ current-headless-version = 1.0.6
 # Tracks the next version to release for each platform
 next-apple-version = 1.0.5
 next-android-version = 1.0.4
-next-gateway-version = 1.1.0
+next-gateway-version = 1.0.7
 next-gui-version = 1.0.7
 next-headless-version = 1.0.7
 


### PR DESCRIPTION
Now that #4397 is complete, we need a way to bake in the desired component version so that it's reported properly to the portal.

This PR adds a global override, "FIREZONE_PACKAGE_VERSION" that can be optionally set to bake the version in. If left blank, the behavior is unchanged, "CARGO_PKG_VERSION" is used instead, which is populated from `connlib-shared`'s Cargo.toml.

## Problem

<img width="520" alt="Screenshot 2024-06-12 at 11 34 45 AM" src="https://github.com/firezone/firezone/assets/167144/b04fcbe5-dcba-4a0d-b93f-7abd923b4f04">
<img width="439" alt="Screenshot 2024-06-12 at 11 34 36 AM" src="https://github.com/firezone/firezone/assets/167144/7b1828fe-4073-4a1f-8cbd-5e55ba241745">
