### PR TITLE
ci: never tolerate warnings in Rust code

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -13,7 +13,7 @@ permissions:
 
 # Never tolerate warnings.
 env:
-  RUSTFLAGS: '-Dwarnings'
+  RUSTFLAGS: "-Dwarnings"
   RUSTDOCFLAGS: "-D warnings"
 
 jobs:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -11,6 +11,11 @@ permissions:
   contents: 'read'
   id-token: 'write'
 
+# Never tolerate warnings.
+env:
+  RUSTFLAGS: '-Dwarnings'
+  RUSTDOCFLAGS: "-D warnings"
+
 jobs:
   bench:
     name: bench-${{ matrix.runs-on }}
@@ -56,11 +61,9 @@ jobs:
         name: Check for unused dependencies
       - run: cargo fmt -- --check
       - run: cargo doc --all-features --no-deps --document-private-items ${{ steps.setup-rust.outputs.packages }}
-        env:
-          RUSTDOCFLAGS: "-D warnings"
         name: "cargo doc"
         shell: bash
-      - run: cargo clippy --all-targets --all-features ${{ steps.setup-rust.outputs.packages }} -- -D warnings
+      - run: cargo clippy --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
         name: "cargo clippy"
         shell: bash
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -981,22 +981,17 @@ mod tests {
 
 #[cfg(all(test, feature = "proptest"))]
 mod proptests {
-    use std::{
-        net::{Ipv4Addr, Ipv6Addr},
-        ops::RangeInclusive,
-    };
-
     use super::*;
     use connlib_shared::{messages::gateway::PortRange, proptest::*};
     use ip_network::{Ipv4Network, Ipv6Network};
     use ip_packet::make::{icmp_request_packet, tcp_packet, udp_packet};
-    use itertools::Itertools;
     use proptest::{
         arbitrary::any,
         collection, prop_oneof,
         sample::select,
         strategy::{Just, Strategy},
     };
+    use std::ops::RangeInclusive;
     use test_strategy::Arbitrary;
 
     #[test_strategy::proptest()]

--- a/rust/relay/src/server/channel_data.rs
+++ b/rust/relay/src/server/channel_data.rs
@@ -79,7 +79,6 @@ impl<'a> ChannelData<'a> {
 #[cfg(all(test, feature = "proptest"))]
 mod tests {
     use super::*;
-    use stun_codec::rfc5766::attributes::ChannelNumber;
 
     #[test_strategy::proptest]
     fn can_reparse_encoded_header(


### PR DESCRIPTION
Our Rust CI runs various jobs in different configurations of packages and / or features. Currently, only the clippy job denies warnings which makes it possible that some code still generates warnings under particular configurations.

To ensure we always fail on warnings, we set a global env var to deny warnings for all Rust CI jobs.