### PR TITLE
test(connlib): reduce cycles of `resource_management` test

### DIFF
--- a/rust/connlib/tunnel/src/device_channel/tun_windows.rs
+++ b/rust/connlib/tunnel/src/device_channel/tun_windows.rs
@@ -341,8 +341,8 @@ mod tests {
     #[test]
     #[ignore = "Needs admin privileges"]
     fn resource_management() {
-        // Each cycle takes about half a second, so this will need over a minute to run.
-        for _ in 0..150 {
+        // Each cycle takes about half a second, so this will take a fair bit to run.
+        for _ in 0..50 {
             let _tun = super::Tun::new().unwrap(); // This will panic if we don't correctly clean-up the wintun interface.
         }
     }


### PR DESCRIPTION
With the performance improvements of `tunnel_test` in #5786, the `resource_management` test is now in the hot-path of CI runtime. We reduce the cycles to 50 should cut down overall CI time by ~ 1 minute as the Windows builds are among the slowest.