### PR TITLE
test(rust): add aarch64 Linux to `runs-on` in CI

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -22,7 +22,6 @@ jobs:
           - runs-on: ubuntu-20.04-arm
           - runs-on: ubuntu-22.04
           - runs-on: macos-14
-          - runs-on: windows-11-arm
           - runs-on: windows-2022
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -59,7 +58,6 @@ jobs:
           - runs-on: macos-12
           - runs-on: macos-13
           - runs-on: macos-14
-          - runs-on: windows-11-arm
           - runs-on: windows-2019
           - runs-on: windows-2022
     runs-on: ${{ matrix.runs-on }}
@@ -89,7 +87,6 @@ jobs:
           - runs-on: ubuntu-20.04-arm
           # Broken on 22.04 <https://github.com/firezone/firezone/issues/3699>
           - runs-on: ubuntu-22.04
-          - runs-on: windows-11-arm
           - runs-on: windows-2019
           - runs-on: windows-2022
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -70,6 +70,7 @@ jobs:
         env:
           # <https://github.com/rust-lang/cargo/issues/5999>
           # Needed to create tunnel interfaces in unit tests
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
         name: "cargo test"

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -19,8 +19,10 @@ jobs:
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         include:
+          - runs-on: ubuntu-20.04-arm
           - runs-on: ubuntu-22.04
           - runs-on: macos-14
+          - runs-on: windows-11-arm
           - runs-on: windows-2022
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -52,10 +54,12 @@ jobs:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         include:
           - runs-on: ubuntu-20.04
+          - runs-on: ubuntu-20.04-arm
           - runs-on: ubuntu-22.04
           - runs-on: macos-12
           - runs-on: macos-13
           - runs-on: macos-14
+          - runs-on: windows-11-arm
           - runs-on: windows-2019
           - runs-on: windows-2022
     runs-on: ${{ matrix.runs-on }}
@@ -82,8 +86,10 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-20.04
+          - runs-on: ubuntu-20.04-arm
           # Broken on 22.04 <https://github.com/firezone/firezone/issues/3699>
           - runs-on: ubuntu-22.04
+          - runs-on: windows-11-arm
           - runs-on: windows-2019
           - runs-on: windows-2022
     runs-on: ${{ matrix.runs-on }}
@@ -123,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: Add Windows as part of issue #3782
-        runs-on: [ubuntu-20.04, ubuntu-22.04]
+        runs-on: [ubuntu-20.04, ubuntu-22.04, ubuntu-20.04-arm]
         test: [linux-group, token-path]
     runs-on: ${{ matrix.runs-on }}
     steps:


### PR DESCRIPTION
Adds ARM runners for static analysis, unit tests, GUI smoke test, and headless Client tests

We could add Window too, but Git for Windows doesn't seem to work on aarch64 yet, which makes it hard to get Bash on the Windows 11 ARM runners