### PR TITLE
fix(portal): Temporarily revert verified routes for API UI

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/api_clients/beta.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/beta.ex
@@ -25,7 +25,7 @@ defmodule Web.Settings.ApiClients.Beta do
       <:title><%= @page_title %></:title>
       <:help>
         API Clients are used to manage Firezone configuration through a REST API. See our
-        <a class={link_style()} href={url(API.Endpoint, ~p"/swaggerui")}>interactive API docs</a>
+        <a class={link_style()} href="api.firezone.dev/swaggerui">interactive API docs</a>
       </:help>
       <:content>
         <.flash kind={:info}>

--- a/elixir/apps/web/lib/web/live/settings/api_clients/beta.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/beta.ex
@@ -25,7 +25,7 @@ defmodule Web.Settings.ApiClients.Beta do
       <:title><%= @page_title %></:title>
       <:help>
         API Clients are used to manage Firezone configuration through a REST API. See our
-        <a class={link_style()} href="api.firezone.dev/swaggerui">interactive API docs</a>
+        <a class={link_style()} href="https://api.firezone.dev/swaggerui">interactive API docs</a>
       </:help>
       <:content>
         <.flash kind={:info}>

--- a/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/index.ex
@@ -56,7 +56,7 @@ defmodule Web.Settings.ApiClients.Index do
       <:title><%= @page_title %></:title>
       <:help>
         API Clients are used to manage Firezone configuration through a REST API. See our
-        <.link navigate={url(API.Endpoint, ~p"/swaggerui")} class={link_style()}>
+        <.link navigate="https://api.firezone.dev/swaggerui" class={link_style()}>
           OpenAPI-powered docs
         </.link>
         for more information.


### PR DESCRIPTION
This temporarily reverts commit d1703d2849e932963d9fc303f327f02a794a4be9.

The long term fix will be to have the API URL be set by environment variables, but in the interest of time it will be hardcoded for now.