### PR TITLE
ci: Use larger runners for slow CI jobs

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -83,11 +83,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-20.04
+          - runs-on: ubuntu-20.04-firezone
           # Broken on 22.04 <https://github.com/firezone/firezone/issues/3699>
-          - runs-on: ubuntu-22.04
-          - runs-on: windows-2019
-          - runs-on: windows-2022
+          - runs-on: ubuntu-22.04-firezone
+          - runs-on: windows-2019-firezone
+          - runs-on: windows-2022-firezone
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-20.04
+          - runs-on: ubuntu-20.04-firezone
             # mark:next-gui-version
             binary-dest-path: firezone-client-gui-linux_1.1.2_x86_64
             rename-script: ../../scripts/build/tauri-rename-ubuntu.sh
@@ -33,7 +33,7 @@ jobs:
             syms-artifact: rust/gui-client/firezone-client-gui-linux_1.1.2_x86_64.dwp
             # mark:next-gui-version
             pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.1.2_x86_64.deb
-          - runs-on: windows-2019
+          - runs-on: windows-2019-firezone
             # mark:next-gui-version
             binary-dest-path: firezone-client-gui-windows_1.1.2_x86_64
             rename-script: ../../scripts/build/tauri-rename-windows.sh


### PR DESCRIPTION
Let's see what kind of bill these rack up vs the speedup and we can reassess from there.