### PR TITLE
fix(snownet): invalidate allocation on channel binding error

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1898,7 +1898,7 @@ mod tests {
         allocation.refresh_with_same_credentials();
 
         let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input_ip4(&failed_refresh(&refresh), Instant::now());
+        allocation.handle_test_input_ip4(&allocation_mismatch(&refresh), Instant::now());
 
         assert_eq!(
             allocation.poll_event(),
@@ -1943,7 +1943,7 @@ mod tests {
         allocation.refresh_with_same_credentials();
 
         let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input_ip4(&failed_refresh(&refresh), Instant::now());
+        allocation.handle_test_input_ip4(&allocation_mismatch(&refresh), Instant::now());
 
         let msg = allocation.encode_to_owned_transmit(PEER2_IP4, b"foobar", Instant::now());
         assert!(msg.is_none(), "expect to no longer have a channel to peer");
@@ -1978,7 +1978,7 @@ mod tests {
         allocation.handle_test_input_ip4(&binding_response(&binding, PEER1), Instant::now());
 
         let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input_ip4(&failed_refresh(&refresh), Instant::now());
+        allocation.handle_test_input_ip4(&allocation_mismatch(&refresh), Instant::now());
 
         let allocate = allocation.next_message().unwrap();
         assert_eq!(allocate.method(), ALLOCATE);
@@ -2035,7 +2035,7 @@ mod tests {
         allocation.advance_to_next_timeout();
 
         let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input_ip4(&failed_refresh(&refresh), Instant::now());
+        allocation.handle_test_input_ip4(&allocation_mismatch(&refresh), Instant::now());
 
         let allocate = allocation.next_message().unwrap();
         allocation.handle_test_input_ip4(&server_error(&allocate), Instant::now()); // These ones are not retried.
@@ -2491,10 +2491,10 @@ mod tests {
         encode(message)
     }
 
-    fn failed_refresh(request: &Message<Attribute>) -> Vec<u8> {
+    fn allocation_mismatch(request: &Message<Attribute>) -> Vec<u8> {
         let mut message = Message::new(
             MessageClass::ErrorResponse,
-            REFRESH,
+            request.method(),
             request.transaction_id(),
         );
         message.add_attribute(ErrorCode::from(AllocationMismatch));

--- a/rust/connlib/snownet/src/ringbuffer.rs
+++ b/rust/connlib/snownet/src/ringbuffer.rs
@@ -42,6 +42,17 @@ impl<T: PartialEq> RingBuffer<T> {
     }
 }
 
+impl<T> Extend<T> for RingBuffer<T>
+where
+    T: PartialEq,
+{
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for val in iter.into_iter() {
+            self.push(val)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,9 @@ export default function Android() {
           <ChangeItem pull="6276">
             Fixes a bug where relayed connections failed to establish after an idle period.
           </ChangeItem>
+          <ChangeItem pull="6277">
+            Fixes a bug where restrictive NATs caused connectivity problems.
+          </ChangeItem>
         </ul>
       </Entry>
 	  */}

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -14,6 +14,9 @@ export default function Apple() {
           <ChangeItem pull="6276">
             Fixes a bug where relayed connections failed to establish after an idle period.
           </ChangeItem>
+          <ChangeItem pull="6277">
+            Fixes a bug where restrictive NATs caused connectivity problems.
+          </ChangeItem>
         </ul>
       </Entry> */}
       <Entry version="1.1.4" date={new Date("2024-08-10")}>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -21,6 +21,9 @@ export default function GUI({ title }: { title: string }) {
           <ChangeItem pull="6276">
             Fixes a bug where relayed connections failed to establish after an idle period.
           </ChangeItem>
+          <ChangeItem pull="6277">
+            Fixes a bug where restrictive NATs caused connectivity problems.
+          </ChangeItem>
         </ul>
       </Entry>
       */}

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -14,6 +14,9 @@ export default function Gateway() {
           <ChangeItem pull="6276">
             Fixes a bug where relayed connections failed to establish after an idle period.
           </ChangeItem>
+          <ChangeItem pull="6277">
+            Fixes a bug where restrictive NATs caused connectivity problems.
+          </ChangeItem>
         </ul>
       </Entry>
       */}

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -15,6 +15,9 @@ export default function Headless() {
           <ChangeItem pull="6276">
             Fixes a bug where relayed connections failed to establish after an idle period.
           </ChangeItem>
+          <ChangeItem pull="6277">
+            Fixes a bug where restrictive NATs caused connectivity problems.
+          </ChangeItem>
         </ul>
       </Entry>
       */}


### PR DESCRIPTION
When we receive an `AllocationMismatch` error response from the relay, it means that our local state is toast and needs to be invalidated.

- If we attempted to allocate, the corrective action is to delete the active allocation.
- If we attempted to refresh or bind a channel, the corrective action is to make a new allocation.

In the case of a channel binding, we also re-schedule the target peer to be rebound to ensure upper layers don't need to retry that. For example, if this happens during a connection setup, we still want to eventually succeed in binding the channel to ensure STUN messages as part of ICE can pass over it without having to first run into an ICE timeout and retry the entire connection.

In certain network configurations, we observed that the NAT between connlib and the relay may have fairly short session timers. Currently, allocations have a lifetime of 10 minutes and are refreshed every 5 minutes. If there is no other traffic from connlib during those 5 minutes, the NAT session might get cut and attempting to use the allocation to e.g. bind a channel doesn't work because the relay doesn't recognise the 3-tuple.

We deem these situations quite rare. Instead of keeping the NAT session alive with additional traffic, we instead implement this corrective action here which transparently creates a new allocation using our new 3-tuple.

Resolves: #6265.