### PR TITLE
chore(connlib): reduce buffer sizes

### DIFF
--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -75,12 +75,14 @@ fn only_generate_candidate_event_after_answer() {
 
     let mut alice = ClientNode::<u64, u64>::new(
         StaticSecret::random_from_rng(rand::thread_rng()),
+        0,
         rand::random(),
     );
     alice.add_local_host_candidate(local_candidate).unwrap();
 
     let mut bob = ServerNode::<u64, u64>::new(
         StaticSecret::random_from_rng(rand::thread_rng()),
+        0,
         rand::random(),
     );
 
@@ -108,10 +110,12 @@ fn only_generate_candidate_event_after_answer() {
 fn alice_and_bob() -> (ClientNode<u64, u64>, ServerNode<u64, u64>) {
     let alice = ClientNode::new(
         StaticSecret::random_from_rng(rand::thread_rng()),
+        0,
         rand::random(),
     );
     let bob = ServerNode::new(
         StaticSecret::random_from_rng(rand::thread_rng()),
+        0,
         rand::random(),
     );
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1,6 +1,6 @@
-use crate::dns;
 use crate::dns::StubResolver;
 use crate::peer_store::PeerStore;
+use crate::{dns, BUF_SIZE};
 use anyhow::Context;
 use bimap::BiMap;
 use connlib_shared::callbacks::Status;
@@ -309,7 +309,7 @@ impl ClientState {
             buffered_events: Default::default(),
             interface_config: Default::default(),
             buffered_packets: Default::default(),
-            node: ClientNode::new(private_key.into(), seed),
+            node: ClientNode::new(private_key.into(), BUF_SIZE, seed),
             system_resolvers: Default::default(),
             sites_status: Default::default(),
             gateways_site: Default::default(),

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -1,7 +1,7 @@
 use crate::peer::ClientOnGateway;
 use crate::peer_store::PeerStore;
 use crate::utils::earliest;
-use crate::{GatewayEvent, GatewayTunnel};
+use crate::{GatewayEvent, GatewayTunnel, BUF_SIZE};
 use anyhow::{bail, Context};
 use boringtun::x25519::PublicKey;
 use chrono::{DateTime, Utc};
@@ -146,7 +146,7 @@ impl GatewayState {
     pub(crate) fn new(private_key: impl Into<StaticSecret>, seed: [u8; 32]) -> Self {
         Self {
             peers: Default::default(),
-            node: ServerNode::new(private_key.into(), seed),
+            node: ServerNode::new(private_key.into(), BUF_SIZE, seed),
             next_expiry_resources_check: Default::default(),
             buffered_events: VecDeque::default(),
         }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -1,6 +1,7 @@
 use crate::{
     device_channel::Device,
     sockets::{NoInterfaces, Sockets},
+    BUF_SIZE,
 };
 use futures_util::FutureExt as _;
 use ip_packet::{IpPacket, MutableIpPacket};
@@ -62,7 +63,7 @@ impl Io {
         device_buffer: &'b mut [u8],
     ) -> Poll<io::Result<Input<'b, impl Iterator<Item = DatagramIn<'b>>>>> {
         if let Poll::Ready(network) = self.sockets.poll_recv_from(ip4_buffer, ip6_bffer, cx)? {
-            return Poll::Ready(Ok(Input::Network(network)));
+            return Poll::Ready(Ok(Input::Network(network.filter(is_max_wg_packet_size))));
         }
 
         ready!(self.sockets.poll_flush(cx))?;
@@ -120,4 +121,15 @@ impl Io {
 
         Ok(())
     }
+}
+
+fn is_max_wg_packet_size(d: &DatagramIn) -> bool {
+    let len = d.packet.len();
+    if len > BUF_SIZE {
+        tracing::debug!(from = %d.from, %len, "Dropping too large datagram (max allowed: {BUF_SIZE} bytes)");
+
+        return false;
+    }
+
+    true
 }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -55,13 +55,13 @@ impl Io {
         })
     }
 
-    pub fn poll<'b>(
+    pub fn poll<'b1, 'b2>(
         &mut self,
         cx: &mut Context<'_>,
-        ip4_buffer: &'b mut [u8],
-        ip6_bffer: &'b mut [u8],
-        device_buffer: &'b mut [u8],
-    ) -> Poll<io::Result<Input<'b, impl Iterator<Item = DatagramIn<'b>>>>> {
+        ip4_buffer: &'b1 mut [u8],
+        ip6_bffer: &'b1 mut [u8],
+        device_buffer: &'b2 mut [u8],
+    ) -> Poll<io::Result<Input<'b2, impl Iterator<Item = DatagramIn<'b1>>>>> {
         if let Poll::Ready(network) = self.sockets.poll_recv_from(ip4_buffer, ip6_bffer, cx)? {
             return Poll::Ready(Ok(Input::Network(network.filter(is_max_wg_packet_size))));
         }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -50,8 +50,12 @@ const REALM: &str = "firezone";
 /// Thus, it is chosen as a safe, upper boundary that is not meant to be hit (and thus doesn't affect performance), yet acts as a safe guard, just in case.
 const MAX_EVENTLOOP_ITERS: u32 = 5000;
 
-/// We need an extra 16 bytes on top of the MTU for write_buf since boringtun copies the extra AEAD tag before decrypting it.
-const BUF_SIZE: usize = DEFAULT_MTU + 16 + 20;
+/// Wireguard has a 16-byte overhead (4b message type + 4b receiver idx + 8b packet counter)
+const WG_OVERHEAD: usize = 16;
+/// In order to do NAT46 without copying, we need 20 extra byte in the buffer (IPv6 packets are 20 byte bigger than IPv4).
+const NAT46_OVERHEAD: usize = 20;
+
+const BUF_SIZE: usize = DEFAULT_MTU + WG_OVERHEAD + NAT46_OVERHEAD;
 
 pub type GatewayTunnel = Tunnel<GatewayState>;
 pub type ClientTunnel = Tunnel<ClientState>;

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -54,8 +54,10 @@ const MAX_EVENTLOOP_ITERS: u32 = 5000;
 const WG_OVERHEAD: usize = 32;
 /// In order to do NAT46 without copying, we need 20 extra byte in the buffer (IPv6 packets are 20 byte bigger than IPv4).
 const NAT46_OVERHEAD: usize = 20;
+/// TURN's data channels have a 4 byte overhead.
+const DATA_CHANNEL_OVERHEAD: usize = 4;
 
-const BUF_SIZE: usize = DEFAULT_MTU + WG_OVERHEAD + NAT46_OVERHEAD;
+const BUF_SIZE: usize = DEFAULT_MTU + WG_OVERHEAD + NAT46_OVERHEAD + DATA_CHANNEL_OVERHEAD;
 
 pub type GatewayTunnel = Tunnel<GatewayState>;
 pub type ClientTunnel = Tunnel<ClientState>;

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -50,8 +50,8 @@ const REALM: &str = "firezone";
 /// Thus, it is chosen as a safe, upper boundary that is not meant to be hit (and thus doesn't affect performance), yet acts as a safe guard, just in case.
 const MAX_EVENTLOOP_ITERS: u32 = 5000;
 
-/// Wireguard has a 16-byte overhead (4b message type + 4b receiver idx + 8b packet counter)
-const WG_OVERHEAD: usize = 16;
+/// Wireguard has a 32-byte overhead (4b message type + 4b receiver idx + 8b packet counter + 16b AEAD tag)
+const WG_OVERHEAD: usize = 32;
 /// In order to do NAT46 without copying, we need 20 extra byte in the buffer (IPv6 packets are 20 byte bigger than IPv4).
 const NAT46_OVERHEAD: usize = 20;
 


### PR DESCRIPTION
Currently, `snownet` allocates a 65KB buffer per connection as a scratch-space for encrypting packets. 65KB is the theoretical limit of a UDP packet. In practice, the largest UDP packets we send are 1336 bytes due to the MTU of 1280 set on our TUN interface and various overheads for WG, TURN channels and NAT46.

Thus, it is unnecessary to allocate such a large buffer per connection. For gateways with many connections, reducing these buffers results in a smaller memory footprint.

Additionally, any UDP packets larger than this buffer could be an indicator of a DoS attack and we can thus drop them without processing. A legitimate client / gateway will never send a packet larger than that.