### PR TITLE
chore(gui-client): reduce "building tray menu" logs to DEBUG

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -194,7 +194,7 @@ fn signed_in(signed_in: &SignedIn) -> Menu {
         .item(Event::SignOut, SIGN_OUT)
         .separator();
 
-    tracing::info!(
+    tracing::debug!(
         resource_count = resources.len(),
         "Building signed-in tray menu"
     );


### PR DESCRIPTION
I don't remember why I had this at INFO but with the new status stuff it results in a lot of noise in the logs.