### PR TITLE
fix(gateway): always masquerade for docker-deployed gateways

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -344,7 +344,6 @@ services:
     environment:
       FIREZONE_TOKEN: ".SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkMjI3NDU2MGItZTk3Yi00NWU0LThiMzQtNjc5Yzc2MTdlOThkbQAAADhPMDJMN1VTMkozVklOT01QUjlKNklMODhRSVFQNlVPOEFRVk82VTVJUEwwVkpDMjJKR0gwPT09PW4GAI0Qi02QAWIAAVGA.emd2izXZdGngSMDruiTNgwRYbNtsVLYf_fouNyoKv8Q"
       RUST_LOG: ${RUST_LOG:-phoenix_channel=trace,firezone_gateway=trace,wire=trace,connlib_gateway_shared=trace,firezone_tunnel=trace,connlib_shared=trace,phoenix_channel=debug,boringtun=debug,snownet=debug,str0m=debug,info}
-      FIREZONE_ENABLE_MASQUERADE: 1
       FIREZONE_API_URL: ws://api:8081
       FIREZONE_ID: 4694E56C-7643-4A15-9DF3-638E5B05F570
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -344,6 +344,7 @@ services:
     environment:
       FIREZONE_TOKEN: ".SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkMjI3NDU2MGItZTk3Yi00NWU0LThiMzQtNjc5Yzc2MTdlOThkbQAAADhPMDJMN1VTMkozVklOT01QUjlKNklMODhRSVFQNlVPOEFRVk82VTVJUEwwVkpDMjJKR0gwPT09PW4GAI0Qi02QAWIAAVGA.emd2izXZdGngSMDruiTNgwRYbNtsVLYf_fouNyoKv8Q"
       RUST_LOG: ${RUST_LOG:-phoenix_channel=trace,firezone_gateway=trace,wire=trace,connlib_gateway_shared=trace,firezone_tunnel=trace,connlib_shared=trace,phoenix_channel=debug,boringtun=debug,snownet=debug,str0m=debug,info}
+      FIREZONE_ENABLE_MASQUERADE: 1 # FIXME: NOOP in latest version. Remove after next release.
       FIREZONE_API_URL: ws://api:8081
       FIREZONE_ID: 4694E56C-7643-4A15-9DF3-638E5B05F570
     build:

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -310,7 +310,7 @@ defmodule Web.Sites.NewToken do
       "--sysctl net.ipv6.conf.all.forwarding=1",
       "--sysctl net.ipv6.conf.default.forwarding=1",
       "--device=\"/dev/net/tun:/dev/net/tun\"",
-      Enum.map(env ++ [{"FIREZONE_ENABLE_MASQUERADE", "1"}], fn {key, value} ->
+      Enum.map(env, fn {key, value} ->
         "--env #{key}=\"#{value}\""
       end),
       "--env FIREZONE_NAME=$(hostname)",

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -99,7 +99,7 @@ CMD $PACKAGE
 FROM runtime AS test
 
 RUN set -xe \
-  && apk add --no-cache iperf3 bind-tools iproute2 jq procps
+  && apk add --no-cache curl iperf3 bind-tools iproute2 jq procps
 
 # used for local development
 FROM test AS dev

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -82,6 +82,8 @@ COPY ./docker-init.sh ./docker-init.sh
 
 # snownet-tests specific runtime base image
 FROM runtime_base AS runtime_snownet-tests
+RUN set -xe \
+  && apk add --no-cache curl
 COPY ./docker-init.sh ./docker-init.sh
 
 # Funnel package specific base image back into `runtime`

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -45,7 +45,7 @@ ARG PACKAGE
 RUN cargo build -p ${PACKAGE} $([ -n "${TARGET}" ] && "--target ${TARGET}")
 
 # Image which is used to run the application binary
-FROM alpine:${ALPINE_VERSION} AS runtime
+FROM alpine:${ALPINE_VERSION} AS runtime_base
 
 # Important!  Update this no-op ENV variable when this Dockerfile
 # is updated with the current date. It will force refresh of all
@@ -59,19 +59,31 @@ ENV REFRESHED_AT=2023-10-23 \
 
 WORKDIR /bin
 
-## curl is needed by the entrypoint script
+FROM runtime_base as runtime_firezone-gateway
+## iptables are needed only by gateway for masquerading
+RUN apk add --no-cache iptables ip6tables
+COPY ./docker-init-gateway.sh ./docker-init.sh
+
+FROM runtime_base as runtime_firezone-relay
+## curl is needed by the entrypoint script for the relay
 RUN set -xe \
   && apk add --no-cache curl
+COPY ./docker-init-relay.sh ./docker-init.sh
 
-COPY ./docker-init.sh .
+FROM runtime_base as runtime_firezone-headless-client
+COPY ./docker-init.sh ./docker-init.sh
 
-## iptables are needed only by gateway for masquerading
+FROM runtime_base as runtime_http-test-server
+COPY ./docker-init.sh ./docker-init.sh
+
+FROM runtime_base as runtime_snownet-tests
+COPY ./docker-init.sh ./docker-init.sh
+
+# consolidate all package specific layers into one
+FROM runtime_${PACKAGE} as runtime
+
 ARG PACKAGE
-RUN set -xe \
-  && \[ "${PACKAGE}" = "firezone-gateway" ] && apk add --no-cache iptables ip6tables || true
-
 ENTRYPOINT ["docker-init.sh"]
-
 ENV PACKAGE=${PACKAGE}
 
 CMD $PACKAGE

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -3,6 +3,8 @@ ARG RUST_VERSION="1.80"
 ARG ALPINE_VERSION="3.20"
 ARG CARGO_CHEF_VERSION="0.1.67"
 
+ARG PACKAGE
+
 # This image is used to prepare Cargo Chef which is used to cache dependencies
 # Keep the Rust version synced with `rust-toolchain.toml`
 FROM rust:${RUST_VERSION}-alpine${ALPINE_VERSION} as chef
@@ -34,14 +36,12 @@ FROM chef as builder
 
 COPY --from=planner /build/recipe.json .
 
-ARG PACKAGE
 RUN set -xe \
   && cargo chef cook --recipe-path recipe.json --bin ${PACKAGE}
 
 COPY . .
 
 ARG TARGET
-ARG PACKAGE
 RUN cargo build -p ${PACKAGE} $([ -n "${TARGET}" ] && "--target ${TARGET}")
 
 # Image which is used to run the application binary
@@ -82,7 +82,6 @@ COPY ./docker-init.sh ./docker-init.sh
 # consolidate all package specific layers into one
 FROM runtime_${PACKAGE} as runtime
 
-ARG PACKAGE
 ENTRYPOINT ["docker-init.sh"]
 ENV PACKAGE=${PACKAGE}
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -44,7 +44,7 @@ COPY . .
 ARG TARGET
 RUN cargo build -p ${PACKAGE} $([ -n "${TARGET}" ] && "--target ${TARGET}")
 
-# Image which is used to run the application binary
+# Base image which is used to run the application binary
 FROM alpine:${ALPINE_VERSION} AS runtime_base
 
 # Important!  Update this no-op ENV variable when this Dockerfile
@@ -59,27 +59,32 @@ ENV REFRESHED_AT=2023-10-23 \
 
 WORKDIR /bin
 
+# Gateway specific runtime base image
 FROM runtime_base as runtime_firezone-gateway
 ## iptables are needed only by gateway for masquerading
 RUN apk add --no-cache iptables ip6tables
 COPY ./docker-init-gateway.sh ./docker-init.sh
 
+# Relay specific runtime base image
 FROM runtime_base as runtime_firezone-relay
 ## curl is needed by the entrypoint script for the relay
 RUN set -xe \
   && apk add --no-cache curl
 COPY ./docker-init-relay.sh ./docker-init.sh
 
+# Headless-client specific runtime base image
 FROM runtime_base as runtime_firezone-headless-client
 COPY ./docker-init.sh ./docker-init.sh
 
+# HTTP test server specific runtime base image
 FROM runtime_base as runtime_http-test-server
 COPY ./docker-init.sh ./docker-init.sh
 
+# snownet-tests specific runtime base image
 FROM runtime_base as runtime_snownet-tests
 COPY ./docker-init.sh ./docker-init.sh
 
-# consolidate all package specific layers into one
+# Funnel package specific base image back into `runtime`
 FROM runtime_${PACKAGE} as runtime
 
 ENTRYPOINT ["docker-init.sh"]

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -7,7 +7,7 @@ ARG PACKAGE
 
 # This image is used to prepare Cargo Chef which is used to cache dependencies
 # Keep the Rust version synced with `rust-toolchain.toml`
-FROM rust:${RUST_VERSION}-alpine${ALPINE_VERSION} as chef
+FROM rust:${RUST_VERSION}-alpine${ALPINE_VERSION} AS chef
 
 ARG CARGO_CHEF_VERSION
 RUN set -xe \
@@ -25,14 +25,14 @@ WORKDIR /build
 
 # Create a cache recipe for dependencies, which allows
 # to leverage Docker layer caching in a later build stage
-FROM chef as planner
+FROM chef AS planner
 
 COPY . .
 
 RUN cargo chef prepare --recipe-path recipe.json
 
 # Build dependencies and application application
-FROM chef as builder
+FROM chef AS builder
 
 COPY --from=planner /build/recipe.json .
 
@@ -60,40 +60,41 @@ ENV REFRESHED_AT=2023-10-23 \
 WORKDIR /bin
 
 # Gateway specific runtime base image
-FROM runtime_base as runtime_firezone-gateway
+FROM runtime_base AS runtime_firezone-gateway
 ## iptables are needed only by gateway for masquerading
 RUN apk add --no-cache iptables ip6tables
 COPY ./docker-init-gateway.sh ./docker-init.sh
 
 # Relay specific runtime base image
-FROM runtime_base as runtime_firezone-relay
+FROM runtime_base AS runtime_firezone-relay
 ## curl is needed by the entrypoint script for the relay
 RUN set -xe \
   && apk add --no-cache curl
 COPY ./docker-init-relay.sh ./docker-init.sh
 
 # Headless-client specific runtime base image
-FROM runtime_base as runtime_firezone-headless-client
+FROM runtime_base AS runtime_firezone-headless-client
 COPY ./docker-init.sh ./docker-init.sh
 
 # HTTP test server specific runtime base image
-FROM runtime_base as runtime_http-test-server
+FROM runtime_base AS runtime_http-test-server
 COPY ./docker-init.sh ./docker-init.sh
 
 # snownet-tests specific runtime base image
-FROM runtime_base as runtime_snownet-tests
+FROM runtime_base AS runtime_snownet-tests
 COPY ./docker-init.sh ./docker-init.sh
 
 # Funnel package specific base image back into `runtime`
-FROM runtime_${PACKAGE} as runtime
+FROM runtime_${PACKAGE} AS runtime
 
+ARG PACKAGE
 ENTRYPOINT ["docker-init.sh"]
 ENV PACKAGE=${PACKAGE}
 
 CMD $PACKAGE
 
 # used as a base for dev and test
-FROM runtime as test
+FROM runtime AS test
 
 RUN set -xe \
   && apk add --no-cache iperf3 bind-tools iproute2 jq procps

--- a/rust/docker-init-gateway.sh
+++ b/rust/docker-init-gateway.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ -f "${FIREZONE_TOKEN}" ]; then
+    FIREZONE_TOKEN="$(cat "${FIREZONE_TOKEN}")"
+    export FIREZONE_TOKEN
+fi
+
+IFACE="tun-firezone"
+# Enable masquerading for our TUN interface
+iptables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -i $IFACE -j ACCEPT
+iptables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -o $IFACE -j ACCEPT
+iptables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o e+ -j MASQUERADE
+iptables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o w+ -j MASQUERADE
+ip6tables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -i $IFACE -j ACCEPT
+ip6tables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -o $IFACE -j ACCEPT
+ip6tables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o e+ -j MASQUERADE
+ip6tables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o w+ -j MASQUERADE
+
+exec "$@"

--- a/rust/docker-init-relay.sh
+++ b/rust/docker-init-relay.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+if [ -f "${FIREZONE_TOKEN}" ]; then
+    FIREZONE_TOKEN="$(cat "${FIREZONE_TOKEN}")"
+    export FIREZONE_TOKEN
+fi
+
+if [ "${LISTEN_ADDRESS_DISCOVERY_METHOD}" = "gce_metadata" ]; then
+    echo "Using GCE metadata to discover listen address"
+
+    if [ "${PUBLIC_IP4_ADDR}" = "" ]; then
+        public_ip4=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip" -H "Metadata-Flavor: Google" -s)
+        export PUBLIC_IP4_ADDR="${public_ip4}"
+        echo "Discovered PUBLIC_IP4_ADDR: ${PUBLIC_IP4_ADDR}"
+    fi
+
+    if [ "${PUBLIC_IP6_ADDR}" = "" ]; then
+        public_ip6=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s" -H "Metadata-Flavor: Google" -s)
+        export PUBLIC_IP6_ADDR="${public_ip6}"
+        echo "Discovered PUBLIC_IP6_ADDR: ${PUBLIC_IP6_ADDR}"
+    fi
+fi
+
+exec "$@"

--- a/rust/docker-init.sh
+++ b/rust/docker-init.sh
@@ -5,31 +5,4 @@ if [ -f "${FIREZONE_TOKEN}" ]; then
     export FIREZONE_TOKEN
 fi
 
-IFACE="tun-firezone"
-# Enable masquerading for our TUN interface
-iptables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -i $IFACE -j ACCEPT
-iptables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -o $IFACE -j ACCEPT
-iptables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o e+ -j MASQUERADE
-iptables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o w+ -j MASQUERADE
-ip6tables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -i $IFACE -j ACCEPT
-ip6tables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -o $IFACE -j ACCEPT
-ip6tables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o e+ -j MASQUERADE
-ip6tables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o w+ -j MASQUERADE
-
-if [ "${LISTEN_ADDRESS_DISCOVERY_METHOD}" = "gce_metadata" ]; then
-    echo "Using GCE metadata to discover listen address"
-
-    if [ "${PUBLIC_IP4_ADDR}" = "" ]; then
-        public_ip4=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip" -H "Metadata-Flavor: Google" -s)
-        export PUBLIC_IP4_ADDR="${public_ip4}"
-        echo "Discovered PUBLIC_IP4_ADDR: ${PUBLIC_IP4_ADDR}"
-    fi
-
-    if [ "${PUBLIC_IP6_ADDR}" = "" ]; then
-        public_ip6=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s" -H "Metadata-Flavor: Google" -s)
-        export PUBLIC_IP6_ADDR="${public_ip6}"
-        echo "Discovered PUBLIC_IP6_ADDR: ${PUBLIC_IP6_ADDR}"
-    fi
-fi
-
 exec "$@"

--- a/rust/docker-init.sh
+++ b/rust/docker-init.sh
@@ -5,18 +5,16 @@ if [ -f "${FIREZONE_TOKEN}" ]; then
     export FIREZONE_TOKEN
 fi
 
-if [ "${FIREZONE_ENABLE_MASQUERADE}" = "1" ]; then
-    IFACE="tun-firezone"
-    # Enable masquerading for ethernet and wireless interfaces
-    iptables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -i $IFACE -j ACCEPT
-    iptables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -o $IFACE -j ACCEPT
-    iptables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o e+ -j MASQUERADE
-    iptables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o w+ -j MASQUERADE
-    ip6tables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -i $IFACE -j ACCEPT
-    ip6tables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -o $IFACE -j ACCEPT
-    ip6tables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o e+ -j MASQUERADE
-    ip6tables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o w+ -j MASQUERADE
-fi
+IFACE="tun-firezone"
+# Enable masquerading for our TUN interface
+iptables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -i $IFACE -j ACCEPT
+iptables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -o $IFACE -j ACCEPT
+iptables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o e+ -j MASQUERADE
+iptables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o w+ -j MASQUERADE
+ip6tables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -i $IFACE -j ACCEPT
+ip6tables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -o $IFACE -j ACCEPT
+ip6tables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o e+ -j MASQUERADE
+ip6tables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o w+ -j MASQUERADE
 
 if [ "${LISTEN_ADDRESS_DISCOVERY_METHOD}" = "gce_metadata" ]; then
     echo "Using GCE metadata to discover listen address"

--- a/terraform/modules/aws/gateway/main.tf
+++ b/terraform/modules/aws/gateway/main.tf
@@ -18,10 +18,6 @@ locals {
     {
       name  = "FIREZONE_API_URL"
       value = var.api_url
-    },
-    {
-      name  = "FIREZONE_ENABLE_MASQUERADE"
-      value = "1"
     }
   ], var.application_environment_variables)
 }

--- a/website/src/app/kb/automate/docker-compose/readme.mdx
+++ b/website/src/app/kb/automate/docker-compose/readme.mdx
@@ -34,10 +34,6 @@ services:
       # See https://docs.rs/env_logger/latest/env_logger/ for more information.
       - RUST_LOG=str0m=warn,info
 
-      # Enable or disable masquerading. Default enabled. Disabling this can prevent
-      # the Gateway from reaching other hosts in your subnet or the internet.
-      # - FIREZONE_ENABLE_MASQUERADE=1
-
       # Human-friendly name to use for this Gateway in the admin portal.
       # $(hostname) is used by default if not set.
       # - FIREZONE_NAME=<name-of-gateway>

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -8,6 +8,14 @@ export default function Gateway() {
 
   return (
     <Entries href={href} arches={arches} title="Gateway">
+      <Entry version="1.1.X" date={new Date("2024-XX-XX")}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          <li className="pl-2">
+            Remove `FIREZONE_ENABLE_MASQUERADE` env variable.
+            Masquerading is now always enabled unconditionally.
+          </li>
+        </ul>
+      </Entry>
       <Entry version="1.1.3" date={new Date("2024-08-02")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <li className="pl-2">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -11,7 +11,7 @@ export default function Gateway() {
       <Entry version="1.1.X" date={new Date("2024-XX-XX")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <li className="pl-2">
-            Remove `FIREZONE_ENABLE_MASQUERADE` env variable.
+            Removes `FIREZONE_ENABLE_MASQUERADE` env variable.
             Masquerading is now always enabled unconditionally.
           </li>
         </ul>


### PR DESCRIPTION
Without masquerading, packets sent by the gateway through the TUN interface use the wrong source address (the TUN device's address) instead of the gateway's actual network interface.

We set this env variable in all our uses of the gateway, thus we might as well remove it and always perform unconditionally.