### PR TITLE
chore(connlib): fix field name for `match_resource_linear` span

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -168,9 +168,9 @@ impl StubResolver {
     /// Attempts to match the given domain against our list of possible patterns.
     ///
     /// This performs a linear search and is thus O(N) and **must not** be called in the hot-path of packet routing.
-    #[tracing::instrument(level = "trace", skip_all, fields(domain))]
-    fn match_resource_linear(&self, domain_name: &DomainName) -> Option<ResourceId> {
-        let name = Candidate::from_domain(domain_name);
+    #[tracing::instrument(level = "trace", skip_all, fields(%domain))]
+    fn match_resource_linear(&self, domain: &DomainName) -> Option<ResourceId> {
+        let name = Candidate::from_domain(domain);
 
         for (pattern, id) in &self.dns_resources {
             if pattern.matches(&name) {


### PR DESCRIPTION
The span of this method didn't end up logging and fields because it got renamed without the span also being adjusted.