### PR TITLE
chore(connlib): be more verbose when probing DNS packets

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -217,7 +217,7 @@ impl StubResolver {
         let Some(datagram) = packet.as_udp() else {
             let protocol = packet.next_header().keyword_str().unwrap_or("unassigned");
 
-            tracing::debug!(%protocol, "DNS is only support over UDP");
+            tracing::debug!(%protocol, "DNS is only supported over UDP");
             return None;
         };
 

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -732,7 +732,7 @@ impl<'a> IpPacket<'a> {
         }
     }
 
-    fn next_header(&self) -> IpNumber {
+    pub fn next_header(&self) -> IpNumber {
         match self {
             Self::Ipv4(p) => p.ip_header().protocol(),
             Self::Ipv6(p) => p.header().next_header(),


### PR DESCRIPTION
Currently, checking whether a packet is a DNS query has multiple silent exit paths. This makes it DNS problems difficult to debug because the packets will be treated as if they have to get routed through the tunnel.

This is also something we should fix but that isn't done in this PR: If we know that a packet is for connlib's DNS stub resolver, we should never route it through the tunnel. Currently, this isn't possible to express with the type signature of our DNS module and requires more refactoring.