### PR TITLE
fix(portal): default email host from web url

### DIFF
--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -556,7 +556,7 @@ defmodule Domain.Config.Definitions do
   """
   defconfig(:outbound_email_from, :string,
     default: fn ->
-      external_uri = URI.parse(compile_config!(:external_url))
+      external_uri = URI.parse(compile_config!(:web_external_url))
       "firezone@#{external_uri.host}"
     end,
     sensitive: true,


### PR DESCRIPTION
Fix after #6202
Variable "outbound_email_from" uses removed variable "external_url"