### PR TITLE
build(deps): use upstream str0m

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5701,8 +5701,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.5.1"
-source = "git+https://github.com/firezone/str0m?branch=main#b59f9eb58a5a5b506e12163b7fb8ccd088f057f1"
+version = "0.6.1"
+source = "git+https://github.com/algesten/str0m?branch=main#386c665b9801783c5840047ffd11025534069758"
 dependencies = [
  "combine",
  "crc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
 hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63", features = ["tokio-runtime"] }
 hickory-proto = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63" }
-str0m = { version = "0.5", default-features = false }
+str0m = { version = "0.6", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.10", features = ["serde"] }
 dns-lookup = "2.0"
@@ -74,7 +74,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }
-str0m = { git = "https://github.com/firezone/str0m", branch = "main" }
+str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 proptest = { git = "https://github.com/thomaseizinger/proptest", branch = "fix/always-check-acceptable-current-state" }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -800,10 +800,8 @@ where
             tracing::info!("Replacing existing established connection");
         };
 
-        let mut agent = IceAgent::new();
+        let mut agent = new_agent();
         agent.set_controlling(true);
-        agent.set_max_candidate_pairs(300);
-        agent.set_timing_advance(Duration::ZERO);
 
         let session_key = Secret::new(random());
         let ice_creds = agent.local_credentials();
@@ -902,13 +900,12 @@ where
             tracing::info!("Replacing existing established connection");
         };
 
-        let mut agent = IceAgent::new();
+        let mut agent = new_agent();
         agent.set_controlling(false);
         agent.set_remote_credentials(IceCreds {
             ufrag: offer.credentials.username,
             pass: offer.credentials.password,
         });
-        agent.set_timing_advance(Duration::ZERO);
 
         let answer = Answer {
             credentials: Credentials {
@@ -1814,4 +1811,14 @@ where
     };
 
     Some(transmit)
+}
+
+fn new_agent() -> IceAgent {
+    let mut agent = IceAgent::new();
+    agent.set_max_candidate_pairs(300);
+    agent.set_timing_advance(Duration::ZERO);
+    agent.set_max_stun_retransmits(8);
+    agent.set_max_stun_rto(Duration::from_millis(1500));
+
+    agent
 }


### PR DESCRIPTION
With the adoption of #5080, connlib is now resilient against temporarily failed connections as they'll be immediately re-established. Thus, we no longer need any of the patches that we are currently maintaining in our str0m fork.

The only difference is an adjustment of the ICE timeout parameters but those can be made configurable in str0m.

Related: https://github.com/algesten/str0m/pull/537.