### PR TITLE
chore(rust/gui-client): log the IPC message variant if the service can't handle it

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1952,6 +1952,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serde_variant",
  "tempfile",
  "thiserror",
  "tokio",
@@ -5381,6 +5382,15 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.11",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_variant"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0068df419f9d9b6488fdded3f1c818522cdea328e02ce9d9f147380265a432"
+dependencies = [
  "serde",
 ]
 

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -23,6 +23,7 @@ rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.125"
+serde_variant = "0.1.3"
 thiserror = { version = "1.0", default-features = false }
 # This actually relies on many other features in Tokio, so this will probably
 # fail to build outside the workspace. <https://github.com/firezone/firezone/pull/4328#discussion_r1540342142>

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -313,13 +313,10 @@ impl<'a> Handler<'a> {
                 Event::Ipc(msg) => {
                     let msg_variant = serde_variant::to_variant_name(&msg)
                         .expect("IPC messages should be enums, not structs or anything else.");
-	            let _entered = tracing::error_span!("handle_ipc_msg", msg = %msg_variant).entered();
+                    let _entered =
+                        tracing::error_span!("handle_ipc_msg", msg = %msg_variant).entered();
                     if let Err(error) = self.handle_ipc_msg(msg).await {
-                        tracing::error!(
-                            ?error,
-                            ?msg_variant,
-                            "Error while handling IPC message from client"
-                        );
+                        tracing::error!(?error, "Error while handling IPC message from client");
                         continue;
                     }
                 }

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -313,6 +313,7 @@ impl<'a> Handler<'a> {
                 Event::Ipc(msg) => {
                     let msg_variant = serde_variant::to_variant_name(&msg)
                         .expect("IPC messages should be enums, not structs or anything else.");
+	            let _entered = tracing::error_span!("handle_ipc_msg", msg = %msg_variant).entered();
                     if let Err(error) = self.handle_ipc_msg(msg).await {
                         tracing::error!(
                             ?error,

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -311,7 +311,8 @@ impl<'a> Handler<'a> {
                     break HandlerOk::Err;
                 }
                 Event::Ipc(msg) => {
-                    let msg_variant = serde_variant::to_variant_name(&msg).expect("IPC messages should support `to_variant_name`");
+                    let msg_variant = serde_variant::to_variant_name(&msg)
+                        .expect("IPC messages should support `to_variant_name`");
                     if let Err(error) = self.handle_ipc_msg(msg).await {
                         tracing::error!(
                             ?error,

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -312,7 +312,7 @@ impl<'a> Handler<'a> {
                 }
                 Event::Ipc(msg) => {
                     let msg_variant = serde_variant::to_variant_name(&msg)
-                        .expect("IPC messages should support `to_variant_name`");
+                        .expect("IPC messages should be enums, not structs or anything else.");
                     if let Err(error) = self.handle_ipc_msg(msg).await {
                         tracing::error!(
                             ?error,

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -311,8 +311,13 @@ impl<'a> Handler<'a> {
                     break HandlerOk::Err;
                 }
                 Event::Ipc(msg) => {
+                    let msg_variant = serde_variant::to_variant_name(&msg).expect("IPC messages should support `to_variant_name`");
                     if let Err(error) = self.handle_ipc_msg(msg).await {
-                        tracing::error!(?error, "Error while handling IPC message from client");
+                        tracing::error!(
+                            ?error,
+                            ?msg_variant,
+                            "Error while handling IPC message from client"
+                        );
                         continue;
                     }
                 }


### PR DESCRIPTION
This would have helped while debugging a customer issue