### PR TITLE
docs(user-guides): update Android Client guide and fix iOS Client guide

### DIFF
--- a/website/src/app/kb/user-guides/android-client/page.tsx
+++ b/website/src/app/kb/user-guides/android-client/page.tsx
@@ -4,7 +4,7 @@ import LastUpdated from "@/components/LastUpdated";
 
 export const metadata: Metadata = {
   title: "Android & ChromeOS Client • Firezone Docs",
-  description: "Firezone Documentation",
+  description: "How to install and use the Firezone Android & ChromeOS Client.",
 };
 
 export default function Page() {

--- a/website/src/app/kb/user-guides/android-client/readme.mdx
+++ b/website/src/app/kb/user-guides/android-client/readme.mdx
@@ -41,21 +41,8 @@ To copy-paste the address of a Resource:
 1. Tap on the address, e.g. `example.com`. Firezone will copy the address to the
    clipboard.
 1. Open your web browser, such as Google Chrome.
-1. Tap `Link your copied` at the top, or the paste button above the keyboard.
-1. Navigate to the link.
+1. Paste the link you copied from Firezone and tap the enter or arrow icon on your keyboard to navigate to the link.
 
-### Quitting
-
-1. Open the device's `Settings` app.
-1. Tap `Network & internet`.
-1. Tap `VPN`.
-1. Tap `Firezone`. Android will show a dialog asking `Disconnect this VPN?`.
-1. Tap `Disconnect`.
-
-When Firezone is disconnected, you can't access private Resources, and the
-device will use its normal DNS and Internet behavior.
-
-If you were signed in, then you will still be signed while disconnected.
 
 ### Signing out
 
@@ -106,6 +93,6 @@ We will add troubleshooting steps here in the future.
   [#3620](https://github.com/firezone/firezone/issues/3620)
 - Some apps do not use Firezone's SplitDNS and so cannot access DNS Resources.
   [#4834](https://github.com/firezone/firezone/issues/4834)
-- Reconnecting does not work
+- Disconnecting the VPN from the System Settings does not work
 
 <SupportOptions />

--- a/website/src/app/kb/user-guides/android-client/readme.mdx
+++ b/website/src/app/kb/user-guides/android-client/readme.mdx
@@ -14,8 +14,43 @@ Google Play Store.
 
 ## Installation
 
-[Download the Firezone app](https://play.google.com/store/apps/details?id=dev.firezone.android)
-from the Google Play Store.
+1. [Download the Firezone app](https://play.google.com/store/apps/details?id=dev.firezone.android)
+   from the Google Play Store.
+1. Run the app. The welcome screen will show "Enable VPN Permission" and the
+   Firezone logo.
+1. Tap `Request Permission`. Android will show a dialog saying,
+   `Connection request`.
+1. Tap `OK`. Firezone will switch to the `Signed Out` screen.
+
+## Usage
+
+### Signing in
+
+1. Tap `Sign In`. Firezone will open a sign-in page in your web browser.
+1. Select your account and sign in. Firezone will show your username and
+   Resources.
+
+### Accessing a Resource
+
+When Firezone is signed in, web browsers and other programs will automatically
+use it to securely connect to Resources.
+
+To copy-paste the address of a Resource:
+
+1. Tap on the Resource.
+1. Tap on the address, e.g. `example.com`. Firezone will copy the address to the
+   clipboard.
+1. Open your web browser, such as Google Chrome.
+1. Tap `Link your copied` at the top, or the paste button above the keyboard.
+1. Navigate to the link.
+
+### Quitting
+
+TODO
+
+### Signing out
+
+TODO
 
 ## Upgrading
 
@@ -23,5 +58,21 @@ Updates for the Android client are handled through the Google Play Store.
 Consult the
 [Play Store documentation](https://support.google.com/googleplay/answer/113412?hl=en)
 for more information on how to update apps on your device.
+
+## Diagnostic logs
+
+TODO
+
+## Uninstalling
+
+TODO
+
+## Troubleshooting
+
+TODO
+
+## Known issues
+
+TODO
 
 <SupportOptions />

--- a/website/src/app/kb/user-guides/android-client/readme.mdx
+++ b/website/src/app/kb/user-guides/android-client/readme.mdx
@@ -41,8 +41,8 @@ To copy-paste the address of a Resource:
 1. Tap on the address, e.g. `example.com`. Firezone will copy the address to the
    clipboard.
 1. Open your web browser, such as Google Chrome.
-1. Paste the link you copied from Firezone and tap the enter or arrow icon on your keyboard to navigate to the link.
-
+1. Paste the link you copied from Firezone.
+1. Tap the enter or arrow icon on your keyboard to navigate to the link.
 
 ### Signing out
 
@@ -94,5 +94,6 @@ We will add troubleshooting steps here in the future.
 - Some apps do not use Firezone's SplitDNS and so cannot access DNS Resources.
   [#4834](https://github.com/firezone/firezone/issues/4834)
 - Disconnecting the VPN from the System Settings does not work
+  [#5413](https://github.com/firezone/firezone/issues/5413)
 
 <SupportOptions />

--- a/website/src/app/kb/user-guides/android-client/readme.mdx
+++ b/website/src/app/kb/user-guides/android-client/readme.mdx
@@ -46,11 +46,28 @@ To copy-paste the address of a Resource:
 
 ### Quitting
 
-TODO
+1. Open the device's `Settings` app.
+1. Tap `Network & internet`.
+1. Tap `VPN`.
+1. Tap `Firezone`. Android will show a dialog asking `Disconnect this VPN?`.
+1. Tap `Disconnect`.
+
+When Firezone is disconnected, you can't access private Resources, and the
+device will use its normal DNS and Internet behavior.
+
+If you were signed in, then you will still be signed while disconnected.
+
+To reconnect,
+
+TODO - How to reconnect?
 
 ### Signing out
 
-TODO
+1. Open the Firezone app
+1. Tap `Sign Out` in the bottom-right corner.
+
+When you're signed out, you can't access private Resources, and the device will
+use its normal DNS and Internet behavior.
 
 ## Upgrading
 
@@ -61,18 +78,37 @@ for more information on how to update apps on your device.
 
 ## Diagnostic logs
 
-TODO
+Firezone writes log files to the device's memory. These logs stay on the device
+and are not transmitted anywhere. If you find a bug, you can send us a `.zip`
+archive of your logs to help us fix the bug.
+
+To export or clear your logs:
+
+1. Open the Firezone app.
+1. Tap `Settings` in the bottom-left corner.
+1. Tap `Logs` in the bottom-right corner.
+1. Tap `EXPORT LOGS` or `CLEAR LOG DIRECTORY`.
 
 ## Uninstalling
 
-TODO
+1. Go to the device's home screen.
+1. Swipe up to open the app drawer.
+1. Long-press the Firezone app icon. A menu will appear.
+1. Tap `App info` in the menu. This will show the app info screen for Firezone.
+1. Tap `Uninstall`. Android will show a dialog asking,
+   `Do you want to uninstall this app?`.
+1. Tap `OK`.
 
 ## Troubleshooting
 
-TODO
+We will add troubleshooting steps here in the future.
 
 ## Known issues
 
-TODO
+- ChromeOS devices using the Android 9 compatibility layer don't work with
+  Firezone. Android 11 and newer do work.
+  [#3620](https://github.com/firezone/firezone/issues/3620)
+- Some apps do not use Firezone's SplitDNS and so cannot access DNS Resources.
+  [#4834](https://github.com/firezone/firezone/issues/4834)
 
 <SupportOptions />

--- a/website/src/app/kb/user-guides/android-client/readme.mdx
+++ b/website/src/app/kb/user-guides/android-client/readme.mdx
@@ -57,10 +57,6 @@ device will use its normal DNS and Internet behavior.
 
 If you were signed in, then you will still be signed while disconnected.
 
-To reconnect,
-
-TODO - How to reconnect?
-
 ### Signing out
 
 1. Open the Firezone app
@@ -110,5 +106,6 @@ We will add troubleshooting steps here in the future.
   [#3620](https://github.com/firezone/firezone/issues/3620)
 - Some apps do not use Firezone's SplitDNS and so cannot access DNS Resources.
   [#4834](https://github.com/firezone/firezone/issues/4834)
+- Reconnecting does not work
 
 <SupportOptions />

--- a/website/src/app/kb/user-guides/ios-client/readme.mdx
+++ b/website/src/app/kb/user-guides/ios-client/readme.mdx
@@ -40,7 +40,9 @@ use it to securely connect to Resources.
 To copy-paste the address of a Resource:
 
 1. Tap on the Resource.
+1. Long-press `ADDRESS`.
 1. Tap `Copy Address`.
+1. Open your web browser.
 1. Long-press your browser's URL bar and tap `Paste and Go`
 
 ### Quitting

--- a/website/src/app/kb/user-guides/ios-client/readme.mdx
+++ b/website/src/app/kb/user-guides/ios-client/readme.mdx
@@ -41,16 +41,16 @@ To copy-paste the address of a Resource:
 
 1. Tap on the Resource.
 1. Long-press `ADDRESS`.
-1. Tap `Copy Address`.
+1. Tap `Copy Address`. Firezone will copy the address to the clipboard.
 1. Open your web browser.
 1. Long-press your browser's URL bar and tap `Paste and Go`
 
 ### Quitting
 
-1. Open the `Settings` app.
+1. Open the device's `Settings` app.
 1. Tap `VPN` to turn the VPN switch off.
 
-When Firezone is not running, you can't access private Resources, and the phone
+When Firezone is not running, you can't access private Resources, and the device
 will use its normal DNS and Internet behavior.
 
 If you were signed in, then you will still be signed in the next time you start
@@ -59,9 +59,10 @@ Firezone.
 ### Signing out
 
 1. Open the Firezone app.
-1. At the top, under `AUTHENTICATION`, tap `Sign Out`.
+1. Tap the icon of a person in the top-left corner.
+1. Tap `Sign out`.
 
-When you're signed out, you can't access private Resources, and the phone will
+When you're signed out, you can't access private Resources, and the device will
 use its normal DNS and Internet behavior.
 
 ## Upgrading
@@ -72,22 +73,22 @@ for more information on how to update apps on your device.
 
 ## Diagnostic logs
 
-Firezone writes log files to the phone's memory. These logs stay on the phone
+Firezone writes log files to the device's memory. These logs stay on the device
 and are not transmitted anywhere. If you find a bug, you can send us an `.aar`
 archive of your logs to help us fix the bug.
 
 To export or clear your logs:
 
 1. Open the Firezone app.
-1. In the upper-right corner, tap the gear icon.
-1. In the bottom-right corner, tap `Diagnostic Logs`.
+1. Tap the gear icon in the upper-right corner.
+1. Tap `Diagnostic Logs` in the bottom-right corner.
 1. Tap `Export Logs` or `Clear Log Directory`.
 
 ## Uninstalling
 
-1. On the phone's home screen, long-press the Firezone app icon.
+1. Long-press the Firezone app icon on the device's home screen.
 1. Tap `Remove App`.
-1. Tap `Delete App`. iOS will show a dialog saying,
+1. Tap `Delete App`. iOS will show a dialog asking,
    `Delete "Firezone"? Deleting this app will also delete its data`.
 1. Tap `Delete`.
 


### PR DESCRIPTION
Closes #4998 

```[tasklist]
### Before merging
- [x] (failed) Figure out how to reconnect Firezone in Android
- [ ] How should the instructions for ChromeOS go? I assume it's a little different from Android
- [ ] Grep for TODOs in all user guides
```