### PR TITLE
fix(gateway): Add default RUST_LOG level to Docker-deployed Gateways

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -185,6 +185,7 @@ defmodule Web.Sites.NewToken do
       end
 
     [
+      {"RUST_LOG=str0m=warn,info"},
       {"FIREZONE_TOKEN", encoded_token},
       api_url_override
     ]

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -185,7 +185,6 @@ defmodule Web.Sites.NewToken do
       end
 
     [
-      {"RUST_LOG=str0m=warn,info"},
       {"FIREZONE_TOKEN", encoded_token},
       api_url_override
     ]
@@ -211,6 +210,7 @@ defmodule Web.Sites.NewToken do
         "--env #{key}=\"#{value}\""
       end),
       "--env FIREZONE_NAME=$(hostname)",
+      "--env RUST_LOG=str0m=warn,info",
       "#{Domain.Config.fetch_env!(:domain, :docker_registry)}/gateway:1"
     ]
     |> List.flatten()


### PR DESCRIPTION
This has been an issue for some time(!)

Fixes #5141 