### PR TITLE
fix(portal): fix search box width

### DIFF
--- a/elixir/apps/web/lib/web/live_table.ex
+++ b/elixir/apps/web/lib/web/live_table.ex
@@ -190,7 +190,7 @@ defmodule Web.LiveTable do
 
   defp filter(%{filter: %{type: {:string, :websearch}}} = assigns) do
     ~H"""
-    <div class="flex items-center order-last">
+    <div class="flex items-center order-last md:w-56">
       <div class="relative w-full" phx-feedback-for={@form[@filter.name].name}>
         <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
           <.icon name="hero-magnifying-glass" class="w-5 h-5 text-neutral-500" />
@@ -225,7 +225,7 @@ defmodule Web.LiveTable do
 
   defp filter(%{filter: %{type: {:string, :email}}} = assigns) do
     ~H"""
-    <div class="flex items-center order-last">
+    <div class="flex items-center order-last md:w-56">
       <div class="relative w-full" phx-feedback-for={@form[@filter.name].name}>
         <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
           <.icon name="hero-magnifying-glass" class="w-5 h-5 text-neutral-500" />


### PR DESCRIPTION
I was taking screenshots and needed to fix this text.

## before
<img width="257" alt="Screenshot 2024-06-24 at 1 00 07 PM" src="https://github.com/firezone/firezone/assets/167144/a6ed1603-2f77-4469-abfa-4b8c17d09863">

## after

<img width="274" alt="Screenshot 2024-06-24 at 12 59 55 PM" src="https://github.com/firezone/firezone/assets/167144/95fbafc6-085c-45ad-9f7a-f5a2c9b57430">
