### PR TITLE
fix(connlib): emit candidates in reverse-priority order

### DIFF
--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -15,3 +15,4 @@ pub use node::{
     Transmit, HANDSHAKE_TIMEOUT,
 };
 pub use stats::{ConnectionStats, NodeStats};
+pub use str0m::Candidate;

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1144,7 +1144,7 @@ fn add_local_candidate<TId>(
     if candidate.kind() == CandidateKind::ServerReflexive {
         pending_events.push_back(Event::NewIceCandidate {
             connection: id,
-            candidate: candidate.to_sdp_string(),
+            candidate,
         });
         return;
     }
@@ -1154,7 +1154,7 @@ fn add_local_candidate<TId>(
     if is_new {
         pending_events.push_back(Event::NewIceCandidate {
             connection: id,
-            candidate: candidate.to_sdp_string(),
+            candidate,
         })
     }
 }
@@ -1170,7 +1170,7 @@ fn remove_local_candidate<TId>(
     if candidate.kind() == CandidateKind::ServerReflexive {
         pending_events.push_back(Event::NewIceCandidate {
             connection: id,
-            candidate: candidate.to_sdp_string(),
+            candidate: candidate.clone(),
         });
         return;
     }
@@ -1180,7 +1180,7 @@ fn remove_local_candidate<TId>(
     if was_present {
         pending_events.push_back(Event::InvalidateIceCandidate {
             connection: id,
-            candidate: candidate.to_sdp_string(),
+            candidate: candidate.clone(),
         })
     }
 }
@@ -1209,7 +1209,7 @@ pub enum Event<TId> {
     /// Candidates are in SDP format although this may change and should be considered an implementation detail of the application.
     NewIceCandidate {
         connection: TId,
-        candidate: String,
+        candidate: Candidate,
     },
 
     /// We invalidated a candidate for this connection and ask to signal that to the remote party.
@@ -1217,7 +1217,7 @@ pub enum Event<TId> {
     /// Candidates are in SDP format although this may change and should be considered an implementation detail of the application.
     InvalidateIceCandidate {
         connection: TId,
-        candidate: String,
+        candidate: Candidate,
     },
 
     ConnectionEstablished(TId),

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -101,9 +101,7 @@ fn only_generate_candidate_event_after_answer() {
     assert!(iter::from_fn(|| alice.poll_event()).any(|ev| ev
         == Event::NewIceCandidate {
             connection: 1,
-            candidate: Candidate::host(local_candidate, Protocol::Udp)
-                .unwrap()
-                .to_sdp_string()
+            candidate: Candidate::host(local_candidate, Protocol::Udp).unwrap()
         }));
 }
 

--- a/rust/connlib/tunnel/src/utils.rs
+++ b/rust/connlib/tunnel/src/utils.rs
@@ -3,7 +3,7 @@ use connlib_shared::messages::{Relay, RelayId};
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools;
 use snownet::RelaySocket;
-use std::{collections::BTreeSet, net::SocketAddr, time::Instant};
+use std::{cmp::Ordering, collections::BTreeSet, net::SocketAddr, time::Instant};
 
 pub fn turn(relays: &[Relay]) -> BTreeSet<(RelayId, RelaySocket, String, String, String)> {
     relays
@@ -83,5 +83,57 @@ pub(crate) fn ipv6(ip: IpNetwork) -> Option<Ipv6Network> {
     match ip {
         IpNetwork::V4(_) => None,
         IpNetwork::V6(v6) => Some(v6),
+    }
+}
+
+/// Helper container to aggregate candidates and emit them in sorted order, starting with the highest-priority one (host candidates).
+///
+/// Whilst no fatal in theory, emitting candidates in the wrong order can cause temporary connectivity problems.
+/// `str0m` needs to "replace" candidates when it receives better ones which can cancel in-flight STUN requests.
+/// By sorting the candidates by priority, we try the best ones first, being symphatic to the ICE algorithm.
+#[derive(Default)]
+pub(crate) struct Candidates(Vec<snownet::Candidate>);
+
+impl Candidates {
+    pub(crate) fn push(&mut self, candidate: snownet::Candidate) {
+        self.0.push(candidate)
+    }
+
+    pub(crate) fn serialize(mut self) -> BTreeSet<String> {
+        self.0.sort_by(priority_desc);
+
+        self.0.into_iter().map(|c| c.to_sdp_string()).collect()
+    }
+}
+
+fn priority_desc(c1: &snownet::Candidate, c2: &snownet::Candidate) -> Ordering {
+    c1.prio().cmp(&c2.prio()).reverse()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    #[test]
+    fn sorts_candidates_by_priority() {
+        let mut candidates = vec![
+            snownet::Candidate::host(
+                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1)),
+                "udp",
+            )
+            .unwrap(),
+            snownet::Candidate::server_reflexive(
+                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 2)),
+                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1)),
+                "udp",
+            )
+            .unwrap(),
+        ];
+
+        candidates.sort_by(priority_desc);
+
+        assert_eq!(candidates[0].kind().to_string(), "host");
+        assert_eq!(candidates[1].kind().to_string(), "srflx");
     }
 }

--- a/rust/snownet-tests/src/main.rs
+++ b/rust/snownet-tests/src/main.rs
@@ -392,7 +392,7 @@ impl<T> Eventloop<T> {
             }) => {
                 return Poll::Ready(Ok(Event::SignalIceCandidate {
                     conn: connection,
-                    candidate,
+                    candidate: candidate.to_sdp_string(),
                 }))
             }
             Some(snownet::Event::ConnectionEstablished(conn)) => {


### PR DESCRIPTION
I noticed we sometimes have a flaky integration test with an ICE timeout in its logs. For example: https://github.com/firezone/firezone/actions/runs/10278933741/job/28443578376

Analyzing this one more closely turned out to be caused by a race condition between client and gateway, when they exchange their ICE candidates.

We send ICE candidates in batches but because they are serialized to strings early, their ordering actually depends on the so-called "foundation" of the ICE candidates. that one is simply a hash of several components. As a result, the ordering of these candidates can vary between test runs.

We should try ICE candidates in order of their reverse-priority (i.e. best first). By introducing a helper-collection, we can enforce this ordering before sending ICE candidates across.