### PR TITLE
ci: Release 1.3.0 for Internet Resource

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -155,9 +155,9 @@ jobs:
             artifact: firezone-client-headless-linux
             image_name: client
             # mark:next-headless-version
-            release_name: headless-client-1.3.0
+            release_name: headless-client-1.3.1
             # mark:next-headless-version
-            version: 1.3.0
+            version: 1.3.1
           - package: firezone-relay
             artifact: firezone-relay
             image_name: relay
@@ -165,9 +165,9 @@ jobs:
             artifact: firezone-gateway
             image_name: gateway
             # mark:next-gateway-version
-            release_name: gateway-1.3.0
+            release_name: gateway-1.3.1
             # mark:next-gateway-version
-            version: 1.3.0
+            version: 1.3.1
           - package: http-test-server
             artifact: http-test-server
             image_name: http-test-server
@@ -347,7 +347,7 @@ jobs:
           - name: relay
           - name: gateway
             # mark:next-gateway-version
-            version: 1.3.0
+            version: 1.3.1
           - name: client
             # mark:next-client-version
             version: 1.0.6

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -26,31 +26,31 @@ jobs:
         include:
           - runs-on: ubuntu-20.04
             # mark:next-gui-version
-            binary-dest-path: firezone-client-gui-linux_1.3.0_x86_64
+            binary-dest-path: firezone-client-gui-linux_1.3.1_x86_64
             rename-script: ../../scripts/build/tauri-rename-ubuntu.sh
             upload-script: ../../scripts/build/tauri-upload-ubuntu.sh
             # mark:next-gui-version
-            syms-artifact: rust/gui-client/firezone-client-gui-linux_1.3.0_x86_64.dwp
+            syms-artifact: rust/gui-client/firezone-client-gui-linux_1.3.1_x86_64.dwp
             # mark:next-gui-version
-            pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.3.0_x86_64.deb
+            pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.3.1_x86_64.deb
           - runs-on: ubuntu-20.04-arm
             # mark:next-gui-version
-            binary-dest-path: firezone-client-gui-linux_1.3.0_aarch64
+            binary-dest-path: firezone-client-gui-linux_1.3.1_aarch64
             rename-script: ../../scripts/build/tauri-rename-ubuntu.sh
             upload-script: ../../scripts/build/tauri-upload-ubuntu.sh
             # mark:next-gui-version
-            syms-artifact: rust/gui-client/firezone-client-gui-linux_1.3.0_aarch64.dwp
+            syms-artifact: rust/gui-client/firezone-client-gui-linux_1.3.1_aarch64.dwp
             # mark:next-gui-version
-            pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.3.0_aarch64.deb
+            pkg-artifact: rust/gui-client/firezone-client-gui-linux_1.3.1_aarch64.deb
           - runs-on: windows-2019
             # mark:next-gui-version
-            binary-dest-path: firezone-client-gui-windows_1.3.0_x86_64
+            binary-dest-path: firezone-client-gui-windows_1.3.1_x86_64
             rename-script: ../../scripts/build/tauri-rename-windows.sh
             upload-script: ../../scripts/build/tauri-upload-windows.sh
             # mark:next-gui-version
-            syms-artifact: rust/gui-client/firezone-client-gui-windows_1.3.0_x86_64.pdb
+            syms-artifact: rust/gui-client/firezone-client-gui-windows_1.3.1_x86_64.pdb
             # mark:next-gui-version
-            pkg-artifact: rust/gui-client/firezone-client-gui-windows_1.3.0_x86_64.msi
+            pkg-artifact: rust/gui-client/firezone-client-gui-windows_1.3.1_x86_64.msi
     env:
       BINARY_DEST_PATH: ${{ matrix.binary-dest-path }}
       AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
@@ -96,7 +96,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         shell: bash
         # mark:next-gui-version
-        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_1.3.0_x64_en-US.msi
+        run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_1.3.1_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ matrix.rename-script }}
@@ -121,6 +121,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           # mark:next-gui-version
-          TAG_NAME: gui-client-1.3.0
+          TAG_NAME: gui-client-1.3.1
         shell: bash
         run: ${{ matrix.upload-script }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,13 @@ jobs:
       matrix:
         include:
           # mark:next-gateway-version
-          - release_name: gateway-1.3.0
+          - release_name: gateway-1.3.1
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
-          - release_name: headless-client-1.3.0
+          - release_name: headless-client-1.3.1
             config_name: release-drafter-headless-client.yml
           # mark:next-gui-version
-          - release_name: gui-client-1.3.0
+          - release_name: gui-client-1.3.1
             config_name: release-drafter-gui-client.yml
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,11 +38,11 @@ jobs:
           if [[ "${{ github.event.release.name }}" =~ gateway* ]]; then
             ARTIFACT=gateway
             # mark:next-gateway-version
-            VERSION="1.3.0"
+            VERSION="1.3.1"
           elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
             ARTIFACT=client
             # mark:next-headless-version
-            VERSION="1.3.0"
+            VERSION="1.3.1"
           else
             echo "Shouldn't have gotten here. Exiting."
             exit 1

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -56,7 +56,7 @@ android {
         targetSdk = 35
         versionCode = (System.currentTimeMillis() / 1000 / 10).toInt()
         // mark:next-android-version
-        versionName = "1.3.0"
+        versionName = "1.3.1"
         multiDexEnabled = true
         testInstrumentationRunner = "dev.firezone.android.core.HiltTestRunner"
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "connlib-client-android"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "android_log-sys",
  "backoff",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "connlib-client-apple"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gateway"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gui-client"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-headless-client"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "atomicwrites",

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "connlib-client-android"
 # mark:next-android-version
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 
 [lib]

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "connlib-client-apple"
 # mark:next-apple-version
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 
 [features]

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gateway"
 # mark:next-gateway-version
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gui-client"
 # mark:next-gui-version
-version = "1.3.0"
+version = "1.3.1"
 description = "Firezone"
 edition = "2021"
 default-run = "firezone-gui-client"

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-headless-client"
 # mark:next-headless-version
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 authors = ["Firezone, Inc."]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -13,18 +13,18 @@
 # the relevant versions in order to push to a newly drafted release.
 
 # Tracks the current version to use for generating download links and changelogs
-current-apple-version = 1.2.1
-current-android-version = 1.2.0
-current-gateway-version = 1.2.0
-current-gui-version = 1.2.2
-current-headless-version = 1.2.0
+current-apple-version = 1.3.0
+current-android-version = 1.3.0
+current-gateway-version = 1.3.0
+current-gui-version = 1.3.0
+current-headless-version = 1.3.0
 
 # Tracks the next version to release for each platform
-next-apple-version = 1.3.0
-next-android-version = 1.3.0
-next-gateway-version = 1.3.0
-next-gui-version = 1.3.0
-next-headless-version = 1.3.0
+next-apple-version = 1.3.1
+next-android-version = 1.3.1
+next-gateway-version = 1.3.1
+next-gui-version = 1.3.1
+next-headless-version = 1.3.1
 
 # macOS uses a slightly different sed syntax
 ifeq ($(shell uname),Darwin)

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/debug";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).debug.network-extension";
@@ -627,7 +627,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/release";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -671,7 +671,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/debug";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).debug.network-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -714,7 +714,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/release";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -908,7 +908,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -959,7 +959,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -10,7 +10,7 @@ module.exports = [
     source: "/dl/firezone-client-gui-windows/latest/x86_64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.2.2/firezone-client-gui-windows_1.2.2_x86_64.msi",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.3.0/firezone-client-gui-windows_1.3.0_x86_64.msi",
     permanent: false,
   },
   /*
@@ -22,35 +22,35 @@ module.exports = [
     source: "/dl/firezone-client-gui-linux/latest/x86_64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.2.2/firezone-client-gui-linux_1.2.2_x86_64.deb",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.3.0/firezone-client-gui-linux_1.3.0_x86_64.deb",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-gui-linux/latest/aarch64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.2.2/firezone-client-gui-linux_1.2.2_aarch64.deb",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.3.0/firezone-client-gui-linux_1.3.0_aarch64.deb",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-headless-linux/latest/x86_64",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.2.0/firezone-client-headless-linux_1.2.0_x86_64",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.3.0/firezone-client-headless-linux_1.3.0_x86_64",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-headless-linux/latest/aarch64",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.2.0/firezone-client-headless-linux_1.2.0_aarch64",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.3.0/firezone-client-headless-linux_1.3.0_aarch64",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-headless-linux/latest/armv7",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.2.0/firezone-client-headless-linux_1.2.0_armv7",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.3.0/firezone-client-headless-linux_1.3.0_armv7",
     permanent: false,
   },
   /*
@@ -62,21 +62,21 @@ module.exports = [
     source: "/dl/firezone-gateway/latest/x86_64",
     destination:
       // mark:current-gateway-version
-      "https://www.github.com/firezone/firezone/releases/download/gateway-1.2.0/firezone-gateway_1.2.0_x86_64",
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.3.0/firezone-gateway_1.3.0_x86_64",
     permanent: false,
   },
   {
     source: "/dl/firezone-gateway/latest/aarch64",
     destination:
       // mark:current-gateway-version
-      "https://www.github.com/firezone/firezone/releases/download/gateway-1.2.0/firezone-gateway_1.2.0_aarch64",
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.3.0/firezone-gateway_1.3.0_aarch64",
     permanent: false,
   },
   {
     source: "/dl/firezone-gateway/latest/armv7",
     destination:
       // mark:current-gateway-version
-      "https://www.github.com/firezone/firezone/releases/download/gateway-1.2.0/firezone-gateway_1.2.0_armv7",
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.3.0/firezone-gateway_1.3.0_armv7",
     permanent: false,
   },
   /*

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -9,8 +9,7 @@ export default function Android() {
       href="https://play.google.com/store/apps/details?id=dev.firezone.android"
       title="Android"
     >
-      {/*
-      <Entry version="1.3.0" date={new Date(todo)}>
+      <Entry version="1.3.0" date={new Date("2024-08-30")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6424">
             Fixes a bug where packets would be lost when a connection is first
@@ -18,18 +17,18 @@ export default function Android() {
             change.
           </ChangeItem>
           <ChangeItem pull="6405">
-            Shows the Git SHA corresponding to the build on the Settings -> Advanced screen.
+            Shows the Git SHA corresponding to the build on the Settings -&gt;
+            Advanced screen.
           </ChangeItem>
           <ChangeItem pull="6495">
-          Fixes a bug where the Firezone tunnel wasn't shutdown properly if you disconnect
-          the VPN in system settings.
+            Fixes a bug where the Firezone tunnel wasn't shutdown properly if
+            you disconnect the VPN in system settings.
           </ChangeItem>
           <ChangeItem pull="6434">
-          Adds the Internet Resource feature.
+            Adds the Internet Resource feature.
           </ChangeItem>
         </ul>
       </Entry>
-      */}
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="5901">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -9,15 +9,13 @@ export default function Apple() {
       href="https://apps.apple.com/us/app/firezone/id6443661826"
       title="macOS / iOS"
     >
-      {/*
-      <Entry version="1.3.0" date={new Date(todo)}>
+      <Entry version="1.3.0" date={new Date("2024-08-30")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6434">
-          Adds the Internet Resource feature.
+            Adds the Internet Resource feature.
           </ChangeItem>
         </ul>
       </Entry>
-      */}
       <Entry version="1.2.1" date={new Date("2024-08-22")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6406">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -13,15 +13,13 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This cannot be done when the issue's PR merges. */}
-      {/*
-      <Entry version="1.3.0" date={new Date(todo)}>
+      <Entry version="1.3.0" date={new Date("2024-08-30")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6434">
-          Adds the Internet Resource feature.
+            Adds the Internet Resource feature.
           </ChangeItem>
         </ul>
       </Entry>
-      */}
       <Entry version="1.2.2" date={new Date("2024-08-29")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6432">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -9,15 +9,13 @@ export default function Gateway() {
 
   return (
     <Entries href={href} arches={arches} title="Gateway">
-      {/*
-      <Entry version="1.3.0" date={new Date(todo)}>
+      <Entry version="1.3.0" date={new Date("2024-08-30")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6434">
-          Adds support for routing the Internet Resource for Clients.
+            Adds support for routing the Internet Resource for Clients.
           </ChangeItem>
         </ul>
       </Entry>
-      */}
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="5901">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -9,15 +9,13 @@ export default function Headless() {
 
   return (
     <Entries href={href} arches={arches} title="Linux headless">
-      {/*
-      <Entry version="1.3.0" date={new Date("2024-08-21")}>
+      <Entry version="1.3.0" date={new Date("2024-08-30")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6434">
-          Adds the Internet Resource feature.
+            Adds the Internet Resource feature.
           </ChangeItem>
         </ul>
       </Entry>
-      */}
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="5901">


### PR DESCRIPTION
This publishes the 1.3.0 clients and gateways so that Internet Resources will work.

The feature is still disabled for the Stripe plans until we publish the launch post. Select customers have the feature enabled.

Closes #2667 