### PR TITLE
fix(windows,linux): ensure `set_routes` is idempotent

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -269,7 +269,7 @@ async fn remove_route(route: &IpNetwork, idx: u32, handle: &Handle) {
         return;
     };
 
-    // We expect this to be called often with an already existing route since set_routes always calls for all routes
+    // Our view of the current routes may be stale. Removing a route that no longer exists shouldn't print a warning.
     if matches!(&err, NetlinkError(err) if err.raw_code() == -ENOENT) {
         return;
     }

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -144,6 +144,7 @@ fn add_route(route: IpNetwork, iface_idx: u32) {
 
 // It's okay if this blocks until the route is removed in the OS.
 fn remove_route(route: IpNetwork, iface_idx: u32) {
+    const ELEMENT_NOT_FOUND: u32 = 0x80070490;
     let entry = forward_entry(route, iface_idx);
 
     // SAFETY: Windows shouldn't store the reference anywhere, it's just a way to pass lots of arguments at once. And no other thread sees this variable.
@@ -151,6 +152,10 @@ fn remove_route(route: IpNetwork, iface_idx: u32) {
     let Err(e) = unsafe { DeleteIpForwardEntry2(&entry) }.ok() else {
         return;
     };
+
+    if e.code().0 as u32 == ELEMENT_NOT_FOUND {
+        return;
+    }
 
     tracing::warn!(%route, "Failed to remove route: {e}")
 }

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -135,11 +135,11 @@ fn add_route(route: IpNetwork, iface_idx: u32) {
     };
 
     // We expect set_routes to call add_route with the same routes always making this error expected
-    if e.code.0 as u32 == DUPLICATE_ERR {
+    if e.code().0 as u32 == DUPLICATE_ERR {
         return;
     }
 
-    tracing::debug!(%route, "Failed to add route: {e}");
+    tracing::warn!(%route, "Failed to add route: {e}");
 }
 
 // It's okay if this blocks until the route is removed in the OS.
@@ -152,7 +152,7 @@ fn remove_route(route: IpNetwork, iface_idx: u32) {
         return;
     };
 
-    tracing::debug!(%route, "Failed to remove route: {e}")
+    tracing::warn!(%route, "Failed to remove route: {e}")
 }
 
 fn forward_entry(route: IpNetwork, iface_idx: u32) -> MIB_IPFORWARD_ROW2 {

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -110,16 +110,12 @@ impl TunDeviceManager {
                 .chain(v6.into_iter().map(IpNetwork::from)),
         );
 
-        if new_routes == self.routes {
-            return Ok(());
-        }
-
-        for new_route in new_routes.difference(&self.routes) {
-            add_route(*new_route, iface_idx)?;
-        }
-
         for old_route in self.routes.difference(&new_routes) {
             remove_route(*old_route, iface_idx)?;
+        }
+
+        for new_route in &new_routes {
+            add_route(*new_route, iface_idx)?;
         }
 
         self.routes = new_routes;


### PR DESCRIPTION
Windows may delete the default route during roaming. To prevent this from causing problems, we make `set_routes` add all routes regardless of the previously stored ones. The known routes are only used to compute, what routes are to be removed.

For Linux we do the same to make it consistent across platforms.

This also give us the chance to not clear the cache when ips are set, since now all routes are always added, meaning they will be always re-added when roaming.

Overall, this more closely aligns Linux and Windows with how Firezone works on Apple and Android. There, we always remove all routes and set new ones. Removing routes happens very rarely (only when CIDR resources are deactivated), thus, not removing all and re-adding the routes is still deemed to be worth it.

With the new implementation, this is guaranteed to always make the new routes take effect and at the same time be idempotent.