### PR TITLE
ci: only post benchmark results on alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,10 +271,14 @@ jobs:
       - name: Merge benchmarks results into one report
         run: jq -s 'reduce .[] as $item ({}; . * $item)' ./${{ github.sha }}/*.bmf.json > bmf.json
       - name: Report results to bencher
-        run: bencher run --file bmf.json --adapter json --github-actions ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bencher run \
+            --project firezone-1l75jv1z \
+            --testbed github-actions \
+            --file bmf.json \
+            --adapter json \
+            --branch "${{ github.head_ref || github.ref_name }}" \
+            --branch-start-point "${{ github.base_ref }}" \
+            --github-actions ${{ secrets.GITHUB_TOKEN }}
         env:
-          BENCHER_PROJECT: firezone-1l75jv1z
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          BENCHER_BRANCH: ${{ github.head_ref || github.ref_name }}
-          BENCHER_BRANCH_START: ${{ github.base_ref }}
-          BENCHER_TESTBED: github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,7 @@ jobs:
             --adapter json \
             --branch "${{ github.head_ref || github.ref_name }}" \
             --branch-start-point "${{ github.base_ref }}" \
-            --github-actions ${{ secrets.GITHUB_TOKEN }}
+            --github-actions ${{ secrets.GITHUB_TOKEN }} \
+            --ci-only-on-alert
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}


### PR DESCRIPTION
It appears that the configuration via env variables doesn't work as expected. This PR changes bencher's config to use commandline arguments. With that, the `--branch-start-point` actually takes effect and copies over the thresholds configured on bencher for the `main` branch.

With the thresholds in place, we can configure bencher to only alert us if a threshold is exceeded and otherwise be quiet and not post a comment.