### PR TITLE
fix(infra): relay listens on UDP only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -447,7 +447,7 @@ services:
     depends_on:
       api:
         condition: "service_healthy"
-    ports:
+    # ports:
       # NOTE: Only 111 ports are used for local dev / testing because Docker Desktop
       # allocates a userland proxy process for each forwarded port X_X.
       #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -420,8 +420,8 @@ services:
     environment:
       PUBLIC_IP4_ADDR: ${RELAY_1_PUBLIC_IP4_ADDR:-172.28.0.101}
       # PUBLIC_IP6_ADDR: fcff:3990:3990::101
-      LOWEST_PORT: 55555
-      HIGHEST_PORT: 55666
+      # LOWEST_PORT: 55555
+      # HIGHEST_PORT: 55666
       # Token for self-hosted Relay
       # FIREZONE_TOKEN: ".SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkNTQ5YzQxMDctMTQ5Mi00ZjhmLWE0ZWMtYTlkMmE2NmQ4YWE5bQAAADhQVTVBSVRFMU84VkRWTk1ITU9BQzc3RElLTU9HVERJQTY3MlM2RzFBQjAyT1MzNEg1TUUwPT09PW4GAEngLBONAWIAAVGA.E-f2MFdGMX7JTL2jwoHBdWcUd2G3UNz2JRZLbQrlf0k"
       # Token for global Relay
@@ -452,8 +452,8 @@ services:
       # allocates a userland proxy process for each forwarded port X_X.
       #
       # Large ranges here will bring your machine to its knees.
-      - "55555-55666:55555-55666/udp"
-      - 3478:3478/udp
+      # - "55555-55666:55555-55666/udp"
+      # - 3478:3478/udp
     networks:
       app:
         ipv4_address: ${RELAY_1_PUBLIC_IP4_ADDR:-172.28.0.101}

--- a/rust/relay/README.md
+++ b/rust/relay/README.md
@@ -44,7 +44,7 @@ firezone-relay --help
 
 ### Ports
 
-By default, the relay listens on port `3478`. This is the standard port for
+By default, the relay listens on port `udp/3478`. This is the standard port for
 STUN/TURN. Additionally, the relay needs to have access to the port range
 `49152` - `65535` for the allocations.
 

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -363,11 +363,6 @@ resource "google_compute_firewall" "stun-turn-ipv4" {
   target_tags   = ["app-${local.application_name}"]
 
   allow {
-    protocol = "tcp"
-    ports    = ["3478", "49152-65535"]
-  }
-
-  allow {
     protocol = "udp"
     ports    = ["3478", "49152-65535"]
   }
@@ -381,11 +376,6 @@ resource "google_compute_firewall" "stun-turn-ipv6" {
 
   source_ranges = ["::/0"]
   target_tags   = ["app-${local.application_name}"]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["3478", "49152-65535"]
-  }
 
   allow {
     protocol = "udp"


### PR DESCRIPTION
I don't believe we use/need TCP for the Relays. Better to keep the ports closed if so.

Also, the docker-compose.yml is updated to allow the `relay-1` service to respond to all its ports, since we don't need those mapped typically.