### PR TITLE
fix(connlib): drop direct traffic from gateway

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5897,7 +5897,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.5.1"
-source = "git+https://github.com/firezone/str0m?branch=main#07c4fb0449db1fdde4b3421a61b666312ec81106"
+source = "git+https://github.com/firezone/str0m?branch=main#b59f9eb58a5a5b506e12163b7fb8ccd088f057f1"
 dependencies = [
  "combine",
  "crc",

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -502,12 +502,20 @@ impl TunnelTest {
 
         match host {
             HostId::Client(_) => {
+                if self.drop_direct_client_traffic
+                    && self.gateways.values().any(|g| g.is_sender(src.ip()))
+                {
+                    tracing::debug!(%src, %dst, "Dropping direct traffic");
+
+                    return;
+                }
+
                 self.client
                     .exec_mut(|c| c.handle_packet(payload, src, dst, self.now));
             }
             HostId::Gateway(id) => {
                 if self.drop_direct_client_traffic && self.client.is_sender(src.ip()) {
-                    tracing::debug!("Dropping direct traffic from client -> gateway");
+                    tracing::debug!(%src, %dst, "Dropping direct traffic");
 
                     return;
                 }


### PR DESCRIPTION
In #5917, we introduced a sampled boolean that controls whether direct traffic from clients to gateways is dropped. To correctly, simulate such a network scenario, we also need to drop traffic from gateways back to clients.