### PR TITLE
chore(rust/windows): more detailed error log for `wintun::Adapter::create`

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -226,7 +226,13 @@ impl Tun {
         let uuid = uuid::Uuid::from_str(TUNNEL_UUID)
             .expect("static UUID should always parse correctly")
             .as_u128();
-        let adapter = &Adapter::create(&wintun, TUNNEL_NAME, TUNNEL_NAME, Some(uuid))?;
+        let adapter = match Adapter::create(&wintun, TUNNEL_NAME, TUNNEL_NAME, Some(uuid)) {
+            Ok(x) => x,
+            Err(error) => {
+                tracing::error!(?error, "Failed in `Adapter::create`");
+                return Err(error)?;
+            }
+        };
         let iface_idx = adapter.get_adapter_index()?;
 
         set_iface_config(adapter.get_luid(), mtu)?;


### PR DESCRIPTION
Without this we don't log the `std::io::ErrorKind`, which is useful to know.

Refs #6547