### PR TITLE
fix(connlib): allow larger DNS responses

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -8,7 +8,7 @@ use connlib_shared::messages::DnsServer;
 use futures_bounded::FuturesTupleSet;
 use futures_util::FutureExt as _;
 use hickory_resolver::{
-    config::{NameServerConfig, Protocol, ResolverConfig},
+    config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts},
     TokioAsyncResolver,
 };
 use ip_packet::{IpPacket, MutableIpPacket};
@@ -199,9 +199,13 @@ fn create_resolvers(
             let mut resolver_config = ResolverConfig::new();
             resolver_config.add_name_server(NameServerConfig::new(srv.address(), Protocol::Udp));
             resolver_config.add_name_server(NameServerConfig::new(srv.address(), Protocol::Tcp));
+
+            let mut resolver_opts = ResolverOpts::default();
+            resolver_opts.edns0 = true;
+
             (
                 sentinel,
-                TokioAsyncResolver::tokio(resolver_config, Default::default()),
+                TokioAsyncResolver::tokio(resolver_config, resolver_opts),
             )
         })
         .collect()

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -198,6 +198,7 @@ fn create_resolvers(
         .map(|(sentinel, srv)| {
             let mut resolver_config = ResolverConfig::new();
             resolver_config.add_name_server(NameServerConfig::new(srv.address(), Protocol::Udp));
+            resolver_config.add_name_server(NameServerConfig::new(srv.address(), Protocol::Tcp));
             (
                 sentinel,
                 TokioAsyncResolver::tokio(resolver_config, Default::default()),


### PR DESCRIPTION
Many name servers apply a limit as to how big a DNS response is allowed to be to protect themselves against DoS attacks. Querying a domain with large records can thus fail if all we have available is UDP. To mitigate this, we configure every upstream / system DNS server to use UDP and TCP and let hickory decide, when to use what.

In addition, we enable EDNS(0), an extension to the original DNS spec that lifts several limits in terms of record sizes.