### PR TITLE
chore(infra): remove double secret "SECRET_KEY_BASE" (#5728)

### DIFF
--- a/terraform/environments/production/portal.tf
+++ b/terraform/environments/production/portal.tf
@@ -231,10 +231,6 @@ locals {
     },
     # Secrets
     {
-      name  = "SECRET_KEY_BASE"
-      value = random_password.secret_key_base.result
-    },
-    {
       name  = "TOKENS_KEY_BASE"
       value = base64encode(random_password.tokens_key_base.result)
     },

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -204,10 +204,6 @@ locals {
     },
     # Secrets
     {
-      name  = "SECRET_KEY_BASE"
-      value = random_password.secret_key_base.result
-    },
-    {
       name  = "TOKENS_KEY_BASE"
       value = base64encode(random_password.tokens_key_base.result)
     },


### PR DESCRIPTION
This is a duplicate var that is replaced with the base64 version just below it.