### PR TITLE
fix(connlib): don't treat pending connections as errors

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2063,6 +2063,7 @@ dependencies = [
 name = "firezone-tunnel"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bimap",
  "boringtun",

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -303,22 +303,24 @@ where
                     relays,
                     site_id,
                 ) {
-                    Ok(firezone_tunnel::Request::NewConnection(connection_request)) => {
+                    Ok(Some(firezone_tunnel::Request::NewConnection(connection_request))) => {
                         // TODO: keep track for the response
                         let _id = self.portal.send(
                             PHOENIX_TOPIC,
                             EgressMessages::RequestConnection(connection_request),
                         );
                     }
-                    Ok(firezone_tunnel::Request::ReuseConnection(connection_request)) => {
+                    Ok(Some(firezone_tunnel::Request::ReuseConnection(connection_request))) => {
                         // TODO: keep track for the response
                         let _id = self.portal.send(
                             PHOENIX_TOPIC,
                             EgressMessages::ReuseConnection(connection_request),
                         );
                     }
+                    Ok(None) => {
+                        tracing::debug!(%resource_id, %gateway_id, "Pending connection");
+                    }
                     Err(e) => {
-                        self.tunnel.cleanup_connection(resource_id);
                         tracing::warn!("Failed to request new connection: {e}");
                     }
                 };

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -50,9 +50,6 @@ pub enum ConnlibError {
     /// A panic occurred with a non-string payload.
     #[error("Panicked with a non-string payload")]
     PanicNonStringPayload,
-    /// Received connection details that might be stale
-    #[error("Unexpected connection details")]
-    UnexpectedConnectionDetails,
     /// Invalid destination for packet
     #[error("Invalid dest address")]
     InvalidDst,
@@ -65,9 +62,6 @@ pub enum ConnlibError {
     /// Packet translation failed
     #[error("failed packet translation")]
     FailedTranslation,
-    /// Connection is still being established, retry later
-    #[error("Pending connection")]
-    PendingConnection,
     #[cfg(target_os = "windows")]
     #[error("Windows error: {0}")]
     WindowsError(#[from] windows::core::Error),

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -33,6 +33,7 @@ hex = "0.4.3"
 proptest = { version = "1.4.0", optional = true }
 ip-packet = { workspace = true }
 rangemap = "1.5.1"
+anyhow = "1.0"
 
 # Needed for Android logging until tracing is fixed
 log = "0.4"

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1,8 +1,9 @@
 use crate::peer_store::PeerStore;
 use crate::{dns, dns::DnsQuery};
+use anyhow::Context;
 use bimap::BiMap;
 use connlib_shared::callbacks::Status;
-use connlib_shared::error::{ConnlibError as Error, ConnlibError};
+use connlib_shared::error::ConnlibError as Error;
 use connlib_shared::messages::client::{Site, SiteId};
 use connlib_shared::messages::{
     client::ResourceDescription, client::ResourceDescriptionCidr, client::ResourceDescriptionDns,
@@ -210,7 +211,7 @@ where
         gateway_id: GatewayId,
         relays: Vec<Relay>,
         site_id: SiteId,
-    ) -> connlib_shared::Result<Request> {
+    ) -> anyhow::Result<Option<Request>> {
         self.role_state.create_or_reuse_connection(
             resource_id,
             gateway_id,
@@ -468,7 +469,7 @@ impl ClientState {
             // If we don't have a peer but we have an ip for a resource it's then not a DNS resource
             debug_assert!(self.cidr_resources.longest_match(dest).is_some());
 
-            self.on_connection_intent_to_resource(resource, None, now);
+            self.on_not_connected_resource(resource, None, now);
             return None;
         };
 
@@ -554,6 +555,8 @@ impl ClientState {
         domain_response: Option<DomainResponse>,
         now: Instant,
     ) -> connlib_shared::Result<()> {
+        debug_assert!(!self.awaiting_connection.contains_key(&resource_id));
+
         let gateway_id = self
             .gateway_by_resource(&resource_id)
             .ok_or(Error::UnknownResource)?;
@@ -566,9 +569,6 @@ impl ClientState {
             .ok_or(Error::ControlProtocolError)?;
 
         let ips = self.get_resource_ip(desc, &domain_response.as_ref().map(|d| d.domain.clone()));
-
-        // Tidy up state once everything succeeded.
-        self.awaiting_connection.remove(&resource_id);
 
         let resource_ids = HashSet::from([resource_id]);
         let peer = GatewayOnClient::new(gateway_id, &ips, resource_ids);
@@ -595,40 +595,44 @@ impl ClientState {
         site_id: SiteId,
         allowed_stun_servers: HashSet<SocketAddr>,
         allowed_turn_servers: HashSet<(RelayId, RelaySocket, String, String, String)>,
-    ) -> connlib_shared::Result<Request> {
+    ) -> anyhow::Result<Option<Request>> {
         tracing::trace!("create_or_reuse_connection");
-
-        self.gateways_site.insert(gateway_id, site_id);
 
         let desc = self
             .resource_ids
             .get(&resource_id)
-            .ok_or(Error::UnknownResource)?;
+            .context("Unknown resource")?;
 
-        let awaiting_connection = self.get_awaiting_connection(&resource_id)?.clone();
-        let domain = awaiting_connection.domain.clone();
+        if self.node.is_expecting_answer(gateway_id) {
+            return Ok(None);
+        }
 
-        self.resources_gateways.insert(resource_id, gateway_id);
+        let awaiting_connection = self
+            .awaiting_connection
+            .remove(&resource_id)
+            .context("No connection details found for resource")?;
+
+        if let Some(old_gateway_id) = self.resources_gateways.insert(resource_id, gateway_id) {
+            if self.peers.get(&old_gateway_id).is_some() {
+                assert_eq!(old_gateway_id, gateway_id, "Resources are not expected to change gateways without a previous message, resource_id = {resource_id}");
+            }
+        }
+
+        self.gateways_site.insert(gateway_id, site_id);
 
         if self.peers.get(&gateway_id).is_some() {
             self.peers.add_ips_with_resource(
                 &gateway_id,
-                &self.get_resource_ip(desc, &domain),
+                &self.get_resource_ip(desc, &awaiting_connection.domain),
                 &resource_id,
             );
 
-            self.awaiting_connection.remove(&resource_id);
-
-            return Ok(Request::ReuseConnection(ReuseConnection {
+            return Ok(Some(Request::ReuseConnection(ReuseConnection {
                 resource_id,
                 gateway_id,
-                payload: domain,
-            }));
+                payload: awaiting_connection.domain,
+            })));
         };
-
-        if self.node.is_expecting_answer(gateway_id) {
-            return Err(Error::PendingConnection);
-        }
 
         let offer = self.node.new_connection(
             gateway_id,
@@ -638,7 +642,7 @@ impl ClientState {
             Instant::now(),
         );
 
-        return Ok(Request::NewConnection(RequestConnection {
+        return Ok(Some(Request::NewConnection(RequestConnection {
             resource_id,
             gateway_id,
             client_preshared_key: Secret::new(Key(*offer.session_key.expose_secret())),
@@ -647,9 +651,9 @@ impl ClientState {
                     username: offer.credentials.username,
                     password: offer.credentials.password,
                 },
-                domain,
+                domain: awaiting_connection.domain,
             },
-        }));
+        })));
     }
 
     pub fn received_domain_parameters(
@@ -797,11 +801,7 @@ impl ClientState {
                 Ok(None)
             }
             Some(dns::ResolveStrategy::DeferredResponse((resource, r_type))) => {
-                self.on_connection_intent_to_resource(
-                    resource.id,
-                    Some(resource.address.clone()),
-                    now,
-                );
+                self.on_not_connected_resource(resource.id, Some(resource.address.clone()), now);
                 self.deferred_dns_queries
                     .insert((resource, r_type), packet.as_immutable().to_owned());
 
@@ -814,22 +814,13 @@ impl ClientState {
         }
     }
 
-    pub(crate) fn get_awaiting_connection(
-        &self,
-        resource: &ResourceId,
-    ) -> Result<&AwaitingConnectionDetails, ConnlibError> {
-        self.awaiting_connection
-            .get(resource)
-            .ok_or(Error::UnexpectedConnectionDetails)
-    }
-
     pub fn on_connection_failed(&mut self, resource: ResourceId) {
         self.awaiting_connection.remove(&resource);
         self.resources_gateways.remove(&resource);
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(%resource, ?domain))]
-    fn on_connection_intent_to_resource(
+    fn on_not_connected_resource(
         &mut self,
         resource: ResourceId,
         domain: Option<DomainName>,
@@ -842,6 +833,13 @@ impl ClientState {
             .values()
             .copied()
             .collect::<HashSet<_>>();
+
+        if self
+            .gateway_by_resource(&resource)
+            .is_some_and(|gateway_id| self.node.is_expecting_answer(gateway_id))
+        {
+            return;
+        }
 
         match self.awaiting_connection.entry(resource) {
             Entry::Occupied(mut occupied) => {

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -617,6 +617,7 @@ impl TunnelTest {
                             HashSet::default(),
                         )
                     })
+                    .unwrap()
                     .unwrap();
 
                 let resource_id = request.resource_id();


### PR DESCRIPTION
When a user sends the first packet to a resource, we generate a "connection intent" and consult the portal, which gateway to use for this resource. This process is throttled to only generate a new intent every 2s.

Once we know, which gateway to use for a certain resource, we initiate a connection via snownet. This involves an OFFER-ANSWER handshake with the gateway. A connection for which we have sent an offer and have not yet received an answer is what we call a "pending connection".

In case the connection setup takes longer than 2s, we will generate another connection intent which can point to the same gateway that we are currently setting up a connection with.

Currently, encountering a "pending connection" during another connection setup is treated as an error which results in some state being cleaned-up / removed. This is where the bug surfaces: If we remove the state for a resource as a result of a 2nd connection intent and then receive the response of the first one, we will be left with no state that knows about this resource.

We fix this by refactoring `create_or_reuse_connection` to be atomic in regards to its state changes: All checks that fail the function are moved to the top which means there is no state to clean up in case of an error. Additionally, we model the case of a "pending connection" using an `Option` to not flood the logs with "pending connection" warnings as those are expected during normal operation.

Fixes: #5385 