### PR TITLE
fix(portal): Restrict creating Resources with addresses in our reserved ranges

### DIFF
--- a/elixir/apps/domain/lib/domain/network.ex
+++ b/elixir/apps/domain/lib/domain/network.ex
@@ -2,7 +2,7 @@ defmodule Domain.Network do
   alias Domain.Repo
   alias Domain.Network.Address
 
-  # Encompasses all CIDR and DNS Resource addresses
+  # Encompasses all of CGNAT and our reserved IPv6 unique local prefix
   @reserved_cidrs %{
     ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 10},
     ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 48}

--- a/elixir/apps/domain/lib/domain/network.ex
+++ b/elixir/apps/domain/lib/domain/network.ex
@@ -4,8 +4,8 @@ defmodule Domain.Network do
 
   @cidrs %{
     # Notice: those are also part of "resources_account_id_cidr_address_index" DB constraint
-    ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 11},
-    ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 107}
+    ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 10},
+    ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 80}
   }
 
   def cidrs, do: @cidrs

--- a/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
@@ -130,7 +130,7 @@ defmodule Domain.Resources.Resource.Changeset do
         changeset
 
       true ->
-        Network.cidrs()
+        Network.reserved_cidrs()
         |> Enum.reduce(changeset, fn {_type, cidr}, changeset ->
           validate_not_in_cidr(changeset, :address, cidr)
         end)

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -938,11 +938,19 @@ defmodule Domain.ResourcesTest do
 
       attrs = %{"address" => "100.64.0.0/8", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)
-      assert "cannot be in the CIDR 100.64.0.0/11" in errors_on(changeset).address
+      assert "cannot be in the CIDR 100.64.0.0/10" in errors_on(changeset).address
+
+      attrs = %{"address" => "100.96.0.0/11", "type" => "cidr"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      assert "cannot be in the CIDR 100.64.0.0/10" in errors_on(changeset).address
 
       attrs = %{"address" => "fd00:2021:1111::/102", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)
-      assert "cannot be in the CIDR fd00:2021:1111::/107" in errors_on(changeset).address
+      assert "cannot be in the CIDR fd00:2021:1111::/80" in errors_on(changeset).address
+
+      attrs = %{"address" => "fd00:2021:1111:8000:/96", "type" => "cidr"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      assert "cannot be in the CIDR fd00:2021:1111::/80" in errors_on(changeset).address
 
       attrs = %{"address" => "::/0", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -946,11 +946,11 @@ defmodule Domain.ResourcesTest do
 
       attrs = %{"address" => "fd00:2021:1111::/102", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)
-      assert "cannot be in the CIDR fd00:2021:1111::/80" in errors_on(changeset).address
+      assert "cannot be in the CIDR fd00:2021:1111::/48" in errors_on(changeset).address
 
-      attrs = %{"address" => "fd00:2021:1111:8000:/96", "type" => "cidr"}
+      attrs = %{"address" => "fd00:2021:1111:8000::/96", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)
-      assert "cannot be in the CIDR fd00:2021:1111::/80" in errors_on(changeset).address
+      assert "cannot be in the CIDR fd00:2021:1111::/48" in errors_on(changeset).address
 
       attrs = %{"address" => "::/0", "type" => "cidr"}
       assert {:error, changeset} = create_resource(attrs, subject)


### PR DESCRIPTION
In the Clients, we need to prioritize DNS Resource traffic before CIDR traffic in order to ensure DNS resources take priority over full-route ones.

Because of this, any CIDR Resources defined within our reserved DNS range will never be routable. This PR updates the portal validations to reflect that.

refs #5840 
refs #2667 
