### PR TITLE
fix(gateway): don't address resources via inaccessible IPs

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -65,6 +65,7 @@ pub type ClientTunnel = Tunnel<ClientState>;
 
 pub use client::{ClientState, Request};
 pub use gateway::{GatewayState, IPV4_PEERS, IPV6_PEERS};
+pub use ip_stack::IpStack;
 
 /// [`Tunnel`] glues together connlib's [`Io`] component and the respective (pure) state of a client or gateway.
 ///
@@ -203,6 +204,8 @@ impl GatewayTunnel {
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<std::io::Result<GatewayEvent>> {
         for _ in 0..MAX_EVENTLOOP_ITERS {
             ready!(self.io.poll_has_sockets(cx)); // Suspend everything if we don't have any sockets.
+
+            self.role_state.set_ip_stack(self.io.ip_stack());
 
             if let Some(other) = self.role_state.poll_event() {
                 return Poll::Ready(Ok(other));

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -101,8 +101,14 @@ impl StateMachineTest for TunnelTest {
             });
         }
 
-        let ip_stack = client.ip_stack().into();
-        client.exec_mut(|c| c.sut.set_ip_stack(ip_stack));
+        let client_ip_stack = client.ip_stack().into();
+        client.exec_mut(|c| c.sut.set_ip_stack(client_ip_stack));
+        for gateway in gateways.values_mut() {
+            let gateway_ip_stack = gateway.ip_stack().into();
+            gateway.exec_mut(|g| {
+                g.sut.set_ip_stack(gateway_ip_stack);
+            });
+        }
 
         let mut this = Self {
             flux_capacitor: ref_state.flux_capacitor.clone(),


### PR DESCRIPTION
Gateways may not run with a dual network stack. A common example here is docker where IPv6 by default does not work. Similarly, AWS does not support IPv6 very well.

Using the same technique as on the client in #6383, we can have the gateway detect its supported IP stack. If we don't have an IPv4 or IPv6 socket, we should not create entries in our translation table for those addresses. Instead, we need to cycle through the provided proxy IPs and utilise our NAT64 / NAT46 implementation to correctly route the traffic.

refs: #6371.