### PR TITLE
fix(connlib): don't upsert existing `Allocation`

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -508,7 +508,7 @@ where
             tracing::info!(%rid, address = ?allocation.server(), "Removed TURN server");
         }
 
-        // Second, upsert all new relays.
+        // Second, insert new relays.
         for (rid, server, username, password, realm) in to_add {
             let Ok(username) = Username::new(username.to_owned()) else {
                 tracing::debug!(%username, "Invalid TURN username");
@@ -519,8 +519,8 @@ where
                 continue;
             };
 
-            if let Some(existing) = self.allocations.get_mut(rid) {
-                existing.update_credentials(*server, username, password, realm, now);
+            if self.allocations.contains_key(rid) {
+                tracing::info!(%rid, address = ?server, "Skipping known TURN server");
                 continue;
             }
 


### PR DESCRIPTION
During deployments of new relays, we get told which relays to disconnect from and connect to. Most likely, some of the relays we already know about.

Previously, we refreshed our state here which causes a reset of the `active_socket` until we pick a new one.

Due to #6099, it could be that we receive a relay that is in fact shutting down and as still "connected". Whilst obviously needing a fix on the portal side, the unfortunate behaviour that gets triggered in connlib here is #6067 in case we are trying to refresh channel bindings at the same time. Channel bindings are refreshed every 5 minutes. If that timer fires after trying to "refresh" an allocation on a relay that actually no longer exists, we end up in a busy loop of:

- Wanting to refresh the channel binding
- Not being able to send the message because we don't have an `active_socket`

In practice, the functionality of "updating credentials" is not needed. A relay that reboots should have a different ID and thus if we receive a relay with the same ID, we know that the existing credentials are still valid. If they ever become invalid, we will automatically disconnect from the relay once we get an authorization error.

Finally, resetting the active socket and performing a "refresh" is an unnecessary message churn that we simply don't need, thus we remove this functionality entirely.

Resolves: #6067.