### PR TITLE
fix(portal): Do not allow emails with just TLD in place

### DIFF
--- a/elixir/apps/domain/lib/domain/repo/changeset.ex
+++ b/elixir/apps/domain/lib/domain/repo/changeset.ex
@@ -193,7 +193,7 @@ defmodule Domain.Repo.Changeset do
 
   def validate_email(%Ecto.Changeset{} = changeset, field) do
     changeset
-    |> validate_format(field, ~r/^[^\s]+@[^\s]+$/, message: "is an invalid email address")
+    |> validate_format(field, ~r/^[^\s]+@[^\s]+\.[^\s]+$/, message: "is an invalid email address")
     |> validate_length(field, max: 160)
   end
 


### PR DESCRIPTION
`foo@bar` was a valid domain, while it's technically possible that somebody owns a TLD with MX records Stripe will not accept that, so we have to adopt this validation and make sure sign ups don't results in HTTP 500s.