### PR TITLE
test(connlib): make strategy-creation more ergonomic

### DIFF
--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -2,6 +2,7 @@ use crate::tests::sut::TunnelTest;
 use proptest::test_runner::Config;
 
 mod assertions;
+mod composite_strategy;
 mod reference;
 mod sim_node;
 mod sim_portal;

--- a/rust/connlib/tunnel/src/tests/composite_strategy.rs
+++ b/rust/connlib/tunnel/src/tests/composite_strategy.rs
@@ -25,14 +25,19 @@ where
     T: fmt::Debug,
 {
     /// Adds a strategy to this [`CompositeStrategy`].
-    pub fn with(mut self, strategy: impl Strategy<Value = T> + 'static) -> Self {
-        self.options.push((1, strategy.boxed()));
+    pub fn with(mut self, prob: u32, strategy: impl Strategy<Value = T> + 'static) -> Self {
+        self.options.push((prob, strategy.boxed()));
 
         self
     }
 
     /// Adds a strategy based on some input element if the element is not empty.
-    pub fn with_if_not_empty<S, E>(self, element: E, make_strategy: impl Fn(E) -> S) -> Self
+    pub fn with_if_not_empty<S, E>(
+        self,
+        prob: u32,
+        element: E,
+        make_strategy: impl Fn(E) -> S,
+    ) -> Self
     where
         S: Strategy<Value = T> + 'static,
         E: IsEmpty,
@@ -41,7 +46,7 @@ where
             return self;
         }
 
-        self.with(make_strategy(element))
+        self.with(prob, make_strategy(element))
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/composite_strategy.rs
+++ b/rust/connlib/tunnel/src/tests/composite_strategy.rs
@@ -51,13 +51,13 @@ pub trait IsEmpty {
 
 impl<T> IsEmpty for Vec<T> {
     fn is_empty(&self) -> bool {
-        Vec::is_empty(&self)
+        Vec::is_empty(self)
     }
 }
 
 impl<T> IsEmpty for Option<T> {
     fn is_empty(&self) -> bool {
-        Option::is_none(&self)
+        Option::is_none(self)
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/composite_strategy.rs
+++ b/rust/connlib/tunnel/src/tests/composite_strategy.rs
@@ -1,0 +1,99 @@
+use proptest::strategy::{BoxedStrategy, Strategy, Union};
+use std::fmt;
+
+#[derive(Debug)]
+pub struct CompositeStrategy<T>
+where
+    T: fmt::Debug,
+{
+    options: Vec<(u32, BoxedStrategy<T>)>,
+}
+
+impl<T> Default for CompositeStrategy<T>
+where
+    T: fmt::Debug,
+{
+    fn default() -> Self {
+        Self {
+            options: Vec::default(),
+        }
+    }
+}
+
+impl<T> CompositeStrategy<T>
+where
+    T: fmt::Debug,
+{
+    /// Adds a strategy to this [`CompositeStrategy`].
+    pub fn with(mut self, strategy: impl Strategy<Value = T> + 'static) -> Self {
+        self.options.push((1, strategy.boxed()));
+
+        self
+    }
+
+    /// Adds a strategy based on some input element if the element is not empty.
+    pub fn with_if_not_empty<S, E>(self, element: E, make_strategy: impl Fn(E) -> S) -> Self
+    where
+        S: Strategy<Value = T> + 'static,
+        E: IsEmpty,
+    {
+        if element.is_empty() {
+            return self;
+        }
+
+        self.with(make_strategy(element))
+    }
+}
+
+pub trait IsEmpty {
+    fn is_empty(&self) -> bool;
+}
+
+impl<T> IsEmpty for Vec<T> {
+    fn is_empty(&self) -> bool {
+        Vec::is_empty(&self)
+    }
+}
+
+impl<T> IsEmpty for Option<T> {
+    fn is_empty(&self) -> bool {
+        Option::is_none(&self)
+    }
+}
+
+impl<A, B> IsEmpty for (A, B)
+where
+    A: IsEmpty,
+    B: IsEmpty,
+{
+    fn is_empty(&self) -> bool {
+        self.0.is_empty() || self.1.is_empty()
+    }
+}
+
+impl<A, B, C> IsEmpty for (A, B, C)
+where
+    A: IsEmpty,
+    B: IsEmpty,
+    C: IsEmpty,
+{
+    fn is_empty(&self) -> bool {
+        self.0.is_empty() || self.1.is_empty() || self.2.is_empty()
+    }
+}
+
+impl<T> Strategy for CompositeStrategy<T>
+where
+    T: fmt::Debug,
+{
+    type Tree = <Union<BoxedStrategy<T>> as Strategy>::Tree;
+
+    type Value = T;
+
+    fn new_tree(
+        &self,
+        runner: &mut proptest::prelude::prop::test_runner::TestRunner,
+    ) -> proptest::prelude::prop::strategy::NewTree<Self> {
+        Union::new_weighted(self.options.clone()).new_tree(runner)
+    }
+}

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -13,7 +13,7 @@ use connlib_shared::{
 };
 use hickory_proto::rr::RecordType;
 use ip_network_table::IpNetworkTable;
-use proptest::{prelude::*, sample, strategy::Union};
+use proptest::{prelude::*, sample};
 use proptest_state_machine::ReferenceStateMachine;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet, VecDeque},

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -190,7 +190,11 @@ impl ReferenceStateMachine for ReferenceState {
                     .prop_map(|servers| Transition::UpdateUpstreamDnsServers { servers }),
             )
             .with(cidr_resource(8).prop_map(Transition::AddCidrResource))
-            .with(add_dns_resource())
+            .with(prop_oneof![
+                non_wildcard_dns_resource(),
+                star_wildcard_dns_resource(),
+                question_mark_wildcard_dns_resource(),
+            ])
             .with_if_not_empty(state.ipv4_cidr_resource_dsts(), |ip4_resources| {
                 icmp_to_cidr_resource(
                     packet_source_v4(state.client.tunnel_ip4),

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -193,25 +193,25 @@ impl ReferenceStateMachine for ReferenceState {
             .with(add_dns_resource())
             .with_if_not_empty(state.ipv4_cidr_resource_dsts(), |ip4_resources| {
                 icmp_to_cidr_resource(
-                    packet_source_v4(state.client.tunnel_ip4).prop_map(IpAddr::V4),
-                    sample::select(ip4_resources).prop_map(IpAddr::V4),
+                    packet_source_v4(state.client.tunnel_ip4),
+                    sample::select(ip4_resources),
                 )
             })
             .with_if_not_empty(state.ipv6_cidr_resource_dsts(), |ip6_resources| {
                 icmp_to_cidr_resource(
-                    packet_source_v6(state.client.tunnel_ip6).prop_map(IpAddr::V6),
-                    sample::select(ip6_resources).prop_map(IpAddr::V6),
+                    packet_source_v6(state.client.tunnel_ip6),
+                    sample::select(ip6_resources),
                 )
             })
             .with_if_not_empty(state.resolved_v4_domains(), |dns_v4_domains| {
                 icmp_to_dns_resource(
-                    packet_source_v4(state.client.tunnel_ip4).prop_map(IpAddr::V4),
+                    packet_source_v4(state.client.tunnel_ip4),
                     sample::select(dns_v4_domains),
                 )
             })
             .with_if_not_empty(state.resolved_v6_domains(), |dns_v6_domains| {
                 icmp_to_dns_resource(
-                    packet_source_v6(state.client.tunnel_ip6).prop_map(IpAddr::V6),
+                    packet_source_v6(state.client.tunnel_ip6),
                     sample::select(dns_v6_domains),
                 )
             })
@@ -222,10 +222,7 @@ impl ReferenceStateMachine for ReferenceState {
                     state.client.ip4_socket,
                 ),
                 |(domains, v4_dns_servers, _)| {
-                    dns_query(
-                        sample::select(domains),
-                        sample::select(v4_dns_servers).prop_map(SocketAddr::V4),
-                    )
+                    dns_query(sample::select(domains), sample::select(v4_dns_servers))
                 },
             )
             .with_if_not_empty(
@@ -235,18 +232,15 @@ impl ReferenceStateMachine for ReferenceState {
                     state.client.ip6_socket,
                 ),
                 |(domains, v6_dns_servers, _)| {
-                    dns_query(
-                        sample::select(domains),
-                        sample::select(v6_dns_servers).prop_map(SocketAddr::V6),
-                    )
+                    dns_query(sample::select(domains), sample::select(v6_dns_servers))
                 },
             )
             .with_if_not_empty(
                 state.resolved_ip4_for_non_resources(),
                 |resolved_non_resource_ip4s| {
                     ping_random_ip(
-                        packet_source_v4(state.client.tunnel_ip4).prop_map(IpAddr::V4),
-                        sample::select(resolved_non_resource_ip4s).prop_map(IpAddr::V4),
+                        packet_source_v4(state.client.tunnel_ip4),
+                        sample::select(resolved_non_resource_ip4s),
                     )
                 },
             )
@@ -254,8 +248,8 @@ impl ReferenceStateMachine for ReferenceState {
                 state.resolved_ip6_for_non_resources(),
                 |resolved_non_resource_ip6s| {
                     ping_random_ip(
-                        packet_source_v6(state.client.tunnel_ip6).prop_map(IpAddr::V6),
-                        sample::select(resolved_non_resource_ip6s).prop_map(IpAddr::V6),
+                        packet_source_v6(state.client.tunnel_ip6),
+                        sample::select(resolved_non_resource_ip6s),
                     )
                 },
             )

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -175,7 +175,7 @@ pub(crate) fn non_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
 }
 
 pub(crate) fn star_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
-    (dns_resource()).prop_flat_map(move |r| {
+    dns_resource().prop_flat_map(move |r| {
         let wildcard_address = format!("*.{}", r.address);
 
         let records = subdomain_records(r.address, domain_name(1..3));

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -165,15 +165,7 @@ where
         )
 }
 
-pub(crate) fn add_dns_resource() -> impl Strategy<Value = Transition> {
-    prop_oneof![
-        non_wildcard_dns_resource(),
-        star_wildcard_dns_resource(),
-        question_mark_wildcard_dns_resource(),
-    ]
-}
-
-fn non_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
+pub(crate) fn non_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
     (dns_resource(), resolved_ips()).prop_map(|(resource, resolved_ips)| {
         Transition::AddDnsResource {
             records: HashMap::from([(resource.address.parse().unwrap(), resolved_ips)]),
@@ -182,7 +174,7 @@ fn non_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
     })
 }
 
-fn star_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
+pub(crate) fn star_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
     (dns_resource()).prop_flat_map(move |r| {
         let wildcard_address = format!("*.{}", r.address);
 
@@ -197,7 +189,7 @@ fn star_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
     })
 }
 
-fn question_mark_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
+pub(crate) fn question_mark_wildcard_dns_resource() -> impl Strategy<Value = Transition> {
     dns_resource().prop_flat_map(move |r| {
         let wildcard_address = format!("?.{}", r.address);
 


### PR DESCRIPTION
When creating the `Transition` strategy, we are currently repeating the same pattern again and again: We want to conditionally add a strategy if one or more parts of our state are not empty.

We reduce this duplication with a custom `CompositeStrategy` that offers a `with_if_not_empty` chainable method to only construct a strategy if the given input element is not empty.

To make this usable across several usecases, we define an `IsEmpty` helper trait that is implemented for `Vec`s, `Option`s and tuples.