### PR TITLE
test(gui-client): add unit test for the elevation check

### DIFF
--- a/rust/gui-client/src-tauri/src/client/elevation.rs
+++ b/rust/gui-client/src-tauri/src/client/elevation.rs
@@ -112,6 +112,9 @@ mod imp {
     impl Drop for ProcessToken {
         fn drop(&mut self) {
             // SAFETY: We got `inner` from `OpenProcessToken` and didn't mutate it after that.
+            // Closing a pseudo-handle is a harmless no-op, though this is a real handle.
+            // <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess>
+            // > The pseudo handle need not be closed when it is no longer needed. Calling the CloseHandle function with a pseudo handle has no effect. If the pseudo handle is duplicated by DuplicateHandle, the duplicate handle must be closed.
             unsafe { CloseHandle(self.inner) }.expect("`CloseHandle` should always succeed");
             self.inner = HANDLE::default();
         }

--- a/rust/gui-client/src-tauri/src/client/elevation.rs
+++ b/rust/gui-client/src-tauri/src/client/elevation.rs
@@ -117,3 +117,12 @@ mod imp {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // Make sure it doesn't crash
+    #[test]
+    fn is_normal_user() {
+        super::is_normal_user().unwrap();
+    }
+}


### PR DESCRIPTION
This will always be elevated in CI, so just check that it doesn't crash.

This came up during debugging while I was offline, and I just want to make CI check for regressions, since there's a lot of `unsafe` code in the Windows impl