### PR TITLE
refactor: Add icons to policy conditions

### DIFF
--- a/elixir/apps/web/lib/web/live/policies/components.ex
+++ b/elixir/apps/web/lib/web/live/policies/components.ex
@@ -294,7 +294,10 @@ defmodule Web.Policies.Components do
         }
       >
         <legend class="flex justify-between items-center text-neutral-700">
-          Client location
+          <span class="flex items-center">
+            <.icon name="hero-globe-americas" class="w-5 h-5 mr-2" />
+            Client location
+          </span>
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
             <.icon
               id="policy_conditions_remote_ip_location_region_chevron"
@@ -379,7 +382,10 @@ defmodule Web.Policies.Components do
         }
       >
         <legend class="flex justify-between items-center text-neutral-700">
-          IP address
+          <span class="flex items-center">
+            <.icon name="hero-globe-alt" class="w-5 h-5 mr-2" />
+            IP address
+          </span>
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
             <.icon id="policy_conditions_remote_ip_chevron" name="hero-chevron-down" class="w-5 h-5" />
           </span>
@@ -460,7 +466,10 @@ defmodule Web.Policies.Components do
         }
       >
         <legend class="flex justify-between items-center text-neutral-700">
-          Authentication Provider
+          <span class="flex items-center">
+            <.icon name="hero-identification" class="w-5 h-5 mr-2" />
+            Identity provider
+          </span>
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
             <.icon
               id="policy_conditions_provider_id_chevron"
@@ -555,7 +564,10 @@ defmodule Web.Policies.Components do
         }
       >
         <legend class="flex justify-between items-center text-neutral-700">
+          <span class="flex items-center">
+            <.icon name="hero-clock" class="w-5 h-5 mr-2" />
           Current time
+          </span>
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
             <.icon
               id="policy_conditions_current_utc_datetime_chevron"

--- a/elixir/apps/web/lib/web/live/policies/components.ex
+++ b/elixir/apps/web/lib/web/live/policies/components.ex
@@ -295,8 +295,7 @@ defmodule Web.Policies.Components do
       >
         <legend class="flex justify-between items-center text-neutral-700">
           <span class="flex items-center">
-            <.icon name="hero-globe-americas" class="w-5 h-5 mr-2" />
-            Client location
+            <.icon name="hero-globe-americas" class="w-5 h-5 mr-2" /> Client location
           </span>
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
             <.icon
@@ -383,8 +382,7 @@ defmodule Web.Policies.Components do
       >
         <legend class="flex justify-between items-center text-neutral-700">
           <span class="flex items-center">
-            <.icon name="hero-globe-alt" class="w-5 h-5 mr-2" />
-            IP address
+            <.icon name="hero-globe-alt" class="w-5 h-5 mr-2" /> IP address
           </span>
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
             <.icon id="policy_conditions_remote_ip_chevron" name="hero-chevron-down" class="w-5 h-5" />
@@ -467,8 +465,7 @@ defmodule Web.Policies.Components do
       >
         <legend class="flex justify-between items-center text-neutral-700">
           <span class="flex items-center">
-            <.icon name="hero-identification" class="w-5 h-5 mr-2" />
-            Identity provider
+            <.icon name="hero-identification" class="w-5 h-5 mr-2" /> Identity provider
           </span>
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
             <.icon
@@ -565,8 +562,7 @@ defmodule Web.Policies.Components do
       >
         <legend class="flex justify-between items-center text-neutral-700">
           <span class="flex items-center">
-            <.icon name="hero-clock" class="w-5 h-5 mr-2" />
-          Current time
+            <.icon name="hero-clock" class="w-5 h-5 mr-2" /> Current time
           </span>
           <span class="shadow bg-white w-6 h-6 flex items-center justify-center rounded-full">
             <.icon


### PR DESCRIPTION
As I was taking screenshots of the new policy conditions feature I realized it would be quick and easy to add icons corresponding to the titles to continue the theme of adding visual hints to break up the text-heavy sections.

It also looks nice in the screenshots for the blog post and newsletter posts.

<img width="669" alt="Screenshot 2024-06-21 at 10 00 14 AM" src="https://github.com/firezone/firezone/assets/167144/61d5d61d-4d4c-4f6f-b325-dbcb81c2c9b7">
