### PR TITLE
chore: remove `.envrc` from Git

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake ./scripts/nix/flake.nix


### PR DESCRIPTION
The `.envrc` file is useful for developers to trigger directory-specific setup using `direnv`. Yet, not all developers use that and forcing the same local setup onto all doesn't make sense either.

Thus, we remove the `.envrc` file from the repository. As an added benefit, this also removes a top-level file from the repo which makes the directory structure look less cluttered.