### PR TITLE
fix(connlib): protect all sockets from routing loops

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
  "log",
  "secrecy",
  "serde_json",
+ "socket-factory",
  "thiserror",
  "tokio",
  "tracing",
@@ -1084,6 +1085,7 @@ dependencies = [
  "oslog",
  "secrecy",
  "serde_json",
+ "socket-factory",
  "swift-bridge",
  "swift-bridge-build",
  "tokio",
@@ -1109,6 +1111,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "socket-factory",
  "time",
  "tokio",
  "tokio-tungstenite",
@@ -1873,6 +1876,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snownet",
+ "socket-factory",
  "static_assertions",
  "tokio",
  "tokio-tungstenite",
@@ -1962,6 +1966,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "socket-factory",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2003,6 +2008,7 @@ dependencies = [
  "secrecy",
  "serde",
  "sha2",
+ "socket-factory",
  "socket2 0.5.7",
  "stun_codec",
  "test-strategy",
@@ -2054,6 +2060,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snownet",
+ "socket-factory",
  "socket2 0.5.7",
  "test-strategy",
  "thiserror",
@@ -3901,6 +3908,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -4561,6 +4569,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "socket-factory",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -5810,6 +5819,14 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "socket-factory"
+version = "0.1.0"
+dependencies = [
+ "socket2 0.5.7",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3908,7 +3908,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3908,6 +3908,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,54 +1,45 @@
 [workspace]
 members = [
-    "bin-shared",
-    "connlib/clients/android",
-    "connlib/clients/apple",
-    "connlib/clients/shared",
-    "connlib/shared",
-    "connlib/snownet",
-    "connlib/tunnel",
-    "gateway",
-    "gui-client/src-tauri",
-    "gui-smoke-test",
-    "headless-client",
-    "http-health-check",
-    "http-test-server",
-    "ip-packet",
-    "phoenix-channel",
-    "relay",
-    "snownet-tests",
-    "socket-factory",
+  "bin-shared",
+  "connlib/clients/android",
+  "connlib/clients/apple",
+  "connlib/clients/shared",
+  "connlib/shared",
+  "connlib/snownet",
+  "connlib/tunnel",
+  "gateway",
+  "gui-client/src-tauri",
+  "gui-smoke-test",
+  "headless-client",
+  "http-health-check",
+  "http-test-server",
+  "ip-packet",
+  "phoenix-channel",
+  "relay",
+  "snownet-tests",
+  "socket-factory",
 ]
 
 resolver = "2"
 
 [workspace.dependencies]
 boringtun = { version = "0.6", default-features = false }
-chrono = { version = "0.4", default-features = false, features = [
-    "std",
-    "clock",
-    "oldtime",
-    "serde",
-] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
 swift-bridge = "0.1.55"
 backoff = { version = "0.4", features = ["tokio"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
-hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63", features = [
-    "tokio-runtime",
-] }
+hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63", features = ["tokio-runtime"] }
 hickory-proto = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63" }
 str0m = { version = "0.5", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.10", features = ["serde"] }
 dns-lookup = "2.0"
 tokio-tungstenite = "0.21"
-rtnetlink = { version = "0.14.1", default-features = false, features = [
-    "tokio_socket",
-] }
+rtnetlink = { version = "0.14.1", default-features = false, features = ["tokio_socket"] }
 tokio = "1.38"
-socket2 = { version = "0.5" }
+
 connlib-client-android = { path = "connlib/clients/android" }
 connlib-client-apple = { path = "connlib/clients/apple" }
 connlib-client-shared = { path = "connlib/clients/shared" }
@@ -81,7 +72,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }
 str0m = { git = "https://github.com/firezone/str0m", branch = "main" }
-ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" }                             # For `Debug` and `Clone`
+ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 proptest = { git = "https://github.com/thomaseizinger/proptest", branch = "fix/always-check-acceptable-current-state" }
 proptest-state-machine = { git = "https://github.com/thomaseizinger/proptest", branch = "fix/always-check-acceptable-current-state" }
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,44 +1,54 @@
 [workspace]
 members = [
-  "bin-shared",
-  "connlib/clients/android",
-  "connlib/clients/apple",
-  "connlib/clients/shared",
-  "connlib/shared",
-  "connlib/snownet",
-  "connlib/tunnel",
-  "gateway",
-  "gui-client/src-tauri",
-  "gui-smoke-test",
-  "headless-client",
-  "http-health-check",
-  "http-test-server",
-  "ip-packet",
-  "phoenix-channel",
-  "relay",
-  "snownet-tests",
+    "bin-shared",
+    "connlib/clients/android",
+    "connlib/clients/apple",
+    "connlib/clients/shared",
+    "connlib/shared",
+    "connlib/snownet",
+    "connlib/tunnel",
+    "gateway",
+    "gui-client/src-tauri",
+    "gui-smoke-test",
+    "headless-client",
+    "http-health-check",
+    "http-test-server",
+    "ip-packet",
+    "phoenix-channel",
+    "relay",
+    "snownet-tests",
+    "socket-factory",
 ]
 
 resolver = "2"
 
 [workspace.dependencies]
 boringtun = { version = "0.6", default-features = false }
-chrono = { version = "0.4", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "std",
+    "clock",
+    "oldtime",
+    "serde",
+] }
 swift-bridge = "0.1.55"
 backoff = { version = "0.4", features = ["tokio"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
-hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63", features = ["tokio-runtime"] }
+hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63", features = [
+    "tokio-runtime",
+] }
 hickory-proto = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63" }
 str0m = { version = "0.5", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.10", features = ["serde"] }
 dns-lookup = "2.0"
 tokio-tungstenite = "0.21"
-rtnetlink = { version = "0.14.1", default-features = false, features = ["tokio_socket"] }
+rtnetlink = { version = "0.14.1", default-features = false, features = [
+    "tokio_socket",
+] }
 tokio = "1.38"
-
+socket2 = { version = "0.5" }
 connlib-client-android = { path = "connlib/clients/android" }
 connlib-client-apple = { path = "connlib/clients/apple" }
 connlib-client-shared = { path = "connlib/clients/shared" }
@@ -53,6 +63,7 @@ firezone-tunnel = { path = "connlib/tunnel" }
 phoenix-channel = { path = "phoenix-channel" }
 http-health-check = { path = "http-health-check" }
 ip-packet = { path = "ip-packet" }
+socket-factory = { path = "socket-factory" }
 
 [workspace.lints.clippy]
 dbg_macro = "warn"
@@ -70,7 +81,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }
 str0m = { git = "https://github.com/firezone/str0m", branch = "main" }
-ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
+ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" }                             # For `Debug` and `Clone`
 proptest = { git = "https://github.com/thomaseizinger/proptest", branch = "fix/always-check-acceptable-current-state" }
 proptest-state-machine = { git = "https://github.com/thomaseizinger/proptest", branch = "fix/always-check-acceptable-current-state" }
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,6 +55,7 @@ phoenix-channel = { path = "phoenix-channel" }
 http-health-check = { path = "http-health-check" }
 ip-packet = { path = "ip-packet" }
 socket-factory = { path = "socket-factory" }
+socket2 = { version = "0.5" }
 
 [workspace.lints.clippy]
 dbg_macro = "warn"

--- a/rust/bin-shared/src/lib.rs
+++ b/rust/bin-shared/src/lib.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{
 };
 use url::Url;
 
-// Mark for Firezone sockets to prevent routing loops
+/// Mark for Firezone sockets to prevent routing loops on Linux.
 pub const FIREZONE_MARK: u32 = 0xfd002021;
 
 #[cfg(any(target_os = "linux", target_os = "windows"))]

--- a/rust/bin-shared/src/lib.rs
+++ b/rust/bin-shared/src/lib.rs
@@ -7,6 +7,9 @@ use tracing_subscriber::{
 };
 use url::Url;
 
+// Mark for Firezone sockets to prevent routing loops
+pub const FIREZONE_MARK: u32 = 0xfd002021;
+
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 pub use tun_device_manager::TunDeviceManager;
 

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -13,7 +13,8 @@ use std::{
     net::{Ipv4Addr, Ipv6Addr},
 };
 
-const FIREZONE_MARK: u32 = 0xfd002021; // Keep this synced with `Sockets` until #5797.
+use crate::FIREZONE_MARK;
+
 const FILE_ALREADY_EXISTS: i32 = -17;
 const FIREZONE_TABLE: u32 = 0x2021_fd00;
 

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -19,6 +19,7 @@ jni = { version = "0.21.1", features = ["invocation"] }
 log = "0.4"
 secrecy = { workspace = true }
 serde_json = "1"
+socket-factory = { workspace = true }
 thiserror = "1"
 tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true, features = ["std", "attributes"] }

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -16,6 +16,7 @@ ip_network = "0.4"
 libc = "0.2"
 secrecy = { workspace = true }
 serde_json = "1"
+socket-factory = { workspace = true }
 swift-bridge = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -5,7 +5,7 @@ mod make_writer;
 
 use connlib_client_shared::{
     callbacks::ResourceDescription, file_logger, keypair, Callbacks, ConnectArgs, Error, LoginUrl,
-    Session, Sockets, Tun, V4RouteList, V6RouteList,
+    Session, Tun, V4RouteList, V6RouteList,
 };
 use ip_network::{Ipv4Network, Ipv6Network};
 use secrecy::SecretString;
@@ -194,7 +194,6 @@ impl WrappedSession {
 
         let args = ConnectArgs {
             url,
-            sockets: Sockets::new(),
             private_key,
             os_version_override,
             app_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -202,6 +201,8 @@ impl WrappedSession {
                 inner: Arc::new(callback_handler),
             },
             max_partition_time: Some(MAX_PARTITION_TIME),
+            tcp_socket_factory: Arc::new(socket_factory::tcp),
+            udp_socket_factory: Arc::new(socket_factory::udp),
         };
         let session = Session::connect(args, runtime.handle().clone());
         let _enter = runtime.enter();

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -16,10 +16,18 @@ firezone-tunnel = { workspace = true }
 ip_network = { version = "0.4", default-features = false }
 phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
+serde = { version = "1.0", default-features = false, features = [
+    "std",
+    "derive",
+] }
+socket-factory = { workspace = true }
 time = { version = "0.3.36", features = ["formatting"] }
 tokio = { workspace = true, features = ["sync"] }
-tokio-tungstenite = { version = "0.21", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.21", default-features = false, features = [
+    "connect",
+    "handshake",
+    "rustls-tls-webpki-roots",
+] }
 tracing = { workspace = true }
 tracing-appender = { version = "0.2.2" }
 tracing-stackdriver = { version = "0.10.0" }

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -16,18 +16,11 @@ firezone-tunnel = { workspace = true }
 ip_network = { version = "0.4", default-features = false }
 phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0", default-features = false, features = [
-    "std",
-    "derive",
-] }
+serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 socket-factory = { workspace = true }
 time = { version = "0.3.36", features = ["formatting"] }
 tokio = { workspace = true, features = ["sync"] }
-tokio-tungstenite = { version = "0.21", default-features = false, features = [
-    "connect",
-    "handshake",
-    "rustls-tls-webpki-roots",
-] }
+tokio-tungstenite = { version = "0.21", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
 tracing = { workspace = true }
 tracing-appender = { version = "0.2.2" }
 tracing-stackdriver = { version = "0.10.0" }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -12,42 +12,23 @@ bytes = { version = "1.4", default-features = false, features = ["std"] }
 chrono = { workspace = true }
 connlib-shared = { workspace = true }
 domain = { workspace = true }
-futures = { version = "0.3", default-features = false, features = [
-    "std",
-    "async-await",
-    "executor",
-] }
+futures =  { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
 futures-bounded = { workspace = true }
-futures-util = { version = "0.3", default-features = false, features = [
-    "std",
-    "async-await",
-    "async-await-macro",
-] }
+futures-util =  { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }
 hex = "0.4.3"
 hickory-proto = { workspace = true }
 hickory-resolver = { workspace = true, features = ["tokio-runtime"] }
 ip-packet = { workspace = true }
 ip_network = { version = "0.4", default-features = false }
 ip_network_table = { version = "0.2", default-features = false }
-itertools = { version = "0.13", default-features = false, features = [
-    "use_std",
-] }
-libc = { version = "0.2", default-features = false, features = [
-    "std",
-    "const-extern-fn",
-    "extra_traits",
-] }
+itertools = { version = "0.13", default-features = false, features = ["use_std"] }
+libc = { version = "0.2", default-features = false, features = ["std", "const-extern-fn", "extra_traits"] }
 proptest = { version = "1", optional = true }
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" }
-rand_core = { version = "0.6", default-features = false, features = [
-    "getrandom",
-] }
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 rangemap = "1.5.1"
 secrecy = { workspace = true }
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-    "std",
-] }
+serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
 socket2 = { version = "0.5" }
@@ -87,10 +68,10 @@ wintun = "0.4.0"
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.57.0"
 features = [
-    "Win32_Foundation",
-    "Win32_NetworkManagement_IpHelper",
-    "Win32_NetworkManagement_Ndis",
-    "Win32_Networking_WinSock",
+  "Win32_Foundation",
+  "Win32_NetworkManagement_IpHelper",
+  "Win32_NetworkManagement_Ndis",
+  "Win32_Networking_WinSock",
 ]
 
 [lints]

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -31,7 +31,7 @@ secrecy = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
-socket2 = { version = "0.5" }
+socket2 = { workspace = true }
 thiserror = { version = "1.0", default-features = false }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -12,24 +12,44 @@ bytes = { version = "1.4", default-features = false, features = ["std"] }
 chrono = { workspace = true }
 connlib-shared = { workspace = true }
 domain = { workspace = true }
-futures =  { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
+futures = { version = "0.3", default-features = false, features = [
+    "std",
+    "async-await",
+    "executor",
+] }
 futures-bounded = { workspace = true }
-futures-util =  { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }
+futures-util = { version = "0.3", default-features = false, features = [
+    "std",
+    "async-await",
+    "async-await-macro",
+] }
 hex = "0.4.3"
 hickory-proto = { workspace = true }
 hickory-resolver = { workspace = true, features = ["tokio-runtime"] }
 ip-packet = { workspace = true }
 ip_network = { version = "0.4", default-features = false }
 ip_network_table = { version = "0.2", default-features = false }
-itertools = { version = "0.13", default-features = false, features = ["use_std"] }
-libc = { version = "0.2", default-features = false, features = ["std", "const-extern-fn", "extra_traits"] }
+itertools = { version = "0.13", default-features = false, features = [
+    "use_std",
+] }
+libc = { version = "0.2", default-features = false, features = [
+    "std",
+    "const-extern-fn",
+    "extra_traits",
+] }
 proptest = { version = "1", optional = true }
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" }
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6", default-features = false, features = [
+    "getrandom",
+] }
 rangemap = "1.5.1"
 secrecy = { workspace = true }
-serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
+serde = { version = "1.0", default-features = false, features = [
+    "derive",
+    "std",
+] }
 snownet = { workspace = true }
+socket-factory = { workspace = true }
 socket2 = { version = "0.5" }
 thiserror = { version = "1.0", default-features = false }
 tokio = { workspace = true }
@@ -67,10 +87,10 @@ wintun = "0.4.0"
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.57.0"
 features = [
-  "Win32_Foundation",
-  "Win32_NetworkManagement_IpHelper",
-  "Win32_NetworkManagement_Ndis",
-  "Win32_Networking_WinSock",
+    "Win32_Foundation",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Networking_WinSock",
 ]
 
 [lints]

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -212,7 +212,7 @@ pub enum DnsQueryError {
     TooManyQueries,
 }
 
-/// Exactly the same as the [TokioRuntimeProvider](hickory_resolver::name_server::TokioRuntimeProvider) but sockets are protected when created
+/// Identical to [`TokioRuntimeProvider`](hickory_resolver::name_server::TokioRuntimeProvider) but using our own [`SocketFactory`].
 #[derive(Clone)]
 struct ProtectedTokioRuntimeProvider {
     handle: TokioHandle,

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -22,32 +22,15 @@ futures = "0.3.29"
 futures-bounded = { workspace = true }
 http-health-check = { workspace = true }
 ip_network = { version = "0.4", default-features = false }
-libc = { version = "0.2", default-features = false, features = [
-    "std",
-    "const-extern-fn",
-    "extra_traits",
-] }
+libc = { version = "0.2", default-features = false, features = ["std", "const-extern-fn", "extra_traits"] }
 phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0", default-features = false, features = [
-    "std",
-    "derive",
-] }
+serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
 static_assertions = "1.1.0"
-tokio = { workspace = true, features = [
-    "sync",
-    "macros",
-    "rt-multi-thread",
-    "fs",
-    "signal",
-] }
-tokio-tungstenite = { version = "0.21", default-features = false, features = [
-    "connect",
-    "handshake",
-    "rustls-tls-webpki-roots",
-] }
+tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread", "fs", "signal"] }
+tokio-tungstenite = { version = "0.21", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
 tracing = { workspace = true }
 tracing-subscriber = "0.3.17"
 url = { version = "2.4.1", default-features = false }

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -22,14 +22,32 @@ futures = "0.3.29"
 futures-bounded = { workspace = true }
 http-health-check = { workspace = true }
 ip_network = { version = "0.4", default-features = false }
-libc = { version = "0.2", default-features = false, features = ["std", "const-extern-fn", "extra_traits"] }
+libc = { version = "0.2", default-features = false, features = [
+    "std",
+    "const-extern-fn",
+    "extra_traits",
+] }
 phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
+serde = { version = "1.0", default-features = false, features = [
+    "std",
+    "derive",
+] }
 snownet = { workspace = true }
+socket-factory = { workspace = true }
 static_assertions = "1.1.0"
-tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread", "fs", "signal"] }
-tokio-tungstenite = { version = "0.21", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "rt-multi-thread",
+    "fs",
+    "signal",
+] }
+tokio-tungstenite = { version = "0.21", default-features = false, features = [
+    "connect",
+    "handshake",
+    "rustls-tls-webpki-roots",
+] }
 tracing = { workspace = true }
 tracing-subscriber = "0.3.17"
 url = { version = "2.4.1", default-features = false }

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Firezone, Inc."]
 
 [dependencies]
 anyhow = { version = "1.0" }
-atomicwrites = "0.4.3" # Needed to safely backup `/etc/resolv.conf` and write the device ID on behalf of `gui-client`
-clap = { version = "4.5", features = ["derive",  "env", "string"] }
+atomicwrites = "0.4.3"                                             # Needed to safely backup `/etc/resolv.conf` and write the device ID on behalf of `gui-client`
+clap = { version = "4.5", features = ["derive", "env", "string"] }
 connlib-client-shared = { workspace = true }
 connlib-shared = { workspace = true }
 firezone-bin-shared = { workspace = true }
@@ -20,6 +20,7 @@ ip_network = { version = "0.4", default-features = false }
 secrecy = { workspace = true }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
+socket-factory = { workspace = true }
 thiserror = { version = "1.0", default-features = false }
 # This actually relies on many other features in Tokio, so this will probably
 # fail to build outside the workspace. <https://github.com/firezone/firezone/pull/4328#discussion_r1540342142>
@@ -29,7 +30,11 @@ tokio-util = { version = "0.7.11", features = ["codec"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 url = { version = "2.3.1", default-features = false }
-uuid = { version = "1.7", default-features = false, features = ["std", "v4", "serde"] }
+uuid = { version = "1.7", default-features = false, features = [
+    "std",
+    "v4",
+    "serde",
+] }
 
 [dev-dependencies]
 tempfile = "3.10.1"
@@ -40,10 +45,10 @@ mutants = "0.0.3" # Needed to mark functions as exempt from `cargo-mutants` test
 [target.'cfg(target_os = "linux")'.dependencies]
 dirs = "5.0.1"
 libc = "0.2.150"
-nix = { version = "0.28.0", features = ["fs", "user"] }
+nix = { version = "0.28.0", features = ["fs", "user", "socket"] }
 resolv-conf = "0.7.0"
 rtnetlink = { workspace = true }
-sd-notify = "0.4.1" # This is a pure Rust re-implementation, so it isn't vulnerable to CVE-2024-3094
+sd-notify = "0.4.1"                                               # This is a pure Rust re-implementation, so it isn't vulnerable to CVE-2024-3094
 
 [target.'cfg(target_os = "macos")'.dependencies]
 dirs = "5.0.1"
@@ -65,7 +70,7 @@ features = [
     "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
 
-    "Win32_Security", # For named pipe IPC
+    "Win32_Security",                 # For named pipe IPC
     "Win32_System_SystemInformation", # For uptime
     "Win32_System_SystemServices",
     "Win32_System_Pipes",

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -41,7 +41,7 @@ mutants = "0.0.3" # Needed to mark functions as exempt from `cargo-mutants` test
 [target.'cfg(target_os = "linux")'.dependencies]
 dirs = "5.0.1"
 libc = "0.2.150"
-nix = { version = "0.28.0", features = ["fs", "user"] }
+nix = { version = "0.28.0", features = ["fs", "user", "socket"] }
 resolv-conf = "0.7.0"
 rtnetlink = { workspace = true }
 sd-notify = "0.4.1" # This is a pure Rust re-implementation, so it isn't vulnerable to CVE-2024-3094

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Firezone, Inc."]
 
 [dependencies]
 anyhow = { version = "1.0" }
-atomicwrites = "0.4.3"                                             # Needed to safely backup `/etc/resolv.conf` and write the device ID on behalf of `gui-client`
-clap = { version = "4.5", features = ["derive", "env", "string"] }
+atomicwrites = "0.4.3" # Needed to safely backup `/etc/resolv.conf` and write the device ID on behalf of `gui-client`
+clap = { version = "4.5", features = ["derive",  "env", "string"] }
 connlib-client-shared = { workspace = true }
 connlib-shared = { workspace = true }
 firezone-bin-shared = { workspace = true }
@@ -30,11 +30,7 @@ tokio-util = { version = "0.7.11", features = ["codec"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 url = { version = "2.3.1", default-features = false }
-uuid = { version = "1.7", default-features = false, features = [
-    "std",
-    "v4",
-    "serde",
-] }
+uuid = { version = "1.7", default-features = false, features = ["std", "v4", "serde"] }
 
 [dev-dependencies]
 tempfile = "3.10.1"
@@ -45,10 +41,10 @@ mutants = "0.0.3" # Needed to mark functions as exempt from `cargo-mutants` test
 [target.'cfg(target_os = "linux")'.dependencies]
 dirs = "5.0.1"
 libc = "0.2.150"
-nix = { version = "0.28.0", features = ["fs", "user", "socket"] }
+nix = { version = "0.28.0", features = ["fs", "user"] }
 resolv-conf = "0.7.0"
 rtnetlink = { workspace = true }
-sd-notify = "0.4.1"                                               # This is a pure Rust re-implementation, so it isn't vulnerable to CVE-2024-3094
+sd-notify = "0.4.1" # This is a pure Rust re-implementation, so it isn't vulnerable to CVE-2024-3094
 
 [target.'cfg(target_os = "macos")'.dependencies]
 dirs = "5.0.1"
@@ -70,7 +66,7 @@ features = [
     "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
 
-    "Win32_Security",                 # For named pipe IPC
+    "Win32_Security", # For named pipe IPC
     "Win32_System_SystemInformation", # For uptime
     "Win32_System_SystemServices",
     "Win32_System_Pipes",

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -6,13 +6,13 @@ use crate::{
 };
 use anyhow::{Context as _, Result};
 use clap::Parser;
-use connlib_client_shared::{file_logger, keypair, ConnectArgs, LoginUrl, Session, Sockets};
+use connlib_client_shared::{file_logger, keypair, ConnectArgs, LoginUrl, Session};
 use futures::{
     future::poll_fn,
     task::{Context, Poll},
     Future as _, SinkExt as _, Stream as _,
 };
-use std::{net::IpAddr, path::PathBuf, pin::pin, time::Duration};
+use std::{net::IpAddr, path::PathBuf, pin::pin, sync::Arc, time::Duration};
 use tokio::{sync::mpsc, time::Instant};
 use tracing::subscriber::set_global_default;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
@@ -341,7 +341,8 @@ impl Handler {
                 self.last_connlib_start_instant = Some(Instant::now());
                 let args = ConnectArgs {
                     url,
-                    sockets: Sockets::new(),
+                    tcp_socket_factory: Arc::new(crate::tcp_socket_factory),
+                    udp_socket_factory: Arc::new(crate::udp_socket_factory),
                     private_key,
                     os_version_override: None,
                     app_version: env!("CARGO_PKG_VERSION").to_string(),

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -20,6 +20,8 @@ use tracing::subscriber::set_global_default;
 use tracing_subscriber::{fmt, layer::SubscriberExt as _, EnvFilter, Layer as _, Registry};
 
 use platform::default_token_path;
+use platform::tcp_socket_factory;
+use platform::udp_socket_factory;
 
 /// Generate a persistent device ID, stores it to disk, and reads it back.
 pub(crate) mod device_id;

--- a/rust/headless-client/src/standalone.rs
+++ b/rust/headless-client/src/standalone.rs
@@ -6,13 +6,14 @@ use crate::{
 };
 use anyhow::{anyhow, Context as _, Result};
 use clap::Parser;
-use connlib_client_shared::{file_logger, keypair, ConnectArgs, LoginUrl, Session, Sockets};
+use connlib_client_shared::{file_logger, keypair, ConnectArgs, LoginUrl, Session};
 use firezone_bin_shared::{setup_global_subscriber, TunDeviceManager};
 use futures::{FutureExt as _, StreamExt as _};
 use secrecy::SecretString;
 use std::{
     path::{Path, PathBuf},
     pin::pin,
+    sync::Arc,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -156,7 +157,8 @@ pub fn run_only_headless_client() -> Result<()> {
     platform::setup_before_connlib()?;
     let args = ConnectArgs {
         url,
-        sockets: Sockets::new(),
+        udp_socket_factory: Arc::new(crate::udp_socket_factory),
+        tcp_socket_factory: Arc::new(crate::tcp_socket_factory),
         private_key,
         os_version_override: None,
         app_version: env!("CARGO_PKG_VERSION").to_string(),

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -7,6 +7,9 @@
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 
+pub(crate) use socket_factory::tcp as tcp_socket_factory;
+pub(crate) use socket_factory::udp as udp_socket_factory;
+
 #[path = "windows/wintun_install.rs"]
 mod wintun_install;
 

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -15,6 +15,7 @@ secrecy = { workspace = true }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 sha2 = "0.10.8"
+socket-factory = { workspace = true }
 thiserror = "1.0.61"
 tokio = { workspace = true, features = ["net", "time"] }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -27,7 +27,7 @@ secrecy = { workspace = true }
 serde = { version = "1.0.203", features = ["derive"] }
 sha2 = "0.10.8"
 socket-factory = { workspace = true }
-socket2 = "0.5.7"
+socket2 = { workspace = true }
 stun_codec = "0.3.4"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "signal"] }
 tracing = { workspace = true, features = ["log"] }

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -29,22 +29,12 @@ sha2 = "0.10.8"
 socket-factory = { workspace = true }
 socket2 = "0.5.7"
 stun_codec = "0.3.4"
-tokio = { workspace = true, features = [
-    "macros",
-    "rt-multi-thread",
-    "net",
-    "time",
-    "signal",
-] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "signal"] }
 tracing = { workspace = true, features = ["log"] }
 tracing-core = "0.1.31"
 tracing-opentelemetry = "0.23.0"
 tracing-stackdriver = { version = "0.10.0", features = ["opentelemetry"] }
-tracing-subscriber = { workspace = true, features = [
-    "env-filter",
-    "json",
-    "fmt",
-] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json", "fmt"] }
 trackable = "1.3.0"
 url = "2.4.1"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -26,14 +26,25 @@ rand = "0.8.5"
 secrecy = { workspace = true }
 serde = { version = "1.0.203", features = ["derive"] }
 sha2 = "0.10.8"
+socket-factory = { workspace = true }
 socket2 = "0.5.7"
 stun_codec = "0.3.4"
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "signal"] }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "net",
+    "time",
+    "signal",
+] }
 tracing = { workspace = true, features = ["log"] }
 tracing-core = "0.1.31"
 tracing-opentelemetry = "0.23.0"
 tracing-stackdriver = { version = "0.10.0", features = ["opentelemetry"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "json", "fmt"] }
+tracing-subscriber = { workspace = true, features = [
+    "env-filter",
+    "json",
+    "fmt",
+] }
 trackable = "1.3.0"
 url = "2.4.1"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -146,6 +146,7 @@ async fn main() -> Result<()> {
             ExponentialBackoffBuilder::default()
                 .with_max_elapsed_time(Some(MAX_PARTITION_TIME))
                 .build(),
+            Arc::new(socket_factory::tcp),
         ))
     } else {
         tracing::warn!(target: "relay", "No portal token supplied, starting standalone mode");

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "socket-factory"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+socket2 = { workspace = true }
+tokio = { version = "1.38", features = ["net"] }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -1,0 +1,35 @@
+use std::net::SocketAddr;
+
+use socket2::SockAddr;
+
+pub trait SocketFactory<S>: Fn(&SocketAddr) -> std::io::Result<S> + Send + Sync + 'static {}
+
+impl<F, S> SocketFactory<S> for F where
+    F: Fn(&SocketAddr) -> std::io::Result<S> + Send + Sync + 'static
+{
+}
+
+pub fn tcp(addr: &SocketAddr) -> std::io::Result<tokio::net::TcpSocket> {
+    let socket = match addr {
+        SocketAddr::V4(_) => tokio::net::TcpSocket::new_v4()?,
+        SocketAddr::V6(_) => tokio::net::TcpSocket::new_v6()?,
+    };
+
+    socket.set_nodelay(true)?;
+
+    Ok(socket)
+}
+pub fn udp(addr: &SocketAddr) -> std::io::Result<tokio::net::UdpSocket> {
+    let addr: SockAddr = (*addr).into();
+    let socket = socket2::Socket::new(addr.domain(), socket2::Type::DGRAM, None)?;
+
+    // Note: for AF_INET sockets IPV6_V6ONLY is not a valid flag
+    if addr.is_ipv6() {
+        socket.set_only_v6(true)?;
+    }
+
+    socket.set_nonblocking(true)?;
+    socket.bind(&addr)?;
+
+    std::net::UdpSocket::from(socket).try_into()
+}


### PR DESCRIPTION
Currently, only connlib's UDP sockets for sending and receiving STUN & WireGuard traffic are protected from routing loops. This is was done via the `Sockets::with_protect` function. Connlib has additional sockets though:

- A TCP socket to the portal.
- UDP & TCP sockets for DNS resolution via hickory.

Both of these can incur routing loops on certain platforms which becomes evident as we try to implement #2667.

To fix this, we generalise the idea of "protecting" a socket via a `SocketFactory` abstraction. By allowing the different platforms to provide a specialised `SocketFactory`, anything Linux-based can give special treatment to the socket before handing it to connlib.

As an additional benefit, this allows us to remove the `Sockets` abstraction from connlib's API again because we can now initialise it internally via the provided `SocketFactory` for UDP sockets.