### PR TITLE
test(connlib): use two relays in `tunnel_test`

### DIFF
--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -1,7 +1,6 @@
 use crate::messages::{
-    client::ResourceDescriptionCidr,
-    client::{ResourceDescription, ResourceDescriptionDns, Site, SiteId},
-    ClientId, GatewayId, ResourceId,
+    client::{ResourceDescription, ResourceDescriptionCidr, ResourceDescriptionDns, Site, SiteId},
+    ClientId, GatewayId, RelayId, ResourceId,
 };
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools;
@@ -138,6 +137,10 @@ pub fn gateway_id() -> impl Strategy<Value = GatewayId> + Clone {
 
 pub fn client_id() -> impl Strategy<Value = ClientId> {
     any::<u128>().prop_map(ClientId::from_u128)
+}
+
+pub fn relay_id() -> impl Strategy<Value = RelayId> {
+    any::<u128>().prop_map(RelayId::from_u128)
 }
 
 pub fn resource_name() -> impl Strategy<Value = String> {

--- a/rust/connlib/tunnel/src/tests/sim_net.rs
+++ b/rust/connlib/tunnel/src/tests/sim_net.rs
@@ -230,10 +230,9 @@ impl Default for RoutingTable {
 
 impl RoutingTable {
     #[allow(private_bounds)]
-    pub(crate) fn add_host<T>(&mut self, host: &Host<T>) -> bool
-    where
-        T: Id,
-    {
+    pub(crate) fn add_host<T>(&mut self, id: impl Into<HostId>, host: &Host<T>) -> bool {
+        let id = id.into();
+
         match (host.ip4, host.ip6) {
             (None, None) => panic!("Node must have at least one network IP"),
             (None, Some(ip6)) => {
@@ -241,14 +240,14 @@ impl RoutingTable {
                     return false;
                 }
 
-                self.routes.insert(ip6, host.inner.id());
+                self.routes.insert(ip6, id);
             }
             (Some(ip4), None) => {
                 if self.contains(ip4) {
                     return false;
                 }
 
-                self.routes.insert(ip4, host.inner.id());
+                self.routes.insert(ip4, id);
             }
             (Some(ip4), Some(ip6)) => {
                 if self.contains(ip4) {
@@ -258,8 +257,8 @@ impl RoutingTable {
                     return false;
                 }
 
-                self.routes.insert(ip4, host.inner.id());
-                self.routes.insert(ip6, host.inner.id());
+                self.routes.insert(ip4, id);
+                self.routes.insert(ip6, id);
             }
         }
 
@@ -296,25 +295,6 @@ impl RoutingTable {
 
     pub(crate) fn host_by_ip(&self, ip: IpAddr) -> Option<HostId> {
         self.routes.exact_match(ip).copied()
-    }
-}
-
-trait Id {
-    fn id(&self) -> HostId;
-}
-
-impl<TId, S> Id for SimNode<TId, S>
-where
-    TId: Into<HostId> + Copy,
-{
-    fn id(&self) -> HostId {
-        self.id.into()
-    }
-}
-
-impl<S> Id for SimRelay<S> {
-    fn id(&self) -> HostId {
-        self.id.into()
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/sim_portal.rs
+++ b/rust/connlib/tunnel/src/tests/sim_portal.rs
@@ -1,6 +1,6 @@
 use connlib_shared::messages::{
     client::{ResourceDescriptionCidr, ResourceDescriptionDns, SiteId},
-    ClientId, GatewayId, RelayId, ResourceId,
+    ClientId, GatewayId, ResourceId,
 };
 use ip_network_table::IpNetworkTable;
 use std::collections::{BTreeMap, HashSet};
@@ -12,16 +12,11 @@ use std::collections::{BTreeMap, HashSet};
 pub(crate) struct SimPortal {
     _client: ClientId,
     gateway: GatewayId,
-    _relay: RelayId,
 }
 
 impl SimPortal {
-    pub(crate) fn new(_client: ClientId, gateway: GatewayId, _relay: RelayId) -> Self {
-        Self {
-            _client,
-            gateway,
-            _relay,
-        }
+    pub(crate) fn new(_client: ClientId, gateway: GatewayId) -> Self {
+        Self { _client, gateway }
     }
 
     /// Picks, which gateway and site we should connect to for the given resource.


### PR DESCRIPTION
With the introduction of a routing table in #5786, we can very easily introduce an additional relay to `tunnel_test`. In production, we are always given two relays and thus, this mimics the production setup more closely.