### PR TITLE
refactor(apple): use `fmt::Layer` with custom writer

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -587,28 +587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
-name = "bindgen"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 1.0.109",
- "which",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,15 +833,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,17 +929,6 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
-dependencies = [
- "glob",
- "libc",
- "libloading 0.8.3",
 ]
 
 [[package]]
@@ -1129,6 +1087,7 @@ dependencies = [
  "connlib-client-shared",
  "ip_network",
  "libc",
+ "oslog",
  "secrecy",
  "serde_json",
  "swift-bridge",
@@ -1136,7 +1095,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-oslog",
  "tracing-subscriber",
  "url",
 ]
@@ -3389,12 +3347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libappindicator"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4343,6 +4295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d2043d1f61d77cb2f4b1f7b7b2295f40507f5f8e9d1c8bf10a1ca5f97a3969"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,12 +4383,6 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -5279,12 +5234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5740,12 +5689,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -6845,21 +6788,6 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "web-time",
-]
-
-[[package]]
-name = "tracing-oslog"
-version = "0.1.2"
-source = "git+https://github.com/Absolucy/tracing-oslog?branch=main#2207764b7edd3a5c059f4c3e8837fe72127067f9"
-dependencies = [
- "bindgen",
- "cc",
- "cfg-if",
- "fnv",
- "once_cell",
- "parking_lot",
- "tracing-core",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -18,11 +18,13 @@ swift-bridge = { workspace = true }
 connlib-client-shared = { workspace = true }
 serde_json = "1"
 tracing = { workspace = true }
-oslog = { version = "0.2.0", default-features = false }
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 url = "2.5.0"
 tokio = { version = "1.38", default-features = false, features = ["rt"] }
+
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+oslog = { version = "0.2.0", default-features = false }
 
 [lib]
 name = "connlib"

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -18,7 +18,7 @@ swift-bridge = { workspace = true }
 connlib-client-shared = { workspace = true }
 serde_json = "1"
 tracing = { workspace = true }
-tracing-oslog = { git = "https://github.com/Absolucy/tracing-oslog", branch = "main" } # Waiting for a release.
+oslog = { version = "0.2.0", default-features = false }
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 url = "2.5.0"

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -1,6 +1,8 @@
 // Swift bridge generated code triggers this below
 #![allow(clippy::unnecessary_cast, improper_ctypes, non_camel_case_types)]
 
+mod make_writer;
+
 use connlib_client_shared::{
     callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, ConnectArgs,
     Error, LoginUrl, Session, Sockets,
@@ -148,8 +150,15 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<file_logger::Han
 
     tracing_subscriber::registry()
         .with(
-            tracing_oslog::OsLogger::new("dev.firezone.firezone", "connlib")
-                .with_filter(EnvFilter::new(log_filter.clone())),
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .without_time()
+                .with_level(false)
+                .with_writer(make_writer::MakeWriter::new(
+                    "dev.firezone.firezone",
+                    "connlib",
+                ))
+                .with_filter(EnvFilter::new(log_filter)),
         )
         .with(file_layer.with_filter(EnvFilter::new(log_filter)))
         .try_init()?;

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -158,7 +158,7 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<file_logger::Han
                     "dev.firezone.firezone",
                     "connlib",
                 ))
-                .with_filter(EnvFilter::new(log_filter)),
+                .with_filter(EnvFilter::new(log_filter.clone())),
         )
         .with(file_layer.with_filter(EnvFilter::new(log_filter)))
         .try_init()?;

--- a/rust/connlib/clients/apple/src/make_writer.rs
+++ b/rust/connlib/clients/apple/src/make_writer.rs
@@ -1,0 +1,68 @@
+//! Heavily inspired from https://github.com/Actyx/tracing-android/blob/master/src/android.rs.
+
+use oslog::OsLog;
+use std::{
+    ffi::{CStr, CString},
+    io::{self, BufWriter},
+};
+use tracing::Level;
+
+const LOGGING_MSG_MAX_LEN: usize = 4000;
+
+pub(crate) struct MakeWriter {
+    oslog: OsLog,
+}
+
+pub(crate) struct Writer<'l> {
+    level: oslog::Level,
+    oslog: &'l OsLog,
+}
+
+impl MakeWriter {
+    pub(crate) fn new(subsystem: &'static str, category: &'static str) -> Self {
+        Self {
+            oslog: OsLog::new(subsystem, category),
+        }
+    }
+
+    fn make_writer_for_level(&self, level: Level) -> BufWriter<Writer<'_>> {
+        let inner = Writer {
+            level: match level {
+                Level::TRACE => oslog::Level::Debug,
+                Level::DEBUG => oslog::Level::Info,
+                Level::INFO => oslog::Level::Default,
+                Level::WARN => oslog::Level::Error,
+                Level::ERROR => oslog::Level::Fault,
+            },
+            oslog: &self.oslog,
+        };
+
+        BufWriter::with_capacity(LOGGING_MSG_MAX_LEN, inner)
+    }
+}
+
+impl<'l> tracing_subscriber::fmt::MakeWriter<'l> for MakeWriter {
+    type Writer = BufWriter<Writer<'l>>;
+
+    fn make_writer(&self) -> Self::Writer {
+        self.make_writer_for_level(Level::INFO)
+    }
+
+    fn make_writer_for(&self, meta: &tracing::Metadata<'_>) -> Self::Writer {
+        self.make_writer_for_level(*meta.level())
+    }
+}
+
+impl io::Write for Writer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let message = std::str::from_utf8(buf)?;
+
+        self.oslog.with_level(self.level, message);
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/rust/connlib/clients/apple/src/make_writer.rs
+++ b/rust/connlib/clients/apple/src/make_writer.rs
@@ -74,7 +74,7 @@ mod oslog {
 
     pub fn new(subsystem: &'static str, category: &'static str) -> OsLog {
         OsLog {
-            inner: ::oslog::Oslog::new(subsystem, category),
+            inner: ::oslog::OsLog::new(subsystem, category),
         }
     }
 }

--- a/rust/connlib/clients/apple/src/make_writer.rs
+++ b/rust/connlib/clients/apple/src/make_writer.rs
@@ -1,35 +1,24 @@
-//! Heavily inspired from https://github.com/Actyx/tracing-android/blob/master/src/android.rs.
-
-use oslog::OsLog;
 use std::io;
 
-const LOGGING_MSG_MAX_LEN: usize = 4000;
-
 pub(crate) struct MakeWriter {
-    oslog: OsLog,
+    oslog: oslog::OsLog,
 }
 
 pub(crate) struct Writer<'l> {
-    level: oslog::Level,
-    oslog: &'l OsLog,
+    level: tracing::Level,
+    oslog: &'l oslog::OsLog,
 }
 
 impl MakeWriter {
     pub(crate) fn new(subsystem: &'static str, category: &'static str) -> Self {
         Self {
-            oslog: OsLog::new(subsystem, category),
+            oslog: oslog::new(subsystem, category),
         }
     }
 
     fn make_writer_for_level(&self, level: tracing::Level) -> Writer<'_> {
         Writer {
-            level: match level {
-                tracing::Level::TRACE => oslog::Level::Debug,
-                tracing::Level::DEBUG => oslog::Level::Info,
-                tracing::Level::INFO => oslog::Level::Default,
-                tracing::Level::WARN => oslog::Level::Error,
-                tracing::Level::ERROR => oslog::Level::Fault,
-            },
+            level,
             oslog: &self.oslog,
         }
     }
@@ -38,11 +27,11 @@ impl MakeWriter {
 impl<'l> tracing_subscriber::fmt::MakeWriter<'l> for MakeWriter {
     type Writer = Writer<'l>;
 
-    fn make_writer(&self) -> Self::Writer {
+    fn make_writer(&'l self) -> Self::Writer {
         self.make_writer_for_level(tracing::Level::INFO)
     }
 
-    fn make_writer_for(&self, meta: &tracing::Metadata<'_>) -> Self::Writer {
+    fn make_writer_for(&'l self, meta: &tracing::Metadata<'_>) -> Self::Writer {
         self.make_writer_for_level(*meta.level())
     }
 }
@@ -59,5 +48,48 @@ impl<'l> io::Write for Writer<'l> {
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod oslog {
+    pub struct OsLog {
+        inner: ::oslog::OsLog,
+    }
+
+    impl OsLog {
+        pub fn with_level(&self, level: tracing::Level, msg: &str) {
+            self.inner.with_level(
+                match level {
+                    tracing::Level::TRACE => ::oslog::Level::Debug,
+                    tracing::Level::DEBUG => ::oslog::Level::Info,
+                    tracing::Level::INFO => ::oslog::Level::Default,
+                    tracing::Level::WARN => ::oslog::Level::Error,
+                    tracing::Level::ERROR => ::oslog::Level::Fault,
+                },
+                msg,
+            )
+        }
+    }
+
+    pub fn new(subsystem: &'static str, category: &'static str) -> OsLog {
+        OsLog {
+            inner: ::oslog::Oslog::new(subsystem, category),
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+mod oslog {
+    pub struct OsLog {}
+
+    impl OsLog {
+        pub fn with_level(&self, _: tracing::Level, _: &str) {
+            unimplemented!("Stub should never be called")
+        }
+    }
+
+    pub fn new(_: &'static str, _: &'static str) -> OsLog {
+        unimplemented!("Stub should never be called")
     }
 }


### PR DESCRIPTION
Currently, we use the `tracing-oslog` crate to ingest logs on MacOS and iOS. This crate has a "feature" where it creates so called "Activities" for spans. Whilst that may initially sound useful, Apple's UI for viewing these activities is absolutely useless.

Instead of tinkering around with that, we remove the `tracing-oslog` crate and let `tracing-subscriber` format our logs first and then only send a single string to the oslog backend.

Related: #5619.