### PR TITLE
fix(website): Only invoke NextJS custom middleware for needed routes

### DIFF
--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -50,6 +50,12 @@ const versionedRedirects = [
   },
 ];
 
+// Restrict the middleware to execute only on the following paths in order
+// to avoid unnecessary processing and invocations
+export const config = {
+  matcher: versionedRedirects.map((redirect) => redirect.source),
+};
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 


### PR DESCRIPTION
NextJS middleware can be filtered based on matched route, which will drastically lower the number of invocations we're currently hitting.

https://vercel.com/docs/functions/edge-middleware/middleware-api#config-object