### PR TITLE
chore(connlib): implement some missing ICMP conversions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3177,6 +3177,7 @@ dependencies = [
  "proptest",
  "test-strategy",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/ip-packet/Cargo.toml
+++ b/rust/ip-packet/Cargo.toml
@@ -15,6 +15,7 @@ pnet_packet = { version = "0.34" }
 hickory-proto = { workspace = true }
 thiserror = "1"
 proptest = { version = "1.4.0", optional = true }
+tracing = "0.1"
 
 [dev-dependencies]
 test-strategy = "0.3.1"


### PR DESCRIPTION
So far, our packet translation only implemented the bare-minimum for ICMP to work. There are a few things left that haven't been dealt with. This PR adds additional conversions where it was easy.

There are still some left that require more elaborate mangling of the packet, like updating pointer fields.