### PR TITLE
ci: Use OTLP_ENDPOINT for both CI relays

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -470,6 +470,7 @@ services:
       RUST_LOG: ${RUST_LOG:-debug}
       RUST_BACKTRACE: 1
       FIREZONE_API_URL: ws://api:8081
+      OTLP_GRPC_ENDPOINT: otlp:4317
     build:
       target: dev
       context: rust


### PR DESCRIPTION
~~Relays are still failing to boot~~. By setting OTLP_ENDPOINT for both relays in CI we will more closely mimic staging/prod env.

Edit: They just started working randomly. It had failed with a core dump error after #6034 was merged, which is a bit concerning.