### PR TITLE
feat(gateway): allow out-of-order `allow_access` requests

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -103,6 +103,7 @@ jobs:
           - name: direct-curl-api-restart
           - name: direct-dns-api-down
           - name: direct-dns-relay-down
+          - name: direct-dns-two-resources
           - name: direct-dns
           - name: direct-download-roaming-network
             # Too noisy can cause flaky tests due to the amount of data

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -131,7 +131,7 @@ defmodule API.Gateway.Channel do
       } do
       :ok = Flows.subscribe_to_flow_expiration_events(flow_id)
 
-      client = Clients.fetch_client_by_id!(client_id, preload: [:actor])
+      client = Clients.fetch_client_by_id!(client_id)
       resource = Resources.fetch_resource_by_id!(resource_id)
 
       case API.Client.Channel.map_or_drop_compatible_resource(

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -152,7 +152,8 @@ defmodule API.Gateway.Channel do
             resource: Views.Resource.render(resource),
             expires_at: DateTime.to_unix(authorization_expires_at, :second),
             payload: payload,
-            client: Views.Client.render(client)
+            client_ipv4: client.ipv4,
+            client_ipv6: client.ipv6
           })
 
           Logger.debug("Awaiting gateway connection_ready message",

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -131,6 +131,7 @@ defmodule API.Gateway.Channel do
       } do
       :ok = Flows.subscribe_to_flow_expiration_events(flow_id)
 
+      client = Clients.fetch_client_by_id!(client_id, preload: [:actor])
       resource = Resources.fetch_resource_by_id!(resource_id)
 
       case API.Client.Channel.map_or_drop_compatible_resource(
@@ -150,7 +151,8 @@ defmodule API.Gateway.Channel do
             flow_id: flow_id,
             resource: Views.Resource.render(resource),
             expires_at: DateTime.to_unix(authorization_expires_at, :second),
-            payload: payload
+            payload: payload,
+            client: client
           })
 
           Logger.debug("Awaiting gateway connection_ready message",

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -152,7 +152,7 @@ defmodule API.Gateway.Channel do
             resource: Views.Resource.render(resource),
             expires_at: DateTime.to_unix(authorization_expires_at, :second),
             payload: payload,
-            client: client
+            client: Views.Client.render(client)
           })
 
           Logger.debug("Awaiting gateway connection_ready message",

--- a/elixir/apps/api/lib/api/gateway/views/client.ex
+++ b/elixir/apps/api/lib/api/gateway/views/client.ex
@@ -14,16 +14,4 @@ defmodule API.Gateway.Views.Client do
       }
     }
   end
-
-  def render(%Clients.Client{} = client) do
-    %{
-      id: client.id,
-      peer: %{
-        persistent_keepalive: 25,
-        public_key: client.public_key,
-        ipv4: client.ipv4,
-        ipv6: client.ipv6
-      }
-    }
-  end
 end

--- a/elixir/apps/api/lib/api/gateway/views/client.ex
+++ b/elixir/apps/api/lib/api/gateway/views/client.ex
@@ -14,4 +14,16 @@ defmodule API.Gateway.Views.Client do
       }
     }
   end
+
+  def render(%Clients.Client{} = client) do
+    %{
+      id: client.id,
+      peer: %{
+        persistent_keepalive: 25,
+        public_key: client.public_key,
+        ipv4: client.ipv4,
+        ipv6: client.ipv6
+      }
+    }
+  end
 end

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -118,16 +118,15 @@ defmodule API.Gateway.ChannelTest do
                  %{protocol: :icmp}
                ]
              }
+
       assert payload.client == %{
                id: client.id,
                peer: %{
                  ipv4: client.ipv4,
                  ipv6: client.ipv6,
                  persistent_keepalive: 25,
-                 preshared_key: preshared_key,
                  public_key: client.public_key
-               },
-               payload: client_payload
+               }
              }
 
       assert payload.ref

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -118,6 +118,17 @@ defmodule API.Gateway.ChannelTest do
                  %{protocol: :icmp}
                ]
              }
+      assert payload.client == %{
+               id: client.id,
+               peer: %{
+                 ipv4: client.ipv4,
+                 ipv6: client.ipv6,
+                 persistent_keepalive: 25,
+                 preshared_key: preshared_key,
+                 public_key: client.public_key
+               },
+               payload: client_payload
+             }
 
       assert payload.ref
       assert payload.flow_id == flow_id

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -119,19 +119,11 @@ defmodule API.Gateway.ChannelTest do
                ]
              }
 
-      assert payload.client == %{
-               id: client.id,
-               peer: %{
-                 ipv4: client.ipv4,
-                 ipv6: client.ipv6,
-                 persistent_keepalive: 25,
-                 public_key: client.public_key
-               }
-             }
-
       assert payload.ref
       assert payload.flow_id == flow_id
       assert payload.client_id == client.id
+      assert payload.client_ipv4 == client.ipv4
+      assert payload.client_ipv6 == client.ipv6
       assert DateTime.from_unix!(payload.expires_at) == DateTime.truncate(expires_at, :second)
     end
 

--- a/rust/connlib/tunnel/src/peer_store.rs
+++ b/rust/connlib/tunnel/src/peer_store.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 use std::hash::Hash;
 use std::net::IpAddr;
 
@@ -65,6 +65,10 @@ where
         }
 
         old_peer
+    }
+
+    pub(crate) fn entry(&mut self, id: TId) -> Entry<'_, TId, P> {
+        self.peer_by_id.entry(id)
     }
 
     pub(crate) fn remove(&mut self, id: &TId) -> Option<P> {

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -310,14 +310,14 @@ impl Eventloop {
 
     pub fn allow_access(&mut self, result: Result<Vec<IpAddr>, Timeout>, req: AllowAccess) {
         let addresses = result
-            .inspect_err(|e| tracing::debug!(client = %req.client.id, reference = %req.reference, "DNS resolution timed out as part of allow access request: {e}"))
+            .inspect_err(|e| tracing::debug!(client = %req.client_id, reference = %req.reference, "DNS resolution timed out as part of allow access request: {e}"))
             .unwrap_or_default();
 
         if let (Ok(()), Some(resolve_request)) = (
             self.tunnel.allow_access(
-                req.client.id,
-                req.client.peer.ipv4,
-                req.client.peer.ipv6,
+                req.client_id,
+                req.client_ipv4,
+                req.client_ipv6,
                 req.payload.as_ref().map(|r| r.as_tuple()),
                 req.expires_at,
                 req.resource.into_resolved(addresses.clone()),

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -83,15 +83,15 @@ impl ResolveRequest {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct AllowAccess {
-    pub client_id: ClientId,
     pub resource: ResourceDescription,
     #[serde(with = "ts_seconds_option")]
     pub expires_at: Option<DateTime<Utc>>,
     pub payload: Option<ResolveRequest>,
     #[serde(rename = "ref")]
     pub reference: String,
+    pub client: Client,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]

--- a/rust/gateway/src/messages.rs
+++ b/rust/gateway/src/messages.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeSet, net::IpAddr};
+use std::{
+    collections::BTreeSet,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
 
 use chrono::{serde::ts_seconds_option, DateTime, Utc};
 use connlib_shared::{
@@ -85,13 +88,17 @@ impl ResolveRequest {
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct AllowAccess {
+    pub client_id: ClientId,
     pub resource: ResourceDescription,
     #[serde(with = "ts_seconds_option")]
     pub expires_at: Option<DateTime<Utc>>,
     pub payload: Option<ResolveRequest>,
     #[serde(rename = "ref")]
     pub reference: String,
-    pub client: Client,
+    /// Tunnel IPv4 address.
+    pub client_ipv4: Ipv4Addr,
+    /// Tunnel IPv6 address.
+    pub client_ipv6: Ipv6Addr,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]

--- a/scripts/tests/direct-dns-two-resources.sh
+++ b/scripts/tests/direct-dns-two-resources.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# The integration tests call this to test Linux DNS control, using the `/etc/resolv.conf`
+# method which only works well inside Alpine Docker containers.
+
+source "./scripts/tests/lib.sh"
+
+RESOURCE1=dns.httpbin
+RESOURCE2=download.httpbin
+
+echo "# Try to ping httpbin as DNS resource 1"
+client_ping_resource "$RESOURCE1"
+
+echo "# Try to ping httpbin as DNS resource 2"
+client_ping_resource "$RESOURCE2"


### PR DESCRIPTION
Currently, the gateway requires a strict ordering of first receiving a `request_connection` message, following by multiple `allow_access` messages. Additionally, access can be granted as part of the initial `request_connection` message too.

This isn't an ideal design. Setting up a new connection is infallible, all we need to do is send our ICE credentials back to the client. However, untangling that will require a bit more effort.

Starting with #6335, following this strict order on the client is a more difficult. Whilst we can send them in order, it is harder to maintain those ordering guarantees across all our systems.

To avoid this, we change the gateway to perform an upsert for its local ACLs for a client. In case that an `allow_access` call would somehow get to the gateway earlier, we can simply already create the `Peer` and only set up the actual connection later.