### PR TITLE
fix(android): Fix crash in `setDns` on 32-bit Android by using jlong consistently for the SessionWrapper pointer

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -438,6 +438,8 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_co
         None => return std::ptr::null(),
     };
 
+    // Note: this pointer will probably be casted into a jlong after it is received by android.
+    // jlong is 64bits so the worst case scenario it will be padded, in that case, when casting it back to a pointer we expect `as` to select only the relevant bytes
     Box::into_raw(Box::new(session))
 }
 
@@ -449,7 +451,7 @@ pub struct SessionWrapper {
 }
 
 /// # Safety
-/// Pointers must be valid
+/// session_ptr should have been obtained from `connect` function
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_disconnect(
@@ -469,7 +471,8 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_di
 /// <https://github.com/firezone/firezone/issues/4350>
 ///
 /// # Safety
-/// Pointers must be valid
+/// session_ptr should have been obtained from `connect` function, and shouldn't be dropped with disconnect
+/// at any point before or during operation of this function.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_setDns(
@@ -492,7 +495,8 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_se
 }
 
 /// # Safety
-/// Pointers must be valid
+/// session_ptr should have been obtained from `connect` function, and shouldn't be dropped with disconnect
+/// at any point before or during operation of this function.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_reconnect(

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -10,6 +10,7 @@ use connlib_client_shared::{
 use jni::{
     objects::{GlobalRef, JClass, JObject, JString, JValue},
     strings::JNIString,
+    sys::jlong,
     JNIEnv, JavaVM,
 };
 use secrecy::SecretString;
@@ -454,8 +455,9 @@ pub struct SessionWrapper {
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_disconnect(
     mut env: JNIEnv,
     _: JClass,
-    session: *mut SessionWrapper,
+    session_ptr: jlong,
 ) {
+    let session = session_ptr as *mut SessionWrapper;
     catch_and_throw(&mut env, |_| {
         Box::from_raw(session).inner.disconnect();
     });
@@ -473,7 +475,7 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_di
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_setDns(
     mut env: JNIEnv,
     _: JClass,
-    session: *const SessionWrapper,
+    session_ptr: jlong,
     dns_list: JString,
 ) {
     let dns = String::from(
@@ -485,7 +487,7 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_se
             .expect("Invalid string returned from android client"),
     );
     let dns: Vec<IpAddr> = serde_json::from_str(&dns).unwrap();
-    let session = &*session;
+    let session = &*(session_ptr as *const SessionWrapper);
     session.inner.set_dns(dns);
 }
 
@@ -496,7 +498,8 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_se
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_reconnect(
     _: JNIEnv,
     _: JClass,
-    session: *const SessionWrapper,
+    session_ptr: jlong,
 ) {
-    (*session).inner.reconnect();
+    let session = &*(session_ptr as *const SessionWrapper);
+    session.inner.reconnect();
 }


### PR DESCRIPTION
`connlibSessionPtr` is a `Long`, which is 64-bits. On 32-bit Android architectures, this overwrites part of the `dns_list` for the `setDns` native function call because Rust uses a `32-bit` sized pointer for `SessionWrapper` in the function definition.

This causes a JNI crash, detailed below. To fix this, we make sure `jlong` is received in Rust, and do the pointer conversion in the body of the functions that need to use it.

Adding @ReactorScram to review for visibility.


```
runtime.cc:655] Runtime aborting...
runtime.cc:655] Dumping all threads without mutator lock held
runtime.cc:655] All threads:
runtime.cc:655] DALVIK THREADS (35):
runtime.cc:655] "ConnectivityThread" prio=5 tid=35 Runnable
runtime.cc:655]   | group="" sCount=0 dsCount=0 flags=0 obj=0x131809a8 self=0xa42dea10
runtime.cc:655]   | sysTid=8854 nice=0 cgrp=default sched=0/0 handle=0x7fbb71c0
runtime.cc:655]   | state=R schedstat=( 0 0 0 ) utm=8 stm=0 core=2 HZ=100
runtime.cc:655]   | stack=0x7fab4000-0x7fab6000 stackSize=1040KB
runtime.cc:655]   | held mutexes= "abort lock" "mutator lock"(shared held)
runtime.cc:655]   native: #00 pc 0037b1dd  /apex/com.android.art/lib/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, int, BacktraceMap*, char const*, art::ArtMethod*, void*, bool)+76)
runtime.cc:655]   native: #01 pc 0044cd01  /apex/com.android.art/lib/libart.so (art::Thread::DumpStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, bool, BacktraceMap*, bool) const+388)
runtime.cc:655]   native: #02 pc 00448447  /apex/com.android.art/lib/libart.so (art::Thread::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, bool, BacktraceMap*, bool) const+34)
runtime.cc:655]   native: #03 pc 00465995  /apex/com.android.art/lib/libart.so (art::DumpCheckpoint::Run(art::Thread*)+688)
runtime.cc:655]   native: #04 pc 00460e57  /apex/com.android.art/lib/libart.so (art::ThreadList::RunCheckpoint(art::Closure*, art::Closure*)+354)
runtime.cc:655]   native: #05 pc 0046034f  /apex/com.android.art/lib/libart.so (art::ThreadList::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, bool)+1514)
runtime.cc:655]   native: #06 pc 0040a3af  /apex/com.android.art/lib/libart.so (art::Runtime::Abort(char const*)+1510)
runtime.cc:655]   native: #07 pc 0000d989  /system/lib/libbase.so (android::base::SetAborter(std::__1::function<void (char const*)>&&)::$_3::__invoke(char const*)+48)
runtime.cc:655]   native: #08 pc 0000d295  /system/lib/libbase.so (android::base::LogMessage::~LogMessage()+224)
runtime.cc:655]   native: #09 pc 002965db  /apex/com.android.art/lib/libart.so (art::JavaVMExt::JniAbort(char const*, char const*)+1962)
runtime.cc:655]   native: #10 pc 002966a5  /apex/com.android.art/lib/libart.so (art::JavaVMExt::JniAbortF(char const*, char const*, ...)+64)
runtime.cc:655]   native: #11 pc 004521c1  /apex/com.android.art/lib/libart.so (art::Thread::DecodeJObject(_jobject*) const+544)
runtime.cc:655]   native: #12 pc 0028a6e7  /apex/com.android.art/lib/libart.so (art::(anonymous namespace)::ScopedCheck::CheckInstance(art::ScopedObjectAccess&, art::(anonymous namespace)::ScopedCheck::InstanceKind, _jobject*, bool)+82)
runtime.cc:655]   native: #13 pc 00289779  /apex/com.android.art/lib/libart.so (art::(anonymous namespace)::ScopedCheck::CheckPossibleHeapValue(art::ScopedObjectAccess&, char, art::(anonymous namespace)::JniValueType)+552)
runtime.cc:655]   native: #14 pc 00288f55  /apex/com.android.art/lib/libart.so (art::(anonymous namespace)::ScopedCheck::Check(art::ScopedObjectAccess&, bool, char const*, art::(anonymous namespace)::JniValueType*)+592)
runtime.cc:655]   native: #15 pc 0027cbe7  /apex/com.android.art/lib/libart.so (art::(anonymous namespace)::CheckJNI::GetObjectClass(_JNIEnv*, _jobject*)+586)
runtime.cc:655]   native: #16 pc 003412db  /data/app/~~X6p_4xQWTraApNXlo4SIHA==/dev.firezone.android-zJrN9FN3yhs12tvUNeoOmw==/base.apk!libconnlib.so (offset ec000) (???)
runtime.cc:655]   at dev.firezone.android.tunnel.ConnlibSession.setDns(Native method)
runtime.cc:655]   at NetworkMonitor.onLinkPropertiesChanged(NetworkMonitor.kt:28)
runtime.cc:655]   at android.net.ConnectivityManager$NetworkCallback.onAvailable(ConnectivityManager.java:3328)
runtime.cc:655]   at android.net.ConnectivityManager$CallbackHandler.handleMessage(ConnectivityManager.java:3607)
runtime.cc:655]   at android.os.Handler.dispatchMessage(Handler.java:106)
runtime.cc:655]   at android.os.Looper.loop(Looper.java:223)
runtime.cc:655]   at android.os.HandlerThread.run(HandlerThread.java:67)
```