### PR TITLE
chore(rust): bump nightly version used for checking unused deps

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-udeps
       - run: |
           rustup install --no-self-update nightly-2024-07-18 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
-          cargo +nightly-2024-03-26 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
+          cargo +nightly-2024-07-18 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
         name: Check for unused dependencies
       - run: cargo fmt -- --check
       - run: cargo doc --all-features --no-deps --document-private-items ${{ steps.setup-rust.outputs.packages }}

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -56,7 +56,7 @@ jobs:
         timeout-minutes: 5
       - uses: taiki-e/install-action@cargo-udeps
       - run: |
-          rustup install --no-self-update nightly-2024-03-26 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
+          rustup install --no-self-update nightly-2024-07-18 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
           cargo +nightly-2024-03-26 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
         name: Check for unused dependencies
       - run: cargo fmt -- --check

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -56,8 +56,8 @@ jobs:
         timeout-minutes: 5
       - uses: taiki-e/install-action@cargo-udeps
       - run: |
-          rustup install --no-self-update nightly-2024-07-18 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
-          cargo +nightly-2024-07-18 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
+          rustup install --no-self-update nightly-2024-06-01 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
+          cargo +nightly-2024-06-01 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
         name: Check for unused dependencies
       - run: cargo fmt -- --check
       - run: cargo doc --all-features --no-deps --document-private-items ${{ steps.setup-rust.outputs.packages }}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2636,7 +2636,6 @@ name = "gui-smoke-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "libc",
  "subprocess",
  "tracing",
  "tracing-subscriber",

--- a/rust/gui-smoke-test/Cargo.toml
+++ b/rust/gui-smoke-test/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0" }
-libc = "0.2.155"
 subprocess = "0.2.9"
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }


### PR DESCRIPTION
This version was a few months old and started throwing errors about features that stabilized since then.

e.g. https://github.com/firezone/firezone/actions/runs/10011089436/job/27673759249

```
error[E0658]: use of unstable library feature 'proc_macro_byte_character'
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.86/src/wrapper.rs:871:21
    |
871 |                     proc_macro::Literal::byte_character(byte)
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #115268 <https://github.com/rust-lang/rust/issues/115268> for more information
    = help: add `#![feature(proc_macro_byte_character)]` to the crate attributes to enable
    = note: this compiler was built on 2024-03-25; consider upgrading it if it is out of date

error[E0658]: use of unstable library feature 'proc_macro_c_str_literals'
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.86/src/wrapper.rs:898:21
    |
898 |                     proc_macro::Literal::c_string(string)
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #119750 <https://github.com/rust-lang/rust/issues/119750> for more information
    = help: add `#![feature(proc_macro_c_str_literals)]` to the crate attributes to enable
    = note: this compiler was built on 2024-03-25; consider upgrading it if it is out of date

For more information about this error, try `rustc --explain E0658`.
error: could not compile `proc-macro2` (lib) due to 2 previous errors
```