### PR TITLE
fix(infra): blog. and docs. need SSL certs too

### DIFF
--- a/terraform/environments/production/redirects.tf
+++ b/terraform/environments/production/redirects.tf
@@ -34,8 +34,8 @@ resource "google_compute_ssl_policy" "tld" {
   ]
 }
 
-# Create a managed SSL certificate
-resource "google_compute_managed_ssl_certificate" "tld" {
+# Create managed SSL certificates for the A records
+resource "google_compute_managed_ssl_certificate" "all" {
   project = module.google-cloud-project.project.project_id
 
   name = replace(local.tld, ".", "-")
@@ -45,6 +45,8 @@ resource "google_compute_managed_ssl_certificate" "tld" {
   managed {
     domains = [
       local.tld,
+      "blog.${local.tld}",
+      "docs.${local.tld}",
     ]
   }
 
@@ -124,7 +126,7 @@ resource "google_compute_target_https_proxy" "tld" {
 
   url_map = google_compute_url_map.redirects.self_link
 
-  ssl_certificates = [google_compute_managed_ssl_certificate.tld.self_link]
+  ssl_certificates = [google_compute_managed_ssl_certificate.all.self_link]
   ssl_policy       = google_compute_ssl_policy.tld.self_link
   quic_override    = "NONE"
 }


### PR DESCRIPTION
These are needed to be able to redirect.