### PR TITLE
fix(ux): Make all fields live-updated in clients/relays/gateways details pane

### DIFF
--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -847,7 +847,7 @@ defmodule Web.CoreComponents do
         title={
           if @schema.last_seen_at,
             do:
-              "Last connected #{Cldr.DateTime.Relative.to_string!(@schema.last_seen_at, Web.CLDR, relative_to: @relative_to)}",
+              "Last started #{Cldr.DateTime.Relative.to_string!(@schema.last_seen_at, Web.CLDR, relative_to: @relative_to)}",
             else: "Never connected"
         }
       >

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -218,7 +218,7 @@ defmodule Web.Clients.Show do
       cond do
         Map.has_key?(payload.joins, client.id) ->
           {:ok, client} =
-            Clients.fetch_client_by_id(id, socket.assigns.subject,
+            Clients.fetch_client_by_id(client.id, socket.assigns.subject,
               preload: [:actor, last_used_token: [identity: [:provider]]]
             )
 

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -217,6 +217,11 @@ defmodule Web.Clients.Show do
     socket =
       cond do
         Map.has_key?(payload.joins, client.id) ->
+          {:ok, client} =
+            Clients.fetch_client_by_id(id, socket.assigns.subject,
+              preload: [:actor, last_used_token: [identity: [:provider]]]
+            )
+
           assign(socket, client: %{client | online?: true})
 
         Map.has_key?(payload.leaves, client.id) ->

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -132,23 +132,23 @@ defmodule Web.Clients.Show do
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>
-            <:label>Last Connected</:label>
+            <:label>Last started</:label>
             <:value>
               <.relative_datetime datetime={@client.last_seen_at} />
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>
-            <:label>Last Remote IP</:label>
+            <:label>Last seen remote IP</:label>
             <:value>
               <.last_seen schema={@client} />
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>
-            <:label>Client Version</:label>
+            <:label>Client version</:label>
             <:value><%= @client.last_seen_version %></:value>
           </.vertical_table_row>
           <.vertical_table_row>
-            <:label>User Agent</:label>
+            <:label>User agent</:label>
             <:value><%= @client.last_seen_user_agent %></:value>
           </.vertical_table_row>
         </.vertical_table>

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -66,14 +66,14 @@ defmodule Web.Gateways.Show do
           </.vertical_table_row>
           <.vertical_table_row>
             <:label>
-              Last Connected
+              Last started
             </:label>
             <:value>
               <.relative_datetime datetime={@gateway.last_seen_at} />
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>
-            <:label>Last Remote IP</:label>
+            <:label>Last seen remote IP</:label>
             <:value>
               <.last_seen schema={@gateway} />
             </:value>
@@ -91,7 +91,7 @@ defmodule Web.Gateways.Show do
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>
-            <:label>User Agent</:label>
+            <:label>User agent</:label>
             <:value>
               <%= @gateway.last_seen_user_agent %>
             </:value>

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -156,6 +156,9 @@ defmodule Web.Gateways.Show do
     socket =
       cond do
         Map.has_key?(payload.joins, gateway.id) ->
+          {:ok, gateway} =
+            Gateways.fetch_gateway_by_id(id, socket.assigns.subject, preload: [:group])
+
           assign(socket, gateway: %{gateway | online?: true})
 
         Map.has_key?(payload.leaves, gateway.id) ->

--- a/elixir/apps/web/lib/web/live/gateways/show.ex
+++ b/elixir/apps/web/lib/web/live/gateways/show.ex
@@ -157,7 +157,7 @@ defmodule Web.Gateways.Show do
       cond do
         Map.has_key?(payload.joins, gateway.id) ->
           {:ok, gateway} =
-            Gateways.fetch_gateway_by_id(id, socket.assigns.subject, preload: [:group])
+            Gateways.fetch_gateway_by_id(gateway.id, socket.assigns.subject, preload: [:group])
 
           assign(socket, gateway: %{gateway | online?: true})
 

--- a/elixir/apps/web/lib/web/live/relays/show.ex
+++ b/elixir/apps/web/lib/web/live/relays/show.ex
@@ -162,6 +162,9 @@ defmodule Web.Relays.Show do
     socket =
       cond do
         Map.has_key?(payload.joins, relay.id) ->
+          {:ok, relay} =
+            Relays.fetch_relay_by_id(relay.id, socket.assigns.subject, preload: [:group])
+
           assign(socket, relay: %{relay | online?: true})
 
         Map.has_key?(payload.leaves, relay.id) ->

--- a/elixir/apps/web/lib/web/live/relays/show.ex
+++ b/elixir/apps/web/lib/web/live/relays/show.ex
@@ -83,14 +83,14 @@ defmodule Web.Relays.Show do
             </.vertical_table_row>
             <.vertical_table_row>
               <:label>
-                Last Connected
+                Last started
               </:label>
               <:value>
                 <.relative_datetime datetime={@relay.last_seen_at} />
               </:value>
             </.vertical_table_row>
             <.vertical_table_row>
-              <:label>Remote IP</:label>
+              <:label>Last seen remote IP</:label>
               <:value>
                 <.last_seen schema={@relay} />
               </:value>
@@ -102,7 +102,7 @@ defmodule Web.Relays.Show do
               </:value>
             </.vertical_table_row>
             <.vertical_table_row>
-              <:label>User Agent</:label>
+              <:label>User agent</:label>
               <:value>
                 <%= @relay.last_seen_user_agent %>
               </:value>

--- a/elixir/apps/web/test/web/live/clients/show_test.exs
+++ b/elixir/apps/web/test/web/live/clients/show_test.exs
@@ -91,8 +91,8 @@ defmodule Web.Live.Clients.ShowTest do
     assert table["owner"] =~ actor.name
     assert table["status"] =~ "Offline"
     assert table["created"]
-    assert table["last connected"]
-    assert table["last remote ip"] =~ to_string(client.last_seen_remote_ip)
+    assert table["last started"]
+    assert table["last seen remote ip"] =~ to_string(client.last_seen_remote_ip)
     assert table["client version"] =~ client.last_seen_version
     assert table["user agent"] =~ client.last_seen_user_agent
   end

--- a/elixir/apps/web/test/web/live/gateways/show_test.exs
+++ b/elixir/apps/web/test/web/live/gateways/show_test.exs
@@ -89,8 +89,8 @@ defmodule Web.Live.Gateways.ShowTest do
 
     assert table["site"] =~ gateway.group.name
     assert table["name"] =~ gateway.name
-    assert table["last connected"]
-    assert table["last remote ip"] =~ to_string(gateway.last_seen_remote_ip)
+    assert table["last started"]
+    assert table["last seen remote ip"] =~ to_string(gateway.last_seen_remote_ip)
     assert table["status"] =~ "Offline"
     assert table["user agent"] =~ gateway.last_seen_user_agent
     assert table["version"] =~ gateway.last_seen_version

--- a/elixir/apps/web/test/web/live/relays/show_test.exs
+++ b/elixir/apps/web/test/web/live/relays/show_test.exs
@@ -88,8 +88,8 @@ defmodule Web.Live.Relays.ShowTest do
       |> vertical_table_to_map()
 
     assert table["instance group name"] =~ relay.group.name
-    assert table["last connected"]
-    assert table["remote ip"] =~ to_string(relay.last_seen_remote_ip)
+    assert table["last started"]
+    assert table["last seen remote ip"] =~ to_string(relay.last_seen_remote_ip)
     assert table["ipv4 set by public_ip4_addr"] =~ to_string(relay.ipv4)
     assert table["ipv6 set by public_ip6_addr"] =~ to_string(relay.ipv6)
     assert table["status"] =~ "Offline"


### PR DESCRIPTION
Updates `Last connected` to `Last started` and makes sure the details fields are reloaded when presence comes online.