### PR TITLE
chore(infra): revoke oneleet signups, allow `firezonedemo.com`

### DIFF
--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -355,7 +355,7 @@ locals {
     # Sign Up
     {
       name  = "SIGN_UP_WHITELISTED_DOMAINS"
-      value = "firezone.dev,firez.one"
+      value = "firezone.dev,firez.one,firezonedemo.com"
     },
     {
       name  = "FEATURE_REST_API_ENABLED"

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -355,7 +355,7 @@ locals {
     # Sign Up
     {
       name  = "SIGN_UP_WHITELISTED_DOMAINS"
-      value = "firezone.dev,firez.one,pentesters.oneleet.com"
+      value = "firezone.dev,firez.one"
     },
     {
       name  = "FEATURE_REST_API_ENABLED"


### PR DESCRIPTION
- Reverts the access allowing them to sign up on staging.
- Allows `firezonedemo.com` for marketing / sales demos.