### PR TITLE
fix(portal): Clarify how synced users count against billing

### DIFF
--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -230,7 +230,7 @@ defmodule Web.Groups.Show do
                 >
                   Add a policy
                 </.link>
-                to grant access to a resource.
+                to grant this Group access to Resources.
               </div>
             </div>
           </:empty>

--- a/elixir/apps/web/lib/web/live/policies/index.ex
+++ b/elixir/apps/web/lib/web/live/policies/index.ex
@@ -99,7 +99,7 @@ defmodule Web.Policies.Index do
                 <.link class={[link_style()]} navigate={~p"/#{@account}/policies/new"}>
                   Add a policy
                 </.link>
-                to grant access to a resource.
+                to grant access to Resources.
               </div>
             </div>
           </:empty>

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -92,7 +92,7 @@ defmodule Web.Policies.New do
                   field={@form[:description]}
                   label="Description"
                   type="textarea"
-                  placeholder="Optionally, enter a reason for creating a policy here."
+                  placeholder="Why are you creating this policy?"
                   phx-debounce="300"
                 />
               </fieldset>

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -92,7 +92,7 @@ defmodule Web.Policies.New do
                   field={@form[:description]}
                   label="Description"
                   type="textarea"
-                  placeholder="Why are you creating this policy?"
+                  placeholder="Enter an optional reason for creating this policy here."
                   phx-debounce="300"
                 />
               </fieldset>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -239,7 +239,7 @@ defmodule Web.Resources.Show do
                 >
                   Add a policy
                 </.link>
-                to grant access to a resource.
+                to grant access to this Resource.
               </div>
             </div>
           </:empty>

--- a/elixir/apps/web/lib/web/live/settings/billing.ex
+++ b/elixir/apps/web/lib/web/live/settings/billing.ex
@@ -131,7 +131,7 @@ defmodule Web.Settings.Billing do
                 <%= @active_users_count %> used
               </span>
               / <%= @account.limits.monthly_active_users_count %> allowed
-              <p class="text-xs">users with at least one device signed-in within last month</p>
+              <p class="text-xs">Users that have signed in from a device within the last month</p>
             </:value>
           </.vertical_table_row>
 

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/components.ex
@@ -201,6 +201,16 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Components do
                   </p>
                 </div>
               </.inputs_for>
+
+              <p class="text-sm text-neutral-500">
+                <strong>Note:</strong>
+                Only active users count towards your billing limits.
+                See your
+                <.link navigate={~p"/#{@account}/settings/billing"} class={link_style()}>
+                  billing page
+                </.link>
+                for more information.
+              </p>
             </div>
 
             <.submit_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/components.ex
@@ -83,15 +83,13 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Components do
                   </p>
                 </div>
 
-                <div class="hidden">
-                  <.input
-                    type="hidden"
-                    label="Discovery Document URI"
-                    autocomplete="off"
-                    field={adapter_config_form[:discovery_document_uri]}
-                    value="https://oauth.id.jumpcloud.com/.well-known/openid-configuration"
-                  />
-                </div>
+                <.input
+                  type="hidden"
+                  label="Discovery Document URI"
+                  autocomplete="off"
+                  field={adapter_config_form[:discovery_document_uri]}
+                  value="https://oauth.id.jumpcloud.com/.well-known/openid-configuration"
+                />
               </.inputs_for>
 
               <p class="text-sm text-neutral-500">

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/components.ex
@@ -83,7 +83,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Components do
                   </p>
                 </div>
 
-                <div>
+                <div class="hidden">
                   <.input
                     type="hidden"
                     label="Discovery Document URI"
@@ -93,6 +93,16 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Components do
                   />
                 </div>
               </.inputs_for>
+
+              <p class="text-sm text-neutral-500">
+                <strong>Note:</strong>
+                Only active users count towards your billing limits.
+                See your
+                <.link navigate={~p"/#{@account}/settings/billing"} class={link_style()}>
+                  billing page
+                </.link>
+                for more information.
+              </p>
             </div>
 
             <.submit_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/components.ex
@@ -96,6 +96,16 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Components do
                   </p>
                 </div>
               </.inputs_for>
+
+              <p class="text-sm text-neutral-500">
+                <strong>Note:</strong>
+                Only active users count towards your billing limits.
+                See your
+                <.link navigate={~p"/#{@account}/settings/billing"} class={link_style()}>
+                  billing page
+                </.link>
+                for more information.
+              </p>
             </div>
 
             <.submit_button>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/components.ex
@@ -106,6 +106,16 @@ defmodule Web.Settings.IdentityProviders.Okta.Components do
                   </p>
                 </div>
               </.inputs_for>
+
+              <p class="text-sm text-neutral-500">
+                <strong>Note:</strong>
+                Only active users count towards your billing limits.
+                See your
+                <.link navigate={~p"/#{@account}/settings/billing"} class={link_style()}>
+                  billing page
+                </.link>
+                for more information.
+              </p>
             </div>
 
             <.submit_button>

--- a/website/src/app/kb/reference/faq/readme.mdx
+++ b/website/src/app/kb/reference/faq/readme.mdx
@@ -187,6 +187,18 @@ does not require a credit card to get started.
 
 To cancel or change plans, [contact support](mailto:support@firezone.dev).
 
+#### How many seats do I need?
+
+You need one seat for each user who will need access to Firezone. On the Team
+plan, you can manage the number of billed seats in the Account settings page in
+your admin portal.
+
+On the Enterprise plan, you can add or remove seats by contacting your account
+manager. Note that directory sync does not affect your Enterprise bill - only
+active users are counted towards your seat count for billing purposes.
+Enterprise accounts are **never** locked or suspended for exceeding their seat
+count.
+
 ## Security
 
 #### What firewall ports do I have to open to use Firezone?


### PR DESCRIPTION
Fixes #6155 

One question we get with almost each new customer is "if I enable sync, won't that count towards my bill?". This PR aims to answer that question right when they create the provider.

I will also make sure to update Enterprise accounts in Stripe with `monthly_active_users_acount` so that they can view this metric on the Billing page.