### PR TITLE
refactor(connlib): merge `IpPacket` and `MutableIpPacket`

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -58,8 +58,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-          rustup install --no-self-update nightly-2024-06-01 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
-          cargo +nightly-2024-06-01 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
+          rustup install --no-self-update nightly-2024-09-01 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
+          cargo +nightly-2024-09-01 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
         name: Check for unused dependencies
       - run: cargo fmt -- --check
       - run: cargo doc --all-features --no-deps --document-private-items ${{ steps.setup-rust.outputs.packages }}

--- a/rust/bin-shared/benches/tunnel.rs
+++ b/rust/bin-shared/benches/tunnel.rs
@@ -63,8 +63,8 @@ mod platform {
             let mut response_pkt = None;
             let mut time_spent = Duration::from_millis(0);
             loop {
-                let mut req_buf = [0u8; MTU];
-                poll_fn(|cx| tun.poll_read(&mut req_buf, cx)).await?;
+                let mut req_buf = [0u8; MTU + 20];
+                poll_fn(|cx| tun.poll_read(&mut req_buf[20..], cx)).await?;
                 let start = Instant::now();
                 let original_pkt = IpPacket::new(&mut req_buf).unwrap();
                 let Some(original_udp) = original_pkt.as_udp() else {

--- a/rust/bin-shared/benches/tunnel.rs
+++ b/rust/bin-shared/benches/tunnel.rs
@@ -66,11 +66,11 @@ mod platform {
                 let mut req_buf = [0u8; MTU];
                 poll_fn(|cx| tun.poll_read(&mut req_buf, cx)).await?;
                 let start = Instant::now();
-                let original_pkt = IpPacket::new(&req_buf).unwrap();
+                let original_pkt = IpPacket::new(&mut req_buf).unwrap();
                 let Some(original_udp) = original_pkt.as_udp() else {
                     continue;
                 };
-                if original_udp.get_destination() != SERVER_PORT {
+                if original_udp.destination_port() != SERVER_PORT {
                     continue;
                 }
                 if original_udp.payload()[0] != REQ_CODE {
@@ -84,8 +84,8 @@ mod platform {
                         ip_packet::make::udp_packet(
                             original_pkt.destination(),
                             original_pkt.source(),
-                            original_udp.get_destination(),
-                            original_udp.get_source(),
+                            original_udp.destination_port(),
+                            original_udp.source_port(),
                             vec![RESP_CODE],
                         )
                         .unwrap()

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -9,7 +9,7 @@ use boringtun::x25519::PublicKey;
 use boringtun::{noise::rate_limiter::RateLimiter, x25519::StaticSecret};
 use core::fmt;
 use hex_display::HexDisplayExt;
-use ip_packet::{ConvertibleIpv4Packet, ConvertibleIpv6Packet, MutableIpPacket, Packet as _};
+use ip_packet::{ConvertibleIpv4Packet, ConvertibleIpv6Packet, IpPacket, Packet as _};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::{random, SeedableRng};
@@ -292,7 +292,7 @@ where
         packet: &[u8],
         now: Instant,
         buffer: &'b mut [u8],
-    ) -> Result<Option<(TId, MutableIpPacket<'b>)>, Error> {
+    ) -> Result<Option<(TId, IpPacket<'b>)>, Error> {
         self.add_local_as_host_candidate(local)?;
 
         let (from, packet, relayed) = match self.allocations_try_handle(from, local, packet, now) {
@@ -326,7 +326,7 @@ where
     pub fn encapsulate(
         &mut self,
         connection: TId,
-        packet: MutableIpPacket<'_>,
+        packet: IpPacket<'_>,
         now: Instant,
         buffer: &mut EncryptBuffer,
     ) -> Result<Option<EncryptedPacket>, Error> {
@@ -714,7 +714,7 @@ where
         packet: &[u8],
         buffer: &'b mut [u8],
         now: Instant,
-    ) -> ControlFlow<Result<(), Error>, (TId, MutableIpPacket<'b>)> {
+    ) -> ControlFlow<Result<(), Error>, (TId, IpPacket<'b>)> {
         for (cid, conn) in self.connections.iter_established_mut() {
             if !conn.accepts(&from) {
                 continue;
@@ -1711,7 +1711,7 @@ where
         allocations: &mut BTreeMap<RId, Allocation>,
         transmits: &mut VecDeque<Transmit<'static>>,
         now: Instant,
-    ) -> ControlFlow<Result<(), Error>, MutableIpPacket<'b>> {
+    ) -> ControlFlow<Result<(), Error>, IpPacket<'b>> {
         let _guard = self.span.enter();
 
         let control_flow = match self.tunnel.decapsulate(None, packet, &mut buffer[20..]) {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -9,9 +9,7 @@ use boringtun::x25519::PublicKey;
 use boringtun::{noise::rate_limiter::RateLimiter, x25519::StaticSecret};
 use core::fmt;
 use hex_display::HexDisplayExt;
-use ip_packet::{
-    ConvertibleIpv4Packet, ConvertibleIpv6Packet, IpPacket, MutableIpPacket, Packet as _,
-};
+use ip_packet::{ConvertibleIpv4Packet, ConvertibleIpv6Packet, MutableIpPacket, Packet as _};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::{random, SeedableRng};
@@ -328,7 +326,7 @@ where
     pub fn encapsulate(
         &mut self,
         connection: TId,
-        packet: IpPacket<'_>,
+        packet: MutableIpPacket<'_>,
         now: Instant,
         buffer: &mut EncryptBuffer,
     ) -> Result<Option<EncryptedPacket>, Error> {

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -439,7 +439,7 @@ impl ClientState {
 
         let transmit = self
             .node
-            .encapsulate(gid, packet.as_immutable(), now, buffer)
+            .encapsulate(gid, packet, now, buffer)
             .inspect_err(|e| tracing::debug!(%gid, "Failed to encapsulate: {e}"))
             .ok()??;
 
@@ -621,10 +621,7 @@ impl ClientState {
         packet: MutableIpPacket<'a>,
         now: Instant,
     ) -> Result<Option<MutableIpPacket<'static>>, (MutableIpPacket<'a>, IpAddr)> {
-        match self
-            .stub_resolver
-            .handle(&self.dns_mapping, packet.as_immutable())
-        {
+        match self.stub_resolver.handle(&self.dns_mapping, &packet) {
             Some(dns::ResolveStrategy::LocalResponse(query)) => Ok(Some(query)),
             Some(dns::ResolveStrategy::ForwardQuery {
                 upstream: server,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -13,7 +13,7 @@ use connlib_shared::messages::{
 use connlib_shared::{callbacks, PublicKey, StaticSecret};
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_network_table::IpNetworkTable;
-use ip_packet::{IpPacket, MutableIpPacket, Packet as _};
+use ip_packet::{IpPacket, MutableIpPacket};
 use itertools::Itertools;
 
 use crate::peer::GatewayOnClient;
@@ -1367,7 +1367,7 @@ fn maybe_mangle_dns_response_from_cidr_resource<'p>(
         return packet;
     };
 
-    let src_port = udp.get_source();
+    let src_port = udp.source_port();
 
     let Some(sentinel) = dns_mapping.get_by_right(&DnsServer::from((src_ip, src_port))) else {
         return packet;

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -1,4 +1,4 @@
-use ip_packet::{IpPacket, MutableIpPacket, Packet as _};
+use ip_packet::{MutableIpPacket, Packet as _};
 use std::io;
 use std::task::{Context, Poll, Waker};
 use tun::Tun;
@@ -59,12 +59,12 @@ impl Device {
         Poll::Ready(Ok(packet))
     }
 
-    pub fn write(&self, packet: IpPacket<'_>) -> io::Result<usize> {
+    pub fn write(&self, packet: MutableIpPacket<'_>) -> io::Result<usize> {
         tracing::trace!(target: "wire::dev::send", dst = %packet.destination(), src = %packet.source(), bytes = %packet.packet().len());
 
         match packet {
-            IpPacket::Ipv4(msg) => self.tun()?.write4(msg.packet()),
-            IpPacket::Ipv6(msg) => self.tun()?.write6(msg.packet()),
+            MutableIpPacket::Ipv4(msg) => self.tun()?.write4(msg.packet()),
+            MutableIpPacket::Ipv6(msg) => self.tun()?.write6(msg.packet()),
         }
     }
 

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -6,7 +6,7 @@ use domain::base::{
     Message, MessageBuilder, ToName,
 };
 use domain::rdata::AllRecordData;
-use ip_packet::MutableIpPacket;
+use ip_packet::IpPacket;
 use itertools::Itertools;
 use pattern::{Candidate, Pattern};
 use std::collections::{BTreeMap, HashMap};
@@ -32,7 +32,7 @@ pub struct StubResolver {
 #[derive(Debug)]
 pub(crate) enum ResolveStrategy {
     /// The query is for a Resource, we have an IP mapped already, and we can respond instantly
-    LocalResponse(MutableIpPacket<'static>),
+    LocalResponse(IpPacket<'static>),
     /// The query is for a non-Resource, forward it to an upstream or system resolver.
     ForwardQuery {
         upstream: SocketAddr,
@@ -208,7 +208,7 @@ impl StubResolver {
     pub(crate) fn handle(
         &mut self,
         dns_mapping: &bimap::BiMap<IpAddr, DnsServer>,
-        packet: &MutableIpPacket,
+        packet: &IpPacket,
     ) -> Option<ResolveStrategy> {
         let upstream = dns_mapping.get_by_left(&packet.destination())?.address();
         let datagram = packet.as_udp()?;

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -6,8 +6,8 @@ use domain::base::{
     Message, MessageBuilder, ToName,
 };
 use domain::rdata::AllRecordData;
-use ip_packet::IpPacket;
 use ip_packet::Packet as _;
+use ip_packet::{IpPacket, MutableIpPacket};
 use itertools::Itertools;
 use pattern::{Candidate, Pattern};
 use std::collections::{BTreeMap, HashMap};
@@ -33,7 +33,7 @@ pub struct StubResolver {
 #[derive(Debug)]
 pub(crate) enum ResolveStrategy {
     /// The query is for a Resource, we have an IP mapped already, and we can respond instantly
-    LocalResponse(IpPacket<'static>),
+    LocalResponse(MutableIpPacket<'static>),
     /// The query is for a non-Resource, forward it to an upstream or system resolver.
     ForwardQuery {
         upstream: SocketAddr,
@@ -245,8 +245,7 @@ impl StubResolver {
                 datagram.get_source(),
                 response,
             )
-            .expect("src and dst come from the same packet")
-            .into_immutable();
+            .expect("src and dst come from the same packet");
 
             return Some(ResolveStrategy::LocalResponse(packet));
         }
@@ -290,8 +289,7 @@ impl StubResolver {
             datagram.get_source(),
             response,
         )
-        .expect("src and dst come from the same packet")
-        .into_immutable();
+        .expect("src and dst come from the same packet");
 
         Some(ResolveStrategy::LocalResponse(packet))
     }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -11,7 +11,7 @@ use connlib_shared::messages::{
 };
 use connlib_shared::{DomainName, StaticSecret};
 use ip_network::{Ipv4Network, Ipv6Network};
-use ip_packet::MutableIpPacket;
+use ip_packet::IpPacket;
 use secrecy::{ExposeSecret as _, Secret};
 use snownet::{EncryptBuffer, RelaySocket, ServerNode};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -157,7 +157,7 @@ impl GatewayState {
 
     pub(crate) fn encapsulate(
         &mut self,
-        packet: MutableIpPacket<'_>,
+        packet: IpPacket<'_>,
         now: Instant,
         buffer: &mut EncryptBuffer,
     ) -> Option<snownet::EncryptedPacket> {
@@ -195,7 +195,7 @@ impl GatewayState {
         packet: &[u8],
         now: Instant,
         buffer: &'b mut [u8],
-    ) -> Option<MutableIpPacket<'b>> {
+    ) -> Option<IpPacket<'b>> {
         let (cid, packet) = self.node.decapsulate(
             local,
             from,

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -181,7 +181,7 @@ impl GatewayState {
 
         let transmit = self
             .node
-            .encapsulate(peer.id(), packet.as_immutable(), now, buffer)
+            .encapsulate(peer.id(), packet, now, buffer)
             .inspect_err(|e| tracing::debug!(%cid, "Failed to encapsulate: {e}"))
             .ok()??;
 

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -11,7 +11,7 @@ use connlib_shared::messages::{
 };
 use connlib_shared::{DomainName, StaticSecret};
 use ip_network::{Ipv4Network, Ipv6Network};
-use ip_packet::{IpPacket, MutableIpPacket};
+use ip_packet::MutableIpPacket;
 use secrecy::{ExposeSecret as _, Secret};
 use snownet::{EncryptBuffer, RelaySocket, ServerNode};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -195,7 +195,7 @@ impl GatewayState {
         packet: &[u8],
         now: Instant,
         buffer: &'b mut [u8],
-    ) -> Option<IpPacket<'b>> {
+    ) -> Option<MutableIpPacket<'b>> {
         let (cid, packet) = self.node.decapsulate(
             local,
             from,
@@ -217,7 +217,7 @@ impl GatewayState {
             .inspect_err(|e| tracing::debug!(%cid, "Invalid packet: {e:#}"))
             .ok()?;
 
-        Some(packet.into_immutable())
+        Some(packet)
     }
 
     pub fn add_ice_candidate(&mut self, conn_id: ClientId, ice_candidate: String, now: Instant) {

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -1,6 +1,6 @@
 use crate::{device_channel::Device, sockets::Sockets, BUF_SIZE};
 use futures_util::FutureExt as _;
-use ip_packet::MutableIpPacket;
+use ip_packet::IpPacket;
 use snownet::{EncryptBuffer, EncryptedPacket};
 use socket_factory::{DatagramIn, DatagramOut, SocketFactory, TcpSocket, UdpSocket};
 use std::{
@@ -29,7 +29,7 @@ pub struct Io {
 
 pub enum Input<'a, I> {
     Timeout(Instant),
-    Device(MutableIpPacket<'a>),
+    Device(IpPacket<'a>),
     Network(I),
 }
 
@@ -157,7 +157,7 @@ impl Io {
         Ok(())
     }
 
-    pub fn send_device(&self, packet: MutableIpPacket<'_>) -> io::Result<()> {
+    pub fn send_device(&self, packet: IpPacket<'_>) -> io::Result<()> {
         self.device.write(packet)?;
 
         Ok(())

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -1,6 +1,6 @@
 use crate::{device_channel::Device, sockets::Sockets, BUF_SIZE};
 use futures_util::FutureExt as _;
-use ip_packet::{IpPacket, MutableIpPacket};
+use ip_packet::MutableIpPacket;
 use snownet::{EncryptBuffer, EncryptedPacket};
 use socket_factory::{DatagramIn, DatagramOut, SocketFactory, TcpSocket, UdpSocket};
 use std::{
@@ -157,7 +157,7 @@ impl Io {
         Ok(())
     }
 
-    pub fn send_device(&self, packet: IpPacket<'_>) -> io::Result<()> {
+    pub fn send_device(&self, packet: MutableIpPacket<'_>) -> io::Result<()> {
         self.device.write(packet)?;
 
         Ok(())

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -384,7 +384,7 @@ impl ClientOnGateway {
 
         let (source_protocol, real_ip) =
             self.nat_table
-                .translate_outgoing(packet.as_immutable(), state.resolved_ip, now)?;
+                .translate_outgoing(&packet, state.resolved_ip, now)?;
 
         let mut packet = packet
             .translate_destination(self.ipv4, self.ipv6, source_protocol, real_ip)
@@ -415,10 +415,7 @@ impl ClientOnGateway {
         packet: MutableIpPacket<'a>,
         now: Instant,
     ) -> anyhow::Result<Option<MutableIpPacket<'a>>> {
-        let Some((proto, ip)) = self
-            .nat_table
-            .translate_incoming(packet.as_immutable(), now)?
-        else {
+        let Some((proto, ip)) = self.nat_table.translate_incoming(&packet, now)? else {
             return Ok(Some(packet));
         };
 

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -246,10 +246,7 @@ fn assert_correct_src_and_dst_udp_ports(
     }
 }
 
-fn assert_destination_is_cdir_resource(
-    gateway_received_request: &IpPacket<'_>,
-    expected: &IpAddr,
-) {
+fn assert_destination_is_cdir_resource(gateway_received_request: &IpPacket<'_>, expected: &IpAddr) {
     let actual = gateway_received_request.destination();
 
     if actual != *expected {

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::tests::reference::ResourceDst;
 use connlib_shared::{messages::GatewayId, DomainName};
-use ip_packet::MutableIpPacket;
+use ip_packet::IpPacket;
 use itertools::Itertools;
 use std::{
     collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, VecDeque},
@@ -198,8 +198,8 @@ pub(crate) fn assert_dns_packets_properties(ref_client: &RefClient, sim_client: 
 }
 
 fn assert_correct_src_and_dst_ips(
-    client_sent_request: &MutableIpPacket<'_>,
-    client_received_reply: &MutableIpPacket<'_>,
+    client_sent_request: &IpPacket<'_>,
+    client_received_reply: &IpPacket<'_>,
 ) {
     let req_dst = client_sent_request.destination();
     let res_src = client_received_reply.source();
@@ -221,8 +221,8 @@ fn assert_correct_src_and_dst_ips(
 }
 
 fn assert_correct_src_and_dst_udp_ports(
-    client_sent_request: &MutableIpPacket<'_>,
-    client_received_reply: &MutableIpPacket<'_>,
+    client_sent_request: &IpPacket<'_>,
+    client_received_reply: &IpPacket<'_>,
 ) {
     let client_sent_request = client_sent_request.as_udp().unwrap();
     let client_received_reply = client_received_reply.as_udp().unwrap();
@@ -247,7 +247,7 @@ fn assert_correct_src_and_dst_udp_ports(
 }
 
 fn assert_destination_is_cdir_resource(
-    gateway_received_request: &MutableIpPacket<'_>,
+    gateway_received_request: &IpPacket<'_>,
     expected: &IpAddr,
 ) {
     let actual = gateway_received_request.destination();
@@ -260,7 +260,7 @@ fn assert_destination_is_cdir_resource(
 }
 
 fn assert_destination_is_dns_resource(
-    gateway_received_request: &MutableIpPacket<'_>,
+    gateway_received_request: &IpPacket<'_>,
     global_dns_records: &BTreeMap<DomainName, BTreeSet<IpAddr>>,
     domain: &DomainName,
 ) {
@@ -283,8 +283,8 @@ fn assert_destination_is_dns_resource(
 /// Yet, we care that it remains stable to ensure that any form of sticky sessions don't get broken (i.e. packets to one IP are always routed to the same IP on the gateway).
 /// To assert this, we build up a map as we iterate through all packets that have been sent.
 fn assert_proxy_ip_mapping_is_stable(
-    client_sent_request: &MutableIpPacket<'_>,
-    gateway_received_request: &MutableIpPacket<'_>,
+    client_sent_request: &IpPacket<'_>,
+    gateway_received_request: &IpPacket<'_>,
     mapping: &mut HashMap<IpAddr, IpAddr>,
 ) {
     let proxy_ip = client_sent_request.destination();

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -127,10 +127,10 @@ impl SimClient {
             let packet = packet.as_immutable().to_owned();
 
             if let Some(icmp) = packet.as_icmp() {
-                let echo_request = icmp.as_echo_request().expect("to be echo request");
+                let echo_request = icmp.echo_request_header().expect("to be echo request");
 
                 self.sent_icmp_requests
-                    .insert((echo_request.sequence(), echo_request.identifier()), packet);
+                    .insert((echo_request.seq, echo_request.id), packet);
             }
         }
 
@@ -180,12 +180,10 @@ impl SimClient {
     /// Process an IP packet received on the client.
     pub(crate) fn on_received_packet(&mut self, packet: IpPacket<'static>) {
         if let Some(icmp) = packet.as_icmp() {
-            let echo_reply = icmp.as_echo_reply().expect("to be echo reply");
+            let echo_reply = icmp.echo_reply_header().expect("to be echo reply");
 
-            self.received_icmp_replies.insert(
-                (echo_reply.sequence(), echo_reply.identifier()),
-                packet.to_owned(),
-            );
+            self.received_icmp_replies
+                .insert((echo_reply.seq, echo_reply.id), packet.to_owned());
 
             return;
         };

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -24,7 +24,7 @@ use domain::{
 };
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_network_table::IpNetworkTable;
-use ip_packet::MutableIpPacket;
+use ip_packet::IpPacket;
 use itertools::Itertools as _;
 use prop::collection;
 use proptest::prelude::*;
@@ -53,11 +53,11 @@ pub(crate) struct SimClient {
     pub(crate) ipv4_routes: BTreeSet<Ipv4Network>,
     pub(crate) ipv6_routes: BTreeSet<Ipv6Network>,
 
-    pub(crate) sent_dns_queries: HashMap<(SocketAddr, QueryId), MutableIpPacket<'static>>,
-    pub(crate) received_dns_responses: BTreeMap<(SocketAddr, QueryId), MutableIpPacket<'static>>,
+    pub(crate) sent_dns_queries: HashMap<(SocketAddr, QueryId), IpPacket<'static>>,
+    pub(crate) received_dns_responses: BTreeMap<(SocketAddr, QueryId), IpPacket<'static>>,
 
-    pub(crate) sent_icmp_requests: HashMap<(u16, u16), MutableIpPacket<'static>>,
-    pub(crate) received_icmp_replies: BTreeMap<(u16, u16), MutableIpPacket<'static>>,
+    pub(crate) sent_icmp_requests: HashMap<(u16, u16), IpPacket<'static>>,
+    pub(crate) received_icmp_replies: BTreeMap<(u16, u16), IpPacket<'static>>,
 
     buffer: Vec<u8>,
     enc_buffer: EncryptBuffer,
@@ -120,7 +120,7 @@ impl SimClient {
 
     pub(crate) fn encapsulate(
         &mut self,
-        packet: MutableIpPacket<'static>,
+        packet: IpPacket<'static>,
         now: Instant,
     ) -> Option<snownet::Transmit<'static>> {
         {
@@ -174,7 +174,7 @@ impl SimClient {
     }
 
     /// Process an IP packet received on the client.
-    pub(crate) fn on_received_packet(&mut self, packet: MutableIpPacket<'static>) {
+    pub(crate) fn on_received_packet(&mut self, packet: IpPacket<'static>) {
         if let Some(icmp) = packet.as_icmp() {
             let echo_reply = icmp.echo_reply_header().expect("to be echo reply");
 

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -172,13 +172,13 @@ impl SimClient {
         ) else {
             return;
         };
-        let packet = packet.to_owned();
+        let packet = packet.as_immutable().to_owned();
 
         self.on_received_packet(packet);
     }
 
     /// Process an IP packet received on the client.
-    pub(crate) fn on_received_packet(&mut self, packet: IpPacket<'_>) {
+    pub(crate) fn on_received_packet(&mut self, packet: IpPacket<'static>) {
         if let Some(icmp) = packet.as_icmp() {
             let echo_reply = icmp.as_echo_reply().expect("to be echo reply");
 

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -9,7 +9,7 @@ use connlib_shared::{
     messages::{GatewayId, RelayId},
     DomainName,
 };
-use ip_packet::MutableIpPacket;
+use ip_packet::IpPacket;
 use proptest::prelude::*;
 use snownet::{EncryptBuffer, Transmit};
 use std::{
@@ -24,7 +24,7 @@ pub(crate) struct SimGateway {
     pub(crate) sut: GatewayState,
 
     /// The received ICMP packets, indexed by our custom ICMP payload.
-    pub(crate) received_icmp_requests: BTreeMap<u64, MutableIpPacket<'static>>,
+    pub(crate) received_icmp_requests: BTreeMap<u64, IpPacket<'static>>,
 
     buffer: Vec<u8>,
     enc_buffer: EncryptBuffer,
@@ -65,7 +65,7 @@ impl SimGateway {
     fn on_received_packet(
         &mut self,
         global_dns_records: &BTreeMap<DomainName, BTreeSet<IpAddr>>,
-        packet: MutableIpPacket<'static>,
+        packet: IpPacket<'static>,
         now: Instant,
     ) -> Option<Transmit<'static>> {
         // TODO: Instead of handling these things inline, here, should we dispatch them via `RoutingTable`?

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -9,7 +9,7 @@ use connlib_shared::{
     messages::{GatewayId, RelayId},
     DomainName,
 };
-use ip_packet::IpPacket;
+use ip_packet::{IpPacket, MutableIpPacket};
 use proptest::prelude::*;
 use snownet::{EncryptBuffer, Transmit};
 use std::{
@@ -24,7 +24,7 @@ pub(crate) struct SimGateway {
     pub(crate) sut: GatewayState,
 
     /// The received ICMP packets, indexed by our custom ICMP payload.
-    pub(crate) received_icmp_requests: BTreeMap<u64, IpPacket<'static>>,
+    pub(crate) received_icmp_requests: BTreeMap<u64, MutableIpPacket<'static>>,
 
     buffer: Vec<u8>,
     enc_buffer: EncryptBuffer,
@@ -56,7 +56,6 @@ impl SimGateway {
                 now,
                 &mut self.buffer,
             )?
-            .as_immutable()
             .to_owned();
 
         self.on_received_packet(global_dns_records, packet, now)
@@ -66,7 +65,7 @@ impl SimGateway {
     fn on_received_packet(
         &mut self,
         global_dns_records: &BTreeMap<DomainName, BTreeSet<IpAddr>>,
-        packet: IpPacket<'static>,
+        packet: MutableIpPacket<'static>,
         now: Instant,
     ) -> Option<Transmit<'static>> {
         // TODO: Instead of handling these things inline, here, should we dispatch them via `RoutingTable`?

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -9,7 +9,7 @@ use connlib_shared::{
     messages::{GatewayId, RelayId},
     DomainName,
 };
-use ip_packet::{IpPacket, MutableIpPacket};
+use ip_packet::MutableIpPacket;
 use proptest::prelude::*;
 use snownet::{EncryptBuffer, Transmit};
 use std::{

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -56,6 +56,7 @@ impl SimGateway {
                 now,
                 &mut self.buffer,
             )?
+            .as_immutable()
             .to_owned();
 
         self.on_received_packet(global_dns_records, packet, now)
@@ -65,11 +66,9 @@ impl SimGateway {
     fn on_received_packet(
         &mut self,
         global_dns_records: &BTreeMap<DomainName, BTreeSet<IpAddr>>,
-        packet: IpPacket<'_>,
+        packet: IpPacket<'static>,
         now: Instant,
     ) -> Option<Transmit<'static>> {
-        let packet = packet.to_owned();
-
         // TODO: Instead of handling these things inline, here, should we dispatch them via `RoutingTable`?
 
         if let Some(icmp) = packet.as_icmp() {

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -443,7 +443,7 @@ impl TunnelTest {
             }
             self.client.exec_mut(|sim| {
                 while let Some(packet) = sim.sut.poll_packets() {
-                    sim.on_received_packet(packet)
+                    sim.on_received_packet(packet.into_immutable())
                 }
             });
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -443,7 +443,7 @@ impl TunnelTest {
             }
             self.client.exec_mut(|sim| {
                 while let Some(packet) = sim.sut.poll_packets() {
-                    sim.on_received_packet(packet.into_immutable())
+                    sim.on_received_packet(packet)
                 }
             });
 

--- a/rust/ip-packet/src/ipv4_header_slice_mut.rs
+++ b/rust/ip-packet/src/ipv4_header_slice_mut.rs
@@ -7,15 +7,12 @@ pub struct Ipv4HeaderSliceMut<'a> {
 
 impl<'a> Ipv4HeaderSliceMut<'a> {
     /// Creates a new [`Ipv4HeaderSliceMut`].
-    ///
-    /// # Safety
-    ///
-    /// - The byte array must be at least of length 20.
-    /// - The IP version must be 4.
-    pub unsafe fn from_slice_unchecked(slice: &'a mut [u8]) -> Self {
-        debug_assert!(Ipv4HeaderSlice::from_slice(slice).is_ok()); // Debug asserts are no-ops in release mode, so this is still "unchecked".
+    pub fn from_slice(
+        slice: &'a mut [u8],
+    ) -> Result<Self, etherparse::err::ipv4::HeaderSliceError> {
+        Ipv4HeaderSlice::from_slice(slice)?;
 
-        Self { slice }
+        Ok(Self { slice })
     }
 
     pub fn set_checksum(&mut self, checksum: u16) {

--- a/rust/ip-packet/src/ipv6_header_slice_mut.rs
+++ b/rust/ip-packet/src/ipv6_header_slice_mut.rs
@@ -7,15 +7,12 @@ pub struct Ipv6HeaderSliceMut<'a> {
 
 impl<'a> Ipv6HeaderSliceMut<'a> {
     /// Creates a new [`Ipv6HeaderSliceMut`].
-    ///
-    /// # Safety
-    ///
-    /// - The byte array must be at least of length 40.
-    /// - The IP version must be 6.
-    pub unsafe fn from_slice_unchecked(slice: &'a mut [u8]) -> Self {
-        debug_assert!(Ipv6HeaderSlice::from_slice(slice).is_ok()); // Debug asserts are no-ops in release mode, so this is still "unchecked".
+    pub fn from_slice(
+        slice: &'a mut [u8],
+    ) -> Result<Self, etherparse::err::ipv6::HeaderSliceError> {
+        Ipv6HeaderSlice::from_slice(slice)?;
 
-        Self { slice }
+        Ok(Self { slice })
     }
 
     pub fn set_source(&mut self, src: [u8; 16]) {

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -635,7 +635,7 @@ impl<'a> MutableIpPacket<'a> {
         }
     }
 
-    fn as_icmp(&mut self) -> Option<MutableIcmpPacket> {
+    pub fn as_icmp(&mut self) -> Option<MutableIcmpPacket> {
         self.to_immutable()
             .is_icmp()
             .then(|| MutableIcmpPacket::new(self.payload_mut()))

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -549,10 +549,12 @@ impl<'a> MutableIpPacket<'a> {
     }
 
     fn set_ipv4_checksum(&mut self) {
-        if let Self::Ipv4(p) = self {
-            let checksum = ipv4::checksum(&p.to_immutable());
-            p.ip_header_mut().set_checksum(checksum);
-        }
+        let Self::Ipv4(p) = self else {
+            return;
+        };
+
+        let checksum = p.ip_header().to_header().calc_header_checksum();
+        p.ip_header_mut().set_checksum(checksum);
     }
 
     fn set_udp_checksum(&mut self) {

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -718,14 +718,6 @@ impl<'a> MutableIpPacket<'a> {
 }
 
 impl<'a> IpPacket<'a> {
-    pub fn new(buf: &'a [u8]) -> Option<Self> {
-        match buf[0] >> 4 {
-            4 => Some(IpPacket::Ipv4(Ipv4Packet::new(buf)?)),
-            6 => Some(IpPacket::Ipv6(Ipv6Packet::new(buf)?)),
-            _ => None,
-        }
-    }
-
     pub fn to_owned(&self) -> IpPacket<'static> {
         match self {
             IpPacket::Ipv4(i) => Ipv4Packet::owned(i.packet().to_vec())

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -252,18 +252,6 @@ impl<'a> ConvertibleIpv4Packet<'a> {
         self.ip_header().destination_addr()
     }
 
-    fn consume_to_immutable(self) -> Ipv4Packet<'a> {
-        match self.buf {
-            MaybeOwned::RefMut(buf) => {
-                Ipv4Packet::new(&buf[20..]).expect("when constructed we checked that this is some")
-            }
-            MaybeOwned::Owned(mut owned) => {
-                owned.drain(..20);
-                Ipv4Packet::owned(owned).expect("when constructed we checked that this is some")
-            }
-        }
-    }
-
     fn consume_to_ipv6(
         mut self,
         src: Ipv6Addr,
@@ -345,17 +333,6 @@ impl<'a> ConvertibleIpv6Packet<'a> {
 
     fn get_destination(&self) -> Ipv6Addr {
         self.header().destination_addr()
-    }
-
-    fn consume_to_immutable(self) -> Ipv6Packet<'a> {
-        match self.buf {
-            MaybeOwned::RefMut(buf) => {
-                Ipv6Packet::new(buf).expect("when constructed we checked that this is some")
-            }
-            MaybeOwned::Owned(owned) => {
-                Ipv6Packet::owned(owned).expect("when constructed we checked that this is some")
-            }
-        }
     }
 
     fn consume_to_ipv4(

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -222,13 +222,11 @@ impl<'a> ConvertibleIpv4Packet<'a> {
     }
 
     fn ip_header(&self) -> Ipv4HeaderSlice {
-        // TODO: Make `_unchecked` variant public upstream.
         Ipv4HeaderSlice::from_slice(&self.buf[20..]).expect("we checked this during `new`")
     }
 
     fn ip_header_mut(&mut self) -> Ipv4HeaderSliceMut {
-        // Safety: We checked this in `new` / `owned`.
-        unsafe { Ipv4HeaderSliceMut::from_slice_unchecked(&mut self.buf[20..]) }
+        Ipv4HeaderSliceMut::from_slice(&mut self.buf[20..]).expect("we checked this during `new`")
     }
 
     pub fn get_source(&self) -> Ipv4Addr {
@@ -301,13 +299,11 @@ impl<'a> ConvertibleIpv6Packet<'a> {
     }
 
     fn header(&self) -> Ipv6HeaderSlice {
-        // FIXME: Make the `_unchecked` variant public upstream.
         Ipv6HeaderSlice::from_slice(&self.buf).expect("We checked this in `new` / `owned`")
     }
 
     fn header_mut(&mut self) -> Ipv6HeaderSliceMut {
-        // Safety: We checked this in `new` / `owned`.
-        unsafe { Ipv6HeaderSliceMut::from_slice_unchecked(&mut self.buf) }
+        Ipv6HeaderSliceMut::from_slice(&mut self.buf).expect("We checked this in `new` / `owned`")
     }
 
     pub fn get_source(&self) -> Ipv6Addr {

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -425,6 +425,17 @@ impl<'a> MutableIpPacket<'a> {
         Some(packet)
     }
 
+    pub fn to_owned(&self) -> MutableIpPacket<'static> {
+        match self {
+            MutableIpPacket::Ipv4(i) => MutableIpPacket::Ipv4(ConvertibleIpv4Packet {
+                buf: MaybeOwned::Owned(i.buf.to_vec()),
+            }),
+            MutableIpPacket::Ipv6(i) => MutableIpPacket::Ipv6(ConvertibleIpv6Packet {
+                buf: MaybeOwned::Owned(i.buf.to_vec()),
+            }),
+        }
+    }
+
     pub fn to_immutable(&self) -> IpPacket {
         for_both!(self, |i| i.to_immutable().into())
     }

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -11,7 +11,7 @@ use domain::{
 use etherparse::PacketBuilder;
 use std::net::{IpAddr, SocketAddr};
 
-/// Helper macro to turn a [`PacketBuilder`] into a [`MutableIpPacket`].
+/// Helper macro to turn a [`PacketBuilder`] into an [`IpPacket`].
 #[macro_export]
 macro_rules! build {
     ($packet:expr, $payload:ident) => {{

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -1,6 +1,6 @@
 //! Factory module for making all kinds of packets.
 
-use crate::MutableIpPacket;
+use crate::IpPacket;
 use domain::{
     base::{
         iana::{Class, Opcode, Rcode},
@@ -22,7 +22,7 @@ macro_rules! build {
             .write(&mut std::io::Cursor::new(&mut buf[20..]), &$payload)
             .expect("Buffer should be big enough");
 
-        MutableIpPacket::owned(buf).expect("Should be a valid IP packet")
+        IpPacket::owned(buf).expect("Should be a valid IP packet")
     }};
 }
 
@@ -32,7 +32,7 @@ pub fn icmp_request_packet(
     seq: u16,
     identifier: u16,
     payload: &[u8],
-) -> Result<MutableIpPacket<'static>, IpVersionMismatch> {
+) -> Result<IpPacket<'static>, IpVersionMismatch> {
     match (src, dst.into()) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
             let packet = PacketBuilder::ipv4(src.octets(), dst.octets(), 64)
@@ -56,7 +56,7 @@ pub fn icmp_reply_packet(
     seq: u16,
     identifier: u16,
     payload: &[u8],
-) -> Result<MutableIpPacket<'static>, IpVersionMismatch> {
+) -> Result<IpPacket<'static>, IpVersionMismatch> {
     match (src, dst.into()) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
             let packet = PacketBuilder::ipv4(src.octets(), dst.octets(), 64)
@@ -80,7 +80,7 @@ pub fn tcp_packet<IP>(
     sport: u16,
     dport: u16,
     payload: Vec<u8>,
-) -> Result<MutableIpPacket<'static>, IpVersionMismatch>
+) -> Result<IpPacket<'static>, IpVersionMismatch>
 where
     IP: Into<IpAddr>,
 {
@@ -107,7 +107,7 @@ pub fn udp_packet<IP>(
     sport: u16,
     dport: u16,
     payload: Vec<u8>,
-) -> Result<MutableIpPacket<'static>, IpVersionMismatch>
+) -> Result<IpPacket<'static>, IpVersionMismatch>
 where
     IP: Into<IpAddr>,
 {
@@ -132,7 +132,7 @@ pub fn dns_query(
     src: SocketAddr,
     dst: SocketAddr,
     id: u16,
-) -> Result<MutableIpPacket<'static>, IpVersionMismatch> {
+) -> Result<IpPacket<'static>, IpVersionMismatch> {
     // Create the DNS query message
     let mut msg_builder = MessageBuilder::new_vec();
 
@@ -153,9 +153,9 @@ pub fn dns_query(
 
 /// Makes a DNS response to the given DNS query packet, using a resolver callback.
 pub fn dns_ok_response<I>(
-    packet: MutableIpPacket<'static>,
+    packet: IpPacket<'static>,
     resolve: impl Fn(&Name<Vec<u8>>) -> I,
-) -> MutableIpPacket<'static>
+) -> IpPacket<'static>
 where
     I: Iterator<Item = IpAddr>,
 {

--- a/rust/ip-packet/src/proptest.rs
+++ b/rust/ip-packet/src/proptest.rs
@@ -1,8 +1,8 @@
-use crate::MutableIpPacket;
+use crate::IpPacket;
 use proptest::{arbitrary::any, prop_oneof, strategy::Strategy};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-pub fn udp_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
+pub fn udp_packet() -> impl Strategy<Value = IpPacket<'static>> {
     prop_oneof![
         (ip4_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
             crate::make::udp_packet(saddr, daddr, sport, dport, Vec::new()).unwrap()
@@ -13,7 +13,7 @@ pub fn udp_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
     ]
 }
 
-pub fn tcp_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
+pub fn tcp_packet() -> impl Strategy<Value = IpPacket<'static>> {
     prop_oneof![
         (ip4_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
             crate::make::tcp_packet(saddr, daddr, sport, dport, Vec::new()).unwrap()
@@ -24,7 +24,7 @@ pub fn tcp_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
     ]
 }
 
-pub fn icmp_request_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
+pub fn icmp_request_packet() -> impl Strategy<Value = IpPacket<'static>> {
     prop_oneof![
         (ip4_tuple(), any::<u16>(), any::<u16>()).prop_map(|((saddr, daddr), sport, dport)| {
             crate::make::icmp_request_packet(IpAddr::V4(saddr), daddr, sport, dport, &[]).unwrap()
@@ -35,7 +35,7 @@ pub fn icmp_request_packet() -> impl Strategy<Value = MutableIpPacket<'static>> 
     ]
 }
 
-pub fn udp_or_tcp_or_icmp_packet() -> impl Strategy<Value = MutableIpPacket<'static>> {
+pub fn udp_or_tcp_or_icmp_packet() -> impl Strategy<Value = IpPacket<'static>> {
     prop_oneof![udp_packet(), tcp_packet(), icmp_request_packet()]
 }
 

--- a/rust/ip-packet/src/proptests.rs
+++ b/rust/ip-packet/src/proptests.rs
@@ -5,13 +5,13 @@ use proptest::arbitrary::any;
 use proptest::prop_oneof;
 use proptest::strategy::Strategy;
 
-use crate::{build, MutableIpPacket};
+use crate::{build, IpPacket};
 use etherparse::{Ipv4Extensions, Ipv4Header, Ipv4Options, PacketBuilder};
 use proptest::prelude::Just;
 
 const EMPTY_PAYLOAD: &[u8] = &[];
 
-fn tcp_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn tcp_packet_v4() -> impl Strategy<Value = IpPacket<'static>> {
     (
         any::<Ipv4Addr>(),
         any::<Ipv4Addr>(),
@@ -27,7 +27,7 @@ fn tcp_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
         })
 }
 
-fn tcp_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn tcp_packet_v6() -> impl Strategy<Value = IpPacket<'static>> {
     (
         any::<Ipv6Addr>(),
         any::<Ipv6Addr>(),
@@ -43,7 +43,7 @@ fn tcp_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
         })
 }
 
-fn udp_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn udp_packet_v4() -> impl Strategy<Value = IpPacket<'static>> {
     (
         any::<Ipv4Addr>(),
         any::<Ipv4Addr>(),
@@ -59,7 +59,7 @@ fn udp_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
         })
 }
 
-fn udp_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn udp_packet_v6() -> impl Strategy<Value = IpPacket<'static>> {
     (
         any::<Ipv6Addr>(),
         any::<Ipv6Addr>(),
@@ -75,7 +75,7 @@ fn udp_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
         })
 }
 
-fn icmp_request_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn icmp_request_packet_v4() -> impl Strategy<Value = IpPacket<'static>> {
     (
         any::<Ipv4Addr>(),
         any::<Ipv4Addr>(),
@@ -99,7 +99,7 @@ fn icmp_request_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
         })
 }
 
-fn icmp_reply_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn icmp_reply_packet_v4() -> impl Strategy<Value = IpPacket<'static>> {
     (
         any::<Ipv4Addr>(),
         any::<Ipv4Addr>(),
@@ -123,7 +123,7 @@ fn icmp_reply_packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
         })
 }
 
-fn icmp_request_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn icmp_request_packet_v6() -> impl Strategy<Value = IpPacket<'static>> {
     (
         any::<Ipv6Addr>(),
         any::<Ipv6Addr>(),
@@ -138,7 +138,7 @@ fn icmp_request_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
         })
 }
 
-fn icmp_reply_packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn icmp_reply_packet_v6() -> impl Strategy<Value = IpPacket<'static>> {
     (
         any::<Ipv6Addr>(),
         any::<Ipv6Addr>(),
@@ -169,7 +169,7 @@ fn ipv4_options() -> impl Strategy<Value = Ipv4Options> {
     ]
 }
 
-fn packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn packet_v4() -> impl Strategy<Value = IpPacket<'static>> {
     prop_oneof![
         tcp_packet_v4(),
         udp_packet_v4(),
@@ -178,7 +178,7 @@ fn packet_v4() -> impl Strategy<Value = MutableIpPacket<'static>> {
     ]
 }
 
-fn packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
+fn packet_v6() -> impl Strategy<Value = IpPacket<'static>> {
     prop_oneof![
         tcp_packet_v6(),
         udp_packet_v6(),
@@ -189,7 +189,7 @@ fn packet_v6() -> impl Strategy<Value = MutableIpPacket<'static>> {
 
 #[test_strategy::proptest()]
 fn nat_6446(
-    #[strategy(packet_v6())] packet_v6: MutableIpPacket<'static>,
+    #[strategy(packet_v6())] packet_v6: IpPacket<'static>,
     #[strategy(any::<Ipv4Addr>())] new_src: Ipv4Addr,
     #[strategy(any::<Ipv4Addr>())] new_dst: Ipv4Addr,
 ) {
@@ -212,7 +212,7 @@ fn nat_6446(
 
 #[test_strategy::proptest()]
 fn nat_4664(
-    #[strategy(packet_v4())] packet_v4: MutableIpPacket<'static>,
+    #[strategy(packet_v4())] packet_v4: IpPacket<'static>,
     #[strategy(any::<Ipv6Addr>())] new_src: Ipv6Addr,
     #[strategy(any::<Ipv6Addr>())] new_dst: Ipv6Addr,
 ) {

--- a/rust/ip-packet/src/proptests.rs
+++ b/rust/ip-packet/src/proptests.rs
@@ -193,7 +193,7 @@ fn nat_6446(
     #[strategy(any::<Ipv4Addr>())] new_src: Ipv4Addr,
     #[strategy(any::<Ipv4Addr>())] new_dst: Ipv4Addr,
 ) {
-    let header = packet_v6.as_immutable().ipv6_header().unwrap();
+    let header = packet_v6.ipv6_header().unwrap();
     let payload = packet_v6.payload().to_vec();
 
     let packet_v4 = packet_v6.consume_to_ipv4(new_src, new_dst).unwrap();
@@ -206,7 +206,7 @@ fn nat_6446(
         .unwrap();
     new_packet_v6.update_checksum();
 
-    assert_eq!(new_packet_v6.as_immutable().ipv6_header().unwrap(), header);
+    assert_eq!(new_packet_v6.ipv6_header().unwrap(), header);
     assert_eq!(new_packet_v6.payload(), payload);
 }
 
@@ -216,7 +216,7 @@ fn nat_4664(
     #[strategy(any::<Ipv6Addr>())] new_src: Ipv6Addr,
     #[strategy(any::<Ipv6Addr>())] new_dst: Ipv6Addr,
 ) {
-    let header = packet_v4.as_immutable().ipv4_header().unwrap();
+    let header = packet_v4.ipv4_header().unwrap();
     let payload = packet_v4.payload().to_vec();
 
     let packet_v6 = packet_v4.consume_to_ipv6(new_src, new_dst).unwrap();
@@ -236,9 +236,6 @@ fn nat_4664(
     };
     header_without_options.header_checksum = header_without_options.calc_header_checksum();
 
-    assert_eq!(
-        new_packet_v4.as_immutable().ipv4_header().unwrap(),
-        header_without_options
-    );
+    assert_eq!(new_packet_v4.ipv4_header().unwrap(), header_without_options);
     assert_eq!(new_packet_v4.payload(), payload);
 }


### PR DESCRIPTION
Currently, we have two structs for representing IP packets: `IpPacket` and `MutableIpPacket`. As the name suggests, they mostly differ in mutability. This design was originally inspired by the `pnet_packet` crate which we based our `IpPacket` on. With subsequent iterations, we added more and more functionality onto our `IpPacket`, like NAT64 & NAT46 translation. As a result of that, the `MutableIpPacket` is no longer directly based on `pnet_packet` but instead just keeps an internal buffer.

This duplication can be resolved by merging the two structs into a single `IpPacket`. We do this by first replacing all usages of `IpPacket` with `MutableIpPacket`, deleting `IpPacket` and renaming `MutableIpPacket` to `IpPacket`. The final design now has different `self`-receivers: Some functions take `&self`, some `&mut self` and some consume the packet using `self`.

This results in a more ergonomic usage of `IpPacket` across the codebase and deletes a fair bit of code. It also takes us one step closer towards using `etherparse` for all our IP packet interaction-needs. Lastly, I am currently exploring a performance-optimisation idea that stack-allocates all IP packets and for that, the current split between `IpPacket` and `MutableIpPacket` does not really work.

Related: #6366.