### PR TITLE
chore(rust): disable ANSI coloring in log files

### DIFF
--- a/rust/logging/src/file.rs
+++ b/rust/logging/src/file.rs
@@ -40,6 +40,7 @@ where
     let (appender_fmt, handle_fmt) = new_appender(log_dir.to_path_buf(), "log");
     let layer_fmt = tracing_subscriber::fmt::layer()
         .with_writer(appender_fmt)
+        .with_ansi(false)
         .boxed();
 
     let handle = Handle {


### PR DESCRIPTION
Closes #6467

It's still enabled for the stdout / stderr logs