### PR TITLE
refactor(connlib): reduce indentation when looping over gateways

### DIFF
--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -379,10 +379,12 @@ impl TunnelTest {
             });
 
             for (_, gateway) in self.gateways.iter_mut() {
-                if let Some(transmit) = gateway.exec_mut(|g| g.sut.poll_transmit()) {
-                    buffered_transmits.push(transmit, gateway);
-                    continue 'outer;
-                }
+                let Some(transmit) = gateway.exec_mut(|g| g.sut.poll_transmit()) else {
+                    continue;
+                };
+
+                buffered_transmits.push(transmit, gateway);
+                continue 'outer;
             }
 
             for (id, gateway) in self.gateways.iter_mut() {


### PR DESCRIPTION
By leveraging `let-else`, we can perform the main action - pushing to the buffered transmits - on first indentation level of the loop.