### PR TITLE
feat: Internet Resource UI

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
@@ -83,7 +83,7 @@ class ResourceDetailsBottomSheet(private val resource: ViewResource) : BottomShe
             }
         } else {
             resourceAddressTextView.setOnClickListener {
-                copyToClipboard(displayAddress)
+                copyToClipboard(displayAddress!!)
                 Toast.makeText(requireContext(), "Address copied to clipboard", Toast.LENGTH_SHORT).show()
             }
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
@@ -1,7 +1,9 @@
 /* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
 package dev.firezone.android.features.session.ui
 
+import android.view.Gravity
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
@@ -29,12 +31,15 @@ internal class ResourcesAdapter(private val activity: SessionActivity) : ListAda
     ) {
         val resource = getItem(position)
         holder.bind(resource) { newResource -> onSwitchToggled(newResource) }
-        holder.itemView.setOnClickListener {
-            // Show bottom sheet
-            val isFavorite = favoriteResources.contains(resource.id)
-            val fragmentManager = (holder.itemView.context as AppCompatActivity).supportFragmentManager
-            val bottomSheet = ResourceDetailsBottomSheet(resource)
-            bottomSheet.show(fragmentManager, "ResourceDetailsBottomSheet")
+        if (!resource.isInternetResource()) {
+            holder.itemView.setOnClickListener {
+                // Show bottom sheet
+                val isFavorite = favoriteResources.contains(resource.id)
+                val fragmentManager =
+                    (holder.itemView.context as AppCompatActivity).supportFragmentManager
+                val bottomSheet = ResourceDetailsBottomSheet(resource)
+                bottomSheet.show(fragmentManager, "ResourceDetailsBottomSheet")
+            }
         }
     }
 
@@ -42,13 +47,18 @@ internal class ResourcesAdapter(private val activity: SessionActivity) : ListAda
         activity.onViewResourceToggled(resource)
     }
 
+
     class ViewHolder(private val binding: ListItemResourceBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(
             resource: ViewResource,
             onSwitchToggled: (ViewResource) -> Unit,
         ) {
             binding.resourceNameText.text = resource.name
-            binding.addressText.text = resource.address
+            if (!resource.isInternetResource()) {
+                binding.addressText.text = resource.address
+            } else {
+                binding.addressText.visibility = View.GONE
+            }
             // Without this the item gets reset when out of view, isn't android wonderful?
             binding.enableSwitch.setOnCheckedChangeListener(null)
             binding.enableSwitch.isChecked = resource.enabled

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
@@ -1,7 +1,6 @@
 /* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
 package dev.firezone.android.features.session.ui
 
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -46,7 +45,6 @@ internal class ResourcesAdapter(private val activity: SessionActivity) : ListAda
     private fun onSwitchToggled(resource: ViewResource) {
         activity.onViewResourceToggled(resource)
     }
-
 
     class ViewHolder(private val binding: ListItemResourceBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
@@ -52,10 +52,10 @@ internal class ResourcesAdapter(private val activity: SessionActivity) : ListAda
             onSwitchToggled: (ViewResource) -> Unit,
         ) {
             binding.resourceNameText.text = resource.name
-            if (!resource.isInternetResource()) {
-                binding.addressText.text = resource.address
-            } else {
+            if (resource.isInternetResource()) {
                 binding.addressText.visibility = View.GONE
+            } else {
+                binding.addressText.text = resource.address
             }
             // Without this the item gets reset when out of view, isn't android wonderful?
             binding.enableSwitch.setOnCheckedChangeListener(null)

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -97,11 +97,16 @@ internal class SessionActivity : AppCompatActivity() {
         binding.rvResourcesList.adapter = resourcesAdapter
         binding.rvResourcesList.layoutManager = layoutManager
 
+
         binding.tabLayout.addOnTabSelectedListener(
             object : TabLayout.OnTabSelectedListener {
                 override fun onTabSelected(tab: TabLayout.Tab) {
                     viewModel.tabSelected(tab.position)
-                    refreshList()
+
+                    refreshList() {
+                        // TODO: we might want to remember the old position?
+                        binding.rvResourcesList.scrollToPosition(0)
+                    }
                 }
 
                 override fun onTabUnselected(tab: TabLayout.Tab?) {}
@@ -130,9 +135,10 @@ internal class SessionActivity : AppCompatActivity() {
         viewModel.favoriteResourcesLiveData.value = viewModel.repo.getFavoritesSync()
     }
 
-    private fun refreshList() {
+    private fun refreshList(afterLoad: () -> Unit = {}) {
         if (viewModel.forceAllResourcesTab()) {
             binding.tabLayout.selectTab(binding.tabLayout.getTabAt(SessionViewModel.RESOURCES_TAB_ALL), true)
+
         }
         binding.tabLayout.visibility =
             if (viewModel.showFavoritesTab()) {
@@ -141,7 +147,10 @@ internal class SessionActivity : AppCompatActivity() {
                 View.GONE
             }
 
-        resourcesAdapter.submitList(viewModel.resourcesList())
+
+        resourcesAdapter.submitList(viewModel.resourcesList()) {
+            afterLoad()
+        }
     }
 
     companion object {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -97,13 +97,12 @@ internal class SessionActivity : AppCompatActivity() {
         binding.rvResourcesList.adapter = resourcesAdapter
         binding.rvResourcesList.layoutManager = layoutManager
 
-
         binding.tabLayout.addOnTabSelectedListener(
             object : TabLayout.OnTabSelectedListener {
                 override fun onTabSelected(tab: TabLayout.Tab) {
                     viewModel.tabSelected(tab.position)
 
-                    refreshList() {
+                    refreshList {
                         // TODO: we might want to remember the old position?
                         binding.rvResourcesList.scrollToPosition(0)
                     }
@@ -138,7 +137,6 @@ internal class SessionActivity : AppCompatActivity() {
     private fun refreshList(afterLoad: () -> Unit = {}) {
         if (viewModel.forceAllResourcesTab()) {
             binding.tabLayout.selectTab(binding.tabLayout.getTabAt(SessionViewModel.RESOURCES_TAB_ALL), true)
-
         }
         binding.tabLayout.visibility =
             if (viewModel.showFavoritesTab()) {
@@ -146,7 +144,6 @@ internal class SessionActivity : AppCompatActivity() {
             } else {
                 View.GONE
             }
-
 
         resourcesAdapter.submitList(viewModel.resourcesList()) {
             afterLoad()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
@@ -9,7 +9,7 @@ import dev.firezone.android.tunnel.model.TypeEnum
 data class ViewResource(
     val id: String,
     val type: TypeEnum,
-    val address: String,
+    val address: String?,
     val addressDescription: String?,
     val sites: List<Site>?,
     val name: String,

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
@@ -4,9 +4,11 @@ package dev.firezone.android.features.session.ui
 import dev.firezone.android.tunnel.model.Resource
 import dev.firezone.android.tunnel.model.Site
 import dev.firezone.android.tunnel.model.StatusEnum
+import dev.firezone.android.tunnel.model.TypeEnum
 
 data class ViewResource(
     val id: String,
+    val type: TypeEnum,
     val address: String,
     val addressDescription: String?,
     val sites: List<Site>?,
@@ -19,6 +21,7 @@ data class ViewResource(
 fun Resource.toViewResource(enabled: Boolean): ViewResource {
     return ViewResource(
         id = this.id,
+        type = this.type,
         address = this.address,
         addressDescription = this.addressDescription,
         sites = this.sites,
@@ -27,4 +30,8 @@ fun Resource.toViewResource(enabled: Boolean): ViewResource {
         enabled = enabled,
         canBeDisabled = this.canBeDisabled,
     )
+}
+
+fun ViewResource.isInternetResource() : Boolean {
+    return this.type == TypeEnum.Internet
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
@@ -2,9 +2,9 @@
 package dev.firezone.android.features.session.ui
 
 import dev.firezone.android.tunnel.model.Resource
+import dev.firezone.android.tunnel.model.ResourceType
 import dev.firezone.android.tunnel.model.Site
 import dev.firezone.android.tunnel.model.StatusEnum
-import dev.firezone.android.tunnel.model.ResourceType
 
 data class ViewResource(
     val id: String,

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
@@ -4,11 +4,11 @@ package dev.firezone.android.features.session.ui
 import dev.firezone.android.tunnel.model.Resource
 import dev.firezone.android.tunnel.model.Site
 import dev.firezone.android.tunnel.model.StatusEnum
-import dev.firezone.android.tunnel.model.TypeEnum
+import dev.firezone.android.tunnel.model.ResourceType
 
 data class ViewResource(
     val id: String,
-    val type: TypeEnum,
+    val type: ResourceType,
     val address: String?,
     val addressDescription: String?,
     val sites: List<Site>?,
@@ -33,5 +33,5 @@ fun Resource.toViewResource(enabled: Boolean): ViewResource {
 }
 
 fun ViewResource.isInternetResource(): Boolean {
-    return this.type == TypeEnum.Internet
+    return this.type == ResourceType.Internet
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
@@ -32,6 +32,6 @@ fun Resource.toViewResource(enabled: Boolean): ViewResource {
     )
 }
 
-fun ViewResource.isInternetResource() : Boolean {
+fun ViewResource.isInternetResource(): Boolean {
     return this.type == TypeEnum.Internet
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
@@ -9,7 +9,7 @@ import kotlinx.parcelize.Parcelize
 @JsonClass(generateAdapter = true)
 @Parcelize
 data class Resource(
-    val type: TypeEnum,
+    val type: ResourceType,
     val id: String,
     val address: String?,
     @Json(name = "address_description") val addressDescription: String?,
@@ -20,7 +20,7 @@ data class Resource(
     @Json(name = "can_be_disabled") val canBeDisabled: Boolean,
 ) : Parcelable
 
-enum class TypeEnum {
+enum class ResourceType {
     @Json(name = "dns")
     DNS,
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
@@ -11,7 +11,7 @@ import kotlinx.parcelize.Parcelize
 data class Resource(
     val type: TypeEnum,
     val id: String,
-    val address: String,
+    val address: String?,
     @Json(name = "address_description") val addressDescription: String?,
     val sites: List<Site>?,
     val name: String,

--- a/kotlin/android/app/src/main/res/layout/list_item_resource.xml
+++ b/kotlin/android/app/src/main/res/layout/list_item_resource.xml
@@ -30,13 +30,12 @@
 
 	<androidx.appcompat.widget.SwitchCompat
 		android:id="@+id/enable_switch"
-		android:layout_width="114dp"
-		android:layout_height="30dp"
+		android:layout_height="wrap_content"
+		android:layout_width="wrap_content"
 		android:checked="true"
-		android:text="Enabled"
-		app:layout_constraintEnd_toEndOf="parent"
-		app:layout_constraintBottom_toBottomOf="@+id/resourceNameText"
 		android:gravity="center_vertical"
+		app:layout_constraintBottom_toBottomOf="@+id/resourceNameText"
+		app:layout_constraintEnd_toEndOf="parent"
 		app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/kotlin/android/app/src/main/res/layout/list_item_resource.xml
+++ b/kotlin/android/app/src/main/res/layout/list_item_resource.xml
@@ -12,7 +12,7 @@
 		style="@style/AppTheme.Base.Body1"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		app:layout_constraintEnd_toStartOf="@+id/enable_switch"
+		app:layout_constraintEnd_toStartOf="parent"
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintTop_toTopOf="parent"
 		tools:text="Resource Name" />
@@ -24,25 +24,19 @@
 		android:layout_height="wrap_content"
 		android:textColor="@color/neutral_600"
 		app:layout_constraintBottom_toBottomOf="parent"
-		app:layout_constraintEnd_toStartOf="@+id/enable_switch"
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintTop_toBottomOf="@id/resourceNameText"
-		app:layout_constraintVertical_bias="0.0"
 		tools:text="Resource Address" />
 
 	<androidx.appcompat.widget.SwitchCompat
 		android:id="@+id/enable_switch"
-		android:layout_width="101dp"
-		android:layout_height="39dp"
+		android:layout_width="114dp"
+		android:layout_height="30dp"
 		android:checked="true"
-		android:minHeight="48dp"
-		android:scaleX="1"
-		android:scaleY="1"
 		android:text="Enabled"
-		android:textAlignment="viewStart"
-		android:textSize="14sp"
-		app:layout_constraintBottom_toBottomOf="parent"
 		app:layout_constraintEnd_toEndOf="parent"
+		app:layout_constraintBottom_toBottomOf="@+id/resourceNameText"
+		android:gravity="center_vertical"
 		app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use anyhow::Result;
 use connlib_shared::messages::{
-    ConnectionAccepted, GatewayResponse, RelaysPresence, ResourceAccepted, ResourceId,
+    client::ResourceDescriptionInternet, ConnectionAccepted, GatewayResponse, RelaysPresence,
+    ResourceAccepted, ResourceId,
 };
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
@@ -215,9 +216,20 @@ where
             }
             IngressMessages::Init(InitClient {
                 interface,
-                resources,
+                mut resources,
                 relays,
             }) => {
+                resources.push(
+                    connlib_shared::messages::client::ResourceDescription::Internet(
+                        ResourceDescriptionInternet {
+                            name: "Internet resource".to_string(),
+                            id: ResourceId::random(),
+                            sites: vec![],
+                            can_be_disabled: Some(true),
+                        },
+                    ),
+                );
+
                 self.tunnel.set_new_interface_config(interface);
                 self.tunnel.set_resources(resources);
                 self.tunnel.update_relays(BTreeSet::default(), relays);

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -8,8 +8,7 @@ use crate::{
 };
 use anyhow::Result;
 use connlib_shared::messages::{
-    client::ResourceDescriptionInternet, ConnectionAccepted, GatewayResponse, RelaysPresence,
-    ResourceAccepted, ResourceId,
+    ConnectionAccepted, GatewayResponse, RelaysPresence, ResourceAccepted, ResourceId,
 };
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
@@ -216,20 +215,9 @@ where
             }
             IngressMessages::Init(InitClient {
                 interface,
-                mut resources,
+                resources,
                 relays,
             }) => {
-                resources.push(
-                    connlib_shared::messages::client::ResourceDescription::Internet(
-                        ResourceDescriptionInternet {
-                            name: "Internet resource".to_string(),
-                            id: ResourceId::random(),
-                            sites: vec![],
-                            can_be_disabled: Some(true),
-                        },
-                    ),
-                );
-
                 self.tunnel.set_new_interface_config(interface);
                 self.tunnel.set_resources(resources);
                 self.tunnel.update_relays(BTreeSet::default(), relays);

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use anyhow::Result;
 use connlib_shared::messages::{
-    ConnectionAccepted, GatewayResponse, RelaysPresence, ResourceAccepted, ResourceId,
+    client::ResourceDescriptionInternet, ConnectionAccepted, GatewayResponse, RelaysPresence,
+    ResourceAccepted, ResourceId,
 };
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
@@ -215,9 +216,18 @@ where
             }
             IngressMessages::Init(InitClient {
                 interface,
-                resources,
+                mut resources,
                 relays,
             }) => {
+                resources.push(
+                    connlib_shared::messages::client::ResourceDescription::Internet(
+                        ResourceDescriptionInternet {
+                            id: ResourceId::random(),
+                            sites: vec![],
+                        },
+                    ),
+                );
+
                 self.tunnel.set_new_interface_config(interface);
                 self.tunnel.set_resources(resources);
                 self.tunnel.update_relays(BTreeSet::default(), relays);

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -216,20 +216,9 @@ where
             }
             IngressMessages::Init(InitClient {
                 interface,
-                mut resources,
+                resources,
                 relays,
             }) => {
-                resources.push(
-                    connlib_shared::messages::client::ResourceDescription::Internet(
-                        ResourceDescriptionInternet {
-                            name: Some("○ Internet Resource".to_string()),
-                            id: ResourceId::random(),
-                            sites: vec![],
-                            can_be_disabled: Some(true),
-                        },
-                    ),
-                );
-
                 self.tunnel.set_new_interface_config(interface);
                 self.tunnel.set_resources(resources);
                 self.tunnel.update_relays(BTreeSet::default(), relays);

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -222,6 +222,7 @@ where
                 resources.push(
                     connlib_shared::messages::client::ResourceDescription::Internet(
                         ResourceDescriptionInternet {
+                            name: Some("○ Internet Resource".to_string()),
                             id: ResourceId::random(),
                             sites: vec![],
                             can_be_disabled: Some(true),

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -8,8 +8,7 @@ use crate::{
 };
 use anyhow::Result;
 use connlib_shared::messages::{
-    client::ResourceDescriptionInternet, ConnectionAccepted, GatewayResponse, RelaysPresence,
-    ResourceAccepted, ResourceId,
+    ConnectionAccepted, GatewayResponse, RelaysPresence, ResourceAccepted, ResourceId,
 };
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -224,6 +224,7 @@ where
                         ResourceDescriptionInternet {
                             id: ResourceId::random(),
                             sites: vec![],
+                            can_be_disabled: Some(true),
                         },
                     ),
                 );

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -127,9 +127,6 @@ pub struct ResourceDescriptionInternet {
     /// Name for display always set to "Internet Resource"
     pub name: String,
 
-    /// Address for display always set to "All internet addresses"
-    pub address: String,
-
     pub id: ResourceId,
     pub sites: Vec<Site>,
 
@@ -186,7 +183,6 @@ mod tests {
     fn internet_resource(uuid: &str) -> ResourceDescription {
         ResourceDescription::Internet(ResourceDescriptionInternet {
             name: "🌐 Internet Resource".to_string(),
-            address: "All internet addresses".to_string(),
             id: ResourceId::from_str(uuid).unwrap(),
             sites: vec![Site {
                 name: "test".to_string(),

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -79,7 +79,7 @@ impl ResourceDescription {
         }
     }
 
-    fn is_internet_resource(&self) -> bool {
+    pub fn is_internet_resource(&self) -> bool {
         matches!(self, ResourceDescription::Internet(_))
     }
 }
@@ -185,7 +185,7 @@ mod tests {
 
     fn internet_resource(uuid: &str) -> ResourceDescription {
         ResourceDescription::Internet(ResourceDescriptionInternet {
-            name: "Internet Resource".to_string(),
+            name: "🌐 Internet Resource".to_string(),
             address: "All internet addresses".to_string(),
             id: ResourceId::from_str(uuid).unwrap(),
             sites: vec![Site {

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -182,7 +182,7 @@ mod tests {
 
     fn internet_resource(uuid: &str) -> ResourceDescription {
         ResourceDescription::Internet(ResourceDescriptionInternet {
-            name: "🌐 Internet Resource".to_string(),
+            name: "Internet Resource".to_string(),
             id: ResourceId::from_str(uuid).unwrap(),
             sites: vec![Site {
                 name: "test".to_string(),

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -73,13 +73,18 @@ impl ResourceDescriptionCidr {
     }
 }
 
+fn internet_resource_name() -> String {
+    "<-> Internet Resource".to_string()
+}
+
 /// Description of an internet resource.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ResourceDescriptionInternet {
     /// Name of the resource.
     ///
     /// Used only for display.
-    pub name: Option<String>,
+    #[serde(default = "internet_resource_name")]
+    pub name: String,
     /// Resource's id.
     pub id: ResourceId,
     /// Sites for the internet resource
@@ -92,7 +97,7 @@ pub struct ResourceDescriptionInternet {
 impl ResourceDescriptionInternet {
     pub fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionInternet {
         crate::callbacks::ResourceDescriptionInternet {
-            name: self.name.unwrap_or("○ Internet Resource".to_string()),
+            name: self.name,
             id: self.id,
             sites: self.sites,
             can_be_disabled: self.can_be_disabled.unwrap_or_default(),

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -89,7 +89,6 @@ impl ResourceDescriptionInternet {
     pub fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionInternet {
         crate::callbacks::ResourceDescriptionInternet {
             name: "★ Internet Resource".to_string(),
-            address: "All internet addresses".to_string(),
             id: self.id,
             sites: self.sites,
             can_be_disabled: self.can_be_disabled.unwrap_or_default(),

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -76,6 +76,10 @@ impl ResourceDescriptionCidr {
 /// Description of an internet resource.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ResourceDescriptionInternet {
+    /// Name of the resource.
+    ///
+    /// Used only for display.
+    pub name: Option<String>,
     /// Resource's id.
     pub id: ResourceId,
     /// Sites for the internet resource
@@ -88,7 +92,7 @@ pub struct ResourceDescriptionInternet {
 impl ResourceDescriptionInternet {
     pub fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionInternet {
         crate::callbacks::ResourceDescriptionInternet {
-            name: "★ Internet Resource".to_string(),
+            name: self.name.unwrap_or("○ Internet Resource".to_string()),
             id: self.id,
             sites: self.sites,
             can_be_disabled: self.can_be_disabled.unwrap_or_default(),
@@ -268,6 +272,7 @@ mod tests {
             {
                 "id": "1106047c-cd5d-4151-b679-96b93da7383b",
                 "type": "internet",
+                "name": "Internet Resource",
                 "gateway_groups": [{"name": "test", "id": "eb94482a-94f4-47cb-8127-14fb3afa5516"}],
                 "not": "relevant",
                 "some_other": [

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -88,7 +88,7 @@ pub struct ResourceDescriptionInternet {
 impl ResourceDescriptionInternet {
     pub fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionInternet {
         crate::callbacks::ResourceDescriptionInternet {
-            name: "Internet Resource".to_string(),
+            name: "🌐 Internet Resource".to_string(),
             address: "All internet addresses".to_string(),
             id: self.id,
             sites: self.sites,

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -88,7 +88,7 @@ pub struct ResourceDescriptionInternet {
 impl ResourceDescriptionInternet {
     pub fn with_status(self, status: Status) -> crate::callbacks::ResourceDescriptionInternet {
         crate::callbacks::ResourceDescriptionInternet {
-            name: "🌐 Internet Resource".to_string(),
+            name: "★ Internet Resource".to_string(),
             address: "All internet addresses".to_string(),
             id: self.id,
             sites: self.sites,

--- a/rust/connlib/tunnel/src/proptest.rs
+++ b/rust/connlib/tunnel/src/proptest.rs
@@ -80,6 +80,7 @@ pub fn internet_resource(
 ) -> impl Strategy<Value = ResourceDescriptionInternet> {
     (resource_id(), sites, any::<bool>()).prop_map(move |(id, sites, can_be_disabled)| {
         ResourceDescriptionInternet {
+            name: Some("Internet Resource".to_string()),
             id,
             sites,
             can_be_disabled: Some(can_be_disabled),

--- a/rust/connlib/tunnel/src/proptest.rs
+++ b/rust/connlib/tunnel/src/proptest.rs
@@ -80,7 +80,7 @@ pub fn internet_resource(
 ) -> impl Strategy<Value = ResourceDescriptionInternet> {
     (resource_id(), sites, any::<bool>()).prop_map(move |(id, sites, can_be_disabled)| {
         ResourceDescriptionInternet {
-            name: Some("Internet Resource".to_string()),
+            name: "Internet Resource".to_string(),
             id,
             sites,
             can_be_disabled: Some(can_be_disabled),

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -249,7 +249,7 @@ fn signed_in(signed_in: &SignedIn) -> Menu {
         // Always show Resources in the original order
         for res in resources
             .iter()
-            .filter(|res| !favorite_resources.contains(&res.id()) || !res.is_internet_resource())
+            .filter(|res| !favorite_resources.contains(&res.id()) && !res.is_internet_resource())
         {
             submenu = submenu.add_submenu(res.name(), signed_in.resource_submenu(res));
         }
@@ -321,7 +321,7 @@ mod tests {
             {
                 "id": "1106047c-cd5d-4151-b679-96b93da7383b",
                 "type": "internet",
-                "name": "🌐 Internet Resource",
+                "name": "Internet Resource",
                 "address": "All internet addresses",
                 "sites": [{"name": "test", "id": "eb94482a-94f4-47cb-8127-14fb3afa5516"}],
                 "status": "Offline",
@@ -432,17 +432,8 @@ mod tests {
             .add_submenu(
                 "Internet Resource",
                 Menu::default()
-                    .copyable("")
                     .separator()
-                    .disabled("Resource")
-                    .copyable("Internet Resource")
-                    .copyable("")
-                    .item(
-                        Event::AddFavorite(
-                            ResourceId::from_str("1106047c-cd5d-4151-b679-96b93da7383b").unwrap(),
-                        ),
-                        ADD_FAVORITE,
-                    )
+                    .disabled(INTERNET_RESOURCE_DESCRIPTION)
                     .separator()
                     .disabled("Site")
                     .copyable("test")
@@ -493,48 +484,38 @@ mod tests {
                     .copyable("test")
                     .copyable(GATEWAY_CONNECTED),
             )
+            .add_submenu(
+                "Internet Resource",
+                Menu::default()
+                    .separator()
+                    .disabled(INTERNET_RESOURCE_DESCRIPTION)
+                    .separator()
+                    .disabled("Site")
+                    .copyable("test")
+                    .copyable(ALL_GATEWAYS_OFFLINE),
+            )
             .separator()
             .add_submenu(
                 OTHER_RESOURCES,
-                Menu::default()
-                    .add_submenu(
-                        "172.172.0.0/16",
-                        Menu::default()
-                            .copyable("cidr resource")
-                            .separator()
-                            .disabled("Resource")
-                            .copyable("172.172.0.0/16")
-                            .copyable("172.172.0.0/16")
-                            .item(
-                                Event::AddFavorite(ResourceId::from_str(
-                                    "73037362-715d-4a83-a749-f18eadd970e6",
-                                )?),
-                                ADD_FAVORITE,
-                            )
-                            .separator()
-                            .disabled("Site")
-                            .copyable("test")
-                            .copyable(NO_ACTIVITY),
-                    )
-                    .add_submenu(
-                        "Internet Resource",
-                        Menu::default()
-                            .copyable("")
-                            .separator()
-                            .disabled("Resource")
-                            .copyable("Internet Resource")
-                            .copyable("")
-                            .item(
-                                Event::AddFavorite(ResourceId::from_str(
-                                    "1106047c-cd5d-4151-b679-96b93da7383b",
-                                )?),
-                                ADD_FAVORITE,
-                            )
-                            .separator()
-                            .disabled("Site")
-                            .copyable("test")
-                            .copyable(ALL_GATEWAYS_OFFLINE),
-                    ),
+                Menu::default().add_submenu(
+                    "172.172.0.0/16",
+                    Menu::default()
+                        .copyable("cidr resource")
+                        .separator()
+                        .disabled("Resource")
+                        .copyable("172.172.0.0/16")
+                        .copyable("172.172.0.0/16")
+                        .item(
+                            Event::AddFavorite(ResourceId::from_str(
+                                "73037362-715d-4a83-a749-f18eadd970e6",
+                            )?),
+                            ADD_FAVORITE,
+                        )
+                        .separator()
+                        .disabled("Site")
+                        .copyable("test")
+                        .copyable(NO_ACTIVITY),
+                ),
             )
             .add_bottom_section(DISCONNECT_AND_QUIT); // Skip testing the bottom section, it's simple
 
@@ -604,19 +585,10 @@ mod tests {
                     .copyable(GATEWAY_CONNECTED),
             )
             .add_submenu(
-                "🌐 Internet Resource",
+                "Internet Resource",
                 Menu::default()
-                    .copyable("")
                     .separator()
-                    .disabled("Resource")
-                    .copyable("🌐 Internet Resource")
-                    .copyable("")
-                    .item(
-                        Event::AddFavorite(ResourceId::from_str(
-                            "1106047c-cd5d-4151-b679-96b93da7383b",
-                        )?),
-                        ADD_FAVORITE,
-                    )
+                    .disabled(INTERNET_RESOURCE_DESCRIPTION)
                     .separator()
                     .disabled("Site")
                     .copyable("test")

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -39,7 +39,7 @@ const DISCONNECT_AND_QUIT: &str = "Disconnect and quit Firezone";
 const DISABLE: &str = "Disable this resource";
 const ENABLE: &str = "Enable this resource";
 
-pub(crate) const INTERNET_RESOURCE_DESCRIPTION: &str = "All internet traffic";
+pub(crate) const INTERNET_RESOURCE_DESCRIPTION: &str = "All network traffic";
 
 pub(crate) fn loading() -> SystemTray {
     SystemTray::new()

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -113,7 +113,7 @@ impl<'a> SignedIn<'a> {
                 .copyable(&site.name) // Hope this is okay - The code is simpler if every enabled item sends an `Event` on click
                 .copyable(status)
         } else {
-            submenu.separator()
+            submenu
         }
     }
 
@@ -432,7 +432,6 @@ mod tests {
             .add_submenu(
                 "Internet Resource",
                 Menu::default()
-                    .separator()
                     .disabled(INTERNET_RESOURCE_DESCRIPTION)
                     .separator()
                     .disabled("Site")
@@ -487,7 +486,6 @@ mod tests {
             .add_submenu(
                 "Internet Resource",
                 Menu::default()
-                    .separator()
                     .disabled(INTERNET_RESOURCE_DESCRIPTION)
                     .separator()
                     .disabled("Site")
@@ -587,7 +585,6 @@ mod tests {
             .add_submenu(
                 "Internet Resource",
                 Menu::default()
-                    .separator()
                     .disabled(INTERNET_RESOURCE_DESCRIPTION)
                     .separator()
                     .disabled("Site")

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray/builder.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray/builder.rs
@@ -174,7 +174,7 @@ impl Menu {
     }
 
     fn internet_resource(self) -> Self {
-        self.separator().disabled(INTERNET_RESOURCE_DESCRIPTION)
+        self.disabled(INTERNET_RESOURCE_DESCRIPTION)
     }
 
     fn resource_body(self, resource: &ResourceDescription) -> Self {

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray/builder.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray/builder.rs
@@ -1,8 +1,10 @@
 //! An abstraction over Tauri's system tray menu structs, that implements `PartialEq` for unit testing
 
-use connlib_shared::messages::ResourceId;
+use connlib_shared::{callbacks::ResourceDescription, messages::ResourceId};
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+use super::INTERNET_RESOURCE_DESCRIPTION;
 
 /// A menu that can either be assigned to the system tray directly or used as a submenu in another menu.
 ///
@@ -73,6 +75,22 @@ pub(crate) enum Event {
 pub(crate) enum Window {
     About,
     Settings,
+}
+
+fn resource_header(res: &ResourceDescription) -> Item {
+    let Some(address_description) = res.address_description() else {
+        return copyable(&res.pastable());
+    };
+
+    if address_description.is_empty() {
+        return copyable(&res.pastable());
+    }
+
+    let Ok(url) = Url::parse(address_description) else {
+        return copyable(address_description);
+    };
+
+    item(Event::Url(url), format!("<{address_description}>"))
 }
 
 impl Menu {
@@ -153,6 +171,26 @@ impl Menu {
     pub(crate) fn separator(mut self) -> Self {
         self.add_separator();
         self
+    }
+
+    fn internet_resource(self) -> Self {
+        self.separator().disabled(INTERNET_RESOURCE_DESCRIPTION)
+    }
+
+    fn resource_body(self, resource: &ResourceDescription) -> Self {
+        self.separator()
+            .disabled("Resource")
+            .copyable(resource.name())
+            .copyable(resource.pastable().as_ref())
+    }
+
+    pub(crate) fn resource_description(mut self, resource: &ResourceDescription) -> Self {
+        if resource.is_internet_resource() {
+            self.internet_resource()
+        } else {
+            self.add_item(resource_header(resource));
+            self.resource_body(resource)
+        }
     }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -42,6 +42,10 @@ public struct Resource: Decodable, Identifiable, Equatable {
     self.type = type
     self.canBeDisabled = canBeDisabled
   }
+
+  public func isInternetResource() -> Bool {
+    self.type == ResourceType.internet
+  }
 }
 
 public enum ResourceStatus: String, Decodable {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -25,14 +25,14 @@ public enum ResourceList {
 public struct Resource: Decodable, Identifiable, Equatable {
   public let id: String
   public var name: String
-  public var address: String
+  public var address: String?
   public var addressDescription: String?
   public var status: ResourceStatus
   public var sites: [Site]
   public var type: ResourceType
   public var canBeDisabled: Bool
 
-  public init(id: String, name: String, address: String, addressDescription: String?, status: ResourceStatus, sites: [Site], type: ResourceType, canBeDisabled: Bool) {
+  public init(id: String, name: String, address: String?, addressDescription: String?, status: ResourceStatus, sites: [Site], type: ResourceType, canBeDisabled: Bool) {
     self.id = id
     self.name = name
     self.address = address

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -418,12 +418,12 @@ public final class MenuBar: NSObject, ObservableObject {
     // If we have no favorites, then everything is a favorite
     let hasAnyFavorites = newResources.contains { model.favorites.contains($0.id) }
     let newFavorites = if (hasAnyFavorites) {
-      newResources.filter { model.favorites.contains($0.id) }
+      newResources.filter { model.favorites.contains($0.id) || $0.isInternetResource() }
     } else {
       newResources
     }
     let newOthers: [Resource] = if hasAnyFavorites {
-      newResources.filter { !model.favorites.contains($0.id) }
+      newResources.filter { !model.favorites.contains($0.id) || !$0.isInternetResource() }
     } else {
       []
     }
@@ -514,13 +514,8 @@ public final class MenuBar: NSObject, ObservableObject {
   private func nonInternetResourceHeader(resource: Resource) -> NSMenu {
     let subMenu = NSMenu()
 
-    let resourceAddressDescriptionItem = NSMenuItem()
-    let resourceSectionItem = NSMenuItem()
-    let resourceNameItem = NSMenuItem()
-    let resourceAddressItem = NSMenuItem()
-    let toggleFavoriteItem = NSMenuItem()
-
     // AddressDescription first -- will be most common action
+    let resourceAddressDescriptionItem = NSMenuItem()
     if let addressDescription = resource.addressDescription {
       resourceAddressDescriptionItem.title = addressDescription
 
@@ -549,11 +544,13 @@ public final class MenuBar: NSObject, ObservableObject {
 
     subMenu.addItem(NSMenuItem.separator())
 
+    let resourceSectionItem = NSMenuItem()
     resourceSectionItem.title = "Resource"
     resourceSectionItem.isEnabled = false
     subMenu.addItem(resourceSectionItem)
 
     // Resource name
+    let resourceNameItem = NSMenuItem()
     resourceNameItem.action = #selector(resourceValueTapped(_:))
     resourceNameItem.title = resource.name
     resourceNameItem.toolTip = "Resource name (click to copy)"
@@ -562,12 +559,15 @@ public final class MenuBar: NSObject, ObservableObject {
     subMenu.addItem(resourceNameItem)
 
     // Resource address
+    let resourceAddressItem = NSMenuItem()
     resourceAddressItem.action = #selector(resourceValueTapped(_:))
     resourceAddressItem.title = resource.address
     resourceAddressItem.toolTip = "Resource address (click to copy)"
     resourceAddressItem.isEnabled = true
     resourceAddressItem.target = self
     subMenu.addItem(resourceAddressItem)
+
+    let toggleFavoriteItem = NSMenuItem()
 
     if model.favorites.contains(resource.id) {
       toggleFavoriteItem.action = #selector(removeFavoriteTapped(_:))

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -535,7 +535,7 @@ public final class MenuBar: NSObject, ObservableObject {
       }
     } else {
       // Show Address first if addressDescription is missing
-      resourceAddressDescriptionItem.title = resource.address
+      resourceAddressDescriptionItem.title = resource.address! // Address is none only for non-internet resource
       resourceAddressDescriptionItem.action = #selector(resourceValueTapped(_:))
     }
     resourceAddressDescriptionItem.isEnabled = true
@@ -561,7 +561,7 @@ public final class MenuBar: NSObject, ObservableObject {
     // Resource address
     let resourceAddressItem = NSMenuItem()
     resourceAddressItem.action = #selector(resourceValueTapped(_:))
-    resourceAddressItem.title = resource.address
+    resourceAddressItem.title = resource.address!
     resourceAddressItem.toolTip = "Resource address (click to copy)"
     resourceAddressItem.isEnabled = true
     resourceAddressItem.target = self

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -511,18 +511,14 @@ public final class MenuBar: NSObject, ObservableObject {
     model.isResourceEnabled(id) ? "Disable this resource" : "Enable this resource"
   }
 
-  private func createSubMenu(resource: Resource) -> NSMenu {
+  private func nonInternetResourceHeader(resource: Resource) -> NSMenu {
     let subMenu = NSMenu()
+
     let resourceAddressDescriptionItem = NSMenuItem()
     let resourceSectionItem = NSMenuItem()
     let resourceNameItem = NSMenuItem()
     let resourceAddressItem = NSMenuItem()
-    let siteSectionItem = NSMenuItem()
-    let siteNameItem = NSMenuItem()
-    let siteStatusItem = NSMenuItem()
     let toggleFavoriteItem = NSMenuItem()
-    let enableToggle = NSMenuItem()
-
 
     // AddressDescription first -- will be most common action
     if let addressDescription = resource.addressDescription {
@@ -587,6 +583,36 @@ public final class MenuBar: NSObject, ObservableObject {
     toggleFavoriteItem.target = self
     subMenu.addItem(toggleFavoriteItem)
 
+    return subMenu
+  }
+
+  private func internetResourceHeader(resource: Resource) -> NSMenu {
+    let subMenu = NSMenu()
+    let description = NSMenuItem()
+
+    description.title = "All network traffic"
+    description.isEnabled = false
+
+    subMenu.addItem(description)
+
+    return subMenu
+  }
+
+  private func resourceHeader(resource: Resource) -> NSMenu {
+    if resource.isInternetResource() {
+      internetResourceHeader(resource: resource)
+    } else {
+      nonInternetResourceHeader(resource: resource)
+    }
+  }
+
+  private func createSubMenu(resource: Resource) -> NSMenu {
+    let siteSectionItem = NSMenuItem()
+    let siteNameItem = NSMenuItem()
+    let siteStatusItem = NSMenuItem()
+    let enableToggle = NSMenuItem()
+
+    let subMenu = resourceHeader(resource: resource)
 
     // Resource enable / disable toggle
     if resource.canBeDisabled {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -423,7 +423,7 @@ public final class MenuBar: NSObject, ObservableObject {
       newResources
     }
     let newOthers: [Resource] = if hasAnyFavorites {
-      newResources.filter { !model.favorites.contains($0.id) || !$0.isInternetResource() }
+      newResources.filter { !model.favorites.contains($0.id) && !$0.isInternetResource() }
     } else {
       []
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -39,18 +39,18 @@ struct ResourceView: View {
             .font(.system(size: 14))
             .foregroundColor(.secondary)
             .frame(width: 80, alignment: .leading)
-          if let url = URL(string: resource.addressDescription ?? resource.address),
+          if let url = URL(string: resource.addressDescription ?? resource.address!),
              let _ = url.host {
             Button(action: {
               openURL(url)
             }) {
-              Text(resource.addressDescription ?? resource.address)
+              Text(resource.addressDescription ?? resource.address!)
                 .foregroundColor(.blue)
                 .underline()
                 .font(.system(size: 16))
                 .contextMenu {
                   Button(action: {
-                    copyToClipboard(resource.addressDescription ?? resource.address)
+                    copyToClipboard(resource.addressDescription ?? resource.address!)
                   }) {
                     Text("Copy address")
                     Image(systemName: "doc.on.doc")
@@ -58,10 +58,10 @@ struct ResourceView: View {
                 }
             }
           } else {
-            Text(resource.addressDescription ?? resource.address)
+            Text(resource.addressDescription ?? resource.address!)
               .contextMenu {
                 Button(action: {
-                  copyToClipboard(resource.addressDescription ?? resource.address)
+                  copyToClipboard(resource.addressDescription ?? resource.address!)
                 }) {
                   Text("Copy address")
                   Image(systemName: "doc.on.doc")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -130,22 +130,35 @@ struct ResourceSection: View {
   var body: some View {
     ForEach(resources) { resource in
       HStack {
-        NavigationLink { ResourceView(model: model, resource: resource) }
-      label: {
-        HStack {
-          Text(resource.name)
-          if resource.canBeDisabled {
-            Spacer()
-            Toggle("Enabled", isOn: Binding<Bool>(
-              get: { model.isResourceEnabled(resource.id) },
-              set: { newValue in
-                model.store.toggleResourceDisabled(resource: resource.id, enabled: newValue)
-              }
-            )).labelsHidden()
+        if !resource.isInternetResource() {
+            NavigationLink { ResourceView(model: model, resource: resource) }
+          label: {
+            ResourceLable(resource: resource, model: model )
           }
+        } else {
+          ResourceLable(resource: resource, model: model)
         }
       }
       .navigationTitle("All Resources")
+    }
+  }
+}
+
+struct ResourceLable: View {
+  let resource: Resource
+  @ObservedObject var model: SessionViewModel
+
+  var body: some View {
+    HStack {
+      Text(resource.name)
+      if resource.canBeDisabled {
+        Spacer()
+        Toggle("Enabled", isOn: Binding<Bool>(
+          get: { model.isResourceEnabled(resource.id) },
+          set: { newValue in
+            model.store.toggleResourceDisabled(resource: resource.id, enabled: newValue)
+          }
+        )).labelsHidden()
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -133,10 +133,10 @@ struct ResourceSection: View {
         if !resource.isInternetResource() {
             NavigationLink { ResourceView(model: model, resource: resource) }
           label: {
-            ResourceLable(resource: resource, model: model )
+            ResourceLabel(resource: resource, model: model )
           }
         } else {
-          ResourceLable(resource: resource, model: model)
+          ResourceLabel(resource: resource, model: model)
         }
       }
       .navigationTitle("All Resources")
@@ -144,7 +144,7 @@ struct ResourceSection: View {
   }
 }
 
-struct ResourceLable: View {
+struct ResourceLabel: View {
   let resource: Resource
   @ObservedObject var model: SessionViewModel
 


### PR DESCRIPTION
Fixes #6047

On mobile platforms the internet resource is rendered with all non-favorite resources, since it was weird to see within the favorite tab, for the system tray platforms it's rendered as part of favorites if there is any favorite so that it's always visible to the user.

For mobile platforms the resource is non-clickeable, since the menu shouldn't be of interest(maybe I should add it only for the sites?).

For non-mobile there is a sub menu where you can find the sites and the enable/disable.

The current label for the resource is a place holder for the screenshots, and can be set by the portal, if the portal doesn't set any name it will just show "Internet Resource".

### Android screenshot

![image](https://github.com/user-attachments/assets/63deb25f-1cd1-4b49-be80-77570e612aa5)


### Linux Screenshot

![image](https://github.com/user-attachments/assets/7b67033d-71ee-4bac-98c8-4c5810bf43a3)

![image](https://github.com/user-attachments/assets/5bdbced5-bacd-4a09-a59c-aa853bb3baa0)

### Windows Screenshot

![image](https://github.com/user-attachments/assets/a3bbebb3-9a18-4b75-9e18-f58b1b61a7a3)

### MacOS screenshot

<img width="417" alt="image" src="https://github.com/user-attachments/assets/5488d6e4-1cd2-42be-bcd7-3c51ec295590">

### iOS screenshot

![17044](https://github.com/user-attachments/assets/5321c363-5b43-4b1e-ac37-4fd7bdc68e28)

