### PR TITLE
test(rust/client): add unit test for DNS and network change notifiers

### DIFF
--- a/rust/bin-shared/src/network_changes.rs
+++ b/rust/bin-shared/src/network_changes.rs
@@ -19,6 +19,7 @@ mod tests {
     /// Smoke test for the DNS and network change notifiers
     ///
     /// Turn them on, wait a second, turn them off.
+    /// This tests that the threads quit gracefully when we call `close`, and they don't crash on startup.
     #[tokio::test]
     async fn notifiers() {
         let tokio_handle = tokio::runtime::Handle::current();

--- a/rust/bin-shared/src/network_changes.rs
+++ b/rust/bin-shared/src/network_changes.rs
@@ -10,3 +10,29 @@ mod imp;
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 pub use imp::{new_dns_notifier, new_network_notifier};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::DnsControlMethod;
+
+    /// Smoke test for the DNS and network change notifiers
+    ///
+    /// Turn them on, wait a second, turn them off.
+    #[tokio::test]
+    async fn notifiers() {
+        let tokio_handle = tokio::runtime::Handle::current();
+
+        let mut dns = new_dns_notifier(tokio_handle.clone(), DnsControlMethod::default())
+            .await
+            .unwrap();
+        let mut net = new_network_notifier(tokio_handle, DnsControlMethod::default())
+            .await
+            .unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        dns.close().unwrap();
+        net.close().unwrap();
+    }
+}


### PR DESCRIPTION
Part of a yak shave towards removing Tauri.