### PR TITLE
fix(android): correct field name from `can_disable` to `can_be_disabled`

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
@@ -17,7 +17,7 @@ data class Resource(
     val name: String,
     val status: StatusEnum,
     var enabled: Boolean = true,
-    @Json(name = "can_disable") val canBeDisabled: Boolean,
+    @Json(name = "can_be_disabled") val canBeDisabled: Boolean,
 ) : Parcelable
 
 enum class TypeEnum {


### PR DESCRIPTION
Closes #6379

This fixes the crash on my system