### PR TITLE
fix(ui): make internet resource off by default

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.flow.flowOn
 import java.security.MessageDigest
 import javax.inject.Inject
 
-public const val OnSymbol: String = "[ON]"
-public const val OffSymbol: String = "[OFF]"
+public const val OnSymbol: String = "<->"
+public const val OffSymbol: String = " — "
 
 enum class ResourceState {
     @SerializedName("enabled")

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.flow.flowOn
 import java.security.MessageDigest
 import javax.inject.Inject
 
-public const val OnSymbol: String = "<->"
-public const val OffSymbol: String = " — "
+public const val ON_SYMBOL: String = "<->"
+public const val OFF_SYMBOL: String = " — "
 
 enum class ResourceState {
     @SerializedName("enabled")
@@ -35,9 +35,9 @@ fun ResourceState.isEnabled(): Boolean {
 
 fun ResourceState.stateSymbol(): String {
     return if (this.isEnabled()) {
-        OnSymbol
+        ON_SYMBOL
     } else {
-        OffSymbol
+        OFF_SYMBOL
     }
 }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -26,7 +26,7 @@ enum class ResourceState {
     DISABLED,
 
     @SerializedName("unset")
-    UNSET
+    UNSET,
 }
 
 fun ResourceState.isEnabled(): Boolean {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -4,6 +4,7 @@ package dev.firezone.android.core.data
 import android.content.Context
 import android.content.SharedPreferences
 import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import dev.firezone.android.BuildConfig
 import dev.firezone.android.core.data.model.Config
@@ -13,6 +14,29 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import java.security.MessageDigest
 import javax.inject.Inject
+
+enum class InternetResourceState {
+    @SerializedName("enabled")
+    ENABLED,
+
+    @SerializedName("disabled")
+    DISABLED,
+
+    @SerializedName("unset")
+    UNSET
+}
+
+fun InternetResourceState.isEnabled(): Boolean {
+    return this == InternetResourceState.ENABLED
+}
+
+fun InternetResourceState.toggle(): InternetResourceState {
+    return if (this.isEnabled()) {
+        InternetResourceState.DISABLED
+    } else {
+        InternetResourceState.ENABLED
+    }
+}
 
 internal class Repository
     @Inject
@@ -94,14 +118,14 @@ internal class Repository
                 .putString(DEVICE_ID_KEY, value)
                 .apply()
 
-        fun getDisabledResourcesSync(): Set<String> {
-            val jsonString = sharedPreferences.getString(DISABLED_RESOURCES_KEY, null) ?: return hashSetOf()
-            val type = object : TypeToken<HashSet<String>>() {}.type
+        fun getInternetResourceStateSync(): InternetResourceState {
+            val jsonString = sharedPreferences.getString(ENABLED_INTERNET_RESOURCE_KEY, null) ?: return InternetResourceState.UNSET
+            val type = object : TypeToken<InternetResourceState>() {}.type
             return Gson().fromJson(jsonString, type)
         }
 
-        fun saveDisabledResourcesSync(value: Set<String>): Unit =
-            sharedPreferences.edit().putString(DISABLED_RESOURCES_KEY, Gson().toJson(value))
+        fun saveInternetResourceStateSync(value: InternetResourceState): Unit =
+            sharedPreferences.edit().putString(ENABLED_INTERNET_RESOURCE_KEY, Gson().toJson(value))
                 .apply()
 
         fun saveNonce(value: String): Flow<Unit> =
@@ -183,6 +207,6 @@ internal class Repository
             private const val NONCE_KEY = "nonce"
             private const val STATE_KEY = "state"
             private const val DEVICE_ID_KEY = "deviceId"
-            private const val DISABLED_RESOURCES_KEY = "disabledResources"
+            private const val ENABLED_INTERNET_RESOURCE_KEY = "enabledInternetResource"
         }
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -15,7 +15,10 @@ import kotlinx.coroutines.flow.flowOn
 import java.security.MessageDigest
 import javax.inject.Inject
 
-enum class InternetResourceState {
+public const val OnSymbol: String = "[ON]"
+public const val OffSymbol: String = "[OFF]"
+
+enum class ResourceState {
     @SerializedName("enabled")
     ENABLED,
 
@@ -26,15 +29,23 @@ enum class InternetResourceState {
     UNSET
 }
 
-fun InternetResourceState.isEnabled(): Boolean {
-    return this == InternetResourceState.ENABLED
+fun ResourceState.isEnabled(): Boolean {
+    return this == ResourceState.ENABLED
 }
 
-fun InternetResourceState.toggle(): InternetResourceState {
+fun ResourceState.stateSymbol(): String {
     return if (this.isEnabled()) {
-        InternetResourceState.DISABLED
+        OnSymbol
     } else {
-        InternetResourceState.ENABLED
+        OffSymbol
+    }
+}
+
+fun ResourceState.toggle(): ResourceState {
+    return if (this.isEnabled()) {
+        ResourceState.DISABLED
+    } else {
+        ResourceState.ENABLED
     }
 }
 
@@ -118,13 +129,13 @@ internal class Repository
                 .putString(DEVICE_ID_KEY, value)
                 .apply()
 
-        fun getInternetResourceStateSync(): InternetResourceState {
-            val jsonString = sharedPreferences.getString(ENABLED_INTERNET_RESOURCE_KEY, null) ?: return InternetResourceState.UNSET
-            val type = object : TypeToken<InternetResourceState>() {}.type
+        fun getInternetResourceStateSync(): ResourceState {
+            val jsonString = sharedPreferences.getString(ENABLED_INTERNET_RESOURCE_KEY, null) ?: return ResourceState.UNSET
+            val type = object : TypeToken<ResourceState>() {}.type
             return Gson().fromJson(jsonString, type)
         }
 
-        fun saveInternetResourceStateSync(value: InternetResourceState): Unit =
+        fun saveInternetResourceStateSync(value: ResourceState): Unit =
             sharedPreferences.edit().putString(ENABLED_INTERNET_RESOURCE_KEY, Gson().toJson(value))
                 .apply()
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.flow.flowOn
 import java.security.MessageDigest
 import javax.inject.Inject
 
-public const val ON_SYMBOL: String = "<->"
-public const val OFF_SYMBOL: String = " — "
+const val ON_SYMBOL: String = "<->"
+const val OFF_SYMBOL: String = " — "
 
 enum class ResourceState {
     @SerializedName("enabled")
@@ -28,6 +28,8 @@ enum class ResourceState {
     @SerializedName("unset")
     UNSET,
 }
+
+
 
 fun ResourceState.isEnabled(): Boolean {
     return this == ResourceState.ENABLED

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/data/Repository.kt
@@ -29,8 +29,6 @@ enum class ResourceState {
     UNSET,
 }
 
-
-
 fun ResourceState.isEnabled(): Boolean {
     return this == ResourceState.ENABLED
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
@@ -21,12 +21,13 @@ import androidx.fragment.app.activityViewModels
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.button.MaterialButton
 import dev.firezone.android.R
+import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.core.data.isEnabled
 import dev.firezone.android.tunnel.model.Resource
 import dev.firezone.android.tunnel.model.StatusEnum
 import dev.firezone.android.tunnel.model.isInternetResource
 
-class ResourceDetailsBottomSheet(private val resource: Resource, private val activity: SessionActivity) : BottomSheetDialogFragment() {
+class ResourceDetailsBottomSheet(private val resource: ViewResource, private val internetResourceToggle: () -> ResourceState) : BottomSheetDialogFragment() {
     private lateinit var view: View
     private val viewModel: SessionViewModel by activityViewModels()
 
@@ -91,11 +92,11 @@ class ResourceDetailsBottomSheet(private val resource: Resource, private val act
         }
     }
 
-    private fun resourceToggleText(): String {
-        if (activity.internetState().isEnabled()) {
-            return "Disable this resource"
+    private fun resourceToggleText(resource: ViewResource): String {
+        return if (resource.state.isEnabled()) {
+            "Disable this resource"
         } else {
-            return "Enable this resource"
+            "Enable this resource"
         }
     }
 
@@ -180,9 +181,9 @@ class ResourceDetailsBottomSheet(private val resource: Resource, private val act
         if (resource.canBeDisabled) {
             val toggleResourceEnabled: MaterialButton = view.findViewById(R.id.toggleResourceEnabled)
             toggleResourceEnabled.visibility = View.VISIBLE
-            toggleResourceEnabled.text = resourceToggleText()
+            toggleResourceEnabled.text = resourceToggleText(resource)
             toggleResourceEnabled.setOnClickListener {
-                activity.onInternetResourceToggled()
+                resource.state = internetResourceToggle()
                 refreshDisableToggleButton()
             }
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
@@ -21,9 +21,12 @@ import androidx.fragment.app.activityViewModels
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.button.MaterialButton
 import dev.firezone.android.R
+import dev.firezone.android.core.data.isEnabled
+import dev.firezone.android.tunnel.model.Resource
 import dev.firezone.android.tunnel.model.StatusEnum
+import dev.firezone.android.tunnel.model.isInternetResource
 
-class ResourceDetailsBottomSheet(private val resource: ViewResource, private val activity: SessionActivity) : BottomSheetDialogFragment() {
+class ResourceDetailsBottomSheet(private val resource: Resource, private val activity: SessionActivity) : BottomSheetDialogFragment() {
     private lateinit var view: View
     private val viewModel: SessionViewModel by activityViewModels()
 
@@ -51,7 +54,6 @@ class ResourceDetailsBottomSheet(private val resource: ViewResource, private val
 
         resourceHeader()
 
-        refreshDisableToggleButton()
 
         if (!resource.sites.isNullOrEmpty()) {
             val site = resource.sites.first()
@@ -90,7 +92,7 @@ class ResourceDetailsBottomSheet(private val resource: ViewResource, private val
     }
 
     private fun resourceToggleText(): String {
-        if (resource.enabled) {
+        if (activity.internetState().isEnabled()) {
             return "Disable this resource"
         } else {
             return "Enable this resource"
@@ -122,6 +124,8 @@ class ResourceDetailsBottomSheet(private val resource: ViewResource, private val
 
         resourceDescriptionLayout.visibility = View.VISIBLE
         resourceAddressDescriptionTextView.text = "All network traffic"
+
+        refreshDisableToggleButton()
     }
 
     private fun nonInternetResourceHeader() {
@@ -178,10 +182,7 @@ class ResourceDetailsBottomSheet(private val resource: ViewResource, private val
             toggleResourceEnabled.visibility = View.VISIBLE
             toggleResourceEnabled.text = resourceToggleText()
             toggleResourceEnabled.setOnClickListener {
-                resource.enabled = !resource.enabled
-
-                activity.onViewResourceToggled(resource)
-
+                activity.onInternetResourceToggled()
                 refreshDisableToggleButton()
             }
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
@@ -23,11 +23,10 @@ import com.google.android.material.button.MaterialButton
 import dev.firezone.android.R
 import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.core.data.isEnabled
-import dev.firezone.android.tunnel.model.Resource
 import dev.firezone.android.tunnel.model.StatusEnum
-import dev.firezone.android.tunnel.model.isInternetResource
 
-class ResourceDetailsBottomSheet(private val resource: ViewResource, private val internetResourceToggle: () -> ResourceState) : BottomSheetDialogFragment() {
+class ResourceDetailsBottomSheet(private val resource: ResourceViewModel,
+                                 private val internetResourceToggle: () -> ResourceState) : BottomSheetDialogFragment() {
     private lateinit var view: View
     private val viewModel: SessionViewModel by activityViewModels()
 
@@ -92,7 +91,7 @@ class ResourceDetailsBottomSheet(private val resource: ViewResource, private val
         }
     }
 
-    private fun resourceToggleText(resource: ViewResource): String {
+    private fun resourceToggleText(resource: ResourceViewModel): String {
         return if (resource.state.isEnabled()) {
             "Disable this resource"
         } else {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
@@ -25,8 +25,10 @@ import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.core.data.isEnabled
 import dev.firezone.android.tunnel.model.StatusEnum
 
-class ResourceDetailsBottomSheet(private val resource: ResourceViewModel,
-                                 private val internetResourceToggle: () -> ResourceState) : BottomSheetDialogFragment() {
+class ResourceDetailsBottomSheet(
+    private val resource: ResourceViewModel,
+    private val internetResourceToggle: () -> ResourceState,
+) : BottomSheetDialogFragment() {
     private lateinit var view: View
     private val viewModel: SessionViewModel by activityViewModels()
 
@@ -53,7 +55,6 @@ class ResourceDetailsBottomSheet(private val resource: ResourceViewModel,
         val siteStatusLayout: LinearLayout = view.findViewById(R.id.siteStatusLayout)
 
         resourceHeader()
-
 
         if (!resource.sites.isNullOrEmpty()) {
             val site = resource.sites.first()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceDetailsBottomSheet.kt
@@ -178,14 +178,12 @@ class ResourceDetailsBottomSheet(
     }
 
     private fun refreshDisableToggleButton() {
-        if (resource.canBeDisabled) {
-            val toggleResourceEnabled: MaterialButton = view.findViewById(R.id.toggleResourceEnabled)
-            toggleResourceEnabled.visibility = View.VISIBLE
-            toggleResourceEnabled.text = resourceToggleText(resource)
-            toggleResourceEnabled.setOnClickListener {
-                resource.state = internetResourceToggle()
-                refreshDisableToggleButton()
-            }
+        val toggleResourceEnabled: MaterialButton = view.findViewById(R.id.toggleResourceEnabled)
+        toggleResourceEnabled.visibility = View.VISIBLE
+        toggleResourceEnabled.text = resourceToggleText(resource)
+        toggleResourceEnabled.setOnClickListener {
+            resource.state = internetResourceToggle()
+            refreshDisableToggleButton()
         }
     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
@@ -1,7 +1,7 @@
 /* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
 package dev.firezone.android.features.session.ui
 
-import dev.firezone.android.core.data.OnSymbol
+import dev.firezone.android.core.data.ON_SYMBOL
 import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.core.data.stateSymbol
 import dev.firezone.android.tunnel.model.Resource
@@ -10,7 +10,7 @@ import dev.firezone.android.tunnel.model.Site
 import dev.firezone.android.tunnel.model.StatusEnum
 import dev.firezone.android.tunnel.model.isInternetResource
 
-data class ViewResource(
+data class ResourceViewModel(
     val id: String,
     val type: ResourceType,
     val address: String?,
@@ -25,7 +25,7 @@ data class ViewResource(
 
 fun internetResourceDisplayName(resource: Resource, state: ResourceState): String {
     return if (!resource.canBeDisabled) {
-        "$OnSymbol ${resource.name}"
+        "$ON_SYMBOL ${resource.name}"
     } else {
         "${state.stateSymbol()} ${resource.name}"
     }
@@ -39,8 +39,8 @@ fun displayName(resource: Resource, state: ResourceState): String {
     }
 }
 
-fun Resource.toViewResource(resourceState: ResourceState): ViewResource {
-    return ViewResource(
+fun Resource.toViewResource(resourceState: ResourceState): ResourceViewModel {
+    return ResourceViewModel(
         id = this.id,
         type = this.type,
         address = this.address,
@@ -54,7 +54,7 @@ fun Resource.toViewResource(resourceState: ResourceState): ViewResource {
     )
 }
 
-fun ViewResource.isInternetResource(): Boolean {
+fun ResourceViewModel.isInternetResource(): Boolean {
     return this.type == ResourceType.Internet
 }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
@@ -9,48 +9,35 @@ import dev.firezone.android.tunnel.model.Site
 import dev.firezone.android.tunnel.model.StatusEnum
 import dev.firezone.android.tunnel.model.isInternetResource
 
-data class ResourceViewModel(
-    val id: String,
-    val type: ResourceType,
-    val address: String?,
-    val addressDescription: String?,
-    val sites: List<Site>?,
-    val displayName: String,
-    val name: String,
-    val status: StatusEnum,
-    var state: ResourceState,
-)
+class ResourceViewModel(resource: Resource, resourceState: ResourceState) {
+    val id: String = resource.id
+    val type: ResourceType = resource.type
+    val address: String? = resource.address
+    val addressDescription: String? = resource.addressDescription
+    val sites: List<Site>? = resource.sites
+    val displayName: String = displayName(resource, resourceState)
+    val name: String = resource.name
+    val status: StatusEnum = resource.status
+    var state: ResourceState = resourceState
+}
+
+
+fun displayName(
+    resource: Resource,
+    state: ResourceState,
+): String {
+    return if (resource.isInternetResource()) {
+        internetResourceDisplayName(resource, state)
+    } else {
+        resource.name
+    }
+}
 
 fun internetResourceDisplayName(
     resource: Resource,
     state: ResourceState,
 ): String {
     return "${state.stateSymbol()} ${resource.name}"
-}
-
-fun Resource.toResourceViewModel(resourceState: ResourceState): ResourceViewModel {
-    return ResourceViewModel(
-        id = this.id,
-        type = this.type,
-        address = this.address,
-        addressDescription = this.addressDescription,
-        sites = this.sites,
-        name = this.name,
-        displayName = displayName(this, resourceState),
-        status = this.status,
-        state = resourceState,
-    )
-}
-
-fun displayName(
-    resource: Resource,
-    state: ResourceState,
-): String {
-    if (resource.isInternetResource()) {
-        return internetResourceDisplayName(resource, state)
-    } else {
-        return resource.name
-    }
 }
 
 fun ResourceViewModel.isInternetResource(): Boolean {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
@@ -19,7 +19,6 @@ data class ResourceViewModel(
     val displayName: String,
     val name: String,
     val status: StatusEnum,
-    var canBeDisabled: Boolean,
     var state: ResourceState,
 )
 
@@ -27,11 +26,7 @@ fun internetResourceDisplayName(
     resource: Resource,
     state: ResourceState,
 ): String {
-    return if (!resource.canBeDisabled) {
-        "$ON_SYMBOL ${resource.name}"
-    } else {
-        "${state.stateSymbol()} ${resource.name}"
-    }
+    return "${state.stateSymbol()} ${resource.name}"
 }
 
 fun displayName(
@@ -55,7 +50,6 @@ fun Resource.toViewResource(resourceState: ResourceState): ResourceViewModel {
         name = this.name,
         displayName = displayName(this, resourceState),
         status = this.status,
-        canBeDisabled = this.canBeDisabled,
         state = resourceState,
     )
 }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
@@ -1,7 +1,6 @@
 /* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
 package dev.firezone.android.features.session.ui
 
-import dev.firezone.android.core.data.ON_SYMBOL
 import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.core.data.stateSymbol
 import dev.firezone.android.tunnel.model.Resource
@@ -29,18 +28,7 @@ fun internetResourceDisplayName(
     return "${state.stateSymbol()} ${resource.name}"
 }
 
-fun displayName(
-    resource: Resource,
-    state: ResourceState,
-): String {
-    if (resource.isInternetResource()) {
-        return internetResourceDisplayName(resource, state)
-    } else {
-        return resource.name
-    }
-}
-
-fun Resource.toViewResource(resourceState: ResourceState): ResourceViewModel {
+fun Resource.toResourceViewModel(resourceState: ResourceState): ResourceViewModel {
     return ResourceViewModel(
         id = this.id,
         type = this.type,
@@ -52,6 +40,17 @@ fun Resource.toViewResource(resourceState: ResourceState): ResourceViewModel {
         status = this.status,
         state = resourceState,
     )
+}
+
+fun displayName(
+    resource: Resource,
+    state: ResourceState,
+): String {
+    if (resource.isInternetResource()) {
+        return internetResourceDisplayName(resource, state)
+    } else {
+        return resource.name
+    }
 }
 
 fun ResourceViewModel.isInternetResource(): Boolean {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
@@ -21,7 +21,6 @@ class ResourceViewModel(resource: Resource, resourceState: ResourceState) {
     var state: ResourceState = resourceState
 }
 
-
 fun displayName(
     resource: Resource,
     state: ResourceState,

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourceViewModel.kt
@@ -23,7 +23,10 @@ data class ResourceViewModel(
     var state: ResourceState,
 )
 
-fun internetResourceDisplayName(resource: Resource, state: ResourceState): String {
+fun internetResourceDisplayName(
+    resource: Resource,
+    state: ResourceState,
+): String {
     return if (!resource.canBeDisabled) {
         "$ON_SYMBOL ${resource.name}"
     } else {
@@ -31,7 +34,10 @@ fun internetResourceDisplayName(resource: Resource, state: ResourceState): Strin
     }
 }
 
-fun displayName(resource: Resource, state: ResourceState): String {
+fun displayName(
+    resource: Resource,
+    state: ResourceState,
+): String {
     if (resource.isInternetResource()) {
         return internetResourceDisplayName(resource, state)
     } else {
@@ -57,4 +63,3 @@ fun Resource.toViewResource(resourceState: ResourceState): ResourceViewModel {
 fun ResourceViewModel.isInternetResource(): Boolean {
     return this.type == ResourceType.Internet
 }
-

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
@@ -8,11 +8,15 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import dev.firezone.android.core.data.OnSymbol
+import dev.firezone.android.core.data.ResourceState
+import dev.firezone.android.core.data.isEnabled
+import dev.firezone.android.core.data.stateSymbol
 import dev.firezone.android.databinding.ListItemResourceBinding
 import dev.firezone.android.tunnel.model.Resource
 import dev.firezone.android.tunnel.model.isInternetResource
 
-internal class ResourcesAdapter(private val activity: SessionActivity) : ListAdapter<Resource, ResourcesAdapter.ViewHolder>(
+internal class ResourcesAdapter(private val internetResourceToggle: () -> ResourceState) : ListAdapter<ViewResource, ResourcesAdapter.ViewHolder>(
     ResourceDiffCallback(),
 ) {
     override fun onCreateViewHolder(
@@ -33,14 +37,14 @@ internal class ResourcesAdapter(private val activity: SessionActivity) : ListAda
             // Show bottom sheet
             val fragmentManager =
                 (holder.itemView.context as AppCompatActivity).supportFragmentManager
-            val bottomSheet = ResourceDetailsBottomSheet(resource, activity)
+            val bottomSheet = ResourceDetailsBottomSheet(resource, internetResourceToggle)
             bottomSheet.show(fragmentManager, "ResourceDetailsBottomSheet")
         }
     }
 
     class ViewHolder(private val binding: ListItemResourceBinding) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(resource: Resource) {
-            binding.resourceNameText.text = resource.name
+        fun bind(resource: ViewResource) {
+            binding.resourceNameText.text = resource.displayName
             if (resource.isInternetResource()) {
                 binding.addressText.visibility = View.GONE
             } else {
@@ -49,17 +53,17 @@ internal class ResourcesAdapter(private val activity: SessionActivity) : ListAda
         }
     }
 
-    class ResourceDiffCallback : DiffUtil.ItemCallback<Resource>() {
+    class ResourceDiffCallback : DiffUtil.ItemCallback<ViewResource>() {
         override fun areItemsTheSame(
-            oldItem: Resource,
-            newItem: Resource,
+            oldItem: ViewResource,
+            newItem: ViewResource,
         ): Boolean {
             return oldItem.id == newItem.id
         }
 
         override fun areContentsTheSame(
-            oldItem: Resource,
-            newItem: Resource,
+            oldItem: ViewResource,
+            newItem: ViewResource,
         ): Boolean {
             return oldItem == newItem
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
@@ -13,8 +13,8 @@ import dev.firezone.android.databinding.ListItemResourceBinding
 
 internal class ResourcesAdapter(private val internetResourceToggle: () -> ResourceState) :
     ListAdapter<ResourceViewModel, ResourcesAdapter.ViewHolder>(
-    ResourceDiffCallback(),
-) {
+        ResourceDiffCallback(),
+    ) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
@@ -9,8 +9,10 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import dev.firezone.android.databinding.ListItemResourceBinding
+import dev.firezone.android.tunnel.model.Resource
+import dev.firezone.android.tunnel.model.isInternetResource
 
-internal class ResourcesAdapter(private val activity: SessionActivity) : ListAdapter<ViewResource, ResourcesAdapter.ViewHolder>(
+internal class ResourcesAdapter(private val activity: SessionActivity) : ListAdapter<Resource, ResourcesAdapter.ViewHolder>(
     ResourceDiffCallback(),
 ) {
     override fun onCreateViewHolder(
@@ -37,7 +39,7 @@ internal class ResourcesAdapter(private val activity: SessionActivity) : ListAda
     }
 
     class ViewHolder(private val binding: ListItemResourceBinding) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(resource: ViewResource) {
+        fun bind(resource: Resource) {
             binding.resourceNameText.text = resource.name
             if (resource.isInternetResource()) {
                 binding.addressText.visibility = View.GONE
@@ -47,17 +49,17 @@ internal class ResourcesAdapter(private val activity: SessionActivity) : ListAda
         }
     }
 
-    class ResourceDiffCallback : DiffUtil.ItemCallback<ViewResource>() {
+    class ResourceDiffCallback : DiffUtil.ItemCallback<Resource>() {
         override fun areItemsTheSame(
-            oldItem: ViewResource,
-            newItem: ViewResource,
+            oldItem: Resource,
+            newItem: Resource,
         ): Boolean {
             return oldItem.id == newItem.id
         }
 
         override fun areContentsTheSame(
-            oldItem: ViewResource,
-            newItem: ViewResource,
+            oldItem: Resource,
+            newItem: Resource,
         ): Boolean {
             return oldItem == newItem
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ResourcesAdapter.kt
@@ -8,15 +8,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import dev.firezone.android.core.data.OnSymbol
 import dev.firezone.android.core.data.ResourceState
-import dev.firezone.android.core.data.isEnabled
-import dev.firezone.android.core.data.stateSymbol
 import dev.firezone.android.databinding.ListItemResourceBinding
-import dev.firezone.android.tunnel.model.Resource
-import dev.firezone.android.tunnel.model.isInternetResource
 
-internal class ResourcesAdapter(private val internetResourceToggle: () -> ResourceState) : ListAdapter<ViewResource, ResourcesAdapter.ViewHolder>(
+internal class ResourcesAdapter(private val internetResourceToggle: () -> ResourceState) :
+    ListAdapter<ResourceViewModel, ResourcesAdapter.ViewHolder>(
     ResourceDiffCallback(),
 ) {
     override fun onCreateViewHolder(
@@ -43,7 +39,7 @@ internal class ResourcesAdapter(private val internetResourceToggle: () -> Resour
     }
 
     class ViewHolder(private val binding: ListItemResourceBinding) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(resource: ViewResource) {
+        fun bind(resource: ResourceViewModel) {
             binding.resourceNameText.text = resource.displayName
             if (resource.isInternetResource()) {
                 binding.addressText.visibility = View.GONE
@@ -53,17 +49,17 @@ internal class ResourcesAdapter(private val internetResourceToggle: () -> Resour
         }
     }
 
-    class ResourceDiffCallback : DiffUtil.ItemCallback<ViewResource>() {
+    class ResourceDiffCallback : DiffUtil.ItemCallback<ResourceViewModel>() {
         override fun areItemsTheSame(
-            oldItem: ViewResource,
-            newItem: ViewResource,
+            oldItem: ResourceViewModel,
+            newItem: ResourceViewModel,
         ): Boolean {
             return oldItem.id == newItem.id
         }
 
         override fun areContentsTheSame(
-            oldItem: ViewResource,
-            newItem: ViewResource,
+            oldItem: ResourceViewModel,
+            newItem: ResourceViewModel,
         ): Boolean {
             return oldItem == newItem
         }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -79,9 +79,12 @@ class SessionActivity : AppCompatActivity() {
     }
 
     private fun onInternetResourceToggled(): ResourceState {
-        tunnelService?.internetResourceToggled(internetState().toggle())
-        refreshList()
-        Log.d(TAG, "Internet resource toggled ${internetState()}")
+        tunnelService?.let {
+            it.internetResourceToggled(internetState().toggle())
+            refreshList()
+            Log.d(TAG, "Internet resource toggled ${internetState()}")
+        }
+
         return internetState()
     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -16,7 +16,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.tabs.TabLayout
 import dagger.hilt.android.AndroidEntryPoint
 import dev.firezone.android.core.data.ResourceState
-import dev.firezone.android.core.data.isEnabled
 import dev.firezone.android.core.data.toggle
 import dev.firezone.android.databinding.ActivitySessionBinding
 import dev.firezone.android.features.settings.ui.SettingsActivity

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -15,7 +15,8 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.tabs.TabLayout
 import dagger.hilt.android.AndroidEntryPoint
-import dev.firezone.android.core.data.InternetResourceState
+import dev.firezone.android.core.data.ResourceState
+import dev.firezone.android.core.data.isEnabled
 import dev.firezone.android.core.data.toggle
 import dev.firezone.android.databinding.ActivitySessionBinding
 import dev.firezone.android.features.settings.ui.SettingsActivity
@@ -49,7 +50,7 @@ class SessionActivity : AppCompatActivity() {
             }
         }
 
-    private val resourcesAdapter = ResourcesAdapter(this)
+    private val resourcesAdapter = ResourcesAdapter { this.onInternetResourceToggled() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,14 +75,15 @@ class SessionActivity : AppCompatActivity() {
         super.onDestroy()
     }
 
-    fun internetState(): InternetResourceState {
-        return tunnelService?.internetState() ?: InternetResourceState.UNSET
+    fun internetState(): ResourceState {
+        return tunnelService?.internetState() ?: ResourceState.UNSET
     }
 
-    fun onInternetResourceToggled() {
+    private fun onInternetResourceToggled(): ResourceState {
         tunnelService?.internetResourceToggled(internetState().toggle())
-
+        refreshList()
         Log.d(TAG, "Internet resource toggled ${internetState()}")
+        return internetState()
     }
 
     private fun setupViews() {
@@ -157,7 +159,7 @@ class SessionActivity : AppCompatActivity() {
                 View.GONE
             }
 
-        resourcesAdapter.submitList(viewModel.resourcesList()) {
+        resourcesAdapter.submitList(viewModel.resourcesList(internetState())) {
             afterLoad()
         }
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionActivity.kt
@@ -15,6 +15,8 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.tabs.TabLayout
 import dagger.hilt.android.AndroidEntryPoint
+import dev.firezone.android.core.data.InternetResourceState
+import dev.firezone.android.core.data.toggle
 import dev.firezone.android.databinding.ActivitySessionBinding
 import dev.firezone.android.features.settings.ui.SettingsActivity
 import dev.firezone.android.tunnel.TunnelService
@@ -72,9 +74,14 @@ class SessionActivity : AppCompatActivity() {
         super.onDestroy()
     }
 
-    fun onViewResourceToggled(resourceToggled: ViewResource) {
-        Log.d(TAG, "Resource toggled $resourceToggled")
-        tunnelService?.resourceToggled(resourceToggled)
+    fun internetState(): InternetResourceState {
+        return tunnelService?.internetState() ?: InternetResourceState.UNSET
+    }
+
+    fun onInternetResourceToggled() {
+        tunnelService?.internetResourceToggled(internetState().toggle())
+
+        Log.d(TAG, "Internet resource toggled ${internetState()}")
     }
 
     private fun setupViews() {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -59,7 +59,7 @@ internal class SessionViewModel
         fun clearToken() = repo.clearToken()
 
         // The subset of Resources to actually render
-        fun resourcesList(isInternetResourceEnabled: ResourceState): List<ViewResource> {
+        fun resourcesList(isInternetResourceEnabled: ResourceState): List<ResourceViewModel> {
             val resources = resourcesLiveData.value!!.map {
                 if (it.isInternetResource()) {
                     it.toViewResource(isInternetResourceEnabled)

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -60,13 +60,14 @@ internal class SessionViewModel
 
         // The subset of Resources to actually render
         fun resourcesList(isInternetResourceEnabled: ResourceState): List<ResourceViewModel> {
-            val resources = resourcesLiveData.value!!.map {
-                if (it.isInternetResource()) {
-                    it.toViewResource(isInternetResourceEnabled)
-                } else {
-                    it.toViewResource(ResourceState.ENABLED)
+            val resources =
+                resourcesLiveData.value!!.map {
+                    if (it.isInternetResource()) {
+                        it.toViewResource(isInternetResourceEnabled)
+                    } else {
+                        it.toViewResource(ResourceState.ENABLED)
+                    }
                 }
-            }
 
             return if (favoriteResources.isEmpty()) {
                 resources

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.tunnel.TunnelService.Companion.State
 import dev.firezone.android.tunnel.model.Resource
+import dev.firezone.android.tunnel.model.isInternetResource
 import javax.inject.Inject
 
 @HiltViewModel
@@ -57,8 +59,15 @@ internal class SessionViewModel
         fun clearToken() = repo.clearToken()
 
         // The subset of Resources to actually render
-        fun resourcesList(): List<Resource> {
-            val resources = resourcesLiveData.value!!
+        fun resourcesList(isInternetResourceEnabled: ResourceState): List<ViewResource> {
+            val resources = resourcesLiveData.value!!.map {
+                if (it.isInternetResource()) {
+                    it.toViewResource(isInternetResourceEnabled)
+                } else {
+                    it.toViewResource(ResourceState.ENABLED)
+                }
+            }
+
             return if (favoriteResources.isEmpty()) {
                 resources
             } else if (showOnlyFavorites) {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.firezone.android.core.data.Repository
 import dev.firezone.android.tunnel.TunnelService.Companion.State
+import dev.firezone.android.tunnel.model.Resource
 import javax.inject.Inject
 
 @HiltViewModel
@@ -16,14 +17,14 @@ internal class SessionViewModel
         internal lateinit var repo: Repository
         private val _favoriteResourcesLiveData = MutableLiveData<HashSet<String>>(HashSet())
         private val _serviceStatusLiveData = MutableLiveData<State>()
-        private val _resourcesLiveData = MutableLiveData<List<ViewResource>>(emptyList())
+        private val _resourcesLiveData = MutableLiveData<List<Resource>>(emptyList())
         private var showOnlyFavorites: Boolean = false
 
         val favoriteResourcesLiveData: MutableLiveData<HashSet<String>>
             get() = _favoriteResourcesLiveData
         val serviceStatusLiveData: MutableLiveData<State>
             get() = _serviceStatusLiveData
-        val resourcesLiveData: MutableLiveData<List<ViewResource>>
+        val resourcesLiveData: MutableLiveData<List<Resource>>
             get() = _resourcesLiveData
 
         private val favoriteResources: HashSet<String>
@@ -56,7 +57,7 @@ internal class SessionViewModel
         fun clearToken() = repo.clearToken()
 
         // The subset of Resources to actually render
-        fun resourcesList(): List<ViewResource> {
+        fun resourcesList(): List<Resource> {
             val resources = resourcesLiveData.value!!
             return if (favoriteResources.isEmpty()) {
                 resources

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -63,9 +63,9 @@ internal class SessionViewModel
             val resources =
                 resourcesLiveData.value!!.map {
                     if (it.isInternetResource()) {
-                        it.toViewResource(isInternetResourceEnabled)
+                        it.toResourceViewModel(isInternetResourceEnabled)
                     } else {
-                        it.toViewResource(ResourceState.ENABLED)
+                        it.toResourceViewModel(ResourceState.ENABLED)
                     }
                 }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/SessionViewModel.kt
@@ -63,9 +63,9 @@ internal class SessionViewModel
             val resources =
                 resourcesLiveData.value!!.map {
                     if (it.isInternetResource()) {
-                        it.toResourceViewModel(isInternetResourceEnabled)
+                        ResourceViewModel(it, isInternetResourceEnabled)
                     } else {
-                        it.toResourceViewModel(ResourceState.ENABLED)
+                        ResourceViewModel(it, ResourceState.ENABLED)
                     }
                 }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
@@ -14,8 +14,7 @@ data class ViewResource(
     val sites: List<Site>?,
     val name: String,
     val status: StatusEnum,
-    var enabled: Boolean,
-    var canBeDisabled: Boolean = true,
+    var canBeDisabled: Boolean,
 )
 
 fun Resource.toViewResource(enabled: Boolean): ViewResource {
@@ -27,11 +26,7 @@ fun Resource.toViewResource(enabled: Boolean): ViewResource {
         sites = this.sites,
         name = this.name,
         status = this.status,
-        enabled = enabled,
         canBeDisabled = this.canBeDisabled,
     )
 }
 
-fun ViewResource.isInternetResource(): Boolean {
-    return this.type == ResourceType.Internet
-}

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/session/ui/ViewResource.kt
@@ -1,10 +1,14 @@
 /* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
 package dev.firezone.android.features.session.ui
 
+import dev.firezone.android.core.data.OnSymbol
+import dev.firezone.android.core.data.ResourceState
+import dev.firezone.android.core.data.stateSymbol
 import dev.firezone.android.tunnel.model.Resource
 import dev.firezone.android.tunnel.model.ResourceType
 import dev.firezone.android.tunnel.model.Site
 import dev.firezone.android.tunnel.model.StatusEnum
+import dev.firezone.android.tunnel.model.isInternetResource
 
 data class ViewResource(
     val id: String,
@@ -12,12 +16,30 @@ data class ViewResource(
     val address: String?,
     val addressDescription: String?,
     val sites: List<Site>?,
+    val displayName: String,
     val name: String,
     val status: StatusEnum,
     var canBeDisabled: Boolean,
+    var state: ResourceState,
 )
 
-fun Resource.toViewResource(enabled: Boolean): ViewResource {
+fun internetResourceDisplayName(resource: Resource, state: ResourceState): String {
+    return if (!resource.canBeDisabled) {
+        "$OnSymbol ${resource.name}"
+    } else {
+        "${state.stateSymbol()} ${resource.name}"
+    }
+}
+
+fun displayName(resource: Resource, state: ResourceState): String {
+    if (resource.isInternetResource()) {
+        return internetResourceDisplayName(resource, state)
+    } else {
+        return resource.name
+    }
+}
+
+fun Resource.toViewResource(resourceState: ResourceState): ViewResource {
     return ViewResource(
         id = this.id,
         type = this.type,
@@ -25,8 +47,14 @@ fun Resource.toViewResource(enabled: Boolean): ViewResource {
         addressDescription = this.addressDescription,
         sites = this.sites,
         name = this.name,
+        displayName = displayName(this, resourceState),
         status = this.status,
         canBeDisabled = this.canBeDisabled,
+        state = resourceState,
     )
+}
+
+fun ViewResource.isInternetResource(): Boolean {
+    return this.type == ResourceType.Internet
 }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -21,8 +21,8 @@ import com.google.gson.Gson
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import dagger.hilt.android.AndroidEntryPoint
-import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.ResourceState
 import dev.firezone.android.core.data.isEnabled
 import dev.firezone.android.tunnel.callback.ConnlibCallback
 import dev.firezone.android.tunnel.model.Cidr
@@ -268,11 +268,12 @@ class TunnelService : VpnService() {
 
     // UI updates for resources
     fun resourcesUpdated() {
-        val currentlyDisabled = if (internetResource() != null && !resourceState.isEnabled() && internetResource()?.canBeDisabled == true) {
-            setOf(internetResource()!!.id)
-        } else {
-            emptySet()
-        }
+        val currentlyDisabled =
+            if (internetResource() != null && !resourceState.isEnabled() && internetResource()?.canBeDisabled == true) {
+                setOf(internetResource()!!.id)
+            } else {
+                emptySet()
+            }
 
         connlibSessionPtr?.let {
             ConnlibSession.setDisabledResources(it, Gson().toJson(currentlyDisabled))

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -16,17 +16,21 @@ import android.os.Binder
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import com.google.gson.Gson
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import dagger.hilt.android.AndroidEntryPoint
+import dev.firezone.android.core.data.InternetResourceState
 import dev.firezone.android.core.data.Repository
+import dev.firezone.android.core.data.isEnabled
 import dev.firezone.android.features.session.ui.ViewResource
 import dev.firezone.android.features.session.ui.toViewResource
 import dev.firezone.android.tunnel.callback.ConnlibCallback
 import dev.firezone.android.tunnel.model.Cidr
 import dev.firezone.android.tunnel.model.Resource
+import dev.firezone.android.tunnel.model.isInternetResource
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.UUID
@@ -49,9 +53,9 @@ class TunnelService : VpnService() {
     var tunnelIpv6Address: String? = null
     private var tunnelDnsAddresses: MutableList<String> = mutableListOf()
     private var tunnelRoutes: MutableList<Cidr> = mutableListOf()
-    private var _tunnelResources: List<ViewResource> = emptyList()
+    private var _tunnelResources: List<Resource> = emptyList()
     private var _tunnelState: State = State.DOWN
-    private var disabledResources: MutableSet<String> = mutableSetOf()
+    var internetResourceState: InternetResourceState = InternetResourceState.UNSET
 
     // For reacting to changes to the network
     private var networkCallback: NetworkMonitor? = null
@@ -67,7 +71,7 @@ class TunnelService : VpnService() {
     var startedByUser: Boolean = false
     var connlibSessionPtr: Long? = null
 
-    var tunnelResources: List<ViewResource>
+    var tunnelResources: List<Resource>
         get() = _tunnelResources
         set(value) {
             _tunnelResources = value
@@ -82,7 +86,7 @@ class TunnelService : VpnService() {
 
     // Used to update the UI when the SessionActivity is bound to this service
     private var serviceStateLiveData: MutableLiveData<State>? = null
-    private var resourcesLiveData: MutableLiveData<List<ViewResource>>? = null
+    private var resourcesLiveData: MutableLiveData<List<Resource>>? = null
 
     // For binding the SessionActivity view to this service
     private val binder = LocalBinder()
@@ -99,7 +103,7 @@ class TunnelService : VpnService() {
         object : ConnlibCallback {
             override fun onUpdateResources(resourceListJSON: String) {
                 moshi.adapter<List<Resource>>().fromJson(resourceListJSON)?.let {
-                    tunnelResources = it.map { resource -> resource.toViewResource(!disabledResources.contains(resource.id)) }
+                    tunnelResources = it
                     resourcesUpdated()
                 }
             }
@@ -257,24 +261,32 @@ class TunnelService : VpnService() {
         super.onRevoke()
     }
 
+    fun internetState(): InternetResourceState {
+        return internetResourceState
+    }
+
+    fun internetResource(): Resource? {
+        return tunnelResources.firstOrNull { it.isInternetResource() }
+    }
+
     // UI updates for resources
     fun resourcesUpdated() {
-        val newResources = tunnelResources.associateBy { it.id }
-        val currentlyDisabled = disabledResources.filter { newResources[it]?.canBeDisabled ?: false }
+        val currentlyDisabled = if (!internetResourceState.isEnabled() && internetResource()?.canBeDisabled == true) {
+            setOf(internetResource())
+        } else {
+            emptySet()
+        }
 
         connlibSessionPtr?.let {
             ConnlibSession.setDisabledResources(it, Gson().toJson(currentlyDisabled))
         }
     }
 
-    fun resourceToggled(resource: ViewResource) {
-        if (!resource.enabled) {
-            disabledResources.add(resource.id)
-        } else {
-            disabledResources.remove(resource.id)
-        }
+    fun internetResourceToggled(state: InternetResourceState) {
+        internetResourceState = state
 
-        repo.saveDisabledResourcesSync(disabledResources)
+        repo.saveInternetResourceStateSync(internetResourceState)
+
         resourcesUpdated()
     }
 
@@ -304,7 +316,7 @@ class TunnelService : VpnService() {
     private fun connect() {
         val token = appRestrictions.getString("token") ?: repo.getTokenSync()
         val config = repo.getConfigSync()
-        disabledResources = repo.getDisabledResourcesSync().toMutableSet()
+        internetResourceState = repo.getInternetResourceStateSync()
 
         if (!token.isNullOrBlank()) {
             tunnelState = State.CONNECTING
@@ -377,7 +389,7 @@ class TunnelService : VpnService() {
         serviceStateLiveData?.postValue(tunnelState)
     }
 
-    fun setResourcesLiveData(liveData: MutableLiveData<List<ViewResource>>) {
+    fun setResourcesLiveData(liveData: MutableLiveData<List<Resource>>) {
         resourcesLiveData = liveData
 
         // Update the newly bound SessionActivity with our current resources
@@ -388,7 +400,7 @@ class TunnelService : VpnService() {
         serviceStateLiveData?.postValue(state)
     }
 
-    private fun updateResourcesLiveData(resources: List<ViewResource>) {
+    private fun updateResourcesLiveData(resources: List<Resource>) {
         resourcesLiveData?.postValue(resources)
     }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -269,7 +269,7 @@ class TunnelService : VpnService() {
     // UI updates for resources
     fun resourcesUpdated() {
         val currentlyDisabled =
-            if (internetResource() != null && !resourceState.isEnabled() && internetResource()?.canBeDisabled == true) {
+            if (internetResource() != null && !resourceState.isEnabled()) {
                 setOf(internetResource()!!.id)
             } else {
                 emptySet()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
@@ -4,7 +4,6 @@ package dev.firezone.android.tunnel.model
 import android.os.Parcelable
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import dev.firezone.android.features.session.ui.ViewResource
 import kotlinx.parcelize.Parcelize
 
 @JsonClass(generateAdapter = true)

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
@@ -4,6 +4,7 @@ package dev.firezone.android.tunnel.model
 import android.os.Parcelable
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import dev.firezone.android.features.session.ui.ViewResource
 import kotlinx.parcelize.Parcelize
 
 @JsonClass(generateAdapter = true)
@@ -18,6 +19,10 @@ data class Resource(
     val status: StatusEnum,
     @Json(name = "can_be_disabled") val canBeDisabled: Boolean,
 ) : Parcelable
+
+fun Resource.isInternetResource(): Boolean {
+    return this.type == ResourceType.Internet
+}
 
 enum class ResourceType {
     @Json(name = "dns")

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/model/Resource.kt
@@ -16,7 +16,6 @@ data class Resource(
     val sites: List<Site>?,
     val name: String,
     val status: StatusEnum,
-    @Json(name = "can_be_disabled") val canBeDisabled: Boolean,
 ) : Parcelable
 
 fun Resource.isInternetResource(): Boolean {

--- a/rust/connlib/shared/src/callbacks.rs
+++ b/rust/connlib/shared/src/callbacks.rs
@@ -71,14 +71,6 @@ impl ResourceDescription {
         }
     }
 
-    pub fn can_be_disabled(&self) -> bool {
-        match self {
-            ResourceDescription::Dns(r) => r.can_be_disabled,
-            ResourceDescription::Cidr(r) => r.can_be_disabled,
-            ResourceDescription::Internet(r) => r.can_be_disabled,
-        }
-    }
-
     pub fn is_internet_resource(&self) -> bool {
         matches!(self, ResourceDescription::Internet(_))
     }
@@ -99,7 +91,6 @@ pub struct ResourceDescriptionDns {
     pub sites: Vec<Site>,
 
     pub status: Status,
-    pub can_be_disabled: bool,
 }
 
 /// Description of a resource that maps to a CIDR.
@@ -118,7 +109,6 @@ pub struct ResourceDescriptionCidr {
     pub sites: Vec<Site>,
 
     pub status: Status,
-    pub can_be_disabled: bool,
 }
 
 /// Description of an Internet resource
@@ -131,7 +121,6 @@ pub struct ResourceDescriptionInternet {
     pub sites: Vec<Site>,
 
     pub status: Status,
-    pub can_be_disabled: bool,
 }
 
 impl PartialOrd for ResourceDescription {
@@ -176,7 +165,6 @@ mod tests {
                 id: "99ba0c1e-5189-4cfc-a4db-fd6cb1c937fd".parse().unwrap(),
             }],
             status: Status::Online,
-            can_be_disabled: false,
         })
     }
 
@@ -189,7 +177,6 @@ mod tests {
                 id: "99ba0c1e-5189-4cfc-a4db-fd6cb1c937fd".parse().unwrap(),
             }],
             status: Status::Offline,
-            can_be_disabled: true,
         })
     }
 

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -36,7 +36,6 @@ impl ResourceDescriptionDns {
             name: self.name,
             address_description: self.address_description,
             sites: self.sites,
-            can_be_disabled: false,
             status,
         }
     }
@@ -67,7 +66,6 @@ impl ResourceDescriptionCidr {
             name: self.name,
             address_description: self.address_description,
             sites: self.sites,
-            can_be_disabled: false,
             status,
         }
     }
@@ -90,9 +88,6 @@ pub struct ResourceDescriptionInternet {
     /// Sites for the internet resource
     #[serde(rename = "gateway_groups")]
     pub sites: Vec<Site>,
-    /// Whether or not resource can be disabled from UI
-    #[serde(default)]
-    pub can_be_disabled: bool,
 }
 
 impl ResourceDescriptionInternet {
@@ -101,7 +96,6 @@ impl ResourceDescriptionInternet {
             name: self.name,
             id: self.id,
             sites: self.sites,
-            can_be_disabled: self.can_be_disabled,
             status,
         }
     }

--- a/rust/connlib/shared/src/messages/client.rs
+++ b/rust/connlib/shared/src/messages/client.rs
@@ -74,7 +74,7 @@ impl ResourceDescriptionCidr {
 }
 
 fn internet_resource_name() -> String {
-    "<-> Internet Resource".to_string()
+    "Internet Resource".to_string()
 }
 
 /// Description of an internet resource.

--- a/rust/connlib/tunnel/src/proptest.rs
+++ b/rust/connlib/tunnel/src/proptest.rs
@@ -78,13 +78,10 @@ pub fn cidr_resource(
 pub fn internet_resource(
     sites: impl Strategy<Value = Vec<Site>>,
 ) -> impl Strategy<Value = ResourceDescriptionInternet> {
-    (resource_id(), sites, any::<bool>()).prop_map(move |(id, sites, can_be_disabled)| {
-        ResourceDescriptionInternet {
-            name: "Internet Resource".to_string(),
-            id,
-            sites,
-            can_be_disabled,
-        }
+    (resource_id(), sites).prop_map(move |(id, sites)| ResourceDescriptionInternet {
+        name: "Internet Resource".to_string(),
+        id,
+        sites,
     })
 }
 

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -801,7 +801,7 @@ impl Controller {
         let internet_resource = self
             .status
             .internet_resource()
-            .ok_or(anyhow!("Tunnel not ready"))?;
+            .context("Tunnel not ready")?;
 
         let mut disabled_resources = BTreeSet::new();
 

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -805,9 +805,7 @@ impl Controller {
 
         let mut disabled_resources = BTreeSet::new();
 
-        if !self.advanced_settings.internet_resource_enabled()
-            && internet_resource.can_be_disabled()
-        {
+        if !self.advanced_settings.internet_resource_enabled() {
             disabled_resources.insert(internet_resource.id());
         }
 

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -35,8 +35,8 @@ const NO_ACTIVITY: &str = "[-] No activity";
 const GATEWAY_CONNECTED: &str = "[O] Gateway connected";
 const ALL_GATEWAYS_OFFLINE: &str = "[X] All Gateways offline";
 
-const ENABLED_SYMBOL: &str = "[O]";
-const DISABLED_SYMBOL: &str = "[X]";
+const ENABLED_SYMBOL: &str = "<->";
+const DISABLED_SYMBOL: &str = "—";
 
 const ADD_FAVORITE: &str = "Add to favorites";
 const REMOVE_FAVORITE: &str = "Remove from favorites";

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -263,17 +263,13 @@ impl<'a> AppState<'a> {
 }
 
 fn append_status(name: &str, enabled: bool) -> String {
-    let mut result = String::new();
-    if enabled {
-        result.push_str(ENABLED_SYMBOL);
+    let symbol = if enabled {
+        ENABLED_SYMBOL
     } else {
-        result.push_str(DISABLED_SYMBOL);
-    }
+        DISABLED_SYMBOL
+    };
 
-    result.push_str(" ");
-    result.push_str(name);
-
-    result
+    format!("{symbol} {name}")
 }
 
 fn signed_in(signed_in: &SignedIn) -> Menu {

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -559,6 +559,8 @@ mod tests {
                 Menu::default()
                     .disabled(INTERNET_RESOURCE_DESCRIPTION)
                     .separator()
+                    .item(Event::EnableInternetResource, ENABLE)
+                    .separator()
                     .disabled("Site")
                     .copyable("test")
                     .copyable(ALL_GATEWAYS_OFFLINE),
@@ -612,6 +614,8 @@ mod tests {
                 "— Internet Resource",
                 Menu::default()
                     .disabled(INTERNET_RESOURCE_DESCRIPTION)
+                    .separator()
+                    .item(Event::EnableInternetResource, ENABLE)
                     .separator()
                     .disabled("Site")
                     .copyable("test")
@@ -711,6 +715,8 @@ mod tests {
                 "— Internet Resource",
                 Menu::default()
                     .disabled(INTERNET_RESOURCE_DESCRIPTION)
+                    .separator()
+                    .item(Event::EnableInternetResource, ENABLE)
                     .separator()
                     .disabled("Site")
                     .copyable("test")

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -106,7 +106,7 @@ impl<'a> SignedIn<'a> {
     fn resource_submenu(&self, res: &ResourceDescription) -> Menu {
         let mut submenu = Menu::default().resource_description(res);
 
-        if res.is_internet_resource() && res.can_be_disabled() {
+        if res.is_internet_resource() {
             submenu.add_separator();
             if self.is_internet_resource_enabled() {
                 submenu.add_item(item(Event::DisableInternetResource, DISABLE));
@@ -437,8 +437,7 @@ mod tests {
                 "address": "172.172.0.0/16",
                 "address_description": "cidr resource",
                 "sites": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}],
-                "status": "Unknown",
-                "can_be_disabled": false
+                "status": "Unknown"
             },
             {
                 "id": "03000143-e25e-45c7-aafb-144990e57dcd",
@@ -447,8 +446,7 @@ mod tests {
                 "address": "gitlab.mycorp.com",
                 "address_description": "https://gitlab.mycorp.com",
                 "sites": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}],
-                "status": "Online",
-                "can_be_disabled": false
+                "status": "Online"
             },
             {
                 "id": "1106047c-cd5d-4151-b679-96b93da7383b",
@@ -456,8 +454,7 @@ mod tests {
                 "name": "Internet Resource",
                 "address": "All internet addresses",
                 "sites": [{"name": "test", "id": "eb94482a-94f4-47cb-8127-14fb3afa5516"}],
-                "status": "Offline",
-                "can_be_disabled": false
+                "status": "Offline"
             }
         ]"#;
 

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -555,7 +555,7 @@ mod tests {
                     .copyable(GATEWAY_CONNECTED),
             )
             .add_submenu(
-                "Internet Resource",
+                "— Internet Resource",
                 Menu::default()
                     .disabled(INTERNET_RESOURCE_DESCRIPTION)
                     .separator()
@@ -609,7 +609,7 @@ mod tests {
                     .copyable(GATEWAY_CONNECTED),
             )
             .add_submenu(
-                "Internet Resource",
+                "— Internet Resource",
                 Menu::default()
                     .disabled(INTERNET_RESOURCE_DESCRIPTION)
                     .separator()
@@ -708,7 +708,7 @@ mod tests {
                     .copyable(GATEWAY_CONNECTED),
             )
             .add_submenu(
-                "Internet Resource",
+                "— Internet Resource",
                 Menu::default()
                     .disabled(INTERNET_RESOURCE_DESCRIPTION)
                     .separator()

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray/builder.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray/builder.rs
@@ -67,9 +67,9 @@ pub(crate) enum Event {
     Url(Url),
     /// Quits the app, without signing the user out
     Quit,
-    /// A resource was enabled in the UI
+    /// The internet resource was enabled
     EnableInternetResource,
-    /// A resource was disabled in the UI
+    /// The internet resource was disabled
     DisableInternetResource,
 }
 

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray/builder.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray/builder.rs
@@ -68,9 +68,9 @@ pub(crate) enum Event {
     /// Quits the app, without signing the user out
     Quit,
     /// A resource was enabled in the UI
-    EnableResource(ResourceId),
+    EnableInternetResource,
     /// A resource was disabled in the UI
-    DisableResource(ResourceId),
+    DisableInternetResource,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]

--- a/rust/gui-client/src-tauri/src/client/settings.rs
+++ b/rust/gui-client/src-tauri/src/client/settings.rs
@@ -18,7 +18,7 @@ pub(crate) struct AdvancedSettings {
     #[serde(default)]
     pub favorite_resources: HashSet<ResourceId>,
     #[serde(default)]
-    pub disabled_resources: HashSet<ResourceId>,
+    pub internet_resource_enabled: Option<bool>,
     pub log_filter: String,
 }
 
@@ -29,7 +29,7 @@ impl Default for AdvancedSettings {
             auth_base_url: Url::parse("https://app.firez.one").unwrap(),
             api_url: Url::parse("wss://api.firez.one").unwrap(),
             favorite_resources: Default::default(),
-            disabled_resources: Default::default(),
+            internet_resource_enabled: Default::default(),
             log_filter: "firezone_gui_client=debug,info".to_string(),
         }
     }
@@ -42,9 +42,15 @@ impl Default for AdvancedSettings {
             auth_base_url: Url::parse("https://app.firezone.dev").unwrap(),
             api_url: Url::parse("wss://api.firezone.dev").unwrap(),
             favorite_resources: Default::default(),
-            disabled_resources: Default::default(),
+            internet_resource_enabled: Default::default(),
             log_filter: "info".to_string(),
         }
+    }
+}
+
+impl AdvancedSettings {
+    pub fn internet_resource_enabled(&self) -> bool {
+        self.internet_resource_enabled.is_some_and(|v| v)
     }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+class StatusSymbol {
+  static var on: String = "<->"
+  static var off: String = "—"
+
+}
+
 public enum ResourceList {
   case loading
   case loaded([Resource])

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -35,9 +35,8 @@ public struct Resource: Decodable, Identifiable, Equatable {
   public var status: ResourceStatus
   public var sites: [Site]
   public var type: ResourceType
-  public var canBeDisabled: Bool
 
-  public init(id: String, name: String, address: String?, addressDescription: String?, status: ResourceStatus, sites: [Site], type: ResourceType, canBeDisabled: Bool) {
+  public init(id: String, name: String, address: String?, addressDescription: String?, status: ResourceStatus, sites: [Site], type: ResourceType) {
     self.id = id
     self.name = name
     self.address = address
@@ -45,7 +44,6 @@ public struct Resource: Decodable, Identifiable, Equatable {
     self.status = status
     self.sites = sites
     self.type = type
-    self.canBeDisabled = canBeDisabled
   }
 
   public func isInternetResource() -> Bool {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -11,7 +11,6 @@ import Foundation
 class StatusSymbol {
   static var on: String = "<->"
   static var off: String = "—"
-
 }
 
 public enum ResourceList {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -10,7 +10,7 @@ struct Settings: Equatable {
   var authBaseURL: String
   var apiURL: String
   var logFilter: String
-  var disabledResources: Set<String>
+  var internetResourceEnabled: Bool?
 
   var isValid: Bool {
     let authBaseURL = URL(string: authBaseURL)
@@ -38,19 +38,17 @@ struct Settings: Equatable {
           ?? Settings.defaultValue.apiURL,
         logFilter: providerConfiguration[TunnelManagerKeys.logFilter]
           ?? Settings.defaultValue.logFilter,
-        disabledResources: getDisabledResources(disabledResources: providerConfiguration[TunnelManagerKeys.disabledResources])
+        internetResourceEnabled: getInternetResourceEnabled(internetResourceEnabled:  providerConfiguration[TunnelManagerKeys.internetResourceEnabled])
       )
     } else {
       return Settings.defaultValue
     }
   }
 
-  static private func getDisabledResources(disabledResources: String?) -> Set<String> {
-    guard let disabledResourcesJSON = disabledResources, let disabledResourcesData = disabledResourcesJSON.data(using: .utf8)  else{
-      return Set()
-    }
-    return (try? JSONDecoder().decode(Set<String>.self, from: disabledResourcesData))
-      ?? Settings.defaultValue.disabledResources
+  static private func getInternetResourceEnabled(internetResourceEnabled: String?) -> Bool? {
+    guard let internetResourceEnabled = internetResourceEnabled, let jsonData = internetResourceEnabled.data(using: .utf8) else { return nil }
+
+    return try? JSONDecoder().decode(Bool?.self, from: jsonData)
   }
 
   // Used for initializing a new providerConfiguration from Settings
@@ -59,7 +57,7 @@ struct Settings: Equatable {
       TunnelManagerKeys.authBaseURL: authBaseURL,
       TunnelManagerKeys.apiURL: apiURL,
       TunnelManagerKeys.logFilter: logFilter,
-      TunnelManagerKeys.disabledResources: String(data: try! JSONEncoder().encode(disabledResources), encoding: .utf8) ?? "",
+      TunnelManagerKeys.internetResourceEnabled: String(data: try! JSONEncoder().encode(internetResourceEnabled) , encoding: .utf8)!,
     ]
   }
 
@@ -72,14 +70,14 @@ struct Settings: Equatable {
         apiURL: "wss://api.firez.one",
         logFilter:
           "firezone_tunnel=debug,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,snownet=debug,str0m=info,warn",
-        disabledResources: Set()
+        internetResourceEnabled: nil
       )
     #else
       Settings(
         authBaseURL: "https://app.firezone.dev",
         apiURL: "wss://api.firezone.dev",
         logFilter: "str0m=warn,info",
-        disabledResources: Set()
+        internetResourceEnabled: nil
       )
     #endif
   }()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -45,8 +45,8 @@ public final class Store: ObservableObject {
     initTunnelManager()
   }
 
-  public func isResourceEnabled(_ id: String) -> Bool {
-    !tunnelManager.disabledResources.contains(id)
+  public func internetResourceEnabled() -> Bool {
+    tunnelManager.internetResourceEnabled
   }
 
   private func initNotifications() {
@@ -171,10 +171,10 @@ public final class Store: ObservableObject {
     }
   }
 
-  func toggleResourceDisabled(resource: String, enabled: Bool) {
-    tunnelManager.toggleResourceDisabled(resource: resource, enabled: enabled)
+  func toggleInternetResource(enabled: Bool) {
+    tunnelManager.toggleInternetResource(enabled: enabled)
     var newSettings = settings
-    newSettings.disabledResources = tunnelManager.disabledResources
+    newSettings.internetResourceEnabled = tunnelManager.internetResourceEnabled
     Task {
       try await save(newSettings)
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -514,7 +514,7 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   private func internetResourceTitle(resource: Resource) -> String {
-    let status = !model.store.internetResourceEnabled() && resource.canBeDisabled ? StatusSymbol.off : StatusSymbol.on
+    let status = model.store.internetResourceEnabled() ? StatusSymbol.on : StatusSymbol.off
 
     return status + " " + resource.name
   }
@@ -625,17 +625,15 @@ public final class MenuBar: NSObject, ObservableObject {
     subMenu.addItem(description)
 
     // Resource enable / disable toggle
-    if resource.canBeDisabled {
-      subMenu.addItem(NSMenuItem.separator())
-      let enableToggle = NSMenuItem()
-      enableToggle.action = #selector(internetResourceToggle(_:))
-      enableToggle.title = internetResourceToggleTitle()
-      enableToggle.toolTip = "Enable or disable resource"
-      enableToggle.isEnabled = true
-      enableToggle.target = self
-      enableToggle.representedObject = resource.id
-      subMenu.addItem(enableToggle)
-    }
+    subMenu.addItem(NSMenuItem.separator())
+    let enableToggle = NSMenuItem()
+    enableToggle.action = #selector(internetResourceToggle(_:))
+    enableToggle.title = internetResourceToggleTitle()
+    enableToggle.toolTip = "Enable or disable resource"
+    enableToggle.isEnabled = true
+    enableToggle.target = self
+    enableToggle.representedObject = resource.id
+    subMenu.addItem(enableToggle)
 
     return subMenu
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -24,7 +24,7 @@ public final class MenuBar: NSObject, ObservableObject {
   private var lastShownOthers: [Resource] = []
   
   private var wasInternetResourceEnabled: Bool = false
-  
+
   private var cancellables: Set<AnyCancellable> = []
 
   @ObservedObject var model: SessionViewModel

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -436,11 +436,11 @@ public final class MenuBar: NSObject, ObservableObject {
   }
   
   private func displayNameChanged(_ resource: Resource) -> Bool {
-    if resource.isInternetResource() {
-      return wasInternetResourceEnabled != model.store.internetResourceEnabled()
-    } else {
+    if !resource.isInternetResource() {
       return false
     }
+  
+    return wasInternetResourceEnabled != model.store.internetResourceEnabled()
   }
 
   private func populateFavoriteResourcesMenu(_ newFavorites: [Resource]) {
@@ -632,7 +632,6 @@ public final class MenuBar: NSObject, ObservableObject {
     enableToggle.toolTip = "Enable or disable resource"
     enableToggle.isEnabled = true
     enableToggle.target = self
-    enableToggle.representedObject = resource.id
     subMenu.addItem(enableToggle)
 
     return subMenu
@@ -696,8 +695,6 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func internetResourceToggle(_ sender: NSMenuItem) {
-    let id = sender.representedObject as! String
-
     self.model.store.toggleInternetResource(enabled: !model.store.internetResourceEnabled())
     sender.title = internetResourceToggleTitle()
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -499,7 +499,7 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   private func internetResourceTitle(resource: Resource) -> String {
-    let status = !model.store.internetResourceEnabled() && resource.canBeDisabled ? "[OFF]" : "[ON]"
+    let status = !model.store.internetResourceEnabled() && resource.canBeDisabled ? StatusSymbol.off : StatusSymbol.on
 
     return status + " " + resource.name
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -18,20 +18,20 @@ import SwiftUI
 // https://developer.apple.com/documentation/swiftui/menubarextra
 public final class MenuBar: NSObject, ObservableObject {
   private var statusItem: NSStatusItem
-  
+
   // Wish these could be `[String]` but diffing between different types is tricky
   private var lastShownFavorites: [Resource] = []
   private var lastShownOthers: [Resource] = []
-  
+
   private var wasInternetResourceEnabled: Bool = false
-  
+
   private var cancellables: Set<AnyCancellable> = []
-  
+
   @ObservedObject var model: SessionViewModel
-  
+
   private lazy var signedOutIcon = NSImage(named: "MenuBarIconSignedOut")
   private lazy var signedInConnectedIcon = NSImage(named: "MenuBarIconSignedInConnected")
-  
+
   private lazy var connectingAnimationImages = [
     NSImage(named: "MenuBarIconConnecting1"),
     NSImage(named: "MenuBarIconConnecting2"),
@@ -39,25 +39,25 @@ public final class MenuBar: NSObject, ObservableObject {
   ]
   private var connectingAnimationImageIndex: Int = 0
   private var connectingAnimationTimer: Timer?
-  
+
   public init(model: SessionViewModel) {
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     self.model = model
-    
+
     super.init()
-    
+
     if let button = statusItem.button {
       button.image = signedOutIcon
     }
-    
+
     createMenu()
     setupObservers()
   }
-  
+
   func showMenu() {
     statusItem.button?.performClick(nil)
   }
-  
+
   private func setupObservers() {
     model.favorites.$ids
       .receive(on: DispatchQueue.main)
@@ -68,7 +68,7 @@ public final class MenuBar: NSObject, ObservableObject {
         self.populateResourceMenus([])
         self.populateResourceMenus(model.resources.asArray())
       }).store(in: &cancellables)
-    
+
     model.$resources
       .receive(on: DispatchQueue.main)
       .sink(receiveValue: { [weak self] resources in
@@ -76,7 +76,7 @@ public final class MenuBar: NSObject, ObservableObject {
         self.populateResourceMenus(model.resources.asArray())
         self.handleTunnelStatusOrResourcesChanged()
       }).store(in: &cancellables)
-    
+
     model.$status
       .receive(on: DispatchQueue.main)
       .sink(receiveValue: { [weak self] status in
@@ -84,9 +84,9 @@ public final class MenuBar: NSObject, ObservableObject {
         self.updateStatusItemIcon(status: model.status)
       }).store(in: &cancellables)
   }
-  
+
   private lazy var menu = NSMenu()
-  
+
   private lazy var signInMenuItem = createMenuItem(
     menu,
     title: "Sign in",
@@ -173,7 +173,7 @@ public final class MenuBar: NSObject, ObservableObject {
     menuItem.submenu = subMenu
     return menuItem
   }()
-  
+
   private lazy var settingsMenuItem = createMenuItem(
     menu,
     title: "Settings",
@@ -194,33 +194,33 @@ public final class MenuBar: NSObject, ObservableObject {
     }
     return menuItem
   }()
-  
+
   private func createMenu() {
     menu.addItem(signInMenuItem)
     menu.addItem(signOutMenuItem)
     menu.addItem(NSMenuItem.separator())
-    
+
     menu.addItem(resourcesTitleMenuItem)
     menu.addItem(resourcesUnavailableMenuItem)
     menu.addItem(resourcesUnavailableReasonMenuItem)
     menu.addItem(resourcesSeparatorMenuItem)
-    
+
     if (!model.favorites.ids.isEmpty) {
       menu.addItem(otherResourcesMenuItem)
       menu.addItem(otherResourcesSeparatorMenuItem)
     }
-    
+
     menu.addItem(aboutMenuItem)
     menu.addItem(adminPortalMenuItem)
     menu.addItem(helpMenuItem)
     menu.addItem(settingsMenuItem)
     menu.addItem(NSMenuItem.separator())
     menu.addItem(quitMenuItem)
-    
+
     menu.delegate = self
     statusItem.menu = menu
   }
-  
+
   private func createMenuItem(
     _: NSMenu,
     title: String,
@@ -230,56 +230,56 @@ public final class MenuBar: NSObject, ObservableObject {
     target: AnyObject?
   ) -> NSMenuItem {
     let item = NSMenuItem(title: title, action: action, keyEquivalent: key)
-    
+
     item.isHidden = isHidden
     item.target = target
     item.isEnabled = (action != nil)
-    
+
     return item
   }
-  
+
   @objc private func signInButtonTapped() {
     NSApp.activate(ignoringOtherApps: true)
     Task { await WebAuthSession.signIn(store: model.store) }
   }
-  
+
   @objc private func signOutButtonTapped() {
     Task {
       try await model.store.signOut()
     }
   }
-  
+
   @objc private func settingsButtonTapped() {
     AppViewModel.WindowDefinition.settings.openWindow()
   }
-  
+
   @objc private func adminPortalButtonTapped() {
     let url = URL(string: model.store.settings.authBaseURL)!
     NSWorkspace.shared.open(url)
   }
-  
+
   @objc private func documentationButtonTapped() {
     let url = URL(string: "https://www.firezone.dev/kb?utm_source=macos-client")!
     NSWorkspace.shared.open(url)
   }
-  
+
   @objc private func supportButtonTapped() {
     let url = URL(string: "https://www.firezone.dev/support?utm_source=macos-client")!
     NSWorkspace.shared.open(url)
   }
-  
+
   @objc private func aboutButtonTapped() {
     NSApp.activate(ignoringOtherApps: true)
     NSApp.orderFrontStandardAboutPanel(self)
   }
-  
+
   @objc private func quitButtonTapped() {
     Task {
       model.store.stop()
       NSApp.terminate(self)
     }
   }
-  
+
   private func updateStatusItemIcon(status: NEVPNStatus) {
     statusItem.button?.image = {
       switch status {
@@ -297,7 +297,7 @@ public final class MenuBar: NSObject, ObservableObject {
       }
     }()
   }
-  
+
   private func startConnectingAnimation() {
     guard connectingAnimationTimer == nil else { return }
     let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
@@ -309,19 +309,19 @@ public final class MenuBar: NSObject, ObservableObject {
     RunLoop.main.add(timer, forMode: .common)
     connectingAnimationTimer = timer
   }
-  
+
   private func stopConnectingAnimation() {
     connectingAnimationTimer?.invalidate()
     connectingAnimationTimer = nil
   }
-  
+
   private func connectingAnimationShowNextFrame() {
     statusItem.button?.image =
     connectingAnimationImages[connectingAnimationImageIndex]
     connectingAnimationImageIndex =
     (connectingAnimationImageIndex + 1) % connectingAnimationImages.count
   }
-  
+
   private func handleTunnelStatusOrResourcesChanged() {
     let resources = model.resources
     let status = model.status
@@ -403,7 +403,7 @@ public final class MenuBar: NSObject, ObservableObject {
       }
     }()
   }
-  
+
   private func resourceMenuTitle(_ resources: ResourceList) -> String {
     switch resources {
     case .loading:
@@ -416,7 +416,7 @@ public final class MenuBar: NSObject, ObservableObject {
       }
     }
   }
-  
+
   private func populateResourceMenus(_ newResources: [Resource]) {
     // If we have no favorites, then everything is a favorite
     let hasAnyFavorites = newResources.contains { model.favorites.contains($0.id) }
@@ -430,26 +430,26 @@ public final class MenuBar: NSObject, ObservableObject {
     } else {
       []
     }
-    
+
     populateFavoriteResourcesMenu(newFavorites)
     populateOtherResourcesMenu(newOthers)
   }
-  
+
   private func displayNameChanged(_ resource: Resource) -> Bool {
     if !resource.isInternetResource() {
       return false
     }
-    
+
     return wasInternetResourceEnabled != model.store.internetResourceEnabled()
   }
-  
+
   private func populateFavoriteResourcesMenu(_ newFavorites: [Resource]) {
     // Update the menu in place so everything won't vanish if it's open when it updates
     let diff = (newFavorites).difference(
       from: lastShownFavorites,
       by: { $0 == $1 && !displayNameChanged($0) }
     )
-    
+
     let index = menu.index(of: resourcesTitleMenuItem) + 1
     for change in diff {
       switch change {
@@ -463,7 +463,7 @@ public final class MenuBar: NSObject, ObservableObject {
     lastShownFavorites = newFavorites
     wasInternetResourceEnabled = model.store.internetResourceEnabled()
   }
-  
+
   private func populateOtherResourcesMenu(_ newOthers: [Resource]) {
     if (newOthers.isEmpty) {
       removeItemFromMenu(menu: menu, item: otherResourcesMenuItem)
@@ -473,7 +473,7 @@ public final class MenuBar: NSObject, ObservableObject {
       addItemToMenu(menu: menu, item: otherResourcesMenuItem, at: i)
       addItemToMenu(menu: menu, item: otherResourcesSeparatorMenuItem, at: i + 1)
     }
-    
+
     // Update the menu in place so everything won't vanish if it's open when it updates
     let diff = (newOthers).difference(
       from: lastShownOthers,
@@ -490,9 +490,9 @@ public final class MenuBar: NSObject, ObservableObject {
     }
     lastShownOthers = newOthers
     wasInternetResourceEnabled = model.store.internetResourceEnabled()
-    
+
   }
-  
+
   private func addItemToMenu(menu: NSMenu, item: NSMenuItem, at: Int) {
     // Adding an item that already exists will crash the process, so check for it first.
     let i = menu.index(of: otherResourcesMenuItem)
@@ -502,7 +502,7 @@ public final class MenuBar: NSObject, ObservableObject {
     }
     menu.insertItem(otherResourcesMenuItem, at: at)
   }
-  
+
   private func removeItemFromMenu(menu: NSMenu, item: NSMenuItem) {
     // Removing an item that doesn't exist will crash the process, so check for it first.
     let i = menu.index(of: item)
@@ -512,48 +512,48 @@ public final class MenuBar: NSObject, ObservableObject {
     }
     menu.removeItem(item)
   }
-  
+
   private func internetResourceTitle(resource: Resource) -> String {
     let status = model.store.internetResourceEnabled() ? StatusSymbol.on : StatusSymbol.off
-    
+
     return status + " " + resource.name
   }
-  
+
   private func resourceTitle(resource: Resource) -> String {
     if resource.isInternetResource() {
       return internetResourceTitle(resource: resource)
     }
-    
+
     return resource.name
   }
-  
+
   private func createResourceMenuItem(resource: Resource) -> NSMenuItem {
     let item = NSMenuItem(title: resourceTitle(resource: resource), action: nil, keyEquivalent: "")
-    
+
     item.isHidden = false
     item.submenu = createSubMenu(resource: resource)
-    
+
     return item
   }
-  
+
   private func internetResourceToggleTitle() -> String {
     model.isInternetResourceEnabled() ? "Disable this resource" : "Enable this resource"
   }
-  
+
   private func nonInternetResourceHeader(resource: Resource) -> NSMenu {
     let subMenu = NSMenu()
-    
+
     // AddressDescription first -- will be most common action
     let resourceAddressDescriptionItem = NSMenuItem()
     if let addressDescription = resource.addressDescription {
       resourceAddressDescriptionItem.title = addressDescription
-      
+
       if let url = URL(string: addressDescription),
          let _ = url.host {
         // Looks like a URL, so allow opening it
         resourceAddressDescriptionItem.action = #selector(resourceURLTapped(_:))
         resourceAddressDescriptionItem.toolTip = "Click to open"
-        
+
         // TODO: Expose markdown support? Blocked by Tauri clients.
         // Using Markdown here only to highlight the URL
         resourceAddressDescriptionItem.attributedTitle = try? NSAttributedString(markdown: "**[\(addressDescription)](\(addressDescription))**")
@@ -570,14 +570,14 @@ public final class MenuBar: NSObject, ObservableObject {
     resourceAddressDescriptionItem.isEnabled = true
     resourceAddressDescriptionItem.target = self
     subMenu.addItem(resourceAddressDescriptionItem)
-    
+
     subMenu.addItem(NSMenuItem.separator())
-    
+
     let resourceSectionItem = NSMenuItem()
     resourceSectionItem.title = "Resource"
     resourceSectionItem.isEnabled = false
     subMenu.addItem(resourceSectionItem)
-    
+
     // Resource name
     let resourceNameItem = NSMenuItem()
     resourceNameItem.action = #selector(resourceValueTapped(_:))
@@ -586,7 +586,7 @@ public final class MenuBar: NSObject, ObservableObject {
     resourceNameItem.isEnabled = true
     resourceNameItem.target = self
     subMenu.addItem(resourceNameItem)
-    
+
     // Resource address
     let resourceAddressItem = NSMenuItem()
     resourceAddressItem.action = #selector(resourceValueTapped(_:))
@@ -595,9 +595,9 @@ public final class MenuBar: NSObject, ObservableObject {
     resourceAddressItem.isEnabled = true
     resourceAddressItem.target = self
     subMenu.addItem(resourceAddressItem)
-    
+
     let toggleFavoriteItem = NSMenuItem()
-    
+
     if model.favorites.contains(resource.id) {
       toggleFavoriteItem.action = #selector(removeFavoriteTapped(_:))
       toggleFavoriteItem.title = "Remove from favorites"
@@ -611,19 +611,19 @@ public final class MenuBar: NSObject, ObservableObject {
     toggleFavoriteItem.representedObject = resource.id
     toggleFavoriteItem.target = self
     subMenu.addItem(toggleFavoriteItem)
-    
+
     return subMenu
   }
-  
+
   private func internetResourceHeader(resource: Resource) -> NSMenu {
     let subMenu = NSMenu()
     let description = NSMenuItem()
-    
+
     description.title = "All network traffic"
     description.isEnabled = false
-    
+
     subMenu.addItem(description)
-    
+
     // Resource enable / disable toggle
     subMenu.addItem(NSMenuItem.separator())
     let enableToggle = NSMenuItem()
@@ -633,10 +633,10 @@ public final class MenuBar: NSObject, ObservableObject {
     enableToggle.isEnabled = true
     enableToggle.target = self
     subMenu.addItem(enableToggle)
-    
+
     return subMenu
   }
-  
+
   private func resourceHeader(resource: Resource) -> NSMenu {
     if resource.isInternetResource() {
       internetResourceHeader(resource: resource)
@@ -644,22 +644,22 @@ public final class MenuBar: NSObject, ObservableObject {
       nonInternetResourceHeader(resource: resource)
     }
   }
-  
+
   private func createSubMenu(resource: Resource) -> NSMenu {
     let siteSectionItem = NSMenuItem()
     let siteNameItem = NSMenuItem()
     let siteStatusItem = NSMenuItem()
-    
+
     let subMenu = resourceHeader(resource: resource)
-    
+
     // Site details
     if let site = resource.sites.first {
       subMenu.addItem(NSMenuItem.separator())
-      
+
       siteSectionItem.title = "Site"
       siteSectionItem.isEnabled = false
       subMenu.addItem(siteSectionItem)
-      
+
       // Site name
       siteNameItem.title = site.name
       siteNameItem.action = #selector(resourceValueTapped(_:))
@@ -667,7 +667,7 @@ public final class MenuBar: NSObject, ObservableObject {
       siteNameItem.isEnabled = true
       siteNameItem.target = self
       subMenu.addItem(siteNameItem)
-      
+
       // Site status
       siteStatusItem.action = #selector(resourceValueTapped(_:))
       siteStatusItem.title = resource.status.toSiteStatus()
@@ -684,38 +684,38 @@ public final class MenuBar: NSObject, ObservableObject {
       }
       subMenu.addItem(siteStatusItem)
     }
-    
+
     return subMenu
   }
-  
+
   @objc private func resourceValueTapped(_ sender: AnyObject?) {
     if let value = (sender as? NSMenuItem)?.title {
       copyToClipboard(value)
     }
   }
-  
+
   @objc private func internetResourceToggle(_ sender: NSMenuItem) {
     self.model.store.toggleInternetResource(enabled: !model.store.internetResourceEnabled())
     sender.title = internetResourceToggleTitle()
   }
-  
+
   @objc private func resourceURLTapped(_ sender: AnyObject?) {
     if let value = (sender as? NSMenuItem)?.title {
       // URL has already been validated
       NSWorkspace.shared.open(URL(string: value)!)
     }
   }
-  
+
   @objc private func addFavoriteTapped(_ sender: NSMenuItem) {
     let id = sender.representedObject as! String
     setFavorited(id: id, favorited: true)
   }
-  
+
   @objc private func removeFavoriteTapped(_ sender: NSMenuItem) {
     let id = sender.representedObject as! String
     setFavorited(id: id, favorited: false)
   }
-  
+
   private func setFavorited(id: String, favorited: Bool) {
     if favorited {
       model.favorites.add(id)
@@ -723,13 +723,13 @@ public final class MenuBar: NSObject, ObservableObject {
       model.favorites.remove(id)
     }
   }
-  
+
   private func copyToClipboard(_ string: String) {
     let pasteBoard = NSPasteboard.general
     pasteBoard.clearContents()
     pasteBoard.writeObjects([string as NSString])
   }
-  
+
   private func statusToState(status: ResourceStatus) -> NSControl.StateValue {
     switch status {
     case .offline:

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -498,20 +498,22 @@ public final class MenuBar: NSObject, ObservableObject {
     menu.removeItem(item)
   }
 
-  private func internetResourceTitle(resourceName: String) -> String {
-    let status = self.model.store.internetResourceEnabled() ? "[ON]" : "[OFF]"
+  private func internetResourceTitle(resource: Resource) -> String {
+    let status = !model.store.internetResourceEnabled() && resource.canBeDisabled ? "[OFF]" : "[ON]"
 
-    return status + " " + resourceName
+    return status + " " + resource.name
+  }
+
+  private func resourceTitle(resource: Resource) -> String {
+    if resource.isInternetResource() {
+      return internetResourceTitle(resource: resource)
+    }
+
+    return resource.name
   }
 
   private func createResourceMenuItem(resource: Resource) -> NSMenuItem {
-    var resourceTitle = resource.name
-
-    if resource.isInternetResource() && resource.canBeDisabled {
-      resourceTitle = internetResourceTitle(resourceName: resourceTitle)
-    }
-
-    let item = NSMenuItem(title: resourceTitle, action: nil, keyEquivalent: "")
+    let item = NSMenuItem(title: resourceTitle(resource: resource), action: nil, keyEquivalent: "")
 
     item.isHidden = false
     item.submenu = createSubMenu(resource: resource)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -220,14 +220,12 @@ struct ToggleInternetResourceButton: View {
   }
 
   var body: some View {
-    if resource.canBeDisabled {
-      Button(action: {
-        model.store.toggleInternetResource(enabled: !model.isInternetResourceEnabled())
-      }) {
-        HStack {
-          Text(toggleResourceEnabledText())
-          Spacer()
-        }
+    Button(action: {
+      model.store.toggleInternetResource(enabled: !model.isInternetResourceEnabled())
+    }) {
+      HStack {
+        Text(toggleResourceEnabledText())
+        Spacer()
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -173,9 +173,6 @@ struct NonInternetResourceHeader: View {
           }
         }
       }
-
-      ToggleResourceEnabledButton(resource: resource, model: model)
-
     }
   }
 }
@@ -204,17 +201,18 @@ struct InternetResourceHeader: View {
 
         Text("All network traffic")
       }
-      ToggleResourceEnabledButton(resource: resource, model: model)
+
+      ToggleInternetResourceButton(resource: resource, model: model)
     }
   }
 }
 
-struct ToggleResourceEnabledButton: View {
+struct ToggleInternetResourceButton: View {
   var resource: Resource
   @ObservedObject var model: SessionViewModel
 
   private func toggleResourceEnabledText() -> String {
-    if model.isResourceEnabled(resource.id) {
+    if model.isInternetResourceEnabled() {
       "Disable this resource"
     } else {
       "Enable this resource"
@@ -224,7 +222,7 @@ struct ToggleResourceEnabledButton: View {
   var body: some View {
     if resource.canBeDisabled {
       Button(action: {
-        model.store.toggleResourceDisabled(resource: resource.id, enabled: !model.isResourceEnabled(resource.id))
+        model.store.toggleInternetResource(enabled: !model.isInternetResourceEnabled())
       }) {
         HStack {
           Text(toggleResourceEnabledText())

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -127,12 +127,26 @@ struct ResourceSection: View {
   let resources: [Resource]
   @ObservedObject var model: SessionViewModel
 
+  private func internetResourceTitle(resource: Resource) -> String {
+    let status = !model.store.internetResourceEnabled() && resource.canBeDisabled ? "[OFF]" : "[ON]"
+
+    return status + " " + resource.name
+  }
+
+  private func resourceTitle(resource: Resource) -> String {
+    if resource.isInternetResource() {
+      return internetResourceTitle(resource: resource)
+    }
+
+    return resource.name
+  }
+
   var body: some View {
     ForEach(resources) { resource in
       HStack {
           NavigationLink { ResourceView(model: model, resource: resource) }
           label: {
-            Text(resource.name)
+            Text(resourceTitle(resource: resource))
           }
       }
       .navigationTitle("All Resources")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -60,8 +60,8 @@ public final class SessionViewModel: ObservableObject {
       .store(in: &cancellables)
   }
 
-  public func isResourceEnabled(_ resource: String) -> Bool {
-    store.isResourceEnabled(resource)
+  public func isInternetResourceEnabled() -> Bool {
+    store.internetResourceEnabled()
   }
 
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -128,7 +128,7 @@ struct ResourceSection: View {
   @ObservedObject var model: SessionViewModel
 
   private func internetResourceTitle(resource: Resource) -> String {
-    let status = !model.store.internetResourceEnabled() && resource.canBeDisabled ? "[OFF]" : "[ON]"
+    let status = !model.store.internetResourceEnabled() && resource.canBeDisabled ? StatusSymbol.off : StatusSymbol.on
 
     return status + " " + resource.name
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -128,7 +128,7 @@ struct ResourceSection: View {
   @ObservedObject var model: SessionViewModel
 
   private func internetResourceTitle(resource: Resource) -> String {
-    let status = !model.store.internetResourceEnabled() && resource.canBeDisabled ? StatusSymbol.off : StatusSymbol.on
+    let status = model.store.internetResourceEnabled() ? StatusSymbol.on : StatusSymbol.off
 
     return status + " " + resource.name
   }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -221,7 +221,7 @@ class Adapter {
     internetResource = resources().filter{ $0.isInternetResource() }.first
 
     var disablingResources: Set<String> = []
-    if let internetResource = internetResource, internetResource.canBeDisabled && !internetResourceEnabled {
+    if let internetResource = internetResource, !internetResourceEnabled {
       disablingResources.insert(internetResource.id)
     }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -61,10 +61,10 @@ class Adapter {
   private let workQueue = DispatchQueue(label: "FirezoneAdapterWorkQueue")
 
   /// Currently disabled resources
-  private var disabledResources: Set<String> = []
+  private var internetResourceEnabled: Bool = false
 
-  /// Cache of resources that can be disabled
-  private var canBeDisabled: Set<String> = []
+  /// Cache of internet resource
+  private var internetResource: Resource?
 
   /// Adapter state.
   private var state: AdapterState {
@@ -86,7 +86,7 @@ class Adapter {
     apiURL: String,
     token: String,
     logFilter: String,
-    disabledResources: Set<String>,
+    internetResourceEnabled: Bool,
     packetTunnelProvider: PacketTunnelProvider
   ) {
     self.apiURL = apiURL
@@ -97,7 +97,7 @@ class Adapter {
     self.logFilter = logFilter
     self.connlibLogFolderPath = SharedAccess.connlibLogFolderURL?.path ?? ""
     self.networkSettings = nil
-    self.disabledResources = disabledResources
+    self.internetResourceEnabled = internetResourceEnabled
   }
 
   // Could happen abruptly if the process is killed.
@@ -204,10 +204,10 @@ class Adapter {
     return (try? decoder.decode([Resource].self, from: resourceList.data(using: .utf8)!)) ?? []
   }
 
-  public func setDisabledResources(newDisabledResources: Set<String>) {
+  public func setInternetResourceEnabled(_ enabled: Bool) {
     workQueue.async { [weak self] in
       guard let self = self else { return }
-      self.disabledResources = newDisabledResources
+      self.internetResourceEnabled = enabled
       self.resourcesUpdated()
     }
   }
@@ -218,9 +218,13 @@ class Adapter {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
-    canBeDisabled = Set(resources().filter({ $0.canBeDisabled }).map({ $0.id }))
+    internetResource = resources().filter{ $0.isInternetResource() }.first
 
-    let disablingResources = disabledResources.filter({ canBeDisabled.contains($0) })
+    var disablingResources: Set<String> = []
+    if let internetResource = internetResource, internetResource.canBeDisabled && !internetResourceEnabled {
+      disablingResources.insert(internetResource.id)
+    }
+
 
     let currentlyDisabled = try! JSONEncoder().encode(disablingResources)
     session.setDisabledResources(String(data: currentlyDisabled, encoding: .utf8)!)

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -78,14 +78,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
           return
         }
 
-        let disabledResources: Set<String> = if let disabledResourcesJSON = providerConfiguration[TunnelManagerKeys.disabledResources]?.data(using: .utf8) {
-          (try? JSONDecoder().decode(Set<String>.self, from: disabledResourcesJSON )) ?? Set()
+        let internetResourceEnabled: Bool = if let internetResourceEnabledJSON = providerConfiguration[TunnelManagerKeys.internetResourceEnabled]?.data(using: .utf8) {
+          (try? JSONDecoder().decode(Bool.self, from: internetResourceEnabledJSON )) ?? false
         } else {
-          Set()
+          false
         }
 
         let adapter = Adapter(
-          apiURL: apiURL, token: token, logFilter: logFilter, disabledResources: disabledResources, packetTunnelProvider: self)
+          apiURL: apiURL, token: token, logFilter: logFilter, internetResourceEnabled: internetResourceEnabled, packetTunnelProvider: self)
         self.adapter = adapter
 
 
@@ -139,8 +139,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     guard let tunnelMessage =  try? PropertyListDecoder().decode(TunnelMessage.self, from: message) else { return }
 
     switch tunnelMessage {
-    case .setDisabledResources(let value):
-      adapter?.setDisabledResources(newDisabledResources: value)
+    case .internetResourceEnabled(let value):
+      adapter?.setInternetResourceEnabled(value)
     case .signOut:
       Task {
           await clearToken()


### PR DESCRIPTION
With this PR we made internet resource disabled by default.

Since no other resource is disalable and internet resource behavior is particular we remove all client code to make non internet resource disalable.

Also, since the portal never makes the internet resource that can't be disabled we remove the whole code path to handle that.

Additionally, some other smaller refactors across the UI wrt internet resource

Fix #6509