### PR TITLE
fix(portal): Use modal for confirmation dialogs

### DIFF
--- a/elixir/apps/web/assets/js/hooks.js
+++ b/elixir/apps/web/assets/js/hooks.js
@@ -119,6 +119,7 @@ const handleDisableSubmit = (ev) => {
     submit.removeAttribute("disabled");
   }, 5000);
 };
+
 Hooks.AttachDisableSubmit = {
   mounted() {
     this.el.addEventListener("form:disable_and_submit", handleDisableSubmit);
@@ -126,6 +127,24 @@ Hooks.AttachDisableSubmit = {
 
   destroyed() {
     this.el.removeEventListener("form:disable_and_submit", handleDisableSubmit);
+  },
+};
+
+Hooks.ConfirmDialog = {
+  mounted() {
+    this.el.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      ev.preventDefault();
+
+      let id = ev.currentTarget.getAttribute("id");
+      let dialog_el = document.getElementById(id + "_dialog");
+      dialog_el.returnValue = "cancel";
+      dialog_el.close();
+      dialog_el.showModal();
+
+      let close_button = dialog_el.querySelector("[data-dialog-action=cancel]");
+      close_button.focus();
+    });
   },
 };
 

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -406,7 +406,7 @@ defmodule Web.FormComponents do
     <dialog
       id={"#{@id}_dialog"}
       class={[
-        "backdrop:bg-slate-800/75 bg-transparent",
+        "backdrop:bg-gray-800/75 bg-transparent",
         "p-4 w-full max-w-2xl md:inset-0 max-h-full",
         "overflow-y-auto overflow-x-hidden",
         "justify-center items-center"

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -382,6 +382,85 @@ defmodule Web.FormComponents do
     """
   end
 
+  ### Dialogs ###
+
+  attr :id, :string, required: true, doc: "The id of the dialog"
+  attr :class, :string, default: "", doc: "Custom classes to be added to the button"
+  attr :style, :string, default: "danger", doc: "The style of the button"
+  attr :icon, :string, default: "hero-trash-solid", doc: "The icon of the button"
+  attr :size, :string, default: "md", doc: "The size of the button"
+  attr :on_confirm, :string, required: true, doc: "The phx event to broadcast on confirm"
+
+  attr :on_confirm_id, :string,
+    default: nil,
+    doc: "The phx event id value to broadcast on confirm"
+
+  slot :dialog_title, doc: "The title of the dialog"
+  slot :dialog_content, doc: "The content of the dialog"
+  slot :dialog_confirm_button, doc: "The content of the confirm button of the dialog"
+  slot :dialog_cancel_button, doc: "The content of the cancel button of the dialog"
+  slot :inner_block, required: true, doc: "The label for the button"
+
+  def button_with_confirmation(assigns) do
+    ~H"""
+    <dialog
+      id={"#{@id}_dialog"}
+      class={[
+        "backdrop:bg-slate-800/75 bg-transparent",
+        "p-4 w-full max-w-2xl md:inset-0 max-h-full",
+        "overflow-y-auto overflow-x-hidden",
+        "justify-center items-center"
+      ]}
+    >
+      <form method="dialog">
+        <div class="relative bg-white rounded-lg shadow">
+          <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
+            <h3 class="text-xl font-semibold text-neutral-900">
+              <%= render_slot(@dialog_title) %>
+            </h3>
+            <button
+              class="text-neutral-400 bg-transparent hover:text-accent-900"
+              type="submit"
+              value="cancel"
+            >
+              <.icon name="hero-x-mark" class="h-4 w-4" />
+              <span class="sr-only">Close modal</span>
+            </button>
+          </div>
+          <div class="p-4 md:p-5 text-neutral-500">
+            <%= render_slot(@dialog_content) %>
+          </div>
+          <div class="flex items-center justify-end p-4 md:p-5 border-t border-gray-200 rounded-b">
+            <.button
+              data-dialog-action="cancel"
+              type="submit"
+              value="cancel"
+              style="info"
+              class="px-5 py-2.5"
+            >
+              <%= render_slot(@dialog_cancel_button) %>
+            </.button>
+            <.button
+              data-dialog-action="confirm"
+              phx-click={@on_confirm}
+              phx-value-id={@on_confirm_id}
+              type="submit"
+              style="danger"
+              value="confirm"
+              class="py-2.5 px-5 ms-3"
+            >
+              <%= render_slot(@dialog_confirm_button) %>
+            </.button>
+          </div>
+        </div>
+      </form>
+    </dialog>
+    <.button id={@id} style={@style} size={@size} icon={@icon} class={@class} phx-hook="ConfirmDialog">
+      <%= render_slot(@inner_block) %>
+    </.button>
+    """
+  end
+
   ### Buttons ###
 
   @doc """

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -407,13 +407,12 @@ defmodule Web.FormComponents do
       id={"#{@id}_dialog"}
       class={[
         "backdrop:bg-gray-800/75 bg-transparent",
-        "p-4 w-full max-w-2xl md:inset-0 max-h-full",
-        "overflow-y-auto overflow-x-hidden",
-        "justify-center items-center"
+        "p-4 w-full md:inset-0 max-h-full",
+        "overflow-y-auto overflow-x-hidden"
       ]}
     >
-      <form method="dialog">
-        <div class="relative bg-white rounded-lg shadow">
+      <form method="dialog" class="flex items-center justify-center">
+        <div class="relative bg-white rounded-lg shadow max-w-2xl">
           <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
             <h3 class="text-xl font-semibold text-neutral-900">
               <%= render_slot(@dialog_title) %>
@@ -427,7 +426,7 @@ defmodule Web.FormComponents do
               <span class="sr-only">Close modal</span>
             </button>
           </div>
-          <div class="p-4 md:p-5 text-neutral-500">
+          <div class="p-4 md:p-5 text-neutral-500 text-base">
             <%= render_slot(@dialog_content) %>
           </div>
           <div class="flex items-center justify-end p-4 md:p-5 border-t border-gray-200 rounded-b">

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -405,9 +405,9 @@ defmodule Web.Actors.Show do
     </.section>
 
     <.section>
-      <:title>Authorized Activity</:title>
+      <:title>Tunnel Sessions</:title>
       <:help>
-        Authorized attempts by actors to access the resource governed by this policy.
+        Authorized attempts by the actor to access a resource.
       </:help>
       <:content>
         <.live_table

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -249,15 +249,29 @@ defmodule Web.Actors.Show do
             </.button>
           </:action>
           <:action :let={identity}>
-            <.delete_button
+            <.button_with_confirmation
               :if={identity.created_by != :provider}
+              id={"delete_identity_#{identity.id}"}
+              style="danger"
+              icon="hero-trash-solid"
+              on_confirm="delete_identity"
+              on_confirm_id={identity.id}
               size="xs"
-              phx-click="delete_identity"
-              data-confirm="Are you sure you want to delete this identity?"
-              phx-value-id={identity.id}
             >
+              <:dialog_title>Delete Identity</:dialog_title>
+              <:dialog_content>
+                Are you sure you want to delete this identity?
+                This will <strong>immediately</strong>
+                sign out all clients associated with this identity.
+              </:dialog_content>
+              <:dialog_confirm_button>
+                Delete
+              </:dialog_confirm_button>
+              <:dialog_cancel_button>
+                Cancel
+              </:dialog_cancel_button>
               Delete
-            </.delete_button>
+            </.button_with_confirmation>
           </:action>
           <:empty>
             <div class="flex justify-center text-center text-neutral-500 p-4">
@@ -304,12 +318,25 @@ defmodule Web.Actors.Show do
       </:action>
 
       <:action :if={is_nil(@actor.deleted_at)}>
-        <.delete_button
-          phx-click="revoke_all_tokens"
-          data-confirm="Are you sure you want to revoke all tokens? This will immediately sign the actor out of all clients."
+        <.button_with_confirmation
+          id="revoke_all_tokens"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="revoke_all_tokens"
         >
-          Revoke All
-        </.delete_button>
+          <:dialog_title>Revoke All Tokens</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to revoke all tokens?
+            This will <strong>immediately</strong> sign the actor out of all clients.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Revoke All Tokens
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
+          Revoke All Tokens
+        </.button_with_confirmation>
       </:action>
 
       <:content>
@@ -360,14 +387,28 @@ defmodule Web.Actors.Show do
             <span :if={token.type != :client}>N/A</span>
           </:col>
           <:action :let={token}>
-            <.delete_button
+            <.button_with_confirmation
+              id={"revoke_token_#{token.id}"}
+              style="danger"
+              icon="hero-trash-solid"
+              on_confirm="revoke_token"
+              on_confirm_id={token.id}
               size="xs"
-              phx-click="revoke_token"
-              data-confirm="Are you sure you want to revoke this token?"
-              phx-value-id={token.id}
             >
+              <:dialog_title>Revoke the Token</:dialog_title>
+              <:dialog_content>
+                Are you sure you want to revoke the token?
+                This will <strong>immediately</strong>
+                sign the clients out of all associated client sessions.
+              </:dialog_content>
+              <:dialog_confirm_button>
+                Revoke
+              </:dialog_confirm_button>
+              <:dialog_cancel_button>
+                Cancel
+              </:dialog_cancel_button>
               Revoke
-            </.delete_button>
+            </.button_with_confirmation>
           </:action>
           <:empty>
             <div class="text-center text-neutral-500 p-4">No authentication tokens to display.</div>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -156,7 +156,7 @@ defmodule Web.Actors.Show do
           style="warning"
           icon="hero-lock-closed"
           phx-click="disable"
-          data-confirm={"Are you sure want to disable this #{actor_type(@actor.type)} and revoke all its tokens?"}
+          data-confirm={"Are you sure you want to disable this #{actor_type(@actor.type)} and revoke all its tokens?"}
         >
           Disable <%= actor_type(@actor.type) %>
         </.button>
@@ -166,7 +166,7 @@ defmodule Web.Actors.Show do
           style="warning"
           icon="hero-lock-open"
           phx-click="enable"
-          data-confirm={"Are you sure want to enable this #{actor_type(@actor.type)}?"}
+          data-confirm={"Are you sure you want to enable this #{actor_type(@actor.type)}?"}
         >
           Enable <%= actor_type(@actor.type) %>
         </.button>
@@ -497,7 +497,7 @@ defmodule Web.Actors.Show do
         >
           <:dialog_title>Delete <%= actor_type(@actor.type) %></:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this <%= String.downcase(actor_type(@actor.type)) %> along with all associated identities?
+            Are you sure you want to delete this <%= String.downcase(actor_type(@actor.type)) %> along with all associated identities?
           </:dialog_content>
           <:dialog_confirm_button>
             Delete <%= actor_type(@actor.type) %>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -489,12 +489,24 @@ defmodule Web.Actors.Show do
 
     <.danger_zone :if={is_nil(@actor.deleted_at)}>
       <:action :if={not Actors.actor_synced?(@actor) or @identities == []}>
-        <.delete_button
-          phx-click="delete"
-          data-confirm={"Are you sure want to delete this #{actor_type(@actor.type)} along with all associated identities?"}
+        <.button_with_confirmation
+          id="delete_actor"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete <%= actor_type(@actor.type) %></:dialog_title>
+          <:dialog_content>
+            Are you sure want to delete this <%= String.downcase(actor_type(@actor.type)) %> along with all associated identities?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete <%= actor_type(@actor.type) %>
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete <%= actor_type(@actor.type) %>
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -405,9 +405,9 @@ defmodule Web.Actors.Show do
     </.section>
 
     <.section>
-      <:title>Tunnel Sessions</:title>
+      <:title>Authorized Sessions</:title>
       <:help>
-        Authorized attempts by the actor to access a resource.
+        Authorized sessions opened by this Actor to access a Resource.
       </:help>
       <:content>
         <.live_table

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -330,12 +330,12 @@ defmodule Web.Actors.Show do
             This will <strong>immediately</strong> sign the actor out of all clients.
           </:dialog_content>
           <:dialog_confirm_button>
-            Revoke All Tokens
+            Revoke All
           </:dialog_confirm_button>
           <:dialog_cancel_button>
             Cancel
           </:dialog_cancel_button>
-          Revoke All Tokens
+          Revoke All
         </.button_with_confirmation>
       </:action>
 

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -156,9 +156,9 @@ defmodule Web.Clients.Show do
     </.section>
 
     <.section>
-      <:title>Tunnel Sessions</:title>
+      <:title>Authorized Sessions</:title>
       <:help>
-        Authorized attempts by the client to access a resource.
+        Authorized sessions opened by this Client to access a Resource.
       </:help>
       <:content>
         <.live_table

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -156,9 +156,9 @@ defmodule Web.Clients.Show do
     </.section>
 
     <.section>
-      <:title>Authorized Activity</:title>
+      <:title>Tunnel Sessions</:title>
       <:help>
-        Authorized attempts by actors to access the resource governed by this policy.
+        Authorized attempts by the client to access a resource.
       </:help>
       <:content>
         <.live_table

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -108,12 +108,37 @@ defmodule Web.Gateways.Show do
 
     <.danger_zone :if={is_nil(@gateway.deleted_at)}>
       <:action>
-        <.delete_button
-          phx-click="delete"
-          data-confirm="Are you sure you want to delete this gateway?"
+        <.button_with_confirmation
+          id="delete_gateway"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete Gateway</:dialog_title>
+          <:dialog_content>
+            <p>
+              Are you sure you want to delete this gateway?
+            </p>
+            <p class="mt-4 text-sm">
+              Deleting the gateway does not remove it's access token so it can be re-created again,
+              revoke the token on the
+              <.link
+                navigate={~p"/#{@account}/sites/#{@gateway.group}"}
+                class={["font-medium", link_style()]}
+              >
+                site
+              </.link>
+              page if you want to prevent the gateway from connecting to the portal.
+            </p>
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Gateway
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Gateway
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -117,7 +117,7 @@ defmodule Web.Gateways.Show do
           <:dialog_title>Delete Gateway</:dialog_title>
           <:dialog_content>
             <p>
-              Are you sure you want to delete this gateway?
+              Are you sure you want to delete this Gateway?
             </p>
             <p class="mt-4 text-sm">
               Deleting the gateway does not remove it's access token so it can be re-created again,

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -240,12 +240,24 @@ defmodule Web.Groups.Show do
 
     <.danger_zone :if={is_nil(@group.deleted_at) and Actors.group_editable?(@group)}>
       <:action>
-        <.delete_button
-          phx-click="delete"
-          data-confirm="Are you sure want to delete this group and all related policies?"
+        <.button_with_confirmation
+          id="delete_group"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete Group</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to delete this group and all related policies?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Group
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Group
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -248,7 +248,7 @@ defmodule Web.Groups.Show do
         >
           <:dialog_title>Delete Group</:dialog_title>
           <:dialog_content>
-            Are you sure you want to delete this group and all related policies?
+            Are you sure you want to delete this Group and all related Policies?
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Group

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -209,13 +209,25 @@ defmodule Web.Policies.Show do
 
     <.danger_zone :if={is_nil(@policy.deleted_at)}>
       <:action>
-        <.delete_button
-          phx-click="delete"
-          phx-value-id={@policy.id}
-          data-confirm="Are you sure you want to delete this policy?"
+        <.button_with_confirmation
+          id="delete_policy"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
+          on_confirm_id={@policy.id}
         >
+          <:dialog_title>Delete Policy</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to delete this Policy? All tunnel sessions authorized by it will be expired.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Policy
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Policy
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -90,7 +90,7 @@ defmodule Web.Policies.Show do
           phx-click="enable"
           style="warning"
           icon="hero-lock-open"
-          data-confirm="Are you sure want to enable this policy?"
+          data-confirm="Are you sure you want to enable this policy?"
         >
           Enable
         </.button>

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -158,9 +158,9 @@ defmodule Web.Policies.Show do
     </.section>
 
     <.section>
-      <:title>Tunnel Sessions</:title>
+      <:title>Authorized Sessions</:title>
       <:help>
-        Authorized attempts by an actors to access the resource governed by this policy.
+        Authorized sessions opened by Actors to access the Resources governed by this Policy.
       </:help>
       <:content>
         <.live_table
@@ -218,7 +218,7 @@ defmodule Web.Policies.Show do
         >
           <:dialog_title>Delete Policy</:dialog_title>
           <:dialog_content>
-            Are you sure you want to delete this Policy? All tunnel sessions authorized by it will be expired.
+            Are you sure you want to delete this Policy? All sessions authorized by it will be expired.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Policy

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -76,24 +76,48 @@ defmodule Web.Policies.Show do
         </.edit_button>
       </:action>
       <:action :if={is_nil(@policy.deleted_at)}>
-        <.button
+        <.button_with_confirmation
           :if={is_nil(@policy.disabled_at)}
-          phx-click="disable"
+          id="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure? Access granted by this policy will be revoked immediately."
+          on_confirm="disable"
         >
+          <:dialog_title>Disable the Policy</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to disable this policy?
+            This will <strong>immediately</strong>
+            revoke all access granted by it. Keep in mind, other policies may still grant access to the same resource.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Disable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Disable
-        </.button>
-        <.button
+        </.button_with_confirmation>
+        <.button_with_confirmation
           :if={not is_nil(@policy.disabled_at)}
-          phx-click="enable"
+          id="enable"
           style="warning"
           icon="hero-lock-open"
-          data-confirm="Are you sure you want to enable this policy?"
+          on_confirm="enable"
         >
+          <:dialog_title>Enable the Policy</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to enable this policy?
+            This will <strong>immediately</strong>
+            grant access to the specified resource to all members of the given group.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Enable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Enable
-        </.button>
+        </.button_with_confirmation>
       </:action>
       <:content>
         <.vertical_table id="policy">

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -158,9 +158,9 @@ defmodule Web.Policies.Show do
     </.section>
 
     <.section>
-      <:title>Authorized Activity</:title>
+      <:title>Tunnel Sessions</:title>
       <:help>
-        Authorized attempts by actors to access the resource governed by this policy.
+        Authorized attempts by an actors to access the resource governed by this policy.
       </:help>
       <:content>
         <.live_table

--- a/elixir/apps/web/lib/web/live/relay_groups/show.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/show.ex
@@ -143,12 +143,24 @@ defmodule Web.RelayGroups.Show do
 
     <.danger_zone :if={not is_nil(@group.account_id) and is_nil(@group.deleted_at)}>
       <:action :if={@group.account_id}>
-        <.delete_button
-          phx-click="delete"
-          data-confirm="Are you sure want to delete this relay group and disconnect all it's relays?"
+        <.button_with_confirmation
+          id="delete_relay_group"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete Instance Group</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to delete this Instance Group? All relay instances will be disconnected.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Instance Group
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Instance Group
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/relay_groups/show.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/show.ex
@@ -100,12 +100,25 @@ defmodule Web.RelayGroups.Show do
         </.add_button>
       </:action>
       <:action :if={is_nil(@group.deleted_at)}>
-        <.delete_button
-          phx-click="revoke_all_tokens"
-          data-confirm="Are you sure you want to revoke all tokens? This will immediately sign the actor out of all clients."
+        <.button_with_confirmation
+          id="delete_site"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="revoke_all_tokens"
         >
+          <:dialog_title>Revoke all tokens</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to revoke all tokens for this Relay Group?
+            This will <strong>immediately</strong> disconnect all associated Relays.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Revoke All Tokens
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Revoke All Tokens
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
       <:content flash={@flash}>
         <div class="relative overflow-x-auto">

--- a/elixir/apps/web/lib/web/live/relay_groups/show.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/show.ex
@@ -112,12 +112,12 @@ defmodule Web.RelayGroups.Show do
             This will <strong>immediately</strong> disconnect all associated Relays.
           </:dialog_content>
           <:dialog_confirm_button>
-            Revoke All Tokens
+            Revoke All
           </:dialog_confirm_button>
           <:dialog_cancel_button>
             Cancel
           </:dialog_cancel_button>
-          Revoke All Tokens
+          Revoke All
         </.button_with_confirmation>
       </:action>
       <:content flash={@flash}>

--- a/elixir/apps/web/lib/web/live/relays/show.ex
+++ b/elixir/apps/web/lib/web/live/relays/show.ex
@@ -114,9 +114,37 @@ defmodule Web.Relays.Show do
 
     <.danger_zone :if={is_nil(@relay.deleted_at)}>
       <:action :if={@relay.account_id}>
-        <.delete_button phx-click="delete" data-confirm="Are you sure you want to delete this relay?">
+        <.button_with_confirmation
+          id="delete_relay"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
+        >
+          <:dialog_title>Delete Relay</:dialog_title>
+          <:dialog_content>
+            <p>
+              Are you sure you want to delete this relay?
+            </p>
+            <p class="mt-4 text-sm">
+              Deleting the relay does not remove it's access token so it can be re-created again,
+              revoke the token on the
+              <.link
+                navigate={~p"/#{@account}/relay_groups/#{@relay.group}"}
+                class={["font-medium", link_style()]}
+              >
+                instance group
+              </.link>
+              page if you want to prevent the gateway from connecting to the portal.
+            </p>
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Relay
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Relay
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -248,9 +248,9 @@ defmodule Web.Resources.Show do
     </.section>
 
     <.section>
-      <:title>Authorized Activity</:title>
+      <:title>Tunnel Sessions</:title>
       <:help>
-        Authorized attempts by actors to access the resource governed by this policy.
+        Authorized attempts by actors to access the resource.
       </:help>
       <:content>
         <.live_table

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -304,13 +304,25 @@ defmodule Web.Resources.Show do
 
     <.danger_zone :if={is_nil(@resource.deleted_at)}>
       <:action>
-        <.delete_button
-          data-confirm="Are you sure want to delete this resource along with all associated policies?"
-          phx-click="delete"
-          phx-value-id={@resource.id}
+        <.button_with_confirmation
+          id="delete_resource"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
+          on_confirm_id={@resource.id}
         >
+          <:dialog_title>Delete Resource</:dialog_title>
+          <:dialog_content>
+            Are you sure want to delete this resource along with all associated policies and tunnel sessions?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Resource
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Resource
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -248,9 +248,9 @@ defmodule Web.Resources.Show do
     </.section>
 
     <.section>
-      <:title>Tunnel Sessions</:title>
+      <:title>Authorized Sessions</:title>
       <:help>
-        Authorized attempts by actors to access the resource.
+        Authorized sessions opened by Actors to access this Resource.
       </:help>
       <:content>
         <.live_table
@@ -313,7 +313,8 @@ defmodule Web.Resources.Show do
         >
           <:dialog_title>Delete Resource</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this resource along with all associated policies and tunnel sessions?
+            Are you sure want to delete this Resource along with all associated Policies?
+            This will immediately end all active sessions opened for this Resource.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Resource

--- a/elixir/apps/web/lib/web/live/settings/api_clients/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/show.ex
@@ -170,12 +170,24 @@ defmodule Web.Settings.ApiClients.Show do
 
     <.danger_zone :if={is_nil(@actor.deleted_at)}>
       <:action>
-        <.delete_button
-          phx-click="delete"
-          data-confirm="Are you sure want to delete this API Client along with all associated tokens?"
+        <.button_with_confirmation
+          id="delete_api_client"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete API Client</:dialog_title>
+          <:dialog_content>
+            Are you sure want to delete this API Client along with all associated tokens?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete API Client
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete API Client
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/settings/api_clients/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/show.ex
@@ -62,24 +62,44 @@ defmodule Web.Settings.ApiClients.Show do
         </.edit_button>
       </:action>
       <:action :if={Actors.actor_active?(@actor)}>
-        <.button
+        <.button_with_confirmation
+          id="disable"
           style="warning"
           icon="hero-lock-closed"
-          phx-click="disable"
-          data-confirm="Are you sure want to disable this API Client and revoke all its tokens?"
+          on_confirm="disable"
         >
+          <:dialog_title>Disable the API Client</:dialog_title>
+          <:dialog_content>
+            Are you sure want to disable this API Client and revoke all its tokens?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Disable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Disable API Client
-        </.button>
+        </.button_with_confirmation>
       </:action>
       <:action :if={is_nil(@actor.deleted_at) and Actors.actor_disabled?(@actor)}>
-        <.button
+        <.button_with_confirmation
+          id="enable"
           style="warning"
           icon="hero-lock-open"
-          phx-click="enable"
-          data-confirm="Are you sure want to enable this API Client?"
+          on_confirm="enable"
         >
+          <:dialog_title>Enable the API Client</:dialog_title>
+          <:dialog_content>
+            Are you sure want to enable this API Client?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Enable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Enable API Client
-        </.button>
+        </.button_with_confirmation>
       </:action>
       <:content flash={@flash}>
         <.vertical_table id="api-client">
@@ -111,12 +131,24 @@ defmodule Web.Settings.ApiClients.Show do
       </:action>
 
       <:action :if={Actors.actor_active?(@actor)}>
-        <.delete_button
-          phx-click="revoke_all_tokens"
-          data-confirm="Are you sure you want to revoke all tokens for this API client?"
+        <.button_with_confirmation
+          id="revoke_all_tokens"
+          style="warning"
+          icon="hero-lock-open"
+          on_confirm="revoke_all_tokens"
         >
+          <:dialog_title>Revoke all API Client Tokens</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to revoke all Tokens for this API client?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Revoke All
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Revoke All
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
 
       <:content>
@@ -145,17 +177,26 @@ defmodule Web.Settings.ApiClients.Show do
             <%= token.last_seen_remote_ip %>
           </:col>
           <:action :let={token}>
-            <.delete_button
+            <.button_with_confirmation
+              id={"revoke_token_#{token.id}"}
+              style="warning"
+              icon="hero-trash-solid"
+              on_confirm="revoke_token"
+              on_confirm_id={token.id}
               size="xs"
-              phx-click="revoke_token"
-              data-confirm="Are you sure you want to revoke this token?"
-              phx-value-id={token.id}
-              class={[
-                "block w-full py-2 px-4 hover:bg-gray-100"
-              ]}
             >
+              <:dialog_title>Revoke the Token</:dialog_title>
+              <:dialog_content>
+                Are you sure you want to revoke this token?
+              </:dialog_content>
+              <:dialog_confirm_button>
+                Revoke
+              </:dialog_confirm_button>
+              <:dialog_cancel_button>
+                Cancel
+              </:dialog_cancel_button>
               Revoke
-            </.delete_button>
+            </.button_with_confirmation>
           </:action>
           <:empty>
             <div class="flex justify-center text-center text-neutral-500 p-4">

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -159,12 +159,24 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
 
     <.danger_zone :if={is_nil(@provider.deleted_at)}>
       <:action>
-        <.delete_button
-          data-confirm="Are you sure want to delete this provider along with all related data?"
-          phx-click="delete"
+        <.button_with_confirmation
+          id="delete_identity_provider"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete Identity Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure want to delete this provider along with all related data?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Identity Provider
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Identity Provider
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -167,7 +167,8 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider along with all related data?
+            Are you sure want to delete this provider? This will remove
+            <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -50,26 +50,47 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
         </.edit_button>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
-        <.button
+        <.button_with_confirmation
           :if={is_nil(@provider.disabled_at)}
-          phx-click="disable"
+          id="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          on_confirm="disable"
         >
+          <:dialog_title>Disable the Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to disable this Provider?
+            This will <strong>immediately</strong>
+            sign out all Actors who were signed in using this Provider and directory sync will be paused.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Disable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Disable
-        </.button>
-
+        </.button_with_confirmation>
         <%= if @provider.adapter_state["status"] != "pending_access_token" do %>
-          <.button
+          <.button_with_confirmation
             :if={not is_nil(@provider.disabled_at)}
-            phx-click="enable"
+            id="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure you want to enable this provider?"
+            on_confirm="enable"
           >
+            <:dialog_title>Enable the Provider</:dialog_title>
+            <:dialog_content>
+              Are you sure you want to enable this provider?
+            </:dialog_content>
+            <:dialog_confirm_button>
+              Enable
+            </:dialog_confirm_button>
+            <:dialog_cancel_button>
+              Cancel
+            </:dialog_cancel_button>
             Enable
-          </.button>
+          </.button_with_confirmation>
         <% end %>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
@@ -167,8 +188,8 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure you want to delete this provider? This will remove
-            <strong>all</strong> Actors and Groups associated with this provider.
+            Are you sure you want to delete this provider? This will remove <strong>all</strong>
+            Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -55,7 +55,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
         >
           Disable
         </.button>
@@ -66,7 +66,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
             phx-click="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure want to enable this provider?"
+            data-confirm="Are you sure you want to enable this provider?"
           >
             Enable
           </.button>
@@ -167,7 +167,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
@@ -171,12 +171,24 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
 
     <.danger_zone :if={is_nil(@provider.deleted_at)}>
       <:action>
-        <.delete_button
-          data-confirm="Are you sure want to delete this provider along with all related data?"
-          phx-click="delete"
+        <.button_with_confirmation
+          id="delete_identity_provider"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete Identity Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure want to delete this provider along with all related data?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Identity Provider
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Identity Provider
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
@@ -53,26 +53,47 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
         </.edit_button>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
-        <.button
+        <.button_with_confirmation
           :if={is_nil(@provider.disabled_at)}
-          phx-click="disable"
+          id="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          on_confirm="disable"
         >
+          <:dialog_title>Disable the Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to disable this Provider?
+            This will <strong>immediately</strong>
+            sign out all Actors who were signed in using this Provider and directory sync will be paused.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Disable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Disable
-        </.button>
-
+        </.button_with_confirmation>
         <%= if @provider.adapter_state["status"] != "pending_access_token" do %>
-          <.button
+          <.button_with_confirmation
             :if={not is_nil(@provider.disabled_at)}
-            phx-click="enable"
+            id="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure you want to enable this provider?"
+            on_confirm="enable"
           >
+            <:dialog_title>Enable the Provider</:dialog_title>
+            <:dialog_content>
+              Are you sure you want to enable this provider?
+            </:dialog_content>
+            <:dialog_confirm_button>
+              Enable
+            </:dialog_confirm_button>
+            <:dialog_cancel_button>
+              Cancel
+            </:dialog_cancel_button>
             Enable
-          </.button>
+          </.button_with_confirmation>
         <% end %>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
@@ -179,8 +200,8 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure you want to delete this provider? This will remove
-            <strong>all</strong> Actors and Groups associated with this provider.
+            Are you sure you want to delete this provider? This will remove <strong>all</strong>
+            Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
@@ -179,7 +179,8 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider along with all related data?
+            Are you sure want to delete this provider? This will remove
+            <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
@@ -58,7 +58,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
         >
           Disable
         </.button>
@@ -69,7 +69,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
             phx-click="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure want to enable this provider?"
+            data-confirm="Are you sure you want to enable this provider?"
           >
             Enable
           </.button>
@@ -179,7 +179,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -159,12 +159,24 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
 
     <.danger_zone :if={is_nil(@provider.deleted_at)}>
       <:action>
-        <.delete_button
-          data-confirm="Are you sure want to delete this provider along with all related data?"
-          phx-click="delete"
+        <.button_with_confirmation
+          id="delete_identity_provider"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete Identity Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure want to delete this provider along with all related data?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Identity Provider
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Identity Provider
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -50,26 +50,47 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
         </.edit_button>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
-        <.button
+        <.button_with_confirmation
           :if={is_nil(@provider.disabled_at)}
-          phx-click="disable"
+          id="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          on_confirm="disable"
         >
+          <:dialog_title>Disable the Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to disable this Provider?
+            This will <strong>immediately</strong>
+            sign out all Actors who were signed in using this Provider and directory sync will be paused.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Disable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Disable
-        </.button>
-
+        </.button_with_confirmation>
         <%= if @provider.adapter_state["status"] != "pending_access_token" do %>
-          <.button
+          <.button_with_confirmation
             :if={not is_nil(@provider.disabled_at)}
-            phx-click="enable"
+            id="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure you want to enable this provider?"
+            on_confirm="enable"
           >
+            <:dialog_title>Enable the Provider</:dialog_title>
+            <:dialog_content>
+              Are you sure you want to enable this provider?
+            </:dialog_content>
+            <:dialog_confirm_button>
+              Enable
+            </:dialog_confirm_button>
+            <:dialog_cancel_button>
+              Cancel
+            </:dialog_cancel_button>
             Enable
-          </.button>
+          </.button_with_confirmation>
         <% end %>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
@@ -167,8 +188,8 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure you want to delete this provider? This will remove
-            <strong>all</strong> Actors and Groups associated with this provider.
+            Are you sure you want to delete this provider? This will remove <strong>all</strong>
+            Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -167,7 +167,8 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider along with all related data?
+            Are you sure want to delete this provider? This will remove
+            <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -55,7 +55,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
         >
           Disable
         </.button>
@@ -66,7 +66,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
             phx-click="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure want to enable this provider?"
+            data-confirm="Are you sure you want to enable this provider?"
           >
             Enable
           </.button>
@@ -167,7 +167,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -177,12 +177,24 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
 
     <.danger_zone :if={is_nil(@provider.deleted_at)}>
       <:action>
-        <.delete_button
-          data-confirm="Are you sure want to delete this provider along with all related data?"
-          phx-click="delete"
+        <.button_with_confirmation
+          id="delete_identity_provider"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete Identity Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure want to delete this provider along with all related data?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Identity Provider
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Identity Provider
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -50,26 +50,47 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
         </.edit_button>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
-        <.button
+        <.button_with_confirmation
           :if={is_nil(@provider.disabled_at)}
-          phx-click="disable"
+          id="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          on_confirm="disable"
         >
+          <:dialog_title>Disable the Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to disable this Provider?
+            This will <strong>immediately</strong>
+            sign out all Actors who were signed in using this Provider and directory sync will be paused.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Disable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Disable
-        </.button>
-
+        </.button_with_confirmation>
         <%= if @provider.adapter_state["status"] != "pending_access_token" do %>
-          <.button
+          <.button_with_confirmation
             :if={not is_nil(@provider.disabled_at)}
-            phx-click="enable"
+            id="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure you want to enable this provider?"
+            on_confirm="enable"
           >
+            <:dialog_title>Enable the Provider</:dialog_title>
+            <:dialog_content>
+              Are you sure you want to enable this provider?
+            </:dialog_content>
+            <:dialog_confirm_button>
+              Enable
+            </:dialog_confirm_button>
+            <:dialog_cancel_button>
+              Cancel
+            </:dialog_cancel_button>
             Enable
-          </.button>
+          </.button_with_confirmation>
         <% end %>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
@@ -185,8 +206,8 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure you want to delete this provider? This will remove
-            <strong>all</strong> Actors and Groups associated with this provider.
+            Are you sure you want to delete this provider? This will remove <strong>all</strong>
+            Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -185,7 +185,8 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider along with all related data?
+            Are you sure want to delete this provider? This will remove
+            <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -55,7 +55,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
         >
           Disable
         </.button>
@@ -66,7 +66,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
             phx-click="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure want to enable this provider?"
+            data-confirm="Are you sure you want to enable this provider?"
           >
             Enable
           </.button>
@@ -185,7 +185,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -142,7 +142,8 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider along with all related data?
+            Are you sure want to delete this provider? This will remove
+            <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -134,12 +134,24 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
     </.section>
     <.danger_zone :if={is_nil(@provider.deleted_at)}>
       <:action>
-        <.delete_button
-          data-confirm="Are you sure want to delete this provider along with all related data?"
-          phx-click="delete"
+        <.button_with_confirmation
+          id="delete_identity_provider"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete Identity Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure want to delete this provider along with all related data?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Identity Provider
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Identity Provider
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -50,7 +50,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? All users signed into this provider will be immediately signed out."
+          data-confirm="Are you sure you want to disable this provider? All users signed into this provider will be immediately signed out."
         >
           Disable
         </.button>
@@ -59,7 +59,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
           phx-click="enable"
           style="warning"
           icon="hero-lock-open"
-          data-confirm="Are you sure want to enable this provider?"
+          data-confirm="Are you sure you want to enable this provider?"
         >
           Enable
         </.button>
@@ -142,7 +142,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -45,24 +45,46 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
         </.edit_button>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
-        <.button
+        <.button_with_confirmation
           :if={is_nil(@provider.disabled_at)}
-          phx-click="disable"
+          id="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure you want to disable this provider? All users signed into this provider will be immediately signed out."
+          on_confirm="disable"
         >
+          <:dialog_title>Disable the Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to disable this Provider?
+            This will <strong>immediately</strong>
+            sign out all Actors who were signed in using this Provider.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Disable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Disable
-        </.button>
-        <.button
+        </.button_with_confirmation>
+        <.button_with_confirmation
           :if={not is_nil(@provider.disabled_at)}
-          phx-click="enable"
+          id="enable"
           style="warning"
           icon="hero-lock-open"
-          data-confirm="Are you sure you want to enable this provider?"
+          on_confirm="enable"
         >
+          <:dialog_title>Enable the Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to enable this provider?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Enable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Enable
-        </.button>
+        </.button_with_confirmation>
       </:action>
       <:action :if={is_nil(@provider.deleted_at)}>
         <.button
@@ -142,8 +164,8 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure you want to delete this provider? This will remove
-            <strong>all</strong> Actors and Groups associated with this provider.
+            Are you sure you want to delete this provider? This will remove <strong>all</strong>
+            Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Identity Provider

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
@@ -38,24 +38,46 @@ defmodule Web.Settings.IdentityProviders.System.Show do
         <span :if={not is_nil(@provider.deleted_at)} class="text-red-600">(deleted)</span>
       </:title>
       <:action :if={is_nil(@provider.deleted_at)}>
-        <.button
+        <.button_with_confirmation
           :if={is_nil(@provider.disabled_at)}
-          phx-click="disable"
+          id="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure you want to disable this provider? All users signed into this provider will be immediately signed out."
+          on_confirm="disable"
         >
+          <:dialog_title>Disable the Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to disable this Provider?
+            This will <strong>immediately</strong>
+            sign out all Actors who were signed in using this Provider.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Disable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Disable
-        </.button>
-        <.button
+        </.button_with_confirmation>
+        <.button_with_confirmation
           :if={not is_nil(@provider.disabled_at)}
-          phx-click="enable"
+          id="enable"
           style="warning"
           icon="hero-lock-open"
-          data-confirm="Are you sure you want to enable this provider?"
+          on_confirm="enable"
         >
+          <:dialog_title>Enable the Provider</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to enable this provider?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Enable
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Enable
-        </.button>
+        </.button_with_confirmation>
       </:action>
       <:content>
         <.header>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
@@ -43,7 +43,7 @@ defmodule Web.Settings.IdentityProviders.System.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? All users signed into this provider will be immediately signed out."
+          data-confirm="Are you sure you want to disable this provider? All users signed into this provider will be immediately signed out."
         >
           Disable
         </.button>
@@ -52,7 +52,7 @@ defmodule Web.Settings.IdentityProviders.System.Show do
           phx-click="enable"
           style="warning"
           icon="hero-lock-open"
-          data-confirm="Are you sure want to enable this provider?"
+          data-confirm="Are you sure you want to enable this provider?"
         >
           Enable
         </.button>

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -132,12 +132,25 @@ defmodule Web.Sites.Show do
         </.add_button>
       </:action>
       <:action :if={is_nil(@group.deleted_at)}>
-        <.delete_button
-          phx-click="revoke_all_tokens"
-          data-confirm="Are you sure you want to revoke all tokens? This will immediately disconnect all gateways in this site."
+        <.button_with_confirmation
+          id="revoke_all_tokens"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="revoke_all_tokens"
         >
+          <:dialog_title>Revoke all tokens</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to revoke all tokens for this Site?
+            This will <strong>immediately</strong> disconnect all associated Gateways.
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Revoke All Tokens
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Revoke All Tokens
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
       <:help :if={is_nil(@group.deleted_at)}>
         Deploy gateways to terminate connections to your site's resources. All
@@ -268,8 +281,8 @@ defmodule Web.Sites.Show do
         >
           <:dialog_title>Delete Site</:dialog_title>
           <:dialog_content>
-            Are you sure you want to delete this Site? This will
-            <strong>immediately</strong> disconnect all associated Gateways.
+            Are you sure you want to delete this Site? This will <strong>immediately</strong>
+            disconnect all associated Gateways.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Site

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -268,7 +268,8 @@ defmodule Web.Sites.Show do
         >
           <:dialog_title>Delete Site</:dialog_title>
           <:dialog_content>
-            Are you sure you want to delete this Site and disconnect all its Gateways?
+            Are you sure you want to delete this Site? This will
+            <strong>immediately</strong> disconnect all associated Gateways.
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Site

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -260,12 +260,24 @@ defmodule Web.Sites.Show do
 
     <.danger_zone :if={is_nil(@group.deleted_at)}>
       <:action>
-        <.delete_button
-          phx-click="delete"
-          data-confirm="Are you sure you want to delete this Site and disconnect all its Gateways?"
+        <.button_with_confirmation
+          id="delete_site"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete"
         >
+          <:dialog_title>Delete Site</:dialog_title>
+          <:dialog_content>
+            Are you sure you want to delete this Site and disconnect all its Gateways?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Site
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
           Delete Site
-        </.delete_button>
+        </.button_with_confirmation>
       </:action>
     </.danger_zone>
     """

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -144,12 +144,12 @@ defmodule Web.Sites.Show do
             This will <strong>immediately</strong> disconnect all associated Gateways.
           </:dialog_content>
           <:dialog_confirm_button>
-            Revoke All Tokens
+            Revoke All
           </:dialog_confirm_button>
           <:dialog_cancel_button>
             Cancel
           </:dialog_cancel_button>
-          Revoke All Tokens
+          Revoke All
         </.button_with_confirmation>
       </:action>
       <:help :if={is_nil(@group.deleted_at)}>

--- a/elixir/apps/web/test/web/live/actors/show_test.exs
+++ b/elixir/apps/web/test/web/live/actors/show_test.exs
@@ -590,7 +590,7 @@ defmodule Web.Live.Actors.ShowTest do
         |> live(~p"/#{account}/actors/#{actor}")
 
       assert lv
-             |> element("#identity-#{other_identity.id} button", "Delete")
+             |> element("#identity-#{other_identity.id} button[type=submit]", "Delete")
              |> render_click()
              |> Floki.find(".flash-info")
              |> element_to_text() =~ "Identity was deleted."
@@ -667,7 +667,7 @@ defmodule Web.Live.Actors.ShowTest do
 
       assert row1["last used"] == "Never"
       assert around_now?(row1["created"])
-      assert row1["actions"] == "Revoke"
+      assert row1["actions"] =~ "Revoke"
 
       assert row2["type"] == "client"
 
@@ -676,7 +676,7 @@ defmodule Web.Live.Actors.ShowTest do
 
       assert row2["last used"] == "Never"
       assert around_now?(row2["created"])
-      assert row2["actions"] == "Revoke"
+      assert row2["actions"] =~ "Revoke"
     end
 
     test "allows revoking tokens", %{
@@ -701,7 +701,7 @@ defmodule Web.Live.Actors.ShowTest do
         |> live(~p"/#{account}/actors/#{actor}")
 
       assert lv
-             |> element("td button", "Revoke")
+             |> element("td button[type=submit]", "Revoke")
              |> render_click()
 
       assert lv
@@ -734,7 +734,7 @@ defmodule Web.Live.Actors.ShowTest do
         |> live(~p"/#{account}/actors/#{actor}")
 
       assert lv
-             |> element("button", "Revoke All")
+             |> element("button[type=submit]", "Revoke All")
              |> render_click()
 
       assert lv
@@ -776,7 +776,7 @@ defmodule Web.Live.Actors.ShowTest do
         |> live(~p"/#{account}/actors/#{actor}")
 
       lv
-      |> element("button", "Delete User")
+      |> element("button[type=submit]", "Delete User")
       |> render_click()
 
       assert_redirect(lv, ~p"/#{account}/actors")
@@ -799,7 +799,7 @@ defmodule Web.Live.Actors.ShowTest do
         |> live(~p"/#{account}/actors/#{actor}")
 
       lv
-      |> element("button", "Delete User")
+      |> element("button[type=submit]", "Delete User")
       |> render_click()
 
       assert_redirect(lv, ~p"/#{account}/actors")
@@ -819,7 +819,7 @@ defmodule Web.Live.Actors.ShowTest do
         |> live(~p"/#{account}/actors/#{actor}")
 
       assert lv
-             |> element("button", "Delete User")
+             |> element("button[type=submit]", "Delete User")
              |> render_click()
              |> Floki.find(".flash-error")
              |> element_to_text() =~ "You can't delete the last admin of an account."
@@ -1002,7 +1002,7 @@ defmodule Web.Live.Actors.ShowTest do
         |> live(~p"/#{account}/actors/#{actor}")
 
       lv
-      |> element("button", "Delete Service Account")
+      |> element("button[type=submit]", "Delete Service Account")
       |> render_click()
 
       assert_redirect(lv, ~p"/#{account}/actors")
@@ -1096,7 +1096,7 @@ defmodule Web.Live.Actors.ShowTest do
 
       assert row1["last used"] == "Never"
       assert around_now?(row1["created"])
-      assert row1["actions"] == "Revoke"
+      assert row1["actions"] =~ "Revoke"
 
       assert row2["type"] == "client"
 
@@ -1105,7 +1105,7 @@ defmodule Web.Live.Actors.ShowTest do
 
       assert row2["last used"] == "Never"
       assert around_now?(row2["created"])
-      assert row2["actions"] == "Revoke"
+      assert row2["actions"] =~ "Revoke"
     end
 
     test "allows revoking tokens", %{
@@ -1130,7 +1130,7 @@ defmodule Web.Live.Actors.ShowTest do
         |> live(~p"/#{account}/actors/#{actor}")
 
       assert lv
-             |> element("td button", "Revoke")
+             |> element("td button[type=submit]", "Revoke")
              |> render_click()
 
       assert lv
@@ -1163,7 +1163,7 @@ defmodule Web.Live.Actors.ShowTest do
         |> live(~p"/#{account}/actors/#{actor}")
 
       assert lv
-             |> element("button", "Revoke All")
+             |> element("button[type=submit]", "Revoke All")
              |> render_click()
 
       assert lv

--- a/elixir/apps/web/test/web/live/gateways/show_test.exs
+++ b/elixir/apps/web/test/web/live/gateways/show_test.exs
@@ -130,7 +130,7 @@ defmodule Web.Live.Gateways.ShowTest do
       |> live(~p"/#{account}/gateways/#{gateway}")
 
     lv
-    |> element("button", "Delete Gateway")
+    |> element("button[type=submit]", "Delete Gateway")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/sites/#{gateway.group}")

--- a/elixir/apps/web/test/web/live/groups/show_test.exs
+++ b/elixir/apps/web/test/web/live/groups/show_test.exs
@@ -283,7 +283,7 @@ defmodule Web.Live.Groups.ShowTest do
       |> live(~p"/#{account}/groups/#{group}")
 
     lv
-    |> element("button", "Delete Group")
+    |> element("button[type=submit]", "Delete Group")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/groups")

--- a/elixir/apps/web/test/web/live/policies/show_test.exs
+++ b/elixir/apps/web/test/web/live/policies/show_test.exs
@@ -219,7 +219,7 @@ defmodule Web.Live.Policies.ShowTest do
       |> live(~p"/#{account}/policies/#{policy}")
 
     assert lv
-           |> element("button", "Delete Policy")
+           |> element("button[type=submit]", "Delete Policy")
            |> render_click() ==
              {:error, {:live_redirect, %{to: ~p"/#{account}/policies", kind: :push}}}
 
@@ -245,13 +245,13 @@ defmodule Web.Live.Policies.ShowTest do
       |> live(~p"/#{account}/policies/#{policy}")
 
     assert lv
-           |> element("button", "Disable")
+           |> element("button[type=submit]", "Disable")
            |> render_click() =~ "(disabled)"
 
     assert Repo.get(Domain.Policies.Policy, policy.id).disabled_at
 
     refute lv
-           |> element("button", "Enable")
+           |> element("button[type=submit]", "Enable")
            |> render_click() =~ "(disabled)"
 
     refute Repo.get(Domain.Policies.Policy, policy.id).disabled_at

--- a/elixir/apps/web/test/web/live/relay_groups/show_test.exs
+++ b/elixir/apps/web/test/web/live/relay_groups/show_test.exs
@@ -196,7 +196,7 @@ defmodule Web.Live.RelayGroups.ShowTest do
       |> live(~p"/#{account}/relay_groups/#{group}")
 
     lv
-    |> element("button", "Delete")
+    |> element("button[type=submit]", "Delete")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/relay_groups")
@@ -216,7 +216,7 @@ defmodule Web.Live.RelayGroups.ShowTest do
       |> live(~p"/#{account}/relay_groups/#{group}")
 
     assert lv
-           |> element("button", "Revoke All")
+           |> element("button[type=submit]", "Revoke All")
            |> render_click() =~ "1 token(s) were revoked."
 
     assert Repo.get_by(Domain.Tokens.Token, relay_group_id: group.id).deleted_at

--- a/elixir/apps/web/test/web/live/relays/show_test.exs
+++ b/elixir/apps/web/test/web/live/relays/show_test.exs
@@ -157,7 +157,7 @@ defmodule Web.Live.Relays.ShowTest do
       |> live(~p"/#{account}/relays/#{relay}")
 
     lv
-    |> element("button", "Delete Relay")
+    |> element("button[type=submit]", "Delete Relay")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/relay_groups/#{relay.group}")

--- a/elixir/apps/web/test/web/live/resources/show_test.exs
+++ b/elixir/apps/web/test/web/live/resources/show_test.exs
@@ -318,7 +318,7 @@ defmodule Web.Live.Resources.ShowTest do
       |> live(~p"/#{account}/resources/#{resource}")
 
     assert lv
-           |> element("button", "Delete Resource")
+           |> element("button[type=submit]", "Delete Resource")
            |> render_click() ==
              {:error, {:live_redirect, %{to: ~p"/#{account}/resources", kind: :push}}}
 

--- a/elixir/apps/web/test/web/live/settings/api_clients/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/api_clients/show_test.exs
@@ -139,7 +139,7 @@ defmodule Web.Live.Settings.ApiClients.ShowTest do
       |> live(~p"/#{account}/settings/api_clients/#{api_client}")
 
     lv
-    |> element("button", "Delete API Client")
+    |> element("button[type=submit]", "Delete API Client")
     |> render_click()
 
     assert_redirect(lv, ~p"/#{account}/settings/api_clients")
@@ -161,7 +161,7 @@ defmodule Web.Live.Settings.ApiClients.ShowTest do
     refute has_element?(lv, "button", "Enable API Client")
 
     assert lv
-           |> element("button", "Disable API Client")
+           |> element("button[type=submit]", "Disable")
            |> render_click()
            |> Floki.find(".flash-info")
            |> element_to_text() =~ "API Client was disabled."
@@ -182,10 +182,10 @@ defmodule Web.Live.Settings.ApiClients.ShowTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/settings/api_clients/#{api_client}")
 
-    refute has_element?(lv, "button", "Disable API Client")
+    refute has_element?(lv, "button[type=submit]", "Disable API Client")
 
     assert lv
-           |> element("button", "Enable API Client")
+           |> element("button[type=submit]", "Enable")
            |> render_click()
            |> Floki.find(".flash-info")
            |> element_to_text() =~ "API Client was enabled."
@@ -215,7 +215,7 @@ defmodule Web.Live.Settings.ApiClients.ShowTest do
     assert row1["name"] == token.name
     assert row1["expires at"]
     assert row1["last used"] == "Never"
-    assert row1["actions"] == "Revoke"
+    assert row1["actions"] =~ "Revoke"
   end
 
   test "allows revoking tokens", %{
@@ -232,7 +232,7 @@ defmodule Web.Live.Settings.ApiClients.ShowTest do
       |> live(~p"/#{account}/settings/api_clients/#{api_client}")
 
     assert lv
-           |> element("td button", "Revoke")
+           |> element("td button[type=submit]", "Revoke")
            |> render_click()
 
     assert lv
@@ -262,7 +262,7 @@ defmodule Web.Live.Settings.ApiClients.ShowTest do
            |> table_to_map() != []
 
     assert lv
-           |> element("button", "Revoke All")
+           |> element("button[type=submit]", "Revoke All")
            |> render_click()
 
     assert lv

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/show_test.exs
@@ -232,14 +232,14 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/google_workspace/#{provider}")
 
     assert lv
-           |> element("button", "Disable")
+           |> element("button[type=submit]", "Disable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
            |> Map.fetch!("status") == "Disabled"
 
     assert lv
-           |> element("button", "Enable")
+           |> element("button[type=submit]", "Enable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
@@ -258,7 +258,7 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/google_workspace/#{provider}")
 
     lv
-    |> element("button", "Delete Identity Provider")
+    |> element("button[type=submit]", "Delete Identity Provider")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/settings/identity_providers")

--- a/elixir/apps/web/test/web/live/settings/identity_providers/jumpcloud/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/jumpcloud/show_test.exs
@@ -266,14 +266,14 @@ defmodule Web.Live.Settings.IdentityProviders.JumpCloud.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/jumpcloud/#{provider}")
 
     assert lv
-           |> element("button", "Disable")
+           |> element("button[type=submit]", "Disable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
            |> Map.fetch!("status") == "Disabled"
 
     assert lv
-           |> element("button", "Enable")
+           |> element("button[type=submit]", "Enable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
@@ -296,7 +296,7 @@ defmodule Web.Live.Settings.IdentityProviders.JumpCloud.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/jumpcloud/#{provider}")
 
     lv
-    |> element("button", "Delete Identity Provider")
+    |> element("button[type=submit]", "Delete Identity Provider")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/settings/identity_providers")

--- a/elixir/apps/web/test/web/live/settings/identity_providers/microsoft_entra/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/microsoft_entra/show_test.exs
@@ -233,14 +233,14 @@ defmodule Web.Live.Settings.IdentityProviders.MicrosoftEntra.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/microsoft_entra/#{provider}")
 
     assert lv
-           |> element("button", "Disable")
+           |> element("button[type=submit]", "Disable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
            |> Map.fetch!("status") == "Disabled"
 
     assert lv
-           |> element("button", "Enable")
+           |> element("button[type=submit]", "Enable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
@@ -259,7 +259,7 @@ defmodule Web.Live.Settings.IdentityProviders.MicrosoftEntra.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/microsoft_entra/#{provider}")
 
     lv
-    |> element("button", "Delete Identity Provider")
+    |> element("button[type=submit]", "Delete Identity Provider")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/settings/identity_providers")

--- a/elixir/apps/web/test/web/live/settings/identity_providers/okta/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/okta/show_test.exs
@@ -233,14 +233,14 @@ defmodule Web.Live.Settings.IdentityProviders.Okta.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/okta/#{provider}")
 
     assert lv
-           |> element("button", "Disable")
+           |> element("button[type=submit]", "Disable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
            |> Map.fetch!("status") == "Disabled"
 
     assert lv
-           |> element("button", "Enable")
+           |> element("button[type=submit]", "Enable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
@@ -259,7 +259,7 @@ defmodule Web.Live.Settings.IdentityProviders.Okta.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/okta/#{provider}")
 
     lv
-    |> element("button", "Delete Identity Provider")
+    |> element("button[type=submit]", "Delete Identity Provider")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/settings/identity_providers")

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/show_test.exs
@@ -131,14 +131,14 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/openid_connect/#{provider}")
 
     assert lv
-           |> element("button", "Disable")
+           |> element("button[type=submit]", "Disable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
            |> Map.fetch!("status") == "Disabled"
 
     assert lv
-           |> element("button", "Enable")
+           |> element("button[type=submit]", "Enable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
@@ -157,7 +157,7 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/openid_connect/#{provider}")
 
     lv
-    |> element("button", "Delete Identity Provider")
+    |> element("button[type=submit]", "Delete Identity Provider")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/settings/identity_providers")

--- a/elixir/apps/web/test/web/live/settings/identity_providers/system/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/system/show_test.exs
@@ -124,14 +124,14 @@ defmodule Web.Live.Settings.IdentityProviders.System.ShowTest do
       |> live(~p"/#{account}/settings/identity_providers/system/#{provider}")
 
     assert lv
-           |> element("button", "Disable")
+           |> element("button[type=submit]", "Disable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()
            |> Map.fetch!("status") == "Disabled"
 
     assert lv
-           |> element("button", "Enable")
+           |> element("button[type=submit]", "Enable")
            |> render_click()
            |> Floki.find("#provider")
            |> vertical_table_to_map()

--- a/elixir/apps/web/test/web/live/sites/show_test.exs
+++ b/elixir/apps/web/test/web/live/sites/show_test.exs
@@ -180,7 +180,7 @@ defmodule Web.Live.Sites.ShowTest do
       |> live(~p"/#{account}/sites/#{group}")
 
     assert lv
-           |> element("button", "Revoke All")
+           |> element("button[type=submit]", "Revoke All")
            |> render_click() =~ "1 token(s) were revoked."
 
     assert Repo.get_by(Domain.Tokens.Token, gateway_group_id: group.id).deleted_at
@@ -295,7 +295,7 @@ defmodule Web.Live.Sites.ShowTest do
       |> live(~p"/#{account}/sites/#{group}")
 
     lv
-    |> element("button", "Delete")
+    |> element("button[type=submit]", "Delete")
     |> render_click()
 
     assert_redirected(lv, ~p"/#{account}/sites")


### PR DESCRIPTION
Still need to replace a few more `data-confirm` actions (have an issue with HTML <dialog> positioning when it's defined inside Tailwind tables.)

Closes https://github.com/firezone/firezone/issues/5794
Closes #5766
Closes #5887 