### PR TITLE
fix(gui-client): opening a window twice brings it to the foreground

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -770,8 +770,8 @@ impl Controller {
             .get_window(id)
             .context("Couldn't get handle to `{id}` window")?;
 
-        // Needed to bring shown windows to the front on Linux
-        // `request_user_attention` and `set_focus` don't work
+        // Needed to bring shown windows to the front
+        // `request_user_attention` and `set_focus` don't work, at least on Linux
         win.hide()?;
         // Needed to show windows that are completely hidden
         win.show()?;

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -770,8 +770,11 @@ impl Controller {
             .get_window(id)
             .context("Couldn't get handle to `{id}` window")?;
 
+        // Needed to bring shown windows to the front on Linux
+        // `request_user_attention` and `set_focus` don't work
+        win.hide()?;
+        // Needed to show windows that are completely hidden
         win.show()?;
-        win.unminimize()?;
         Ok(())
     }
 }


### PR DESCRIPTION
Closes #6231

Tested manually in Linux and Windows aarch64 VMs, works fine