### PR TITLE
fix(website): Handle JS errors during Mixpanel init

### DIFF
--- a/website/src/components/Analytics/index.tsx
+++ b/website/src/components/Analytics/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, Suspense } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useMixpanel } from "react-mixpanel-browser";
 import { HubSpotSubmittedFormData } from "./types";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 function _Mixpanel() {
   const pathname = usePathname();
@@ -63,9 +64,11 @@ function _Mixpanel() {
 
 export function Mixpanel() {
   return (
-    <Suspense>
-      <_Mixpanel />
-    </Suspense>
+    <ErrorBoundary>
+      <Suspense>
+        <_Mixpanel />
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 

--- a/website/src/components/ErrorBoundary/index.tsx
+++ b/website/src/components/ErrorBoundary/index.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode, useEffect } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({ children }) => {
+  useEffect(() => {
+    const handleErrors = (event: ErrorEvent) => {
+      console.error("ErrorBoundary caught an error", event.error);
+    };
+
+    window.addEventListener("error", handleErrors);
+
+    return () => {
+      window.removeEventListener("error", handleErrors);
+    };
+  }, []);
+
+  return <>{children}</>;
+};
+
+export default ErrorBoundary;

--- a/website/src/components/ErrorBoundary/index.tsx
+++ b/website/src/components/ErrorBoundary/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { ReactNode, useEffect } from "react";
 
 interface ErrorBoundaryProps {


### PR DESCRIPTION
Adds an `ErrorBoundary` to catch the errors that may occur when rendering the Suspense


```
Uncaught Error: Minified React error #419; visit https://react.dev/errors/419 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
```