### PR TITLE
fix(relay): don't hang when connecting to OTLP exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,6 +429,7 @@ services:
       RUST_LOG: ${RUST_LOG:-debug}
       RUST_BACKTRACE: 1
       FIREZONE_API_URL: ws://api:8081
+      OTLP_GRPC_ENDPOINT: otlp:4317
     build:
       target: dev
       context: rust
@@ -446,6 +447,8 @@ services:
       timeout: 5s
     depends_on:
       api:
+        condition: "service_healthy"
+      otel:
         condition: "service_healthy"
     # ports:
       # NOTE: Only 111 ports are used for local dev / testing because Docker Desktop
@@ -469,7 +472,6 @@ services:
       RUST_LOG: ${RUST_LOG:-debug}
       RUST_BACKTRACE: 1
       FIREZONE_API_URL: ws://api:8081
-      OTLP_GRPC_ENDPOINT: otlp:4317
     build:
       target: dev
       context: rust
@@ -487,8 +489,6 @@ services:
       timeout: 5s
     depends_on:
       api:
-        condition: "service_healthy"
-      otel:
         condition: "service_healthy"
     networks:
       app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -449,7 +449,6 @@ services:
       api:
         condition: "service_healthy"
       otel:
-        condition: "service_healthy"
     # ports:
       # NOTE: Only 111 ports are used for local dev / testing because Docker Desktop
       # allocates a userland proxy process for each forwarded port X_X.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -448,7 +448,6 @@ services:
     depends_on:
       api:
         condition: "service_healthy"
-      otel:
     # ports:
       # NOTE: Only 111 ports are used for local dev / testing because Docker Desktop
       # allocates a userland proxy process for each forwarded port X_X.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -469,6 +469,7 @@ services:
       RUST_LOG: ${RUST_LOG:-debug}
       RUST_BACKTRACE: 1
       FIREZONE_API_URL: ws://api:8081
+      OTLP_GRPC_ENDPOINT: otlp:4317
     build:
       target: dev
       context: rust
@@ -487,10 +488,16 @@ services:
     depends_on:
       api:
         condition: "service_healthy"
+      otel:
+        condition: "service_healthy"
     networks:
       app:
         ipv4_address: ${RELAY_2_PUBLIC_IP4_ADDR:-172.28.0.201}
 
+  otel:
+    image: otel/opentelemetry-collector:latest
+    networks:
+      app:
 
 # IPv6 is currently causing flakiness with GH actions and on our testbed.
 # Disabling until there's more time to debug.

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -204,9 +204,7 @@ fn setup_tracing(args: &Args) -> Result<()> {
                 ))
                 .install_batch(opentelemetry_sdk::runtime::Tokio)
                 .context("Failed to create OTLP trace pipeline")?;
-            let relay_tracer = tracer_provider.tracer("relay");
-
-            global::set_tracer_provider(tracer_provider);
+            global::set_tracer_provider(tracer_provider.clone());
 
             tracing::trace!(target: "relay", "Successfully initialized trace provider on tokio runtime");
 
@@ -227,7 +225,7 @@ fn setup_tracing(args: &Args) -> Result<()> {
                 .with(log_layer(args).with_filter(env_filter()))
                 .with(
                     tracing_opentelemetry::layer()
-                        .with_tracer(relay_tracer)
+                        .with_tracer(tracer_provider.tracer("relay"))
                         .with_filter(env_filter()),
                 )
                 .into()


### PR DESCRIPTION
The dependency update in #6003 introduced a regression: Connecting to the OTLP exporter was hanging forever and thus the relay failed to start up.

The hang seems to be related to _dropping_ the `meter_provider`. Looking at the changelog update, this change was actually called out: https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/CHANGELOG.md#v0170.

By setting these providers globally, the relay starts up just fine.

To ensure this doesn't regress again, we add an OTEL collector to our `docker-compose.yml` and configure the `relay-1` to connect to it.