### PR TITLE
chore(aws-infra): log all portal messages on the gateway

### DIFF
--- a/terraform/environments/staging/aws.tf
+++ b/terraform/environments/staging/aws.tf
@@ -160,7 +160,7 @@ module "aws_gateway" {
   image_repo              = module.google-artifact-registry.repo
   image                   = "gateway"
   image_tag               = var.image_tag
-  observability_log_level = "phoenix_channel=debug,firezone_gateway=debug,boringtun=debug,snownet=debug,str0m=info,connlib_gateway_shared=debug,firezone_tunnel=debug,connlib_shared=debug,warn"
+  observability_log_level = "wire::api=trace,phoenix_channel=debug,firezone_gateway=debug,boringtun=debug,snownet=debug,str0m=info,connlib_gateway_shared=debug,firezone_tunnel=debug,connlib_shared=debug,warn"
   application_name        = "gateway"
   application_version     = replace(var.image_tag, ".", "-")
   api_url                 = "wss://api.${local.tld}"


### PR DESCRIPTION
Now that we have split the `wire` target into sub-targets, we can selectively enable the wire messages to and from the API which is very helpful in debugging what messages are being sent.