### PR TITLE
fix(api): fix generated openapi spec

### DIFF
--- a/elixir/apps/api/lib/api/controllers/gateway_group_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/gateway_group_controller.ex
@@ -79,6 +79,14 @@ defmodule API.GatewayGroupController do
 
   operation :update,
     summary: "Update a Gateway Group",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Gateway Group ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ]
+    ],
     request_body:
       {"Gateway Group Attributes", "application/json", API.Schemas.GatewayGroup.Request,
        required: true},

--- a/elixir/apps/api/lib/api/controllers/identity_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/identity_controller.ex
@@ -77,6 +77,12 @@ defmodule API.IdentityController do
   operation :show,
     summary: "Show Identity",
     parameters: [
+      actor_id: [
+        in: :path,
+        description: "Actor ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ],
       id: [
         in: :path,
         description: "Identity ID",

--- a/elixir/apps/api/lib/api/controllers/policy_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/policy_controller.ex
@@ -73,6 +73,14 @@ defmodule API.PolicyController do
 
   operation :update,
     summary: "Update a Policy",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Policy ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ]
+    ],
     request_body:
       {"Policy Attributes", "application/json", API.Schemas.Policy.Request, required: true},
     responses: [

--- a/elixir/apps/api/lib/api/controllers/resource_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/resource_controller.ex
@@ -73,6 +73,14 @@ defmodule API.ResourceController do
 
   operation :update,
     summary: "Update Resource",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Resource ID",
+        type: :string,
+        example: "00000000-0000-0000-0000-000000000000"
+      ]
+    ],
     request_body:
       {"Resource Attributes", "application/json", API.Schemas.Resource.Request, required: true},
     responses: [

--- a/elixir/apps/api/lib/api/router.ex
+++ b/elixir/apps/api/lib/api/router.ex
@@ -51,7 +51,7 @@ defmodule API.Router do
     end
 
     resources "/actors", ActorController, except: [:new, :edit] do
-      resources "/identities", IdentityController, except: [:new, :edit, :update]
+      resources "/identities", IdentityController, except: [:new, :edit, :create, :update]
       post "/providers/:provider_id/identities/", IdentityController, :create
     end
 

--- a/elixir/apps/api/lib/api/schemas/actor_group_membership_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/actor_group_membership_schema.ex
@@ -6,7 +6,7 @@ defmodule API.Schemas.ActorGroupMembership do
     alias OpenApiSpex.Schema
 
     OpenApiSpex.schema(%{
-      title: "Actor Group Membership",
+      title: "ActorGroupMembership",
       description: "Actor Group Membership",
       type: :array,
       items: %Schema{
@@ -33,7 +33,7 @@ defmodule API.Schemas.ActorGroupMembership do
     alias API.Schemas.ActorGroupMembership
 
     OpenApiSpex.schema(%{
-      title: "Actor Group Membership Patch Request",
+      title: "ActorGroupMembershipPatchRequest",
       description: "PATCH body for updating Actor Group Memberships",
       type: :object,
       properties: %{
@@ -72,7 +72,7 @@ defmodule API.Schemas.ActorGroupMembership do
     alias API.Schemas.ActorGroupMembership
 
     OpenApiSpex.schema(%{
-      title: "Actor Group Membership Put Request",
+      title: "ActorGroupMembershipPutRequest",
       description: "PUT body for updating Actor Group Memberships",
       type: :object,
       properties: %{
@@ -102,7 +102,7 @@ defmodule API.Schemas.ActorGroupMembership do
     alias API.Schemas.ActorGroupMembership
 
     OpenApiSpex.schema(%{
-      title: "Actor Group Membership List Response",
+      title: "ActorGroupMembershipListResponse",
       description: "Response schema for Actor Group Memberships",
       type: :object,
       properties: %{
@@ -141,7 +141,7 @@ defmodule API.Schemas.ActorGroupMembership do
     alias OpenApiSpex.Schema
 
     OpenApiSpex.schema(%{
-      title: "Actor Group Membership Response",
+      title: "ActorGroupMembershipResponse",
       description: "Response schema for Actor Group Membership Updates",
       type: :object,
       properties: %{

--- a/elixir/apps/api/lib/api/schemas/actor_group_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/actor_group_schema.ex
@@ -6,7 +6,7 @@ defmodule API.Schemas.ActorGroup do
     alias OpenApiSpex.Schema
 
     OpenApiSpex.schema(%{
-      title: "Actor Group",
+      title: "ActorGroup",
       description: "Actor Group",
       type: :object,
       properties: %{
@@ -27,7 +27,7 @@ defmodule API.Schemas.ActorGroup do
     alias API.Schemas.ActorGroup
 
     OpenApiSpex.schema(%{
-      title: "Actor Group Request",
+      title: "ActorGroupRequest",
       description: "POST body for creating an Actor Group",
       type: :object,
       properties: %{
@@ -48,7 +48,7 @@ defmodule API.Schemas.ActorGroup do
     alias API.Schemas.ActorGroup
 
     OpenApiSpex.schema(%{
-      title: "Actor GroupResponse",
+      title: "ActorGroupResponse",
       description: "Response schema for single Actor Group",
       type: :object,
       properties: %{
@@ -69,7 +69,7 @@ defmodule API.Schemas.ActorGroup do
     alias API.Schemas.ActorGroup
 
     OpenApiSpex.schema(%{
-      title: "Actor Group List Response",
+      title: "ActorGroupListResponse",
       description: "Response schema for multiple Actor Groups",
       type: :object,
       properties: %{

--- a/elixir/apps/api/lib/api/schemas/gateway_group_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/gateway_group_schema.ex
@@ -6,7 +6,7 @@ defmodule API.Schemas.GatewayGroup do
     alias OpenApiSpex.Schema
 
     OpenApiSpex.schema(%{
-      title: "Gateway Group",
+      title: "GatewayGroup",
       description: "Gateway Group",
       type: :object,
       properties: %{
@@ -27,7 +27,7 @@ defmodule API.Schemas.GatewayGroup do
     alias API.Schemas.GatewayGroup
 
     OpenApiSpex.schema(%{
-      title: "Gateway GroupRequest",
+      title: "GatewayGroupRequest",
       description: "POST body for creating a Gateway Group",
       type: :object,
       properties: %{
@@ -48,7 +48,7 @@ defmodule API.Schemas.GatewayGroup do
     alias API.Schemas.GatewayGroup
 
     OpenApiSpex.schema(%{
-      title: "Gateway GroupResponse",
+      title: "GatewayGroupResponse",
       description: "Response schema for single Gateway Group",
       type: :object,
       properties: %{
@@ -69,7 +69,7 @@ defmodule API.Schemas.GatewayGroup do
     alias API.Schemas.GatewayGroup
 
     OpenApiSpex.schema(%{
-      title: "Gateway Group List Response",
+      title: "GatewayGroupListResponse",
       description: "Response schema for multiple Gateway Groups",
       type: :object,
       properties: %{

--- a/elixir/apps/api/lib/api/schemas/gateway_group_token_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/gateway_group_token_schema.ex
@@ -6,7 +6,7 @@ defmodule API.Schemas.GatewayGroupToken do
     alias OpenApiSpex.Schema
 
     OpenApiSpex.schema(%{
-      title: "Gateway Group Token",
+      title: "GatewayGroupToken",
       description: "Gateway Group Token",
       type: :object,
       properties: %{
@@ -27,7 +27,7 @@ defmodule API.Schemas.GatewayGroupToken do
     alias API.Schemas.GatewayGroupToken
 
     OpenApiSpex.schema(%{
-      title: "New Gateway Group Token Response",
+      title: "NewGatewayGroupTokenResponse",
       description: "Response schema for a new Gateway Group Token",
       type: :object,
       properties: %{
@@ -48,7 +48,7 @@ defmodule API.Schemas.GatewayGroupToken do
     alias API.Schemas.GatewayGroupToken
 
     OpenApiSpex.schema(%{
-      title: "Deleted Gateway Group Token Response",
+      title: "DeletedGatewayGroupTokenResponse",
       description: "Response schema for a new Gateway Group Token",
       type: :object,
       properties: %{
@@ -68,7 +68,7 @@ defmodule API.Schemas.GatewayGroupToken do
     alias API.Schemas.GatewayGroupToken
 
     OpenApiSpex.schema(%{
-      title: "Deleted Gateway Group Token List Response",
+      title: "DeletedGatewayGroupTokenListResponse",
       description: "Response schema for deleted Gateway Group Tokens",
       type: :object,
       properties: %{

--- a/elixir/apps/api/lib/api/schemas/gateway_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/gateway_schema.ex
@@ -46,7 +46,7 @@ defmodule API.Schemas.Gateway do
     alias API.Schemas.Gateway
 
     OpenApiSpex.schema(%{
-      title: "Gateway Response",
+      title: "GatewayResponse",
       description: "Response schema for single Gateway",
       type: :object,
       properties: %{

--- a/elixir/apps/api/lib/api/schemas/identity_provider_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/identity_provider_schema.ex
@@ -6,7 +6,7 @@ defmodule API.Schemas.IdentityProvider do
     alias OpenApiSpex.Schema
 
     OpenApiSpex.schema(%{
-      title: "Identity Provider",
+      title: "IdentityProvider",
       description: "Identity Provider",
       type: :object,
       properties: %{
@@ -27,7 +27,7 @@ defmodule API.Schemas.IdentityProvider do
     alias API.Schemas.IdentityProvider
 
     OpenApiSpex.schema(%{
-      title: "Identity Provider Response",
+      title: "IdentityProviderResponse",
       description: "Response schema for single Identity Provider",
       type: :object,
       properties: %{
@@ -48,7 +48,7 @@ defmodule API.Schemas.IdentityProvider do
     alias API.Schemas.IdentityProvider
 
     OpenApiSpex.schema(%{
-      title: "Identity Provider List Response",
+      title: "IdentityProviderListResponse",
       description: "Response schema for multiple Identity Providers",
       type: :object,
       properties: %{

--- a/elixir/apps/api/lib/api/schemas/identity_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/identity_schema.ex
@@ -40,8 +40,6 @@ defmodule API.Schemas.Identity do
       required: [:identity],
       example: %{
         "identity" => %{
-          "actor_id" => "cdfa97e6-cca1-41db-8fc7-864daedb46df",
-          "provider_id" => "989f9e96-e348-47ec-ba85-869fcd7adb19",
           "provider_identifier" => "foo@bar.com"
         }
       }
@@ -77,7 +75,7 @@ defmodule API.Schemas.Identity do
     alias API.Schemas.Identity
 
     OpenApiSpex.schema(%{
-      title: "Identity List Response",
+      title: "IdentityListResponse",
       description: "Response schema for multiple Identities",
       type: :object,
       properties: %{

--- a/elixir/apps/api/lib/api/schemas/policy_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/policy_schema.ex
@@ -31,7 +31,7 @@ defmodule API.Schemas.Policy do
     alias API.Schemas.Policy
 
     OpenApiSpex.schema(%{
-      title: "Policy Request",
+      title: "PolicyRequest",
       description: "POST body for creating a Policy",
       type: :object,
       properties: %{
@@ -54,7 +54,7 @@ defmodule API.Schemas.Policy do
     alias API.Schemas.Policy
 
     OpenApiSpex.schema(%{
-      title: "Policy Response",
+      title: "PolicyResponse",
       description: "Response schema for single Policy",
       type: :object,
       properties: %{
@@ -77,7 +77,7 @@ defmodule API.Schemas.Policy do
     alias API.Schemas.Policy
 
     OpenApiSpex.schema(%{
-      title: "Policy List Response",
+      title: "PolicyListResponse",
       description: "Response schema for multiple Policies",
       type: :object,
       properties: %{

--- a/elixir/apps/api/lib/api/schemas/resource_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/resource_schema.ex
@@ -82,8 +82,8 @@ defmodule API.Schemas.Resource do
     alias API.Schemas.Resource
 
     OpenApiSpex.schema(%{
-      title: "Gateway List Response",
-      description: "Response schema for multiple Gateways",
+      title: "ResourceListResponse",
+      description: "Response schema for multiple Resources",
       type: :object,
       properties: %{
         data: %Schema{description: "Resource details", type: :array, items: Resource.Schema},

--- a/elixir/apps/api/test/api/controllers/identity_controller_test.exs
+++ b/elixir/apps/api/test/api/controllers/identity_controller_test.exs
@@ -109,8 +109,11 @@ defmodule API.IdentityControllerTest do
   end
 
   describe "create/2" do
-    test "returns error when not authorized", %{conn: conn, actor: actor} do
-      conn = post(conn, "/actors/#{actor.id}/identities", %{})
+    test "returns error when not authorized", %{conn: conn, account: account, actor: actor} do
+      {oidc_provider, _bypass} =
+        Fixtures.Auth.start_and_create_openid_connect_provider(account: account)
+
+      conn = post(conn, "/actors/#{actor.id}/providers/#{oidc_provider.id}/identities", %{})
       assert json_response(conn, 401) == %{"error" => %{"reason" => "Unauthorized"}}
     end
 
@@ -119,13 +122,16 @@ defmodule API.IdentityControllerTest do
       account: account,
       actor: api_actor
     } do
+      {oidc_provider, _bypass} =
+        Fixtures.Auth.start_and_create_openid_connect_provider(account: account)
+
       actor = Fixtures.Actors.create_actor(account: account)
 
       conn =
         conn
         |> authorize_conn(api_actor)
         |> put_req_header("content-type", "application/json")
-        |> post("/actors/#{actor.id}/identities")
+        |> post("/actors/#{actor.id}/providers/#{oidc_provider.id}/identities")
 
       assert resp = json_response(conn, 400)
       assert resp == %{"error" => %{"reason" => "Bad Request"}}
@@ -144,8 +150,7 @@ defmodule API.IdentityControllerTest do
         conn
         |> authorize_conn(api_actor)
         |> put_req_header("content-type", "application/json")
-        |> post("/actors/#{actor.id}/identities",
-          provider_id: "1234",
+        |> post("/actors/#{actor.id}/providers/1234/identities",
           identity: attrs
         )
 
@@ -169,8 +174,7 @@ defmodule API.IdentityControllerTest do
         conn
         |> authorize_conn(api_actor)
         |> put_req_header("content-type", "application/json")
-        |> post("/actors/#{actor.id}/identities",
-          provider_id: oidc_provider.id,
+        |> post("/actors/#{actor.id}/providers/#{oidc_provider.id}/identities",
           identity: attrs
         )
 
@@ -201,8 +205,7 @@ defmodule API.IdentityControllerTest do
         conn
         |> authorize_conn(api_actor)
         |> put_req_header("content-type", "application/json")
-        |> post("/actors/#{actor.id}/identities",
-          provider_id: oidc_provider.id,
+        |> post("/actors/#{actor.id}/providers/#{oidc_provider.id}/identities",
           identity: attrs
         )
 


### PR DESCRIPTION
(External contribution)

Hi, first thanks to @bmanifold for his awesome work! I've not yet tested the API but here is a first PR fixing various small mistakes in the generated openapi spec:

Schema names cannot contain spaces
Add missing path parameters in the spec
Remove duplicated endpoint for creating an identity (not sure about that, I'll let you check)
If you want to validate the generated spec you can paste it here: https://editor.swagger.io/ (or at the bottow of your swagger ui)

Please review commit by commit