### PR TITLE
fix(apple): Trigger connlib reset() when IPv4, IPv6, or available network gateways has changed

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -53,7 +53,7 @@ class Adapter {
   private var lastFetchedResolvers: [String] = []
 
   /// Remembers the last _relevant_ path update.
-  /// A path update is considered relevant if certain properties change that require us to reset connlib's network state. 
+  /// A path update is considered relevant if certain properties change that require us to reset connlib's network state.
   private var lastRelevantPath: Network.NWPath?
 
   /// Private queue used to ensure consistent ordering among path update and connlib callbacks

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -293,9 +293,9 @@ extension Adapter {
       // out of a different interface even when 0.0.0.0 is used as the source.
       // If our primary interface changes, we can be certain the old socket shouldn't be
       // used anymore.
-      if path.connectivityDifferentFrom(path: lastRelevantPath) == true {
-        session.reset()
+      if lastRelevantPath?.connectivityDifferentFrom(path: path) != false {
         lastRelevantPath = path
+        session.reset()
       }
 
       if shouldFetchSystemResolvers(path: path) {
@@ -491,12 +491,7 @@ extension Adapter: CallbackHandlerDelegate {
 #endif
 
 extension Network.NWPath {
-  func connectivityDifferentFrom(path: Network.NWPath?) -> Bool {
-    // Consider connectivity different if we haven't initialized yet. Prevents an edge case
-    // where the network meaningfully changed while our Adapter was coming up and we don't
-    // detect it.
-    guard let path = path else { return true }
-
+  func connectivityDifferentFrom(path: Network.NWPath) -> Bool {
     // We define a path as different from another if the following properties change
     return path.supportsIPv4 != self.supportsIPv4 ||
       path.supportsIPv6 != self.supportsIPv6 ||

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -52,7 +52,8 @@ class Adapter {
   /// Track our last fetched DNS resolvers to know whether to tell connlib they've updated
   private var lastFetchedResolvers: [String] = []
 
-  /// Used to avoid needlessly sending resets to connlib while still triggering reset
+  /// Remembers the last _relevant_ path update.
+  /// A path update is considered relevant if certain properties change that require us to reset connlib's network state. 
   private var lastRelevantPath: Network.NWPath?
 
   /// Private queue used to ensure consistent ordering among path update and connlib callbacks

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -9,6 +9,16 @@ export default function Apple() {
       href="https://apps.apple.com/us/app/firezone/id6443661826"
       title="macOS / iOS"
     >
+      {/*
+      <Entry version="1.3.1" date={new Date("2024-08-31")}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem pull="6521">
+            Gracefully handles cases where the device's local interface IPv4/IPv6 address or
+            local network gateway changes while the client is connected.
+          </ChangeItem>
+        </ul>
+      </Entry>
+      */}
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6434">


### PR DESCRIPTION
On Apple, we try to be smart about triggering connlib's `reset()` in order to keep from triggering endless update loops. This can happen because connlib itself triggers path monitoring updates through onUpdateRoutes and such.

Before, we only kept track of whether our primary interface changed in order to consider the path updated. Now, we also track IPv4/IPv6 connectivity and the network's available gateways (read: routers) to trigger changes. This fixes the case where our interface loses or gains IPv4 / IPv6 connectivity, or the router address changes.

Fixes #6515 