### PR TITLE
fix(connlib): clear timeout after it fired

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -96,7 +96,10 @@ impl Io {
 
         if let Some(timeout) = self.timeout.as_mut() {
             if timeout.poll_unpin(cx).is_ready() {
-                return Poll::Ready(Ok(Input::Timeout(timeout.deadline().into())));
+                let deadline = timeout.deadline().into();
+                self.timeout.as_mut().take(); // Clear the timeout.
+
+                return Poll::Ready(Ok(Input::Timeout(deadline)));
             }
         }
 


### PR DESCRIPTION
We don't want the timer to fire multiple times at the same `Instant` unless it has been specifically set to that `Instant` again. Thus, clear the timer after it fired.

I don't think this fixed #6067 but it can't hurt.