### PR TITLE
fix(infra): Manually manage the version of Erlang cluster state

### DIFF
--- a/terraform/environments/production/portal.tf
+++ b/terraform/environments/production/portal.tf
@@ -1,3 +1,9 @@
+locals {
+  # The version of the Erlang cluster state,
+  # change this to prevent new nodes from joining the cluster of the old ones,
+  # ie. when some internal messages introduced a breaking change.
+  cluster_version = "1.0"
+}
 
 # Generate secrets
 resource "random_password" "erlang_cluster_cookie" {
@@ -274,7 +280,7 @@ locals {
         cluster_name          = local.cluster.name
         cluster_name_label    = "cluster_name"
         cluster_version_label = "cluster_version"
-        cluster_version       = split(".", local.portal_image_tag)[0]
+        cluster_version       = local.cluster_version
         node_name_label       = "application"
         polling_interval_ms   = 10000
       })
@@ -447,7 +453,7 @@ module "domain" {
 
   application_labels = {
     "cluster_name"    = local.cluster.name
-    "cluster_version" = split(".", local.portal_image_tag)[0]
+    "cluster_version" = local.cluster_version
   }
 }
 
@@ -525,7 +531,7 @@ module "web" {
 
   application_labels = {
     "cluster_name"    = local.cluster.name
-    "cluster_version" = split(".", local.portal_image_tag)[0]
+    "cluster_version" = local.cluster_version
   }
 }
 
@@ -601,7 +607,7 @@ module "api" {
 
   application_labels = {
     "cluster_name"    = local.cluster.name
-    "cluster_version" = split(".", local.portal_image_tag)[0]
+    "cluster_version" = local.cluster_version
   }
 
   application_token_scopes = [

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -1,3 +1,9 @@
+locals {
+  # The version of the Erlang cluster state,
+  # change this to prevent new nodes from joining the cluster of the old ones,
+  # ie. when some internal messages introduced a breaking change.
+  cluster_version = "1.0"
+}
 
 # Generate secrets
 resource "random_password" "erlang_cluster_cookie" {
@@ -247,7 +253,7 @@ locals {
         cluster_name          = local.cluster.name
         cluster_name_label    = "cluster_name"
         cluster_version_label = "cluster_version"
-        cluster_version       = split(".", var.image_tag)[0]
+        cluster_version       = local.cluster_version
         node_name_label       = "application"
         polling_interval_ms   = 7000
       })
@@ -427,7 +433,7 @@ module "domain" {
 
   application_labels = {
     "cluster_name"    = local.cluster.name
-    "cluster_version" = split(".", var.image_tag)[0]
+    "cluster_version" = local.cluster_version
   }
 }
 
@@ -508,7 +514,7 @@ module "web" {
 
   application_labels = {
     "cluster_name"    = local.cluster.name
-    "cluster_version" = split(".", var.image_tag)[0]
+    "cluster_version" = local.cluster_version
   }
 }
 
@@ -583,7 +589,7 @@ module "api" {
 
   application_labels = {
     "cluster_name"    = local.cluster.name
-    "cluster_version" = split(".", var.image_tag)[0]
+    "cluster_version" = local.cluster_version
   }
 
   application_token_scopes = [


### PR DESCRIPTION
Whenever we deploy we risk of having a "split brain" every time deployment doesn't finalize for all the components. This causes our API layer (relays, clients, gateways) to see each other but their status (due to missing presence) is rendered incorrectly in web.

To solve this we will be managing the cluster state manually and changing it version every time there is a breaking change to the state, this is more prone to "human errors" but, since we don't change it much, still better for overall uptime of the portal.