### PR TITLE
chore(rust/gui-client/windows): update `windows` to 0.58

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1825,9 +1825,9 @@ dependencies = [
  "tracing",
  "tun",
  "uuid",
- "windows 0.57.0",
- "windows-core 0.57.0",
- "windows-implement 0.57.0",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
+ "windows-implement 0.58.0",
  "winreg 0.52.0",
  "wintun",
  "zbus",
@@ -1917,7 +1917,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "windows 0.57.0",
+ "windows 0.58.0",
  "winreg 0.52.0",
  "wintun",
  "zip",
@@ -1961,7 +1961,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "windows 0.57.0",
+ "windows 0.58.0",
  "windows-service",
  "winreg 0.52.0",
 ]
@@ -7246,6 +7246,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-bindgen"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7272,7 +7282,7 @@ checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
  "windows-implement 0.56.0",
  "windows-interface 0.56.0",
- "windows-result",
+ "windows-result 0.1.1",
  "windows-targets 0.52.6",
 ]
 
@@ -7284,7 +7294,20 @@ checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
- "windows-result",
+ "windows-result 0.1.1",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -7321,6 +7344,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7343,6 +7377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "windows-metadata"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7358,6 +7403,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-service"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7366,6 +7420,16 @@ dependencies = [
  "bitflags 2.5.0",
  "widestring",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -35,13 +35,13 @@ zbus = "4.4" # Can't use `zbus`'s `tokio` feature here, or it will break toast p
 known-folders = "1.1.0"
 ring = "0.17"
 uuid = { version = "1.10.0", features = ["v4"] }
-windows-core = "0.57.0"
-windows-implement = "0.57.0"
+windows-core = "0.58.0"
+windows-implement = "0.58.0"
 wintun = "0.4.0"
 winreg = "0.52.0"
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.57.0"
+version = "0.58.0"
 features = [
   # For implementing COM interfaces
   "implement",

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -73,7 +73,7 @@ winreg = "0.52.0"
 wintun = "0.4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
-version = "0.57.0"
+version = "0.58.0"
 features = [
   "Win32_Foundation",
   "Win32_System_Threading",

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -100,7 +100,6 @@ pub(crate) fn run(
         inject_faults: cli.inject_faults,
     };
 
-    tracing::info!("Setting up Tauri app instance...");
     let (setup_result_tx, mut setup_result_rx) =
         tokio::sync::oneshot::channel::<Result<(), Error>>();
     let app = tauri::Builder::default()
@@ -144,8 +143,6 @@ pub(crate) fn run(
             }
         })
         .setup(move |app| {
-            tracing::info!("Entered Tauri's `setup`");
-
             let setup_inner = move || {
                 // Check for updates
                 let ctlr_tx_clone = ctlr_tx.clone();
@@ -995,8 +992,13 @@ async fn run_controller(
         // Code down here may not run because the `select` sometimes `continue`s.
     }
 
+    tracing::debug!("Closing...");
+
+    if let Err(error) = dns_notifier.close() {
+        tracing::error!(?error, "dns_notifier");
+    }
     if let Err(error) = network_notifier.close() {
-        tracing::error!(?error, "com_worker");
+        tracing::error!(?error, "network_notifier");
     }
     if let Err(error) = controller.ipc_client.disconnect_from_ipc().await {
         tracing::error!(?error, "ipc_client");

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -60,7 +60,7 @@ windows-service = "0.7.0"
 winreg = "0.52.0"
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.57.0"
+version = "0.58.0"
 features = [
     # For DNS control and route control
     "Win32_Foundation",

--- a/rust/headless-client/src/ipc_service/ipc/windows.rs
+++ b/rust/headless-client/src/ipc_service/ipc/windows.rs
@@ -32,7 +32,7 @@ pub(crate) async fn connect_to_service(id: ServiceId) -> Result<ClientStream, Er
             ErrorKind::NotFound => Error::NotFound(path),
             _ => Error::Other(error.into()),
         })?;
-    let handle = HANDLE(stream.as_raw_handle() as isize);
+    let handle = HANDLE(stream.as_raw_handle());
     let mut server_pid: u32 = 0;
     // SAFETY: Windows doesn't store this pointer or handle, and we just got the handle
     // from Tokio, so it should be valid.
@@ -74,7 +74,7 @@ impl Server {
             .connect()
             .await
             .context("Couldn't accept IPC connection from GUI")?;
-        let handle = HANDLE(server.as_raw_handle() as isize);
+        let handle = HANDLE(server.as_raw_handle());
         let mut client_pid: u32 = 0;
         // SAFETY: Windows doesn't store this pointer or handle, and we just got the handle
         // from Tokio, so it should be valid.


### PR DESCRIPTION
Updates `windows` crates to 0.58 without the bug in #6551.

Supersedes #6556.

The bug was calling `try_send()?` on an MPSC channel of capacity 1, which would bail out of the worker thread if we got 2 DNS change notifications faster than the controller task / thread could process the first one.