### PR TITLE
docs: GitHub releases -> Changelog

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -127,7 +127,7 @@ android {
             firebaseAppDistribution {
                 serviceCredentialsFile = System.getenv("FIREBASE_CREDENTIALS_PATH")
                 artifactType = "AAB"
-                releaseNotes = "https://github.com/firezone/firezone/releases"
+                releaseNotes = "https://www.firezone.dev/changelog"
                 groups = "firezone-engineering"
                 artifactPath = "app/build/outputs/bundle/release/app-release.aab"
             }

--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -72,7 +72,7 @@ if [ ! -e /usr/local/bin/firezone-gateway ]; then
   echo "Downloading ${FIREZONE_VERSION} version from ${FIREZONE_ARTIFACT_URL}..."
   arch=\$(uname -m)
 
-  # See https://www.github.com/firezone/firezone/releases for available binaries
+  # See https://www.firezone.dev/changelog for available binaries
   curl -fsSL ${FIREZONE_ARTIFACT_URL}/${FIREZONE_VERSION}/\$arch -o /tmp/firezone-gateway
 
   if file /tmp/firezone-gateway | grep -q "ELF"; then

--- a/website/src/app/kb/administer/upgrading/readme.mdx
+++ b/website/src/app/kb/administer/upgrading/readme.mdx
@@ -86,8 +86,7 @@ if you consistently encounter issues with the upgrade process.
 
 After running the upgrade, check that the version reported by the Gateway in the
 admin portal matches the latest published version on our
-[GitHub releases page](https://github.com/firezone/firezone/releases) to ensure
-it's up to date:
+[changelog page](/changelog) to ensure it's up to date:
 
 <Image
   src="/images/kb/administer/upgrading/gateway-upgrade-verify.png"

--- a/website/src/app/kb/architecture/core-components/readme.mdx
+++ b/website/src/app/kb/architecture/core-components/readme.mdx
@@ -146,10 +146,8 @@ locations:
   [Apple App Store](https://apps.apple.com/us/app/firezone/id6443661826)
 - **Android**:
   [Google Play Store](https://play.google.com/store/apps/details?id=dev.firezone.android)
-- **Windows**:
-  [GitHub releases](https://www.github.com/firezone/firezone/releases)
-- **Linux**:
-  [GitHub releases](https://www.github.com/firezone/firezone/releases)
+- **Windows**: [Changelog page](/changelog)
+- **Linux**: [Changelog page](/changelog)
 
 We recommend only using Clients from these official sources to ensure you're
 always running an authentic version with the latest security patches.
@@ -173,7 +171,7 @@ functionality. For more information on deploying Gateways, see the
 
 Gateways can be downloaded from the following locations:
 
-- Binary: [GitHub releases](https://www.github.com/firezone/firezone/releases)
+- Binary: [Changelog page](/changelog)
 - Docker: `docker pull ghcr.io/firezone/gateway`
 
 ### Resources

--- a/website/src/app/kb/deploy/clients/readme.mdx
+++ b/website/src/app/kb/deploy/clients/readme.mdx
@@ -31,9 +31,9 @@ so we can prioritize appropriately.
 | Platform           | Distribution Method                                                                                                                                      |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Android / ChromeOS | The Android / ChromeOS client is available exclusively from the [Google Play Store](https://play.google.com/store/apps/details?id=dev.firezone.android). |
-| Linux              | The Linux client is available as a self-contained, statically-linked binary from our [releases page](https://www.github.com/firezone/firezone/releases). |
+| Linux              | The headless and GUI Linux clients are available from our [changelog page](/changelog).                                                                  |
 | macOS / iOS        | The macOS and iOS clients are available exclusively from the [Apple App Store](https://apps.apple.com/us/app/firezone/id6443661826).                     |
-| Windows            | The Windows client is available as a standalone MSI installer from our [releases page](https://www.github.com/firezone/firezone/releases).               |
+| Windows            | The Windows client is available as a standalone MSI installer from our [changelog page](/changelog).                                                     |
 
 ## Headless mode operation
 

--- a/website/src/app/kb/readme.mdx
+++ b/website/src/app/kb/readme.mdx
@@ -28,6 +28,7 @@ Use the links below to get started.
   start syncing users and groups.
 - [Administer](/kb/administer): Everything related to typical, day-to-day
   management of your deployment.
+- [Automate](/kb/automate): Deploy with automation tools like Terraform.
 - [End-user guides](/kb/user-guides): Instructions you can pass along to
   Firezone end-users, such as installing Clients, using them, and related
   troubleshooting tips.

--- a/website/src/app/kb/reference/faq/readme.mdx
+++ b/website/src/app/kb/reference/faq/readme.mdx
@@ -101,13 +101,12 @@ Firezone does not store or handle end-user credentials like passwords.
 
 #### Where should I run my Gateway(s)?
 
-Gateways are [released](https://github.com/firezone/firezone/releases) as
-self-contained binaries for Linux that we package as a Docker image or systemd
-unit, which you can run on any Linux-based server or VM (e.g. on AWS, GCP,
-Azure, or on-premise). You only need a single Gateway in each Site to provide
-secure remote access to Resources associated with that Site. However, we
-recommend deploying two or more Gateways for load-balancing and automatic
-failover.
+Gateways are [released](/changelog) as self-contained binaries for Linux that we
+package as a Docker image or systemd unit, which you can run on any Linux-based
+server or VM (e.g. on AWS, GCP, Azure, or on-premise). You only need a single
+Gateway in each Site to provide secure remote access to Resources associated
+with that Site. However, we recommend deploying two or more Gateways for
+load-balancing and automatic failover.
 
 #### What is a service account?
 
@@ -153,10 +152,9 @@ approximately 5 minutes before being disconnected.
 
 #### How do end users get Firezone?
 
-Windows and Linux users can download the Client from
-[here](https://github.com/firezone/firezone/releases). MacOS, iOS, iPadOS,
-Android, and ChromeOS users can download the Client from their device’s app
-store.
+Windows and Linux users can download the Client from [here](/changelog). MacOS,
+iOS, iPadOS, Android, and ChromeOS users can download the Client from their
+device’s app store.
 
 #### Do users need to interact with the Firezone Client?
 

--- a/website/src/app/kb/reference/glossary/readme.mdx
+++ b/website/src/app/kb/reference/glossary/readme.mdx
@@ -20,11 +20,11 @@ can be assigned one or more [Policies](/kb/deploy/policies) to grant access to
 your infrastructure. Gateways must be defined within a Site, and any traffic
 to/from Resources associated with a Site will pass through one of that Site’s
 Gateways. We distribute the Gateway as self-contained binaries on our
-[releases page](https://github.com/firezone/firezone/releases), or as a Docker
-image or systemd unit file with instructions shown when you deploy the Gateway
-from the admin portal. Gateways can run on everything from a Raspberry Pi to
-bare metal servers and everything in between. Gateways are designed to be
-lightweight and don't require persistent storage to function.
+[changelog page](/changelog), or as a Docker image or systemd unit file with
+instructions shown when you deploy the Gateway from the admin portal. Gateways
+can run on everything from a Raspberry Pi to bare metal servers and everything
+in between. Gateways are designed to be lightweight and don't require persistent
+storage to function.
 
 **Group**: [User groups](/kb/deploy/groups) consist of one or more users,
 usually members of the same team or department (e.g. Engineering, DevOps, Sales)

--- a/website/src/app/kb/user-guides/linux-client/readme.mdx
+++ b/website/src/app/kb/user-guides/linux-client/readme.mdx
@@ -24,9 +24,8 @@ your identity provider interactively.
 
 ## Installation
 
-Download the Linux headless Client from our
-[releases page](https://github.com/firezone/firezone/releases), or use one of
-the direct links below:
+Download the Linux headless Client from our [changelog page](/changelog), or use
+one of the direct links below:
 
 - [Download the Linux Client for `x86_64`](/dl/firezone-client-headless-linux/latest/x86_64)
 - [Download the Linux Client for `ARMv7l`](/dl/firezone-client-headless-linux/latest/armv7)

--- a/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
@@ -21,8 +21,7 @@ present to authenticate with your identity provider interactively.
 
 ## Installation
 
-Download the `.deb` package from our
-[releases page](https://github.com/firezone/firezone/releases), or from the
+Download the `.deb` package from our [changelog page](/changelog), or from the
 direct link below:
 
 - [Download the Linux GUI `.deb` for `x86-64`](/dl/firezone-client-gui-linux/latest/x86_64)

--- a/website/src/app/kb/user-guides/windows-client/readme.mdx
+++ b/website/src/app/kb/user-guides/windows-client/readme.mdx
@@ -14,8 +14,7 @@ to authenticate with your identity provider interactively.
 
 ## Installation
 
-Download the `.msi` installer from
-[our releases page](https://github.com/firezone/firezone/releases) or from the
+Download the `.msi` installer from [our changelog page](/changelog) or from the
 direct link below:
 
 - [Download the Windows `.msi` installer for `x86-64`](/dl/firezone-client-gui-windows/latest/x86_64)


### PR DESCRIPTION
Needs to be updated with proper links pointing to changelog, not GH releases.