### PR TITLE
fix(website): Wrap app in MixpanelProvider

### DIFF
--- a/website/src/app/support/_page.tsx
+++ b/website/src/app/support/_page.tsx
@@ -21,8 +21,9 @@ import { FaSlack } from "react-icons/fa";
 
 export default function _Page() {
   const openChat = (e: React.MouseEvent) => {
+    const winAny = window as any;
     e.preventDefault();
-    window.HubSpotConversations.widget.open();
+    winAny.HubSpotConversations.widget.open();
   };
 
   return (

--- a/website/src/components/Analytics/index.tsx
+++ b/website/src/components/Analytics/index.tsx
@@ -1,16 +1,12 @@
 import Mixpanel from "./Mixpanel";
 import GoogleAds from "./GoogleAds";
 import LinkedInInsights from "./LinkedInInsights";
-import { GoogleAnalytics } from "@next/third-parties/google";
 
 export default function Analytics() {
-  const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
-
   return (
     <>
       <Mixpanel />
       <GoogleAds />
-      {gaId && gaId.length > 0 && <GoogleAnalytics gaId={gaId} />}
       <LinkedInInsights />
     </>
   );

--- a/website/src/components/Analytics/index.tsx
+++ b/website/src/components/Analytics/index.tsx
@@ -1,12 +1,16 @@
 import Mixpanel from "./Mixpanel";
 import GoogleAds from "./GoogleAds";
 import LinkedInInsights from "./LinkedInInsights";
+import { GoogleAnalytics } from "@next/third-parties/google";
 
 export default function Analytics() {
+  const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
+
   return (
     <>
       <Mixpanel />
       <GoogleAds />
+      {gaId && gaId.length > 0 && <GoogleAnalytics gaId={gaId} />}
       <LinkedInInsights />
     </>
   );

--- a/website/src/components/Providers/index.jsx
+++ b/website/src/components/Providers/index.jsx
@@ -1,21 +1,23 @@
 "use client";
 import { MixpanelProvider } from "react-mixpanel-browser";
 import { HubspotProvider } from "next-hubspot";
-import { GoogleAnalytics } from "@next/third-parties/google";
 
 export default function Provider({ children }) {
   const mpToken = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
-  const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
   const host = "https://t.firez.one";
 
   return (
-    <>
+    <HubspotProvider>
       <MixpanelProvider
         token={mpToken}
-        config={{ api_host: host, record_sessions_percent: 5 }}
-      />
-      <HubspotProvider>{children}</HubspotProvider>
-      <GoogleAnalytics gaId />
-    </>
+        config={{
+          track_page_view: true,
+          api_host: host,
+          record_sessions_percent: 5,
+        }}
+      >
+        {children}
+      </MixpanelProvider>
+    </HubspotProvider>
   );
 }

--- a/website/src/components/Providers/index.jsx
+++ b/website/src/components/Providers/index.jsx
@@ -11,7 +11,9 @@ export default function Provider({ children }) {
       <MixpanelProvider
         token={mpToken}
         config={{
-          track_page_view: true,
+          // This doesn't work for the website because page views happen client-side.
+          // We handle this in the Mixpanel component with useSearchParams instead.
+          // track_page_view: true,
           api_host: host,
           record_sessions_percent: 5,
         }}


### PR DESCRIPTION
We need to wrap the `children` by `MixpanelProvider` and not simply include the Provider on the page.

Fixes #5744 