### PR TITLE
chore(ci): pull images in parallel

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -142,6 +142,9 @@ jobs:
             export RUST_LOG="${{ matrix.test.rust_log }}"
           fi
 
+          # Pull all images in parallel
+          docker compose pull
+
           # Start one-by-one to avoid variability in service startup order
           docker compose up -d dns.httpbin httpbin download.httpbin
           docker compose up -d api web domain --no-build


### PR DESCRIPTION
We spend quite a bit of time booting up the images for our integration tests. What is important is that we start them in a certain sequence, the download however can happen in parallel.