### PR TITLE
feat(snownet,relay): include sticky session ID in STUN requests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5511,6 +5511,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "secrecy",
+ "sha2",
  "str0m",
  "stun_codec",
  "thiserror",

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -14,6 +14,7 @@ ip-packet = { workspace = true }
 once_cell = "1.17.1"
 rand = "0.8"
 secrecy = { workspace = true }
+sha2 = "0.10.8"
 str0m = { workspace = true }
 stun_codec = "0.3.4"
 thiserror = "1"

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -24,7 +24,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeInclusive;
 use std::time::{Duration, Instant, SystemTime};
 use stun_codec::rfc5389::attributes::{
-    ErrorCode, MessageIntegrity, Nonce, Realm, Username, XorMappedAddress,
+    ErrorCode, MessageIntegrity, Nonce, Realm, Software, Username, XorMappedAddress,
 };
 use stun_codec::rfc5389::errors::{BadRequest, StaleNonce, Unauthorized};
 use stun_codec::rfc5389::methods::BINDING;
@@ -416,7 +416,7 @@ where
         }
     }
 
-    #[tracing::instrument(level = "info", skip_all, fields(tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
+    #[tracing::instrument(level = "info", skip_all, fields(software = request.software().map(|s| field::display(s.description())), tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
     fn handle_binding_request(&mut self, request: Binding, sender: ClientSocket) {
         let mut message = Message::new(
             MessageClass::SuccessResponse,
@@ -433,7 +433,7 @@ where
     /// Handle a TURN allocate request.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc8656#name-receiving-an-allocate-reque> for details.
-    #[tracing::instrument(level = "info", skip_all, fields(allocation, tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
+    #[tracing::instrument(level = "info", skip_all, fields(allocation, software = request.software().map(|s| field::display(s.description())), tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
     fn handle_allocate_request(
         &mut self,
         request: Allocate,
@@ -552,7 +552,7 @@ where
     /// Handle a TURN refresh request.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc8656#name-receiving-a-refresh-request> for details.
-    #[tracing::instrument(level = "info", skip_all, fields(allocation, tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
+    #[tracing::instrument(level = "info", skip_all, fields(allocation, software = request.software().map(|s| field::display(s.description())), tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
     fn handle_refresh_request(
         &mut self,
         request: Refresh,
@@ -601,7 +601,7 @@ where
     /// Handle a TURN channel bind request.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc8656#name-receiving-a-channelbind-req> for details.
-    #[tracing::instrument(level = "info", skip_all, fields(allocation, peer, channel, tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
+    #[tracing::instrument(level = "info", skip_all, fields(allocation, peer, channel, software = request.software().map(|s| field::display(s.description())), tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
     fn handle_channel_bind_request(
         &mut self,
         request: ChannelBind,
@@ -705,7 +705,7 @@ where
     ///
     /// This TURN server implementation does not support relaying data other than through channels.
     /// Thus, creating a permission is a no-op that always succeeds.
-    #[tracing::instrument(level = "info", skip_all, fields(tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
+    #[tracing::instrument(level = "info", skip_all, fields(software = request.software().map(|s| field::display(s.description())), tid = %format_args!("{:X}", request.transaction_id().as_bytes().hex()), %sender))]
     fn handle_create_permission_request(
         &mut self,
         request: CreatePermission,
@@ -1270,7 +1270,8 @@ stun_codec::define_attribute_enums!(
         Realm,
         Username,
         RequestedAddressFamily,
-        AdditionalAddressFamily
+        AdditionalAddressFamily,
+        Software
     ]
 );
 


### PR DESCRIPTION
For most cases, TURN identifies clients by their 3-tuple. This can make it hard to correlate logs in case the client roams or its NAT session gets reset, both of which cause the port to change.

To make problem analysis easier, we include the RFC-recommended `SOFTWARE` attribute in all STUN requests created by `snownet`. Typically, this includes a textual description of who sent the request and a version number. See [0] for details. We don't track the version of `snownet` individually and passing the actual client-version across this many layers is deemed too complicated for now.

What we can add though is a parameter that includes a sticky session ID. This session ID is computed based on the `Node`'s public key, meaning it doesn't change until the user logs-out and in again.

On the relay, we now look for a `SOFTWARE` attribute in all STUN requests and optionally include it in all spans if it is present.

[0]: https://datatracker.ietf.org/doc/html/rfc5389#section-15.10