### PR TITLE
refactor(connlib): replace `domain` with `hickory-proto`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1117,9 +1117,9 @@ dependencies = [
  "base64 0.22.1",
  "boringtun",
  "chrono",
- "domain",
  "futures",
  "futures-util",
+ "hickory-proto",
  "ip-packet",
  "ip_network",
  "itertools 0.13.0",
@@ -1581,20 +1581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "domain"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd50aea158e9a57c9c9075ca7a3dfa4c08d9a468b405832383876f9df85379b"
-dependencies = [
- "bytes",
- "octseq",
- "pin-project-lite",
- "rand 0.8.5",
- "serde",
- "time",
-]
-
-[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,7 +1848,6 @@ dependencies = [
  "clap",
  "connlib-shared",
  "dns-lookup",
- "domain",
  "either",
  "firezone-bin-shared",
  "firezone-tunnel",
@@ -2037,7 +2022,6 @@ dependencies = [
  "chrono",
  "connlib-shared",
  "derivative",
- "domain",
  "firezone-relay",
  "futures",
  "futures-bounded",
@@ -2708,6 +2692,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand 0.8.5",
+ "serde",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -4142,16 +4127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "octseq"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ed2eaec452d98ccc1c615dd843fd039d9445f2fb4da114ee7e6af5fcb68be98"
-dependencies = [
- "bytes",
- "serde",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,7 +35,6 @@ hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "
 hickory-proto = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63" }
 str0m = { version = "0.5", default-features = false }
 futures-bounded = "0.2.1"
-domain = { version = "0.10", features = ["serde"] }
 dns-lookup = "2.0"
 tokio-tungstenite = "0.21"
 rtnetlink = { version = "0.14.1", default-features = false, features = ["tokio_socket"] }

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -13,7 +13,6 @@ anyhow = "1.0.82"
 base64 = { version = "0.22", default-features = false, features = ["std"] }
 boringtun = { workspace = true }
 chrono = { workspace = true }
-domain = { workspace = true }
 futures =  { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
 futures-util =  { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }
 ip-packet = { workspace = true }
@@ -32,6 +31,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 thiserror = { version = "1.0", default-features = false }
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
+hickory-proto = { workspace = true, features = ["serde-config"] }
 url = { version = "2.4.1", default-features = false }
 uuid = { version = "1.10", default-features = false, features = ["std", "v4", "serde"] }
 

--- a/rust/connlib/shared/src/lib.rs
+++ b/rust/connlib/shared/src/lib.rs
@@ -22,7 +22,7 @@ pub use phoenix_channel::{LoginUrl, LoginUrlError};
 
 use rand_core::OsRng;
 
-pub type DomainName = domain::base::Name<Vec<u8>>;
+pub type DomainName = hickory_proto::rr::domain::Name;
 
 /// Bundle ID / App ID that the client uses to distinguish itself from other programs on the system
 ///

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -10,7 +10,6 @@ boringtun = { workspace = true }
 bytes = { version = "1.4", default-features = false, features = ["std"] }
 chrono = { workspace = true }
 connlib-shared = { workspace = true }
-domain = { workspace = true }
 futures =  { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
 futures-bounded = { workspace = true }
 futures-util =  { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1187,7 +1187,7 @@ fn maybe_mangle_dns_query_to_cidr_resource<'p>(
         return packet;
     };
 
-    let Ok(message) = domain::base::Message::from_slice(dgm.payload()) else {
+    let Ok(message) = hickory_proto::op::Message::from_vec(dgm.payload()) else {
         return packet;
     };
 
@@ -1218,7 +1218,7 @@ fn maybe_mangle_dns_response_from_cidr_resource<'p>(
         return packet;
     };
 
-    let Ok(message) = domain::base::Message::from_slice(udp.payload()) else {
+    let Ok(message) = hickory_proto::op::Message::from_vec(udp.payload()) else {
         return packet;
     };
 
@@ -1231,10 +1231,7 @@ fn maybe_mangle_dns_response_from_cidr_resource<'p>(
 
     let rtt = now.duration_since(query_sent_at);
 
-    let domains = message
-        .question()
-        .filter_map(|q| Some(q.ok()?.into_qname()))
-        .join(",");
+    let domains = message.queries().iter().map(|q| q.name()).join(",");
 
     tracing::trace!(old_src = %src_ip, new_src = %sentinel, ?rtt, %domains, "Mangling DNS response from CIDR resource");
 

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -593,31 +593,31 @@ mod tests {
 
     #[test]
     fn wildcard_matching() {
-        let resources = HashMap::from([("*.foo.com".to_string(), 0), ("*.com".to_string(), 1)]);
+        let res = resolver([("*.foo.com", rid(0)), ("*.com", rid(1))]);
 
-        assert_eq!(match_domain(&domain("a.foo.com"), &resources), Some(0));
-        assert_eq!(match_domain(&domain("foo.com"), &resources), Some(0));
-        assert_eq!(match_domain(&domain("a.b.foo.com"), &resources), Some(0));
-        assert_eq!(match_domain(&domain("oo.com"), &resources), Some(1));
-        assert_eq!(match_domain(&domain("oo.xyz"), &resources), None);
+        assert_eq!(res.match_resource(&domain("a.foo.com")), Some(rid(0)));
+        assert_eq!(res.match_resource(&domain("foo.com")), Some(rid(0)));
+        assert_eq!(res.match_resource(&domain("a.b.foo.com")), Some(rid(0)));
+        assert_eq!(res.match_resource(&domain("oo.com")), Some(rid(1)));
+        assert_eq!(res.match_resource(&domain("oo.xyz")), None);
     }
 
     #[test]
     fn question_mark_matching() {
-        let resources = HashMap::from([("?.bar.com".to_string(), 1)]);
+        let res = resolver([("?.bar.com", rid(1))]);
 
-        assert_eq!(match_domain(&domain("a.bar.com"), &resources), Some(1));
-        assert_eq!(match_domain(&domain("bar.com"), &resources), Some(1));
-        assert_eq!(match_domain(&domain("a.b.bar.com"), &resources), None);
+        assert_eq!(res.match_resource(&domain("a.bar.com")), Some(rid(1)));
+        assert_eq!(res.match_resource(&domain("bar.com")), Some(rid(1)));
+        assert_eq!(res.match_resource(&domain("a.b.bar.com")), None);
     }
 
     #[test]
     fn exact_matching() {
-        let resources = HashMap::from([("baz.com".to_string(), 2)]);
+        let res = resolver([("baz.com", rid(2))]);
 
-        assert_eq!(match_domain(&domain("baz.com"), &resources), Some(2));
-        assert_eq!(match_domain(&domain("a.baz.com"), &resources), None);
-        assert_eq!(match_domain(&domain("a.b.baz.com"), &resources), None);
+        assert_eq!(res.match_resource(&domain("baz.com")), Some(rid(2)));
+        assert_eq!(res.match_resource(&domain("a.baz.com")), None);
+        assert_eq!(res.match_resource(&domain("a.b.baz.com")), None);
     }
 
     #[test]
@@ -653,5 +653,19 @@ mod tests {
 
     fn domain(name: &str) -> DomainName {
         DomainName::vec_from_str(name).unwrap()
+    }
+
+    fn resolver<const N: usize>(records: [(&str, ResourceId); N]) -> StubResolver {
+        let mut stub_resolver = StubResolver::new(HashMap::default());
+
+        for (domain, id) in records {
+            stub_resolver.add_resource(id, domain.to_owned())
+        }
+
+        stub_resolver
+    }
+
+    fn rid(id: u128) -> ResourceId {
+        ResourceId::from_u128(id)
     }
 }

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -287,7 +287,7 @@ impl ClientOnGateway {
             if self
                 .permanent_translations
                 .values()
-                .filter(|state| state.resource_id == resource_id && state.name == domain)
+                .filter(|state| state.resource_id == resource_id && &state.name == domain)
                 .all(|state| state.no_incoming_in_120s(now))
             {
                 tracing::debug!(%domain, conn_id = %self.id, %resource_id, %resolved_ip, %proxy_ip, "Refreshing DNS");

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -542,7 +542,7 @@ impl ReferenceState {
                 client
                     .known_hosts
                     .keys()
-                    .map(|h| DomainName::vec_from_str(h).unwrap()),
+                    .map(|h| DomainName::from_utf8(h).unwrap()),
             )
             .collect()
     }

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -3,7 +3,7 @@ use super::{
     sim_net::{any_port, dual_ip_stack, host, Host},
     strategies::latency,
 };
-use crate::{tests::sut::hickory_name_to_domain, GatewayState};
+use crate::GatewayState;
 use connlib_shared::DomainName;
 use ip_packet::IpPacket;
 use proptest::prelude::*;
@@ -72,11 +72,7 @@ impl SimGateway {
 
         if packet.as_udp().is_some() {
             let response = ip_packet::make::dns_ok_response(packet, |name| {
-                global_dns_records
-                    .get(&hickory_name_to_domain(name.clone()))
-                    .cloned()
-                    .into_iter()
-                    .flatten()
+                global_dns_records.get(name).cloned().into_iter().flatten()
             });
 
             let transmit = self.sut.encapsulate(response, now)?.into_owned();

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -28,7 +28,6 @@ use snownet::Transmit;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     net::IpAddr,
-    str::FromStr as _,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -757,7 +756,7 @@ impl TunnelTest {
             .get(&query.name)
             .expect("Forwarded DNS query to be for known domain");
 
-        let name = domain_to_hickory_name(query.name.clone());
+        let name = query.name.clone();
         let requested_type = query.record_type;
 
         let record_data = all_ips
@@ -802,23 +801,4 @@ fn on_gateway_event(
         }),
         GatewayEvent::RefreshDns { .. } => todo!(),
     }
-}
-
-pub(crate) fn hickory_name_to_domain(mut name: hickory_proto::rr::Name) -> DomainName {
-    name.set_fqdn(false); // Hack to work around hickory always parsing as FQ
-    let name = name.to_string();
-
-    let domain = DomainName::from_chars(name.chars()).unwrap();
-    debug_assert_eq!(name, domain.to_string());
-
-    domain
-}
-
-pub(crate) fn domain_to_hickory_name(domain: DomainName) -> hickory_proto::rr::Name {
-    let domain = domain.to_string();
-
-    let name = hickory_proto::rr::Name::from_str(&domain).unwrap();
-    debug_assert_eq!(name.to_string(), domain);
-
-    name
 }

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -14,7 +14,6 @@ chrono = { workspace = true }
 clap = "4.5.4"
 connlib-shared = { workspace = true }
 dns-lookup = { workspace = true }
-domain = { workspace = true }
 either = "1"
 firezone-bin-shared = { workspace = true }
 firezone-tunnel = { workspace = true }


### PR DESCRIPTION
`cargo-mutants` uncovered that some of the code for building DNS responses is not actually covered by tests. We've been meaning to refactor that anyway. Instead of adding bytes for the byte-juggling that we do when building DNS responses, we replace the `domain` library with `hickory-proto` which is the first step towards using a more high-level API for constructing DNS responses.

Resolves: #5539.