### PR TITLE
feat(connlib): remember recently connected gateways

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -49,6 +49,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +83,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -2026,6 +2044,7 @@ dependencies = [
  "ip_network",
  "ip_network_table",
  "itertools 0.13.0",
+ "lru",
  "proptest",
  "proptest-state-machine",
  "rand 0.8.5",
@@ -2628,6 +2647,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -3287,7 +3310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3353,6 +3376,15 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+dependencies = [
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -7858,6 +7890,26 @@ dependencies = [
  "serde",
  "static_assertions",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -4,10 +4,7 @@ use connlib_shared::messages::{
     ResourceId, ReuseConnection,
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{BTreeSet, HashSet},
-    net::IpAddr,
-};
+use std::{collections::BTreeSet, net::IpAddr};
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 pub struct InitClient {
@@ -91,7 +88,7 @@ pub enum ReplyMessages {
 pub enum EgressMessages {
     PrepareConnection {
         resource_id: ResourceId,
-        connected_gateway_ids: HashSet<GatewayId>,
+        connected_gateway_ids: BTreeSet<GatewayId>,
     },
     RequestConnection(RequestConnection),
     ReuseConnection(ReuseConnection),
@@ -548,7 +545,7 @@ mod test {
             "client",
             EgressMessages::PrepareConnection {
                 resource_id: "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3".parse().unwrap(),
-                connected_gateway_ids: HashSet::new(),
+                connected_gateway_ids: BTreeSet::new(),
             },
             None,
         );

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -20,6 +20,7 @@ ip-packet = { workspace = true }
 ip_network = { version = "0.4", default-features = false }
 ip_network_table = { version = "0.2", default-features = false }
 itertools = { version = "0.13", default-features = false, features = ["use_std"] }
+lru = "0.12.4"
 proptest = { version = "1", optional = true }
 rand = "0.8.5"
 rangemap = "1.5.1"

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -290,7 +290,6 @@ pub struct ClientState {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AwaitingConnectionDetails {
-    gateways: HashSet<GatewayId>,
     pub last_intent_sent_at: Instant,
     domain: Option<ResolveRequest>,
 }
@@ -756,7 +755,6 @@ impl ClientState {
             }
             Entry::Vacant(vacant) => {
                 vacant.insert(AwaitingConnectionDetails {
-                    gateways: gateways.clone(),
                     last_intent_sent_at: now,
                     // Note: in case of an overlapping CIDR resource this should be None instead of Some if the resource_id
                     // is for a CIDR resource.

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -988,6 +988,7 @@ impl ClientState {
         tracing::info!("Resetting network state");
 
         self.node.reset();
+        self.recently_connected_gateways.clear(); // Ensure we don't have sticky gateways when we roam.
         self.drain_node_events();
     }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -289,8 +289,8 @@ pub struct ClientState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct AwaitingConnectionDetails {
-    pub last_intent_sent_at: Instant,
+struct AwaitingConnectionDetails {
+    last_intent_sent_at: Instant,
     domain: Option<ResolveRequest>,
 }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -16,7 +16,7 @@ use ip_network::{Ipv4Network, Ipv6Network};
 use rand::rngs::OsRng;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
     task::{Context, Poll},
@@ -275,7 +275,7 @@ pub enum ClientEvent {
     },
     ConnectionIntent {
         resource: ResourceId,
-        connected_gateway_ids: HashSet<GatewayId>,
+        connected_gateway_ids: BTreeSet<GatewayId>,
     },
     SendProxyIps {
         connections: Vec<ReuseConnection>,

--- a/rust/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/connlib/tunnel/src/tests/stub_portal.rs
@@ -16,7 +16,7 @@ use proptest::{
     strategy::{Just, Strategy},
 };
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
     iter,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
@@ -117,7 +117,7 @@ impl StubPortal {
     pub(crate) fn handle_connection_intent(
         &self,
         resource: ResourceId,
-        _connected_gateway_ids: HashSet<GatewayId>,
+        _connected_gateway_ids: BTreeSet<GatewayId>,
     ) -> (GatewayId, client::SiteId) {
         let site_id = self
             .sites_by_resource


### PR DESCRIPTION
Previously, `connlib` would only send the currently connected gateways to the portal upon a new connection intent. With our introduced idle connection timeout, this could result in the portal choosing a different gateway upon reconnecting to the resource.

To fix this, we introduce an LRU cache with at most 100 entries. Iteration over the LRU cache happens in MRU order, meaning a recently connected gateway will be at the front of the list.

We assume that this list is processed in order and thus still prefer gateways that we are still connected to.

Related: #6347.