### PR TITLE
fix(connlib): prevent panic on internet resource for apps

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
@@ -29,6 +29,9 @@ enum class TypeEnum {
 
     @Json(name = "cidr")
     CIDR,
+
+    @Json(name = "internet")
+    Internet,
 }
 
 enum class StatusEnum {

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use anyhow::Result;
 use connlib_shared::messages::{
-    ConnectionAccepted, GatewayResponse, RelaysPresence, ResourceAccepted, ResourceId,
+    client::ResourceDescriptionInternet, ConnectionAccepted, GatewayResponse, RelaysPresence,
+    ResourceAccepted, ResourceId,
 };
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
@@ -220,6 +221,15 @@ where
                 resources,
                 relays,
             }) => {
+                let mut resources = resources.clone();
+                resources.push(
+                    connlib_shared::messages::client::ResourceDescription::Internet(
+                        ResourceDescriptionInternet {
+                            id: ResourceId::random(),
+                            sites: vec![],
+                        },
+                    ),
+                );
                 self.tunnel.set_new_interface_config(interface);
                 self.tunnel.set_resources(resources);
                 self.tunnel.update_relays(BTreeSet::default(), relays);

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -8,8 +8,7 @@ use crate::{
 };
 use anyhow::Result;
 use connlib_shared::messages::{
-    client::ResourceDescriptionInternet, ConnectionAccepted, GatewayResponse, RelaysPresence,
-    ResourceAccepted, ResourceId,
+    ConnectionAccepted, GatewayResponse, RelaysPresence, ResourceAccepted, ResourceId,
 };
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -221,15 +221,6 @@ where
                 resources,
                 relays,
             }) => {
-                let mut resources = resources.clone();
-                resources.push(
-                    connlib_shared::messages::client::ResourceDescription::Internet(
-                        ResourceDescriptionInternet {
-                            id: ResourceId::random(),
-                            sites: vec![],
-                        },
-                    ),
-                );
                 self.tunnel.set_new_interface_config(interface);
                 self.tunnel.set_resources(resources);
                 self.tunnel.update_relays(BTreeSet::default(), relays);

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -34,7 +34,7 @@ impl ResourceDescription {
         match self {
             ResourceDescription::Dns(r) => &r.name,
             ResourceDescription::Cidr(r) => &r.name,
-            ResourceDescription::Internet(_) => "Internet",
+            ResourceDescription::Internet(r) => &r.name,
         }
     }
 
@@ -120,8 +120,15 @@ pub struct ResourceDescriptionCidr {
 /// Description of an Internet resource
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ResourceDescriptionInternet {
+    /// Name for display always set to "Internet Resource"
+    pub name: String,
+
+    /// Address for display always set to "All internet addresses"
+    pub address: String,
+
     pub id: ResourceId,
     pub sites: Vec<Site>,
+
     pub status: Status,
     pub can_be_disabled: bool,
 }

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -86,6 +86,8 @@ pub struct ResourceDescriptionInternet {
 impl ResourceDescriptionInternet {
     pub fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionInternet {
         crate::callbacks::ResourceDescriptionInternet {
+            name: "Internet Resource".to_string(),
+            address: "All internet addresses".to_string(),
             id: self.id,
             sites: self.sites,
             can_be_disabled: false,

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -338,9 +338,8 @@ mod tests {
             {
                 "id": "1106047c-cd5d-4151-b679-96b93da7383b",
                 "type": "internet",
-                "name": "internet",
-                "address": "0.0.0.0/0",
-                "address_description": "The whole entire Internet",
+                "name": "Internet Resource",
+                "address": "All internet addresses",
                 "sites": [{"name": "test", "id": "eb94482a-94f4-47cb-8127-14fb3afa5516"}],
                 "status": "Offline",
                 "can_be_disabled": false
@@ -448,12 +447,12 @@ mod tests {
                     .copyable(GATEWAY_CONNECTED),
             )
             .add_submenu(
-                "Internet",
+                "Internet Resource",
                 Menu::default()
                     .copyable("")
                     .separator()
                     .disabled("Resource")
-                    .copyable("Internet")
+                    .copyable("Internet Resource")
                     .copyable("")
                     .item(
                         Event::AddFavorite(
@@ -535,12 +534,12 @@ mod tests {
                             .copyable(NO_ACTIVITY),
                     )
                     .add_submenu(
-                        "Internet",
+                        "Internet Resource",
                         Menu::default()
                             .copyable("")
                             .separator()
                             .disabled("Resource")
-                            .copyable("Internet")
+                            .copyable("Internet Resource")
                             .copyable("")
                             .item(
                                 Event::AddFavorite(ResourceId::from_str(
@@ -622,12 +621,12 @@ mod tests {
                     .copyable(GATEWAY_CONNECTED),
             )
             .add_submenu(
-                "Internet",
+                "Internet Resource",
                 Menu::default()
                     .copyable("")
                     .separator()
                     .disabled("Resource")
-                    .copyable("Internet")
+                    .copyable("Internet Resource")
                     .copyable("")
                     .item(
                         Event::AddFavorite(ResourceId::from_str(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -77,4 +77,5 @@ public enum ResourceType: String, Decodable {
   case dns = "dns"
   case cidr = "cidr"
   case ip = "ip"
+  case internet = "internet"
 }


### PR DESCRIPTION
[Refs](https://github.com/firezone/firezone/pull/6299#discussion_r1724108733)

The problem right now, after #6325 we send the internet resource up to the clients. The clients expect a certain format for the resources and panic if it isn't followed.

Particularly, in the case of no `address` or no `name`.

To fix this, we add a name and an address for the internet resource when it is converted to the callback type.

Setting the `name` at that point actually makes a lot of sense since it homogenizes the name across all platforms. But the internet resource having an address makes no sense.

So in a next PR, when I do the last UI changes I plan to make `address` optional for all resources on the clients and specialize the display of the internet resource.

For now I wanted to get this in so that we don't ever panic on the internet resource existing. (This was tested on all platforms and it works)