### PR TITLE
fix(connlib): mark ips as outdated instead of removing them from DNS internal mapping

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -153,6 +153,7 @@ impl GatewayOnClient {
 
         let proxy_ip = ip_provider.get_proxy_ip_for(ip)?;
 
+        tracing::debug!(%proxy_ip, real_ip = %ip, "Adding translation");
         self.translations.insert(proxy_ip, *ip);
         Some(proxy_ip)
     }


### PR DESCRIPTION
This is done so that the resource id can still be found with the dns internal mapping