### PR TITLE
chore(kotlin/android): bump NDK version

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 
     // Life is easier if we just match the default NDK on the Ubuntu 22.04 runners
     // https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#android
-    ndkVersion = "25.2.9519653"
+    ndkVersion = "27.0.12077973"
 
     defaultConfig {
         applicationId = "dev.firezone.android"


### PR DESCRIPTION
NDK 27 is the new default on the Ubuntu 22.04 runner: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#android

GitHub stopped supporting NDK <= 25 yesterday: https://github.com/actions/runner-images/issues/10342 We've had a lot of CI runs fail because of this

Back-link to internal Slack: https://firezonehq.slack.com/archives/C04HRQTFY0Z/p1724165422547389