### PR TITLE
test(connlib): ensure portal `init` doesn't interrupt data plane

### DIFF
--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -374,7 +374,7 @@ impl ReferenceStateMachine for ReferenceState {
                     .exec_mut(|client| client.connected_dns_resources.clear());
             }
             Transition::ReconnectPortal => {
-                // Reconnecting to the portal should have no noticable impact on the data plane.
+                // Reconnecting to the portal should have no noticeable impact on the data plane.
             }
         };
 

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -156,6 +156,7 @@ impl ReferenceStateMachine for ReferenceState {
                     question_mark_wildcard_dns_resource(sample::select(state.portal.all_sites())),
                 ],
             )
+            .with(1, Just(Transition::ReconnectPortal))
             .with_if_not_empty(
                 10,
                 state.client.inner().ipv4_cidr_resource_dsts(),
@@ -372,6 +373,9 @@ impl ReferenceStateMachine for ReferenceState {
                     .client
                     .exec_mut(|client| client.connected_dns_resources.clear());
             }
+            Transition::ReconnectPortal => {
+                // Reconnecting to the portal should have no noticable impact on the data plane.
+            }
         };
 
         state
@@ -557,6 +561,7 @@ impl ReferenceStateMachine for ReferenceState {
 
                 !is_assigned_ip4 && !is_assigned_ip6 && !is_previous_port
             }
+            Transition::ReconnectPortal => true,
         }
     }
 }

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -83,6 +83,9 @@ pub(crate) enum Transition {
         ip6: Option<Ipv6Addr>,
         port: u16,
     },
+
+    /// Reconnect to the portal.
+    ReconnectPortal,
 }
 
 pub(crate) fn ping_random_ip<I>(


### PR DESCRIPTION
The connection to the portal could be interrupted at any point, most notably when it is being re-deployed. Doing so results in a new `init` message being pushed to all clients and gateways. This must not interrupt the data plane.

To ensure this, we add a new `ReconnectPortal` transition to `tunnel_test` where we simulate receiving a new `init` message with the same values as we already have locally, i.e. same set of relays and resources.

This resolves an existing TODO where the logic of performing non-destructive updates to resources in `set_resources` wasn't tested.