### PR TITLE
chore(gateway): downgrade `warn` logs

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -200,7 +200,7 @@ impl GatewayState {
             now,
             buffer,
         )
-        .inspect_err(|e| tracing::warn!(%local, %from, num_bytes = %packet.len(), "Failed to decapsulate incoming packet: {e}"))
+        .inspect_err(|e| tracing::debug!(%local, %from, num_bytes = %packet.len(), "Failed to decapsulate incoming packet: {e}"))
         .ok()??;
 
         tracing::Span::current().record("src", tracing::field::display(packet.source()));
@@ -214,7 +214,7 @@ impl GatewayState {
 
         let packet = peer
             .decapsulate(packet, now)
-            .inspect_err(|e| tracing::warn!(%conn_id, %local, %from, "Invalid packet: {e}"))
+            .inspect_err(|e| tracing::debug!(%conn_id, %local, %from, "Invalid packet: {e}"))
             .ok()?;
 
         tracing::trace!("Decapsulated packet");

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -217,8 +217,6 @@ impl GatewayState {
             .inspect_err(|e| tracing::debug!(%conn_id, %local, %from, "Invalid packet: {e}"))
             .ok()?;
 
-        tracing::trace!("Decapsulated packet");
-
         Some(packet.into_immutable())
     }
 


### PR DESCRIPTION
Whilst it has been helpful to find issues such as #5611, having these logs on `warn` spams the end user too much and creates a false sense that things might not be working as there can be a variety of reasons why packets might not be able to be routed.