### PR TITLE
fix(gateway): skip translation if we don't have any proxy IPs

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -266,6 +266,11 @@ impl ClientOnGateway {
     ) -> connlib_shared::Result<()> {
         match (resource, domain_ips) {
             (ResourceDescription::Dns(r), Some((name, resource_ips))) => {
+                if resource_ips.is_empty() {
+                    tracing::debug!("Client hasn't sent us any proxy IPs, skipping IP translation");
+                    return Ok(());
+                }
+
                 self.assign_translations(name, r.id, &r.addresses, resource_ips, now);
             }
             (ResourceDescription::Cidr(_), None) => {}


### PR DESCRIPTION
Without this, a < 1.1.0 client connecting to a > 1.1.0 gateway (i.e. current main) causes lots of very strange logs that say:

> Assigned translation proxy_ip=X.X.X.X real_ip=X.X.X.X

Where X.X.X.X are the same IP.