### PR TITLE
fix(android,apple): remove ANSI escape codes from logs

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -141,10 +141,10 @@ fn init_logging(log_dir: &Path, log_filter: String) -> firezone_logging::file::H
         .with(file_layer)
         .with(
             tracing_subscriber::fmt::layer()
-                .with_ansi(false)
+                .with_writer(make_writer::MakeWriter::new("connlib"))
                 .without_time()
                 .with_level(false)
-                .with_writer(make_writer::MakeWriter::new("connlib")),
+                .with_ansi(false),
         )
         .with(firezone_logging::filter(&log_filter))
         .try_init();

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -153,13 +153,13 @@ fn init_logging(
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .without_time()
-                .with_level(false)
                 .with_writer(make_writer::MakeWriter::new(
                     "dev.firezone.firezone",
                     "connlib",
-                )),
+                ))
+                .without_time()
+                .with_level(false)
+                .with_ansi(false),
         )
         .with(file_layer)
         .with(firezone_logging::filter(&log_filter))


### PR DESCRIPTION
I worked out that for some reason, calling `with_ansi` _after_ setting the writer actually removes all ANSI escape codes from the logs.