### PR TITLE
ci(client/tauri): upgrade pnpm from 8.x to 9.3

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v3
       with:
-        version: 8
+        version: 9.3
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -114,9 +114,6 @@ jobs:
           path: |
             ${{ matrix.pkg-artifact }}
           if-no-files-found: error
-      - name: Debug build issue 5859
-        shell: bash
-        run: git diff
       - name: Upload Release Assets
         # Only upload the windows build to the drafted release on main builds
         if: ${{ github.ref_name == 'main' }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -114,6 +114,9 @@ jobs:
           path: |
             ${{ matrix.pkg-artifact }}
           if-no-files-found: error
+      - name: Debug build issue 5859
+        shell: bash
+        run: git diff
       - name: Upload Release Assets
         # Only upload the windows build to the drafted release on main builds
         if: ${{ github.ref_name == 'main' }}


### PR DESCRIPTION
Closes #5859

The Git version was always showing `-modified` because the lockfile was made by pnpm 9, and pnpm would modify it to work with pnpm 8.