### PR TITLE
fix(windows): prevent routing loops for TCP connections

### DIFF
--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -14,7 +14,7 @@ git-version = "0.3.9"
 ip_network = { version = "0.4", default-features = false, features = ["serde"] }
 socket-factory = { workspace = true }
 thiserror = "1.0.63"
-tokio = { workspace = true, features = ["rt", "sync", "net"] }
+tokio = { workspace = true, features = ["io-util", "net", "rt", "sync"] }
 tracing = { workspace = true }
 tun = { workspace = true }
 

--- a/rust/bin-shared/src/tun_device_manager.rs
+++ b/rust/bin-shared/src/tun_device_manager.rs
@@ -24,18 +24,52 @@ mod tests {
         net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},
         time::Duration,
     };
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
     #[tokio::test]
     #[ignore = "Needs admin / sudo and Internet"]
     async fn tunnel() {
         let _guard = firezone_logging::test("debug");
 
-        no_packet_loops().await;
+        no_packet_loops_tcp().await;
+        no_packet_loops_udp().await;
         tunnel_drop();
     }
 
-    // Starts up a WinTUN device, adds a "full-route" (`0.0.0.0/0`) and checks if we can still send packets to IPs outside of our tunnel.
-    async fn no_packet_loops() {
+    // Starts up a WinTun device, claims all routes, and checks if we can still make
+    // TCP connections outside of our tunnel.
+    async fn no_packet_loops_tcp() {
+        let ipv4 = Ipv4Addr::from([100, 90, 215, 97]);
+        let ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0x0016, 0x588f]);
+
+        let mut device_manager = TunDeviceManager::new(1280).unwrap();
+        let _tun = device_manager.make_tun().unwrap();
+        device_manager.set_ips(ipv4, ipv6).await.unwrap();
+
+        // Configure `0.0.0.0/0` route.
+        device_manager
+            .set_routes(
+                vec![Ipv4Network::new(Ipv4Addr::UNSPECIFIED, 0).unwrap()],
+                vec![],
+            )
+            .await
+            .unwrap();
+
+        let remote = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::from([1, 1, 1, 1]), 80));
+
+        let socket = crate::platform::tcp_socket_factory(&remote).unwrap();
+        let mut stream = socket.connect(remote).await.unwrap();
+
+        // Send an HTTP request
+        stream.write_all("GET /\r\n\r\n".as_bytes()).await.unwrap();
+        let mut bytes = vec![];
+        stream.read_to_end(&mut bytes).await.unwrap();
+        let s = String::from_utf8(bytes).unwrap();
+        assert_eq!(s, "<html>\r\n<head><title>400 Bad Request</title></head>\r\n<body>\r\n<center><h1>400 Bad Request</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>\r\n");
+    }
+
+    // Starts up a WinTUN device, adds a "full-route" (`0.0.0.0/0`), and checks if we can still send packets to IPs outside of our tunnel.
+    async fn no_packet_loops_udp() {
         let ipv4 = Ipv4Addr::from([100, 90, 215, 97]);
         let ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0x0016, 0x588f]);
 

--- a/rust/bin-shared/src/tun_device_manager.rs
+++ b/rust/bin-shared/src/tun_device_manager.rs
@@ -21,7 +21,7 @@ mod tests {
     use socket_factory::DatagramOut;
     use std::{
         borrow::Cow,
-        net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+        net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},
         time::Duration,
     };
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};

--- a/rust/bin-shared/src/tun_device_manager.rs
+++ b/rust/bin-shared/src/tun_device_manager.rs
@@ -31,25 +31,14 @@ mod tests {
     async fn tunnel() {
         let _guard = firezone_logging::test("debug");
 
-        no_packet_loops_tcp(SocketAddr::V4(SocketAddrV4::new(
-            Ipv4Addr::from([1, 1, 1, 1]),
-            80,
-        )))
-        .await;
-        no_packet_loops_tcp(SocketAddr::V6(SocketAddrV6::new(
-            Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0x0, 0x0, 0x0, 0x0, 0x1111),
-            80,
-            0,
-            0,
-        )))
-        .await;
+        no_packet_loops_tcp().await;
         no_packet_loops_udp().await;
         tunnel_drop();
     }
 
     // Starts up a WinTun device, claims all routes, and checks if we can still make
     // TCP connections outside of our tunnel.
-    async fn no_packet_loops_tcp(remote: SocketAddr) {
+    async fn no_packet_loops_tcp() {
         let ipv4 = Ipv4Addr::from([100, 90, 215, 97]);
         let ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0x0016, 0x588f]);
 
@@ -66,6 +55,7 @@ mod tests {
             .await
             .unwrap();
 
+        let remote = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::from([1, 1, 1, 1]), 80));
         let socket = crate::platform::tcp_socket_factory(&remote).unwrap();
         let mut stream = socket.connect(remote).await.unwrap();
 

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -247,6 +247,8 @@ async fn add_route(route: &IpNetwork, idx: u32, handle: &Handle) {
     };
 
     let Err(err) = res else {
+        tracing::debug!(%route, iface_idx = %idx, "Created new route");
+
         return;
     };
 
@@ -267,6 +269,8 @@ async fn remove_route(route: &IpNetwork, idx: u32, handle: &Handle) {
     let res = handle.route().del(message).execute().await;
 
     let Err(err) = res else {
+        tracing::debug!(%route, iface_idx = %idx, "Removed route");
+
         return;
     };
 

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -6,7 +6,7 @@ use ring::digest;
 use std::{
     collections::HashSet,
     io::{self, Read as _},
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
     os::windows::process::CommandExt,
     path::{Path, PathBuf},
     process::{Command, Stdio},

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -110,7 +110,7 @@ impl TunDeviceManager {
         );
 
         for old_route in self.routes.difference(&new_routes) {
-            remove_route(*old_route, iface_idx);
+            remove_route(*old_route, None, iface_idx);
         }
 
         for new_route in &new_routes {
@@ -152,6 +152,7 @@ pub(crate) fn remove_route(route: IpNetwork, next_hop: Option<IpAddr>, iface_idx
     // SAFETY: Windows shouldn't store the reference anywhere, it's just a way to pass lots of arguments at once. And no other thread sees this variable.
 
     let Err(e) = unsafe { DeleteIpForwardEntry2(&entry) }.ok() else {
+        let next_hop = next_hop.map(tracing::field::display);
         tracing::debug!(%route, next_hop, %iface_idx, "Removed route");
 
         return;

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -124,7 +124,7 @@ impl TunDeviceManager {
 }
 
 // It's okay if this blocks until the route is added in the OS.
-pub(crate) fn add_route(route: IpNetwork, next_hop: Option<IpAddr>, iface_idx: u32) {
+fn add_route(route: IpNetwork, next_hop: Option<IpAddr>, iface_idx: u32) {
     const DUPLICATE_ERR: u32 = 0x80071392;
     let entry = forward_entry(route, next_hop, iface_idx);
 
@@ -145,7 +145,7 @@ pub(crate) fn add_route(route: IpNetwork, next_hop: Option<IpAddr>, iface_idx: u
 }
 
 // It's okay if this blocks until the route is removed in the OS.
-pub(crate) fn remove_route(route: IpNetwork, next_hop: Option<IpAddr>, iface_idx: u32) {
+fn remove_route(route: IpNetwork, next_hop: Option<IpAddr>, iface_idx: u32) {
     const ELEMENT_NOT_FOUND: u32 = 0x80070490;
     let entry = forward_entry(route, next_hop, iface_idx);
 

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -124,7 +124,7 @@ impl TunDeviceManager {
 }
 
 // It's okay if this blocks until the route is added in the OS.
-fn add_route(route: IpNetwork, iface_idx: u32) {
+pub(crate) fn add_route(route: IpNetwork, iface_idx: u32) {
     const DUPLICATE_ERR: u32 = 0x80071392;
     let entry = forward_entry(route, iface_idx);
 

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -296,7 +296,9 @@ fn sock_addr_to_ip_addr(addr: &IP_ADAPTER_GATEWAY_ADDRESS_LH) -> Option<IpAddr> 
     const SOCKADDR_IN_LENGTH: usize = std::mem::size_of::<SOCKADDR_IN>();
     const SOCKADDR6_IN_LENGTH: usize = std::mem::size_of::<SOCKADDR_IN6>();
 
-    Some(match addr.Address.iSockaddrLength as usize {
+    dbg!(SOCKADDR_IN_LENGTH, SOCKADDR6_IN_LENGTH);
+
+    Some(match dbg!(addr.Address.iSockaddrLength) as usize {
         SOCKADDR_IN_LENGTH => {
             // Safety: We checked that it has the right length.
             let addr: &SOCKADDR_IN = unsafe { std::ptr::read(addr.Address.lpSockaddr as *const _) };

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -113,11 +113,11 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
 
         let route = match addr {
             IpAddr::V4(_) if dp.PrefixLength == 32 => {
-                // Safety: Access to the union is safe.
+                // Safety: Any 32 bit number is a valid IPv4 address
                 IpAddr::V4(unsafe { dp.Prefix.Ipv4 }.sin_addr.into())
             }
             IpAddr::V6(_) if dp.PrefixLength == 128 => {
-                // Safety: Access to the union is safe.
+                // Safety: Any 128 bit number is a valid IPv6 address
                 IpAddr::V6(unsafe { dp.Prefix.Ipv6 }.sin6_addr.into())
             }
             IpAddr::V4(_) | IpAddr::V6(_) => continue,

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -123,6 +123,7 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
 
         if let Err(e) = unsafe { DeleteIpForwardEntry2(entry) }.ok() {
             tracing::warn!("Failed to delete routing entry: {e}");
+            continue;
         };
 
         tracing::debug!(%route, %next_hop, %iface_idx, "Deleted stale route entry");

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -121,11 +121,11 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
         let iface_idx = entry_ref.InterfaceIndex;
 
         if let Err(e) = unsafe { DeleteIpForwardEntry2(entry) }.ok() {
-            tracing::warn!("Failed to delete routing entry: {e}");
+            tracing::warn!("Failed to remove routing entry: {e}");
             continue;
         };
 
-        tracing::debug!(%route, %iface_idx, "Deleted stale route entry");
+        tracing::debug!(%route, %iface_idx, "Removed stale route entry");
     }
 
     Ok(())
@@ -167,7 +167,9 @@ impl RoutingTableEntry {
                 }
             })?;
 
-        tracing::debug!(%route, "Created new route");
+        let iface_idx = prototype.InterfaceIndex;
+
+        tracing::debug!(%route, %iface_idx, "Created new route");
 
         Ok(Self {
             entry: prototype,
@@ -186,7 +188,7 @@ impl Drop for RoutingTableEntry {
             return;
         };
 
-        tracing::debug!(route = %self.route, %iface_idx, "Deleted route");
+        tracing::debug!(route = %self.route, %iface_idx, "Removed route");
     }
 }
 

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -118,9 +118,14 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
             continue;
         }
 
+        let next_hop = SocketAddr::from(entry_ref.NextHop);
+        let iface_idx = entry_ref.InterfaceIndex;
+
         if let Err(e) = unsafe { DeleteIpForwardEntry2(entry) }.ok() {
             tracing::warn!("Failed to delete routing entry: {e}");
         };
+
+        tracing::debug!(%route, %next_hop, %iface_idx, "Deleted stale route entry");
     }
 
     Ok(())
@@ -160,6 +165,8 @@ impl RoutingTableEntry {
                     Err(io::Error::other(e))
                 }
             })?;
+
+        tracing::debug!(%route, "Created new route");
 
         Ok(Self { entry: prototype })
     }

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -61,7 +61,7 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
     let socket = socket_factory::tcp(addr)?;
     // socket.bind((local, 0).into())?; // To avoid routing loops, all TCP sockets are bound to the "best" source IP.
 
-    crate::tun_device_manager::windows::add_route(&(addr.ip().into()), ifindex);
+    crate::tun_device_manager::windows::add_route(addr.ip().into(), ifindex);
 
     Ok(socket)
 }

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -87,7 +87,7 @@ struct RoutingTableEntry {
 
 impl RoutingTableEntry {
     /// Creates a new routing table entry by using the given prototype and overriding the route.
-    fn create(route: IpAddr, mut prototype: MIB_IPFORWARD_ROW2) -> io::Result<()> {
+    fn create(route: IpAddr, mut prototype: MIB_IPFORWARD_ROW2) -> io::Result<Self> {
         let prefix = &mut prototype.DestinationPrefix;
         match route {
             IpAddr::V4(x) => {
@@ -215,7 +215,6 @@ fn is_tun(adapter: &IP_ADAPTER_ADDRESSES_LH) -> bool {
     friendly_name == TUNNEL_NAME
 }
 
-#[derive(PartialEq, Eq)]
 struct Route {
     metric: u32,
     addr: IpAddr,
@@ -234,6 +233,14 @@ impl PartialOrd for Route {
         Some(self.cmp(other))
     }
 }
+
+impl PartialEq for Route {
+    fn eq(&self, other: &Self) -> bool {
+        self.metric.eq(&other.metric) && self.addr.eq(&other.addr)
+    }
+}
+
+impl Eq for Route {}
 
 fn find_best_route_for_luid(luid: &NET_LUID_LH, dst: IpAddr) -> Result<Route> {
     let addr: SOCKADDR_INET = SocketAddr::from((dst, 0)).into();

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -105,20 +105,13 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
         let dp = entry_ref.DestinationPrefix;
 
         let route = match addr {
-            IpAddr::V4(_) => {
-                if dp.PrefixLength != 32 {
-                    continue;
-                }
-
+            IpAddr::V4(_) if dp.PrefixLength == 32 => {
                 IpAddr::V4(unsafe { dp.Prefix.Ipv4 }.sin_addr.into())
             }
-            IpAddr::V6(_) => {
-                if dp.PrefixLength != 128 {
-                    continue;
-                };
-
-                IpAddr::V6(unsafe { dp.Prefix.Ipv6 }.sin6_addr.into())
+            IpAddr::V6(_) if dp.PrefixLength == 128 => {
+                IpAddr::V6(unsafe { dp.Prefix.Ipv6 }.sin_addr.into())
             }
+            _ => continue,
         };
 
         if route != addr {

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -100,6 +100,7 @@ impl RoutingTableEntry {
             }
         }
 
+        // Safety: The prototype is initialised correctly.
         unsafe { CreateIpForwardEntry2(&prototype) }
             .ok()
             .map_err(|e| io::Error::other(e))?;
@@ -110,6 +111,7 @@ impl RoutingTableEntry {
 
 impl Drop for RoutingTableEntry {
     fn drop(&mut self) {
+        // Safety: The entry we stored is valid.
         let Err(e) = unsafe { DeleteIpForwardEntry2(&self.entry) }.ok() else {
             return;
         };

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -56,12 +56,12 @@ pub fn app_local_data_dir() -> Result<PathBuf> {
 }
 
 pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
-    let (_, ifindex) = get_best_non_tunnel_route(addr.ip())?;
+    let (local, ifindex) = get_best_non_tunnel_route(addr.ip())?;
 
     let socket = socket_factory::tcp(addr)?;
-    // socket.bind((local, 0).into())?; // To avoid routing loops, all TCP sockets are bound to the "best" source IP.
+    socket.bind((local, 0).into())?; // To avoid routing loops, all TCP sockets are bound to the "best" source IP.
 
-    crate::tun_device_manager::windows::add_route(addr.ip().into(), ifindex);
+    crate::tun_device_manager::windows::add_route(addr.ip().into(), Some(IpAddr::V4(Ipv4Addr::new(192, 168, 86, 1))), ifindex);
 
     Ok(socket)
 }

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -6,7 +6,7 @@ use std::{
     cmp::Ordering,
     io,
     mem::MaybeUninit,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     path::PathBuf,
     ptr::null,
 };
@@ -54,7 +54,7 @@ pub fn app_local_data_dir() -> Result<PathBuf> {
     Ok(path)
 }
 
-pub fn tcp_socket_factory(addr: &std::net::SocketAddr) -> io::Result<TcpSocket> {
+pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
     let route = get_best_non_tunnel_route(addr.ip())?;
 
     let mut socket = socket_factory::tcp(addr)?;
@@ -69,7 +69,7 @@ pub fn tcp_socket_factory(addr: &std::net::SocketAddr) -> io::Result<TcpSocket> 
     Ok(socket)
 }
 
-pub fn udp_socket_factory(src_addr: &std::net::SocketAddr) -> io::Result<UdpSocket> {
+pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
     let source_ip_resolver = |dst| Ok(Some(get_best_non_tunnel_route(dst)?.addr));
 
     let socket =
@@ -87,14 +87,14 @@ struct RoutingTableEntry {
 
 impl RoutingTableEntry {
     /// Creates a new routing table entry by using the given prototype and overriding the route.
-    fn create(route: std::net::IpAddr, mut prototype: MIB_IPFORWARD_ROW2) -> io::Result<Self> {
+    fn create(route: IpAddr, mut prototype: MIB_IPFORWARD_ROW2) -> io::Result<Self> {
         let prefix = &mut prototype.DestinationPrefix;
         match route {
-            std::net::IpAddr::V4(x) => {
+            IpAddr::V4(x) => {
                 prefix.PrefixLength = 32;
                 prefix.Prefix.Ipv4 = SocketAddrV4::new(x, 0).into();
             }
-            std::net::IpAddr::V6(x) => {
+            IpAddr::V6(x) => {
                 prefix.PrefixLength = 128;
                 prefix.Prefix.Ipv6 = SocketAddrV6::new(x, 0, 0, 0).into();
             }
@@ -131,7 +131,7 @@ impl Drop for RoutingTableEntry {
 /// This function performs multiple syscalls and is thus fairly expensive.
 /// It should **not** be called on a per-packet basis.
 /// Callers should instead cache the result until network interfaces change.
-fn get_best_non_tunnel_route(dst: std::net::IpAddr) -> io::Result<Route> {
+fn get_best_non_tunnel_route(dst: IpAddr) -> io::Result<Route> {
     let route = list_adapters()?
         .filter(|adapter| !is_tun(adapter))
         .filter_map(|adapter| find_best_route_for_luid(&adapter.Luid, dst).ok())
@@ -219,7 +219,7 @@ fn is_tun(adapter: &IP_ADAPTER_ADDRESSES_LH) -> bool {
 
 struct Route {
     metric: u32,
-    addr: std::net::IpAddr,
+    addr: IpAddr,
 
     original: MIB_IPFORWARD_ROW2,
 }
@@ -244,8 +244,8 @@ impl PartialEq for Route {
 
 impl Eq for Route {}
 
-fn find_best_route_for_luid(luid: &NET_LUID_LH, dst: std::net::IpAddr) -> Result<Route> {
-    let addr: SOCKADDR_INET = std::net::SocketAddr::from((dst, 0)).into();
+fn find_best_route_for_luid(luid: &NET_LUID_LH, dst: IpAddr) -> Result<Route> {
+    let addr: SOCKADDR_INET = SocketAddr::from((dst, 0)).into();
     let mut best_route: MaybeUninit<MIB_IPFORWARD_ROW2> = MaybeUninit::zeroed();
     let mut best_src: MaybeUninit<SOCKADDR_INET> = MaybeUninit::zeroed();
 
@@ -278,12 +278,12 @@ fn find_best_route_for_luid(luid: &NET_LUID_LH, dst: std::net::IpAddr) -> Result
 }
 
 // SAFETY: si_family must be always set in the union, which will be the case for a valid SOCKADDR_INET
-unsafe fn to_ip_addr(addr: SOCKADDR_INET, dst: std::net::IpAddr) -> Option<std::net::IpAddr> {
+unsafe fn to_ip_addr(addr: SOCKADDR_INET, dst: IpAddr) -> Option<IpAddr> {
     match (addr.si_family, dst) {
-        (ADDRESS_FAMILY(0), std::net::IpAddr::V4(_)) | (ADDRESS_FAMILY(2), _) => {
+        (ADDRESS_FAMILY(0), IpAddr::V4(_)) | (ADDRESS_FAMILY(2), _) => {
             Some(Ipv4Addr::from(addr.Ipv4.sin_addr).into())
         }
-        (ADDRESS_FAMILY(0), std::net::IpAddr::V6(_)) | (ADDRESS_FAMILY(23), _) => {
+        (ADDRESS_FAMILY(0), IpAddr::V6(_)) | (ADDRESS_FAMILY(23), _) => {
             Some(Ipv6Addr::from(addr.Ipv6.sin6_addr).into())
         }
         _ => None,

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -120,7 +120,7 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
                 // Safety: Access to the union is safe.
                 IpAddr::V6(unsafe { dp.Prefix.Ipv6 }.sin6_addr.into())
             }
-            _ => continue,
+            IpAddr::V4(_) | IpAddr::V6(_) => continue,
         };
 
         if route != addr {

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -10,13 +10,12 @@ use std::{
     path::PathBuf,
     ptr::null,
 };
-use windows::Win32::NetworkManagement::IpHelper::IP_ADAPTER_GATEWAY_ADDRESS_LH;
 use windows::Win32::NetworkManagement::{IpHelper::GetAdaptersAddresses, Ndis::NET_LUID_LH};
 use windows::Win32::{
     NetworkManagement::IpHelper::{
         GetBestRoute2, GET_ADAPTERS_ADDRESSES_FLAGS, IP_ADAPTER_ADDRESSES_LH, MIB_IPFORWARD_ROW2,
     },
-    Networking::WinSock::{ADDRESS_FAMILY, AF_UNSPEC, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_INET},
+    Networking::WinSock::{ADDRESS_FAMILY, AF_UNSPEC, SOCKADDR_INET},
 };
 
 use crate::tun_device_manager::windows::{add_route, remove_route};

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -118,7 +118,6 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
             continue;
         }
 
-        let next_hop = SocketAddr::from(entry_ref.NextHop);
         let iface_idx = entry_ref.InterfaceIndex;
 
         if let Err(e) = unsafe { DeleteIpForwardEntry2(entry) }.ok() {
@@ -126,7 +125,7 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
             continue;
         };
 
-        tracing::debug!(%route, %next_hop, %iface_idx, "Deleted stale route entry");
+        tracing::debug!(%route, %iface_idx, "Deleted stale route entry");
     }
 
     Ok(())

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -109,7 +109,7 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
                 IpAddr::V4(unsafe { dp.Prefix.Ipv4 }.sin_addr.into())
             }
             IpAddr::V6(_) if dp.PrefixLength == 128 => {
-                IpAddr::V6(unsafe { dp.Prefix.Ipv6 }.sin_addr.into())
+                IpAddr::V6(unsafe { dp.Prefix.Ipv6 }.sin6_addr.into())
             }
             _ => continue,
         };

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -17,9 +17,8 @@ use heartbeat::{Heartbeat, MissedLastHeartbeat};
 use rand_core::{OsRng, RngCore};
 use secrecy::{ExposeSecret, Secret};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use socket_factory::{SocketFactory, TcpSocket};
+use socket_factory::{SocketFactory, TcpSocket, TcpStream};
 use std::task::{Context, Poll, Waker};
-use tokio::net::TcpStream;
 use tokio_tungstenite::client_async_tls;
 use tokio_tungstenite::tungstenite::http::StatusCode;
 use tokio_tungstenite::{

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
 use socket2::SockAddr;
 use std::any::Any;
 use std::collections::hash_map::Entry;
+use std::pin::Pin;
 use tokio::io::Interest;
 
 pub trait SocketFactory<S>: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}
@@ -53,12 +54,17 @@ pub fn udp(addr: &SocketAddr) -> io::Result<UdpSocket> {
 pub struct TcpSocket {
     inner: tokio::net::TcpSocket,
     /// A location to store additional data with the [`TcpSocket`].
-    backpack: Option<Box<dyn Any + Send + Sync + 'static>>,
+    backpack: Option<Box<dyn Any + Send + Sync + Unpin + 'static>>,
 }
 
 impl TcpSocket {
-    pub async fn connect(self, addr: SocketAddr) -> io::Result<tokio::net::TcpStream> {
-        self.inner.connect(addr).await
+    pub async fn connect(self, addr: SocketAddr) -> io::Result<TcpStream> {
+        let tcp_stream = self.inner.connect(addr).await?;
+
+        Ok(TcpStream {
+            inner: tcp_stream,
+            _backpack: self.backpack,
+        })
     }
 
     pub fn bind(&self, addr: SocketAddr) -> io::Result<()> {
@@ -68,8 +74,45 @@ impl TcpSocket {
     /// Pack some custom data into the backpack of this [`TcpSocket`].
     ///
     /// The data will be carried around until the [`TcpSocket`] is dropped.
-    pub fn pack(&mut self, luggage: impl Any + Send + Sync + 'static) {
+    pub fn pack(&mut self, luggage: impl Any + Send + Sync + Unpin + 'static) {
         self.backpack = Some(Box::new(luggage));
+    }
+}
+
+pub struct TcpStream {
+    inner: tokio::net::TcpStream,
+    /// A location to store additional data with the [`TcpStream`].
+    _backpack: Option<Box<dyn Any + Send + Sync + Unpin + 'static>>,
+}
+
+impl tokio::io::AsyncWrite for TcpStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        Pin::new(&mut self.as_mut().inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.as_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.as_mut().inner).poll_shutdown(cx)
+    }
+}
+
+impl tokio::io::AsyncRead for TcpStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.as_mut().inner).poll_read(cx, buf)
     }
 }
 


### PR DESCRIPTION
In #6032, we attempted to fix routing loops for Windows and did so successfully for UDP packets. For TCP sockets, we believed that binding the socket to an interface is enough to prevent routing loops. This assumptions is wrong.

>  On Windows, a call to bind() affects card selection only incoming traffic, not outgoing traffic.
>
> Thus, on a client running in a multi-homed system (i.e., more than one interface card), it's the network stack that selects the card to use, and it makes its selection based solely on the destination IP, which in turn is based on the routing table. A call to bind() will not affect the choice of the card in any way.

On most of our testing machines, this problem didn't surface but it turns out that on some machines, especially with WiFi cards there is a conflict between the routes added on the system. In particular, with the Internet resource active, we also add a catch-all route that we _want_ to have the most priority, i.e. Windows SHOULD send all traffic to our TUN device. Except for traffic that we generate, like TCP connections to the portal or UDP packets sent to gateways, relays or DNS servers.

It appears that on some systems, mostly with Ethernet adapters, Windows picks the "correct" interface for our socket and sends traffic via that but on other systems, it doesn't. TCP sockets are only used for the WebSocket connection to the portal. Without that one, Firezone completely stops working because we can't send any control messages.

To reliably fix this issue, we need to add a dedicated route for the target IP of each TCP socket that is more specific than the Internet resource route (`0.0.0.0/0`) but otherwise identical. We do this as part of creating a new TCP socket. This route is for the _default_ interface and thus, doesn't get automatically removed when Firezone exits.

We implement a RAII guard that attempts to drop the route on a best-effort basis. Despite this RAII guard, this route can linger around in case Firezone is being forced to exit or exits in otherwise unclean ways. To avoid lingering routes, we always delete all routing table entries matching the IP of the portal just before we are about to add one.

Fixes: #6591.

[0]: https://forums.codeguru.com/showthread.php?487139-Socket-binding-with-routing-table&s=a31637836c1bf7f0bc71c1955e47bdf9&p=1891235#post1891235