### PR TITLE
chore(connlib): improve logging

### DIFF
--- a/rust/connlib/shared/src/error.rs
+++ b/rust/connlib/shared/src/error.rs
@@ -50,9 +50,6 @@ pub enum ConnlibError {
     /// A panic occurred with a non-string payload.
     #[error("Panicked with a non-string payload")]
     PanicNonStringPayload,
-    /// Invalid destination for packet
-    #[error("Invalid dest address")]
-    InvalidDst,
     /// Exhausted nat table
     #[error("exhausted nat")]
     ExhaustedNat,
@@ -79,8 +76,11 @@ pub enum ConnlibError {
     #[error("Error while rewriting `/etc/resolv.conf`: {0}")]
     ResolvConf(anyhow::Error),
 
-    #[error("Packet not allowed; source = {src}")]
-    UnallowedPacket { src: IpAddr },
+    #[error("Source not allowed: {src}")]
+    SrcNotAllowed { src: IpAddr },
+
+    #[error("Destination not allowed: {dst}")]
+    DstNotAllowed { dst: IpAddr },
 
     // Error variants for `systemd-resolved` DNS control
     #[error("Failed to control system DNS with `resolvectl`")]

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -287,7 +287,7 @@ impl Allocation {
         self.send_binding_requests();
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(tid, method, class, rtt))]
+    #[tracing::instrument(level = "debug", skip_all, fields(%from, tid, method, class, rtt))]
     pub fn handle_input(
         &mut self,
         from: SocketAddr,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -291,7 +291,6 @@ where
     /// - `Ok(None)` if the packet was handled internally, for example, a response from a TURN server.
     /// - `Ok(Some)` if the packet was an encrypted wireguard packet from a peer.
     ///   The `Option` contains the connection on which the packet was decrypted.
-    #[tracing::instrument(level = "debug", skip_all, fields(%from))]
     pub fn decapsulate<'s>(
         &mut self,
         local: SocketAddr,
@@ -330,7 +329,6 @@ where
     /// Wireguard is an IP tunnel, so we "enforce" that only IP packets are sent through it.
     /// We say "enforce" an [`IpPacket`] can be created from an (almost) arbitrary byte buffer at virtually no cost.
     /// Nevertheless, using [`IpPacket`] in our API has good documentation value.
-    #[tracing::instrument(level = "debug", skip_all, fields(id = %connection))]
     pub fn encapsulate<'s>(
         &'s mut self,
         connection: TId,


### PR DESCRIPTION
Currently, the logging of fields in spans for encapsulate and decapsulate operations is a bit inconsistent between client and gateway. Logging the `from` field for every message is actually quite redundant because most of these logs are emitted within `snownet`'s `Allocation` which can add its own span to indicate, which relay we are talking to.

For most other operations, it is much more useful to log the connection ID instead of IPs.

This should make the logs a bit more succinct.