### PR TITLE
fix(relay): don't log all request failures on the same level

### DIFF
--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -250,6 +250,8 @@ where
             }
             // Could parse the bytes but message was semantically invalid (like missing attribute).
             Ok(Err(error_response)) => {
+                tracing::warn!(target: "relay", %sender, method = %error_response.method(), "Failed to decode message");
+
                 self.send_message(error_response, sender);
             }
             // Parsing the bytes failed.

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -1151,7 +1151,6 @@ fn derive_relay_addresses(
     }
 }
 
-/// Private helper trait to make [`error_response`] more ergonomic to use.
 trait StunRequest {
     fn transaction_id(&self) -> TransactionId;
     fn method(&self) -> Method;

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -968,9 +968,13 @@ where
             request.transaction_id(),
         );
 
+        let is_auth_error = error_code == ErrorCode::from(Unauthorized)
+            || error_code == ErrorCode::from(StaleNonce);
+
+        message.add_attribute(Attribute::from(error_code));
+
         // In case of a 401 or 438 response, attach a realm and nonce.
-        if error_code == ErrorCode::from(Unauthorized) || error_code == ErrorCode::from(StaleNonce)
-        {
+        if is_auth_error {
             let new_nonce = Uuid::from_u128(self.rng.gen());
 
             self.add_nonce(new_nonce);
@@ -978,8 +982,6 @@ where
             message.add_attribute(Nonce::new(new_nonce.to_string()).unwrap());
             message.add_attribute((*FIREZONE).clone());
         }
-
-        message.add_attribute(Attribute::from(error_code));
 
         message
     }


### PR DESCRIPTION
Currently, the relay logs all failed requests on WARN. This is a bit excessive because during normal operation, clients are expected to hit several 401s due to stale or missing nonces.

In order to not flood the logs with these, we introduce a new type, `ResponseErrorLevel` that represents the subset of `tracing::Level` that `make_error_response` can log:

- `Warn`
- `Debug`

Both variants mapping to the variants in `tracing::Level` with the same name, and the function will log accordingly.

So now the caller can pick what level of error is meant to be used and reduce the noise on the logs when it's meant to be part of normal operation.

Fixes: #5490.