### PR TITLE
fix(android): Bump AGP to 8.5.0 and reorder rust gradle plugin

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -1,8 +1,8 @@
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
 
 plugins {
-    id("com.android.application")
     id("org.mozilla.rust-android-gradle.rust-android")
+    id("com.android.application")
     id("com.google.dagger.hilt.android")
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")

--- a/kotlin/android/build.gradle.kts
+++ b/kotlin/android/build.gradle.kts
@@ -13,12 +13,12 @@ buildscript {
 }
 
 plugins {
+    id("org.mozilla.rust-android-gradle.rust-android") version "0.9.4" apply false
     id("org.jetbrains.kotlin.android") version "1.8.22" apply false
-    id("com.android.application") version "8.3.0" apply false
+    id("com.android.application") version "8.5.0" apply false
     id("com.google.firebase.appdistribution") version "5.0.0" apply false
     id("com.google.dagger.hilt.android") version "2.51.1" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
-    id("org.mozilla.rust-android-gradle.rust-android") version "0.9.4" apply false
     id("com.google.firebase.crashlytics") version "3.0.1" apply false
 }
 


### PR DESCRIPTION
Fixes the issue with #5664 by re-ordering the gradle plugin (yes, really).

See https://github.com/mozilla/rust-android-gradle/issues/148

Supersedes #5664 