### PR TITLE
refactor(connlib): simplify sampling of initial state

### DIFF
--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -60,18 +60,32 @@ impl ReferenceStateMachine for ReferenceState {
         let client_tunnel_ip4 = tunnel_ip4s().next().unwrap();
         let client_tunnel_ip6 = tunnel_ip6s().next().unwrap();
 
-        (
-            ref_client_host(Just(client_tunnel_ip4), Just(client_tunnel_ip6)),
-            gateways_and_portal(),
-            relays(),
-            global_dns_records(), // Start out with a set of global DNS records so we have something to resolve outside of DNS resources.
-            any::<bool>(),
-        )
+        stub_portal()
+            .prop_flat_map(move |portal| {
+                let gateways = portal.gateways();
+                let dns_resource_records = portal.dns_resource_records();
+                let client = ref_client_host(Just(client_tunnel_ip4), Just(client_tunnel_ip6));
+                let relays = relays();
+                let global_dns_records = global_dns_records(); // Start out with a set of global DNS records so we have something to resolve outside of DNS resources.
+                let drop_direct_client_traffic = any::<bool>();
+
+                (
+                    client,
+                    gateways,
+                    Just(portal),
+                    dns_resource_records,
+                    relays,
+                    global_dns_records,
+                    drop_direct_client_traffic,
+                )
+            })
             .prop_filter_map(
                 "network IPs must be unique",
                 |(
                     c,
-                    (gateways, portal, records),
+                    gateways,
+                    portal,
+                    records,
                     relays,
                     mut global_dns,
                     drop_direct_client_traffic,

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -57,14 +57,11 @@ impl ReferenceStateMachine for ReferenceState {
     type Transition = Transition;
 
     fn init_state() -> BoxedStrategy<Self::State> {
-        let client_tunnel_ip4 = tunnel_ip4s().next().unwrap();
-        let client_tunnel_ip6 = tunnel_ip6s().next().unwrap();
-
         stub_portal()
             .prop_flat_map(move |portal| {
                 let gateways = portal.gateways();
                 let dns_resource_records = portal.dns_resource_records();
-                let client = ref_client_host(Just(client_tunnel_ip4), Just(client_tunnel_ip6));
+                let client = portal.client();
                 let relays = relays();
                 let global_dns_records = global_dns_records(); // Start out with a set of global DNS records so we have something to resolve outside of DNS resources.
                 let drop_direct_client_traffic = any::<bool>();

--- a/rust/connlib/tunnel/src/tests/strategies.rs
+++ b/rust/connlib/tunnel/src/tests/strategies.rs
@@ -72,26 +72,6 @@ pub(crate) fn packet_source_v6(client: Ipv6Addr) -> impl Strategy<Value = Ipv6Ad
     ]
 }
 
-/// An [`Iterator`] over the possible IPv4 addresses of a tunnel interface.
-///
-/// We use the CG-NAT range for IPv4.
-/// See <https://github.com/firezone/firezone/blob/81dfa90f38299595e14ce9e022d1ee919909f124/elixir/apps/domain/lib/domain/network.ex#L7>.
-pub(crate) fn tunnel_ip4s() -> impl Iterator<Item = Ipv4Addr> {
-    Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 0), 11)
-        .unwrap()
-        .hosts()
-}
-
-/// An [`Iterator`] over the possible IPv6 addresses of a tunnel interface.
-///
-/// See <https://github.com/firezone/firezone/blob/81dfa90f38299595e14ce9e022d1ee919909f124/elixir/apps/domain/lib/domain/network.ex#L8>.
-pub(crate) fn tunnel_ip6s() -> impl Iterator<Item = Ipv6Addr> {
-    Ipv6Network::new(Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, 0), 107)
-        .unwrap()
-        .subnets_with_prefix(128)
-        .map(|n| n.network_address())
-}
-
 pub(crate) fn latency(max: u64) -> impl Strategy<Value = Duration> {
     (10..max).prop_map(Duration::from_millis)
 }


### PR DESCRIPTION
Instead of having one giant, composed strategy, we introduce a dedicated `stub_portal` strategy. That one samples what is defined in the portal in production: sites, gateways and resources.

Based on a sampled portal, we can then sample gateways, a client and DNS records for our resources.