### PR TITLE
ci(rust): setup mold linker for Linux runners

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -68,7 +68,13 @@ runs:
       run: Set-MpPreference -DisableRealtimeMonitoring $true
       shell: powershell
 
-    - uses: rui314/setup-mold@v1
+    - name: Use mold on Linux
+      if: ${{ runner.os == 'Linux' }}
+      uses: rui314/setup-mold@v1
+
+    - name: Use lld on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: echo "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=rust-lld" >> $GITHUB_ENV;
 
     # Common to either cache backend
     - name: Extract Rust version

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -68,6 +68,8 @@ runs:
       run: Set-MpPreference -DisableRealtimeMonitoring $true
       shell: powershell
 
+    - uses: rui314/setup-mold@v1
+
     # Common to either cache backend
     - name: Extract Rust version
       run: |

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -75,6 +75,7 @@ runs:
     - name: Use lld on Windows
       if: ${{ runner.os == 'Windows' }}
       run: echo "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=rust-lld" >> $GITHUB_ENV;
+      shell: bash
 
     # Common to either cache backend
     - name: Extract Rust version

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -87,9 +87,6 @@ jobs:
       - name: Build release exe and MSI / deb
         # Signs the exe before bundling it into the MSI
         run: pnpm build
-      - name: Check what linker was used
-        if: ${{ runner.os == 'Linux' }}
-        run: readelf -p .comment ${{ matrix.binary-dest-path }}
       # We need to sign the exe inside the MSI. Currently
       # we do this in a "beforeBundleCommand" hook in tauri.windows.conf.json.
       # But this will soon be natively supported in Tauri.
@@ -127,3 +124,6 @@ jobs:
           TAG_NAME: gui-client-1.1.8
         shell: bash
         run: ${{ matrix.upload-script }}
+      - name: Check what linker was used
+        if: ${{ runner.os == 'Linux' }}
+        run: readelf -p .comment ${{ matrix.binary-dest-path }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Build release exe and MSI / deb
         # Signs the exe before bundling it into the MSI
         run: pnpm build
+      - name: Check what linker was used
+        if: ${{ runner.os == 'Linux' }}
+        run: readelf -p .comment ${{ matrix.binary-dest-path }}
       # We need to sign the exe inside the MSI. Currently
       # we do this in a "beforeBundleCommand" hook in tauri.windows.conf.json.
       # But this will soon be natively supported in Tauri.

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -124,6 +124,3 @@ jobs:
           TAG_NAME: gui-client-1.1.8
         shell: bash
         run: ${{ matrix.upload-script }}
-      - name: Check what linker was used
-        if: ${{ runner.os == 'Linux' }}
-        run: readelf -p .comment ${{ matrix.binary-dest-path }}


### PR DESCRIPTION
`mold` is a much faster linker compared to GNU's `ld`.