### PR TITLE
feat(relay): add ec2 metadata discovery

### DIFF
--- a/rust/docker-init-relay.sh
+++ b/rust/docker-init-relay.sh
@@ -19,6 +19,25 @@ if [ "${LISTEN_ADDRESS_DISCOVERY_METHOD}" = "gce_metadata" ]; then
         export PUBLIC_IP6_ADDR="${public_ip6}"
         echo "Discovered PUBLIC_IP6_ADDR: ${PUBLIC_IP6_ADDR}"
     fi
+elif [ "${LISTEN_ADDRESS_DISCOVERY_METHOD}" = "aws_ec2_metadata" ]; then
+    echo "Using AWS EC2 metadata to discover listen address"
+    token=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+
+    if [ "${PUBLIC_IP4_ADDR}" = "" ]; then
+        public_ip4=$(curl --fail "http://169.254.169.254/latest/meta-data/public-ipv4" -H "X-aws-ec2-metadata-token: $token")
+        if [ $? -eq 0 ]; then
+            export PUBLIC_IP4_ADDR="${public_ip4}"
+            echo "Discovered PUBLIC_IP4_ADDR: ${PUBLIC_IP4_ADDR}"
+        fi
+    fi
+
+    if [ "${PUBLIC_IP6_ADDR}" = "" ]; then
+        public_ip6=$(curl --fail "http://169.254.169.254/latest/meta-data/ipv6" -H "X-aws-ec2-metadata-token: $token")
+        if [ $? -eq 0 ]; then
+            export PUBLIC_IP6_ADDR="${public_ip6}"
+            echo "Discovered PUBLIC_IP6_ADDR: ${PUBLIC_IP6_ADDR}"
+        fi
+    fi
 fi
 
 if [ "${OTEL_METADATA_DISCOVERY_METHOD}" = "gce_metadata" ]; then


### PR DESCRIPTION
This PR adds support for EC2 IMDSv2 metadata API in order to discover public IPv4 and IPv6.