### PR TITLE
feat(connlib): add placeholder for Internet Resource

### DIFF
--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -19,6 +19,7 @@ pub enum Status {
 pub enum ResourceDescription {
     Dns(ResourceDescriptionDns),
     Cidr(ResourceDescriptionCidr),
+    Internet(ResourceDescriptionCidr),
 }
 
 impl ResourceDescription {
@@ -26,6 +27,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => r.address_description.as_deref(),
             ResourceDescription::Cidr(r) => r.address_description.as_deref(),
+            ResourceDescription::Internet(_) => None,
         }
     }
 
@@ -33,6 +35,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => &r.name,
             ResourceDescription::Cidr(r) => &r.name,
+            ResourceDescription::Internet(_) => "Internet",
         }
     }
 
@@ -40,6 +43,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => r.status,
             ResourceDescription::Cidr(r) => r.status,
+            ResourceDescription::Internet(r) => r.status,
         }
     }
 
@@ -47,6 +51,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => r.id,
             ResourceDescription::Cidr(r) => r.id,
+            ResourceDescription::Internet(r) => r.id,
         }
     }
 
@@ -55,6 +60,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => Cow::from(&r.address),
             ResourceDescription::Cidr(r) => Cow::from(r.address.to_string()),
+            ResourceDescription::Internet(_) => Cow::default(),
         }
     }
 
@@ -62,6 +68,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => &r.sites,
             ResourceDescription::Cidr(r) => &r.sites,
+            ResourceDescription::Internet(r) => &r.sites,
         }
     }
 }
@@ -98,6 +105,14 @@ pub struct ResourceDescriptionCidr {
     pub address_description: Option<String>,
     pub sites: Vec<Site>,
 
+    pub status: Status,
+}
+
+/// Description of an Internet resource
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ResourceDescriptionInternet {
+    pub id: ResourceId,
+    pub sites: Vec<Site>,
     pub status: Status,
 }
 

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -70,6 +70,16 @@ impl ResourceDescriptionCidr {
     }
 }
 
+/// Description of an internet resource.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ResourceDescriptionInternet {
+    /// Resource's id.
+    pub id: ResourceId,
+    // TBD
+    #[serde(rename = "gateway_groups")]
+    pub sites: Vec<Site>,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialOrd, Ord)]
 pub struct Site {
     pub id: SiteId,
@@ -110,7 +120,7 @@ impl ResourceDescription {
     pub fn dns_name(&self) -> Option<&str> {
         match self {
             ResourceDescription::Dns(r) => Some(&r.address),
-            ResourceDescription::Cidr(_) => None,
+            ResourceDescription::Cidr(_) | ResourceDescription::Internet(_) => None,
         }
     }
 
@@ -118,6 +128,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => r.id,
             ResourceDescription::Cidr(r) => r.id,
+            ResourceDescription::Internet(r) => r.id,
         }
     }
 
@@ -125,6 +136,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => HashSet::from_iter(r.sites.iter()),
             ResourceDescription::Cidr(r) => HashSet::from_iter(r.sites.iter()),
+            ResourceDescription::Internet(_) => HashSet::default(),
         }
     }
 
@@ -132,6 +144,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => &mut r.sites,
             ResourceDescription::Cidr(r) => &mut r.sites,
+            ResourceDescription::Internet(r) => &mut r.sites,
         }
     }
 
@@ -140,6 +153,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => &r.name,
             ResourceDescription::Cidr(r) => &r.name,
+            ResourceDescription::Internet(_) => "Internet",
         }
     }
 
@@ -163,6 +177,7 @@ impl ResourceDescription {
             ResourceDescription::Cidr(r) => {
                 crate::callbacks::ResourceDescription::Cidr(r.with_status(status))
             }
+            ResourceDescription::Internet(_) => todo!(),
         }
     }
 }
@@ -184,4 +199,43 @@ impl Ord for ResourceDescription {
 pub enum ResourceDescription {
     Dns(ResourceDescriptionDns),
     Cidr(ResourceDescriptionCidr),
+    Internet(ResourceDescriptionInternet),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_deserialize_internet_resource() {
+        let resources = r#"[
+            {
+                "id": "73037362-715d-4a83-a749-f18eadd970e6",
+                "type": "cidr",
+                "name": "172.172.0.0/16",
+                "address": "172.172.0.0/16",
+                "address_description": "cidr resource",
+                "gateway_groups": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}]
+            },
+            {
+                "id": "03000143-e25e-45c7-aafb-144990e57dcd",
+                "type": "dns",
+                "name": "gitlab.mycorp.com",
+                "address": "gitlab.mycorp.com",
+                "address_description": "dns resource",
+                "gateway_groups": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}]
+            },
+            {
+                "id": "1106047c-cd5d-4151-b679-96b93da7383b",
+                "type": "internet",
+                "gateway_groups": [{"name": "test", "id": "eb94482a-94f4-47cb-8127-14fb3afa5516"}],
+                "not": "relevant",
+                "some_other": [
+                    "field"
+                ]
+            }
+        ]"#;
+
+        serde_json::from_str::<Vec<ResourceDescription>>(resources).unwrap();
+    }
 }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -937,6 +937,7 @@ impl ClientState {
                         }
                     }
                 }
+                ResourceDescription::Internet(_) => {}
             }
 
             self.resource_ids
@@ -1074,6 +1075,7 @@ fn get_addresses_for_awaiting_resource(
             .map_into()
             .collect_vec(),
         ResourceDescription::Cidr(r) => vec![r.address],
+        ResourceDescription::Internet(_) => vec![],
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/connlib/tunnel/src/tests/stub_portal.rs
@@ -55,6 +55,7 @@ impl StubPortal {
             client::ResourceDescription::Cidr(cidr) => {
                 self.cidr_resources.insert(cidr.id, cidr);
             }
+            client::ResourceDescription::Internet(_) => {}
         }
     }
 


### PR DESCRIPTION
In preparation for #2667, we add an `internet` variant to our list of possible resource types. This is backwards-compatible with existing clients and ensures that, once the portal starts sending Internet resources to clients, they won't fail to deserialise these messages.

The portal will have a version check to not send this to older clients anyway but the sooner we can land this, the better. It simplifies the initial development as we start preparing for the next client release.

Adding new fields to a JSON message is always backwards-compatible so we can extend this later with whatever we need.