### PR TITLE
chore(connlib): don't duplicate log for optional fields

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1010,13 +1010,10 @@ impl ClientState {
         }
 
         let name = new_resource.name();
-        let address = new_resource.address_string();
+        let address = new_resource.address_string().map(tracing::field::display);
         let sites = new_resource.sites_string();
 
-        match address {
-            Some(address) => tracing::info!(%name, %address, %sites, "Activating resource"),
-            None => tracing::info!(%name, %sites, "Activating resource"),
-        }
+        tracing::info!(%name, address, %sites, "Activating resource");
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(?id))]
@@ -1037,13 +1034,10 @@ impl ClientState {
         }
 
         let name = resource.name();
-        let address = resource.address_string();
+        let address = resource.address_string().map(tracing::field::display);
         let sites = resource.sites_string();
 
-        match address {
-            Some(address) => tracing::info!(%name, %address, %sites, "Deactivating resource"),
-            None => tracing::info!(%name, %sites, "Deactivating resource"),
-        }
+        tracing::info!(%name, address, %sites, "Deactivating resource");
 
         self.awaiting_connection_details.remove(&id);
 


### PR DESCRIPTION
Instead of conditionally composing the log message, we can `.map` the `Option` to a `DisplayValue` and **omit** the `%` sigil.

Related: https://github.com/tokio-rs/tracing/issues/3054.