### PR TITLE
chore(phoenix-channel): remove outdated TODO

### DIFF
--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -27,8 +27,6 @@ use std::mem;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
-// TODO: Refactor this PhoenixChannel to be compatible with the needs of the client and gateway
-// See https://github.com/firezone/firezone/issues/2158
 pub struct PhoenixChannel<TInitReq, TInboundMsg, TOutboundRes> {
     state: State,
     waker: Option<Waker>,


### PR DESCRIPTION
This TODO has been addressed. `phoenix-channel` is used by all components: gateway, relay and all clients.