### PR TITLE
build(deps): bump `quinn-udp` dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2933,7 +2933,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.11",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2933,7 +2933,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.11",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4907,10 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.0"
-source = "git+https://github.com/quinn-rs/quinn?branch=main#88f48b0179f358cea0b76fc550e629007bfc957d"
+version = "0.5.2"
+source = "git+https://github.com/quinn-rs/quinn?branch=main#3f489e2eab014ddd04de58e570ba56e9b027f0bc"
 dependencies = [
- "bytes",
  "libc",
  "once_cell",
  "socket2 0.5.7",

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -3,7 +3,6 @@ use crate::{
     dns::DnsQuery,
     sockets::{Received, Sockets},
 };
-use bytes::Bytes;
 use connlib_shared::messages::DnsServer;
 use futures::Future;
 use futures_bounded::FuturesTupleSet;
@@ -16,7 +15,6 @@ use hickory_resolver::{
     AsyncResolver, TokioHandle,
 };
 use ip_packet::{IpPacket, MutableIpPacket};
-use quinn_udp::Transmit;
 use socket_factory::SocketFactory;
 use std::{
     collections::HashMap,
@@ -24,7 +22,8 @@ use std::{
     net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::Arc,
-    task::{ready, Context, Poll},
+    task::ready,
+    task::{Context, Poll},
     time::{Duration, Instant},
 };
 use tokio::net::{TcpSocket, UdpSocket};
@@ -187,13 +186,7 @@ impl Io {
     }
 
     pub fn send_network(&mut self, transmit: snownet::Transmit) -> io::Result<()> {
-        self.sockets.try_send(Transmit {
-            destination: transmit.dst,
-            ecn: None,
-            contents: Bytes::copy_from_slice(&transmit.payload),
-            segment_size: None,
-            src_ip: transmit.src.map(|s| s.ip()),
-        })?;
+        self.sockets.try_send(transmit)?;
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -185,7 +185,7 @@ impl Io {
     }
 
     pub fn send_network(&mut self, transmit: snownet::Transmit) -> io::Result<()> {
-        self.sockets.try_send(transmit)?;
+        self.sockets.send(transmit)?;
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -22,8 +22,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::Arc,
-    task::ready,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::{Duration, Instant},
 };
 use tokio::net::{TcpSocket, UdpSocket};

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -259,7 +259,7 @@ impl Socket {
                 Ok(()) => {
                     self.buffered_transmits.pop_front();
                 }
-                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue, // False positive wake-up?
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue, // False positive wake-up: Loop to `poll_send_ready` and return `Pending`.
                 Err(e) => return Poll::Ready(Err(e)),
             }
         }

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -50,6 +50,9 @@ impl Sockets {
         Ok(())
     }
 
+    /// Flushes all buffered data on the sockets.
+    ///
+    /// Returns `Ready` if the socket is able to accept more data.
     pub fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         if let Some(socket) = self.socket_v4.as_mut() {
             ready!(socket.poll_flush(cx))?;
@@ -163,6 +166,7 @@ struct Socket {
     state: UdpSocketState,
     port: u16,
     socket: UdpSocket,
+
     buffered_transmits: VecDeque<snownet::Transmit<'static>>,
 }
 

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -252,6 +252,7 @@ impl Socket {
     }
 
     fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // Only pop if we successfully send it
         while let Some(transmit) = self.buffered_transmits.front() {
             ready!(self.socket.poll_send_ready(cx))?;
 

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -260,11 +260,18 @@ impl Socket {
             }
         }
 
+        assert!(self.buffered_transmits.is_empty());
+
         Poll::Ready(Ok(()))
     }
 
     fn send(&mut self, transmit: snownet::Transmit) -> io::Result<()> {
         tracing::trace!(target: "wire::net::send", src = ?transmit.src, dst = %transmit.dst, num_bytes = %transmit.payload.len());
+
+        debug_assert!(
+            self.buffered_transmits.len() < 10_000,
+            "We are not flushing the packets for some reason"
+        );
 
         match self.try_send(&transmit) {
             Ok(()) => Ok(()),

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -66,22 +66,17 @@ impl Sockets {
     }
 
     pub fn try_send(&mut self, transmit: snownet::Transmit) -> io::Result<()> {
-        match transmit.dst {
-            SocketAddr::V4(dst) => {
-                let socket = self.socket_v4.as_mut().ok_or(io::Error::new(
-                    io::ErrorKind::NotConnected,
-                    format!("failed send packet to {dst}: no IPv4 socket"),
-                ))?;
-                socket.send(transmit)?;
-            }
-            SocketAddr::V6(dst) => {
-                let socket = self.socket_v6.as_mut().ok_or(io::Error::new(
-                    io::ErrorKind::NotConnected,
-                    format!("failed send packet to {dst}: no IPv6 socket"),
-                ))?;
-                socket.send(transmit)?;
-            }
-        }
+        let socket = match transmit.dst {
+            SocketAddr::V4(dst) => self.socket_v4.as_mut().ok_or(io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("failed send packet to {dst}: no IPv4 socket"),
+            ))?,
+            SocketAddr::V6(dst) => self.socket_v6.as_mut().ok_or(io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("failed send packet to {dst}: no IPv6 socket"),
+            ))?,
+        };
+        socket.send(transmit)?;
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -286,17 +286,16 @@ impl Socket {
     }
 
     fn try_send(&self, transmit: &snownet::Transmit) -> io::Result<()> {
+        let transmit = quinn_udp::Transmit {
+            destination: transmit.dst,
+            ecn: None,
+            contents: &transmit.payload,
+            segment_size: None,
+            src_ip: transmit.src.map(|s| s.ip()),
+        };
+
         self.socket.try_io(Interest::WRITABLE, || {
-            self.state.send(
-                (&self.socket).into(),
-                &quinn_udp::Transmit {
-                    destination: transmit.dst,
-                    ecn: None,
-                    contents: &transmit.payload,
-                    segment_size: None,
-                    src_ip: transmit.src.map(|s| s.ip()),
-                },
-            )
+            self.state.send((&self.socket).into(), &transmit)
         })
     }
 }

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -65,7 +65,7 @@ impl Sockets {
         Poll::Ready(Ok(()))
     }
 
-    pub fn try_send(&mut self, transmit: snownet::Transmit) -> io::Result<()> {
+    pub fn send(&mut self, transmit: snownet::Transmit) -> io::Result<()> {
         let socket = match transmit.dst {
             SocketAddr::V4(dst) => self.socket_v4.as_mut().ok_or(io::Error::new(
                 io::ErrorKind::NotConnected,


### PR DESCRIPTION
In the new version, `quinn-udp` no longer supports sending multiple `Transmit`s at once via `sendmmsg`. We made use of that to send all buffered packets in one go.

In reality, these buffered packets can only be control messages like STUN requests to relays or something like that. For the hot-patch of routing packets, we only ever read a single IP packet from the TUN device and attempt to send it out right away. At most, we may buffer one packet at a time here in case the socket is busy.

Getting these wake-ups right is quite tricky. I think we should prioritise #3837 soon. Once that is integrated, we can use `async/await` for the high-level integration between `Io` and the state which allows us to simply suspend until we can send the message, avoiding the need for a dedicated buffer.