### PR TITLE
fix(ux): Mention (Sites) on Gateway Groups section of REST API docs

### DIFF
--- a/elixir/apps/api/lib/api/controllers/gateway_group_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/gateway_group_controller.ex
@@ -6,7 +6,7 @@ defmodule API.GatewayGroupController do
 
   action_fallback API.FallbackController
 
-  tags ["Gateway Groups"]
+  tags ["Gateway Groups (Sites)"]
 
   operation :index,
     summary: "List Gateway Groups",


### PR DESCRIPTION
I'm thinking if we can just add `(Sites)` next the Gateway Groups title, that will be enough for users to make the connection.