### PR TITLE
feat(portal): Allow Policies to be searched by Resource/Group

### DIFF
--- a/elixir/apps/domain/lib/domain/policies/policy/query.ex
+++ b/elixir/apps/domain/lib/domain/policies/policy/query.ex
@@ -126,18 +126,6 @@ defmodule Domain.Policies.Policy.Query do
         fun: &filter_by_actor_group_id/2
       },
       %Domain.Repo.Filter{
-        name: :actor_group_name,
-        title: "Actor Group Name",
-        type: {:string, :websearch},
-        fun: &filter_by_actor_group_name/2
-      },
-      %Domain.Repo.Filter{
-        name: :resource_name,
-        title: "Resource Name",
-        type: {:string, :websearch},
-        fun: &filter_by_resource_name/2
-      },
-      %Domain.Repo.Filter{
         name: :group_or_resource_name,
         title: "Group Name or Resource Name",
         type: {:string, :websearch},
@@ -166,36 +154,6 @@ defmodule Domain.Policies.Policy.Query do
 
   def filter_by_actor_group_id(queryable, actor_group_id) do
     {queryable, dynamic([policies: policies], policies.actor_group_id == ^actor_group_id)}
-  end
-
-  def filter_by_actor_group_name(queryable, actor_group_name) do
-    queryable =
-      with_named_binding(queryable, :actor_group, fn queryable, binding ->
-        join(queryable, :inner, [policies: policies], actor_group in assoc(policies, ^binding),
-          as: ^binding
-        )
-      end)
-
-    {queryable,
-     dynamic(
-       [actor_group: actor_group],
-       ilike(actor_group.name, ^"%#{actor_group_name}%")
-     )}
-  end
-
-  def filter_by_resource_name(queryable, resource_name) do
-    queryable =
-      with_named_binding(queryable, :resource, fn queryable, binding ->
-        join(queryable, :inner, [policies: policies], resource in assoc(policies, ^binding),
-          as: ^binding
-        )
-      end)
-
-    {queryable,
-     dynamic(
-       [resource: resource],
-       ilike(resource.name, ^"%#{resource_name}%")
-     )}
   end
 
   def filter_by_group_or_resource_name(queryable, name) do

--- a/elixir/apps/domain/lib/domain/policies/policy/query.ex
+++ b/elixir/apps/domain/lib/domain/policies/policy/query.ex
@@ -126,6 +126,18 @@ defmodule Domain.Policies.Policy.Query do
         fun: &filter_by_actor_group_id/2
       },
       %Domain.Repo.Filter{
+        name: :actor_group_name,
+        title: "Actor Group Name",
+        type: {:string, :websearch},
+        fun: &filter_by_actor_group_name/2
+      },
+      %Domain.Repo.Filter{
+        name: :resource_name,
+        title: "Resource Name",
+        type: {:string, :websearch},
+        fun: &filter_by_resource_name/2
+      },
+      %Domain.Repo.Filter{
         name: :group_or_resource_name,
         title: "Group Name or Resource Name",
         type: {:string, :websearch},
@@ -154,6 +166,36 @@ defmodule Domain.Policies.Policy.Query do
 
   def filter_by_actor_group_id(queryable, actor_group_id) do
     {queryable, dynamic([policies: policies], policies.actor_group_id == ^actor_group_id)}
+  end
+
+  def filter_by_actor_group_name(queryable, actor_group_name) do
+    queryable =
+      with_named_binding(queryable, :actor_group, fn queryable, binding ->
+        join(queryable, :inner, [policies: policies], actor_group in assoc(policies, ^binding),
+          as: ^binding
+        )
+      end)
+
+    {queryable,
+     dynamic(
+       [actor_group: actor_group],
+       ilike(actor_group.name, ^"%#{actor_group_name}%")
+     )}
+  end
+
+  def filter_by_resource_name(queryable, resource_name) do
+    queryable =
+      with_named_binding(queryable, :resource, fn queryable, binding ->
+        join(queryable, :inner, [policies: policies], resource in assoc(policies, ^binding),
+          as: ^binding
+        )
+      end)
+
+    {queryable,
+     dynamic(
+       [resource: resource],
+       ilike(resource.name, ^"%#{resource_name}%")
+     )}
   end
 
   def filter_by_group_or_resource_name(queryable, name) do

--- a/elixir/apps/domain/lib/domain/policies/policy/query.ex
+++ b/elixir/apps/domain/lib/domain/policies/policy/query.ex
@@ -126,6 +126,24 @@ defmodule Domain.Policies.Policy.Query do
         fun: &filter_by_actor_group_id/2
       },
       %Domain.Repo.Filter{
+        name: :actor_group_name,
+        title: "Actor Group Name",
+        type: {:string, :websearch},
+        fun: &filter_by_actor_group_name/2
+      },
+      %Domain.Repo.Filter{
+        name: :resource_name,
+        title: "Resource Name",
+        type: {:string, :websearch},
+        fun: &filter_by_resource_name/2
+      },
+      %Domain.Repo.Filter{
+        name: :group_or_resource_name,
+        title: "Group Name or Resource Name",
+        type: {:string, :websearch},
+        fun: &filter_by_group_or_resource_name/2
+      },
+      %Domain.Repo.Filter{
         name: :status,
         title: "Status",
         type: :string,
@@ -148,6 +166,58 @@ defmodule Domain.Policies.Policy.Query do
 
   def filter_by_actor_group_id(queryable, actor_group_id) do
     {queryable, dynamic([policies: policies], policies.actor_group_id == ^actor_group_id)}
+  end
+
+  def filter_by_actor_group_name(queryable, actor_group_name) do
+    queryable =
+      with_named_binding(queryable, :actor_group, fn queryable, binding ->
+        join(queryable, :inner, [policies: policies], actor_group in assoc(policies, ^binding),
+          as: ^binding
+        )
+      end)
+
+    {queryable,
+     dynamic(
+       [actor_group: actor_group],
+       ilike(actor_group.name, ^"%#{actor_group_name}%")
+     )}
+  end
+
+  def filter_by_resource_name(queryable, resource_name) do
+    queryable =
+      with_named_binding(queryable, :resource, fn queryable, binding ->
+        join(queryable, :inner, [policies: policies], resource in assoc(policies, ^binding),
+          as: ^binding
+        )
+      end)
+
+    {queryable,
+     dynamic(
+       [resource: resource],
+       ilike(resource.name, ^"%#{resource_name}%")
+     )}
+  end
+
+  def filter_by_group_or_resource_name(queryable, name) do
+    queryable =
+      queryable
+      |> with_named_binding(:resource, fn queryable, binding ->
+        join(queryable, :inner, [policies: policies], resource in assoc(policies, ^binding),
+          as: ^binding
+        )
+      end)
+      |> with_named_binding(:actor_group, fn queryable, binding ->
+        join(queryable, :inner, [policies: policies], actor_group in assoc(policies, ^binding),
+          as: ^binding
+        )
+      end)
+
+    {queryable,
+     dynamic(
+       [actor_group: actor_group, resource: resource],
+       ilike(actor_group.name, ^"%#{name}%") or
+         ilike(resource.name, ^"%#{name}%")
+     )}
   end
 
   def filter_by_status(queryable, "active") do

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -29,7 +29,11 @@ defmodule Web.Groups.Show do
         )
         |> assign_live_table("policies",
           query_module: Policies.Policy.Query,
-          hide_filters: [:resource_id],
+          hide_filters: [
+            :resource_id,
+            :actor_group_name,
+            :group_or_resource_name
+          ],
           enforce_filters: [
             {:actor_group_id, group.id}
           ],

--- a/elixir/apps/web/lib/web/live/policies/index.ex
+++ b/elixir/apps/web/lib/web/live/policies/index.ex
@@ -15,9 +15,7 @@ defmodule Web.Policies.Index do
         sortable_fields: [],
         hide_filters: [
           :actor_group_id,
-          :actor_group_name,
-          :resource_id,
-          :resource_name
+          :resource_id
         ],
         callback: &handle_policies_update!/2
       )

--- a/elixir/apps/web/lib/web/live/policies/index.ex
+++ b/elixir/apps/web/lib/web/live/policies/index.ex
@@ -15,7 +15,9 @@ defmodule Web.Policies.Index do
         sortable_fields: [],
         hide_filters: [
           :actor_group_id,
-          :resource_id
+          :actor_group_name,
+          :resource_id,
+          :resource_name
         ],
         callback: &handle_policies_update!/2
       )

--- a/elixir/apps/web/lib/web/live/policies/index.ex
+++ b/elixir/apps/web/lib/web/live/policies/index.ex
@@ -13,7 +13,12 @@ defmodule Web.Policies.Index do
       |> assign_live_table("policies",
         query_module: Policies.Policy.Query,
         sortable_fields: [],
-        hide_filters: [:resource_id, :actor_group_id],
+        hide_filters: [
+          :actor_group_id,
+          :actor_group_name,
+          :resource_id,
+          :resource_name
+        ],
         callback: &handle_policies_update!/2
       )
 

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -31,7 +31,11 @@ defmodule Web.Resources.Show do
         )
         |> assign_live_table("policies",
           query_module: Policies.Policy.Query,
-          hide_filters: [:actor_group_id],
+          hide_filters: [
+            :actor_group_id,
+            :resource_name,
+            :group_or_resource_name
+          ],
           enforce_filters: [
             {:resource_id, resource.id}
           ],


### PR DESCRIPTION
Why:

* When using the Portal UI, it can be difficult to find a given Policy as only 10 are shown on the page at a time.  It was also difficult to determine which Resources a Group had access to and vice versa what Groups were allowed to access a given Resource.  This change allows searching by either Resource or Group to filter what Policies are shown.

Closes: #5624