### PR TITLE
fix(portal): Use verified routes for OpenAPI docs

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/api_clients/beta.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/beta.ex
@@ -25,7 +25,7 @@ defmodule Web.Settings.ApiClients.Beta do
       <:title><%= @page_title %></:title>
       <:help>
         API Clients are used to manage Firezone configuration through a REST API. See our
-        <a class={link_style()} href="api.firezone.dev/swaggerui">interactive API docs</a>
+        <a class={link_style()} href={url(API.Endpoint, ~p"/swaggerui")}>interactive API docs</a>
       </:help>
       <:content>
         <.flash kind={:info}>

--- a/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
@@ -56,7 +56,7 @@ defmodule Web.Settings.ApiClients.Index do
       <:title><%= @page_title %></:title>
       <:help>
         API Clients are used to manage Firezone configuration through a REST API. See our
-        <.link navigate="https://api.firezone.dev/swaggerui" class={link_style()}>
+        <.link navigate={url(API.Endpoint, ~p"/swaggerui")} class={link_style()}>
           OpenAPI-powered docs
         </.link>
         for more information.


### PR DESCRIPTION
Removes the hardcoded API link for an VerifiedRoutes version instead.