### PR TITLE
docs(docker-compose) Duplicated sysctls `src_valid_mark`

### DIFF
--- a/website/src/app/kb/automate/docker-compose/readme.mdx
+++ b/website/src/app/kb/automate/docker-compose/readme.mdx
@@ -50,7 +50,6 @@ services:
       # Enable IP forwarding
       - net.ipv4.ip_forward=1
       - net.ipv4.conf.all.src_valid_mark=1
-      - net.ipv4.conf.all.src_valid_mark=1
       - net.ipv6.conf.all.disable_ipv6=0
       - net.ipv6.conf.all.forwarding=1
       - net.ipv6.conf.default.forwarding=1


### PR DESCRIPTION
One of the lines at sysctls section in docker-compose.yml example file is duplicated:

- net.ipv4.conf.all.src_valid_mark=1

So I deleted it to make it clearer.