### PR TITLE
fix(ci): Fix update-release-draft name so we can require it in branch protection rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     secrets: inherit
 
   update-release-draft:
+    name: update-release-draft-${{ matrix.config_name }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
This makes the job name deterministic so we can add it to branch protection rules.