### PR TITLE
fix(android): on full route dont allow bypass vpn

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -314,8 +314,10 @@ class TunnelService : VpnService() {
 
     private fun buildVpnService(): Int {
         Builder().apply {
-            // Allow traffic to bypass the VPN interface when Always-on VPN is enabled.
-            allowBypass()
+            if (tunnelRoutes.all { it.prefix != 0 }) {
+                // Allow traffic to bypass the VPN interface when Always-on VPN is enabled.
+                allowBypass()
+            }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 setMetered(false) // Inherit the metered status from the underlying networks.


### PR DESCRIPTION
If blocking non-vpn connections `allowBypass` breaks the VPN.

To fix this, we disable `allowBypass` when full-route is enable.

Fixes #4834 (hopefully)