### PR TITLE
fix(phoenix-channel): reset heartbeat interval on reconnect

### DIFF
--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -49,6 +49,7 @@ impl Heartbeat {
 
     pub fn reset(&mut self) {
         self.pending = None;
+        self.interval.reset();
     }
 
     pub fn poll(


### PR DESCRIPTION
Currently, the heartbeat interval of `PhoenixChannel` keeps running across re-connects. Whilst not necessarily harmful, it is better to reset it together with reconnecting to the websocket to ensure it is aligned to 30s intervals _after_ we connected.