### PR TITLE
fix(website): Use custom middleware for versioned redirects

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -6,7 +6,6 @@ module.exports = [
    * Windows GUI Client
    *
    */
-  // latest
   {
     source: "/dl/firezone-client-gui-windows/latest/x86_64",
     destination:
@@ -14,19 +13,11 @@ module.exports = [
       "https://www.github.com/firezone/firezone/releases/download/gui-client-1.0.7/firezone-client-gui-windows_1.0.7_x86_64.msi",
     permanent: false,
   },
-  // versioned
-  {
-    source: "/dl/firezone-client-gui-windows/:version/x86_64",
-    destination:
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-:version/firezone-client-gui-windows_:version_x86_64.msi",
-    permanent: false,
-  },
   /*
    *
    * Linux Clients
    *
    */
-  // latest
   {
     source: "/dl/firezone-client-gui-linux/latest/x86_64",
     destination:
@@ -62,43 +53,11 @@ module.exports = [
       "https://www.github.com/firezone/firezone/releases/download/headless-client-1.0.7/firezone-client-headless-linux_1.0.7_armv7",
     permanent: false,
   },
-  // versioned
-  {
-    source: "/dl/firezone-client-gui-linux/:version/x86_64",
-    destination:
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-:version/firezone-client-gui-linux_:version_x86_64.deb",
-    permanent: false,
-  },
-  {
-    source: "/dl/firezone-client-gui-linux/:version/aarch64",
-    destination:
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-:version/firezone-client-gui-linux_:version_aarch64.deb",
-    permanent: false,
-  },
-  {
-    source: "/dl/firezone-client-headless-linux/:version/x86_64",
-    destination:
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-:version/firezone-client-headless-linux_:version_x86_64",
-    permanent: false,
-  },
-  {
-    source: "/dl/firezone-client-headless-linux/:version/aarch64",
-    destination:
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-:version/firezone-client-headless-linux_:version_aarch64",
-    permanent: false,
-  },
-  {
-    source: "/dl/firezone-client-headless-linux/:version/armv7",
-    destination:
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-:version/firezone-client-headless-linux_:version_armv7",
-    permanent: false,
-  },
   /*
    *
    * Gateway
    *
    */
-  // latest
   {
     source: "/dl/firezone-gateway/latest/x86_64",
     destination:
@@ -118,25 +77,6 @@ module.exports = [
     destination:
       // mark:current-gateway-version
       "https://www.github.com/firezone/firezone/releases/download/gateway-1.0.7/firezone-gateway_1.0.7_armv7",
-    permanent: false,
-  },
-  // versioned
-  {
-    source: "/dl/firezone-gateway/:version/x86_64",
-    destination:
-      "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_x86_64",
-    permanent: false,
-  },
-  {
-    source: "/dl/firezone-gateway/:version/aarch64",
-    destination:
-      "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_aarch64",
-    permanent: false,
-  },
-  {
-    source: "/dl/firezone-gateway/:version/armv7",
-    destination:
-      "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_armv7",
     permanent: false,
   },
 ];

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -1,0 +1,67 @@
+import { NextResponse, NextRequest } from "next/server";
+
+// This middleware is needed because NextJS doesn't populate params in the destination
+// more than once. See https://github.com/vercel/next.js/issues/66891
+const versionedRedirects = [
+  {
+    source: /^\/dl\/firezone-client-gui-windows\/(\d+\.\d+\.\d+)\/x86_64$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-:version/firezone-client-gui-windows_:version_x86_64.msi",
+  },
+  {
+    source: /^\/dl\/firezone-client-gui-linux\/(\d+\.\d+\.\d+)\/x86_64$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-:version/firezone-client-gui-linux_:version_x86_64.deb",
+  },
+  {
+    source: /^\/dl\/firezone-client-gui-linux\/(\d+\.\d+\.\d+)\/aarch64$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-:version/firezone-client-gui-linux_:version_aarch64.deb",
+  },
+  {
+    source: /^\/dl\/firezone-client-headless-linux\/(\d+\.\d+\.\d+)\/x86_64$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-:version/firezone-client-headless-linux_:version_x86_64",
+  },
+  {
+    source: /^\/dl\/firezone-client-headless-linux\/(\d+\.\d+\.\d+)\/aarch64$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-:version/firezone-client-headless-linux_:version_aarch64",
+  },
+  {
+    source: /^\/dl\/firezone-client-headless-linux\/(\d+\.\d+\.\d+)\/armv7$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-:version/firezone-client-headless-linux_:version_armv7",
+  },
+  {
+    source: /^\/dl\/firezone-gateway\/(\d+\.\d+\.\d+)\/x86_64$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_x86_64",
+  },
+  {
+    source: /^\/dl\/firezone-gateway\/(\d+\.\d+\.\d+)\/aarch64$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_aarch64",
+  },
+  {
+    source: /^\/dl\/firezone-gateway\/(\d+\.\d+\.\d+)\/armv7$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/gateway-:version/firezone-gateway_:version_armv7",
+  },
+];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  for (const redirect of versionedRedirects) {
+    const match = pathname.match(redirect.source);
+
+    if (match) {
+      const version = match[1];
+      const destination = redirect.destination.replace(/:version/g, version);
+      return NextResponse.redirect(destination);
+    }
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION
Because of https://github.com/vercel/next.js/issues/66891, we need custom middleware to populate the version in multiple places of the `destination` URL for redirect artifact permalinks.