### PR TITLE
build(deps): use upstream `str0m`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5721,7 +5721,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.6.2"
-source = "git+https://github.com/firezone/str0m?branch=main#94775f23167bd364ab7bd7f9bb96ddbe12a885ea"
+source = "git+https://github.com/algesten/str0m?branch=main#b800a7b9cf79b1aa19bf2f5c2b050f4b14428e39"
 dependencies = [
  "combine",
  "crc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -75,7 +75,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }
-str0m = { git = "https://github.com/firezone/str0m", branch = "main" }
+str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "master" }


### PR DESCRIPTION
https://github.com/algesten/str0m/pull/489 got merged, we can thus depend on upstream again.