### PR TITLE
chore(rust/gui-client): log OS name when the GUI client starts

### DIFF
--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -130,6 +130,7 @@ fn start_logging(directives: &str) -> Result<logging::Handles> {
     let logging_handles = logging::setup(directives)?;
     tracing::info!(
         arch = std::env::consts::ARCH,
+        os = std::env::consts::OS,
         ?directives,
         git_version = firezone_bin_shared::git_version!("gui-client-*"),
         system_uptime_seconds = firezone_headless_client::uptime::get().map(|dur| dur.as_secs()),


### PR DESCRIPTION
Closes #6568

This way when I'm looking at customer logs, I don't have to remember the whole issue to know if they're Linux or Windows.