### PR TITLE
feat(portal): allow dns pool libcluster

### DIFF
--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -354,6 +354,7 @@ defmodule Domain.Config.Definitions do
         Elixir.Cluster.Strategy.Epmd,
         Elixir.Cluster.Strategy.Gossip,
         Elixir.Cluster.Strategy.Kubernetes,
+        Elixir.Cluster.Strategy.DNSPoll,
         Elixir.Domain.Cluster.GoogleComputeLabelsStrategy
       ]
     ),


### PR DESCRIPTION
This PR adds support for DNSPoll libcluster strategy. I've tested this and no need to do some custom dumping of the json config.