### PR TITLE
fix(android): Handle onRevoke to stop connlib when VPN profile is revoked

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -199,6 +199,12 @@ class TunnelService : VpnService() {
         super.onDestroy()
     }
 
+    override fun onRevoke() {
+        Log.d(TAG, "onRevoke")
+        disconnect()
+        super.onRevoke()
+    }
+
     // Call this to stop the tunnel and shutdown the service, leaving the token intact.
     fun disconnect() {
         Log.d(TAG, "disconnect")


### PR DESCRIPTION
If the Firezone VPN profile is removed while Firezone is signed in, we fail to shut down connlib and upon the next `buildVpnService()` call, we get a NullPointerException because the app isn't "ready". It needs a call to `prepare()` to register the profile again.

Fixes #5466 

https://developer.android.com/reference/android/net/VpnService#onRevoke()