### PR TITLE
fix(portal): Disable IP check for browser session tokens

### DIFF
--- a/elixir/apps/domain/lib/domain/auth.ex
+++ b/elixir/apps/domain/lib/domain/auth.ex
@@ -745,13 +745,14 @@ defmodule Domain.Auth do
          %Context{type: context_type} = context
        )
        when token_type == :browser or context_type == :browser do
-    cond do
-      # We disabled this check because Google Chrome uses "Happy Eyeballs" algorithm which sometimes
-      # connects to the server using IPv4 for HTTP request and then uses IPv6 for WebSockets.
-      # This causes the remote IP to change leading to LiveView auth redirect loops.
-      # token.created_by_remote_ip.address != context.remote_ip -> {:error, :invalid_remote_ip}
-      token.created_by_user_agent != context.user_agent -> {:error, :invalid_user_agent}
-      true -> :ok
+    # We disabled this check because Google Chrome uses "Happy Eyeballs" algorithm which sometimes
+    # connects to the server using IPv4 for HTTP request and then uses IPv6 for WebSockets.
+    # This causes the remote IP to change leading to LiveView auth redirect loops.
+    # token.created_by_remote_ip.address != context.remote_ip -> {:error, :invalid_remote_ip}
+    if token.created_by_user_agent != context.user_agent do
+      {:error, :invalid_user_agent}
+    else
+      :ok
     end
   end
 

--- a/elixir/apps/domain/lib/domain/auth.ex
+++ b/elixir/apps/domain/lib/domain/auth.ex
@@ -746,7 +746,10 @@ defmodule Domain.Auth do
        )
        when token_type == :browser or context_type == :browser do
     cond do
-      token.created_by_remote_ip.address != context.remote_ip -> {:error, :invalid_remote_ip}
+      # We disabled this check because Google Chrome uses "Happy Eyeballs" algorithm which sometimes
+      # connects to the server using IPv4 for HTTP request and then uses IPv6 for WebSockets.
+      # This causes the remote IP to change leading to LiveView auth redirect loops.
+      # token.created_by_remote_ip.address != context.remote_ip -> {:error, :invalid_remote_ip}
       token.created_by_user_agent != context.user_agent -> {:error, :invalid_user_agent}
       true -> :ok
     end

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -4147,14 +4147,14 @@ defmodule Domain.AuthTest do
       assert authenticate(nonce <> fragment, context) == {:error, :unauthorized}
     end
 
-    test "returns an error when browser ip address is changed", %{
-      nonce: nonce,
-      browser_context: context,
-      browser_fragment: fragment
-    } do
-      context = %{context | remote_ip: Domain.Fixture.unique_ipv4()}
-      assert authenticate(nonce <> fragment, context) == {:error, :unauthorized}
-    end
+    # test "returns an error when browser ip address is changed", %{
+    #   nonce: nonce,
+    #   browser_context: context,
+    #   browser_fragment: fragment
+    # } do
+    #   context = %{context | remote_ip: Domain.Fixture.unique_ipv4()}
+    #   assert authenticate(nonce <> fragment, context) == {:error, :unauthorized}
+    # end
 
     test "returns subject for client token", %{
       account: account,

--- a/terraform/environments/production/portal.tf
+++ b/terraform/environments/production/portal.tf
@@ -513,8 +513,7 @@ module "web" {
   application_name    = "web"
   application_version = replace(local.portal_image_tag, ".", "-")
 
-  application_dns_tld_v4 = "app.${local.tld}"
-  application_dns_tld_v6 = "app-ipv6.${local.tld}"
+  application_dns_tld = "app.${local.tld}"
 
   application_cdn_enabled = true
 
@@ -584,8 +583,7 @@ module "api" {
   application_name    = "api"
   application_version = replace(local.portal_image_tag, ".", "-")
 
-  application_dns_tld_v4 = "api.${local.tld}"
-  application_dns_tld_v6 = "api.${local.tld}"
+  application_dns_tld = "api.${local.tld}"
 
   application_ports = [
     {

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -492,8 +492,7 @@ module "web" {
   application_name    = "web"
   application_version = replace(var.image_tag, ".", "-")
 
-  application_dns_tld_v4 = "app.${local.tld}"
-  application_dns_tld_v6 = "app-ipv6.${local.tld}"
+  application_dns_tld = "app.${local.tld}"
 
   application_cdn_enabled = true
 
@@ -566,8 +565,7 @@ module "api" {
   application_name    = "api"
   application_version = replace(var.image_tag, ".", "-")
 
-  application_dns_tld_v4 = "api.${local.tld}"
-  application_dns_tld_v6 = "api.${local.tld}"
+  application_dns_tld = "api.${local.tld}"
 
   application_ports = [
     {

--- a/terraform/modules/google-cloud/apps/elixir/dns.tf
+++ b/terraform/modules/google-cloud/apps/elixir/dns.tf
@@ -1,10 +1,10 @@
 # Create DNS records for the application
 resource "google_dns_record_set" "application-ipv4" {
-  count = var.application_dns_tld_v4 != null ? 1 : 0
+  count = var.application_dns_tld != null ? 1 : 0
 
   project = var.project_id
 
-  name = "${var.application_dns_tld_v4}."
+  name = "${var.application_dns_tld}."
   type = "A"
   ttl  = 300
 
@@ -19,11 +19,11 @@ resource "google_dns_record_set" "application-ipv4" {
 }
 
 resource "google_dns_record_set" "application-ipv6" {
-  count = var.application_dns_tld_v6 != null ? 1 : 0
+  count = var.application_dns_tld != null ? 1 : 0
 
   project = var.project_id
 
-  name = "${var.application_dns_tld_v6}."
+  name = "${var.application_dns_tld}."
   type = "AAAA"
   ttl  = 300
 

--- a/terraform/modules/google-cloud/apps/elixir/network.tf
+++ b/terraform/modules/google-cloud/apps/elixir/network.tf
@@ -9,7 +9,7 @@ locals {
     "35.191.0.0/16"
   ]
 
-  public_application = var.application_dns_tld_v4 != null
+  public_application = var.application_dns_tld != null
 }
 
 # Define a security policy which allows to filter traffic by IP address,
@@ -288,38 +288,19 @@ resource "google_compute_ssl_policy" "application" {
 }
 
 ## Create a managed SSL certificate
-locals {
-  ssl_managed_domains = distinct(compact([
-    var.application_dns_tld_v4,
-    var.application_dns_tld_v6
-  ]))
-}
-
-# This is a black magic to ensure that the certificate is recreated when the domains change,
-# see https://github.com/hashicorp/terraform-provider-google/issues/5356#issuecomment-617974978
-resource "random_id" "certificate" {
-  byte_length = 4
-
-  keepers = {
-    domains = join(",", local.ssl_managed_domains)
-  }
-}
-
 resource "google_compute_managed_ssl_certificate" "default" {
   count = local.public_application ? 1 : 0
 
   project = var.project_id
 
-  name = "${local.application_name}-mig-lb-cert-v${random_id.certificate.hex}"
+  name = "${local.application_name}-mig-lb-cert"
 
   type = "MANAGED"
 
   managed {
-    domains = local.ssl_managed_domains
-  }
-
-  lifecycle {
-    create_before_destroy = true
+    domains = [
+      var.application_dns_tld,
+    ]
   }
 
   depends_on = [
@@ -382,7 +363,7 @@ resource "google_compute_target_https_proxy" "default" {
 
   url_map = google_compute_url_map.default[0].self_link
 
-  ssl_certificates = [for cert in google_compute_managed_ssl_certificate.default : cert.id]
+  ssl_certificates = google_compute_managed_ssl_certificate.default[*].self_link
   ssl_policy       = google_compute_ssl_policy.application[0].self_link
   quic_override    = "NONE"
 }

--- a/terraform/modules/google-cloud/apps/elixir/outputs.tf
+++ b/terraform/modules/google-cloud/apps/elixir/outputs.tf
@@ -11,5 +11,5 @@ output "instance_group" {
 }
 
 output "host" {
-  value = var.application_dns_tld_v4
+  value = var.application_dns_tld
 }

--- a/terraform/modules/google-cloud/apps/elixir/variables.tf
+++ b/terraform/modules/google-cloud/apps/elixir/variables.tf
@@ -224,20 +224,12 @@ variable "application_token_scopes" {
   description = "Any extra oAuth2 token scopes granted to the token of default service account."
 }
 
-variable "application_dns_tld_v4" {
+variable "application_dns_tld" {
   type     = string
   nullable = true
   default  = null
 
-  description = "IPv4 DNS host which will be used to create DNS records for the application and provision SSL-certificates."
-}
-
-variable "application_dns_tld_v6" {
-  type     = string
-  nullable = true
-  default  = null
-
-  description = "IPv6 DNS host which will be used to create DNS records for the application and provision SSL-certificates."
+  description = "DNS host which will be used to create DNS records for the application and provision SSL-certificates."
 }
 
 variable "application_cdn_enabled" {


### PR DESCRIPTION
This PR reverts commit that moves out IPv6 address to a separate subdomain (deploying that will cause a prod downtime) and simply removes the check that causes redirect loops.