### PR TITLE
fix(ci): Always build debug images - release binaries with debug tools

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
       stage: "debug"
       profile: "debug"
 
-  # Builds debug images with release binaries for compability tests in case the merge_group was skipped.
+  # Builds debug images with release binaries for compatibility tests in case the merge_group was skipped.
   build-test-images:
     uses: ./.github/workflows/_build_artifacts.yml
     secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,15 @@ jobs:
       stage: "debug"
       profile: "debug"
 
+  # Builds debug images with release binaries for compability tests in case the merge_group was skipped.
+  build-test-images:
+    uses: ./.github/workflows/_build_artifacts.yml
+    secrets: inherit
+    with:
+      image_prefix: "debug"
+      stage: "debug"
+      profile: "release"
+
   # Re-run CI checks to make sure everything's green, since "Merging as administrator"
   # won't trigger these in the merge group.
   ci:


### PR DESCRIPTION
This will always build images we can use for last-minute compatibility tests, even if the merge group was bypassed.