### PR TITLE
fix(connlib): sending unallowed packets after reconnection

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -911,6 +911,7 @@ impl ClientState {
         self.peers.remove(gateway_id);
         self.dns_resources_internal_ips
             .retain(|_, (candidate, _)| candidate != gateway_id);
+        self.resources_gateways.retain(|_, g| g != gateway_id);
     }
 
     fn routes(&self) -> impl Iterator<Item = IpNetwork> + '_ {


### PR DESCRIPTION
## The problem

To find the correct peer for a given resource we keep a map of `resource_id -> gateway_id` in the client state called `resources_gateways`.

For CIDR resource connlib when sees a packet it does the following steps:
1. Find the packet's corresponding resource
2. Find the resource corresponding gateway
3. Find the peer corresponding to the gateway, if none, request access/connection

The problem was that when roaming, we didn't cleanup the map between `resource_id -> gateway_id` so if after disconnecting with a gateway we created a new connection due to a another resource, in step 3, connlib would find a connected gateway and not request access.

This would cause the client to send unallowed packets to the gateway.

## Steps to reproduce

1. Open the client
2. Ping a CIDR resource on a gateway
3. roam and wait until disconnection
4. Ping a different resource on the same gateway
5. Ping the same CIDR resource as in step 2

This will result in no reply for step 5

## The fix

Cleanup the `resource -> gateway` map after disconnecting with a gateway. 