### PR TITLE
ci: assert that we sample certain transitions

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -88,12 +88,17 @@ jobs:
       - uses: ./.github/actions/setup-rust
         id: setup-rust
       - uses: ./.github/actions/setup-tauri
+      - uses: taiki-e/install-action@ripgrep
       - name: "cargo test"
         shell: bash
         run: |
 
           # First, run all tests.
           cargo test --all-features ${{ steps.setup-rust.outputs.packages }} -- --include-ignored --nocapture
+
+          # Assert that we sample certain transitions
+          rg SendICMPPacketToCidrResource $TESTCASES_DIR
+          rg SendICMPPacketToDnsResource $TESTCASES_DIR
 
           # Backup dumped state and transition samples
           mv $TESTCASES_DIR $TESTCASES_BACKUP_DIR

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -88,7 +88,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         id: setup-rust
       - uses: ./.github/actions/setup-tauri
-      - uses: taiki-e/install-action@ripgrep
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: ripgrep
       - name: "cargo test"
         shell: bash
         run: |
@@ -99,6 +101,7 @@ jobs:
           # Assert that we sample certain transitions
           rg SendICMPPacketToCidrResource $TESTCASES_DIR
           rg SendICMPPacketToDnsResource $TESTCASES_DIR
+          rg SendDnsQueries $TESTCASES_DIR
 
           # Backup dumped state and transition samples
           mv $TESTCASES_DIR $TESTCASES_BACKUP_DIR


### PR DESCRIPTION
It happened in the past that we screwed up the `preconditions` of the state machine test such that no more transitions were sampled that actually send packets. To protect against this, we use the newly introduced logs and grep for certain transitions.

In the future, we can consider emitting a more structured output, like writing all testcases to a DB and run more complex queries against it to ensure that certain cases are covered.