### PR TITLE
ci: Increase default assert_receive timeout to 500ms from 100ms

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Run Tests
         env:
           E2E_DEFAULT_WAIT_SECONDS: 20
+          CI_ASSERT_RECEIVE_TIMEOUT_MS: 500
         run: |
           mix test --warnings-as-errors \
             --exclude flaky:true \

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run Tests
         env:
           E2E_DEFAULT_WAIT_SECONDS: 20
-          CI_ASSERT_RECEIVE_TIMEOUT_MS: 500
+          CI_ASSERT_RECEIVE_TIMEOUT_MS: 250
         run: |
           mix test --warnings-as-errors \
             --exclude flaky:true \

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -73,10 +73,15 @@ config :wallaby,
   js_logger: false,
   hackney_options: [timeout: 10_000, recv_timeout: 10_000]
 
-config :ex_unit,
+ex_unit_config = [
   formatters: [JUnitFormatter, ExUnit.CLIFormatter],
   capture_log: true,
   exclude: [:acceptance]
+] ++ case System.get_env("CI_ASSERT_RECEIVE_TIMEOUT_MS") do
+  nil -> []
+  timeout -> [assert_receive_timeout: String.to_integer(timeout)]
+end
+config :ex_unit, ex_unit_config
 
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -73,14 +73,17 @@ config :wallaby,
   js_logger: false,
   hackney_options: [timeout: 10_000, recv_timeout: 10_000]
 
-ex_unit_config = [
-  formatters: [JUnitFormatter, ExUnit.CLIFormatter],
-  capture_log: true,
-  exclude: [:acceptance]
-] ++ case System.get_env("CI_ASSERT_RECEIVE_TIMEOUT_MS") do
-  nil -> []
-  timeout -> [assert_receive_timeout: String.to_integer(timeout)]
-end
+ex_unit_config =
+  [
+    formatters: [JUnitFormatter, ExUnit.CLIFormatter],
+    capture_log: true,
+    exclude: [:acceptance]
+  ] ++
+    case System.get_env("CI_ASSERT_RECEIVE_TIMEOUT_MS") do
+      nil -> []
+      timeout -> [assert_receive_timeout: String.to_integer(timeout)]
+    end
+
 config :ex_unit, ex_unit_config
 
 # Initialize plugs at runtime for faster development compilation


### PR DESCRIPTION
We seem to be hitting `assert_receive`-style much more frequently after "upgrading" to Enterprise Cloud (our credits expired, I was able to renew them).

This updates the global timeout to 500ms for `assert_receive` to reduce the likelihood `assert_push` and friends will time out on slow GH runners.

E.g.

https://github.com/firezone/firezone/actions/runs/9556532328/job/26341986456