### PR TITLE
refactor(connlib): consolidate DNS functionality in `StubResolver`

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -737,9 +737,13 @@ impl ClientState {
 
     pub(crate) fn update_interface_config(&mut self, config: InterfaceConfig) {
         self.interface_config = Some(config.clone());
-        let dns_changed = self
-            .stub_resolver
-            .update_upstream_resolvers(config.upstream_dns);
+        let dns_changed = self.stub_resolver.update_upstream_resolvers(
+            config
+                .upstream_dns
+                .into_iter()
+                .map(|d| d.address())
+                .collect(),
+        );
 
         if !dns_changed {
             return;

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -17,7 +17,7 @@ use ip_packet::{IpPacket, MutableIpPacket};
 use itertools::Itertools;
 
 use crate::peer::GatewayOnClient;
-use crate::utils::{self, earliest, turn};
+use crate::utils::{self, turn};
 use crate::{ClientEvent, ClientTunnel, Tun};
 use secrecy::{ExposeSecret as _, Secret};
 use snownet::{ClientNode, RelaySocket, Transmit};
@@ -767,10 +767,7 @@ impl ClientState {
     }
 
     pub fn poll_timeout(&mut self) -> Option<Instant> {
-        let next_node_timeout = self.node.poll_timeout();
-        let next_stub_resolver_timeout = self.stub_resolver.poll_timeout();
-
-        earliest(next_stub_resolver_timeout, next_node_timeout)
+        self.node.poll_timeout()
     }
 
     pub fn handle_timeout(&mut self, now: Instant) {

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -397,12 +397,7 @@ impl ClientState {
     ) -> Option<snownet::Transmit<'s>> {
         let packet = match self.stub_resolver.try_handle_tun_inbound(
             packet,
-            |ip| {
-                self.interface_config
-                    .as_ref()
-                    .is_some_and(|i| !i.upstream_dns.is_empty())
-                    && self.active_cidr_resources.longest_match(ip).is_some()
-            },
+            |ip| self.active_cidr_resources.longest_match(ip).is_some(),
             now,
         ) {
             ControlFlow::Break(dns::ResolveStrategy::LocalResponse(query)) => {

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -216,11 +216,10 @@ impl StubResolver {
         Some(domain.clone())
     }
 
-    /// Parses an incoming packet as a DNS query and decides how to respond to it
+    /// Tries to handle a packet arriving on the TUN interface.
     ///
-    /// Returns:
-    /// - `None` if the packet is not a valid DNS query destined for one of our sentinel resolvers
-    /// - Otherwise, a strategy for responding to the query
+    /// If the packet is a DNS query, we compute a [`ResolveStrategy`].
+    /// Otherwise, we continue with processing the packet.
     pub(crate) fn try_handle_tun_inbound<'p>(
         &mut self,
         dns_mapping: &bimap::BiMap<IpAddr, DnsServer>,

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -41,7 +41,7 @@ pub struct StubResolver {
     upstream_resolvers: Vec<DnsServer>,
 
     /// Maps from connlib-assigned IP of a DNS server back to the originally configured system DNS resolver.
-    pub(crate) dns_mapping: BiMap<IpAddr, DnsServer>,
+    dns_mapping: BiMap<IpAddr, DnsServer>,
 
     /// DNS queries that had their destination IP mangled because they are forwarded through the tunnel.
     ///

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -496,6 +496,8 @@ impl StubResolver {
             &effective_dns_servers,
             self.dns_sentinels().map(Into::into).collect_vec(),
         );
+        self.mangled_dns_queries.clear();
+        self.forwarded_dns_queries.clear();
 
         true
     }

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -351,6 +351,7 @@ impl StubResolver {
         ControlFlow::Break(ResolveStrategy::LocalResponse(packet))
     }
 
+    /// Tries to handle a packet arriving at the network interface, effectively intercepting DNS queries forwarded to upstream resolvers.
     pub(crate) fn try_handle_network_inbound(
         &mut self,
         from: SocketAddr,
@@ -387,6 +388,7 @@ impl StubResolver {
         ControlFlow::Break(ip_packet.into_immutable())
     }
 
+    /// Tries to handle a packet arriving at the tunnel interface.
     pub(crate) fn try_handle_tunnel_inbound<'p>(
         &mut self,
         mut packet: MutableIpPacket<'p>,

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -237,7 +237,7 @@ impl StubResolver {
     pub(crate) fn try_handle_tun_inbound<'p>(
         &mut self,
         mut packet: MutableIpPacket<'p>,
-        forward_query_through_tunnel: impl Fn(IpAddr) -> bool,
+        is_cidr_resource: impl Fn(IpAddr) -> bool,
         now: Instant,
     ) -> ControlFlow<ResolveStrategy, MutableIpPacket<'p>> {
         let Some(upstream) = self
@@ -313,7 +313,7 @@ impl StubResolver {
             _ => {
                 let query_id = message.header().id();
 
-                if forward_query_through_tunnel(upstream.ip()) {
+                if !self.upstream_resolvers.is_empty() && is_cidr_resource(upstream.ip()) {
                     tracing::trace!(old_dst = %packet.destination(), new_dst = %upstream.ip(), "Mangling DNS query to be sent through tunnel");
 
                     self.mangled_dns_queries.insert(query_id, now + IDS_EXPIRE);

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -203,7 +203,7 @@ impl StubResolver {
     /// Returns:
     /// - `None` if the packet is not a valid DNS query destined for one of our sentinel resolvers
     /// - Otherwise, a strategy for responding to the query
-    pub(crate) fn handle<'p>(
+    pub(crate) fn try_handle_tun_inbound<'p>(
         &mut self,
         dns_mapping: &bimap::BiMap<IpAddr, DnsServer>,
         packet: MutableIpPacket<'p>,
@@ -308,6 +308,14 @@ impl StubResolver {
         .into_immutable();
 
         ControlFlow::Break(ResolveStrategy::LocalResponse(packet))
+    }
+
+    pub(crate) fn try_handle_network_inbound(
+        &mut self,
+        _from: SocketAddr,
+        _packet: &[u8],
+    ) -> ControlFlow<(), ()> {
+        ControlFlow::Continue(())
     }
 }
 


### PR DESCRIPTION
Currently, `connlib`'s DNS functionality is spread out over multiple places:

- DNS resources are tracked in `StubResolver`
- Forwarding and the necessary state is in `ClientState`
- Mangling of DNS queries to DNS servers that are CIDR resources is also in `ClientState`
- Computation of `connlib`'s sentinel DNS servers happens also in `ClientState`

Having all of this functionality spread out across multiple places makes it harder to understand the code and requires passing around data like the `dns_mapping`.

We can clean this up by moving all of the above functionality into `StubResolver` and calling its functions at the right point in `connlib`'s pipe-and-filter architecture within `encapsulate` and `decapsulate`.

Related: #6297.
Resolves: #5391.