### PR TITLE
ci: increase sleep for flaky integration tests due to slow GH runners

### DIFF
--- a/scripts/tests/direct-download-roaming-network.sh
+++ b/scripts/tests/direct-download-roaming-network.sh
@@ -19,7 +19,6 @@ sleep 3 # Download a bit
 
 docker network disconnect firezone_app firezone-client-1 # Disconnect the client
 sleep 3
-
 docker network connect firezone_app firezone-client-1 --ip 172.28.0.200 # Reconnect client with a different IP
 
 # Send SIGHUP, triggering `reconnect` internally

--- a/scripts/tests/direct-download-roaming-network.sh
+++ b/scripts/tests/direct-download-roaming-network.sh
@@ -18,7 +18,7 @@ DOWNLOAD_PID=$!
 sleep 3 # Download a bit
 
 docker network disconnect firezone_app firezone-client-1 # Disconnect the client
-sleep 1
+sleep 3
 
 docker network connect firezone_app firezone-client-1 --ip 172.28.0.200 # Reconnect client with a different IP
 

--- a/scripts/tests/systemd/dns-systemd-resolved.sh
+++ b/scripts/tests/systemd/dns-systemd-resolved.sh
@@ -45,7 +45,7 @@ stat "/usr/bin/$BINARY_NAME"
 sudo systemctl start "$SERVICE_NAME" || debug_exit
 
 # Wait for connlib to set DNS sentinel and update Resources
-sleep 1
+sleep 3
 
 resolvectl dns tun-firezone
 resolvectl query "$HTTPBIN" || debug_exit


### PR DESCRIPTION
Both of these deal with the tunnel interface being initialized, which seems to take more than 1s when we have a lot of jobs running.