### PR TITLE
chore(connlib): only refresh DNS for connections that are in use

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -273,7 +273,7 @@ impl ClientOnGateway {
         let expired_translations = self
             .permanent_translations
             .iter()
-            .filter(|(_, state)| state.no_response_in_30s(now));
+            .filter(|(_, state)| state.no_response_in_30s(now) && state.is_used(now));
 
         let mut for_refresh = HashSet::new();
 


### PR DESCRIPTION
With the current behavior after a connection stops being used it will trigger a refresh DNS after every 30 seconds forever.

This can be bad for a gateway that could be handling more than thousands of domain names.

This was prevented before by only setting `slated_for_refresh` when we see the first packet, this was deprecated in favor of checking times in the `handle_timeout`.

So the solution now is to check that the connection is being used currently before triggering any DNS refresh.