### PR TITLE
chore(connlib): tune logs around proxy IPs and DNS resources

### DIFF
--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -79,7 +79,7 @@ pub enum ConnlibError {
     #[error("Error while rewriting `/etc/resolv.conf`: {0}")]
     ResolvConf(anyhow::Error),
 
-    #[error("source: {src}; allowed_ips: {allowed_ips:?}")]
+    #[error("Unallowed packet! source: {src}; allowed_ips: {allowed_ips:?}")]
     UnallowedPacket {
         src: IpAddr,
         allowed_ips: HashSet<IpAddr>,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -244,7 +244,6 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(self, resource_id))]
     pub fn received_domain_parameters(
         &mut self,
         resource_id: ResourceId,
@@ -489,8 +488,6 @@ impl ClientState {
             .encapsulate(gateway_id, packet.as_immutable(), now)
             .inspect_err(|e| tracing::debug!("Failed to encapsulate: {e}"))
             .ok()??;
-
-        tracing::trace!("Encapsulated packet");
 
         Some(transmit)
     }
@@ -915,9 +912,7 @@ impl ClientState {
         self.dns_resources_internal_ips
             .retain(|proxy_ip, (candidate, resources)| {
                 if candidate == gateway_id {
-                    let domains = resources.iter().map(|r| &r.address).join(",");
-
-                    tracing::debug!(%proxy_ip, %domains, "Disassociating proxy IP");
+                    tracing::debug!(%proxy_ip, num_domains = %resources.len(), "Disassociating proxy IP");
 
                     return false;
                 }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -840,6 +840,8 @@ impl ClientState {
             .gateway_by_resource(&resource)
             .is_some_and(|gateway_id| self.node.is_expecting_answer(gateway_id))
         {
+            tracing::debug!("Already connecting to gateway");
+
             return;
         }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -734,7 +734,7 @@ impl ClientState {
             return Err(Error::ControlProtocolError);
         };
 
-        tracing::info!(domain = %domain_response.domain, addresses = ?domain_response.address, "Received DNS response");
+        tracing::debug!(domain = %domain_response.domain, addresses = ?domain_response.address, "Received DNS response");
 
         let resource_description =
             DnsResource::from_description(&resource_description, domain_response.domain.clone());

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -142,21 +142,21 @@ impl GatewayOnClient {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(gateway = %self.id, %real_ip))]
+    #[tracing::instrument(name = "translation", level = "debug", skip_all, fields(gateway = %self.id))]
     pub fn get_or_assign_translation(
         &mut self,
         real_ip: &IpAddr,
         ip_provider: &mut IpProvider,
     ) -> Option<IpAddr> {
         if let Some(proxy_ip) = self.translations.get_by_right(real_ip) {
-            tracing::debug!(%proxy_ip, "Re-use existing translation");
+            tracing::debug!("Existing translation: {real_ip} -> {proxy_ip}");
 
             return Some(*proxy_ip);
         }
 
         let proxy_ip = ip_provider.get_proxy_ip_for(real_ip)?;
 
-        tracing::debug!(%proxy_ip, "Create new translation");
+        tracing::debug!("New translation: {real_ip} -> {proxy_ip}");
 
         self.translations.insert(proxy_ip, *real_ip);
         Some(proxy_ip)


### PR DESCRIPTION
Adds and tunes some logs around creating, using and disassociated proxy IPs for DNS resources.