### PR TITLE
chore(connlib): fix test compilation without proptest flag

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1511,9 +1511,10 @@ mod tests {
     }
 }
 
-#[cfg(test)]
-mod testutils {
+#[cfg(all(test, feature = "proptest"))]
+mod proptests {
     use super::*;
+    use connlib_shared::{messages::client::ResourceDescriptionDns, proptest::*};
 
     pub fn expected_routes(resource_routes: Vec<IpNetwork>) -> HashSet<IpNetwork> {
         HashSet::from_iter(
@@ -1530,13 +1531,6 @@ mod testutils {
     ) -> HashSet<T> {
         HashSet::from_iter(val.into_iter().map(|b| b.to_owned()))
     }
-}
-
-#[cfg(all(test, feature = "proptest"))]
-mod proptests {
-    use super::*;
-    use connlib_shared::{messages::client::ResourceDescriptionDns, proptest::*};
-    use testutils::*;
 
     #[test_strategy::proptest]
     fn cidr_resources_are_turned_into_routes(

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -108,7 +108,7 @@ impl NatTable {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "proptest"))]
 mod tests {
     use super::*;
     use ip_packet::{proptest::*, MutableIpPacket};


### PR DESCRIPTION
Fixes plain `cargo test`