### PR TITLE
chore: Next Gateway version 1.1.0

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -163,9 +163,9 @@ jobs:
             artifact: firezone-gateway
             image_name: gateway
             # mark:next-gateway-version
-            version: 1.0.9
+            version: 1.1.0
             # mark:next-gateway-version
-            release_name: gateway-1.0.9
+            release_name: gateway-1.1.0
           - package: snownet-tests
             artifact: snownet-tests
             image_name: snownet-tests
@@ -350,7 +350,7 @@ jobs:
           - name: relay
           - name: gateway
             # mark:next-gateway-version
-            version: 1.0.9
+            version: 1.1.0
           - name: client
             # mark:next-client-version
             version: 1.0.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         include:
           # mark:next-gateway-version
-          - release_name: gateway-1.0.9
+          - release_name: gateway-1.1.0
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
           - release_name: headless-client-1.0.9

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
           if [[ "${{ github.event.release.name }}" =~ gateway* ]]; then
             ARTIFACT=gateway
             # mark:next-gateway-version
-            VERSION="1.0.9"
+            VERSION="1.1.0"
           elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
             ARTIFACT=client
             # mark:next-headless-version

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gateway"
-version = "1.0.9"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gateway"
 # mark:next-gateway-version
-version = "1.0.9"
+version = "1.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -22,7 +22,7 @@ current-headless-version = 1.0.8
 # Tracks the next version to release for each platform
 next-apple-version = 1.0.6
 next-android-version = 1.0.5
-next-gateway-version = 1.0.9
+next-gateway-version = 1.1.0
 next-gui-version = 1.0.10
 next-headless-version = 1.0.9
 


### PR DESCRIPTION
This will draft the 1.1.0 release and version artifacts correctly.