### PR TITLE
test(connlib): index ICMP packets by custom payload

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -1058,7 +1058,7 @@ mod proptests {
             let packet = match protocol {
                 Protocol::Tcp { dport } => tcp_packet(src, dest, sport, *dport, payload.clone()),
                 Protocol::Udp { dport } => udp_packet(src, dest, sport, *dport, payload.clone()),
-                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
+                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
             }
             .unwrap();
             assert!(peer.ensure_allowed_dst(&packet).is_ok());
@@ -1091,7 +1091,7 @@ mod proptests {
             let packet = match protocol {
                 Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload.clone()),
                 Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload.clone()),
-                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
+                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
             }
             .unwrap();
             assert!(peer.ensure_allowed_dst(&packet).is_ok());
@@ -1133,7 +1133,7 @@ mod proptests {
             let packet = match protocol {
                 Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload.clone()),
                 Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload.clone()),
-                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
+                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
             }
             .unwrap();
             assert!(peer.ensure_allowed_dst(&packet).is_ok());
@@ -1148,7 +1148,7 @@ mod proptests {
             let packet = match protocol {
                 Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload.clone()),
                 Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload.clone()),
-                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
+                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
             }
             .unwrap();
             assert!(peer.ensure_allowed_dst(&packet).is_ok());
@@ -1191,7 +1191,7 @@ mod proptests {
             let packet = match protocol {
                 Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload.clone()),
                 Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload.clone()),
-                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
+                Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
             }
             .unwrap();
 
@@ -1222,7 +1222,7 @@ mod proptests {
         let packet = match protocol {
             Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload),
             Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload),
-            Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
+            Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
         }
         .unwrap();
 
@@ -1260,14 +1260,14 @@ mod proptests {
         let packet_allowed = match protocol_allowed {
             Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload.clone()),
             Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload.clone()),
-            Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
+            Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
         }
         .unwrap();
 
         let packet_rejected = match protocol_removed {
             Protocol::Tcp { dport } => tcp_packet(src, dest, sport, dport, payload),
             Protocol::Udp { dport } => udp_packet(src, dest, sport, dport, payload),
-            Protocol::Icmp => icmp_request_packet(src, dest, 1, 0),
+            Protocol::Icmp => icmp_request_packet(src, dest, 1, 0, &[]),
         }
         .unwrap();
 

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -33,7 +33,7 @@ pub(crate) fn assert_icmp_packets_properties(
             .flatten()
             .collect(),
         &sim_client.received_icmp_replies,
-        |(_, seq_a, id_a), (seq_b, id_b)| seq_a == seq_b && id_a == id_b,
+        |(_, (_, seq_a, id_a)), (seq_b, id_b)| seq_a == seq_b && id_a == id_b,
     );
 
     if !unexpected_icmp_replies.is_empty() {
@@ -61,9 +61,7 @@ pub(crate) fn assert_icmp_packets_properties(
     for (gateway, expected_icmp_handshakes) in &ref_client.expected_icmp_handshakes {
         let received_icmp_requests = &sim_gateways.get(gateway).unwrap().received_icmp_requests;
 
-        for ((resource_dst, seq, identifier), gateway_received_request) in
-            expected_icmp_handshakes.iter().zip(received_icmp_requests)
-        {
+        for (payload, (resource_dst, seq, identifier)) in expected_icmp_handshakes {
             let _guard =
                 tracing::info_span!(target: "assertions", "icmp", %seq, %identifier).entered();
 
@@ -78,8 +76,12 @@ pub(crate) fn assert_icmp_packets_properties(
                 tracing::error!(target: "assertions", "❌ Missing ICMP reply on client");
                 continue;
             };
-
             assert_correct_src_and_dst_ips(client_sent_request, client_received_reply);
+
+            let Some(gateway_received_request) = received_icmp_requests.get(payload) else {
+                tracing::error!(target: "assertions", "❌ Missing ICMP request on gateway");
+                continue;
+            };
 
             {
                 let expected = ref_client.tunnel_ip_for(gateway_received_request.source());
@@ -211,7 +213,7 @@ fn assert_destination_is_cdir_resource(gateway_received_request: &IpPacket<'_>, 
     let actual = gateway_received_request.destination();
 
     if actual != *expected {
-        tracing::error!(target: "assertions", %actual, %expected, "❌ Unknown resource IP");
+        tracing::error!(target: "assertions", %actual, %expected, "❌ Incorrect resource destination");
     } else {
         tracing::info!(target: "assertions", ip = %actual, "✅ ICMP request targets correct resource");
     }

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -370,13 +370,19 @@ impl ReferenceStateMachine for ReferenceState {
                 dst,
                 seq,
                 identifier,
+                payload,
             } => {
                 state.client.exec_mut(|client| {
                     // If the Internet Resource is active, all packets are expected to be routed.
                     if client.active_internet_resource().is_some() {
-                        client.on_icmp_packet_to_internet(*src, *dst, *seq, *identifier, |r| {
-                            state.portal.gateway_for_resource(r).copied()
-                        })
+                        client.on_icmp_packet_to_internet(
+                            *src,
+                            *dst,
+                            *seq,
+                            *identifier,
+                            *payload,
+                            |r| state.portal.gateway_for_resource(r).copied(),
+                        )
                     }
                 });
             }
@@ -385,10 +391,10 @@ impl ReferenceStateMachine for ReferenceState {
                 dst,
                 seq,
                 identifier,
-                ..
+                payload,
             } => {
                 state.client.exec_mut(|client| {
-                    client.on_icmp_packet_to_cidr(*src, *dst, *seq, *identifier, |r| {
+                    client.on_icmp_packet_to_cidr(*src, *dst, *seq, *identifier, *payload, |r| {
                         state.portal.gateway_for_resource(r).copied()
                     })
                 });
@@ -398,9 +404,10 @@ impl ReferenceStateMachine for ReferenceState {
                 dst,
                 seq,
                 identifier,
+                payload,
                 ..
             } => state.client.exec_mut(|client| {
-                client.on_icmp_packet_to_dns(*src, dst.clone(), *seq, *identifier, |r| {
+                client.on_icmp_packet_to_dns(*src, dst.clone(), *seq, *identifier, *payload, |r| {
                     state.portal.gateway_for_resource(r).copied()
                 })
             }),
@@ -482,10 +489,13 @@ impl ReferenceStateMachine for ReferenceState {
                 dst,
                 seq,
                 identifier,
+                payload,
                 ..
             } => {
-                let is_valid_icmp_packet =
-                    state.client.inner().is_valid_icmp_packet(seq, identifier);
+                let is_valid_icmp_packet = state
+                    .client
+                    .inner()
+                    .is_valid_icmp_packet(seq, identifier, payload);
                 let is_cidr_resource = state.client.inner().cidr_resource_by_ip(*dst).is_some();
 
                 is_valid_icmp_packet && !is_cidr_resource
@@ -494,6 +504,7 @@ impl ReferenceStateMachine for ReferenceState {
                 seq,
                 identifier,
                 dst,
+                payload,
                 ..
             } => {
                 let ref_client = state.client.inner();
@@ -504,7 +515,7 @@ impl ReferenceStateMachine for ReferenceState {
                     return false;
                 };
 
-                ref_client.is_valid_icmp_packet(seq, identifier)
+                ref_client.is_valid_icmp_packet(seq, identifier, payload)
                     && state.gateways.contains_key(gateway)
             }
             Transition::SendICMPPacketToDnsResource {
@@ -512,6 +523,7 @@ impl ReferenceStateMachine for ReferenceState {
                 identifier,
                 dst,
                 src,
+                payload,
                 ..
             } => {
                 let ref_client = state.client.inner();
@@ -522,7 +534,7 @@ impl ReferenceStateMachine for ReferenceState {
                     return false;
                 };
 
-                ref_client.is_valid_icmp_packet(seq, identifier)
+                ref_client.is_valid_icmp_packet(seq, identifier, payload)
                     && ref_client.dns_records.get(dst).is_some_and(|r| match src {
                         IpAddr::V4(_) => r.contains(&Rtype::A),
                         IpAddr::V6(_) => r.contains(&Rtype::AAAA),

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -159,16 +159,23 @@ impl StateMachineTest for TunnelTest {
                 dst,
                 seq,
                 identifier,
+                payload,
             }
             | Transition::SendICMPPacketToCidrResource {
                 src,
                 dst,
                 seq,
                 identifier,
-                ..
+                payload,
             } => {
-                let packet =
-                    ip_packet::make::icmp_request_packet(src, dst, seq, identifier).unwrap();
+                let packet = ip_packet::make::icmp_request_packet(
+                    src,
+                    dst,
+                    seq,
+                    identifier,
+                    &payload.to_be_bytes(),
+                )
+                .unwrap();
 
                 let transmit = state.client.exec_mut(|sim| sim.encapsulate(packet, now));
 
@@ -179,6 +186,7 @@ impl StateMachineTest for TunnelTest {
                 dst,
                 seq,
                 identifier,
+                payload,
                 resolved_ip,
                 ..
             } => {
@@ -195,8 +203,14 @@ impl StateMachineTest for TunnelTest {
                     });
                 let dst = *resolved_ip.select(available_ips);
 
-                let packet =
-                    ip_packet::make::icmp_request_packet(src, dst, seq, identifier).unwrap();
+                let packet = ip_packet::make::icmp_request_packet(
+                    src,
+                    dst,
+                    seq,
+                    identifier,
+                    &payload.to_be_bytes(),
+                )
+                .unwrap();
 
                 let transmit = state
                     .client

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -31,6 +31,7 @@ pub(crate) enum Transition {
         dst: IpAddr,
         seq: u16,
         identifier: u16,
+        payload: u64,
     },
     /// Send an ICMP packet to a CIDR resource.
     SendICMPPacketToCidrResource {
@@ -38,6 +39,7 @@ pub(crate) enum Transition {
         dst: IpAddr,
         seq: u16,
         identifier: u16,
+        payload: u64,
     },
     /// Send an ICMP packet to a DNS resource.
     SendICMPPacketToDnsResource {
@@ -48,6 +50,7 @@ pub(crate) enum Transition {
 
         seq: u16,
         identifier: u16,
+        payload: u64,
     },
 
     /// Send a DNS query.
@@ -103,15 +106,17 @@ where
         dst.prop_map(Into::into),
         any::<u16>(),
         any::<u16>(),
+        any::<u64>(),
     )
-        .prop_map(
-            |(src, dst, seq, identifier)| Transition::SendICMPPacketToNonResourceIp {
+        .prop_map(|(src, dst, seq, identifier, payload)| {
+            Transition::SendICMPPacketToNonResourceIp {
                 src,
                 dst,
                 seq,
                 identifier,
-            },
-        )
+                payload,
+            }
+        })
 }
 
 pub(crate) fn icmp_to_cidr_resource<I>(
@@ -126,15 +131,17 @@ where
         any::<u16>(),
         any::<u16>(),
         src.prop_map(Into::into),
+        any::<u64>(),
     )
-        .prop_map(
-            |(dst, seq, identifier, src)| Transition::SendICMPPacketToCidrResource {
+        .prop_map(|(dst, seq, identifier, src, payload)| {
+            Transition::SendICMPPacketToCidrResource {
                 src,
                 dst,
                 seq,
                 identifier,
-            },
-        )
+                payload,
+            }
+        })
 }
 
 pub(crate) fn icmp_to_dns_resource<I>(
@@ -150,14 +157,16 @@ where
         any::<u16>(),
         src.prop_map(Into::into),
         any::<sample::Selector>(),
+        any::<u64>(),
     )
-        .prop_map(|(dst, seq, identifier, src, resolved_ip)| {
+        .prop_map(|(dst, seq, identifier, src, resolved_ip, payload)| {
             Transition::SendICMPPacketToDnsResource {
                 src,
                 dst,
                 resolved_ip,
                 seq,
                 identifier,
+                payload,
             }
         })
 }

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -1518,6 +1518,10 @@ impl<'a> IcmpEchoRequest<'a> {
     pub fn identifier(&self) -> u16 {
         for_both!(self, |i| i.get_identifier())
     }
+
+    pub fn payload(&self) -> &[u8] {
+        for_both!(self, |i| i.payload())
+    }
 }
 
 impl<'a> IcmpEchoReply<'a> {

--- a/rust/ip-packet/src/proptest.rs
+++ b/rust/ip-packet/src/proptest.rs
@@ -27,10 +27,10 @@ pub fn tcp_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
 pub fn icmp_request_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
     prop_oneof![
         (ip4_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
-            crate::make::icmp_request_packet(IpAddr::V4(saddr), daddr, sport, dport).unwrap()
+            crate::make::icmp_request_packet(IpAddr::V4(saddr), daddr, sport, dport, &[]).unwrap()
         }),
         (ip6_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
-            crate::make::icmp_request_packet(IpAddr::V6(saddr), daddr, sport, dport).unwrap()
+            crate::make::icmp_request_packet(IpAddr::V6(saddr), daddr, sport, dport, &[]).unwrap()
         }),
     ]
 }

--- a/rust/ip-packet/src/proptests.rs
+++ b/rust/ip-packet/src/proptests.rs
@@ -69,7 +69,7 @@ fn icmp_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
         any::<IcmpKind>(),
     )
         .prop_map(|(src, dst, id, seq, kind)| {
-            icmp_packet(src.into(), dst.into(), id, seq, kind).unwrap()
+            icmp_packet(src.into(), dst.into(), id, seq, &[], kind).unwrap()
         })
 }
 
@@ -83,7 +83,7 @@ fn icmp_packet_v4_header_options() -> impl Strategy<Value = MutableIpPacket<'sta
         (5u8..15),
     )
         .prop_map(|(src, dst, id, seq, kind, header_length)| {
-            icmp4_packet_with_options(src, dst, id, seq, kind, header_length)
+            icmp4_packet_with_options(src, dst, id, seq, &[], kind, header_length)
         })
 }
 
@@ -96,7 +96,7 @@ fn icmp_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
         any::<IcmpKind>(),
     )
         .prop_map(|(src, dst, id, seq, kind)| {
-            icmp_packet(src.into(), dst.into(), id, seq, kind).unwrap()
+            icmp_packet(src.into(), dst.into(), id, seq, &[], kind).unwrap()
         })
 }
 


### PR DESCRIPTION
In the `tunnel_test` test suite, we send ICMP requests with arbitrary sequence numbers and identifiers. Due to the NAT implementation of the gateway, the sequence number and identifier chosen by the client are not necessarily the same as the ones sent to the resource. Thus, it is impossible to correlate the ICMP packets sent by the client with the ones arriving at the gateway.

Currently, our test suite thus relies on the ordering of packets to match them up and assert properties on them, like whether they target the correct resource. As soon as we want to send multiple packets concurrently, this order is not necessarily stable.

ICMP echo requests can contain an arbitrary payload. We utilise this payload to embed a random u64 that acts as the unique identifier of an ICMP request. This allows us to correlate the packets arriving at the gateway with the ones sent by the client, making the test suite more robust and ready for handling concurrent ICMP packets.