### PR TITLE
chore(connlib): ensure span is activate during test init

### DIFF
--- a/rust/connlib/tunnel/src/tests/sim_net.rs
+++ b/rust/connlib/tunnel/src/tests/sim_net.rs
@@ -109,7 +109,7 @@ where
         span: Span,
     ) -> Host<U> {
         Host {
-            inner: f(self.inner.clone(), self.ip4, self.ip6),
+            inner: span.in_scope(|| f(self.inner.clone(), self.ip4, self.ip6)),
             ip4: self.ip4,
             ip6: self.ip6,
             span,


### PR DESCRIPTION
Applying the initial `init` closure may also print logs that are currently not captured within the corresponding span. By using `in_scope`, we ensure those logs are also correctly captured in the corresponding span.