### PR TITLE
ci: only set up runtime tauri deps for smoke tests

### DIFF
--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -25,17 +25,17 @@ runs:
       # This is what the Tauri CI tests use
       # <https://github.com/tauri-apps/tauri/blob/3fb414b61ad7cfce67751230826fddfb39effec5/.github/workflows/bench.yml#L74>
     - name: Install Tauri runtime deps
-      if: ${{ runner.os == 'Linux' && inputs.runtime }}
+      if: ${{ runner.os == 'Linux' && inputs.runtime == 'true' }}
       run: sudo apt-get install at-spi2-core xvfb
       shell: bash
     - uses: actions/cache@v4
-      if: ${{ runner.os == 'Windows' && inputs.runtime }}
+      if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' }}
       id: cache-webview2-installer
       with:
         path: WebView2Installer.exe
         key: ${{ runner.os }}-${{ runner.arch }}-webview2-offline-installer
     - name: Download WebView2 bootstrapper
-      if: ${{ runner.os == 'Windows' && steps.cache-webview2-installer.outputs.cache-hit != 'true' && inputs.runtime }}
+      if: ${{ runner.os == 'Windows' && steps.cache-webview2-installer.outputs.cache-hit != 'true' && inputs.runtime == 'true' }}
       # This is the "Evergreen" bootstrapper from Microsoft
       # <https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH#download>
       # Unfortunately, this makes the test non-deterministic.
@@ -43,7 +43,7 @@ runs:
       run: Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=2124701 -OutFile WebView2Installer.exe
       shell: pwsh
     - name: Install WebView2
-      if: ${{ runner.os == 'Windows' && inputs.runtime }}
+      if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' }}
       # This downloads about 200 MB and takes about 5 minutes on my VM
       # So we could fault in WebView2 from the client exe without the MSI if we needed.
       # Currently the MSI does this and it's a little janky.

--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -1,6 +1,11 @@
 # From https://tauri.app/v1/guides/getting-started/prerequisites
 name: "Setup Tauri"
 description: "Sets up the dependencies for building and testing Tauri apps"
+inputs:
+  runtime:
+    description: "Whether to also set up runtime dependencies"
+    required: false
+    default: false
 runs:
   using: "composite"
   steps:
@@ -20,17 +25,17 @@ runs:
       # This is what the Tauri CI tests use
       # <https://github.com/tauri-apps/tauri/blob/3fb414b61ad7cfce67751230826fddfb39effec5/.github/workflows/bench.yml#L74>
     - name: Install Tauri runtime deps
-      if: ${{ runner.os == 'Linux' }}
+      if: ${{ runner.os == 'Linux' && inputs.runtime }}
       run: sudo apt-get install at-spi2-core xvfb
       shell: bash
     - uses: actions/cache@v4
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ runner.os == 'Windows' && inputs.runtime }}
       id: cache-webview2-installer
       with:
         path: WebView2Installer.exe
         key: ${{ runner.os }}-${{ runner.arch }}-webview2-offline-installer
     - name: Download WebView2 bootstrapper
-      if: ${{ runner.os == 'Windows' && steps.cache-webview2-installer.outputs.cache-hit != 'true' }}
+      if: ${{ runner.os == 'Windows' && steps.cache-webview2-installer.outputs.cache-hit != 'true' && inputs.runtime }}
       # This is the "Evergreen" bootstrapper from Microsoft
       # <https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH#download>
       # Unfortunately, this makes the test non-deterministic.
@@ -38,7 +43,7 @@ runs:
       run: Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=2124701 -OutFile WebView2Installer.exe
       shell: pwsh
     - name: Install WebView2
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ runner.os == 'Windows' && inputs.runtime }}
       # This downloads about 200 MB and takes about 5 minutes on my VM
       # So we could fault in WebView2 from the client exe without the MSI if we needed.
       # Currently the MSI does this and it's a little janky.

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -99,7 +99,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri
         timeout-minutes: 5
-        runtime: true
+        with:
+          runtime: true
       - name: pnpm install
         run: |
           pnpm install

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -63,8 +63,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         id: setup-rust
-      - uses: ./.github/actions/setup-tauri
-        timeout-minutes: 5
+      # - uses: ./.github/actions/setup-tauri
+      #   timeout-minutes: 5
       - run: cargo test --all-features ${{ steps.setup-rust.outputs.packages }} -- --include-ignored
         env:
           # <https://github.com/rust-lang/cargo/issues/5999>

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -64,8 +64,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         id: setup-rust
       - uses: ./.github/actions/setup-tauri
-        with:
-          runtime: false
       - run: cargo test --all-features ${{ steps.setup-rust.outputs.packages }} -- --include-ignored
         env:
           # <https://github.com/rust-lang/cargo/issues/5999>
@@ -101,6 +99,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri
         timeout-minutes: 5
+        runtime: true
       - name: pnpm install
         run: |
           pnpm install

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -63,8 +63,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         id: setup-rust
-      # - uses: ./.github/actions/setup-tauri
-      #   timeout-minutes: 5
+      - uses: ./.github/actions/setup-tauri
+        with:
+          runtime: false
       - run: cargo test --all-features ${{ steps.setup-rust.outputs.packages }} -- --include-ignored
         env:
           # <https://github.com/rust-lang/cargo/issues/5999>


### PR DESCRIPTION
Setting up Tauri's runtime dependencies takes about a minute and is unnecessary for the Rust unit tests. The Rust Windows unit tests jobs are amongst the slowest and thus impact the overall CI runtime.

See https://github.com/firezone/firezone/actions/runs/9719218798/job/26828616349 for a recent run on `main`.