### PR TITLE
build(nix): install RA into dev-shell

### DIFF
--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -57,7 +57,7 @@
             packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.nodePackages.pnpm cargo-udeps pkgs.cargo-sort ];
             buildInputs = packages ++ [
               (rustVersion.override {
-                extensions = [ "rust-src" ];
+                extensions = [ "rust-src" "rust-analyzer" ];
                 targets = [ "x86_64-unknown-linux-musl" ];
               })
             ];


### PR DESCRIPTION
Instead of forcing NIx users of the respository (me) to install RA globally, we can install the equivalent version of whatever Rust version we depend on.