### PR TITLE
fix(connlib): prevent routing loops on windows

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1084,7 +1084,6 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "ring",
  "secrecy",
  "serde",
  "serde_json",
@@ -5628,11 +5627,7 @@ dependencies = [
  "quinn-udp",
  "socket2",
  "tokio",
-<<<<<<< HEAD
  "tracing",
-=======
- "windows 0.57.0",
->>>>>>> a445f2c3a (wip get_best_route)
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1906,6 +1906,7 @@ dependencies = [
  "firezone-bin-shared",
  "futures",
  "git-version",
+ "hex-literal",
  "humantime",
  "ip_network",
  "ipconfig",
@@ -2642,6 +2643,12 @@ name = "hex-display"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b53d6a634507c5d9fdee77261ae54a8d1ff7887f5304389025b03c3292a1756"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hickory-proto"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1910,7 +1910,6 @@ dependencies = [
  "humantime",
  "ip_network",
  "ipconfig",
- "itertools 0.13.0",
  "known-folders",
  "libc",
  "mutants",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1910,6 +1910,7 @@ dependencies = [
  "humantime",
  "ip_network",
  "ipconfig",
+ "itertools 0.13.0",
  "known-folders",
  "libc",
  "mutants",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5628,7 +5628,11 @@ dependencies = [
  "quinn-udp",
  "socket2",
  "tokio",
+<<<<<<< HEAD
  "tracing",
+=======
+ "windows 0.57.0",
+>>>>>>> a445f2c3a (wip get_best_route)
 ]
 
 [[package]]

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -27,7 +27,7 @@ netlink-packet-route = { version = "0.19", default-features = false }
 rtnetlink = { workspace = true }
 libc = "0.2"
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 known-folders = "1.1.0"
 ring = "0.17"
 uuid = { version = "1.10.0", features = ["v4"] }

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -36,7 +36,7 @@ windows-implement = "0.57.0"
 wintun = "0.4.0"
 winreg = "0.52.0"
 
-[target.'cfg(windows)'.dependencies.windows]
+[target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.57.0"
 features = [
   # For implementing COM interfaces

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -36,7 +36,7 @@ windows-implement = "0.57.0"
 wintun = "0.4.0"
 winreg = "0.52.0"
 
-[target.'cfg(target_os = "windows")'.dependencies.windows]
+[target.'cfg(windows)'.dependencies.windows]
 version = "0.57.0"
 features = [
   # For implementing COM interfaces

--- a/rust/bin-shared/src/lib.rs
+++ b/rust/bin-shared/src/lib.rs
@@ -9,6 +9,9 @@ use tracing_subscriber::{
     fmt, prelude::__tracing_subscriber_SubscriberExt, EnvFilter, Layer, Registry,
 };
 
+// wintun automatically append " Tunnel" to this
+pub const TUNNEL_NAME: &str = "Firezone";
+
 /// Bundle ID / App ID that the client uses to distinguish itself from other programs on the system
 ///
 /// e.g. In ProgramData and AppData we use this to name our subdirectories for configs and data,

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -1,4 +1,5 @@
 use crate::windows::CREATE_NO_WINDOW;
+use crate::TUNNEL_NAME;
 use anyhow::{Context as _, Result};
 use connlib_shared::DEFAULT_MTU;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
@@ -26,9 +27,6 @@ use windows::Win32::{
     Networking::WinSock::{AF_INET, AF_INET6},
 };
 use wintun::Adapter;
-
-// wintun automatically append " Tunnel" to this
-pub(crate) const TUNNEL_NAME: &str = "Firezone";
 
 /// The ring buffer size used for Wintun.
 ///

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -25,7 +25,6 @@ phoenix-channel = { workspace = true }
 proptest = { version = "1", optional = true }
 rand = { version = "0.8", default-features = false, features = ["std"] }
 rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
-ring = "0.17"
 secrecy = { workspace = true, features = ["serde", "bytes"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -26,7 +26,7 @@ socket-factory = { workspace = true }
 thiserror = { version = "1.0", default-features = false }
 # This actually relies on many other features in Tokio, so this will probably
 # fail to build outside the workspace. <https://github.com/firezone/firezone/pull/4328#discussion_r1540342142>
-tokio = { workspace = true, features = ["macros", "signal", "process"] }
+tokio = { workspace = true, features = ["macros", "signal", "process", "time"] }
 tokio-stream = "0.1.15"
 tokio-util = { version = "0.7.11", features = ["codec"] }
 tracing = { workspace = true }

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -61,7 +61,6 @@ thiserror = { version = "1.0", default-features = false }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 windows-service = "0.7.0"
 winreg = "0.52.0"
-itertools = { version = "0.13" }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.57.0"

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -61,6 +61,7 @@ thiserror = { version = "1.0", default-features = false }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 windows-service = "0.7.0"
 winreg = "0.52.0"
+itertools = { version = "0.13" }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.57.0"

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -35,6 +35,7 @@ url = { version = "2.5.2", default-features = false }
 uuid = { version = "1.10", default-features = false, features = ["std", "v4", "serde"] }
 
 [dev-dependencies]
+hex-literal = "0.4.1"
 tempfile = "3.10.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -62,7 +62,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 windows-service = "0.7.0"
 winreg = "0.52.0"
 
-[target.'cfg(target_os = "windows")'.dependencies.windows]
+[target.'cfg(windows)'.dependencies.windows]
 version = "0.57.0"
 features = [
     # For DNS control and route control

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -35,11 +35,13 @@ url = { version = "2.5.2", default-features = false }
 uuid = { version = "1.10", default-features = false, features = ["std", "v4", "serde"] }
 
 [dev-dependencies]
-hex-literal = "0.4.1"
 tempfile = "3.10.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 mutants = "0.0.3" # Needed to mark functions as exempt from `cargo-mutants` testing
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+hex-literal = "0.4.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dirs = "5.0.1"

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -196,7 +196,7 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAdd
         let Ok(route) = find_best_route_for_luid(luid, dst) else {
             continue;
         };
-        routes.push((best_route, best_src));
+        routes.push(route);
     }
 
     routes.sort_by(|a, b| a.metric.cmp(&b.metric));

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -127,7 +127,7 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAdd
         .ok()?
         .filter(|adapter| {
             !adapter.FriendlyName.is_null()
-                || adapter.FriendlyName.to_string() != Ok(filter.to_string())
+                || !matches!(adapter.FriendlyName.to_string(), Ok(filter.to_string()))
         })
         .map(|adapter| adapter.Luid)
         .collect();

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -64,6 +64,8 @@ fn get_best_route(dst: IpAddr, filter: &str) -> IpAddr {
         let mut luids = Vec::new();
         loop {
             let address: &IP_ADAPTER_ADDRESSES_LH = std::mem::transmute(next_address);
+            // TODO: This is completely wrong as the AdapterName is some hex string and "Firezone" is just an alias
+            // We might need to use ConvertInterfaceLuidToAlias or ConvertAliasToLuid to compare
             if !address.AdapterName.is_null() && &address.AdapterName.to_string().unwrap() == filter
             {
                 continue;

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -52,13 +52,17 @@ fn get_best_route(dst: IpAddr, filter: &str) -> IpAddr {
         // TODO: iterate until it doesn't overflow
         let mut addresses: Vec<u8> = vec![0u8; 15000];
         let mut addresses_len = addresses.len() as u32;
-        GetAdaptersAddresses(
+        let res = GetAdaptersAddresses(
             AF_UNSPEC.0 as u32,
             GET_ADAPTERS_ADDRESSES_FLAGS(0),
             Some(null()),
             Some(addresses.as_mut_ptr() as *mut _),
             &mut addresses_len as *mut _,
         );
+
+        if res.is_err() {
+            todo!()
+        }
 
         let mut next_address = addresses.as_ptr() as *const _;
         let mut luids = Vec::new();
@@ -84,7 +88,7 @@ fn get_best_route(dst: IpAddr, filter: &str) -> IpAddr {
             let mut best_route: MaybeUninit<MIB_IPFORWARD_ROW2> = MaybeUninit::zeroed();
             let mut best_src: MaybeUninit<SOCKADDR_INET> = MaybeUninit::zeroed();
 
-            GetBestRoute2(
+            let res = GetBestRoute2(
                 Some(luid as *const _),
                 0,
                 None,
@@ -93,6 +97,10 @@ fn get_best_route(dst: IpAddr, filter: &str) -> IpAddr {
                 best_route.as_mut_ptr(),
                 best_src.as_mut_ptr(),
             );
+
+            if res.is_err() {
+                continue;
+            }
 
             let best_route = best_route.assume_init();
             let best_src = best_src.assume_init();

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -192,7 +192,7 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAdd
         .ok()?
         .filter(|adapter| !is_adapter_name(adapter, filter))
         .map(|adapter| adapter.Luid)
-        .filter_map(|luid| find_best_route_for_luid(&luid, dst))
+        .filter_map(|luid| find_best_route_for_luid(&luid, dst).ok())
         .collect();
 
     routes.sort_by(|a, b| a.metric.cmp(&b.metric));

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -24,8 +24,8 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
 }
 
 pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
-    let socket = socket = socket_factory::udp(src_addr)?
-        .with_source_ip_resolver(Box::new(|addr| get_best_non_tunnel_route(addr)));
+    let socket = socket =
+        socket_factory::udp(src_addr)?.with_source_ip_resolver(Box::new(get_best_non_tunnel_route));
 
     Ok(socket)
 }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -15,17 +15,20 @@ use socket_factory::{TcpSocket, UdpSocket};
 
 pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
     let socket = socket_factory::tcp(addr)?;
-    socket.bind(get_best_route(
-        addr.ip(),
-        connlib_shared::windows::TUNNEL_NAME,
-    ));
+    socket.bind(
+        (
+            get_best_route(addr.ip(), connlib_shared::windows::TUNNEL_NAME),
+            0,
+        )
+            .into(),
+    );
     Ok(socket)
 }
 
-pub fn udp_socket_factory(addr: &SocketAddr) -> io::Result<UdpSocket> {
-    let socket = socket_factory::udp(addr)?;
+pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
+    let socket = socket_factory::udp(src_addr)?;
     socket.set_source_ip_resolver(Box::new(|addr| {
-        get_best_route(addr.ip(), connlib_shared::windows::TUNNEL_NAME)
+        Some(get_best_route(addr, connlib_shared::windows::TUNNEL_NAME))
     }));
     Ok(socket)
 }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -167,6 +167,7 @@ mod test {
     use firezone_bin_shared::TunDeviceManager;
     use ip_network::Ipv4Network;
     use socket_factory::DatagramOut;
+    use std::borrow::Cow;
     use std::net::ToSocketAddrs;
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
 
@@ -215,7 +216,9 @@ mod test {
             .send(DatagramOut {
                 src: None,
                 dst: server,
-                packet: &hex_literal::hex!("000100002112A4420123456789abcdef01234567"),
+                packet: Cow::Borrowed(&hex_literal::hex!(
+                    "000100002112A4420123456789abcdef01234567"
+                )),
             })
             .unwrap();
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -14,14 +14,11 @@ use socket_factory::udp;
 use socket_factory::{TcpSocket, UdpSocket};
 
 pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
+    let local = get_best_route_excluding_interface(addr.ip(), connlib_shared::windows::TUNNEL_NAME);
+
     let socket = socket_factory::tcp(addr)?;
-    socket.bind(
-        (
-            get_best_route_excluding_interface(addr.ip(), connlib_shared::windows::TUNNEL_NAME),
-            0,
-        )
-            .into(),
-    );
+    socket.bind((local, 0).into());
+
     Ok(socket)
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -228,7 +228,7 @@ mod test {
 
             let _response = result.unwrap().next().unwrap();
 
-            Poll::Ready(())
+            std::task::Poll::Ready(())
         })
         .await;
     }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -7,8 +7,104 @@
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 
-pub(crate) use socket_factory::tcp as tcp_socket_factory;
-pub(crate) use socket_factory::udp as udp_socket_factory;
+use socket_factory::tcp;
+use socket_factory::udp;
+
+pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
+    let socket = socket_factory::tcp(addr)?;
+    socket.bind(get_best_route(addr, connlib_shared::windows::TUNNEL_NAME));
+    Ok(socket)
+}
+
+pub fn socket_factory_udp(addr: &SocketAddr) -> io::Result<UdpSocket> {
+    let socket = socket_factory::udp(addr)?;
+    socket
+        .set_source_ip_resolver(|addr| get_best_route(addr, connlib_shared::windows::TUNNEL_NAME));
+    Ok(socket)
+}
+
+fn get_best_route(dst: IpAddr, filter: String) -> IpAddr {
+    use std::mem::{size_of, size_of_val, MaybeUninit};
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::ptr::null;
+
+    use windows::Win32::NetworkManagement::IpHelper::GetAdaptersAddresses;
+    use windows::Win32::NetworkManagement::IpHelper::GetBestRoute2;
+    use windows::Win32::NetworkManagement::IpHelper::GET_ADAPTERS_ADDRESSES_FLAGS;
+    use windows::Win32::NetworkManagement::IpHelper::IP_ADAPTER_ADDRESSES_LH;
+    use windows::Win32::NetworkManagement::IpHelper::MIB_IPFORWARD_ROW2;
+    use windows::Win32::Networking::WinSock::ADDRESS_FAMILY;
+    use windows::Win32::Networking::WinSock::AF_UNSPEC;
+    use windows::Win32::Networking::WinSock::SOCKADDR_INET;
+    // SAFETY: lol
+    unsafe {
+        // TODO: iterate until it doesn't overflow
+        let mut addresses: Vec<u8> = vec![0u8; 15000];
+        let mut addresses_len = size_of_val(&addresses) as u32;
+        GetAdaptersAddresses(
+            AF_UNSPEC.0 as u32,
+            GET_ADAPTERS_ADDRESSES_FLAGS(0),
+            Some(null()),
+            Some(addresses.as_mut_ptr() as *mut _),
+            &mut addresses_len as *mut _,
+        );
+
+        let mut next_address = addresses.as_ptr() as *const _;
+        let mut luids = Vec::new();
+        loop {
+            let address: &IP_ADAPTER_ADDRESSES_LH = std::mem::transmute(next_address);
+            if address.AdapterName == filter {
+                continue;
+            }
+
+            luids.push(address.Luid);
+            if address.Next.is_null() {
+                break;
+            }
+            next_address = address.Next;
+        }
+
+        let mut routes: Vec<(MIB_IPFORWARD_ROW2, SOCKADDR_INET)> = Vec::new();
+        for luid in &luids {
+            let addr: SOCKADDR_INET = SocketAddr::from((dst, 0)).into();
+            let mut best_route: MaybeUninit<MIB_IPFORWARD_ROW2> = MaybeUninit::zeroed();
+            let mut best_src: MaybeUninit<SOCKADDR_INET> = MaybeUninit::zeroed();
+
+            GetBestRoute2(
+                Some(luid as *const _),
+                0,
+                None,
+                &addr as *const _,
+                0,
+                best_route.as_mut_ptr(),
+                best_src.as_mut_ptr(),
+            );
+
+            let best_route = best_route.assume_init();
+            let best_src = best_src.assume_init();
+            routes.push((best_route, best_src));
+        }
+
+        routes.sort_by(|(a, _), (b, _)| a.Metric.cmp(&b.Metric));
+
+        let addr = routes.first().unwrap().1;
+        match addr.si_family {
+            ADDRESS_FAMILY(0) => todo!(),
+            ADDRESS_FAMILY(2) => Ipv4Addr::from(addr.Ipv4.sin_addr).into(),
+            ADDRESS_FAMILY(23) => Ipv6Addr::from(addr.Ipv6.sin6_addr).into(),
+            _ => panic!("Invalid address"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn best_route_works() {
+        dbg!(get_best_route("8.8.8.8".parse().unwrap()));
+    }
+}
 
 // The return value is useful on Linux
 #[allow(clippy::unnecessary_wraps)]

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -5,7 +5,7 @@
 //! We must tell Windows explicitly when our service is stopping.
 
 use anyhow::Result;
-use itertools::Itertools as _;
+use itertools::Itertools;
 use std::{
     cmp::Ordering,
     io,
@@ -135,7 +135,7 @@ struct Route {
 
 impl PartialOrd for Route {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.metric.cmp(other.metric))
+        Some(self.metric.cmp(&other.metric))
     }
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -189,7 +189,7 @@ mod test {
         let ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0x0016, 0x588f]);
 
         let mut device_manager = TunDeviceManager::new().unwrap();
-        let mut tun = device_manager.make_tun().unwrap();
+        let _tun = device_manager.make_tun().unwrap();
         device_manager.set_ips(ipv4, ipv6).await.unwrap();
 
         // Configure `0.0.0.0/0` route.
@@ -202,7 +202,7 @@ mod test {
             .unwrap();
 
         // Make a socket.
-        let socket =
+        let mut socket =
             udp_socket_factory(&SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)))
                 .unwrap();
 
@@ -223,7 +223,7 @@ mod test {
             .unwrap();
 
         let mut buf = [0u8; 1000];
-        let datagram = std::future::poll_fn(|cx| socket.poll_recv_from(&mut buf, cx))
+        let _response = std::future::poll_fn(|cx| socket.poll_recv_from(&mut buf, cx))
             .await
             .unwrap()
             .next()

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -26,7 +26,7 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
 }
 
 pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
-    let socket = socket_factory::udp(src_addr)?;
+    let mut socket = socket_factory::udp(src_addr)?;
     socket.set_source_ip_resolver(Box::new(|addr| {
         Some(get_best_route(addr, connlib_shared::windows::TUNNEL_NAME))
     }));

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -71,9 +71,9 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> IpAddr {
         let mut luids = Vec::new();
         loop {
             let address: &IP_ADAPTER_ADDRESSES_LH = std::mem::transmute(next_address);
-            // TODO: This is completely wrong as the AdapterName is some hex string and "Firezone" is just an alias
-            // We might need to use ConvertInterfaceLuidToAlias or ConvertAliasToLuid to compare
-            if !address.AdapterName.is_null() && &address.AdapterName.to_string().unwrap() == filter
+
+            if !address.FriendlyName.is_null()
+                && &address.FriendlyName.to_string().unwrap() == filter
             {
                 continue;
             }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -118,7 +118,8 @@ fn is_adapter_name(adapter: &IP_ADAPTER_ADDRESSES_LH, name: &str) -> bool {
     }
 
     // SAFETY: It should be safe to call to_string since we checked it's not null and the reference should be valid
-    let Ok(friendly_name) = unsafe { adapter.FriendlyName.to_string() } else {
+    // Note: the "()" around the unsafe looks weird but there can't be a "}" right before an else in an let ... else statement
+    let Ok(friendly_name) = (unsafe { adapter.FriendlyName.to_string() }) else {
         return false;
     };
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -125,14 +125,14 @@ fn list_adapters() -> Result<Adapters> {
 /// It should **not** be called on a per-packet basis.
 /// Callers should instead cache the result until network interfaces change.
 fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAddr> {
-    let luids = list_adapters()
+    let luids: Vec<_> = list_adapters()
         .ok()?
         .filter(|adapter| {
             !adapter.FriendlyName.is_null()
                 || adapter.FriendlyName.to_string() != Ok(filter.to_string())
         })
         .map(|adapter| adapter.Luid)
-        .collect_vec();
+        .collect();
 
     // SAFETY: lol
     unsafe {

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -178,9 +178,6 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAdd
     }
 }
 
-#[path = "windows/wintun_install.rs"]
-mod wintun_install;
-
 // The return value is useful on Linux
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -240,12 +240,12 @@ mod test {
 
     #[test]
     fn best_route_ip4_does_not_fail() {
-        get_best_route_excluding_interface("8.8.8.8".parse().unwrap(), "Firezone");
+        get_best_non_tunnel_route("8.8.8.8".parse().unwrap()).unwrap();
     }
 
     #[test]
     fn best_route_ip6_does_not_fail() {
-        get_best_route_excluding_interface("2404:6800:4006:811::200e".parse().unwrap(), "Firezone");
+        get_best_non_tunnel_route("2404:6800:4006:811::200e".parse().unwrap()).unwrap();
     }
 
     // Starts up a WinTUN device, adds a "full-route" (`0.0.0.0/0`) and checks if we can still send packets to IPs outside of our tunnel.

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -9,12 +9,13 @@ use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 
+use connlib_shared::windows::TUNNEL_NAME;
 use socket_factory::tcp;
 use socket_factory::udp;
 use socket_factory::{TcpSocket, UdpSocket};
 
 pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
-    let local = get_best_route_excluding_interface(addr.ip(), connlib_shared::windows::TUNNEL_NAME);
+    let local = get_best_route_excluding_interface(addr.ip(), TUNNEL_NAME);
 
     let socket = socket_factory::tcp(addr)?;
     socket.bind((local, 0).into());
@@ -25,10 +26,7 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
 pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
     let socket = socket =
         socket_factory::udp(src_addr)?.with_source_ip_resolver(Box::new(|addr| {
-            Some(get_best_route_excluding_interface(
-                addr,
-                connlib_shared::windows::TUNNEL_NAME,
-            ))
+            Some(get_best_route_excluding_interface(addr, TUNNEL_NAME))
         }));
 
     Ok(socket)

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -138,14 +138,8 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> IpAddr {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-    #[test]
-    fn best_route_works() {
-        dbg!(get_best_route("8.8.8.8".parse().unwrap(), "Firezone"));
-    }
-}
+#[path = "windows/wintun_install.rs"]
+mod wintun_install;
 
 // The return value is useful on Linux
 #[allow(clippy::unnecessary_wraps)]
@@ -165,4 +159,19 @@ pub(crate) fn default_token_path() -> std::path::PathBuf {
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn notify_service_controller() -> Result<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn best_route_ip4_does_not_fail() {
+        get_best_route_excluding_interface("8.8.8.8".parse().unwrap(), "Firezone");
+    }
+
+    #[test]
+    fn best_route_ip6_does_not_fail() {
+        get_best_route_excluding_interface("2404:6800:4006:811::200e".parse().unwrap(), "Firezone");
+    }
 }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -82,15 +82,15 @@ fn list_adapters() -> Result<Adapters> {
     let mut buffer: Vec<u8> = vec![0u8; 15000];
     let mut buffer_len = buffer.len() as u32;
     // Safety we just allocated buffer with the len we are passing
-    unsafe {
-        let mut res = GetAdaptersAddresses(
+    let mut res = unsafe {
+        GetAdaptersAddresses(
             AF_UNSPEC.0 as u32,
             GET_ADAPTERS_ADDRESSES_FLAGS(0),
             Some(null()),
             Some(buffer.as_mut_ptr() as *mut _),
             &mut buffer_len as *mut _,
-        );
-    }
+        )
+    };
 
     // Incase of a buffer overflow buffer_len will contain the neccesary length
     if res == ERROR_BUFFER_OVERFLOW {

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -10,15 +10,13 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 
 use connlib_shared::windows::TUNNEL_NAME;
-use socket_factory::tcp;
-use socket_factory::udp;
 use socket_factory::{TcpSocket, UdpSocket};
 
 pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
     let local = get_best_non_tunnel_route(addr.ip()).ok_or(io::Error::other("No route to host"))?;
 
     let socket = socket_factory::tcp(addr)?;
-    socket.bind((local, 0).into()); // To avoid routing loops, all TCP sockets are bound to "best" source IP.
+    socket.bind((local, 0).into())?; // To avoid routing loops, all TCP sockets are bound to "best" source IP.
 
     Ok(socket)
 }
@@ -50,7 +48,7 @@ fn get_best_non_tunnel_route(dst: IpAddr) -> Option<IpAddr> {
 /// It should **not** be called on a per-packet basis.
 /// Callers should instead cache the result until network interfaces change.
 fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAddr> {
-    use std::mem::{size_of, size_of_val, MaybeUninit};
+    use std::mem::MaybeUninit;
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::ptr::null;
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -17,7 +17,7 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
     let socket = socket_factory::tcp(addr)?;
     socket.bind(
         (
-            get_best_route(addr.ip(), connlib_shared::windows::TUNNEL_NAME),
+            get_best_route_excluding_interface(addr.ip(), connlib_shared::windows::TUNNEL_NAME),
             0,
         )
             .into(),
@@ -28,13 +28,16 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
 pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
     let socket = socket =
         socket_factory::udp(src_addr)?.with_source_ip_resolver(Box::new(|addr| {
-            Some(get_best_route(addr, connlib_shared::windows::TUNNEL_NAME))
+            Some(get_best_route_excluding_interface(
+                addr,
+                connlib_shared::windows::TUNNEL_NAME,
+            ))
         }));
 
     Ok(socket)
 }
 
-fn get_best_route(dst: IpAddr, filter: &str) -> IpAddr {
+fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> IpAddr {
     use std::mem::{size_of, size_of_val, MaybeUninit};
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::ptr::null;

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -128,7 +128,7 @@ fn is_adapter_name(adapter: &IP_ADAPTER_ADDRESSES_LH, name: &str) -> bool {
     &friendly_name == name
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 struct Route {
     metric: u32,
     addr: IpAddr,

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -35,7 +35,7 @@ fn get_best_non_tunnel_route(dst: IpAddr) -> io::Result<Option<IpAddr>> {
 
     tracing::debug!(%src, %dst, "Resolved best route outside of tunnel interface");
 
-    Ok(src)
+    Ok(Some(src))
 }
 
 /// Finds the best route (i.e. source interface) for a given destination IP, excluding interfaces where the name matches the given filter.

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -143,7 +143,7 @@ fn to_ip_addr(addr: SOCKADDR_INET, dst: IpAddr) -> Option<IpAddr> {
     }
 }
 
-fn find_best_route_for_luid(luid: &NET_LUID_H, dst: IpAddr) -> Result<Route> {
+fn find_best_route_for_luid(luid: &NET_LUID_LH, dst: IpAddr) -> Result<Route> {
     let addr: SOCKADDR_INET = SocketAddr::from((dst, 0)).into();
     let mut best_route: MaybeUninit<MIB_IPFORWARD_ROW2> = MaybeUninit::zeroed();
     let mut best_src: MaybeUninit<SOCKADDR_INET> = MaybeUninit::zeroed();

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -72,13 +72,12 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> IpAddr {
         loop {
             let address: &IP_ADAPTER_ADDRESSES_LH = std::mem::transmute(next_address);
 
-            if !address.FriendlyName.is_null()
-                && &address.FriendlyName.to_string().unwrap() == filter
+            if address.FriendlyName.is_null()
+                || &address.FriendlyName.to_string().unwrap() != filter
             {
-                continue;
+                luids.push(address.Luid);
             }
 
-            luids.push(address.Luid);
             if address.Next.is_null() {
                 break;
             }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -100,7 +100,12 @@ fn get_best_route(dst: IpAddr, filter: &str) -> IpAddr {
 
         let addr = routes.first().unwrap().1;
         match addr.si_family {
-            ADDRESS_FAMILY(0) => todo!(),
+            // TODO: it might be better to only get the family that we care about?
+            // we will also want to discard the not matching version addresses
+            ADDRESS_FAMILY(0) => match dst {
+                IpAddr::V4(_) => Ipv4Addr::from(addr.Ipv4.sin_addr).into(),
+                IpAddr::V6(_) => Ipv6Addr::from(addr.Ipv6.sin6_addr).into(),
+            },
             ADDRESS_FAMILY(2) => Ipv4Addr::from(addr.Ipv4.sin_addr).into(),
             ADDRESS_FAMILY(23) => Ipv6Addr::from(addr.Ipv6.sin6_addr).into(),
             _ => panic!("Invalid address"),

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -168,7 +168,6 @@ mod test {
     use ip_network::Ipv4Network;
     use socket_factory::DatagramOut;
     use std::borrow::Cow;
-    use std::net::ToSocketAddrs;
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
 
     #[test]

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -127,7 +127,7 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAdd
         .ok()?
         .filter(|adapter| {
             !adapter.FriendlyName.is_null()
-                || !matches!(adapter.FriendlyName.to_string(), Ok(filter.to_string()))
+                || !matches!(Ok(filter.to_string()), adapter.FriendlyName.to_string())
         })
         .map(|adapter| adapter.Luid)
         .collect();

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -188,7 +188,7 @@ fn find_best_route_for_luid(luid: &NET_LUID_LH, dst: IpAddr) -> Result<Route> {
 /// It should **not** be called on a per-packet basis.
 /// Callers should instead cache the result until network interfaces change.
 fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAddr> {
-    let routes: Vec<_> = list_adapters()
+    let mut routes: Vec<_> = list_adapters()
         .ok()?
         .filter(|adapter| !is_adapter_name(adapter, filter))
         .map(|adapter| adapter.Luid)

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -222,11 +222,12 @@ mod test {
             })
             .unwrap();
 
-        let mut buf = [0u8; 1000];
-        let _response = std::future::poll_fn(|cx| socket.poll_recv_from(&mut buf, cx))
-            .await
-            .unwrap()
-            .next()
-            .unwrap();
+        std::future::poll_fn(|cx| {
+            let mut buf = [0u8; 1000];
+            let result = std::task::ready!(socket.poll_recv_from(&mut buf, cx));
+
+            let _response = result.uwrap().next().unwrap();
+        })
+        .await;
     }
 }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -24,7 +24,7 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
 }
 
 pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
-    let socket = socket =
+    let socket =
         socket_factory::udp(src_addr)?.with_source_ip_resolver(Box::new(get_best_non_tunnel_route));
 
     Ok(socket)

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -105,9 +105,10 @@ fn list_adapters() -> Result<Adapters> {
 
     WIN32_ERROR(res).ok()?;
 
+    let next = buffer.as_ptr() as *const _;
     Ok(Adapters {
         _buffer: buffer,
-        next: buffer.as_ptr() as *const _,
+        next,
     })
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -60,13 +60,9 @@ impl Iterator for Adapters {
     type Item = &'static IP_ADAPTER_ADDRESSES_LH;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.next.is_null() {
-            return None;
-        }
-
-        // SAFETY: We expect windows to give us a valid linked list where each item fo the list is actually an IP_ADAPTER_ADDRESSES_LH
-        // furthermore, we return None if next is null in the previous line.
-        let adapter = unsafe { self.next.as_ref() };
+        // SAFETY: We expect windows to give us a valid linked list where each item fo the list is actually an IP_ADAPTER_ADDRESSES_LH.
+        // TODO: pointer alignment?
+        let adapter = unsafe { self.next.as_ref()? };
 
         self.next = adapter.Next;
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -51,7 +51,7 @@ fn get_best_route(dst: IpAddr, filter: &str) -> IpAddr {
     unsafe {
         // TODO: iterate until it doesn't overflow
         let mut addresses: Vec<u8> = vec![0u8; 15000];
-        let mut addresses_len = size_of_val(&addresses) as u32;
+        let mut addresses_len = addresses.len() as u32;
         GetAdaptersAddresses(
             AF_UNSPEC.0 as u32,
             GET_ADAPTERS_ADDRESSES_FLAGS(0),

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -18,7 +18,7 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
     let local = get_best_route_excluding_interface(addr.ip(), TUNNEL_NAME);
 
     let socket = socket_factory::tcp(addr)?;
-    socket.bind((local, 0).into());
+    socket.bind((local, 0).into()); // To avoid routing loops, all TCP sockets are bound to "best" source IP.
 
     Ok(socket)
 }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -145,7 +145,7 @@ fn is_adapter_name(adapter: &IP_ADAPTER_ADDRESSES_LH, name: &str) -> bool {
         return false;
     };
 
-    &friendly_name == name
+    friendly_name == name
 }
 
 #[derive(PartialEq, Eq)]
@@ -162,7 +162,7 @@ impl Ord for Route {
 
 impl PartialOrd for Route {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -43,6 +43,12 @@ fn get_best_non_tunnel_route(dst: IpAddr) -> IpAddr {
 /// To prevent routing loops on Windows, we need to explicitly set a source IP for all packets.
 /// Windows uses a computed metric per interface for routing.
 /// We implement the same logic here, with the addition of explicitly filtering out our TUN interface.
+///
+/// # Performance
+///
+/// This function performs multiple syscalls and is thus fairly expensive.
+/// It should **not** be called on a per-packet basis.
+/// Callers should instead cache the result until network interfaces change.
 fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> IpAddr {
     use std::mem::{size_of, size_of_val, MaybeUninit};
     use std::net::{Ipv4Addr, Ipv6Addr};

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -26,10 +26,11 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
 }
 
 pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
-    let mut socket = socket_factory::udp(src_addr)?;
-    socket.set_source_ip_resolver(Box::new(|addr| {
-        Some(get_best_route(addr, connlib_shared::windows::TUNNEL_NAME))
-    }));
+    let socket = socket =
+        socket_factory::udp(src_addr)?.with_source_ip_resolver(Box::new(|addr| {
+            Some(get_best_route(addr, connlib_shared::windows::TUNNEL_NAME))
+        }));
+
     Ok(socket)
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -203,7 +203,7 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAdd
     }
 
     routes.sort_by(|a, b| a.metric.cmp(&b.metric));
-    routes.first()?.addr
+    Some(routes.first()?.addr)
 }
 
 // The return value is useful on Linux

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -192,7 +192,7 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAdd
         .ok()?
         .filter(|adapter| !is_adapter_name(adapter, filter))
         .map(|adapter| adapter.Luid)
-        .filter_ok(|luid| find_best_route_for_luid(luid, dst))
+        .filter_map(|luid| find_best_route_for_luid(luid, dst))
         .collect();
 
     routes.sort_by(|a, b| a.metric.cmp(&b.metric));

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -89,16 +89,18 @@ fn list_adapters() -> Result<Adapters> {
     };
 
     // Incase of a buffer overflow buffer_len will contain the neccesary length
-    if res == ERROR_BUFFER_OVERFLOW {
-        // Safety we just allocated buffer with the len we are passing
-        buffer = vec![0u8; buffer_len];
-        res = GetAdaptersAddresses(
-            AF_UNSPEC.0 as u32,
-            GET_ADAPTERS_ADDRESSES_FLAGS(0),
-            Some(null()),
-            Some(buffer.as_mut_ptr() as *mut _),
-            &mut buffer_len as *mut _,
-        );
+    if res == ERROR_BUFFER_OVERFLOW.0 {
+        buffer = vec![0u8; buffer_len as usize];
+        // SAFETY: we just allocated buffer with the len we are passing
+        res = unsafe {
+            GetAdaptersAddresses(
+                AF_UNSPEC.0 as u32,
+                GET_ADAPTERS_ADDRESSES_FLAGS(0),
+                Some(null()),
+                Some(buffer.as_mut_ptr() as *mut _),
+                &mut buffer_len as *mut _,
+            )
+        };
     }
 
     WIN32_ERROR(res).ok()?;

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -63,7 +63,8 @@ fn get_best_route(dst: IpAddr, filter: &str) -> IpAddr {
         let mut luids = Vec::new();
         loop {
             let address: &IP_ADAPTER_ADDRESSES_LH = std::mem::transmute(next_address);
-            if &address.AdapterName.to_string().unwrap() == filter {
+            if !address.AdapterName.is_null() && &address.AdapterName.to_string().unwrap() == filter
+            {
                 continue;
             }
 
@@ -112,7 +113,7 @@ mod test {
     use super::*;
     #[test]
     fn best_route_works() {
-        dbg!(get_best_route("8.8.8.8".parse().unwrap()));
+        dbg!(get_best_route("8.8.8.8".parse().unwrap(), "Firezone"));
     }
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -28,12 +28,13 @@ pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
     Ok(socket)
 }
 
-fn get_best_non_tunnel_route(dst: IpAddr) -> Option<IpAddr> {
-    let src = get_best_route_excluding_interface(dst, TUNNEL_NAME)?;
+fn get_best_non_tunnel_route(dst: IpAddr) -> io::Result<Option<IpAddr>> {
+    let src = get_best_route_excluding_interface(dst, TUNNEL_NAME)
+        .ok_or(io::Error::other("No route to host"))?;
 
     tracing::debug!(%src, %dst, "Resolved best route outside of tunnel interface");
 
-    Some(src)
+    Ok(src)
 }
 
 /// Finds the best route (i.e. source interface) for a given destination IP, excluding interfaces where the name matches the given filter.

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -32,6 +32,11 @@ pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
     Ok(socket)
 }
 
+/// Finds the best route (i.e. source interface) for a given destination IP, excluding interfaces where the name matches the given filter.
+///
+/// To prevent routing loops on Windows, we need to explicitly set a source IP for all packets.
+/// Windows uses a computed metric per interface for routing.
+/// We implement the same logic here, with the addition of explicitly filtering out our TUN interface.
 fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> IpAddr {
     use std::mem::{size_of, size_of_val, MaybeUninit};
     use std::net::{Ipv4Addr, Ipv6Addr};

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -117,7 +117,8 @@ fn is_adapter_name(adapter: &IP_ADAPTER_ADDRESSES_LH, name: &str) -> bool {
         return false;
     }
 
-    let Ok(friendly_name) = adapter.FriendlyName.to_string() else {
+    // SAFETY: It should be safe to call to_string since we checked it's not null and the reference should be valid
+    let Ok(friendly_name) = unsafe { adapter.FriendlyName.to_string() } else {
         return false;
     };
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -13,7 +13,8 @@ use connlib_shared::windows::TUNNEL_NAME;
 use socket_factory::{TcpSocket, UdpSocket};
 
 pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
-    let local = get_best_non_tunnel_route(addr.ip()).ok_or(io::Error::other("No route to host"))?;
+    let local =
+        get_best_non_tunnel_route(addr.ip())?.ok_or(io::Error::other("No route to host"))?;
 
     let socket = socket_factory::tcp(addr)?;
     socket.bind((local, 0).into())?; // To avoid routing loops, all TCP sockets are bound to "best" source IP.

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -107,7 +107,7 @@ fn list_adapters() -> Result<Adapters> {
 
     Ok(Adapters {
         _buffer: buffer,
-        next: buffer as *const _,
+        next: buffer.as_ptr() as *const _,
     })
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -192,7 +192,7 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAdd
         .ok()?
         .filter(|adapter| !is_adapter_name(adapter, filter))
         .map(|adapter| adapter.Luid)
-        .filter_map(|luid| find_best_route_for_luid(luid, dst))
+        .filter_map(|luid| find_best_route_for_luid(&luid, dst))
         .collect();
 
     routes.sort_by(|a, b| a.metric.cmp(&b.metric));

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -9,7 +9,7 @@ use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 
-use connlib_shared::windows::TUNNEL_NAME;
+use firezone_bin_shared::TUNNEL_NAME;
 use socket_factory::{TcpSocket, UdpSocket};
 
 pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -60,7 +60,7 @@ fn get_best_route(dst: IpAddr, filter: &str) -> IpAddr {
             &mut addresses_len as *mut _,
         );
 
-        if res.is_err() {
+        if res != 0 {
             todo!()
         }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -288,7 +288,9 @@ mod test {
             .unwrap();
 
         // First send seems to always result as would block
-        std::future::poll_fn(|cx| socket.poll_flush(cx)).await().unwrap();
+        std::future::poll_fn(|cx| socket.poll_flush(cx))
+            .await
+            .unwrap();
 
         let task = std::future::poll_fn(|cx| {
             let mut buf = [0u8; 1000];

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -226,7 +226,9 @@ mod test {
             let mut buf = [0u8; 1000];
             let result = std::task::ready!(socket.poll_recv_from(&mut buf, cx));
 
-            let _response = result.uwrap().next().unwrap();
+            let _response = result.unwrap().next().unwrap();
+
+            Poll::Ready(())
         })
         .await;
     }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -134,9 +134,15 @@ struct Route {
     addr: IpAddr,
 }
 
+impl Ord for Route {
+    fn partial_cmp(&self, other: &Self) -> Ordering {
+        self.metric.cmp(&other.metric)
+    }
+}
+
 impl PartialOrd for Route {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.metric.cmp(&other.metric))
+        Some(self.cmp(&other))
     }
 }
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -287,6 +287,9 @@ mod test {
             })
             .unwrap();
 
+        // First send seems to always result as would block
+        std::future::poll_fn(|cx| socket.poll_flush(cx)).await().unwrap();
+
         let task = std::future::poll_fn(|cx| {
             let mut buf = [0u8; 1000];
             let result = std::task::ready!(socket.poll_recv_from(&mut buf, cx));

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -207,15 +207,10 @@ mod test {
                 .unwrap();
 
         // Send a STUN request.
-        let server = "stun.cloudflare.com:3478"
-            .to_socket_addrs()
-            .unwrap()
-            .next()
-            .unwrap();
         socket
             .send(DatagramOut {
                 src: None,
-                dst: server,
+                dst: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(141, 101, 90, 0), 3478)), // stun.cloudflare.com,
                 packet: Cow::Borrowed(&hex_literal::hex!(
                     "000100002112A4420123456789abcdef01234567"
                 )),

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -239,13 +239,13 @@ mod test {
     use std::time::Duration;
 
     #[test]
-    fn best_route_ip4_does_not_fail() {
-        get_best_non_tunnel_route("8.8.8.8".parse().unwrap()).unwrap();
+    fn best_route_ip4_does_not_panic_or_segfault() {
+        let _ = get_best_non_tunnel_route("8.8.8.8".parse().unwrap());
     }
 
     #[test]
-    fn best_route_ip6_does_not_fail() {
-        get_best_non_tunnel_route("2404:6800:4006:811::200e".parse().unwrap()).unwrap();
+    fn best_route_ip6_does_not_panic_or_segfault() {
+        let _ = get_best_non_tunnel_route("2404:6800:4006:811::200e".parse().unwrap());
     }
 
     // Starts up a WinTUN device, adds a "full-route" (`0.0.0.0/0`) and checks if we can still send packets to IPs outside of our tunnel.

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -5,7 +5,6 @@
 //! We must tell Windows explicitly when our service is stopping.
 
 use anyhow::Result;
-use itertools::Itertools;
 use std::{
     cmp::Ordering,
     io,

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -135,7 +135,7 @@ struct Route {
 }
 
 impl Ord for Route {
-    fn partial_cmp(&self, other: &Self) -> Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         self.metric.cmp(&other.metric)
     }
 }

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -30,7 +30,7 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
     let local = get_best_non_tunnel_route(addr.ip())?;
 
     let socket = socket_factory::tcp(addr)?;
-    socket.bind((local, 0).into())?; // To avoid routing loops, all TCP sockets are bound to "best" source IP.
+    socket.bind((local, 0).into())?; // To avoid routing loops, all TCP sockets are bound to the "best" source IP.
 
     Ok(socket)
 }
@@ -53,7 +53,7 @@ impl Iterator for Adapters {
     type Item = &'static IP_ADAPTER_ADDRESSES_LH;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // SAFETY: We expect windows to give us a valid linked list where each item fo the list is actually an IP_ADAPTER_ADDRESSES_LH.
+        // SAFETY: We expect windows to give us a valid linked list where each item of the list is actually an IP_ADAPTER_ADDRESSES_LH.
         // TODO: pointer alignment?
         let adapter = unsafe { self.next.as_ref()? };
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -163,7 +163,10 @@ pub(crate) fn notify_service_controller() -> Result<()> {
 mod test {
     use super::*;
     use firezone_bin_shared::TunDeviceManager;
+    use ip_network::Ipv4Network;
     use socket_factory::{DatagramIn, DatagramOut};
+    use std::net::ToSocketAddrs;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
 
     #[test]
     fn best_route_ip4_does_not_fail() {

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -83,13 +83,14 @@ impl Iterator for Adapters {
 /// It should **not** be called on a per-packet basis.
 /// Callers should instead cache the result until network interfaces change.
 fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAddr> {
-    list_adapters()
+    let route = list_adapters()
         .ok()?
         .filter(|adapter| !is_adapter_name(adapter, filter))
         .map(|adapter| adapter.Luid)
         .filter_map(|luid| find_best_route_for_luid(&luid, dst).ok())
-        .min()
-        .map(|r| r.addr)
+        .min()?;
+
+    Some(route.addr)
 }
 
 fn list_adapters() -> Result<Adapters> {

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -5,10 +5,13 @@
 //! We must tell Windows explicitly when our service is stopping.
 
 use anyhow::Result;
+use std::io;
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 
 use socket_factory::tcp;
 use socket_factory::udp;
+use socket_factory::{TcpSocket, UdpSocket};
 
 pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
     let socket = socket_factory::tcp(addr)?;
@@ -16,7 +19,7 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
     Ok(socket)
 }
 
-pub fn socket_factory_udp(addr: &SocketAddr) -> io::Result<UdpSocket> {
+pub fn udp_socket_factory(addr: &SocketAddr) -> io::Result<UdpSocket> {
     let socket = socket_factory::udp(addr)?;
     socket
         .set_source_ip_resolver(|addr| get_best_route(addr, connlib_shared::windows::TUNNEL_NAME));

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -89,7 +89,7 @@ fn get_best_non_tunnel_route(dst: IpAddr) -> io::Result<IpAddr> {
     Ok(src)
 }
 
-fn list_adapters() -> Result<Adapters> {
+fn list_adapters() -> io::Result<Adapters> {
     use windows::Win32::Foundation::ERROR_BUFFER_OVERFLOW;
     use windows::Win32::Foundation::WIN32_ERROR;
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -54,7 +54,6 @@ impl Iterator for Adapters {
 
     fn next(&mut self) -> Option<Self::Item> {
         // SAFETY: We expect windows to give us a valid linked list where each item of the list is actually an IP_ADAPTER_ADDRESSES_LH.
-        // TODO: pointer alignment?
         let adapter = unsafe { self.next.as_ref()? };
 
         self.next = adapter.Next;

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -47,8 +47,6 @@ fn get_best_non_tunnel_route(dst: IpAddr) -> io::Result<Option<IpAddr>> {
     let src = get_best_route_excluding_interface(dst, TUNNEL_NAME)
         .ok_or(io::Error::other("No route to host"))?;
 
-    tracing::debug!(%src, %dst, "Resolved best route outside of tunnel interface");
-
     Ok(Some(src))
 }
 
@@ -90,7 +88,11 @@ fn get_best_route_excluding_interface(dst: IpAddr, filter: &str) -> Option<IpAdd
         .filter_map(|luid| find_best_route_for_luid(&luid, dst).ok())
         .min()?;
 
-    Some(route.addr)
+    let src = route.addr;
+
+    tracing::debug!(%src, %dst, "Resolved best route outside of tunnel interface");
+
+    Some(src)
 }
 
 fn list_adapters() -> Result<Adapters> {

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -140,8 +140,8 @@ fn is_adapter_name(adapter: &IP_ADAPTER_ADDRESSES_LH, name: &str) -> bool {
     }
 
     // SAFETY: It should be safe to call to_string since we checked it's not null and the reference should be valid
-    // Note: the "()" around the unsafe looks weird but there can't be a "}" right before an else in an let ... else statement
-    let Ok(friendly_name) = (unsafe { adapter.FriendlyName.to_string() }) else {
+    let friendly_name = unsafe { adapter.FriendlyName.to_string() };
+    let Ok(friendly_name) = friendly_name else {
         return false;
     };
 

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -128,6 +128,7 @@ fn is_adapter_name(adapter: &IP_ADAPTER_ADDRESSES_LH, name: &str) -> bool {
     &friendly_name == name
 }
 
+#[derive(PartialEq)]
 struct Route {
     metric: u32,
     addr: IpAddr,

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -13,12 +13,3 @@ tracing = "0.1"
 
 [features]
 hickory = ["dep:hickory-proto", "dep:async-trait"]
-
-[target.'cfg(target_os = "windows")'.dependencies.windows]
-version = "0.57.0"
-features = [
-  "Win32_Foundation",
-  "Win32_NetworkManagement_IpHelper",
-  "Win32_NetworkManagement_Ndis",
-  "Win32_Networking_WinSock",
-]

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -13,3 +13,12 @@ tracing = "0.1"
 
 [features]
 hickory = ["dep:hickory-proto", "dep:async-trait"]
+
+[target.'cfg(target_os = "windows")'.dependencies.windows]
+version = "0.57.0"
+features = [
+  "Win32_Foundation",
+  "Win32_NetworkManagement_IpHelper",
+  "Win32_NetworkManagement_Ndis",
+  "Win32_Networking_WinSock",
+]

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -1,9 +1,9 @@
-use std::net::{IpAddr, SocketAddr};
+use std::collections::HashMap;
 use std::{
     borrow::Cow,
     collections::VecDeque,
     io::{self, IoSliceMut},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     slice,
     task::{ready, Context, Poll},
 };
@@ -72,6 +72,8 @@ impl std::os::fd::AsFd for TcpSocket {
 pub struct UdpSocket {
     inner: tokio::net::UdpSocket,
     state: quinn_udp::UdpSocketState,
+    source_ip_resolver: Box<dyn Fn(IpAddr) -> Option<IpAddr> + Send + Sync + 'static>,
+    routes: HashMap<IpAddr, IpAddr>,
 
     port: u16,
 
@@ -86,8 +88,17 @@ impl UdpSocket {
             state: quinn_udp::UdpSocketState::new(quinn_udp::UdpSockRef::from(&inner))?,
             port,
             inner,
+            source_ip_resolver: Box::new(|_| None),
             buffered_datagrams: VecDeque::new(),
+            routes: Default::default(),
         })
+    }
+
+    pub fn set_source_ip_resolver(
+        &mut self,
+        resolver: Box<dyn Fn(IpAddr) -> Option<IpAddr> + 'static + Send + Sync>,
+    ) {
+        self.source_ip_resolver = resolver;
     }
 }
 
@@ -225,13 +236,25 @@ impl UdpSocket {
         }
     }
 
-    pub fn try_send(&self, transmit: &DatagramOut) -> io::Result<()> {
+    fn get_source(&mut self, dst: IpAddr) -> Option<IpAddr> {
+        match self.routes.entry(dst) {
+            std::collections::hash_map::Entry::Occupied(entry) => Some(*entry.get()),
+            std::collections::hash_map::Entry::Vacant(v) => {
+                let src = (self.source_ip_resolver)(dst)?;
+                Some(*v.insert(src))
+            }
+        }
+    }
+    pub fn try_send(&mut self, transmit: &DatagramOut) -> io::Result<()> {
         let transmit = quinn_udp::Transmit {
             destination: transmit.dst,
             ecn: None,
             contents: &transmit.packet,
             segment_size: None,
-            src_ip: transmit.src.map(|s| s.ip()),
+            src_ip: transmit
+                .src
+                .map(|s| s.ip())
+                .or_else(|| self.get_source(transmit.dst.ip())),
         };
 
         self.inner.try_io(Interest::WRITABLE, || {
@@ -296,86 +319,5 @@ mod hickory {
         ) -> Poll<io::Result<usize>> {
             <TokioUdpSocket as DnsUdpSocketTrait>::poll_send_to(&self.inner, cx, buf, target)
         }
-    }
-}
-
-#[cfg(target_os = "windows")]
-fn get_best_route(dst: IpAddr) -> IpAddr {
-    use std::mem::{size_of, size_of_val, MaybeUninit};
-    use std::net::{Ipv4Addr, Ipv6Addr};
-    use std::ptr::null;
-
-    use windows::Win32::NetworkManagement::IpHelper::GetAdaptersAddresses;
-    use windows::Win32::NetworkManagement::IpHelper::GetBestRoute2;
-    use windows::Win32::NetworkManagement::IpHelper::GET_ADAPTERS_ADDRESSES_FLAGS;
-    use windows::Win32::NetworkManagement::IpHelper::IP_ADAPTER_ADDRESSES_LH;
-    use windows::Win32::NetworkManagement::IpHelper::MIB_IPFORWARD_ROW2;
-    use windows::Win32::Networking::WinSock::ADDRESS_FAMILY;
-    use windows::Win32::Networking::WinSock::AF_UNSPEC;
-    use windows::Win32::Networking::WinSock::SOCKADDR_INET;
-    // SAFETY: lol
-    unsafe {
-        // TODO: iterate until it doesn't overflow
-        let mut addresses: Vec<u8> = vec![0u8; 15000];
-        let mut addresses_len = size_of_val(&addresses) as u32;
-        GetAdaptersAddresses(
-            AF_UNSPEC.0 as u32,
-            GET_ADAPTERS_ADDRESSES_FLAGS(0),
-            Some(null()),
-            Some(addresses.as_mut_ptr() as *mut _),
-            &mut addresses_len as *mut _,
-        );
-
-        let mut next_address = addresses.as_ptr() as *const _;
-        let mut luids = Vec::new();
-        loop {
-            let address: &IP_ADAPTER_ADDRESSES_LH = std::mem::transmute(next_address);
-            luids.push(address.Luid);
-            if address.Next.is_null() {
-                break;
-            }
-            next_address = address.Next;
-        }
-
-        let mut routes: Vec<(MIB_IPFORWARD_ROW2, SOCKADDR_INET)> = Vec::new();
-        for luid in &luids {
-            let addr: SOCKADDR_INET = SocketAddr::from((dst, 0)).into();
-            let mut best_route: MaybeUninit<MIB_IPFORWARD_ROW2> = MaybeUninit::zeroed();
-            let mut best_src: MaybeUninit<SOCKADDR_INET> = MaybeUninit::zeroed();
-
-            GetBestRoute2(
-                Some(luid as *const _),
-                0,
-                None,
-                &addr as *const _,
-                0,
-                best_route.as_mut_ptr(),
-                best_src.as_mut_ptr(),
-            );
-
-            let best_route = best_route.assume_init();
-            let best_src = best_src.assume_init();
-            routes.push((best_route, best_src));
-        }
-
-        routes.sort_by(|(a, _), (b, _)| a.Metric.cmp(&b.Metric));
-
-        let addr = routes.first().unwrap().1;
-        match addr.si_family {
-            ADDRESS_FAMILY(0) => todo!(),
-            ADDRESS_FAMILY(2) => Ipv4Addr::from(addr.Ipv4.sin_addr).into(),
-            ADDRESS_FAMILY(23) => Ipv6Addr::from(addr.Ipv6.sin6_addr).into(),
-            _ => panic!("Invalid address"),
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn best_route_works() {
-        dbg!(get_best_route("8.8.8.8".parse().unwrap()));
     }
 }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -98,11 +98,12 @@ impl UdpSocket {
         })
     }
 
-    pub fn set_source_ip_resolver(
-        &mut self,
+    pub fn with_source_ip_resolver(
+        mut self,
         resolver: Box<dyn Fn(IpAddr) -> Option<IpAddr> + Send + Sync + 'static>,
-    ) {
+    ) -> Self {
         self.source_ip_resolver = resolver;
+        self
     }
 }
 

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -1,3 +1,4 @@
+use std::net::{IpAddr, SocketAddr};
 use std::{
     borrow::Cow,
     collections::VecDeque,
@@ -295,5 +296,86 @@ mod hickory {
         ) -> Poll<io::Result<usize>> {
             <TokioUdpSocket as DnsUdpSocketTrait>::poll_send_to(&self.inner, cx, buf, target)
         }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn get_best_route(dst: IpAddr) -> IpAddr {
+    use std::mem::{size_of, size_of_val, MaybeUninit};
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::ptr::null;
+
+    use windows::Win32::NetworkManagement::IpHelper::GetAdaptersAddresses;
+    use windows::Win32::NetworkManagement::IpHelper::GetBestRoute2;
+    use windows::Win32::NetworkManagement::IpHelper::GET_ADAPTERS_ADDRESSES_FLAGS;
+    use windows::Win32::NetworkManagement::IpHelper::IP_ADAPTER_ADDRESSES_LH;
+    use windows::Win32::NetworkManagement::IpHelper::MIB_IPFORWARD_ROW2;
+    use windows::Win32::Networking::WinSock::ADDRESS_FAMILY;
+    use windows::Win32::Networking::WinSock::AF_UNSPEC;
+    use windows::Win32::Networking::WinSock::SOCKADDR_INET;
+    // SAFETY: lol
+    unsafe {
+        // TODO: iterate until it doesn't overflow
+        let mut addresses: Vec<u8> = vec![0u8; 15000];
+        let mut addresses_len = size_of_val(&addresses) as u32;
+        GetAdaptersAddresses(
+            AF_UNSPEC.0 as u32,
+            GET_ADAPTERS_ADDRESSES_FLAGS(0),
+            Some(null()),
+            Some(addresses.as_mut_ptr() as *mut _),
+            &mut addresses_len as *mut _,
+        );
+
+        let mut next_address = addresses.as_ptr() as *const _;
+        let mut luids = Vec::new();
+        loop {
+            let address: &IP_ADAPTER_ADDRESSES_LH = std::mem::transmute(next_address);
+            luids.push(address.Luid);
+            if address.Next.is_null() {
+                break;
+            }
+            next_address = address.Next;
+        }
+
+        let mut routes: Vec<(MIB_IPFORWARD_ROW2, SOCKADDR_INET)> = Vec::new();
+        for luid in &luids {
+            let addr: SOCKADDR_INET = SocketAddr::from((dst, 0)).into();
+            let mut best_route: MaybeUninit<MIB_IPFORWARD_ROW2> = MaybeUninit::zeroed();
+            let mut best_src: MaybeUninit<SOCKADDR_INET> = MaybeUninit::zeroed();
+
+            GetBestRoute2(
+                Some(luid as *const _),
+                0,
+                None,
+                &addr as *const _,
+                0,
+                best_route.as_mut_ptr(),
+                best_src.as_mut_ptr(),
+            );
+
+            let best_route = best_route.assume_init();
+            let best_src = best_src.assume_init();
+            routes.push((best_route, best_src));
+        }
+
+        routes.sort_by(|(a, _), (b, _)| a.Metric.cmp(&b.Metric));
+
+        let addr = routes.first().unwrap().1;
+        match addr.si_family {
+            ADDRESS_FAMILY(0) => todo!(),
+            ADDRESS_FAMILY(2) => Ipv4Addr::from(addr.Ipv4.sin_addr).into(),
+            ADDRESS_FAMILY(23) => Ipv6Addr::from(addr.Ipv6.sin6_addr).into(),
+            _ => panic!("Invalid address"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn best_route_works() {
+        dbg!(get_best_route("8.8.8.8".parse().unwrap()));
     }
 }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -98,6 +98,9 @@ impl UdpSocket {
         })
     }
 
+    /// Configures a new source IP resolver for this UDP socket.
+    ///
+    /// In case [`DatagramOut::src`] is [`None`], this function will be used to set a source IP given the destination IP of the datagram.
     pub fn with_source_ip_resolver(
         mut self,
         resolver: Box<dyn Fn(IpAddr) -> Option<IpAddr> + Send + Sync + 'static>,

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -286,6 +286,9 @@ impl UdpSocket {
         let src = match self.src_by_dst_cache.entry(dst) {
             Entry::Occupied(occ) => *occ.get(),
             Entry::Vacant(vac) => {
+                // Caching errors could be a good idea to not incur in multiple calls for the resolver which can be costly
+                // For some cases like hosts ipv4-only stack trying to send ipv6 packets this can happen quite often but doing this is also a risk
+                // that in case that the adapter for some reason is temporarily unavailable it'd prevent the system from recovery.
                 let Some(src) = (self.source_ip_resolver)(dst)? else {
                     return Ok(None);
                 };

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -249,18 +249,6 @@ impl UdpSocket {
         }
     }
 
-    /// Attempt to resolve the source IP to use for sending to the given destination IP.
-    fn resolve_source_for(&mut self, dst: IpAddr) -> Option<IpAddr> {
-        let src = match self.src_by_dst_cache.entry(dst) {
-            Entry::Occupied(occ) => *occ.get(),
-            Entry::Vacant(vac) => {
-                let src = (self.source_ip_resolver)(dst)?;
-                *vac.insert(src)
-            }
-        };
-
-        Some(src)
-    }
     pub fn try_send(&mut self, transmit: &DatagramOut) -> io::Result<()> {
         let destination = transmit.dst;
         let src_ip = transmit
@@ -279,6 +267,19 @@ impl UdpSocket {
         self.inner.try_io(Interest::WRITABLE, || {
             self.state.send((&self.inner).into(), &transmit)
         })
+    }
+
+    /// Attempt to resolve the source IP to use for sending to the given destination IP.
+    fn resolve_source_for(&mut self, dst: IpAddr) -> Option<IpAddr> {
+        let src = match self.src_by_dst_cache.entry(dst) {
+            Entry::Occupied(occ) => *occ.get(),
+            Entry::Vacant(vac) => {
+                let src = (self.source_ip_resolver)(dst)?;
+                *vac.insert(src)
+            }
+        };
+
+        Some(src)
     }
 }
 

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -107,6 +107,8 @@ impl UdpSocket {
     /// In case [`DatagramOut::src`] is [`None`], this function will be used to set a source IP given the destination IP of the datagram.
     /// The resulting IPs will be cached.
     /// To evict this cache, drop the [`UdpSocket`] and make a new one.
+    ///
+    /// Errors during resolution result in the packet being dropped.
     pub fn with_source_ip_resolver(
         mut self,
         resolver: Box<dyn Fn(IpAddr) -> std::io::Result<Option<IpAddr>> + Send + Sync + 'static>,

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -100,7 +100,7 @@ impl UdpSocket {
 
     pub fn set_source_ip_resolver(
         &mut self,
-        resolver: Box<dyn Fn(IpAddr) -> Option<IpAddr> + 'static + Send + Sync>,
+        resolver: Box<dyn Fn(IpAddr) -> Option<IpAddr> + Send + Sync + 'static>,
     ) {
         self.source_ip_resolver = resolver;
     }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -256,7 +256,16 @@ impl UdpSocket {
 
         let src_ip = match src_ip {
             Some(src_ip) => Some(src_ip),
-            None => self.resolve_source_for(transmit.dst.ip())?,
+            None => match self.resolve_source_for(transmit.dst.ip()) {
+                Ok(src_ip) => src_ip,
+                Err(e) => {
+                    tracing::trace!(
+                        dst = %transmit.dst.ip(),
+                        "No available interface for packet: {e}"
+                    );
+                    return Ok(());
+                }
+            },
         };
 
         let transmit = quinn_udp::Transmit {

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -53,6 +53,10 @@ impl TcpSocket {
     pub async fn connect(self, addr: SocketAddr) -> io::Result<tokio::net::TcpStream> {
         self.inner.connect(addr).await
     }
+
+    pub fn bind(&self, addr: SocketAddr) -> io::Result<()> {
+        self.inner.bind(addr)
+    }
 }
 
 #[cfg(unix)]

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -258,7 +258,7 @@ impl UdpSocket {
 
         let src_ip = match src_ip {
             Some(src_ip) => Some(src_ip),
-            None => match self.resolve_source_for(transmit.dst.ip()) {
+            None => match self.resolve_source_for(destination.ip()) {
                 Ok(src_ip) => src_ip,
                 Err(e) => {
                     tracing::trace!(


### PR DESCRIPTION
In `connlib`, traffic is sent through sockets via one of three ways:

1. Direct p2p traffic between clients and gateways: For these, we always explicitly set the source IP (and thus interface).
2. UDP traffic to the relays: For these, we let the OS pick an appropriate source interface.
3. WebSocket traffic over TCP to the portal: For this too, we let the OS pick the source interface.

For (2) and (3), it is possible to run into routing loops, depending on the routes that we have configured on the TUN device.

In Linux, we can prevent routing loops by marking a socket [0] and repeating the mark when we add routes [1]. Packets sent via a marked socket won't be routed by a rule that contains this mark. On Android, we can do something similar by "protecting" a socket via a syscall on the Java side [2].

On Windows, routing works slightly different. There, the source interface is determined based on a computed metric [3] [4]. To prevent routing loops on Windows, we thus need to find the "next best" interface after our TUN interface. We can achieve this with a combination of several syscalls:

1. List all interfaces on the machine
2. Ask Windows for the best route on each interface, except our TUN interface.
3. Sort by Windows' routing metric and pick the lowest one (lower is better).

Thanks to the abstraction of `SocketFactory` that we already previously introduced, Integrating this into `connlib` isn't too difficult:

1. For TCP sockets, we simply resolve the best route after creating the socket and then bind it to that local interface. That way, all packets will always going via that interface, regardless of which routes are present on our TUN interface.
2. UDP is connection-less so we need to decide per-packet, which interface to use. "Pick the best interface for me" is modelled in `connlib` via the `DatagramOut::src` field being `None`.
	- To ensure those packets don't cause a routing loop, we introduce a "source IP resolver" for our `UdpSocket`. This function gets called every time we need to send a packet without a source IP.
	- For improved performance, we cache these results. The Windows client uses this source IP resolver to use the above devised strategy to find a suitable source IP.
	- In case the source IP resolution fails, we don't send the packet. This is important, otherwise, the kernel might choose our TUN interface again and trigger a routing loop.

The last remark to make here is that this also works for connection roaming. The TCP socket gets thrown away when we reconnect to the portal. Thus, the new socket will pick the new best interface as it is re-created. The UDP sockets also get thrown away as part of roaming. That clears the above cache which is what we want: Upon roaming, the best interface for a given destination IP will likely have changed.

[0]: https://github.com/firezone/firezone/blob/59014a962240b32799b932a23f3b7e3ec30b20ee/rust/headless-client/src/linux.rs#L19-L29
[1]: https://github.com/firezone/firezone/blob/59014a962240b32799b932a23f3b7e3ec30b20ee/rust/bin-shared/src/tun_device_manager/linux.rs#L204-L224
[2]: https://github.com/firezone/firezone/blob/59014a962240b32799b932a23f3b7e3ec30b20ee/rust/connlib/clients/android/src/lib.rs#L535-L549
[3]: https://learn.microsoft.com/en-us/previous-versions/technet-magazine/cc137807(v=msdn.10)?redirectedfrom=MSDN
[4]: https://learn.microsoft.com/en-us/windows-server/networking/technologies/network-subsystem/net-sub-interface-metric

Fixes: #5955.