### PR TITLE
chore: remove `connlib-shared` dependency from `bin-shared`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1771,7 +1771,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "connlib-shared",
  "futures",
  "git-version",
  "hex-literal",
@@ -1790,7 +1789,6 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "tun",
- "url",
  "uuid",
  "windows 0.57.0",
  "windows-core 0.57.0",

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -8,10 +8,8 @@ description = "Firezone-specific modules shared between binaries."
 [dependencies]
 anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
-connlib-shared = { workspace = true }
 futures = "0.3"
 git-version = "0.3.9"
-ip-packet = { workspace = true }
 ip_network = { version = "0.4", default-features = false, features = ["serde"] }
 socket-factory = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync"] }
@@ -19,7 +17,6 @@ tracing = { workspace = true }
 tracing-log = "0.2"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tun = { workspace = true }
-url = { version = "2.5.2", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
@@ -60,6 +57,10 @@ features = [
   "Win32_System_Registry",
   "Win32_System_Threading",
 ]
+
+[target.'cfg(windows)'.dev-dependencies]
+ip-packet = { workspace = true }
+tokio = { workspace = true, features = ["net", "time"] }
 
 [lints]
 workspace = true

--- a/rust/bin-shared/benches/tunnel.rs
+++ b/rust/bin-shared/benches/tunnel.rs
@@ -49,7 +49,7 @@ mod platform {
 
         let ipv4 = Ipv4Addr::from([100, 90, 215, 97]);
         let ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0x0016, 0x588f]);
-        let mut device_manager = TunDeviceManager::new()?;
+        let mut device_manager = TunDeviceManager::new(MTU)?;
         let mut tun = device_manager.make_tun()?;
 
         device_manager.set_ips(ipv4, ipv6).await?;

--- a/rust/bin-shared/src/tun_device_manager.rs
+++ b/rust/bin-shared/src/tun_device_manager.rs
@@ -43,7 +43,7 @@ mod tests {
         let ipv4 = Ipv4Addr::from([100, 90, 215, 97]);
         let ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0x0016, 0x588f]);
 
-        let mut device_manager = TunDeviceManager::new().unwrap();
+        let mut device_manager = TunDeviceManager::new(1280).unwrap();
         let _tun = device_manager.make_tun().unwrap();
         device_manager.set_ips(ipv4, ipv6).await.unwrap();
 
@@ -96,9 +96,11 @@ mod tests {
     /// Checks for regressions in issue #4765, un-initializing Wintun
     /// Redundant but harmless on Linux.
     fn tunnel_drop() {
+        let mut tun_device_manager = TunDeviceManager::new(1280).unwrap();
+
         // Each cycle takes about half a second, so this will take a fair bit to run.
         for _ in 0..50 {
-            let _tun = platform::Tun::new().unwrap(); // This will panic if we don't correctly clean-up the wintun interface.
+            let _tun = tun_device_manager.make_tun().unwrap(); // This will panic if we don't correctly clean-up the wintun interface.
         }
     }
 }

--- a/rust/bin-shared/src/tun_device_manager.rs
+++ b/rust/bin-shared/src/tun_device_manager.rs
@@ -34,16 +34,8 @@ mod tests {
             .with_test_writer()
             .try_init();
 
-        // Run these tests in series since they would fight over the tunnel interface
-        // if they ran concurrently
-        create_tun();
         no_packet_loops().await;
         tunnel_drop();
-    }
-
-    fn create_tun() {
-        let mut tun_device_manager = TunDeviceManager::new().unwrap();
-        let _tun = tun_device_manager.make_tun().unwrap();
     }
 
     // Starts up a WinTUN device, adds a "full-route" (`0.0.0.0/0`) and checks if we can still send packets to IPs outside of our tunnel.

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -2,7 +2,9 @@ use crate::eventloop::{Eventloop, PHOENIX_TOPIC};
 use anyhow::{Context, Result};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
-use connlib_shared::{get_user_agent, keypair, messages::Interface, LoginUrl, StaticSecret};
+use connlib_shared::{
+    get_user_agent, keypair, messages::Interface, LoginUrl, StaticSecret, DEFAULT_MTU,
+};
 use firezone_bin_shared::{
     linux::{tcp_socket_factory, udp_socket_factory},
     setup_global_subscriber, TunDeviceManager,
@@ -118,7 +120,7 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
     )?;
 
     let (sender, receiver) = mpsc::channel::<Interface>(10);
-    let mut tun_device_manager = TunDeviceManager::new()?;
+    let mut tun_device_manager = TunDeviceManager::new(DEFAULT_MTU)?;
     let tun = tun_device_manager.make_tun()?;
     tunnel.set_tun(Box::new(tun));
 

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -22,7 +22,7 @@ use url::Url;
 
 pub mod ipc;
 use backoff::ExponentialBackoffBuilder;
-use connlib_shared::get_user_agent;
+use connlib_shared::{get_user_agent, DEFAULT_MTU};
 use ipc::{Server as IpcServer, ServiceId};
 use phoenix_channel::PhoenixChannel;
 use secrecy::Secret;
@@ -219,7 +219,7 @@ impl<'a> Handler<'a> {
             .await
             .context("Failed to wait for incoming IPC connection from a GUI")?;
         let (cb_tx, cb_rx) = mpsc::channel(1_000);
-        let tun_device = TunDeviceManager::new()?;
+        let tun_device = TunDeviceManager::new(DEFAULT_MTU)?;
 
         Ok(Self {
             callback_handler: CallbackHandler { cb_tx },

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context as _, Result};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use connlib_client_shared::{file_logger, keypair, ConnectArgs, LoginUrl, Session};
-use connlib_shared::get_user_agent;
+use connlib_shared::{get_user_agent, DEFAULT_MTU};
 use firezone_bin_shared::{
     new_dns_notifier, new_network_notifier,
     platform::{tcp_socket_factory, udp_socket_factory},
@@ -204,7 +204,7 @@ fn main() -> Result<()> {
         // Deactivate Firezone DNS control in case the system or IPC service crashed
         // and we need to recover. <https://github.com/firezone/firezone/issues/4899>
         dns_controller.deactivate()?;
-        let mut tun_device = TunDeviceManager::new()?;
+        let mut tun_device = TunDeviceManager::new(DEFAULT_MTU)?;
         let mut cb_rx = ReceiverStream::new(cb_rx).fuse();
 
         let tokio_handle = tokio::runtime::Handle::current();


### PR DESCRIPTION
The `firezone-bin-shared` crate is meant to house non-tunnel related things. That allows it to compile in parallel to everything else. It currently only depends on `connlib-shared` to access the `DEFAULT_MTU` constant. We can remove that by requiring the MTU as a ctor parameter of `TunDeviceManager`.

A longer write-up of the intended dependency structure is in #4470.