### PR TITLE
chore(gui-client/windows): bump `tauri-winrt-notification`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1961,7 +1961,7 @@ dependencies = [
  "tauri-build",
  "tauri-runtime",
  "tauri-utils",
- "tauri-winrt-notification 0.2.0",
+ "tauri-winrt-notification 0.5.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -6418,12 +6418,13 @@ dependencies = [
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d59cba96cdbf291d74490ac477c66885ebdc87e28faca532ec1e00f4f3bd578"
+checksum = "8b6a48a4bd95615e18e3ff58f76dc0d4a3c0683d2b590e667995ff9bbaff1f17"
 dependencies = [
- "quick-xml 0.30.0",
- "windows 0.54.0",
+ "quick-xml 0.31.0",
+ "thiserror",
+ "windows 0.57.0",
  "windows-version",
 ]
 
@@ -7522,16 +7523,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -7565,16 +7556,6 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result",
  "windows-targets 0.52.5",
 ]
 

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -58,7 +58,7 @@ nix = { version =  "0.28.0", features = ["user"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-tauri-winrt-notification = "0.2.0"
+tauri-winrt-notification = "0.5.0"
 windows-core = "0.57.0"
 windows-implement = "0.57.0"
 winreg = "0.52.0"

--- a/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
@@ -71,7 +71,7 @@ pub(crate) fn show_clickable_notification(
         .title(title)
         .text1(body)
         .scenario(tauri_winrt_notification::Scenario::Reminder)
-        .on_activated(move || {
+        .on_activated(move |_| {
             if let Some(req) = req.take() {
                 if let Err(error) = tx.blocking_send(req) {
                     tracing::error!(


### PR DESCRIPTION
This eliminates `windows` 0.54.0 so it should speed up Windows builds a little. It's 6% faster on my Macbook according to `cargo build --timing`, in debug mode.