### PR TITLE
fix(portal): Do not crash WebSocket when client version is invalid

### DIFF
--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -192,17 +192,15 @@ defmodule API.Client.ChannelTest do
 
       client = %{client | last_seen_version: "development"}
 
-      {:ok, _reply, socket} =
-        API.Client.Socket
-        |> socket("client:#{client.id}", %{
-          opentelemetry_ctx: OpenTelemetry.Ctx.new(),
-          opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test"),
-          client: client,
-          subject: subject
-        })
-        |> subscribe_and_join(API.Client.Channel, "client")
-
-      assert socket.assigns.gateway_version_requirement == "> 0.0.0"
+      assert API.Client.Socket
+             |> socket("client:#{client.id}", %{
+               opentelemetry_ctx: OpenTelemetry.Ctx.new(),
+               opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test"),
+               client: client,
+               subject: subject
+             })
+             |> subscribe_and_join(API.Client.Channel, "client") ==
+               {:error, %{reason: :invalid_version}}
     end
 
     test "sends list of resources after join", %{


### PR DESCRIPTION
```
** (Version.InvalidVersionError) invalid version: "development"
    (elixir 1.16.2) lib/version.ex:475:in `Version.to_matchable/2'
    (elixir 1.16.2) lib/version.ex:304:in `Version.match?/3'
    (api 0.1.0+deadbeef) lib/api/client/channel.ex:625:in `anonymous fn/2 in API.Client.Channel.select_gateway_version_requirement/1'
    (elixir 1.16.2) lib/enum.ex:4316:in `Enum.find_value_list/3'
    (api 0.1.0+deadbeef) lib/api/client/channel.ex:622:in `API.Client.Channel.select_gateway_version_requirement/1'
    (api 0.1.0+deadbeef) lib/api/client/channel.ex:24:in `anonymous fn/2 in API.Client.Channel.join/3'
    (opentelemetry 1.4.0) /app/deps/opentelemetry/src/otel_tracer_default.erl:47:in `:otel_tracer_default.with_span/5'
    (phoenix 1.7.12) lib/phoenix/channel/server.ex:391:in `Phoenix.Channel.Server.channel_join/4'
```