### PR TITLE
ci: add `opentelemetry_sdk` to dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,7 @@ updates:
           - opentelemetry-otlp
           - tracing-opentelemetry
           - tracing-stackdriver
+          - opentelemetry_sdk
         update-types:
           - minor
       windows:


### PR DESCRIPTION
These need to be bumped in a group.