### PR TITLE
fix(portal): redirect back to resources / sites after edit

### DIFF
--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -115,7 +115,7 @@ defmodule Web.Resources.Edit do
 
     case Resources.update_resource(socket.assigns.resource, attrs, socket.assigns.subject) do
       {:ok, resource} ->
-        socket = put_flash(socket, :info, "Resource #{resource.name} updated successfully")
+        socket = put_flash(socket, :info, "Resource #{resource.name} updated successfully.")
 
         if site_id = socket.assigns.params["site_id"] do
           {:noreply,
@@ -123,8 +123,7 @@ defmodule Web.Resources.Edit do
              to: ~p"/#{socket.assigns.account}/sites/#{site_id}"
            )}
         else
-          {:noreply,
-           push_navigate(socket, to: ~p"/#{socket.assigns.account}/resources")}
+          {:noreply, push_navigate(socket, to: ~p"/#{socket.assigns.account}/resources")}
         end
 
       {:error, changeset} ->

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -115,14 +115,16 @@ defmodule Web.Resources.Edit do
 
     case Resources.update_resource(socket.assigns.resource, attrs, socket.assigns.subject) do
       {:ok, resource} ->
+        socket = put_flash(socket, :info, "Resource #{resource.name} updated successfully")
+
         if site_id = socket.assigns.params["site_id"] do
           {:noreply,
            push_navigate(socket,
-             to: ~p"/#{socket.assigns.account}/resources/#{resource.id}?site_id=#{site_id}"
+             to: ~p"/#{socket.assigns.account}/sites/#{site_id}"
            )}
         else
           {:noreply,
-           push_navigate(socket, to: ~p"/#{socket.assigns.account}/resources/#{resource.id}")}
+           push_navigate(socket, to: ~p"/#{socket.assigns.account}/resources")}
         end
 
       {:error, changeset} ->

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -117,7 +117,9 @@ defmodule Web.Resources.Edit do
       {:ok, resource} ->
         if site_id = socket.assigns.params["site_id"] do
           {:noreply,
-           push_navigate(socket, to: ~p"/#{socket.assigns.account}/sites/#{site_id}?#resources")}
+           push_navigate(socket,
+             to: ~p"/#{socket.assigns.account}/resources/#{resource.id}?site_id=#{site_id}"
+           )}
         else
           {:noreply,
            push_navigate(socket, to: ~p"/#{socket.assigns.account}/resources/#{resource.id}")}

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -189,10 +189,17 @@ defmodule Web.Resources.New do
 
     case Resources.create_resource(attrs, socket.assigns.subject) do
       {:ok, resource} ->
-        {:noreply,
-         push_navigate(socket,
-           to: ~p"/#{socket.assigns.account}/resources/#{resource}?#{socket.assigns.params}"
-         )}
+        socket = put_flash(socket, :info, "Resource #{resource.name} created successfully.")
+
+        if site_id = socket.assigns.params["site_id"] do
+          {:noreply,
+           socket
+           |> push_navigate(to: ~p"/#{socket.assigns.account}/sites/#{site_id}")}
+        else
+          {:noreply,
+           socket
+           |> push_navigate(to: ~p"/#{socket.assigns.account}/resources")}
+        end
 
       {:error, changeset} ->
         changeset = Map.put(changeset, :action, :validate)

--- a/elixir/apps/web/test/web/live/resources/edit_test.exs
+++ b/elixir/apps/web/test/web/live/resources/edit_test.exs
@@ -324,7 +324,7 @@ defmodule Web.Live.Resources.EditTest do
            |> form("form", resource: attrs)
            |> render_submit() ==
              {:error,
-              {:live_redirect, %{to: ~p"/#{account}/sites/#{group}?#resources", kind: :push}}}
+              {:live_redirect, %{to: ~p"/#{account}/resources/#{resource.id}?site_id=#{group}", kind: :push}}}
 
     assert saved_resource = Repo.get_by(Domain.Resources.Resource, id: resource.id)
     assert saved_resource.name == attrs.name

--- a/elixir/apps/web/test/web/live/resources/edit_test.exs
+++ b/elixir/apps/web/test/web/live/resources/edit_test.exs
@@ -266,7 +266,8 @@ defmodule Web.Live.Resources.EditTest do
            |> form("form", resource: attrs)
            |> render_submit() ==
              {:error,
-              {:live_redirect, %{to: ~p"/#{account}/sites/#{group}?#resources", kind: :push}}}
+              {:live_redirect,
+               %{to: ~p"/#{account}/resources/#{resource.id}?site_id=#{group}", kind: :push}}}
   end
 
   test "shows disabled traffic filter form when traffic filters disabled", %{

--- a/elixir/apps/web/test/web/live/resources/edit_test.exs
+++ b/elixir/apps/web/test/web/live/resources/edit_test.exs
@@ -209,6 +209,8 @@ defmodule Web.Live.Resources.EditTest do
     resource: resource,
     conn: conn
   } do
+    conn = authorize_conn(conn, identity)
+
     attrs = %{
       name: "foobar.com",
       filters: %{
@@ -220,16 +222,17 @@ defmodule Web.Live.Resources.EditTest do
 
     {:ok, lv, _html} =
       conn
-      |> authorize_conn(identity)
       |> live(~p"/#{account}/resources/#{resource}/edit")
 
-    assert lv
-           |> form("form", resource: attrs)
-           |> render_submit() ==
-             {:error, {:live_redirect, %{to: ~p"/#{account}/resources/#{resource}", kind: :push}}}
+    {:ok, _lv, html} =
+      lv
+      |> form("form", resource: attrs)
+      |> render_submit()
+      |> follow_redirect(conn, ~p"/#{account}/resources")
 
     assert saved_resource = Repo.get_by(Domain.Resources.Resource, id: resource.id)
     assert saved_resource.name == attrs.name
+    assert html =~ "Resource #{saved_resource.name} updated successfully."
 
     saved_filters =
       for filter <- saved_resource.filters, into: %{} do
@@ -248,6 +251,8 @@ defmodule Web.Live.Resources.EditTest do
     resource: resource,
     conn: conn
   } do
+    conn = authorize_conn(conn, identity)
+
     attrs = %{
       name: "foobar.com",
       filters: %{
@@ -259,15 +264,15 @@ defmodule Web.Live.Resources.EditTest do
 
     {:ok, lv, _html} =
       conn
-      |> authorize_conn(identity)
       |> live(~p"/#{account}/resources/#{resource}/edit?site_id=#{group}")
 
-    assert lv
-           |> form("form", resource: attrs)
-           |> render_submit() ==
-             {:error,
-              {:live_redirect,
-               %{to: ~p"/#{account}/resources/#{resource.id}?site_id=#{group}", kind: :push}}}
+    {:ok, _lv, html} =
+      lv
+      |> form("form", resource: attrs)
+      |> render_submit()
+      |> follow_redirect(conn, ~p"/#{account}/sites/#{group}")
+
+    assert html =~ "Resource #{attrs.name} updated successfully."
   end
 
   test "shows disabled traffic filter form when traffic filters disabled", %{
@@ -311,24 +316,25 @@ defmodule Web.Live.Resources.EditTest do
   } do
     Domain.Config.feature_flag_override(:traffic_filters, false)
 
+    conn = authorize_conn(conn, identity)
+
     attrs = %{
       name: "foobar.com"
     }
 
     {:ok, lv, _html} =
       conn
-      |> authorize_conn(identity)
       |> live(~p"/#{account}/resources/#{resource}/edit?site_id=#{group}")
 
-    assert lv
-           |> form("form", resource: attrs)
-           |> render_submit() ==
-             {:error,
-              {:live_redirect,
-               %{to: ~p"/#{account}/resources/#{resource.id}?site_id=#{group}", kind: :push}}}
+    {:ok, _lv, html} =
+      lv
+      |> form("form", resource: attrs)
+      |> render_submit()
+      |> follow_redirect(conn, ~p"/#{account}/sites/#{group}")
 
     assert saved_resource = Repo.get_by(Domain.Resources.Resource, id: resource.id)
     assert saved_resource.name == attrs.name
+    assert html =~ "Resource #{saved_resource.name} updated successfully."
 
     assert saved_resource.filters == []
   end

--- a/elixir/apps/web/test/web/live/resources/edit_test.exs
+++ b/elixir/apps/web/test/web/live/resources/edit_test.exs
@@ -324,7 +324,8 @@ defmodule Web.Live.Resources.EditTest do
            |> form("form", resource: attrs)
            |> render_submit() ==
              {:error,
-              {:live_redirect, %{to: ~p"/#{account}/resources/#{resource.id}?site_id=#{group}", kind: :push}}}
+              {:live_redirect,
+               %{to: ~p"/#{account}/resources/#{resource.id}?site_id=#{group}", kind: :push}}}
 
     assert saved_resource = Repo.get_by(Domain.Resources.Resource, id: resource.id)
     assert saved_resource.name == attrs.name

--- a/elixir/apps/web/test/web/live/resources/new_test.exs
+++ b/elixir/apps/web/test/web/live/resources/new_test.exs
@@ -407,7 +407,8 @@ defmodule Web.Live.Resources.NewTest do
 
     resource = Repo.get_by(Domain.Resources.Resource, %{name: attrs.name, address: attrs.address})
 
-    assert assert_redirect(lv, ~p"/#{account}/resources/#{resource}")
+    flash = assert_redirect(lv, ~p"/#{account}/resources")
+    assert flash["info"] == "Resource #{resource.name} created successfully."
   end
 
   test "creates a resource on valid attrs and site_id set", %{
@@ -448,7 +449,8 @@ defmodule Web.Live.Resources.NewTest do
 
     resource = Repo.get_by(Domain.Resources.Resource, %{name: attrs.name, address: attrs.address})
 
-    assert assert_redirect(lv, ~p"/#{account}/resources/#{resource}?site_id=#{group.id}")
+    flash = assert_redirect(lv, ~p"/#{account}/sites/#{group}")
+    assert flash["info"] == "Resource #{resource.name} created successfully."
   end
 
   test "shows disabled traffic filter form when traffic filters disabled", %{
@@ -514,7 +516,7 @@ defmodule Web.Live.Resources.NewTest do
     assert %{connections: [connection]} = Repo.preload(resource, :connections)
     assert connection.gateway_group_id == group.id
 
-    assert assert_redirect(lv, ~p"/#{account}/resources/#{resource}?site_id=#{group.id}")
+    assert assert_redirect(lv, ~p"/#{account}/sites/#{group}")
   end
 
   test "prevents saving resource if traffic filters set when traffic filters disabled", %{


### PR DESCRIPTION
- Updates `new` and `edit` flows to redirect back to sites or resources after save
- Adds flash message pertaining to the above

Fixes #5776 