### PR TITLE
refactor(connlib): remove `CidrV4` and `CidrV6` types from callbacks

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -4,9 +4,10 @@
 // ecosystem, so it's used here for consistency.
 
 use connlib_client_shared::{
-    callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, ConnectArgs,
-    Error, LoginUrl, LoginUrlError, Session, Sockets,
+    callbacks::ResourceDescription, file_logger, keypair, Callbacks, ConnectArgs, Error, LoginUrl,
+    LoginUrlError, Session, Sockets, V4RouteList, V6RouteList,
 };
+use ip_network::{Ipv4Network, Ipv6Network};
 use jni::{
     objects::{GlobalRef, JClass, JObject, JString, JValue},
     strings::JNIString,
@@ -191,18 +192,18 @@ impl Callbacks for CallbackHandler {
 
     fn on_update_routes(
         &self,
-        route_list_4: Vec<Cidrv4>,
-        route_list_6: Vec<Cidrv6>,
+        route_list_4: Vec<Ipv4Network>,
+        route_list_6: Vec<Ipv6Network>,
     ) -> Option<RawFd> {
         self.env(|mut env| {
             let route_list_4 = env
-                .new_string(serde_json::to_string(&route_list_4)?)
+                .new_string(serde_json::to_string(&V4RouteList::new(route_list_4))?)
                 .map_err(|source| CallbackError::NewStringFailed {
                     name: "route_list_4",
                     source,
                 })?;
             let route_list_6 = env
-                .new_string(serde_json::to_string(&route_list_6)?)
+                .new_string(serde_json::to_string(&V6RouteList::new(route_list_6))?)
                 .map_err(|source| CallbackError::NewStringFailed {
                     name: "route_list_6",
                     source,

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -4,9 +4,10 @@
 mod make_writer;
 
 use connlib_client_shared::{
-    callbacks::ResourceDescription, file_logger, keypair, Callbacks, Cidrv4, Cidrv6, ConnectArgs,
-    Error, LoginUrl, Session, Sockets,
+    callbacks::ResourceDescription, file_logger, keypair, Callbacks, ConnectArgs, Error, LoginUrl,
+    Session, Sockets, V4RouteList, V6RouteList,
 };
+use ip_network::{Ipv4Network, Ipv6Network};
 use secrecy::SecretString;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
@@ -122,12 +123,12 @@ impl Callbacks for CallbackHandler {
 
     fn on_update_routes(
         &self,
-        route_list_4: Vec<Cidrv4>,
-        route_list_6: Vec<Cidrv6>,
+        route_list_4: Vec<Ipv4Network>,
+        route_list_6: Vec<Ipv6Network>,
     ) -> Option<RawFd> {
         self.inner.on_update_routes(
-            serde_json::to_string(&route_list_4).unwrap(),
-            serde_json::to_string(&route_list_6).unwrap(),
+            serde_json::to_string(&V4RouteList::new(route_list_4)).unwrap(),
+            serde_json::to_string(&V6RouteList::new(route_list_6)).unwrap(),
         );
 
         None

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -26,7 +26,6 @@ bimap = "0.6"
 ip_network = { version = "0.4", default-features = false }
 phoenix-channel = { workspace = true }
 
-
 [target.'cfg(target_os = "android")'.dependencies]
 tracing = { workspace = true, features = ["std", "attributes"] }
 

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -1,8 +1,10 @@
 //! Main connlib library for clients.
+pub use crate::serde_routelist::{V4RouteList, V6RouteList};
 pub use connlib_shared::messages::client::ResourceDescription;
 pub use connlib_shared::{
-    callbacks, keypair, Callbacks, Cidrv4, Cidrv6, Error, LoginUrl, LoginUrlError, StaticSecret,
+    callbacks, keypair, Callbacks, Error, LoginUrl, LoginUrlError, StaticSecret,
 };
+pub use eventloop::Eventloop;
 pub use firezone_tunnel::Sockets;
 pub use tracing_appender::non_blocking::WorkerGuard;
 
@@ -18,11 +20,11 @@ use tokio::sync::mpsc::UnboundedReceiver;
 mod eventloop;
 pub mod file_logger;
 mod messages;
+mod serde_routelist;
 
 const PHOENIX_TOPIC: &str = "client";
 
 use eventloop::Command;
-pub use eventloop::Eventloop;
 use secrecy::Secret;
 use tokio::task::JoinHandle;
 

--- a/rust/connlib/clients/shared/src/serde_routelist.rs
+++ b/rust/connlib/clients/shared/src/serde_routelist.rs
@@ -1,0 +1,46 @@
+use ip_network::{Ipv4Network, Ipv6Network};
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+#[derive(serde::Serialize, Clone, Copy, Debug)]
+struct Cidr<T> {
+    address: T,
+    prefix: u8,
+}
+
+/// Custom adaptor for a different serialisation format for the Apple and Android clients.
+#[derive(serde::Serialize)]
+#[serde(transparent)]
+pub struct V4RouteList(Vec<Cidr<Ipv4Addr>>);
+
+impl V4RouteList {
+    pub fn new(route: Vec<Ipv4Network>) -> Self {
+        Self(
+            route
+                .into_iter()
+                .map(|n| Cidr {
+                    address: n.network_address(),
+                    prefix: n.netmask(),
+                })
+                .collect(),
+        )
+    }
+}
+
+/// Custom adaptor for a different serialisation format for the Apple and Android clients.
+#[derive(serde::Serialize)]
+#[serde(transparent)]
+pub struct V6RouteList(Vec<Cidr<Ipv6Addr>>);
+
+impl V6RouteList {
+    pub fn new(route: Vec<Ipv6Network>) -> Self {
+        Self(
+            route
+                .into_iter()
+                .map(|n| Cidr {
+                    address: n.network_address(),
+                    prefix: n.netmask(),
+                })
+                .collect(),
+        )
+    }
+}

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -10,54 +10,6 @@ use crate::messages::ResourceId;
 // Avoids having to map types for Windows
 type RawFd = i32;
 
-#[derive(Serialize, Clone, Copy, Debug)]
-/// Identical to `ip_network::Ipv4Network` except we implement `Serialize` on the Rust side and the equivalent of `Deserialize` on the Swift / Kotlin side to avoid manually serializing and deserializing.
-pub struct Cidrv4 {
-    address: Ipv4Addr,
-    prefix: u8,
-}
-
-/// Identical to `ip_network::Ipv6Network` except we implement `Serialize` on the Rust side and the equivalent of `Deserialize` on the Swift / Kotlin side to avoid manually serializing and deserializing.
-#[derive(Serialize, Clone, Copy, Debug)]
-pub struct Cidrv6 {
-    address: Ipv6Addr,
-    prefix: u8,
-}
-
-impl From<Ipv4Network> for Cidrv4 {
-    fn from(value: Ipv4Network) -> Self {
-        Self {
-            address: value.network_address(),
-            prefix: value.netmask(),
-        }
-    }
-}
-
-impl From<Ipv6Network> for Cidrv6 {
-    fn from(value: Ipv6Network) -> Self {
-        Self {
-            address: value.network_address(),
-            prefix: value.netmask(),
-        }
-    }
-}
-
-impl From<Cidrv4> for IpNetwork {
-    fn from(x: Cidrv4) -> Self {
-        Ipv4Network::new(x.address, x.prefix)
-            .expect("A Cidrv4 should always translate to a valid Ipv4Network")
-            .into()
-    }
-}
-
-impl From<Cidrv6> for IpNetwork {
-    fn from(x: Cidrv6) -> Self {
-        Ipv6Network::new(x.address, x.prefix)
-            .expect("A Cidrv6 should always translate to a valid Ipv6Network")
-            .into()
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Status {
     Unknown,
@@ -200,7 +152,7 @@ pub trait Callbacks: Clone + Send + Sync {
     }
 
     /// Called when the route list changes.
-    fn on_update_routes(&self, _: Vec<Cidrv4>, _: Vec<Cidrv6>) -> Option<RawFd> {
+    fn on_update_routes(&self, _: Vec<Ipv4Network>, _: Vec<Ipv6Network>) -> Option<RawFd> {
         None
     }
 

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -16,7 +16,7 @@ pub mod proptest;
 
 pub use boringtun::x25519::PublicKey;
 pub use boringtun::x25519::StaticSecret;
-pub use callbacks::{Callbacks, Cidrv4, Cidrv6};
+pub use callbacks::Callbacks;
 pub use error::ConnlibError as Error;
 pub use error::Result;
 pub use phoenix_channel::{LoginUrl, LoginUrlError};

--- a/rust/connlib/shared/src/tun_device_manager/linux.rs
+++ b/rust/connlib/shared/src/tun_device_manager/linux.rs
@@ -1,9 +1,6 @@
 //! Virtual network interface
 
-use crate::{
-    callbacks::{Cidrv4, Cidrv6},
-    DEFAULT_MTU,
-};
+use crate::DEFAULT_MTU;
 use anyhow::{anyhow, Context as _, Result};
 use futures::TryStreamExt;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
@@ -132,7 +129,11 @@ impl TunDeviceManager {
         Ok(())
     }
 
-    pub async fn set_routes(&mut self, ipv4: Vec<Cidrv4>, ipv6: Vec<Cidrv6>) -> Result<()> {
+    pub async fn set_routes(
+        &mut self,
+        ipv4: Vec<Ipv4Network>,
+        ipv6: Vec<Ipv6Network>,
+    ) -> Result<()> {
         let new_routes: HashSet<IpNetwork> = ipv4
             .into_iter()
             .map(IpNetwork::from)

--- a/rust/connlib/shared/src/tun_device_manager/windows.rs
+++ b/rust/connlib/shared/src/tun_device_manager/windows.rs
@@ -1,5 +1,5 @@
+use crate::windows::{CREATE_NO_WINDOW, TUNNEL_NAME};
 use anyhow::Result;
-use connlib_shared::windows::{CREATE_NO_WINDOW, TUNNEL_NAME};
 use ip_network::{Ipv4Network, Ipv6Network};
 use std::{
     net::{Ipv4Addr, Ipv6Addr},

--- a/rust/connlib/shared/src/tun_device_manager/windows.rs
+++ b/rust/connlib/shared/src/tun_device_manager/windows.rs
@@ -1,5 +1,6 @@
-use crate::windows::{CREATE_NO_WINDOW, TUNNEL_NAME};
 use anyhow::Result;
+use connlib_shared::windows::{CREATE_NO_WINDOW, TUNNEL_NAME};
+use ip_network::{Ipv4Network, Ipv6Network};
 use std::{
     net::{Ipv4Addr, Ipv6Addr},
     os::windows::process::CommandExt,

--- a/rust/connlib/shared/src/tun_device_manager/windows.rs
+++ b/rust/connlib/shared/src/tun_device_manager/windows.rs
@@ -1,7 +1,4 @@
-use crate::{
-    windows::{CREATE_NO_WINDOW, TUNNEL_NAME},
-    Cidrv4, Cidrv6,
-};
+use crate::windows::{CREATE_NO_WINDOW, TUNNEL_NAME};
 use anyhow::Result;
 use std::{
     net::{Ipv4Addr, Ipv6Addr},
@@ -53,7 +50,7 @@ impl TunDeviceManager {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    pub async fn set_routes(&mut self, _: Vec<Cidrv4>, _: Vec<Cidrv6>) -> Result<()> {
+    pub async fn set_routes(&mut self, _: Vec<Ipv4Network>, _: Vec<Ipv6Network>) -> Result<()> {
         // TODO: Windows still does route updates in `tun_windows.rs`. I can move it up
         // here, but since the Client and Gateway don't know the index of the WinTun
         // interface, I'd have to use the Windows API

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -23,8 +23,7 @@ use tun_android as tun;
 mod utils;
 
 use connlib_shared::{error::ConnlibError, messages::Interface, Callbacks, Error};
-use connlib_shared::{Cidrv4, Cidrv6};
-use ip_network::IpNetwork;
+use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_packet::{IpPacket, MutableIpPacket, Packet as _};
 use std::collections::HashSet;
 use std::io;
@@ -38,18 +37,18 @@ pub struct Device {
 }
 
 #[allow(dead_code)]
-fn ipv4(ip: IpNetwork) -> Option<Cidrv4> {
+fn ipv4(ip: IpNetwork) -> Option<Ipv4Network> {
     match ip {
-        IpNetwork::V4(v4) => Some(v4.into()),
+        IpNetwork::V4(v4) => Some(v4),
         IpNetwork::V6(_) => None,
     }
 }
 
 #[allow(dead_code)]
-fn ipv6(ip: IpNetwork) -> Option<Cidrv6> {
+fn ipv6(ip: IpNetwork) -> Option<Ipv6Network> {
     match ip {
         IpNetwork::V4(_) => None,
-        IpNetwork::V6(v6) => Some(v6.into()),
+        IpNetwork::V6(v6) => Some(v6),
     }
 }
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -4,7 +4,7 @@ use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use connlib_shared::messages::Interface;
 use connlib_shared::tun_device_manager::TunDeviceManager;
-use connlib_shared::{get_user_agent, keypair, Callbacks, Cidrv4, Cidrv6, LoginUrl, StaticSecret};
+use connlib_shared::{get_user_agent, keypair, Callbacks, LoginUrl, StaticSecret};
 use firezone_cli_utils::{setup_global_subscriber, CommonArgs};
 use firezone_tunnel::{GatewayTunnel, Sockets};
 use futures::channel::mpsc;
@@ -139,8 +139,8 @@ async fn update_device_task(
 
         if let Err(e) = tun_device
             .set_routes(
-                vec![Cidrv4::from(PEERS_IPV4.parse::<Ipv4Network>().unwrap())],
-                vec![Cidrv6::from(PEERS_IPV6.parse::<Ipv6Network>().unwrap())],
+                vec![PEERS_IPV4.parse::<Ipv4Network>().unwrap()],
+                vec![PEERS_IPV6.parse::<Ipv6Network>().unwrap()],
             )
             .await
         {

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -10,7 +10,7 @@
 
 use anyhow::{Context as _, Result};
 use connlib_client_shared::{Callbacks, Error as ConnlibError};
-use connlib_shared::{callbacks, Cidrv4, Cidrv6};
+use connlib_shared::callbacks;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     path::PathBuf,
@@ -43,6 +43,7 @@ pub use ipc_service::{ipc, run_only_ipc_service, ClientMsg as IpcClientMsg};
 pub use standalone::run_only_headless_client;
 
 use dns_control::DnsController;
+use ip_network::{Ipv4Network, Ipv6Network};
 
 /// Only used on Linux
 pub const FIREZONE_GROUP: &str = "firezone-client";
@@ -84,8 +85,8 @@ enum InternalServerMsg {
         dns: Vec<IpAddr>,
     },
     OnUpdateRoutes {
-        ipv4: Vec<Cidrv4>,
-        ipv6: Vec<Cidrv6>,
+        ipv4: Vec<Ipv4Network>,
+        ipv6: Vec<Ipv6Network>,
     },
 }
 
@@ -143,7 +144,7 @@ impl Callbacks for CallbackHandler {
             .expect("Should be able to send OnUpdateResources");
     }
 
-    fn on_update_routes(&self, ipv4: Vec<Cidrv4>, ipv6: Vec<Cidrv6>) -> Option<i32> {
+    fn on_update_routes(&self, ipv4: Vec<Ipv4Network>, ipv6: Vec<Ipv6Network>) -> Option<i32> {
         self.cb_tx
             .try_send(InternalServerMsg::OnUpdateRoutes { ipv4, ipv6 })
             .expect("Should be able to send messages");


### PR DESCRIPTION
These are only necessary for the Android and Apple client. Other clients should not need to bother with these custom types.

Required-for: #5843.