### PR TITLE
fix(website): add dedicated network to `docker-compose` example

### DIFF
--- a/website/src/app/kb/automate/docker-compose/readme.mdx
+++ b/website/src/app/kb/automate/docker-compose/readme.mdx
@@ -62,7 +62,6 @@ services:
     devices:
       - /dev/net/tun:/dev/net/tun
     init: true
-
 # If you want to access services within the same compose file, they must share a network.
 #    networks:
 #      fz-net:

--- a/website/src/app/kb/automate/docker-compose/readme.mdx
+++ b/website/src/app/kb/automate/docker-compose/readme.mdx
@@ -62,17 +62,19 @@ services:
     devices:
       - /dev/net/tun:/dev/net/tun
     init: true
-    networks:
-      fz-net:
 
-  # Heads-up for Linux users.
-  # Due to limitations of `systemd-resolved` on Linux, a "two-label" domain is necessary if you want to define this as a DNS resource.
-  # i.e. just using `yourservice` won't work.
-  yourservice.docker:
-    image: "..."
-    networks:
-      fz-net:
-
-networks:
-  fz-net:
+# If you want to access services within the same compose file, they must share a network.
+#    networks:
+#      fz-net:
+#
+#   # Heads-up for Linux users.
+#   # Due to limitations of `systemd-resolved` on Linux, a "two-label" domain is necessary if you want to define this as a DNS resource.
+#   # i.e. just using `yourservice` won't work.
+#   yourservice.docker:
+#     image: "..."
+#     networks:
+#       fz-net:
+#
+# networks:
+#   fz-net:
 ```

--- a/website/src/app/kb/automate/docker-compose/readme.mdx
+++ b/website/src/app/kb/automate/docker-compose/readme.mdx
@@ -67,7 +67,7 @@ services:
 
   # Heads-up for Linux users.
   # Due to limitations of `systemd-resolved` on Linux, a "two-label" domain is necessary if you want to define this as a DNS resource.
-  # i.e. just using `yourserver` won't work.
+  # i.e. just using `yourservice` won't work.
   yourservice.docker:
     image: "..."
     networks:

--- a/website/src/app/kb/automate/docker-compose/readme.mdx
+++ b/website/src/app/kb/automate/docker-compose/readme.mdx
@@ -61,4 +61,18 @@ services:
       start_period: 1m
     devices:
       - /dev/net/tun:/dev/net/tun
+    init: true
+    networks:
+      fz-net:
+
+  # Heads-up for Linux users.
+  # Due to limitations of `systemd-resolved` on Linux, a "two-label" domain is necessary if you want to define this as a DNS resource.
+  # i.e. just using `yourserver` won't work.
+  yourservice.docker:
+    image: "..."
+    networks:
+      fz-net:
+
+networks:
+  fz-net:
 ```


### PR DESCRIPTION
In my testing, Docker-defined resources are not reachable unless you explicitly declare a network and add both services to it. Additionally, `systemd-resolved` refuses to resolve single-label domain names, meaning a "two-label" domain needs to be used to access this as a DNS resource.