### PR TITLE
fix(portal): Update client identity on every connection

### DIFF
--- a/elixir/apps/api/test/api/client/socket_test.exs
+++ b/elixir/apps/api/test/api/client/socket_test.exs
@@ -120,12 +120,14 @@ defmodule API.Client.SocketTest do
     test "updates existing client" do
       account = Fixtures.Accounts.create_account()
       context = Fixtures.Auth.build_context(type: :client)
-      identity = Fixtures.Auth.create_identity(account: account)
+      actor = Fixtures.Actors.create_actor(account: account)
+      identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+      new_identity = Fixtures.Auth.create_identity(account: account, actor: actor)
 
       {_token, encoded_token} =
         Fixtures.Auth.create_and_encode_token(
           account: account,
-          identity: identity,
+          identity: new_identity,
           context: context
         )
 
@@ -140,6 +142,7 @@ defmodule API.Client.SocketTest do
       assert client.last_seen_remote_ip_location_city == "Kyiv"
       assert client.last_seen_remote_ip_location_lat == 50.4333
       assert client.last_seen_remote_ip_location_lon == 30.5167
+      assert client.identity_id == new_identity.id
     end
 
     test "uses region code to put default coordinates" do

--- a/elixir/apps/domain/lib/domain/clients/client/changeset.ex
+++ b/elixir/apps/domain/lib/domain/clients/client/changeset.ex
@@ -15,6 +15,7 @@ defmodule Domain.Clients.Client.Changeset do
                               last_seen_remote_ip_location_lon
                               last_seen_version
                               last_seen_at
+                              identity_id
                               updated_at]a
   @update_fields ~w[name]a
   @required_fields @upsert_fields

--- a/elixir/apps/domain/test/domain/clients_test.exs
+++ b/elixir/apps/domain/test/domain/clients_test.exs
@@ -457,9 +457,16 @@ defmodule Domain.ClientsTest do
     end
 
     test "updates client when it already exists", %{
+      account: account,
+      admin_actor: actor,
       admin_subject: subject
     } do
-      client = Fixtures.Clients.create_client(subject: subject)
+      previous_identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+
+      previous_subject =
+        Fixtures.Auth.create_subject(account: account, identity: previous_identity)
+
+      client = Fixtures.Clients.create_client(subject: previous_subject)
       attrs = Fixtures.Clients.client_attrs(external_id: client.external_id)
 
       subject = %{
@@ -489,7 +496,8 @@ defmodule Domain.ClientsTest do
       assert updated_client.public_key == attrs.public_key
 
       assert updated_client.actor_id == client.actor_id
-      assert updated_client.identity_id == client.identity_id
+      assert updated_client.identity_id == subject.identity.id
+      assert updated_client.identity_id != client.identity_id
       assert updated_client.ipv4 == client.ipv4
       assert updated_client.ipv6 == client.ipv6
       assert updated_client.last_seen_at


### PR DESCRIPTION
This identity must track the last sign in method used by the client

Closes #5633