### PR TITLE
feat(connlib): suspend if we don't have UDP sockets

### DIFF
--- a/rust/connlib/clients/shared/src/callbacks.rs
+++ b/rust/connlib/clients/shared/src/callbacks.rs
@@ -1,5 +1,4 @@
 use connlib_shared::callbacks::ResourceDescription;
-use firezone_tunnel::NoInterfaces;
 use ip_network::{Ipv4Network, Ipv6Network};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -36,9 +35,6 @@ pub trait Callbacks: Clone + Send + Sync {
 /// Unified error type to use across connlib.
 #[derive(thiserror::Error, Debug)]
 pub enum DisconnectError {
-    /// Failed to bind to interfaces.
-    #[error(transparent)]
-    NoInterfaces(#[from] NoInterfaces),
     /// A panic occurred.
     #[error("Connlib panicked: {0}")]
     Panic(String),

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -78,9 +78,7 @@ where
                 }
                 Poll::Ready(Some(Command::Reset)) => {
                     self.portal.reconnect();
-                    if let Err(e) = self.tunnel.reset() {
-                        tracing::warn!("Failed to reconnect tunnel: {e}");
-                    }
+                    self.tunnel.reset();
 
                     continue;
                 }

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -136,7 +136,7 @@ where
         tcp_socket_factory,
         udp_socket_factory,
         BTreeMap::from([(portal.server_host().to_owned(), portal.resolved_addresses())]),
-    )?;
+    );
 
     let mut eventloop = Eventloop::new(tunnel, callbacks, portal, rx);
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -110,7 +110,7 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
         private_key,
         Arc::new(tcp_socket_factory),
         Arc::new(udp_socket_factory),
-    )?;
+    );
     let portal = PhoenixChannel::connect(
         Secret::new(login),
         get_user_agent(None, env!("CARGO_PKG_VERSION")),


### PR DESCRIPTION
Previously, failing to bind to any interfaces was a hard-error. In reality and in `connlib`'s current state, this is quite unlikely because machines will at least have a loopback interface that we will bind to.

However, with #6382 in the pipeline, it may be more likely that we actually end up with no functional UDP sockets. Furthermore, we are considering to extend those connectivity checks in the future.

Thus, it is important that the case of "no available UDP sockets" is gracefully handled.

Instead of failing with a hard-error, we now suspend `connlib's` network stack. The connectivity to the portal is unaffected by this and we will still also receive commands from the client application like `reset`. When we receive a `reset`, we attempt to rebind the sockets and thus retry connectivity.

Because we are suspending the entire eventloop, this won't send any messages or trigger any timers whatsoever. For example, if we hypothetically started up without network interfaces, this is now the log output:

```
2024-08-22T01:50:42.170101Z  INFO firezone_headless_client: arch="x86_64" git_version="headless-client-1.2.0-2-gc8eed5938-modified"
2024-08-22T01:50:42.178777Z DEBUG phoenix_channel: Connecting to portal host=api.firez.one user_agent=NixOS/24.5.0 connlib/1.2.1 (x86_64; 6.8.12)
2024-08-22T01:50:42.178978Z DEBUG firezone_headless_client::dns_control::linux: Deactivating DNS control...
2024-08-22T01:50:42.180691Z ERROR firezone_tunnel::sockets: No available UDP sockets
2024-08-22T01:50:42.197098Z  INFO firezone_tunnel::device_channel: Initializing TUN device name=tun-firezone
2024-08-22T01:50:42.197165Z DEBUG firezone_tunnel::client: Unable to update DNS servesr without interface configuration
2024-08-22T01:50:42.453988Z DEBUG tungstenite::handshake::client: Client handshake done.
2024-08-22T01:50:42.454161Z  INFO phoenix_channel: Connected to portal host=api.firez.one
2024-08-22T01:50:42.676825Z DEBUG firezone_tunnel::client: Updating DNS servers mapping={fd00:2021:1111:8000:100:100:111:0 <> [2606:4700:4700::1111]:53, 100.100.111.1 <> 1.1.1.1:53}
2024-08-22T01:50:42.677084Z  INFO firezone_tunnel::client: Activating resource name=IPerf3 address=10.0.32.101/32 sites=AWS Dev (Gateways track `main`)
2024-08-22T01:50:42.677173Z  INFO firezone_tunnel::client: Activating resource name=*.slack.com address=**.slack.com sites=Vultr Stable (Latest Release Gateways)
2024-08-22T01:50:42.677223Z  INFO firezone_tunnel::client: Activating resource name=*.slack-edge.com address=**.slack-edge.com sites=Vultr Stable (Latest Release Gateways)
2024-08-22T01:50:42.677283Z  INFO firezone_tunnel::client: Activating resource name=*.spotify.com address=**.spotify.com sites=AWS Dev (Gateways track `main`)
2024-08-22T01:50:42.677345Z  INFO firezone_tunnel::client: Activating resource name=*.github.com address=**.github.com sites=AWS Dev (Gateways track `main`)
2024-08-22T01:50:42.677418Z  INFO firezone_tunnel::client: Activating resource name=whatismyip.com address=**.whatismyip.com sites=AWS Dev (Gateways track `main`)
2024-08-22T01:50:42.677489Z  INFO firezone_tunnel::client: Activating resource name=ifconfig.net address=ifconfig.net sites=Vultr Stable (Latest Release Gateways)
2024-08-22T01:50:42.677538Z  INFO firezone_tunnel::client: Activating resource name=*.google.com address=**.google.com sites=AWS Dev (Gateways track `main`)
2024-08-22T01:50:42.677632Z  INFO firezone_tunnel::client: Activating resource name=*.fastmail.com address=**.fastmail.com sites=AWS Dev (Gateways track `main`)
2024-08-22T01:50:42.677682Z  INFO firezone_tunnel::client: Activating resource name=speed.cloudflare.com address=speed.cloudflare.com sites=Vultr Stable (Latest Release Gateways)
2024-08-22T01:50:42.678212Z  INFO snownet::node: Added new TURN server rid=b6fc4d73-9c8e-44df-a941-da7d2134cb70 address=Dual { v4: 34.40.133.55:3478, v6: [2600:1900:40b0:1504:0:97::]:3478 }
2024-08-22T01:50:42.678322Z  INFO snownet::node: Added new TURN server rid=c818b11a-d0cc-4f2a-bb88-473d8298a885 address=Dual { v4: 34.81.229.132:3478, v6: [2600:1900:4030:b0d9:0:9b::]:3478 }
2024-08-22T01:50:42.678365Z  INFO connlib_client_shared::eventloop: Firezone Started!
```

After this, nothing will happen other than receiving messages via from the portal or the client app.

Related: #6382.
Related: #6385.