### PR TITLE
refactor(apple): tidy up error handling around `Session.start`

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -132,15 +132,15 @@ class Adapter {
           logFilter,
           callbackHandler
         )
-      // Update our internal state
-      self.state = .tunnelStarted(session: session)
 
       // Start listening for network change events. The first few will be our
       // tunnel interface coming up, but that's ok -- it will trigger a `set_dns`
       // connlib.
       beginPathMonitoring()
+
+      // Update state in case everything succeeded
+      self.state = .tunnelStarted(session: session)
     } catch let error {
-      state = .tunnelStopped
       throw AdapterError.connlibConnectError(error)
     }
   }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -111,9 +111,7 @@ class Adapter {
   public func start(completionHandler: @escaping (AdapterError?) -> Void) throws {
     Log.tunnel.log("Adapter.start")
     guard case .tunnelStopped = self.state else {
-      Log.tunnel.error("\(#function): Invalid Adapter state")
-      completionHandler(.invalidState)
-      return
+      throw AdapterError.invalidState
     }
 
     callbackHandler.delegate = self

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -106,9 +106,7 @@ class Adapter {
   }
 
   /// Start the tunnel.
-  /// - Parameters:
-  ///   - completionHandler: completion handler.
-  public func start(completionHandler: @escaping (AdapterError?) -> Void) throws {
+  public func start() throws {
     Log.tunnel.log("Adapter.start")
     guard case .tunnelStopped = self.state else {
       throw AdapterError.invalidState
@@ -141,10 +139,6 @@ class Adapter {
       // tunnel interface coming up, but that's ok -- it will trigger a `set_dns`
       // connlib.
       beginPathMonitoring()
-
-      // Tell the system the tunnel is up, moving the tunnelManager status to
-      // `connected`.
-      completionHandler(nil)
     } catch let error {
       state = .tunnelStopped
       throw AdapterError.connlibConnectError(error)

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -148,7 +148,6 @@ class Adapter {
       // `connected`.
       completionHandler(nil)
     } catch let error {
-      Log.tunnel.error("\(#function): Adapter.start: Error: \(error)")
       state = .tunnelStopped
       throw AdapterError.connlibConnectError(error)
     }

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -82,7 +82,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
           apiURL: apiURL, token: token, logFilter: logFilter, packetTunnelProvider: self)
         self.adapter = adapter
 
-        try adapter.start(completionHandler: completionHandler)
+        try adapter.start()
+
+        // Tell the system the tunnel is up, moving the tunnelManager status to
+        // `connected`.
+        completionHandler(nil)
       } catch {
         Log.tunnel.error("\(#function): Error! \(error)")
         completionHandler(error)


### PR DESCRIPTION
Whilst investigating #5965, I noticed that the code around `Adapter.start` on the Swift side can be tidied up a bit to prevent duplicate logs.