### PR TITLE
chore(headless-client): fix typo in match statement

### DIFF
--- a/rust/headless-client/src/standalone.rs
+++ b/rust/headless-client/src/standalone.rs
@@ -191,8 +191,8 @@ pub fn run_only_headless_client() -> Result<()> {
                         is_authentication_error: _,
                     }) => return Err(anyhow!(error_msg).context("Firezone disconnected")),
                     InternalServerMsg::Ipc(IpcServerMsg::Ok)
-                    | InternalServerMsg::Ipc(IpcServerMsg::OnTunnelReady)
-                    | InternalServerMsg::Ipc(IpcServerMsg::OnUpdateResources(_)) => {
+                    | InternalServerMsg::Ipc(IpcServerMsg::OnTunnelReady) => {}
+                    InternalServerMsg::Ipc(IpcServerMsg::OnUpdateResources(_)) => {
                         // On every resources update, flush DNS to mitigate <https://github.com/firezone/firezone/issues/5052>
                         dns_controller.flush()?;
                     }


### PR DESCRIPTION
PR #5700 had a typo in it. I didn't notice that these match arms use `|`, so I accidentally flush the DNS for an event that doesn't need it. Only `OnUpdateResources` should flush DNS.