### PR TITLE
chore(rust/gui-client): log connlib connection errors

### DIFF
--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -419,19 +419,19 @@ impl<'a> Handler<'a> {
                 self.ipc_tx
                     .send(&ServerMsg::ClearedLogs(result.map_err(|e| e.to_string())))
                     .await
-                    .context("Error while sending IPC message")?;
+                    .context("Error while sending IPC message")?
             }
             ClientMsg::Connect { api_url, token } => {
                 // Warning: Connection errors don't bubble to callers of `handle_ipc_msg`.
                 let token = secrecy::SecretString::from(token);
-                let connect_result = self.connect_to_firezone(&api_url, token);
-                if let Err(error) = &connect_result {
+                let result = self.connect_to_firezone(&api_url, token);
+                if let Err(error) = &result {
                     tracing::error!(?error, "Failed to connect connlib session");
                 }
                 self.ipc_tx
-                    .send(&ServerMsg::ConnectResult(connect_result))
+                    .send(&ServerMsg::ConnectResult(result))
                     .await
-                    .context("Failed to send `ConnectResult`")?;
+                    .context("Failed to send `ConnectResult`")?
             }
             ClientMsg::Disconnect => {
                 if let Some(connlib) = self.connlib.take() {
@@ -457,7 +457,7 @@ impl<'a> Handler<'a> {
                 self.connlib
                     .as_mut()
                     .context("No connlib session")?
-                    .set_dns(resolvers);
+                    .set_dns(resolvers)
             }
             ClientMsg::SetDisabledResources(disabled_resources) => {
                 self.connlib


### PR DESCRIPTION
Old behavior: Connection errors are sent to the GUI but the IPC service forgets about them.

New behavior: Clone the error and log it on both sides.

Found while debugging a customer issue. This would have made the logs easier to read.