### PR TITLE
fix: refer to correct tag in git-version

### DIFF
--- a/rust/bin-shared/src/lib.rs
+++ b/rust/bin-shared/src/lib.rs
@@ -54,9 +54,9 @@ pub use tun_device_manager::TunDeviceManager;
 /// * `-modified` is present if the working dir has any changes from that commit number
 #[macro_export]
 macro_rules! git_version {
-    () => {
+    ($regex:literal) => {
         $crate::__reexport::git_version!(
-            args = ["--always", "--dirty=-modified", "--tags"],
+            args = ["--always", "--dirty=-modified", "--tags", "--match", $regex],
             fallback = "unknown"
         )
     };

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -131,7 +131,7 @@ fn start_logging(directives: &str) -> Result<logging::Handles> {
     tracing::info!(
         arch = std::env::consts::ARCH,
         ?directives,
-        git_version = firezone_bin_shared::git_version!(),
+        git_version = firezone_bin_shared::git_version!("gui-client-*"),
         system_uptime_seconds = firezone_headless_client::uptime::get().map(|dur| dur.as_secs()),
         "`gui-client` started logging"
     );

--- a/rust/gui-client/src-tauri/src/client/about.rs
+++ b/rust/gui-client/src-tauri/src/client/about.rs
@@ -7,7 +7,7 @@ pub(crate) fn get_cargo_version() -> String {
 
 #[tauri::command]
 pub(crate) fn get_git_version() -> String {
-    firezone_bin_shared::git_version!().to_string()
+    firezone_bin_shared::git_version!("gui-client-*").to_string()
 }
 
 #[cfg(test)]

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -104,7 +104,7 @@ fn run_debug_ipc_service(cli: Cli) -> Result<()> {
     crate::setup_stdout_logging()?;
     tracing::info!(
         arch = std::env::consts::ARCH,
-        git_version = firezone_bin_shared::git_version!(),
+        git_version = firezone_bin_shared::git_version!("gui-client-*"),
         system_uptime_seconds = crate::uptime::get().map(|dur| dur.as_secs()),
     );
     if !platform::elevation_check()? {
@@ -452,7 +452,7 @@ fn setup_logging(log_dir: Option<PathBuf>) -> Result<firezone_logging::file::Han
     set_global_default(subscriber).context("`set_global_default` should always work)")?;
     tracing::info!(
         arch = std::env::consts::ARCH,
-        git_version = firezone_bin_shared::git_version!(),
+        git_version = firezone_bin_shared::git_version!("gui-client-*"),
         system_uptime_seconds = crate::uptime::get().map(|dur| dur.as_secs()),
         ?directives
     );

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -138,7 +138,7 @@ fn main() -> Result<()> {
 
     tracing::info!(
         arch = std::env::consts::ARCH,
-        git_version = firezone_bin_shared::git_version!()
+        git_version = firezone_bin_shared::git_version!("headless-client-*")
     );
 
     let rt = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
The output of `git describe` always refers to the last tag that it can find. This leads to confusing versions being printed such as:

```
2024-08-19T00:24:08.983891Z  INFO firezone_headless_client: arch="x86_64" git_version="gateway-1.1.5-30-gf82fee162-modified"
```

Note that this is code running in the headless-client and it refers to the gateway tag. Whilst not wrong from git's PoV, it is certainly confusing.

We can fix this by providing a glob-pattern to `git describe` via `--match`. This makes git ignore any other tags and print a version identifier that refers to the current program:

```
2024-08-19T00:39:48.634191Z  INFO firezone_headless_client: arch="x86_64" git_version="headless-client-1.1.7-31-ga08a3411d-modified"
```