### PR TITLE
fix(ci): Add http test server image specifiers to CI

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -33,6 +33,9 @@ on:
       gateway_image:
         description: "The gateway image that was built"
         value: ${{ jobs.data-plane.outputs.gateway_image }}
+      http_test_server_image:
+        description: "The http_test_server image that was built"
+        value: ${{ jobs.data-plane.outputs.http_test_server_image }}
 
 permissions:
   # write permission is required to create a github release
@@ -178,6 +181,7 @@ jobs:
       client_image: ${{ steps.image-name.outputs.client_image }}
       relay_image: ${{ steps.image-name.outputs.relay_image }}
       gateway_image: ${{ steps.image-name.outputs.gateway_image }}
+      http_test_server_image: ${{ steps.image-name.outputs.http_test_server_image }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -143,7 +143,7 @@ jobs:
           fi
 
           # Start one-by-one to avoid variability in service startup order
-          docker compose up -d dns.httpbin httpbin download.httpbin
+          docker compose up -d dns.httpbin httpbin download.httpbin --no-build
           docker compose up -d api web domain --no-build
           docker compose up -d otel --no-build
           docker compose up -d relay-1 --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       gateway_image: ${{ needs.build-artifacts.outputs.gateway_image }}
       client_image: ${{ needs.build-artifacts.outputs.client_image }}
       relay_image: ${{ needs.build-artifacts.outputs.relay_image }}
+      http_test_server_image: ${{ needs.build-artifacts.outputs.http_test_server_image }}
 
   snownet-tests:
     needs: build-artifacts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/api:main
       args:
         APPLICATION_NAME: api
-    image: ${API_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/api}:${API_TAG:-main}
+    image: ${API_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/api}:${API_TAG:-latest}
     hostname: api.cluster.local
     ports:
       - 8081:8081/tcp
@@ -438,7 +438,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/dev/relay}:${RELAY_TAG:-main}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/dev/relay}:${RELAY_TAG:-latest}
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/web:main
       args:
         APPLICATION_NAME: web
-    image: ${WEB_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/web}:${WEB_TAG:-main}
+    image: ${WEB_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/web}:${WEB_TAG:-latest}
     hostname: web.cluster.local
     ports:
       - 8080:8080/tcp
@@ -192,7 +192,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/domain:main
       args:
         APPLICATION_NAME: domain
-    image: ${DOMAIN_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/domain}:${DOMAIN_TAG:-main}
+    image: ${DOMAIN_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/domain}:${DOMAIN_TAG:-latest}
     hostname: domain.cluster.local
     environment:
       # Erlang
@@ -258,7 +258,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/elixir:main
       args:
         APPLICATION_NAME: api
-    image: ${ELIXIR_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/elixir}:${ELIXIR_TAG:-main}
+    image: ${ELIXIR_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/elixir}:${ELIXIR_TAG:-latest}
     hostname: elixir
     environment:
       # Web Server
@@ -324,7 +324,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/client:main
       args:
         PACKAGE: firezone-headless-client
-    image: ${CLIENT_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/dev/client}:${CLIENT_TAG:-main}
+    image: ${CLIENT_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/client}:${CLIENT_TAG:-latest}
     cap_add:
       - NET_ADMIN
     sysctls:
@@ -355,7 +355,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/gateway:main
       args:
         PACKAGE: firezone-gateway
-    image: ${GATEWAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/dev/gateway}:${GATEWAY_TAG:-main}
+    image: ${GATEWAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/gateway}:${GATEWAY_TAG:-latest}
     cap_add:
       - NET_ADMIN
     sysctls:
@@ -392,7 +392,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/http-test-server:main
       args:
         PACKAGE: http-test-server
-    image: ${HTTP_TEST_SERVER_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/dev/http-test-server}:${HTTP_TEST_SERVER_TAG:-main}
+    image: ${HTTP_TEST_SERVER_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/http-test-server}:${HTTP_TEST_SERVER_TAG:-latest}
     environment:
       PORT: 80
     networks:
@@ -479,7 +479,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/dev/relay}:${RELAY_TAG:-main}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/relay}:${RELAY_TAG:-latest}
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -324,7 +324,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/client:main
       args:
         PACKAGE: firezone-headless-client
-    image: ${CLIENT_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/client}:${CLIENT_TAG:-latest}
+    image: ${CLIENT_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/client}:${CLIENT_TAG:-latest}
     cap_add:
       - NET_ADMIN
     sysctls:
@@ -355,7 +355,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/gateway:main
       args:
         PACKAGE: firezone-gateway
-    image: ${GATEWAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/gateway}:${GATEWAY_TAG:-latest}
+    image: ${GATEWAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/gateway}:${GATEWAY_TAG:-latest}
     cap_add:
       - NET_ADMIN
     sysctls:
@@ -392,7 +392,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/http-test-server:main
       args:
         PACKAGE: http-test-server
-    image: ${HTTP_TEST_SERVER_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/http-test-server}:${HTTP_TEST_SERVER_TAG:-latest}
+    image: ${HTTP_TEST_SERVER_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/http-test-server}:${HTTP_TEST_SERVER_TAG:-latest}
     environment:
       PORT: 80
     networks:
@@ -438,7 +438,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/dev/relay}:${RELAY_TAG:-latest}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-latest}
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 10s
@@ -479,7 +479,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/relay}:${RELAY_TAG:-latest}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-latest}
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/web:main
       args:
         APPLICATION_NAME: web
-    image: ${WEB_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/web}:${WEB_TAG:-latest}
+    image: ${WEB_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/web}:${WEB_TAG:-main}
     hostname: web.cluster.local
     ports:
       - 8080:8080/tcp
@@ -123,7 +123,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/api:main
       args:
         APPLICATION_NAME: api
-    image: ${API_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/api}:${API_TAG:-latest}
+    image: ${API_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/api}:${API_TAG:-main}
     hostname: api.cluster.local
     ports:
       - 8081:8081/tcp
@@ -192,7 +192,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/domain:main
       args:
         APPLICATION_NAME: domain
-    image: ${DOMAIN_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/domain}:${DOMAIN_TAG:-latest}
+    image: ${DOMAIN_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/domain}:${DOMAIN_TAG:-main}
     hostname: domain.cluster.local
     environment:
       # Erlang
@@ -258,7 +258,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/elixir:main
       args:
         APPLICATION_NAME: api
-    image: ${ELIXIR_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/elixir}:${ELIXIR_TAG:-latest}
+    image: ${ELIXIR_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/elixir}:${ELIXIR_TAG:-main}
     hostname: elixir
     environment:
       # Web Server
@@ -324,7 +324,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/client:main
       args:
         PACKAGE: firezone-headless-client
-    image: ${CLIENT_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/client}:${CLIENT_TAG:-latest}
+    image: ${CLIENT_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/client}:${CLIENT_TAG:-main}
     cap_add:
       - NET_ADMIN
     sysctls:
@@ -355,7 +355,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/gateway:main
       args:
         PACKAGE: firezone-gateway
-    image: ${GATEWAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/gateway}:${GATEWAY_TAG:-latest}
+    image: ${GATEWAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/gateway}:${GATEWAY_TAG:-main}
     cap_add:
       - NET_ADMIN
     sysctls:
@@ -392,7 +392,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/http-test-server:main
       args:
         PACKAGE: http-test-server
-    image: ${HTTP_TEST_SERVER_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/http-test-server}:${HTTP_TEST_SERVER_TAG:-latest}
+    image: ${HTTP_TEST_SERVER_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/http-test-server}:${HTTP_TEST_SERVER_TAG:-main}
     environment:
       PORT: 80
     networks:
@@ -438,7 +438,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-latest}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-main}
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 10s
@@ -479,7 +479,7 @@ services:
         - type=registry,ref=us-east1-docker.pkg.dev/firezone-staging/cache/relay:main
       args:
         PACKAGE: firezone-relay
-    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-latest}
+    image: ${RELAY_IMAGE:-us-east1-docker.pkg.dev/firezone-staging/firezone/debug/relay}:${RELAY_TAG:-main}
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 10s

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -89,7 +89,7 @@ You should now be able to connect to `http://localhost:8080/<account-uuid-here>`
 and sign in with the following credentials:
 
 ```text
-Email:    firezone@localhost
+Email:    firezone@localhost.localdomain
 Password: Firezone1234
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -89,7 +89,7 @@ You should now be able to connect to `http://localhost:8080/<account-uuid-here>`
 and sign in with the following credentials:
 
 ```text
-Email:    firezone@localhost.localdomain
+Email:    firezone@localhost.local
 Password: Firezone1234
 ```
 

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -216,7 +216,7 @@ context = %Domain.Auth.Context{type: :client, user_agent: user_agent, remote_ip:
 # For an admin user, imitating the browser session
 context = %Domain.Auth.Context{type: :browser, user_agent: user_agent, remote_ip: remote_ip}
 provider = Domain.Repo.get_by(Domain.Auth.Provider, adapter: :userpass)
-identity = Domain.Repo.get_by(Domain.Auth.Identity, provider_id: provider.id, provider_identifier: "firezone@localhost")
+identity = Domain.Repo.get_by(Domain.Auth.Identity, provider_id: provider.id, provider_identifier: "firezone@localhost.localdomain")
 token = Domain.Auth.create_token(identity, context, "", nil)
 browser_token = Domain.Tokens.encode_fragment!(token)
 {:ok, subject} = Domain.Auth.authenticate(browser_token, context)

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -216,7 +216,7 @@ context = %Domain.Auth.Context{type: :client, user_agent: user_agent, remote_ip:
 # For an admin user, imitating the browser session
 context = %Domain.Auth.Context{type: :browser, user_agent: user_agent, remote_ip: remote_ip}
 provider = Domain.Repo.get_by(Domain.Auth.Provider, adapter: :userpass)
-identity = Domain.Repo.get_by(Domain.Auth.Identity, provider_id: provider.id, provider_identifier: "firezone@localhost.localdomain")
+identity = Domain.Repo.get_by(Domain.Auth.Identity, provider_id: provider.id, provider_identifier: "firezone@localhost.local")
 token = Domain.Auth.create_token(identity, context, "", nil)
 browser_token = Domain.Tokens.encode_fragment!(token)
 {:ok, subject} = Domain.Auth.authenticate(browser_token, context)

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -125,8 +125,8 @@ IO.puts("")
     adapter_config: %{}
   })
 
-unprivileged_actor_email = "firezone-unprivileged-1@localhost.localdomain"
-admin_actor_email = "firezone@localhost.localdomain"
+unprivileged_actor_email = "firezone-unprivileged-1@localhost.local"
+admin_actor_email = "firezone@localhost.local"
 
 {:ok, unprivileged_actor} =
   Actors.create_actor(account, %{
@@ -204,8 +204,8 @@ admin_actor_oidc_identity
 |> Repo.update!()
 
 # Other Account Users
-other_unprivileged_actor_email = "other-unprivileged-1@localhost.localdomain"
-other_admin_actor_email = "other@localhost.localdomain"
+other_unprivileged_actor_email = "other-unprivileged-1@localhost.local"
+other_admin_actor_email = "other@localhost.local"
 
 {:ok, other_unprivileged_actor} =
   Actors.create_actor(other_account, %{

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -125,8 +125,8 @@ IO.puts("")
     adapter_config: %{}
   })
 
-unprivileged_actor_email = "firezone-unprivileged-1@localhost"
-admin_actor_email = "firezone@localhost"
+unprivileged_actor_email = "firezone-unprivileged-1@localhost.localdomain"
+admin_actor_email = "firezone@localhost.localdomain"
 
 {:ok, unprivileged_actor} =
   Actors.create_actor(account, %{
@@ -204,8 +204,8 @@ admin_actor_oidc_identity
 |> Repo.update!()
 
 # Other Account Users
-other_unprivileged_actor_email = "other-unprivileged-1@localhost"
-other_admin_actor_email = "other@localhost"
+other_unprivileged_actor_email = "other-unprivileged-1@localhost.localdomain"
+other_admin_actor_email = "other@localhost.localdomain"
 
 {:ok, other_unprivileged_actor} =
   Actors.create_actor(other_account, %{


### PR DESCRIPTION
- Adds `http_test_server_image` to inputs so that it gets set properly for CI (`debug`) and CD (`perf`)
- Updates `dev` -> `debug` in docker-compose.yml to fix pulls
- Fixes issue with seeds and relevant docs from #6205 