### PR TITLE
chore: instruct users to use `systemctl edit`

### DIFF
--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -35,6 +35,9 @@ After=network.target
 Documentation=https://www.firezone.dev/kb
 
 [Service]
+
+# DO NOT EDIT ANY OF THE BELOW BY HAND. USE `systemctl edit firezone-gateway` INSTEAD TO CUSTOMIZE.
+
 Type=simple
 Environment="FIREZONE_NAME=$FIREZONE_NAME"
 Environment="FIREZONE_ID=$FIREZONE_ID"


### PR DESCRIPTION
Edit to unit files are likely to be overwritten by upgrades to it. To prevent users from losing their edits, redirect them to use `systemd`'s `edit` functionality instead.