### PR TITLE
feat(connlib): short-circuit access request to DNS resources

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -275,6 +275,7 @@ pub enum ClientEvent {
         resource: ResourceId,
         connected_gateway_ids: HashSet<GatewayId>,
     },
+    // FIXME: Refactor this to "request-access" or something similar.
     RefreshResources {
         connections: Vec<ReuseConnection>,
     },


### PR DESCRIPTION
Currently, we always emit a connection intent whenever we see a DNS query for a domain of one of our DNS resources. However, especially for wildcard DNS resources, we are very likely already connected to the corresponding gateway. In that case, sending a connection intent triggers another handshake with the portal only to learn that - surprise - we should reuse a connection that we already have to that gateway.

We can short-circuit this by checking if we are already connected to the gateway for this resource and directly requested access for the domain name in question. We reuse the same event here as we do for refreshing DNS resources. At a later stage, we should rename this to something else to make this clearer.

Co-authored-by: Gabi <gabrielalejandro7@gmail.com>