### PR TITLE
fix(portal): Remove OneLeet CAA record

### DIFF
--- a/terraform/environments/production/dns.tf
+++ b/terraform/environments/production/dns.tf
@@ -155,17 +155,17 @@ resource "google_dns_record_set" "google-dkim" {
 
 # Oneleet Trust page
 
-resource "google_dns_record_set" "trust-dns-caa" {
+resource "google_dns_record_set" "oneleet-trust" {
   project      = module.google-cloud-project.project.project_id
   managed_zone = module.google-cloud-dns.zone_name
 
-  type = "CAA"
   name = "trust.${module.google-cloud-dns.dns_name}"
+  type = "CNAME"
+  ttl  = 3600
+
   rrdatas = [
-    "0 issue \"letsencrypt.org\"",
-    "0 iodef \"mailto:security@firezone.dev\""
+    "trust.oneleet.com."
   ]
-  ttl = 3600
 }
 
 # Stripe checkout pages

--- a/terraform/environments/production/dns.tf
+++ b/terraform/environments/production/dns.tf
@@ -168,19 +168,6 @@ resource "google_dns_record_set" "trust-dns-caa" {
   ttl = 3600
 }
 
-resource "google_dns_record_set" "oneleet-trust" {
-  project      = module.google-cloud-project.project.project_id
-  managed_zone = module.google-cloud-dns.zone_name
-
-  name = "trust.${module.google-cloud-dns.dns_name}"
-  type = "CNAME"
-  ttl  = 3600
-
-  rrdatas = [
-    "trust.oneleet.com."
-  ]
-}
-
 # Stripe checkout pages
 
 resource "google_dns_record_set" "stripe-checkout" {


### PR DESCRIPTION
The CAA can't be set for a domain that has a CNAME record, see https://letsencrypt.org/docs/caa/

> Note also that CAA checking follows CNAME redirects, just like all other DNS requests. If “[community.example.org](http://community.example.org/)” is a CNAME to “[example.forum.com](http://example.forum.com/)”, the CA will respect any CAA records that are set on “[example.forum.com](http://example.forum.com/)”. It is not allowed for a domain name with a CNAME record to have any other records, so there cannot be conflicts between CAA records on the original name and CAA records on the target of the redirect.