### PR TITLE
fix(portal): Do not fail when email identity is not found

### DIFF
--- a/elixir/apps/domain/lib/domain/tokens.ex
+++ b/elixir/apps/domain/lib/domain/tokens.ex
@@ -101,6 +101,8 @@ defmodule Domain.Tokens do
 
   def use_token(encoded_token, %Auth.Context{} = context) do
     with {:ok, {account_id, id, nonce, secret}} <- peek_token(encoded_token, context),
+         true <- not is_nil(account_id),
+         true <- not is_nil(id),
          {:ok, token} <- fetch_token_for_use(id, account_id, context.type),
          true <-
            Domain.Crypto.equal?(

--- a/elixir/apps/domain/lib/domain/tokens.ex
+++ b/elixir/apps/domain/lib/domain/tokens.ex
@@ -101,8 +101,6 @@ defmodule Domain.Tokens do
 
   def use_token(encoded_token, %Auth.Context{} = context) do
     with {:ok, {account_id, id, nonce, secret}} <- peek_token(encoded_token, context),
-         true <- not is_nil(account_id),
-         true <- not is_nil(id),
          {:ok, token} <- fetch_token_for_use(id, account_id, context.type),
          true <-
            Domain.Crypto.equal?(

--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -167,7 +167,14 @@ defmodule Web.AuthController do
               # by looking at the cookies
               Domain.Tokens.encode_fragment!(%Domain.Tokens.Token{
                 type: :email,
-                secret_fragment: Domain.Crypto.random_token(27)
+                secret_nonce: Domain.Crypto.random_token(5, encoder: :user_friendly),
+                secret_fragment: Domain.Crypto.random_token(27, encoder: :hex32),
+                account_id: Ecto.UUID.generate(),
+                actor_id: Ecto.UUID.generate(),
+                id: Ecto.UUID.generate(),
+                expires_at: DateTime.utc_now(),
+                created_by_user_agent: context.user_agent,
+                created_by_remote_ip: context.remote_ip
               })
           end
         end,

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -470,6 +470,12 @@ defmodule Web.AuthControllerTest do
                "signed_provider_identifier",
                signed_provider_identifier
              ) == {:ok, "foo@bar"}
+
+      assert {nonce, "foo@bar", %{}} =
+               conn.cookies["fz_auth_state_#{provider.id}"]
+               |> :erlang.binary_to_term()
+
+      assert String.length(nonce) == 259
     end
   end
 


### PR DESCRIPTION
We were generating fake tokens when identity was not found but those had empty ids so the code crashed. Now we fake the entire token and make sure it's length is stable.