### PR TITLE
fix(gateway): ignore DNS64 IP addresses

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1911,6 +1911,7 @@ dependencies = [
  "futures-bounded",
  "http-health-check",
  "ip_network",
+ "itertools 0.13.0",
  "libc",
  "phoenix-channel",
  "secrecy",

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -35,6 +35,7 @@ either = "1"
 http-health-check = { workspace = true }
 static_assertions = "1.1.0"
 snownet = { workspace = true }
+itertools = "0.13.0"
 
 [dev-dependencies]
 serde_json = { version = "1.0", default-features = false, features = ["std"] }


### PR DESCRIPTION
Many parts of the Internet, especially cloud services, utilize NAT64 & DNS64 to deal with the IPv4 exhaustion problem. In such an environment, AAAA queries for an IPv4-only domain are answered with synthesized IPv6 addresses from the `0064:ff9b/96` subnet. See [RFC6147](https://datatracker.ietf.org/doc/html/rfc6147) for details. For these synthesized addresses to be routable, a NAT64 gateway needs to be present too.

Within connlib, we already implement IP translation (i.e. NAT64) according to RFC6145 because we resolve all DNS queries for DNS resources locally on the client before we establish a connection to the gateway. As a result, a client might send IPv6 traffic but the domain the client is trying to reach only resolves to IPv4 on the gateway. At this point, the gateway needs to translate the packets. 

If a domain has IPv6 records (even if they are DNS64 records), we currently don't perform any translation across IP versions and simply assign each proxy IP to a resolved one.

As a result, IPv6 traffic within firezone completely breaks in case the sysadmin that set up the gateway didn't also set up a NAT64 gateway next to the DNS64 resolver. It turns out, making this mistake is quite easy. Our AWS staging environment has this problem. One option would be to blame the user and just not do anything about this. Another option is what we do in this PR: Ignore all DNS64 records during DNS resolution on the gateway.

Connlib already implements NAT64 and therefore gracefully handles the case where a domain resolves only to IPv4 addresses. Thus, making use of those DNS64 records only causes problems in case the environment of the gateway is not set up correctly. Ignoring them on the other hand allows things to work smoothly.

The only downside here is that the NAT64 implementation of connlib is not yet battle-tested compared to an external NAT64 gateway. Thus one might argue that fixing the environment might be the better option. However, unless we re-design firezone and remove NAT64 from connlib entirely, we need to implement it correctly anyway for the case where there is no DNS64 resolver on in the gateway's environment. Plus, there is always the option of making this behaviour configurable if desired.