### PR TITLE
refactor(gui-client): remove unused debug commands

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1941,7 +1941,6 @@ dependencies = [
  "futures",
  "git-version",
  "hex",
- "hostname 0.4.0",
  "keyring",
  "minidumper",
  "native-dialog",

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -24,8 +24,6 @@ firezone-headless-client = { path = "../../headless-client" }
 futures = { version = "0.3", default-features = false }
 git-version = "0.3.9"
 hex = "0.4.3"
-# Same crate Hickory uses
-hostname = "0.4.0"
 keyring = "2.3.3"
 minidumper = "0.8.2"
 native-dialog = "0.7.0"

--- a/rust/gui-client/src-tauri/src/client/debug_commands.rs
+++ b/rust/gui-client/src-tauri/src/client/debug_commands.rs
@@ -1,52 +1,11 @@
 //! CLI subcommands used to test features / dependencies before integrating
 //! them with the GUI, or to exercise features programmatically.
 
-use crate::client;
 use anyhow::Result;
 
 #[derive(clap::Subcommand)]
-pub enum Cmd {
-    CheckForUpdates,
-    Crash,
-    DnsChanges,
-    Hostname,
-    NetworkChanges,
-}
+pub enum Cmd {}
 
 pub fn run(cmd: Cmd) -> Result<()> {
-    match cmd {
-        Cmd::CheckForUpdates => check_for_updates()?,
-        Cmd::Crash => crash()?,
-        Cmd::DnsChanges => client::network_changes::run_dns_debug()?,
-        Cmd::Hostname => hostname(),
-        Cmd::NetworkChanges => client::network_changes::run_debug()?,
-    };
-
-    Ok(())
-}
-
-fn check_for_updates() -> Result<()> {
-    firezone_headless_client::debug_command_setup()?;
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let version = rt.block_on(client::updates::check())?;
-    tracing::info!("{:?}", version);
-
-    Ok(())
-}
-
-fn crash() -> Result<()> {
-    // `_` doesn't seem to work here, the log files end up empty
-    let _handles = client::logging::setup("debug")?;
-    tracing::info!("started log (DebugCrash)");
-
-    panic!("purposely panicking to see if it shows up in logs");
-}
-
-#[allow(clippy::print_stdout)]
-fn hostname() {
-    println!(
-        "{:?}",
-        hostname::get().ok().and_then(|x| x.into_string().ok())
-    );
+    match cmd {}
 }

--- a/rust/gui-client/src-tauri/src/client/debug_commands.rs
+++ b/rust/gui-client/src-tauri/src/client/debug_commands.rs
@@ -25,6 +25,6 @@ pub fn run(cmd: Cmd) -> Result<()> {
 fn set_autostart(enabled: bool) -> Result<()> {
     firezone_headless_client::debug_command_setup()?;
     let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(client::gui::set_autostart(enabled))?;
+    rt.block_on(crate::client::gui::set_autostart(enabled))?;
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/client/network_changes.rs
+++ b/rust/gui-client/src-tauri/src/client/network_changes.rs
@@ -13,4 +13,4 @@ mod imp;
 #[allow(clippy::unnecessary_wraps)]
 mod imp;
 
-pub(crate) use imp::{check_internet, run_debug, run_dns_debug, DnsListener, Worker};
+pub(crate) use imp::{check_internet, DnsListener, Worker};

--- a/rust/gui-client/src-tauri/src/client/network_changes/linux.rs
+++ b/rust/gui-client/src-tauri/src/client/network_changes/linux.rs
@@ -5,16 +5,6 @@ use firezone_headless_client::dns_control::system_resolvers_for_gui;
 use std::net::IpAddr;
 use tokio::time::Interval;
 
-pub(crate) fn run_dns_debug() -> Result<()> {
-    tracing::warn!("network_changes not implemented yet on Linux");
-    Ok(())
-}
-
-pub(crate) fn run_debug() -> Result<()> {
-    tracing::warn!("network_changes not implemented yet on Linux");
-    Ok(())
-}
-
 /// TODO: Implement for Linux
 pub(crate) fn check_internet() -> Result<bool> {
     Ok(true)

--- a/rust/gui-client/src-tauri/src/client/network_changes/macos.rs
+++ b/rust/gui-client/src-tauri/src/client/network_changes/macos.rs
@@ -5,14 +5,6 @@ use anyhow::Result;
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {}
 
-pub(crate) fn run_debug() -> Result<()> {
-    unimplemented!()
-}
-
-pub(crate) fn run_dns_debug() -> Result<()> {
-    unimplemented!()
-}
-
 pub(crate) fn check_internet() -> Result<bool> {
     tracing::error!("This is not the real macOS client, so `network_changes` is not implemented");
     Ok(true)


### PR DESCRIPTION
It turns out they were all unused, but I like having a place to keep them for new features.