### PR TITLE
feat(gateway): resolve DNS in the background

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1917,7 +1917,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snownet",
- "static_assertions",
  "tokio",
  "tokio-tungstenite",
  "tracing",

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -50,9 +50,8 @@ pub enum ConnlibError {
     /// A panic occurred with a non-string payload.
     #[error("Panicked with a non-string payload")]
     PanicNonStringPayload,
-    /// Invalid destination for packet
-    #[error("Invalid dest address")]
-    InvalidDst,
+    #[error("Filter engine disallowed packet to {0}")]
+    Filtered(IpAddr),
     /// Exhausted nat table
     #[error("exhausted nat")]
     ExhaustedNat,

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -392,6 +392,8 @@ impl ClientOnGateway {
         };
 
         let Some(resolved_ip) = state.resolved_ip else {
+            tracing::debug!(proxy_ip = %packet.destination(), "Proxy IP has not yet been resolved");
+
             state.slated_for_refresh = true; // We are trying to access a resource via a proxy IP that hasn't been resolved yet: Refresh DNS.
 
             return Ok(packet);

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
-use connlib_shared::messages::gateway::{ResolvedResourceDescriptionDns, ResourceDescription};
+use connlib_shared::messages::gateway::ResourceDescription;
 use connlib_shared::messages::{
     gateway::Filter, gateway::Filters, ClientId, GatewayId, ResourceId,
 };
@@ -196,7 +196,7 @@ impl ClientOnGateway {
         self.recalculate_filters();
     }
 
-    fn assign_translations(
+    pub(crate) fn assign_translations(
         &mut self,
         name: DomainName,
         resource_id: ResourceId,
@@ -233,29 +233,6 @@ impl ClientOnGateway {
                 },
             );
         }
-    }
-
-    pub(crate) fn assign_proxies(
-        &mut self,
-        resource: &ResourceDescription<ResolvedResourceDescriptionDns>,
-        domain_ips: Option<(DomainName, Vec<IpAddr>)>,
-        now: Instant,
-    ) -> connlib_shared::Result<()> {
-        match (resource, domain_ips) {
-            (ResourceDescription::Dns(r), Some((name, resource_ips))) => {
-                if resource_ips.is_empty() {
-                    tracing::debug!("Client hasn't sent us any proxy IPs, skipping IP translation");
-                    return Ok(());
-                }
-
-                self.assign_translations(name, r.id, &r.addresses, resource_ips, now);
-            }
-            (ResourceDescription::Cidr(_), None) => {}
-            _ => {
-                return Err(connlib_shared::Error::InvalidResource);
-            }
-        }
-        Ok(())
     }
 
     pub(crate) fn is_emptied(&self) -> bool {

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -273,6 +273,7 @@ impl ClientOnGateway {
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
         let conn_id = self.id;
 
+        // FIXME: This is O(n^2) with n being the number of proxy IPs (8 per resolved domain).
         let events = self
             .permanent_translations
             .iter()

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -214,7 +214,7 @@ impl ClientOnGateway {
                         resource_id,
                         name: name.clone(),
                         last_response: now,
-                        slated_for_refresh: false,
+                        slated_for_refresh: true,
                     },
                 );
             }

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -479,8 +479,7 @@ impl ClientOnGateway {
             .longest_match(dst)
             .is_some_and(|(_, filter)| filter.is_allowed(&packet.to_immutable()))
         {
-            tracing::warn!(%dst, "unallowed packet");
-            return Err(connlib_shared::Error::InvalidDst);
+            return Err(connlib_shared::Error::Filtered(dst));
         };
 
         Ok(())
@@ -636,7 +635,7 @@ mod tests {
 
         assert!(matches!(
             peer.ensure_allowed_dst(&tcp_packet),
-            Err(connlib_shared::Error::InvalidDst)
+            Err(connlib_shared::Error::Filtered(..))
         ));
         assert!(peer.ensure_allowed_dst(&udp_packet).is_ok());
 
@@ -644,11 +643,11 @@ mod tests {
 
         assert!(matches!(
             peer.ensure_allowed_dst(&tcp_packet),
-            Err(connlib_shared::Error::InvalidDst)
+            Err(connlib_shared::Error::Filtered(..))
         ));
         assert!(matches!(
             peer.ensure_allowed_dst(&udp_packet),
-            Err(connlib_shared::Error::InvalidDst)
+            Err(connlib_shared::Error::Filtered(..))
         ));
     }
 
@@ -910,7 +909,7 @@ mod proptests {
 
         assert!(matches!(
             peer.ensure_allowed_dst(&packet),
-            Err(connlib_shared::Error::InvalidDst)
+            Err(connlib_shared::Error::Filtered(..))
         ));
     }
 
@@ -972,7 +971,7 @@ mod proptests {
         assert!(peer.ensure_allowed_dst(&packet_allowed).is_ok());
         assert!(matches!(
             peer.ensure_allowed_dst(&packet_rejected),
-            Err(connlib_shared::Error::InvalidDst)
+            Err(connlib_shared::Error::Filtered(..))
         ));
     }
 

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -33,7 +33,6 @@ dns-lookup = { workspace = true }
 libc = { version = "0.2", default-features = false, features = ["std", "const-extern-fn", "extra_traits"] }
 either = "1"
 http-health-check = { workspace = true }
-static_assertions = "1.1.0"
 snownet = { workspace = true }
 
 [dev-dependencies]

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -53,7 +53,7 @@ impl Eventloop {
         Self {
             tunnel,
             portal,
-            resolve_tasks: futures_bounded::FuturesTupleSet::new(DNS_RESOLUTION_TIMEOUT, 100),
+            resolve_tasks: futures_bounded::FuturesTupleSet::new(DNS_RESOLUTION_TIMEOUT, 1000),
         }
     }
 }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -25,12 +25,6 @@ pub const PHOENIX_TOPIC: &str = "gateway";
 /// How long we allow a DNS resolution via `libc::get_addr_info`.
 const DNS_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(10);
 
-// DNS resolution happens as part of every connection setup.
-// For a connection to succeed, DNS resolution must be less than `snownet`'s handshake timeout.
-static_assertions::const_assert!(
-    DNS_RESOLUTION_TIMEOUT.as_secs() < snownet::HANDSHAKE_TIMEOUT.as_secs()
-);
-
 #[derive(Debug, Clone)]
 enum ResolveTrigger {
     RequestConnection(RequestConnection),

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -178,7 +178,20 @@ impl Eventloop {
                     };
                 }
                 // Client wants to access a CIDR resource, accept the connection instantly.
-                None => self.accept_connection(&req, None),
+                None => {
+                    self.accept_connection(&req, None);
+
+                    let _result = self.tunnel.allow_access(
+                        req.resource.into_resolved(vec![]),
+                        req.client.id,
+                        req.expires_at,
+                        None,
+                    );
+                    debug_assert!(
+                        _result.is_ok(),
+                        "Allow access can only fail for non-existent peer and we just added accepted the connection"
+                    );
+                }
                 // Clients requires a `domain_response`, resolve DNS first and then accept the connection. FIXME: This is legacy code for backwards compatibility and should be removed.
                 Some(ResolveRequest::ReturnResponse(name)) => {
                     if self

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -311,7 +311,7 @@ impl Eventloop {
             .inspect_err(|e| tracing::debug!(client = %req.client_id, reference = %req.reference, "DNS resolution timed out as part of allow access request: {e}"))
             .unwrap_or_default();
 
-        if let (Ok(()), Some(resolve_request)) = (
+        if let (Ok(()), Some(ResolveRequest::ReturnResponse(domain))) = (
             self.tunnel.allow_access(
                 req.resource.into_resolved(addresses.clone()),
                 req.client_id,
@@ -326,7 +326,7 @@ impl Eventloop {
                     reference: req.reference,
                     gateway_payload: GatewayResponse::ResourceAccepted(ResourceAccepted {
                         domain_response: connlib_shared::messages::DomainResponse {
-                            domain: resolve_request.name(),
+                            domain,
                             address: addresses,
                         },
                     }),


### PR DESCRIPTION
When receiving a connection request for a DNS resource, the gateway will first resolve the domain name and only then respond with the ICE credentials needed by the client to establish the connection. This was necessary because prior to #4994, the response sent to the client included the resolved IPs for the domain name.

With #4994, the gateway only needs to resolve the domain name in order to correctly map the client's proxy IPs upon incoming traffic. As a result, we can remove the DNS resolution from the hot-path of connection setup and always directly accept a client's connection request.

Currently, if the DNS resolution fails, we never respond to the client, thus forcing it into a timeout to try and establish a new connection. Now, we always accept the connection and perform the DNS resolution in the background. If that fails, we return an empty list of IPs. This would result in the gateway not performing any translation.

The gateway already has functionality to refresh a DNS mapping if we have seen outgoing traffic for a proxy IP but no incoming traffic. We can extend this to also refresh DNS if there isn't even a mapping for the given proxy IP. This way, a failed DNS resolution as part of an allow or connection request is self-healing as soon as the client starts using the proxy IP.