### PR TITLE
docs(user-guide/windows): fix incorrect service name

### DIFF
--- a/website/src/app/kb/user-guides/windows-client/readme.mdx
+++ b/website/src/app/kb/user-guides/windows-client/readme.mdx
@@ -111,7 +111,7 @@ In the Start Menu, search for "Windows Powershell". Open it and run this
 command:
 
 ```pwsh
-Get-Service -Name FirezoneClientIpcServiceDebug
+Get-Service -Name FirezoneClientIpcService
 ```
 
 Good output


### PR DESCRIPTION
Somehow I had put the debug service there not the prod one