### PR TITLE
ci: fix changelog link YAML

### DIFF
--- a/.github/release-drafter-gateway.yml
+++ b/.github/release-drafter-gateway.yml
@@ -51,6 +51,7 @@ exclude-labels:
   - "skip-changelog"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-template: |
-  Please see our [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)
+template: >
+  Please see our
+  [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)
   for more details.

--- a/.github/release-drafter-gui-client.yml
+++ b/.github/release-drafter-gui-client.yml
@@ -51,6 +51,7 @@ exclude-labels:
   - "skip-changelog"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-template: |
-  Please see our [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)
+template: >
+  Please see our
+  [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)
   for more details.

--- a/.github/release-drafter-headless-client.yml
+++ b/.github/release-drafter-headless-client.yml
@@ -51,6 +51,7 @@ exclude-labels:
   - "skip-changelog"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-template: |
-  Please see our [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)
+template: >
+  Please see our
+  [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)
   for more details.


### PR DESCRIPTION
Fixes the newline in the release changelog. This is maintained on the website now.