### PR TITLE
Revert "fix(infra): Don't override gateway install version from TF_VAR_image_tag; default to `latest`"

### DIFF
--- a/terraform/environments/production/gateways.tf
+++ b/terraform/environments/production/gateways.tf
@@ -24,6 +24,8 @@ module "gateways" {
   name    = "gateway"
   api_url = "wss://api.${local.tld}"
   token   = var.gateway_token
+
+  vsn = local.gateway_image_tag
 }
 
 # Allow gateways to access the Metabase

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -15,8 +15,9 @@ locals {
     "35.235.240.0/20"
   ]
 
-  relay_image_tag  = var.relay_image_tag != null ? var.relay_image_tag : var.image_tag
-  portal_image_tag = var.portal_image_tag != null ? var.portal_image_tag : var.image_tag
+  gateway_image_tag = var.gateway_image_tag != null ? var.gateway_image_tag : var.image_tag
+  relay_image_tag   = var.relay_image_tag != null ? var.relay_image_tag : var.image_tag
+  portal_image_tag  = var.portal_image_tag != null ? var.portal_image_tag : var.image_tag
 }
 
 terraform {

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -6,6 +6,10 @@ output "image_tag" {
   value = var.image_tag
 }
 
+output "gateway_image_tag" {
+  value = local.gateway_image_tag
+}
+
 output "relay_image_tag" {
   value = local.relay_image_tag
 }

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -88,6 +88,11 @@ variable "relay_image_tag" {
   default = null
 }
 
+variable "gateway_image_tag" {
+  type    = string
+  default = null
+}
+
 variable "portal_image_tag" {
   type    = string
   default = null


### PR DESCRIPTION
Reverts firezone/firezone#5414