### PR TITLE
chore(rust): introduce `tokio` workspace dependency

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,6 +37,7 @@ domain = { version = "0.10", features = ["serde"] }
 dns-lookup = "2.0"
 tokio-tungstenite = "0.21"
 rtnetlink = { version = "0.14.1", default-features = false, features = ["tokio_socket"] }
+tokio = "1.38"
 
 connlib-client-android = { path = "connlib/clients/android"}
 connlib-client-apple = { path = "connlib/clients/apple"}

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 serde_json = "1"
 thiserror = "1"
 url = "2.4.0"
-tokio = { version = "1.38", default-features = false, features = ["rt"] }
+tokio = { workspace = true, features = ["rt"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.3.1"

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -21,7 +21,7 @@ tracing = { workspace = true }
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 url = "2.5.0"
-tokio = { version = "1.38", default-features = false, features = ["rt"] }
+tokio = { workspace = true, features = ["rt"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 oslog = { version = "0.2.0", default-features = false }

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -8,7 +8,7 @@ mock = ["connlib-shared/mock"]
 
 [dependencies]
 anyhow = "1.0.82"
-tokio = { version = "1.38", default-features = false, features = ["sync", "rt"] }
+tokio = { workspace = true, features = ["sync"] }
 secrecy = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
@@ -33,7 +33,7 @@ tracing = { workspace = true, features = ["std", "attributes"] }
 [dev-dependencies]
 chrono = { workspace = true }
 serde_json = { version = "1.0", features = ["std"] }
-tokio = { version = "1.38", default-features = false, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -23,7 +23,7 @@ rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 thiserror = { version = "1.0", default-features = false }
-tokio = { version = "1.38", features = ["fs"] }
+tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
 url = { version = "2.4.1", default-features = false }
 uuid = { version = "1.7", default-features = false, features = ["std", "v4", "serde"] }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 secrecy = { workspace = true }
 async-trait = { version = "0.1", default-features = false }
-tokio = { version = "1.38", default-features = false, features = ["rt", "rt-multi-thread", "sync", "process"] }
+tokio = { workspace = true }
 thiserror = { version = "1.0", default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -65,6 +65,7 @@ rtnetlink = { workspace = true }
 
 # Windows tunnel dependencies
 [target.'cfg(target_os = "windows")'.dependencies]
+tokio = { workspace = true, features = ["sync"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 wintun = "0.4.0"
 

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -21,7 +21,7 @@ firezone-cli-utils = { workspace = true }
 phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
-tokio = { version = "1.38", default-features = false, features = ["sync", "macros", "rt-multi-thread", "fs", "signal"] }
+tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread", "fs", "signal"] }
 tokio-tungstenite = { version = "0.21", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
 tracing = { workspace = true }
 tracing-subscriber = "0.3.17"

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -41,7 +41,7 @@ tauri-runtime = "0.14.2"
 tauri-utils = "1.5.3"
 time = { version = "0.3.36", features = ["formatting"] }
 thiserror = { version = "1.0", default-features = false }
-tokio = { version = "1.38.0", features = ["signal", "time", "macros", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["signal", "time", "macros", "rt", "rt-multi-thread"] }
 tokio-util = { version = "0.7.11", features = ["codec"] }
 tracing = { workspace = true }
 tracing-log = "0.2"

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0.117"
 thiserror = { version = "1.0", default-features = false }
 # This actually relies on many other features in Tokio, so this will probably
 # fail to build outside the workspace. <https://github.com/firezone/firezone/pull/4328#discussion_r1540342142>
-tokio = { version = "1.38.0", features = ["macros", "signal"] }
+tokio = { workspace = true, features = ["macros", "signal", "process"] }
 tokio-stream = "0.1.15"
 tokio-util = { version = "0.7.11", features = ["codec"] }
 tracing = { workspace = true }

--- a/rust/http-health-check/Cargo.toml
+++ b/rust/http-health-check/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 axum = { version = "0.7.5", default-features = false, features = ["http1", "tokio"] }
-tokio = { version = "1.38.0", features = ["net"] }
+tokio = { workspace = true, features = ["net"] }
 clap = { version = "4.5.4", features = ["derive", "env"] }
 
 [lints]

--- a/rust/http-test-server/Cargo.toml
+++ b/rust/http-test-server/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 axum = { version = "0.7.5", features = ["http1", "tokio"] }
-tokio = { version = "1.38.0", features = ["net"] }
+tokio = { workspace = true, features = ["net"] }
 serde = {version = "1", features = ["derive"]}
 futures = "0.3"
 

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -16,7 +16,7 @@ rand_core = "0.6.4"
 url = "2.4.1"
 serde_json = "1.0.117"
 thiserror = "1.0.61"
-tokio = { version = "1.38.0", features = ["net", "time"] }
+tokio = { workspace = true, features = ["net", "time"] }
 backoff = "0.4.0"
 uuid = { version = "1.7", default-features = false, features = ["std", "v4"] }
 sha2 = "0.10.8"
@@ -27,7 +27,7 @@ libc = "0.2"
 hostname = "0.4.0"
 
 [dev-dependencies]
-tokio = { version = "1.38.0", features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.29"
 hex = "0.4.3"
 rand = "0.8.5"
 stun_codec = "0.3.4"
-tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread", "net", "time", "signal"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "signal"] }
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json", "fmt"] }
 tracing-stackdriver = { version = "0.10.0", features = ["opentelemetry"] }

--- a/rust/snownet-tests/Cargo.toml
+++ b/rust/snownet-tests/Cargo.toml
@@ -18,7 +18,7 @@ secrecy = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-hex = "0.1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 system-info = { version = "0.1.2", features = ["std"]}


### PR DESCRIPTION
We are referencing the `tokio` dependency a lot and it makes sense to ensure that version is tracked only once across the whole workspace.

Extracted out of #5797.