### PR TITLE
fix(ci): restore version naming in _build_artifacts.yml

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -154,6 +154,8 @@ jobs:
             image_name: client
             # mark:next-headless-version
             release_name: headless-client-1.1.0
+            # mark:next-headless-version
+            version: 1.1.0
           - package: firezone-relay
             artifact: firezone-relay
             image_name: relay
@@ -162,6 +164,8 @@ jobs:
             image_name: gateway
             # mark:next-gateway-version
             release_name: gateway-1.1.1
+            # mark:next-gateway-version
+            version: 1.1.1
           - package: snownet-tests
             artifact: snownet-tests
             image_name: snownet-tests


### PR DESCRIPTION
Reverts part of #5487 to fix empty version numbers in release artifacts.