### PR TITLE
chore: enable tracing of function timing for debug subcommands

### DIFF
--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -25,7 +25,10 @@ use std::{
 use tokio::sync::mpsc;
 use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 use tracing::subscriber::set_global_default;
-use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Layer as _, Registry};
+use tracing_subscriber::{
+    fmt::{format::FmtSpan, SubscriberBuilder},
+    EnvFilter,
+};
 use url::Url;
 
 use platform::default_token_path;
@@ -578,8 +581,10 @@ pub fn debug_command_setup() -> Result<()> {
     let filter = EnvFilter::builder()
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
         .from_env_lossy();
-    let layer = fmt::layer().with_filter(filter);
-    let subscriber = Registry::default().with(layer);
+    let subscriber = SubscriberBuilder::default()
+        .with_span_events(FmtSpan::CLOSE)
+        .with_env_filter(filter)
+        .finish();
     set_global_default(subscriber)?;
     Ok(())
 }


### PR DESCRIPTION
e.g. `#[tracing::instrument]` will now print the time a function spent busy and idle without having to add a timer crate or manually capture `Instant`s

Split off from #5357 

Doesn't affect any production code