### PR TITLE
chore(rust): use `#[expect]` instead of `#[allow]`

### DIFF
--- a/rust/bin-shared/benches/tunnel.rs
+++ b/rust/bin-shared/benches/tunnel.rs
@@ -10,8 +10,10 @@ fn main() -> Result<()> {
 
 #[cfg(not(target_os = "windows"))]
 mod platform {
-    #[allow(clippy::unnecessary_wraps)]
-    #[allow(clippy::unused_async)]
+    #[expect(
+        clippy::unused_async,
+        reason = "Must match signature of Windows platform"
+    )]
     pub(crate) async fn perf() -> anyhow::Result<()> {
         Ok(())
     }

--- a/rust/bin-shared/src/network_changes.rs
+++ b/rust/bin-shared/src/network_changes.rs
@@ -1,11 +1,17 @@
 #[cfg(target_os = "linux")]
 #[path = "network_changes/linux.rs"]
-#[allow(clippy::unnecessary_wraps)]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Signatures must match other platforms"
+)]
 mod imp;
 
 #[cfg(target_os = "windows")]
 #[path = "network_changes/windows.rs"]
-#[allow(clippy::unnecessary_wraps)]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Signatures must match other platforms"
+)]
 mod imp;
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]

--- a/rust/bin-shared/src/network_changes.rs
+++ b/rust/bin-shared/src/network_changes.rs
@@ -8,10 +8,6 @@ mod imp;
 
 #[cfg(target_os = "windows")]
 #[path = "network_changes/windows.rs"]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "Signatures must match other platforms"
-)]
 mod imp;
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]

--- a/rust/bin-shared/src/network_changes/linux.rs
+++ b/rust/bin-shared/src/network_changes/linux.rs
@@ -115,8 +115,6 @@ impl Worker {
         Ok(())
     }
 
-    // `Result` needed to match Windows
-    #[allow(clippy::unnecessary_wraps)]
     pub async fn notified(&mut self) -> Result<()> {
         if self.just_started {
             self.just_started = false;

--- a/rust/bin-shared/src/network_changes/windows.rs
+++ b/rust/bin-shared/src/network_changes/windows.rs
@@ -80,8 +80,7 @@ use windows::{
     },
 };
 
-// async needed to match Linux
-#[allow(clippy::unused_async)]
+#[expect(clippy::unused_async, reason = "Must match signature of Linux code")]
 pub async fn new_dns_notifier(
     tokio_handle: tokio::runtime::Handle,
     _method: DnsControlMethod,
@@ -92,8 +91,7 @@ pub async fn new_dns_notifier(
     })
 }
 
-// Async on Linux due to `zbus`
-#[allow(clippy::unused_async)]
+#[expect(clippy::unused_async, reason = "Async on Linux due to `zbus`")]
 pub async fn new_network_notifier(
     _tokio_handle: tokio::runtime::Handle,
     _method: DnsControlMethod,
@@ -161,8 +159,6 @@ impl Worker {
         Ok(())
     }
 
-    // `Result` needed to match Linux
-    #[allow(clippy::unnecessary_wraps)]
     pub async fn notified(&mut self) -> Result<()> {
         self.rx
             .notified()

--- a/rust/bin-shared/src/network_changes/windows.rs
+++ b/rust/bin-shared/src/network_changes/windows.rs
@@ -80,7 +80,6 @@ use windows::{
     },
 };
 
-#[expect(clippy::unused_async, reason = "Must match signature of Linux code")]
 pub async fn new_dns_notifier(
     tokio_handle: tokio::runtime::Handle,
     _method: DnsControlMethod,
@@ -91,7 +90,6 @@ pub async fn new_dns_notifier(
     })
 }
 
-#[expect(clippy::unused_async, reason = "Async on Linux due to `zbus`")]
 pub async fn new_network_notifier(
     _tokio_handle: tokio::runtime::Handle,
     _method: DnsControlMethod,

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -46,8 +46,7 @@ pub struct TunDeviceManager {
 }
 
 impl TunDeviceManager {
-    // Fallible on Linux
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps, reason = "Fallible on Linux")]
     pub fn new(mtu: usize) -> Result<Self> {
         Ok(Self {
             iface_idx: None,
@@ -260,7 +259,10 @@ impl Tun {
     }
 
     // Moves packets from the Internet towards the user
-    #[allow(clippy::unnecessary_wraps)] // Fn signature must align with other platform implementations.
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "Fn signature must align with other platform implementations"
+    )]
     fn write(&self, bytes: &[u8]) -> io::Result<usize> {
         let len = bytes
             .len()

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -321,7 +321,7 @@ macro_rules! string_from_jstring {
 
 // TODO: Refactor this when we refactor PhoenixChannel.
 // See https://github.com/firezone/firezone/issues/2158
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn connect(
     env: &mut JNIEnv,
     api_url: JString,
@@ -395,7 +395,6 @@ fn connect(
 /// # Safety
 /// Pointers must be valid
 /// fd must be a valid file descriptor
-#[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_connect(
     mut env: JNIEnv,
@@ -444,13 +443,11 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_co
 pub struct SessionWrapper {
     inner: Session,
 
-    #[allow(dead_code)] // Only here so we don't drop the memory early.
     runtime: Runtime,
 }
 
 /// # Safety
 /// session_ptr should have been obtained from `connect` function
-#[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_disconnect(
     mut env: JNIEnv,
@@ -468,7 +465,6 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_di
 /// # Safety
 /// session_ptr should have been obtained from `connect` function, and shouldn't be dropped with disconnect
 /// at any point before or during operation of this function.
-#[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_setDisabledResources(
     mut env: JNIEnv,
@@ -500,7 +496,6 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_se
 /// # Safety
 /// session_ptr should have been obtained from `connect` function, and shouldn't be dropped with disconnect
 /// at any point before or during operation of this function.
-#[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_setDns(
     mut env: JNIEnv,
@@ -524,7 +519,6 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_se
 /// # Safety
 /// session_ptr should have been obtained from `connect` function, and shouldn't be dropped with disconnect
 /// at any point before or during operation of this function.
-#[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_reset(
     _: JNIEnv,
@@ -538,7 +532,6 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_re
 /// # Safety
 /// session_ptr should have been obtained from `connect` function, and shouldn't be dropped with disconnect
 /// at any point before or during operation of this function.
-#[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_setTun(
     mut env: JNIEnv,

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -90,10 +90,16 @@ mod ffi {
 pub struct WrappedSession {
     inner: Session,
 
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "Runtime must be kept alive until Session is dropped"
+    )]
     runtime: Runtime,
 
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "Logger handle must be kept alive until Session is dropped"
+    )]
     logger: firezone_logging::file::Handle,
 }
 
@@ -171,7 +177,7 @@ fn init_logging(
 impl WrappedSession {
     // TODO: Refactor this when we refactor PhoenixChannel.
     // See https://github.com/firezone/firezone/issues/2158
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn connect(
         api_url: String,
         token: String,

--- a/rust/connlib/clients/shared/src/messages.rs
+++ b/rust/connlib/clients/shared/src/messages.rs
@@ -75,7 +75,6 @@ pub struct GatewayIceCandidates {
 /// The replies that can arrive from the channel by a client
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
-#[allow(clippy::large_enum_variant)]
 pub enum ReplyMessages {
     ConnectionDetails(ConnectionDetails),
     Connect(Connect),

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -536,7 +536,7 @@ where
     }
 
     #[must_use]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn init_connection(
         &mut self,
         cid: TId,
@@ -619,7 +619,6 @@ where
     /// Those are fully encrypted and thus any byte pattern may appear at the front of the packet.
     /// We can detect this by further checking the origin of the packet.
     #[must_use]
-    #[allow(clippy::type_complexity)]
     fn allocations_try_handle<'p>(
         &mut self,
         from: SocketAddr,
@@ -1703,7 +1702,6 @@ where
         Ok(Some(&buffer[..len]))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn decapsulate<'b>(
         &mut self,
         packet: &[u8],

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1806,7 +1806,7 @@ mod proptests {
         )
     }
 
-    #[allow(clippy::redundant_clone)] // False positive.
+    #[expect(clippy::redundant_clone)] // False positive.
     pub fn hashset<T: std::hash::Hash + Eq, B: ToOwned<Owned = T>>(
         val: impl IntoIterator<Item = B>,
     ) -> HashSet<T> {

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -259,7 +259,7 @@ impl GatewayState {
         peer.refresh_translation(name, resource_id, resolved_ips, now);
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn allow_access(
         &mut self,
         client: ClientId,

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -28,7 +28,7 @@ type IcmpSeq = u16;
 type IcmpIdentifier = u16;
 
 #[test]
-#[allow(clippy::print_stdout, clippy::print_stderr)]
+#[expect(clippy::print_stdout, clippy::print_stderr)]
 fn tunnel_test() {
     let config = Config {
         source_file: Some(file!()),

--- a/rust/connlib/tunnel/src/tests/flux_capacitor.rs
+++ b/rust/connlib/tunnel/src/tests/flux_capacitor.rs
@@ -36,7 +36,7 @@ impl FluxCapacitor {
     const SMALL_TICK: Duration = Duration::from_millis(10);
     const LARGE_TICK: Duration = Duration::from_millis(100);
 
-    #[allow(private_bounds)]
+    #[expect(private_bounds)]
     pub(crate) fn now<T>(&self) -> T
     where
         T: PickNow,

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -214,7 +214,7 @@ impl SimClient {
                     let record = record.unwrap();
                     let domain = record.owner().to_name();
 
-                    #[allow(clippy::wildcard_enum_match_arm)]
+                    #[expect(clippy::wildcard_enum_match_arm)]
                     let ip = match record
                         .into_any_record::<AllRecordData<_, _>>()
                         .unwrap()

--- a/rust/connlib/tunnel/src/tests/sim_dns.rs
+++ b/rust/connlib/tunnel/src/tests/sim_dns.rs
@@ -67,13 +67,10 @@ impl SimDns {
             .get(&name)
             .into_iter()
             .flatten()
-            .filter(|ip| {
-                #[allow(clippy::wildcard_enum_match_arm)]
-                match qtype {
-                    Rtype::A => ip.is_ipv4(),
-                    Rtype::AAAA => ip.is_ipv6(),
-                    _ => todo!(),
-                }
+            .filter(|ip| match qtype {
+                Rtype::A => ip.is_ipv4(),
+                Rtype::AAAA => ip.is_ipv6(),
+                _ => todo!(),
             })
             .copied()
             .map(|ip| match ip {

--- a/rust/connlib/tunnel/src/tests/sim_net.rs
+++ b/rust/connlib/tunnel/src/tests/sim_net.rs
@@ -182,7 +182,6 @@ impl Default for RoutingTable {
 }
 
 impl RoutingTable {
-    #[allow(private_bounds)]
     pub(crate) fn add_host<T>(&mut self, id: impl Into<HostId>, host: &Host<T>) -> bool {
         let id = id.into();
 
@@ -218,7 +217,6 @@ impl RoutingTable {
         true
     }
 
-    #[allow(private_bounds)]
     pub(crate) fn remove_host<T>(&mut self, host: &Host<T>) {
         match (host.ip4, host.ip6) {
             (None, None) => panic!("Node must have at least one network IP"),

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -14,7 +14,7 @@ use std::{
 /// The possible transitions of the state machine.
 #[derive(Clone, derivative::Derivative)]
 #[derivative(Debug)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub(crate) enum Transition {
     /// Activate a resource on the client.
     ActivateResource(ResourceDescription),

--- a/rust/connlib/tunnel/src/utils.rs
+++ b/rust/connlib/tunnel/src/utils.rs
@@ -70,7 +70,7 @@ pub(crate) fn network_contains_network(ip_a: IpNetwork, ip_b: IpNetwork) -> bool
     ip_a.contains(ip_b.network_address()) && ip_a.netmask() <= ip_b.netmask()
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn ipv4(ip: IpNetwork) -> Option<Ipv4Network> {
     match ip {
         IpNetwork::V4(v4) => Some(v4),
@@ -78,7 +78,7 @@ pub(crate) fn ipv4(ip: IpNetwork) -> Option<Ipv4Network> {
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn ipv6(ip: IpNetwork) -> Option<Ipv6Network> {
     match ip {
         IpNetwork::V4(_) => None,

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -59,7 +59,6 @@ pub trait GuiIntegration {
 }
 
 // Allow dead code because `UpdateNotificationClicked` doesn't work on Linux yet
-#[allow(dead_code)]
 pub enum ControllerRequest {
     /// The GUI wants us to use these settings in-memory, they've already been saved to disk
     ApplySettings(Box<AdvancedSettings>),
@@ -132,7 +131,7 @@ impl Status {
     }
 
     fn internet_resource(&self) -> Option<ResourceDescription> {
-        #[allow(clippy::wildcard_enum_match_arm)]
+        #[expect(clippy::wildcard_enum_match_arm)]
         match self {
             Status::TunnelReady { resources } => {
                 resources.iter().find(|r| r.is_internet_resource()).cloned()
@@ -194,7 +193,7 @@ impl<I: GuiIntegration> Controller<I> {
                         break;
                     };
 
-                    #[allow(clippy::wildcard_enum_match_arm)]
+                    #[expect(clippy::wildcard_enum_match_arm)]
                     match req {
                         // SAFETY: Crashing is unsafe
                         Req::Fail(Failure::Crash) => {

--- a/rust/gui-client/src-common/src/crash_handling.rs
+++ b/rust/gui-client/src-common/src/crash_handling.rs
@@ -131,7 +131,7 @@ impl Default for Handler {
 impl minidumper::ServerHandler for Handler {
     /// Called when a crash has been received and a backing file needs to be
     /// created to store it.
-    #[allow(clippy::print_stderr)]
+    #[expect(clippy::print_stderr)]
     fn create_minidump_file(&self) -> Result<(File, PathBuf), std::io::Error> {
         let format = time::format_description::parse(firezone_logging::file::TIME_FORMAT)
             .expect("static format description should always be parsable");

--- a/rust/gui-client/src-common/src/deep_link/linux.rs
+++ b/rust/gui-client/src-common/src/deep_link/linux.rs
@@ -24,7 +24,7 @@ impl Server {
     ///
     /// Still uses `thiserror` so we can catch the deep_link `CantListen` error
     /// On Windows this uses async because of #5143 and #5566.
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub async fn new() -> Result<Self, super::Error> {
         let path = sock_path()?;
         let dir = path

--- a/rust/gui-client/src-common/src/errors.rs
+++ b/rust/gui-client/src-common/src/errors.rs
@@ -3,7 +3,6 @@ use anyhow::Result;
 use firezone_headless_client::{ipc, IpcServiceError, FIREZONE_GROUP};
 
 // TODO: Replace with `anyhow` gradually per <https://github.com/firezone/firezone/pull/3546#discussion_r1477114789>
-#[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Failed to connect to Firezone for non-Portal-related reason")]

--- a/rust/gui-client/src-common/src/updates.rs
+++ b/rust/gui-client/src-common/src/updates.rs
@@ -258,7 +258,6 @@ pub(crate) async fn check() -> Result<Release> {
     })
 }
 
-#[allow(clippy::print_stderr)]
 fn parse_version_from_url(url: &Url) -> Result<Version> {
     let filename = url
         .path_segments()

--- a/rust/gui-client/src-tauri/src/client/elevation.rs
+++ b/rust/gui-client/src-tauri/src/client/elevation.rs
@@ -43,7 +43,7 @@ mod platform {
     ///
     /// On Windows, some users will run as admin, and the GUI does work correctly,
     /// unlike on Linux where most distros don't like to mix root GUI apps with X11 / Wayland.
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     pub(crate) fn gui_check() -> Result<bool, Error> {
         Ok(true)
     }

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -29,18 +29,17 @@ pub(crate) mod system_tray;
 
 #[cfg(target_os = "linux")]
 #[path = "gui/os_linux.rs"]
-#[allow(clippy::unnecessary_wraps)]
 mod os;
 
 // Stub only
 #[cfg(target_os = "macos")]
 #[path = "gui/os_macos.rs"]
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 mod os;
 
 #[cfg(target_os = "windows")]
 #[path = "gui/os_windows.rs"]
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 mod os;
 
 pub(crate) use os::set_autostart;
@@ -299,7 +298,7 @@ pub(crate) fn run(
         Ok(x) => x,
         Err(error) => {
             tracing::error!(?error, "Failed to build Tauri app instance");
-            #[allow(clippy::wildcard_enum_match_arm)]
+            #[expect(clippy::wildcard_enum_match_arm)]
             match error {
                 tauri::Error::Runtime(tauri_runtime::Error::CreateWebview(_)) => {
                     return Err(Error::WebViewNotInstalled);

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -39,7 +39,6 @@ mod os;
 
 #[cfg(target_os = "windows")]
 #[path = "gui/os_windows.rs"]
-#[expect(clippy::unnecessary_wraps)]
 mod os;
 
 pub(crate) use os::set_autostart;

--- a/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
@@ -2,7 +2,6 @@ use super::{ControllerRequest, CtlrTx};
 use anyhow::{Context, Result};
 use firezone_bin_shared::BUNDLE_ID;
 
-#[expect(clippy::unused_async)]
 pub(crate) async fn set_autostart(_enabled: bool) -> Result<()> {
     todo!()
 }

--- a/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/os_windows.rs
@@ -2,7 +2,7 @@ use super::{ControllerRequest, CtlrTx};
 use anyhow::{Context, Result};
 use firezone_bin_shared::BUNDLE_ID;
 
-#[allow(clippy::unused_async)]
+#[expect(clippy::unused_async)]
 pub(crate) async fn set_autostart(_enabled: bool) -> Result<()> {
     todo!()
 }

--- a/rust/headless-client/src/device_id.rs
+++ b/rust/headless-client/src/device_id.rs
@@ -82,7 +82,7 @@ fn set_permissions(dir: &Path) -> Result<()> {
 
 /// Does nothing on non-Linux systems
 #[cfg(not(target_os = "linux"))]
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn set_permissions(_: &Path) -> Result<()> {
     Ok(())
 }

--- a/rust/headless-client/src/dns_control/linux.rs
+++ b/rust/headless-client/src/dns_control/linux.rs
@@ -6,7 +6,6 @@ use std::{net::IpAddr, process::Command, str::FromStr};
 mod etc_resolv_conf;
 
 impl DnsController {
-    #[allow(clippy::unnecessary_wraps)]
     pub fn deactivate(&mut self) -> Result<()> {
         tracing::debug!("Deactivating DNS control...");
         if let DnsControlMethod::EtcResolvConf = self.dns_control_method {

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -52,7 +52,7 @@ impl DnsController {
     /// it would be bad if this was called from 2 threads at once.
     ///
     /// Must be async and an owned `Vec` to match the Linux signature
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub async fn set_dns(&mut self, dns_config: Vec<IpAddr>) -> Result<()> {
         match self.dns_control_method {
             DnsControlMethod::Disabled => {}

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -120,7 +120,6 @@ pub fn run_only_ipc_service() -> Result<()> {
     // SAFETY: We haven't spawned any other threads, this code should be the first
     // thing to run after entering `main` and parsing CLI args.
     // So nobody else is reading the environment.
-    #[allow(unused_unsafe)]
     unsafe {
         // This removes the token from the environment per <https://security.stackexchange.com/a/271285>. We run as root so it may not do anything besides defense-in-depth.
         std::env::remove_var(TOKEN_ENV_KEY);

--- a/rust/headless-client/src/ipc_service/ipc/linux.rs
+++ b/rust/headless-client/src/ipc_service/ipc/linux.rs
@@ -17,7 +17,7 @@ pub type ClientStream = UnixStream;
 pub(crate) type ServerStream = UnixStream;
 
 /// Connect to the IPC service
-#[allow(clippy::wildcard_enum_match_arm)]
+#[expect(clippy::wildcard_enum_match_arm)]
 pub async fn connect_to_service(id: ServiceId) -> Result<ClientStream, Error> {
     let path = ipc_path(id);
     let stream = UnixStream::connect(&path)

--- a/rust/headless-client/src/ipc_service/ipc/windows.rs
+++ b/rust/headless-client/src/ipc_service/ipc/windows.rs
@@ -22,8 +22,8 @@ pub(crate) type ServerStream = named_pipe::NamedPipeServer;
 /// Connect to the IPC service
 ///
 /// This is async on Linux
-#[allow(clippy::unused_async)]
-#[allow(clippy::wildcard_enum_match_arm)]
+#[expect(clippy::unused_async)]
+#[expect(clippy::wildcard_enum_match_arm)]
 pub(crate) async fn connect_to_service(id: ServiceId) -> Result<ClientStream, Error> {
     let path = ipc_path(id);
     let stream = named_pipe::ClientOptions::new()
@@ -47,7 +47,7 @@ impl Server {
     /// Platform-specific setup
     ///
     /// This is async on Linux
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub(crate) async fn new(id: ServiceId) -> Result<Self> {
         let pipe_path = ipc_path(id);
         Ok(Self { pipe_path })

--- a/rust/headless-client/src/ipc_service/linux.rs
+++ b/rust/headless-client/src/ipc_service/linux.rs
@@ -23,7 +23,7 @@ pub(crate) fn run_ipc_service(cli: CliCommon) -> Result<()> {
 
 /// Returns true if the IPC service can run properly
 // Fallible on Windows
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn elevation_check() -> Result<bool> {
     Ok(nix::unistd::getuid().is_root())
 }

--- a/rust/headless-client/src/known_dirs/linux.rs
+++ b/rust/headless-client/src/known_dirs/linux.rs
@@ -16,12 +16,12 @@ use std::path::PathBuf;
 /// `BUNDLE_ID` because we need our own subdir
 ///
 /// `config` to match how Windows has `config` and `data` both under `AppData/Local/$BUNDLE_ID`
-#[allow(clippy::unnecessary_wraps)] // Signature must match Windows
+#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
 pub fn ipc_service_config() -> Option<PathBuf> {
     Some(PathBuf::from("/var/lib").join(BUNDLE_ID).join("config"))
 }
 
-#[allow(clippy::unnecessary_wraps)] // Signature must match Windows
+#[expect(clippy::unnecessary_wraps)] // Signature must match Windows
 pub fn ipc_service_logs() -> Option<PathBuf> {
     // TODO: This is magic, it must match the systemd file
     Some(PathBuf::from("/var/log").join(BUNDLE_ID))

--- a/rust/headless-client/src/known_dirs/windows.rs
+++ b/rust/headless-client/src/known_dirs/windows.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 /// by both programs. All writes should use `atomicwrites`.
 ///
 /// On Windows, `C:/ProgramData/$BUNDLE_ID/config`
-#[expect(clippy::unnecessary_wraps)]
 pub fn ipc_service_config() -> Option<PathBuf> {
     Some(
         get_known_folder_path(KnownFolder::ProgramData)?

--- a/rust/headless-client/src/known_dirs/windows.rs
+++ b/rust/headless-client/src/known_dirs/windows.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 /// by both programs. All writes should use `atomicwrites`.
 ///
 /// On Windows, `C:/ProgramData/$BUNDLE_ID/config`
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub fn ipc_service_config() -> Option<PathBuf> {
     Some(
         get_known_folder_path(KnownFolder::ProgramData)?

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -70,7 +70,7 @@ pub struct CliCommon {
 ///
 /// i.e. callbacks
 // The names are CamelCase versions of the connlib callbacks.
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 pub enum ConnlibMsg {
     OnDisconnect {
         error_msg: String,

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -119,7 +119,6 @@ fn main() -> Result<()> {
     // SAFETY: We haven't spawned any other threads, this code should be the first
     // thing to run after entering `main` and parsing CLI args.
     // So nobody else is reading the environment.
-    #[allow(unused_unsafe)]
     unsafe {
         // This removes the token from the environment per <https://security.stackexchange.com/a/271285>. We run as root so it may not do anything besides defense-in-depth.
         std::env::remove_var(TOKEN_ENV_KEY);

--- a/rust/headless-client/src/signals/windows.rs
+++ b/rust/headless-client/src/signals/windows.rs
@@ -30,7 +30,7 @@ impl Terminate {
 }
 
 impl Hangup {
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     pub fn new() -> Result<Self> {
         Ok(Self {})
     }

--- a/rust/headless-client/src/uptime/mod.rs
+++ b/rust/headless-client/src/uptime/mod.rs
@@ -39,7 +39,7 @@ pub fn get() -> Option<Duration> {
 
 #[cfg(target_os = "windows")]
 // `Result` is needed to match other platforms' signatures
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub fn get() -> Option<Duration> {
     let ret: u64 = unsafe { windows::Win32::System::SystemInformation::GetTickCount64() };
     Some(Duration::from_millis(ret))

--- a/rust/headless-client/src/windows.rs
+++ b/rust/headless-client/src/windows.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use std::path::{Path, PathBuf};
 
 // The return value is useful on Linux
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn check_token_permissions(_path: &Path) -> Result<()> {
     // TODO: For Headless Client, make sure the token is only readable by admin / our service user on Windows
     Ok(())
@@ -22,7 +22,7 @@ pub(crate) fn default_token_path() -> std::path::PathBuf {
 // Does nothing on Windows. On Linux this notifies systemd that we're ready.
 // When we eventually have a system service for the Windows Headless Client,
 // this could notify the Windows service controller too.
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn notify_service_controller() -> Result<()> {
     Ok(())
 }

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -170,13 +170,10 @@ where
         let name = query.qname().to_name();
 
         let records = resolve(&name)
-            .filter(|ip| {
-                #[allow(clippy::wildcard_enum_match_arm)]
-                match query.qtype() {
-                    Rtype::A => ip.is_ipv4(),
-                    Rtype::AAAA => ip.is_ipv6(),
-                    _ => todo!(),
-                }
+            .filter(|ip| match query.qtype() {
+                Rtype::A => ip.is_ipv4(),
+                Rtype::AAAA => ip.is_ipv6(),
+                _ => todo!(),
             })
             .map(|ip| match ip {
                 IpAddr::V4(v4) => AllRecordData::<Vec<_>, Name<Vec<_>>>::A(v4.into()),

--- a/rust/logging/src/file.rs
+++ b/rust/logging/src/file.rs
@@ -149,7 +149,7 @@ impl Appender {
 
     /// Does nothing on non-Linux systems
     #[cfg(not(target_os = "linux"))]
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     fn set_permissions(_f: &fs::File) -> io::Result<()> {
         Ok(())
     }

--- a/rust/phoenix-channel/src/login_url.rs
+++ b/rust/phoenix-channel/src/login_url.rs
@@ -172,7 +172,7 @@ fn get_host_name() -> Option<String> {
     hostname::get().ok().and_then(|x| x.into_string().ok())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn get_websocket_path<E>(
     mut api_url: Url,
     token: &SecretString,

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -204,7 +204,6 @@ pub struct DatagramOut<'a> {
 }
 
 impl UdpSocket {
-    #[allow(clippy::type_complexity)]
     pub fn poll_recv_from<'b>(
         &self,
         buffer: &'b mut [u8],


### PR DESCRIPTION
The `expect` attribute is similar to `allow` in that it will silence a particular lint. In addition to `allow` however, `expect` will fail as soon as the lint is no longer emitted. This ensures we don't end up with stale `allow` attributes in our codebase. Additionally, it provides a way of adding a `reason` to document, why the lint is being suppressed.