### PR TITLE
fix(ux): Trim whitespace from address before validation

### DIFF
--- a/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
@@ -13,6 +13,7 @@ defmodule Domain.Resources.Resource.Changeset do
     |> changeset()
     |> validate_required(@required_fields)
     |> put_change(:account_id, account.id)
+    |> update_change(:address, &String.trim/1)
     |> validate_address()
     |> cast_assoc(:connections,
       with: &Connection.Changeset.changeset(account.id, &1, &2, subject),

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -981,6 +981,28 @@ defmodule Domain.ResourcesTest do
     #   assert errors_on(changeset) == %{name: ["has already been taken"]}
     # end
 
+    test "trims whitespace from address before validation", %{subject: subject} do
+      attrs = %{"type" => "dns", "address" => " foo  "}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      refute Map.has_key?(errors_on(changeset), :address)
+
+      attrs = %{"type" => "dns", "address" => "\tfoo\t"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      refute Map.has_key?(errors_on(changeset), :address)
+
+      attrs = %{"type" => "dns", "address" => "\nfoo\n"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      refute Map.has_key?(errors_on(changeset), :address)
+
+      attrs = %{"type" => "dns", "address" => "\rfoo\r"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      refute Map.has_key?(errors_on(changeset), :address)
+
+      attrs = %{"type" => "dns", "address" => "\vfoo\v"}
+      assert {:error, changeset} = create_resource(attrs, subject)
+      refute Map.has_key?(errors_on(changeset), :address)
+    end
+
     test "creates a dns resource", %{account: account, subject: subject} do
       gateway = Fixtures.Gateways.create_gateway(account: account)
 


### PR DESCRIPTION
When a user copy-pastes an address into the `address` field that contains a leading or trailing whitespace, it's not apparent why the address is invalid. This is common when copy-pasting DNS names from cloud consoles that have poor UIs, such as Azure.

Fixes #6059 