### PR TITLE
fix(android): Use SCHEDULE_EXACT_ALARM instead of USE_EXACT_ALARM

### DIFF
--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <queries>
         <intent>


### PR DESCRIPTION
See https://developer.android.com/develop/background-work/services/fg-service-types#system-exempted and https://developer.android.com/develop/background-work/services/alarms/schedule

We have to use `SCHEDULE_EXACT_ALARM` if we're not an alarm clock or calendar app.