### PR TITLE
refactor(infra): Update CAA DNS records

### DIFF
--- a/terraform/environments/production/dns.tf
+++ b/terraform/environments/production/dns.tf
@@ -1,4 +1,4 @@
-# Allow Google Cloud and Let's Encrypt to issue certificates for our domain
+# Allow Google Cloud to issue certificates for our domain
 resource "google_dns_record_set" "dns-caa" {
   project      = module.google-cloud-project.project.project_id
   managed_zone = module.google-cloud-dns.zone_name
@@ -6,8 +6,7 @@ resource "google_dns_record_set" "dns-caa" {
   type = "CAA"
   name = module.google-cloud-dns.dns_name
   rrdatas = [
-    "0 issue \"letsencrypt.org\"",
-    "0 issue \"pki.goog\"",
+    "0 issue \"pki.goog;validationmethods=dns-01\"",
     "0 iodef \"mailto:security@firezone.dev\""
   ]
   ttl = 3600

--- a/terraform/environments/production/dns.tf
+++ b/terraform/environments/production/dns.tf
@@ -1,5 +1,5 @@
 # Allow Google Cloud to issue certificates for our domain
-resource "google_dns_record_set" "dns-caa" {
+resource "google_dns_record_set" "default-dns-caa" {
   project      = module.google-cloud-project.project.project_id
   managed_zone = module.google-cloud-dns.zone_name
 
@@ -11,6 +11,46 @@ resource "google_dns_record_set" "dns-caa" {
   ]
   ttl = 3600
 }
+
+resource "google_dns_record_set" "www-dns-caa" {
+  project      = module.google-cloud-project.project.project_id
+  managed_zone = module.google-cloud-dns.zone_name
+
+  type = "CAA"
+  name = "www.${module.google-cloud-dns.dns_name}"
+  rrdatas = [
+    "0 issue \"letsencrypt.org\"",
+    "0 iodef \"mailto:security@firezone.dev\""
+  ]
+  ttl = 3600
+}
+
+resource "google_dns_record_set" "blog-dns-caa" {
+  project      = module.google-cloud-project.project.project_id
+  managed_zone = module.google-cloud-dns.zone_name
+
+  type = "CAA"
+  name = "blog.${module.google-cloud-dns.dns_name}"
+  rrdatas = [
+    "0 issue \"letsencrypt.org\"",
+    "0 iodef \"mailto:security@firezone.dev\""
+  ]
+  ttl = 3600
+}
+
+resource "google_dns_record_set" "docs-dns-caa" {
+  project      = module.google-cloud-project.project.project_id
+  managed_zone = module.google-cloud-dns.zone_name
+
+  type = "CAA"
+  name = "docs.${module.google-cloud-dns.dns_name}"
+  rrdatas = [
+    "0 issue \"letsencrypt.org\"",
+    "0 iodef \"mailto:security@firezone.dev\""
+  ]
+  ttl = 3600
+}
+
 
 # Website
 

--- a/terraform/environments/staging/dns.tf
+++ b/terraform/environments/staging/dns.tf
@@ -1,4 +1,4 @@
-# Allow Google Cloud and Let's Encrypt to issue certificates for our domain
+# Allow Google Cloud to issue certificates for our domain
 resource "google_dns_record_set" "dns-caa" {
   project      = module.google-cloud-project.project.project_id
   managed_zone = module.google-cloud-dns.zone_name
@@ -6,8 +6,7 @@ resource "google_dns_record_set" "dns-caa" {
   type = "CAA"
   name = module.google-cloud-dns.dns_name
   rrdatas = [
-    "0 issue \"letsencrypt.org\"",
-    "0 issue \"pki.goog\"",
+    "0 issue \"pki.goog;validationmethods=dns-01\"",
     "0 iodef \"mailto:security@firezone.dev\""
   ]
   ttl = 3600

--- a/terraform/environments/staging/dns.tf
+++ b/terraform/environments/staging/dns.tf
@@ -1,5 +1,5 @@
 # Allow Google Cloud to issue certificates for our domain
-resource "google_dns_record_set" "dns-caa" {
+resource "google_dns_record_set" "default-dns-caa" {
   project      = module.google-cloud-project.project.project_id
   managed_zone = module.google-cloud-dns.zone_name
 
@@ -7,6 +7,19 @@ resource "google_dns_record_set" "dns-caa" {
   name = module.google-cloud-dns.dns_name
   rrdatas = [
     "0 issue \"pki.goog;validationmethods=dns-01\"",
+    "0 iodef \"mailto:security@firezone.dev\""
+  ]
+  ttl = 3600
+}
+
+resource "google_dns_record_set" "discourse-dns-caa" {
+  project      = module.google-cloud-project.project.project_id
+  managed_zone = module.google-cloud-dns.zone_name
+
+  type = "CAA"
+  name = "discourse.${module.google-cloud-dns.dns_name}"
+  rrdatas = [
+    "0 issue \"letsencrypt.org\"",
     "0 iodef \"mailto:security@firezone.dev\""
   ]
   ttl = 3600


### PR DESCRIPTION
fixes #5341 

Why:

* Since we are using Google managed certs there does not appear to be any reason to allow Let's Encrypt to issue certs for our domains. This commit updates the CAA records for firezone.dev and firez.one domains to only allow Google to issue certs.  Along with that, this commit also adds the `verificationmethods` flag to each of the records to only allow the `dns-01` method for domain verification.