### PR TITLE
revert: emit candidates in reverse-priority order

### DIFF
--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -15,4 +15,3 @@ pub use node::{
     Transmit, HANDSHAKE_TIMEOUT,
 };
 pub use stats::{ConnectionStats, NodeStats};
-pub use str0m::Candidate;

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1144,7 +1144,7 @@ fn add_local_candidate<TId>(
     if candidate.kind() == CandidateKind::ServerReflexive {
         pending_events.push_back(Event::NewIceCandidate {
             connection: id,
-            candidate,
+            candidate: candidate.to_sdp_string(),
         });
         return;
     }
@@ -1154,7 +1154,7 @@ fn add_local_candidate<TId>(
     if is_new {
         pending_events.push_back(Event::NewIceCandidate {
             connection: id,
-            candidate,
+            candidate: candidate.to_sdp_string(),
         })
     }
 }
@@ -1170,7 +1170,7 @@ fn remove_local_candidate<TId>(
     if candidate.kind() == CandidateKind::ServerReflexive {
         pending_events.push_back(Event::NewIceCandidate {
             connection: id,
-            candidate: candidate.clone(),
+            candidate: candidate.to_sdp_string(),
         });
         return;
     }
@@ -1180,7 +1180,7 @@ fn remove_local_candidate<TId>(
     if was_present {
         pending_events.push_back(Event::InvalidateIceCandidate {
             connection: id,
-            candidate: candidate.clone(),
+            candidate: candidate.to_sdp_string(),
         })
     }
 }
@@ -1209,7 +1209,7 @@ pub enum Event<TId> {
     /// Candidates are in SDP format although this may change and should be considered an implementation detail of the application.
     NewIceCandidate {
         connection: TId,
-        candidate: Candidate,
+        candidate: String,
     },
 
     /// We invalidated a candidate for this connection and ask to signal that to the remote party.
@@ -1217,7 +1217,7 @@ pub enum Event<TId> {
     /// Candidates are in SDP format although this may change and should be considered an implementation detail of the application.
     InvalidateIceCandidate {
         connection: TId,
-        candidate: Candidate,
+        candidate: String,
     },
 
     ConnectionEstablished(TId),

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -99,7 +99,9 @@ fn only_generate_candidate_event_after_answer() {
     assert!(iter::from_fn(|| alice.poll_event()).any(|ev| ev
         == Event::NewIceCandidate {
             connection: 1,
-            candidate: Candidate::host(local_candidate, Protocol::Udp).unwrap()
+            candidate: Candidate::host(local_candidate, Protocol::Udp)
+                .unwrap()
+                .to_sdp_string()
         }));
 }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -19,7 +19,7 @@ use ip_packet::{IpPacket, MutableIpPacket, Packet as _};
 use itertools::Itertools;
 
 use crate::peer::GatewayOnClient;
-use crate::utils::{self, earliest, turn, Candidates};
+use crate::utils::{self, earliest, turn};
 use crate::{ClientEvent, ClientTunnel, Tun};
 use domain::base::Message;
 use secrecy::{ExposeSecret as _, Secret};
@@ -864,8 +864,8 @@ impl ClientState {
 
     fn drain_node_events(&mut self) {
         let mut resources_changed = false; // Track this separately to batch together `ResourcesChanged` events.
-        let mut added_ice_candidates = BTreeMap::<GatewayId, Candidates>::default();
-        let mut removed_ice_candidates = BTreeMap::<GatewayId, Candidates>::default();
+        let mut added_ice_candidates = BTreeMap::<GatewayId, BTreeSet<String>>::default();
+        let mut removed_ice_candidates = BTreeMap::<GatewayId, BTreeSet<String>>::default();
 
         while let Some(event) = self.node.poll_event() {
             match event {
@@ -880,7 +880,7 @@ impl ClientState {
                     added_ice_candidates
                         .entry(connection)
                         .or_default()
-                        .push(candidate);
+                        .insert(candidate);
                 }
                 snownet::Event::InvalidateIceCandidate {
                     connection,
@@ -889,7 +889,7 @@ impl ClientState {
                     removed_ice_candidates
                         .entry(connection)
                         .or_default()
-                        .push(candidate);
+                        .insert(candidate);
                 }
                 snownet::Event::ConnectionEstablished(id) => {
                     self.update_site_status_by_gateway(&id, Status::Online);
@@ -909,7 +909,7 @@ impl ClientState {
             self.buffered_events
                 .push_back(ClientEvent::AddedIceCandidates {
                     conn_id,
-                    candidates: candidates.serialize(),
+                    candidates,
                 })
         }
 
@@ -917,7 +917,7 @@ impl ClientState {
             self.buffered_events
                 .push_back(ClientEvent::RemovedIceCandidates {
                     conn_id,
-                    candidates: candidates.serialize(),
+                    candidates,
                 })
         }
     }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -1,6 +1,6 @@
 use crate::peer::ClientOnGateway;
 use crate::peer_store::PeerStore;
-use crate::utils::{earliest, Candidates};
+use crate::utils::earliest;
 use crate::{GatewayEvent, GatewayTunnel};
 use boringtun::x25519::PublicKey;
 use chrono::{DateTime, Utc};
@@ -347,8 +347,8 @@ impl GatewayState {
             Some(_) => {}
         }
 
-        let mut added_ice_candidates = BTreeMap::<ClientId, Candidates>::default();
-        let mut removed_ice_candidates = BTreeMap::<ClientId, Candidates>::default();
+        let mut added_ice_candidates = BTreeMap::<ClientId, BTreeSet<String>>::default();
+        let mut removed_ice_candidates = BTreeMap::<ClientId, BTreeSet<String>>::default();
 
         while let Some(event) = self.node.poll_event() {
             match event {
@@ -362,7 +362,7 @@ impl GatewayState {
                     added_ice_candidates
                         .entry(connection)
                         .or_default()
-                        .push(candidate);
+                        .insert(candidate);
                 }
                 snownet::Event::InvalidateIceCandidate {
                     connection,
@@ -371,7 +371,7 @@ impl GatewayState {
                     removed_ice_candidates
                         .entry(connection)
                         .or_default()
-                        .push(candidate);
+                        .insert(candidate);
                 }
                 snownet::Event::ConnectionEstablished(_) => {}
             }
@@ -381,7 +381,7 @@ impl GatewayState {
             self.buffered_events
                 .push_back(GatewayEvent::AddedIceCandidates {
                     conn_id,
-                    candidates: candidates.serialize(),
+                    candidates,
                 })
         }
 
@@ -389,7 +389,7 @@ impl GatewayState {
             self.buffered_events
                 .push_back(GatewayEvent::RemovedIceCandidates {
                     conn_id,
-                    candidates: candidates.serialize(),
+                    candidates,
                 })
         }
     }

--- a/rust/tests/snownet-tests/src/main.rs
+++ b/rust/tests/snownet-tests/src/main.rs
@@ -387,7 +387,7 @@ impl<T> Eventloop<T> {
             }) => {
                 return Poll::Ready(Ok(Event::SignalIceCandidate {
                     conn: connection,
-                    candidate: candidate.to_sdp_string(),
+                    candidate,
                 }))
             }
             Some(snownet::Event::ConnectionEstablished(conn)) => {


### PR DESCRIPTION
This ended up not fixing anything and the order is now guaranteed to be deterministic due to an upstream change.

Related: https://github.com/algesten/str0m/pull/557.
Reverts: #6200.