### PR TITLE
ux(gui-client): remove keyboard accelerators

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -210,7 +210,6 @@ fn signing_in(waiting_message: &str) -> SystemTrayMenu {
 }
 
 trait FirezoneMenu {
-    fn accelerated(self, id: Event, title: &str, accelerator: &str) -> Self;
     fn add_bottom_section(self, quit_text: &str) -> Self;
     fn copyable(self, s: &str) -> Self;
     fn disabled<S: Into<String>>(self, title: S) -> Self;
@@ -219,13 +218,6 @@ trait FirezoneMenu {
 }
 
 impl FirezoneMenu for SystemTrayMenu {
-    /// An item with an event and a keyboard accelerator
-    ///
-    /// Doesn't work on Windows: <https://github.com/tauri-apps/wry/issues/451>
-    fn accelerated(self, id: Event, title: &str, accelerator: &str) -> Self {
-        self.add_item(item(id, title).accelerator(accelerator))
-    }
-
     /// Things that always show, like About, Settings, Help, Quit, etc.
     fn add_bottom_section(self, quit_text: &str) -> Self {
         self.separator()
@@ -243,13 +235,9 @@ impl FirezoneMenu for SystemTrayMenu {
                         "Support...",
                     ),
             ))
-            .accelerated(
-                Event::ShowWindow(Window::Settings),
-                "Settings",
-                "Ctrl+Shift+,",
-            )
+            .item(Event::ShowWindow(Window::Settings), "Settings")
             .separator()
-            .accelerated(Event::Quit, quit_text, "Ctrl+Q")
+            .item(Event::Quit, quit_text)
     }
 
     fn copyable(self, s: &str) -> Self {


### PR DESCRIPTION
Closes #5953

Update: It's a known bug in WRY: https://github.com/tauri-apps/wry/issues/451

In all my testing on Windows I've never seen these work. I tried them a couple days ago on Linux and I haven't seen them work there either. No clue why. Tauri bug? Windows bug?