### PR TITLE
refactor(connlib): don't re-initialise `Tun` on config updates

### DIFF
--- a/rust/connlib/shared/src/tun_device_manager/linux.rs
+++ b/rust/connlib/shared/src/tun_device_manager/linux.rs
@@ -76,6 +76,8 @@ impl TunDeviceManager {
             .await
             .context("Failed to delete existing addresses")?;
 
+        self.routes.clear(); // Deleting the IPs clears all routes.
+
         handle
             .link()
             .set(index)

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -85,7 +85,7 @@ impl Device {
         callbacks: &impl Callbacks,
     ) -> Result<(), ConnlibError> {
         // On Android / Linux we recreate the tunnel every time we re-configure it
-        self.tun = Some(Tun::new(config, dns_config.clone(), callbacks)?);
+        self.tun = Some(Tun::new()?);
 
         callbacks.on_set_interface_config(config.ipv4, config.ipv6, dns_config);
 

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -77,27 +77,12 @@ impl Device {
         Ok(())
     }
 
-    #[cfg(target_os = "linux")]
-    pub(crate) fn set_config(
-        &mut self,
-        config: &Interface,
-        dns_config: Vec<IpAddr>,
-        callbacks: &impl Callbacks,
-    ) -> Result<(), ConnlibError> {
-        if self.tun.is_none() {
-            self.tun = Some(Tun::new()?);
-
-            if let Some(waker) = self.waker.take() {
-                waker.wake();
-            }
-        }
-
-        callbacks.on_set_interface_config(config.ipv4, config.ipv6, dns_config);
-
-        Ok(())
-    }
-
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "windows"))]
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "windows",
+        target_os = "linux"
+    ))]
     pub(crate) fn set_config(
         &mut self,
         config: &Interface,

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -417,8 +417,6 @@ impl Callbacks for CallbackHandler {
             .try_send(InternalServerMsg::OnSetInterfaceConfig { ipv4, ipv6, dns })
             .expect("Should be able to send TunnelReady");
 
-        tracing::info!("Message sent!");
-
         None
     }
 

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -416,6 +416,9 @@ impl Callbacks for CallbackHandler {
         self.cb_tx
             .try_send(InternalServerMsg::OnSetInterfaceConfig { ipv4, ipv6, dns })
             .expect("Should be able to send TunnelReady");
+
+        tracing::info!("Message sent!");
+
         None
     }
 


### PR DESCRIPTION
Currently, connlib re-initialises the TUN device on Linux every time its configuration gets updated such as when roaming from one network to another. This is unnecessary. Instead, we can adopt the same approach as already used on MacOS, iOS and Windows and only initialise it if it doesn't exist yet.

Doing so surfaces an interesting bug. Currently, attempting to re-initialise the TUN device fails with a warning:

> connlib_client_shared::eventloop: Failed to set interface on tunnel: Resource busy (os error 16)

See https://github.com/firezone/firezone/actions/runs/9656570163/job/26634409346#step:7:103 for an example. As a consequence, we never actually trigger the `on_set_interface_config` callback and thus never actually set the new IPs on the TUN device.

Now that we _are_ calling this callback, we execute `TunDeviceManager::set_ips` which first clears all IPs from the device and then attaches the new ones. A consequence of this is that the Linux kernel will clear all routes associated with the device. This clashes with an optimisation we have in `TunDeviceManager` where we remember the previously set routes and don't set new ones if they are the same.

This `HashSet` needs to be cleared upon setting new IPs in order to actually set the new routes correctly afterwards. Without that, we stop receiving traffic on the TUN device.