### PR TITLE
fix(ux): Improve styling of sign in / sign up pages

### DIFF
--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -14,6 +14,17 @@ defmodule Web.CoreComponents do
   alias Phoenix.LiveView.JS
   alias Domain.Actors
 
+  def hero_logo(assigns) do
+    ~H"""
+    <a href={~p"/"} class="mb-6">
+      <img src={~p"/images/logo.svg"} class="pl-10 h-32" alt="Firezone Logo" />
+      <p class="mt-4 text-3xl">
+        Welcome to Firezone.
+      </p>
+    </a>
+    """
+  end
+
   def logo(assigns) do
     ~H"""
     <a href={~p"/"} class="flex items-center mb-6 text-2xl">

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -14,14 +14,16 @@ defmodule Web.CoreComponents do
   alias Phoenix.LiveView.JS
   alias Domain.Actors
 
+  attr :text, :string, default: "Welcome to Firezone."
+
   def hero_logo(assigns) do
     ~H"""
-    <a href={~p"/"} class="mb-6">
-      <img src={~p"/images/logo.svg"} class="pl-10 h-32" alt="Firezone Logo" />
+    <div class="mb-6">
+      <img src={~p"/images/logo.svg"} class="mx-auto pr-10 h-32" alt="Firezone Logo" />
       <p class="mt-4 text-3xl">
-        Welcome to Firezone.
+        <%= @text %>
       </p>
-    </a>
+    </div>
     """
   end
 

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -524,13 +524,14 @@ defmodule Web.FormComponents do
     </.submit_button>
   """
 
-  attr :rest, :global
+  attr :rest, :global, include: ~w(class icon)
+  attr :style, :string, default: "primary", doc: "The style of the button"
   slot :inner_block, required: true
 
   def submit_button(assigns) do
     ~H"""
     <div class="flex justify-end">
-      <.button type="submit" style="primary" {@rest}>
+      <.button type="submit" style={@style} {@rest}>
         <%= render_slot(@inner_block) %>
       </.button>
     </div>

--- a/elixir/apps/web/lib/web/controllers/home_html.ex
+++ b/elixir/apps/web/lib/web/controllers/home_html.ex
@@ -5,20 +5,16 @@ defmodule Web.HomeHTML do
     ~H"""
     <section>
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
-        <.logo />
+        <.hero_logo />
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
-            <h1 class="text-xl text-center leading-tight tracking-tight text-neutral-900 sm:text-2xl">
-              Welcome to Firezone
-            </h1>
-
-            <h3
+            <h2
               :if={@accounts != []}
-              class="text-m leading-tight tracking-tight text-neutral-900 sm:text-xl"
+              class="text-lg sm:text-xl leading-tight tracking-tight text-neutral-900"
             >
-              Recently used accounts
-            </h3>
+              Sign in with a recently used account
+            </h2>
 
             <div :if={@accounts != []} class="space-y-3 items-center">
               <.account_button
@@ -33,6 +29,9 @@ defmodule Web.HomeHTML do
 
             <.flash kind={:error} flash={@flash} />
 
+            <h2 class="text-lg sm:text-xl leading-tight tracking-tight text-neutral-900">
+              Sign in using your account ID or slug
+            </h2>
             <.form :let={f} for={%{}} action={~p"/?#{@params}"} class="space-y-4 lg:space-y-6">
               <.input
                 field={f[:account_id_or_slug]}
@@ -44,7 +43,7 @@ defmodule Web.HomeHTML do
                 autofocus
               />
 
-              <.button class="w-full">
+              <.button class="w-full" style="info">
                 Go to Sign In page
               </.button>
             </.form>

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -45,14 +45,10 @@ defmodule Web.SignIn do
     ~H"""
     <section>
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
-        <.hero_logo />
+        <.hero_logo text={@account.name} />
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
-            <h1 class="pb-6 text-2xl sm:text-3xl text-center leading-tight tracking-tight text-neutral-900">
-              <%= @account.name %>
-            </h1>
-
             <h2 class="text-lg sm:text-xl leading-tight tracking-tight text-neutral-900">
               Sign in with a configured provider
             </h2>

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -45,15 +45,17 @@ defmodule Web.SignIn do
     ~H"""
     <section>
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
-        <.logo />
+        <.hero_logo />
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
-            <h1 class="text-xl text-center leading-tight tracking-tight text-neutral-900 sm:text-2xl">
-              <span>
-                Sign in to <%= @account.name %>
-              </span>
+            <h1 class="pb-6 text-2xl sm:text-3xl text-center leading-tight tracking-tight text-neutral-900">
+              <%= @account.name %>
             </h1>
+
+            <h2 class="text-lg sm:text-xl leading-tight tracking-tight text-neutral-900">
+              Sign in with a configured provider
+            </h2>
 
             <.flash flash={@flash} kind={:error} />
             <.flash flash={@flash} kind={:info} />
@@ -77,9 +79,9 @@ defmodule Web.SignIn do
               </:item>
 
               <:item :if={adapter_enabled?(@providers_by_adapter, :userpass)}>
-                <h3 class="text-m leading-tight tracking-tight text-neutral-900 sm:text-xl">
+                <h2 class="text-lg sm:text-xl leading-tight tracking-tight text-neutral-900">
                   Sign in with username and password
-                </h3>
+                </h2>
 
                 <.providers_group_form
                   adapter="userpass"
@@ -91,9 +93,9 @@ defmodule Web.SignIn do
               </:item>
 
               <:item :if={adapter_enabled?(@providers_by_adapter, :email)}>
-                <h3 class="text-m leading-tight tracking-tight text-neutral-900 sm:text-xl">
+                <h2 class="text-lg sm:text-xl leading-tight tracking-tight text-neutral-900">
                   Sign in with email
-                </h3>
+                </h2>
 
                 <.providers_group_form
                   adapter="email"
@@ -189,7 +191,7 @@ defmodule Web.SignIn do
         />
       </div>
 
-      <.submit_button class="w-full">
+      <.submit_button class="w-full" style="info" icon="hero-key">
         Sign in
       </.submit_button>
     </.form>
@@ -220,7 +222,7 @@ defmodule Web.SignIn do
         placeholder="Enter your email"
         required
       />
-      <.submit_button class="w-full" style="info">
+      <.submit_button class="w-full" style="info" icon="hero-envelope">
         Request sign in token
       </.submit_button>
     </.form>

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -89,14 +89,10 @@ defmodule Web.SignUp do
     ~H"""
     <section>
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
-        <.logo />
+        <.hero_logo />
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
-            <h1 class="text-center text-xl leading-tight tracking-tight text-neutral-900 sm:text-2xl">
-              Welcome to Firezone
-            </h1>
-
             <.flash flash={@flash} kind={:error} />
             <.flash flash={@flash} kind={:info} />
 
@@ -200,9 +196,9 @@ defmodule Web.SignUp do
 
   def sign_up_form(assigns) do
     ~H"""
-    <h3 class="text-center text-m leading-tight tracking-tight text-neutral-900 sm:text-xl">
-      Sign Up Now
-    </h3>
+    <h2 class="text-lg sm:text-xl leading-tight tracking-tight text-neutral-900">
+      Sign up for a new account
+    </h2>
     <.form for={@form} class="space-y-4 lg:space-y-6" phx-submit="submit" phx-change="validate">
       <div class="bg-white grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
         <.input

--- a/elixir/apps/web/test/web/acceptance/auth/openid_connect_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/openid_connect_test.exs
@@ -13,10 +13,10 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
 
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> assert_path(~p"/#{account.id}")
     |> assert_el(Query.text("You may not authenticate to this account."))
   end
@@ -41,7 +41,7 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
 
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
     |> assert_el(Query.css("#user-menu-button"))
@@ -69,7 +69,7 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
 
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
     |> assert_el(Query.css("#user-menu-button"))
@@ -110,7 +110,7 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
 
     session
     |> visit(~p"/#{account}?#{redirect_params}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
     |> assert_el(Query.text("Client redirected"))
@@ -175,7 +175,7 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
     # Sign In as a portal user
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
     |> assert_el(Query.css("#user-menu-button"))
@@ -185,7 +185,7 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
     # And then to a client
     session
     |> visit(~p"/#{account}?#{redirect_params}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> assert_el(Query.text("Client redirected"))
     |> assert_path(~p"/handle_client_sign_in_callback")
@@ -237,7 +237,7 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
     # And then to a client
     session
     |> visit(~p"/#{account}?#{redirect_params}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> Vault.userpass_flow(oidc_login, oidc_password)
     |> assert_el(Query.text("Client redirected"))
@@ -246,7 +246,7 @@ defmodule Web.Acceptance.Auth.OpenIDConnectTest do
     # Sign In as an portal user
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> click(Query.link("Sign in with Vault"))
     |> assert_el(Query.css("#user-menu-button"))
     |> Auth.assert_authenticated(identity)

--- a/elixir/apps/web/test/web/acceptance/auth/userpass_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/userpass_test.exs
@@ -249,7 +249,7 @@ defmodule Web.Acceptance.Auth.UserPassTest do
   defp password_login_flow(session, account, username, password, redirect_params \\ %{}) do
     session
     |> visit(~p"/#{account}?#{redirect_params}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> assert_el(Query.text("Sign in with username and password"))
     |> fill_form(%{
       "userpass[provider_identifier]" => username,

--- a/elixir/apps/web/test/web/acceptance/auth_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth_test.exs
@@ -14,7 +14,7 @@ defmodule Web.Acceptance.AuthTest do
 
     session
     |> visit(~p"/#{account}")
-    |> assert_el(Query.text("Sign in to #{account.name}"))
+    |> assert_el(Query.text("#{account.name}"))
     |> assert_el(Query.link("Sign in with #{openid_connect_provider.name}"))
     |> assert_el(Query.text("Sign in with username and password"))
     |> assert_el(Query.text("Sign in with email"))


### PR DESCRIPTION
- Use consistently-sized titles and spacing for form sections
- Use larger and centered hero logo to match Welcome screen in client apps
- If more than one action exists, use `style=info` instead of showing multiple primary CTA buttons

Fixes #5730 
Fixes a regression that was originally fixed in #3390 
refs #5032 

## Before

<img width="1159" alt="Screenshot 2024-07-24 at 11 38 29 PM" src="https://github.com/user-attachments/assets/a5261982-4975-4a8c-a30b-4d136a3b9b0f">
<img width="1159" alt="Screenshot 2024-07-24 at 11 38 21 PM" src="https://github.com/user-attachments/assets/49a8d0c0-0753-4bfb-98db-c0654a3e4805">
<img width="1159" alt="Screenshot 2024-07-24 at 11 38 17 PM" src="https://github.com/user-attachments/assets/9ef8f105-d3f6-4b36-8e9f-d05296c5b3e1">


## After

<img width="1159" alt="Screenshot 2024-07-24 at 11 32 19 PM" src="https://github.com/user-attachments/assets/85535cdb-a2d2-4002-a742-8a99f24cd465">
<img width="1159" alt="Screenshot 2024-07-24 at 11 32 15 PM" src="https://github.com/user-attachments/assets/3bf7bc55-fb8e-45c4-88aa-03a22f999426">
<img width="1159" alt="Screenshot 2024-07-24 at 11 32 10 PM" src="https://github.com/user-attachments/assets/535de033-02ab-45c1-906e-180fdeabf03d">
