### PR TITLE
chore(connlib): lazily init errors for unavailable sockets

### DIFF
--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -59,14 +59,18 @@ impl Sockets {
 
     pub fn send(&mut self, datagram: DatagramOut) -> io::Result<()> {
         let socket = match datagram.dst {
-            SocketAddr::V4(dst) => self.socket_v4.as_mut().ok_or(io::Error::new(
-                io::ErrorKind::NotConnected,
-                format!("failed send packet to {dst}: no IPv4 socket"),
-            ))?,
-            SocketAddr::V6(dst) => self.socket_v6.as_mut().ok_or(io::Error::new(
-                io::ErrorKind::NotConnected,
-                format!("failed send packet to {dst}: no IPv6 socket"),
-            ))?,
+            SocketAddr::V4(dst) => self.socket_v4.as_mut().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    format!("failed send packet to {dst}: no IPv4 socket"),
+                )
+            })?,
+            SocketAddr::V6(dst) => self.socket_v6.as_mut().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    format!("failed send packet to {dst}: no IPv6 socket"),
+                )
+            })?,
         };
         socket.send(datagram)?;
 


### PR DESCRIPTION
On a system with only a single IP stack (either V4 or V6), we will only have a single socket. When the system gets busy, the `send` function is extremely hot for obvious reasons. With only a single socket active, we allocated a lot of strings and errors here that ended up not being used at all. This accounts for about 1% of CPU time spent during a speedtest.