### PR TITLE
feat(portal): sync all google workspace organization units

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
@@ -123,6 +123,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClient do
       URI.parse("#{endpoint}/admin/directory/v1/customer/my_customer/orgunits")
       |> URI.append_query(
         URI.encode_query(%{
+          "type" => "ALL",
           "maxResults" => @max_results
         })
       )

--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
@@ -65,7 +65,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       end
 
       assert_receive {:bypass_request, conn}
-      assert conn.params == %{"maxResults" => "350"}
+      assert conn.params == %{"maxResults" => "350", "type" => "ALL"}
       assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer #{api_token}"]
     end
 


### PR DESCRIPTION
Currently only root OUs are synced into Firezone. An additional query parameter is needed to list all OUs.

Ref: https://developers.google.com/admin-sdk/directory/reference/rest/v1/orgunits/list