### PR TITLE
fix(apple): stringify errors from `WrappedSession::connect`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arbitrary"
@@ -1082,6 +1082,7 @@ dependencies = [
 name = "connlib-client-apple"
 version = "1.1.3"
 dependencies = [
+ "anyhow",
  "backoff",
  "connlib-client-shared",
  "connlib-shared",

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -11,6 +11,7 @@ mock = ["connlib-client-shared/mock"]
 swift-bridge-build = "0.1.53"
 
 [dependencies]
+anyhow = "1.0.86"
 backoff = "0.4.0"
 connlib-client-shared = { workspace = true }
 connlib-shared = { workspace = true }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -13,7 +13,7 @@ public enum AdapterError: Error {
   case invalidState
 
   /// connlib failed to start
-  case connlibConnectError(Error)
+  case connlibConnectError(String)
 }
 
 /// Enum representing internal state of the  adapter
@@ -141,7 +141,8 @@ class Adapter {
       // Update state in case everything succeeded
       self.state = .tunnelStarted(session: session)
     } catch let error {
-      throw AdapterError.connlibConnectError(error)
+      let msg = error as! RustString
+      throw AdapterError.connlibConnectError(msg.toString())
     }
   }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -142,6 +142,7 @@ class Adapter {
       self.state = .tunnelStarted(session: session)
     } catch let error {
       let msg = error as! RustString
+      // `toString` needed to deep copy the string and avoid a possible dangling pointer
       throw AdapterError.connlibConnectError(msg.toString())
     }
   }


### PR DESCRIPTION
Errors returned from `WrappedSession.connect` are always a `RustString` but those are only pointers to the actual data. See https://chinedufn.github.io/swift-bridge/built-in/string/index.html#ruststring for details. To see the actual string on the Swift side (and in the logs), we need to call `.toString()` on it.

Fixes: #5965.