### PR TITLE
feat(apple): Add button to show menuBar from FirstTimeView

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -36,7 +36,7 @@ struct FirezoneApp: App {
       "Welcome to Firezone",
       id: AppViewModel.WindowDefinition.main.identifier
     ) {
-      AppView(model: appViewModel)
+      AppView(model: appViewModel, menuBar: appDelegate.menuBar)
     }
     .handlesExternalEvents(
       matching: [AppViewModel.WindowDefinition.main.externalEventMatchString]
@@ -58,7 +58,7 @@ struct FirezoneApp: App {
 #if os(macOS)
   @MainActor
   final class AppDelegate: NSObject, NSApplicationDelegate {
-    private var menuBar: MenuBar?
+    var menuBar: MenuBar?
     public var store: Store?
 
     func applicationDidFinishLaunching(_: Notification) {

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -36,7 +36,10 @@ struct FirezoneApp: App {
       "Welcome to Firezone",
       id: AppViewModel.WindowDefinition.main.identifier
     ) {
-      AppView(model: appViewModel, menuBar: appDelegate.menuBar)
+      if let menuBar = appDelegate.menuBar {
+        // menuBar will be initialized by this point
+        AppView(model: appViewModel).environmentObject(menuBar)
+      }
     }
     .handlesExternalEvents(
       matching: [AppViewModel.WindowDefinition.main.externalEventMatchString]

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -61,13 +61,10 @@ public class AppViewModel: ObservableObject {
 }
 
 public struct AppView: View {
-  var menuBar: MenuBar?
-
   @ObservedObject var model: AppViewModel
 
-  public init(model: AppViewModel, menuBar: MenuBar?) {
+  public init(model: AppViewModel) {
     self.model = model
-    self.menuBar = menuBar
   }
 
   @ViewBuilder
@@ -94,7 +91,7 @@ public struct AppView: View {
     case .invalid:
       GrantVPNView(model: GrantVPNViewModel(store: model.store))
     default:
-      FirstTimeView(menuBar: menuBar)
+      FirstTimeView()
     }
 #endif
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -61,10 +61,13 @@ public class AppViewModel: ObservableObject {
 }
 
 public struct AppView: View {
+  var menuBar: MenuBar?
+
   @ObservedObject var model: AppViewModel
 
-  public init(model: AppViewModel) {
+  public init(model: AppViewModel, menuBar: MenuBar?) {
     self.model = model
+    self.menuBar = menuBar
   }
 
   @ViewBuilder
@@ -91,7 +94,7 @@ public struct AppView: View {
     case .invalid:
       GrantVPNView(model: GrantVPNViewModel(store: model.store))
     default:
-      FirstTimeView()
+      FirstTimeView(menuBar: menuBar)
     }
 #endif
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
@@ -23,7 +23,7 @@ struct FirstTimeView: View {
           .padding(.horizontal, 10)
         Spacer()
         Text(
-          "You can sign in to Firezone by clicking on the Firezone icon in the macOS menu bar.\nYou may now close this window."
+          "You can sign in to Firezone by clicking on the Firezone icon in the macOS menu bar or clicking 'Open menu' below.\nYou may now close this window."
         )
         .font(.body)
         .multilineTextAlignment(.center)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 #if os(macOS)
 struct FirstTimeView: View {
+  var menuBar: MenuBar?
+
   var body: some View {
     VStack(
       alignment: .center,
@@ -27,11 +29,21 @@ struct FirstTimeView: View {
         .multilineTextAlignment(.center)
 
         Spacer()
-        Button("Close this Window") {
-          AppViewModel.WindowDefinition.main.window()?.close()
+        HStack {
+          Button("Close this window") {
+            AppViewModel.WindowDefinition.main.window()?.close()
+          }
+          .buttonStyle(.borderedProminent)
+          .controlSize(.large)
+          Button("Open menu") {
+            DispatchQueue.main.async {
+              menuBar?.showMenu()
+            }
+            AppViewModel.WindowDefinition.main.window()?.close()
+          }
+          .buttonStyle(.borderedProminent)
+          .controlSize(.large)
         }
-        .buttonStyle(.borderedProminent)
-        .controlSize(.large)
         Spacer()
           .frame(maxHeight: 20)
         Text(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 #if os(macOS)
 struct FirstTimeView: View {
-  var menuBar: MenuBar?
+  @EnvironmentObject var menuBar: MenuBar
 
   var body: some View {
     VStack(
@@ -37,7 +37,7 @@ struct FirstTimeView: View {
           .controlSize(.large)
           Button("Open menu") {
             DispatchQueue.main.async {
-              menuBar?.showMenu()
+              menuBar.showMenu()
             }
             AppViewModel.WindowDefinition.main.window()?.close()
           }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
@@ -23,7 +23,7 @@ struct FirstTimeView: View {
           .padding(.horizontal, 10)
         Spacer()
         Text(
-          "You can sign in to Firezone by clicking on the Firezone icon in the macOS menu bar or clicking 'Open menu' below.\nYou may now close this window."
+          "You can sign in by clicking the Firezone icon in the macOS menu bar or clicking 'Open menu' below."
         )
         .font(.body)
         .multilineTextAlignment(.center)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -48,6 +48,10 @@ public final class MenuBar: NSObject {
     setupObservers()
   }
 
+  func showMenu() {
+    statusItem.button?.performClick(nil)
+  }
+
   private func setupObservers() {
     model.store.$status
       .receive(on: DispatchQueue.main)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -16,7 +16,7 @@ import SwiftUI
 @MainActor
 // TODO: Refactor to MenuBarExtra for macOS 13+
 // https://developer.apple.com/documentation/swiftui/menubarextra
-public final class MenuBar: NSObject {
+public final class MenuBar: NSObject, ObservableObject {
   private var statusItem: NSStatusItem
   private var resources: [Resource]?
   private var cancellables: Set<AnyCancellable> = []


### PR DESCRIPTION
Fixes #5500 

Unfortunately showing the menubar menu _only_ on re-launch is non-trivial due to the way "re-launches" are processed in macOS.

We can handle them with the `applicationDidBecomeActive` override in `AppDelegate`, but then this will be triggered whenever we sign in, open Settings, or open About window because we activate the app then as well in order to bring the Window to the foreground.

There's no good to way to determine who asked us to activate either.

Instead, we show the Welcome window (FirstTimeView on macOS), and in there is a new button to show the app menu to use as a fallback for users who need an alternative way to open the menu with a busy menubar.


<img width="1012" alt="Screenshot 2024-06-23 at 5 14 57 PM" src="https://github.com/firezone/firezone/assets/167144/1a7dde08-1e83-4dc8-9516-e0390f29c941">
