### PR TITLE
refactor(clients): init `PhoenixChannel` in upper layers

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1060,10 +1060,13 @@ name = "connlib-client-android"
 version = "1.1.4"
 dependencies = [
  "android_log-sys",
+ "backoff",
  "connlib-client-shared",
+ "connlib-shared",
  "ip_network",
  "jni 0.21.1",
  "log",
+ "phoenix-channel",
  "secrecy",
  "serde_json",
  "socket-factory",
@@ -1079,10 +1082,13 @@ dependencies = [
 name = "connlib-client-apple"
 version = "1.1.3"
 dependencies = [
+ "backoff",
  "connlib-client-shared",
+ "connlib-shared",
  "ip_network",
  "libc",
  "oslog",
+ "phoenix-channel",
  "secrecy",
  "serde_json",
  "socket-factory",
@@ -1945,6 +1951,7 @@ version = "1.1.4"
 dependencies = [
  "anyhow",
  "atomicwrites",
+ "backoff",
  "clap",
  "connlib-client-shared",
  "connlib-shared",
@@ -1959,6 +1966,7 @@ dependencies = [
  "libc",
  "mutants",
  "nix 0.28.0",
+ "phoenix-channel",
  "resolv-conf",
  "ring",
  "rtnetlink",

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -13,10 +13,13 @@ doc = false
 mock = ["connlib-client-shared/mock"]
 
 [dependencies]
+backoff = "0.4.0"
 connlib-client-shared = { workspace = true }
+connlib-shared = { workspace = true }
 ip_network = "0.4"
 jni = { version = "0.21.1", features = ["invocation"] }
 log = "0.4"
+phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
 serde_json = "1"
 socket-factory = { workspace = true }

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -361,6 +361,7 @@ fn connect(
         .thread_name("connlib")
         .enable_all()
         .build()?;
+    let _guard = runtime.enter(); // Constructing `PhoenixChannel` requires a runtime context.
 
     let tcp_socket_factory = Arc::new(protected_tcp_socket_factory(callbacks.clone()));
 

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -11,9 +11,12 @@ mock = ["connlib-client-shared/mock"]
 swift-bridge-build = "0.1.53"
 
 [dependencies]
+backoff = "0.4.0"
 connlib-client-shared = { workspace = true }
+connlib-shared = { workspace = true }
 ip_network = "0.4"
 libc = "0.2"
+phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
 serde_json = "1"
 socket-factory = { workspace = true }

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -194,6 +194,7 @@ impl WrappedSession {
             .enable_all()
             .build()
             .map_err(|e| e.to_string())?;
+        let _guard = runtime.enter(); // Constructing `PhoenixChannel` requires a runtime context.
 
         let args = ConnectArgs {
             private_key,

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -216,7 +216,6 @@ impl WrappedSession {
         )
         .map_err(|e| e.to_string())?;
         let session = Session::connect(args, portal, runtime.handle().clone());
-        let _enter = runtime.enter();
         session.set_tun(Tun::new().map_err(|e| e.to_string())?);
 
         Ok(Self {

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -3,12 +3,15 @@
 
 mod make_writer;
 
+use backoff::ExponentialBackoffBuilder;
 use connlib_client_shared::{
     callbacks::ResourceDescription, file_logger, keypair, Callbacks, ConnectArgs, Error, LoginUrl,
     Session, Tun, V4RouteList, V6RouteList,
 };
+use connlib_shared::get_user_agent;
 use ip_network::{Ipv4Network, Ipv6Network};
-use secrecy::SecretString;
+use phoenix_channel::PhoenixChannel;
+use secrecy::{Secret, SecretString};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     path::PathBuf,
@@ -193,18 +196,25 @@ impl WrappedSession {
             .map_err(|e| e.to_string())?;
 
         let args = ConnectArgs {
-            url,
             private_key,
-            os_version_override,
-            app_version: env!("CARGO_PKG_VERSION").to_string(),
             callbacks: CallbackHandler {
                 inner: Arc::new(callback_handler),
             },
-            max_partition_time: Some(MAX_PARTITION_TIME),
             tcp_socket_factory: Arc::new(socket_factory::tcp),
             udp_socket_factory: Arc::new(socket_factory::udp),
         };
-        let session = Session::connect(args, runtime.handle().clone());
+        let portal = PhoenixChannel::connect(
+            Secret::new(url),
+            get_user_agent(os_version_override, env!("CARGO_PKG_VERSION")),
+            "client",
+            (),
+            ExponentialBackoffBuilder::default()
+                .with_max_elapsed_time(Some(MAX_PARTITION_TIME))
+                .build(),
+            Arc::new(socket_factory::tcp),
+        )
+        .map_err(|e| e.to_string())?;
+        let session = Session::connect(args, portal, runtime.handle().clone());
         let _enter = runtime.enter();
         session.set_tun(Tun::new().map_err(|e| e.to_string())?);
 

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -8,16 +8,16 @@ pub use eventloop::Eventloop;
 pub use firezone_tunnel::Tun;
 pub use tracing_appender::non_blocking::WorkerGuard;
 
-use backoff::ExponentialBackoffBuilder;
-use connlib_shared::get_user_agent;
+use eventloop::Command;
 use firezone_tunnel::ClientTunnel;
+use messages::{IngressMessages, ReplyMessages};
 use phoenix_channel::PhoenixChannel;
 use socket_factory::SocketFactory;
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::task::JoinHandle;
 
 mod eventloop;
 pub mod file_logger;
@@ -25,10 +25,6 @@ mod messages;
 mod serde_routelist;
 
 const PHOENIX_TOPIC: &str = "client";
-
-use eventloop::Command;
-use secrecy::Secret;
-use tokio::task::JoinHandle;
 
 /// A session is the entry-point for connlib, maintains the runtime and the tunnel.
 ///
@@ -40,14 +36,10 @@ pub struct Session {
 
 /// Arguments for `connect`, since Clippy said 8 args is too many
 pub struct ConnectArgs<CB> {
-    pub url: LoginUrl,
     pub tcp_socket_factory: Arc<dyn SocketFactory<tokio::net::TcpSocket>>,
     pub udp_socket_factory: Arc<dyn SocketFactory<tokio::net::UdpSocket>>,
     pub private_key: StaticSecret,
-    pub os_version_override: Option<String>,
-    pub app_version: String,
     pub callbacks: CB,
-    pub max_partition_time: Option<Duration>,
 }
 
 impl Session {
@@ -56,12 +48,13 @@ impl Session {
     /// This connects to the portal a specified using [`LoginUrl`] and creates a wireguard tunnel using the provided private key.
     pub fn connect<CB: Callbacks + 'static>(
         args: ConnectArgs<CB>,
+        portal: PhoenixChannel<(), IngressMessages, ReplyMessages>,
         handle: tokio::runtime::Handle,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
         let callbacks = args.callbacks.clone();
-        let connect_handle = handle.spawn(connect(args, rx));
+        let connect_handle = handle.spawn(connect(args, portal, rx));
         handle.spawn(connect_supervisor(connect_handle, callbacks));
 
         Self { channel: tx }
@@ -117,31 +110,20 @@ impl Session {
 /// Connects to the portal and starts a tunnel.
 ///
 /// When this function exits, the tunnel failed unrecoverably and you need to call it again.
-async fn connect<CB>(args: ConnectArgs<CB>, rx: UnboundedReceiver<Command>) -> Result<(), Error>
+async fn connect<CB>(
+    args: ConnectArgs<CB>,
+    portal: PhoenixChannel<(), IngressMessages, ReplyMessages>,
+    rx: UnboundedReceiver<Command>,
+) -> Result<(), Error>
 where
     CB: Callbacks + 'static,
 {
     let ConnectArgs {
-        url,
         private_key,
-        os_version_override,
-        app_version,
         callbacks,
         udp_socket_factory,
         tcp_socket_factory,
-        max_partition_time,
     } = args;
-
-    let portal = PhoenixChannel::connect(
-        Secret::new(url),
-        get_user_agent(os_version_override, &app_version),
-        PHOENIX_TOPIC,
-        (),
-        ExponentialBackoffBuilder::default()
-            .with_max_elapsed_time(max_partition_time)
-            .build(),
-        tcp_socket_factory.clone(),
-    )?;
 
     let tunnel = ClientTunnel::new(
         private_key,

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -110,7 +110,7 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
             .with_max_elapsed_time(None)
             .build(),
         Arc::new(socket_factory::tcp),
-    );
+    )?;
 
     let (sender, receiver) = mpsc::channel::<Interface>(10);
     let tun_device_manager = TunDeviceManager::new()?;

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Firezone, Inc."]
 [dependencies]
 anyhow = { version = "1.0" }
 atomicwrites = "0.4.3" # Needed to safely backup `/etc/resolv.conf` and write the device ID on behalf of `gui-client`
+backoff = "0.4.0"
 clap = { version = "4.5", features = ["derive",  "env", "string"] }
 connlib-client-shared = { workspace = true }
 connlib-shared = { workspace = true }
@@ -17,6 +18,7 @@ futures = "0.3.30"
 git-version = "0.3.9"
 humantime = "2.1"
 ip_network = { version = "0.4", default-features = false }
+phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -19,8 +19,12 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
 use url::Url;
 
 pub mod ipc;
+use backoff::ExponentialBackoffBuilder;
+use connlib_shared::get_user_agent;
 use firezone_bin_shared::TunDeviceManager;
 use ipc::{Server as IpcServer, ServiceId};
+use phoenix_channel::PhoenixChannel;
+use secrecy::Secret;
 
 #[cfg(target_os = "linux")]
 #[path = "ipc_service/linux.rs"]
@@ -347,16 +351,24 @@ impl<'a> Handler<'a> {
 
                 self.last_connlib_start_instant = Some(Instant::now());
                 let args = ConnectArgs {
-                    url,
                     tcp_socket_factory: Arc::new(crate::tcp_socket_factory),
                     udp_socket_factory: Arc::new(crate::udp_socket_factory),
                     private_key,
-                    os_version_override: None,
-                    app_version: env!("CARGO_PKG_VERSION").to_string(),
                     callbacks: self.callback_handler.clone(),
-                    max_partition_time: Some(Duration::from_secs(60 * 60 * 24 * 30)),
                 };
-                let new_session = Session::connect(args, tokio::runtime::Handle::try_current()?);
+                let portal = PhoenixChannel::connect(
+                    Secret::new(url),
+                    get_user_agent(None, env!("CARGO_PKG_VERSION")),
+                    "client",
+                    (),
+                    ExponentialBackoffBuilder::default()
+                        .with_max_elapsed_time(Some(Duration::from_secs(60 * 60 * 24 * 30)))
+                        .build(),
+                    Arc::new(crate::tcp_socket_factory),
+                )?;
+
+                let new_session =
+                    Session::connect(args, portal, tokio::runtime::Handle::try_current()?);
                 new_session.set_tun(self.tun_device.make_tun()?);
                 new_session.set_dns(dns_control::system_resolvers().unwrap_or_default());
                 self.connlib = Some(new_session);

--- a/rust/headless-client/src/standalone.rs
+++ b/rust/headless-client/src/standalone.rs
@@ -171,6 +171,7 @@ pub fn run_only_headless_client() -> Result<()> {
         private_key,
         callbacks,
     };
+    let _guard = rt.enter(); // Constructing `PhoenixChannel` requires a runtime context.
     let portal = PhoenixChannel::connect(
         Secret::new(url),
         get_user_agent(None, env!("CARGO_PKG_VERSION")),

--- a/rust/headless-client/src/standalone.rs
+++ b/rust/headless-client/src/standalone.rs
@@ -5,11 +5,14 @@ use crate::{
     DnsController, InternalServerMsg, IpcServerMsg, TOKEN_ENV_KEY,
 };
 use anyhow::{anyhow, Context as _, Result};
+use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use connlib_client_shared::{file_logger, keypair, ConnectArgs, LoginUrl, Session};
+use connlib_shared::get_user_agent;
 use firezone_bin_shared::{setup_global_subscriber, TunDeviceManager};
 use futures::{FutureExt as _, StreamExt as _};
-use secrecy::SecretString;
+use phoenix_channel::PhoenixChannel;
+use secrecy::{Secret, SecretString};
 use std::{
     path::{Path, PathBuf},
     pin::pin,
@@ -163,16 +166,22 @@ pub fn run_only_headless_client() -> Result<()> {
     let mut last_connlib_start_instant = Some(Instant::now());
     platform::setup_before_connlib()?;
     let args = ConnectArgs {
-        url,
         udp_socket_factory: Arc::new(crate::udp_socket_factory),
         tcp_socket_factory: Arc::new(crate::tcp_socket_factory),
         private_key,
-        os_version_override: None,
-        app_version: env!("CARGO_PKG_VERSION").to_string(),
         callbacks,
-        max_partition_time,
     };
-    let session = Session::connect(args, rt.handle().clone());
+    let portal = PhoenixChannel::connect(
+        Secret::new(url),
+        get_user_agent(None, env!("CARGO_PKG_VERSION")),
+        "client",
+        (),
+        ExponentialBackoffBuilder::default()
+            .with_max_elapsed_time(max_partition_time)
+            .build(),
+        Arc::new(crate::tcp_socket_factory),
+    )?;
+    let session = Session::connect(args, portal, rt.handle().clone());
     platform::notify_service_controller()?;
 
     let result = rt.block_on(async {

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -147,7 +147,7 @@ async fn main() -> Result<()> {
                 .with_max_elapsed_time(Some(MAX_PARTITION_TIME))
                 .build(),
             Arc::new(socket_factory::tcp),
-        ))
+        )?)
     } else {
         tracing::warn!(target: "relay", "No portal token supplied, starting standalone mode");
 


### PR DESCRIPTION
This represents a step towards #3837. Eventually, we'd like the abstractions of `Session` and `Eventloop` to go away entirely. For that, we need to thin them out.

The introduction of `ConnectArgs` was already a hint that we are passing a lot of data across layers that we shouldn't. To avoid that, we can simply initialise `PhoenixChannel` earlier and thus each callsite can specify the desired configuration directly.

I've left `ConnectArgs` intact to keep the diff small.