### PR TITLE
feat(portal): ecs metadata discovery

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -280,6 +280,7 @@ RUN set -xe \
     # Install Firezone runtime deps
     && apk add --no-cache --update-cache \
     curl \
+    jq \
     tini
 
 # Create default user and home directory, set owner to default

--- a/elixir/rel/env.sh.eex
+++ b/elixir/rel/env.sh.eex
@@ -30,6 +30,8 @@ if [[ "${RELEASE_HOST_DISCOVERY_METHOD}" == "gce_metadata" ]]; then
   export GCP_INSTANCE_NAME=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google" -s)
   export GCP_INSTANCE_ZONE=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/zone" -H "Metadata-Flavor: Google" -s | sed 's:.*/::')
   RELEASE_HOSTNAME="$GCP_INSTANCE_NAME.$GCP_INSTANCE_ZONE.c.${GCP_PROJECT_ID}.internal"
+elif [[ "${RELEASE_HOST_DISCOVERY_METHOD}" == "aws_ecs_metadata" ]]; then
+  RELEASE_HOSTNAME=$(curl "${ECS_CONTAINER_METADATA_URI_V4}" | jq -r '.Networks[0].IPv4Addresses[0]')
 else
   RELEASE_HOSTNAME=${RELEASE_HOSTNAME:-127.0.0.1}
 fi


### PR DESCRIPTION
This PR adds support for ECS metadata API (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html) in order to discover hostname.

It also adds jq in the runtime image

Unlike EC2 or GCP VM, ECS tasks do not have a DNS record, we can only use their IP as RELEASE_HOSTNAME. So I use their IPv4, IPv6 only networks are therefore not supported.