### PR TITLE
feat(android): add setDisabledResources FFI

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -13,7 +13,7 @@ use connlib_shared::{
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     net::IpAddr,
     task::{Context, Poll},
 };
@@ -35,6 +35,7 @@ pub enum Command {
     Reset,
     SetDns(Vec<IpAddr>),
     SetTun(Box<dyn Tun>),
+    SetDisabledResources(HashSet<ResourceId>),
 }
 
 impl<C: Callbacks> Eventloop<C> {
@@ -65,6 +66,10 @@ where
                 Poll::Ready(Some(Command::SetDns(dns))) => {
                     self.tunnel.set_new_dns(dns);
 
+                    continue;
+                }
+                Poll::Ready(Some(Command::SetDisabledResources(resources))) => {
+                    self.tunnel.set_disabled_resources(resources);
                     continue;
                 }
                 Poll::Ready(Some(Command::SetTun(tun))) => {

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -1,13 +1,13 @@
 //! Main connlib library for clients.
 pub use crate::serde_routelist::{V4RouteList, V6RouteList};
 pub use connlib_shared::messages::client::ResourceDescription;
-use connlib_shared::messages::ResourceId;
 pub use connlib_shared::{
     callbacks, keypair, Callbacks, Error, LoginUrl, LoginUrlError, StaticSecret,
 };
 pub use eventloop::Eventloop;
 pub use tracing_appender::non_blocking::WorkerGuard;
 
+use connlib_shared::messages::ResourceId;
 use eventloop::Command;
 use firezone_tunnel::ClientTunnel;
 use messages::{IngressMessages, ReplyMessages};

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -1,6 +1,7 @@
 //! Main connlib library for clients.
 pub use crate::serde_routelist::{V4RouteList, V6RouteList};
 pub use connlib_shared::messages::client::ResourceDescription;
+use connlib_shared::messages::ResourceId;
 pub use connlib_shared::{
     callbacks, keypair, Callbacks, Error, LoginUrl, LoginUrlError, StaticSecret,
 };
@@ -12,7 +13,7 @@ use firezone_tunnel::ClientTunnel;
 use messages::{IngressMessages, ReplyMessages};
 use phoenix_channel::PhoenixChannel;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -92,6 +93,12 @@ impl Session {
     /// The implementation is idempotent; calling it with the same set of servers is safe.
     pub fn set_dns(&self, new_dns: Vec<IpAddr>) {
         let _ = self.channel.send(Command::SetDns(new_dns));
+    }
+
+    pub fn set_disabled_resources(&self, disabled_resources: HashSet<ResourceId>) {
+        let _ = self
+            .channel
+            .send(Command::SetDisabledResources(disabled_resources));
     }
 
     /// Sets a new [`Tun`] device handle.

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -88,7 +88,7 @@ pub struct ResourceDescriptionDns {
     pub sites: Vec<Site>,
 
     pub status: Status,
-    pub disableable: bool,
+    pub can_toggle: bool,
 }
 
 /// Description of a resource that maps to a CIDR.
@@ -107,7 +107,7 @@ pub struct ResourceDescriptionCidr {
     pub sites: Vec<Site>,
 
     pub status: Status,
-    pub disableable: bool,
+    pub can_toggle: bool,
 }
 
 /// Description of an Internet resource
@@ -116,7 +116,7 @@ pub struct ResourceDescriptionInternet {
     pub id: ResourceId,
     pub sites: Vec<Site>,
     pub status: Status,
-    pub disableable: bool,
+    pub can_toggle: bool,
 }
 
 /// Traits that will be used by connlib to callback the client upper layers.

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -88,6 +88,7 @@ pub struct ResourceDescriptionDns {
     pub sites: Vec<Site>,
 
     pub status: Status,
+    pub disableable: bool,
 }
 
 /// Description of a resource that maps to a CIDR.
@@ -106,6 +107,7 @@ pub struct ResourceDescriptionCidr {
     pub sites: Vec<Site>,
 
     pub status: Status,
+    pub disableable: bool,
 }
 
 /// Description of an Internet resource
@@ -114,6 +116,7 @@ pub struct ResourceDescriptionInternet {
     pub id: ResourceId,
     pub sites: Vec<Site>,
     pub status: Status,
+    pub disableable: bool,
 }
 
 /// Traits that will be used by connlib to callback the client upper layers.

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -35,7 +35,7 @@ impl ResourceDescriptionDns {
             name: self.name,
             address_description: self.address_description,
             sites: self.sites,
-            disableable: false,
+            can_toggle: false,
             status,
         }
     }
@@ -66,7 +66,7 @@ impl ResourceDescriptionCidr {
             name: self.name,
             address_description: self.address_description,
             sites: self.sites,
-            disableable: false,
+            can_toggle: false,
             status,
         }
     }
@@ -87,7 +87,7 @@ impl ResourceDescriptionInternet {
         crate::callbacks::ResourceDescriptionInternet {
             id: self.id,
             sites: self.sites,
-            disableable: false,
+            can_toggle: false,
             status,
         }
     }

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -35,6 +35,7 @@ impl ResourceDescriptionDns {
             name: self.name,
             address_description: self.address_description,
             sites: self.sites,
+            disableable: false,
             status,
         }
     }
@@ -65,6 +66,7 @@ impl ResourceDescriptionCidr {
             name: self.name,
             address_description: self.address_description,
             sites: self.sites,
+            disableable: false,
             status,
         }
     }
@@ -85,6 +87,7 @@ impl ResourceDescriptionInternet {
         crate::callbacks::ResourceDescriptionInternet {
             id: self.id,
             sites: self.sites,
+            disableable: false,
             status,
         }
     }

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -229,7 +229,7 @@ mod tests {
                 "address_description": "cidr resource",
                 "sites": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}],
                 "status": "Unknown",
-                "disableable": false
+                "can_toggle": false
             },
             {
                 "id": "03000143-e25e-45c7-aafb-144990e57dcd",
@@ -239,7 +239,7 @@ mod tests {
                 "address_description": "dns resource",
                 "sites": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}],
                 "status": "Online",
-                "disableable": false
+                "can_toggle": false
             },
             {
                 "id": "1106047c-cd5d-4151-b679-96b93da7383b",
@@ -249,7 +249,7 @@ mod tests {
                 "address_description": "The whole entire Internet",
                 "sites": [{"name": "test", "id": "eb94482a-94f4-47cb-8127-14fb3afa5516"}],
                 "status": "Offline",
-                "disableable": false
+                "can_toggle": false
             }
         ]"#;
 
@@ -290,7 +290,7 @@ mod tests {
                 "address_description": "https://example.com",
                 "sites": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}],
                 "status": "Online",
-                "disableable": false
+                "can_toggle": false
             }
         ]"#;
         let resources: Vec<_> = serde_json::from_str(s).unwrap();

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -228,7 +228,8 @@ mod tests {
                 "address": "172.172.0.0/16",
                 "address_description": "cidr resource",
                 "sites": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}],
-                "status": "Unknown"
+                "status": "Unknown",
+                "disableable": false
             },
             {
                 "id": "03000143-e25e-45c7-aafb-144990e57dcd",
@@ -237,7 +238,8 @@ mod tests {
                 "address": "gitlab.mycorp.com",
                 "address_description": "dns resource",
                 "sites": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}],
-                "status": "Online"
+                "status": "Online",
+                "disableable": false
             },
             {
                 "id": "1106047c-cd5d-4151-b679-96b93da7383b",
@@ -246,7 +248,8 @@ mod tests {
                 "address": "0.0.0.0/0",
                 "address_description": "The whole entire Internet",
                 "sites": [{"name": "test", "id": "eb94482a-94f4-47cb-8127-14fb3afa5516"}],
-                "status": "Offline"
+                "status": "Offline",
+                "disableable": false
             }
         ]"#;
 
@@ -286,7 +289,8 @@ mod tests {
                 "address": "example.com",
                 "address_description": "https://example.com",
                 "sites": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}],
-                "status": "Online"
+                "status": "Online",
+                "disableable": false
             }
         ]"#;
         let resources: Vec<_> = serde_json::from_str(s).unwrap();


### PR DESCRIPTION
Builds on top of  #6164

Part of the effor towards https://github.com/firezone/firezone/issues/6074

Prepares connlib to call `setDisableResource` from android.

Furthermore, we add a `can_toggle` parameter for resources which default to false for now, in the future the portal will set it for the internet resource, and further in the future it may be used for other resources.

The `can_toggle` parameter only affect UI.