### PR TITLE
chore(connlib): don't add routes for DNS sentinel servers

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -813,8 +813,6 @@ impl ClientState {
             .map(|(ip, _)| ip)
             .chain(iter::once(IPV4_RESOURCES.into()))
             .chain(iter::once(IPV6_RESOURCES.into()))
-            .chain(iter::once(DNS_SENTINELS_V4.into()))
-            .chain(iter::once(DNS_SENTINELS_V6.into()))
             .chain(
                 self.internet_resource
                     .map(|_| Ipv4Network::DEFAULT_ROUTE.into()),
@@ -1841,9 +1839,7 @@ mod proptests {
             resource_routes
                 .into_iter()
                 .chain(iter::once(IPV4_RESOURCES.into()))
-                .chain(iter::once(IPV6_RESOURCES.into()))
-                .chain(iter::once(DNS_SENTINELS_V4.into()))
-                .chain(iter::once(DNS_SENTINELS_V6.into())),
+                .chain(iter::once(IPV6_RESOURCES.into())),
         )
     }
 

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -934,25 +934,15 @@ fn ref_client(
 }
 
 fn default_routes_v4() -> Vec<Ipv4Network> {
-    vec![
-        Ipv4Network::new(Ipv4Addr::new(100, 96, 0, 0), 11).unwrap(),
-        Ipv4Network::new(Ipv4Addr::new(100, 100, 111, 0), 24).unwrap(),
-    ]
+    vec![Ipv4Network::new(Ipv4Addr::new(100, 96, 0, 0), 11).unwrap()]
 }
 
 fn default_routes_v6() -> Vec<Ipv6Network> {
-    vec![
-        Ipv6Network::new(
-            Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0x8000, 0, 0, 0, 0),
-            107,
-        )
-        .unwrap(),
-        Ipv6Network::new(
-            Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0x8000, 0x0100, 0x0100, 0x0111, 0),
-            120,
-        )
-        .unwrap(),
-    ]
+    vec![Ipv6Network::new(
+        Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0x8000, 0, 0, 0, 0),
+        107,
+    )
+    .unwrap()]
 }
 
 fn known_hosts() -> impl Strategy<Value = BTreeMap<String, Vec<IpAddr>>> {


### PR DESCRIPTION
We reserve an IP range _within_ the CG-NAT range for the sentinel DNS servers. It is unnecessary to explicitly add that one as a route because it is already covered by the routing entry of the entire CG-NAT range.