### PR TITLE
chore(connlib): mitigate WARN logs from phoenix-channel

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -9,7 +9,7 @@ use crate::{
 use anyhow::Result;
 use connlib_shared::messages::{
     ClientPayload, ConnectionAccepted, GatewayResponse, RelaysPresence, RequestConnection,
-    ResourceId, ReuseConnection,
+    ResourceAccepted, ResourceId, ReuseConnection,
 };
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel};
@@ -293,6 +293,12 @@ where
                 ) {
                     tracing::warn!("Failed to accept connection: {e}");
                 }
+            }
+            ReplyMessages::Connect(Connect {
+                gateway_payload: GatewayResponse::ResourceAccepted(ResourceAccepted { .. }),
+                ..
+            }) => {
+                tracing::trace!("Connection response received, ignored as it's deprecated")
             }
             ReplyMessages::ConnectionDetails(ConnectionDetails {
                 gateway_id,

--- a/rust/connlib/shared/src/messages.rs
+++ b/rust/connlib/shared/src/messages.rs
@@ -236,11 +236,18 @@ pub struct DomainResponse {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ConnectionAccepted {
     pub ice_parameters: Answer,
+    pub domain_response: Option<DomainResponse>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ResourceAccepted {
+    pub domain_response: DomainResponse,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub enum GatewayResponse {
     ConnectionAccepted(ConnectionAccepted),
+    ResourceAccepted(ResourceAccepted),
 }
 
 #[derive(Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -293,6 +293,7 @@ impl Eventloop {
                 reference: req.reference,
                 gateway_payload: GatewayResponse::ConnectionAccepted(ConnectionAccepted {
                     ice_parameters: answer,
+                    domain_response: None,
                 }),
             }),
         );


### PR DESCRIPTION
Merging #6708 had an unintended side-effect that we are seeing a lot of WARN logs from phoenix-channel because we can no longer parse the response from gateways. We didn't do anything with these responses but gateways are sending them for backwards-compatibility reasons.

To not confuse ourselves while debugging, we revert the client-side bit of #6708 to remove these warnings.