### PR TITLE
chore(connlib): minimize debug print of `DnsServer`

### DIFF
--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -271,10 +271,18 @@ pub enum GatewayResponse {
     ResourceAccepted(ResourceAccepted),
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
 #[serde(tag = "protocol", rename_all = "snake_case")]
 pub enum DnsServer {
     IpPort(IpDnsServer),
+}
+
+impl fmt::Debug for DnsServer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IpPort(IpDnsServer { address }) => address.fmt(f),
+        }
+    }
 }
 
 impl DnsServer {


### PR DESCRIPTION
The `DnsServer` struct is quite nested. All it really contains (currently) is a `SocketAddr`. To make logs containing this structure easier to use, only print the inner address on debug.