### PR TITLE
fix(gui-client): reload IPC service log filter when the settings change

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use firezone_bin_shared::{new_dns_notifier, new_network_notifier};
 use firezone_headless_client::{
     IpcClientMsg::{self, SetDisabledResources},
-    IpcServerMsg,
+    IpcServerMsg, LogFilterReloader,
 };
 use secrecy::{ExposeSecret, SecretString};
 use std::{
@@ -70,7 +70,7 @@ pub(crate) struct Managed {
 pub(crate) fn run(
     cli: client::Cli,
     advanced_settings: settings::AdvancedSettings,
-    reloader: logging::Reloader,
+    reloader: LogFilterReloader,
 ) -> Result<(), Error> {
     // Need to keep this alive so crashes will be handled. Dropping detaches it.
     let _crash_handler = match client::crash_handling::attach_handler() {
@@ -484,7 +484,7 @@ struct Controller {
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
     ctlr_tx: CtlrTx,
     ipc_client: ipc::Client,
-    log_filter_reloader: logging::Reloader,
+    log_filter_reloader: LogFilterReloader,
     status: Status,
     tray: system_tray::Tray,
     uptime: client::uptime::Tracker,
@@ -537,8 +537,9 @@ impl Controller {
                 self.log_filter_reloader
                     .reload(filter)
                     .context("Couldn't reload log filter")?;
+                self.ipc_client.send_msg(&IpcClientMsg::ReloadLogFilter).await?;
                 tracing::debug!(
-                    "Applied new settings. Log level will take effect immediately for the GUI and later for the IPC service."
+                    "Applied new settings. Log level will take effect immediately."
                 );
                 // Refresh the menu in case the favorites were reset.
                 self.refresh_system_tray_menu()?;
@@ -842,7 +843,7 @@ async fn run_controller(
     ctlr_tx: CtlrTx,
     mut rx: mpsc::Receiver<ControllerRequest>,
     advanced_settings: AdvancedSettings,
-    log_filter_reloader: logging::Reloader,
+    log_filter_reloader: LogFilterReloader,
 ) -> Result<(), Error> {
     tracing::info!("Entered `run_controller`");
     let ipc_client = ipc::Client::new(ctlr_tx.clone()).await?;

--- a/rust/gui-client/src-tauri/src/client/logging.rs
+++ b/rust/gui-client/src-tauri/src/client/logging.rs
@@ -2,7 +2,7 @@
 
 use crate::client::gui::{ControllerRequest, CtlrTx, Managed};
 use anyhow::{bail, Context, Result};
-use firezone_headless_client::known_dirs;
+use firezone_headless_client::{known_dirs, LogFilterReloader};
 use serde::Serialize;
 use std::{
     fs,
@@ -12,17 +12,15 @@ use std::{
 use tokio::{sync::oneshot, task::spawn_blocking};
 use tracing::subscriber::set_global_default;
 use tracing_log::LogTracer;
-use tracing_subscriber::{fmt, layer::SubscriberExt, reload, EnvFilter, Layer, Registry};
+use tracing_subscriber::{fmt, layer::SubscriberExt, reload, Layer, Registry};
 
 /// If you don't store `Handles` in a variable, the file logger handle will drop immediately,
 /// resulting in empty log files.
 #[must_use]
 pub(crate) struct Handles {
     pub logger: firezone_logging::file::Handle,
-    pub reloader: Reloader,
+    pub reloader: LogFilterReloader,
 }
-
-pub(crate) type Reloader = reload::Handle<EnvFilter, Registry>;
 
 struct LogPath {
     /// Where to find the logs on disk

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -433,7 +433,7 @@ impl<'a> Handler<'a> {
                 }
             }
             ClientMsg::ReloadLogFilter => {
-                let filter = spawn_blocking(|| get_log_filter()).await??;
+                let filter = spawn_blocking(get_log_filter).await??;
                 self.log_filter_reloader.reload(filter)?;
             }
             ClientMsg::Reset => self.connlib.as_mut().context("No connlib session")?.reset(),

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -1,6 +1,6 @@
 use crate::{
     device_id, dns_control::DnsController, known_dirs, signals, CallbackHandler, CliCommon,
-    ConnlibMsg, IpcServerMsg,
+    ConnlibMsg, IpcServerMsg, LogFilterReloader,
 };
 use anyhow::{bail, Context as _, Result};
 use clap::Parser;
@@ -15,7 +15,7 @@ use futures::{
     Future as _, SinkExt as _, Stream as _,
 };
 use std::{collections::BTreeSet, net::IpAddr, path::PathBuf, pin::pin, sync::Arc, time::Duration};
-use tokio::{sync::mpsc, time::Instant};
+use tokio::{sync::mpsc, task::spawn_blocking, time::Instant};
 use tracing::subscriber::set_global_default;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer, Registry};
 use url::Url;
@@ -74,6 +74,7 @@ pub enum ClientMsg {
     ClearLogs,
     Connect { api_url: String, token: String },
     Disconnect,
+    ReloadLogFilter,
     Reset,
     SetDns(Vec<IpAddr>),
     SetDisabledResources(BTreeSet<ResourceId>),
@@ -101,7 +102,7 @@ pub fn run_only_ipc_service() -> Result<()> {
 }
 
 fn run_debug_ipc_service(cli: Cli) -> Result<()> {
-    crate::setup_stdout_logging()?;
+    let log_filter_reloader = crate::setup_stdout_logging()?;
     tracing::info!(
         arch = std::env::consts::ARCH,
         git_version = firezone_bin_shared::git_version!(),
@@ -114,7 +115,11 @@ fn run_debug_ipc_service(cli: Cli) -> Result<()> {
     let _guard = rt.enter();
     let mut signals = signals::Terminate::new()?;
 
-    rt.block_on(ipc_listen(cli.common.dns_control, &mut signals))
+    rt.block_on(ipc_listen(
+        cli.common.dns_control,
+        &log_filter_reloader,
+        &mut signals,
+    ))
 }
 
 #[cfg(not(debug_assertions))]
@@ -127,7 +132,7 @@ fn run_smoke_test() -> Result<()> {
 /// This makes the timing neater in case the GUI starts up slowly.
 #[cfg(debug_assertions)]
 fn run_smoke_test() -> Result<()> {
-    crate::setup_stdout_logging()?;
+    let log_filter_reloader = crate::setup_stdout_logging()?;
     if !platform::elevation_check()? {
         bail!("IPC service failed its elevation check, try running as admin / root");
     }
@@ -145,7 +150,7 @@ fn run_smoke_test() -> Result<()> {
     rt.block_on(async {
         device_id::get_or_create().context("Failed to read / create device ID")?;
         let mut server = IpcServer::new(ServiceId::Prod).await?;
-        let _ = Handler::new(&mut server, &mut dns_controller)
+        let _ = Handler::new(&mut server, &mut dns_controller, &log_filter_reloader)
             .await?
             .run(&mut signals)
             .await;
@@ -159,6 +164,7 @@ fn run_smoke_test() -> Result<()> {
 /// client a hint about that before we exit.
 async fn ipc_listen(
     dns_control_method: DnsControlMethod,
+    log_filter_reloader: &LogFilterReloader,
     signals: &mut signals::Terminate,
 ) -> Result<()> {
     // Create the device ID and IPC service config dir if needed
@@ -167,7 +173,11 @@ async fn ipc_listen(
     let mut server = IpcServer::new(ServiceId::Prod).await?;
     let mut dns_controller = DnsController { dns_control_method };
     loop {
-        let mut handler_fut = pin!(Handler::new(&mut server, &mut dns_controller));
+        let mut handler_fut = pin!(Handler::new(
+            &mut server,
+            &mut dns_controller,
+            log_filter_reloader
+        ));
         let Some(handler) = poll_fn(|cx| {
             if let Poll::Ready(()) = signals.poll_recv(cx) {
                 Poll::Ready(None)
@@ -199,6 +209,7 @@ struct Handler<'a> {
     ipc_rx: ipc::ServerRead,
     ipc_tx: ipc::ServerWrite,
     last_connlib_start_instant: Option<Instant>,
+    log_filter_reloader: &'a LogFilterReloader,
     tun_device: TunDeviceManager,
 }
 
@@ -220,7 +231,11 @@ enum HandlerOk {
 }
 
 impl<'a> Handler<'a> {
-    async fn new(server: &mut IpcServer, dns_controller: &'a mut DnsController) -> Result<Self> {
+    async fn new(
+        server: &mut IpcServer,
+        dns_controller: &'a mut DnsController,
+        log_filter_reloader: &'a LogFilterReloader,
+    ) -> Result<Self> {
         dns_controller.deactivate()?;
         let (ipc_rx, ipc_tx) = server
             .next_client_split()
@@ -237,6 +252,7 @@ impl<'a> Handler<'a> {
             ipc_rx,
             ipc_tx,
             last_connlib_start_instant: None,
+            log_filter_reloader,
             tun_device,
         })
     }
@@ -416,6 +432,10 @@ impl<'a> Handler<'a> {
                     tracing::error!("Error - Got Disconnect when we're already not connected");
                 }
             }
+            ClientMsg::ReloadLogFilter => {
+                let filter = spawn_blocking(|| get_log_filter()).await??;
+                self.log_filter_reloader.reload(filter)?;
+            }
             ClientMsg::Reset => self.connlib.as_mut().context("No connlib session")?.reset(),
             ClientMsg::SetDns(v) => self
                 .connlib
@@ -437,7 +457,9 @@ impl<'a> Handler<'a> {
 ///
 /// Returns: A `Handle` that must be kept alive. Dropping it stops logging
 /// and flushes the log file.
-fn setup_logging(log_dir: Option<PathBuf>) -> Result<firezone_logging::file::Handle> {
+fn setup_logging(
+    log_dir: Option<PathBuf>,
+) -> Result<(firezone_logging::file::Handle, LogFilterReloader)> {
     // If `log_dir` is Some, use that. Else call `ipc_service_logs`
     let log_dir = log_dir.map_or_else(
         || known_dirs::ipc_service_logs().context("Should be able to compute IPC service logs dir"),
@@ -447,7 +469,8 @@ fn setup_logging(log_dir: Option<PathBuf>) -> Result<firezone_logging::file::Han
         .context("We should have permissions to create our log dir")?;
     let (layer, handle) = firezone_logging::file::layer(&log_dir);
     let directives = get_log_filter().context("Couldn't read log filter")?;
-    let filter = firezone_logging::try_filter(&directives)?;
+    let (filter, reloader) =
+        tracing_subscriber::reload::Layer::new(firezone_logging::try_filter(&directives)?);
     let subscriber = Registry::default().with(layer.with_filter(filter));
     set_global_default(subscriber).context("`set_global_default` should always work)")?;
     tracing::info!(
@@ -456,7 +479,7 @@ fn setup_logging(log_dir: Option<PathBuf>) -> Result<firezone_logging::file::Han
         system_uptime_seconds = crate::uptime::get().map(|dur| dur.as_secs()),
         ?directives
     );
-    Ok(handle)
+    Ok((handle, reloader))
 }
 
 /// Reads the log filter for the IPC service or for debug commands

--- a/rust/headless-client/src/ipc_service/linux.rs
+++ b/rust/headless-client/src/ipc_service/linux.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, Result};
 ///
 /// Linux uses the CLI args from here, Windows does not
 pub(crate) fn run_ipc_service(cli: CliCommon) -> Result<()> {
-    let _handle = super::setup_logging(cli.log_dir)?;
+    let (_handle, log_filter_reloader) = super::setup_logging(cli.log_dir)?;
     if !elevation_check()? {
         bail!("IPC service failed its elevation check, try running as admin / root");
     }
@@ -14,7 +14,11 @@ pub(crate) fn run_ipc_service(cli: CliCommon) -> Result<()> {
     let _guard = rt.enter();
     let mut signals = signals::Terminate::new()?;
 
-    rt.block_on(super::ipc_listen(cli.dns_control, &mut signals))
+    rt.block_on(super::ipc_listen(
+        cli.dns_control,
+        &log_filter_reloader,
+        &mut signals,
+    ))
 }
 
 /// Returns true if the IPC service can run properly

--- a/rust/headless-client/src/ipc_service/windows.rs
+++ b/rust/headless-client/src/ipc_service/windows.rs
@@ -206,7 +206,7 @@ fn fallible_service_run(
     // Add new features in `service_run_async` if possible.
     // We don't want to bail out of `fallible_service_run` and forget to tell
     // Windows that we're shutting down.
-    let result = rt.block_on(service_run_async(log_filter_reloader, shutdown_rx));
+    let result = rt.block_on(service_run_async(&log_filter_reloader, shutdown_rx));
     if let Err(error) = &result {
         tracing::error!(?error);
     }

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -37,6 +37,8 @@ pub use ipc_service::{ipc, run_only_ipc_service, ClientMsg as IpcClientMsg};
 
 use ip_network::{Ipv4Network, Ipv6Network};
 
+pub type LogFilterReloader = tracing_subscriber::reload::Handle<EnvFilter, Registry>;
+
 /// Only used on Linux
 pub const FIREZONE_GROUP: &str = "firezone-client";
 
@@ -145,12 +147,14 @@ impl Callbacks for CallbackHandler {
 }
 
 /// Sets up logging for stdout only, with INFO level by default
-pub fn setup_stdout_logging() -> Result<()> {
-    let filter = EnvFilter::new(ipc_service::get_log_filter().context("Can't read log filter")?);
+pub fn setup_stdout_logging() -> Result<LogFilterReloader> {
+    let directives = ipc_service::get_log_filter().context("Can't read log filter")?;
+    let (filter, reloader) =
+        tracing_subscriber::reload::Layer::new(firezone_logging::try_filter(&directives)?);
     let layer = fmt::layer().with_filter(filter);
     let subscriber = Registry::default().with(layer);
     set_global_default(subscriber)?;
-    Ok(())
+    Ok(reloader)
 }
 
 #[cfg(test)]

--- a/website/src/app/kb/client-apps/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/client-apps/linux-gui-client/readme.mdx
@@ -192,6 +192,15 @@ restarting the tunnel service. Quit the Firezone GUI, then run:
 sudo systemctl restart firezone-client-ipc
 ```
 
+### Viewing logs
+
+The Firezone Client is split into 2 main processes: An IPC service which runs
+the tunnel, and a GUI which allows the user to control Firezone.
+
+- IPC service logs are stored at `/var/log/dev.firezone.client/`
+- GUI logs are stored at `$HOME/.cache/dev.firezone.client/data/logs/`, where
+  `$HOME` is, e.g. `/home/username/`
+
 ## Known issues
 
 - **DNS Resources**: Web browsers that enable "Secure DNS" or DNS-over-HTTPS by

--- a/website/src/app/kb/client-apps/windows-client/readme.mdx
+++ b/website/src/app/kb/client-apps/windows-client/readme.mdx
@@ -178,6 +178,16 @@ Get-DnsClientNrptRule | where Comment -eq firezone-fd0020211111 | foreach { Remo
 1. Enter the above command and
    [Check if Firezone is controlling DNS](#check-if-firezone-is-controlling-dns)
 
+### Viewing logs
+
+The Firezone Client is split into 2 main processes: An IPC service which runs
+the tunnel, and a GUI which allows the user to control Firezone.
+
+- IPC service logs are stored at `%PROGRAMDATA%\dev.firezone.client\data\logs\`,
+  where `%PROGRAMDATA%` is almost always `C:\ProgramData`
+- GUI logs are stored at `%LOCALAPPDATA%\dev.firezone.client\data\logs`, where
+  `%LOCALAPPDATA%` is, e.g. `C:\Users\username\AppData\Local`
+
 ## Known issues
 
 - **DNS Resources**: Web browsers that enable "Secure DNS" or DNS-over-HTTPS by

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -25,6 +25,9 @@ export default function GUI({ title }: { title: string }) {
           <ChangeItem enable={title === "Windows"} pull="6308">
             Fixes a bug where the GUI could not run if the user is Administrator
           </ChangeItem>
+          <ChangeItem pull="6351">
+            The log filter on the IPC service is now reloaded immediately when you change the setting in the GUI.
+          </ChangeItem>
         </ul>
       </Entry>
       */}


### PR DESCRIPTION
Closes #6302

Tested with CI-built MSI on x86_64 Windows, and with dev-built `run-debug` on aarch Linux.
