### PR TITLE
fix(portal): Update Resource definition in OpenAPI spec

### DIFF
--- a/elixir/apps/api/lib/api/schemas/resource_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/resource_schema.ex
@@ -37,7 +37,20 @@ defmodule API.Schemas.Resource do
       description: "POST body for creating a Resource",
       type: :object,
       properties: %{
-        resource: %Schema{anyOf: [Resource.Schema]}
+        resource: %Schema{
+          anyOf: [
+            Resource.Schema,
+            %Schema{
+              type: :array,
+              items: %Schema{
+                type: :object,
+                properties: %{
+                  gateway_group_id: %Schema{type: :string, description: "Gateway Group ID"}
+                }
+              }
+            }
+          ]
+        }
       },
       required: [:resource],
       example: %{
@@ -46,7 +59,12 @@ defmodule API.Schemas.Resource do
           "name" => "Prod DB",
           "address" => "10.0.0.10",
           "description" => "Production Database",
-          "type" => "ip"
+          "type" => "ip",
+          "connections" => [
+            %{
+              "gateway_group_id" => "0642e09d-b3a2-47e4-9cd1-c2195faeeb67"
+            }
+          ]
         }
       }
     })

--- a/elixir/apps/api/lib/api/schemas/resource_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/resource_schema.ex
@@ -39,8 +39,12 @@ defmodule API.Schemas.Resource do
       properties: %{
         resource: %Schema{
           anyOf: [
-            Resource.Schema,
-            %Schema{
+            Resource.Schema
+          ],
+          properties: %{
+            connections: %Schema{
+              title: "Connections",
+              description: "Gateway Groups to connect the Resource to",
               type: :array,
               items: %Schema{
                 type: :object,
@@ -49,7 +53,7 @@ defmodule API.Schemas.Resource do
                 }
               }
             }
-          ]
+          }
         }
       },
       required: [:resource],


### PR DESCRIPTION
Update Resource definition in OpenAPI spec to include "connections" i.e. which gateway groups/sites a new Resource would be connected to.

<img width="775" alt="Screenshot 2024-08-09 at 2 57 04 AM" src="https://github.com/user-attachments/assets/502979b1-e928-4e36-91c0-ed7b62f7c4a8">
