### PR TITLE
fix(snownet): use unused channels before reused expired ones

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1388,7 +1388,7 @@ mod tests {
     }
 
     #[test]
-    fn uses_unused_channels_first_before_reusing_expired_one_() {
+    fn uses_next_channel_as_long_as_its_available_before_reusing() {
         let mut channel_bindings = ChannelBindings::default();
         let mut now = Instant::now();
 
@@ -1398,7 +1398,7 @@ mod tests {
         }
 
         now += Duration::from_secs(15 * 60); // All channels are expired and could be re-bound.
-        channel_bindings.set_confirmed(ChannelBindings::LAST_CHANNEL, now);
+        channel_bindings.set_confirmed(ChannelBindings::LAST_CHANNEL, now); // Last channel is in use
 
         let channel = channel_bindings.new_channel_to_peer(PEER1, now).unwrap();
         channel_bindings.set_confirmed(channel, now);
@@ -1406,9 +1406,10 @@ mod tests {
         assert_eq!(channel, ChannelBindings::FIRST_CHANNEL);
 
         now += Duration::from_secs(15 * 60); // All channels are expired and could be re-bound.
-        channel_bindings.set_confirmed(ChannelBindings::LAST_CHANNEL, now);
+        channel_bindings.set_confirmed(ChannelBindings::LAST_CHANNEL, now); // Last channel is in use
         let channel = channel_bindings.new_channel_to_peer(PEER1, now).unwrap();
 
+        // We don't reuse the first channel, instead we should prefer the second channel
         assert_ne!(channel, ChannelBindings::FIRST_CHANNEL)
     }
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1352,7 +1352,7 @@ mod tests {
         let mut channel_bindings = ChannelBindings::default();
         let start = Instant::now();
 
-        for channel in ChannelBindings::FIRST_CHANNEL..ChannelBindings::LAST_CHANNEL {
+        for channel in ChannelBindings::FIRST_CHANNEL..=ChannelBindings::LAST_CHANNEL {
             let allocated_channel = channel_bindings.new_channel_to_peer(PEER1, start).unwrap();
 
             assert_eq!(channel, allocated_channel)


### PR DESCRIPTION
Within each allocation, a client has 4095 channels that it can bind to a different peers. Each channel bindings is valid for 10 minutes unless rebound. Additionally, there is a 5min cool-down period after a channel binding expires before it can be rebound to a different peer.

This patch fixes a bug in snownet where we would have first attempted to rebind the last bound channel instead of just picking the next unused one. In the case of a clock drift between client and relay, this caused unnecessary errors when attempting to rebind channels.

Fixes: #5603.