### PR TITLE
ci(rust): run mutation tests on `tunnel`, `relay` and `snownet`

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -63,6 +63,8 @@ runs:
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
+    - uses: rui314/setup-mold@v1
+
     - name: Disable Windows Defender
       if: ${{ inputs.cache_backend == 'sccache' && runner.os == 'Windows' }}
       run: Set-MpPreference -DisableRealtimeMonitoring $true

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
 
   mutants:
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -98,7 +98,7 @@ jobs:
         name: "cargo test"
         shell: bash
 
-  incremental-mutants:
+  mutants:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     strategy:
@@ -117,7 +117,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: mutants-incremental.out
+          name: mutants.out
           path: mutants.out
 
   # Runs the Tauri client smoke test, built in debug mode. We can't run it in release

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 ]
+        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
@@ -112,7 +112,7 @@ jobs:
         name: Install cargo-mutants using install-action
         with:
           tool: cargo-mutants
-      - run: cargo mutants --no-shuffle --in-place --package firezone-tunnel --package snownet --package firezone-relay --features proptest --shard ${{ matrix.shard }}/15
+      - run: cargo mutants --no-shuffle --in-place --package firezone-tunnel --package snownet --package firezone-relay --features proptest --shard ${{ matrix.shard }}/10
         env:
           CARGO_PROFILE_TEST_OPT_LEVEL: 1
       - name: Archive mutants.out

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 ]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
@@ -112,7 +112,7 @@ jobs:
         name: Install cargo-mutants using install-action
         with:
           tool: cargo-mutants
-      - run: cargo mutants --no-shuffle --in-place --package firezone-tunnel --package snownet --package firezone-relay --shard ${{ matrix.shard }}/10
+      - run: cargo mutants --no-shuffle --in-place --package firezone-tunnel --package snownet --package firezone-relay --shard ${{ matrix.shard }}/15
       - name: Archive mutants.out
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -112,7 +112,7 @@ jobs:
         name: Install cargo-mutants using install-action
         with:
           tool: cargo-mutants
-      - run: cargo mutants --no-shuffle --in-place --package firezone-tunnel --package snownet --package firezone-relay --shard ${{ matrix.shard }}/15
+      - run: cargo mutants --no-shuffle --in-place --package firezone-tunnel --package snownet --package firezone-relay --features proptest --shard ${{ matrix.shard }}/15
       - name: Archive mutants.out
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
 
   mutants:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -98,6 +98,28 @@ jobs:
         name: "cargo test"
         shell: bash
 
+  incremental-mutants:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
+      - uses: taiki-e/install-action@v2
+        name: Install cargo-mutants using install-action
+        with:
+          tool: cargo-mutants
+      - run: cargo mutants --no-shuffle --in-place --package firezone-tunnel --package snownet --package firezone-relay --shard ${{ matrix.shard }}/10
+      - name: Archive mutants.out
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mutants-incremental.out
+          path: mutants.out
+
   # Runs the Tauri client smoke test, built in debug mode. We can't run it in release
   # mode because of a known issue: <https://github.com/firezone/firezone/blob/456e044f882c2bb314e19cc44c0d19c5ad817b7c/rust/windows-client/src-tauri/src/client.rs#L162-L164>
   gui-smoke-test:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -113,6 +113,8 @@ jobs:
         with:
           tool: cargo-mutants
       - run: cargo mutants --no-shuffle --in-place --package firezone-tunnel --package snownet --package firezone-relay --features proptest --shard ${{ matrix.shard }}/15
+        env:
+          CARGO_PROFILE_TEST_OPT_LEVEL: 1
       - name: Archive mutants.out
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+        shard: [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust

--- a/rust/.cargo/mutants.toml
+++ b/rust/.cargo/mutants.toml
@@ -1,0 +1,8 @@
+exclude_globs = [
+    "connlib/tunnel/src/io.rs",
+    "connlib/tunnel/src/device_channel.rs",
+    "connlib/tunnel/src/device_channel/*",
+    "connlib/tunnel/src/tests.rs",
+    "connlib/tunnel/src/tests/*",
+    "connlib/tunnel/src/sockets.rs",
+]

--- a/rust/.cargo/mutants.toml
+++ b/rust/.cargo/mutants.toml
@@ -1,8 +1,15 @@
 exclude_globs = [
+    "connlib/tunnel/src/lib.rs",
     "connlib/tunnel/src/io.rs",
     "connlib/tunnel/src/device_channel.rs",
     "connlib/tunnel/src/device_channel/*",
     "connlib/tunnel/src/tests.rs",
     "connlib/tunnel/src/tests/*",
     "connlib/tunnel/src/sockets.rs",
+]
+exclude_re = [
+    "tests::",
+    "proptests::",
+    "ClientTunnel::",
+    "GatewayTunnel::",
 ]

--- a/rust/.cargo/mutants.toml
+++ b/rust/.cargo/mutants.toml
@@ -6,6 +6,11 @@ exclude_globs = [
     "connlib/tunnel/src/tests.rs",
     "connlib/tunnel/src/tests/*",
     "connlib/tunnel/src/sockets.rs",
+    "relay/src/sockets.rs",
+    "relay/src/proptests.rs",
+    "relay/src/main.rs",
+    "relay/src/sleep.rs",
+    "relay/src/server/client_message.rs",
 ]
 exclude_re = [
     "tests::",

--- a/rust/.cargo/mutants.toml
+++ b/rust/.cargo/mutants.toml
@@ -1,20 +1,22 @@
 exclude_globs = [
-    "connlib/tunnel/src/lib.rs",
-    "connlib/tunnel/src/io.rs",
     "connlib/tunnel/src/device_channel.rs",
     "connlib/tunnel/src/device_channel/*",
+    "connlib/tunnel/src/io.rs",
+    "connlib/tunnel/src/lib.rs",
+    "connlib/tunnel/src/sockets.rs",
     "connlib/tunnel/src/tests.rs",
     "connlib/tunnel/src/tests/*",
-    "connlib/tunnel/src/sockets.rs",
-    "relay/src/sockets.rs",
-    "relay/src/proptests.rs",
     "relay/src/main.rs",
-    "relay/src/sleep.rs",
+    "relay/src/proptest.rs",
+    "relay/src/proptests.rs",
     "relay/src/server/client_message.rs",
+    "relay/src/sleep.rs",
+    "relay/src/sockets.rs",
 ]
 exclude_re = [
     "tests::",
     "proptests::",
     "ClientTunnel::",
     "GatewayTunnel::",
+    "impl Display"
 ]

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,2 +1,3 @@
 target/
 *.pem
+mutants.out*

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "hex-display",
  "http-health-check",
  "mio",
+ "mutants",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5685,6 +5685,7 @@ dependencies = [
  "hex",
  "hex-display",
  "ip-packet",
+ "mutants",
  "once_cell",
  "rand 0.8.5",
  "secrecy",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2050,6 +2050,7 @@ dependencies = [
  "ip_network",
  "ip_network_table",
  "itertools 0.13.0",
+ "mutants",
  "proptest",
  "proptest-state-machine",
  "quinn-udp",

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -18,6 +18,7 @@ str0m = { workspace = true }
 stun_codec = "0.3.4"
 thiserror = "1"
 tracing = { workspace = true }
+mutants = "0.0.3"
 
 [dev-dependencies]
 firezone-relay = { workspace = true }

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -11,6 +11,7 @@ bytes = "1.4.0"
 hex = "0.4.0"
 hex-display = "0.3.0"
 ip-packet = { workspace = true }
+mutants = "0.0.3"
 once_cell = "1.17.1"
 rand = "0.8"
 secrecy = { workspace = true }
@@ -18,7 +19,6 @@ str0m = { workspace = true }
 stun_codec = "0.3.4"
 thiserror = "1"
 tracing = { workspace = true }
-mutants = "0.0.3"
 
 [dev-dependencies]
 firezone-relay = { workspace = true }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1036,6 +1036,7 @@ where
         self.established.iter_mut().map(|(id, conn)| (*id, conn))
     }
 
+    #[mutants::skip]
     fn len(&self) -> usize {
         self.initial.len() + self.established.len()
     }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = { version = "1.0", default-features = false }
 tokio = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 tun = { workspace = true }
+mutants = "0.0.3"
 
 [dev-dependencies]
 derivative = "2.2.0"

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -21,6 +21,7 @@ ip-packet = { workspace = true }
 ip_network = { version = "0.4", default-features = false }
 ip_network_table = { version = "0.2", default-features = false }
 itertools = { version = "0.13", default-features = false, features = ["use_std"] }
+mutants = "0.0.3"
 proptest = { version = "1", optional = true }
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
@@ -34,7 +35,6 @@ thiserror = { version = "1.0", default-features = false }
 tokio = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 tun = { workspace = true }
-mutants = "0.0.3"
 
 [dev-dependencies]
 derivative = "2.2.0"

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -294,16 +294,19 @@ impl ClientState {
     }
 
     #[cfg(all(test, feature = "proptest"))]
+    #[mutants::skip]
     pub(crate) fn tunnel_ip4(&self) -> Option<Ipv4Addr> {
         Some(self.interface_config.as_ref()?.ipv4)
     }
 
     #[cfg(all(test, feature = "proptest"))]
+    #[mutants::skip]
     pub(crate) fn tunnel_ip6(&self) -> Option<Ipv6Addr> {
         Some(self.interface_config.as_ref()?.ipv6)
     }
 
     #[cfg(all(test, feature = "proptest"))]
+    #[mutants::skip]
     pub(crate) fn tunnel_ip_for(&self, dst: IpAddr) -> Option<IpAddr> {
         Some(match dst {
             IpAddr::V4(_) => self.tunnel_ip4()?.into(),

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -16,6 +16,7 @@ hex = "0.4.3"
 hex-display = "0.3.0"
 http-health-check = { workspace = true }
 mio = "0.8.11"
+mutants = "0.0.3"
 once_cell = "1.17.1"
 opentelemetry = { version = "0.22.0", features = ["metrics"] }
 opentelemetry-otlp = { version = "0.15.0", features = ["metrics"] }
@@ -38,7 +39,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json", "fmt"
 trackable = "1.3.0"
 url = "2.4.1"
 uuid = { version = "1.10.0", features = ["v4"] }
-mutants = "0.0.3"
 
 [dev-dependencies]
 difference = "2.0.0"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -38,6 +38,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json", "fmt"
 trackable = "1.3.0"
 url = "2.4.1"
 uuid = { version = "1.10.0", features = ["v4"] }
+mutants = "0.0.3"
 
 [dev-dependencies]
 difference = "2.0.0"

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -208,14 +208,17 @@ where
         self.public_address
     }
 
+    #[mutants::skip]
     pub fn public_ip4(&self) -> Option<IpAddr> {
         Some(IpAddr::V4(*self.public_address.as_v4()?))
     }
 
+    #[mutants::skip]
     pub fn public_ip6(&self) -> Option<IpAddr> {
         Some(IpAddr::V6(*self.public_address.as_v6()?))
     }
 
+    #[mutants::skip]
     pub fn listen_port(&self) -> u16 {
         self.listen_port
     }
@@ -227,14 +230,17 @@ where
         self.nonces.add_new(nonce);
     }
 
+    #[mutants::skip]
     pub fn num_relayed_bytes(&self) -> u64 {
         self.data_relayed
     }
 
+    #[mutants::skip]
     pub fn num_allocations(&self) -> usize {
         self.allocations.len()
     }
 
+    #[mutants::skip]
     pub fn num_active_channels(&self) -> usize {
         self.channels_by_client_and_number
             .iter()


### PR DESCRIPTION
We have a fair amount of (unit) test coverage now thanks to the proptests. What we don't know though is which code paths are actually covered. Mutation testing attempts to find out, which conditions or functions in the code can be changed and whether the (unit) tests detect the change.

This is very much WIP for now. We need to work out, which of the found mutations are actually valid and either write tests for the functions or exclude them from mutations.