### PR TITLE
feat(connlib): respond w/ ICMP unreachable on socket error

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2045,6 +2045,7 @@ dependencies = [
  "ip_network",
  "ip_network_table",
  "itertools 0.13.0",
+ "libc",
  "lru",
  "proptest",
  "proptest-state-machine",
@@ -3281,9 +3282,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libdbus-sys"
@@ -4726,7 +4727,7 @@ dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp",
+ "quinn-udp 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 2.0.0",
  "rustls",
  "socket2",
@@ -4763,6 +4764,18 @@ dependencies = [
  "socket2",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.4"
+source = "git+https://github.com/firezone/quinn?branch=main#8db4894a5c126483fab116e042d529de2f5ea470"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5560,7 +5573,7 @@ dependencies = [
 name = "socket-factory"
 version = "0.1.0"
 dependencies = [
- "quinn-udp",
+ "quinn-udp 0.5.4 (git+https://github.com/firezone/quinn?branch=main)",
  "socket2",
  "tokio",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,6 +190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +1715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
+name = "etherparse"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21696e6dfe1057a166a042c6d27b89a46aad2ee1003e6e1e03c49d54fd3270d7"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +2051,7 @@ dependencies = [
  "derivative",
  "divan",
  "domain",
+ "either",
  "firezone-relay",
  "futures",
  "futures-util",
@@ -3044,6 +3060,7 @@ name = "ip-packet"
 version = "0.1.0"
 dependencies = [
  "domain",
+ "etherparse",
  "pnet_packet",
  "proptest",
  "test-strategy",

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -12,6 +12,7 @@ chrono = { workspace = true }
 connlib-shared = { workspace = true }
 divan = { version = "0.1.14", optional = true }
 domain = { workspace = true }
+either = "1.13.0"
 futures =  { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
 futures-util =  { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }
 glob = "0.3.1"

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -39,6 +39,7 @@ uuid = { version = "1.10", default-features = false, features = ["std", "v4"] }
 derivative = "2.2.0"
 firezone-relay = { workspace = true, features = ["proptest"] }
 ip-packet = { workspace = true, features = ["proptest"] }
+libc = "0.2.158"
 proptest-state-machine = "0.3"
 rand = "0.8"
 serde_json = "1.0"

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -73,14 +73,7 @@ impl Sockets {
             return Ok(());
         };
 
-        match socket.send(datagram) {
-            Ok(()) => {}
-            Err(e) if is_network_unreachable(&e) => {
-                tracing::info!(%dst, "{e}: Discarding socket");
-                *maybe_socket = None;
-            }
-            Err(e) => return Err(e),
-        };
+        socket.send(datagram)?;
 
         Ok(())
     }
@@ -152,21 +145,5 @@ where
         }
 
         None
-    }
-}
-
-/// Hacky way of detecting `NetworkUnreachable` until <https://github.com/rust-lang/rust/issues/86442> stabilizes.
-fn is_network_unreachable(e: &io::Error) -> bool {
-    format!("{:?}", e.kind()) == "NetworkUnreachable"
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn network_unreachable_works() {
-        let err = std::io::Error::from_raw_os_error(libc::ENETUNREACH); // This is what `std` uses internally to map it.
-
-        assert!(super::is_network_unreachable(&err))
     }
 }

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -60,37 +60,29 @@ impl Sockets {
         Poll::Ready(Ok(()))
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(dst = %datagram.dst))]
     pub fn send(&mut self, datagram: DatagramOut) -> io::Result<()> {
         let dst = datagram.dst;
-        let socket = match (dst, self.socket_v4.as_mut(), self.socket_v6.as_mut()) {
-            (SocketAddr::V4(_), Some(v4), _) => v4,
-            (SocketAddr::V6(_), _, Some(v6)) => v6,
-            (_, _, _) => {
-                tracing::trace!("Dropping packet: No socket");
-                return Ok(());
-            }
+        let maybe_socket = match (dst, &mut self.socket_v4, &mut self.socket_v6) {
+            (SocketAddr::V4(_), v4, _) => v4,
+            (SocketAddr::V6(_), _, v6) => v6,
+        };
+
+        let Some(socket) = maybe_socket else {
+            tracing::trace!(%dst, "Dropping packet: No socket");
+
+            return Ok(());
         };
 
         match socket.send(datagram) {
-            Ok(()) => Ok(()),
+            Ok(()) => {}
             Err(e) if is_network_unreachable(&e) => {
-                match dst {
-                    SocketAddr::V4(_) => {
-                        tracing::info!("{e}: Discarding IPv4 socket");
-                        self.socket_v4 = None;
-                    }
-                    SocketAddr::V6(_) => {
-                        tracing::info!("{e}: Discarding IPv6 socket");
-
-                        self.socket_v6 = None;
-                    }
-                };
-
-                Ok(())
+                tracing::info!(%dst, "{e}: Discarding socket");
+                *maybe_socket = None;
             }
-            Err(e) => Err(e),
-        }
+            Err(e) => return Err(e),
+        };
+
+        Ok(())
     }
 
     pub fn poll_recv_from<'b>(

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -66,7 +66,7 @@ impl Sockets {
         let socket = match (dst, self.socket_v4.as_mut(), self.socket_v6.as_mut()) {
             (SocketAddr::V4(_), Some(v4), _) => v4,
             (SocketAddr::V6(_), _, Some(v6)) => v6,
-            (SocketAddr::V4(_), None, _) | (SocketAddr::V6(_), _, None) => {
+            (_, _, _) => {
                 tracing::trace!("Dropping packet: No socket");
                 return Ok(());
             }

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -169,6 +169,15 @@ pub(crate) fn assert_dns_packets_properties(ref_client: &RefClient, sim_client: 
     }
 }
 
+pub(crate) fn assert_icmp_errors(ref_client: &RefClient, sim_client: &SimClient) {
+    let expected = &ref_client.expected_icmp_errors;
+    let actual = &sim_client.received_icmp_errors;
+
+    if actual != expected {
+        tracing::error!(target: "assertions", ?actual, ?expected, "❌ ICMP errors don't match");
+    }
+}
+
 fn assert_correct_src_and_dst_ips(
     client_sent_request: &IpPacket<'_>,
     client_received_reply: &IpPacket<'_>,

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -56,6 +56,8 @@ pub(crate) struct SimClient {
     pub(crate) sent_icmp_requests: HashMap<(u16, u16), IpPacket<'static>>,
     pub(crate) received_icmp_replies: BTreeMap<(u16, u16), IpPacket<'static>>,
 
+    pub(crate) received_icmp_errors: VecDeque<IpPacket<'static>>,
+
     buffer: Vec<u8>,
 }
 
@@ -71,6 +73,7 @@ impl SimClient {
             sent_icmp_requests: Default::default(),
             received_icmp_replies: Default::default(),
             buffer: vec![0u8; (1 << 16) - 1],
+            received_icmp_errors: Default::default(),
         }
     }
 
@@ -302,6 +305,9 @@ pub struct RefClient {
     #[derivative(Debug = "ignore")]
     pub(crate) expected_icmp_handshakes:
         BTreeMap<GatewayId, BTreeMap<u64, (ResourceDst, IcmpSeq, IcmpIdentifier)>>,
+    /// The expected ICMP errors that we are emitting.
+    #[derivative(Debug = "ignore")]
+    pub(crate) expected_icmp_errors: VecDeque<IpPacket<'static>>,
     /// The expected DNS handshakes.
     #[derivative(Debug = "ignore")]
     pub(crate) expected_dns_handshakes: VecDeque<(SocketAddr, QueryId)>,
@@ -823,6 +829,7 @@ fn ref_client(
                     expected_dns_handshakes: Default::default(),
                     disabled_resources: Default::default(),
                     resources: Default::default(),
+                    expected_icmp_errors: Default::default(),
                 }
             },
         )

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -349,6 +349,7 @@ impl TunnelTest {
             sim_gateways,
             &ref_state.global_dns_records,
         );
+        assert_icmp_errors(ref_client, sim_client);
         assert_dns_packets_properties(ref_client, sim_client);
         assert_known_hosts_are_valid(ref_client, sim_client);
         assert_dns_servers_are_valid(ref_client, sim_client);

--- a/rust/ip-packet/Cargo.toml
+++ b/rust/ip-packet/Cargo.toml
@@ -15,6 +15,7 @@ pnet_packet = { version = "0.35" }
 proptest = { version = "1", optional = true }
 thiserror = "1"
 tracing = "0.1"
+etherparse = "0.15.0"
 
 [dev-dependencies]
 test-strategy = "0.3.1"

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-quinn-udp = "0.5.2"
+quinn-udp = { git = "https://github.com/firezone/quinn", branch = "main" }
 socket2 = { workspace = true }
 tokio = { version = "1.39", features = ["net"] }
 tracing = "0.1"


### PR DESCRIPTION
Whenever `connlib` receives an IP packet from the TUN interface, we pass it to our state machine for processing. In most cases, the outcome of this processing is a `Transmit`: The encrypted WG packet that needs to be sent to the gateway.

In case the IP packet was a DNS query, we might forward it to one of our DNS servers. Sending such a packet can fail with "Destination Unreachable". This is an ICMP error code that is forwarded to us by the operating system. To let the application know that this DNS server is not routable, we now respond with the same ICMP error code back to the application via the TUN interface.

Resolves: #6353. (Hopefully)