### PR TITLE
fix: backwards-compatible DNS resource addresses for gateways

### DIFF
--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -751,8 +751,8 @@ IO.puts("")
   Resources.create_resource(
     %{
       type: :dns,
-      name: "*.httpbin",
-      address: "*.httpbin",
+      name: "**.httpbin",
+      address: "**.httpbin",
       address_description: "http://httpbin/",
       connections: [%{gateway_group_id: gateway_group.id}],
       filters: [


### PR DESCRIPTION
In #6214, we introduced a new wildcard format for DNS addresses. For clients with a version < 1.2, the addresses get mapped back to the old format on the fly where possible. We forgot that the same thing needs to happen for gateways as those also match against the address as part of connection setup.