### PR TITLE
feat: imply room-participation from WebSocket connection

### DIFF
--- a/elixir/apps/api/lib/api/client/socket.ex
+++ b/elixir/apps/api/lib/api/client/socket.ex
@@ -40,7 +40,7 @@ defmodule API.Client.Socket do
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
         if auto_join_room do
-          API.Client.Channel.join("client", %{}, socket)
+          Process.send_after(self(), {:join_channel, %{}}, 0)
         end
 
         {:ok, socket}
@@ -59,6 +59,12 @@ defmodule API.Client.Socket do
 
   def connect(_params, _socket, _connect_info) do
     {:error, :missing_token}
+  end
+
+  @impl true
+  def handle_info({:join_channel, %{}}, socket) do
+    API.Client.Channel.join("client", %{}, socket)
+    {:noreply, socket}
   end
 
   @impl true

--- a/elixir/apps/api/lib/api/client/socket.ex
+++ b/elixir/apps/api/lib/api/client/socket.ex
@@ -12,7 +12,7 @@ defmodule API.Client.Socket do
 
   @impl true
   def connect(
-        %{"token" => token, "auto_join_room" => auto_join_room} = attrs,
+        %{"token" => token} = attrs,
         socket,
         connect_info
       ) do
@@ -39,7 +39,7 @@ defmodule API.Client.Socket do
           |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
-        if auto_join_room do
+        if Map.get(attrs, "auto_join_room", false) do
           Process.send_after(
             self(),
             %{event: "phx_join", topic: "client"},

--- a/elixir/apps/api/lib/api/client/socket.ex
+++ b/elixir/apps/api/lib/api/client/socket.ex
@@ -40,7 +40,11 @@ defmodule API.Client.Socket do
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
         if auto_join_room do
-          Process.send_after(self(), {:join_channel, %{}}, 0)
+          Process.send_after(
+            self(),
+            %{event: "phx_join", topic: "client"},
+            0
+          )
         end
 
         {:ok, socket}
@@ -59,12 +63,6 @@ defmodule API.Client.Socket do
 
   def connect(_params, _socket, _connect_info) do
     {:error, :missing_token}
-  end
-
-  @impl true
-  def handle_info({:join_channel, %{}}, socket) do
-    API.Client.Channel.join("client", %{}, socket)
-    {:noreply, socket}
   end
 
   @impl true

--- a/elixir/apps/api/lib/api/client/socket.ex
+++ b/elixir/apps/api/lib/api/client/socket.ex
@@ -11,7 +11,11 @@ defmodule API.Client.Socket do
   ## Authentication
 
   @impl true
-  def connect(%{"token" => token} = attrs, socket, connect_info) do
+  def connect(
+        %{"token" => token, "auto_join_room" => auto_join_room} = attrs,
+        socket,
+        connect_info
+      ) do
     :otel_propagator_text_map.extract(connect_info.trace_context_headers)
 
     OpenTelemetry.Tracer.with_span "client.connect" do
@@ -35,7 +39,9 @@ defmodule API.Client.Socket do
           |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
-        API.Client.Channel.join("client", %{}, socket)
+        if auto_join_room do
+          API.Client.Channel.join("client", %{}, socket)
+        end
 
         {:ok, socket}
       else

--- a/elixir/apps/api/lib/api/client/socket.ex
+++ b/elixir/apps/api/lib/api/client/socket.ex
@@ -35,6 +35,8 @@ defmodule API.Client.Socket do
           |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
+        API.Client.Channel.join("client", %{}, socket)
+
         {:ok, socket}
       else
         {:error, :unauthorized} ->

--- a/elixir/apps/api/lib/api/gateway/socket.ex
+++ b/elixir/apps/api/lib/api/gateway/socket.ex
@@ -40,7 +40,7 @@ defmodule API.Gateway.Socket do
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
         if auto_join_room do
-          API.Gateway.Channel.join("gateway", %{}, socket)
+          Process.send_after(self(), {:join_channel, %{}}, 0)
         end
 
         {:ok, socket}
@@ -59,6 +59,12 @@ defmodule API.Gateway.Socket do
 
   def connect(_params, _socket, _connect_info) do
     {:error, :missing_token}
+  end
+
+  @impl true
+  def handle_info({:join_channel, %{}}, socket) do
+    API.Gateway.Channel.join("gateway", %{}, socket)
+    {:noreply, socket}
   end
 
   @impl true

--- a/elixir/apps/api/lib/api/gateway/socket.ex
+++ b/elixir/apps/api/lib/api/gateway/socket.ex
@@ -40,7 +40,11 @@ defmodule API.Gateway.Socket do
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
         if auto_join_room do
-          Process.send_after(self(), {:join_channel, %{}}, 0)
+          Process.send_after(
+            self(),
+            %{event: "phx_join", topic: "gateway"},
+            0
+          )
         end
 
         {:ok, socket}
@@ -59,12 +63,6 @@ defmodule API.Gateway.Socket do
 
   def connect(_params, _socket, _connect_info) do
     {:error, :missing_token}
-  end
-
-  @impl true
-  def handle_info({:join_channel, %{}}, socket) do
-    API.Gateway.Channel.join("gateway", %{}, socket)
-    {:noreply, socket}
   end
 
   @impl true

--- a/elixir/apps/api/lib/api/gateway/socket.ex
+++ b/elixir/apps/api/lib/api/gateway/socket.ex
@@ -12,7 +12,7 @@ defmodule API.Gateway.Socket do
 
   @impl true
   def connect(
-        %{"token" => encoded_token, "auto_join_room" => auto_join_room} = attrs,
+        %{"token" => encoded_token} = attrs,
         socket,
         connect_info
       ) do
@@ -39,7 +39,7 @@ defmodule API.Gateway.Socket do
           |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
-        if auto_join_room do
+        if Map.get(attrs, "auto_join_room", false) do
           Process.send_after(
             self(),
             %{event: "phx_join", topic: "gateway"},

--- a/elixir/apps/api/lib/api/gateway/socket.ex
+++ b/elixir/apps/api/lib/api/gateway/socket.ex
@@ -35,6 +35,8 @@ defmodule API.Gateway.Socket do
           |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
+        API.Gateway.Channel.join("gateway", %{}, socket)
+
         {:ok, socket}
       else
         {:error, :unauthorized} ->

--- a/elixir/apps/api/lib/api/relay/socket.ex
+++ b/elixir/apps/api/lib/api/relay/socket.ex
@@ -12,7 +12,11 @@ defmodule API.Relay.Socket do
 
   @impl true
   def connect(
-        %{"token" => encoded_token, "stamp_secret" => stamp_secret} = attrs,
+        %{
+          "token" => encoded_token,
+          "stamp_secret" => stamp_secret,
+          "auto_join_room" => auto_join_room
+        } = attrs,
         socket,
         connect_info
       ) do
@@ -38,7 +42,9 @@ defmodule API.Relay.Socket do
           |> assign(:opentelemetry_span_ctx, OpenTelemetry.Tracer.current_span_ctx())
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
-        API.Relay.Channel.join("relay", %{stamp_secret: stamp_secret}, socket)
+        if auto_join_room do
+          API.Relay.Channel.join("relay", %{"stamp_secret" => stamp_secret}, socket)
+        end
 
         {:ok, socket}
       else

--- a/elixir/apps/api/lib/api/relay/socket.ex
+++ b/elixir/apps/api/lib/api/relay/socket.ex
@@ -43,7 +43,17 @@ defmodule API.Relay.Socket do
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
         if auto_join_room do
-          Process.send_after(self(), {:join_channel, %{stamp_secret: stamp_secret}}, 0)
+          Process.send_after(
+            self(),
+            %{
+              event: "phx_join",
+              topic: "client",
+              payload: %{
+                stamp_secret: stamp_secret
+              }
+            },
+            0
+          )
         end
 
         {:ok, socket}
@@ -62,12 +72,6 @@ defmodule API.Relay.Socket do
 
   def connect(_params, _socket, _connect_info) do
     {:error, :missing_token}
-  end
-
-  @impl true
-  def handle_info({:join_channel, %{stamp_secret}}, socket) do
-    API.Relay.Channel.join("relay", %{"stamp_secret" => stamp_secret}, socket)
-    {:noreply, socket}
   end
 
   @impl true

--- a/elixir/apps/api/lib/api/relay/socket.ex
+++ b/elixir/apps/api/lib/api/relay/socket.ex
@@ -43,7 +43,7 @@ defmodule API.Relay.Socket do
           |> assign(:opentelemetry_ctx, OpenTelemetry.Ctx.get_current())
 
         if auto_join_room do
-          API.Relay.Channel.join("relay", %{"stamp_secret" => stamp_secret}, socket)
+          Process.send_after(self(), {:join_channel, %{stamp_secret: stamp_secret}}, 0)
         end
 
         {:ok, socket}
@@ -62,6 +62,12 @@ defmodule API.Relay.Socket do
 
   def connect(_params, _socket, _connect_info) do
     {:error, :missing_token}
+  end
+
+  @impl true
+  def handle_info({:join_channel, %{stamp_secret}}, socket) do
+    API.Relay.Channel.join("relay", %{"stamp_secret" => stamp_secret}, socket)
+    {:noreply, socket}
   end
 
   @impl true

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -377,8 +377,6 @@ fn connect(
     let portal = PhoenixChannel::connect(
         Secret::new(url),
         get_user_agent(Some(os_version), env!("CARGO_PKG_VERSION")),
-        "client",
-        (),
         ExponentialBackoffBuilder::default()
             .with_max_elapsed_time(Some(MAX_PARTITION_TIME))
             .build(),

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -214,8 +214,6 @@ impl WrappedSession {
         let portal = PhoenixChannel::connect(
             Secret::new(url),
             get_user_agent(os_version_override, env!("CARGO_PKG_VERSION")),
-            "client",
-            (),
             ExponentialBackoffBuilder::default()
                 .with_max_elapsed_time(Some(MAX_PARTITION_TIME))
                 .build(),

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -24,7 +24,7 @@ pub struct Eventloop<C: Callbacks> {
     tunnel: ClientTunnel,
     callbacks: C,
 
-    portal: PhoenixChannel<(), IngressMessages, ReplyMessages>,
+    portal: PhoenixChannel<IngressMessages, ReplyMessages>,
     rx: tokio::sync::mpsc::UnboundedReceiver<Command>,
 
     connection_intents: SentConnectionIntents,
@@ -43,7 +43,7 @@ impl<C: Callbacks> Eventloop<C> {
     pub(crate) fn new(
         tunnel: ClientTunnel,
         callbacks: C,
-        portal: PhoenixChannel<(), IngressMessages, ReplyMessages>,
+        portal: PhoenixChannel<IngressMessages, ReplyMessages>,
         rx: tokio::sync::mpsc::UnboundedReceiver<Command>,
     ) -> Self {
         Self {

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -48,7 +48,7 @@ impl Session {
     /// This connects to the portal a specified using [`LoginUrl`] and creates a wireguard tunnel using the provided private key.
     pub fn connect<CB: Callbacks + 'static>(
         args: ConnectArgs<CB>,
-        portal: PhoenixChannel<(), IngressMessages, ReplyMessages>,
+        portal: PhoenixChannel<IngressMessages, ReplyMessages>,
         handle: tokio::runtime::Handle,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -118,7 +118,7 @@ impl Session {
 /// When this function exits, the tunnel failed unrecoverably and you need to call it again.
 async fn connect<CB>(
     args: ConnectArgs<CB>,
-    portal: PhoenixChannel<(), IngressMessages, ReplyMessages>,
+    portal: PhoenixChannel<IngressMessages, ReplyMessages>,
     rx: UnboundedReceiver<Command>,
 ) -> Result<(), DisconnectError>
 where

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -40,7 +40,7 @@ enum ResolveTrigger {
 
 pub struct Eventloop {
     tunnel: GatewayTunnel,
-    portal: PhoenixChannel<(), IngressMessages, ()>,
+    portal: PhoenixChannel<IngressMessages, ()>,
     tun_device_channel: mpsc::Sender<Interface>,
 
     resolve_tasks: futures_bounded::FuturesTupleSet<Vec<IpAddr>, ResolveTrigger>,
@@ -49,7 +49,7 @@ pub struct Eventloop {
 impl Eventloop {
     pub(crate) fn new(
         tunnel: GatewayTunnel,
-        portal: PhoenixChannel<(), IngressMessages, ()>,
+        portal: PhoenixChannel<IngressMessages, ()>,
         tun_device_channel: mpsc::Sender<Interface>,
     ) -> Self {
         Self {

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -1,4 +1,4 @@
-use crate::eventloop::{Eventloop, PHOENIX_TOPIC};
+use crate::eventloop::Eventloop;
 use anyhow::{Context, Result};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
@@ -114,8 +114,6 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
     let portal = PhoenixChannel::connect(
         Secret::new(login),
         get_user_agent(None, env!("CARGO_PKG_VERSION")),
-        PHOENIX_TOPIC,
-        (),
         ExponentialBackoffBuilder::default()
             .with_max_elapsed_time(None)
             .build(),

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -499,8 +499,6 @@ impl<'a> Handler<'a> {
         let portal = PhoenixChannel::connect(
             Secret::new(url),
             get_user_agent(None, env!("CARGO_PKG_VERSION")),
-            "client",
-            (),
             ExponentialBackoffBuilder::default()
                 .with_max_elapsed_time(Some(Duration::from_secs(60 * 60 * 24 * 30)))
                 .build(),

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -195,8 +195,6 @@ fn main() -> Result<()> {
     let portal = PhoenixChannel::connect(
         Secret::new(url),
         get_user_agent(None, env!("CARGO_PKG_VERSION")),
-        "client",
-        (),
         ExponentialBackoffBuilder::default()
             .with_max_elapsed_time(max_partition_time)
             .build(),

--- a/rust/phoenix-channel/src/login_url.rs
+++ b/rust/phoenix-channel/src/login_url.rs
@@ -60,6 +60,7 @@ impl LoginUrl {
             None,
             None,
             None,
+            None,
         )?;
 
         Ok(LoginUrl {
@@ -90,6 +91,7 @@ impl LoginUrl {
             None,
             None,
             None,
+            None,
         )?;
 
         Ok(LoginUrl {
@@ -105,6 +107,7 @@ impl LoginUrl {
         listen_port: u16,
         ipv4_address: Option<Ipv4Addr>,
         ipv6_address: Option<Ipv6Addr>,
+        stamp_secret: &SecretString,
     ) -> Result<Self, LoginUrlError<E>> {
         let url = get_websocket_path(
             url.try_into().map_err(LoginUrlError::InvalidUrl)?,
@@ -116,6 +119,7 @@ impl LoginUrl {
             Some(listen_port),
             ipv4_address,
             ipv6_address,
+            Some(stamp_secret),
         )?;
 
         Ok(LoginUrl {
@@ -183,6 +187,7 @@ fn get_websocket_path<E>(
     port: Option<u16>,
     ipv4_address: Option<Ipv4Addr>,
     ipv6_address: Option<Ipv6Addr>,
+    stamp_secret: Option<&SecretString>,
 ) -> Result<Url, LoginUrlError<E>> {
     set_ws_scheme(&mut api_url)?;
 
@@ -218,6 +223,9 @@ fn get_websocket_path<E>(
         }
         if let Some(port) = port {
             query_pairs.append_pair("port", &port.to_string());
+        }
+        if let Some(stamp_secret) = stamp_secret {
+            query_pairs.append_pair("stamp_secret", &stamp_secret.expose_secret().to_string());
         }
     }
 

--- a/rust/phoenix-channel/src/login_url.rs
+++ b/rust/phoenix-channel/src/login_url.rs
@@ -202,9 +202,11 @@ fn get_websocket_path<E>(
     }
 
     {
-        let mut query_pairs = api_url.query_pairs_mut();
+        let mut query_pairs: url::form_urlencoded::Serializer<url::UrlQuery> =
+            api_url.query_pairs_mut();
         query_pairs.clear();
         query_pairs.append_pair("token", token.expose_secret());
+        query_pairs.append_pair("auto_join_room", "true");
 
         if let Some(public_key) = public_key {
             query_pairs.append_pair("public_key", &STANDARD.encode(public_key));


### PR DESCRIPTION
This implements the first half of what I described in https://github.com/firezone/firezone/issues/6466#issuecomment-2316373740. For the client's, having to manually join the right room upon connect is error prone. We even had race conditions in the past where we still had messages buffered that got lost upon re-connect because we weren't in the right room yet.

By directly joining the room when the socket is established, this cannot happen and it simplifies the client's state machine.

There are still some open questions:

- ~Where is the response to joining a room generated? Will this trigger a response to the client for a message they never sent?~
- Can we also do an implicit disconnect as soon as we leave the room / the process handling messages for the room topic disconnects / disappears?