### PR TITLE
fix(infra): Resolve capacity issues during rollouts

### DIFF
--- a/terraform/environments/production/bi.tf
+++ b/terraform/environments/production/bi.tf
@@ -65,7 +65,7 @@ module "metabase" {
   compute_network    = module.google-cloud-vpc.id
   compute_subnetwork = google_compute_subnetwork.tools.self_link
 
-  compute_instance_type              = "n1-standard-1"
+  compute_instance_type              = "n2-standard-2"
   compute_region                     = local.metabase_region
   compute_instance_availability_zone = local.metabase_zone
 

--- a/terraform/environments/production/portal.tf
+++ b/terraform/environments/production/portal.tf
@@ -392,7 +392,7 @@ module "domain" {
 
   compute_instance_type               = "n4-standard-2"
   compute_instance_region             = local.region
-  compute_instance_availability_zones = ["${local.region}-d", "${local.region}-c"]
+  compute_instance_availability_zones = ["${local.region}-d"]
   compute_boot_disk_type              = "hyperdisk-balanced"
 
   dns_managed_zone_name = module.google-cloud-dns.zone_name
@@ -455,10 +455,10 @@ module "web" {
   source     = "../../modules/google-cloud/apps/elixir"
   project_id = module.google-cloud-project.project.project_id
 
-  compute_instance_type               = "n4-standard-2"
+  compute_instance_type               = "n2-standard-2"
   compute_instance_region             = local.region
-  compute_instance_availability_zones = ["${local.region}-d", "${local.region}-c"]
-  compute_boot_disk_type              = "hyperdisk-balanced"
+  compute_instance_availability_zones = ["${local.region}-d"]
+  compute_boot_disk_type              = "pd-ssd"
 
   dns_managed_zone_name = module.google-cloud-dns.zone_name
 
@@ -535,7 +535,7 @@ module "api" {
 
   compute_instance_type               = "n4-standard-2"
   compute_instance_region             = local.region
-  compute_instance_availability_zones = ["${local.region}-d", "${local.region}-c"]
+  compute_instance_availability_zones = ["${local.region}-d"]
   compute_boot_disk_type              = "hyperdisk-balanced"
 
   dns_managed_zone_name = module.google-cloud-dns.zone_name

--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -10,93 +10,93 @@ module "relays" {
   instances = {
     "asia-east1" = {
       cidr_range = "10.129.0.0/24"
-      type       = "n2-highcpu-2"
-      replicas   = 1
-      zones      = ["asia-east1-a", "asia-east1-b", "asia-east1-c"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["asia-east1-c"]
     }
 
     "asia-south1" = {
       cidr_range = "10.130.0.0/24"
-      type       = "f1-micro"
-      replicas   = 1
-      zones      = ["asia-south1-a", "asia-south1-b", "asia-south1-c"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["asia-south1-c"]
     }
 
     "australia-southeast1" = {
       cidr_range = "10.131.0.0/24"
-      type       = "f1-micro"
-      replicas   = 1
-      zones      = ["australia-southeast1-a", "australia-southeast1-b", "australia-southeast1-c"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["australia-southeast1-c"]
     }
 
     "europe-west1" = {
       cidr_range = "10.132.0.0/24"
-      type       = "f1-micro"
-      replicas   = 1
-      zones      = ["europe-west1-b", "europe-west1-c", "europe-west1-d"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["europe-west1-d"]
     }
 
     # "me-central1" = {
     #   cidr_range = "10.133.0.0/24"
-    #   type       = "n2-highcpu-2"
-    #   replicas   = 1
-    #   zones      = ["me-central1-a"]
+    #   type       = "e2-micro"
+    #   replicas   = 2
+    #   zones      ["me-central1-a"]
     # }
 
     "southamerica-east1" = {
       cidr_range = "10.134.0.0/24"
-      type       = "f1-micro"
-      replicas   = 1
-      zones      = ["southamerica-east1-a", "southamerica-east1-b", "southamerica-east1-c"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["southamerica-east1-c"]
     }
 
     "us-central1" = {
       cidr_range = "10.135.0.0/24"
-      type       = "f1-micro"
-      replicas   = 1
-      zones      = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-d", "us-central1-f"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-central1-f"]
     }
 
     "us-east1" = {
       cidr_range = "10.136.0.0/24"
-      type       = "f1-micro"
-      replicas   = 1
-      zones      = ["us-east1-a", "us-east1-b", "us-east1-c", "us-east1-d"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-east1-c"]
     }
 
     "us-west2" = {
       cidr_range = "10.137.0.0/24"
-      type       = "n2-highcpu-2"
-      replicas   = 1
-      zones      = ["us-west2-a", "us-west2-b", "us-west2-c"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-west2-b"]
     }
 
     "europe-central2" = {
       cidr_range = "10.138.0.0/24"
-      type       = "f1-micro"
-      replicas   = 1
-      zones      = ["europe-central2-a", "europe-central2-b", "europe-central2-c"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["europe-central2-c"]
     }
 
     "europe-north1" = {
       cidr_range = "10.139.0.0/24"
-      type       = "f1-micro"
-      replicas   = 1
-      zones      = ["europe-north1-a", "europe-north1-b", "europe-north1-c"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["europe-north1-c"]
     }
 
     "europe-west2" = {
       cidr_range = "10.140.0.0/24"
-      type       = "n2-highcpu-2"
-      replicas   = 1
-      zones      = ["europe-west2-a", "europe-west2-b", "europe-west2-c"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["europe-west2-c"]
     }
 
     "us-east4" = {
       cidr_range = "10.141.0.0/24"
-      type       = "f1-micro"
-      replicas   = 1
-      zones      = ["us-east4-a", "us-east4-b", "us-east4-c"]
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-east4-c"]
     }
   }
 

--- a/terraform/modules/google-cloud/apps/gateway-region-instance-group/main.tf
+++ b/terraform/modules/google-cloud/apps/gateway-region-instance-group/main.tf
@@ -52,6 +52,10 @@ resource "google_compute_instance_template" "application" {
     provisioning_model  = "STANDARD"
   }
 
+  reservation_affinity {
+    type = "ANY_RESERVATION"
+  }
+
   disk {
     source_image = data.google_compute_image.ubuntu.self_link
     auto_delete  = true

--- a/website/src/app/kb/architecture/tech-stack/readme.mdx
+++ b/website/src/app/kb/architecture/tech-stack/readme.mdx
@@ -106,20 +106,20 @@ Firezone uses the following tools for ops and infrastructure:
 The Firezone-managed components are deployed globally across the following GCP
 zones for load balancing and latency optimization:
 
-| City                               | Region                 | Zones                                                                               |
-| ---------------------------------- | ---------------------- | ----------------------------------------------------------------------------------- |
-| Changhua, Taiwan                   | `asia-east1`           | `asia-east1-a`, `asia-east1-b`, `asia-east1-c`                                      |
-| Mumbai, India                      | `asia-south1`          | `asia-south1-a`, `asia-south1-b`, `asia-south1-c`                                   |
-| Sydney, Australia                  | `australia-southeast1` | `australia-southeast1-a`, `australia-southeast1-b`, `australia-southeast1-c`        |
-| Warsaw, Poland                     | `europe-central2`      | `europe-central2-a`, `europe-central2-b`, `europe-central2-c`                       |
-| Hamina, Finland                    | `europe-north1`        | `europe-north1-a`, `europe-north1-b`, `europe-north1-c`                             |
-| Saint-Ghislain, Belgium            | `europe-west1`         | `europe-west1-b`, `europe-west1-c`, `europe-west1-d`                                |
-| London, UK                         | `europe-west2`         | `europe-west2-a`, `europe-west2-b`, `europe-west2-c`                                |
-| São Paulo, Brazil                  | `southamerica-east1`   | `southamerica-east1-a`, `southamerica-east1-b`, `southamerica-east1-c`              |
-| Council Bluffs, Iowa, USA          | `us-central1`          | `us-central1-a`, `us-central1-b`, `us-central1-c`, `us-central1-d`, `us-central1-f` |
-| Moncks Corner, South Carolina, USA | `us-east1`             | `us-east1-a`, `us-east1-b`, `us-east1-c`, `us-east1-d`                              |
-| Los Angeles, California, USA       | `us-west2`             | `us-west2-a`, `us-west2-b`, `us-west2-c`                                            |
-| Ashburn, Northern Virginia, USA    | `us-east4`             | `us-east4-a`, `us-east4-b`, `us-east4-c`                                            |
+| City                               | Region                 | Zones                    |
+| ---------------------------------- | ---------------------- | ------------------------ |
+| Changhua, Taiwan                   | `asia-east1`           | `asia-east1-c`           |
+| Mumbai, India                      | `asia-south1`          | `asia-south1-c`          |
+| Sydney, Australia                  | `australia-southeast1` | `australia-southeast1-c` |
+| Warsaw, Poland                     | `europe-central2`      | `europe-central2-c`      |
+| Hamina, Finland                    | `europe-north1`        | `europe-north1-c`        |
+| Saint-Ghislain, Belgium            | `europe-west1`         | `europe-west1-d`         |
+| London, UK                         | `europe-west2`         | `europe-west2-c`         |
+| São Paulo, Brazil                  | `southamerica-east1`   | `southamerica-east1-c`   |
+| Council Bluffs, Iowa, USA          | `us-central1`          | `us-central1-f`          |
+| Moncks Corner, South Carolina, USA | `us-east1`             | `us-east1-c`             |
+| Los Angeles, California, USA       | `us-west2`             | `us-west2-b`             |
+| Ashburn, Northern Virginia, USA    | `us-east4`             | `us-east4-c`             |
 
 <Link
   target="_blank"


### PR DESCRIPTION
I've managed to finally reserve enough e2 instances for our needs and also used e2 for gateways to workaround the quota issues. The `web` app still used n2 because quota doesn't allow additional n4's. Rollouts also fixed to not go over the reservations/quotas.