### PR TITLE
fix(gateway): handle `init` messages during operation

### DIFF
--- a/rust/connlib/shared/src/tun_device_manager/linux.rs
+++ b/rust/connlib/shared/src/tun_device_manager/linux.rs
@@ -76,6 +76,8 @@ impl TunDeviceManager {
             .await
             .context("Failed to delete existing addresses")?;
 
+        self.routes.clear(); // Deleting the IPs clears all routes.
+
         handle
             .link()
             .set(index)

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -85,7 +85,7 @@ impl Device {
         callbacks: &impl Callbacks,
     ) -> Result<(), ConnlibError> {
         // On Android / Linux we recreate the tunnel every time we re-configure it
-        self.tun = Some(Tun::new(config, dns_config.clone(), callbacks)?);
+        self.tun = Some(Tun::new()?);
 
         callbacks.on_set_interface_config(config.ipv4, config.ipv6, dns_config);
 

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -77,27 +77,12 @@ impl Device {
         Ok(())
     }
 
-    #[cfg(target_os = "linux")]
-    pub(crate) fn set_config(
-        &mut self,
-        config: &Interface,
-        dns_config: Vec<IpAddr>,
-        callbacks: &impl Callbacks,
-    ) -> Result<(), ConnlibError> {
-        if self.tun.is_none() {
-            self.tun = Some(Tun::new()?);
-
-            if let Some(waker) = self.waker.take() {
-                waker.wake();
-            }
-        }
-
-        callbacks.on_set_interface_config(config.ipv4, config.ipv6, dns_config);
-
-        Ok(())
-    }
-
-    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "windows"))]
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "windows",
+        target_os = "linux"
+    ))]
     pub(crate) fn set_config(
         &mut self,
         config: &Interface,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -235,6 +235,9 @@ impl Eventloop {
                 };
                 self.tunnel.update_relays(HashSet::default(), init.relays);
 
+                // FIXME(tech-debt): Currently, the `Tunnel` creates the TUN device as part of `set_interface`.
+                // For the gateway, it doesn't do anything else so in an ideal world, we would cause the side-effect out here and just pass an opaque `Device` to the `Tunnel`.
+                // That requires more refactoring of other platforms, so for now, we need to rely on the `Tunnel` interface and cause the side-effect separately via the `TunDeviceManager`.
                 if let Err(e) = self.tun_device_channel.try_send(init.interface) {
                     tracing::warn!("Failed to set interface: {e}");
                 }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -6,12 +6,13 @@ use crate::CallbackHandler;
 use anyhow::Result;
 use boringtun::x25519::PublicKey;
 use connlib_shared::messages::{
-    ClientId, ConnectionAccepted, RelaysPresence, ResourceAccepted, ResourceId,
+    ClientId, ConnectionAccepted, Interface, RelaysPresence, ResourceAccepted, ResourceId,
 };
 use connlib_shared::{messages::GatewayResponse, DomainName};
 #[cfg(not(target_os = "windows"))]
 use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
 use firezone_tunnel::GatewayTunnel;
+use futures::channel::mpsc;
 use futures_bounded::Timeout;
 use phoenix_channel::PhoenixChannel;
 use std::collections::HashSet;
@@ -41,6 +42,7 @@ enum ResolveTrigger {
 pub struct Eventloop {
     tunnel: GatewayTunnel<CallbackHandler>,
     portal: PhoenixChannel<(), IngressMessages, ()>,
+    tun_device_channel: mpsc::Sender<Interface>,
 
     resolve_tasks: futures_bounded::FuturesTupleSet<Vec<IpAddr>, ResolveTrigger>,
 }
@@ -49,11 +51,13 @@ impl Eventloop {
     pub(crate) fn new(
         tunnel: GatewayTunnel<CallbackHandler>,
         portal: PhoenixChannel<(), IngressMessages, ()>,
+        tun_device_channel: mpsc::Sender<Interface>,
     ) -> Self {
         Self {
             tunnel,
             portal,
             resolve_tasks: futures_bounded::FuturesTupleSet::new(DNS_RESOLUTION_TIMEOUT, 100),
+            tun_device_channel,
         }
     }
 }
@@ -223,10 +227,17 @@ impl Eventloop {
                 .tunnel
                 .update_relays(HashSet::from_iter(disconnected_ids), connected),
             phoenix_channel::Event::InboundMessage {
-                msg: IngressMessages::Init(_),
+                msg: IngressMessages::Init(init),
                 ..
             } => {
-                // TODO: Handle `init` message during operation.
+                if let Err(e) = self.tunnel.set_interface(&init.interface) {
+                    tracing::warn!("Failed to set interface: {e}");
+                };
+                self.tunnel.update_relays(HashSet::default(), init.relays);
+
+                if let Err(e) = self.tun_device_channel.try_send(init.interface) {
+                    tracing::warn!("Failed to set interface: {e}");
+                }
             }
             phoenix_channel::Event::InboundMessage {
                 msg: IngressMessages::ResourceUpdated(resource_description),

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -118,6 +118,13 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
     let update_device_task = async move {
         while let Some(next_interface) = receiver.next().await {
             if let Err(e) = tun_device
+                .set_ips(next_interface.ipv4, next_interface.ipv6)
+                .await
+            {
+                tracing::warn!("Failed to set interface: {e}");
+            }
+
+            if let Err(e) = tun_device
                 .set_routes(
                     vec![Cidrv4::from(PEERS_IPV4.parse::<Ipv4Network>().unwrap())],
                     vec![Cidrv6::from(PEERS_IPV6.parse::<Ipv6Network>().unwrap())],
@@ -126,13 +133,6 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
             {
                 tracing::warn!("Failed to set routes: {e}");
             };
-
-            if let Err(e) = tun_device
-                .set_ips(next_interface.ipv4, next_interface.ipv6)
-                .await
-            {
-                tracing::warn!("Failed to set interface: {e}");
-            }
         }
     };
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -1,15 +1,17 @@
 use crate::eventloop::{Eventloop, PHOENIX_TOPIC};
-use crate::messages::InitGateway;
 use anyhow::{Context, Result};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
+use connlib_shared::messages::Interface;
+use connlib_shared::tun_device_manager::TunDeviceManager;
 use connlib_shared::{get_user_agent, keypair, Callbacks, Cidrv4, Cidrv6, LoginUrl, StaticSecret};
 use firezone_cli_utils::{setup_global_subscriber, CommonArgs};
 use firezone_tunnel::{GatewayTunnel, Sockets};
-use futures::{future, TryFutureExt};
+use futures::channel::mpsc;
+use futures::{future, StreamExt, TryFutureExt};
 use ip_network::{Ipv4Network, Ipv6Network};
+use phoenix_channel::PhoenixChannel;
 use secrecy::{Secret, SecretString};
-use std::collections::HashSet;
 use std::convert::Infallible;
 use std::path::Path;
 use std::pin::pin;
@@ -98,9 +100,8 @@ async fn get_firezone_id(env_id: Option<String>) -> Result<String> {
 }
 
 async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
-    let mut tunnel = GatewayTunnel::new(private_key, Sockets::new(), CallbackHandler)?;
-
-    let (portal, init) = phoenix_channel::init::<_, InitGateway, _, _>(
+    let tunnel = GatewayTunnel::new(private_key, Sockets::new(), CallbackHandler)?;
+    let portal = PhoenixChannel::connect(
         Secret::new(login),
         get_user_agent(None, env!("CARGO_PKG_VERSION")),
         PHOENIX_TOPIC,
@@ -108,29 +109,35 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
         ExponentialBackoffBuilder::default()
             .with_max_elapsed_time(None)
             .build(),
-    )
-    .await??;
+    );
 
-    tunnel
-        .set_interface(&init.interface)
-        .context("Failed to set interface")?;
-    let mut tun_device = connlib_shared::tun_device_manager::TunDeviceManager::new()?;
-    tun_device
-        .set_ips(init.interface.ipv4, init.interface.ipv6)
-        .await?;
+    let (sender, mut receiver) = mpsc::channel::<Interface>(10);
+
+    let mut tun_device = TunDeviceManager::new()?;
     tun_device
         .set_routes(
             vec![Cidrv4::from(PEERS_IPV4.parse::<Ipv4Network>().unwrap())],
             vec![Cidrv6::from(PEERS_IPV6.parse::<Ipv6Network>().unwrap())],
         )
         .await?;
-    tunnel.update_relays(HashSet::default(), init.relays);
 
-    let mut eventloop = Eventloop::new(tunnel, portal);
+    let update_device_task = async move {
+        while let Some(next_interface) = receiver.next().await {
+            if let Err(e) = tun_device
+                .set_ips(next_interface.ipv4, next_interface.ipv6)
+                .await
+            {
+                tracing::warn!("Failed to set interface: {e}");
+            }
+        }
+    };
 
-    future::poll_fn(|cx| eventloop.poll(cx))
-        .await
-        .context("Eventloop failed")?;
+    let mut eventloop = Eventloop::new(tunnel, portal, sender);
+    let eventloop_task = future::poll_fn(move |cx| eventloop.poll(cx));
+
+    let ((), result) = futures::join!(update_device_task, eventloop_task);
+
+    result.context("Eventloop failed")?;
 
     unreachable!()
 }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -121,7 +121,7 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
                 .set_ips(next_interface.ipv4, next_interface.ipv6)
                 .await
             {
-                tracing::warn!("Failed to set interface: {e}");
+                tracing::warn!("Failed to set interface: {e:#}");
             }
 
             if let Err(e) = tun_device
@@ -131,7 +131,7 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
                 )
                 .await
             {
-                tracing::warn!("Failed to set routes: {e}");
+                tracing::warn!("Failed to set routes: {e:#}");
             };
         }
     };

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -114,15 +114,19 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
     let (sender, mut receiver) = mpsc::channel::<Interface>(10);
 
     let mut tun_device = TunDeviceManager::new()?;
-    tun_device
-        .set_routes(
-            vec![Cidrv4::from(PEERS_IPV4.parse::<Ipv4Network>().unwrap())],
-            vec![Cidrv6::from(PEERS_IPV6.parse::<Ipv6Network>().unwrap())],
-        )
-        .await?;
 
     let update_device_task = async move {
         while let Some(next_interface) = receiver.next().await {
+            if let Err(e) = tun_device
+                .set_routes(
+                    vec![Cidrv4::from(PEERS_IPV4.parse::<Ipv4Network>().unwrap())],
+                    vec![Cidrv6::from(PEERS_IPV6.parse::<Ipv6Network>().unwrap())],
+                )
+                .await
+            {
+                tracing::warn!("Failed to set routes: {e}");
+            };
+
             if let Err(e) = tun_device
                 .set_ips(next_interface.ipv4, next_interface.ipv6)
                 .await

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -158,7 +158,6 @@ mod test {
     use connlib_shared::messages::gateway::PortRange;
     use connlib_shared::messages::gateway::ResourceDescriptionDns;
     use connlib_shared::messages::Turn;
-    use phoenix_channel::InitMessage;
     use phoenix_channel::PhoenixMessage;
 
     #[test]
@@ -405,141 +404,176 @@ mod test {
 
     #[test]
     fn init_phoenix_message() {
-        let m = InitMessage::Init(InitGateway {
-            interface: Interface {
-                ipv4: "100.115.164.78".parse().unwrap(),
-                ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                upstream_dns: vec![],
-            },
-            config: Config {
-                ipv4_masquerade_enabled: true,
-                ipv6_masquerade_enabled: true,
-            },
-            relays: vec![],
-        });
+        let m = PhoenixMessage::new_message(
+            "gateway",
+            IngressMessages::Init(InitGateway {
+                interface: Interface {
+                    ipv4: "100.115.164.78".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
+                    upstream_dns: vec![],
+                },
+                config: Config {
+                    ipv4_masquerade_enabled: true,
+                    ipv6_masquerade_enabled: true,
+                },
+                relays: vec![],
+            }),
+            None,
+        );
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message = serde_json::from_str::<InitMessage<InitGateway>>(message).unwrap();
+        let ingress_message =
+            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
         assert_eq!(m, ingress_message);
     }
 
     #[test]
     fn additional_fields_are_ignore() {
-        let m = InitMessage::Init(InitGateway {
-            interface: Interface {
-                ipv4: "100.115.164.78".parse().unwrap(),
-                ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                upstream_dns: vec![],
-            },
-            config: Config {
-                ipv4_masquerade_enabled: true,
-                ipv6_masquerade_enabled: true,
-            },
-            relays: vec![],
-        });
+        let m = PhoenixMessage::new_message(
+            "gateway",
+            IngressMessages::Init(InitGateway {
+                interface: Interface {
+                    ipv4: "100.115.164.78".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
+                    upstream_dns: vec![],
+                },
+                config: Config {
+                    ipv4_masquerade_enabled: true,
+                    ipv6_masquerade_enabled: true,
+                },
+                relays: vec![],
+            }),
+            None,
+        );
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","irrelevant":"field","payload":{"more":"info","interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true,"ignored":"field"}}}"#;
-        let ingress_message = serde_json::from_str::<InitMessage<InitGateway>>(message).unwrap();
+        let ingress_message =
+            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
         assert_eq!(m, ingress_message);
     }
 
     #[test]
     fn additional_null_fields_are_ignored() {
-        let m = InitMessage::Init(InitGateway {
-            interface: Interface {
-                ipv4: "100.115.164.78".parse().unwrap(),
-                ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                upstream_dns: vec![],
-            },
-            config: Config {
-                ipv4_masquerade_enabled: true,
-                ipv6_masquerade_enabled: true,
-            },
-            relays: vec![],
-        });
+        let m = PhoenixMessage::new_message(
+            "gateway",
+            IngressMessages::Init(InitGateway {
+                interface: Interface {
+                    ipv4: "100.115.164.78".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
+                    upstream_dns: vec![],
+                },
+                config: Config {
+                    ipv4_masquerade_enabled: true,
+                    ipv6_masquerade_enabled: true,
+                },
+                relays: vec![],
+            }),
+            None,
+        );
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":null,"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message = serde_json::from_str::<InitMessage<InitGateway>>(message).unwrap();
+        let ingress_message =
+            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
         assert_eq!(m, ingress_message);
     }
 
     #[test]
     fn additional_number_fields_are_ignored() {
-        let m = InitMessage::Init(InitGateway {
-            interface: Interface {
-                ipv4: "100.115.164.78".parse().unwrap(),
-                ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                upstream_dns: vec![],
-            },
-            config: Config {
-                ipv4_masquerade_enabled: true,
-                ipv6_masquerade_enabled: true,
-            },
-            relays: vec![],
-        });
+        let m = PhoenixMessage::new_message(
+            "gateway",
+            IngressMessages::Init(InitGateway {
+                interface: Interface {
+                    ipv4: "100.115.164.78".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
+                    upstream_dns: vec![],
+                },
+                config: Config {
+                    ipv4_masquerade_enabled: true,
+                    ipv6_masquerade_enabled: true,
+                },
+                relays: vec![],
+            }),
+            None,
+        );
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":0.3,"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message = serde_json::from_str::<InitMessage<InitGateway>>(message).unwrap();
+        let ingress_message =
+            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
         assert_eq!(m, ingress_message);
     }
 
     #[test]
     fn additional_boolean_fields_are_ignored() {
-        let m = InitMessage::Init(InitGateway {
-            interface: Interface {
-                ipv4: "100.115.164.78".parse().unwrap(),
-                ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                upstream_dns: vec![],
-            },
-            config: Config {
-                ipv4_masquerade_enabled: true,
-                ipv6_masquerade_enabled: true,
-            },
-            relays: vec![],
-        });
+        let m = PhoenixMessage::new_message(
+            "gateway",
+            IngressMessages::Init(InitGateway {
+                interface: Interface {
+                    ipv4: "100.115.164.78".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
+                    upstream_dns: vec![],
+                },
+                config: Config {
+                    ipv4_masquerade_enabled: true,
+                    ipv6_masquerade_enabled: true,
+                },
+                relays: vec![],
+            }),
+            None,
+        );
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":true,"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message = serde_json::from_str::<InitMessage<InitGateway>>(message).unwrap();
+        let ingress_message =
+            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
         assert_eq!(m, ingress_message);
     }
 
     #[test]
     fn additional_object_fields_are_ignored() {
-        let m = InitMessage::Init(InitGateway {
-            interface: Interface {
-                ipv4: "100.115.164.78".parse().unwrap(),
-                ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                upstream_dns: vec![],
-            },
-            config: Config {
-                ipv4_masquerade_enabled: true,
-                ipv6_masquerade_enabled: true,
-            },
-            relays: vec![],
-        });
+        let m = PhoenixMessage::new_message(
+            "gateway",
+            IngressMessages::Init(InitGateway {
+                interface: Interface {
+                    ipv4: "100.115.164.78".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
+                    upstream_dns: vec![],
+                },
+                config: Config {
+                    ipv4_masquerade_enabled: true,
+                    ipv6_masquerade_enabled: true,
+                },
+                relays: vec![],
+            }),
+            None,
+        );
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":{"ignored":"field"},"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message = serde_json::from_str::<InitMessage<InitGateway>>(message).unwrap();
+        let ingress_message =
+            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
         assert_eq!(m, ingress_message);
     }
 
     #[test]
     fn additional_array_fields_are_ignored() {
-        let m = InitMessage::Init(InitGateway {
-            interface: Interface {
-                ipv4: "100.115.164.78".parse().unwrap(),
-                ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                upstream_dns: vec![],
-            },
-            config: Config {
-                ipv4_masquerade_enabled: true,
-                ipv6_masquerade_enabled: true,
-            },
-            relays: vec![],
-        });
+        let m = PhoenixMessage::new_message(
+            "gateway",
+            IngressMessages::Init(InitGateway {
+                interface: Interface {
+                    ipv4: "100.115.164.78".parse().unwrap(),
+                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
+                    upstream_dns: vec![],
+                },
+                config: Config {
+                    ipv4_masquerade_enabled: true,
+                    ipv6_masquerade_enabled: true,
+                },
+                relays: vec![],
+            }),
+            None,
+        );
 
         let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":[true,false],"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message = serde_json::from_str::<InitMessage<InitGateway>>(message).unwrap();
+        let ingress_message =
+            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
         assert_eq!(m, ingress_message);
     }
 

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -417,8 +417,6 @@ impl Callbacks for CallbackHandler {
             .try_send(InternalServerMsg::OnSetInterfaceConfig { ipv4, ipv6, dns })
             .expect("Should be able to send TunnelReady");
 
-        tracing::info!("Message sent!");
-
         None
     }
 

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -416,6 +416,9 @@ impl Callbacks for CallbackHandler {
         self.cb_tx
             .try_send(InternalServerMsg::OnSetInterfaceConfig { ipv4, ipv6, dns })
             .expect("Should be able to send TunnelReady");
+
+        tracing::info!("Message sent!");
+
         None
     }
 

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -416,7 +416,6 @@ impl Callbacks for CallbackHandler {
         self.cb_tx
             .try_send(InternalServerMsg::OnSetInterfaceConfig { ipv4, ipv6, dns })
             .expect("Should be able to send TunnelReady");
-
         None
     }
 


### PR DESCRIPTION
Currently, the gateway only handles an `init` message on startup. For clients, we handle `init` messages also during operation so it only makes sense to do the same thing for gateways.

This allows us to remove some old code from `phoenix_channel`. In particular, the `init` function which used to wait for the `init` message before continuing. In https://github.com/firezone/firezone/pull/4594, we refactored `phoenix-channel` to reconnect internally on errors. As a result, the `connect` function became synchronous and no longer needed an `async` context.

At the time, the gateway wasn't updated to make use of this. We can now simplify the gateway code and resolve the outstanding TODO of handling `init` messages during operation.