### PR TITLE
chore(changelog): fix formatting

### DIFF
--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,7 +14,7 @@ export default function GUI({ title }: { title: string }) {
     <Entries href={href} arches={arches} title={title}>
       <Entry version="1.1.9" date={new Date("2024-08-02")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem enable pull="6143">
+          <ChangeItem pull="6143">
             Fixes an issue where DNS queries could time out on some networks.
           </ChangeItem>
         </ul>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -12,6 +12,18 @@ export default function GUI({ title }: { title: string }) {
 
   return (
     <Entries href={href} arches={arches} title={title}>
+      {/*
+      <Entry version="1.1.10" date={new Date("Invalid date")}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem enable={title === "Linux GUI"}>
+            This is a maintenance release with no user-facing changes.
+          </ChangeItem>
+          <ChangeItem enable={title === "Windows"}>
+            This is a maintenance release with no user-facing changes.
+          </ChangeItem>
+        </ul>
+      </Entry>
+      */}
       <Entry version="1.1.9" date={new Date("2024-08-02")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6143">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -9,9 +9,18 @@ export default function Headless() {
 
   return (
     <Entries href={href} arches={arches} title="Linux headless">
+      {/*
+      <Entry version="1.1.5" date={new Date("Invalid date")}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem>
+            This is a maintenance release with no user-facing changes
+          </ChangeItem>
+        </ul>
+      </Entry>
+      */}
       <Entry version="1.1.4" date={new Date("2024-08-02")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem enable pull="6143">
+          <ChangeItem pull="6143">
             Fixes an issue where DNS queries could time out on some networks.
           </ChangeItem>
         </ul>


### PR DESCRIPTION
`enable` in `ChangeItem` is only needed for the GUI Client since it's shared between Linux and Windows.

Also added the commented-out draft release so we can accumulate upcoming changes there