### PR TITLE
chore(connlib): use `Relaxed` ordering

### DIFF
--- a/rust/connlib/tunnel/src/tests/run_count_appender.rs
+++ b/rust/connlib/tunnel/src/tests/run_count_appender.rs
@@ -5,7 +5,7 @@ use tracing_appender::rolling::RollingFileAppender;
 #[allow(dead_code)]
 pub(crate) fn appender() -> RollingFileAppender {
     static RUN_COUNT: AtomicU32 = AtomicU32::new(0);
-    let run_count = RUN_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let run_count = RUN_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
     tracing_appender::rolling::never(".", format!("run_{run_count:04}.log"))
 }


### PR DESCRIPTION
Feedback from #5948.