### PR TITLE
ci: Use NDK on GitHub runners

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 
     // Life is easier if we just match the default NDK on the Ubuntu 22.04 runners
     // https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#android
-    ndkVersion = "27.1.12297006"
+    ndkVersion = "27"
 
     defaultConfig {
         applicationId = "dev.firezone.android"

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 
     // Life is easier if we just match the default NDK on the Ubuntu 22.04 runners
     // https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#android
-    ndkVersion = "27"
+    ndkVersion = "27.1.12297006"
 
     defaultConfig {
         applicationId = "dev.firezone.android"

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 
     // Life is easier if we just match the default NDK on the Ubuntu 22.04 runners
     // https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#android
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "27.1.12297006"
 
     defaultConfig {
         applicationId = "dev.firezone.android"


### PR DESCRIPTION
GitHub is rolling out an update to their runner images that bumps the NDK version: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240908.1. This causes CI to fail whenever we are given a machine that already uses the new image.

Here is one of these failures: https://github.com/firezone/firezone/actions/runs/10804517190/job/29970095787?pr=6564