### PR TITLE
docs(gui-client/windows): add new known issue

### DIFF
--- a/website/src/app/kb/user-guides/windows-client/readme.mdx
+++ b/website/src/app/kb/user-guides/windows-client/readme.mdx
@@ -192,5 +192,7 @@ Get-DnsClientNrptRule | where Comment -eq firezone-fd0020211111 | foreach { Remo
 - After clearing diagnostic logs, no more logs are written until the GUI and
   tunnel service each restart.
   [#4764](https://github.com/firezone/firezone/issues/4764)
+- When restarting the GUI, the GUI may fail to connect to the IPC service and
+  crash [#5441](https://github.com/firezone/firezone/issues/5441)
 
 <SupportOptions />


### PR DESCRIPTION
It's actually bailing out, not crashing, but I think "crash" is more understandable to users.