### PR TITLE
chore(website): Add back @patticatti's dark scroll bars

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -37,4 +37,49 @@
       rgba(0, 0, 0, 0) 100%
     );
   }
+
+  /* For WebKit browsers (Chrome, Safari) */
+  .dark-scroll::-webkit-scrollbar {
+    width: 12px; /* Adjust the width of the scrollbar */
+  }
+
+  .dark-scroll::-webkit-scrollbar-button {
+    height: 0;
+    width: 0;
+    display: none;
+  }
+
+  .dark-scroll::-webkit-scrollbar-thumb {
+    background-color: #666; /* White color at 20% opacity */
+    border-radius: 10px; /* Optional: Rounds the corners of the scrollbar thumb */
+  }
+
+  .dark-scroll::-webkit-scrollbar-track {
+    background-color: #222; /* White color at 40% opacity */
+    border-radius: 10px; /* Optional: Rounds the corners of the scrollbar track */
+  }
+
+  /* For Firefox */
+  * .dark-scroll {
+    scrollbar-width: thin;
+    scrollbar-color: #666 #222;
+  }
+
+  .dark-scroll::-ms-scrollbar {
+    width: 12px; /* Adjust the width of the scrollbar */
+  }
+
+  .dark-scroll::-ms-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.2); /* White color at 20% opacity */
+    border-radius: 10px; /* Optional: Rounds the corners of the scrollbar thumb */
+  }
+
+  .dark-scroll::-ms-scrollbar-track {
+    background-color: rgba(255, 255, 255, 0.4); /* White color at 40% opacity */
+    border-radius: 10px; /* Optional: Rounds the corners of the scrollbar track */
+  }
+
+  .dark-scroll::-ms-scrollbar-button {
+    display: none;
+  }
 }

--- a/website/src/components/CustomerTestimonials/index.tsx
+++ b/website/src/components/CustomerTestimonials/index.tsx
@@ -122,7 +122,7 @@ export default function CustomerTestimonials() {
 
         <div
           ref={scrollRef}
-          className="sm:fade-side flex gap-12 px-8 sm:px-0 w-full snap-x snap-mandatory pb-24 sm:pb-12 overflow-x-auto"
+          className="sm:fade-side flex gap-12 px-8 sm:px-0 w-full snap-x snap-mandatory pb-24 sm:pb-12 overflow-x-auto dark-scroll"
         >
           {customerData.map((item, index) => (
             <TestimonialBox


### PR DESCRIPTION
Adds custom scroll bar styling for dark sections. Use by adding the `dark-scroll` class to overflow containers.