### PR TITLE
chore(gui-client): bump `keyring-rs`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3307,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9961b98f55dc0b2737000132505bdafa249abab147ee9de43c50ae04a054aa6c"
+checksum = "c118b1bc529b034aad851808f41f49a69a337d10e112039e7f342e5fd514635b"
 dependencies = [
  "byteorder",
  "dbus-secret-service",

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -51,7 +51,7 @@ uuid = { version = "1.10.0", features = ["v4"] }
 zip = { version = "2", features = ["deflate", "time"], default-features = false }
 
 [dependencies.keyring]
-version = "3.0.3"
+version = "3.0.4"
 features = [
     "crypto-rust", # Don't rely on OpenSSL
     "sync-secret-service", # Can't use Tokio because of <https://github.com/hwchen/keyring-rs/issues/132>

--- a/rust/gui-client/src-tauri/src/client/auth.rs
+++ b/rust/gui-client/src-tauri/src/client/auth.rs
@@ -277,19 +277,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn keyring_is_persistent() {
         assert!(matches!(
-            keyring::secret_service::default_credential_builder().persistence(),
-            keyring::credential::CredentialPersistence::UntilDelete
-        ));
-    }
-
-    #[test]
-    #[cfg(target_os = "windows")]
-    fn keyring_is_persistent() {
-        assert!(matches!(
-            keyring::windows::default_credential_builder().persistence(),
+            keyring::default::default_credential_builder().persistence(),
             keyring::credential::CredentialPersistence::UntilDelete
         ));
     }


### PR DESCRIPTION
Removes a few lines on our side that don't need to be platform-specific.

Thanks Daniel! <https://github.com/hwchen/keyring-rs/pull/198>