### PR TITLE
chore(connlib): track dedicated `TunConfig`

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -171,15 +171,11 @@ where
             firezone_tunnel::ClientEvent::ResourcesChanged { resources } => {
                 self.callbacks.on_update_resources(resources)
             }
-            firezone_tunnel::ClientEvent::TunInterfaceUpdated {
-                ip4,
-                ip6,
-                dns_by_sentinel,
-            } => {
-                let dns_servers = dns_by_sentinel.left_values().copied().collect();
+            firezone_tunnel::ClientEvent::TunInterfaceUpdated(config) => {
+                let dns_servers = config.dns_by_sentinel.left_values().copied().collect();
 
                 self.callbacks
-                    .on_set_interface_config(ip4, ip6, dns_servers);
+                    .on_set_interface_config(config.ip4, config.ip6, dns_servers);
             }
             firezone_tunnel::ClientEvent::TunRoutesUpdated { ip4, ip6 } => {
                 self.callbacks.on_update_routes(ip4, ip6);

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -870,7 +870,7 @@ impl ClientState {
     }
 
     pub(crate) fn update_interface_config(&mut self, config: InterfaceConfig) {
-        tracing::debug!(upstream_dns = ?config.upstream_dns, ipv4 = %config.ipv4, ipv6 = %config.ipv6, "Received interface configuration from portal");
+        tracing::trace!(upstream_dns = ?config.upstream_dns, ipv4 = %config.ipv4, ipv6 = %config.ipv6, "Received interface configuration from portal");
 
         match self.tun_config.as_mut() {
             Some(existing) => {

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -828,7 +828,7 @@ impl ClientState {
             .chain(iter::once(IPV4_RESOURCES.into()))
             .chain(iter::once(IPV6_RESOURCES.into()))
             .chain(iter::once(DNS_SENTINELS_V4.into()))
-            .chain(iter::once(DNS_SENTINELS_V4.into()))
+            .chain(iter::once(DNS_SENTINELS_V6.into()))
             .chain(
                 self.internet_resource
                     .map(|_| Ipv4Network::DEFAULT_ROUTE.into()),
@@ -1787,7 +1787,7 @@ mod proptests {
                 .chain(iter::once(IPV4_RESOURCES.into()))
                 .chain(iter::once(IPV6_RESOURCES.into()))
                 .chain(iter::once(DNS_SENTINELS_V4.into()))
-                .chain(iter::once(DNS_SENTINELS_V4.into())),
+                .chain(iter::once(DNS_SENTINELS_V6.into())),
         )
     }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1165,8 +1165,7 @@ impl ClientState {
         let new_tun_config = TunConfig {
             ip4: config.ip4,
             ip6: config.ip6,
-            dns_by_sentinel: self
-                .dns_mapping
+            dns_by_sentinel: dns_mapping
                 .iter()
                 .map(|(sentinel_dns, effective_dns)| (*sentinel_dns, effective_dns.address()))
                 .collect::<BiMap<_, _>>(),

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -828,6 +828,8 @@ impl ClientState {
             .map(|(ip, _)| ip)
             .chain(iter::once(IPV4_RESOURCES.into()))
             .chain(iter::once(IPV6_RESOURCES.into()))
+            .chain(iter::once(DNS_SENTINELS_V4.into()))
+            .chain(iter::once(DNS_SENTINELS_V4.into()))
             .chain(
                 self.internet_resource
                     .map(|_| Ipv4Network::DEFAULT_ROUTE.into()),
@@ -836,7 +838,6 @@ impl ClientState {
                 self.internet_resource
                     .map(|_| Ipv6Network::DEFAULT_ROUTE.into()),
             )
-            .chain(self.dns_mapping.left_values().copied().map(Into::into))
     }
 
     fn is_resource_enabled(&self, resource: &ResourceId) -> bool {
@@ -1159,11 +1160,6 @@ impl ClientState {
                     .iter()
                     .map(|(sentinel_dns, effective_dns)| (*sentinel_dns, effective_dns.address()))
                     .collect(),
-            });
-        self.buffered_events
-            .push_back(ClientEvent::TunRoutesUpdated {
-                ip4: self.routes().filter_map(utils::ipv4).collect(),
-                ip6: self.routes().filter_map(utils::ipv6).collect(),
             });
     }
 
@@ -1764,7 +1760,9 @@ mod proptests {
             resource_routes
                 .into_iter()
                 .chain(iter::once(IPV4_RESOURCES.into()))
-                .chain(iter::once(IPV6_RESOURCES.into())),
+                .chain(iter::once(IPV6_RESOURCES.into()))
+                .chain(iter::once(DNS_SENTINELS_V4.into()))
+                .chain(iter::once(DNS_SENTINELS_V4.into())),
         )
     }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -302,21 +302,24 @@ pub enum ClientEvent {
         resources: Vec<callbacks::ResourceDescription>,
     },
     // TODO: Make this more fine-granular.
-    TunInterfaceUpdated {
-        ip4: Ipv4Addr,
-        ip6: Ipv6Addr,
-        /// The map of DNS servers that connlib will use.
-        ///
-        /// - The "left" values are the connlib-assigned, proxy (or "sentinel") IPs.
-        /// - The "right" values are the effective DNS servers.
-        ///   If upstream DNS servers are configured (in the portal), we will use those.
-        ///   Otherwise, we will use the DNS servers configured on the system.
-        dns_by_sentinel: BiMap<IpAddr, SocketAddr>,
-    },
+    TunInterfaceUpdated(TunConfig),
     TunRoutesUpdated {
         ip4: Vec<Ipv4Network>,
         ip6: Vec<Ipv6Network>,
     },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TunConfig {
+    pub ip4: Ipv4Addr,
+    pub ip6: Ipv6Addr,
+    /// The map of DNS servers that connlib will use.
+    ///
+    /// - The "left" values are the connlib-assigned, proxy (or "sentinel") IPs.
+    /// - The "right" values are the effective DNS servers.
+    ///   If upstream DNS servers are configured (in the portal), we will use those.
+    ///   Otherwise, we will use the DNS servers configured on the system.
+    pub dns_by_sentinel: BiMap<IpAddr, SocketAddr>,
 }
 
 #[derive(Debug, Clone)]

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -127,6 +127,15 @@ pub(crate) fn assert_known_hosts_are_valid(ref_client: &RefClient, sim_client: &
     }
 }
 
+pub(crate) fn assert_dns_servers_are_valid(ref_client: &RefClient, sim_client: &SimClient) {
+    let expected = ref_client.expected_dns_servers();
+    let actual = sim_client.effective_dns_servers();
+
+    if actual != expected {
+        tracing::error!(target: "assertions", ?actual, ?expected, "❌ Effective DNS servers are incorrect");
+    }
+}
+
 pub(crate) fn assert_dns_packets_properties(ref_client: &RefClient, sim_client: &SimClient) {
     let unexpected_dns_replies = find_unexpected_entries(
         &ref_client.expected_dns_handshakes,

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -410,12 +410,12 @@ impl ReferenceStateMachine for ReferenceState {
             Transition::UpdateSystemDnsServers(servers) => {
                 state
                     .client
-                    .exec_mut(|client| client.system_dns_resolvers.clone_from(servers));
+                    .exec_mut(|client| client.set_system_dns_resolvers(servers));
             }
             Transition::UpdateUpstreamDnsServers(servers) => {
                 state
                     .client
-                    .exec_mut(|client| client.upstream_dns_resolvers.clone_from(servers));
+                    .exec_mut(|client| client.set_upstream_dns_resolvers(servers));
             }
             Transition::RoamClient { ip4, ip6, .. } => {
                 state.network.remove_host(&state.client);

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -59,15 +59,17 @@ impl ReferenceStateMachine for ReferenceState {
     type Transition = Transition;
 
     fn init_state() -> BoxedStrategy<Self::State> {
-        stub_portal()
-            .prop_flat_map(|portal| {
+        (stub_portal(), dns_servers())
+            .prop_flat_map(|(portal, dns_servers)| {
                 let gateways = portal.gateways();
                 let dns_resource_records = portal.dns_resource_records();
-                let client = portal.client();
+                let client = portal.client(
+                    system_dns_servers(dns_servers.values().cloned().collect()),
+                    upstream_dns_servers(dns_servers.values().cloned().collect()),
+                );
                 let relays = relays();
                 let global_dns_records = global_dns_records(); // Start out with a set of global DNS records so we have something to resolve outside of DNS resources.
                 let drop_direct_client_traffic = any::<bool>();
-                let dns_servers = dns_servers();
 
                 (
                     client,
@@ -77,7 +79,7 @@ impl ReferenceStateMachine for ReferenceState {
                     relays,
                     global_dns_records,
                     drop_direct_client_traffic,
-                    dns_servers,
+                    Just(dns_servers),
                 )
             })
             .prop_filter_map(
@@ -176,11 +178,13 @@ impl ReferenceStateMachine for ReferenceState {
         CompositeStrategy::default()
             .with(
                 1,
-                update_system_dns_servers(state.dns_servers.values().cloned().collect()),
+                system_dns_servers(state.dns_servers.values().cloned().collect())
+                    .prop_map(Transition::UpdateSystemDnsServers),
             )
             .with(
                 1,
-                update_upstream_dns_servers(state.dns_servers.values().cloned().collect()),
+                upstream_dns_servers(state.dns_servers.values().cloned().collect())
+                    .prop_map(Transition::UpdateUpstreamDnsServers),
             )
             .with_if_not_empty(
                 5,

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -830,8 +830,11 @@ fn ref_client(
 
 fn known_hosts() -> impl Strategy<Value = BTreeMap<String, Vec<IpAddr>>> {
     collection::btree_map(
-        domain_name(2..4).prop_map(|d| d.parse().unwrap()),
-        collection::vec(any::<IpAddr>(), 1..6),
-        0..15,
+        prop_oneof![
+            Just("api.firezone.dev".to_owned()),
+            Just("api.firez.one".to_owned())
+        ],
+        collection::vec(any::<IpAddr>(), 1..3),
+        1..=2,
     )
 }

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -257,10 +257,10 @@ pub struct RefClient {
 
     /// The DNS resolvers configured on the client outside of connlib.
     #[derivative(Debug = "ignore")]
-    pub(crate) system_dns_resolvers: Vec<IpAddr>,
+    system_dns_resolvers: Vec<IpAddr>,
     /// The upstream DNS resolvers configured in the portal.
     #[derivative(Debug = "ignore")]
-    pub(crate) upstream_dns_resolvers: Vec<DnsServer>,
+    upstream_dns_resolvers: Vec<DnsServer>,
 
     /// Tracks all resources in the order they have been added in.
     ///
@@ -730,6 +730,18 @@ impl RefClient {
 
     pub(crate) fn all_resources(&self) -> Vec<ResourceDescription> {
         self.resources.clone()
+    }
+
+    pub(crate) fn set_system_dns_resolvers(&mut self, servers: &Vec<IpAddr>) {
+        self.system_dns_resolvers.clone_from(servers);
+    }
+
+    pub(crate) fn set_upstream_dns_resolvers(&mut self, servers: &Vec<DnsServer>) {
+        self.upstream_dns_resolvers.clone_from(servers);
+    }
+
+    pub(crate) fn upstream_dns_resolvers(&self) -> Vec<DnsServer> {
+        self.upstream_dns_resolvers.clone()
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/sim_dns.rs
+++ b/rust/connlib/tunnel/src/tests/sim_dns.rs
@@ -61,6 +61,7 @@ impl SimDns {
 
         let query = query.sole_question().unwrap();
         let name = query.qname().to_vec();
+        let qtype = query.qtype();
 
         let records = global_dns_records
             .get(&name)
@@ -68,7 +69,7 @@ impl SimDns {
             .flatten()
             .filter(|ip| {
                 #[allow(clippy::wildcard_enum_match_arm)]
-                match query.qtype() {
+                match qtype {
                     Rtype::A => ip.is_ipv4(),
                     Rtype::AAAA => ip.is_ipv6(),
                     _ => todo!(),
@@ -87,7 +88,7 @@ impl SimDns {
 
         let payload = answers.finish();
 
-        tracing::debug!(%name, "Responding to DNS query");
+        tracing::debug!(%name, %qtype, "Responding to DNS query");
 
         Some(Transmit {
             src: Some(transmit.dst),

--- a/rust/connlib/tunnel/src/tests/strategies.rs
+++ b/rust/connlib/tunnel/src/tests/strategies.rs
@@ -11,7 +11,7 @@ use connlib_shared::{
         client::{
             ResourceDescriptionCidr, ResourceDescriptionDns, ResourceDescriptionInternet, Site,
         },
-        RelayId,
+        DnsServer, RelayId,
     },
     DomainName,
 };
@@ -259,4 +259,22 @@ pub(crate) fn documentation_ip6s(subnet: u16, num_ips: usize) -> impl Strategy<V
     .collect_vec();
 
     sample::select(ips)
+}
+
+pub(crate) fn system_dns_servers(
+    dns_servers: Vec<Host<RefDns>>,
+) -> impl Strategy<Value = Vec<IpAddr>> {
+    let max = dns_servers.len();
+
+    sample::subsequence(dns_servers, ..=max)
+        .prop_map(|seq| seq.into_iter().map(|h| h.single_socket().ip()).collect())
+}
+
+pub(crate) fn upstream_dns_servers(
+    dns_servers: Vec<Host<RefDns>>,
+) -> impl Strategy<Value = Vec<DnsServer>> {
+    let max = dns_servers.len();
+
+    sample::subsequence(dns_servers, ..=max)
+        .prop_map(|seq| seq.into_iter().map(|h| h.single_socket().into()).collect())
 }

--- a/rust/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/connlib/tunnel/src/tests/stub_portal.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::proptest::*;
 use connlib_shared::{
-    messages::{client, gateway, GatewayId, ResourceId},
+    messages::{client, gateway, DnsServer, GatewayId, ResourceId},
     DomainName,
 };
 use ip_network::{Ipv4Network, Ipv6Network};
@@ -197,11 +197,20 @@ impl StubPortal {
             .prop_map(BTreeMap::from_iter)
     }
 
-    pub(crate) fn client(&self) -> impl Strategy<Value = Host<RefClient>> {
+    pub(crate) fn client(
+        &self,
+        system_dns: impl Strategy<Value = Vec<IpAddr>>,
+        upstream_dns: impl Strategy<Value = Vec<DnsServer>>,
+    ) -> impl Strategy<Value = Host<RefClient>> {
         let client_tunnel_ip4 = tunnel_ip4s().next().unwrap();
         let client_tunnel_ip6 = tunnel_ip6s().next().unwrap();
 
-        ref_client_host(Just(client_tunnel_ip4), Just(client_tunnel_ip6))
+        ref_client_host(
+            Just(client_tunnel_ip4),
+            Just(client_tunnel_ip6),
+            system_dns,
+            upstream_dns,
+        )
     }
 
     pub(crate) fn dns_resource_records(

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -257,7 +257,7 @@ impl TunnelTest {
             Transition::ReconnectPortal => {
                 let ipv4 = state.client.inner().sut.tunnel_ip4().unwrap();
                 let ipv6 = state.client.inner().sut.tunnel_ip6().unwrap();
-                let upstream_dns = ref_state.client.inner().upstream_dns_resolvers.clone();
+                let upstream_dns = ref_state.client.inner().upstream_dns_resolvers();
                 let all_resources = ref_state.client.inner().all_resources();
 
                 // Simulate receiving `init`.

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -677,6 +677,10 @@ impl TunnelTest {
             ClientEvent::TunInterfaceUpdated {
                 dns_by_sentinel, ..
             } => {
+                if self.client.inner().dns_by_sentinel == dns_by_sentinel {
+                    tracing::error!("Emitted `TunInterfaceUpdated` without changing DNS servers");
+                }
+
                 self.client
                     .exec_mut(|c| c.dns_by_sentinel = dns_by_sentinel);
             }

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -670,15 +670,13 @@ impl TunnelTest {
             ClientEvent::ResourcesChanged { .. } => {
                 tracing::warn!("Unimplemented");
             }
-            ClientEvent::TunInterfaceUpdated {
-                dns_by_sentinel, ..
-            } => {
-                if self.client.inner().dns_by_sentinel == dns_by_sentinel {
+            ClientEvent::TunInterfaceUpdated(config) => {
+                if self.client.inner().dns_by_sentinel == config.dns_by_sentinel {
                     tracing::error!("Emitted `TunInterfaceUpdated` without changing DNS servers");
                 }
 
                 self.client
-                    .exec_mut(|c| c.dns_by_sentinel = dns_by_sentinel);
+                    .exec_mut(|c| c.dns_by_sentinel = config.dns_by_sentinel);
             }
             ClientEvent::TunRoutesUpdated { .. } => {}
             ClientEvent::RequestConnection {

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -351,11 +351,7 @@ impl TunnelTest {
         );
         assert_dns_packets_properties(ref_client, sim_client);
         assert_known_hosts_are_valid(ref_client, sim_client);
-        assert_eq!(
-            sim_client.effective_dns_servers(),
-            ref_client.expected_dns_servers(),
-            "Effective DNS servers should match either system or upstream DNS"
-        );
+        assert_dns_servers_are_valid(ref_client, sim_client);
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -1,7 +1,4 @@
-use super::{
-    sim_dns::RefDns,
-    sim_net::{any_ip_stack, any_port, Host},
-};
+use super::sim_net::{any_ip_stack, any_port, Host};
 use connlib_shared::{
     messages::{client::ResourceDescription, DnsServer, RelayId, ResourceId},
     DomainName,
@@ -218,29 +215,5 @@ pub(crate) fn roam_client() -> impl Strategy<Value = Transition> {
         ip4: ip_stack.as_v4().copied(),
         ip6: ip_stack.as_v6().copied(),
         port,
-    })
-}
-
-pub(crate) fn update_system_dns_servers(
-    dns_servers: Vec<Host<RefDns>>,
-) -> impl Strategy<Value = Transition> {
-    let max = dns_servers.len();
-
-    sample::subsequence(dns_servers, ..=max).prop_map(|seq| {
-        Transition::UpdateSystemDnsServers(
-            seq.into_iter().map(|h| h.single_socket().ip()).collect(),
-        )
-    })
-}
-
-pub(crate) fn update_upstream_dns_servers(
-    dns_servers: Vec<Host<RefDns>>,
-) -> impl Strategy<Value = Transition> {
-    let max = dns_servers.len();
-
-    sample::subsequence(dns_servers, ..=max).prop_map(|seq| {
-        Transition::UpdateUpstreamDnsServers(
-            seq.into_iter().map(|h| h.single_socket().into()).collect(),
-        )
     })
 }


### PR DESCRIPTION
Currently, `connlib` tracks the `Interface` as it is given it by the portal. This includes the tunnel IP addresses plus the upstream servers.

Upstreams servers however only take effect when they are defined. Without upstream DNS servers, `connlib` uses the system-defined DNS servers. In that case, the `Interface` no longer accurately represents, what we actually configure on the TUN device.

To fix this, we introduce a dedicated `TunConfig` struct that tracks, what is actually set on the interface. This also allows us to track, whether or not we need to re-emit this configuration after a change.

Related: #6423.