### PR TITLE
fix(connlib): remove resource-gateway mapping when removing resource

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -979,6 +979,8 @@ impl ClientState {
             self.update_site_status_by_gateway(&gateway_id, Status::Unknown);
             // TODO: should we have a Node::remove_connection?
         }
+
+        self.resources_gateways.remove(&id);
     }
 
     fn update_dns_mapping(&mut self) -> bool {


### PR DESCRIPTION
Working on some tests, but without this when we remove a resource and re-add it, if we still have a connection to the gateway, we never generate a connection intent only if we don't have a way to map resource_id -> gateway_id.