### PR TITLE
test(connlib): replace panics with ERROR logs

### DIFF
--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -219,7 +219,7 @@ impl SimClient {
             }
         }
 
-        unimplemented!("Unhandled packet")
+        tracing::error!("Unhandled packet");
     }
 
     pub(crate) fn update_relays<'a>(

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -94,7 +94,8 @@ impl SimGateway {
             return Some(transmit);
         }
 
-        panic!("Unhandled packet")
+        tracing::error!("Unhandled packet");
+        None
     }
 
     pub(crate) fn update_relays<'a>(

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -549,7 +549,8 @@ impl TunnelTest {
         let now = self.flux_capacitor.now();
 
         let Some(host) = self.network.host_by_ip(dst.ip()) else {
-            panic!("Unhandled packet: {src} -> {dst}")
+            tracing::error!("Unhandled packet: {src} -> {dst}");
+            return;
         };
 
         match host {


### PR DESCRIPTION
In order to see all things that went wrong during a test run, we install a special subscriber with the logger for `tunnel_test` that panics after it has received at least 1 `ERROR` log.

The panics changed in this PR are still from a time when we didn't have that. We change them so that we have better diagnostics for when they get hit.