### PR TITLE
fix(infra): Copy artifacts from `github.sha` to `edge` in prod when deploying

### DIFF
--- a/.github/workflows/_deploy_production.yml
+++ b/.github/workflows/_deploy_production.yml
@@ -58,6 +58,39 @@ jobs:
           docker buildx imagetools create \
             -t ${{ steps.login-production.outputs.registry }}/firezone/${{ matrix.image }}:${{ inputs.tag }} \
             $SOURCE_TAG
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions"
+          service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
+          export_environment_variables: true
+          create_credentials_file: true
+      - name: Copy Google Cloud Storage binaries to "edge" version
+        # TODO: Add relay here when we deploy Relay from prod artifacts instead of Docker
+        if: ${{ matrix.image == 'gateway' || matrix.image == 'client' }}
+        run: |
+          set -xe
+
+          ARCHITECTURES=(x86_64 aarch64 armv7)
+
+          for arch in "${ARCHITECTURES[@]}"; do
+            # Copy sha256sum.txt
+            gcloud storage cp \
+              gs://firezone-staging-artifacts/firezone-${{ matrix.image }}/${{ github.sha }}/${arch}.sha256sum.txt \
+              gs://firezone-prod-artifacts/firezone-${{ matrix.image }}/edge/${arch}.sha256sum.txt
+            gcloud storage cp \
+              gs://firezone-staging-artifacts/firezone-${{ matrix.image }}/${{ github.sha }}/${arch}.sha256sum.txt \
+              gs://firezone-prod-artifacts/firezone-${{ matrix.image }}/${{ github.sha }}/${arch}.sha256sum.txt
+
+            # Copy binaries
+            gcloud storage cp \
+              gs://firezone-staging-artifacts/firezone-${{ matrix.image }}/${{ github.sha }}/${arch} \
+              gs://firezone-prod-artifacts/firezone-${{ matrix.image }}/edge/${arch}
+            gcloud storage cp \
+              gs://firezone-staging-artifacts/firezone-${{ matrix.image }}/${{ github.sha }}/${arch} \
+              gs://firezone-prod-artifacts/firezone-${{ matrix.image }}/${{ github.sha }}/${arch}
+          done
 
   deploy-production:
     needs: push

--- a/.github/workflows/_deploy_production.yml
+++ b/.github/workflows/_deploy_production.yml
@@ -68,6 +68,9 @@ jobs:
           create_credentials_file: true
       - name: Copy Google Cloud Storage binaries to "edge" version
         # TODO: Add relay here when we deploy Relay from prod artifacts instead of Docker
+        # To do that properly we need to:
+        #   - Update publish.yml to publish versioned Relays too (and start versioning Relay changes)
+        #   - Add arm64 and armv7l architectures to the Relay builds (we only build for amd64 currently because that's all we need to)
         if: ${{ matrix.image == 'gateway' || matrix.image == 'client' }}
         run: |
           set -xe


### PR DESCRIPTION
This will allow us to run prod smoke tests using the `SHA` from `main` when deploying, without having to release/publish the Gateway first.


Fixes this issue seen in logs:

```
{
  "insertId": "tz43hng1m3lbbe",
  "jsonPayload": {
    "message": "Jun 17 22:36:57 gateway-cn9m firezone-gateway-init[3413]: curl: (22) The requested URL returned error: 404"
  },
  "resource": {
    "type": "gce_instance",
    "labels": {
      "project_id": "firezone-prod",
      "zone": "us-east1-d",
      "instance_id": "8536982484474988766"
    }
  },
  "timestamp": "2024-06-17T22:36:57.601613147Z",
  "labels": {
    "compute.googleapis.com/resource_name": "gateway-cn9m"
  },
  "logName": "projects/firezone-prod/logs/syslog",
  "receiveTimestamp": "2024-06-17T22:36:57.745513999Z"
},
{
  "insertId": "tz43hng1m3lbbd",
  "jsonPayload": {
    "message": "Jun 17 22:36:57 gateway-cn9m firezone-gateway-init[3411]: Downloading 6c310610f363268056e40baffca804b517267d90 version from https://storage.googleapis.com/firezone-prod-artifacts/firezone-gateway..."
  },
  "resource": {
    "type": "gce_instance",
    "labels": {
      "project_id": "firezone-prod",
      "zone": "us-east1-d",
      "instance_id": "8536982484474988766"
    }
  },
  "timestamp": "2024-06-17T22:36:57.501343894Z",
  "labels": {
    "compute.googleapis.com/resource_name": "gateway-cn9m"
  },
  "logName": "projects/firezone-prod/logs/syslog",
  "receiveTimestamp": "2024-06-17T22:36:57.745513999Z"
}
```