### PR TITLE
chore(connlib): demote log for unknown incoming packets to debug

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -463,7 +463,7 @@ impl ClientState {
             now,
             buffer,
         )
-        .inspect_err(|e| tracing::warn!(%local, %from, num_bytes = %packet.len(), "Failed to decapsulate incoming packet: {e}"))
+        .inspect_err(|e| tracing::debug!(%local, %from, num_bytes = %packet.len(), "Failed to decapsulate incoming packet: {e}"))
         .ok()??;
 
         let Some(peer) = self.peers.get_mut(&conn_id) else {


### PR DESCRIPTION
There are several reasons why we would legitimately receive a packet that we can't handle, i.e. when a connection got cleared locally but the gateway is still trying to send us packets for that socket. Not handling these packets can be a bug but more often than not, it is not an issue.

Additionally, all our unit-tests actually `.unwrap` the `Node::encapsulate` function so any unhandled packets in the tests will be caught.