### PR TITLE
refactor(connlib): remove cyclic `From` impls

### DIFF
--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -117,19 +117,6 @@ impl ResourceDescription {
     }
 }
 
-impl From<ResourceDescription> for crate::messages::client::ResourceDescription {
-    fn from(value: ResourceDescription) -> Self {
-        match value {
-            ResourceDescription::Dns(r) => {
-                crate::messages::client::ResourceDescription::Dns(r.into())
-            }
-            ResourceDescription::Cidr(r) => {
-                crate::messages::client::ResourceDescription::Cidr(r.into())
-            }
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub struct ResourceDescriptionDns {
     /// Resource's id.
@@ -145,18 +132,6 @@ pub struct ResourceDescriptionDns {
     pub sites: Vec<Site>,
 
     pub status: Status,
-}
-
-impl From<ResourceDescriptionDns> for crate::messages::client::ResourceDescriptionDns {
-    fn from(r: ResourceDescriptionDns) -> Self {
-        crate::messages::client::ResourceDescriptionDns {
-            id: r.id,
-            address: r.address,
-            address_description: r.address_description,
-            name: r.name,
-            sites: r.sites,
-        }
-    }
 }
 
 /// Description of a resource that maps to a CIDR.
@@ -175,18 +150,6 @@ pub struct ResourceDescriptionCidr {
     pub sites: Vec<Site>,
 
     pub status: Status,
-}
-
-impl From<ResourceDescriptionCidr> for crate::messages::client::ResourceDescriptionCidr {
-    fn from(r: ResourceDescriptionCidr) -> Self {
-        crate::messages::client::ResourceDescriptionCidr {
-            id: r.id,
-            address: r.address,
-            address_description: r.address_description,
-            name: r.name,
-            sites: r.sites,
-        }
-    }
 }
 
 /// Traits that will be used by connlib to callback the client upper layers.

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -28,7 +28,7 @@ pub struct ResourceDescriptionDns {
 }
 
 impl ResourceDescriptionDns {
-    fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionDns {
+    pub fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionDns {
         crate::callbacks::ResourceDescriptionDns {
             id: self.id,
             address: self.address,
@@ -58,7 +58,7 @@ pub struct ResourceDescriptionCidr {
 }
 
 impl ResourceDescriptionCidr {
-    fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionCidr {
+    pub fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionCidr {
         crate::callbacks::ResourceDescriptionCidr {
             id: self.id,
             address: self.address,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1584,6 +1584,8 @@ mod proptests {
         #[strategy(dns_resource())] resource2: ResourceDescriptionDns,
         #[strategy(cidr_resource(8))] resource3: ResourceDescriptionCidr,
     ) {
+        use callbacks as cb;
+
         let mut client_state = ClientState::for_test();
 
         client_state.add_resources(&[
@@ -1592,31 +1594,21 @@ mod proptests {
         ]);
 
         assert_eq!(
-            hashset(
-                client_state
-                    .resources()
-                    .into_iter()
-                    .map_into::<ResourceDescription>()
-            ),
+            hashset(client_state.resources()),
             hashset([
-                ResourceDescription::Cidr(resource1.clone()),
-                ResourceDescription::Dns(resource2.clone())
+                cb::ResourceDescription::Cidr(resource1.clone().with_status(Status::Unknown)),
+                cb::ResourceDescription::Dns(resource2.clone().with_status(Status::Unknown))
             ])
         );
 
         client_state.add_resources(&[ResourceDescription::Cidr(resource3.clone())]);
 
         assert_eq!(
-            hashset(
-                client_state
-                    .resources()
-                    .into_iter()
-                    .map_into::<ResourceDescription>()
-            ),
+            hashset(client_state.resources()),
             hashset([
-                ResourceDescription::Cidr(resource1),
-                ResourceDescription::Dns(resource2),
-                ResourceDescription::Cidr(resource3)
+                cb::ResourceDescription::Cidr(resource1.with_status(Status::Unknown)),
+                cb::ResourceDescription::Dns(resource2.with_status(Status::Unknown)),
+                cb::ResourceDescription::Cidr(resource3.with_status(Status::Unknown)),
             ])
         );
     }
@@ -1626,6 +1618,8 @@ mod proptests {
         #[strategy(cidr_resource(8))] resource: ResourceDescriptionCidr,
         #[strategy(ip_network(8))] new_address: IpNetwork,
     ) {
+        use callbacks as cb;
+
         let mut client_state = ClientState::for_test();
         client_state.add_resources(&[ResourceDescription::Cidr(resource.clone())]);
 
@@ -1637,13 +1631,10 @@ mod proptests {
         client_state.add_resources(&[ResourceDescription::Cidr(updated_resource.clone())]);
 
         assert_eq!(
-            hashset(
-                client_state
-                    .resources()
-                    .into_iter()
-                    .map_into::<ResourceDescription>()
-            ),
-            hashset([ResourceDescription::Cidr(updated_resource),])
+            hashset(client_state.resources()),
+            hashset([cb::ResourceDescription::Cidr(
+                updated_resource.with_status(Status::Unknown)
+            )])
         );
         assert_eq!(
             hashset(client_state.routes()),
@@ -1656,6 +1647,8 @@ mod proptests {
         #[strategy(dns_resource())] resource: ResourceDescriptionDns,
         #[strategy(ip_network(8))] address: IpNetwork,
     ) {
+        use callbacks as cb;
+
         let mut client_state = ClientState::for_test();
         client_state.add_resources(&[ResourceDescription::Dns(resource.clone())]);
 
@@ -1670,13 +1663,10 @@ mod proptests {
         client_state.add_resources(&[ResourceDescription::Cidr(dns_as_cidr_resource.clone())]);
 
         assert_eq!(
-            hashset(
-                client_state
-                    .resources()
-                    .into_iter()
-                    .map_into::<ResourceDescription>()
-            ),
-            hashset([ResourceDescription::Cidr(dns_as_cidr_resource),])
+            hashset(client_state.resources()),
+            hashset([cb::ResourceDescription::Cidr(
+                dns_as_cidr_resource.with_status(Status::Unknown)
+            )])
         );
         assert_eq!(
             hashset(client_state.routes()),
@@ -1689,6 +1679,8 @@ mod proptests {
         #[strategy(dns_resource())] dns_resource: ResourceDescriptionDns,
         #[strategy(cidr_resource(8))] cidr_resource: ResourceDescriptionCidr,
     ) {
+        use callbacks as cb;
+
         let mut client_state = ClientState::for_test();
         client_state.add_resources(&[
             ResourceDescription::Dns(dns_resource.clone()),
@@ -1698,13 +1690,10 @@ mod proptests {
         client_state.remove_resources(&[dns_resource.id]);
 
         assert_eq!(
-            hashset(
-                client_state
-                    .resources()
-                    .into_iter()
-                    .map_into::<ResourceDescription>()
-            ),
-            hashset([ResourceDescription::Cidr(cidr_resource.clone())])
+            hashset(client_state.resources()),
+            hashset([cb::ResourceDescription::Cidr(
+                cidr_resource.clone().with_status(Status::Unknown)
+            )])
         );
         assert_eq!(
             hashset(client_state.routes()),
@@ -1724,6 +1713,8 @@ mod proptests {
         #[strategy(cidr_resource(8))] cidr_resource1: ResourceDescriptionCidr,
         #[strategy(cidr_resource(8))] cidr_resource2: ResourceDescriptionCidr,
     ) {
+        use callbacks as cb;
+
         let mut client_state = ClientState::for_test();
         client_state.add_resources(&[
             ResourceDescription::Dns(dns_resource1),
@@ -1736,15 +1727,10 @@ mod proptests {
         ]);
 
         assert_eq!(
-            hashset(
-                client_state
-                    .resources()
-                    .into_iter()
-                    .map_into::<ResourceDescription>()
-            ),
+            hashset(client_state.resources()),
             hashset([
-                ResourceDescription::Dns(dns_resource2),
-                ResourceDescription::Cidr(cidr_resource2.clone()),
+                cb::ResourceDescription::Dns(dns_resource2.with_status(Status::Unknown)),
+                cb::ResourceDescription::Cidr(cidr_resource2.clone().with_status(Status::Unknown)),
             ])
         );
         assert_eq!(


### PR DESCRIPTION
We have several representations of `ResourceDescription` within connlib. The ones within the `callbacks` module are meant for _presentation_ to the clients and thus contain additional information like the site status.

The `From` impls deleted within the PR are only used within tests. We can rewrite those tests by asserting on the presented data instead.

This is better because it means information about resources only flows in one direction: From connlib to the clients.