### PR TITLE
feat(apple): permit resources to be disabled

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -60,6 +60,9 @@ mod ffi {
         // <https://github.com/firezone/firezone/issues/4350>
         #[swift_bridge(swift_name = "setDns")]
         fn set_dns(&mut self, dns_servers: String);
+
+        #[swift_bridge(swift_name = "setDisabledResources")]
+        fn set_disabled_resources(&mut self, disabled_resources: String);
         fn disconnect(self);
     }
 
@@ -232,6 +235,12 @@ impl WrappedSession {
     fn set_dns(&mut self, dns_servers: String) {
         self.inner
             .set_dns(serde_json::from_str(&dns_servers).unwrap())
+    }
+
+    fn set_disabled_resources(&mut self, disabled_resources: String) {
+        tracing::error!("disabled resources: {disabled_resources}");
+        self.inner
+            .set_disabled_resources(serde_json::from_str(&disabled_resources).unwrap())
     }
 
     fn disconnect(self) {

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -238,7 +238,6 @@ impl WrappedSession {
     }
 
     fn set_disabled_resources(&mut self, disabled_resources: String) {
-        tracing::error!("disabled resources: {disabled_resources}");
         self.inner
             .set_disabled_resources(serde_json::from_str(&disabled_resources).unwrap())
     }

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -66,7 +66,7 @@ impl ResourceDescriptionCidr {
             name: self.name,
             address_description: self.address_description,
             sites: self.sites,
-            can_toggle: false,
+            can_toggle: true,
             status,
         }
     }

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -66,7 +66,7 @@ impl ResourceDescriptionCidr {
             name: self.name,
             address_description: self.address_description,
             sites: self.sites,
-            can_toggle: true,
+            can_toggle: false,
             status,
         }
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -20,12 +20,13 @@ public enum TunnelManagerKeys {
   static let authBaseURL = "authBaseURL"
   static let apiURL = "apiURL"
   public static let logFilter = "logFilter"
+  public static let disabledResoruces = "disabledResources"
 }
 
 public enum TunnelMessage: Codable {
   case getResourceList(Data)
   case signOut
-  case setDisabledResources(String)
+  case setDisabledResources(Set<String>)
 
   enum CodingKeys: String, CodingKey {
     case type
@@ -43,7 +44,7 @@ public enum TunnelMessage: Codable {
       let type = try container.decode(MessageType.self, forKey: .type)
       switch type {
       case .setDisabledResources:
-          let value = try container.decode(String.self, forKey: .value)
+          let value = try container.decode(Set<String>.self, forKey: .value)
           self = .setDisabledResources(value)
       case .getResourceList:
           let value = try container.decode(Data.self, forKey: .value)
@@ -260,9 +261,7 @@ class TunnelManager {
 
     guard session().status == .connected else { return }
 
-    let ids = String(data: try! JSONEncoder().encode(disabledResources), encoding: .utf8)!
-
-    try? session().sendProviderMessage(encoder.encode(TunnelMessage.setDisabledResources(ids))) { _ in }
+    try? session().sendProviderMessage(encoder.encode(TunnelMessage.setDisabledResources(disabledResources))) { _ in }
   }
 
   func fetchResources(callback: @escaping (Data) -> Void) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -20,7 +20,7 @@ public enum TunnelManagerKeys {
   static let authBaseURL = "authBaseURL"
   static let apiURL = "apiURL"
   public static let logFilter = "logFilter"
-  public static let disabledResoruces = "disabledResources"
+  public static let disabledResources = "disabledResources"
 }
 
 public enum TunnelMessage: Codable {
@@ -154,7 +154,7 @@ public class TunnelManager {
           // Found it
           let settings = Settings.fromProviderConfiguration(providerConfiguration)
           let actorName = providerConfiguration[TunnelManagerKeys.actorName]
-          if let disabledResourcesData = providerConfiguration[TunnelManagerKeys.disabledResoruces]?.data(using: .utf8) {
+          if let disabledResourcesData = providerConfiguration[TunnelManagerKeys.disabledResources]?.data(using: .utf8) {
             self.disabledResources = (try? JSONDecoder().decode(Set<String>.self, from: disabledResourcesData)) ?? Set()
 
           }
@@ -262,7 +262,7 @@ public class TunnelManager {
     try? session().sendProviderMessage(encoder.encode(TunnelMessage.setDisabledResources(disabledResources))) { _ in }
   }
 
-  func toggleResource(resource: String, enabled: Bool) {
+  func toggleResourceDisabled(resource: String, enabled: Bool) {
     if enabled {
       disabledResources.remove(resource)
     } else {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -16,8 +16,9 @@ public struct Resource: Decodable, Identifiable, Equatable {
   public var status: ResourceStatus
   public var sites: [Site]
   public var type: ResourceType
+  public var canToggle: Bool
 
-  public init(id: String, name: String, address: String, addressDescription: String?, status: ResourceStatus, sites: [Site], type: ResourceType) {
+  public init(id: String, name: String, address: String, addressDescription: String?, status: ResourceStatus, sites: [Site], type: ResourceType, canToggle: Bool) {
     self.id = id
     self.name = name
     self.address = address
@@ -25,6 +26,7 @@ public struct Resource: Decodable, Identifiable, Equatable {
     self.status = status
     self.sites = sites
     self.type = type
+    self.canToggle = canToggle
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -16,7 +16,7 @@ public struct Resource: Decodable, Identifiable, Equatable {
   public var status: ResourceStatus
   public var sites: [Site]
   public var type: ResourceType
-  public var canToggle: Bool
+  public var canDisable: Bool
 
   public init(id: String, name: String, address: String, addressDescription: String?, status: ResourceStatus, sites: [Site], type: ResourceType, canToggle: Bool) {
     self.id = id
@@ -26,7 +26,7 @@ public struct Resource: Decodable, Identifiable, Equatable {
     self.status = status
     self.sites = sites
     self.type = type
-    self.canToggle = canToggle
+    self.canDisable = canToggle
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -16,7 +16,7 @@ public struct Resource: Decodable, Identifiable, Equatable {
   public var status: ResourceStatus
   public var sites: [Site]
   public var type: ResourceType
-  public var canDisable: Bool
+  public var canToggle: Bool
 
   public init(id: String, name: String, address: String, addressDescription: String?, status: ResourceStatus, sites: [Site], type: ResourceType, canToggle: Bool) {
     self.id = id
@@ -26,7 +26,7 @@ public struct Resource: Decodable, Identifiable, Equatable {
     self.status = status
     self.sites = sites
     self.type = type
-    self.canDisable = canToggle
+    self.canToggle = canToggle
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -38,7 +38,7 @@ struct Settings: Equatable {
           ?? Settings.defaultValue.apiURL,
         logFilter: providerConfiguration[TunnelManagerKeys.logFilter]
           ?? Settings.defaultValue.logFilter,
-        disabledResources: getDisabledResources(disabledResources: providerConfiguration[TunnelManagerKeys.disabledResoruces])
+        disabledResources: getDisabledResources(disabledResources: providerConfiguration[TunnelManagerKeys.disabledResources])
       )
     } else {
       return Settings.defaultValue
@@ -59,7 +59,7 @@ struct Settings: Equatable {
       TunnelManagerKeys.authBaseURL: authBaseURL,
       TunnelManagerKeys.apiURL: apiURL,
       TunnelManagerKeys.logFilter: logFilter,
-      TunnelManagerKeys.disabledResoruces: String(data: try! JSONEncoder().encode(disabledResources), encoding: .utf8) ?? "",
+      TunnelManagerKeys.disabledResources: String(data: try! JSONEncoder().encode(disabledResources), encoding: .utf8) ?? "",
     ]
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -10,6 +10,7 @@ struct Settings: Equatable {
   var authBaseURL: String
   var apiURL: String
   var logFilter: String
+  var disabledResources: Set<String>
 
   var isValid: Bool {
     let authBaseURL = URL(string: authBaseURL)
@@ -26,6 +27,7 @@ struct Settings: Equatable {
       && !logFilter.isEmpty
   }
 
+
   // Convert provider configuration (which may have empty fields if it was tampered with) to Settings
   static func fromProviderConfiguration(_ providerConfiguration: [String: Any]?) -> Settings {
     if let providerConfiguration = providerConfiguration as? [String: String] {
@@ -35,19 +37,29 @@ struct Settings: Equatable {
         apiURL: providerConfiguration[TunnelManagerKeys.apiURL]
           ?? Settings.defaultValue.apiURL,
         logFilter: providerConfiguration[TunnelManagerKeys.logFilter]
-          ?? Settings.defaultValue.logFilter
+          ?? Settings.defaultValue.logFilter,
+        disabledResources: getDisabledResources(disabledResources: providerConfiguration[TunnelManagerKeys.disabledResoruces])
       )
     } else {
       return Settings.defaultValue
     }
   }
 
+  static private func getDisabledResources(disabledResources: String?) -> Set<String> {
+    guard let disabledResourcesJSON = disabledResources, let disabledResourcesData = disabledResourcesJSON.data(using: .utf8)  else{
+      return Set()
+    }
+    return (try? JSONDecoder().decode(Set<String>.self, from: disabledResourcesData))
+      ?? Settings.defaultValue.disabledResources
+  }
+
   // Used for initializing a new providerConfiguration from Settings
   func toProviderConfiguration() -> [String: String] {
     return [
-      "authBaseURL": authBaseURL,
-      "apiURL": apiURL,
-      "logFilter": logFilter,
+      TunnelManagerKeys.authBaseURL: authBaseURL,
+      TunnelManagerKeys.apiURL: apiURL,
+      TunnelManagerKeys.logFilter: logFilter,
+      TunnelManagerKeys.disabledResoruces: String(data: try! JSONEncoder().encode(disabledResources), encoding: .utf8) ?? "",
     ]
   }
 
@@ -59,13 +71,15 @@ struct Settings: Equatable {
         authBaseURL: "https://app.firez.one",
         apiURL: "wss://api.firez.one",
         logFilter:
-          "firezone_tunnel=debug,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,snownet=debug,str0m=info,warn"
+          "firezone_tunnel=debug,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,snownet=debug,str0m=info,warn",
+        disabledResources: Set()
       )
     #else
       Settings(
         authBaseURL: "https://app.firezone.dev",
         apiURL: "wss://api.firezone.dev",
-        logFilter: "str0m=warn,info"
+        logFilter: "str0m=warn,info",
+        disabledResources: Set()
       )
     #endif
   }()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -28,7 +28,7 @@ public final class Store: ObservableObject {
   // we could periodically update it if we need to.
   @Published private(set) var decision: UNAuthorizationStatus
 
-  public let tunnelManager: TunnelManager
+  private let tunnelManager: TunnelManager
   private var sessionNotification: SessionNotification
   private var cancellables: Set<AnyCancellable> = []
   private var resourcesTimer: Timer?
@@ -43,6 +43,10 @@ public final class Store: ObservableObject {
 
     initNotifications()
     initTunnelManager()
+  }
+
+  public func isResourceEnabled(_ resource: String) -> Bool {
+    !tunnelManager.disabledResources.contains(resource)
   }
 
   private func initNotifications() {
@@ -138,7 +142,7 @@ public final class Store: ObservableObject {
 
   // Network Extensions don't have a 2-way binding up to the GUI process,
   // so we need to periodically ask the tunnel process for them.
-  func beginUpdatingResources(callback: @escaping (Data) -> Void) {
+  func beginUpdatingResources(callback: @escaping ([Resource]) -> Void) {
     Log.app.log("\(#function)")
 
     tunnelManager.fetchResources(callback: callback)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -45,8 +45,8 @@ public final class Store: ObservableObject {
     initTunnelManager()
   }
 
-  public func isResourceEnabled(_ resource: String) -> Bool {
-    !tunnelManager.disabledResources.contains(resource)
+  public func isResourceEnabled(_ id: String) -> Bool {
+    !tunnelManager.disabledResources.contains(id)
   }
 
   private func initNotifications() {
@@ -171,8 +171,8 @@ public final class Store: ObservableObject {
     }
   }
 
-  func toggleResource(resource: String, enabled: Bool) {
-    tunnelManager.toggleResource(resource: resource, enabled: enabled)
+  func toggleResourceDisabled(resource: String, enabled: Bool) {
+    tunnelManager.toggleResourceDisabled(resource: resource, enabled: enabled)
     var newSettings = settings
     newSettings.disabledResources = tunnelManager.disabledResources
     Task {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -28,7 +28,7 @@ public final class Store: ObservableObject {
   // we could periodically update it if we need to.
   @Published private(set) var decision: UNAuthorizationStatus
 
-  private let tunnelManager: TunnelManager
+  public let tunnelManager: TunnelManager
   private var sessionNotification: SessionNotification
   private var cancellables: Set<AnyCancellable> = []
   private var resourcesTimer: Timer?
@@ -159,6 +159,7 @@ public final class Store: ObservableObject {
   func save(_ newSettings: Settings) async throws {
     Task {
       do {
+        Log.app.error("searchme: \(newSettings.disabledResources)")
         try await tunnelManager.saveSettings(newSettings)
         DispatchQueue.main.async { self.settings = newSettings }
       } catch {
@@ -169,6 +170,11 @@ public final class Store: ObservableObject {
 
   func toggleResource(resource: String, enabled: Bool) {
     tunnelManager.toggleResource(resource: resource, enabled: enabled)
+    var newSettings = settings
+    newSettings.disabledResources = tunnelManager.disabledResources
+    Task {
+      try await save(newSettings)
+    }
   }
 
   // Handles the frequent VPN state changes during sign in, sign out, etc.

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -167,6 +167,10 @@ public final class Store: ObservableObject {
     }
   }
 
+  func toggleResource(resource: String, enabled: Bool) {
+    tunnelManager.toggleResource(resource: resource, enabled: enabled)
+  }
+
   // Handles the frequent VPN state changes during sign in, sign out, etc.
   private func handleVPNStatusChange(status: NEVPNStatus) async {
     self.status = status

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -163,7 +163,6 @@ public final class Store: ObservableObject {
   func save(_ newSettings: Settings) async throws {
     Task {
       do {
-        Log.app.error("searchme: \(newSettings.disabledResources)")
         try await tunnelManager.saveSettings(newSettings)
         DispatchQueue.main.async { self.settings = newSettings }
       } catch {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -429,7 +429,7 @@ public final class MenuBar: NSObject, ObservableObject {
     let siteSectionItem = NSMenuItem()
     let siteNameItem = NSMenuItem()
     let siteStatusItem = NSMenuItem()
-    let resourceToggle = NSMenuItem()
+    let enableToggle = NSMenuItem()
 
 
     // AddressDescription first -- will be most common action
@@ -482,16 +482,16 @@ public final class MenuBar: NSObject, ObservableObject {
     subMenu.addItem(resourceAddressItem)
 
     // Resource toggle
-    if resource.canToggle {
+    if resource.canDisable {
       subMenu.addItem(NSMenuItem.separator())
-      resourceToggle.action = #selector(resourceToggle(_:))
-      resourceToggle.title = "Enabled"
-      resourceToggle.toolTip = "Toggle resource"
-      resourceToggle.isEnabled = true
-      resourceToggle.target = self
-      resourceToggle.state = model.isResourceEnabled(resource.id) ? .on : .off
-      resourceToggle.representedObject = resource.id
-      subMenu.addItem(resourceToggle)
+      enableToggle.action = #selector(resourceToggle(_:))
+      enableToggle.title = "Enabled"
+      enableToggle.toolTip = "Toggle resource"
+      enableToggle.isEnabled = true
+      enableToggle.target = self
+      enableToggle.state = model.isResourceEnabled(resource.id) ? .on : .off
+      enableToggle.representedObject = resource.id
+      subMenu.addItem(enableToggle)
     }
 
     // Site details
@@ -540,7 +540,7 @@ public final class MenuBar: NSObject, ObservableObject {
     sender.state = sender.state == .on ? .off : .on
     let id = sender.representedObject as! String
 
-    self.model.store.toggleResource(resource: id, enabled: sender.state == .on)
+    self.model.store.toggleResourceDisabled(resource: id, enabled: sender.state == .on)
   }
 
   @objc private func resourceURLTapped(_ sender: AnyObject?) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -433,6 +433,7 @@ public final class MenuBar: NSObject, ObservableObject {
     let siteSectionItem = NSMenuItem()
     let siteNameItem = NSMenuItem()
     let siteStatusItem = NSMenuItem()
+    let resourceToggle = NSMenuItem()
 
 
     // AddressDescription first -- will be most common action
@@ -484,6 +485,19 @@ public final class MenuBar: NSObject, ObservableObject {
     resourceAddressItem.target = self
     subMenu.addItem(resourceAddressItem)
 
+    // Resource toggle
+    if resource.canToggle {
+      subMenu.addItem(NSMenuItem.separator())
+      resourceToggle.action = #selector(resourceToggle(_:))
+      resourceToggle.title = "Enabled"
+      resourceToggle.toolTip = "Toggle resource"
+      resourceToggle.isEnabled = true
+      resourceToggle.target = self
+      resourceToggle.state = .on
+      resourceToggle.representedObject = resource.id
+      subMenu.addItem(resourceToggle)
+    }
+
     // Site details
     if let site = resource.sites.first {
       subMenu.addItem(NSMenuItem.separator())
@@ -524,6 +538,12 @@ public final class MenuBar: NSObject, ObservableObject {
     if let value = (sender as? NSMenuItem)?.title {
       copyToClipboard(value)
     }
+  }
+
+  @objc private func resourceToggle(_ sender: NSMenuItem) {
+    sender.state = sender.state == .on ? .off : .on
+    let id = sender.representedObject as! String
+    self.model.store.toggleResource(resource: id, enabled: sender.state == .on)
   }
 
   @objc private func resourceURLTapped(_ sender: AnyObject?) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -489,7 +489,7 @@ public final class MenuBar: NSObject, ObservableObject {
       resourceToggle.toolTip = "Toggle resource"
       resourceToggle.isEnabled = true
       resourceToggle.target = self
-      resourceToggle.state = model.isResourceEnabled(resource.id) ? .off : .on
+      resourceToggle.state = model.isResourceEnabled(resource.id) ? .on : .off
       resourceToggle.representedObject = resource.id
       subMenu.addItem(resourceToggle)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -420,6 +420,10 @@ public final class MenuBar: NSObject, ObservableObject {
     return item
   }
 
+  private func resourceTitle(_ id: String) -> String {
+    model.isResourceEnabled(id) ? "Disable this resource" : "Enable this resource"
+  }
+
   private func createSubMenu(resource: Resource) -> NSMenu {
     let subMenu = NSMenu()
     let resourceAddressDescriptionItem = NSMenuItem()
@@ -485,11 +489,10 @@ public final class MenuBar: NSObject, ObservableObject {
     if resource.canToggle {
       subMenu.addItem(NSMenuItem.separator())
       enableToggle.action = #selector(resourceToggle(_:))
-      enableToggle.title = "Enabled"
-      enableToggle.toolTip = "Toggle resource"
+      enableToggle.title = resourceTitle(resource.id)
+      enableToggle.toolTip = "Enable or disable resource"
       enableToggle.isEnabled = true
       enableToggle.target = self
-      enableToggle.state = model.isResourceEnabled(resource.id) ? .on : .off
       enableToggle.representedObject = resource.id
       subMenu.addItem(enableToggle)
     }
@@ -537,10 +540,10 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func resourceToggle(_ sender: NSMenuItem) {
-    sender.state = sender.state == .on ? .off : .on
     let id = sender.representedObject as! String
 
-    self.model.store.toggleResourceDisabled(resource: id, enabled: sender.state == .on)
+    self.model.store.toggleResourceDisabled(resource: id, enabled: !model.isResourceEnabled(id))
+    sender.title = resourceTitle(id)
   }
 
   @objc private func resourceURLTapped(_ sender: AnyObject?) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -493,7 +493,7 @@ public final class MenuBar: NSObject, ObservableObject {
       resourceToggle.toolTip = "Toggle resource"
       resourceToggle.isEnabled = true
       resourceToggle.target = self
-      resourceToggle.state = .on
+      resourceToggle.state = model.store.tunnelManager.disabledResources.contains(resource.id) ? .off : .on
       resourceToggle.representedObject = resource.id
       subMenu.addItem(resourceToggle)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -59,15 +59,11 @@ public final class MenuBar: NSObject, ObservableObject {
         guard let self = self else { return }
 
         if status == .connected {
-          model.store.beginUpdatingResources { data in
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            if let newResources = try? decoder.decode([Resource].self, from: data) {
+          model.store.beginUpdatingResources { newResources in
               // Handle resource changes
               self.populateResourceMenu(newResources)
               self.handleTunnelStatusOrResourcesChanged(status: status, resources: newResources)
               self.resources = newResources
-            }
           }
         } else {
           model.store.endUpdatingResources()
@@ -493,7 +489,7 @@ public final class MenuBar: NSObject, ObservableObject {
       resourceToggle.toolTip = "Toggle resource"
       resourceToggle.isEnabled = true
       resourceToggle.target = self
-      resourceToggle.state = model.store.tunnelManager.disabledResources.contains(resource.id) ? .off : .on
+      resourceToggle.state = model.isResourceEnabled(resource.id) ? .off : .on
       resourceToggle.representedObject = resource.id
       subMenu.addItem(resourceToggle)
     }
@@ -543,6 +539,7 @@ public final class MenuBar: NSObject, ObservableObject {
   @objc private func resourceToggle(_ sender: NSMenuItem) {
     sender.state = sender.state == .on ? .off : .on
     let id = sender.representedObject as! String
+
     self.model.store.toggleResource(resource: id, enabled: sender.state == .on)
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -482,7 +482,7 @@ public final class MenuBar: NSObject, ObservableObject {
     subMenu.addItem(resourceAddressItem)
 
     // Resource toggle
-    if resource.canDisable {
+    if resource.canToggle {
       subMenu.addItem(NSMenuItem.separator())
       enableToggle.action = #selector(resourceToggle(_:))
       enableToggle.title = "Enabled"

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -77,12 +77,12 @@ struct SessionView: View {
                 label: {
                   HStack {
                     Text(resource.name)
-                    if resource.canToggle {
+                    if resource.canDisable {
                       Spacer()
                       Toggle("Enabled", isOn: Binding<Bool>(
                         get: { model.isResourceEnabled(resource.id) },
                         set: { newValue in
-                          model.store.toggleResource(resource: resource.id, enabled: newValue)
+                          model.store.toggleResourceDisabled(resource: resource.id, enabled: newValue)
                         }
                       )).labelsHidden()
                     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -77,7 +77,7 @@ struct SessionView: View {
                 label: {
                   HStack {
                     Text(resource.name)
-                    if resource.canDisable {
+                    if resource.canToggle {
                       Spacer()
                       Toggle("Enabled", isOn: Binding<Bool>(
                         get: { model.isResourceEnabled(resource.id) },

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -85,6 +85,7 @@ class Adapter {
     apiURL: String,
     token: String,
     logFilter: String,
+    disabledResources: Set<String>,
     packetTunnelProvider: PacketTunnelProvider
   ) {
     self.apiURL = apiURL
@@ -95,6 +96,7 @@ class Adapter {
     self.logFilter = logFilter
     self.connlibLogFolderPath = SharedAccess.connlibLogFolderURL?.path ?? ""
     self.networkSettings = nil
+    self.disabledResources = disabledResources
   }
 
   // Could happen abruptly if the process is killed.

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -196,6 +196,13 @@ class Adapter {
     }
   }
 
+  func resources() -> [Resource] {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    guard let resourceList = resourceListJSON else { return [] }
+    return (try? decoder.decode([Resource].self, from: resourceList.data(using: .utf8)!)) ?? []
+  }
+
   public func setDisabledResources(newDisabledResources: Set<String>) {
     workQueue.async { [weak self] in
       guard let self = self else { return }
@@ -210,9 +217,7 @@ class Adapter {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
-    guard let resourceList = resourceListJSON else { return }
-    guard let resources = try? decoder.decode([Resource].self, from: resourceList.data(using: .utf8)!) else { return }
-    canBeToggled = Set(resources.filter({ $0.canToggle }).map({ $0.id }))
+    canBeToggled = Set(resources().filter({ $0.canToggle }).map({ $0.id }))
 
     let disablingResources = disabledResources.filter({ canBeToggled.contains($0) })
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -62,8 +62,8 @@ class Adapter {
   /// Currently disabled resources
   private var disabledResources: Set<String> = []
 
-  /// Cache of resources that can be toggled
-  private var canBeToggled: Set<String> = []
+  /// Cache of resources that can be disabled
+  private var canBeDisabled: Set<String> = []
 
   /// Adapter state.
   private var state: AdapterState {
@@ -217,9 +217,9 @@ class Adapter {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
-    canBeToggled = Set(resources().filter({ $0.canToggle }).map({ $0.id }))
+    canBeDisabled = Set(resources().filter({ $0.canDisable }).map({ $0.id }))
 
-    let disablingResources = disabledResources.filter({ canBeToggled.contains($0) })
+    let disablingResources = disabledResources.filter({ canBeDisabled.contains($0) })
 
     let currentlyDisabled = try! JSONEncoder().encode(disablingResources)
     session.setDisabledResources(String(data: currentlyDisabled, encoding: .utf8)!)

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -217,7 +217,7 @@ class Adapter {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
-    canBeDisabled = Set(resources().filter({ $0.canDisable }).map({ $0.id }))
+    canBeDisabled = Set(resources().filter({ $0.canToggle }).map({ $0.id }))
 
     let disablingResources = disabledResources.filter({ canBeDisabled.contains($0) })
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -187,6 +187,14 @@ class Adapter {
       }
     }
   }
+
+  public func setDisabledResources(disabledResources: String) {
+    workQueue.async { [weak self] in
+      guard let self = self else { return }
+      guard case .tunnelStarted(let session) = self.state else { return }
+      session.setDisabledResources(disabledResources)
+    }
+  }
 }
 
 // MARK: Responding to path updates

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -133,7 +133,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     switch tunnelMessage {
     case .setDisabledResources(let value):
-      adapter?.setDisabledResources(disabledResources: value)
+      adapter?.setDisabledResources(newDisabledResources: value)
     case .signOut:
       Task {
           await clearToken()

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -78,7 +78,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
           return
         }
 
-        let disabledResources: Set<String> = if let disabledResourcesJSON = providerConfiguration[TunnelManagerKeys.disabledResoruces]?.data(using: .utf8) {
+        let disabledResources: Set<String> = if let disabledResourcesJSON = providerConfiguration[TunnelManagerKeys.disabledResources]?.data(using: .utf8) {
           (try? JSONDecoder().decode(Set<String>.self, from: disabledResourcesJSON )) ?? Set()
         } else {
           Set()

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -78,9 +78,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
           return
         }
 
+        let disabledResources: Set<String> = if let disabledResourcesJSON = providerConfiguration[TunnelManagerKeys.disabledResoruces]?.data(using: .utf8) {
+          (try? JSONDecoder().decode(Set<String>.self, from: disabledResourcesJSON )) ?? Set()
+        } else {
+          Set()
+        }
+
         let adapter = Adapter(
-          apiURL: apiURL, token: token, logFilter: logFilter, packetTunnelProvider: self)
+          apiURL: apiURL, token: token, logFilter: logFilter, disabledResources: disabledResources, packetTunnelProvider: self)
         self.adapter = adapter
+
 
         try adapter.start()
 


### PR DESCRIPTION
Work for #6074 equivalent to #6166 for MacOS

MacOs view:

<img width="547" alt="image" src="https://github.com/user-attachments/assets/f465183e-247b-49b5-a916-3ecc5f0a02f4">


iOS(ipad) view:

![image](https://github.com/user-attachments/assets/e64da75a-c69f-4e6a-aeeb-739958c3b046)

Other than implementing the resource disabling, this PR also refactor the IPC between the network extension and the app so that it's some form of structured IPC instead of relying on it being deserializable to string to match the message.

One big difference with Android is that we don't introduce the concept of a `ResourceView` for swift, the main reason for this is that on iOS the resources are bound to the view instead of just being a parameter for creating the view. So if we modify the `disabled` property it'd update the UI unnecessarily, also it'd update the `Store` value for the resource and then we need to copy that over again to the view. Making it easier to go out of sync.