### PR TITLE
fix(portal): Fix flash width and hero logo on auth pages

### DIFF
--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -19,7 +19,7 @@ defmodule Web.CoreComponents do
   def hero_logo(assigns) do
     ~H"""
     <div class="mb-6">
-      <img src={~p"/images/logo.svg"} class="mx-auto pr-10 h-32" alt="Firezone Logo" />
+      <img src={~p"/images/logo.svg"} class="mx-auto pr-10 h-24" alt="Firezone Logo" />
       <p class="text-center mt-4 text-3xl">
         <%= @text %>
       </p>

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -284,7 +284,7 @@ defmodule Web.CoreComponents do
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
       id={@id}
       class={[
-        "p-4 text-sm flash-#{@kind}",
+        "w-fit p-4 text-sm flash-#{@kind}",
         @kind == :success && "text-green-800 bg-green-100",
         @kind == :info && "text-blue-800 bg-blue-100",
         @kind == :warning && "text-yellow-800 bg-yellow-100",

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -284,7 +284,7 @@ defmodule Web.CoreComponents do
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
       id={@id}
       class={[
-        "w-fit p-4 text-sm flash-#{@kind}",
+        "p-4 text-sm flash-#{@kind}",
         @kind == :success && "text-green-800 bg-green-100",
         @kind == :info && "text-blue-800 bg-blue-100",
         @kind == :warning && "text-yellow-800 bg-yellow-100",

--- a/elixir/apps/web/lib/web/controllers/sign_in_html.ex
+++ b/elixir/apps/web/lib/web/controllers/sign_in_html.ex
@@ -30,7 +30,7 @@ defmodule Web.SignInHTML do
         <main class="h-auto pt-16">
           <section>
             <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
-              <.logo />
+              <.hero_logo text={@account.name} />
 
               <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
                 <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">
@@ -55,7 +55,7 @@ defmodule Web.SignInHTML do
     <main class="h-auto pt-16">
       <section>
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
-          <.logo />
+          <.hero_logo text={@account.name} />
 
           <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
             <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -177,7 +177,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
                       not is_nil(@provider.sync_disabled_at) or
                       (@provider.last_syncs_failed > 3 and not is_nil(@provider.last_sync_error))
                   }
-                  class="p-3 mt-2 border-l-4 border-red-500 bg-red-100 rounded-md"
+                  class="w-fit p-3 mt-2 border-l-4 border-red-500 bg-red-100 rounded-md"
                 >
                   <p class="font-medium text-red-700">
                     IdP provider reported an error during the last sync:

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
@@ -187,7 +187,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
                         not is_nil(@provider.sync_disabled_at) or
                         (@provider.last_syncs_failed > 3 and not is_nil(@provider.last_sync_error))
                     }
-                    class="p-3 mt-2 border-l-4 border-red-500 bg-red-100 rounded-md"
+                    class="w-fit p-3 mt-2 border-l-4 border-red-500 bg-red-100 rounded-md"
                   >
                     <p class="font-medium text-red-700">
                       IdP provider reported an error during the last sync:

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -177,7 +177,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
                       not is_nil(@provider.sync_disabled_at) or
                       (@provider.last_syncs_failed > 3 and not is_nil(@provider.last_sync_error))
                   }
-                  class="p-3 mt-2 border-l-4 border-red-500 bg-red-100 rounded-md"
+                  class="w-fit p-3 mt-2 border-l-4 border-red-500 bg-red-100 rounded-md"
                 >
                   <p class="font-medium text-red-700">
                     IdP provider reported an error during the last sync:

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -175,7 +175,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
                       not is_nil(@provider.sync_disabled_at) or
                       (@provider.last_syncs_failed > 3 and not is_nil(@provider.last_sync_error))
                   }
-                  class="p-3 mt-2 border-l-4 border-red-500 bg-red-100 rounded-md"
+                  class="w-fit p-3 mt-2 border-l-4 border-red-500 bg-red-100 rounded-md"
                 >
                   <p class="font-medium text-red-700">
                     IdP provider reported an error during the last sync:

--- a/elixir/apps/web/lib/web/live/sign_in/email.ex
+++ b/elixir/apps/web/lib/web/live/sign_in/email.ex
@@ -53,7 +53,7 @@ defmodule Web.SignIn.Email do
     ~H"""
     <section>
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto lg:py-0">
-        <.logo />
+        <.hero_logo text={@account.name} />
 
         <div class="w-full col-span-6 mx-auto bg-white rounded shadow md:mt-0 sm:max-w-lg xl:p-0">
           <div class="p-6 space-y-4 lg:space-y-6 sm:p-8">

--- a/elixir/apps/web/test/web/controllers/sign_in_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/sign_in_controller_test.exs
@@ -40,12 +40,20 @@ defmodule Web.SignInControllerTest do
       assert query_params["account_slug"] == account.slug
     end
 
-    test "redirects to sign in page when cookie not present", %{account: account} do
+    test "instructs user to restart sign in when cookie not present", %{account: account} do
       conn =
         build_conn()
         |> get(~p"/#{account}/sign_in/client_redirect")
 
       assert redirected_to(conn, 302) =~ ~p"/#{account}/sign_in/client_auth_error"
+    end
+
+    test "displays account name on client auth error page", %{account: account} do
+      conn =
+        build_conn()
+        |> get(~p"/#{account}/sign_in/client_auth_error")
+
+      assert html_response(conn, 200) =~ account.name
     end
   end
 end


### PR DESCRIPTION
# Before

<img width="1131" alt="Screenshot 2024-08-29 at 8 54 21 AM" src="https://github.com/user-attachments/assets/65aadaaa-dc92-4b2d-8fd4-a8ec776bc697">
<img width="3120" alt="Screenshot 2024-08-29 at 9 00 38 AM" src="https://github.com/user-attachments/assets/aa9846dc-9a01-4282-b9eb-539b38e7f67d">

<img width="702" alt="Screenshot 2024-08-29 at 9 03 26 AM" src="https://github.com/user-attachments/assets/39e30430-ed0a-46c6-84a1-f4edecacbdb3">


# After

<img width="1100" alt="Screenshot 2024-08-29 at 8 54 30 AM" src="https://github.com/user-attachments/assets/9b5ee17a-e95f-4195-8439-f94298d6ecf9">
<img width="3120" alt="Screenshot 2024-08-29 at 9 00 54 AM" src="https://github.com/user-attachments/assets/be962785-684f-4de1-bf60-31e3567440ca">
<img width="621" alt="Screenshot 2024-08-29 at 9 09 54 AM" src="https://github.com/user-attachments/assets/33b6d501-b5ad-494d-8c75-faf6bf63068f">
<img width="572" alt="Screenshot 2024-08-29 at 9 14 52 AM" src="https://github.com/user-attachments/assets/c72cfc5a-8824-49e2-9ba2-984ebd490251">
