### PR TITLE
fix(relay): set better OTEL metadata

### DIFF
--- a/rust/docker-init-relay.sh
+++ b/rust/docker-init-relay.sh
@@ -24,13 +24,14 @@ fi
 if [ "${OTEL_METADATA_DISCOVERY_METHOD}" = "gce_metadata" ]; then
     echo "Using GCE metadata to set OTEL metadata"
 
-    instance_id=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google" -s)
-    instance_name=$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google" -s)
+    instance_id=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google" -s)           # i.e. 5832583187537235075
+    instance_name=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google" -s)       # i.e. relay-m5k7
+    zone=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/zone" -H "Metadata-Flavor: Google" -s | cut -d/ -f4)  # i.e. us-east-1
 
     # Source for attribute names:
     # - https://opentelemetry.io/docs/specs/semconv/attributes-registry/service/
     # - https://opentelemetry.io/docs/specs/semconv/attributes-registry/gcp/#gcp---google-compute-engine-gce-attributes:
-    export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=${instance_id},gcp.gce.instance.name=${instance_name}"
+    export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=${instance_id},gcp.gce.instance.name=${instance_name},cloud.region=${zone}"
     echo "Discovered OTEL metadata: ${OTEL_RESOURCE_ATTRIBUTES}"
 fi
 


### PR DESCRIPTION
Previously, the `service.name` attribute got overridden with "unknown service" from the detector used in `Resource::default`. To avoid this, we are now manually composing the two other detectors.

This gives us a useful set of default labels from within the code yet it allows overriding all of them using `OTEL_RESOURCE_ATTRIBUTES`.