### PR TITLE
refactor(connlib): only buffer 1 unsent packet if socket is busy

### DIFF
--- a/rust/bin-shared/src/tun_device_manager.rs
+++ b/rust/bin-shared/src/tun_device_manager.rs
@@ -59,6 +59,10 @@ mod tests {
         )))
         .unwrap();
 
+        std::future::poll_fn(|cx| socket.poll_send_ready(cx))
+            .await
+            .unwrap();
+
         // Send a STUN request.
         socket
             .send(DatagramOut {
@@ -68,11 +72,6 @@ mod tests {
                     "000100002112A4420123456789abcdef01234567"
                 )),
             })
-            .unwrap();
-
-        // First send seems to always result as would block
-        std::future::poll_fn(|cx| socket.poll_flush(cx))
-            .await
             .unwrap();
 
         let task = std::future::poll_fn(|cx| {

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -15,6 +15,7 @@ use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
 use std::{
     collections::{BTreeMap, BTreeSet},
+    io,
     net::IpAddr,
     task::{Context, Poll},
 };
@@ -89,6 +90,9 @@ where
             match self.tunnel.poll_next_event(cx) {
                 Poll::Ready(Ok(event)) => {
                     self.handle_tunnel_event(event);
+                    continue;
+                }
+                Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::WouldBlock => {
                     continue;
                 }
                 Poll::Ready(Err(e)) => {

--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -11,7 +11,7 @@ mod utils;
 
 pub use allocation::RelaySocket;
 pub use node::{
-    Answer, Client, ClientNode, Credentials, Error, Event, Node, Offer, Server, ServerNode,
-    Transmit, HANDSHAKE_TIMEOUT,
+    Answer, Client, ClientNode, Credentials, EncryptBuffer, EncryptedPacket, Error, Event, Node,
+    Offer, Server, ServerNode, Transmit, HANDSHAKE_TIMEOUT,
 };
 pub use stats::{ConnectionStats, NodeStats};

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -419,11 +419,12 @@ impl ClientState {
         )
     }
 
-    pub(crate) fn encapsulate<'s>(
-        &'s mut self,
+    pub(crate) fn encapsulate<'b>(
+        &mut self,
         packet: MutableIpPacket<'_>,
         now: Instant,
-    ) -> Option<snownet::Transmit<'s>> {
+        buffer: &'b mut [u8],
+    ) -> Option<snownet::Transmit<'b>> {
         let (packet, dst) = match self.try_handle_dns_query(packet, now) {
             Ok(response) => {
                 self.buffered_packets.push_back(response?.to_owned());
@@ -469,7 +470,7 @@ impl ClientState {
 
         let transmit = self
             .node
-            .encapsulate(gid, packet.as_immutable(), now)
+            .encapsulate(gid, packet.as_immutable(), now, buffer)
             .inspect_err(|e| tracing::debug!(%gid, "Failed to encapsulate: {e}"))
             .ok()??;
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -22,7 +22,7 @@ use crate::{ClientEvent, ClientTunnel, Tun};
 use domain::base::Message;
 use lru::LruCache;
 use secrecy::{ExposeSecret as _, Secret};
-use snownet::{ClientNode, RelaySocket, Transmit};
+use snownet::{ClientNode, EncryptBuffer, RelaySocket, Transmit};
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
@@ -419,12 +419,12 @@ impl ClientState {
         )
     }
 
-    pub(crate) fn encapsulate<'b>(
+    pub(crate) fn encapsulate(
         &mut self,
         packet: MutableIpPacket<'_>,
         now: Instant,
-        buffer: &'b mut [u8],
-    ) -> Option<snownet::Transmit<'b>> {
+        buffer: &mut EncryptBuffer,
+    ) -> Option<snownet::EncryptedPacket> {
         let (packet, dst) = match self.try_handle_dns_query(packet, now) {
             Ok(response) => {
                 self.buffered_packets.push_back(response?.to_owned());

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -155,11 +155,12 @@ impl GatewayState {
         self.node.public_key()
     }
 
-    pub(crate) fn encapsulate<'s>(
-        &'s mut self,
+    pub(crate) fn encapsulate<'b>(
+        &mut self,
         packet: MutableIpPacket<'_>,
         now: Instant,
-    ) -> Option<snownet::Transmit<'s>> {
+        buffer: &'b mut [u8],
+    ) -> Option<snownet::Transmit<'b>> {
         let dst = packet.destination();
 
         if !is_client(dst) {
@@ -180,7 +181,7 @@ impl GatewayState {
 
         let transmit = self
             .node
-            .encapsulate(peer.id(), packet.as_immutable(), now)
+            .encapsulate(peer.id(), packet.as_immutable(), now, buffer)
             .inspect_err(|e| tracing::debug!(%cid, "Failed to encapsulate: {e}"))
             .ok()??;
 

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -13,7 +13,7 @@ use connlib_shared::{DomainName, StaticSecret};
 use ip_network::{Ipv4Network, Ipv6Network};
 use ip_packet::{IpPacket, MutableIpPacket};
 use secrecy::{ExposeSecret as _, Secret};
-use snownet::{RelaySocket, ServerNode};
+use snownet::{EncryptBuffer, RelaySocket, ServerNode};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::{Duration, Instant};
@@ -155,12 +155,12 @@ impl GatewayState {
         self.node.public_key()
     }
 
-    pub(crate) fn encapsulate<'b>(
+    pub(crate) fn encapsulate(
         &mut self,
         packet: MutableIpPacket<'_>,
         now: Instant,
-        buffer: &'b mut [u8],
-    ) -> Option<snownet::Transmit<'b>> {
+        buffer: &mut EncryptBuffer,
+    ) -> Option<snownet::EncryptedPacket> {
         let dst = packet.destination();
 
         if !is_client(dst) {

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -95,6 +95,7 @@ impl Io {
     ) -> Poll<io::Result<()>> {
         ready!(self.sockets.poll_send_ready(cx))?;
 
+        // If the `unwritten_packet` is set, `EncryptBuffer` is still holding a packet that we need so send.
         let Some(unwritten_packet) = self.unwritten_packet.take() else {
             return Poll::Ready(Ok(()));
         };

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -45,16 +45,13 @@ impl Sockets {
         Poll::Ready(())
     }
 
-    /// Flushes all buffered data on the sockets.
-    ///
-    /// Returns `Ready` if the socket is able to accept more data.
-    pub fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        if let Some(socket) = self.socket_v4.as_mut() {
-            ready!(socket.poll_flush(cx))?;
+    pub fn poll_send_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if let Some(socket) = self.socket_v4.as_ref() {
+            ready!(socket.poll_send_ready(cx))?;
         }
 
-        if let Some(socket) = self.socket_v6.as_mut() {
-            ready!(socket.poll_flush(cx))?;
+        if let Some(socket) = self.socket_v6.as_ref() {
+            ready!(socket.poll_send_ready(cx))?;
         }
 
         Poll::Ready(Ok(()))

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -147,7 +147,11 @@ impl SimClient {
             }
         }
 
-        Some(self.sut.encapsulate(packet, now)?.into_owned())
+        Some(
+            self.sut
+                .encapsulate(packet, now, &mut self.buffer)?
+                .into_owned(),
+        )
     }
 
     pub(crate) fn receive(&mut self, transmit: Transmit, now: Instant) {

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -78,7 +78,10 @@ impl SimGateway {
                 self.received_icmp_requests.insert(payload, packet.clone());
 
                 let echo_response = ip_packet::make::icmp_response_packet(packet);
-                let transmit = self.sut.encapsulate(echo_response, now)?.into_owned();
+                let transmit = self
+                    .sut
+                    .encapsulate(echo_response, now, &mut self.buffer)?
+                    .into_owned();
 
                 return Some(transmit);
             }
@@ -89,7 +92,10 @@ impl SimGateway {
                 global_dns_records.get(name).cloned().into_iter().flatten()
             });
 
-            let transmit = self.sut.encapsulate(response, now)?.into_owned();
+            let transmit = self
+                .sut
+                .encapsulate(response, now, &mut self.buffer)?
+                .into_owned();
 
             return Some(transmit);
         }


### PR DESCRIPTION
Currently, we buffer UDP packets whenever the socket is busy and try to flush them out at a later point. This requires allocations and is tricky to get right.

In order to solve both of these problems, we refactor `snownet` to return us an `EncryptedPacket` instead of a `Transmit`. An `EncryptedPacket` is an indirection-abstraction that can be turned into a `Transmit` given an `EncryptBuffer`. This combination of types allows us to hold on to the `EncryptedPacket` (which does not contain any references itself) in the `io` component whilst we are waiting for the socket to be ready to send again.

This means we will immediately suspend the event loop in case the socket is no longer ready for sending and resend the datagram in the `EncryptBuffer` once we get re-polled.