### PR TITLE
fix(portal): "Are you sure want" --> "Are you sure you want"

### DIFF
--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -156,7 +156,7 @@ defmodule Web.Actors.Show do
           style="warning"
           icon="hero-lock-closed"
           phx-click="disable"
-          data-confirm={"Are you sure want to disable this #{actor_type(@actor.type)} and revoke all its tokens?"}
+          data-confirm={"Are you sure you want to disable this #{actor_type(@actor.type)} and revoke all its tokens?"}
         >
           Disable <%= actor_type(@actor.type) %>
         </.button>
@@ -166,7 +166,7 @@ defmodule Web.Actors.Show do
           style="warning"
           icon="hero-lock-open"
           phx-click="enable"
-          data-confirm={"Are you sure want to enable this #{actor_type(@actor.type)}?"}
+          data-confirm={"Are you sure you want to enable this #{actor_type(@actor.type)}?"}
         >
           Enable <%= actor_type(@actor.type) %>
         </.button>
@@ -497,7 +497,7 @@ defmodule Web.Actors.Show do
         >
           <:dialog_title>Delete <%= actor_type(@actor.type) %></:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this <%= String.downcase(actor_type(@actor.type)) %> along with all associated identities?
+            Are you sure you want to delete this <%= String.downcase(actor_type(@actor.type)) %> along with all associated identities?
           </:dialog_content>
           <:dialog_confirm_button>
             Delete <%= actor_type(@actor.type) %>

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -90,7 +90,7 @@ defmodule Web.Policies.Show do
           phx-click="enable"
           style="warning"
           icon="hero-lock-open"
-          data-confirm="Are you sure want to enable this policy?"
+          data-confirm="Are you sure you want to enable this policy?"
         >
           Enable
         </.button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -55,7 +55,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
         >
           Disable
         </.button>
@@ -66,7 +66,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
             phx-click="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure want to enable this provider?"
+            data-confirm="Are you sure you want to enable this provider?"
           >
             Enable
           </.button>
@@ -163,7 +163,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
@@ -58,7 +58,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
         >
           Disable
         </.button>
@@ -69,7 +69,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
             phx-click="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure want to enable this provider?"
+            data-confirm="Are you sure you want to enable this provider?"
           >
             Enable
           </.button>
@@ -175,7 +175,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -55,7 +55,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
         >
           Disable
         </.button>
@@ -66,7 +66,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
             phx-click="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure want to enable this provider?"
+            data-confirm="Are you sure you want to enable this provider?"
           >
             Enable
           </.button>
@@ -163,7 +163,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -55,7 +55,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
+          data-confirm="Are you sure you want to disable this provider? Users will no longer be able to sign in with this provider and directory sync will be paused."
         >
           Disable
         </.button>
@@ -66,7 +66,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
             phx-click="enable"
             style="warning"
             icon="hero-lock-open"
-            data-confirm="Are you sure want to enable this provider?"
+            data-confirm="Are you sure you want to enable this provider?"
           >
             Enable
           </.button>
@@ -181,7 +181,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -50,7 +50,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? All users signed into this provider will be immediately signed out."
+          data-confirm="Are you sure you want to disable this provider? All users signed into this provider will be immediately signed out."
         >
           Disable
         </.button>
@@ -59,7 +59,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
           phx-click="enable"
           style="warning"
           icon="hero-lock-open"
-          data-confirm="Are you sure want to enable this provider?"
+          data-confirm="Are you sure you want to enable this provider?"
         >
           Enable
         </.button>
@@ -142,7 +142,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
         >
           <:dialog_title>Delete Identity Provider</:dialog_title>
           <:dialog_content>
-            Are you sure want to delete this provider? This will remove
+            Are you sure you want to delete this provider? This will remove
             <strong>all</strong> Actors and Groups associated with this provider.
           </:dialog_content>
           <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
@@ -43,7 +43,7 @@ defmodule Web.Settings.IdentityProviders.System.Show do
           phx-click="disable"
           style="warning"
           icon="hero-lock-closed"
-          data-confirm="Are you sure want to disable this provider? All users signed into this provider will be immediately signed out."
+          data-confirm="Are you sure you want to disable this provider? All users signed into this provider will be immediately signed out."
         >
           Disable
         </.button>
@@ -52,7 +52,7 @@ defmodule Web.Settings.IdentityProviders.System.Show do
           phx-click="enable"
           style="warning"
           icon="hero-lock-open"
-          data-confirm="Are you sure want to enable this provider?"
+          data-confirm="Are you sure you want to enable this provider?"
         >
           Enable
         </.button>


### PR DESCRIPTION
Closes #5887

Nit: We could say just "Enable this policy?" and reduce the word count to less than half. It's not perfect by-the-book English but then users can scan the dialog without thinking, "Oh no, an entire sentence."

I think many programs do that for confirmation dialogs.