### PR TITLE
fix(phoenix-channel): fail on login error with portal

### DIFF
--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -225,6 +225,8 @@ where
     ) -> Self {
         let next_request_id = Arc::new(AtomicU64::new(0));
 
+        tracing::debug!(host = %url.expose_secret().host(), %user_agent, "Connecting to portal");
+
         Self {
             reconnect_backoff,
             url: url.clone(),


### PR DESCRIPTION
Joining the "login" topic on the portal, i.e. `client`, `gateway` or `relay` can fail. Usually, that is only due to a bug, yet we can and should not operate if we haven't joined the login topic successfully.

Currently, we just hang in this scenario without an useful error message. With this PR, we fail the entire connlib session. For the headless client, it looks like this:

```
2024-06-21T08:44:47.792921Z  INFO firezone_headless_client: git_version="gateway-1.1.0-8-ge16dcb8e5-modified"
2024-06-21T08:44:47.793138Z  INFO firezone_headless_client: Running in headless / standalone mode
2024-06-21T08:44:47.801781Z  INFO firezone_headless_client::dns_control::linux: dns_control_method=Some(Systemd)
2024-06-21T08:44:48.110502Z  INFO phoenix_channel: Connected to portal host=api.firez.one
2024-06-21T08:44:48.372602Z ERROR connlib_client_shared: connlib failed: connection to the portal failed: login failed
2024-06-21T08:44:48.372661Z ERROR firezone_headless_client: Got `on_disconnect` from connlib error=PortalConnectionFailed(LoginFailed)
Error: Firezone disconnected

Caused by:
    connection to the portal failed: login failed
```