### PR TITLE
revert(connlib): don't return old IPs for DNS resource (#5435)

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -748,17 +748,6 @@ impl ClientState {
             })
             .collect();
 
-        // First, remove all IPs for this particular resource.
-        {
-            for (_, resources) in self.dns_resources_internal_ips.values_mut() {
-                resources.remove(&resource_description);
-            }
-
-            self.dns_resources_internal_ips
-                .retain(|_, (_, resources)| !resources.is_empty());
-        }
-
-        // Second, add the new IPs.
         for addr in addrs.clone() {
             self.dns_resources_internal_ips
                 .entry(addr)


### PR DESCRIPTION
This turns out to break things because we can no longer associate a working but outdated IP with the DNS resource. Putting this up here in case we want to merge a fix before we decide on a different one.

Reverts: #5435.