### PR TITLE
feat(portal): Reinit client when itself or a known group were updated

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -56,17 +56,8 @@ defmodule API.Client.Channel do
     end
   end
 
-  @impl true
-  def handle_info({:after_join, {opentelemetry_ctx, opentelemetry_span_ctx}}, socket) do
-    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
-    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
-
-    OpenTelemetry.Tracer.with_span "client.after_join" do
-      :ok = Clients.connect_client(socket.assigns.client)
-
-      # Subscribe for account config updates
-      :ok = Accounts.subscribe_to_events_in_account(socket.assigns.client.account_id)
-
+  def init(socket) do
+    OpenTelemetry.Tracer.with_span "client.init" do
       {:ok, resources} =
         Resources.all_authorized_resources(socket.assigns.subject,
           preload: [
@@ -79,15 +70,11 @@ defmodule API.Client.Channel do
 
       # We subscribe for all resource events but only care about update events,
       # where resource might be renamed which should be propagated to the UI.
-      :ok = Enum.each(resources, &Resources.subscribe_to_events_for_resource/1)
-
-      # We subscribe for membership updates for all actor groups the client is a member of,
-      :ok = Actors.subscribe_to_membership_updates_for_actor(socket.assigns.subject.actor)
-
-      # We subscribe for policy access events for the actor and the groups the client is a member of,
-      actor_group_ids = Actors.all_actor_group_ids!(socket.assigns.subject.actor)
-      :ok = Enum.each(actor_group_ids, &Policies.subscribe_to_events_for_actor_group/1)
-      :ok = Policies.subscribe_to_events_for_actor(socket.assigns.subject.actor)
+      :ok =
+        Enum.each(resources, fn resource ->
+          :ok = Resources.unsubscribe_from_events_for_resource(resource)
+          :ok = Resources.subscribe_to_events_for_resource(resource)
+        end)
 
       # Return all connected relays for the account
       {:ok, relays} = select_relays(socket)
@@ -97,16 +84,38 @@ defmodule API.Client.Channel do
       resources =
         map_and_filter_compatible_resources(resources, socket.assigns.client.last_seen_version)
 
-      :ok =
-        push(socket, "init", %{
-          resources: Views.Resource.render_many(resources),
-          relays: Views.Relay.render_many(relays, socket.assigns.subject.expires_at),
-          interface:
-            Views.Interface.render(%{
-              socket.assigns.client
-              | account: socket.assigns.subject.account
-            })
-        })
+      push(socket, "init", %{
+        resources: Views.Resource.render_many(resources),
+        relays: Views.Relay.render_many(relays, socket.assigns.subject.expires_at),
+        interface:
+          Views.Interface.render(%{
+            socket.assigns.client
+            | account: socket.assigns.subject.account
+          })
+      })
+    end
+  end
+
+  @impl true
+  def handle_info({:after_join, {opentelemetry_ctx, opentelemetry_span_ctx}}, socket) do
+    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
+    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
+
+    OpenTelemetry.Tracer.with_span "client.after_join" do
+      :ok = Clients.connect_client(socket.assigns.client)
+
+      # Subscribe for account config updates
+      :ok = Accounts.subscribe_to_events_in_account(socket.assigns.client.account_id)
+
+      # We subscribe for membership updates for all actor groups the client is a member of,
+      :ok = Actors.subscribe_to_membership_updates_for_actor(socket.assigns.subject.actor)
+
+      # We subscribe for policy access events for the actor and the groups the client is a member of,
+      actor_group_ids = Actors.all_actor_group_ids!(socket.assigns.subject.actor)
+      :ok = Enum.each(actor_group_ids, &Policies.subscribe_to_events_for_actor_group/1)
+      :ok = Policies.subscribe_to_events_for_actor(socket.assigns.subject.actor)
+
+      :ok = init(socket)
 
       {:noreply, socket}
     end
@@ -125,6 +134,18 @@ defmodule API.Client.Channel do
       })
 
     {:noreply, socket}
+  end
+
+  # This event is sent when client is updated (eg. changed, verified, etc.),
+  # so we just re-initialize the client the same way as after join
+  def handle_info(:updated, socket) do
+    OpenTelemetry.Ctx.attach(socket.assigns.opentelemetry_ctx)
+    OpenTelemetry.Tracer.set_current_span(socket.assigns.opentelemetry_span_ctx)
+
+    OpenTelemetry.Tracer.with_span "client.updated" do
+      :ok = init(socket)
+      {:noreply, socket}
+    end
   end
 
   # Message is scheduled by schedule_expiration/1 on topic join to be sent

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -717,6 +717,18 @@ defmodule API.Client.ChannelTest do
     end
   end
 
+  describe "handle_info/2 :updated" do
+    test "sends init message", %{
+      socket: socket
+    } do
+      assert_push "init", %{}
+
+      send(socket.channel_pid, :updated)
+
+      assert_push "init", %{}
+    end
+  end
+
   describe "handle_info/2 :token_expired" do
     test "sends a token_expired messages and closes the socket", %{
       socket: socket

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -156,7 +156,8 @@ defmodule API.Client.ChannelTest do
 
   describe "join/3" do
     test "tracks presence after join", %{account: account, client: client} do
-      presence = Domain.Clients.Presence.list(Domain.Clients.account_presence_topic(account))
+      presence =
+        Domain.Clients.Presence.list(Domain.Clients.account_clients_presence_topic(account))
 
       assert %{metas: [%{online_at: online_at, phx_ref: _ref}]} = Map.fetch!(presence, client.id)
       assert is_number(online_at)

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -51,7 +51,8 @@ defmodule API.Gateway.ChannelTest do
 
   describe "join/3" do
     test "tracks presence after join", %{account: account, gateway: gateway} do
-      presence = Domain.Gateways.Presence.list(Domain.Gateways.account_presence_topic(account))
+      presence =
+        Domain.Gateways.Presence.list(Domain.Gateways.account_gateways_presence_topic(account))
 
       assert %{metas: [%{online_at: online_at, phx_ref: _ref}]} = Map.fetch!(presence, gateway.id)
       assert is_number(online_at)

--- a/elixir/apps/domain/lib/domain/clients.ex
+++ b/elixir/apps/domain/lib/domain/clients.ex
@@ -181,6 +181,14 @@ defmodule Domain.Clients do
         with: &Client.Changeset.update(&1, attrs),
         preload: [:online?]
       )
+      |> case do
+        {:ok, client} ->
+          :ok = broadcast_to_client(client, :updated)
+          {:ok, client}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 
@@ -197,6 +205,7 @@ defmodule Domain.Clients do
       |> case do
         {:ok, client} ->
           client = Repo.preload(client, [:verified_by_actor, :verified_by_identity])
+          :ok = broadcast_to_client(client, :updated)
           {:ok, client}
 
         {:error, reason} ->
@@ -215,6 +224,14 @@ defmodule Domain.Clients do
         with: &Client.Changeset.remove_verification(&1),
         preload: [:online?]
       )
+      |> case do
+        {:ok, client} ->
+          :ok = broadcast_to_client(client, :updated)
+          {:ok, client}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 

--- a/elixir/apps/domain/lib/domain/clients.ex
+++ b/elixir/apps/domain/lib/domain/clients.ex
@@ -107,7 +107,7 @@ defmodule Domain.Clients do
   @doc false
   def preload_clients_presence([client]) do
     client.account_id
-    |> account_presence_topic()
+    |> account_clients_presence_topic()
     |> Presence.get_by_key(client.id)
     |> case do
       [] -> %{client | online?: false}
@@ -124,7 +124,7 @@ defmodule Domain.Clients do
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
       |> Enum.reduce(%{}, fn account_id, acc ->
-        connected_clients = account_id |> account_presence_topic() |> Presence.list()
+        connected_clients = account_id |> account_clients_presence_topic() |> Presence.list()
         Map.merge(acc, connected_clients)
       end)
 
@@ -291,56 +291,57 @@ defmodule Domain.Clients do
 
   def connect_client(%Client{} = client) do
     with {:ok, _} <-
-           Presence.track(self(), account_presence_topic(client.account_id), client.id, %{
+           Presence.track(self(), account_clients_presence_topic(client.account_id), client.id, %{
              online_at: System.system_time(:second)
            }),
-         {:ok, _} <- Presence.track(self(), actor_presence_topic(client.actor_id), client.id, %{}) do
+         {:ok, _} <-
+           Presence.track(self(), actor_clients_presence_topic(client.actor_id), client.id, %{}) do
       :ok = PubSub.subscribe(client_topic(client))
-      # :ok = PubSub.subscribe(actor_topic(client.actor_id))
+      # :ok = PubSub.subscribe(actor_clients_topic(client.actor_id))
       # :ok = PubSub.subscribe(identity_topic(client.actor_id))
-      :ok = PubSub.subscribe(account_topic(client.account_id))
+      :ok = PubSub.subscribe(account_clients_topic(client.account_id))
       :ok
     end
   end
 
   ### Presence
 
-  def account_presence_topic(account_or_id),
-    do: "presences:#{account_topic(account_or_id)}"
+  def account_clients_presence_topic(account_or_id),
+    do: "presences:#{account_clients_topic(account_or_id)}"
 
-  defp actor_presence_topic(actor_or_id),
-    do: "presences:#{actor_topic(actor_or_id)}"
+  defp actor_clients_presence_topic(actor_or_id),
+    do: "presences:#{actor_clients_topic(actor_or_id)}"
 
   ### PubSub
 
   defp client_topic(%Client{} = client), do: client_topic(client.id)
   defp client_topic(client_id), do: "clients:#{client_id}"
 
-  defp account_topic(%Accounts.Account{} = account), do: account_topic(account.id)
-  defp account_topic(account_id), do: "account_clients:#{account_id}"
+  defp account_clients_topic(%Accounts.Account{} = account), do: account_clients_topic(account.id)
+  defp account_clients_topic(account_id), do: "account_clients:#{account_id}"
 
-  defp actor_topic(%Actors.Actor{} = actor), do: actor_topic(actor.id)
-  defp actor_topic(actor_id), do: "actor_clients:#{actor_id}"
+  defp actor_clients_topic(%Actors.Actor{} = actor), do: actor_clients_topic(actor.id)
+  defp actor_clients_topic(actor_id), do: "actor_clients:#{actor_id}"
 
   def subscribe_to_clients_presence_in_account(account_or_id) do
-    PubSub.subscribe(account_presence_topic(account_or_id))
+    PubSub.subscribe(account_clients_presence_topic(account_or_id))
   end
 
   def unsubscribe_from_clients_presence_in_account(account_or_id) do
-    PubSub.unsubscribe(account_presence_topic(account_or_id))
+    PubSub.unsubscribe(account_clients_presence_topic(account_or_id))
   end
 
   def subscribe_to_clients_presence_for_actor(actor_or_id) do
-    PubSub.subscribe(actor_presence_topic(actor_or_id))
+    PubSub.subscribe(actor_clients_presence_topic(actor_or_id))
   end
 
   def unsubscribe_from_clients_presence_for_actor(actor_or_id) do
-    PubSub.unsubscribe(actor_presence_topic(actor_or_id))
+    PubSub.unsubscribe(actor_clients_presence_topic(actor_or_id))
   end
 
   def broadcast_to_account_clients(account_or_id, payload) do
     account_or_id
-    |> account_topic()
+    |> account_clients_topic()
     |> PubSub.broadcast(payload)
   end
 
@@ -352,7 +353,7 @@ defmodule Domain.Clients do
 
   defp broadcast_to_actor_clients(actor_or_id, payload) do
     actor_or_id
-    |> actor_topic()
+    |> actor_clients_topic()
     |> PubSub.broadcast(payload)
   end
 

--- a/elixir/apps/domain/lib/domain/gateways.ex
+++ b/elixir/apps/domain/lib/domain/gateways.ex
@@ -90,6 +90,14 @@ defmodule Domain.Gateways do
           |> Group.Changeset.update(attrs, subject)
         end
       )
+      |> case do
+        {:ok, group} ->
+          :ok = broadcast_to_group(group, :updated)
+          {:ok, group}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 
@@ -184,7 +192,7 @@ defmodule Domain.Gateways do
   @doc false
   def preload_gateways_presence([gateway]) do
     gateway.account_id
-    |> account_presence_topic()
+    |> gateways_in_account_presence_topic()
     |> Presence.get_by_key(gateway.id)
     |> case do
       [] -> %{gateway | online?: false}
@@ -201,7 +209,7 @@ defmodule Domain.Gateways do
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
       |> Enum.reduce(%{}, fn account_id, acc ->
-        connected_gateways = account_id |> account_presence_topic() |> Presence.list()
+        connected_gateways = account_id |> gateways_in_account_presence_topic() |> Presence.list()
         Map.merge(acc, connected_gateways)
       end)
 
@@ -212,7 +220,7 @@ defmodule Domain.Gateways do
 
   def all_online_gateway_ids_by_group_id!(group_id) do
     group_id
-    |> group_presence_topic()
+    |> gateways_in_group_presence_topic()
     |> Presence.list()
     |> Map.keys()
   end
@@ -227,7 +235,7 @@ defmodule Domain.Gateways do
 
       connected_gateway_ids =
         resource.account_id
-        |> account_presence_topic()
+        |> gateways_in_account_presence_topic()
         |> Presence.list()
         |> Map.keys()
 
@@ -250,7 +258,7 @@ defmodule Domain.Gateways do
   def gateway_can_connect_to_resource?(%Gateway{} = gateway, %Resources.Resource{} = resource) do
     connected_gateway_ids =
       resource.account_id
-      |> account_presence_topic()
+      |> gateways_in_account_presence_topic()
       |> Presence.list()
       |> Map.keys()
 
@@ -375,13 +383,23 @@ defmodule Domain.Gateways do
 
   def connect_gateway(%Gateway{} = gateway) do
     with {:ok, _} <-
-           Presence.track(self(), group_presence_topic(gateway.group_id), gateway.id, %{}),
+           Presence.track(
+             self(),
+             gateways_in_group_presence_topic(gateway.group_id),
+             gateway.id,
+             %{}
+           ),
          {:ok, _} <-
-           Presence.track(self(), account_presence_topic(gateway.account_id), gateway.id, %{
-             online_at: System.system_time(:second)
-           }) do
+           Presence.track(
+             self(),
+             gateways_in_account_presence_topic(gateway.account_id),
+             gateway.id,
+             %{
+               online_at: System.system_time(:second)
+             }
+           ) do
       :ok = PubSub.subscribe(gateway_topic(gateway))
-      :ok = PubSub.subscribe(group_topic(gateway.group_id))
+      :ok = PubSub.subscribe(gateways_in_group_topic(gateway.group_id))
       :ok = PubSub.subscribe(account_topic(gateway.account_id))
       :ok
     end
@@ -389,11 +407,11 @@ defmodule Domain.Gateways do
 
   ### Presence
 
-  def account_presence_topic(account_or_id),
+  def gateways_in_account_presence_topic(account_or_id),
     do: "presences:#{account_topic(account_or_id)}"
 
-  defp group_presence_topic(group_or_id),
-    do: "presences:#{group_topic(group_or_id)}"
+  defp gateways_in_group_presence_topic(group_or_id),
+    do: "presences:#{gateways_in_group_topic(group_or_id)}"
 
   ### PubSub
 
@@ -403,31 +421,52 @@ defmodule Domain.Gateways do
   defp account_topic(%Accounts.Account{} = account), do: account_topic(account.id)
   defp account_topic(account_id), do: "account_gateways:#{account_id}"
 
+  defp gateways_in_group_topic(%Group{} = group), do: gateways_in_group_topic(group.id)
+  defp gateways_in_group_topic(group_id), do: "group_gateways:#{group_id}"
+
   defp group_topic(%Group{} = group), do: group_topic(group.id)
-  defp group_topic(group_id), do: "group_gateways:#{group_id}"
+  defp group_topic(group_id), do: "group:#{group_id}"
+
+  def subscribe_to_group_updates(group_or_id) do
+    group_or_id
+    |> group_topic()
+    |> PubSub.subscribe()
+  end
+
+  def unsubscribe_from_group_updates(group_or_id) do
+    group_or_id
+    |> group_topic()
+    |> PubSub.unsubscribe()
+  end
 
   def subscribe_to_gateways_presence_in_account(%Accounts.Account{} = account) do
     account
-    |> account_presence_topic()
+    |> gateways_in_account_presence_topic()
     |> PubSub.subscribe()
   end
 
   def unsubscribe_from_gateways_presence_in_account(%Accounts.Account{} = account) do
     account
-    |> account_presence_topic()
+    |> gateways_in_account_presence_topic()
     |> PubSub.unsubscribe()
   end
 
   def subscribe_to_gateways_presence_in_group(group_or_id) do
     group_or_id
-    |> group_presence_topic()
+    |> gateways_in_group_presence_topic()
     |> PubSub.subscribe()
   end
 
   def unsubscribe_from_gateways_presence_in_group(group_or_id) do
     group_or_id
-    |> group_presence_topic()
+    |> gateways_in_group_presence_topic()
     |> PubSub.unsubscribe()
+  end
+
+  def broadcast_to_group(group_or_id, payload) do
+    group_or_id
+    |> group_topic()
+    |> PubSub.broadcast(payload)
   end
 
   def broadcast_to_gateway(gateway_or_id, payload) do
@@ -438,7 +477,7 @@ defmodule Domain.Gateways do
 
   defp broadcast_to_gateways_in_group(group_or_id, payload) do
     group_or_id
-    |> group_topic()
+    |> gateways_in_group_topic()
     |> PubSub.broadcast(payload)
   end
 

--- a/elixir/apps/domain/test/domain/clients_test.exs
+++ b/elixir/apps/domain/test/domain/clients_test.exs
@@ -659,11 +659,15 @@ defmodule Domain.ClientsTest do
       unprivileged_subject: subject
     } do
       client = Fixtures.Clients.create_client(actor: actor)
+      :ok = Domain.PubSub.subscribe("clients:#{client.id}")
+
       attrs = %{name: "new name"}
 
       assert {:ok, client} = update_client(client, attrs, subject)
 
       assert client.name == attrs.name
+
+      assert_receive :updated
     end
 
     test "does not allow unprivileged actor to update other actors clients", %{
@@ -757,12 +761,15 @@ defmodule Domain.ClientsTest do
   describe "verify_client/2" do
     test "allows admin actor to verify clients", %{admin_actor: actor, admin_subject: subject} do
       client = Fixtures.Clients.create_client(actor: actor)
+      :ok = Domain.PubSub.subscribe("clients:#{client.id}")
 
       assert {:ok, client} = verify_client(client, subject)
       assert client.verified_at
       assert client.verified_by == :identity
       assert client.verified_by_actor_id == subject.actor.id
       assert client.verified_by_identity_id == subject.identity.id
+
+      assert_receive :verified
 
       assert {:ok, double_verified_client} = verify_client(client, subject)
       assert double_verified_client.verified_at == client.verified_at
@@ -794,6 +801,7 @@ defmodule Domain.ClientsTest do
       admin_subject: subject
     } do
       client = Fixtures.Clients.create_client(actor: actor)
+      :ok = Domain.PubSub.subscribe("clients:#{client.id}")
 
       assert {:ok, client} = verify_client(client, subject)
       assert {:ok, client} = remove_client_verification(client, subject)
@@ -802,6 +810,8 @@ defmodule Domain.ClientsTest do
       assert is_nil(client.verified_by)
       assert is_nil(client.verified_by_actor_id)
       assert is_nil(client.verified_by_identity_id)
+
+      assert_receive :updated
     end
 
     test "returns error when subject has no permission to verify clients", %{

--- a/elixir/apps/domain/test/domain/clients_test.exs
+++ b/elixir/apps/domain/test/domain/clients_test.exs
@@ -769,7 +769,7 @@ defmodule Domain.ClientsTest do
       assert client.verified_by_actor_id == subject.actor.id
       assert client.verified_by_identity_id == subject.identity.id
 
-      assert_receive :verified
+      assert_receive :updated
 
       assert {:ok, double_verified_client} = verify_client(client, subject)
       assert double_verified_client.verified_at == client.verified_at

--- a/elixir/apps/domain/test/domain/gateways_test.exs
+++ b/elixir/apps/domain/test/domain/gateways_test.exs
@@ -274,6 +274,19 @@ defmodule Domain.GatewaysTest do
       assert group.name == "foo"
     end
 
+    test "broadcasts an update event", %{account: account, subject: subject} do
+      group = Fixtures.Gateways.create_group(account: account)
+      :ok = subscribe_to_group_updates(group)
+
+      attrs = %{
+        name: "foo"
+      }
+
+      assert {:ok, _group} = update_group(group, attrs, subject)
+
+      assert_receive :updated
+    end
+
     test "returns error when subject has no permission to manage groups", %{
       account: account,
       subject: subject


### PR DESCRIPTION
This allows us to push a whole set of resources at once when client was verified/unverified/updated/blocked.

Closes #6560