### PR TITLE
refactor(gui-client): clean up a few things around IPC

### DIFF
--- a/rust/gui-client/src-tauri/src/client/debug_commands.rs
+++ b/rust/gui-client/src-tauri/src/client/debug_commands.rs
@@ -23,7 +23,7 @@ pub fn run(cmd: Cmd) -> Result<()> {
 }
 
 fn set_autostart(enabled: bool) -> Result<()> {
-    firezone_headless_client::debug_command_setup()?;
+    firezone_headless_client::setup_stdout_logging()?;
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(crate::client::gui::set_autostart(enabled))?;
     Ok(())

--- a/rust/gui-client/src-tauri/src/client/deep_link/linux.rs
+++ b/rust/gui-client/src-tauri/src/client/deep_link/linux.rs
@@ -81,7 +81,7 @@ impl Server {
 }
 
 pub(crate) async fn open(url: &url::Url) -> Result<()> {
-    firezone_headless_client::debug_command_setup()?;
+    firezone_headless_client::setup_stdout_logging()?;
 
     let path = sock_path()?;
     let mut stream = UnixStream::connect(&path).await?;

--- a/rust/gui-client/src-tauri/src/client/ipc/linux.rs
+++ b/rust/gui-client/src-tauri/src/client/ipc/linux.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context as _, Result};
-use firezone_headless_client::{ipc::ServiceId, platform::sock_path};
+use firezone_headless_client::ipc::{platform::sock_path, ServiceId};
 use tokio::net::UnixStream;
 
 /// A type alias to abstract over the Windows and Unix IPC primitives

--- a/rust/gui-client/src-tauri/src/client/ipc/linux.rs
+++ b/rust/gui-client/src-tauri/src/client/ipc/linux.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context as _, Result};
-use firezone_headless_client::platform::sock_path;
+use firezone_headless_client::{ipc::ServiceId, platform::sock_path};
 use tokio::net::UnixStream;
 
 /// A type alias to abstract over the Windows and Unix IPC primitives
@@ -7,7 +7,7 @@ pub(crate) type IpcStream = UnixStream;
 
 /// Connect to the IPC service
 pub(crate) async fn connect_to_service() -> Result<IpcStream> {
-    let path = sock_path();
+    let path = sock_path(ServiceId::Prod);
     let stream = UnixStream::connect(&path).await.with_context(|| {
         format!(
             "Couldn't connect to Unix domain socket at `{}`",

--- a/rust/gui-client/src-tauri/src/client/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/client/ipc/windows.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, Result};
+use firezone_headless_client::ipc;
 use std::os::windows::io::AsRawHandle;
 use tokio::net::windows::named_pipe;
 use windows::Win32::{Foundation::HANDLE, System::Pipes::GetNamedPipeServerProcessId};
@@ -11,7 +12,7 @@ pub(crate) type IpcStream = named_pipe::NamedPipeClient;
 /// This is async on Linux
 #[allow(clippy::unused_async)]
 pub(crate) async fn connect_to_service() -> Result<IpcStream> {
-    let path = firezone_headless_client::ipc::platform::pipe_path();
+    let path = ipc::platform::pipe_path(ipc::ServiceId::Prod);
     let stream = named_pipe::ClientOptions::new()
         .open(path)
         .with_context(|| "Couldn't connect to named pipe server at `{path}`")?;

--- a/rust/headless-client/src/ipc.rs
+++ b/rust/headless-client/src/ipc.rs
@@ -14,8 +14,14 @@ pub(crate) use platform::{Server, Stream};
 #[derive(Clone, Copy)]
 pub enum ServiceId {
     /// The IPC service used by Firezone GUI Client in production
+    ///
+    /// This must go in `/run/dev.firezone.client` on Linux, which requires
+    /// root permission
     Prod,
     /// An IPC service used for unit tests.
+    ///
+    /// This must go in `/run/user/$UID/dev.firezone.client` on Linux so
+    /// the unit tests won't need root.
     ///
     /// Includes an ID so that multiple tests can
     /// run in parallel

--- a/rust/headless-client/src/ipc.rs
+++ b/rust/headless-client/src/ipc.rs
@@ -1,5 +1,5 @@
-// Setting `path` directly helps `cargo-mutants` skip over uncompiled code
-// for other platforms, e.g. skip Linux code when building for Windows.
+// There is no special way to prevent `cargo-mutants` from throwing false
+// positives on code for other platforms.
 #[cfg(target_os = "linux")]
 #[path = "ipc/linux.rs"]
 pub mod platform;

--- a/rust/headless-client/src/ipc.rs
+++ b/rust/headless-client/src/ipc.rs
@@ -1,3 +1,5 @@
+// Setting `path` directly helps `cargo-mutants` skip over uncompiled code
+// for other platforms, e.g. skip Linux code when building for Windows.
 #[cfg(target_os = "linux")]
 #[path = "ipc/linux.rs"]
 pub mod platform;

--- a/rust/headless-client/src/ipc.rs
+++ b/rust/headless-client/src/ipc.rs
@@ -1,11 +1,21 @@
 #[cfg(target_os = "linux")]
-mod linux;
-#[cfg(target_os = "linux")]
-use linux as platform;
+#[path = "ipc/linux.rs"]
+mod platform;
 
 #[cfg(target_os = "windows")]
-pub mod windows;
-#[cfg(target_os = "windows")]
-pub use windows as platform;
+#[path = "ipc/windows.rs"]
+pub mod platform;
 
 pub(crate) use platform::{Server, Stream};
+
+/// A name that both the server and client can use to find each other
+#[derive(Clone, Copy)]
+pub enum ServiceId {
+    /// The IPC service used by Firezone GUI Client in production
+    Prod,
+    /// An IPC service used for unit tests.
+    ///
+    /// Includes an ID so that multiple tests can
+    /// run in parallel
+    Test(&'static str),
+}

--- a/rust/headless-client/src/ipc.rs
+++ b/rust/headless-client/src/ipc.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "linux")]
 #[path = "ipc/linux.rs"]
-mod platform;
+pub mod platform;
 
 #[cfg(target_os = "windows")]
 #[path = "ipc/windows.rs"]

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -698,7 +698,7 @@ fn get_log_filter() -> Result<String> {
     Ok(SERVICE_RUST_LOG.to_string())
 }
 
-/// Sets up logging for stderr only, with INFO level by default
+/// Sets up logging for stdout only, with INFO level by default
 pub fn setup_stdout_logging() -> Result<()> {
     let filter = EnvFilter::new(get_log_filter().context("Can't read log filter")?);
     let layer = fmt::layer().with_filter(filter);

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -46,7 +46,6 @@ pub mod heartbeat;
 pub mod ipc;
 pub mod known_dirs;
 
-// Setting `path` explicitly like this hides other platforms from `cargo-mutants`
 #[cfg(target_os = "linux")]
 #[path = "linux.rs"]
 pub mod platform;

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -46,18 +46,17 @@ pub mod heartbeat;
 pub mod ipc;
 pub mod known_dirs;
 
+// Setting `path` explicitly like this hides other platforms from `cargo-mutants`
 #[cfg(target_os = "linux")]
-pub mod linux;
-#[cfg(target_os = "linux")]
-pub use linux as platform;
+#[path = "linux.rs"]
+pub mod platform;
 
 #[cfg(target_os = "windows")]
-pub mod windows;
-#[cfg(target_os = "windows")]
-pub(crate) use windows as platform;
+#[path = "windows.rs"]
+pub mod platform;
 
 use dns_control::DnsController;
-use ipc::{Server as IpcServer, Stream as IpcStream};
+use ipc::{Server as IpcServer, ServiceId, Stream as IpcStream};
 
 /// Only used on Linux
 pub const FIREZONE_GROUP: &str = "firezone-client";
@@ -367,7 +366,7 @@ pub fn run_only_ipc_service() -> Result<()> {
 }
 
 pub(crate) fn run_debug_ipc_service() -> Result<()> {
-    debug_command_setup()?;
+    setup_stdout_logging()?;
     let rt = tokio::runtime::Runtime::new()?;
     let _guard = rt.enter();
     rt.spawn(crate::heartbeat::heartbeat());
@@ -446,7 +445,7 @@ async fn ipc_listen() -> Result<std::convert::Infallible> {
     // Create the device ID and IPC service config dir if needed
     // This also gives the GUI a safe place to put the log filter config
     device_id::get_or_create().context("Failed to read / create device ID")?;
-    let mut server = IpcServer::new().await?;
+    let mut server = IpcServer::new(ServiceId::Prod).await?;
     loop {
         dns_control::deactivate()?;
         let stream = server
@@ -700,7 +699,7 @@ fn get_log_filter() -> Result<String> {
 }
 
 /// Sets up logging for stderr only, with INFO level by default
-pub fn debug_command_setup() -> Result<()> {
+pub fn setup_stdout_logging() -> Result<()> {
     let filter = EnvFilter::new(get_log_filter().context("Can't read log filter")?);
     let layer = fmt::layer().with_filter(filter);
     let subscriber = Registry::default().with(layer);
@@ -774,7 +773,7 @@ mod tests {
     async fn ipc_server() -> anyhow::Result<()> {
         let _ = tracing_subscriber::fmt().with_test_writer().try_init();
 
-        let mut server = crate::IpcServer::new_for_test().await?;
+        let mut server = super::IpcServer::new(super::ServiceId::Test("H6L73DG5")).await?;
         for i in 0..5 {
             if let Ok(Err(err)) = timeout(Duration::from_secs(1), server.next_client()).await {
                 Err(err).with_context(|| {

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -1,7 +1,6 @@
 //! Implementation, Linux-specific
 
 use super::{CliCommon, SignalKind, FIREZONE_GROUP, TOKEN_ENV_KEY};
-use crate::ipc::ServiceId;
 use anyhow::{bail, Context as _, Result};
 use futures::future::{select, Either};
 use std::{
@@ -71,24 +70,6 @@ pub(crate) fn check_token_permissions(path: &Path) -> Result<()> {
         );
     }
     Ok(())
-}
-
-/// The path for our Unix Domain Socket
-///
-/// Docker keeps theirs in `/run` and also appears to use filesystem permissions
-/// for security, so we're following their lead. `/run` and `/var/run` are symlinked
-/// on some systems, `/run` should be the newer version.
-///
-/// Also systemd can create this dir with the `RuntimeDir=` directive which is nice.
-pub fn sock_path(id: ServiceId) -> PathBuf {
-    match id {
-        ServiceId::Prod => PathBuf::from("/run")
-            .join(connlib_shared::BUNDLE_ID)
-            .join("ipc.sock"),
-        ServiceId::Test(id) => crate::known_dirs::runtime()
-            .expect("`runtime_dir` should always be computable")
-            .join(format!("ipc_test_{id}.sock")),
-    }
 }
 
 /// Cross-platform entry point for systemd / Windows services

--- a/rust/headless-client/src/linux.rs
+++ b/rust/headless-client/src/linux.rs
@@ -1,7 +1,7 @@
 //! Implementation, Linux-specific
 
-use super::{CliCommon, SignalKind, FIREZONE_GROUP, TOKEN_ENV_KEY};
-use anyhow::{bail, Context as _, Result};
+use super::{CliCommon, SignalKind, TOKEN_ENV_KEY};
+use anyhow::{bail, Result};
 use futures::future::{select, Either};
 use std::{
     path::{Path, PathBuf},
@@ -86,13 +86,6 @@ pub(crate) fn run_ipc_service(cli: CliCommon) -> Result<()> {
         tracing::error!(?error, "`ipc_listen` failed");
     }
     Ok(())
-}
-
-pub fn firezone_group() -> Result<nix::unistd::Group> {
-    let group = nix::unistd::Group::from_name(FIREZONE_GROUP)
-        .context("can't get group by name")?
-        .with_context(|| format!("`{FIREZONE_GROUP}` group must exist on the system"))?;
-    Ok(group)
 }
 
 pub(crate) fn install_ipc_service() -> Result<()> {

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -21,6 +21,7 @@ use windows_service::{
     service_manager::{ServiceManager, ServiceManagerAccess},
 };
 
+#[path = "windows/wintun_install.rs"]
 mod wintun_install;
 
 const SERVICE_NAME: &str = "firezone_client_ipc";


### PR DESCRIPTION
Extracted from https://github.com/firezone/firezone/pull/5426
- Replace `new` and `new_for_test` for IPC servers with `enum ServiceId`
- Rename `debug_command_setup` to `setup_stdout_logging`

It turned out there is no clever way to hide other platforms from `cargo-mutants`, I thought I had such a way