### PR TITLE
ci: Fix scoping dialyzer cache to elixir version

### DIFF
--- a/.github/actions/setup-elixir/action.yml
+++ b/.github/actions/setup-elixir/action.yml
@@ -6,8 +6,12 @@ inputs:
     type: string
     required: true
 outputs:
-  otp-version: ${{ steps.versions.outputs.erlang }}
-  elixir-version: ${{ steps.versions.outputs.elixir }}
+  otp-version:
+    description: "The OTP version"
+    value: ${{ steps.versions.outputs.erlang }}
+  elixir-version:
+    description: "The Elixir version"
+    value: ${{ steps.versions.outputs.elixir }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-elixir/action.yml
+++ b/.github/actions/setup-elixir/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: "Limit deps to mix env"
     type: string
     required: true
+outputs:
+  otp-version: ${{ steps.versions.outputs.erlang }}
+  elixir-version: ${{ steps.versions.outputs.elixir }}
 runs:
   using: "composite"
   steps:
@@ -29,7 +32,7 @@ runs:
         path: |
           elixir/deps
           elixir/_build/${{ inputs.mix_env }}
-        key: ${{ runner.os }}-${{ inputs.mix_env }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('elixir/mix.lock') }}
+        key: elixir-deps-${{ runner.os }}-${{ runner.arch }}-${{ inputs.mix_env }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('elixir/mix.lock') }}
     - name: Install Dependencies
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       shell: bash
@@ -42,7 +45,7 @@ runs:
       run: mix deps.compile --skip-umbrella-children
     - uses: actions/cache/save@v4
       name: Save Elixir Deps Cache
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      if: ${{ github.ref_name == 'main' }}
       with:
         path: |
           elixir/deps

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -65,6 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-elixir
+        id: setup-beam
         with:
           mix_env: ${{ env.MIX_ENV }}
       - name: Compile Application
@@ -74,10 +75,10 @@ jobs:
         id: plt_cache
         with:
           path: elixir/priv/plts
-          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('elixir/mix.lock') }}
+          key: dialyzer-ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('elixir/mix.lock') }}
           # This will make sure that we can incrementally build the PLT from older cache and save it under a new key
           restore-keys: |
-            ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-
+            dialyzer-ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-
       - name: Create PLTs
         if: ${{ steps.plt_cache.outputs.cache-hit != 'true' }}
         run: mix dialyzer --plt
@@ -85,7 +86,7 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         name: Save PLT cache
         with:
-          key: ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ${{ steps.plt_cache.outputs.cache-primary-key }}
           path: elixir/priv/plts
       - name: Run Dialyzer
         run: mix dialyzer --format dialyxir


### PR DESCRIPTION
This fixes a CI bug where the dialyzer cache was not being scoped to the elixir version, causing cache issues that fail CI jobs.

This also performs some tidying up of the cache key to scope it by runner arch too for elixir deps, and make clear what the cache key references.

https://github.com/firezone/firezone/actions/runs/9877195625