### PR TITLE
build(deps): bump tokio-tungstenite to 0.23

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "libc",
  "log",
  "phoenix-channel",
+ "rustls",
  "secrecy",
  "serde_json",
  "socket-factory",
@@ -1027,6 +1028,7 @@ dependencies = [
  "libc",
  "oslog",
  "phoenix-channel",
+ "rustls",
  "secrecy",
  "serde_json",
  "socket-factory",
@@ -1057,8 +1059,8 @@ dependencies = [
  "serde_json",
  "socket-factory",
  "thiserror",
+ "time",
  "tokio",
- "tokio-tungstenite",
  "tracing",
  "tun",
  "url",
@@ -1816,6 +1818,7 @@ dependencies = [
  "ip_network",
  "libc",
  "phoenix-channel",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -1823,7 +1826,6 @@ dependencies = [
  "socket-factory",
  "static_assertions",
  "tokio",
- "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1855,6 +1857,7 @@ dependencies = [
  "output_vt100",
  "rand 0.8.5",
  "reqwest",
+ "rustls",
  "sadness-generator",
  "secrecy",
  "semver",
@@ -1906,6 +1909,7 @@ dependencies = [
  "phoenix-channel",
  "resolv-conf",
  "rtnetlink",
+ "rustls",
  "sd-notify",
  "secrecy",
  "serde",
@@ -1961,6 +1965,7 @@ dependencies = [
  "phoenix-channel",
  "proptest",
  "rand 0.8.5",
+ "rustls",
  "secrecy",
  "serde",
  "sha2",
@@ -2804,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
@@ -2817,6 +2822,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4666,6 +4672,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp 0.5.2",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quinn-udp"
 version = "0.5.4"
 source = "git+https://github.com/quinn-rs/quinn?branch=main#061a74fb6ef67b12f78bc2a3cfc9906e54762eeb"
@@ -4907,9 +4960,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4928,13 +4981,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.0",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -5021,6 +5075,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5044,11 +5104,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -5068,15 +5128,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5545,7 +5605,7 @@ dependencies = [
 name = "socket-factory"
 version = "0.1.0"
 dependencies = [
- "quinn-udp",
+ "quinn-udp 0.5.4",
  "socket2",
  "tokio",
  "tracing",
@@ -6282,9 +6342,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -6304,9 +6364,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",
@@ -6658,9 +6718,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
 dependencies = [
  "byteorder",
  "bytes",
@@ -6673,7 +6733,6 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror",
- "url",
  "utf-8",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,9 +37,10 @@ str0m = { version = "0.6.2", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.10", features = ["serde"] }
 dns-lookup = "2.0"
-tokio-tungstenite = "0.21"
+tokio-tungstenite = "0.23.1"
 rtnetlink = { version = "0.14.1", default-features = false, features = ["tokio_socket"] }
 tokio = "1.39"
+rustls = { version = "0.23.10", default-features = false, features = ["ring"] }
 
 connlib-client-android = { path = "connlib/clients/android" }
 connlib-client-apple = { path = "connlib/clients/apple" }

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -22,6 +22,7 @@ jni = { version = "0.21.1", features = ["invocation"] }
 libc = "0.2"
 log = "0.4"
 phoenix-channel = { workspace = true }
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde_json = "1"
 socket-factory = { workspace = true }

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -366,6 +366,16 @@ fn connect(
 
     let tcp_socket_factory = Arc::new(protected_tcp_socket_factory(callbacks.clone()));
 
+    // On Android, the VpnService may still be loaded into memory when reconnecting.
+    // Only install the crypto-provider if we haven't done so previously.
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect(
+                "Calling `install_default` should succeed if we don't have a crypto provider yet.",
+            );
+    }
+
     let args = ConnectArgs {
         tcp_socket_factory: tcp_socket_factory.clone(),
         udp_socket_factory: Arc::new(protected_udp_socket_factory(callbacks.clone())),

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -579,9 +579,9 @@ fn protected_udp_socket_factory(callbacks: CallbackHandler) -> impl SocketFactor
 
 /// Installs the `ring` crypto provider for rustls.
 fn install_rustls_crypto_provider() {
-    let exising = rustls::crypto::ring::default_provider().install_default();
+    let existing = rustls::crypto::ring::default_provider().install_default();
 
-    if exising.is_err() {
+    if existing.is_err() {
         // On Android, connlib gets loaded as shared library by the JVM and may remain loaded even if we disconnect the tunnel.
         tracing::debug!("Skipping install of crypto provider because we already have one.");
     }

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -19,6 +19,7 @@ firezone-logging = { workspace = true }
 ip_network = "0.4"
 libc = "0.2"
 phoenix-channel = { workspace = true }
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde_json = "1"
 socket-factory = { workspace = true }

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -256,9 +256,9 @@ fn err_to_string(result: Result<WrappedSession>) -> Result<WrappedSession, Strin
 
 /// Installs the `ring` crypto provider for rustls.
 fn install_rustls_crypto_provider() {
-    let exising = rustls::crypto::ring::default_provider().install_default();
+    let existing = rustls::crypto::ring::default_provider().install_default();
 
-    if exising.is_err() {
+    if existing.is_err() {
         // On Apple platforms, network extensions get terminated on disconnect and thus all memory is free'd.
         // Therefore, this should not never happen unless the above is somehow no longer true.
         tracing::warn!("Skipping install of crypto provider because we already have one.");

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -201,6 +201,10 @@ impl WrappedSession {
             .build()?;
         let _guard = runtime.enter(); // Constructing `PhoenixChannel` requires a runtime context.
 
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("Calling `install_default` only once per process always succeeds");
+
         let args = ConnectArgs {
             private_key,
             callbacks: CallbackHandler {

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -18,19 +18,15 @@ secrecy = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 socket-factory = { workspace = true }
 thiserror = "1.0.63"
+time = { version = "0.3.36", features = ["formatting"] }
 tokio = { workspace = true, features = ["sync"] }
-tokio-tungstenite = { version = "0.21", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
-tracing = { workspace = true }
-tun = { workspace = true }
-url = { version = "2.5.2", features = ["serde"] }
-
-[target.'cfg(target_os = "android")'.dependencies]
 tracing = { workspace = true, features = ["std", "attributes"] }
+tun = { workspace = true }
+url = { version = "2.4.1", features = ["serde"] }
 
 [dev-dependencies]
 chrono = { workspace = true }
 serde_json = { version = "1.0", features = ["std"] }
-tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -24,13 +24,13 @@ futures-bounded = { workspace = true }
 ip_network = { version = "0.4", default-features = false }
 libc = { version = "0.2", default-features = false, features = ["std", "const-extern-fn", "extra_traits"] }
 phoenix-channel = { workspace = true }
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
 static_assertions = "1.1.0"
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread", "fs", "signal"] }
-tokio-tungstenite = { version = "0.21", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
 tracing = { workspace = true }
 tracing-subscriber = "0.3.17"
 url = { version = "2.5.2", default-features = false }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -58,6 +58,10 @@ async fn try_main() -> Result<()> {
         public_key.to_bytes(),
     )?;
 
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Calling `install_default` only once per process always succeeds");
+
     let task = tokio::spawn(run(login, private_key)).err_into();
 
     let ctrl_c = pin!(ctrl_c().map_err(anyhow::Error::new));

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -31,6 +31,10 @@ const ID_PATH: &str = "/var/lib/firezone/gateway_id";
 
 #[tokio::main]
 async fn main() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Calling `install_default` only once per process always succeeds");
+
     // Enforce errors only being printed on a single line using the technique recommended in the anyhow docs:
     // https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations
     //
@@ -57,10 +61,6 @@ async fn try_main() -> Result<()> {
         cli.firezone_name,
         public_key.to_bytes(),
     )?;
-
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .expect("Calling `install_default` only once per process always succeeds");
 
     let task = tokio::spawn(run(login, private_key)).err_into();
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -33,7 +33,7 @@ const ID_PATH: &str = "/var/lib/firezone/gateway_id";
 async fn main() {
     rustls::crypto::ring::default_provider()
         .install_default()
-        .expect("Calling `install_default` only once per process always succeeds");
+        .expect("Calling `install_default` only once per process should always succeed");
 
     // Enforce errors only being printed on a single line using the technique recommended in the anyhow docs:
     // https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -29,7 +29,8 @@ minidumper = "0.8.2"
 native-dialog = "0.7.0"
 output_vt100 = "0.1"
 rand = "0.8.5"
-reqwest = { version = "0.12.4", default-features = false, features = ["stream", "rustls-tls"] }
+reqwest = { version = "0.12.5", default-features = false, features = ["stream", "rustls-tls"] }
+rustls = { workspace = true }
 sadness-generator = "0.5.0"
 secrecy = { workspace = true }
 semver = { version = "1.0.22", features = ["serde"] }

--- a/rust/gui-client/src-tauri/src/bin/firezone-client-ipc.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-client-ipc.rs
@@ -1,7 +1,7 @@
 fn main() -> anyhow::Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
-        .expect("Calling `install_default` only once per process always succeeds");
+        .expect("Calling `install_default` only once per process should always succeed");
 
     firezone_headless_client::run_only_ipc_service()
 }

--- a/rust/gui-client/src-tauri/src/bin/firezone-client-ipc.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-client-ipc.rs
@@ -1,3 +1,7 @@
 fn main() -> anyhow::Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Calling `install_default` only once per process always succeeds");
+
     firezone_headless_client::run_only_ipc_service()
 }

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -34,7 +34,7 @@ pub(crate) fn run() -> Result<()> {
 
     rustls::crypto::ring::default_provider()
         .install_default()
-        .expect("Calling `install_default` only once per process always succeeds");
+        .expect("Calling `install_default` only once per process should always succeed");
 
     match cli.command {
         None => {

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -32,6 +32,10 @@ pub(crate) fn run() -> Result<()> {
     std::panic::set_hook(Box::new(tracing_panic::panic_hook));
     let cli = Cli::parse();
 
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Calling `install_default` only once per process always succeeds");
+
     match cli.command {
         None => {
             if cli.no_deep_links {

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3.30"
 humantime = "2.1"
 ip_network = { version = "0.4", default-features = false }
 phoenix-channel = { workspace = true }
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.117"

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -103,7 +103,7 @@ enum Cmd {
 fn main() -> Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
-        .expect("Calling `install_default` only once per process always succeeds");
+        .expect("Calling `install_default` only once per process should always succeed");
 
     let mut cli = Cli::try_parse()?;
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -101,6 +101,10 @@ enum Cmd {
 }
 
 fn main() -> Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Calling `install_default` only once per process always succeeds");
+
     let mut cli = Cli::try_parse()?;
 
     // Modifying the environment of a running process is unsafe. If any other

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -23,6 +23,7 @@ opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio"] }
 phoenix-channel = { path = "../phoenix-channel" }
 proptest = { version = "1", optional = true }
 rand = "0.8.5"
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { version = "1.0.204", features = ["derive"] }
 sha2 = "0.10.8"

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -98,7 +98,7 @@ enum LogFormat {
 async fn main() -> Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
-        .expect("Calling `install_default` only once per process always succeeds");
+        .expect("Calling `install_default` only once per process should always succeed");
 
     let args = Args::parse();
 

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -123,6 +123,10 @@ async fn main() -> Result<()> {
         make_is_healthy(last_heartbeat_sent.clone()),
     ));
 
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Calling `install_default` only once per process always succeeds");
+
     let channel = if let Some(token) = args.token.as_ref() {
         use secrecy::ExposeSecret;
 

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -96,6 +96,10 @@ enum LogFormat {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Calling `install_default` only once per process always succeeds");
+
     let args = Args::parse();
 
     setup_tracing(&args)?;
@@ -122,10 +126,6 @@ async fn main() -> Result<()> {
         args.health_check.health_check_addr,
         make_is_healthy(last_heartbeat_sent.clone()),
     ));
-
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .expect("Calling `install_default` only once per process always succeeds");
 
     let channel = if let Some(token) = args.token.as_ref() {
         use secrecy::ExposeSecret;


### PR DESCRIPTION
With the upgrade to 0.23, `tokio-tungstenite` pulls in `rustls` 0.27 which supports multiple crypto providers. By default, this uses the `aws-lc-crypto` provider. The previous default was `ring`.

This PR bumps the necessary versions and installs the `ring` crypto provider at the beginning of each application, before connlib starts. We try and do this as early as possible to make it obvious that it only needs to happen once per process.

Resolves: #5380.