### PR TITLE
fix(connlib): only emit route changes from disabled_resource if routes actually changed

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -89,8 +89,13 @@ impl ClientTunnel {
     }
 
     pub fn set_disabled_resources(&mut self, new_disabled_resources: BTreeSet<ResourceId>) {
+        let old_routes = self.role_state.routes();
         self.role_state
             .set_disabled_resource(new_disabled_resources);
+
+        if HashSet::from_iter(self.role_state.routes()) == HashSet::from_iter(old_routes) {
+            return;
+        }
 
         self.role_state
             .buffered_events

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -89,11 +89,11 @@ impl ClientTunnel {
     }
 
     pub fn set_disabled_resources(&mut self, new_disabled_resources: BTreeSet<ResourceId>) {
-        let old_routes = self.role_state.routes();
+        let old_routes = HashSet::<IpNetwork>::from_iter(self.role_state.routes());
         self.role_state
             .set_disabled_resource(new_disabled_resources);
 
-        if HashSet::from_iter(self.role_state.routes()) == HashSet::from_iter(old_routes) {
+        if HashSet::<IpNetwork>::from_iter(self.role_state.routes()) == old_routes {
             return;
         }
 

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -9,6 +9,17 @@ export default function Android() {
       href="https://play.google.com/store/apps/details?id=dev.firezone.android"
       title="Android"
     >
+      {/*
+      <Entry version="1.2.1" date={new Date(todo)}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem pull="6424">
+            Fixes a bug where packets would be lost when a connection is first
+            established to a gateway, due to routes being updated with no actual
+            change.
+          </ChangeItem>
+        </ul>
+      </Entry>
+      */}
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="5901">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -17,7 +17,7 @@ export default function Apple() {
           </ChangeItem>
           <ChangeItem pull="6424">
             Fixes a bug where packets would be lost when a connection is first
-            esbalished to a gateway, due to routes being updated with no actual
+            established to a gateway, due to routes being updated with no actual
             change.
           </ChangeItem>
         </ul>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -15,6 +15,11 @@ export default function Apple() {
           <ChangeItem pull="6406">
             Shows the Git SHA corresponding to the build on the Settings -> Advanced screen.
           </ChangeItem>
+          <ChangeItem pull="6424">
+            Fixes a bug where packets would be lost when a connection is first
+            esbalished to a gateway, due to routes being updated with no actual
+            change.
+          </ChangeItem>
         </ul>
       </Entry>
       */}


### PR DESCRIPTION
Right now, whenever a connection is established we update the site status.

In order to do that, we call `on_update_resources`, when `on_update_resources` is called this in turn calls `set_disabled_resources`, since we apply from the application side the "disabled" given the current resources.

`set_disabled_resources` currently, always call `on_update_routes`, which causes connectivity issues on Android and MacOS, since the packets aren't correctly routed when the routes are changed.

To fix this we make `set_disabled_resources` only emit the routes when they have actually changed.

Fixes: #6387.