### PR TITLE
fix(gui-client): use `format!` and `with_context` in error messages where needed

### DIFF
--- a/rust/gui-client/src-tauri/src/client/deep_link/windows.rs
+++ b/rust/gui-client/src-tauri/src/client/deep_link/windows.rs
@@ -68,13 +68,14 @@ impl Server {
 
 /// Open a deep link by sending it to the already-running instance of the app
 pub async fn open(url: &url::Url) -> Result<()> {
+    let path = pipe_path();
     let mut client = named_pipe::ClientOptions::new()
-        .open(pipe_path())
-        .context("Couldn't connect to named pipe server")?;
+        .open(&path)
+        .with_context(|| format!("Couldn't connect to named pipe server at `{path}`"))?;
     client
         .write_all(url.as_str().as_bytes())
         .await
-        .context("Couldn't write bytes to named pipe server")?;
+        .with_context(|| format!("Couldn't write bytes to named pipe server at `{path}`"))?;
     Ok(())
 }
 

--- a/rust/gui-client/src-tauri/src/client/ipc/windows.rs
+++ b/rust/gui-client/src-tauri/src/client/ipc/windows.rs
@@ -14,8 +14,8 @@ pub(crate) type IpcStream = named_pipe::NamedPipeClient;
 pub(crate) async fn connect_to_service() -> Result<IpcStream> {
     let path = ipc::platform::pipe_path(ipc::ServiceId::Prod);
     let stream = named_pipe::ClientOptions::new()
-        .open(path)
-        .with_context(|| "Couldn't connect to named pipe server at `{path}`")?;
+        .open(&path)
+        .with_context(|| format!("Couldn't connect to named pipe server at `{path}`"))?;
     let handle = HANDLE(stream.as_raw_handle() as isize);
     let mut server_pid: u32 = 0;
     // SAFETY: Windows doesn't store this pointer or handle, and we just got the handle


### PR DESCRIPTION
Found during #5441 