### PR TITLE
test(connlib): always run all assertions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1477,12 +1477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,7 +2044,6 @@ dependencies = [
  "ip_network_table",
  "itertools 0.13.0",
  "libc",
- "pretty_assertions",
  "proptest",
  "proptest-state-machine",
  "quinn-udp",
@@ -4762,16 +4755,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "pretty_assertions"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
-dependencies = [
- "diff",
- "yansi",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -8082,12 +8065,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zbus"

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -41,7 +41,6 @@ derivative = "2.2.0"
 firezone-relay = { workspace = true, features = ["proptest"] }
 hickory-proto = { workspace = true }
 ip-packet = { workspace = true, features = ["proptest"] }
-pretty_assertions = "1.4.0"
 proptest-state-machine = "0.3"
 rand = "0.8"
 serde_json = "1.0"


### PR DESCRIPTION
Currently, `tunnel_test` aborts a `Transition` as soon as one assertion fails. This often makes it hard to debug a problem as it can be useful to see which assertions pass and which fail to figure out, what went wrong.

To resolve this, we replace all `assert` macros with either `info!` or `error!` trace events. All "failed assertions" must be logged as `error!`.

Before running these assertions, we temporarily install a custom tracing layer that keeps track of how many `error!` events are emitted. If we emit at least one `error!` event, the layer pancis upon `Drop` which happens at the end of the `check_invariants` function.