### PR TITLE
fix(portal): Fix nil error for address_description

### DIFF
--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -116,25 +116,19 @@ defmodule Web.Resources.Show do
               <%= @resource.address %>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row>
+          <.vertical_table_row :if={@resource.address_description}>
             <:label>
               Address Description
             </:label>
             <:value>
-              <a
-                href={
-                  if String.starts_with?(@resource.address_description, ["http", "ftp", "//"]) do
-                    @resource.address_description
-                  else
-                    "//" <> @resource.address_description
-                  end
-                }
-                target="_blank"
-                class={link_style()}
-              >
+              <%= if http_link?(@resource.address_description) do %>
+                <.link class={link_style()} navigate={@resource.address_description} target="_blank">
+                  <%= @resource.address_description %>
+                  <.icon name="hero-arrow-top-right-on-square" class="mb-3 w-3 h-3" />
+                </.link>
+              <% else %>
                 <%= @resource.address_description %>
-                <.icon name="hero-arrow-top-right-on-square" class="mb-3 w-3 h-3" />
-              </a>
+              <% end %>
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>
@@ -338,6 +332,16 @@ defmodule Web.Resources.Show do
       {:noreply, push_navigate(socket, to: ~p"/#{socket.assigns.account}/sites/#{site_id}")}
     else
       {:noreply, push_navigate(socket, to: ~p"/#{socket.assigns.account}/resources")}
+    end
+  end
+
+  defp http_link?(address_description) do
+    uri = URI.parse(address_description)
+
+    if not is_nil(uri.scheme) and not is_nil(uri.host) and String.starts_with?(uri.scheme, "http") do
+      true
+    else
+      false
     end
   end
 end

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -116,7 +116,7 @@ defmodule Web.Resources.Show do
               <%= @resource.address %>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row :if={@resource.address_description}>
+          <.vertical_table_row>
             <:label>
               Address Description
             </:label>
@@ -334,6 +334,8 @@ defmodule Web.Resources.Show do
       {:noreply, push_navigate(socket, to: ~p"/#{socket.assigns.account}/resources")}
     end
   end
+
+  defp http_link?(nil), do: false
 
   defp http_link?(address_description) do
     uri = URI.parse(address_description)

--- a/elixir/apps/web/test/web/live/resources/show_test.exs
+++ b/elixir/apps/web/test/web/live/resources/show_test.exs
@@ -143,7 +143,7 @@ defmodule Web.Live.Resources.ShowTest do
       |> render()
       |> vertical_table_to_map()
 
-    refute table["address description"]
+    assert table["address description"] == ""
   end
 
   test "renders link for address_descriptions that look like links", %{

--- a/elixir/apps/web/test/web/live/resources/show_test.exs
+++ b/elixir/apps/web/test/web/live/resources/show_test.exs
@@ -118,10 +118,51 @@ defmodule Web.Live.Resources.ShowTest do
     assert table["name"] =~ resource.name
     assert table["address"] =~ resource.address
     assert table["created"] =~ actor.name
+    assert table["address description"] =~ resource.address_description
 
     for filter <- resource.filters do
       assert String.downcase(table["traffic restriction"]) =~ Atom.to_string(filter.protocol)
     end
+  end
+
+  test "omits address_description row if null", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    resource = Fixtures.Resources.create_resource(account: account, address_description: nil)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    table =
+      lv
+      |> element("#resource")
+      |> render()
+      |> vertical_table_to_map()
+
+    refute table["address description"]
+  end
+
+  test "renders link for address_descriptions that look like links", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    resource =
+      Fixtures.Resources.create_resource(
+        account: account,
+        address_description: "http://example.com"
+      )
+
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    assert Floki.find(html, "a[href='https://example.com']")
   end
 
   test "renders traffic filters on show page even when traffic filters disabled", %{


### PR DESCRIPTION
We try to parse `address_description` as a link on the resources/show page, but it can be nil.