### PR TITLE
chore(apple): log connect errors on the connlib side

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arbitrary"
@@ -1082,6 +1082,7 @@ dependencies = [
 name = "connlib-client-apple"
 version = "1.1.3"
 dependencies = [
+ "anyhow",
  "backoff",
  "connlib-client-shared",
  "connlib-shared",

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -11,6 +11,7 @@ mock = ["connlib-client-shared/mock"]
 swift-bridge-build = "0.1.53"
 
 [dependencies]
+anyhow = "1.0.86"
 backoff = "0.4.0"
 connlib-client-shared = { workspace = true }
 connlib-shared = { workspace = true }

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod make_writer;
 
+use anyhow::{Context as _, Result};
 use backoff::ExponentialBackoffBuilder;
 use connlib_client_shared::{
     callbacks::ResourceDescription, file_logger, keypair, Callbacks, ConnectArgs, Error, LoginUrl,
@@ -37,7 +38,7 @@ mod ffi {
     extern "Rust" {
         type WrappedSession;
 
-        #[swift_bridge(associated_to = WrappedSession)]
+        #[swift_bridge(associated_to = WrappedSession, return_with = log_and_convert)]
         fn connect(
             api_url: String,
             token: String,
@@ -47,7 +48,7 @@ mod ffi {
             log_dir: String,
             log_filter: String,
             callback_handler: CallbackHandler,
-        ) -> Result<WrappedSession, String>;
+        ) -> Option<WrappedSession>;
 
         fn reconnect(&mut self);
 
@@ -174,8 +175,8 @@ impl WrappedSession {
         log_dir: String,
         log_filter: String,
         callback_handler: ffi::CallbackHandler,
-    ) -> Result<Self, String> {
-        let logger = init_logging(log_dir.into(), log_filter).map_err(|e| e.to_string())?;
+    ) -> Result<Self> {
+        let logger = init_logging(log_dir.into(), log_filter).context("Failed to init logger")?;
         let secret = SecretString::from(token);
 
         let (private_key, public_key) = keypair();
@@ -186,14 +187,14 @@ impl WrappedSession {
             device_name_override,
             public_key.to_bytes(),
         )
-        .map_err(|e| e.to_string())?;
+        .context("Failed to create LoginUrl")?;
 
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .thread_name("connlib")
             .enable_all()
             .build()
-            .map_err(|e| e.to_string())?;
+            .context("Failed to make runtime")?;
         let _guard = runtime.enter(); // Constructing `PhoenixChannel` requires a runtime context.
 
         let args = ConnectArgs {
@@ -214,9 +215,9 @@ impl WrappedSession {
                 .build(),
             Arc::new(socket_factory::tcp),
         )
-        .map_err(|e| e.to_string())?;
+        .context("Failed to connect phoenix channel")?;
         let session = Session::connect(args, portal, runtime.handle().clone());
-        session.set_tun(Tun::new().map_err(|e| e.to_string())?);
+        session.set_tun(Tun::new().context("Failed to create Tun device")?);
 
         Ok(Self {
             inner: session,
@@ -237,4 +238,10 @@ impl WrappedSession {
     fn disconnect(self) {
         self.inner.disconnect()
     }
+}
+
+fn log_and_convert(result: Result<WrappedSession>) -> Option<WrappedSession> {
+    result
+        .map_err(|e| tracing::error!("Failed to connect: {e:#}"))
+        .ok()
 }


### PR DESCRIPTION
Currently, errors during `Session::connect` on Apple platforms are meant to be returned as an error. This doesn't seem to work though as the error on the Swift side appears to always be `null`.

Instead of returning an error, we convert the function signature to an `Optional` and log the error on the Rust side.