### PR TITLE
test(headless-client): remove `sleep 3`

### DIFF
--- a/scripts/tests/systemd/dns-systemd-resolved.sh
+++ b/scripts/tests/systemd/dns-systemd-resolved.sh
@@ -44,11 +44,6 @@ resolvectl dns tun-firezone && exit 1
 stat "/usr/bin/$BINARY_NAME"
 sudo systemctl start "$SERVICE_NAME" || debug_exit
 
-# TODO: Remove after #6026 goes into the next release. Until then, the compat tests will need the `sleep 3` to keep passing
-# This is needed for the compatibility tests to pass, but once #6026
-# is in `main`, it should be redundant
-sleep 3
-
 resolvectl dns tun-firezone
 resolvectl query "$HTTPBIN" || debug_exit
 


### PR DESCRIPTION
This should be redundant now that we fixed the systemd notification in #6026 and cut a release. (Since compatibility tests will use the last release, not the tip of `main`)