### PR TITLE
fix(connlib): Disable hickory cache

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -305,6 +305,7 @@ pub(crate) fn build_response_from_resolve_result(
     let mut message = original_pkt.unwrap_as_dns();
 
     message.set_message_type(MessageType::Response);
+    message.set_recursion_available(true);
 
     let response = match response.map_err(|err| err.kind().clone()) {
         Ok(response) => message.add_answers(response.records().to_vec()),

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -273,6 +273,8 @@ fn create_resolvers(
 
             let mut resolver_opts = ResolverOpts::default();
             resolver_opts.edns0 = true;
+            resolver_opts.cache_size = 0;
+            resolver_opts.attempts = 1;
 
             (
                 sentinel,


### PR DESCRIPTION
This seems to fix #6033 

What **seems** to be happening is that sometimes responses are delayed and hickory cache the negative response.

We disable the cache, and the multiple attempts to be as transparent as possible until #6141 is implemented.

Furthermore, the lack of recursion available in responses can cause issues in some clients and enabling it shouldn't cause any problems.