### PR TITLE
test(connlib): reset time between failing test runs

### DIFF
--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -1,7 +1,7 @@
-use crate::tests::sut::TunnelTest;
+use crate::tests::{flux_capacitor::FluxCapacitor, sut::TunnelTest};
 use assertions::PanicOnErrorEvents;
 use proptest::test_runner::{Config, TestError, TestRunner};
-use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
+use proptest_state_machine::ReferenceStateMachine;
 use reference::ReferenceState;
 use std::sync::atomic::{self, AtomicU32};
 use tracing::level_filters::LevelFilter;
@@ -45,7 +45,9 @@ fn tunnel_test() {
         &ReferenceState::sequential_strategy(5..15),
         |(mut ref_state, transitions, mut seen_counter)| {
             let test_index = test_index.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            let _guard = init_logging(&ref_state, test_index);
+            let flux_capacitor = FluxCapacitor::default();
+
+            let _guard = init_logging(flux_capacitor.clone(), test_index);
 
             std::fs::write(
                 format!("testcases/{test_index}.state"),
@@ -62,7 +64,7 @@ fn tunnel_test() {
 
             println!("Running test case {test_index:04} with {num_transitions:02} transitions");
 
-            let mut sut = TunnelTest::init_test(&ref_state);
+            let mut sut = TunnelTest::init_test(&ref_state, flux_capacitor);
 
             // Check the invariants on the initial state
             TunnelTest::check_invariants(&sut, &ref_state);
@@ -89,8 +91,6 @@ fn tunnel_test() {
                 // Check the invariants after the transition is applied
                 TunnelTest::check_invariants(&sut, &ref_state);
             }
-
-            TunnelTest::teardown(sut);
 
             Ok(())
         },
@@ -120,18 +120,21 @@ fn tunnel_test() {
 ///
 /// Finally, we install [`PanicOnErrorEvents`] into the registry.
 /// An `ERROR` log is treated as a fatal error and will fail the test.
-fn init_logging(ref_state: &ReferenceState, test_index: u32) -> tracing::subscriber::DefaultGuard {
+fn init_logging(
+    flux_capacitor: FluxCapacitor,
+    test_index: u32,
+) -> tracing::subscriber::DefaultGuard {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
                 .with_test_writer()
-                .with_timer(ref_state.flux_capacitor.clone())
+                .with_timer(flux_capacitor.clone())
                 .with_filter(EnvFilter::from_default_env()),
         )
         .with(
             tracing_subscriber::fmt::layer()
                 .with_writer(std::fs::File::create(format!("testcases/{test_index}.log")).unwrap())
-                .with_timer(ref_state.flux_capacitor.clone())
+                .with_timer(flux_capacitor)
                 .with_ansi(false)
                 .with_filter(
                     EnvFilter::builder()

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -1,6 +1,6 @@
 use super::{
-    composite_strategy::CompositeStrategy, flux_capacitor::FluxCapacitor, sim_client::*,
-    sim_dns::*, sim_gateway::*, sim_net::*, strategies::*, stub_portal::StubPortal, transition::*,
+    composite_strategy::CompositeStrategy, sim_client::*, sim_dns::*, sim_gateway::*, sim_net::*,
+    strategies::*, stub_portal::StubPortal, transition::*,
 };
 use crate::dns::is_subdomain;
 use connlib_shared::{
@@ -40,9 +40,6 @@ pub(crate) struct ReferenceState {
     pub(crate) global_dns_records: BTreeMap<DomainName, BTreeSet<IpAddr>>,
 
     pub(crate) network: RoutingTable,
-
-    #[derivative(Debug = "ignore")]
-    pub(crate) flux_capacitor: FluxCapacitor,
 }
 
 #[derive(Debug, Clone)]
@@ -165,7 +162,6 @@ impl ReferenceStateMachine for ReferenceState {
                         global_dns_records,
                         network,
                         drop_direct_client_traffic,
-                        flux_capacitor: FluxCapacitor::default(),
                     }
                 },
             )


### PR DESCRIPTION
`tunnel_test` uses the `FluxCapacitor` component to rapidly advance time within a test-run. This component is also used by the logger in the tests to print _relative_ timestamps which makes it easier to compare different test runs.

Currently, this component is initialised in the `ReferenceState` although it isn't really part of the test-input itself. It is only needed during the execution of a transition.

When proptest finds a failing test run, it will reuse the same `ReferenceState` and attempt to shrink it to find the minimally-failing input. It does this by calling `.clone`. Because `FluxCapacitor` uses interior mutability to advance time, this means the time isn't actually reset to `0` whilst proptest is shrinking the input.

This has / had on impact on the outcome of the test, it only makes the logs harder and more confusing to read.

We fix this by removing the `StateMachineTest` trait implementation of `TunnelTest` and passing an additional parameter to `init_state`. This trait was originally needed because we were using the "no-boilerplate" version of `proptest-state-machine`. We have recently migrated away from that to get more fine-grained control over logging and test execution, meaning we no longer need this trait and can simply call these functions ourselves.