### PR TITLE
ci: Bump GUI to 1.2.2

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -26,31 +26,31 @@ jobs:
         include:
           - runs-on: ubuntu-20.04
             # mark:next-gui-version
-            binary-dest-path: firezone-client-gui-linux_1.2.2_x86_64
+            binary-dest-path: firezone-client-gui-linux_1.2.3_x86_64
             rename-script: ../../scripts/build/tauri-rename-ubuntu.sh
             upload-script: ../../scripts/build/tauri-upload-ubuntu.sh
             # mark:next-gui-version
-            syms-artifact: rust/gui-client/firezone-client-gui-linux_1.2.2_x86_64.dwp
+            syms-artifact: rust/gui-client/firezone-client-gui-linux_1.2.3_x86_64.dwp
             # mark:next-gui-version
-            pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.2.2_x86_64.deb
+            pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.2.3_x86_64.deb
           - runs-on: ubuntu-20.04-arm
             # mark:next-gui-version
-            binary-dest-path: firezone-client-gui-linux_1.2.2_aarch64
+            binary-dest-path: firezone-client-gui-linux_1.2.3_aarch64
             rename-script: ../../scripts/build/tauri-rename-ubuntu.sh
             upload-script: ../../scripts/build/tauri-upload-ubuntu.sh
             # mark:next-gui-version
-            syms-artifact: rust/gui-client/firezone-client-gui-linux_1.2.2_aarch64.dwp
+            syms-artifact: rust/gui-client/firezone-client-gui-linux_1.2.3_aarch64.dwp
             # mark:next-gui-version
-            pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.2.2_aarch64.deb
+            pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.2.3_aarch64.deb
           - runs-on: windows-2019
             # mark:next-gui-version
-            binary-dest-path: firezone-client-gui-windows_1.2.2_x86_64
+            binary-dest-path: firezone-client-gui-windows_1.2.3_x86_64
             rename-script: ../../scripts/build/tauri-rename-windows.sh
             upload-script: ../../scripts/build/tauri-upload-windows.sh
             # mark:next-gui-version
-            syms-artifact: rust/gui-client/firezone-client-gui-windows_1.2.2_x86_64.pdb
+            syms-artifact: rust/gui-client/firezone-client-gui-windows_1.2.3_x86_64.pdb
             # mark:next-gui-version
-            pkg-artifact: rust/gui-client/firezone-client-gui-windows_1.2.2_x86_64.msi
+            pkg-artifact: rust/gui-client/firezone-client-gui-windows_1.2.3_x86_64.msi
     env:
       BINARY_DEST_PATH: ${{ matrix.binary-dest-path }}
       AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
@@ -96,7 +96,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         shell: bash
         # mark:next-gui-version
-        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_1.2.2_x64_en-US.msi
+        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_1.2.3_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ matrix.rename-script }}
@@ -121,6 +121,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           # mark:next-gui-version
-          TAG_NAME: gui-client-1.2.2
+          TAG_NAME: gui-client-1.2.3
         shell: bash
         run: ${{ matrix.upload-script }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           - release_name: headless-client-1.2.1
             config_name: release-drafter-headless-client.yml
           # mark:next-gui-version
-          - release_name: gui-client-1.2.2
+          - release_name: gui-client-1.2.3
             config_name: release-drafter-gui-client.yml
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gui-client"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gui-client"
 # mark:next-gui-version
-version = "1.2.2"
+version = "1.2.3"
 description = "Firezone"
 edition = "2021"
 default-run = "firezone-gui-client"

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -16,14 +16,14 @@
 current-apple-version = 1.2.1
 current-android-version = 1.2.0
 current-gateway-version = 1.2.0
-current-gui-version = 1.2.1
+current-gui-version = 1.2.2
 current-headless-version = 1.2.0
 
 # Tracks the next version to release for each platform
 next-apple-version = 1.2.2
 next-android-version = 1.2.1
 next-gateway-version = 1.3.0
-next-gui-version = 1.2.2
+next-gui-version = 1.2.3
 next-headless-version = 1.2.1
 
 # macOS uses a slightly different sed syntax

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -10,7 +10,7 @@ module.exports = [
     source: "/dl/firezone-client-gui-windows/latest/x86_64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.2.1/firezone-client-gui-windows_1.2.1_x86_64.msi",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.2.2/firezone-client-gui-windows_1.2.2_x86_64.msi",
     permanent: false,
   },
   /*
@@ -22,14 +22,14 @@ module.exports = [
     source: "/dl/firezone-client-gui-linux/latest/x86_64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.2.1/firezone-client-gui-linux_1.2.1_x86_64.deb",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.2.2/firezone-client-gui-linux_1.2.2_x86_64.deb",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-gui-linux/latest/aarch64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.2.1/firezone-client-gui-linux_1.2.1_aarch64.deb",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.2.2/firezone-client-gui-linux_1.2.2_aarch64.deb",
     permanent: false,
   },
   {

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -25,7 +25,7 @@ export default function GUI({ title }: { title: string }) {
             Shows an orange dot on the tray icon when an update is ready to download.
           </ChangeItem>
           <ChangeItem enable={title === "Windows"} pull="6472">
-            Fixes DNS control for domain-joined systems
+            Fixes an issue where Split DNS didn't work for domain-joined Windows machines
           </ChangeItem>
         </ul>
       </Entry>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,7 +14,12 @@ export default function GUI({ title }: { title: string }) {
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This cannot be done when the issue's PR merges. */}
       {/*
-      <Entry version="1.2.2" date={new Date(todo)}>
+      <Entry version="1.2.3" date={new Date(todo)}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+        </ul>
+      </Entry>
+      */}
+      <Entry version="1.2.2" date={new Date("2024-08-29")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6432">
             Shows an orange dot on the tray icon when an update is ready to download.
@@ -24,7 +29,6 @@ export default function GUI({ title }: { title: string }) {
           </ChangeItem>
         </ul>
       </Entry>
-      */}
       <Entry version="1.2.1" date={new Date("2024-08-27")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6414">


### PR DESCRIPTION
- No known issues from the knowledge base were fixed
- I confirmed on the Windows laptop that the fix for #6469 is in this MSI.
- The changelog looks good in the Vercel preview