### PR TITLE
refactor(rust/gui-client): control our dependency list in Debian

### DIFF
--- a/rust/gui-client/build.sh
+++ b/rust/gui-client/build.sh
@@ -31,6 +31,11 @@ INTERMEDIATE_DIR=$(ls -d "$BUNDLES_DIR"/*/)
 cp src-tauri/deb_files/postinst src-tauri/deb_files/prerm "$INTERMEDIATE_DIR/control/"
 
 pushd "$INTERMEDIATE_DIR"
+# Substitute our own list of deps
+# This does nothing right now, but we'll need it for replacing Tauri
+sed '/^Depends:/c\Depends: libayatana-appindicator3-1, libwebkit2gtk-4.0-37, libgtk-3-0' control/control > control/control.new
+mv control/control.new control/control
+
 # Rebuild the control tarball
 tar -C "control" -czf "control.tar.gz" control md5sums postinst prerm
 


### PR DESCRIPTION
If we get rid of Tauri we'll have to remove `webkit2gtk` and add `libxdotool3` as dependencies.

For now this does nothing, since we're still using Tauri.

We want to get rid of Tauri because Tauri 1 only works on Ubuntu 22.04 and older, and Tauri 2 only works on 24.04 and newer, and we assume supporting both Tauri 1 and Tauri 2 side-by-side and bundling them with a shim is too much work.

However, Tauri's bundler is convenient, especially for Windows MSIs, so we want to keep that around a little bit longer. To use Tauri's bundler on Debian without listing WebKit as a dependency and compiling Tauri itself, we need to hack around it and tell the deb file not to depend on WebKit.