### PR TITLE
fix(portal): fix dump config smtp

### DIFF
--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -606,7 +606,7 @@ defmodule Domain.Config.Definitions do
     dump: fn map ->
       Dumper.keyword(map)
       |> Keyword.update(:tls_options, nil, &Dumper.dump_ssl_opts/1)
-      |> Keyword.update(:sockopts, nil, &Dumper.dump_ssl_opts/1)
+      |> Keyword.update(:sockopts, [], &Dumper.dump_ssl_opts/1)
     end
   )
 


### PR DESCRIPTION
This can cause issue when sockopts is ommited and tls is not used. Tested with SMTP without and with TLS

cf #6665