### PR TITLE
test(snownet): add debug assert

### DIFF
--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -638,6 +638,8 @@ impl<R> TestNode<R> {
     }
 
     fn receive(&mut self, local: SocketAddr, from: SocketAddr, packet: &[u8], now: Instant) {
+        debug_assert!(self.local.contains(&local));
+
         if let Some((_, packet)) = self
             .span
             .in_scope(|| {


### PR DESCRIPTION
Within `snownet`'s test harness, packets are dispatched in a particular order and of none of them match. They are assumed to be for the node directly. We add a debug assert to ensure that the given address is in fact part of the "local" interfaces that we have configured in the tests.