### PR TITLE
chore: optimise `tunnel_test` debug output

### DIFF
--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -29,12 +29,13 @@ pub(crate) struct ReferenceState {
     pub(crate) relays: BTreeMap<RelayId, Host<u64>>,
     pub(crate) portal: StubPortal,
 
+    pub(crate) drop_direct_client_traffic: bool,
+
     /// All IP addresses a domain resolves to in our test.
     ///
     /// This is used to e.g. mock DNS resolution on the gateway.
     pub(crate) global_dns_records: BTreeMap<DomainName, HashSet<IpAddr>>,
 
-    pub(crate) drop_direct_client_traffic: bool,
     pub(crate) network: RoutingTable,
 }
 

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -211,7 +211,8 @@ impl SimClient {
 ///
 /// The reference state machine is designed to be as abstract as possible over connlib's functionality.
 /// For example, we try to model connectivity to _resources_ and don't really care, which gateway is being used to route us there.
-#[derive(Debug, Clone)]
+#[derive(Clone, derivative::Derivative)]
+#[derivative(Debug)]
 pub struct RefClient {
     pub(crate) id: ClientId,
     pub(crate) key: PrivateKey,
@@ -225,28 +226,35 @@ pub struct RefClient {
     pub(crate) upstream_dns_resolvers: Vec<DnsServer>,
 
     /// The CIDR resources the client is aware of.
+    #[derivative(Debug = "ignore")]
     pub(crate) cidr_resources: IpNetworkTable<ResourceDescriptionCidr>,
     /// The DNS resources the client is aware of.
+    #[derivative(Debug = "ignore")]
     pub(crate) dns_resources: BTreeMap<ResourceId, ResourceDescriptionDns>,
 
     /// The client's DNS records.
     ///
     /// The IPs assigned to a domain by connlib are an implementation detail that we don't want to model in these tests.
     /// Instead, we just remember what _kind_ of records we resolved to be able to sample a matching src IP.
+    #[derivative(Debug = "ignore")]
     pub(crate) dns_records: BTreeMap<DomainName, HashSet<RecordType>>,
 
     /// The CIDR resources the client is connected to.
+    #[derivative(Debug = "ignore")]
     pub(crate) connected_cidr_resources: HashSet<ResourceId>,
 
     /// The DNS resources the client is connected to.
+    #[derivative(Debug = "ignore")]
     pub(crate) connected_dns_resources: HashSet<(ResourceId, DomainName)>,
 
     /// The expected ICMP handshakes.
     ///
     /// This is indexed by gateway because our assertions rely on the order of the sent packets.
+    #[derivative(Debug = "ignore")]
     pub(crate) expected_icmp_handshakes:
         HashMap<GatewayId, VecDeque<(ResourceDst, IcmpSeq, IcmpIdentifier)>>,
     /// The expected DNS handshakes.
+    #[derivative(Debug = "ignore")]
     pub(crate) expected_dns_handshakes: VecDeque<QueryId>,
 }
 

--- a/rust/connlib/tunnel/src/tests/sim_net.rs
+++ b/rust/connlib/tunnel/src/tests/sim_net.rs
@@ -27,9 +27,11 @@ pub(crate) struct Host<T> {
 
     // In production, we always rebind to a new port.
     // To mimic this, we track the used ports here to not sample an existing one.
+    #[derivative(Debug = "ignore")]
     pub(crate) old_ports: HashSet<u16>,
 
     default_port: u16,
+    #[derivative(Debug = "ignore")]
     allocated_ports: HashSet<(u16, AddressFamily)>,
 
     // The latency of incoming and outgoing packets.
@@ -41,6 +43,7 @@ pub(crate) struct Host<T> {
     /// Messages that have "arrived" and are waiting to be dispatched.
     ///
     /// We buffer them here because we need also apply our latency on inbound packets.
+    #[derivative(Debug = "ignore")]
     inbox: BufferedTransmits,
 }
 

--- a/rust/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/connlib/tunnel/src/tests/stub_portal.rs
@@ -7,14 +7,17 @@ use std::{
 };
 
 /// Stub implementation of the portal.
-#[derive(Debug, Clone)]
+#[derive(Clone, derivative::Derivative)]
+#[derivative(Debug)]
 pub(crate) struct StubPortal {
     gateways_by_site: HashMap<client::SiteId, HashSet<GatewayId>>,
 
+    #[derivative(Debug = "ignore")]
     sites_by_resource: HashMap<ResourceId, client::SiteId>,
     cidr_resources: HashMap<ResourceId, client::ResourceDescriptionCidr>,
     dns_resources: HashMap<ResourceId, client::ResourceDescriptionDns>,
 
+    #[derivative(Debug = "ignore")]
     gateway_selector: Selector,
 }
 


### PR DESCRIPTION
When `tunnel_test` fails, it prints the initial state in verbose debug formatting. Most of the fields in `RefClient` track state _during_ the runtime of the test and are all empty initially. The same thing applies to `Host`.

To make this output easier to read and scroll, we ignore some of these fields in the debug output.