### PR TITLE
docs: Prettier prosewrap for docs

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,16 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": false,
-  "proseWrap": "preserve"
+  "proseWrap": "always",
+  "overrides": [
+    {
+      "files": [
+        "website/src/app/blog/**/*.md",
+        "website/src/app/blog/**/*.mdx"
+      ],
+      "options": {
+        "proseWrap": "preserve"
+      }
+    }
+  ]
 }

--- a/website/src/app/blog/sans-io/readme.mdx
+++ b/website/src/app/blog/sans-io/readme.mdx
@@ -648,7 +648,6 @@ on drafts of this post.
     [this article](/kb/architecture/tech-stack) in our architecture docs.
 
 [^2]: Technically, a thread-per-core runtime could allow non-`'static` `Future`s.
-
 [^3]:
     `boringtun` does call `Instant::now` internally and is thus unfortunately
     partly impure, see https://github.com/cloudflare/boringtun/issues/391.

--- a/website/src/app/blog/sans-io/readme.mdx
+++ b/website/src/app/blog/sans-io/readme.mdx
@@ -648,6 +648,7 @@ on drafts of this post.
     [this article](/kb/architecture/tech-stack) in our architecture docs.
 
 [^2]: Technically, a thread-per-core runtime could allow non-`'static` `Future`s.
+
 [^3]:
     `boringtun` does call `Instant::now` internally and is thus unfortunately
     partly impure, see https://github.com/cloudflare/boringtun/issues/391.

--- a/website/src/app/kb/deploy/dns/readme.mdx
+++ b/website/src/app/kb/deploy/dns/readme.mdx
@@ -65,10 +65,23 @@ the [upstream resolvers](#configuring-client-dns-upstream-resolvers) if
 configured in your account. Otherwise, it forwards the query to the default
 system resolver on the Client host.
 
+<Alert color="warning">
+
+Queries forwarded to upstream resolvers are **never** routed through Firezone
+unless (1) you've defined custom upstream resolver(s) below, and (2) those
+resolvers are defined as Resources in your account. This ensures that queries
+for Firezone infrastructure and services on the Client's local LAN continue to
+be resolvable even if the Client's DHCP-provided DNS server collides with an IP
+or CIDR Resource in your account.
+
+</Alert>
+
 <Alert color="info">
-  Firezone only intercepts queries for the `A`, `AAAA`, and `PTR` record types
-  for your DNS Resources. All other record types are forwarded to the upstream
-  resolver(s).
+
+Firezone only intercepts queries for the `A`, `AAAA`, and `PTR` record types for
+your DNS Resources. All other record types are forwarded to the upstream
+resolver(s).
+
 </Alert>
 
 ## Configuring Client DNS upstream resolvers
@@ -100,7 +113,8 @@ network.
 ## Configuring Gateway resolvers
 
 Firezone makes no assumptions about the DNS environment in which the Gateway
-runs. It uses the default system resolver you've configured on the Gateway host.
+runs. It uses the default system resolver you've configured on the Gateway host,
+typically defined in `/etc/resolv.conf`.
 
 This resolver is used for DNS Resources defined in your Firezone account so it's
 important that your Gateway host has DNS configured properly for Clients to

--- a/website/src/app/kb/reference/faq/readme.mdx
+++ b/website/src/app/kb/reference/faq/readme.mdx
@@ -49,8 +49,8 @@ stack, it supports all application protocols without modification.
 #### How long does it take to set up Firezone?
 
 Firezone can be set up in less than 10 minutes, and Gateways can be added by
-running a simple Docker command. Check out the [Quickstart Guide](/kb/quickstart)
-for step-by-step instructions.
+running a simple Docker command. Check out the
+[Quickstart Guide](/kb/quickstart) for step-by-step instructions.
 
 #### Do I have to be technical to run Firezone?
 
@@ -79,8 +79,8 @@ Firezone uses a split control plane and data plane architecture to allow for
 things like key distribution, user authentication, and policy enforcement to
 happen out-of-band with the hot data paths. The data plane components such as
 the Clients and Gateway are specifically designed to be self-hosted, but the
-control plane, due to its reliability, security, and persistence requirements, is
-not.
+control plane, due to its reliability, security, and persistence requirements,
+is not.
 
 That said, Firezone's product is 100% open source and can be found at our
 [main repository](https://github.com/firezone/firezone). Our license does not

--- a/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/user-guides/linux-gui-client/readme.mdx
@@ -186,6 +186,7 @@ sudo systemctl restart firezone-client-ipc
   [#4764](https://github.com/firezone/firezone/issues/4764)
 - The GUI Client does not run on Ubuntu 24.04 yet
   [#4883](https://github.com/firezone/firezone/issues/4883)
-- If you update Firezone while the GUI is running, you must manually restart the GUI [#5790](https://github.com/firezone/firezone/issues/5790)
+- If you update Firezone while the GUI is running, you must manually restart the
+  GUI [#5790](https://github.com/firezone/firezone/issues/5790)
 
 <SupportOptions />


### PR DESCRIPTION
When writing docs it's helpful to have Prettier format long lines automatically. This non-intuitively applies to not only prose, but tables, MDX components, and other items as well.

Since many times this content is not prose but reference material, we can have prettier format these and leave the `blog/` section left at `preserve` to allow post authors to manage newlines as they see fit.