### PR TITLE
build(rust): avoid unnecessary rebuilds

### DIFF
--- a/rust/bin-shared/src/lib.rs
+++ b/rust/bin-shared/src/lib.rs
@@ -15,19 +15,6 @@ pub mod windows;
 #[cfg(target_os = "windows")]
 pub use windows as platform;
 
-/// Output of `git describe` at compile time
-/// e.g. `1.0.0-pre.4-20-ged5437c88-modified` where:
-///
-/// * `1.0.0-pre.4` is the most recent ancestor tag
-/// * `20` is the number of commits since then
-/// * `g` doesn't mean anything
-/// * `ed5437c88` is the Git commit hash
-/// * `-modified` is present if the working dir has any changes from that commit number
-pub const GIT_VERSION: &str = git_version::git_version!(
-    args = ["--always", "--dirty=-modified", "--tags"],
-    fallback = "unknown"
-);
-
 pub const TOKEN_ENV_KEY: &str = "FIREZONE_TOKEN";
 
 // wintun automatically append " Tunnel" to this
@@ -56,3 +43,26 @@ pub use network_changes::{new_dns_notifier, new_network_notifier};
 
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 pub use tun_device_manager::TunDeviceManager;
+
+/// Output of `git describe` at compile time
+/// e.g. `1.0.0-pre.4-20-ged5437c88-modified` where:
+///
+/// * `1.0.0-pre.4` is the most recent ancestor tag
+/// * `20` is the number of commits since then
+/// * `g` doesn't mean anything
+/// * `ed5437c88` is the Git commit hash
+/// * `-modified` is present if the working dir has any changes from that commit number
+#[macro_export]
+macro_rules! git_version {
+    () => {
+        $crate::__reexport::git_version!(
+            args = ["--always", "--dirty=-modified", "--tags"],
+            fallback = "unknown"
+        )
+    };
+}
+
+#[doc(hidden)]
+pub mod __reexport {
+    pub use git_version::git_version;
+}

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -131,7 +131,7 @@ fn start_logging(directives: &str) -> Result<logging::Handles> {
     tracing::info!(
         arch = std::env::consts::ARCH,
         ?directives,
-        git_version = firezone_bin_shared::GIT_VERSION,
+        git_version = firezone_bin_shared::git_version!(),
         system_uptime_seconds = firezone_headless_client::uptime::get().map(|dur| dur.as_secs()),
         "`gui-client` started logging"
     );

--- a/rust/gui-client/src-tauri/src/client/about.rs
+++ b/rust/gui-client/src-tauri/src/client/about.rs
@@ -7,7 +7,7 @@ pub(crate) fn get_cargo_version() -> String {
 
 #[tauri::command]
 pub(crate) fn get_git_version() -> String {
-    firezone_bin_shared::GIT_VERSION.to_string()
+    firezone_bin_shared::git_version!().to_string()
 }
 
 #[cfg(test)]

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -104,7 +104,7 @@ fn run_debug_ipc_service(cli: Cli) -> Result<()> {
     crate::setup_stdout_logging()?;
     tracing::info!(
         arch = std::env::consts::ARCH,
-        git_version = firezone_bin_shared::GIT_VERSION,
+        git_version = firezone_bin_shared::git_version!(),
         system_uptime_seconds = crate::uptime::get().map(|dur| dur.as_secs()),
     );
     if !platform::elevation_check()? {
@@ -452,7 +452,7 @@ fn setup_logging(log_dir: Option<PathBuf>) -> Result<firezone_logging::file::Han
     set_global_default(subscriber).context("`set_global_default` should always work)")?;
     tracing::info!(
         arch = std::env::consts::ARCH,
-        git_version = firezone_bin_shared::GIT_VERSION,
+        git_version = firezone_bin_shared::git_version!(),
         system_uptime_seconds = crate::uptime::get().map(|dur| dur.as_secs()),
         ?directives
     );

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -138,7 +138,7 @@ fn main() -> Result<()> {
 
     tracing::info!(
         arch = std::env::consts::ARCH,
-        git_version = firezone_bin_shared::GIT_VERSION
+        git_version = firezone_bin_shared::git_version!()
     );
 
     let rt = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
Parsing the current Git version within `firezone-bin-shared` means this crate (and all its dependents) need to be rebuilt everytime one makes a commit, even if none of the code actually changes.

To avoid this whilst still allowing `firezone-bin-shared` to export a useful, shared function, we export a macro instead that can be called from the respective crates that need the GIT version. This means only those binaries will be marked as dirty and rebuilds of e.g. unit tests don't need to rebuild these workspace crates.