### PR TITLE
ci: Sleep 3 seconds after upping services for integration tests

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -150,6 +150,11 @@ jobs:
           docker compose up -d gateway --no-build
           docker compose up -d client --no-build
 
+          # Wait a few seconds for the services to fully start. GH runners are
+          # slow, so this gives the Client enough time to initialize its tun interface,
+          # for example.
+          sleep 3
+
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 
       - name: Show Client logs


### PR DESCRIPTION
Fixes #4921 