### PR TITLE
chore(phoenix-channel): only flush after writing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -313,7 +313,7 @@ services:
     environment:
       FIREZONE_DNS_CONTROL: "${FIREZONE_DNS_CONTROL:-etc-resolv-conf}"
       FIREZONE_TOKEN: "n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAGUmu74wBYgABUYA.UN3vSLLcAMkHeEh5VHumPOutkuue8JA6wlxM9JxJEPE"
-      RUST_LOG: ${RUST_LOG:-firezone_linux_client=trace,wire=trace,connlib_client_shared=trace,firezone_tunnel=trace,connlib_shared=trace,boringtun=debug,snownet=debug,str0m=debug,info}
+      RUST_LOG: ${RUST_LOG:-firezone_linux_client=trace,wire=trace,connlib_client_shared=trace,firezone_tunnel=trace,connlib_shared=trace,boringtun=debug,snownet=debug,str0m=debug,phoenix_channel=debug,info}
       FIREZONE_API_URL: ws://api:8081
     init: true
     build:

--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -49,7 +49,6 @@ impl Heartbeat {
 
     pub fn reset(&mut self) {
         self.pending = None;
-        self.interval.reset();
     }
 
     pub fn poll(

--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -49,6 +49,7 @@ impl Heartbeat {
 
     pub fn reset(&mut self) {
         self.pending = None;
+        self.interval.reset();
     }
 
     pub fn poll(

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -20,7 +20,6 @@ use std::task::{Context, Poll, Waker};
 use tokio::net::TcpStream;
 use tokio_tungstenite::connect_async_with_config;
 use tokio_tungstenite::tungstenite::http::StatusCode;
-use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::{
     connect_async,
     tungstenite::{handshake::client::Request, Message},


### PR DESCRIPTION
Currently, `phoenix-channel` calls `flush` manually to ensure we don't have messages sitting in a buffer somewhere. This is somewhat wasteful if we haven't actually written any message. We can move the flushing to directly after sending the message.

To avoid further buffering on the TCP level, we disable Nagle's algorithm to avoid buffering on the TCP level.