### PR TITLE
fix(client): increase mpsc channel size

### DIFF
--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -212,7 +212,7 @@ impl<'a> Handler<'a> {
             .next_client_split()
             .await
             .context("Failed to wait for incoming IPC connection from a GUI")?;
-        let (cb_tx, cb_rx) = mpsc::channel(10);
+        let (cb_tx, cb_rx) = mpsc::channel(1_000);
         let tun_device = TunDeviceManager::new()?;
 
         Ok(Self {

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -167,6 +167,6 @@ mod tests {
     // Make sure it's okay to store a bunch of these to mitigate #5880
     #[test]
     fn callback_msg_size() {
-        assert_eq!(size_of::<InternalServerMsg>(), 56)
+        assert_eq!(std::mem::size_of::<InternalServerMsg>(), 56)
     }
 }

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -159,3 +159,14 @@ pub fn setup_stdout_logging() -> Result<()> {
     set_global_default(subscriber)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Make sure it's okay to store a bunch of these to mitigate #5880
+    #[test]
+    fn callback_msg_size() {
+        assert_eq!(size_of::<InternalServerMsg>(), 56)
+    }
+}

--- a/rust/headless-client/src/standalone.rs
+++ b/rust/headless-client/src/standalone.rs
@@ -162,7 +162,7 @@ pub fn run_only_headless_client() -> Result<()> {
         return Ok(());
     }
 
-    let (cb_tx, cb_rx) = mpsc::channel(10);
+    let (cb_tx, cb_rx) = mpsc::channel(1_000);
     let callbacks = CallbackHandler { cb_tx };
 
     // The name matches that in `ipc_service.rs`

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -15,11 +15,8 @@ export default function GUI({ title }: { title: string }) {
       {/*
       <Entry version="1.1.10" date={new Date("Invalid date")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem enable={title === "Linux GUI"}>
-            This is a maintenance release with no user-facing changes.
-          </ChangeItem>
-          <ChangeItem enable={title === "Windows"}>
-            This is a maintenance release with no user-facing changes.
+          <ChangeItem pull="6184">
+            Mitigates a bug where the IPC service can panic if an internal channel fills up
           </ChangeItem>
         </ul>
       </Entry>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -12,8 +12,8 @@ export default function Headless() {
       {/*
       <Entry version="1.1.5" date={new Date("Invalid date")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem>
-            This is a maintenance release with no user-facing changes
+          <ChangeItem pull="6184">
+            Mitigates a bug where the Client can panic if an internal channel fills up
           </ChangeItem>
         </ul>
       </Entry>


### PR DESCRIPTION
Mitigates #5880.

This should fix the issue for all practical purposes, but we don't need a channel there, so it does not close the ticket. A more permanent fix would involve factoring out the callbacks or cheating and using a Mutex inside the callbacks to do a swap-and-notify thing.

This affects both the Headless Client and the GUI Client's IPC service, on both Linux and Windows.