### PR TITLE
fix(android): Use DisconnectMonitor to shut tunnel down when VPN is disconnected

### DIFF
--- a/kotlin/android/app/src/main/AndroidManifest.xml
+++ b/kotlin/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     </queries>
 
     <application
+        android:enableOnBackInvokedCallback="true"
         android:gwpAsanMode="always"
         android:name=".core.FirezoneApp"
         android:allowBackup="false"

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -34,9 +34,12 @@ class SessionActivity : AppCompatActivity() {
             ) {
                 val binder = service as TunnelService.LocalBinder
                 tunnelService = binder.getService()
-                serviceBound = true
-                tunnelService?.setServiceStateLiveData(viewModel.serviceStatusLiveData)
-                tunnelService?.setResourcesLiveData(viewModel.resourcesLiveData)
+
+                tunnelService?.let {
+                    serviceBound = true
+                    it.setServiceStateLiveData(viewModel.serviceStatusLiveData)
+                    it.setResourcesLiveData(viewModel.resourcesLiveData)
+                }
             }
 
             override fun onServiceDisconnected(name: ComponentName?) {
@@ -60,11 +63,13 @@ class SessionActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         if (serviceBound) {
             unbindService(serviceConnection)
             serviceBound = false
+            tunnelService = null
         }
+
+        super.onDestroy()
     }
 
     fun onViewResourceToggled(resourceToggled: ViewResource) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
@@ -16,6 +16,12 @@ class DisconnectMonitor(private val tunnelService: TunnelService) : Connectivity
         network: Network,
         linkProperties: LinkProperties,
     ) {
+        super.onLinkPropertiesChanged(network, linkProperties)
+
+        if (tunnelService.tunnelIpv4Address.isNullOrBlank() || tunnelService.tunnelIpv6Address.isNullOrBlank()) {
+            return
+        }
+
         val ipv4Found = linkProperties.linkAddresses.find { it.address.hostAddress == tunnelService.tunnelIpv4Address }
         val ipv6Found = linkProperties.linkAddresses.find { it.address.hostAddress == tunnelService.tunnelIpv6Address }
 
@@ -23,8 +29,6 @@ class DisconnectMonitor(private val tunnelService: TunnelService) : Connectivity
             // Matched both IPv4 and IPv6 addresses, this is our VPN network
             vpnNetwork = network
         }
-
-        super.onLinkPropertiesChanged(network, linkProperties)
     }
 
     override fun onLost(network: Network) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
@@ -5,7 +5,7 @@ import android.net.Network
 import dev.firezone.android.tunnel.TunnelService
 
 // None of the TunnelService lifecycle callbacks are called when a user disconnects the VPN
-// from the system settings. This class listens for network changes and disconnects the VPN
+// from the system settings. This class listens for network changes and shuts down the service
 // when the network is lost, which achieves the same effect.
 class DisconnectMonitor(private val tunnelService: TunnelService) : ConnectivityManager.NetworkCallback() {
     private var vpnNetwork: Network? = null

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
@@ -19,7 +19,7 @@ class DisconnectMonitor(private val tunnelService: TunnelService) : Connectivity
         val ipv4Found = linkProperties.linkAddresses.find { it.address.hostAddress == tunnelService.tunnelIpv4Address }
         val ipv6Found = linkProperties.linkAddresses.find { it.address.hostAddress == tunnelService.tunnelIpv6Address }
 
-        if (ipv4 != null && ipv6 != null) {
+        if (ipv4Found != null && ipv6Found != null) {
             // Matched both IPv4 and IPv6 addresses, this is our VPN network
             vpnNetwork = network
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/DisconnectMonitor.kt
@@ -1,0 +1,37 @@
+/* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.Network
+import dev.firezone.android.tunnel.TunnelService
+
+// None of the TunnelService lifecycle callbacks are called when a user disconnects the VPN
+// from the system settings. This class listens for network changes and disconnects the VPN
+// when the network is lost, which achieves the same effect.
+class DisconnectMonitor(private val tunnelService: TunnelService) : ConnectivityManager.NetworkCallback() {
+    private var vpnNetwork: Network? = null
+
+    // Android doesn't provide a good way to associate a network with a VPN service, so we
+    // have to use the IP addresses of the tunnel to determine if the network is our VPN.
+    override fun onLinkPropertiesChanged(
+        network: Network,
+        linkProperties: LinkProperties,
+    ) {
+        val ipv4Found = linkProperties.linkAddresses.find { it.address.hostAddress == tunnelService.tunnelIpv4Address }
+        val ipv6Found = linkProperties.linkAddresses.find { it.address.hostAddress == tunnelService.tunnelIpv6Address }
+
+        if (ipv4 != null && ipv6 != null) {
+            // Matched both IPv4 and IPv6 addresses, this is our VPN network
+            vpnNetwork = network
+        }
+
+        super.onLinkPropertiesChanged(network, linkProperties)
+    }
+
+    override fun onLost(network: Network) {
+        if (network == vpnNetwork) {
+            tunnelService.disconnect()
+        }
+
+        super.onLost(network)
+    }
+}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -1,6 +1,7 @@
 /* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
 package dev.firezone.android.tunnel
 
+import DisconnectMonitor
 import NetworkMonitor
 import android.app.ActivityManager
 import android.content.BroadcastReceiver
@@ -46,14 +47,20 @@ class TunnelService : VpnService() {
     @Inject
     internal lateinit var moshi: Moshi
 
-    private var tunnelIpv4Address: String? = null
-    private var tunnelIpv6Address: String? = null
+    var tunnelIpv4Address: String? = null
+    var tunnelIpv6Address: String? = null
     private var tunnelDnsAddresses: MutableList<String> = mutableListOf()
     private var tunnelRoutes: MutableList<Cidr> = mutableListOf()
     private var _tunnelResources: List<ViewResource> = emptyList()
     private var _tunnelState: State = State.DOWN
-    private var networkCallback: NetworkMonitor? = null
     private var disabledResources: MutableSet<String> = mutableSetOf()
+
+    // For reacting to changes to the network
+    private var networkCallback: NetworkMonitor? = null
+
+    // For reacting to disconnects of our VPN service, for example when the user disconnects
+    // the VPN from the system settings or MDM disconnects us.
+    private var disconnectCallback: DisconnectMonitor? = null
 
     // General purpose mutex lock for preventing network monitoring from calling connlib
     // during shutdown.
@@ -280,13 +287,24 @@ class TunnelService : VpnService() {
 
     private fun startNetworkMonitoring() {
         networkCallback = NetworkMonitor(this)
+        disconnectCallback = DisconnectMonitor(this)
 
-        val networkRequest =
-            NetworkRequest.Builder().addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
-                .build()
+        val networkRequest = NetworkRequest.Builder()
+
         val connectivityManager =
             getSystemService(ConnectivityManager::class.java) as ConnectivityManager
-        connectivityManager.requestNetwork(networkRequest, networkCallback!!)
+
+        // Listens for changes *not* including VPN networks
+        connectivityManager.requestNetwork(
+            networkRequest.addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN).build(),
+            networkCallback!!,
+        )
+
+        // Listens for changes for *all* networks
+        connectivityManager.requestNetwork(
+            networkRequest.removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN).build(),
+            disconnectCallback!!,
+        )
     }
 
     private fun stopNetworkMonitoring() {
@@ -296,6 +314,14 @@ class TunnelService : VpnService() {
             connectivityManager.unregisterNetworkCallback(it)
 
             networkCallback = null
+        }
+
+        disconnectCallback?.let {
+            val connectivityManager =
+                getSystemService(ConnectivityManager::class.java) as ConnectivityManager
+            connectivityManager.unregisterNetworkCallback(it)
+
+            disconnectCallback = null
         }
     }
 

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -20,6 +20,10 @@ export default function Android() {
           <ChangeItem pull="6405">
             Shows the Git SHA corresponding to the build on the Settings -> Advanced screen.
           </ChangeItem>
+          <ChangeItem pull="6495">
+          Fixes a bug where the Firezone tunnel wasn't shutdown properly if you disconnect
+          the VPN in system settings.
+          </ChangeItem>
         </ul>
       </Entry>
       */}


### PR DESCRIPTION
When a user disconnects our VPN from system settings, Android does _not_ call any of the typical TunnelService callbacks. It does, however, send a standard NetworkMonitor event we can intercept in the `onLost` callback. We use that to shut down the TunnelService if we detect our VPN network has been lost.

Unfortunately, network monitoring in Android is broad - we are notified when _any_ network is lost, not just ours. So to filter others out, we listen for `linkProperties` changing, and if the link addresses match our tunnel IPv4 and IPv6, we save that network ID to match on in the `onLost` callback later.

Resolves #5413 