### PR TITLE
fix(connlib): de-prioritise timeout handling

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -696,6 +696,11 @@ where
                     },
                 );
 
+                // Ensure time-sensitive tasks get done.
+                // str0m needs a `handle_timeout` after it received input to evaluate nominations etc.
+                // Ensure this happens even if are busy with handling packets and timer processing gets delayed.
+                agent.handle_timeout(now);
+
                 return ControlFlow::Break(Ok(()));
             }
         }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -94,12 +94,6 @@ impl Io {
             return Poll::Ready(Ok(Input::DnsResponse(query, response)));
         }
 
-        if let Some(timeout) = self.timeout.as_mut() {
-            if timeout.poll_unpin(cx).is_ready() {
-                return Poll::Ready(Ok(Input::Timeout(timeout.deadline().into())));
-            }
-        }
-
         if let Poll::Ready(network) = self.sockets.poll_recv_from(ip4_buffer, ip6_bffer, cx)? {
             return Poll::Ready(Ok(Input::Network(network)));
         }
@@ -108,6 +102,12 @@ impl Io {
 
         if let Poll::Ready(packet) = self.device.poll_read(device_buffer, cx)? {
             return Poll::Ready(Ok(Input::Device(packet)));
+        }
+
+        if let Some(timeout) = self.timeout.as_mut() {
+            if timeout.poll_unpin(cx).is_ready() {
+                return Poll::Ready(Ok(Input::Timeout(timeout.deadline().into())));
+            }
         }
 
         Poll::Pending


### PR DESCRIPTION
`connlib`'s event loop performs work in a very particular order:

1. Local buffers like IP, UDP and DNS packets are emptied.
2. Time-sensitive tasks, if any, are performed.
3. New UDP packets are processed.
4. New IP packets (from the TUN device) are processed.

This priority ensures we don't accept more work (i.e. new packets) until we have finished processing existing work. As a result, we can keep local buffers small and processing latencies low.

I am not completely confident on the issue of #6067 but if the busy-loop originates from a bad timer, then the above priority means we never get to the part where we read new UDP or IP packets.

A naive fix for this problem is to just de-prioritise the polling of the timer within `Io::poll`. I say naive because without additional changes, this could delay the processing of time-sensitive tasks on a very busy client / gateway where packets are constantly arriving and thus we never reach part where the timer gets polled.

Thankfully, there is an easy fix for that: The only thing that really needs to do time-sensitive stuff is a connection's `IceAgent`. Thus, we can simply call `handle_timeout` there every time the agent receives a packet.