### PR TITLE
feat(gateway): send errors during connection setup to client

### DIFF
--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -4,7 +4,7 @@ use std::{collections::HashSet, net::IpAddr};
 use thiserror::Error;
 
 /// Unified Result type to use across connlib.
-pub type Result<T> = std::result::Result<T, ConnlibError>;
+pub type Result<T, E = ConnlibError> = std::result::Result<T, E>;
 
 /// Unified error type to use across connlib.
 #[derive(Error, Debug)]
@@ -18,9 +18,6 @@ pub enum ConnlibError {
     /// Tried to access a resource which didn't exists.
     #[error("Tried to access an undefined resource")]
     UnknownResource,
-    /// One of the stored resources isn't a valid CIDR/DNS.
-    #[error("Invalid resource")]
-    InvalidResource,
     /// Error regarding our own control protocol.
     #[error("Control plane protocol error. Unexpected messages or message order.")]
     ControlProtocolError,

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -232,8 +232,28 @@ pub enum GatewayResponse {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, thiserror::Error)]
 pub enum ConnectionFailedError {
-    #[error("DNS resolution failed")]
-    DnsResolutionFailed,
+    #[error("Failed to resolve DNS records")]
+    Dns,
+    #[error("Failed to accept connection")]
+    Accept,
+}
+
+impl From<ConnectionFailedError> for GatewayResponse {
+    fn from(error: ConnectionFailedError) -> Self {
+        GatewayResponse::ConnectionFailed(ConnectionFailed { error })
+    }
+}
+
+impl From<ResourceAccepted> for GatewayResponse {
+    fn from(accepted: ResourceAccepted) -> Self {
+        GatewayResponse::ResourceAccepted(accepted)
+    }
+}
+
+impl From<ConnectionAccepted> for GatewayResponse {
+    fn from(accepted: ConnectionAccepted) -> Self {
+        GatewayResponse::ConnectionAccepted(accepted)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -219,9 +219,21 @@ pub struct ResourceAccepted {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ConnectionFailed {
+    pub error: ConnectionFailedError,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub enum GatewayResponse {
     ConnectionAccepted(ConnectionAccepted),
+    ConnectionFailed(ConnectionFailed),
     ResourceAccepted(ResourceAccepted),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, thiserror::Error)]
+pub enum ConnectionFailedError {
+    #[error("DNS resolution failed")]
+    DnsResolutionFailed,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -234,7 +234,7 @@ pub enum GatewayResponse {
 pub enum ConnectionFailedError {
     #[error("Failed to resolve DNS records")]
     Dns,
-    #[error("Failed to accept connection")]
+    #[error("Failed to allow access to resource")]
     AllowAccess,
 }
 

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -235,7 +235,7 @@ pub enum ConnectionFailedError {
     #[error("Failed to resolve DNS records")]
     Dns,
     #[error("Failed to accept connection")]
-    Accept,
+    AllowAccess,
 }
 
 impl From<ConnectionFailedError> for GatewayResponse {

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use bimap::BiMap;
 use chrono::{DateTime, Utc};
-use connlib_shared::messages::gateway::{ResolvedResourceDescriptionDns, ResourceDescription};
+use connlib_shared::messages::gateway::ResourceDescription;
 use connlib_shared::messages::{
     gateway::Filter, gateway::Filters, ClientId, GatewayId, ResourceId,
 };
@@ -219,7 +219,7 @@ impl ClientOnGateway {
         self.recalculate_filters();
     }
 
-    fn assign_translations(
+    pub(crate) fn assign_translations(
         &mut self,
         name: DomainName,
         resource_id: ResourceId,
@@ -256,24 +256,6 @@ impl ClientOnGateway {
                 },
             );
         }
-    }
-
-    pub(crate) fn assign_proxies(
-        &mut self,
-        resource: &ResourceDescription<ResolvedResourceDescriptionDns>,
-        domain_ips: Option<(DomainName, Vec<IpAddr>)>,
-        now: Instant,
-    ) -> connlib_shared::Result<()> {
-        match (resource, domain_ips) {
-            (ResourceDescription::Dns(r), Some((name, resource_ips))) => {
-                self.assign_translations(name, r.id, &r.addresses, resource_ips, now);
-            }
-            (ResourceDescription::Cidr(_), None) => {}
-            _ => {
-                return Err(connlib_shared::Error::InvalidResource);
-            }
-        }
-        Ok(())
     }
 
     pub(crate) fn is_emptied(&self) -> bool {

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -337,14 +337,6 @@ impl Eventloop {
             req.payload.as_ref().map(|r| r.as_tuple()),
         );
 
-        match result {
-            Ok(maybe_domain_response) => maybe_domain_response,
-            Err(e) => {
-                tracing::warn!(client = %req.client_id, "Failed to allow access: {e}");
-                return;
-            }
-        };
-
         match (result, req.payload) {
             (Ok(()), Some(ResolveRequest::ReturnResponse(domain))) => {
                 self.send_connection_reply(
@@ -357,10 +349,10 @@ impl Eventloop {
                     },
                 );
             }
-            (
-                Ok(_) | Err(_),
-                Some(ResolveRequest::ReturnResponse(_) | ResolveRequest::MapResponse { .. }) | None,
-            ) => {}
+            (Err(e), _) => {
+                tracing::warn!(client = %req.client_id, "Failed to allow access: {e}");
+            }
+            (Ok(_), Some(ResolveRequest::MapResponse { .. }) | None) => {}
         }
     }
 

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -139,6 +139,7 @@ pub struct ClientIceCandidates {
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 pub enum EgressMessages {
+    // FIXME: `GatewayResponse` also contains an error case so we should rename this at some point.
     ConnectionReady(ConnectionReady),
     BroadcastIceCandidates(ClientsIceCandidates),
     BroadcastInvalidatedIceCandidates(ClientsIceCandidates),


### PR DESCRIPTION
Currently, the gateway will only log errors during DNS resolution and / or accepting a connection without responding to the client. As a result, the client has rely on timeouts for these situations.

The portal already allows us to send opaque data as part of the `payload` field during the connection setup. Whilst the event `connection_ready` is a bit of a misnomer for errors, we can use this to send back an error response to the client in case DNS resolution or accepting a connection fails.

This should allow the client to react much quicker to problems on the gateway and at least clean-up its local state and trigger another connection intent. It also allows us to print a more specific warning into the clients logs.

Finally, the log levels for these problems is turned up to WARN on the gateway. Failure to accept a connection or resolve DNS is an issue that massively impacts firezone's functionality and is thus be something that an admin needs to be alerted about.

This is backwards compatible. Old clients will simply fail to deserialise error message.