### PR TITLE
fix(portal): Fix all website links in product

### DIFF
--- a/elixir/apps/web/lib/web/components/navigation_components.ex
+++ b/elixir/apps/web/lib/web/components/navigation_components.ex
@@ -330,15 +330,15 @@ defmodule Web.NavigationComponents do
     <.website_link href="/kb/deploy/gateways" class="text-neutral-900">Deploy Gateway(s)</.website_link>
     <.website_link href={~p"/contact/sales"}>Contact Sales</.website_link>
   """
-  attr :href, :string, required: true
-  attr :anchor, :string, required: false, default: ""
+  attr :path, :string, required: true
+  attr :fragment, :string, required: false, default: ""
   slot :inner_block, required: true
   attr :rest, :global
 
   def website_link(assigns) do
     ~H"""
     <.link
-      navigate={"https://www.firezone.dev#{@href}?utm_source=product##{@anchor}"}
+      navigate={"https://www.firezone.dev#{@path}?utm_source=product##{@fragment}"}
       class={link_style()}
       target="_blank"
       {@rest}

--- a/elixir/apps/web/lib/web/components/navigation_components.ex
+++ b/elixir/apps/web/lib/web/components/navigation_components.ex
@@ -331,13 +331,14 @@ defmodule Web.NavigationComponents do
     <.website_link href={~p"/contact/sales"}>Contact Sales</.website_link>
   """
   attr :href, :string, required: true
+  attr :anchor, :string, required: false, default: ""
   slot :inner_block, required: true
   attr :rest, :global
 
   def website_link(assigns) do
     ~H"""
     <.link
-      navigate={"https://www.firezone.dev?utm_source=product#{@href}"}
+      navigate={"https://www.firezone.dev#{@href}?utm_source=product##{@anchor}"}
       class={link_style()}
       target="_blank"
       {@rest}

--- a/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/new_token.ex
@@ -204,7 +204,7 @@ defmodule Web.RelayGroups.NewToken do
           <div id="connection-status" class="flex justify-between items-center">
             <p class="text-sm">
               Relay not connecting? See our
-              <.website_link href="/kb/administer/troubleshooting">
+              <.website_link path="/kb/administer/troubleshooting">
                 relay troubleshooting guide
               </.website_link>.
             </p>

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -40,7 +40,7 @@ defmodule Web.Settings.DNS do
         All other queries will use the resolver below if configured.
         If no resolver is configured, the client's default system resolver will be used.
         <p class="mt-3">
-          <.website_link href="/kb/deploy/dns">
+          <.website_link path="/kb/deploy/dns">
             Read more about configuring DNS in Firezone.
           </.website_link>
         </p>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -86,7 +86,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
       <:help>
         Directory sync is enabled for this provider. Users, groups, and organizational units will
         be synced every 10 minutes on average, but could take longer for very large organizations.
-        <.website_link href="/kb/authenticate/directory-sync">
+        <.website_link path="/kb/authenticate/directory-sync">
           Read more
         </.website_link>
         about directory sync.

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
@@ -61,7 +61,7 @@ defmodule Web.Settings.IdentityProviders.Index do
         </.add_button>
       </:action>
       <:help>
-        <.website_link href="/kb/authenticate">
+        <.website_link path="/kb/authenticate">
           Read more
         </.website_link>
         about how authentication works in Firezone.

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
@@ -87,7 +87,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
       <:help>
         Directory sync is enabled for this provider. Users and groups will be synced every 10
         minutes on average, but could take longer for very large organizations.
-        <.website_link href="/kb/authenticate/directory-sync">
+        <.website_link path="/kb/authenticate/directory-sync">
           Read more
         </.website_link>
         about directory sync.

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -86,7 +86,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
       <:help>
         Directory sync is enabled for this provider. Users and groups will be synced every 10
         minutes on average, but could take longer for very large organizations.
-        <.website_link href="/kb/authenticate/directory-sync">
+        <.website_link path="/kb/authenticate/directory-sync">
           Read more
         </.website_link>
         about directory sync.

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/new.ex
@@ -39,9 +39,9 @@ defmodule Web.Settings.IdentityProviders.New do
       <:help>
         Set up SSO authentication using your own identity provider. Directory sync
         also available for certain providers. <br /> Learn more about
-        <.website_link href="/kb/authenticate/oidc">SSO authentication</.website_link>
+        <.website_link path="/kb/authenticate/oidc">SSO authentication</.website_link>
         and
-        <.website_link href="/kb/authenticate/directory-sync">directory sync</.website_link>
+        <.website_link path="/kb/authenticate/directory-sync">directory sync</.website_link>
         in our docs.
       </:help>
       <:content>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -84,7 +84,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
       <:help>
         Directory sync is enabled for this provider. Users and groups will be synced every 10
         minutes on average, but could take longer for very large organizations.
-        <.website_link href="/kb/authenticate/directory-sync">
+        <.website_link path="/kb/authenticate/directory-sync">
           Read more
         </.website_link>
         about directory sync.

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -109,7 +109,7 @@ defmodule Web.SignIn do
         <div :if={Web.Auth.fetch_auth_context_type!(@params) == :browser} class="mx-auto p-6 sm:p-8">
           <p class="py-2">
             Meant to sign in from a client instead?
-            <.website_link href="/kb/user-guides">Read the docs.</.website_link>
+            <.website_link path="/kb/user-guides">Read the docs.</.website_link>
           </p>
           <p class="py-2">
             Looking for a different account?

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -57,7 +57,7 @@ defmodule Web.Sites.NewToken do
         Gateways require egress connectivity to the control plane API and relay servers.
         <strong>No ingress firewall rules</strong>
         are required or recommended. See our
-        <.website_link href="/kb/deploy/gateways#firewall-ports">
+        <.website_link href="/kb/deploy/gateways" anchor="firewall-ports">
           deploy guide
         </.website_link>
         for more information.
@@ -161,7 +161,7 @@ defmodule Web.Sites.NewToken do
           <div id="connection-status" class="flex justify-between items-center">
             <p class="text-sm">
               Gateway not connecting? See our
-              <.website_link href="/kb/administer/troubleshooting#gateway-not-connecting">
+              <.website_link href="/kb/administer/troubleshooting" anchor="gateway-not-connecting">
                 gateway troubleshooting guide
               </.website_link>.
             </p>

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -57,14 +57,14 @@ defmodule Web.Sites.NewToken do
         Gateways require egress connectivity to the control plane API and relay servers.
         <strong>No ingress firewall rules</strong>
         are required or recommended. See our
-        <.website_link href="/kb/deploy/gateways" anchor="firewall-ports">
+        <.website_link path="/kb/deploy/gateways" fragment="firewall-ports">
           deploy guide
         </.website_link>
         for more information.
       </:help>
       <:help>
         Read the
-        <.website_link href="/kb/deploy/gateways">
+        <.website_link path="/kb/deploy/gateways">
           gateway deployment guide
         </.website_link>
         for more detailed instructions.
@@ -161,7 +161,7 @@ defmodule Web.Sites.NewToken do
           <div id="connection-status" class="flex justify-between items-center">
             <p class="text-sm">
               Gateway not connecting? See our
-              <.website_link href="/kb/administer/troubleshooting" anchor="gateway-not-connecting">
+              <.website_link path="/kb/administer/troubleshooting" fragment="gateway-not-connecting">
                 gateway troubleshooting guide
               </.website_link>.
             </p>


### PR DESCRIPTION
Adds a dedicated `anchor` attr to the `website_link` component because the order of components in a URL must be `/path?params#anchor`.