### PR TITLE
refactor(snownet): change `reconnect` to `reset`

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -64,7 +64,7 @@ where
                 }
                 Poll::Ready(Some(Command::Reconnect)) => {
                     self.portal.reconnect();
-                    if let Err(e) = self.tunnel.reconnect() {
+                    if let Err(e) = self.tunnel.reset() {
                         tracing::warn!("Failed to reconnect tunnel: {e}");
                     }
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -153,7 +153,7 @@ where
     /// - it times out
     /// - we change our IP or port
     ///
-    /// `snownet` cannot control which IP / port we are binding to, thus upper layers MUST ensure that a new IP / port is allocated after calling [`Node::clear`].
+    /// `snownet` cannot control which IP / port we are binding to, thus upper layers MUST ensure that a new IP / port is allocated after calling [`Node::reset`].
     pub fn reset(&mut self) {
         self.bindings.clear();
         self.allocations.clear();

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -143,17 +143,22 @@ where
         }
     }
 
-    pub fn reconnect(&mut self, now: Instant) {
-        for binding in self.bindings.values_mut() {
-            binding.refresh(now);
-        }
+    /// Resets this [`Node`].
+    ///
+    /// # Implementation note
+    ///
+    /// This also clears all [`Allocation`]s.
+    /// An [`Allocation`] on a TURN server is identified by the client's 3-tuple (IP, port, protocol).
+    /// Thus, clearing the [`Allocation`]'s state here without closing it means we won't be able to make a new one until:
+    /// - it times out
+    /// - we change our IP or port
+    ///
+    /// `snownet` cannot control which IP / port we are binding to, thus upper layers MUST ensure that a new IP / port is allocated after calling [`Node::clear`].
+    pub fn reset(&mut self) {
+        self.bindings.clear();
+        self.allocations.clear();
 
-        // FIXME(tech-debt): A refresh here is unnecessary.
-        // We always rebind the sockets one layer up, which changes our outgoing port and thus means we are a "new" client from TURN's perspective (TURN operates on 3-tuples).
-        // Thus, a "reset" operation that just clears the local state would be sufficient here and would likely simplify the internals of `Allocation`.
-        for allocation in self.allocations.values_mut() {
-            allocation.refresh(now);
-        }
+        self.buffered_transmits.clear();
 
         self.pending_events.clear();
 

--- a/rust/connlib/snownet/src/stun_binding.rs
+++ b/rust/connlib/snownet/src/stun_binding.rs
@@ -122,21 +122,6 @@ impl StunBinding {
         true
     }
 
-    pub(crate) fn refresh(&mut self, now: Instant) {
-        self.last_now = now;
-        self.backoff.clock.now = now;
-
-        self.backoff.reset();
-        let backoff = self
-            .backoff
-            .next_backoff()
-            .expect("to have backoff right after resetting");
-
-        let (state, transmit) = new_binding_request(self.server, now, backoff);
-        self.state = state;
-        self.buffered_transmits.push_back(transmit);
-    }
-
     pub fn handle_timeout(&mut self, now: Instant) {
         self.last_now = now;
         self.backoff.clock.now = now;

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -90,8 +90,8 @@ where
         })
     }
 
-    pub fn reconnect(&mut self) -> std::io::Result<()> {
-        self.role_state.reconnect(Instant::now());
+    pub fn reset(&mut self) -> std::io::Result<()> {
+        self.role_state.reset();
         self.io.sockets_mut().rebind()?;
 
         Ok(())

--- a/rust/connlib/tunnel/src/tests/sim_node.rs
+++ b/rust/connlib/tunnel/src/tests/sim_node.rs
@@ -122,7 +122,6 @@ impl SimNode<ClientId, ClientState> {
         &mut self,
         ip4_socket: Option<SocketAddrV4>,
         ip6_socket: Option<SocketAddrV6>,
-        now: Instant,
     ) {
         // 1. Remember what the current sockets were.
         self.old_sockets.extend(self.ip4_socket.map(SocketAddr::V4));
@@ -132,15 +131,7 @@ impl SimNode<ClientId, ClientState> {
         self.ip4_socket = ip4_socket;
         self.ip6_socket = ip6_socket;
 
-        // 3. Ensure our new sockets aren't present in old sockets (a client should be able to roam "back" to a previous network interface).
-        if let Some(s4) = self.ip4_socket.map(SocketAddr::V4) {
-            self.old_sockets.retain(|s| s != &s4);
-        }
-        if let Some(s6) = self.ip6_socket.map(SocketAddr::V6) {
-            self.old_sockets.retain(|s| s != &s6);
-        }
-
-        self.state.reconnect(now);
+        self.state.reset();
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -213,7 +213,12 @@ impl StateMachineTest for TunnelTest {
             Transition::RoamClient {
                 ip4_socket,
                 ip6_socket,
-            } => state.client.roam(ip4_socket, ip6_socket, state.now),
+            } => {
+                state.client.roam(ip4_socket, ip6_socket);
+
+                // In prod, we reconnect to the portal and receive a new `init` message.
+                state.client.init_relays([&state.relay], ref_state.now);
+            }
         };
         state.advance(ref_state, &mut buffered_transmits);
         assert!(buffered_transmits.is_empty()); // Sanity check to ensure we handled all packets.


### PR DESCRIPTION
Currently, `snownet` still supports this notion of "reconnecting" which is a mix between resetting some state but keeping other. In particular, we currently retain the `StunBinding` and `Allocation` state. This used to be important because allocations are bound to the 3-tuple of the client and thus needed to be kept around in case we weren't actually roaming.

We always rebind the the local UDP sockets upon reconnecting and thus the 3-tuple always changes anyway. In addition, we always reconnect to the portal, meaning we receive another `init` message and thus can actually completely clear the `Node`'s state.

This PR does that an in the process, rebrands `reconnect` as `reset` which now makes more sense.

Related: #5619.