### PR TITLE
fix(portal): Don't send null address_description

### DIFF
--- a/elixir/apps/api/lib/api/client/views/resource.ex
+++ b/elixir/apps/api/lib/api/client/views/resource.ex
@@ -15,7 +15,10 @@ defmodule API.Client.Views.Resource do
       id: resource.id,
       type: :cidr,
       address: address,
-      address_description: resource.address_description,
+      # FIXME: This is a workaround due to clients expecting address_description not
+      # to be null. Remove this to send null address_description on or after 8/13/24
+      # once we can reasonably expect clients to have upgraded.
+      address_description: resource.address_description || address,
       name: resource.name,
       gateway_groups: Views.GatewayGroup.render_many(resource.gateway_groups),
       filters: Enum.flat_map(resource.filters, &render_filter/1)

--- a/elixir/apps/api/lib/api/client/views/resource.ex
+++ b/elixir/apps/api/lib/api/client/views/resource.ex
@@ -30,7 +30,10 @@ defmodule API.Client.Views.Resource do
       id: resource.id,
       type: resource.type,
       address: resource.address,
-      address_description: resource.address_description,
+      # TODO: This is a workaround due to clients expecting address_description not
+      # to be null. Remove this to send null address_description on or after 8/13/24
+      # once we can reasonably expect clients to have upgraded.
+      address_description: resource.address_description || resource.address,
       name: resource.name,
       gateway_groups: Views.GatewayGroup.render_many(resource.gateway_groups),
       filters: Enum.flat_map(resource.filters, &render_filter/1)

--- a/elixir/apps/api/lib/api/client/views/resource.ex
+++ b/elixir/apps/api/lib/api/client/views/resource.ex
@@ -15,7 +15,7 @@ defmodule API.Client.Views.Resource do
       id: resource.id,
       type: :cidr,
       address: address,
-      # FIXME: This is a workaround due to clients expecting address_description not
+      # TODO: This is a workaround due to clients expecting address_description not
       # to be null. Remove this to send null address_description on or after 8/13/24
       # once we can reasonably expect clients to have upgraded.
       address_description: resource.address_description || address,

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -688,6 +688,18 @@ IO.puts("")
     admin_subject
   )
 
+{:ok, address_description_null_resource} =
+  Resources.create_resource(
+    %{
+      type: :dns,
+      name: "Google",
+      address: "*.google.com",
+      connections: [%{gateway_group_id: gateway_group.id}],
+      filters: []
+    },
+    admin_subject
+  )
+
 {:ok, dns_gitlab_resource} =
   Resources.create_resource(
     %{
@@ -754,6 +766,7 @@ IO.puts("")
 
 IO.puts("Created resources:")
 IO.puts("  #{dns_google_resource.address} - DNS - gateways: #{gateway_name}")
+IO.puts("  #{address_description_null_resource.address} - DNS - gateways: #{gateway_name}")
 IO.puts("  #{dns_gitlab_resource.address} - DNS - gateways: #{gateway_name}")
 IO.puts("  #{firez_one.address} - DNS - gateways: #{gateway_name}")
 IO.puts("  #{firezone_dev.address} - DNS - gateways: #{gateway_name}")
@@ -809,6 +822,16 @@ IO.puts("")
       name: "All Access To ip6only.me",
       actor_group_id: synced_group.id,
       resource_id: ip6only.id
+    },
+    admin_subject
+  )
+
+{:ok, _} =
+  Policies.create_policy(
+    %{
+      name: "All access to Google",
+      actor_group_id: everyone_group.id,
+      resource_id: address_description_null_resource.id
     },
     admin_subject
   )


### PR DESCRIPTION
In #5273, I assumed that connlib optionally expected `address_description`, but this is not the case. That feature assumes the admin will optionally enter `address_description` to **override** the address shown in Clients. The Clients already expect an optional type for `address_description` and implement the correct behavior.

This PR is a workaround to prevent breaking existing Clients until we can be relatively sure most clients have upgraded, in ~2 months.