### PR TITLE
fix(android): Strip scope id off IPv6 addresses Android

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
@@ -25,7 +25,10 @@ class NetworkMonitor(private val tunnelService: TunnelService) : ConnectivityMan
 
             if (lastDns != linkProperties.dnsServers) {
                 lastDns = linkProperties.dnsServers
-                ConnlibSession.setDns(tunnelService.connlibSessionPtr!!, Gson().toJson(linkProperties.dnsServers))
+
+                // Stripe the scope id from IPv6 addresses. See https://github.com/firezone/firezone/issues/5781
+                val dnsList = linkProperties.dnsServers.map { it.hostAddress!!.split("%")[0] }
+                ConnlibSession.setDns(tunnelService.connlibSessionPtr!!, Gson().toJson(dnsList))
             }
 
             if (lastNetwork != network) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/NetworkMonitor.kt
@@ -26,7 +26,7 @@ class NetworkMonitor(private val tunnelService: TunnelService) : ConnectivityMan
             if (lastDns != linkProperties.dnsServers) {
                 lastDns = linkProperties.dnsServers
 
-                // Stripe the scope id from IPv6 addresses. See https://github.com/firezone/firezone/issues/5781
+                // Strip the scope id from IPv6 addresses. See https://github.com/firezone/firezone/issues/5781
                 val dnsList = linkProperties.dnsServers.map { it.hostAddress!!.split("%")[0] }
                 ConnlibSession.setDns(tunnelService.connlibSessionPtr!!, Gson().toJson(dnsList))
             }

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -462,6 +462,7 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_di
 ///
 /// `dns_list` must not have any IPv6 scopes
 /// <https://github.com/firezone/firezone/issues/4350>
+/// <https://github.com/firezone/firezone/issues/5781>
 ///
 /// # Safety
 /// session_ptr should have been obtained from `connect` function, and shouldn't be dropped with disconnect

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import Entries from "./Entries";
 import Entry from "./Entry";
 
@@ -7,6 +8,16 @@ export default function Android() {
       href="https://play.google.com/store/apps/details?id=dev.firezone.android"
       title="Android"
     >
+      {/*
+      <Entry version="1.1.3" date={new Date("2024-07-03")}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          <li className="pl-2">
+          Fixes <Link href="https://github.com/firezone/firezone/issues/5781" className="text-accent-500 underline hover:no-underline">an issue</Link> where
+          the app would crash if IPv6 scopes were present in the DNS servers discovered on the local system.
+          </li>
+        </ul>
+      </Entry>
+      */}
       <Entry version="1.1.2" date={new Date("2024-07-03")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <li className="pl-2">


### PR DESCRIPTION
Fixes #5781