### PR TITLE
test(connlib): remove `Tick` transition

### DIFF
--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -16,7 +16,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt, iter,
     net::IpAddr,
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 /// The reference state machine of the tunnel.
@@ -120,10 +120,6 @@ impl ReferenceStateMachine for ReferenceState {
     /// Here, we should only generate [`Transition`]s that make sense for the current state.
     fn transitions(state: &Self::State) -> BoxedStrategy<Self::Transition> {
         CompositeStrategy::default()
-            .with(
-                1,
-                (0..=1000u64).prop_map(|millis| Transition::Tick { millis }),
-            )
             .with(
                 1,
                 system_dns_servers()
@@ -336,7 +332,6 @@ impl ReferenceStateMachine for ReferenceState {
             } => state.client.exec_mut(|client| {
                 client.on_icmp_packet_to_dns(*src, dst.clone(), *seq, *identifier)
             }),
-            Transition::Tick { millis } => state.now += Duration::from_millis(*millis),
             Transition::UpdateSystemDnsServers { servers } => {
                 state
                     .client
@@ -453,7 +448,6 @@ impl ReferenceStateMachine for ReferenceState {
 
                 true
             }
-            Transition::Tick { .. } => true,
             Transition::SendICMPPacketToNonResourceIp {
                 dst,
                 seq,

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -34,7 +34,7 @@ use std::{
     net::IpAddr,
     str::FromStr as _,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Instant,
 };
 use tracing::debug_span;
 use tracing::subscriber::DefaultGuard;
@@ -239,9 +239,6 @@ impl StateMachineTest for TunnelTest {
                 });
 
                 buffered_transmits.push(transmit, &state.client);
-            }
-            Transition::Tick { millis } => {
-                state.now += Duration::from_millis(millis);
             }
             Transition::UpdateSystemDnsServers { servers } => {
                 state

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -74,9 +74,6 @@ pub(crate) enum Transition {
     /// The upstream DNS servers changed.
     UpdateUpstreamDnsServers { servers: Vec<DnsServer> },
 
-    /// Advance time by this many milliseconds.
-    Tick { millis: u64 },
-
     /// Remove a resource from the client.
     RemoveResource(ResourceId),
 


### PR DESCRIPTION
When the property-based state machine test was first created, I envisioned that we could also easily test advancing time. Unfortunately, the tricky part of advancing time is to correctly encode the _expected_ behaviour as it requires knowledge of all timeouts etc.

Thus, the `Tick` transition has been left lingering and doesn't actually test much. It is obviously still sampled by the test runner and thus "wastes" test cases that don't end up exercising anything meaningful because the time advancements are < 1000ms.

There are plans to more roughly test time-related things by implementing delays between applying `Transmit`s. Until then, we can remove the `Tick` transition.