### PR TITLE
ci: don't build optimised Rust tests

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -70,7 +70,6 @@ jobs:
           # Needed to create tunnel interfaces in unit tests
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
-          CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise proptests take forever.
         name: "cargo test"
         shell: bash
 


### PR DESCRIPTION
In #5786, we massively increase the performance of `tunnel_test` and thus, it is no longer necessary to build all tests using optimisation level 1. Windows is very slow in compiling Rust and forcing it to compile with optimisations doesn't help that.

On `main`, the compile phase takes ~ **8min**: https://github.com/firezone/firezone/actions/runs/9847792756/job/27188488313#step:5:968

With this patch, the compile phase takes ~**6min**: https://github.com/firezone/firezone/actions/runs/9849448280/job/27193128597?pr=5805#step:5:967