### PR TITLE
feat(website): Add deployed sha to changelog page

### DIFF
--- a/.github/workflows/_deploy_production.yml
+++ b/.github/workflows/_deploy_production.yml
@@ -154,7 +154,7 @@ jobs:
     steps:
       - name: Update FIREZONE_DEPLOYED_SHA
         run: |
-          curl -X PATCH "https://api.vercel.com/v9/projects/${VERCEL_PROJECT}/env/${VERCEL_ENV_VAR_ID}?slug=${VERCEL_SLUG}" \
+          curl --fail -X PATCH "https://api.vercel.com/v9/projects/${VERCEL_PROJECT}/env/${VERCEL_ENV_VAR_ID}?slug=${VERCEL_SLUG}" \
             -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" -H "Content-Type: application/json" \
             -d '{
               "comment": "latest deployed SHA for control plane",

--- a/.github/workflows/_deploy_production.yml
+++ b/.github/workflows/_deploy_production.yml
@@ -154,7 +154,7 @@ jobs:
     steps:
       - name: Update FIREZONE_DEPLOYED_SHA
         run: |
-          curl -X PATCH "https://api.vercel.com/v9/projects/${VERCEL_PROJECT}/env/${ENV_VAR_ID}?slug=${VERCEL_SLUG}" \
+          curl -X PATCH "https://api.vercel.com/v9/projects/${VERCEL_PROJECT}/env/${VERCEL_ENV_VAR_ID}?slug=${VERCEL_SLUG}" \
             -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" -H "Content-Type: application/json" \
             -d '{
               "comment": "latest deployed SHA for control plane",

--- a/website/src/components/Changelog/index.tsx
+++ b/website/src/components/Changelog/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TabsGroup, TabsItem } from "@/components/Tabs";
+import Link from "next/link";
 import Android from "./Android";
 import Apple from "./Apple";
 import Gateway from "./Gateway";
@@ -10,6 +11,8 @@ import { HiServerStack } from "react-icons/hi2";
 import { FaApple, FaAndroid, FaWindows, FaLinux } from "react-icons/fa";
 
 export default function Changelog() {
+  const sha = process.env.FIREZONE_DEPLOYED_SHA;
+
   return (
     <section className="mx-auto max-w-xl md:max-w-screen-xl">
       <TabsGroup>
@@ -32,6 +35,18 @@ export default function Changelog() {
           <Headless />
         </TabsItem>
       </TabsGroup>
+      {sha && (
+        <p className="text-sm md:text-lg mt-4 md:mt-8">
+          Current SHA of Portal and Relays in production is{" "}
+          <Link
+            href={"https://www.github.com/firezone/firezone/tree/#{sha}"}
+            className="underline hover:no-underline text-accent-500"
+          >
+            {sha}
+          </Link>
+          .
+        </p>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
It would be good to track the currently deployed SHA in production.

refs #5447 