### PR TITLE
build(nix): install `rust-src` as part of toolchain

### DIFF
--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -57,6 +57,7 @@
             packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.nodePackages.pnpm cargo-udeps pkgs.cargo-sort ];
             buildInputs = packages ++ [
               (rustVersion.override {
+                extensions = [ "rust-src" ];
                 targets = [ "x86_64-unknown-linux-musl" ];
               })
             ];


### PR DESCRIPTION
In order for `rust-analyzer` to show the correct version of the Rust standard library, we need to install `rust-src` together with the toolchain version that we use in the Nix dev-shell.