### PR TITLE
chore(infra): Use N4 for portal and N1 for tooling

### DIFF
--- a/terraform/environments/production/bi.tf
+++ b/terraform/environments/production/bi.tf
@@ -65,7 +65,7 @@ module "metabase" {
   compute_network    = module.google-cloud-vpc.id
   compute_subnetwork = google_compute_subnetwork.tools.self_link
 
-  compute_instance_type              = "n2-standard-2"
+  compute_instance_type              = "n1-standard-1"
   compute_region                     = local.metabase_region
   compute_instance_availability_zone = local.metabase_zone
 

--- a/terraform/environments/production/gateways.tf
+++ b/terraform/environments/production/gateways.tf
@@ -2,8 +2,8 @@
 locals {
   gateways_region         = local.region
   gateways_zone           = local.availability_zone
-  gateways_instance_type  = "e2-highcpu-2"
-  gateways_instance_count = 1
+  gateways_instance_type  = "n1-standard-1"
+  gateways_instance_count = 2
 }
 
 # Reserve instances for the gateway

--- a/terraform/environments/production/portal.tf
+++ b/terraform/environments/production/portal.tf
@@ -455,10 +455,10 @@ module "web" {
   source     = "../../modules/google-cloud/apps/elixir"
   project_id = module.google-cloud-project.project.project_id
 
-  compute_instance_type               = "n2-standard-2"
+  compute_instance_type               = "n4-standard-2"
   compute_instance_region             = local.region
   compute_instance_availability_zones = ["${local.region}-d"]
-  compute_boot_disk_type              = "pd-ssd"
+  compute_boot_disk_type              = "hyperdisk-balanced"
 
   dns_managed_zone_name = module.google-cloud-dns.zone_name
 


### PR DESCRIPTION
Google has bumped out quotas so we can remove the multi-arch mess we had to workaround it.