### PR TITLE
fix(apple): use jsonl file suffix for app-side logs for consistency

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -100,7 +100,7 @@ private final class LogWriter {
 
     let logFileURL = folderURL
       .appendingPathComponent(dateFormatter.string(from: Date()))
-      .appendingPathExtension("log")
+      .appendingPathExtension("jsonl")
 
     // Create log file
     guard fileManager.createFile(atPath: logFileURL.path, contents: "".data(using: .utf8)),


### PR DESCRIPTION
refs #5504 