### PR TITLE
fix(connlib): Don't use `operatingSystemVersionString` on Apple OSes

### DIFF
--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -76,7 +76,7 @@ fn additional_info() -> String {
     match (info.architecture(), kernel_version()) {
         (None, None) => "".to_string(),
         (None, Some(k)) => format!(" ({k})"),
-        (Some(a), None) => format!(" ({a}"),
+        (Some(a), None) => format!(" ({a})"),
         (Some(a), Some(k)) => format!(" ({a}; {k})"),
     }
 }

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -68,16 +68,16 @@ pub fn get_user_agent(os_version_override: Option<String>, app_version: &str) ->
     let os_version = os_version_override.unwrap_or(info.version().to_string());
     let additional_info = additional_info();
     let lib_name = LIB_NAME;
-    format!("{os_type}/{os_version}{additional_info}{lib_name}/{app_version}")
+    format!("{os_type}/{os_version} {lib_name}/{app_version}{additional_info}")
 }
 
 fn additional_info() -> String {
     let info = os_info::get();
     match (info.architecture(), kernel_version()) {
-        (None, None) => " ".to_string(),
-        (None, Some(k)) => format!(" {k} "),
-        (Some(a), None) => format!(" {a} "),
-        (Some(a), Some(k)) => format!(" ({a};{k};) "),
+        (None, None) => "".to_string(),
+        (None, Some(k)) => format!(" ({k})"),
+        (Some(a), None) => format!(" ({a}"),
+        (Some(a), Some(k)) => format!(" ({a}; {k})"),
     }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/DeviceMetadata.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/DeviceMetadata.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 #if os(iOS)
-  import UIKit.UIDevice
+import UIKit
 #endif
 
 public class DeviceMetadata {
@@ -22,21 +22,24 @@ public class DeviceMetadata {
     return !fileExists
   }
 
-  public static func getDeviceName() -> String? {
+  public static func getDeviceName() -> String {
     // Returns a generic device name on iOS 16 and higher
     // See https://github.com/firezone/firezone/issues/3034
-    #if os(iOS)
-      return UIDevice.current.name
-    #else
-      // Fallback to connlib's gethostname()
-      return nil
-    #endif
+#if os(iOS)
+    return UIDevice.current.name
+#else
+    // Use hostname
+    return ProcessInfo.processInfo.hostName
+#endif
   }
 
-  public static func getOSVersion() -> String? {
-    // Returns the OS version
+  public static func getOSVersion() -> String {
+    // Returns the OS version. Must be valid ASCII.
     // See https://github.com/firezone/firezone/issues/3034
-    return ProcessInfo.processInfo.operatingSystemVersionString
+    // See https://github.com/firezone/firezone/issues/5467
+    let os = ProcessInfo.processInfo.operatingSystemVersion
+
+    return "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
   }
 
   // Returns the Firezone ID as cached by the application or generates and persists a new one


### PR DESCRIPTION
The [HTTP 1.1 RFC](https://datatracker.ietf.org/doc/html/rfc2616) states that HTTP headers should be US-ASCII. This is not the case when the macOS Client is run from a host that has a non-English language selected as its system default due to the way we build the user agent.

This PR fixes that by normalizing how we build the user agent by more granularly selecting which fields compose it, and not just relying on OS-provided version strings that may contain non-ASCII characters.

fixes https://github.com/firezone/firezone/issues/5467