### PR TITLE
refactor(headless-client): remove FIREZONE_PACKAGE_VERSION

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -161,8 +161,6 @@ jobs:
             artifact: firezone-gateway
             image_name: gateway
             # mark:next-gateway-version
-            version: 1.1.1
-            # mark:next-gateway-version
             release_name: gateway-1.1.1
           - package: snownet-tests
             artifact: snownet-tests
@@ -200,9 +198,7 @@ jobs:
             PROFILE=""
           fi
 
-          # Override version by setting it inside cross container if it's provided
-          ${{ matrix.name.version && format('CROSS_CONTAINER_OPTS="--env FIREZONE_PACKAGE_VERSION={0}"', matrix.name.version) }} \
-            cross build $PROFILE -p ${{ matrix.name.package }} --target ${{ matrix.arch.target }}
+          cross build $PROFILE -p ${{ matrix.name.package }} --target ${{ matrix.arch.target }}
 
           # Used for Docker images
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -153,8 +153,6 @@ jobs:
             artifact: firezone-client-headless-linux
             image_name: client
             # mark:next-headless-version
-            version: 1.1.0
-            # mark:next-headless-version
             release_name: headless-client-1.1.0
           - package: firezone-relay
             artifact: firezone-relay

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -50,8 +50,6 @@ jobs:
       - run: touch local.properties
       - name: Bundle and sign release
         env:
-          # mark:next-android-version
-          FIREZONE_PACKAGE_VERSION: 1.1.0
           KEYSTORE_BASE64: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_PASSWORD }}
           KEYSTORE_KEY_PASSWORD: ${{ secrets.GOOGLE_UPLOAD_KEYSTORE_KEY_PASSWORD }}

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -95,8 +95,6 @@ jobs:
           ONLY_ACTIVE_ARCH: no
           # Needed because `productbuild` doesn't support picking this up automatically like Xcode does
           INSTALLER_CODE_SIGN_IDENTITY: "3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
-          # mark:next-apple-version
-          FIREZONE_PACKAGE_VERSION: 1.1.0
         run: |
           # Use the same Xcode version as development
           sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -49,8 +49,6 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
-      # mark:next-gui-version
-      FIREZONE_PACKAGE_VERSION: 1.1.0
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -381,7 +381,7 @@ fn connect(
         sockets,
         private_key,
         os_version_override: Some(os_version),
-        firezone_package_version: env!("CARGO_PKG_VERSION").to_string(),
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
         callbacks,
         max_partition_time: Some(MAX_PARTITION_TIME),
     };

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -4,8 +4,8 @@
 // ecosystem, so it's used here for consistency.
 
 use connlib_client_shared::{
-    callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error,
-    LoginUrl, LoginUrlError, Session, Sockets,
+    callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, ConnectArgs,
+    Error, LoginUrl, LoginUrlError, Session, Sockets,
 };
 use jni::{
     objects::{GlobalRef, JClass, JObject, JString, JValue},
@@ -346,14 +346,14 @@ fn connect(
 
     let handle = init_logging(&PathBuf::from(log_dir), log_filter);
 
-    let callback_handler = CallbackHandler {
+    let callbacks = CallbackHandler {
         vm: env.get_java_vm().map_err(ConnectError::GetJavaVmFailed)?,
         callback_handler,
         handle,
     };
 
     let (private_key, public_key) = keypair();
-    let login = LoginUrl::client(
+    let url = LoginUrl::client(
         api_url.as_str(),
         &secret,
         device_id,
@@ -368,7 +368,7 @@ fn connect(
         .build()?;
 
     let sockets = Sockets::with_protect({
-        let callbacks = callback_handler.clone();
+        let callbacks = callbacks.clone();
         move |fd| {
             callbacks
                 .protect_file_descriptor(fd)
@@ -376,15 +376,15 @@ fn connect(
         }
     });
 
-    let session = Session::connect(
-        login,
+    let args = ConnectArgs {
+        url,
         sockets,
         private_key,
-        Some(os_version),
-        callback_handler,
-        Some(MAX_PARTITION_TIME),
-        runtime.handle().clone(),
-    );
+        os_version_override: Some(os_version),
+        callbacks,
+        max_partition_time: Some(MAX_PARTITION_TIME),
+    };
+    let session = Session::connect(args, runtime.handle().clone());
 
     Ok(SessionWrapper {
         inner: session,

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -381,6 +381,7 @@ fn connect(
         sockets,
         private_key,
         os_version_override: Some(os_version),
+        firezone_package_version: env!("CARGO_PKG_VERSION").to_string(),
         callbacks,
         max_partition_time: Some(MAX_PARTITION_TIME),
     };

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -2,8 +2,8 @@
 #![allow(clippy::unnecessary_cast, improper_ctypes, non_camel_case_types)]
 
 use connlib_client_shared::{
-    callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, Error,
-    LoginUrl, Session, Sockets,
+    callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, ConnectArgs,
+    Error, LoginUrl, Session, Sockets,
 };
 use secrecy::SecretString;
 use std::{
@@ -175,7 +175,7 @@ impl WrappedSession {
         let secret = SecretString::from(token);
 
         let (private_key, public_key) = keypair();
-        let login = LoginUrl::client(
+        let url = LoginUrl::client(
             api_url.as_str(),
             &secret,
             device_id,
@@ -191,17 +191,17 @@ impl WrappedSession {
             .build()
             .map_err(|e| e.to_string())?;
 
-        let session = Session::connect(
-            login,
-            Sockets::new(),
+        let args = ConnectArgs {
+            url,
+            sockets: Sockets::new(),
             private_key,
             os_version_override,
-            CallbackHandler {
+            callbacks: CallbackHandler {
                 inner: Arc::new(callback_handler),
             },
-            Some(MAX_PARTITION_TIME),
-            runtime.handle().clone(),
-        );
+            max_partition_time: Some(MAX_PARTITION_TIME),
+        };
+        let session = Session::connect(args, runtime.handle().clone());
 
         Ok(Self {
             inner: session,

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -196,6 +196,7 @@ impl WrappedSession {
             sockets: Sockets::new(),
             private_key,
             os_version_override,
+            firezone_package_version: env!("CARGO_PKG_VERSION").to_string(),
             callbacks: CallbackHandler {
                 inner: Arc::new(callback_handler),
             },

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -196,7 +196,7 @@ impl WrappedSession {
             sockets: Sockets::new(),
             private_key,
             os_version_override,
-            firezone_package_version: env!("CARGO_PKG_VERSION").to_string(),
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
             callbacks: CallbackHandler {
                 inner: Arc::new(callback_handler),
             },

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -38,7 +38,7 @@ pub struct ConnectArgs<CB> {
     pub sockets: Sockets,
     pub private_key: StaticSecret,
     pub os_version_override: Option<String>,
-    pub firezone_package_version: String,
+    pub app_version: String,
     pub callbacks: CB,
     pub max_partition_time: Option<Duration>,
 }
@@ -114,7 +114,7 @@ where
         sockets,
         private_key,
         os_version_override,
-        firezone_package_version,
+        app_version,
         callbacks,
         max_partition_time,
     } = args;
@@ -123,7 +123,7 @@ where
 
     let portal = PhoenixChannel::connect(
         Secret::new(url),
-        get_user_agent(os_version_override, &firezone_package_version),
+        get_user_agent(os_version_override, &app_version),
         PHOENIX_TOPIC,
         (),
         ExponentialBackoffBuilder::default()

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -32,30 +32,28 @@ pub struct Session {
     channel: tokio::sync::mpsc::UnboundedSender<Command>,
 }
 
+/// Arguments for `connect`, since Clippy said 8 args is too many
+pub struct ConnectArgs<CB> {
+    pub url: LoginUrl,
+    pub sockets: Sockets,
+    pub private_key: StaticSecret,
+    pub os_version_override: Option<String>,
+    pub callbacks: CB,
+    pub max_partition_time: Option<Duration>,
+}
+
 impl Session {
     /// Creates a new [`Session`].
     ///
     /// This connects to the portal a specified using [`LoginUrl`] and creates a wireguard tunnel using the provided private key.
     pub fn connect<CB: Callbacks + 'static>(
-        url: LoginUrl,
-        sockets: Sockets,
-        private_key: StaticSecret,
-        os_version_override: Option<String>,
-        callbacks: CB,
-        max_partition_time: Option<Duration>,
+        args: ConnectArgs<CB>,
         handle: tokio::runtime::Handle,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
-        let connect_handle = handle.spawn(connect(
-            url,
-            sockets,
-            private_key,
-            os_version_override,
-            callbacks.clone(),
-            max_partition_time,
-            rx,
-        ));
+        let callbacks = args.callbacks.clone();
+        let connect_handle = handle.spawn(connect(args, rx));
         handle.spawn(connect_supervisor(connect_handle, callbacks));
 
         Self { channel: tx }
@@ -106,19 +104,20 @@ impl Session {
 /// Connects to the portal and starts a tunnel.
 ///
 /// When this function exits, the tunnel failed unrecoverably and you need to call it again.
-async fn connect<CB>(
-    url: LoginUrl,
-    sockets: Sockets,
-    private_key: StaticSecret,
-    os_version_override: Option<String>,
-    callbacks: CB,
-    max_partition_time: Option<Duration>,
-    rx: UnboundedReceiver<Command>,
-) -> Result<(), Error>
+async fn connect<CB>(args: ConnectArgs<CB>, rx: UnboundedReceiver<Command>) -> Result<(), Error>
 where
     CB: Callbacks + 'static,
 {
-    let tunnel = ClientTunnel::new(private_key, sockets, callbacks.clone())?;
+    let ConnectArgs {
+        url,
+        sockets,
+        private_key,
+        os_version_override,
+        callbacks,
+        max_partition_time,
+    } = args;
+
+    let tunnel = ClientTunnel::new(private_key, sockets, callbacks)?;
 
     let portal = PhoenixChannel::connect(
         Secret::new(url),

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -51,7 +51,10 @@ pub fn keypair() -> (StaticSecret, PublicKey) {
     (private_key, public_key)
 }
 
-pub fn get_user_agent(os_version_override: Option<String>) -> String {
+pub fn get_user_agent(
+    os_version_override: Option<String>,
+    firezone_package_version: &str,
+) -> String {
     // Note: we could switch to sys-info and get the hostname
     // but we lose the arch
     // and neither of the libraries provide the kernel version.
@@ -67,9 +70,8 @@ pub fn get_user_agent(os_version_override: Option<String>) -> String {
 
     let os_version = os_version_override.unwrap_or(info.version().to_string());
     let additional_info = additional_info();
-    let version = option_env!("FIREZONE_PACKAGE_VERSION").unwrap_or("development");
     let lib_name = LIB_NAME;
-    format!("{os_type}/{os_version}{additional_info}{lib_name}/{version}")
+    format!("{os_type}/{os_version}{additional_info}{lib_name}/{firezone_package_version}")
 }
 
 fn additional_info() -> String {

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -51,10 +51,7 @@ pub fn keypair() -> (StaticSecret, PublicKey) {
     (private_key, public_key)
 }
 
-pub fn get_user_agent(
-    os_version_override: Option<String>,
-    firezone_package_version: &str,
-) -> String {
+pub fn get_user_agent(os_version_override: Option<String>, app_version: &str) -> String {
     // Note: we could switch to sys-info and get the hostname
     // but we lose the arch
     // and neither of the libraries provide the kernel version.

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -68,7 +68,7 @@ pub fn get_user_agent(os_version_override: Option<String>, app_version: &str) ->
     let os_version = os_version_override.unwrap_or(info.version().to_string());
     let additional_info = additional_info();
     let lib_name = LIB_NAME;
-    format!("{os_type}/{os_version}{additional_info}{lib_name}/{firezone_package_version}")
+    format!("{os_type}/{os_version}{additional_info}{lib_name}/{app_version}")
 }
 
 fn additional_info() -> String {

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -102,7 +102,7 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
 
     let (portal, init) = phoenix_channel::init::<_, InitGateway, _, _>(
         Secret::new(login),
-        get_user_agent(None),
+        get_user_agent(None, env!("CARGO_PKG_VERSION")),
         PHOENIX_TOPIC,
         (),
         ExponentialBackoffBuilder::default()

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -11,7 +11,7 @@
 use anyhow::{anyhow, bail, Context as _, Result};
 use clap::Parser;
 use connlib_client_shared::{
-    file_logger, keypair, Callbacks, Error as ConnlibError, LoginUrl, Session, Sockets,
+    file_logger, keypair, Callbacks, ConnectArgs, Error as ConnlibError, LoginUrl, Session, Sockets,
 };
 use connlib_shared::{callbacks, tun_device_manager, Cidrv4, Cidrv6};
 use firezone_cli_utils::setup_global_subscriber;
@@ -271,7 +271,7 @@ pub fn run_only_headless_client() -> Result<()> {
     };
 
     let (private_key, public_key) = keypair();
-    let login = LoginUrl::client(
+    let url = LoginUrl::client(
         cli.api_url,
         &token,
         firezone_id,
@@ -285,18 +285,18 @@ pub fn run_only_headless_client() -> Result<()> {
     }
 
     let (cb_tx, mut cb_rx) = mpsc::channel(10);
-    let callback_handler = CallbackHandler { cb_tx };
+    let callbacks = CallbackHandler { cb_tx };
 
     platform::setup_before_connlib()?;
-    let session = Session::connect(
-        login,
-        Sockets::new(),
+    let args = ConnectArgs {
+        url,
+        sockets: Sockets::new(),
         private_key,
-        None,
-        callback_handler,
+        os_version_override: None,
+        callbacks,
         max_partition_time,
-        rt.handle().clone(),
-    );
+    };
+    let session = Session::connect(args, rt.handle().clone());
     // TODO: this should be added dynamically
     session.set_dns(dns_control::system_resolvers().unwrap_or_default());
     platform::notify_service_controller()?;
@@ -564,7 +564,7 @@ impl Handler {
                     device_id::get_or_create().context("Failed to get / create device ID")?;
                 let (private_key, public_key) = keypair();
 
-                let login = LoginUrl::client(
+                let url = LoginUrl::client(
                     Url::parse(&api_url)?,
                     &token,
                     device_id.id,
@@ -573,15 +573,15 @@ impl Handler {
                 )?;
 
                 self.last_connlib_start_instant = Some(Instant::now());
-                let new_session = connlib_client_shared::Session::connect(
-                    login,
-                    Sockets::new(),
+                let args = ConnectArgs {
+                    url,
+                    sockets: Sockets::new(),
                     private_key,
-                    None,
-                    self.callback_handler.clone(),
-                    Some(Duration::from_secs(60 * 60 * 24 * 30)),
-                    tokio::runtime::Handle::try_current()?,
-                );
+                    os_version_override: None,
+                    callbacks: self.callback_handler.clone(),
+                    max_partition_time: Some(Duration::from_secs(60 * 60 * 24 * 30)),
+                };
+                let new_session = Session::connect(args, tokio::runtime::Handle::try_current()?);
                 new_session.set_dns(dns_control::system_resolvers().unwrap_or_default());
                 self.connlib = Some(new_session);
             }

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -293,7 +293,7 @@ pub fn run_only_headless_client() -> Result<()> {
         sockets: Sockets::new(),
         private_key,
         os_version_override: None,
-        firezone_package_version: env!("CARGO_PKG_VERSION").to_string(),
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
         callbacks,
         max_partition_time,
     };
@@ -579,7 +579,7 @@ impl Handler {
                     sockets: Sockets::new(),
                     private_key,
                     os_version_override: None,
-                    firezone_package_version: env!("CARGO_PKG_VERSION").to_string(),
+                    app_version: env!("CARGO_PKG_VERSION").to_string(),
                     callbacks: self.callback_handler.clone(),
                     max_partition_time: Some(Duration::from_secs(60 * 60 * 24 * 30)),
                 };

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -11,7 +11,7 @@
 use anyhow::{anyhow, bail, Context as _, Result};
 use clap::Parser;
 use connlib_client_shared::{
-    file_logger, keypair, Callbacks, Error as ConnlibError, LoginUrl, Session, Sockets,
+    file_logger, keypair, Callbacks, ConnectArgs, Error as ConnlibError, LoginUrl, Session, Sockets,
 };
 use connlib_shared::{callbacks, tun_device_manager, Cidrv4, Cidrv6};
 use firezone_cli_utils::setup_global_subscriber;
@@ -271,7 +271,7 @@ pub fn run_only_headless_client() -> Result<()> {
     };
 
     let (private_key, public_key) = keypair();
-    let login = LoginUrl::client(
+    let url = LoginUrl::client(
         cli.api_url,
         &token,
         firezone_id,
@@ -285,18 +285,19 @@ pub fn run_only_headless_client() -> Result<()> {
     }
 
     let (cb_tx, mut cb_rx) = mpsc::channel(10);
-    let callback_handler = CallbackHandler { cb_tx };
+    let callbacks = CallbackHandler { cb_tx };
 
     platform::setup_before_connlib()?;
-    let session = Session::connect(
-        login,
-        Sockets::new(),
+    let args = ConnectArgs {
+        url,
+        sockets: Sockets::new(),
         private_key,
-        None,
-        callback_handler,
+        os_version_override: None,
+        firezone_package_version: env!("CARGO_PKG_VERSION").to_string(),
+        callbacks,
         max_partition_time,
-        rt.handle().clone(),
-    );
+    };
+    let session = Session::connect(args, rt.handle().clone());
     // TODO: this should be added dynamically
     session.set_dns(dns_control::system_resolvers().unwrap_or_default());
     platform::notify_service_controller()?;
@@ -564,7 +565,7 @@ impl Handler {
                     device_id::get_or_create().context("Failed to get / create device ID")?;
                 let (private_key, public_key) = keypair();
 
-                let login = LoginUrl::client(
+                let url = LoginUrl::client(
                     Url::parse(&api_url)?,
                     &token,
                     device_id.id,
@@ -573,15 +574,16 @@ impl Handler {
                 )?;
 
                 self.last_connlib_start_instant = Some(Instant::now());
-                let new_session = connlib_client_shared::Session::connect(
-                    login,
-                    Sockets::new(),
+                let args = ConnectArgs {
+                    url,
+                    sockets: Sockets::new(),
                     private_key,
-                    None,
-                    self.callback_handler.clone(),
-                    Some(Duration::from_secs(60 * 60 * 24 * 30)),
-                    tokio::runtime::Handle::try_current()?,
-                );
+                    os_version_override: None,
+                    firezone_package_version: env!("CARGO_PKG_VERSION").to_string(),
+                    callbacks: self.callback_handler.clone(),
+                    max_partition_time: Some(Duration::from_secs(60 * 60 * 24 * 30)),
+                };
+                let new_session = Session::connect(args, tokio::runtime::Handle::try_current()?);
                 new_session.set_dns(dns_control::system_resolvers().unwrap_or_default());
                 self.connlib = Some(new_session);
             }


### PR DESCRIPTION
Closes #5481 

With this, I can connect to the staging portal without a build.rs or any extra env var setup

<img width="387" alt="image" src="https://github.com/firezone/firezone/assets/13400041/9c080b36-3a76-49c7-b706-20723697edc7">


```[tasklist]
### Next steps
- [x] Split out a refactor PR for `ConnectArgs` (#5488)
- [x] Try doing this for other Clients
- [x] Check Gateway
- [x] Check Tauri Client
- [x] Change to `app_version`
- [x] Open for review
- [ ] Use `option_env` so that `FIREZONE_PACKAGE_VERSION` can still override the Cargo.toml version for local testing
- [ ] Check Android Client
- [ ] Check Apple Client
```