### PR TITLE
chore(gateway): emit warn on dead but used IPs

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -311,6 +311,7 @@ impl ClientOnGateway {
             let resource_id = expired_state.resource_id;
             let resolved_ip = expired_state.resolved_ip;
 
+            // Only refresh DNS for a domain if all of the resolved IPs stop responding in order to not kill existing connections.
             if self
                 .permanent_translations
                 .values()
@@ -328,6 +329,7 @@ impl ClientOnGateway {
                 for_refresh.insert((expired_state.name.clone(), expired_state.resource_id));
             }
 
+            // Check each state individually for whether it is dead.
             if expired_state.is_dead_ip() {
                 dead_ips
                     .entry(domain.clone())


### PR DESCRIPTION
As part of our NAT table, we keep track of the last time a resolved IP sent us traffic. This is primarily used to detect and correct changes in the DNS record. If we keep getting traffic for a proxy IP but the resolved IP doesn't respond for more than 30s, we re-query the corresponding domain name.

We can also use this to detect and warn the administrator of entirely dead but used IPs. A dead-but-used IP is one that has never sent us any traffic, yet we are actively trying to contact it. For example, if the environment uses DNS64 but is missing a NAT64 gateway, DNS queries for IPv4-only resources will give us synthesized IPv6 addresses from the `0064:ff9b/96` subnet but without a NAT64 gateway, those will never work.

Whilst this log isn't specific to issues around DNS64 and NAT64, emitting a warning that a resolved IP does not work at all should send the administrator into the right direction whilst debugging this issue.