### PR TITLE
ci(kotlin): don't be verbose in building Rust

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -232,7 +232,6 @@ cargo {
     // Needed for Ubuntu 22.04
     pythonCommand = "python3"
     prebuiltToolchains = true
-    verbose = true
     module = "../../../rust/connlib/clients/android"
     libname = "connlib"
     targets =


### PR DESCRIPTION
Additional verbosity doesn't give us a lot more useful information but spams the log a lot. We don't compile with `cargo --verbose` anywhere else either.