### PR TITLE
chore: remove `uptime_lib` dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2011,7 +2011,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "uptime_lib",
  "url",
  "uuid",
  "windows 0.57.0",
@@ -7060,17 +7059,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "uptime_lib"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e71ddbefed856d5881821d6ada4e606bbb91fd332296963ed596e2ad2100f3"
-dependencies = [
- "libc",
- "thiserror",
- "windows 0.52.0",
-]
 
 [[package]]
 name = "url"

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -28,7 +28,6 @@ tokio = { version = "1.38.0", features = ["macros", "signal"] }
 tokio-util = { version = "0.7.11", features = ["codec"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-uptime_lib = "0.3.0"
 url = { version = "2.3.1", default-features = false }
 uuid = { version = "1.7", default-features = false, features = ["std", "v4", "serde"] }
 

--- a/rust/headless-client/src/heartbeat.rs
+++ b/rust/headless-client/src/heartbeat.rs
@@ -10,11 +10,11 @@ use tokio::time::{sleep_until, Instant};
 
 /// Logs a heartbeat to `tracing::info!`. Put this in a Tokio task and forget about it.
 pub async fn heartbeat() {
+    let start = Instant::now();
     let mut hb = Heartbeat::default();
     loop {
         sleep_until(hb.next_instant).await;
-        let system_uptime = uptime_lib::get().ok();
-        tracing::info!(?system_uptime, "Heartbeat");
+        tracing::info!(heartbeat_uptime = ?start.elapsed(), "Heartbeat");
         hb.tick();
     }
 }


### PR DESCRIPTION
This pulls in the `windows` crate which takes notoriously long to compile. We already depend on it in 4 different versions. Whilst this particular change does not remove one of those 4, having one less dependency that pulls in `windows` makes it easier to sync up the others.