### PR TITLE
ci: pre-install required tools for smoke tests

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -114,6 +114,8 @@ jobs:
         run: pnpm tailwindcss -i src/input.css -o src/output.css
       - name: Build client
         run: cargo build -p firezone-gui-client
+      - uses: taiki-e/install-action@dump_syms
+      - uses: taiki-e/install-action@minidump-stackwalk
       - name: Run smoke tests (Linux)
         if: ${{ runner.os == 'Linux' }}
         run: bash ../../scripts/tests/smoke-test-gui-linux.sh

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -114,8 +114,9 @@ jobs:
         run: pnpm tailwindcss -i src/input.css -o src/output.css
       - name: Build client
         run: cargo build -p firezone-gui-client
-      - uses: taiki-e/install-action@dump_syms
-      - uses: taiki-e/install-action@minidump-stackwalk
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: dump_syms,minidump-stackwalk
       - name: Run smoke tests (Linux)
         if: ${{ runner.os == 'Linux' }}
         run: bash ../../scripts/tests/smoke-test-gui-linux.sh

--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -22,7 +22,6 @@ export RUST_LOG=firezone_gui_client=debug,warn
 export WEBKIT_DISABLE_COMPOSITING_MODE=1
 
 cargo build -p "$PACKAGE"
-cargo install --quiet --locked dump_syms minidump-stackwalk
 # The dwp doesn't actually do anything if the exe already has all the debug info
 # Getting this to coordinate between Linux and Windows is tricky
 dump_syms ../target/debug/firezone-gui-client --output "$SYMS_PATH"

--- a/scripts/tests/smoke-test-gui-linux.sh
+++ b/scripts/tests/smoke-test-gui-linux.sh
@@ -21,7 +21,6 @@ PACKAGE=firezone-gui-client
 export RUST_LOG=firezone_gui_client=debug,warn
 export WEBKIT_DISABLE_COMPOSITING_MODE=1
 
-cargo build -p "$PACKAGE"
 # The dwp doesn't actually do anything if the exe already has all the debug info
 # Getting this to coordinate between Linux and Windows is tricky
 dump_syms ../target/debug/firezone-gui-client --output "$SYMS_PATH"

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -64,7 +64,6 @@ function crash_test() {
 function get_stacktrace() {
     # Per `crash_handling.rs`
     SYMS_PATH="../target/debug/firezone-gui-client.syms"
-    cargo install --quiet --locked dump_syms minidump-stackwalk
     dump_syms ../target/debug/firezone_gui_client.pdb ../target/debug/firezone-gui-client.exe --output "$SYMS_PATH"
     ls -lash ../target/debug
     minidump-stackwalk --symbols-path "$SYMS_PATH" "$DUMP_PATH"

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -35,7 +35,7 @@ function smoke_test() {
     done
 
     # Run the smoke test normally
-    $PWD/../target/debug/$PACKAGE -- smoke-test
+    $PWD/../target/debug/$PACKAGE smoke-test
 
     # Make sure the files were written in the right paths
     for file in "${files[@]}"
@@ -55,7 +55,7 @@ function crash_test() {
     rm -f "$DUMP_PATH"
 
     # Fail if it returns success, this is supposed to crash
-    $PWD/../target/debug/$PACKAGE -- --crash && exit 1
+    $PWD/../target/debug/$PACKAGE --crash && exit 1
 
     # Fail if the crash file wasn't written
     stat "$DUMP_PATH"

--- a/scripts/tests/smoke-test-gui-windows.sh
+++ b/scripts/tests/smoke-test-gui-windows.sh
@@ -35,7 +35,7 @@ function smoke_test() {
     done
 
     # Run the smoke test normally
-    cargo run --bin "$PACKAGE" -- smoke-test
+    $PWD/../target/debug/$PACKAGE -- smoke-test
 
     # Make sure the files were written in the right paths
     for file in "${files[@]}"
@@ -55,7 +55,7 @@ function crash_test() {
     rm -f "$DUMP_PATH"
 
     # Fail if it returns success, this is supposed to crash
-    cargo run --bin "$PACKAGE" -- --crash && exit 1
+    $PWD/../target/debug/$PACKAGE -- --crash && exit 1
 
     # Fail if the crash file wasn't written
     stat "$DUMP_PATH"


### PR DESCRIPTION
Currently, the smoke tests rebuild the `dump_syms` and `minidump-stackwalk` tools from scratch every time which is slow, especially on Windows.

We can speed this up by utilising the `taiki-e/install-action` GitHub action which discovers and downloads the latest binary releases of those projects and installs them into $PATH.

I think those binaries might also be cached as part of the Rust cache action (https://github.com/Swatinem/rust-cache) so the visible speed-up is only within a few seconds and comes from the binaries not being re-built inside the script.

Caching those binaries on Github still requires us to build them at least once and also rebuild them in case the cache gets invalidated. Hence I still think this is a good idea on its own.