### PR TITLE
feat(gateway): NAT & mangling for DNS resources

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1179,6 +1179,7 @@ dependencies = [
  "domain",
  "futures",
  "futures-util",
+ "ip-packet",
  "ip_network",
  "itertools 0.13.0",
  "known-folders",

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -31,6 +31,7 @@ ring = "0.17"
 domain = { workspace = true }
 libc = "0.2"
 phoenix-channel = { workspace = true }
+ip-packet = { workspace = true }
 proptest = { version = "1.4.0", optional = true }
 itertools = "0.13"
 

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 mock = []
-proptest = ["dep:proptest", "dep:itertools"]
+proptest = ["dep:proptest"]
 
 [dependencies]
 anyhow = "1.0.82"
@@ -32,13 +32,12 @@ domain = { workspace = true }
 libc = "0.2"
 phoenix-channel = { workspace = true }
 proptest = { version = "1.4.0", optional = true }
-itertools = { version = "0.13", optional = true }
+itertools = "0.13"
 
 # Needed for Android logging until tracing is working
 log = "0.4"
 
 [dev-dependencies]
-itertools = "0.13"
 tokio = { version = "1.38", features = ["macros", "rt"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -60,7 +60,7 @@ pub enum ConnlibError {
     #[error("exhausted nat")]
     ExhaustedNat,
     // TODO: we might want to log some extra parameters on these failed translations
-    /// Exhausted nat table
+    /// Packet translation failed
     #[error("failed packet translation")]
     FailedTranslation,
     /// Connection is still being established, retry later

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -56,6 +56,13 @@ pub enum ConnlibError {
     /// Invalid destination for packet
     #[error("Invalid dest address")]
     InvalidDst,
+    /// Exhausted nat table
+    #[error("exhausted nat")]
+    ExhaustedNat,
+    // TODO: we might want to log some extra parameters on these failed translations
+    /// Exhausted nat table
+    #[error("failed packet translation")]
+    FailedTranslation,
     /// Connection is still being established, retry later
     #[error("Pending connection")]
     PendingConnection,

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -59,6 +59,8 @@ pub enum ConnlibError {
     /// Exhausted nat table
     #[error("exhausted nat")]
     ExhaustedNat,
+    #[error(transparent)]
+    UnsupportedProtocol(ip_packet::UnsupportedProtocol),
     // TODO: we might want to log some extra parameters on these failed translations
     /// Packet translation failed
     #[error("failed packet translation")]

--- a/rust/connlib/shared/src/messages/gateway.rs
+++ b/rust/connlib/shared/src/messages/gateway.rs
@@ -1,6 +1,9 @@
 //! Gateway related messages that are needed within connlib
 
+use std::net::IpAddr;
+
 use ip_network::IpNetwork;
+use itertools::Itertools;
 use serde::Deserialize;
 
 use super::ResourceId;
@@ -48,7 +51,7 @@ pub struct ResolvedResourceDescriptionDns {
     /// Used only for display.
     pub name: String,
 
-    pub addresses: Vec<IpNetwork>,
+    pub addresses: Vec<IpAddr>,
 
     pub filters: Filters,
 }
@@ -91,7 +94,7 @@ fn max_port() -> u16 {
 impl ResourceDescription<ResourceDescriptionDns> {
     pub fn into_resolved(
         self,
-        addresses: Vec<IpNetwork>,
+        addresses: Vec<IpAddr>,
     ) -> ResourceDescription<ResolvedResourceDescriptionDns> {
         match self {
             ResourceDescription::Dns(ResourceDescriptionDns {
@@ -104,6 +107,7 @@ impl ResourceDescription<ResourceDescriptionDns> {
                 domain: address,
                 name,
                 addresses,
+
                 filters,
             }),
             ResourceDescription::Cidr(c) => ResourceDescription::Cidr(c),
@@ -130,7 +134,7 @@ impl ResourceDescription<ResourceDescriptionDns> {
 impl ResourceDescription<ResolvedResourceDescriptionDns> {
     pub fn addresses(&self) -> Vec<IpNetwork> {
         match self {
-            ResourceDescription::Dns(r) => r.addresses.clone(),
+            ResourceDescription::Dns(r) => r.addresses.iter().copied().map_into().collect_vec(),
             ResourceDescription::Cidr(r) => vec![r.address],
         }
     }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -47,6 +47,7 @@ firezone-relay = { workspace = true, features = ["proptest"] }
 rand = "0.8"
 hickory-proto = { workspace = true }
 derivative = "2.2.0"
+ip-packet = { workspace = true, features = ["proptest"] }
 
 [features]
 proptest = ["dep:proptest", "connlib-shared/proptest"]

--- a/rust/connlib/tunnel/proptest-regressions/peer/nat_table.txt
+++ b/rust/connlib/tunnel/proptest-regressions/peer/nat_table.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 1e03c37afda9f91fb4bf23e693921b59530eaefdb95094db03ac8d1e448b68d4 # shrinks to input = _TranslatesBackAndForthUdpPacketArgs { packet: Ipv4(ConvertibleIpv4Packet { buf: Owned([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 0, 0, 28, 0, 0, 0, 0, 64, 17, 122, 210, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 255, 222]) }), outside_dst: 0.0.0.0, response_delay: 9223372036854758677.681955028s }
+cc 95107af217cd84a6eacda3264751e15825f7fb92d7cc70378baaf2f7a0958b1c # shrinks to input = _TranslatesBackAndForthUdpPacketArgs { packet: Ipv4(ConvertibleIpv4Packet { buf: Owned([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 0, 0, 28, 0, 0, 0, 0, 64, 17, 122, 210, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 255, 222]) }), outside_dst: ::ffff:0.0.0.0, response_delay: 0 }
+cc 6937709663669c298021f536f9f921964928d1ab8640068da13db6e1cde363a4 # shrinks to input = _TranslatesBackAndForthUdpPacketArgs { packet: Ipv4(ConvertibleIpv4Packet { buf: Owned([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 0, 0, 28, 0, 0, 0, 0, 64, 17, 122, 210, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 255, 222]) }), outside_dst: 0.0.0.0, response_delay: 60 }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -170,7 +170,10 @@ impl GatewayState {
 
         let peer = self.peers.peer_by_ip_mut(dest)?;
 
-        let packet = peer.encapsulate(packet, now)?;
+        let packet = peer
+            .encapsulate(packet, now)
+            .inspect_err(|e| tracing::debug!("Failed to encapsulate: {e}"))
+            .ok()??;
 
         let transmit = self
             .node

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -343,7 +343,7 @@ impl GatewayState {
             Some(next_expiry_resources_check) if now >= next_expiry_resources_check => {
                 self.peers.iter_mut().for_each(|p| {
                     p.expire_resources(utc_now);
-                    p.expire_nat(now)
+                    p.handle_timeout(now)
                 });
                 self.peers.retain(|_, p| !p.is_emptied());
 

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -209,13 +209,10 @@ impl GatewayState {
             return None;
         };
 
-        let packet = match peer.decapsulate(packet, now) {
-            Ok(packet) => packet,
-            Err(e) => {
-                tracing::warn!(%conn_id, %local, %from, "Invalid packet: {e}");
-                return None;
-            }
-        };
+        let packet = peer
+            .decapsulate(packet, now)
+            .inspect_err(|e| tracing::warn!(%conn_id, %local, %from, "Invalid packet: {e}"))
+            .ok()?;
 
         tracing::trace!("Decapsulated packet");
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -8,7 +8,7 @@ use chrono::Utc;
 use connlib_shared::{
     callbacks,
     messages::{ClientId, GatewayId, Relay, RelayId, ResourceId, ReuseConnection},
-    Callbacks, Result,
+    Callbacks, DomainName, Result,
 };
 use io::Io;
 use std::{
@@ -302,5 +302,10 @@ pub enum GatewayEvent {
     InvalidIceCandidate {
         conn_id: ClientId,
         candidate: String,
+    },
+    RefreshDns {
+        name: DomainName,
+        conn_id: ClientId,
+        resource_id: ResourceId,
     },
 }

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -621,16 +621,16 @@ mod tests {
         );
 
         let tcp_packet = ip_packet::make::tcp_packet(
-            source_v4_addr().into(),
-            cidr_v4_resource().hosts().next().unwrap().into(),
+            source_v4_addr(),
+            cidr_v4_resource().hosts().next().unwrap(),
             5401,
             80,
             vec![0; 100],
         );
 
         let udp_packet = ip_packet::make::udp_packet(
-            source_v4_addr().into(),
-            cidr_v4_resource().hosts().next().unwrap().into(),
+            source_v4_addr(),
+            cidr_v4_resource().hosts().next().unwrap(),
             5401,
             80,
             vec![0; 100],

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -1,0 +1,106 @@
+//! a stateful symmetric NAT table that performs conversion between a client's picked proxy ip and the actual resource's IP
+use bimap::BiMap;
+use ip_packet::{IpPacket, Protocol};
+use itertools::Itertools;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+/// The stateful NAT table converts a client's picked proxy ip for a domain name into the real IP for that IP
+/// it also picks a source port to keep track of the original proxy IP used.
+/// The NAT sessions, i.e. the mapping between (source_port, proxy_ip) to (source_port', real_ip) is kept for 60 seconds
+/// after no incoming traffic is received.
+///
+/// Note that for ICMP echo/reply the identity number is used as a stand in for the source port.
+///
+/// Also, the proxy_ip and the real_ip version may not coincide, in that case a translation mechanism must be used (RFC6145)
+///
+/// This nat table doesn't perform any mangling just provides the converted port/ip for upper layers
+#[derive(Default, Debug)]
+pub(crate) struct NatTable {
+    pub(crate) table: BiMap<(Protocol, IpAddr), (Protocol, IpAddr)>,
+    pub(crate) last_seen: HashMap<(Protocol, IpAddr), Instant>,
+}
+
+impl NatTable {
+    pub(crate) fn handle_timeout(&mut self, now: Instant) {
+        let mut removed = Vec::new();
+        for (r, e) in self.last_seen.iter() {
+            if now.duration_since(*e) >= Duration::from_secs(60) {
+                let inside = self.table.remove_by_right(r);
+                tracing::trace!(?inside, outside = ?r, "NAT session expired");
+                removed.push(*r);
+            }
+        }
+
+        for r in removed {
+            self.last_seen.remove(&r);
+        }
+    }
+
+    pub(crate) fn translate_outgoing(
+        &mut self,
+        outgoing_pkt: &IpPacket,
+        real_address: IpAddr,
+        now: Instant,
+    ) -> Option<(Protocol, IpAddr)> {
+        let source_protocol = outgoing_pkt.source_protocol()?;
+        let inside = (source_protocol, outgoing_pkt.destination());
+        if let Some(outside) = self.table.get_by_left(&inside) {
+            if outside.1 == real_address {
+                tracing::trace!(?inside, ?outside, "Translating packet");
+
+                self.last_seen.insert(*outside, now);
+                return Some(*outside);
+            }
+
+            tracing::trace!(?inside, ?outside, "Outgoing packet for expired translation");
+        }
+
+        let mut occupied_ports = self
+            .table
+            .iter()
+            .filter(|(_, (proto, ip))| *ip == real_address && proto.same_type(&source_protocol))
+            .map(|(_, (proto, _))| proto.value())
+            .sorted_unstable();
+
+        for p in 1.. {
+            if !occupied_ports.contains(&p) {
+                let proxy_protocol = source_protocol.with_value(p);
+
+                let inside = (source_protocol, outgoing_pkt.destination());
+                let outside = (proxy_protocol, real_address);
+
+                self.table.insert(inside, outside);
+                self.last_seen.insert(outside, now);
+
+                tracing::trace!(?inside, ?outside, "New NAT session");
+
+                return Some((proxy_protocol, real_address));
+            }
+        }
+
+        tracing::warn!("available nat ports exhausted");
+        None
+    }
+
+    pub(crate) fn translate_incoming(
+        &mut self,
+        incoming_packet: &IpPacket,
+        now: Instant,
+    ) -> Option<(Protocol, IpAddr)> {
+        let outside = (
+            incoming_packet.destination_protocol()?,
+            incoming_packet.source(),
+        );
+
+        if let Some(inside) = self.table.get_by_right(&outside) {
+            tracing::trace!(?inside, ?outside, "Reverting translation");
+
+            self.last_seen.insert(*inside, now);
+            return Some(*inside);
+        }
+
+        None
+    }
+}

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -47,7 +47,7 @@ impl NatTable {
         let inside = (source_protocol, outgoing_pkt.destination());
         if let Some(outside) = self.table.get_by_left(&inside) {
             if outside.1 == real_address {
-                tracing::trace!(?inside, ?outside, "Translating packet");
+                tracing::trace!(?inside, ?outside, "Translating outgoing packet");
 
                 self.last_seen.insert(*outside, now);
                 return Some(*outside);
@@ -72,7 +72,7 @@ impl NatTable {
         self.table.insert(inside, outside);
         self.last_seen.insert(outside, now);
 
-        tracing::trace!(?inside, ?outside, "New NAT session");
+        tracing::debug!(?inside, ?outside, "New NAT session");
 
         Some(outside)
     }
@@ -88,13 +88,13 @@ impl NatTable {
         );
 
         if let Some(inside) = self.table.get_by_right(&outside) {
-            tracing::trace!(?inside, ?outside, "Reverting translation");
+            tracing::trace!(?inside, ?outside, "Translating incoming packet");
 
             self.last_seen.insert(*inside, now);
             return Some(*inside);
         }
 
-        tracing::trace!(?outside, "Incoming packet not translated");
+        tracing::trace!(?outside, "No active NAT session; skipping translation");
 
         None
     }

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -125,6 +125,7 @@ mod tests {
 
         let _set_default = tracing_subscriber::fmt()
             .with_env_filter("trace")
+            .with_test_writer()
             .set_default();
         let sent_at = Instant::now();
         let mut table = NatTable::default();
@@ -176,6 +177,7 @@ mod tests {
 
         let _set_default = tracing_subscriber::fmt()
             .with_env_filter("trace")
+            .with_test_writer()
             .set_default();
         let mut table = NatTable::default();
 

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -24,11 +24,13 @@ pub(crate) struct NatTable {
 impl NatTable {
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
         let mut removed = Vec::new();
-        for (r, e) in self.last_seen.iter() {
+        for (outside, e) in self.last_seen.iter() {
             if now.duration_since(*e) >= Duration::from_secs(60) {
-                let inside = self.table.remove_by_right(r);
-                tracing::debug!(?inside, outside = ?r, "NAT session expired");
-                removed.push(*r);
+                if let Some((inside, _)) = self.table.remove_by_right(outside) {
+                    tracing::debug!(?inside, ?outside, "NAT session expired");
+                }
+
+                removed.push(*outside);
             }
         }
 

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -149,7 +149,7 @@ mod tests {
 
         // Translate in
         let translate_incoming = table
-            .translate_incoming(packet.as_immutable(), sent_at + response_delay)
+            .translate_incoming(response.as_immutable(), sent_at + response_delay)
             .unwrap();
 
         // Assert

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -5,20 +5,18 @@ use crate::messages::{
 use crate::CallbackHandler;
 use anyhow::Result;
 use boringtun::x25519::PublicKey;
-use connlib_shared::messages::RelaysPresence;
-use connlib_shared::{
-    messages::{GatewayResponse, ResourceAccepted},
-    DomainName,
+use connlib_shared::messages::{
+    ClientId, ConnectionAccepted, RelaysPresence, ResourceAccepted, ResourceId,
 };
+use connlib_shared::{messages::GatewayResponse, DomainName};
 #[cfg(not(target_os = "windows"))]
 use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
-use either::Either;
 use firezone_tunnel::GatewayTunnel;
 use futures_bounded::Timeout;
-use ip_network::IpNetwork;
 use phoenix_channel::PhoenixChannel;
 use std::collections::HashSet;
 use std::convert::Infallible;
+use std::net::IpAddr;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -33,12 +31,18 @@ static_assertions::const_assert!(
     DNS_RESOLUTION_TIMEOUT.as_secs() < snownet::HANDSHAKE_TIMEOUT.as_secs()
 );
 
+#[derive(Debug, Clone)]
+enum ResolveTrigger {
+    RequestConnection(RequestConnection),
+    AllowAccess(AllowAccess),
+    Refresh(DomainName, ClientId, ResourceId),
+}
+
 pub struct Eventloop {
     tunnel: GatewayTunnel<CallbackHandler>,
     portal: PhoenixChannel<(), IngressMessages, ()>,
 
-    resolve_tasks:
-        futures_bounded::FuturesTupleSet<Vec<IpNetwork>, Either<RequestConnection, AllowAccess>>,
+    resolve_tasks: futures_bounded::FuturesTupleSet<Vec<IpAddr>, ResolveTrigger>,
 }
 
 impl Eventloop {
@@ -70,12 +74,16 @@ impl Eventloop {
             }
 
             match self.resolve_tasks.poll_unpin(cx) {
-                Poll::Ready((result, Either::Left(req))) => {
+                Poll::Ready((result, ResolveTrigger::RequestConnection(req))) => {
                     self.accept_connection(result, req);
                     continue;
                 }
-                Poll::Ready((result, Either::Right(req))) => {
+                Poll::Ready((result, ResolveTrigger::AllowAccess(req))) => {
                     self.allow_access(result, req);
+                    continue;
+                }
+                Poll::Ready((result, ResolveTrigger::Refresh(name, conn_id, resource_id))) => {
+                    self.refresh_translation(result, conn_id, resource_id, name);
                     continue;
                 }
                 Poll::Pending => {}
@@ -119,6 +127,22 @@ impl Eventloop {
                     }),
                 );
             }
+            firezone_tunnel::GatewayEvent::RefreshDns {
+                name,
+                conn_id,
+                resource_id,
+            } => {
+                if self
+                    .resolve_tasks
+                    .try_push(
+                        resolve(Some(name.clone())),
+                        ResolveTrigger::Refresh(name, conn_id, resource_id),
+                    )
+                    .is_err()
+                {
+                    tracing::warn!("Too many dns resolution requests, dropping existing one");
+                };
+            }
         }
     }
 
@@ -131,8 +155,8 @@ impl Eventloop {
                 if self
                     .resolve_tasks
                     .try_push(
-                        resolve(req.client.payload.domain.clone()),
-                        Either::Left(req),
+                        resolve(req.client.payload.domain.as_ref().map(|r| r.name())),
+                        ResolveTrigger::RequestConnection(req),
                     )
                     .is_err()
                 {
@@ -145,7 +169,10 @@ impl Eventloop {
             } => {
                 if self
                     .resolve_tasks
-                    .try_push(resolve(req.payload.clone()), Either::Right(req))
+                    .try_push(
+                        resolve(req.payload.as_ref().map(|r| r.name())),
+                        ResolveTrigger::AllowAccess(req),
+                    )
                     .is_err()
                 {
                     tracing::warn!("Too many allow access requests, dropping existing one");
@@ -221,7 +248,7 @@ impl Eventloop {
 
     pub fn accept_connection(
         &mut self,
-        result: Result<Vec<IpNetwork>, Timeout>,
+        result: Result<Vec<IpAddr>, Timeout>,
         req: RequestConnection,
     ) {
         let addresses = result
@@ -236,16 +263,24 @@ impl Eventloop {
             req.client.peer.ipv4,
             req.client.peer.ipv6,
             req.relays,
-            req.client.payload.domain,
+            req.client.payload.domain.as_ref().map(|r| r.as_tuple()),
             req.expires_at,
-            req.resource.into_resolved(addresses),
+            req.resource.into_resolved(addresses.clone()),
         ) {
             Ok(accepted) => {
                 self.portal.send(
                     PHOENIX_TOPIC,
                     EgressMessages::ConnectionReady(ConnectionReady {
                         reference: req.reference,
-                        gateway_payload: GatewayResponse::ConnectionAccepted(accepted),
+                        gateway_payload: GatewayResponse::ConnectionAccepted(ConnectionAccepted {
+                            ice_parameters: accepted,
+                            domain_response: req.client.payload.domain.map(|r| {
+                                connlib_shared::messages::DomainResponse {
+                                    domain: r.name(),
+                                    address: addresses,
+                                }
+                            }),
+                        }),
                     }),
                 );
 
@@ -260,33 +295,52 @@ impl Eventloop {
         }
     }
 
-    pub fn allow_access(&mut self, result: Result<Vec<IpNetwork>, Timeout>, req: AllowAccess) {
+    pub fn allow_access(&mut self, result: Result<Vec<IpAddr>, Timeout>, req: AllowAccess) {
         let addresses = result
             .inspect_err(|e| tracing::debug!(client = %req.client_id, reference = %req.reference, "DNS resolution timed out as part of allow access request: {e}"))
             .unwrap_or_default();
 
-        let maybe_domain_response = self.tunnel.allow_access(
-            req.resource.into_resolved(addresses),
-            req.client_id,
-            req.expires_at,
+        if let (Ok(()), Some(resolve_request)) = (
+            self.tunnel.allow_access(
+                req.resource.into_resolved(addresses.clone()),
+                req.client_id,
+                req.expires_at,
+                req.payload.as_ref().map(|r| r.as_tuple()),
+            ),
             req.payload,
-        );
-
-        if let Some(domain_response) = maybe_domain_response {
+        ) {
             self.portal.send(
                 PHOENIX_TOPIC,
                 EgressMessages::ConnectionReady(ConnectionReady {
                     reference: req.reference,
                     gateway_payload: GatewayResponse::ResourceAccepted(ResourceAccepted {
-                        domain_response,
+                        domain_response: connlib_shared::messages::DomainResponse {
+                            domain: resolve_request.name(),
+                            address: addresses,
+                        },
                     }),
                 }),
             );
         }
     }
+
+    pub fn refresh_translation(
+        &mut self,
+        result: Result<Vec<IpAddr>, Timeout>,
+        conn_id: ClientId,
+        resource_id: ResourceId,
+        name: DomainName,
+    ) {
+        let addresses = result
+            .inspect_err(|e| tracing::debug!(%conn_id, "DNS resolution timed out as part of allow access request: {e}"))
+            .unwrap_or_default();
+
+        self.tunnel
+            .refresh_translation(conn_id, resource_id, name, addresses);
+    }
 }
 
-async fn resolve(domain: Option<DomainName>) -> Vec<IpNetwork> {
+async fn resolve(domain: Option<DomainName>) -> Vec<IpAddr> {
     let Some(domain) = domain.clone() else {
         return vec![];
     };
@@ -309,12 +363,12 @@ async fn resolve(domain: Option<DomainName>) -> Vec<IpNetwork> {
 }
 
 #[cfg(target_os = "windows")]
-fn resolve_addresses(_: &str) -> std::io::Result<Vec<IpNetwork>> {
+fn resolve_addresses(_: &str) -> std::io::Result<Vec<IpAddr>> {
     unimplemented!()
 }
 
 #[cfg(not(target_os = "windows"))]
-fn resolve_addresses(addr: &str) -> std::io::Result<Vec<IpNetwork>> {
+fn resolve_addresses(addr: &str) -> std::io::Result<Vec<IpAddr>> {
     use libc::{AF_INET, AF_INET6};
     let addr_v4: std::io::Result<Vec<_>> = resolve_address_family(addr, AF_INET)
         .map_err(|e| e.into())
@@ -325,11 +379,11 @@ fn resolve_addresses(addr: &str) -> std::io::Result<Vec<IpNetwork>> {
     match (addr_v4, addr_v6) {
         (Ok(v4), Ok(v6)) => Ok(v6
             .iter()
-            .map(|a| a.sockaddr.ip().into())
-            .chain(v4.iter().map(|a| a.sockaddr.ip().into()))
+            .map(|a| a.sockaddr.ip())
+            .chain(v4.iter().map(|a| a.sockaddr.ip()))
             .collect()),
-        (Ok(v4), Err(_)) => Ok(v4.iter().map(|a| a.sockaddr.ip().into()).collect()),
-        (Err(_), Ok(v6)) => Ok(v6.iter().map(|a| a.sockaddr.ip().into()).collect()),
+        (Ok(v4), Err(_)) => Ok(v4.iter().map(|a| a.sockaddr.ip()).collect()),
+        (Err(_), Ok(v6)) => Ok(v6.iter().map(|a| a.sockaddr.ip()).collect()),
         (Err(e), Err(_)) => Err(e),
     }
 }

--- a/rust/ip-packet/Cargo.toml
+++ b/rust/ip-packet/Cargo.toml
@@ -13,8 +13,8 @@ proptest = ["dep:proptest"]
 [dependencies]
 pnet_packet = { version = "0.34" }
 hickory-proto = { workspace = true }
-proptest = { version = "1.4.0", optional = true }
 thiserror = "1"
+proptest = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 test-strategy = "0.3.1"

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -43,8 +43,11 @@ macro_rules! swap_src_dst {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Protocol {
+    /// Contains either the source or destination port.
     Tcp(u16),
+    /// Contains either the source or destination port.
     Udp(u16),
+    /// Contains the `identifier` of the ICMP packet.
     Icmp(u16),
 }
 

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -160,13 +160,19 @@ pub(crate) fn icmp_packet(
     }
 }
 
-pub fn tcp_packet(
-    saddr: IpAddr,
-    daddr: IpAddr,
+pub fn tcp_packet<IP>(
+    saddr: IP,
+    daddr: IP,
     sport: u16,
     dport: u16,
     payload: Vec<u8>,
-) -> MutableIpPacket<'static> {
+) -> MutableIpPacket<'static>
+where
+    IP: Into<IpAddr>,
+{
+    let saddr = saddr.into();
+    let daddr = daddr.into();
+
     match (saddr, daddr) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
             use crate::ip::IpNextHeaderProtocols;
@@ -196,13 +202,19 @@ pub fn tcp_packet(
     }
 }
 
-pub fn udp_packet(
-    saddr: IpAddr,
-    daddr: IpAddr,
+pub fn udp_packet<IP>(
+    saddr: IP,
+    daddr: IP,
     sport: u16,
     dport: u16,
     payload: Vec<u8>,
-) -> MutableIpPacket<'static> {
+) -> MutableIpPacket<'static>
+where
+    IP: Into<IpAddr>,
+{
+    let saddr = saddr.into();
+    let daddr = daddr.into();
+
     match (saddr, daddr) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
             use crate::ip::IpNextHeaderProtocols;

--- a/rust/ip-packet/src/proptest.rs
+++ b/rust/ip-packet/src/proptest.rs
@@ -1,0 +1,48 @@
+use crate::MutableIpPacket;
+use proptest::{arbitrary::any, prop_oneof, strategy::Strategy};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+pub fn udp_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
+    prop_oneof![
+        (ip4_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
+            crate::make::udp_packet(saddr, daddr, sport, dport, Vec::new())
+        }),
+        (ip6_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
+            crate::make::udp_packet(saddr, daddr, sport, dport, Vec::new())
+        }),
+    ]
+}
+
+pub fn tcp_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
+    prop_oneof![
+        (ip4_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
+            crate::make::tcp_packet(saddr, daddr, sport, dport, Vec::new())
+        }),
+        (ip6_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
+            crate::make::tcp_packet(saddr, daddr, sport, dport, Vec::new())
+        }),
+    ]
+}
+
+pub fn icmp_request_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
+    prop_oneof![
+        (ip4_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
+            crate::make::icmp_request_packet(IpAddr::V4(saddr), daddr, sport, dport)
+        }),
+        (ip6_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
+            crate::make::icmp_request_packet(IpAddr::V6(saddr), daddr, sport, dport)
+        }),
+    ]
+}
+
+pub fn udp_or_tcp_or_icmp_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
+    prop_oneof![udp_packet(), tcp_packet(), icmp_request_packet()]
+}
+
+fn ip4_tuple() -> impl Strategy<Value = (Ipv4Addr, Ipv4Addr)> {
+    (any::<Ipv4Addr>(), any::<Ipv4Addr>())
+}
+
+fn ip6_tuple() -> impl Strategy<Value = (Ipv6Addr, Ipv6Addr)> {
+    (any::<Ipv6Addr>(), any::<Ipv6Addr>())
+}

--- a/rust/ip-packet/src/proptests.rs
+++ b/rust/ip-packet/src/proptests.rs
@@ -16,9 +16,7 @@ fn tcp_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
         any::<u16>(),
         any::<Vec<u8>>(),
     )
-        .prop_map(|(src, dst, sport, dport, payload)| {
-            tcp_packet(src.into(), dst.into(), sport, dport, payload)
-        })
+        .prop_map(|(src, dst, sport, dport, payload)| tcp_packet(src, dst, sport, dport, payload))
 }
 
 fn tcp_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
@@ -29,9 +27,7 @@ fn tcp_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
         any::<u16>(),
         any::<Vec<u8>>(),
     )
-        .prop_map(|(src, dst, sport, dport, payload)| {
-            tcp_packet(src.into(), dst.into(), sport, dport, payload)
-        })
+        .prop_map(|(src, dst, sport, dport, payload)| tcp_packet(src, dst, sport, dport, payload))
 }
 
 fn udp_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
@@ -42,9 +38,7 @@ fn udp_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
         any::<u16>(),
         any::<Vec<u8>>(),
     )
-        .prop_map(|(src, dst, sport, dport, payload)| {
-            udp_packet(src.into(), dst.into(), sport, dport, payload)
-        })
+        .prop_map(|(src, dst, sport, dport, payload)| udp_packet(src, dst, sport, dport, payload))
 }
 
 fn udp_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
@@ -55,9 +49,7 @@ fn udp_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
         any::<u16>(),
         any::<Vec<u8>>(),
     )
-        .prop_map(|(src, dst, sport, dport, payload)| {
-            udp_packet(src.into(), dst.into(), sport, dport, payload)
-        })
+        .prop_map(|(src, dst, sport, dport, payload)| udp_packet(src, dst, sport, dport, payload))
 }
 
 fn icmp_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {


### PR DESCRIPTION
As part of #4994, the IP translation and mangling of packets to and from DNS resources is moved to the gateway. This PR represents the "gateway-half" of the required changes.

Eventually, the client will send a list of proxy IPs that it assigned for a certain DNS resource. The gateway assigns each proxy IP to a real IP and mangles outgoing and incoming traffic accordingly. There are a number of things that we need to take care of as part of that:

- We need to implement NAT to correctly route traffic. Our NAT table maps from source port* and destination IP to an assigned port* and real IP. We say port* because that is only true for UDP and TCP. For ICMP, we use the identifier.
- We need to translate between IPv4 and IPv6 in case a DNS resource e.g. only resolves to IPv6 addresses but the client gave out an IPv4 proxy address to the application. This translation is was added in #5364 and is now being used here.

This PR is backwards-compatible because currently, clients don't send any IPs to the gateway. No proxy IPs means we cannot do any translation and thus, packets are simply routed through as is which is what the current clients expect.