### PR TITLE
feat(connlib): discard sockets on `NetworkUnreachable` error

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2044,6 +2044,7 @@ dependencies = [
  "ip_network",
  "ip_network_table",
  "itertools 0.13.0",
+ "libc",
  "lru",
  "proptest",
  "proptest-state-machine",
@@ -3280,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libdbus-sys"
@@ -4725,7 +4726,7 @@ dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp",
+ "quinn-udp 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 2.0.0",
  "rustls",
  "socket2",
@@ -4762,6 +4763,18 @@ dependencies = [
  "socket2",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.4"
+source = "git+https://github.com/firezone/quinn?branch=main#8db4894a5c126483fab116e042d529de2f5ea470"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5559,7 +5572,7 @@ dependencies = [
 name = "socket-factory"
 version = "0.1.0"
 dependencies = [
- "quinn-udp",
+ "quinn-udp 0.5.4 (git+https://github.com/firezone/quinn?branch=main)",
  "socket2",
  "tokio",
  "tracing",

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -39,6 +39,7 @@ uuid = { version = "1.10", default-features = false, features = ["std", "v4"] }
 derivative = "2.2.0"
 firezone-relay = { workspace = true, features = ["proptest"] }
 ip-packet = { workspace = true, features = ["proptest"] }
+libc = "0.2.158"
 proptest-state-machine = "0.3"
 rand = "0.8"
 serde_json = "1.0"

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -60,37 +60,29 @@ impl Sockets {
         Poll::Ready(Ok(()))
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(dst = %datagram.dst))]
     pub fn send(&mut self, datagram: DatagramOut) -> io::Result<()> {
         let dst = datagram.dst;
-        let socket = match (dst, self.socket_v4.as_mut(), self.socket_v6.as_mut()) {
-            (SocketAddr::V4(_), Some(v4), _) => v4,
-            (SocketAddr::V6(_), _, Some(v6)) => v6,
-            (_, _, _) => {
-                tracing::trace!("Dropping packet: No socket");
-                return Ok(());
-            }
+        let maybe_socket = match (dst, &mut self.socket_v4, &mut self.socket_v6) {
+            (SocketAddr::V4(_), v4, _) => v4,
+            (SocketAddr::V6(_), _, v6) => v6,
+        };
+
+        let Some(socket) = maybe_socket else {
+            tracing::trace!(%dst, "Dropping packet: No socket");
+
+            return Ok(());
         };
 
         match socket.send(datagram) {
-            Ok(()) => Ok(()),
+            Ok(()) => {}
             Err(e) if is_network_unreachable(&e) => {
-                match dst {
-                    SocketAddr::V4(_) => {
-                        tracing::info!("{e}: Discarding IPv4 socket");
-                        self.socket_v4 = None;
-                    }
-                    SocketAddr::V6(_) => {
-                        tracing::info!("{e}: Discarding IPv6 socket");
-
-                        self.socket_v6 = None;
-                    }
-                };
-
-                Ok(())
+                tracing::info!(%dst, "{e}: Discarding socket");
+                *maybe_socket = None;
             }
-            Err(e) => Err(e),
-        }
+            Err(e) => return Err(e),
+        };
+
+        Ok(())
     }
 
     pub fn poll_recv_from<'b>(

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -66,7 +66,7 @@ impl Sockets {
         let socket = match (dst, self.socket_v4.as_mut(), self.socket_v6.as_mut()) {
             (SocketAddr::V4(_), Some(v4), _) => v4,
             (SocketAddr::V6(_), _, Some(v6)) => v6,
-            (SocketAddr::V4(_), None, _) | (SocketAddr::V6(_), _, None) => {
+            (_, _, _) => {
                 tracing::trace!("Dropping packet: No socket");
                 return Ok(());
             }

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-quinn-udp = "0.5.2"
+quinn-udp = { git = "https://github.com/firezone/quinn", branch = "main" }
 socket2 = { workspace = true }
 tokio = { version = "1.39", features = ["net"] }
 tracing = "0.1"


### PR DESCRIPTION
In `connlib`, we use `quinn-udp` to send UDP packets. In its current design, `quinn-udp` swallows all `io::Error`s upon sending and logs them as a `warn` (throttled to 1 / min). See https://github.com/quinn-rs/quinn/issues/1971 and linked issues for context.

In Firezone, this isn't really what we want. When `connlib` starts up, we try to bind two UDP sockets:

- Unspecified IPv4
- Unspecified IPv6

If either of those fail, that particular socket gets disabled. Binding to a particular address family only fails if we don't have a single interface that offers this address. On many machines, there are IPv6 interfaces but they may only have a link-local address or are otherwise non-functional yet we can still bind to them.

The problem only surfaces when we try to send a packet to an IPv6 destination. If there are no routes configured, the syscall will fail with `NetworkUnreachable`. This error is currently swallowed by `quinn-udp`.

To expose this error, we fork `quinn-udp` and bubble up all `io::Error`s during sending. Effectively this doesn't change anything in `connlib` because all errors returned from `Tunnel::poll_next_event` are already non-fatal. They are simply logged on `warn` and the event loop continues on.

Now that we can intercept the error, we utilise that knowledge to pro-actively disable the offending socket, i.e. setting it to `None`. This would surface our own error when trying to send a packet. Therefore, we also refactor `send` to log a message on `trace` that we are dropping the packet. `connlib`'s state machine already logs retries of packets (like the STUN requests to the relays) on `debug`, hence we log this on `trace` to not duplicate those logs.

In case we disable both sockets as a result of this, `connlib`'s network stack will completely suspend until we receive a `reset` instruction from the client. If this happens on the gateway, things are somewhat irreparably broken. However, roaming on gateways is already something we don't support very well. We don't reset any network state for example so whatever behaviour we have is not intentional. So far, there don't seem to be any complaints about this from users. When we choose to support roaming on gateways, we can build on top of this functionality and it will self-heal, similarly to what the clients do, assuming we get a notification from whatever components monitors the network interfaces.