### PR TITLE
chore(connlib): better logging of resource activation

### DIFF
--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -11,6 +11,7 @@ bytes = { version = "1.4", default-features = false, features = ["std"] }
 chrono = { workspace = true }
 connlib-shared = { workspace = true }
 domain = { workspace = true }
+firezone-logging = { workspace = true }
 futures =  { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
 futures-util =  { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }
 hex = "0.4.3"

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -112,23 +112,14 @@ impl StubResolver {
         Some((fqdn, self.fqdn_to_ips.get(fqdn).unwrap()))
     }
 
-    pub(crate) fn add_resource(&mut self, id: ResourceId, address: String) {
-        let existing = self.dns_resources.insert(address.clone(), id);
+    pub(crate) fn add_resource(&mut self, id: ResourceId, address: String) -> bool {
+        let existing = self.dns_resources.insert(address, id);
 
-        if existing.is_none() {
-            tracing::info!(%address, "Activating DNS resource");
-        }
+        existing.is_none()
     }
 
     pub(crate) fn remove_resource(&mut self, id: ResourceId) {
-        self.dns_resources.retain(|address, r| {
-            if *r == id {
-                tracing::info!(%address, "Deactivating DNS resource");
-                return false;
-            }
-
-            true
-        });
+        self.dns_resources.retain(|_, r| *r != id);
     }
 
     fn get_or_assign_a_records(


### PR DESCRIPTION
Currently, the logging for which resources get activated and de-activated is spread between the `dns` and `client` module. It also doesn't include the sites that the resource is defined in.

The name of a resource alone is not enough to unique identify it. To fix both of these papercuts, we move the logging to the `client` module and include the sites in the log message.

The log messages now read like this:

```
2024-08-12T02:26:01.477844Z  INFO firezone_tunnel::client: Activating resource name=IPerf3 address=10.0.32.101/32 sites=AWS Dev (Gateways track `main`)
2024-08-12T02:26:01.477904Z  INFO firezone_tunnel::client: Activating resource name=*.slack.com address=*.slack.com sites=Vultr Stable (Latest Release Gateways)
2024-08-12T02:26:01.477942Z  INFO firezone_tunnel::client: Activating resource name=*.slack-edge.com address=*.slack-edge.com sites=Vultr Stable (Latest Release Gateways)
2024-08-12T02:26:01.477984Z  INFO firezone_tunnel::client: Activating resource name=*.spotify.com address=*.spotify.com sites=AWS Dev (Gateways track `main`)
```