### PR TITLE
docs(contributing): corrections

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -159,6 +159,7 @@ We use [pre-commit](https://pre-commit.com) to catch any static analysis issues
 before code is committed. 
 
 - Install system-wide with Homebrew: `brew install pre-commit` or pip: `pip install pre-commit`.
+- Install Python packages we need with `pip install -r .github/requirements.txt`
 - Install the repo-specific checks with `pre-commit install --config .github/pre-commit-config.yaml`
   (As in `.github/workflows/_static-analysis.yml`)
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -158,8 +158,7 @@ If you are using Nix, see [scripts/nix/README](../scripts/nix/README.md).
 We use [pre-commit](https://pre-commit.com) to catch any static analysis issues
 before code is committed. 
 
-- Install system-wide with Homebrew: `brew install pre-commit` or pip: `pip install pre-commit`.
-- Install Python packages we need with `pip install -r .github/requirements.txt`
+- Install pre-commit and other Python packages with `pip install -r .github/requirements.txt`
 - Install the repo-specific checks with `pre-commit install --config .github/pre-commit-config.yaml`
   (As in `.github/workflows/_static-analysis.yml`)
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -144,9 +144,7 @@ Install the language runtimes defined in the [.tool-versions](../.tool-versions)
 file by running `asdf install` from the project root.
 
 - Note: For a fresh install of `asdf` you will need to install some
-  [asdf-plugins](https://asdf-vm.com/manage/plugins.html). Running
-  `asdf install` will show which `asdf` plugins need to be installed prior to
-  installing the required language runtimes.
+  [asdf-plugins](https://asdf-vm.com/manage/plugins.html). e.g. `asdf plugin add nodejs && asdf install nodejs` to set up the NodeJS plugin and package.
 
 This is used to run static analysis checks during [pre-commit](#pre-commit) and
 for any local, non-Docker development or testing.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -156,8 +156,11 @@ If you are using Nix, see [scripts/nix/README](../scripts/nix/README.md).
 ### Pre-commit
 
 We use [pre-commit](https://pre-commit.com) to catch any static analysis issues
-before code is committed. Install with Homebrew: `brew install pre-commit` or
-pip: `pip install pre-commit`.
+before code is committed. 
+
+- Install system-wide with Homebrew: `brew install pre-commit` or pip: `pip install pre-commit`.
+- Install the repo-specific checks with `pre-commit install --config .github/pre-commit-config.yaml`
+  (As in `.github/workflows/_static-analysis.yml`)
 
 ### Elixir Development
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -156,7 +156,7 @@ If you are using Nix, see [scripts/nix/README](../scripts/nix/README.md).
 ### Pre-commit
 
 We use [pre-commit](https://pre-commit.com) to catch any static analysis issues
-before code is committed. 
+before code is committed.
 
 - Install pre-commit and other Python packages with `pip install -r .github/requirements.txt`
 - Install the repo-specific checks with `pre-commit install --config .github/pre-commit-config.yaml`


### PR DESCRIPTION
1. `asdf install` doesn't seem to list which plugins you need, so we explain that
2. No longer recommending `brew` for installing `pre-commit` since all systems should have `pip` from `asdf` by the time they reach this step
3. Explain how to install from `requirements.txt` since that is needed for all the pre-commit stuff to run like prettier and codespell.