### PR TITLE
test(connlib): proactively force connections through relay

### DIFF
--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -1,6 +1,6 @@
 use super::{
     reference::{private_key, PrivateKey},
-    sim_net::{any_ip_stack, any_port, host, Host},
+    sim_net::{any_port, dual_ip_stack, host, Host},
 };
 use crate::{tests::sut::hickory_name_to_domain, GatewayState};
 use connlib_shared::DomainName;
@@ -99,7 +99,7 @@ impl RefGateway {
 }
 
 pub(crate) fn ref_gateway_host() -> impl Strategy<Value = Host<RefGateway>> {
-    host(any_ip_stack(), any_port(), ref_gateway())
+    host(dual_ip_stack(), any_port(), ref_gateway())
 }
 
 fn ref_gateway() -> impl Strategy<Value = RefGateway> {

--- a/rust/connlib/tunnel/src/tests/sim_net.rs
+++ b/rust/connlib/tunnel/src/tests/sim_net.rs
@@ -99,10 +99,10 @@ impl<T> Host<T> {
         }
     }
 
-    pub(crate) fn can_route_to(&self, network: IpNetwork) -> bool {
-        match network {
-            IpNetwork::V4(_) => self.ip4.is_some(),
-            IpNetwork::V6(_) => self.ip6.is_some(),
+    pub(crate) fn is_sender(&self, src: IpAddr) -> bool {
+        match src {
+            IpAddr::V4(src) => self.ip4.is_some_and(|v4| v4 == src),
+            IpAddr::V6(src) => self.ip6.is_some_and(|v6| v6 == src),
         }
     }
 }

--- a/rust/connlib/tunnel/src/tests/strategies.rs
+++ b/rust/connlib/tunnel/src/tests/strategies.rs
@@ -189,21 +189,6 @@ pub(crate) fn gateways_and_portal() -> impl Strategy<
                 (Just(gateways), Just(portal), dns_resource_records)
             },
         )
-        .prop_filter(
-            "gateway must be able to access their assigned CIDR resources",
-            |(gateways, portal, _)| {
-                portal.cidr_resources().all(|(rid, r)| {
-                    portal
-                        .gateway_for_resource(*rid)
-                        .and_then(|g| gateways.get(g))
-                        .is_some_and(|g| {
-                            // TODO: PRODUCTION CODE DOES NOT HANDLE THIS!
-
-                            g.can_route_to(r.address)
-                        })
-                })
-            },
-        )
 }
 
 fn any_site(sites: HashSet<Site>) -> impl Strategy<Value = Site> {

--- a/rust/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/connlib/tunnel/src/tests/stub_portal.rs
@@ -78,12 +78,6 @@ impl StubPortal {
             .collect()
     }
 
-    pub(crate) fn cidr_resources(
-        &self,
-    ) -> impl Iterator<Item = (&ResourceId, &client::ResourceDescriptionCidr)> + '_ {
-        self.cidr_resources.iter()
-    }
-
     /// Picks, which gateway and site we should connect to for the given resource.
     pub(crate) fn handle_connection_intent(
         &self,


### PR DESCRIPTION
Currently, the relay path in `tunnel_test` is only hit accidentally because we don't run the gateways in dual-stack mode and thus, some testcases have a client and gateways that can't talk to each other (and thus fall back to the relay).

This requires us to filter out certain resources because we can't route to an IPv6 CIDR resource from an IPv4-only gateway. This causes quite a lot of rejections which creates problems when one attempts up the number of test cases (i.e. 10_000).

To fix this, we run the gateways always in dual-stack mode and introduce a dedicated flag that sometimes drop all direct traffic between the client and the gateways.