### PR TITLE
chore: Revert hardcoding gateway artifact URL

### DIFF
--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -11,9 +11,7 @@ RUST_LOG=${RUST_LOG:-str0m=warn,info}
 
 # Can be used to download a specific version of the gateway from a custom URL
 FIREZONE_VERSION=${FIREZONE_VERSION:-latest}
-# TODO: Remove this workaround after 1.0.8 gateway is released. See https://github.com/firezone/firezone/issues/5370
-# FIREZONE_ARTIFACT_URL=${FIREZONE_ARTIFACT_URL:-https://www.firezone.dev/dl/firezone-gateway}
-FIREZONE_ARTIFACT_URL=https://www.firezone.dev/dl/firezone-gateway
+FIREZONE_ARTIFACT_URL=${FIREZONE_ARTIFACT_URL:-https://www.firezone.dev/dl/firezone-gateway}
 
 # Optional environment variables to configure logging and tracing
 FIREZONE_OTLP_GRPC_ENDPOINT=${OTLP_GRPC_ENDPOINT:-}


### PR DESCRIPTION
This was needed to work around an issue with installing systemd Gateways from our Terraform examples. Now that the publish workflow is fixed this is no longer necessary.