### PR TITLE
fix(website): Add API route to return deployed SHA

### DIFF
--- a/website/src/app/api/deployed-sha.ts
+++ b/website/src/app/api/deployed-sha.ts
@@ -1,0 +1,7 @@
+// pages/api/deployed-sha.ts
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const sha = process.env.FIREZONE_DEPLOYED_SHA;
+  res.status(200).json({ sha });
+}

--- a/website/src/app/api/deployed-sha.ts
+++ b/website/src/app/api/deployed-sha.ts
@@ -1,7 +1,0 @@
-// pages/api/deployed-sha.ts
-import { NextApiRequest, NextApiResponse } from "next";
-
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const sha = process.env.FIREZONE_DEPLOYED_SHA;
-  res.status(200).json({ sha });
-}

--- a/website/src/app/api/deployed-sha/route.ts
+++ b/website/src/app/api/deployed-sha/route.ts
@@ -1,0 +1,7 @@
+// app/api/deployed-sha/route.ts
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const sha = process.env.FIREZONE_DEPLOYED_SHA;
+  return NextResponse.json({ sha });
+}

--- a/website/src/app/changelog/page.tsx
+++ b/website/src/app/changelog/page.tsx
@@ -9,5 +9,5 @@ export const metadata: Metadata = {
 export default function Page() {
   const sha = process.env.FIREZONE_DEPLOYED_SHA;
 
-  return <Changelog sha={sha} />;
+  return <Changelog />;
 }

--- a/website/src/components/Changelog/index.tsx
+++ b/website/src/components/Changelog/index.tsx
@@ -9,8 +9,20 @@ import GUI from "./GUI";
 import Headless from "./Headless";
 import { HiServerStack } from "react-icons/hi2";
 import { FaApple, FaAndroid, FaWindows, FaLinux } from "react-icons/fa";
+import { useEffect, useState } from "react";
 
-export default function Changelog({ sha }: { sha: string | undefined }) {
+export default function Changelog() {
+  const [sha, setSha] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const fetchSha = async () => {
+      const response = await fetch("/api/deployed-sha");
+      const data = await response.json();
+      setSha(data.sha);
+    };
+    fetchSha();
+  }, []);
+
   return (
     <section className="mx-auto max-w-xl md:max-w-screen-xl">
       <TabsGroup>


### PR DESCRIPTION
Env vars are read at build-time and injected in the Client component. This fixes that for `DEPLOYED_SHA` which can be updated on each deploy.

