### PR TITLE
fix(connlib): don't return old IPs for DNS resource

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -744,6 +744,17 @@ impl ClientState {
             })
             .collect();
 
+        // First, remove all IPs for this particular resource.
+        {
+            for (_, resources) in self.dns_resources_internal_ips.values_mut() {
+                resources.remove(&resource_description);
+            }
+
+            self.dns_resources_internal_ips
+                .retain(|_, (_, resources)| !resources.is_empty());
+        }
+
+        // Second, add the new IPs.
         for addr in addrs.clone() {
             self.dns_resources_internal_ips
                 .entry(addr)


### PR DESCRIPTION
Whenever we resolve a domain name to real IPs, we assign one proxy IP per resolved IP. In case the DNS records for that domain actually changed, we only appended the new proxy IPs to the list we assigned to that domain.

If a domain no longer resolves to a certain IP, we should clear the assigned proxy IP and stop returning in DNS responses. To achieve this, we first remove all proxy IPs from our mapping of IP -> domain and then add all _current_ proxy IPs back to the map.