### PR TITLE
chore(connlib): shrink "packet not allowed" log

### DIFF
--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -1,6 +1,6 @@
 //! Error module.
 use base64::DecodeError;
-use std::{collections::HashSet, net::IpAddr};
+use std::net::IpAddr;
 use thiserror::Error;
 
 /// Unified Result type to use across connlib.

--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -79,11 +79,8 @@ pub enum ConnlibError {
     #[error("Error while rewriting `/etc/resolv.conf`: {0}")]
     ResolvConf(anyhow::Error),
 
-    #[error("Unallowed packet! source: {src}; allowed_ips: {allowed_ips:?}")]
-    UnallowedPacket {
-        src: IpAddr,
-        allowed_ips: HashSet<IpAddr>,
-    },
+    #[error("Packet not allowed; source = {src}")]
+    UnallowedPacket { src: IpAddr },
 
     // Error variants for `systemd-resolved` DNS control
     #[error("Failed to control system DNS with `resolvectl`")]

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -473,7 +473,7 @@ impl ClientState {
         };
 
         peer.ensure_allowed_src(&packet)
-            .inspect_err(|e| tracing::debug!(%conn_id, %local, %from, "{e}"))
+            .inspect_err(|e| tracing::warn!(%conn_id, %local, %from, "{e}"))
             .ok()?;
 
         let packet = maybe_mangle_dns_response_from_cidr_resource(

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -473,7 +473,7 @@ impl ClientState {
         };
 
         peer.ensure_allowed_src(&packet)
-            .inspect_err(|e| tracing::warn!(%conn_id, %local, %from, "{e}"))
+            .inspect_err(|e| tracing::debug!(%conn_id, %local, %from, "{e}"))
             .ok()?;
 
         let packet = maybe_mangle_dns_response_from_cidr_resource(

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -473,7 +473,7 @@ impl ClientState {
         };
 
         peer.ensure_allowed_src(&packet)
-            .inspect_err(|e| tracing::warn!(%conn_id, %local, %from, "Packet not allowed: {e}"))
+            .inspect_err(|e| tracing::warn!(%conn_id, %local, %from, "{e}"))
             .ok()?;
 
         let packet = maybe_mangle_dns_response_from_cidr_resource(

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -452,7 +452,6 @@ impl ClientOnGateway {
         if !self.allowed_ips().contains(&packet.source()) {
             return Err(connlib_shared::Error::UnallowedPacket {
                 src: packet.source(),
-                allowed_ips: HashSet::from(self.allowed_ips()),
             });
         }
 
@@ -488,15 +487,7 @@ impl GatewayOnClient {
         pkt: &MutableIpPacket,
     ) -> Result<(), connlib_shared::Error> {
         if self.allowed_ips.longest_match(pkt.source()).is_none() {
-            return Err(connlib_shared::Error::UnallowedPacket {
-                src: pkt.source(),
-
-                allowed_ips: self
-                    .allowed_ips
-                    .iter()
-                    .map(|(ip, _)| ip.network_address())
-                    .collect(),
-            });
+            return Err(connlib_shared::Error::UnallowedPacket { src: pkt.source() });
         }
 
         Ok(())


### PR DESCRIPTION
All allowed IPs can be a fair few which clutters the log. Remove the `HashSet` from the error and also remove the stuttering; the error already says "Packet not allowed".