### PR TITLE
fix(windows): clear all routes when setting new IPs

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -94,6 +94,8 @@ impl TunDeviceManager {
             .stdout(Stdio::null())
             .status()?;
 
+        self.routes.clear();
+
         Ok(())
     }
 


### PR DESCRIPTION
Related: #5392.