### PR TITLE
chore(infra): Add CAA record for trust.firezone.dev

### DIFF
--- a/terraform/environments/production/dns.tf
+++ b/terraform/environments/production/dns.tf
@@ -155,6 +155,19 @@ resource "google_dns_record_set" "google-dkim" {
 
 # Oneleet Trust page
 
+resource "google_dns_record_set" "trust-dns-caa" {
+  project      = module.google-cloud-project.project.project_id
+  managed_zone = module.google-cloud-dns.zone_name
+
+  type = "CAA"
+  name = "trust.${module.google-cloud-dns.dns_name}"
+  rrdatas = [
+    "0 issue \"letsencrypt.org\"",
+    "0 iodef \"mailto:security@firezone.dev\""
+  ]
+  ttl = 3600
+}
+
 resource "google_dns_record_set" "oneleet-trust" {
   project      = module.google-cloud-project.project.project_id
   managed_zone = module.google-cloud-dns.zone_name


### PR DESCRIPTION
Why:

* `trust.firezone.dev` is actually being hosted by `trust.oneleet.com` which means Oneleet needs to issue the cert for `trust.firezone.dev` and can't use the Google CA used for the rest of `firezone.dev`.

Closes #6661