### PR TITLE
build(deps): remove `proptest` fork

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "proptest"
 version = "1.5.0"
-source = "git+https://github.com/thomaseizinger/proptest?branch=fix/always-check-acceptable-current-state#b52c68ff423efe4a558b5967c86c17c457d3a84d"
+source = "git+https://github.com/proptest-rs/proptest?branch=master#c012218897b41606a5f8a21718d44d10509cb502"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -4704,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "proptest-state-machine"
 version = "0.3.0"
-source = "git+https://github.com/thomaseizinger/proptest?branch=fix/always-check-acceptable-current-state#b52c68ff423efe4a558b5967c86c17c457d3a84d"
+source = "git+https://github.com/proptest-rs/proptest?branch=master#c012218897b41606a5f8a21718d44d10509cb502"
 dependencies = [
  "proptest",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -76,8 +76,8 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }
 str0m = { git = "https://github.com/firezone/str0m", branch = "main" }
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
-proptest = { git = "https://github.com/thomaseizinger/proptest", branch = "fix/always-check-acceptable-current-state" }
-proptest-state-machine = { git = "https://github.com/thomaseizinger/proptest", branch = "fix/always-check-acceptable-current-state" }
+proptest = { git = "https://github.com/proptest-rs/proptest", branch = "master" }
+proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "master" }
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "deps/bump-otel-0.23" } # Waiting for release.
 
 [profile.release]


### PR DESCRIPTION
The bugfix we have been waiting on has been merged and thus we no longer need to rely on our fork.

Related: https://github.com/proptest-rs/proptest/pull/482.