### PR TITLE
test(connlib): add `Idle` transition

### DIFF
--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -80,63 +80,6 @@ fn migrate_connection_to_new_relay() {
 }
 
 #[test]
-fn idle_connection_is_closed_after_5_minutes() {
-    let _guard = setup_tracing();
-    let mut clock = Clock::new();
-
-    let (alice, bob) = alice_and_bob();
-
-    let mut relays = [(
-        1,
-        TestRelay::new(
-            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3478),
-            debug_span!("Roger"),
-        ),
-    )];
-    let mut alice = TestNode::new(debug_span!("Alice"), alice, "1.1.1.1:80").with_relays(
-        "alice",
-        BTreeSet::default(),
-        &mut relays,
-        clock.now,
-    );
-    let mut bob = TestNode::new(debug_span!("Bob"), bob, "2.2.2.2:80").with_relays(
-        "bob",
-        BTreeSet::default(),
-        &mut relays,
-        clock.now,
-    );
-    let firewall = Firewall::default();
-
-    handshake(&mut alice, &mut bob, &clock);
-
-    loop {
-        if alice.is_connected_to(&bob) && bob.is_connected_to(&alice) {
-            break;
-        }
-
-        progress(&mut alice, &mut bob, &mut relays, &firewall, &mut clock);
-    }
-
-    alice.ping(ip("9.9.9.9"), ip("8.8.8.8"), &bob, clock.now);
-    bob.ping(ip("8.8.8.8"), ip("9.9.9.9"), &alice, clock.now);
-
-    let start = clock.now;
-
-    while clock.elapsed(start) <= Duration::from_secs(5 * 60) {
-        progress(&mut alice, &mut bob, &mut relays, &firewall, &mut clock);
-    }
-
-    assert_eq!(alice.packets_from(ip("8.8.8.8")).count(), 1);
-    assert_eq!(bob.packets_from(ip("9.9.9.9")).count(), 1);
-    assert!(alice
-        .events
-        .contains(&(Event::ConnectionClosed(1), clock.now)));
-    assert!(bob
-        .events
-        .contains(&(Event::ConnectionClosed(1), clock.now)));
-}
-
-#[test]
 fn connection_times_out_after_20_seconds() {
     let (mut alice, _) = alice_and_bob();
 

--- a/rust/connlib/tunnel/src/tests/flux_capacitor.rs
+++ b/rust/connlib/tunnel/src/tests/flux_capacitor.rs
@@ -54,7 +54,7 @@ impl FluxCapacitor {
         self.tick(Self::LARGE_TICK);
     }
 
-    fn tick(&self, tick: Duration) {
+    pub(crate) fn tick(&self, tick: Duration) {
         {
             let mut guard = self.now.lock().unwrap();
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -281,6 +281,15 @@ impl StateMachineTest for TunnelTest {
                     c.sut.set_resources(all_resources);
                 });
             }
+            Transition::Idle => {
+                const IDLE_DURATION: Duration = Duration::from_secs(5 * 60);
+                let cut_off = state.flux_capacitor.now::<Instant>() + IDLE_DURATION;
+
+                while state.flux_capacitor.now::<Instant>() <= cut_off {
+                    state.flux_capacitor.tick(Duration::from_secs(5));
+                    state.advance(ref_state, &mut buffered_transmits);
+                }
+            }
         };
         state.advance(ref_state, &mut buffered_transmits);
 

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -65,6 +65,9 @@ pub(crate) enum Transition {
 
     /// Reconnect to the portal.
     ReconnectPortal,
+
+    /// Idle connlib for a while, forcing connection to auto-close.
+    Idle,
 }
 
 pub(crate) fn ping_random_ip<I>(


### PR DESCRIPTION
In #5948, we start testing network latency within `tunnel_test` to make sure _some_ time-related things are triggered. Building on top of that, we now add an `Idle` transition that does nothing for 5 minutes. After 5 minutes of idling, we auto-close a connection.

Using this new state transition, we can replace another test within `snownet`, further reducing that (duplicated) test suite. In addition, this gives us some more coverage of code by testing whether allocations and channel bindings can be refreshed accordingly.