### PR TITLE
build(nix): install musl targets in dev-shell

### DIFF
--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -55,7 +55,11 @@
 
           mkShellWithRustVersion = rustVersion: pkgs.mkShell {
             packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.nodePackages.pnpm cargo-udeps pkgs.cargo-sort ];
-            buildInputs = rustVersion ++ packages;
+            buildInputs = packages ++ [
+              (rustVersion.override {
+                targets = [ "x86_64-unknown-linux-musl" ];
+              })
+            ];
             name = "rust-env";
             src = ../../rust;
 
@@ -64,13 +68,8 @@
           };
         in
         {
-          devShells.default = mkShellWithRustVersion [
-            (pkgs.rust-bin.fromRustupToolchainFile ../../rust/rust-toolchain.toml)
-          ];
-
-          devShells.nightly = mkShellWithRustVersion [
-            (pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default))
-          ];
+          devShells.default = mkShellWithRustVersion (pkgs.rust-bin.fromRustupToolchainFile ../../rust/rust-toolchain.toml);
+          devShells.nightly = mkShellWithRustVersion rust-nightly;
         }
       );
 }


### PR DESCRIPTION
To build for musl, the target needs to be installed. Within the Nix dev-shell, we don't manage versions / components via rustup, thus they need to be added manually.