### PR TITLE
fix(apple): Don't bold addressDescription in macOS Menubar

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -543,7 +543,7 @@ public final class MenuBar: NSObject, ObservableObject {
   private func nonInternetResourceHeader(resource: Resource) -> NSMenu {
     let subMenu = NSMenu()
 
-    // AddressDescription first -- will be most common action
+    // Show addressDescription first if it's present
     let resourceAddressDescriptionItem = NSMenuItem()
     if let addressDescription = resource.addressDescription {
       resourceAddressDescriptionItem.title = addressDescription
@@ -554,11 +554,10 @@ public final class MenuBar: NSObject, ObservableObject {
         resourceAddressDescriptionItem.action = #selector(resourceURLTapped(_:))
         resourceAddressDescriptionItem.toolTip = "Click to open"
 
-        // TODO: Expose markdown support? Blocked by Tauri clients.
         // Using Markdown here only to highlight the URL
-        resourceAddressDescriptionItem.attributedTitle = try? NSAttributedString(markdown: "**[\(addressDescription)](\(addressDescription))**")
+        resourceAddressDescriptionItem.attributedTitle = try? NSAttributedString(markdown: "[\(addressDescription)](\(addressDescription))")
       } else {
-        resourceAddressDescriptionItem.attributedTitle = try? NSAttributedString(markdown: "**\(addressDescription)**")
+        resourceAddressDescriptionItem.title = addressDescription
         resourceAddressDescriptionItem.action = #selector(resourceValueTapped(_:))
         resourceAddressDescriptionItem.toolTip = "Click to copy"
       }

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -9,6 +9,16 @@ export default function Apple() {
       href="https://apps.apple.com/us/app/firezone/id6443661826"
       title="macOS / iOS"
     >
+      {/*
+      <Entry version="1.3.2" date={new Date(todo)}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem pull="6521">
+          Fixes a bug where the addressDescription wasn't fully displayed in the macOS
+          menu bar if it exceeded a certain length.
+          </ChangeItem>
+        </ul>
+      </Entry>
+      */}
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6521">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -12,7 +12,7 @@ export default function Apple() {
       {/*
       <Entry version="1.3.2" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6521">
+          <ChangeItem pull="6632">
           Fixes a bug where the addressDescription wasn't fully displayed in the macOS
           menu bar if it exceeded a certain length.
           </ChangeItem>


### PR DESCRIPTION
When the addressDescription looks like a URI, we highlight it with markdown and set its click handler to open the URL when clicked. We were also making it bold, which seems to break macOS's menubar width calculation, causing the field to truncate (typically after `https://`) instead of expanding the container to contain it.

By removing the bold formatting, the container is properly sized, fixing the display issue.


# Before
<img width="553" alt="Screenshot 2024-09-07 at 10 44 37 AM" src="https://github.com/user-attachments/assets/4596bf54-918d-4a59-81d6-a18e436da5ad">

# After
<img width="569" alt="Screenshot 2024-09-07 at 10 45 38 AM" src="https://github.com/user-attachments/assets/0400731f-e189-4416-a670-d5c3b314d71b">

