### PR TITLE
fix(client/windows): put NRPT rules in a special spot if Group Policy is active

### DIFF
--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -69,6 +69,7 @@ features = [
     "Win32_Networking_WinSock",
 
     "Win32_Security", # For named pipe IPC
+    "Win32_System_GroupPolicy", # For NRPT when GPO is used
     "Win32_System_SystemInformation", # For uptime
     "Win32_System_SystemServices",
     "Win32_System_Pipes",

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -114,11 +114,6 @@ fn activate(dns_config: &[IpAddr]) -> Result<()> {
 
     let hklm = winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE);
 
-    // If this key exists, our local NRPT rules are ignored and we have to stick
-    // them in with group policies for some reason.
-    let group_policy_key_exists = hklm.open_subkey(group_nrpt_path()).is_ok();
-    tracing::debug!(?group_policy_key_exists);
-
     let dns_config_string = dns_config
         .iter()
         .map(|ip| ip.to_string())
@@ -129,7 +124,12 @@ fn activate(dns_config: &[IpAddr]) -> Result<()> {
     let (key, _) = hklm.create_subkey(local_nrpt_path().join(NRPT_REG_KEY))?;
     set_nrpt_rule(&key, &dns_config_string)?;
 
+    // If this key exists, our local NRPT rules are ignored and we have to stick
+    // them in with group policies for some reason.
+    let group_policy_key_exists = hklm.open_subkey(group_nrpt_path()).is_ok();
+    tracing::debug!(?group_policy_key_exists);
     if group_policy_key_exists {
+        // TODO: Possible TOCTOU problem - We check whether the key exists, then create a subkey if it does. If Group Policy is disabled between those two steps, and something else removes that parent key, we'll re-create it, which might be bad. We can set up unit tests to see if it's possible to avoid this in the registry, but for now it's not a huge deal.
         let (key, _) = hklm.create_subkey(group_nrpt_path().join(NRPT_REG_KEY))?;
         set_nrpt_rule(&key, &dns_config_string)?;
         refresh_group_policy()?;

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -19,6 +19,9 @@ export default function GUI({ title }: { title: string }) {
           <ChangeItem pull="6432">
             Shows an orange dot on the tray icon when an update is ready to download.
           </ChangeItem>
+          <ChangeItem enable={title === "Windows"} pull="6472">
+            Fixes DNS control for domain-joined systems
+          </ChangeItem>
         </ul>
       </Entry>
       */}


### PR DESCRIPTION
Closes #6469

DNS deactivation now also uses the registry instead of PowerShell, but this may not be faster, since the latency would already be hidden from users most of the time.

