### PR TITLE
chore(connlib): emit INFO logs for resource changes

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -123,7 +123,7 @@ impl StubResolver {
     pub(crate) fn remove_resource(&mut self, id: ResourceId) {
         self.dns_resources.retain(|_, r| {
             if r.id == id {
-                tracing::info!(address = %r.address, "Deactivating DNS resources");
+                tracing::info!(address = %r.address, "Deactivating DNS resource");
                 return false;
             }
 

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -111,12 +111,24 @@ impl StubResolver {
     }
 
     pub(crate) fn add_resource(&mut self, resource: &ResourceDescriptionDns) {
-        self.dns_resources
+        let existing = self
+            .dns_resources
             .insert(resource.address.clone(), resource.clone());
+
+        if existing.is_none() {
+            tracing::info!(address = %resource.address, "Activating DNS resource");
+        }
     }
 
     pub(crate) fn remove_resource(&mut self, id: ResourceId) {
-        self.dns_resources.retain(|_, r| r.id != id);
+        self.dns_resources.retain(|_, r| {
+            if r.id == id {
+                tracing::info!(address = %r.address, "Deactivating DNS resources");
+                return false;
+            }
+
+            true
+        });
     }
 
     fn get_or_assign_ips(&mut self, fqdn: DomainName) -> Vec<IpAddr> {


### PR DESCRIPTION
When operating just the headless client, it is currently impossible to know, when resources become activate / inactive. To fix this, we add INFO logs every time we activate or deactivate a resource. This should also prove useful when debugging issues with customers because we now have a timestamped record of what resources were active at that time.