### PR TITLE
fix(api): add missing path parameter

### DIFF
--- a/elixir/apps/api/lib/api/controllers/identity_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/identity_controller.ex
@@ -33,7 +33,8 @@ defmodule API.IdentityController do
   operation :create,
     summary: "Create an Identity for an Actor",
     parameters: [
-      actor_id: [in: :path, description: "Actor ID", type: :string]
+      actor_id: [in: :path, description: "Actor ID", type: :string],
+      provider_id: [in: :path, description: "Provider ID", type: :string]
     ],
     request_body:
       {"Identity Attributes", "application/json", API.Schemas.Identity.Request, required: true},


### PR DESCRIPTION
Looks like I forgot one: https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fapi.firez.one%2Fopenapi