### PR TITLE
test(gui-client): fix zip file export in smoke tests

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -170,8 +170,7 @@ pub(crate) fn run(
                     let ctlr_tx = ctlr_tx.clone();
                     tokio::spawn(async move {
                         if let Err(error) = smoke_test(ctlr_tx).await {
-                            tracing::error!(?error, "Error during smoke test");
-                            tracing::error!("Crashing on purpose so a dev can see our stacktraces");
+                            tracing::error!(?error, "Error during smoke test, crashing on purpose so a dev can see our stacktraces");
                             unsafe { sadness_generator::raise_segfault() }
                         }
                     });

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -323,12 +323,7 @@ async fn smoke_test(ctlr_tx: CtlrTx) -> Result<()> {
         .await
         .context("Failed to get zip file metadata")?
         .len();
-    if zip_len <= 22 {
-        tracing::error!(
-            ?path,
-            ?zip_len,
-            "Exported zip log just has the empty header"
-        );
+    if zip_len == 0 {
         bail!("Exported log zip has 0 bytes");
     }
     tokio::fs::remove_file(&path)

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -323,8 +323,8 @@ async fn smoke_test(ctlr_tx: CtlrTx) -> Result<()> {
         .await
         .context("Failed to get zip file metadata")?
         .len();
-    if zip_len == 0 {
-        bail!("Exported log zip has 0 bytes");
+    if zip_len <= 22 {
+        bail!("Exported log zip just has the file header");
     }
     tokio::fs::remove_file(&path)
         .await

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -323,7 +323,12 @@ async fn smoke_test(ctlr_tx: CtlrTx) -> Result<()> {
         .await
         .context("Failed to get zip file metadata")?
         .len();
-    if zip_len == 0 {
+    if zip_len <= 22 {
+        tracing::error!(
+            ?path,
+            ?zip_len,
+            "Exported zip log just has the empty header"
+        );
         bail!("Exported log zip has 0 bytes");
     }
     tokio::fs::remove_file(&path)

--- a/rust/gui-client/src-tauri/src/client/logging.rs
+++ b/rust/gui-client/src-tauri/src/client/logging.rs
@@ -82,7 +82,7 @@ pub(crate) async fn clear_logs() -> StdResult<(), String> {
 
 #[tauri::command]
 pub(crate) async fn export_logs(managed: tauri::State<'_, Managed>) -> StdResult<(), String> {
-    export_logs_inner(managed.ctlr_tx.clone()).map_err(|e| e.to_string())
+    show_export_dialog(managed.ctlr_tx.clone()).map_err(|e| e.to_string())
 }
 
 #[derive(Clone, Default, Serialize)]
@@ -112,7 +112,7 @@ pub(crate) async fn clear_logs_inner() -> Result<()> {
 }
 
 /// Pops up the "Save File" dialog
-pub(crate) fn export_logs_inner(ctlr_tx: CtlrTx) -> Result<()> {
+fn show_export_dialog(ctlr_tx: CtlrTx) -> Result<()> {
     let now = chrono::Local::now();
     let datetime_string = now.format("%Y_%m_%d-%H-%M");
     let stem = PathBuf::from(format!("firezone_logs_{datetime_string}"));

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -155,7 +155,6 @@ enum CmdIpc {
     Install,
     Run,
     RunDebug,
-    SmokeTest,
 }
 
 impl Default for CmdIpc {
@@ -361,11 +360,11 @@ pub fn run_only_ipc_service() -> Result<()> {
     match cli.command {
         CmdIpc::Install => platform::install_ipc_service(),
         CmdIpc::Run => platform::run_ipc_service(cli.common),
-        CmdIpc::RunDebug | CmdIpc::SmokeTest => run_debug_ipc_service(&cli),
+        CmdIpc::RunDebug => run_debug_ipc_service(),
     }
 }
 
-pub(crate) fn run_debug_ipc_service(cli: &CliIpcService) -> Result<()> {
+pub(crate) fn run_debug_ipc_service() -> Result<()> {
     setup_stdout_logging()?;
     let rt = tokio::runtime::Runtime::new()?;
     let _guard = rt.enter();
@@ -373,7 +372,7 @@ pub(crate) fn run_debug_ipc_service(cli: &CliIpcService) -> Result<()> {
     let mut signals = Signals::new()?;
 
     // Couldn't get the loop to work here yet, so SIGHUP is not implemented
-    let service_fut = async {
+    rt.block_on(async {
         let ipc_service = pin!(ipc_listen());
 
         match future::select(pin!(signals.recv()), ipc_service).await {
@@ -387,20 +386,7 @@ pub(crate) fn run_debug_ipc_service(cli: &CliIpcService) -> Result<()> {
             future::Either::Right((Ok(impossible), _)) => match impossible {},
             future::Either::Right((Err(error), _)) => Err(error).context("ipc_listen failed"),
         }
-    };
-
-    if let CmdIpc::SmokeTest = &cli.command {
-        rt.block_on(async {
-            let delay = 10;
-            tracing::info!("Will quit on purpose in {delay} seconds as part of the smoke test.");
-            tokio::time::timeout(Duration::from_secs(10), service_fut)
-                .await
-                .unwrap_err();
-            Ok(())
-        })
-    } else {
-        rt.block_on(service_fut)
-    }
+    })
 }
 
 #[derive(Clone)]

--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -13,16 +13,16 @@ LOGS_PATH="$HOME/.cache/$BUNDLE_ID/data/logs"
 
 #DEVICE_ID_PATH="/var/lib/$BUNDLE_ID/config/firezone-id.json"
 DUMP_PATH="$LOGS_PATH/last_crash.dmp"
+IPC_LOGS_PATH="/var/log/$BUNDLE_ID"
 RAN_BEFORE_PATH="$HOME/.local/share/$BUNDLE_ID/data/ran_before.txt"
 SETTINGS_PATH="$HOME/.config/$BUNDLE_ID/config/advanced_settings.json"
 SYMS_PATH="../target/debug/firezone-gui-client.syms"
 
-GUI_BIN=firezone-gui-client
-IPC_BIN=firezone-client-ipc
+PACKAGE=firezone-gui-client
 export RUST_LOG=firezone_gui_client=debug,warn
 export WEBKIT_DISABLE_COMPOSITING_MODE=1
 
-cargo build --bin "$GUI_BIN" --bin "$IPC_BIN"
+cargo build -p "$PACKAGE"
 cargo install --quiet --locked dump_syms minidump-stackwalk
 # The dwp doesn't actually do anything if the exe already has all the debug info
 # Getting this to coordinate between Linux and Windows is tricky
@@ -32,13 +32,15 @@ ls -lash ../target/debug
 sudo groupadd --force "$FZ_GROUP"
 sudo adduser "$USER" "$FZ_GROUP"
 
+# Make the IPC log dir so that the zip export doesn't bail out
+sudo mkdir -p "$IPC_LOGS_PATH"
+
 function run_fz_gui() {
     pwd
-    sudo "$PWD/../target/debug/$IPC_BIN" smoke-test
     # Does what it says
     sudo --preserve-env \
     su --login "$USER" --command \
-    "xvfb-run --auto-servernum $PWD/../target/debug/$GUI_BIN $*"
+    "xvfb-run --auto-servernum $PWD/../target/debug/$PACKAGE $*"
 }
 
 function smoke_test() {

--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -11,7 +11,6 @@ FZ_GROUP="firezone-client"
 
 LOGS_PATH="$HOME/.cache/$BUNDLE_ID/data/logs"
 
-#DEVICE_ID_PATH="/var/lib/$BUNDLE_ID/config/firezone-id.json"
 DUMP_PATH="$LOGS_PATH/last_crash.dmp"
 IPC_LOGS_PATH="/var/log/$BUNDLE_ID"
 RAN_BEFORE_PATH="$HOME/.local/share/$BUNDLE_ID/data/ran_before.txt"
@@ -64,7 +63,8 @@ function smoke_test() {
     # Make sure the files were written in the right paths
     # TODO: Inject some bogus sign-in sequence to test the actor_name file
     # https://stackoverflow.com/questions/41321092
-    bash -c "stat \"${LOGS_PATH}/\"connlib*log"
+    # TODO: Smoke test the IPC service
+    # bash -c "stat \"${LOGS_PATH}/\"connlib*log"
     stat "$SETTINGS_PATH"
     # stat "$DEVICE_ID_PATH"
     # `ran_before` is now only written after a successful sign-in

--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Put `set -euox` in the top-level scripts directly. If it's only sourced,
+# and the source path is wrong, it will not throw an error and it'll be hard
+# to debug.
+# <https://github.com/firezone/firezone/actions/runs/9602401296/job/26483176628#step:11:12>
 set -euox pipefail
 
 BUNDLE_ID="dev.firezone.client"

--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -9,10 +9,11 @@ set -euox pipefail
 BUNDLE_ID="dev.firezone.client"
 FZ_GROUP="firezone-client"
 
+LOGS_PATH="$HOME/.cache/$BUNDLE_ID/data/logs"
+
 #DEVICE_ID_PATH="/var/lib/$BUNDLE_ID/config/firezone-id.json"
 DUMP_PATH="$LOGS_PATH/last_crash.dmp"
 IPC_LOGS_PATH="/var/log/$BUNDLE_ID"
-LOGS_PATH="$HOME/.cache/$BUNDLE_ID/data/logs"
 RAN_BEFORE_PATH="$HOME/.local/share/$BUNDLE_ID/data/ran_before.txt"
 SETTINGS_PATH="$HOME/.config/$BUNDLE_ID/config/advanced_settings.json"
 SYMS_PATH="../target/debug/firezone-gui-client.syms"
@@ -32,7 +33,7 @@ sudo groupadd --force "$FZ_GROUP"
 sudo adduser "$USER" "$FZ_GROUP"
 
 # Make the IPC log dir so that the zip export doesn't bail out
-mkdir "$IPC_LOGS_PATH"
+sudo mkdir -p "$IPC_LOGS_PATH"
 
 function run_fz_gui() {
     pwd

--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -13,16 +13,16 @@ LOGS_PATH="$HOME/.cache/$BUNDLE_ID/data/logs"
 
 #DEVICE_ID_PATH="/var/lib/$BUNDLE_ID/config/firezone-id.json"
 DUMP_PATH="$LOGS_PATH/last_crash.dmp"
-IPC_LOGS_PATH="/var/log/$BUNDLE_ID"
 RAN_BEFORE_PATH="$HOME/.local/share/$BUNDLE_ID/data/ran_before.txt"
 SETTINGS_PATH="$HOME/.config/$BUNDLE_ID/config/advanced_settings.json"
 SYMS_PATH="../target/debug/firezone-gui-client.syms"
 
-PACKAGE=firezone-gui-client
+GUI_BIN=firezone-gui-client
+IPC_BIN=firezone-client-ipc
 export RUST_LOG=firezone_gui_client=debug,warn
 export WEBKIT_DISABLE_COMPOSITING_MODE=1
 
-cargo build -p "$PACKAGE"
+cargo build --bin "$GUI_BIN" --bin "$IPC_BIN"
 cargo install --quiet --locked dump_syms minidump-stackwalk
 # The dwp doesn't actually do anything if the exe already has all the debug info
 # Getting this to coordinate between Linux and Windows is tricky
@@ -32,15 +32,13 @@ ls -lash ../target/debug
 sudo groupadd --force "$FZ_GROUP"
 sudo adduser "$USER" "$FZ_GROUP"
 
-# Make the IPC log dir so that the zip export doesn't bail out
-sudo mkdir -p "$IPC_LOGS_PATH"
-
 function run_fz_gui() {
     pwd
+    sudo "$PWD/../target/debug/$IPC_BIN" smoke-test
     # Does what it says
     sudo --preserve-env \
     su --login "$USER" --command \
-    "xvfb-run --auto-servernum $PWD/../target/debug/$PACKAGE $*"
+    "xvfb-run --auto-servernum $PWD/../target/debug/$GUI_BIN $*"
 }
 
 function smoke_test() {

--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -10,10 +10,11 @@ BUNDLE_ID="dev.firezone.client"
 FZ_GROUP="firezone-client"
 
 #DEVICE_ID_PATH="/var/lib/$BUNDLE_ID/config/firezone-id.json"
-LOGS_PATH="$HOME/.cache/$BUNDLE_ID/data/logs"
 DUMP_PATH="$LOGS_PATH/last_crash.dmp"
-SETTINGS_PATH="$HOME/.config/$BUNDLE_ID/config/advanced_settings.json"
+IPC_LOGS_PATH="/var/log/$BUNDLE_ID"
+LOGS_PATH="$HOME/.cache/$BUNDLE_ID/data/logs"
 RAN_BEFORE_PATH="$HOME/.local/share/$BUNDLE_ID/data/ran_before.txt"
+SETTINGS_PATH="$HOME/.config/$BUNDLE_ID/config/advanced_settings.json"
 SYMS_PATH="../target/debug/firezone-gui-client.syms"
 
 PACKAGE=firezone-gui-client
@@ -29,6 +30,9 @@ ls -lash ../target/debug
 
 sudo groupadd --force "$FZ_GROUP"
 sudo adduser "$USER" "$FZ_GROUP"
+
+# Make the IPC log dir so that the zip export doesn't bail out
+mkdir "$IPC_LOGS_PATH"
 
 function run_fz_gui() {
     pwd

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -42,7 +42,6 @@ function smoke_test() {
     do
         stat "$file"
     done
-    stat "$LOCALAPPDATA/$BUNDLE_ID/data/logs/"connlib*log
 
     # Clean up so the test can be cycled
     for file in "${files[@]}"

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -12,7 +12,6 @@ if [[ -z "$ProgramData" ]]; then
 fi
 
 BUNDLE_ID="dev.firezone.client"
-DEVICE_ID_PATH="$ProgramData/$BUNDLE_ID/config/firezone-id.json"
 DUMP_PATH="$LOCALAPPDATA/$BUNDLE_ID/data/logs/last_crash.dmp"
 IPC_LOGS_PATH="$ProgramData/$BUNDLE_ID/data/logs"
 PACKAGE=firezone-gui-client
@@ -24,7 +23,6 @@ function smoke_test() {
     files=(
         "$LOCALAPPDATA/$BUNDLE_ID/config/advanced_settings.json"
         "$LOCALAPPDATA/$BUNDLE_ID/data/wintun.dll"
-        "$DEVICE_ID_PATH"
     )
 
     # Make sure the files we want to check don't exist on the system yet
@@ -37,19 +35,6 @@ function smoke_test() {
 
     # Run the smoke test normally
     cargo run --bin "$PACKAGE" -- smoke-test
-
-    # Note the device ID
-    DEVICE_ID_1=$(cat "$DEVICE_ID_PATH")
-
-    # Run the test again and make sure the device ID is not changed
-    cargo run --bin "$PACKAGE" -- smoke-test
-    DEVICE_ID_2=$(cat "$DEVICE_ID_PATH")
-
-    if [ "$DEVICE_ID_1" != "$DEVICE_ID_2" ]
-    then
-        echo "The device ID should not change if the file is intact between runs"
-        exit 1
-    fi
 
     # Make sure the files were written in the right paths
     for file in "${files[@]}"

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -18,7 +18,7 @@ IPC_LOGS_PATH="$ProgramData/$BUNDLE_ID/data/logs"
 PACKAGE=firezone-gui-client
 
 # Make the IPC log dir so that the zip export doesn't bail out
-mkdir "$IPC_LOGS_PATH"
+mkdir -p "$IPC_LOGS_PATH"
 
 function smoke_test() {
     files=(

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -3,7 +3,7 @@
 # Read it before running on a dev system.
 # This script must run from an elevated shell so that Firezone won't try to elevate.
 
-source "./scripts/tests/lib.sh"
+set -euox pipefail
 
 # This prevents a `shellcheck` lint warning about using an unset CamelCase var
 if [[ -z "$ProgramData" ]]; then
@@ -32,11 +32,7 @@ function smoke_test() {
     done
 
     # Run the smoke test normally
-    if ! cargo run --bin "$PACKAGE" -- smoke-test
-    then
-        echo "Smoke test failed L463MPIN"
-        exit 1
-    fi
+    cargo run --bin "$PACKAGE" -- smoke-test
 
     # Note the device ID
     DEVICE_ID_1=$(cat "$DEVICE_ID_PATH")

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -32,7 +32,11 @@ function smoke_test() {
     done
 
     # Run the smoke test normally
-    cargo run --bin "$PACKAGE" -- smoke-test
+    if ! cargo run --bin "$PACKAGE" -- smoke-test
+    then
+        echo "Smoke test failed L463MPIN"
+        exit 1
+    fi
 
     # Note the device ID
     DEVICE_ID_1=$(cat "$DEVICE_ID_PATH")

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -20,9 +20,10 @@ PACKAGE=firezone-gui-client
 mkdir -p "$IPC_LOGS_PATH"
 
 function smoke_test() {
+    # This array used to have more items
+    # TODO: Smoke-test the IPC service
     files=(
         "$LOCALAPPDATA/$BUNDLE_ID/config/advanced_settings.json"
-        "$LOCALAPPDATA/$BUNDLE_ID/data/wintun.dll"
     )
 
     # Make sure the files we want to check don't exist on the system yet

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -14,11 +14,8 @@ fi
 BUNDLE_ID="dev.firezone.client"
 DEVICE_ID_PATH="$ProgramData/$BUNDLE_ID/config/firezone-id.json"
 DUMP_PATH="$LOCALAPPDATA/$BUNDLE_ID/data/logs/last_crash.dmp"
-IPC_LOGS_PATH="$ProgramData/$BUNDLE_ID/data/logs"
-PACKAGE=firezone-gui-client
-
-# Make the IPC log dir so that the zip export doesn't bail out
-mkdir -p "$IPC_LOGS_PATH"
+GUI_BIN=firezone-gui-client
+IPC_BIN=firezone-client-ipc
 
 function smoke_test() {
     files=(
@@ -28,21 +25,21 @@ function smoke_test() {
     )
 
     # Make sure the files we want to check don't exist on the system yet
-    # I'm leaning on ChatGPT and `shellcheck` for the syntax here.
-    # Maybe this is about ready to be translated into Python or Rust.
     for file in "${files[@]}"
     do
-        stat "$file" && exit 1
+        rm -f "$file"
     done
 
     # Run the smoke test normally
-    cargo run --bin "$PACKAGE" -- smoke-test
+    cargo run --bin "$IPC_BIN" -- smoke-test
+    cargo run --bin "$GUI_BIN" -- smoke-test
 
     # Note the device ID
     DEVICE_ID_1=$(cat "$DEVICE_ID_PATH")
 
     # Run the test again and make sure the device ID is not changed
-    cargo run --bin "$PACKAGE" -- smoke-test
+    cargo run --bin "$IPC_BIN" -- smoke-test
+    cargo run --bin "$GUI_BIN" -- smoke-test
     DEVICE_ID_2=$(cat "$DEVICE_ID_PATH")
 
     if [ "$DEVICE_ID_1" != "$DEVICE_ID_2" ]
@@ -57,12 +54,6 @@ function smoke_test() {
         stat "$file"
     done
     stat "$LOCALAPPDATA/$BUNDLE_ID/data/logs/"connlib*log
-
-    # Clean up so the test can be cycled
-    for file in "${files[@]}"
-    do
-        rm "$file"
-    done
 }
 
 function crash_test() {
@@ -70,7 +61,7 @@ function crash_test() {
     rm -f "$DUMP_PATH"
 
     # Fail if it returns success, this is supposed to crash
-    cargo run --bin "$PACKAGE" -- --crash && exit 1
+    cargo run --bin "$GUI_BIN" -- --crash && exit 1
 
     # Fail if the crash file wasn't written
     stat "$DUMP_PATH"

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -14,7 +14,11 @@ fi
 BUNDLE_ID="dev.firezone.client"
 DEVICE_ID_PATH="$ProgramData/$BUNDLE_ID/config/firezone-id.json"
 DUMP_PATH="$LOCALAPPDATA/$BUNDLE_ID/data/logs/last_crash.dmp"
+IPC_LOGS_PATH="$ProgramData/$BUNDLE_ID/data/logs"
 PACKAGE=firezone-gui-client
+
+# Make the IPC log dir so that the zip export doesn't bail out
+mkdir "$IPC_LOGS_PATH"
 
 function smoke_test() {
     files=(


### PR DESCRIPTION
Closes #5464

These were silently broken, it was exporting an empty zip and passing the test anyway. So this PR will cause the test to fail if the zip wasn't fully exported, and then it will fix the export.