### PR TITLE
fix(connlib): use 120 prefix for macos address

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -38,6 +38,8 @@ class NetworkSettings {
 
     // Set tunnel addresses and routes
     let ipv4Settings = NEIPv4Settings(addresses: [tunnelAddressIPv4!], subnetMasks: ["255.255.255.255"])
+    // This is a hack since macos routing table ignores, for full route, any prefix smaller than 120.
+    // Without this, adding a full route, remove the previous default route and leaves the system with none, breaking completely IPv6 on the user's system.
     let ipv6Settings = NEIPv6Settings(addresses: [tunnelAddressIPv6!], networkPrefixLengths: [120])
     let dnsSettings = NEDNSSettings(servers: dnsAddresses)
     ipv4Settings.includedRoutes = routes4

--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -38,7 +38,7 @@ class NetworkSettings {
 
     // Set tunnel addresses and routes
     let ipv4Settings = NEIPv4Settings(addresses: [tunnelAddressIPv4!], subnetMasks: ["255.255.255.255"])
-    let ipv6Settings = NEIPv6Settings(addresses: [tunnelAddressIPv6!], networkPrefixLengths: [128])
+    let ipv6Settings = NEIPv6Settings(addresses: [tunnelAddressIPv6!], networkPrefixLengths: [120])
     let dnsSettings = NEDNSSettings(servers: dnsAddresses)
     ipv4Settings.includedRoutes = routes4
     ipv6Settings.includedRoutes = routes6


### PR DESCRIPTION
Otherwise with full route when we try to create the default route for ipv6 it just removes the previous default route and never adds ours, completely breaking ipv6 [this seems to be the reason](https://github.com/WireGuard/wireguard-apple/blob/2fec12a6e1f6e3460b6ee483aa00ad29cddadab1/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift#L137-L141)  