### PR TITLE
ci: link check mdx too

### DIFF
--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: lycheeverse/lychee-action@v1.10.0
         with:
           fail: true
-          args: --offline --verbose --no-progress **/*.md
+          args: --offline --verbose --no-progress **/*.md **/*.mdx
 
   global-linter:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
I verified that these checks don't hit the network. Should be helpful for anything NextJS doesn't catch.