### PR TITLE
chore(rust): bump Rust to 1.80.1

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,5 +1,5 @@
 # Keep synced with `rust-toolchain.toml`
-ARG RUST_VERSION="1.80"
+ARG RUST_VERSION="1.80.1"
 ARG ALPINE_VERSION="3.20"
 ARG CARGO_CHEF_VERSION="0.1.67"
 

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Keep synced with `Dockerfile`
-channel = "1.80"
+channel = "1.80.1"


### PR DESCRIPTION
This fixes some little bugs that probably don't affect us.