### PR TITLE
feat(relay): set OTEL metadata for metrics and traces

### DIFF
--- a/rust/docker-init-relay.sh
+++ b/rust/docker-init-relay.sh
@@ -25,9 +25,10 @@ if [ "${OTEL_METADATA_DISCOVERY_METHOD}" = "gce_metadata" ]; then
     echo "Using GCE metadata to set OTEL metadata"
 
     instance_id=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google" -s)
-    export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=${instance_id}"
-    echo "Discovered OTEL metadata: ${OTEL_RESOURCE_ATTRIBUTES}"
+    instance_name=$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google" -s)
 
+    export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=${instance_id},gcp.gce.instance.name=${instance_name}"
+    echo "Discovered OTEL metadata: ${OTEL_RESOURCE_ATTRIBUTES}"
 fi
 
 exec "$@"

--- a/rust/docker-init-relay.sh
+++ b/rust/docker-init-relay.sh
@@ -21,4 +21,13 @@ if [ "${LISTEN_ADDRESS_DISCOVERY_METHOD}" = "gce_metadata" ]; then
     fi
 fi
 
+if [ "${OTEL_METADATA_DISCOVERY_METHOD}" = "gce_metadata" ]; then
+    echo "Using GCE metadata to set OTEL metadata"
+
+    instance_id=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google" -s)
+    export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=${instance_id}"
+    echo "Discovered OTEL metadata: ${OTEL_RESOURCE_ATTRIBUTES}"
+
+fi
+
 exec "$@"

--- a/rust/docker-init-relay.sh
+++ b/rust/docker-init-relay.sh
@@ -27,6 +27,9 @@ if [ "${OTEL_METADATA_DISCOVERY_METHOD}" = "gce_metadata" ]; then
     instance_id=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google" -s)
     instance_name=$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google" -s)
 
+    # Source for attribute names:
+    # - https://opentelemetry.io/docs/specs/semconv/attributes-registry/service/
+    # - https://opentelemetry.io/docs/specs/semconv/attributes-registry/gcp/#gcp---google-compute-engine-gce-attributes:
     export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=${instance_id},gcp.gce.instance.name=${instance_name}"
     echo "Discovered OTEL metadata: ${OTEL_RESOURCE_ATTRIBUTES}"
 fi

--- a/rust/relay/README.md
+++ b/rust/relay/README.md
@@ -53,6 +53,16 @@ STUN/TURN. Additionally, the relay needs to have access to the port range
 When given a `token`, the relay will connect to the Firezone portal and wait for
 an `init` message before commencing relay operations.
 
+### Metrics
+
+The relay parses the `OTLP_GRPC_ENDPOINT` env variable.
+Traces and metrics will be sent to an OTLP collector listening on that endpoint.
+
+It is recommended to set additional environment variables to scope your metrics:
+
+- `OTEL_SERVICE_NAME`: Translates to the `service.name`.
+- `OTEL_RESOURCE_ATTRIBUTES`: Additional, comma-separated key=value attributes.
+
 ## Design
 
 The relay is designed in a sans-IO fashion, meaning the core components do not

--- a/rust/relay/README.md
+++ b/rust/relay/README.md
@@ -63,6 +63,15 @@ It is recommended to set additional environment variables to scope your metrics:
 - `OTEL_SERVICE_NAME`: Translates to the `service.name`.
 - `OTEL_RESOURCE_ATTRIBUTES`: Additional, comma-separated key=value attributes.
 
+By default, we set the following OTEL attributes:
+
+- `service.name=relay`
+- `service.namespace=firezone`
+
+The [`docker-init-relay.sh`](../docker-init-relay.sh) script integrates with GCE.
+When `OTEL_METADATA_DISCOVERY_METHOD=gce_metadata`, the `service.instance.id`
+variables is set to the instance ID of the VM.
+
 ## Design
 
 The relay is designed in a sans-IO fashion, meaning the core components do not

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -199,10 +199,6 @@ fn setup_tracing(args: &Args) -> Result<()> {
             let tracer_provider = opentelemetry_otlp::new_pipeline()
                 .tracing()
                 .with_exporter(exporter)
-                .with_trace_config(
-                    Config::default()
-                        .with_resource(Resource::new(vec![KeyValue::new("service.name", "relay")])),
-                )
                 .install_batch(Tokio)
                 .context("Failed to create OTLP trace pipeline")?;
             global::set_tracer_provider(tracer_provider.clone());
@@ -215,6 +211,7 @@ fn setup_tracing(args: &Args) -> Result<()> {
 
             let meter_provider = opentelemetry_otlp::new_pipeline()
                 .metrics(Tokio)
+                .with_resource(Resource::default())
                 .with_exporter(exporter)
                 .build()
                 .context("Failed to create OTLP metrics pipeline")?;

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -42,10 +42,6 @@ locals {
       value = "127.0.0.1:4317"
     },
     {
-      name  = "OTEL_SERVICE_NAME"
-      value = local.application_name
-    },
-    {
       name  = "FIREZONE_TOKEN"
       value = var.token
     },

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -38,6 +38,10 @@ locals {
       value = "127.0.0.1:4317"
     },
     {
+      name  = "OTEL_SERVICE_NAME"
+      value = local.application_name
+    },
+    {
       name  = "FIREZONE_TOKEN"
       value = var.token
     },

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -18,6 +18,10 @@ locals {
       value = "gce_metadata"
     },
     {
+      name  = "OTEL_METADATA_DISCOVERY_METHOD"
+      value = "gce_metadata"
+    },
+    {
       name  = "RUST_LOG"
       value = var.observability_log_level
     },


### PR DESCRIPTION
I recently discovered that the metrics reporting to Google Cloud Metrics for the relays is actually working. Unfortunately, they are all bucketed together because we don't set the metadata correctly.

This PR aims to fix that be setting some useful default metadata for traces and metrics and additionally, discoveres instance ID and name from GCE metadata.

Related: #2033.