### PR TITLE
ci: Don't clobber assets for published releases

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -215,13 +215,21 @@ jobs:
         run: |
           set -xe
 
+          # Only clobber existing release assets if the release is a draft
+          is_draft=$(gh release view ${{ matrix.name.release_name }} --json isDraft --jq '.isDraft' | tr -d '\n')
+          if [[ "$is_draft" == "true" ]]; then
+            clobber="--clobber"
+          else
+            clobber=""
+          fi
+
           # Used for release artifact
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} $BINARY_DEST_PATH
           sha256sum $BINARY_DEST_PATH > $BINARY_DEST_PATH.sha256sum.txt
           gh release upload ${{ matrix.name.release_name }} \
             ${{ env.BINARY_DEST_PATH }} \
             ${{ env.BINARY_DEST_PATH }}.sha256sum.txt \
-            --clobber \
+            $clobber \
             --repo ${{ github.repository }}
       - name: Authenticate to Google Cloud
         id: auth

--- a/scripts/build/tauri-upload-ubuntu.sh
+++ b/scripts/build/tauri-upload-ubuntu.sh
@@ -4,8 +4,16 @@ set -euox pipefail
 
 # This artifact name is tied to the update checker in `gui-client/src-tauri/src/client/updates.rs`
 
+# Only clobber existing release assets if the release is a draft
+is_draft=$(gh release view "$TAG_NAME" --json isDraft --jq '.isDraft' | tr -d '\n')
+if [[ "$is_draft" == "true" ]]; then
+    clobber="--clobber"
+else
+    clobber=""
+fi
+
 gh release upload "$TAG_NAME" \
     "$BINARY_DEST_PATH".deb \
     "$BINARY_DEST_PATH".deb.sha256sum.txt \
-    --clobber \
+    $clobber \
     --repo "$REPOSITORY"

--- a/scripts/build/tauri-upload-windows.sh
+++ b/scripts/build/tauri-upload-windows.sh
@@ -2,10 +2,18 @@
 
 set -euox pipefail
 
+# Only clobber existing release assets if the release is a draft
+is_draft=$(gh release view "$TAG_NAME" --json isDraft --jq '.isDraft' | tr -d '\n')
+if [[ "$is_draft" == "true" ]]; then
+    clobber="--clobber"
+else
+    clobber=""
+fi
+
 # This artifact name is tied to the update checker in `gui-client/src-tauri/src/client/updates.rs`
 # So we can't put the version number in it until we stop using Github for update checks.
 gh release upload "$TAG_NAME" \
     "$BINARY_DEST_PATH".msi \
     "$BINARY_DEST_PATH".msi.sha256sum.txt \
-    --clobber \
+    $clobber \
     --repo "$REPOSITORY"


### PR DESCRIPTION
Adds a sanity check to prevent clobbering assets on published releases. Otherwise, assets will continue to be pushed to the published release until the version is bumped.