### PR TITLE
refactor(connlib): model "routing table updates"

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use anyhow::Result;
 use connlib_shared::messages::{
-    ConnectionAccepted, GatewayResponse, RelaysPresence, ResourceAccepted, ResourceId,
-    ReuseConnection,
+    ClientPayload, ConnectionAccepted, GatewayResponse, RelaysPresence, RequestConnection,
+    ResourceAccepted, ResourceId, ReuseConnection,
 };
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
@@ -184,6 +184,26 @@ where
             firezone_tunnel::ClientEvent::TunRoutesUpdated { ip4, ip6 } => {
                 self.callbacks.on_update_routes(ip4, ip6);
             }
+            firezone_tunnel::ClientEvent::RequestConnection {
+                gateway_id,
+                offer,
+                preshared_key,
+                resource_id,
+                maybe_domain,
+            } => {
+                self.portal.send(
+                    PHOENIX_TOPIC,
+                    EgressMessages::RequestConnection(RequestConnection {
+                        gateway_id,
+                        resource_id,
+                        client_preshared_key: preshared_key,
+                        client_payload: ClientPayload {
+                            ice_parameters: offer,
+                            domain: maybe_domain,
+                        },
+                    }),
+                );
+            }
         }
     }
 
@@ -296,25 +316,9 @@ where
 
                 match self
                     .tunnel
-                    .create_or_reuse_connection(resource_id, gateway_id, site_id)
+                    .on_routing_details(resource_id, gateway_id, site_id)
                 {
-                    Ok(Some(firezone_tunnel::Request::NewConnection(connection_request))) => {
-                        // TODO: keep track for the response
-                        let _id = self.portal.send(
-                            PHOENIX_TOPIC,
-                            EgressMessages::RequestConnection(connection_request),
-                        );
-                    }
-                    Ok(Some(firezone_tunnel::Request::ReuseConnection(connection_request))) => {
-                        // TODO: keep track for the response
-                        let _id = self.portal.send(
-                            PHOENIX_TOPIC,
-                            EgressMessages::ReuseConnection(connection_request),
-                        );
-                    }
-                    Ok(None) => {
-                        tracing::debug!(%resource_id, %gateway_id, "Pending connection");
-                    }
+                    Ok(()) => {}
                     Err(e) => {
                         tracing::warn!("Failed to request new connection: {e}");
                     }

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -153,7 +153,7 @@ where
                 );
                 self.connection_intents.register_new_intent(id, resource);
             }
-            firezone_tunnel::ClientEvent::SendProxyIps { connection } => {
+            firezone_tunnel::ClientEvent::RequestAccess { connection } => {
                 self.portal
                     .send(PHOENIX_TOPIC, EgressMessages::ReuseConnection(connection));
             }

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -153,11 +153,9 @@ where
                 );
                 self.connection_intents.register_new_intent(id, resource);
             }
-            firezone_tunnel::ClientEvent::SendProxyIps { connections } => {
-                for connection in connections {
-                    self.portal
-                        .send(PHOENIX_TOPIC, EgressMessages::ReuseConnection(connection));
-                }
+            firezone_tunnel::ClientEvent::SendProxyIps { connection } => {
+                self.portal
+                    .send(PHOENIX_TOPIC, EgressMessages::ReuseConnection(connection));
             }
             firezone_tunnel::ClientEvent::ResourcesChanged { resources } => {
                 self.callbacks.on_update_resources(resources)

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -9,6 +9,7 @@ use crate::{
 use anyhow::Result;
 use connlib_shared::messages::{
     ConnectionAccepted, GatewayResponse, RelaysPresence, ResourceAccepted, ResourceId,
+    ReuseConnection,
 };
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
@@ -153,9 +154,19 @@ where
                 );
                 self.connection_intents.register_new_intent(id, resource);
             }
-            firezone_tunnel::ClientEvent::RequestAccess { connection } => {
-                self.portal
-                    .send(PHOENIX_TOPIC, EgressMessages::ReuseConnection(connection));
+            firezone_tunnel::ClientEvent::RequestAccess {
+                resource_id,
+                gateway_id,
+                maybe_domain,
+            } => {
+                self.portal.send(
+                    PHOENIX_TOPIC,
+                    EgressMessages::ReuseConnection(ReuseConnection {
+                        resource_id,
+                        gateway_id,
+                        payload: maybe_domain,
+                    }),
+                );
             }
             firezone_tunnel::ClientEvent::ResourcesChanged { resources } => {
                 self.callbacks.on_update_resources(resources)

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -422,14 +422,14 @@ impl ClientState {
             &resource_id,
         );
         self.buffered_events.push_back(ClientEvent::SendProxyIps {
-            connections: vec![ReuseConnection {
+            connection: ReuseConnection {
                 resource_id,
                 gateway_id,
                 payload: Some(ResolveRequest {
                     name: fqdn.clone(),
                     proxy_ips: ips.clone(),
                 }),
-            }],
+            },
         })
     }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -190,7 +190,7 @@ impl ClientTunnel {
         site_id: SiteId,
     ) -> anyhow::Result<()> {
         self.role_state
-            .on_routing_details(resource_id, gateway_id, site_id)
+            .on_routing_details(resource_id, gateway_id, site_id, Instant::now())
     }
 
     pub fn received_offer_response(
@@ -549,6 +549,7 @@ impl ClientState {
         resource_id: ResourceId,
         gateway_id: GatewayId,
         site_id: SiteId,
+        now: Instant,
     ) -> anyhow::Result<()> {
         tracing::trace!("Updating resource routing table");
 
@@ -598,7 +599,7 @@ impl ClientState {
         let offer = self.node.new_connection(
             gateway_id,
             awaiting_connection_details.last_intent_sent_at,
-            Instant::now(),
+            now,
         );
 
         self.buffered_events

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -422,14 +422,12 @@ impl ClientState {
             &resource_id,
         );
         self.buffered_events.push_back(ClientEvent::RequestAccess {
-            connection: ReuseConnection {
-                resource_id,
-                gateway_id,
-                payload: Some(ResolveRequest {
-                    name: fqdn.clone(),
-                    proxy_ips: ips.clone(),
-                }),
-            },
+            resource_id,
+            gateway_id,
+            maybe_domain: Some(ResolveRequest {
+                name: fqdn.clone(),
+                proxy_ips: ips.clone(),
+            }),
         })
     }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -407,7 +407,7 @@ impl ClientState {
         self.node.public_key()
     }
 
-    fn send_proxy_ips(
+    fn request_access(
         &mut self,
         resource_ip: &IpAddr,
         resource_id: ResourceId,
@@ -421,7 +421,7 @@ impl ClientState {
             &ips.iter().copied().map_into().collect_vec(),
             &resource_id,
         );
-        self.buffered_events.push_back(ClientEvent::SendProxyIps {
+        self.buffered_events.push_back(ClientEvent::RequestAccess {
             connection: ReuseConnection {
                 resource_id,
                 gateway_id,
@@ -482,7 +482,7 @@ impl ClientState {
         // for DNS resource we will send the IP one at a time.
         if is_dns_resource && peer.allowed_ips.exact_match(dst).is_none() {
             let gateway_id = peer.id();
-            self.send_proxy_ips(&dst, resource, gateway_id);
+            self.request_access(&dst, resource, gateway_id);
             return None;
         }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -278,7 +278,7 @@ pub enum ClientEvent {
         resource: ResourceId,
         connected_gateway_ids: BTreeSet<GatewayId>,
     },
-    SendProxyIps {
+    RequestAccess {
         connection: ReuseConnection,
     },
     /// The list of resources has changed and UI clients may have to be updated.

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -279,7 +279,7 @@ pub enum ClientEvent {
         connected_gateway_ids: BTreeSet<GatewayId>,
     },
     SendProxyIps {
-        connections: Vec<ReuseConnection>,
+        connection: ReuseConnection,
     },
     /// The list of resources has changed and UI clients may have to be updated.
     ResourcesChanged {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -8,7 +8,7 @@ use boringtun::x25519::StaticSecret;
 use chrono::Utc;
 use connlib_shared::{
     callbacks,
-    messages::{ClientId, GatewayId, Relay, RelayId, ResourceId, ReuseConnection},
+    messages::{ClientId, GatewayId, Relay, RelayId, ResolveRequest, ResourceId},
     DomainName, PublicKey, DEFAULT_MTU,
 };
 use io::Io;
@@ -279,7 +279,12 @@ pub enum ClientEvent {
         connected_gateway_ids: BTreeSet<GatewayId>,
     },
     RequestAccess {
-        connection: ReuseConnection,
+        /// The resource we want to access.
+        resource_id: ResourceId,
+        /// The gateway we want to access the resource through.
+        gateway_id: GatewayId,
+        /// In the case of a DNS resource, its domain and the IPs we assigned to it.
+        maybe_domain: Option<ResolveRequest>,
     },
     /// The list of resources has changed and UI clients may have to be updated.
     ResourcesChanged {

--- a/rust/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/connlib/tunnel/src/tests/stub_portal.rs
@@ -132,7 +132,7 @@ impl StubPortal {
 
     pub(crate) fn map_client_resource_to_gateway_resource(
         &self,
-        resolved_ips: Vec<IpAddr>,
+        resolved_ips: BTreeSet<IpAddr>,
         resource_id: ResourceId,
     ) -> gateway::ResourceDescription<gateway::ResolvedResourceDescriptionDns> {
         let cidr_resource = self.cidr_resources.iter().find_map(|(_, r)| {
@@ -151,7 +151,7 @@ impl StubPortal {
                 name: r.name.clone(),
                 filters: Vec::new(),
                 domain: r.address.clone(),
-                addresses: resolved_ips.clone(),
+                addresses: Vec::from_iter(resolved_ips),
             })
         });
         let internet_resource = Some(gateway::ResourceDescription::Internet(

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -638,7 +638,7 @@ impl TunnelTest {
                     portal.handle_connection_intent(resource, connected_gateway_ids);
 
                 self.client
-                    .exec_mut(|c| c.sut.on_routing_details(resource, gateway, site))
+                    .exec_mut(|c| c.sut.on_routing_details(resource, gateway, site, now))
                     .unwrap();
             }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -736,7 +736,7 @@ impl TunnelTest {
                 };
             }
 
-            ClientEvent::SendProxyIps { connection } => {
+            ClientEvent::RequestAccess { connection } => {
                 let gateway = self
                     .gateways
                     .get_mut(&connection.gateway_id)

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -736,14 +736,14 @@ impl TunnelTest {
                 };
             }
 
-            ClientEvent::RequestAccess { connection } => {
-                let gateway = self
-                    .gateways
-                    .get_mut(&connection.gateway_id)
-                    .expect("unknown gateway");
+            ClientEvent::RequestAccess {
+                resource_id,
+                gateway_id,
+                maybe_domain,
+            } => {
+                let gateway = self.gateways.get_mut(&gateway_id).expect("unknown gateway");
 
-                let resolved_ips = connection
-                    .payload
+                let resolved_ips = maybe_domain
                     .as_ref()
                     .map(|r| r.name.clone())
                     .into_iter()
@@ -751,8 +751,8 @@ impl TunnelTest {
                     .flatten()
                     .collect();
 
-                let resource = portal
-                    .map_client_resource_to_gateway_resource(resolved_ips, connection.resource_id);
+                let resource =
+                    portal.map_client_resource_to_gateway_resource(resolved_ips, resource_id);
 
                 gateway
                     .exec_mut(|g| {
@@ -760,7 +760,7 @@ impl TunnelTest {
                             resource,
                             self.client.inner().id,
                             None,
-                            connection.payload.map(|r| (r.name, r.proxy_ips)),
+                            maybe_domain.map(|r| (r.name, r.proxy_ips)),
                             now,
                         )
                     })


### PR DESCRIPTION
Upon receiving packets for a resource that we are not connected to, connlib emits a "connection intent" to the portal. In case there are gateways online for this resource, the portal sends us a "connection details" event.

Currently, this is handled in a `create_or_reuse_connection` function. What the current name doesn't capture is that this message is essentially an update to connlib's "routing table", i.e. which gateway in which site to use for the given resource. If we move this concern to the fore-front of the design, whether or not we will make a new connection or reuse an existing one kind of becomes secondary.

Re-framing the way we handle this messages makes it more natural to design it in an asynchronous way, i.e. set its return type to `()` and schedule events to be emitted. The translation of `Request::NewConnection` is more or less 1-to-1 with the introduction of `ClientEvent::RequestConnection`. The translation of `Request::ReuseConnection` turns into the also renamed `ClientEvent::RequestAccess`. This captures better what we need to do: When we have an existing connection, we need to request access for it, otherwise the gateway will drop all packets we send to this resource.

The motivation for this refactoring is #6335. Buffering the initial packets while establishing a new connection opens up a race condition where we may send `RequestAccess` before the gateway has processed `RequestConnection`. In order to avoid this, we need to be able to locally buffer our `RequestAccess` messages and wait until the gateway has confirmed our connection.