### PR TITLE
docs(gui-client): remove outdated comment block

### DIFF
--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -41,6 +41,7 @@ pub(crate) enum Error {
 }
 
 /// The program's entry point, equivalent to `main`
+#[instrument(skip_all)]
 pub(crate) fn run() -> Result<()> {
     std::panic::set_hook(Box::new(tracing_panic::panic_hook));
     let cli = Cli::parse();

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -41,26 +41,6 @@ pub(crate) enum Error {
 }
 
 /// The program's entry point, equivalent to `main`
-///
-/// When a user runs the Windows client normally without admin permissions, this will happen:
-///
-/// 1. The exe runs with ``, blank arguments
-/// 2. We call `elevation::check` and find out we don't have permission to open a wintun adapter
-/// 3. We spawn powershell's `Start-Process` cmdlet with `RunAs` to launch our `elevated` subcommand with admin permissions
-/// 4. The original un-elevated process from Step 1 exits
-/// 5. The exe runs with `elevated`, which won't recursively try to elevate itself if elevation failed
-/// 6. The elevated process from Step 5 enters the GUI module and spawns a new process for crash handling
-/// 7. That crash handler process starts with `crash-handler-server`. Instead of running the GUI, it enters the `crash_handling` module and becomes a crash server.
-/// 8. The GUI process from Step 6 connects to the crash server as a client
-/// 9. The GUI process registers itself as a named pipe server for deep links
-/// 10. The GUI process registers the exe to receive deep links.
-/// 11. When a web browser gets a deep link for authentication, Windows calls the exe with `open-deep-link` and the URL. This process connects to the pipe server inside the GUI process (Step 5), sends the URL to the GUI, then exits.
-/// 12. The GUI process (Step 5) receives the deep link URL.
-/// 13. (TBD - connlib may run in a subprocess in the near future <https://github.com/firezone/firezone/issues/2975>)
-///
-/// In total there are 4 subcommands (non-elevated, elevated GUI, crash handler, and deep link process)
-/// In steady state, the only processes running will be the GUI and the crash handler.
-#[instrument(skip_all)]
 pub(crate) fn run() -> Result<()> {
     std::panic::set_hook(Box::new(tracing_panic::panic_hook));
     let cli = Cli::parse();


### PR DESCRIPTION
This explanation of the processes is no longer accurate after the IPC service split.