### PR TITLE
feat(portal): Wildcard dns with backwards compatibility

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -752,18 +752,16 @@ defmodule API.Client.Channel do
   end
 
   defp map_and_filter_compatible_resource(resource, client_version) do
-    cond do
-      Version.match?(client_version, ">= 1.2.0") ->
-        {:cont, resource}
-
-      true ->
-        resource.address
-        |> String.codepoints()
-        |> Resources.map_resource_address()
-        |> case do
-          {:cont, address} -> {:cont, %{resource | address: address}}
-          :drop -> :drop
-        end
+    if Version.match?(client_version, ">= 1.2.0") do
+      {:cont, resource}
+    else
+      resource.address
+      |> String.codepoints()
+      |> Resources.map_resource_address()
+      |> case do
+        {:cont, address} -> {:cont, %{resource | address: address}}
+        :drop -> :drop
+      end
     end
   end
 end

--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -91,6 +91,9 @@ defmodule API.Client.Channel do
       :ok = Enum.each(relays, &Relays.subscribe_to_relay_presence/1)
       :ok = maybe_subscribe_for_relays_presence(relays, socket)
 
+      resources =
+        map_and_filter_compatible_resources(resources, socket.assigns.client.last_seen_version)
+
       :ok =
         push(socket, "init", %{
           resources: Views.Resource.render_many(resources),
@@ -223,7 +226,20 @@ defmodule API.Client.Channel do
              preload: [:gateway_groups]
            ) do
         {:ok, resource} ->
-          push(socket, "resource_created_or_updated", Views.Resource.render(resource))
+          case map_and_filter_compatible_resource(
+                 resource,
+                 socket.assigns.client.last_seen_version
+               ) do
+            {:cont, resource} ->
+              push(
+                socket,
+                "resource_created_or_updated",
+                Views.Resource.render(resource)
+              )
+
+            :drop ->
+              :ok
+          end
 
         {:error, _reason} ->
           :ok
@@ -269,7 +285,20 @@ defmodule API.Client.Channel do
              preload: [:gateway_groups]
            ) do
         {:ok, resource} ->
-          push(socket, "resource_created_or_updated", Views.Resource.render(resource))
+          case map_and_filter_compatible_resource(
+                 resource,
+                 socket.assigns.client.last_seen_version
+               ) do
+            {:cont, resource} ->
+              push(
+                socket,
+                "resource_created_or_updated",
+                Views.Resource.render(resource)
+              )
+
+            :drop ->
+              :ok
+          end
 
         {:error, _reason} ->
           :ok
@@ -302,7 +331,20 @@ defmodule API.Client.Channel do
              preload: [:gateway_groups]
            ) do
         {:ok, resource} ->
-          push(socket, "resource_created_or_updated", Views.Resource.render(resource))
+          case map_and_filter_compatible_resource(
+                 resource,
+                 socket.assigns.client.last_seen_version
+               ) do
+            {:cont, resource} ->
+              push(
+                socket,
+                "resource_created_or_updated",
+                Views.Resource.render(resource)
+              )
+
+            :drop ->
+              :ok
+          end
 
         {:error, _reason} ->
           :ok
@@ -697,6 +739,31 @@ defmodule API.Client.Channel do
     |> case do
       [] -> {:error, :not_found}
       gateways -> {:ok, gateways}
+    end
+  end
+
+  defp map_and_filter_compatible_resources(resources, client_version) do
+    Enum.flat_map(resources, fn resource ->
+      case map_and_filter_compatible_resource(resource, client_version) do
+        {:cont, resource} -> [resource]
+        :drop -> []
+      end
+    end)
+  end
+
+  defp map_and_filter_compatible_resource(resource, client_version) do
+    cond do
+      Version.match?(client_version, ">= 1.2.0") ->
+        {:cont, resource}
+
+      true ->
+        resource.address
+        |> String.codepoints()
+        |> Resources.map_resource_address()
+        |> case do
+          {:cont, address} -> {:cont, %{resource | address: address}}
+          :drop -> :drop
+        end
     end
   end
 end

--- a/elixir/apps/api/lib/api/client/views/resource.ex
+++ b/elixir/apps/api/lib/api/client/views/resource.ex
@@ -15,10 +15,7 @@ defmodule API.Client.Views.Resource do
       id: resource.id,
       type: :cidr,
       address: address,
-      # TODO: This is a workaround due to clients expecting address_description not
-      # to be null. Remove this to send null address_description on or after 8/13/24
-      # once we can reasonably expect clients to have upgraded.
-      address_description: resource.address_description || address,
+      address_description: resource.address_description,
       name: resource.name,
       gateway_groups: Views.GatewayGroup.render_many(resource.gateway_groups),
       filters: Enum.flat_map(resource.filters, &render_filter/1)
@@ -30,10 +27,7 @@ defmodule API.Client.Views.Resource do
       id: resource.id,
       type: resource.type,
       address: resource.address,
-      # TODO: This is a workaround due to clients expecting address_description not
-      # to be null. Remove this to send null address_description on or after 8/13/24
-      # once we can reasonably expect clients to have upgraded.
-      address_description: resource.address_description || resource.address,
+      address_description: resource.address_description,
       name: resource.name,
       gateway_groups: Views.GatewayGroup.render_many(resource.gateway_groups),
       filters: Enum.flat_map(resource.filters, &render_filter/1)

--- a/elixir/apps/domain/lib/domain/resources.ex
+++ b/elixir/apps/domain/lib/domain/resources.ex
@@ -283,4 +283,30 @@ defmodule Domain.Resources do
     |> account_topic()
     |> PubSub.broadcast(payload)
   end
+
+  @doc false
+  # This is the code that will be removed in future version of Firezone (in 1.3-1.4)
+  # and is reused to prevent breaking changes
+  def map_resource_address(address, acc \\ "")
+
+  def map_resource_address(["*", "*" | rest], ""),
+    do: map_resource_address(rest, "*")
+
+  def map_resource_address(["*", "*" | _rest], _acc),
+    do: :drop
+
+  def map_resource_address(["*" | rest], ""),
+    do: map_resource_address(rest, "?")
+
+  def map_resource_address(["*" | _rest], _acc),
+    do: :drop
+
+  def map_resource_address(["?" | _rest], _acc),
+    do: :drop
+
+  def map_resource_address([char | rest], acc),
+    do: map_resource_address(rest, acc <> char)
+
+  def map_resource_address([], acc),
+    do: {:cont, acc}
 end

--- a/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
@@ -59,7 +59,7 @@ defmodule Domain.Resources.Resource.Changeset do
     |> validate_does_not_end_with(:address, "localhost",
       message: "localhost cannot be used, please add a DNS alias to /etc/hosts instead"
     )
-    |> validate_format(:address, ~r/^([*?]\.)?[\p{L}0-9-]{1,63}(\.[\p{L}0-9-]{1,63})*$/iu)
+    |> validate_format(:address, ~r/^[\p{L}\*\?0-9-]{1,63}(\.[\p{L}\*\?0-9-]{1,63})*$/iu)
   end
 
   defp validate_cidr_address(changeset) do

--- a/elixir/apps/domain/priv/repo/migrations/20240725202649_migrate_dns_resource_patterns.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20240725202649_migrate_dns_resource_patterns.exs
@@ -1,0 +1,11 @@
+defmodule Domain.Repo.Migrations.MigrateDnsResourcePatterns do
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    UPDATE resources
+    SET address = replace(replace(address, '*', '**'), '?', '*')
+    WHERE type = 'dns'
+    """)
+  end
+end

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -640,8 +640,8 @@ IO.puts("")
   Resources.create_resource(
     %{
       type: :dns,
-      name: "*.firez.one",
-      address: "*.firez.one",
+      name: "**.firez.one",
+      address: "**.firez.one",
       address_description: "https://firez.one/",
       connections: [%{gateway_group_id: gateway_group.id}],
       filters: []
@@ -653,8 +653,8 @@ IO.puts("")
   Resources.create_resource(
     %{
       type: :dns,
-      name: "?.firezone.dev",
-      address: "?.firezone.dev",
+      name: "*.firezone.dev",
+      address: "*.firezone.dev",
       address_description: "https://firezone.dev/",
       connections: [%{gateway_group_id: gateway_group.id}],
       filters: []
@@ -751,8 +751,8 @@ IO.puts("")
   Resources.create_resource(
     %{
       type: :dns,
-      name: "?.httpbin",
-      address: "?.httpbin",
+      name: "*.httpbin",
+      address: "*.httpbin",
       address_description: "http://httpbin/",
       connections: [%{gateway_group_id: gateway_group.id}],
       filters: [

--- a/elixir/apps/domain/test/domain/actors_test.exs
+++ b/elixir/apps/domain/test/domain/actors_test.exs
@@ -2752,7 +2752,7 @@ defmodule Domain.ActorsTest do
       assert {:ok, _actor} = disable_actor(actor, subject)
 
       expires_at = Repo.one(Domain.Flows.Flow).expires_at
-      assert DateTime.diff(expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expires_at, DateTime.utc_now()) <= 1
     end
 
     test "returns error when trying to disable the last admin actor" do
@@ -3003,7 +3003,7 @@ defmodule Domain.ActorsTest do
       assert {:ok, _actor} = delete_actor(actor, subject)
 
       expires_at = Repo.one(Domain.Flows.Flow).expires_at
-      assert DateTime.diff(expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expires_at, DateTime.utc_now()) <= 1
     end
 
     test "returns error when trying to delete the last admin actor", %{

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -933,7 +933,7 @@ defmodule Domain.AuthTest do
       assert {:ok, _provider} = disable_provider(provider, subject)
 
       expires_at = Repo.one(Domain.Flows.Flow).expires_at
-      assert DateTime.diff(expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expires_at, DateTime.utc_now()) <= 1
     end
 
     test "returns error when trying to disable the last provider", %{
@@ -1153,7 +1153,7 @@ defmodule Domain.AuthTest do
       assert {:ok, _provider} = delete_provider(provider, subject)
 
       expires_at = Repo.one(Domain.Flows.Flow).expires_at
-      assert DateTime.diff(expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expires_at, DateTime.utc_now()) <= 1
     end
 
     test "returns error when trying to delete the last provider", %{
@@ -2876,7 +2876,7 @@ defmodule Domain.AuthTest do
       assert delete_identities_for(actor, subject) == :ok
 
       expires_at = Repo.one(Domain.Flows.Flow).expires_at
-      assert DateTime.diff(expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expires_at, DateTime.utc_now()) <= 1
     end
 
     test "updates dynamic group memberships", %{

--- a/elixir/apps/domain/test/domain/flows_test.exs
+++ b/elixir/apps/domain/test/domain/flows_test.exs
@@ -930,7 +930,7 @@ defmodule Domain.FlowsTest do
       actor_group: actor_group
     } do
       assert {:ok, [expired_flow]} = expire_flows_for(actor_group)
-      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) <= 1
       assert expired_flow.id == flow.id
     end
 
@@ -939,7 +939,7 @@ defmodule Domain.FlowsTest do
       identity: identity
     } do
       assert {:ok, [expired_flow]} = expire_flows_for(identity)
-      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) <= 1
       assert expired_flow.id == flow.id
     end
   end
@@ -974,7 +974,7 @@ defmodule Domain.FlowsTest do
       policy: policy
     } do
       assert {:ok, [expired_flow]} = expire_flows_for(actor.id, policy.actor_group_id)
-      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) <= 1
       assert expired_flow.id == flow.id
     end
 
@@ -984,7 +984,7 @@ defmodule Domain.FlowsTest do
       subject: subject
     } do
       assert {:ok, [expired_flow]} = expire_flows_for(actor, subject)
-      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) <= 1
       assert expired_flow.id == flow.id
     end
 
@@ -994,7 +994,7 @@ defmodule Domain.FlowsTest do
       subject: subject
     } do
       assert {:ok, [expired_flow]} = expire_flows_for(policy, subject)
-      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) <= 1
       assert expired_flow.id == flow.id
     end
 
@@ -1004,7 +1004,7 @@ defmodule Domain.FlowsTest do
       subject: subject
     } do
       assert {:ok, [expired_flow]} = expire_flows_for(resource, subject)
-      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) <= 1
       assert expired_flow.id == flow.id
     end
 
@@ -1014,7 +1014,7 @@ defmodule Domain.FlowsTest do
       subject: subject
     } do
       assert {:ok, [expired_flow]} = expire_flows_for(actor_group, subject)
-      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) <= 1
       assert expired_flow.id == flow.id
     end
 
@@ -1024,7 +1024,7 @@ defmodule Domain.FlowsTest do
       subject: subject
     } do
       assert {:ok, [expired_flow]} = expire_flows_for(identity, subject)
-      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) <= 1
       assert expired_flow.id == flow.id
     end
 
@@ -1034,7 +1034,7 @@ defmodule Domain.FlowsTest do
       subject: subject
     } do
       assert {:ok, [expired_flow]} = expire_flows_for(provider, subject)
-      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expired_flow.expires_at, DateTime.utc_now()) <= 1
       assert expired_flow.id == flow.id
     end
 

--- a/elixir/apps/domain/test/domain/policies_test.exs
+++ b/elixir/apps/domain/test/domain/policies_test.exs
@@ -511,7 +511,7 @@ defmodule Domain.PoliciesTest do
       assert {:ok, _policy} = disable_policy(policy, subject)
 
       expires_at = Repo.one(Domain.Flows.Flow).expires_at
-      assert DateTime.diff(expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expires_at, DateTime.utc_now()) <= 1
     end
 
     test "broadcasts an account message when policy is disabled", %{
@@ -888,7 +888,7 @@ defmodule Domain.PoliciesTest do
       assert {:ok, [_deleted_policy]} = delete_policies_for(resource, subject)
 
       expires_at = Repo.one(Domain.Flows.Flow).expires_at
-      assert DateTime.diff(expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expires_at, DateTime.utc_now()) <= 1
     end
 
     test "broadcasts an account message when policy is deleted", %{

--- a/elixir/apps/domain/test/domain/tokens_test.exs
+++ b/elixir/apps/domain/test/domain/tokens_test.exs
@@ -524,7 +524,7 @@ defmodule Domain.TokensTest do
       assert {:ok, _token} = delete_token_for(subject)
 
       expires_at = Repo.one(Domain.Flows.Flow).expires_at
-      assert DateTime.diff(expires_at, DateTime.utc_now()) < 1
+      assert DateTime.diff(expires_at, DateTime.utc_now()) <= 1
     end
 
     test "does not delete tokens for other actors", %{account: account, subject: subject} do

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -142,10 +142,10 @@ defmodule Web.Resources.New do
                     |> String.codepoints()
                     |> Resources.map_resource_address() == :drop
                 }
-                class="flex items-center gap-2 text-sm leading-6 text-yellow-600 mt-2 w-full"
+                class="flex items-center gap-2 text-sm leading-6 text-accent-600 mt-2 w-full"
               >
                 <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
-                This is an advanced address format that is not supported by clients prior to v1.2.
+                This is an advanced address format. This Resource will be available to Clients v1.2.0 and higher only.
               </p>
               <p :if={@form[:type].value == :dns} class="mt-2 text-xs text-neutral-500">
                 Wildcards are supported:<br />

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -134,12 +134,32 @@ defmodule Web.Resources.New do
                 disabled={is_nil(@form[:type].value)}
                 required
               />
+              <p
+                :if={
+                  @form[:type].value == :dns and
+                    is_binary(@form[:address].value) and
+                    @form[:address].value
+                    |> String.codepoints()
+                    |> Resources.map_resource_address() == :drop
+                }
+                class="flex items-center gap-2 text-sm leading-6 text-yellow-600 mt-2 w-full"
+              >
+                <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
+                This is an advanced address format that is not supported by clients prior to v1.2.
+              </p>
               <p :if={@form[:type].value == :dns} class="mt-2 text-xs text-neutral-500">
                 Wildcards are supported:<br />
+                <code class="ml-2 px-0.5 font-semibold">**.c.com</code>
+                matches any level of subdomains (e.g., <code class="px-0.5 font-semibold">foo.c.com</code>,
+                <code class="px-0.5 font-semibold">bar.foo.c.com</code>
+                and <code class="px-0.5 font-semibold">c.com</code>).<br />
                 <code class="ml-2 px-0.5 font-semibold">*.c.com</code>
-                will match recursively (<code class="px-0.5 font-semibold">b.c.com</code> and <code class="px-0.5 font-semibold">a.b.c.com</code>).<br />
-                <code class="ml-2 px-0.5 font-semibold">?.c.com</code>
-                will match top-level subdomains only (<code class="px-0.5 font-semibold">b.c.com</code>).
+                matches a zero and single level subdomains (e.g.,
+                <code class="px-0.5 font-semibold">foo.c.com</code>
+                and <code class="px-0.5 font-semibold">c.com</code>
+                but not <code class="px-0.5 font-semibold">bar.foo.c.com</code>). <br />
+                <code class="ml-2 px-0.5 font-semibold">us-east?.c.com</code>
+                matches a single character (e.g., <code class="px-0.5 font-semibold">us-east1.c.com</code>).
               </p>
               <p :if={@form[:type].value == :ip} class="mt-2 text-xs text-neutral-500">
                 IPv4 and IPv6 addresses are supported.

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -24,12 +24,18 @@ From there, you can select the type of Resource you want to create:
 
 - **DNS**: A domain name pattern to match.
   - By default, the pattern will only match exactly the name you enter.
-  - To recursively match all subdomains, use a wildcard, such as
-    `*.example.com`. This will match `example.com`, `sub2.example.com`, and
+  - To recursively match all subdomains, use a double-wildcard, such as
+    `**.example.com`. This will match `example.com`, `sub2.example.com`, and
     `sub1.sub2.example.com`.
-  - To non-recursively match all subdomains, use a question mark, such as
-    `?.example.com`. This will match `example.com`, `sub1.example.com`, and
+  - To non-recursively match all subdomains, use a wildcard mark, such as
+    `*.example.com`. This will match `example.com`, `sub1.example.com`, and
     `sub2.example.com` **but not** `sub1.sub2.example.com`.
+  - To match a single character, use a question mark, such as
+    `us-east?.example.com`. This will match `us-east1.example.com`,
+    `.example.com`, **but not** `us-eastXY.example.com`.
+  - Any matching patterns can be placed in between domain name components, eg.
+    `foo.*.example.com` (will match `foo.bar.example.com`) or
+    `foo.**.example.com` (will match `foo.bar.buz.example.com).
 - **IP**: A single IPv4 or IPv6 address
 - **CIDR**: A range of IPv4 or IPv6 addresses in CIDR notation, such as
   `10.1.2.0/24` or `2001:db8::/48`

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -23,19 +23,26 @@ To create a Resource, go to `Sites -> <site name> -> Add a Resource`.
 From there, you can select the type of Resource you want to create:
 
 - **DNS**: A domain name pattern to match.
-  - By default, the pattern will only match the exact name you enter.
-  - To match all subdomains recursively, use a double-wildcard, such as
-    `**.example.com`. This will match `example.com`, `sub.example.com`, and
-    `sub.sub.example.com`.
-  - To match all subdomains non-recursively, use a single wildcard, such as
-    `*.example.com`. This will match `sub.example.com` but not
-    `sub.sub.example.com`.
-  - To match a single character, use a question mark, such as
-    `us-east?.example.com`. This will match `us-east1.example.com` but not
-    `us-eastXY.example.com`.
-  - Wildcards can be placed between domain components, e.g., `foo.*.example.com`
-    will match `foo.bar.example.com` or `foo.**.example.com` will match
-    `foo.bar.baz.example.com`.
+  - By default, the pattern will only match exactly the name you enter.
+  - To recursively match all subdomains, use a wildcard, such as
+    `*.example.com`. This will match `example.com`, `sub2.example.com`, and
+    `sub1.sub2.example.com`.
+  - To non-recursively match all subdomains, use a question mark, such as
+    `?.example.com`. This will match `example.com`, `sub1.example.com`, and
+    `sub2.example.com` **but not** `sub1.sub2.example.com`.
+    {/* - By default, the pattern will only match the exact name you enter. */}
+    {/* - To match all subdomains recursively, use a double-wildcard, such as */}
+    {/* `**.example.com`. This will match `example.com`, `sub.example.com`, and */}
+    {/* `sub.sub.example.com`. */}
+    {/* - To match all subdomains non-recursively, use a single wildcard, such as */}
+    {/* `*.example.com`. This will match `sub.example.com` but not */}
+    {/* `sub.sub.example.com`. */}
+    {/* - To match a single character, use a question mark, such as */}
+    {/* `us-east?.example.com`. This will match `us-east1.example.com` but not */}
+    {/* `us-eastXY.example.com`. */}
+    {/* - Wildcards can be placed between domain components, e.g., `foo.*.example.com` */}
+    {/* will match `foo.bar.example.com` or `foo.**.example.com` will match */}
+    {/* `foo.bar.baz.example.com`. */}
 - **IP**: A single IPv4 or IPv6 address
 - **CIDR**: A range of IPv4 or IPv6 addresses in CIDR notation, such as
   `10.1.2.0/24` or `2001:db8::/48`

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -23,19 +23,19 @@ To create a Resource, go to `Sites -> <site name> -> Add a Resource`.
 From there, you can select the type of Resource you want to create:
 
 - **DNS**: A domain name pattern to match.
-  - By default, the pattern will only match exactly the name you enter.
-  - To recursively match all subdomains, use a double-wildcard, such as
-    `**.example.com`. This will match `example.com`, `sub2.example.com`, and
-    `sub1.sub2.example.com`.
-  - To non-recursively match all subdomains, use a wildcard mark, such as
-    `*.example.com`. This will match `example.com`, `sub1.example.com`, and
-    `sub2.example.com` **but not** `sub1.sub2.example.com`.
+  - By default, the pattern will only match the exact name you enter.
+  - To match all subdomains recursively, use a double-wildcard, such as
+    `**.example.com`. This will match `example.com`, `sub.example.com`, and
+    `sub.sub.example.com`.
+  - To match all subdomains non-recursively, use a single wildcard, such as
+    `*.example.com`. This will match `sub.example.com` but not
+    `sub.sub.example.com`.
   - To match a single character, use a question mark, such as
-    `us-east?.example.com`. This will match `us-east1.example.com`,
-    `.example.com`, **but not** `us-eastXY.example.com`.
-  - Any matching patterns can be placed in between domain name components, eg.
-    `foo.*.example.com` (will match `foo.bar.example.com`) or
-    `foo.**.example.com` (will match `foo.bar.buz.example.com).
+    `us-east?.example.com`. This will match `us-east1.example.com` but not
+    `us-eastXY.example.com`.
+  - Wildcards can be placed between domain components, e.g., `foo.*.example.com`
+    will match `foo.bar.example.com` or `foo.**.example.com` will match
+    `foo.bar.baz.example.com`.
 - **IP**: A single IPv4 or IPv6 address
 - **CIDR**: A range of IPv4 or IPv6 addresses in CIDR notation, such as
   `10.1.2.0/24` or `2001:db8::/48`


### PR DESCRIPTION
If a new resource is created that will use format not supported by previous client versions we temporarily show a warning:
<img width="683" alt="Screenshot 2024-08-07 at 2 28 57 PM" src="https://github.com/user-attachments/assets/bbfdfc96-0c4b-4226-93c5-bc2b5fdb9d30">

It will also be excluded from `resources` list for older clients (below 1.2).