### PR TITLE
ci: timeout `curl` requests after 30s

### DIFF
--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -54,7 +54,7 @@ function remove_iptables_drop_rules() {
 }
 
 function client_curl_resource() {
-    client curl --fail "$1" >/dev/null
+    client curl --connect-timeout 30 --fail "$1" >/dev/null
 }
 
 function client_ping_resource() {


### PR DESCRIPTION
Currently, we rely on curl's default timeout when connecting to a resource. This is problematic because the `direct-dns` and `relayed-dns` integration tests check that a certain resource _isn't_ accessible and this test currently waits for 5 minutes to assert that.

We can shorten this and thus every CI by passing a `--connect-timeout` to `curl`.

See https://github.com/firezone/firezone/actions/runs/9656570163/job/26634409843#step:6:445 for an example CI run on `main`.