### PR TITLE
feat(portal): Add optional top banner

### DIFF
--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -1,10 +1,11 @@
 <.topbar subject={@subject}>
   <:banner>
     Upgrade your Gateway(s) to 1.1.0 or later by June 27th, 2024.
-    <.website_link path="/blog/improving-reliability-for-dns-resources">Read more about this change.</.website_link>
+    <.website_link path="/blog/improving-reliability-for-dns-resources">
+      Read more about this change.
+    </.website_link>
   </:banner>
 </.topbar>
-
 
 <.sidebar>
   <.sidebar_item

--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -1,4 +1,10 @@
-<.topbar subject={@subject} />
+<.topbar subject={@subject}>
+  <:banner>
+    Upgrade your Gateway(s) to 1.1.0 or later by June 27th, 2024.
+    <.website_link path="/blog/improving-reliability-for-dns-resources">Read more about this change.</.website_link>
+  </:banner>
+</.topbar>
+
 
 <.sidebar>
   <.sidebar_item

--- a/elixir/apps/web/lib/web/components/navigation_components.ex
+++ b/elixir/apps/web/lib/web/components/navigation_components.ex
@@ -19,7 +19,7 @@ defmodule Web.NavigationComponents do
             data-drawer-toggle="drawer-navigation"
             aria-controls="drawer-navigation"
             class={[
-              "p-2 mr-2 text-neutral-600 rounded cursor-pointer lg:hidden",
+              "mr-2 text-neutral-600 rounded cursor-pointer lg:hidden",
               "hover:text-neutral-900 hover:bg-neutral-100"
             ]}
           >
@@ -33,18 +33,18 @@ defmodule Web.NavigationComponents do
             </span>
           </a>
         </div>
-        <div class="flex items-center lg:order-2">
+        <div class="flex items-center order-2">
           <a
             target="_blank"
             href="https://www.firezone.dev/kb?utm_source=product"
-            class="mr-6 mt-1 text-neutral-700 hover:text-neutral-900 hover:underline lg:ml-2 hidden lg:block"
+            class="mr-6 mt-1 text-neutral-700 hover:text-neutral-900 hover:underline ml-2"
           >
             Docs
           </a>
           <a
             target="_blank"
             href="https://firezone.statuspage.io"
-            class="mr-6 mt-1 text-neutral-700 hover:text-neutral-900 hover:underline lg:ml-2 hidden lg:block"
+            class="mr-6 mt-1 text-neutral-700 hover:text-neutral-900 hover:underline ml-2"
           >
             Status
           </a>
@@ -104,12 +104,14 @@ defmodule Web.NavigationComponents do
     required: true,
     doc: "The items for the navigation bar should use `sidebar_item` component."
 
+  attr :banner, :boolean, required: false, default: false
+
   def sidebar(assigns) do
     ~H"""
     <aside class={~w[
         fixed top-0 left-0 z-40
         w-64 h-screen
-        pt-14 pb-8
+        #{@banner && "pt-24" || "pt-14"} pb-8
         transition-transform -translate-x-full
         bg-white border-r border-neutral-200
         lg:translate-x-0

--- a/elixir/apps/web/lib/web/components/navigation_components.ex
+++ b/elixir/apps/web/lib/web/components/navigation_components.ex
@@ -4,11 +4,15 @@ defmodule Web.NavigationComponents do
   import Web.CoreComponents
 
   attr :subject, :any, required: true
+  slot :banner, required: false, doc: "Optional top banner to show"
 
   def topbar(assigns) do
     ~H"""
-    <nav class="bg-neutral-50 border-b border-neutral-200 px-4 py-2.5 fixed left-0 right-0 top-0 z-50">
-      <div class="flex flex-wrap justify-between items-center">
+    <nav class="bg-neutral-50 border-b border-neutral-200 fixed left-0 right-0 top-0 z-50">
+      <div :if={@banner} class="text-center text-sm py-2 bg-accent-100 text-accent-800">
+        <%= render_slot(@banner) %>
+      </div>
+      <div class="px-4 py-2.5 flex flex-wrap justify-between items-center">
         <div class="flex justify-start items-center">
           <button
             data-drawer-target="drawer-navigation"

--- a/elixir/apps/web/lib/web/components/navigation_components.ex
+++ b/elixir/apps/web/lib/web/components/navigation_components.ex
@@ -111,7 +111,7 @@ defmodule Web.NavigationComponents do
     <aside class={~w[
         fixed top-0 left-0 z-40
         w-64 h-screen
-        #{@banner && "pt-24" || "pt-14"} pb-8
+        #{(@banner && "pt-24") || "pt-14"} pb-8
         transition-transform -translate-x-full
         bg-white border-r border-neutral-200
         lg:translate-x-0


### PR DESCRIPTION
It would be good to have a site-wide banner for announcements in the product.

This is just a draft to see what everyone thinks of the styling. Also, it might be nice to be able to enable/disable it remotely, perhaps from an Ops command.

<img width="1552" alt="Screenshot 2024-06-20 at 11 10 15 PM" src="https://github.com/firezone/firezone/assets/167144/7ade627e-2e0c-448f-8c1d-ac255d80e8f8">

```[tasklist]
- [ ] Fix colors
- [ ] Make dismissible
- [ ] Fix small width screen layout
```

Fixes #5462 