### PR TITLE
feat(portal): Allow updating policies and resources

### DIFF
--- a/elixir/apps/api/lib/api/controllers/policy_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/policy_controller.ex
@@ -91,9 +91,17 @@ defmodule API.PolicyController do
   def update(conn, %{"id" => id, "policy" => params}) do
     subject = conn.assigns.subject
 
-    with {:ok, policy} <- Policies.fetch_policy_by_id(id, subject),
-         {:ok, policy} <- Policies.update_or_replace_policy(policy, params, subject) do
-      render(conn, :show, policy: policy)
+    with {:ok, policy} <- Policies.fetch_policy_by_id(id, subject) do
+      case Policies.update_or_replace_policy(policy, params, subject) do
+        {:updated, updated_policy} ->
+          render(conn, :show, policy: policy)
+
+        {:replaced, _replaced_policy, replacement_policy} ->
+          render(conn, :show, policy: replacement_policy)
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 

--- a/elixir/apps/api/lib/api/controllers/policy_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/policy_controller.ex
@@ -94,7 +94,7 @@ defmodule API.PolicyController do
     with {:ok, policy} <- Policies.fetch_policy_by_id(id, subject) do
       case Policies.update_or_replace_policy(policy, params, subject) do
         {:updated, updated_policy} ->
-          render(conn, :show, policy: policy)
+          render(conn, :show, policy: updated_policy)
 
         {:replaced, _replaced_policy, replacement_policy} ->
           render(conn, :show, policy: replacement_policy)

--- a/elixir/apps/api/lib/api/controllers/policy_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/policy_controller.ex
@@ -92,7 +92,7 @@ defmodule API.PolicyController do
     subject = conn.assigns.subject
 
     with {:ok, policy} <- Policies.fetch_policy_by_id(id, subject),
-         {:ok, policy} <- Policies.update_policy(policy, params, subject) do
+         {:ok, policy} <- Policies.update_or_replace_policy(policy, params, subject) do
       render(conn, :show, policy: policy)
     end
   end

--- a/elixir/apps/api/lib/api/controllers/resource_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/resource_controller.ex
@@ -91,9 +91,17 @@ defmodule API.ResourceController do
     subject = conn.assigns.subject
     attrs = set_param_defaults(params)
 
-    with {:ok, resource} <- Resources.fetch_resource_by_id(id, subject),
-         {:ok, resource} <- Resources.update_resource(resource, attrs, subject) do
-      render(conn, :show, resource: resource)
+    with {:ok, resource} <- Resources.fetch_resource_by_id(id, subject) do
+      case Resources.update_or_replace_resource(resource, attrs, subject) do
+        {:updated, updated_resource} ->
+          render(conn, :show, resource: updated_resource)
+
+        {:replaced, _updated_resource, created_resource} ->
+          render(conn, :show, resource: created_resource)
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -496,7 +496,10 @@ defmodule API.Client.ChannelTest do
       subject: subject
     } do
       assert_push "init", %{}
-      {:ok, _resource} = Domain.Resources.update_resource(resource, %{name: "foobar"}, subject)
+
+      {:updated, _resource} =
+        Domain.Resources.update_or_replace_resource(resource, %{name: "foobar"}, subject)
+
       assert_push "resource_created_or_updated", %{}
     end
 
@@ -1252,8 +1255,8 @@ defmodule API.Client.ChannelTest do
           }
         )
 
-      {:ok, resource} =
-        Domain.Resources.update_resource(
+      {:updated, resource} =
+        Domain.Resources.update_or_replace_resource(
           resource,
           %{connections: [%{gateway_group_id: gateway_group.id}]},
           subject

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -268,8 +268,12 @@ defmodule API.Gateway.ChannelTest do
 
       assert_push "allow_access", %{}
 
-      {:ok, resource} =
-        Domain.Resources.update_resource(resource, %{"name" => Ecto.UUID.generate()}, subject)
+      {:updated, resource} =
+        Domain.Resources.update_or_replace_resource(
+          resource,
+          %{"name" => Ecto.UUID.generate()},
+          subject
+        )
 
       assert_push "resource_updated", payload
 
@@ -659,8 +663,12 @@ defmodule API.Gateway.ChannelTest do
 
       assert_push "request_connection", %{}
 
-      {:ok, resource} =
-        Domain.Resources.update_resource(resource, %{"name" => Ecto.UUID.generate()}, subject)
+      {:updated, resource} =
+        Domain.Resources.update_or_replace_resource(
+          resource,
+          %{"name" => Ecto.UUID.generate()},
+          subject
+        )
 
       assert_push "resource_updated", payload
 

--- a/elixir/apps/domain/lib/domain/application.ex
+++ b/elixir/apps/domain/lib/domain/application.ex
@@ -7,7 +7,9 @@ defmodule Domain.Application do
 
     _ = OpentelemetryLoggerMetadata.setup()
     _ = OpentelemetryEcto.setup([:domain, :repo])
-    _ = OpentelemetryFinch.setup()
+
+    # Can be uncommented when this bug is fixed: https://github.com/open-telemetry/opentelemetry-erlang-contrib/issues/327
+    # _ = OpentelemetryFinch.setup()
 
     Supervisor.start_link(children(), strategy: :one_for_one, name: __MODULE__.Supervisor)
   end

--- a/elixir/apps/domain/lib/domain/policies.ex
+++ b/elixir/apps/domain/lib/domain/policies.ex
@@ -2,7 +2,6 @@ defmodule Domain.Policies do
   alias Domain.{Repo, PubSub}
   alias Domain.{Auth, Accounts, Actors, Clients, Resources, Flows}
   alias Domain.Policies.{Authorizer, Policy, Condition}
-  require Ecto.Query
 
   def fetch_policy_by_id(id, %Auth.Subject{} = subject, opts \\ []) do
     required_permissions =

--- a/elixir/apps/domain/lib/domain/policies.ex
+++ b/elixir/apps/domain/lib/domain/policies.ex
@@ -70,58 +70,21 @@ defmodule Domain.Policies do
   def update_or_replace_policy(%Policy{} = policy, attrs, %Auth.Subject{} = subject) do
     with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_policies_permission()),
          :ok <- ensure_has_access_to(subject, policy) do
-      Ecto.Multi.new()
-      |> Ecto.Multi.one(:policy, fn
-        _effects_so_far ->
-          Policy.Query.not_deleted()
-          |> Policy.Query.by_id(policy.id)
-          |> Authorizer.for_subject(subject)
-          |> Ecto.Query.lock("FOR NO KEY UPDATE")
-      end)
-      |> Ecto.Multi.run(:changesets, fn
-        _repo, %{policy: policy} ->
-          {update_changeset, create_changeset} =
-            Policy.Changeset.update_or_replace(policy, attrs, subject)
-
-          {:ok, {update_changeset, create_changeset}}
-      end)
-      |> Ecto.Multi.update(:update_policy, fn
-        %{changesets: {update_changeset, _create_changeset}} ->
-          update_changeset
-      end)
-      |> Ecto.Multi.run(:create_policy, fn
-        _repo, %{changesets: {_update_changeset, nil}} ->
-          {:ok, nil}
-
-        repo, %{changesets: {_update_changeset, create_changeset}} ->
-          {:ok, created_policy} = repo.insert(create_changeset)
-          {:ok, created_policy}
-      end)
-      |> Ecto.Multi.run(:replace_policy, fn
-        _repo, %{update_policy: _updated_policy, create_policy: nil} ->
-          {:ok, nil}
-
-        repo, %{update_policy: updated_policy, create_policy: created_policy} ->
+      Policy.Query.not_deleted()
+      |> Policy.Query.by_id(policy.id)
+      |> Authorizer.for_subject(subject)
+      |> Repo.fetch_and_update_or_replace(Policy.Query,
+        with: &Policy.Changeset.update_or_replace(&1, attrs, subject),
+        on_replace: fn repo, updated_policy, created_policy ->
           Ecto.Changeset.change(updated_policy, replaced_by_policy_id: created_policy.id)
           |> repo.update()
-      end)
-      |> Repo.transaction()
-      |> case do
-        {:ok, %{update_policy: updated_policy, create_policy: nil}} ->
-          :ok = broadcast_policy_events(:update, updated_policy)
-          {:updated, updated_policy}
-
-        {:ok, %{replace_policy: replaced_policy, create_policy: create_policy}} ->
+        end,
+        after_update_commit: &broadcast_policy_events(:update, &1),
+        after_replace_commit: fn {replaced_policy, _created_policy}, _changesets ->
           {:ok, _flows} = Flows.expire_flows_for(replaced_policy, subject)
           :ok = broadcast_policy_events(:delete, replaced_policy)
-          {:replaced, replaced_policy, create_policy}
-
-        {:error, :policy, changeset, _changes_so_far} ->
-          {:error, changeset}
-
-        {:error, :update_policy, changeset, _changes_so_far} ->
-          {:error, changeset}
-      end
+        end
+      )
     end
   end
 

--- a/elixir/apps/domain/lib/domain/policies.ex
+++ b/elixir/apps/domain/lib/domain/policies.ex
@@ -79,9 +79,10 @@ defmodule Domain.Policies do
           |> repo.update()
         end,
         after_update_commit: &broadcast_policy_events(:update, &1),
-        after_replace_commit: fn {replaced_policy, _created_policy}, _changesets ->
+        after_replace_commit: fn {replaced_policy, created_policy}, _changesets ->
           {:ok, _flows} = Flows.expire_flows_for(replaced_policy, subject)
           :ok = broadcast_policy_events(:delete, replaced_policy)
+          :ok = broadcast_policy_events(:create, created_policy)
         end
       )
     end

--- a/elixir/apps/domain/lib/domain/policies/policy.ex
+++ b/elixir/apps/domain/lib/domain/policies/policy.ex
@@ -2,6 +2,8 @@ defmodule Domain.Policies.Policy do
   use Domain, :schema
 
   schema "policies" do
+    field :persistent_id, Ecto.UUID
+
     field :description, :string
 
     embeds_many :conditions, Domain.Policies.Condition, on_replace: :delete
@@ -13,6 +15,9 @@ defmodule Domain.Policies.Policy do
     field :created_by, Ecto.Enum, values: ~w[actor identity]a
     belongs_to :created_by_identity, Domain.Auth.Identity
     belongs_to :created_by_actor, Domain.Actors.Actor
+
+    belongs_to :replaced_by_policy, Domain.Policies.Policy
+    has_one :replaces_policy, Domain.Policies.Policy, foreign_key: :replaced_by_policy_id
 
     field :disabled_at, :utc_datetime_usec
     field :deleted_at, :utc_datetime_usec

--- a/elixir/apps/domain/lib/domain/repo/changeset.ex
+++ b/elixir/apps/domain/lib/domain/repo/changeset.ex
@@ -47,6 +47,11 @@ defmodule Domain.Repo.Changeset do
     end
   end
 
+  def any_field_changed?(%Ecto.Changeset{} = changeset, fields) do
+    changed_fields = Map.keys(changeset.changes)
+    Enum.any?(changed_fields, &(&1 in fields))
+  end
+
   @doc """
   Takes value from `value_field` and puts it's hash of a given type to `hash_field`.
   """

--- a/elixir/apps/domain/lib/domain/resources/resource.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource.ex
@@ -2,6 +2,8 @@ defmodule Domain.Resources.Resource do
   use Domain, :schema
 
   schema "resources" do
+    field :persistent_id, Ecto.UUID
+
     field :address, :string
     field :address_description, :string
     field :name, :string
@@ -29,6 +31,9 @@ defmodule Domain.Resources.Resource do
     field :created_by, Ecto.Enum, values: ~w[identity actor system]a
     belongs_to :created_by_actor, Domain.Actors.Actor
     belongs_to :created_by_identity, Domain.Auth.Identity
+
+    belongs_to :replaced_by_resource, Domain.Resources.Resource
+    has_one :replaces_resource, Domain.Resources.Resource, foreign_key: :replaced_by_resource_id
 
     field :deleted_at, :utc_datetime_usec
     timestamps()

--- a/elixir/apps/domain/priv/repo/migrations/20240910191608_add_policies_replaced_by_policy_id.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20240910191608_add_policies_replaced_by_policy_id.exs
@@ -1,0 +1,20 @@
+defmodule Domain.Repo.Migrations.AddPoliciesReplacedByPolicyId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:policies) do
+      add(:persistent_id, :binary_id)
+      add(:replaced_by_policy_id, references(:policies, type: :binary_id, on_delete: :delete_all))
+    end
+
+    execute("UPDATE policies SET persistent_id = gen_random_uuid()")
+
+    execute("ALTER TABLE policies ALTER COLUMN persistent_id SET NOT NULL")
+
+    create(
+      constraint(:policies, :replaced_policies_are_deleted,
+        check: "replaced_by_policy_id IS NULL OR deleted_at IS NOT NULL"
+      )
+    )
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20240916174626_add_resources_replaced_by_resource_id.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20240916174626_add_resources_replaced_by_resource_id.exs
@@ -1,0 +1,24 @@
+defmodule Domain.Repo.Migrations.AddResourcesReplacedByResourceId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resources) do
+      add(:persistent_id, :binary_id)
+
+      add(
+        :replaced_by_resource_id,
+        references(:resources, type: :binary_id, on_delete: :delete_all)
+      )
+    end
+
+    execute("UPDATE resources SET persistent_id = gen_random_uuid()")
+
+    execute("ALTER TABLE resources ALTER COLUMN persistent_id SET NOT NULL")
+
+    create(
+      constraint(:resources, :replaced_resources_are_deleted,
+        check: "replaced_by_resource_id IS NULL OR deleted_at IS NOT NULL"
+      )
+    )
+  end
+end

--- a/elixir/apps/domain/test/support/fixtures/policies.ex
+++ b/elixir/apps/domain/test/support/fixtures/policies.ex
@@ -69,4 +69,27 @@ defmodule Domain.Fixtures.Policies do
     {:ok, policy} = Policies.delete_policy(policy, subject)
     policy
   end
+
+  def replace_policy(policy, attrs \\ %{}) do
+    attrs = policy_attrs(attrs)
+    policy = Repo.preload(policy, :account)
+
+    subject =
+      Fixtures.Auth.create_subject(
+        account: policy.account,
+        actor: [type: :account_admin_user]
+      )
+
+    {resource_id, attrs} =
+      pop_assoc_fixture_id(attrs, :resource, fn ->
+        Fixtures.Resources.create_resource(account: policy.account, subject: subject)
+      end)
+
+    attrs = Map.put(attrs, :resource_id, resource_id)
+
+    {:replaced, replaced_policy, replacement_policy} =
+      Policies.update_or_replace_policy(policy, attrs, subject)
+
+    {replaced_policy, replacement_policy}
+  end
 end

--- a/elixir/apps/web/lib/web/auth.ex
+++ b/elixir/apps/web/lib/web/auth.ex
@@ -699,13 +699,23 @@ defmodule Web.Auth do
     if remaining_time > 0 do
       :timer.sleep(remaining_time)
     else
+      log_constant_time_exceeded(constant_time, elapsed_time, remaining_time)
+    end
+
+    result
+  end
+
+  if Mix.env() in [:dev, :test] do
+    def log_constant_time_exceeded(_constant_time, _elapsed_time, _remaining_time) do
+      :ok
+    end
+  else
+    def log_constant_time_exceeded(constant_time, elapsed_time, remaining_time) do
       Logger.error("Execution took longer than the given constant time",
         constant_time: constant_time,
         elapsed_time: elapsed_time,
         remaining_time: remaining_time
       )
     end
-
-    result
   end
 end

--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -19,6 +19,8 @@ defmodule Web.AuthController do
     http_only: true
   ]
 
+  @constant_execution_time Application.compile_env(:web, :constant_execution_time, 2000)
+
   action_fallback Web.FallbackController
 
   @doc """
@@ -145,7 +147,7 @@ defmodule Web.AuthController do
               })
           end
         end,
-        2000
+        @constant_execution_time
       )
 
     put_auth_state(conn, provider.id, {fragment, provider_identifier, redirect_params})

--- a/elixir/apps/web/lib/web/live/policies/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies/edit.ex
@@ -1,7 +1,7 @@
 defmodule Web.Policies.Edit do
   use Web, :live_view
   import Web.Policies.Components
-  alias Domain.Policies
+  alias Domain.{Resources, Actors, Policies, Auth}
 
   def mount(%{"id" => id}, _session, socket) do
     with {:ok, policy} <-
@@ -9,13 +9,26 @@ defmodule Web.Policies.Edit do
              preload: [:actor_group, :resource],
              filter: [deleted?: false]
            ) do
-      form = to_form(Policies.Policy.Changeset.update(policy, %{}))
+      # TODO: unify this dropdown and the one we use for live table filters
+      resources = Resources.all_resources!(socket.assigns.subject, preload: [:gateway_groups])
+      # TODO: unify this dropdown and the one we use for live table filters
+      actor_groups = Actors.all_groups!(socket.assigns.subject, preload: :provider)
+      providers = Auth.all_active_providers_for_account!(socket.assigns.account)
+
+      form =
+        policy
+        |> Policies.change_policy(%{}, socket.assigns.subject)
+        |> to_form()
 
       socket =
         assign(socket,
           page_title: "Edit Policy #{policy.id}",
+          timezone: Map.get(socket.private.connect_params, "timezone", "UTC"),
           policy: policy,
-          form: form
+          form: form,
+          resources: resources,
+          actor_groups: actor_groups,
+          providers: providers
         )
 
       {:ok, socket, temporary_assigns: [form: %Phoenix.HTML.Form{}]}
@@ -43,12 +56,63 @@ defmodule Web.Policies.Edit do
           <h2 class="mb-4 text-xl text-neutral-900">Edit Policy details</h2>
           <.form for={@form} class="space-y-4 lg:space-y-6" phx-submit="submit" phx-change="validate">
             <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
-              <.input
-                field={@form[:description]}
-                type="textarea"
-                label="Policy Description"
-                placeholder="Enter a policy description here"
-                phx-debounce="300"
+              <fieldset class="flex flex-col gap-2">
+                <.input
+                  field={@form[:actor_group_id]}
+                  label="Group"
+                  type="group_select"
+                  options={Web.Groups.Components.select_options(@actor_groups)}
+                  value={@form[:actor_group_id].value}
+                  required
+                />
+
+                <% resource_id =
+                  @form[:resource_id].value ||
+                    (length(@resources) > 0 and Enum.at(@resources, 0).id) %>
+
+                <.input
+                  field={@form[:resource_id]}
+                  label="Resource"
+                  type="group_select"
+                  options={resource_options(@resources, @account)}
+                  value={resource_id}
+                  required
+                />
+
+                <% resource = Enum.find(@resources, &(&1.id == resource_id)) %>
+
+                <p
+                  :if={not is_nil(resource) and length(resource.connections) == 0}
+                  class="flex items-center gap-2 text-sm leading-6 text-orange-600 mt-2 w-full"
+                  data-validation-error-for="policy[resource_id]"
+                >
+                  <.icon name="hero-exclamation-triangle-mini" class="h-4 w-4" />
+                  This Resource isn't linked to any Sites, so Clients won't be able to access it.
+                </p>
+
+                <.input
+                  field={@form[:description]}
+                  label="Description"
+                  type="textarea"
+                  placeholder="Enter an optional reason for creating this policy here."
+                  phx-debounce="300"
+                />
+              </fieldset>
+
+              <.conditions_form
+                :if={is_nil(resource) or resource.type != :internet}
+                form={@form}
+                account={@account}
+                timezone={@timezone}
+                providers={@providers}
+              />
+
+              <.options_form
+                :if={not is_nil(resource) and resource.type == :internet}
+                form={@form}
+                account={@account}
+                timezone={@timezone}
+                providers={@providers}
               />
             </div>
 
@@ -63,18 +127,34 @@ defmodule Web.Policies.Edit do
   end
 
   def handle_event("validate", %{"policy" => params}, socket) do
+    params = map_condition_params(params, empty_values: :drop)
+
     changeset =
-      Policies.Policy.Changeset.update(socket.assigns.policy, params)
+      Policies.change_policy(socket.assigns.policy, params, socket.assigns.subject)
       |> Map.put(:action, :validate)
 
     {:noreply, assign(socket, form: to_form(changeset))}
   end
 
   def handle_event("submit", %{"policy" => params}, socket) do
-    with {:ok, policy} <-
-           Policies.update_policy(socket.assigns.policy, params, socket.assigns.subject) do
-      {:noreply, push_navigate(socket, to: ~p"/#{socket.assigns.account}/policies/#{policy}")}
-    else
+    params = map_condition_params(params, empty_values: :drop)
+
+    params =
+      if Domain.Accounts.policy_conditions_enabled?(socket.assigns.account) do
+        params
+      else
+        Map.delete(params, "conditions")
+      end
+
+    case Policies.update_or_replace_policy(socket.assigns.policy, params, socket.assigns.subject) do
+      {:updated, updated_policy} ->
+        {:noreply,
+         push_navigate(socket, to: ~p"/#{socket.assigns.account}/policies/#{updated_policy}")}
+
+      {:replaced, _replaced_policy, created_policy} ->
+        {:noreply,
+         push_navigate(socket, to: ~p"/#{socket.assigns.account}/policies/#{created_policy}")}
+
       {:error, changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
     end

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -144,7 +144,7 @@ defmodule Web.Policies.Show do
               <%= @policy.id %>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row>
+          <.vertical_table_row :if={not is_nil(@policy.deleted_at)}>
             <:label>
               Persistent ID
             </:label>
@@ -152,7 +152,9 @@ defmodule Web.Policies.Show do
               <%= @policy.persistent_id %>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row :if={not is_nil(@policy.replaced_by_policy)}>
+          <.vertical_table_row :if={
+            not is_nil(@policy.deleted_at) and not is_nil(@policy.replaced_by_policy)
+          }>
             <:label>
               Replaced by Policy
             </:label>
@@ -165,7 +167,9 @@ defmodule Web.Policies.Show do
               </.link>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row :if={not is_nil(@policy.replaces_policy)}>
+          <.vertical_table_row :if={
+            not is_nil(@policy.deleted_at) and not is_nil(@policy.replaces_policy)
+          }>
             <:label>
               Replaced Policy
             </:label>

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -50,6 +50,147 @@ defmodule Web.Resources.Edit do
           <h2 class="mb-4 text-xl text-neutral-900">Edit Resource details</h2>
 
           <.form for={@form} phx-change={:change} phx-submit={:submit} class="space-y-4 lg:space-y-6">
+            <div :if={@resource.type != :internet}>
+              <p class="mb-2 text-sm text-neutral-900">
+                Type
+              </p>
+              <ul class="grid w-full gap-6 md:grid-cols-3">
+                <li>
+                  <.input
+                    id="resource-type--dns"
+                    type="radio_button_group"
+                    field={@form[:type]}
+                    value="dns"
+                    checked={@form[:type].value == :dns}
+                    required
+                  />
+                  <label for="resource-type--dns" class={~w[
+                    inline-flex items-center justify-between w-full
+                    p-5 text-gray-500 bg-white border border-gray-200
+                    rounded cursor-pointer peer-checked:border-accent-500
+                    peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
+                  ]}>
+                    <div class="block">
+                      <div class="w-full font-semibold mb-3">
+                        <.icon name="hero-globe-alt" class="w-5 h-5 mr-1" /> DNS
+                      </div>
+                      <div class="w-full text-sm">
+                        Manage access to an application or service by DNS address.
+                      </div>
+                    </div>
+                  </label>
+                </li>
+                <li>
+                  <.input
+                    id="resource-type--ip"
+                    type="radio_button_group"
+                    field={@form[:type]}
+                    value="ip"
+                    checked={@form[:type].value == :ip}
+                    required
+                  />
+                  <label for="resource-type--ip" class={~w[
+                    inline-flex items-center justify-between w-full
+                    p-5 text-gray-500 bg-white border border-gray-200
+                    rounded cursor-pointer peer-checked:border-accent-600
+                    peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
+                  ]}>
+                    <div class="block">
+                      <div class="w-full font-semibold mb-3">
+                        <.icon name="hero-server" class="w-5 h-5 mr-1" /> IP
+                      </div>
+                      <div class="w-full text-sm">
+                        Manage access to a specific host by IP address.
+                      </div>
+                    </div>
+                  </label>
+                </li>
+                <li>
+                  <.input
+                    id="resource-type--cidr"
+                    type="radio_button_group"
+                    field={@form[:type]}
+                    value="cidr"
+                    checked={@form[:type].value == :cidr}
+                    required
+                  />
+                  <label for="resource-type--cidr" class={~w[
+                    inline-flex items-center justify-between w-full
+                    p-5 text-gray-500 bg-white border border-gray-200
+                    rounded cursor-pointer peer-checked:border-accent-500
+                    peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
+                  ]}>
+                    <div class="block">
+                      <div class="w-full font-semibold mb-3">
+                        <.icon name="hero-server-stack" class="w-5 h-5 mr-1" /> CIDR
+                      </div>
+                      <div class="w-full text-sm">
+                        Manage access to a network, VPC or subnet by CIDR address.
+                      </div>
+                    </div>
+                  </label>
+                </li>
+              </ul>
+            </div>
+
+            <div :if={@resource.type != :internet}>
+              <.input
+                field={@form[:address]}
+                autocomplete="off"
+                label="Address"
+                placeholder={
+                  cond do
+                    @form[:type].value == :dns -> "gitlab.company.com"
+                    @form[:type].value == :cidr -> "10.0.0.0/24"
+                    @form[:type].value == :ip -> "10.3.2.1"
+                    true -> "First select a type above"
+                  end
+                }
+                class={is_nil(@form[:type].value) && "cursor-not-allowed"}
+                disabled={is_nil(@form[:type].value)}
+                required
+              />
+
+              <p
+                :if={
+                  @form[:type].value == :dns and
+                    is_binary(@form[:address].value) and
+                    @form[:address].value
+                    |> String.codepoints()
+                    |> Resources.map_resource_address() == :drop
+                }
+                class="flex items-center gap-2 text-sm leading-6 text-accent-600 mt-2 w-full"
+              >
+                <.icon name="hero-exclamation-triangle" class="w-4 h-4" />
+                This is an advanced address format. This Resource will be available to Clients and Gateways v1.2.0 and higher only.
+              </p>
+              <div :if={@form[:type].value == :dns}>
+                <div class="mt-2 text-xs text-neutral-500">
+                  <.badge type="info" class="p-0 mr-2">NEW</.badge>
+                  Wildcard matching is supported:
+                </div>
+                <div class="mt-2 text-xs text-neutral-500">
+                  <code class="ml-2 px-0.5 font-semibold">**.c.com</code>
+                  matches any level of subdomains (e.g. <code class="px-0.5 font-semibold">foo.c.com</code>,
+                  <code class="px-0.5 font-semibold">bar.foo.c.com</code>
+                  and <code class="px-0.5 font-semibold">c.com</code>).<br />
+                  <code class="ml-2 px-0.5 font-semibold">*.c.com</code>
+                  matches zero or single-level subdomains (e.g.
+                  <code class="px-0.5 font-semibold">foo.c.com</code>
+                  and <code class="px-0.5 font-semibold">c.com</code>
+                  but not <code class="px-0.5 font-semibold">bar.foo.c.com</code>). <br />
+                  <code class="ml-2 px-0.5 font-semibold">us-east?.c.com</code>
+                  matches a single character (e.g. <code class="px-0.5 font-semibold">us-east1.c.com</code>).
+                </div>
+              </div>
+              <div :if={@form[:type].value == :ip} class="mt-2 text-xs text-neutral-500">
+                IPv4 and IPv6 addresses are supported.
+              </div>
+              <div :if={@form[:type].value == :cidr} class="mt-2 text-xs text-neutral-500">
+                IPv4 and IPv6 CIDR ranges are supported.
+              </div>
+            </div>
+
             <.input
               :if={@resource.type != :internet}
               field={@form[:name]}
@@ -135,12 +276,12 @@ defmodule Web.Resources.Edit do
           {:noreply, push_navigate(socket, to: ~p"/#{socket.assigns.account}/resources")}
         end
 
-      {:replaced, updated_resource, created_resource} ->
+      {:replaced, _updated_resource, created_resource} ->
         socket =
           put_flash(
             socket,
             :info,
-            "New version of resource #{resource.name} is created successfully."
+            "New version of resource #{created_resource.name} is created successfully."
           )
 
         if site_id = socket.assigns.params["site_id"] do

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -118,9 +118,30 @@ defmodule Web.Resources.Edit do
       |> map_connections_form_attrs()
       |> maybe_delete_connections(socket.assigns.params)
 
-    case Resources.update_resource(socket.assigns.resource, attrs, socket.assigns.subject) do
-      {:ok, resource} ->
+    case Resources.update_or_replace_resource(
+           socket.assigns.resource,
+           attrs,
+           socket.assigns.subject
+         ) do
+      {:updated, resource} ->
         socket = put_flash(socket, :info, "Resource #{resource.name} updated successfully.")
+
+        if site_id = socket.assigns.params["site_id"] do
+          {:noreply,
+           push_navigate(socket,
+             to: ~p"/#{socket.assigns.account}/sites/#{site_id}"
+           )}
+        else
+          {:noreply, push_navigate(socket, to: ~p"/#{socket.assigns.account}/resources")}
+        end
+
+      {:replaced, updated_resource, created_resource} ->
+        socket =
+          put_flash(
+            socket,
+            :info,
+            "New version of resource #{resource.name} is created successfully."
+          )
 
         if site_id = socket.assigns.params["site_id"] do
           {:noreply,

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -128,7 +128,7 @@ defmodule Web.Resources.Show do
               <%= @resource.id %>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row>
+          <.vertical_table_row :if={not is_nil(@resource.deleted_at)}>
             <:label>
               Persistent ID
             </:label>
@@ -136,7 +136,6 @@ defmodule Web.Resources.Show do
               <%= @resource.persistent_id %>
             </:value>
           </.vertical_table_row>
-
           <.vertical_table_row>
             <:label>
               Name
@@ -212,7 +211,9 @@ defmodule Web.Resources.Show do
               </div>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row :if={not is_nil(@resource.replaced_by_resource)}>
+          <.vertical_table_row :if={
+            not is_nil(@resource.deleted_at) and not is_nil(@resource.replaced_by_resource)
+          }>
             <:label>
               Replaced by Resource
             </:label>
@@ -225,7 +226,9 @@ defmodule Web.Resources.Show do
               </.link>
             </:value>
           </.vertical_table_row>
-          <.vertical_table_row :if={not is_nil(@resource.replaces_resource)}>
+          <.vertical_table_row :if={
+            not is_nil(@resource.deleted_at) and not is_nil(@resource.replaces_resource)
+          }>
             <:label>
               Replaced Resource
             </:label>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -7,7 +7,13 @@ defmodule Web.Resources.Show do
   def mount(%{"id" => id} = params, _session, socket) do
     with {:ok, resource} <-
            Resources.fetch_resource_by_id(id, socket.assigns.subject,
-             preload: [:gateway_groups, :created_by_actor, created_by_identity: [:actor]]
+             preload: [
+               :gateway_groups,
+               :created_by_actor,
+               created_by_identity: [:actor],
+               replaced_by_resource: [],
+               replaces_resource: []
+             ]
            ),
          {:ok, actor_groups_peek} <-
            Resources.peek_resource_actor_groups([resource], 3, socket.assigns.subject) do
@@ -95,7 +101,17 @@ defmodule Web.Resources.Show do
     <.section>
       <:title>
         Resource: <code><%= @resource.name %></code>
-        <span :if={not is_nil(@resource.deleted_at)} class="text-red-600">(deleted)</span>
+
+        <span
+          :if={not is_nil(@resource.deleted_at) and is_nil(@resource.replaced_by_resource_id)}
+          }
+          class="text-red-600"
+        >
+          (deleted)
+        </span>
+        <span :if={not is_nil(@resource.replaced_by_resource_id)} class={["text-red-500"]}>
+          (replaced)
+        </span>
       </:title>
       <:action :if={is_nil(@resource.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/resources/#{@resource.id}/edit?#{@params}"}>
@@ -104,6 +120,23 @@ defmodule Web.Resources.Show do
       </:action>
       <:content>
         <.vertical_table id="resource">
+          <.vertical_table_row>
+            <:label>
+              ID
+            </:label>
+            <:value>
+              <%= @resource.id %>
+            </:value>
+          </.vertical_table_row>
+          <.vertical_table_row>
+            <:label>
+              Persistent ID
+            </:label>
+            <:value>
+              <%= @resource.persistent_id %>
+            </:value>
+          </.vertical_table_row>
+
           <.vertical_table_row>
             <:label>
               Name
@@ -177,6 +210,32 @@ defmodule Web.Resources.Show do
               <div :for={filter <- @resource.filters} :if={@resource.filters != []} %>
                 <.filter_description filter={filter} />
               </div>
+            </:value>
+          </.vertical_table_row>
+          <.vertical_table_row :if={not is_nil(@resource.replaced_by_resource)}>
+            <:label>
+              Replaced by Resource
+            </:label>
+            <:value>
+              <.link
+                navigate={~p"/#{@account}/resources/#{@resource.replaced_by_resource}"}
+                class={["text-accent-600"] ++ link_style()}
+              >
+                <%= @resource.replaced_by_resource.name %>
+              </.link>
+            </:value>
+          </.vertical_table_row>
+          <.vertical_table_row :if={not is_nil(@resource.replaces_resource)}>
+            <:label>
+              Replaced Resource
+            </:label>
+            <:value>
+              <.link
+                navigate={~p"/#{@account}/resources/#{@resource.replaces_resource}"}
+                class={["text-accent-600"] ++ link_style()}
+              >
+                <%= @resource.replaces_resource.name %>
+              </.link>
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>
@@ -347,7 +406,13 @@ defmodule Web.Resources.Show do
   def handle_info({_action, _resource_id}, socket) do
     {:ok, resource} =
       Resources.fetch_resource_by_id(socket.assigns.resource.id, socket.assigns.subject,
-        preload: [:gateway_groups, :policies, created_by_identity: [:actor]]
+        preload: [
+          :gateway_groups,
+          :policies,
+          created_by_identity: [:actor],
+          replaced_by_resource: [],
+          replaces_resource: []
+        ]
       )
 
     {:noreply, assign(socket, resource: resource)}

--- a/elixir/apps/web/test/web/live/policies/show_test.exs
+++ b/elixir/apps/web/test/web/live/policies/show_test.exs
@@ -75,7 +75,7 @@ defmodule Web.Live.Policies.ShowTest do
                }}}
   end
 
-  test "renders deleted gateway group without action buttons", %{
+  test "renders deleted policy without action buttons", %{
     account: account,
     policy: policy,
     identity: identity,
@@ -90,6 +90,57 @@ defmodule Web.Live.Policies.ShowTest do
 
     assert html =~ "(deleted)"
     assert active_buttons(html) == []
+  end
+
+  test "renders replaced policy", %{
+    account: account,
+    policy: policy,
+    identity: identity,
+    conn: conn
+  } do
+    {replaced_policy, replacement_policy} = Fixtures.Policies.replace_policy(policy)
+
+    {:ok, lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/policies/#{replaced_policy}")
+
+    assert html =~ "(replaced)"
+    assert active_buttons(html) == []
+
+    table =
+      lv
+      |> element("#policy")
+      |> render()
+      |> vertical_table_to_map()
+
+    replacement_policy = Repo.preload(replacement_policy, [:actor_group, :resource])
+    assert table["replaced by policy"] =~ replacement_policy.actor_group.name
+    assert table["replaced by policy"] =~ replacement_policy.resource.name
+  end
+
+  test "renders replacement policy", %{
+    account: account,
+    policy: policy,
+    identity: identity,
+    conn: conn
+  } do
+    {replaced_policy, replacement_policy} = Fixtures.Policies.replace_policy(policy)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/policies/#{replacement_policy}")
+
+    table =
+      lv
+      |> element("#policy")
+      |> render()
+      |> vertical_table_to_map()
+
+    replaced_policy = Repo.preload(replaced_policy, [:actor_group, :resource])
+    assert table["replaced policy"] =~ replaced_policy.actor_group.name
+    assert table["replaced policy"] =~ replaced_policy.resource.name
   end
 
   test "renders breadcrumbs item", %{

--- a/elixir/apps/web/test/web/live/policies/show_test.exs
+++ b/elixir/apps/web/test/web/live/policies/show_test.exs
@@ -119,29 +119,30 @@ defmodule Web.Live.Policies.ShowTest do
     assert table["replaced by policy"] =~ replacement_policy.resource.name
   end
 
-  test "renders replacement policy", %{
-    account: account,
-    policy: policy,
-    identity: identity,
-    conn: conn
-  } do
-    {replaced_policy, replacement_policy} = Fixtures.Policies.replace_policy(policy)
+  # For now we don't show prev/next version buttons in the UI of the latest version of a policy
+  # test "renders replacement policy", %{
+  #   account: account,
+  #   policy: policy,
+  #   identity: identity,
+  #   conn: conn
+  # } do
+  #   {replaced_policy, replacement_policy} = Fixtures.Policies.replace_policy(policy)
 
-    {:ok, lv, _html} =
-      conn
-      |> authorize_conn(identity)
-      |> live(~p"/#{account}/policies/#{replacement_policy}")
+  #   {:ok, lv, _html} =
+  #     conn
+  #     |> authorize_conn(identity)
+  #     |> live(~p"/#{account}/policies/#{replacement_policy}")
 
-    table =
-      lv
-      |> element("#policy")
-      |> render()
-      |> vertical_table_to_map()
+  #   table =
+  #     lv
+  #     |> element("#policy")
+  #     |> render()
+  #     |> vertical_table_to_map()
 
-    replaced_policy = Repo.preload(replaced_policy, [:actor_group, :resource])
-    assert table["replaced policy"] =~ replaced_policy.actor_group.name
-    assert table["replaced policy"] =~ replaced_policy.resource.name
-  end
+  #   replaced_policy = Repo.preload(replaced_policy, [:actor_group, :resource])
+  #   assert table["replaced policy"] =~ replaced_policy.actor_group.name
+  #   assert table["replaced policy"] =~ replaced_policy.resource.name
+  # end
 
   test "renders breadcrumbs item", %{
     account: account,

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -45,6 +45,8 @@ config :web, Web.Plugs.SecureHeaders,
     "script-src 'self' 'unsafe-inline' https://cdn.mxpnl.com https://*.hs-analytics.net"
   ]
 
+config :web, :constant_execution_time, 1
+
 ###############################
 ##### API #####################
 ###############################


### PR DESCRIPTION
Now you can "edit" any fields on the policy, when one of fields that govern the access is changed (resource, actor group or conditions) a new policy will be created and an old one is deleted. This will be broadcasted to the clients right away to minimize downtime. New policy will have it's own flows to prevent confusion while auditing. To make experience better for external systems we added `persistent_id` that will be the same across all versions of a given policy.

Resources work in a similar fashion but when they are replaced we will also replace all corresponding policies.

An additional nice effect of this approach is that we also got configuration audit log for resources and policies.

Fixes #2504 