### PR TITLE
fix(portal): Do not send resources not connected to any sites down to clients

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -74,6 +74,7 @@ defmodule API.Client.Channel do
           ]
         )
 
+      # We pre-filter them before subscribing to events to avoid accidentally rendering them later
       resources = Policies.pre_filter_non_conforming_resources(resources, socket.assigns.client)
 
       # We subscribe for all resource events but only care about update events,
@@ -781,6 +782,9 @@ defmodule API.Client.Channel do
 
   def map_or_drop_compatible_resource(resource, client_or_gateway_version) do
     cond do
+      resource.gateway_groups == [] ->
+        :drop
+
       resource.type == :internet and Version.match?(client_or_gateway_version, ">= 1.3.0") ->
         {:cont, resource}
 

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -69,6 +69,11 @@ defmodule API.Client.ChannelTest do
         connections: [%{gateway_group_id: gateway_group.id}]
       )
 
+    offline_resource =
+      Fixtures.Resources.create_resource(account: account)
+      |> Ecto.Changeset.change(connections: [])
+      |> Repo.update!()
+
     dns_resource_policy =
       Fixtures.Policies.create_policy(
         account: account,
@@ -107,6 +112,12 @@ defmodule API.Client.ChannelTest do
       resource: internet_resource
     )
 
+    Fixtures.Policies.create_policy(
+      account: account,
+      actor_group: actor_group,
+      resource: offline_resource
+    )
+
     expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
 
     subject = %{subject | expires_at: expires_at}
@@ -137,6 +148,7 @@ defmodule API.Client.ChannelTest do
       internet_resource: internet_resource,
       unauthorized_resource: unauthorized_resource,
       nonconforming_resource: nonconforming_resource,
+      offline_resource: offline_resource,
       dns_resource_policy: dns_resource_policy,
       socket: socket
     }
@@ -247,7 +259,8 @@ defmodule API.Client.ChannelTest do
       cidr_resource: cidr_resource,
       ip_resource: ip_resource,
       nonconforming_resource: nonconforming_resource,
-      internet_resource: internet_resource
+      internet_resource: internet_resource,
+      offline_resource: offline_resource
     } do
       assert_push "init", %{
         resources: resources,
@@ -331,6 +344,7 @@ defmodule API.Client.ChannelTest do
              } in resources
 
       refute Enum.any?(resources, &(&1.id == nonconforming_resource.id))
+      refute Enum.any?(resources, &(&1.id == offline_resource.id))
 
       assert interface == %{
                ipv4: client.ipv4,


### PR DESCRIPTION
This is only possible for internet resources, any other resource will always have at least one site connected at all times.

Closes #6510