### PR TITLE
fix(style): Set prettier prosewrap to `preserve` to let authors write MD in their own style

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,5 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": false,
-  "proseWrap": "always"
+  "proseWrap": "preserve"
 }

--- a/rust/gui-client/docs/intended_behavior.md
+++ b/rust/gui-client/docs/intended_behavior.md
@@ -68,7 +68,7 @@ x86_64 only, see issue #2992. Best performed on a clean VM.
 1. Expect "Firezone connected" notification
 1. Check the IP again, expect the gateway's IP
 1. Export the logs
-1. Expect the zip file to start with "firezone_logs_"
+1. Expect the zip file to start with `firezone_logs_`
 1. Expect the zip to contain a single directory in the root of the zip, to prevent zip bombing
 1. Expect two subdirectories in the zip, "connlib", and "app", with 2 files each, totalling 4 files
 

--- a/website/src/app/blog/enterprises-choose-open-source/readme.mdx
+++ b/website/src/app/blog/enterprises-choose-open-source/readme.mdx
@@ -67,7 +67,7 @@ or erode a competitive advantage.
 #### The future is open source
 
 While open source may have gotten an
-[unconventional start](https://en.wikipedia.org/wiki/Open-source-software_movement#:~:text=Brief%20history,-Further%20information%3A%20Open&text=The%20label%20%22open%20source%22%20was,source%2Dcode%20release%20for%20Navigator.)
+[unconventional start](https://en.wikipedia.org/wiki/Open-source-software_movement#Brief_history)
 from hackers, visionaries and technologists, the benefits are clear. It’s being
 used to modernize and standardize IT infrastructure, security, scalability, and
 application development. Open source is now a preferred development strategy for

--- a/website/src/app/blog/sans-io/readme.mdx
+++ b/website/src/app/blog/sans-io/readme.mdx
@@ -647,9 +647,7 @@ on drafts of this post.
     For more details on Firezone's tech stack, see
     [this article](/kb/architecture/tech-stack) in our architecture docs.
 
-[^2]:
-    Technically, a thread-per-core runtime could allow non-`'static` `Future`s.
-
+[^2]: Technically, a thread-per-core runtime could allow non-`'static` `Future`s.
 [^3]:
     `boringtun` does call `Instant::now` internally and is thus unfortunately
     partly impure, see https://github.com/cloudflare/boringtun/issues/391.

--- a/website/src/app/blog/sans-io/readme.mdx
+++ b/website/src/app/blog/sans-io/readme.mdx
@@ -648,6 +648,7 @@ on drafts of this post.
     [this article](/kb/architecture/tech-stack) in our architecture docs.
 
 [^2]: Technically, a thread-per-core runtime could allow non-`'static` `Future`s.
+
 [^3]:
     `boringtun` does call `Instant::now` internally and is thus unfortunately
     partly impure, see https://github.com/cloudflare/boringtun/issues/391.


### PR DESCRIPTION
Prettier has three options for prose-wrap:

- `always`: Format prose (markdown) to the line-length (current)
- `never`: Use a single line for all prose (proposed)
- `preserve`: Don't lint prose

Settled on `preserve` due to discussion.


Fixes #5686 