### PR TITLE
fix(portal): Fix placement of 'sign-in w/ providers' heading

### DIFF
--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -49,10 +49,6 @@ defmodule Web.SignIn do
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
-            <h2 class="text-lg sm:text-xl leading-tight tracking-tight text-neutral-900">
-              Sign in with a configured provider
-            </h2>
-
             <.flash flash={@flash} kind={:error} />
             <.flash flash={@flash} kind={:info} />
 
@@ -66,6 +62,10 @@ defmodule Web.SignIn do
               </:separator>
 
               <:item :if={adapter_enabled?(@providers_by_adapter, :openid_connect)}>
+                <h2 class="text-lg sm:text-xl leading-tight tracking-tight text-neutral-900">
+                  Sign in with a configured provider
+                </h2>
+
                 <.providers_group_form
                   adapter="openid_connect"
                   providers={@providers_by_adapter[:openid_connect]}


### PR DESCRIPTION
Small UI/UX change.  The 'Sign in with a configured provider' header was always being shown, even if the account didn't have an OIDC provider configured (i.e. all new accounts)

### Before
<img width="607" alt="Screenshot 2024-07-31 at 11 17 29 AM" src="https://github.com/user-attachments/assets/e6d6d79d-509d-4d29-a051-7d836aa5b720">

### After
<img width="593" alt="Screenshot 2024-07-31 at 12 21 58 PM" src="https://github.com/user-attachments/assets/db02979a-12b6-4620-b84c-0309931a6b52">

<img width="696" alt="Screenshot 2024-07-31 at 12 18 35 PM" src="https://github.com/user-attachments/assets/db2b94b1-05e1-4f81-a2c5-e2befb19957e">
