### PR TITLE
fix(portal): Fix verified shield alignment/spacing

### DIFF
--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -972,8 +972,8 @@ defmodule Web.CoreComponents do
         class="text-accent-500 hover:underline"
         navigate={~p"/#{@schema.account_id}/actors/#{@schema.verified_by_identity.actor_id}"}
       >
-      <%= assigns.schema.verified_by_actor.name %>
-    </.link>
+        <%= assigns.schema.verified_by_actor.name %>
+      </.link>
     </div>
     """
   end

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -946,29 +946,35 @@ defmodule Web.CoreComponents do
 
   def verified_by(%{schema: %{verified_by: :system}} = assigns) do
     ~H"""
-    <.icon name="hero-shield-check" class="w-4 h-4 mr-1" /> Verified
-    <.relative_datetime datetime={@schema.verified_at} /> by system
+    <div class="flex items-center gap-x-1">
+      <.icon name="hero-shield-check" class="w-4 h-4" /> Verified
+      <.relative_datetime datetime={@schema.verified_at} /> by system
+    </div>
     """
   end
 
   def verified_by(%{schema: %{verified_by: :actor}} = assigns) do
     ~H"""
-    <.icon name="hero-shield-check" class="w-4 h-4 mr-1" /> Verified
-    <.relative_datetime datetime={@schema.verified_at} /> by
-    <.actor_link account={@account} actor={@schema.verified_by_actor} />
+    <div class="flex items-center gap-x-1">
+      <.icon name="hero-shield-check" class="w-4 h-4" /> Verified
+      <.relative_datetime datetime={@schema.verified_at} /> by
+      <.actor_link account={@account} actor={@schema.verified_by_actor} />
+    </div>
     """
   end
 
   def verified_by(%{schema: %{verified_by: :identity}} = assigns) do
     ~H"""
-    <.icon name="hero-shield-check" class="w-4 h-4 mr-1" /> Verified
-    <.relative_datetime datetime={@schema.verified_at} /> by
-    <.link
-      class="text-accent-500 hover:underline"
-      navigate={~p"/#{@schema.account_id}/actors/#{@schema.verified_by_identity.actor_id}"}
-    >
+    <div class="flex items-center gap-x-1">
+      <.icon name="hero-shield-check" class="w-4 h-4" /> Verified
+      <.relative_datetime datetime={@schema.verified_at} /> by
+      <.link
+        class="text-accent-500 hover:underline"
+        navigate={~p"/#{@schema.account_id}/actors/#{@schema.verified_by_identity.actor_id}"}
+      >
       <%= assigns.schema.verified_by_actor.name %>
     </.link>
+    </div>
     """
   end
 

--- a/elixir/apps/web/lib/web/live/clients/index.ex
+++ b/elixir/apps/web/lib/web/live/clients/index.ex
@@ -66,10 +66,12 @@ defmodule Web.Clients.Index do
           metadata={@clients_metadata}
         >
           <:col :let={client} field={{:clients, :name}} label="name">
-            <.link navigate={~p"/#{@account}/clients/#{client.id}"} class={[link_style()]}>
-              <%= client.name %>
-            </.link>
-            <.icon :if={not is_nil(client.verified_at)} name="hero-shield-check" class="w-4 h-4" />
+            <div class="flex items-center space-x-1">
+              <.link navigate={~p"/#{@account}/clients/#{client.id}"} class={[link_style()]}>
+                <%= client.name %>
+              </.link>
+              <.icon :if={not is_nil(client.verified_at)} name="hero-shield-check" class="w-4 h-4" />
+            </div>
           </:col>
           <:col :let={client} label="user">
             <.link navigate={~p"/#{@account}/actors/#{client.actor.id}"} class={[link_style()]}>

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -143,7 +143,7 @@ defmodule Web.Clients.Show do
           <.vertical_table_row>
             <:label>Last used sign in method</:label>
             <:value>
-              <span :if={@client.actor.type != :service_account}>
+              <div :if={@client.actor.type != :service_account} class="flex items-center">
                 <.identity_identifier account={@account} identity={@client.last_used_token.identity} />
                 <.link
                   navigate={
@@ -153,8 +153,8 @@ defmodule Web.Clients.Show do
                 >
                   show tokens
                 </.link>
-              </span>
-              <span :if={@client.actor.type == :service_account}>
+              </div>
+              <div :if={@client.actor.type == :service_account}>
                 token
                 <.link
                   navigate={
@@ -167,7 +167,7 @@ defmodule Web.Clients.Show do
                 <span :if={not is_nil(@client.last_used_token.deleted_at)}>
                   (deleted)
                 </span>
-              </span>
+              </div>
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>


### PR DESCRIPTION
Was taking screenshots for the new verification feature and noticed the alignment / spacing was off, so decided to quickly adjust them.


# Before
<img width="269" alt="Screenshot 2024-09-13 at 9 20 39 AM" src="https://github.com/user-attachments/assets/6b5ba98f-f38c-4acb-a762-79e89901bd1e">
<img width="785" alt="Screenshot 2024-09-13 at 9 20 15 AM" src="https://github.com/user-attachments/assets/5ff981bd-0643-474c-8324-5a5aaa3dcb2f">


# After

<img width="293" alt="Screenshot 2024-09-13 at 9 36 58 AM" src="https://github.com/user-attachments/assets/b5667d2a-2ada-46c3-b3b6-4e1cacde5e18">

<img width="620" alt="Screenshot 2024-09-13 at 9 31 41 AM" src="https://github.com/user-attachments/assets/586ce7f8-eccc-4ecf-a65b-bca799eddeb6">
