### PR TITLE
fix(apple): Fix ResourceList bug showing cached Resources from last session

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -248,6 +248,7 @@ class TunnelManager {
           if session.status == .disconnected {
             // Reset resource list on disconnect
             resourceListHash = Data()
+            resourcesListCache = Data()
           }
 
           await statusChangeHandler?(session.status)


### PR DESCRIPTION
On macOS and iOS, the TunnelManager instance stays active across sessions. This contains a Resource cache used to fetch Resources from the tunnel process.

This cache wasn't cleared across sessions, so the first time the callback fired the Resources shown were the ones from the last session. After `1s`, they were correctly set to the current session's Resources due to the `beginUpdatingResources` timer.

We were already clearing the stored Hash of the Resource cache on disconnect, but not the Resource cache itself. This patch fixes that bug by re-initializing the cache when the tunnel session is `disconnected`.