### PR TITLE
chore(ux): Fix minor API beta page UX issues and add reply-to address

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/api_clients/beta.ex
+++ b/elixir/apps/web/lib/web/live/settings/api_clients/beta.ex
@@ -34,13 +34,13 @@ defmodule Web.Settings.ApiClients.Beta do
         for more information.
       </:help>
       <:content>
-        <.flash kind={:info}>
-          <p class="flex items-center gap-1.5 text-sm font-semibold leading-6">
-            <span class="hero-wrench-screwdriver h-4 w-4"></span> REST API Beta
-          </p>
-          The REST API is currently in closed beta.
-          <span :if={@requested == false}>
-            <p>
+        <div class="w-1/2 mx-auto">
+          <.flash kind={:info}>
+            <p class="flex items-center gap-1.5 text-sm font-semibold leading-6">
+              <span class="hero-wrench-screwdriver h-4 w-4"></span> REST API Beta
+            </p>
+            The REST API is currently in closed beta.
+            <span :if={@requested == false}>
               <a
                 id="beta-request"
                 href="#"
@@ -50,14 +50,12 @@ defmodule Web.Settings.ApiClients.Beta do
                 Click here
               </a>
               to request access.
-            </p>
-          </span>
-          <span :if={@requested == true}>
-            <p>
+            </span>
+            <span :if={@requested == true}>
               Your request to join the closed beta has been made.
-            </p>
-          </span>
-        </.flash>
+            </span>
+          </.flash>
+        </div>
       </:content>
     </.section>
     """

--- a/elixir/apps/web/lib/web/mailer/beta_email.ex
+++ b/elixir/apps/web/lib/web/mailer/beta_email.ex
@@ -12,28 +12,12 @@ defmodule Web.Mailer.BetaEmail do
     default_email()
     |> subject("REST API Beta Request - #{account.slug}")
     |> to("support@firezone.dev")
+    |> reply_to(
+      Kernel.get_in(subject, :identity, :provider_identifier) || "notifications@firezone.dev"
+    )
     |> render_text_body(__MODULE__, :rest_api_request,
       account: account,
       subject: subject
     )
   end
-
-  # def sign_up_link_email(
-  #      %Domain.Accounts.Account{} = account,
-  #      %Domain.Auth.Identity{} = identity,
-  #      user_agent,
-  #      remote_ip
-  #    ) do
-  #  sign_in_form_url = url(~p"/#{account}")
-
-  #  default_email()
-  #  |> subject("Welcome to Firezone")
-  #  |> to(identity.provider_identifier)
-  #  |> render_body(__MODULE__, :sign_up_link,
-  #    account: account,
-  #    sign_in_form_url: sign_in_form_url,
-  #    user_agent: user_agent,
-  #    remote_ip: "#{:inet.ntoa(remote_ip)}"
-  #  )
-  # end
 end

--- a/elixir/apps/web/lib/web/mailer/beta_email.ex
+++ b/elixir/apps/web/lib/web/mailer/beta_email.ex
@@ -12,12 +12,14 @@ defmodule Web.Mailer.BetaEmail do
     default_email()
     |> subject("REST API Beta Request - #{account.slug}")
     |> to("support@firezone.dev")
-    |> reply_to(
-      Kernel.get_in(subject, [:identity, :provider_identifier]) || "notifications@firezone.dev"
-    )
+    |> reply_to(identity_to_reply_to(subject.identity))
     |> render_text_body(__MODULE__, :rest_api_request,
       account: account,
       subject: subject
     )
   end
+
+  defp identity_to_reply_to(nil), do: "notifications@firezone.dev"
+
+  defp identity_to_reply_to(%Domain.Auth.Identity{} = identity), do: identity.provider_identifier
 end

--- a/elixir/apps/web/lib/web/mailer/beta_email.ex
+++ b/elixir/apps/web/lib/web/mailer/beta_email.ex
@@ -13,7 +13,7 @@ defmodule Web.Mailer.BetaEmail do
     |> subject("REST API Beta Request - #{account.slug}")
     |> to("support@firezone.dev")
     |> reply_to(
-      Kernel.get_in(subject, :identity, :provider_identifier) || "notifications@firezone.dev"
+      Kernel.get_in(subject, [:identity, :provider_identifier]) || "notifications@firezone.dev"
     )
     |> render_text_body(__MODULE__, :rest_api_request,
       account: account,


### PR DESCRIPTION
Fixes help text, opens link in new page, quick polish on flash styling, and adds `reply-to` so I can handle the email chain directly in HubSpot.

<img width="1233" alt="Screenshot 2024-08-07 at 10 44 36 AM" src="https://github.com/user-attachments/assets/eb261ab3-9c3f-4aec-b530-fb14bbaf7c3d">
