### PR TITLE
fix(client/windows): set MTU even if IPv6 is disabled

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -388,7 +388,6 @@ fn try_set_mtu(luid: NET_LUID_LH, family: ADDRESS_FAMILY, mtu: u32) -> Result<()
     // https://stackoverflow.com/questions/54857292/setipinterfaceentry-returns-error-invalid-parameter
     row.SitePrefixLength = 0;
 
-    // Set MTU for IPv4
     row.NlMtu = mtu;
 
     // SAFETY: TODO

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -13,6 +13,15 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This cannot be done when the issue's PR merges. */}
+      {/*
+      <Entry version="1.3.3" date={new Date("invalid")}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem enable={title === "Windows"} pull="6681">
+            Fixes a bug where sign-in fails if IPv6 is disabled
+          </ChangeItem>
+        </ul>
+      </Entry>
+      */}
       <Entry version="1.3.2" date={new Date("2024-09-06")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6624">


### PR DESCRIPTION
Refs #6547, this fixes a similar error message but it's not the same exact issue.

When IPv6 is disabled on a system, our call to set the MTU was failing with error code 0x80070490. This patch allows some of the MTU-related syscalls to fail with a warning log.

To replicate the issue, run this command to set a registry value to disable IPv6, then reboot the system:

`reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters" /v DisabledComponents /t REG_DWORD /d 255 /f`

```[tasklist]
- [x] Update changelog
- [x] Apply PR feedback
```