### PR TITLE
chore(connlib): warn on truncates DNS response from upstream

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -668,6 +668,15 @@ impl ClientState {
 
         let (destination, _) = self.forwarded_dns_queries.remove(&(query_id, from))?;
 
+        if message.header().tc() {
+            let domain = message
+                .first_question()
+                .map(|q| q.into_qname())
+                .map(tracing::field::display);
+
+            tracing::warn!(server = %from, domain, "Upstream DNS server had to truncate response");
+        }
+
         tracing::trace!(server = %from, %query_id, "Received forwarded DNS response");
 
         let daddr = destination.ip();


### PR DESCRIPTION
DNS queries for non-resources get forwarded by connlib byte-for-byte and only the IP & UDP headers gets rewritten. The responses for some DNS queries don't fit into UDP packets. To signal this, DNS servers set the TC (truncated) bit on the response.

If set, most clients will discard the response and requery over TCP. DNS over TCP is not yet supported in connlib, meaning any query response that has the TC bit set will most likely lead to DNS issues downstream.

To make these cases easier to debug, we log a warning whenever we encounter a DNS response from an upstream server that that has the TC bit set.