### PR TITLE
ci: fix flaky integration test

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1191,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.0.1"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
 dependencies = [
  "crc-catalog",
 ]
@@ -5158,9 +5158,9 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6220f78bb44c15f326b0596113305f6101097a18755d53727a575c97e09fb24"
+checksum = "d4dea4fe3384a24652f065296ac333c810dfd0c5b39b98a2214762c16aaadc3c"
 dependencies = [
  "bytes",
  "crc",
@@ -5617,8 +5617,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.6.1"
-source = "git+https://github.com/algesten/str0m?branch=main#386c665b9801783c5840047ffd11025534069758"
+version = "0.6.2"
+source = "git+https://github.com/firezone/str0m?branch=main#94775f23167bd364ab7bd7f9bb96ddbe12a885ea"
 dependencies = [
  "combine",
  "crc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
 hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63", features = ["tokio-runtime"] }
 hickory-proto = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63" }
-str0m = { version = "0.6", default-features = false }
+str0m = { version = "0.6.2", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.10", features = ["serde"] }
 dns-lookup = "2.0"
@@ -74,7 +74,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }
-str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
+str0m = { git = "https://github.com/firezone/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "master" }


### PR DESCRIPTION
My attempts at fixing the flaky integration test with #6200 failed. Unfortunately, we need to go back to a fork of str0m to fix this. I am in discussion with the other maintainers on whether or not we can land this patch.

Diff to upstream `str0m`: https://github.com/algesten/str0m/compare/main...firezone:str0m:main
Example of a flaky test run: https://github.com/firezone/firezone/actions/runs/10328744448/job/28595705615?pr=6237

Related: https://github.com/algesten/str0m/pull/489.