### PR TITLE
fix(portal): bump auth constant time to 2s

### DIFF
--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -138,7 +138,7 @@ defmodule Web.AuthController do
               })
           end
         end,
-        1000
+        2000
       )
 
     put_auth_state(conn, provider.id, {fragment, provider_identifier, redirect_params})


### PR DESCRIPTION
Fixes https://console.cloud.google.com/monitoring/alerting/incidents/0.nes28ktmvdk8?channelType=slack&project=firezone-prod

```
elapsed_time: 1300
```