### PR TITLE
fix(connlib): filter DNS servers on unsupported network stack

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -1,4 +1,4 @@
-use crate::{device_channel::Device, sockets::Sockets, BUF_SIZE};
+use crate::{device_channel::Device, ip_stack::IpStack, sockets::Sockets, BUF_SIZE};
 use futures_util::FutureExt as _;
 use ip_packet::{IpPacket, MutableIpPacket};
 use socket_factory::{DatagramIn, DatagramOut, SocketFactory, TcpSocket, UdpSocket};
@@ -118,6 +118,10 @@ impl Io {
         self.device.write(packet)?;
 
         Ok(())
+    }
+
+    pub fn ip_stack(&self) -> IpStack {
+        self.sockets.ip_stack()
     }
 }
 

--- a/rust/connlib/tunnel/src/ip_stack.rs
+++ b/rust/connlib/tunnel/src/ip_stack.rs
@@ -1,0 +1,34 @@
+use core::fmt;
+use std::net::IpAddr;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum IpStack {
+    None,
+    V4,
+    V6,
+    Dual,
+}
+
+impl fmt::Display for IpStack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IpStack::None => write!(f, "None"),
+            IpStack::V4 => write!(f, "IPv4-only"),
+            IpStack::V6 => write!(f, "IPv6-only"),
+            IpStack::Dual => write!(f, "Dual (IPv4 & IPv6)"),
+        }
+    }
+}
+
+impl IpStack {
+    pub fn can_send(&self, ip: IpAddr) -> bool {
+        match (self, ip) {
+            (IpStack::None, _) => false,
+            (IpStack::Dual, _) => true,
+            (IpStack::V4, IpAddr::V4(_)) => true,
+            (IpStack::V6, IpAddr::V6(_)) => true,
+            (IpStack::V4, IpAddr::V6(_)) => false,
+            (IpStack::V6, IpAddr::V4(_)) => false,
+        }
+    }
+}

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -1,3 +1,4 @@
+use crate::ip_stack::IpStack;
 use socket_factory::{DatagramIn, DatagramOut, SocketFactory, UdpSocket};
 use std::{
     io,
@@ -43,6 +44,15 @@ impl Sockets {
         }
 
         Poll::Ready(())
+    }
+
+    pub fn ip_stack(&self) -> IpStack {
+        match (self.socket_v4.as_ref(), self.socket_v6.as_ref()) {
+            (None, None) => IpStack::None,
+            (None, Some(_)) => IpStack::V6,
+            (Some(_), None) => IpStack::V4,
+            (Some(_), Some(_)) => IpStack::Dual,
+        }
     }
 
     /// Flushes all buffered data on the sockets.

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -143,3 +143,13 @@ fn init_logging(ref_state: &ReferenceState, test_index: u32) -> tracing::subscri
         .with(PanicOnErrorEvents::new(test_index))
         .set_default()
 }
+
+impl From<firezone_relay::IpStack> for crate::ip_stack::IpStack {
+    fn from(value: firezone_relay::IpStack) -> Self {
+        match value {
+            firezone_relay::IpStack::Ip4(_) => crate::ip_stack::IpStack::V4,
+            firezone_relay::IpStack::Ip6(_) => crate::ip_stack::IpStack::V6,
+            firezone_relay::IpStack::Dual { .. } => crate::ip_stack::IpStack::Dual,
+        }
+    }
+}

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -423,8 +423,13 @@ impl ReferenceStateMachine for ReferenceState {
                     .network
                     .add_host(state.client.inner().id, &state.client));
 
+                let new_ip_stack = state.client.ip_stack().into();
+
                 // When roaming, we are not connected to any resource and wait for the next packet to re-establish a connection.
-                state.client.exec_mut(|client| client.reset_connections());
+                state.client.exec_mut(|client| {
+                    client.reset_connections();
+                    client.update_ip_stack(new_ip_stack);
+                });
             }
             Transition::ReconnectPortal => {
                 // Reconnecting to the portal should have no noticeable impact on the data plane.

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -584,15 +584,13 @@ impl RefClient {
     /// If there are upstream DNS servers configured in the portal, it should use those.
     /// Otherwise it should use whatever was configured on the system prior to connlib starting.
     pub(crate) fn expected_dns_servers(&self) -> BTreeSet<SocketAddr> {
-        let upstream = self
-            .upstream_dns_resolvers
-            .iter()
-            .filter(|s| self.ip_stack.can_send(s.ip()))
-            .map(DnsServer::address)
-            .collect::<BTreeSet<_>>();
-
-        if !upstream.is_empty() {
-            return upstream;
+        if !self.upstream_dns_resolvers.is_empty() {
+            return self
+                .upstream_dns_resolvers
+                .iter()
+                .filter(|s| self.ip_stack.can_send(s.ip()))
+                .map(DnsServer::address)
+                .collect();
         }
 
         self.system_dns_resolvers

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -6,7 +6,7 @@ use super::{
     transition::DnsQuery,
     IcmpIdentifier, IcmpSeq, QueryId,
 };
-use crate::{proptest::*, ClientState};
+use crate::{ip_stack::IpStack, proptest::*, ClientState};
 use bimap::BiMap;
 use connlib_shared::{
     messages::{

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -583,6 +583,9 @@ impl RefClient {
     ///
     /// If there are upstream DNS servers configured in the portal, it should use those.
     /// Otherwise it should use whatever was configured on the system prior to connlib starting.
+    ///
+    /// Both of these lists are filtered by the supported IP stack.
+    /// We always respect the upstream DNS set, even if it means that the client ends up with no functional DNS servers.
     pub(crate) fn expected_dns_servers(&self) -> BTreeSet<SocketAddr> {
         if !self.upstream_dns_resolvers.is_empty() {
             return self

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -584,13 +584,15 @@ impl RefClient {
     /// If there are upstream DNS servers configured in the portal, it should use those.
     /// Otherwise it should use whatever was configured on the system prior to connlib starting.
     pub(crate) fn expected_dns_servers(&self) -> BTreeSet<SocketAddr> {
-        if !self.upstream_dns_resolvers.is_empty() {
-            return self
-                .upstream_dns_resolvers
-                .iter()
-                .filter(|s| self.ip_stack.can_send(s.ip()))
-                .map(DnsServer::address)
-                .collect();
+        let upstream = self
+            .upstream_dns_resolvers
+            .iter()
+            .filter(|s| self.ip_stack.can_send(s.ip()))
+            .map(DnsServer::address)
+            .collect::<BTreeSet<_>>();
+
+        if !upstream.is_empty() {
+            return upstream;
         }
 
         self.system_dns_resolvers

--- a/rust/connlib/tunnel/src/tests/sim_net.rs
+++ b/rust/connlib/tunnel/src/tests/sim_net.rs
@@ -63,6 +63,10 @@ impl<T> Host<T> {
         }
     }
 
+    pub(crate) fn ip_stack(&self) -> IpStack {
+        IpStack::from((self.ip4, self.ip6))
+    }
+
     pub(crate) fn inner(&self) -> &T {
         &self.inner
     }
@@ -151,11 +155,16 @@ where
 {
     pub(crate) fn map<U>(
         &self,
-        f: impl FnOnce(T, Option<Ipv4Addr>, Option<Ipv6Addr>) -> U,
+        f: impl FnOnce(T, firezone_relay::IpStack) -> U,
         span: Span,
     ) -> Host<U> {
         Host {
-            inner: span.in_scope(|| f(self.inner.clone(), self.ip4, self.ip6)),
+            inner: span.in_scope(|| {
+                f(
+                    self.inner.clone(),
+                    firezone_relay::IpStack::from((self.ip4, self.ip6)),
+                )
+            }),
             ip4: self.ip4,
             ip6: self.ip6,
             span,

--- a/rust/connlib/tunnel/src/tests/sim_relay.rs
+++ b/rust/connlib/tunnel/src/tests/sim_relay.rs
@@ -11,7 +11,7 @@ use snownet::{RelaySocket, Transmit};
 use std::{
     borrow::Cow,
     collections::HashSet,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{SocketAddr, SocketAddrV4, SocketAddrV6},
     time::{Duration, Instant, SystemTime},
 };
 
@@ -41,9 +41,9 @@ pub(crate) fn map_explode<'a>(
 }
 
 impl SimRelay {
-    pub(crate) fn new(seed: u64, ip4: Option<Ipv4Addr>, ip6: Option<Ipv6Addr>) -> Self {
+    pub(crate) fn new(seed: u64, ip_stack: IpStack) -> Self {
         let sut = firezone_relay::Server::new(
-            IpStack::from((ip4, ip6)),
+            ip_stack,
             rand::rngs::StdRng::seed_from_u64(seed),
             3478,
             49152..=65535,

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -56,7 +56,7 @@ impl StateMachineTest for TunnelTest {
         // Construct client, gateway and relay from the initial state.
         let mut client = ref_state
             .client
-            .map(|ref_client, _, _| ref_client.init(), debug_span!("client"));
+            .map(|ref_client, _| ref_client.init(), debug_span!("client"));
 
         let mut gateways = ref_state
             .gateways
@@ -100,6 +100,9 @@ impl StateMachineTest for TunnelTest {
                 g.update_relays(iter::empty(), relays.iter(), ref_state.flux_capacitor.now())
             });
         }
+
+        let ip_stack = client.ip_stack().into();
+        client.exec_mut(|c| c.sut.set_ip_stack(ip_stack));
 
         let mut this = Self {
             flux_capacitor: ref_state.flux_capacitor.clone(),

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -63,7 +63,7 @@ impl StateMachineTest for TunnelTest {
             .iter()
             .map(|(gid, gateway)| {
                 let gateway = gateway.map(
-                    |ref_gateway, _, _| ref_gateway.init(*gid),
+                    |ref_gateway, _| ref_gateway.init(*gid),
                     debug_span!("gateway", %gid),
                 );
 
@@ -85,7 +85,7 @@ impl StateMachineTest for TunnelTest {
             .dns_servers
             .iter()
             .map(|(did, dns_server)| {
-                let dns_server = dns_server.map(|_, _, _| SimDns {}, debug_span!("dns", %did));
+                let dns_server = dns_server.map(|_, _| SimDns {}, debug_span!("dns", %did));
 
                 (*did, dns_server)
             })
@@ -239,9 +239,11 @@ impl StateMachineTest for TunnelTest {
                 debug_assert!(state
                     .network
                     .add_host(state.client.inner().id, &state.client));
+                let ip_stack = state.client.ip_stack().into();
 
                 state.client.exec_mut(|c| {
                     c.sut.reset();
+                    c.sut.set_ip_stack(ip_stack);
 
                     // In prod, we reconnect to the portal and receive a new `init` message.
                     c.update_relays(iter::empty(), state.relays.iter(), now);


### PR DESCRIPTION
Building on top of #6382, we can use the status of our sockets to pro-actively tell our state machine about our network stack. For example, if we don't have an IPv6 socket (anymore), we filter out any IPv6 DNS servers and emit a new event to tell the client to update the available servers.

If we have a broken socket, our interaction with the relays when booting up should already trigger the deactivation of the socket. Thus, we should settle on the right DNS servers before a user starts to access resources.

This surfaces an interesting edge-case: If an admin configures an upstream DNS and a client doesn't have a compatible IP stack, this will result in the client having **no** DNS servers at all. We could also fallback to the system resolvers in that case but we would effectively undermine the admin's decision to force a certain DNS server onto the clients.

Resolves: #6353.