### PR TITLE
fix(ux): Make 'New' page title consistent

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/api_clients/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/new.ex
@@ -12,7 +12,7 @@ defmodule Web.Settings.ApiClients.New do
     socket =
       assign(socket,
         form: to_form(changeset),
-        page_title: "Add an API Client"
+        page_title: "New API Client"
       )
 
     {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}

--- a/elixir/apps/web/lib/web/live/settings/api_clients/new_token.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/new_token.ex
@@ -16,7 +16,7 @@ defmodule Web.Settings.ApiClients.NewToken do
           actor: actor,
           encoded_token: nil,
           form: to_form(changeset),
-          page_title: "Add an API Token"
+          page_title: "New API Token"
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}


### PR DESCRIPTION
Fixes a couple items missed from #5938 