### PR TITLE
fix(windows): prevent deadlock when closing wintun

### DIFF
--- a/rust/connlib/tunnel/src/device_channel/tun_windows.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_windows.rs
@@ -42,11 +42,11 @@ pub(crate) struct Tun {
 
 impl Drop for Tun {
     fn drop(&mut self) {
-        tracing::info!(
+        tracing::debug!(
             channel_capacity = self.packet_rx.capacity(),
             "Shutting down packet channel..."
         );
-        self.packet_rx.close();
+        self.packet_rx.close(); // This avoids a deadlock when we join the worker thread, see PR 5571
         if let Err(error) = self.session.shutdown() {
             tracing::error!(?error, "wintun::Session::shutdown");
         }

--- a/rust/connlib/tunnel/src/device_channel/tun_windows.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_windows.rs
@@ -14,7 +14,7 @@ use std::{
     sync::Arc,
     task::{ready, Context, Poll},
 };
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, error::TrySendError};
 use windows::Win32::{
     NetworkManagement::{
         IpHelper::{
@@ -42,6 +42,11 @@ pub(crate) struct Tun {
 
 impl Drop for Tun {
     fn drop(&mut self) {
+        tracing::info!(
+            channel_capacity = self.packet_rx.capacity(),
+            "Shutting down packet channel..."
+        );
+        self.packet_rx.close();
         if let Err(error) = self.session.shutdown() {
             tracing::error!(?error, "wintun::Session::shutdown");
         }
@@ -246,9 +251,17 @@ fn start_recv_thread(
             loop {
                 match session.receive_blocking() {
                     Ok(pkt) => {
-                        if packet_tx.blocking_send(pkt).is_err() {
-                            // Most likely the receiver was dropped and we're closing down the connlib session.
-                            break;
+                        match packet_tx.try_send(pkt) {
+                            Ok(()) => {}
+                            Err(TrySendError::Closed(_)) => {
+                                // This is redundant since we aren't using
+                                // `blocking_send` anymore but it's defense in depth.
+                                tracing::info!(
+                                    "Closing worker thread because packet channel closed"
+                                );
+                                break;
+                            }
+                            Err(TrySendError::Full(_)) => {} // Just drop the packet, it's IP
                         }
                     }
                     Err(wintun::Error::ShuttingDown) => break,
@@ -258,7 +271,7 @@ fn start_recv_thread(
                     }
                 }
             }
-            tracing::debug!("recv_task exiting gracefully");
+            tracing::info!("recv_task exiting gracefully");
         })
 }
 


### PR DESCRIPTION
Refs #5441, but without a reliable way to replicate that issue, I'm not sure if this will completely fix it.

Before this PR, a deadlock can happen between 2 threads, call them "main thread" and "worker thread".
The deadlock is more likely if more traffic is flowing through the tunnel.

# Test results

I ran a build from this PR inside the resource-constrained VM and it's likely the deadlock could have triggered there, since the packet channel had 0 capacity (it was full) when we reached `Tun::drop`:

```jsonl
{"time":"2024-06-26T22:43:33.2398441Z","target":"firezone_headless_client::ipc_service","logging.googleapis.com/sourceLocation":{"file":"headless-client\\src\\ipc_service.rs","line":"304"},"severity":"INFO","gitVersion":"e591bb9","logFilter":"\"str0m=warn,info\""}
..
{"time":"2024-06-26T22:45:42.9035226Z","target":"firezone_tunnel::device_channel::tun_windows","logging.googleapis.com/sourceLocation":{"file":"connlib\\tunnel\\src\\device_channel\\tun_windows.rs","line":"45"},"severity":"INFO","channelCapacity":0,"message":"Shutting down packet channel..."}
{"time":"2024-06-26T22:45:42.9035467Z","target":"firezone_tunnel::device_channel::tun_windows","logging.googleapis.com/sourceLocation":{"file":"connlib\\tunnel\\src\\device_channel\\tun_windows.rs","line":"274"},"severity":"INFO","message":"recv_task exiting gracefully"}
{"time":"2024-06-26T22:45:43.4978015Z","target":"connlib_client_shared","logging.googleapis.com/sourceLocation":{"file":"connlib\\clients\\shared\\src\\lib.rs","line":"150"},"severity":"INFO","message":"connlib exited gracefully"}
```

I followed these steps:
- Run Firezone and sign in
- Start a speed test using Cloudflare
- During the download phase, quit the GUI

I did the same test with 0fac698 (`main`) and got the "All pipe instances are busy" error dialog 3 out of 5 times.

# Details

The deadlock will happen in this scenario:

- The main thread enters `Tun::drop` here https://github.com/firezone/firezone/blob/0fac698dfc9696b7ca8d110c9b0af5199dd760e2/rust/connlib/tunnel/src/device_channel/tun_windows.rs#L44
- The worker thread is waiting for space in the packet channel (`packet_tx` and `packet_rx`) here https://github.com/firezone/firezone/blob/0fac698dfc9696b7ca8d110c9b0af5199dd760e2/rust/connlib/tunnel/src/device_channel/tun_windows.rs#L249
- The main thread tells wintun to shut down. If the worker was on line 247 waiting on wintun, this would unblock it, but the worker is not on line 247. https://github.com/firezone/firezone/blob/0fac698dfc9696b7ca8d110c9b0af5199dd760e2/rust/connlib/tunnel/src/device_channel/tun_windows.rs#L45
- The main thread waits to join the worker thread https://github.com/firezone/firezone/blob/0fac698dfc9696b7ca8d110c9b0af5199dd760e2/rust/connlib/tunnel/src/device_channel/tun_windows.rs#L52

The threads are now deadlocked. The main thread is waiting for the worker thread to exit, and the worker thread is waiting for the main thread to either call `poll_recv`, which would cause `blocking_send` to return, or for the main thread to complete `Tun::drop`, which would cause Rust to drop `packet_rx`, which would cause `blocking_send` to return an error.

This PR makes 2 changes to prevent this deadlock. Each change alone should work, but for defense-in-depth we make both changes:

1. When the main thread starts `Tun::drop`, we `close` the packet channel, which would unblock any thread waiting on `Sender::blocking_send`
2. We use `Sender::try_send` instead of `Sender::blocking_send`. If the main thread can't consume packets fast enough, we're going to drop them anyway, because the ring buffer in wintun will eventually fill up. So dropping them here isn't much different from dropping them anywhere else, and this keeps the worker thread from locking up.