### PR TITLE
chore(test): only call `handle_timeout` when necessary

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -147,10 +147,12 @@ impl ClientTunnel {
                     continue;
                 }
                 Poll::Ready(io::Input::Device(packet)) => {
+                    let now = Instant::now();
                     let Some(enc_packet) =
                         self.role_state
-                            .encapsulate(packet, Instant::now(), &mut self.encrypt_buf)
+                            .encapsulate(packet, now, &mut self.encrypt_buf)
                     else {
+                        self.role_state.handle_timeout(now);
                         continue;
                     };
 
@@ -165,7 +167,7 @@ impl ClientTunnel {
                             received.local,
                             received.from,
                             received.packet,
-                            std::time::Instant::now(),
+                            Instant::now(),
                             self.decrypt_buf.as_mut(),
                         ) else {
                             continue;
@@ -239,11 +241,12 @@ impl GatewayTunnel {
                     continue;
                 }
                 Poll::Ready(io::Input::Device(packet)) => {
-                    let Some(enc_packet) = self.role_state.encapsulate(
-                        packet,
-                        std::time::Instant::now(),
-                        &mut self.encrypt_buf,
-                    ) else {
+                    let now = Instant::now();
+                    let Some(enc_packet) =
+                        self.role_state
+                            .encapsulate(packet, now, &mut self.encrypt_buf)
+                    else {
+                        self.role_state.handle_timeout(now, Utc::now());
                         continue;
                     };
 
@@ -258,7 +261,7 @@ impl GatewayTunnel {
                             received.local,
                             received.from,
                             received.packet,
-                            std::time::Instant::now(),
+                            Instant::now(),
                             self.device_read_buf.as_mut(),
                         ) else {
                             continue;

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -149,12 +149,12 @@ impl SimClient {
             }
         }
 
-        Some(
-            self.sut
-                .encapsulate(packet, now, &mut self.enc_buffer)?
-                .to_transmit(&self.enc_buffer)
-                .into_owned(),
-        )
+        let Some(enc_packet) = self.sut.encapsulate(packet, now, &mut self.enc_buffer) else {
+            self.sut.handle_timeout(now); // If we handled the packet internally, make sure to advance state.
+            return None;
+        };
+
+        Some(enc_packet.to_transmit(&self.enc_buffer).into_owned())
     }
 
     pub(crate) fn receive(&mut self, transmit: Transmit, now: Instant) {

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -478,7 +478,11 @@ impl TunnelTest {
         while let Some(transmit) = self.client.poll_transmit(now) {
             self.client.exec_mut(|c| c.receive(transmit, now))
         }
-        self.client.exec_mut(|c| c.sut.handle_timeout(now));
+        self.client.exec_mut(|c| {
+            if c.sut.poll_timeout().is_some_and(|t| t <= now) {
+                c.sut.handle_timeout(now)
+            }
+        });
 
         for (_, gateway) in self.gateways.iter_mut() {
             while let Some(transmit) = gateway.poll_transmit(now) {
@@ -491,7 +495,11 @@ impl TunnelTest {
                 buffered_transmits.push_from(reply, gateway, now);
             }
 
-            gateway.exec_mut(|g| g.sut.handle_timeout(now, self.flux_capacitor.now()));
+            gateway.exec_mut(|g| {
+                if g.sut.poll_timeout().is_some_and(|t| t <= now) {
+                    g.sut.handle_timeout(now, self.flux_capacitor.now())
+                }
+            });
         }
 
         for (_, relay) in self.relays.iter_mut() {
@@ -503,7 +511,11 @@ impl TunnelTest {
                 buffered_transmits.push_from(reply, relay, now);
             }
 
-            relay.exec_mut(|r| r.sut.handle_timeout(now))
+            relay.exec_mut(|r| {
+                if r.sut.poll_timeout().is_some_and(|t| t <= now) {
+                    r.sut.handle_timeout(now)
+                }
+            })
         }
 
         for (_, dns_server) in self.dns_servers.iter_mut() {


### PR DESCRIPTION
As measured by running `perf` on our tests, a big part of why they are slow is that we are calling `handle_timeout` basically on every iteration of the `advance` loop in the test. Similar as in production, there is no need to do that. Instead, we only call `handle_timeout` of a particular component (client, gateway or relay) if they indicate that they have something they are waiting for (as defined by `poll_timeout`).

Simply doing that makes the tests fail for certain scenarios where we handle IP packets that aren't mean for the tunnel (such as DNS queries or STUN messages for the relay / ICE agent). To fix this, we call `handle_timeout` whenever `encapsulate` returns `None`. This is fairly common across sans-IO systems: When a function that usually 1-to-1 transforms a packet instead handles it internally, it must have changed internal state. To make code-organisation easier, `handle_timeout` is treated as the "work-horse" of a sans-IO system: It is where all the code goes that needs to perform processing upon multiple conditions.

Making this change drops the runtime of `tunnel_test` from ~33s to ~12s on my machine (tests compiled with opt-level 2).