### PR TITLE
ci: use correct service name in `docker-compose.yml`

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -145,6 +145,7 @@ jobs:
           # Start one-by-one to avoid variability in service startup order
           docker compose up -d dns.httpbin httpbin download.httpbin
           docker compose up -d api web domain --no-build
+          docker compose up -d otel --no-build
           docker compose up -d relay-1 --no-build
           docker compose up -d relay-2 --no-build
           docker compose up -d gateway --no-build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,7 +429,7 @@ services:
       RUST_LOG: ${RUST_LOG:-debug}
       RUST_BACKTRACE: 1
       FIREZONE_API_URL: ws://api:8081
-      OTLP_GRPC_ENDPOINT: otlp:4317
+      OTLP_GRPC_ENDPOINT: otel:4317
     build:
       target: dev
       context: rust
@@ -470,7 +470,7 @@ services:
       RUST_LOG: ${RUST_LOG:-debug}
       RUST_BACKTRACE: 1
       FIREZONE_API_URL: ws://api:8081
-      OTLP_GRPC_ENDPOINT: otlp:4317
+      OTLP_GRPC_ENDPOINT: otel:4317
     build:
       target: dev
       context: rust


### PR DESCRIPTION
The compose service I defined is called `otel` not `otlp`. With this fix in place, the relay successfully connects to the OTLP exporter.

it is worthwhile noting that the connection to the OTLP exporter itself is not critical for relay operation. Even if it fails, it won't affect the actual data plane. I do think it makes sense to still have a working OTLP exporter in the compose definition. As it makes it easier to test whether the ingestion of metrics and traces works as expected.