### PR TITLE
chore(headless-client/windows): fix `cargo test -p firezone-headless-client` on Windows

### DIFF
--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -67,6 +67,7 @@ features = [
     # For named pipe IPC
     "Win32_Security",
     "Win32_System_SystemServices",
+    "Win32_System_Pipes",
 ]
 
 [lints]


### PR DESCRIPTION
This is a funny one. `cargo test -p firezone-headless-client -p firezone-gui-client` actually passes, because the GUI client uses the pipes feature, and Cargo apparently just does one build for both packages. But if you build the headless Client by itself, it fails to build.

I think this caused `cargo-mutants` to consider all its headless Client mutants to be unviable, and so it didn't show coverage for that package.