### PR TITLE
fix(connlib): prioritize dns resources to CIDR ones in case of an overlap

### DIFF
--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -157,6 +157,7 @@ pub fn ip_network(network: IpAddr, host_mask_bits: usize) -> impl Strategy<Value
         IpAddr::V4(_) => 32,
         IpAddr::V6(_) => 128,
     };
+
     assert!(host_mask_bits <= max_netmask);
 
     (0..host_mask_bits).prop_map(move |mask| {

--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -72,12 +72,6 @@ pub fn cidr_resource(
         })
 }
 
-pub fn overlapping_cidr_resource(
-    network: IpNetwork,
-) -> impl Strategy<Value = ResourceDescriptionCidr> {
-    cidr_resource(overlapping_network(network), sites())
-}
-
 pub fn cidr_v4_resource(host_mask_bits: usize) -> impl Strategy<Value = ResourceDescriptionCidr> {
     cidr_resource(
         any_ip4_network(host_mask_bits),
@@ -182,12 +176,6 @@ fn number_of_hosts_ipv6(mask: u8) -> u128 {
         .checked_pow(128 - mask as u32)
         .map(|i| i - 1)
         .unwrap_or(u128::MAX)
-}
-
-pub fn overlapping_network(network: IpNetwork) -> impl Strategy<Value = IpNetwork> {
-    (0..=network.netmask()).prop_map(move |netmask| {
-        IpNetwork::new_truncate(network.network_address(), netmask).unwrap()
-    })
 }
 
 // Note: for these tests we don't really care that it's a valid host

--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -72,6 +72,12 @@ pub fn cidr_resource(
         })
 }
 
+pub fn overlapping_cidr_resource(
+    network: IpNetwork,
+) -> impl Strategy<Value = ResourceDescriptionCidr> {
+    cidr_resource(overlapping_network(network), sites())
+}
+
 pub fn cidr_v4_resource(host_mask_bits: usize) -> impl Strategy<Value = ResourceDescriptionCidr> {
     cidr_resource(
         any_ip4_network(host_mask_bits),
@@ -157,7 +163,6 @@ pub fn ip_network(network: IpAddr, host_mask_bits: usize) -> impl Strategy<Value
         IpAddr::V4(_) => 32,
         IpAddr::V6(_) => 128,
     };
-
     assert!(host_mask_bits <= max_netmask);
 
     (0..host_mask_bits).prop_map(move |mask| {
@@ -177,6 +182,12 @@ fn number_of_hosts_ipv6(mask: u8) -> u128 {
         .checked_pow(128 - mask as u32)
         .map(|i| i - 1)
         .unwrap_or(u128::MAX)
+}
+
+pub fn overlapping_network(network: IpNetwork) -> impl Strategy<Value = IpNetwork> {
+    (0..=network.netmask()).prop_map(move |netmask| {
+        IpNetwork::new_truncate(network.network_address(), netmask as u8).unwrap()
+    })
 }
 
 // Note: for these tests we don't really care that it's a valid host

--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -190,19 +190,6 @@ pub fn overlapping_network(network: IpNetwork) -> impl Strategy<Value = IpNetwor
     })
 }
 
-fn number_of_hosts_ipv4(mask: u8) -> u32 {
-    2u32.checked_pow(32 - mask as u32)
-        .map(|i| i - 1)
-        .unwrap_or(u32::MAX)
-}
-
-fn number_of_hosts_ipv6(mask: u8) -> u128 {
-    2u128
-        .checked_pow(128 - mask as u32)
-        .map(|i| i - 1)
-        .unwrap_or(u128::MAX)
-}
-
 // Note: for these tests we don't really care that it's a valid host
 // we only need a host.
 // If we filter valid hosts it generates too many rejects

--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -186,7 +186,7 @@ fn number_of_hosts_ipv6(mask: u8) -> u128 {
 
 pub fn overlapping_network(network: IpNetwork) -> impl Strategy<Value = IpNetwork> {
     (0..=network.netmask()).prop_map(move |netmask| {
-        IpNetwork::new_truncate(network.network_address(), netmask as u8).unwrap()
+        IpNetwork::new_truncate(network.network_address(), netmask).unwrap()
     })
 }
 

--- a/rust/connlib/shared/src/proptest.rs
+++ b/rust/connlib/shared/src/proptest.rs
@@ -190,6 +190,19 @@ pub fn overlapping_network(network: IpNetwork) -> impl Strategy<Value = IpNetwor
     })
 }
 
+fn number_of_hosts_ipv4(mask: u8) -> u32 {
+    2u32.checked_pow(32 - mask as u32)
+        .map(|i| i - 1)
+        .unwrap_or(u32::MAX)
+}
+
+fn number_of_hosts_ipv6(mask: u8) -> u128 {
+    2u128
+        .checked_pow(128 - mask as u32)
+        .map(|i| i - 1)
+        .unwrap_or(u128::MAX)
+}
+
 // Note: for these tests we don't really care that it's a valid host
 // we only need a host.
 // If we filter valid hosts it generates too many rejects

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -745,14 +745,14 @@ impl ClientState {
     }
 
     fn get_resource_by_destination(&self, destination: IpAddr) -> Option<ResourceId> {
+        let maybe_dns_resource_id = self.stub_resolver.resolve_resource_by_ip(&destination);
+
         let maybe_cidr_resource_id = self
             .cidr_resources
             .longest_match(destination)
             .map(|(_, res)| res.id);
 
-        let maybe_dns_resource_id = self.stub_resolver.resolve_resource_by_ip(&destination);
-
-        maybe_cidr_resource_id.or(maybe_dns_resource_id)
+        maybe_dns_resource_id.or(maybe_cidr_resource_id)
     }
 
     #[must_use]

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -696,6 +696,10 @@ impl ClientState {
                 vacant.insert(AwaitingConnectionDetails {
                     gateways: gateways.clone(),
                     last_intent_sent_at: now,
+                    // Note: in case of an overlapping CIDR resource this should be None instead of Some if the resource_id
+                    // is for a CIDR resource.
+                    // But this should never happen as DNS resources are always preferred, so we don't encode the logic here.
+                    // Tests will prevent this from ever happening.
                     domain: self.stub_resolver.get_fqdn(destination).map(|(fqdn, ips)| {
                         ResolveRequest {
                             name: fqdn.clone(),

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -151,17 +151,6 @@ impl ReferenceStateMachine for ReferenceState {
                 )
                 .prop_map(|resource| Transition::AddCidrResource { resource }),
             )
-            .with(
-                1,
-                (
-                    cidr_resource_overlapping_dns_resources(),
-                    sample::select(state.all_gateways()),
-                )
-                    .prop_map(|(resource, gateway)| Transition::AddCidrResource {
-                        resource,
-                        gateway,
-                    }),
-            )
             .with(1, roam_client())
             .with(
                 1,

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -1,3 +1,5 @@
+use crate::client::{IPV4_RESOURCES, IPV6_RESOURCES};
+
 use super::{
     composite_strategy::CompositeStrategy, sim_client::*, sim_gateway::*, sim_net::*, sim_relay::*,
     strategies::*, stub_portal::StubPortal, transition::*,
@@ -9,6 +11,7 @@ use connlib_shared::{
     DomainName, StaticSecret,
 };
 use hickory_proto::rr::RecordType;
+use ip_network::IpNetwork;
 use prop::collection;
 use proptest::{prelude::*, sample};
 use proptest_state_machine::ReferenceStateMachine;
@@ -16,6 +19,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt, iter,
     net::IpAddr,
+    str::FromStr,
     time::Instant,
 };
 
@@ -148,6 +152,17 @@ impl ReferenceStateMachine for ReferenceState {
                 cidr_resource(
                     any_ip_network(8),
                     sample::select(state.portal.all_sites()).prop_map(|s| vec![s]),
+                )
+                .prop_filter(
+                    "tests doesn't support yet CIDR resources overlapping DNS resources",
+                    |r| {
+                        IpNetwork::from_str(IPV4_RESOURCES)
+                            .unwrap()
+                            .contains(r.address.network_address())
+                            || IpNetwork::from_str(IPV6_RESOURCES)
+                                .unwrap()
+                                .contains(r.address.network_address())
+                    },
                 )
                 .prop_map(|resource| Transition::AddCidrResource { resource }),
             )

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -151,17 +151,17 @@ impl ReferenceStateMachine for ReferenceState {
                 )
                 .prop_map(|resource| Transition::AddCidrResource { resource }),
             )
-            // .with(
-            //     1,
-            //     (
-            //         cidr_resource_overlapping_dns_resources(),
-            //         sample::select(state.all_gateways()),
-            //     )
-            //         .prop_map(|(resource, gateway)| Transition::AddCidrResource {
-            //             resource,
-            //             gateway,
-            //         }),
-            // )
+            .with(
+                1,
+                (
+                    cidr_resource_overlapping_dns_resources(),
+                    sample::select(state.all_gateways()),
+                )
+                    .prop_map(|(resource, gateway)| Transition::AddCidrResource {
+                        resource,
+                        gateway,
+                    }),
+            )
             .with(1, roam_client())
             .with(
                 1,

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -151,6 +151,17 @@ impl ReferenceStateMachine for ReferenceState {
                 )
                 .prop_map(|resource| Transition::AddCidrResource { resource }),
             )
+            // .with(
+            //     1,
+            //     (
+            //         cidr_resource_overlapping_dns_resources(),
+            //         sample::select(state.all_gateways()),
+            //     )
+            //         .prop_map(|(resource, gateway)| Transition::AddCidrResource {
+            //             resource,
+            //             gateway,
+            //         }),
+            // )
             .with(1, roam_client())
             .with(
                 1,

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -179,6 +179,7 @@ where
         )
 }
 
+// Adds a non-overlapping CIDR resource with the gateway
 pub(crate) fn add_cidr_resource(
     sites: impl Strategy<Value = Vec<Site>>,
 ) -> impl Strategy<Value = Transition> {
@@ -186,6 +187,7 @@ pub(crate) fn add_cidr_resource(
         .prop_filter(
             "tests doesn't support yet CIDR resources overlapping DNS resources",
             |r| {
+                // This works because CIDR resourc's host mask is always <8 while IP resource is 21
                 !IpNetwork::from_str(IPV4_RESOURCES)
                     .unwrap()
                     .contains(r.address.network_address())

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -186,10 +186,10 @@ pub(crate) fn add_cidr_resource(
         .prop_filter(
             "tests doesn't support yet CIDR resources overlapping DNS resources",
             |r| {
-                IpNetwork::from_str(IPV4_RESOURCES)
+                !IpNetwork::from_str(IPV4_RESOURCES)
                     .unwrap()
                     .contains(r.address.network_address())
-                    || IpNetwork::from_str(IPV6_RESOURCES)
+                    && !IpNetwork::from_str(IPV6_RESOURCES)
                         .unwrap()
                         .contains(r.address.network_address())
             },

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -1,5 +1,3 @@
-use crate::client::{IPV4_RESOURCES, IPV6_RESOURCES};
-
 use super::{
     sim_net::{any_ip_stack, any_port},
     strategies::*,

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -229,11 +229,3 @@ pub(crate) fn roam_client() -> impl Strategy<Value = Transition> {
         port,
     })
 }
-
-pub(crate) fn cidr_resource_overlapping_dns_resources(
-) -> impl Strategy<Value = ResourceDescriptionCidr> {
-    prop_oneof![
-        overlapping_cidr_resource(IPV4_RESOURCES.parse().unwrap()),
-        overlapping_cidr_resource(IPV6_RESOURCES.parse().unwrap()),
-    ]
-}

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -1,3 +1,5 @@
+use crate::client::{IPV4_RESOURCES, IPV6_RESOURCES};
+
 use super::{
     sim_net::{any_ip_stack, any_port},
     strategies::*,
@@ -226,4 +228,12 @@ pub(crate) fn roam_client() -> impl Strategy<Value = Transition> {
         ip6: ip_stack.as_v6().copied(),
         port,
     })
+}
+
+pub(crate) fn cidr_resource_overlapping_dns_resources(
+) -> impl Strategy<Value = ResourceDescriptionCidr> {
+    prop_oneof![
+        overlapping_cidr_resource(IPV4_RESOURCES.parse().unwrap()),
+        overlapping_cidr_resource(IPV6_RESOURCES.parse().unwrap()),
+    ]
 }

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -1,3 +1,5 @@
+use crate::client::{IPV4_RESOURCES, IPV6_RESOURCES};
+
 use super::{
     sim_net::{any_ip_stack, any_port},
     strategies::*,
@@ -11,10 +13,12 @@ use connlib_shared::{
     DomainName,
 };
 use hickory_proto::rr::RecordType;
+use ip_network::IpNetwork;
 use proptest::{prelude::*, sample};
 use std::{
     collections::{HashMap, HashSet},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    str::FromStr,
 };
 
 /// The possible transitions of the state machine.
@@ -173,6 +177,24 @@ where
                 dns_server,
             },
         )
+}
+
+pub(crate) fn add_cidr_resource(
+    sites: impl Strategy<Value = Vec<Site>>,
+) -> impl Strategy<Value = Transition> {
+    cidr_resource(any_ip_network(8), sites)
+        .prop_filter(
+            "tests doesn't support yet CIDR resources overlapping DNS resources",
+            |r| {
+                IpNetwork::from_str(IPV4_RESOURCES)
+                    .unwrap()
+                    .contains(r.address.network_address())
+                    || IpNetwork::from_str(IPV6_RESOURCES)
+                        .unwrap()
+                        .contains(r.address.network_address())
+            },
+        )
+        .prop_map(|resource| Transition::AddCidrResource { resource })
 }
 
 pub(crate) fn non_wildcard_dns_resource(


### PR DESCRIPTION
For full route this happens always and if we don't prioritize DNS resources any packet for DNS IPs will get routed to the full route gateway which might not have the correct resource.

TODO: this still needs unit tests
TODO: Waiting on #5891