### PR TITLE
feat(portal): New version of the  WS control protocol

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -7,9 +7,11 @@ defmodule API.Client.Channel do
   require OpenTelemetry.Tracer
 
   @gateway_compatibility [
+    # We introduced new websocket protocol and the clients of version 1.4+
+    # are only compatible with gateways of version 1.4+
+    {">= 1.4.0", ">= 1.4.0"},
     # The clients of version of 1.1+ are compatible with gateways of version 1.1+,
     # but the clients of versions prior to that can connect to any gateway
-    {">= 1.4.0", ">= 1.4.0"},
     {">= 1.1.0", ">= 1.1.0"}
   ]
 

--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -502,7 +502,6 @@ defmodule API.Client.Channel do
         {:ok,
          %{
            resource_id: resource_id,
-           persistent_keepalive: 25,
            preshared_key: preshared_key,
            ice_credentials: ice_credentials,
            gateway_id: gateway_id,
@@ -552,14 +551,10 @@ defmodule API.Client.Channel do
     end
   end
 
-  # This message is sent to the client to request a network flow with a gateway that can server given resource.
+  # This message is sent to the client to request a network flow with a gateway that can serve given resource.
   #
   # `connected_gateway_ids` is used to indicate that the client is already connected to some of the gateways,
   # so the gateway can be reused by multiplexing the connection.
-  #
-  # `client_payload` is an arbitrary data that the client wants to send to the gateway, typically it will be
-  # either empty, or contain dns hostname of a given resource to connect to (so that it can be resolved on the
-  # gateway).
   def handle_in(
         "create_flow",
         %{

--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -971,8 +971,9 @@ defmodule API.Client.Channel do
     end
   end
 
-  # Ice credentials must stay the same for all connections between client and gateway as long as they do not loose their state,
-  # so we can leverage public_key which is reset on each restart of the client or gateway.
+  # Ice credentials must stay the same for all connections between client and gateway as long as they
+  # do not loose their state, so we can leverage public_key which is reset on each restart of the client
+  # or gateway.
   defp generate_ice_credentials(client, gateway) do
     ice_credential_seed =
       [

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -311,7 +311,8 @@ defmodule API.Gateway.Channel do
         gateway_ice_credentials: ice_credentials.gateway,
         client: Views.Client.render(client, preshared_key),
         client_ice_credentials: ice_credentials.client,
-        expires_at: DateTime.to_unix(authorization_expires_at, :second)
+        expires_at:
+          if(authorization_expires_at, do: DateTime.to_unix(authorization_expires_at, :second))
       })
 
       Logger.debug("Awaiting gateway flow_authorized message",

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -308,8 +308,9 @@ defmodule API.Gateway.Channel do
         flow_id: flow_id,
         actor: Views.Actor.render(client.actor),
         resource: Views.Resource.render(resource),
-        ice_credentials: ice_credentials,
+        gateway_ice_credentials: ice_credentials.gateway,
         client: Views.Client.render(client, preshared_key),
+        client_ice_credentials: ice_credentials.client,
         expires_at: DateTime.to_unix(authorization_expires_at, :second)
       })
 
@@ -484,6 +485,7 @@ defmodule API.Gateway.Channel do
               :connect,
               socket_ref,
               resource_id,
+              socket.assigns.gateway.group_id,
               socket.assigns.gateway.id,
               socket.assigns.gateway.public_key,
               preshared_key,

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -25,6 +25,10 @@ defmodule API.Gateway.Channel do
     end
   end
 
+  ####################################
+  ##### Channel lifecycle events #####
+  ####################################
+
   @impl true
   def handle_info({:after_join, {opentelemetry_ctx, opentelemetry_span_ctx}}, socket) do
     OpenTelemetry.Ctx.attach(opentelemetry_ctx)
@@ -64,116 +68,9 @@ defmodule API.Gateway.Channel do
     end
   end
 
-  def handle_info(
-        {:ice_candidates, client_id, candidates, {opentelemetry_ctx, opentelemetry_span_ctx}},
-        socket
-      ) do
-    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
-    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
-
-    OpenTelemetry.Tracer.with_span "gateway.ice_candidates",
-      attributes: %{
-        client_id: client_id,
-        candidates_length: length(candidates)
-      } do
-      push(socket, "ice_candidates", %{
-        client_id: client_id,
-        candidates: candidates
-      })
-
-      {:noreply, socket}
-    end
-  end
-
-  def handle_info(
-        {:invalidate_ice_candidates, client_id, candidates,
-         {opentelemetry_ctx, opentelemetry_span_ctx}},
-        socket
-      ) do
-    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
-    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
-
-    OpenTelemetry.Tracer.with_span "gateway.invalidate_ice_candidates",
-      attributes: %{
-        client_id: client_id,
-        candidates_length: length(candidates)
-      } do
-      push(socket, "invalidate_ice_candidates", %{
-        client_id: client_id,
-        candidates: candidates
-      })
-
-      {:noreply, socket}
-    end
-  end
-
-  def handle_info(
-        {:allow_access, {channel_pid, socket_ref}, attrs,
-         {opentelemetry_ctx, opentelemetry_span_ctx}},
-        socket
-      ) do
-    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
-    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
-
-    %{
-      client_id: client_id,
-      resource_id: resource_id,
-      flow_id: flow_id,
-      authorization_expires_at: authorization_expires_at,
-      client_payload: payload
-    } = attrs
-
-    OpenTelemetry.Tracer.with_span "gateway.allow_access",
-      attributes: %{
-        flow_id: flow_id,
-        client_id: client_id,
-        resource_id: resource_id
-      } do
-      :ok = Flows.subscribe_to_flow_expiration_events(flow_id)
-
-      client = Clients.fetch_client_by_id!(client_id)
-      resource = Resources.fetch_resource_by_id!(resource_id)
-
-      case API.Client.Channel.map_or_drop_compatible_resource(
-             resource,
-             socket.assigns.gateway.last_seen_version
-           ) do
-        {:cont, resource} ->
-          :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
-          :ok = Resources.subscribe_to_events_for_resource(resource_id)
-
-          opentelemetry_headers = :otel_propagator_text_map.inject([])
-          ref = encode_ref(socket, channel_pid, socket_ref, resource_id, opentelemetry_headers)
-
-          push(socket, "allow_access", %{
-            ref: ref,
-            client_id: client_id,
-            flow_id: flow_id,
-            resource: Views.Resource.render(resource),
-            expires_at: DateTime.to_unix(authorization_expires_at, :second),
-            payload: payload,
-            client_ipv4: client.ipv4,
-            client_ipv6: client.ipv6
-          })
-
-          Logger.debug("Awaiting gateway connection_ready message",
-            client_id: client_id,
-            resource_id: resource_id,
-            flow_id: flow_id
-          )
-
-        :drop ->
-          Logger.debug("Resource is not compatible with the gateway version",
-            gateway_id: socket.assigns.gateway.id,
-            client_id: client_id,
-            resource_id: resource_id,
-            flow_id: flow_id
-          )
-      end
-
-      {:noreply, socket}
-    end
-  end
+  ####################################
+  ##### Reacting to domain events ####
+  ####################################
 
   # Resource is updated, eg. traffic filters are changed
   def handle_info({:update_resource, resource_id}, socket) do
@@ -229,73 +126,6 @@ defmodule API.Gateway.Channel do
         client_id: client_id,
         resource_id: resource_id
       })
-
-      {:noreply, socket}
-    end
-  end
-
-  def handle_info(
-        {:request_connection, {channel_pid, socket_ref}, attrs,
-         {opentelemetry_ctx, opentelemetry_span_ctx}},
-        socket
-      ) do
-    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
-    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
-
-    %{
-      client_id: client_id,
-      resource_id: resource_id,
-      flow_id: flow_id,
-      authorization_expires_at: authorization_expires_at,
-      client_payload: payload,
-      client_preshared_key: preshared_key
-    } = attrs
-
-    OpenTelemetry.Tracer.with_span "gateway.request_connection" do
-      :ok = Flows.subscribe_to_flow_expiration_events(flow_id)
-
-      Logger.debug("Gateway received connection request message",
-        client_id: client_id,
-        resource_id: resource_id
-      )
-
-      client = Clients.fetch_client_by_id!(client_id, preload: [:actor])
-      resource = Resources.fetch_resource_by_id!(resource_id)
-
-      case API.Client.Channel.map_or_drop_compatible_resource(
-             resource,
-             socket.assigns.gateway.last_seen_version
-           ) do
-        {:cont, resource} ->
-          :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
-          :ok = Resources.subscribe_to_events_for_resource(resource_id)
-
-          opentelemetry_headers = :otel_propagator_text_map.inject([])
-          ref = encode_ref(socket, channel_pid, socket_ref, resource_id, opentelemetry_headers)
-
-          push(socket, "request_connection", %{
-            ref: ref,
-            flow_id: flow_id,
-            actor: Views.Actor.render(client.actor),
-            resource: Views.Resource.render(resource),
-            client: Views.Client.render(client, payload, preshared_key),
-            expires_at: DateTime.to_unix(authorization_expires_at, :second)
-          })
-
-          Logger.debug("Awaiting gateway connection_ready message",
-            client_id: client_id,
-            resource_id: resource_id,
-            flow_id: flow_id
-          )
-
-        :drop ->
-          Logger.debug("Resource is not compatible with the gateway version",
-            gateway_id: socket.assigns.gateway.id,
-            client_id: client_id,
-            resource_id: resource_id,
-            flow_id: flow_id
-          )
-      end
 
       {:noreply, socket}
     end
@@ -382,6 +212,302 @@ defmodule API.Gateway.Channel do
     end
   end
 
+  ##############################################################
+  ##### Forwarding messages from the client to the gateway #####
+  ##############################################################
+
+  def handle_info(
+        {:ice_candidates, client_id, candidates, {opentelemetry_ctx, opentelemetry_span_ctx}},
+        socket
+      ) do
+    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
+    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
+
+    OpenTelemetry.Tracer.with_span "gateway.ice_candidates",
+      attributes: %{
+        client_id: client_id,
+        candidates_length: length(candidates)
+      } do
+      push(socket, "ice_candidates", %{
+        client_id: client_id,
+        candidates: candidates
+      })
+
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info(
+        {:invalidate_ice_candidates, client_id, candidates,
+         {opentelemetry_ctx, opentelemetry_span_ctx}},
+        socket
+      ) do
+    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
+    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
+
+    OpenTelemetry.Tracer.with_span "gateway.invalidate_ice_candidates",
+      attributes: %{
+        client_id: client_id,
+        candidates_length: length(candidates)
+      } do
+      push(socket, "invalidate_ice_candidates", %{
+        client_id: client_id,
+        candidates: candidates
+      })
+
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info(
+        {:authorize_flow, {channel_pid, socket_ref}, payload,
+         {opentelemetry_ctx, opentelemetry_span_ctx}},
+        socket
+      ) do
+    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
+    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
+
+    %{
+      client_id: client_id,
+      resource_id: resource_id,
+      flow_id: flow_id,
+      authorization_expires_at: authorization_expires_at,
+      ice_credentials: ice_credentials,
+      preshared_key: preshared_key
+    } = payload
+
+    OpenTelemetry.Tracer.with_span "gateway.authorize_flow" do
+      :ok = Flows.subscribe_to_flow_expiration_events(flow_id)
+
+      Logger.debug("Gateway authorizes a new network flow",
+        flow_id: flow_id,
+        client_id: client_id,
+        resource_id: resource_id
+      )
+
+      client = Clients.fetch_client_by_id!(client_id, preload: [:actor])
+      resource = Resources.fetch_resource_by_id!(resource_id)
+
+      :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
+      :ok = Resources.subscribe_to_events_for_resource(resource_id)
+
+      opentelemetry_headers = :otel_propagator_text_map.inject([])
+
+      ref =
+        encode_ref(socket, {
+          channel_pid,
+          socket_ref,
+          resource_id,
+          preshared_key,
+          ice_credentials,
+          opentelemetry_headers
+        })
+
+      push(socket, "authorize_flow", %{
+        ref: ref,
+        flow_id: flow_id,
+        actor: Views.Actor.render(client.actor),
+        resource: Views.Resource.render(resource),
+        ice_credentials: ice_credentials,
+        client: Views.Client.render(client, preshared_key),
+        expires_at: DateTime.to_unix(authorization_expires_at, :second)
+      })
+
+      Logger.debug("Awaiting gateway flow_authorized message",
+        client_id: client_id,
+        resource_id: resource_id,
+        flow_id: flow_id
+      )
+
+      {:noreply, socket}
+    end
+  end
+
+  # DEPRECATED IN 1.4
+  def handle_info(
+        {:allow_access, {channel_pid, socket_ref}, attrs,
+         {opentelemetry_ctx, opentelemetry_span_ctx}},
+        socket
+      ) do
+    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
+    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
+
+    %{
+      client_id: client_id,
+      resource_id: resource_id,
+      flow_id: flow_id,
+      authorization_expires_at: authorization_expires_at,
+      client_payload: payload
+    } = attrs
+
+    OpenTelemetry.Tracer.with_span "gateway.allow_access",
+      attributes: %{
+        flow_id: flow_id,
+        client_id: client_id,
+        resource_id: resource_id
+      } do
+      :ok = Flows.subscribe_to_flow_expiration_events(flow_id)
+
+      client = Clients.fetch_client_by_id!(client_id)
+      resource = Resources.fetch_resource_by_id!(resource_id)
+
+      case API.Client.Channel.map_or_drop_compatible_resource(
+             resource,
+             socket.assigns.gateway.last_seen_version
+           ) do
+        {:cont, resource} ->
+          :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
+          :ok = Resources.subscribe_to_events_for_resource(resource_id)
+
+          opentelemetry_headers = :otel_propagator_text_map.inject([])
+          ref = encode_ref(socket, {channel_pid, socket_ref, resource_id, opentelemetry_headers})
+
+          push(socket, "allow_access", %{
+            ref: ref,
+            client_id: client_id,
+            flow_id: flow_id,
+            resource: Views.Resource.render(resource),
+            expires_at: DateTime.to_unix(authorization_expires_at, :second),
+            payload: payload,
+            client_ipv4: client.ipv4,
+            client_ipv6: client.ipv6
+          })
+
+          Logger.debug("Awaiting gateway connection_ready message",
+            client_id: client_id,
+            resource_id: resource_id,
+            flow_id: flow_id
+          )
+
+        :drop ->
+          Logger.debug("Resource is not compatible with the gateway version",
+            gateway_id: socket.assigns.gateway.id,
+            client_id: client_id,
+            resource_id: resource_id,
+            flow_id: flow_id
+          )
+      end
+
+      {:noreply, socket}
+    end
+  end
+
+  # DEPRECATED IN 1.4
+  def handle_info(
+        {:request_connection, {channel_pid, socket_ref}, attrs,
+         {opentelemetry_ctx, opentelemetry_span_ctx}},
+        socket
+      ) do
+    OpenTelemetry.Ctx.attach(opentelemetry_ctx)
+    OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
+
+    %{
+      client_id: client_id,
+      resource_id: resource_id,
+      flow_id: flow_id,
+      authorization_expires_at: authorization_expires_at,
+      client_payload: payload,
+      client_preshared_key: preshared_key
+    } = attrs
+
+    OpenTelemetry.Tracer.with_span "gateway.request_connection" do
+      :ok = Flows.subscribe_to_flow_expiration_events(flow_id)
+
+      Logger.debug("Gateway received connection request message",
+        client_id: client_id,
+        resource_id: resource_id
+      )
+
+      client = Clients.fetch_client_by_id!(client_id, preload: [:actor])
+      resource = Resources.fetch_resource_by_id!(resource_id)
+
+      case API.Client.Channel.map_or_drop_compatible_resource(
+             resource,
+             socket.assigns.gateway.last_seen_version
+           ) do
+        {:cont, resource} ->
+          :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
+          :ok = Resources.subscribe_to_events_for_resource(resource_id)
+
+          opentelemetry_headers = :otel_propagator_text_map.inject([])
+          ref = encode_ref(socket, {channel_pid, socket_ref, resource_id, opentelemetry_headers})
+
+          push(socket, "request_connection", %{
+            ref: ref,
+            flow_id: flow_id,
+            actor: Views.Actor.render(client.actor),
+            resource: Views.Resource.render(resource),
+            client: Views.Client.render(client, payload, preshared_key),
+            expires_at: DateTime.to_unix(authorization_expires_at, :second)
+          })
+
+          Logger.debug("Awaiting gateway connection_ready message",
+            client_id: client_id,
+            resource_id: resource_id,
+            flow_id: flow_id
+          )
+
+        :drop ->
+          Logger.debug("Resource is not compatible with the gateway version",
+            gateway_id: socket.assigns.gateway.id,
+            client_id: client_id,
+            resource_id: resource_id,
+            flow_id: flow_id
+          )
+      end
+
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_in("flow_authorized", %{"ref" => signed_ref}, socket) do
+    OpenTelemetry.Tracer.with_span "gateway.flow_authorized" do
+      case decode_ref(socket, signed_ref) do
+        {:ok,
+         {
+           channel_pid,
+           socket_ref,
+           resource_id,
+           preshared_key,
+           ice_credentials,
+           opentelemetry_headers
+         }} ->
+          :otel_propagator_text_map.extract(opentelemetry_headers)
+
+          opentelemetry_ctx = OpenTelemetry.Ctx.get_current()
+          opentelemetry_span_ctx = OpenTelemetry.Tracer.current_span_ctx()
+
+          send(
+            channel_pid,
+            {
+              :connect,
+              socket_ref,
+              resource_id,
+              socket.assigns.gateway.id,
+              socket.assigns.gateway.public_key,
+              preshared_key,
+              ice_credentials,
+              {opentelemetry_ctx, opentelemetry_span_ctx}
+            }
+          )
+
+          Logger.debug("Gateway replied to the Client with :authorize_flow message",
+            resource_id: resource_id,
+            channel_pid: inspect(channel_pid)
+          )
+
+          {:reply, :ok, socket}
+
+        {:error, :invalid_ref} ->
+          OpenTelemetry.Tracer.set_status(:error, "invalid ref")
+          Logger.error("Gateway replied with an invalid ref")
+          {:reply, {:error, %{reason: :invalid_ref}}, socket}
+      end
+    end
+  end
+
+  # DEPRECATED IN 1.4
   @impl true
   def handle_in(
         "connection_ready",
@@ -419,6 +545,10 @@ defmodule API.Gateway.Channel do
       end
     end
   end
+
+  #####################################
+  ##### Gateway-initiated actions #####
+  #####################################
 
   def handle_in(
         "broadcast_ice_candidates",
@@ -516,9 +646,9 @@ defmodule API.Gateway.Channel do
     end
   end
 
-  defp encode_ref(socket, channel_pid, socket_ref, resource_id, opentelemetry_headers) do
+  defp encode_ref(socket, tuple) do
     ref =
-      {channel_pid, socket_ref, resource_id, opentelemetry_headers}
+      tuple
       |> :erlang.term_to_binary()
       |> Base.url_encode64()
 
@@ -531,12 +661,12 @@ defmodule API.Gateway.Channel do
 
     with {:ok, ref} <-
            Plug.Crypto.verify(key_base, "gateway_reply_ref", signed_ref, max_age: :infinity) do
-      {channel_pid, socket_ref, resource_id, opentelemetry_headers} =
+      tuple =
         ref
         |> Base.url_decode64!()
         |> Plug.Crypto.non_executable_binary_to_term([:safe])
 
-      {:ok, {channel_pid, socket_ref, resource_id, opentelemetry_headers}}
+      {:ok, tuple}
     else
       {:error, :invalid} -> {:error, :invalid_ref}
     end

--- a/elixir/apps/api/lib/api/gateway/views/client.ex
+++ b/elixir/apps/api/lib/api/gateway/views/client.ex
@@ -4,13 +4,10 @@ defmodule API.Gateway.Views.Client do
   def render(%Clients.Client{} = client, preshared_key) do
     %{
       id: client.id,
-      peer: %{
-        persistent_keepalive: 25,
-        public_key: client.public_key,
-        preshared_key: preshared_key,
-        ipv4: client.ipv4,
-        ipv6: client.ipv6
-      }
+      public_key: client.public_key,
+      preshared_key: preshared_key,
+      ipv4: client.ipv4,
+      ipv6: client.ipv6
     }
   end
 

--- a/elixir/apps/api/lib/api/gateway/views/client.ex
+++ b/elixir/apps/api/lib/api/gateway/views/client.ex
@@ -1,6 +1,20 @@
 defmodule API.Gateway.Views.Client do
   alias Domain.Clients
 
+  def render(%Clients.Client{} = client, preshared_key) do
+    %{
+      id: client.id,
+      peer: %{
+        persistent_keepalive: 25,
+        public_key: client.public_key,
+        preshared_key: preshared_key,
+        ipv4: client.ipv4,
+        ipv6: client.ipv6
+      }
+    }
+  end
+
+  # DEPRECATED IN 1.4
   def render(%Clients.Client{} = client, client_payload, preshared_key) do
     %{
       id: client.id,

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -1084,6 +1084,512 @@ defmodule API.Client.ChannelTest do
     end
   end
 
+  describe "handle_in/3 create_flow" do
+    test "returns error when resource is not found", %{socket: socket} do
+      resource_id = Ecto.UUID.generate()
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource_id,
+        "connected_gateway_ids" => []
+      })
+
+      # assert_reply ref, :error, %{reason: :not_found}
+      assert_push "flow_creation_failed", %{reason: :not_found, resource_id: ^resource_id}
+    end
+
+    test "returns error when all gateways are offline", %{
+      dns_resource: resource,
+      socket: socket
+    } do
+      global_relay_group = Fixtures.Relays.create_global_group()
+
+      global_relay =
+        Fixtures.Relays.create_relay(
+          group: global_relay_group,
+          last_seen_remote_ip_location_lat: 37,
+          last_seen_remote_ip_location_lon: -120
+        )
+
+      stamp_secret = Ecto.UUID.generate()
+      :ok = Domain.Relays.connect_relay(global_relay, stamp_secret)
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      })
+
+      # assert_reply ref, :error, %{reason: :offline}
+      assert_push "flow_creation_failed", %{reason: :offline, resource_id: resource_id}
+      assert resource_id == resource.id
+    end
+
+    test "returns error when client has no policy allowing access to resource", %{
+      account: account,
+      socket: socket
+    } do
+      resource = Fixtures.Resources.create_resource(account: account)
+
+      gateway = Fixtures.Gateways.create_gateway(account: account)
+      :ok = Domain.Gateways.connect_gateway(gateway)
+
+      attrs = %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      }
+
+      push(socket, "create_flow", attrs)
+
+      # assert_reply ref, :error, %{reason: :not_found}
+
+      assert_push "flow_creation_failed", %{reason: :not_found, resource_id: resource_id}
+      assert resource_id == resource.id
+    end
+
+    test "returns error when flow is not authorized due to failing conditions", %{
+      account: account,
+      client: client,
+      actor_group: actor_group,
+      gateway_group: gateway_group,
+      gateway: gateway,
+      socket: socket
+    } do
+      resource =
+        Fixtures.Resources.create_resource(
+          account: account,
+          connections: [%{gateway_group_id: gateway_group.id}]
+        )
+
+      Fixtures.Policies.create_policy(
+        account: account,
+        actor_group: actor_group,
+        resource: resource,
+        conditions: [
+          %{
+            property: :remote_ip_location_region,
+            operator: :is_not_in,
+            values: [client.last_seen_remote_ip_location_region]
+          }
+        ]
+      )
+
+      attrs = %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      }
+
+      :ok = Domain.Gateways.connect_gateway(gateway)
+
+      push(socket, "create_flow", attrs)
+      # assert_reply ref, :error, %{reason: :not_found}
+
+      assert_push "flow_creation_failed", %{
+        reason: :forbidden,
+        violated_properties: [:remote_ip_location_region],
+        resource_id: resource_id
+      }
+
+      assert resource_id == resource.id
+    end
+
+    test "returns error when all gateways connected to the resource are offline", %{
+      account: account,
+      dns_resource: resource,
+      socket: socket
+    } do
+      gateway = Fixtures.Gateways.create_gateway(account: account)
+      :ok = Domain.Gateways.connect_gateway(gateway)
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      })
+
+      # assert_reply ref, :error, %{reason: :offline}
+
+      assert_push "flow_creation_failed", %{
+        reason: :offline,
+        resource_id: resource_id
+      }
+
+      assert resource_id == resource.id
+    end
+
+    test "returns online gateway connected to a resource", %{
+      dns_resource: resource,
+      client: client,
+      gateway_group_token: gateway_group_token,
+      gateway: gateway,
+      socket: socket
+    } do
+      global_relay_group = Fixtures.Relays.create_global_group()
+
+      global_relay =
+        Fixtures.Relays.create_relay(
+          group: global_relay_group,
+          last_seen_remote_ip_location_lat: 37,
+          last_seen_remote_ip_location_lon: -120
+        )
+
+      stamp_secret = Ecto.UUID.generate()
+      :ok = Domain.Relays.connect_relay(global_relay, stamp_secret)
+
+      Fixtures.Relays.update_relay(global_relay,
+        last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second)
+      )
+
+      :ok = Domain.Gateways.connect_gateway(gateway)
+      Domain.PubSub.subscribe(Domain.Tokens.socket_id(gateway_group_token))
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      })
+
+      assert_receive {:authorize_flow, {_channel_pid, _socket_ref}, payload, _opentelemetry_ctx}
+
+      assert %{
+               client_id: client_id,
+               resource_id: resource_id,
+               flow_id: _flow_id,
+               authorization_expires_at: authorization_expires_at,
+               ice_credentials: _ice_credentials,
+               preshared_key: preshared_key
+             } = payload
+
+      assert client_id == client.id
+      assert resource_id == resource.id
+      assert authorization_expires_at == socket.assigns.subject.expires_at
+      assert String.length(preshared_key) == 32
+    end
+
+    test "returns online gateway connected to an internet resource", %{
+      account: account,
+      internet_resource: resource,
+      client: client,
+      gateway_group_token: gateway_group_token,
+      gateway: gateway,
+      socket: socket
+    } do
+      Fixtures.Accounts.update_account(account,
+        features: %{
+          internet_resource: true
+        }
+      )
+
+      global_relay_group = Fixtures.Relays.create_global_group()
+
+      global_relay =
+        Fixtures.Relays.create_relay(
+          group: global_relay_group,
+          last_seen_remote_ip_location_lat: 37,
+          last_seen_remote_ip_location_lon: -120
+        )
+
+      stamp_secret = Ecto.UUID.generate()
+      :ok = Domain.Relays.connect_relay(global_relay, stamp_secret)
+
+      Fixtures.Relays.update_relay(global_relay,
+        last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second)
+      )
+
+      :ok = Domain.Gateways.connect_gateway(gateway)
+      Domain.PubSub.subscribe(Domain.Tokens.socket_id(gateway_group_token))
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      })
+
+      assert_receive {:authorize_flow, {_channel_pid, _socket_ref}, payload, _opentelemetry_ctx}
+
+      assert %{
+               client_id: client_id,
+               resource_id: resource_id,
+               flow_id: _flow_id,
+               authorization_expires_at: authorization_expires_at,
+               ice_credentials: _ice_credentials,
+               preshared_key: preshared_key
+             } = payload
+
+      assert client_id == client.id
+      assert resource_id == resource.id
+      assert authorization_expires_at == socket.assigns.subject.expires_at
+      assert String.length(preshared_key) == 32
+    end
+
+    test "broadcasts authorize_flow to the gateway and flow_created to the client", %{
+      dns_resource: resource,
+      dns_resource_policy: policy,
+      client: client,
+      gateway_group_token: gateway_group_token,
+      gateway: gateway,
+      subject: subject,
+      socket: socket
+    } do
+      global_relay_group = Fixtures.Relays.create_global_group()
+
+      global_relay =
+        Fixtures.Relays.create_relay(
+          group: global_relay_group,
+          last_seen_remote_ip_location_lat: 37,
+          last_seen_remote_ip_location_lon: -120
+        )
+
+      stamp_secret = Ecto.UUID.generate()
+      :ok = Domain.Relays.connect_relay(global_relay, stamp_secret)
+
+      Fixtures.Relays.update_relay(global_relay,
+        last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second)
+      )
+
+      :ok = Domain.Gateways.connect_gateway(gateway)
+      Domain.PubSub.subscribe(Domain.Tokens.socket_id(gateway_group_token))
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      })
+
+      assert_receive {:authorize_flow, {channel_pid, socket_ref}, payload, _opentelemetry_ctx}
+
+      assert %{
+               client_id: client_id,
+               resource_id: resource_id,
+               flow_id: flow_id,
+               authorization_expires_at: authorization_expires_at,
+               ice_credentials: ice_credentials,
+               preshared_key: preshared_key
+             } = payload
+
+      assert flow = Repo.get(Domain.Flows.Flow, flow_id)
+      assert flow.client_id == client.id
+      assert flow.resource_id == resource_id
+      assert flow.gateway_id == gateway.id
+      assert flow.policy_id == policy.id
+      assert flow.token_id == subject.token_id
+
+      assert client_id == client.id
+      assert resource_id == resource.id
+      assert authorization_expires_at == socket.assigns.subject.expires_at
+
+      otel_ctx = {OpenTelemetry.Ctx.new(), OpenTelemetry.Tracer.start_span("connect")}
+
+      send(
+        channel_pid,
+        {:connect, socket_ref, resource_id, gateway.group_id, gateway.id, gateway.public_key,
+         preshared_key, ice_credentials, otel_ctx}
+      )
+
+      gateway_group_id = gateway.group_id
+      gateway_id = gateway.id
+      gateway_public_key = gateway.public_key
+
+      assert_push "flow_created", %{
+        gateway_public_key: ^gateway_public_key,
+        resource_id: ^resource_id,
+        client_ice_credentials: %{username: client_ice_username, password: client_ice_password},
+        gateway_group_id: ^gateway_group_id,
+        gateway_id: ^gateway_id,
+        gateway_ice_credentials: %{username: gateway_ice_username, password: gateway_ice_password},
+        preshared_key: ^preshared_key
+      }
+
+      assert String.length(client_ice_username) == 4
+      assert String.length(client_ice_password) == 22
+      assert String.length(gateway_ice_username) == 4
+      assert String.length(gateway_ice_password) == 22
+      assert client_ice_username != gateway_ice_username
+      assert client_ice_password != gateway_ice_password
+    end
+
+    test "works with service accounts", %{
+      account: account,
+      dns_resource: resource,
+      gateway: gateway,
+      gateway_group_token: gateway_group_token,
+      actor_group: actor_group
+    } do
+      actor = Fixtures.Actors.create_actor(type: :service_account, account: account)
+      client = Fixtures.Clients.create_client(account: account, actor: actor)
+      Fixtures.Actors.create_membership(account: account, actor: actor, group: actor_group)
+
+      identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+      subject = Fixtures.Auth.create_subject(account: account, actor: actor, identity: identity)
+
+      {:ok, _reply, socket} =
+        API.Client.Socket
+        |> socket("client:#{client.id}", %{
+          opentelemetry_ctx: OpenTelemetry.Ctx.new(),
+          opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test"),
+          client: client,
+          subject: subject
+        })
+        |> subscribe_and_join(API.Client.Channel, "client")
+
+      global_relay_group = Fixtures.Relays.create_global_group()
+
+      global_relay =
+        Fixtures.Relays.create_relay(
+          group: global_relay_group,
+          last_seen_remote_ip_location_lat: 37,
+          last_seen_remote_ip_location_lon: -120
+        )
+
+      stamp_secret = Ecto.UUID.generate()
+      :ok = Domain.Relays.connect_relay(global_relay, stamp_secret)
+
+      Fixtures.Relays.update_relay(global_relay,
+        last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second)
+      )
+
+      :ok = Domain.Gateways.connect_gateway(gateway)
+      Domain.PubSub.subscribe(Domain.Tokens.socket_id(gateway_group_token))
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      })
+
+      assert_receive {:authorize_flow, {_channel_pid, _socket_ref}, _payload, _opentelemetry_ctx}
+    end
+
+    test "selects compatible gateway versions", %{
+      account: account,
+      gateway_group: gateway_group,
+      dns_resource: resource,
+      subject: subject,
+      client: client
+    } do
+      global_relay_group = Fixtures.Relays.create_global_group()
+
+      relay =
+        Fixtures.Relays.create_relay(
+          group: global_relay_group,
+          last_seen_remote_ip_location_lat: 37,
+          last_seen_remote_ip_location_lon: -120
+        )
+
+      :ok = Domain.Relays.connect_relay(relay, Ecto.UUID.generate())
+
+      Fixtures.Relays.update_relay(relay,
+        last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second)
+      )
+
+      client = %{client | last_seen_version: "1.4.55"}
+
+      gateway =
+        Fixtures.Gateways.create_gateway(
+          account: account,
+          group: gateway_group,
+          context:
+            Fixtures.Auth.build_context(
+              type: :gateway_group,
+              user_agent: "Linux/24.04 connlib/1.0.412"
+            )
+        )
+
+      :ok = Domain.Gateways.connect_gateway(gateway)
+
+      {:ok, _reply, socket} =
+        API.Client.Socket
+        |> socket("client:#{client.id}", %{
+          opentelemetry_ctx: OpenTelemetry.Ctx.new(),
+          opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test"),
+          client: client,
+          subject: subject
+        })
+        |> subscribe_and_join(API.Client.Channel, "client")
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      })
+
+      assert_push "flow_creation_failed", %{
+        reason: :not_found,
+        resource_id: resource_id
+      }
+
+      assert resource_id == resource.id
+
+      gateway =
+        Fixtures.Gateways.create_gateway(
+          account: account,
+          group: gateway_group,
+          context:
+            Fixtures.Auth.build_context(
+              type: :gateway_group,
+              user_agent: "Linux/24.04 connlib/1.4.11"
+            )
+        )
+
+      :ok = Domain.Gateways.connect_gateway(gateway)
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => []
+      })
+
+      assert_receive {:authorize_flow, {_channel_pid, _socket_ref}, _payload, _opentelemetry_ctx}
+    end
+
+    test "selects already connected gateway", %{
+      account: account,
+      gateway_group: gateway_group,
+      dns_resource: resource,
+      socket: socket
+    } do
+      global_relay_group = Fixtures.Relays.create_global_group()
+
+      relay =
+        Fixtures.Relays.create_relay(
+          group: global_relay_group,
+          last_seen_remote_ip_location_lat: 37,
+          last_seen_remote_ip_location_lon: -120
+        )
+
+      :ok = Domain.Relays.connect_relay(relay, Ecto.UUID.generate())
+
+      Fixtures.Relays.update_relay(relay,
+        last_seen_at: DateTime.utc_now() |> DateTime.add(-10, :second)
+      )
+
+      gateway1 =
+        Fixtures.Gateways.create_gateway(
+          account: account,
+          group: gateway_group
+        )
+
+      :ok = Domain.Gateways.connect_gateway(gateway1)
+
+      gateway2 =
+        Fixtures.Gateways.create_gateway(
+          account: account,
+          group: gateway_group
+        )
+
+      :ok = Domain.Gateways.connect_gateway(gateway2)
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => [gateway2.id]
+      })
+
+      assert_receive {:authorize_flow, {_channel_pid, _socket_ref}, %{flow_id: flow_id}, _}
+      assert flow = Repo.get(Domain.Flows.Flow, flow_id)
+      assert flow.gateway_id == gateway2.id
+
+      push(socket, "create_flow", %{
+        "resource_id" => resource.id,
+        "connected_gateway_ids" => [gateway1.id]
+      })
+
+      assert_receive {:authorize_flow, {_channel_pid, _socket_ref}, %{flow_id: flow_id}, _}
+      assert flow = Repo.get(Domain.Flows.Flow, flow_id)
+      assert flow.gateway_id == gateway1.id
+    end
+  end
+
   describe "handle_in/3 prepare_connection" do
     test "returns error when resource is not found", %{socket: socket} do
       ref = push(socket, "prepare_connection", %{"resource_id" => Ecto.UUID.generate()})

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -1779,7 +1779,6 @@ defmodule API.Client.ChannelTest do
 
       assert_reply ref, :ok, %{
         resource_id: ^resource_id,
-        persistent_keepalive: 25,
         preshared_key: ^preshared_key,
         ice_credentials: ^ice_credentials,
         gateway_id: ^gateway_id,

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -793,6 +793,43 @@ defmodule API.Client.ChannelTest do
     end
   end
 
+  describe "handle_info/2 :create_resource" do
+    test "pushes message to the socket for authorized clients", %{
+      gateway_group: gateway_group,
+      dns_resource: resource,
+      socket: socket
+    } do
+      send(socket.channel_pid, {:create_resource, resource.id})
+
+      assert_push "resource_created_or_updated", payload
+
+      assert payload == %{
+               id: resource.id,
+               type: :dns,
+               name: resource.name,
+               address: resource.address,
+               address_description: resource.address_description,
+               gateway_groups: [
+                 %{id: gateway_group.id, name: gateway_group.name}
+               ],
+               filters: [
+                 %{protocol: :tcp, port_range_end: 80, port_range_start: 80},
+                 %{protocol: :tcp, port_range_end: 433, port_range_start: 433},
+                 %{protocol: :udp, port_range_end: 200, port_range_start: 100},
+                 %{protocol: :icmp}
+               ]
+             }
+    end
+
+    test "does not push resources that can't be access by the client", %{
+      nonconforming_resource: resource,
+      socket: socket
+    } do
+      send(socket.channel_pid, {:create_resource, resource.id})
+      refute_push "resource_created_or_updated", %{}
+    end
+  end
+
   describe "handle_info/2 :update_resource" do
     test "pushes message to the socket for authorized clients", %{
       gateway_group: gateway_group,
@@ -1609,368 +1646,6 @@ defmodule API.Client.ChannelTest do
       })
 
       assert_receive {:allow_access, _refs, _payload, _opentelemetry_ctx}
-    end
-  end
-
-  describe "handle_in/3 create_flow" do
-    test "returns error when resource is not found", %{socket: socket} do
-      attrs = %{
-        "resource_id" => Ecto.UUID.generate(),
-        "connected_gateway_ids" => []
-      }
-
-      ref = push(socket, "create_flow", attrs)
-      assert_reply ref, :error, %{reason: :not_found}
-    end
-
-    test "returns error when gateway is not found", %{dns_resource: resource, socket: socket} do
-      attrs = %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => []
-      }
-
-      ref = push(socket, "create_flow", attrs)
-      assert_reply ref, :error, %{reason: :offline}
-    end
-
-    test "returns error when gateway is not connected to resource", %{
-      account: account,
-      dns_resource: resource,
-      socket: socket
-    } do
-      gateway = Fixtures.Gateways.create_gateway(account: account)
-      :ok = Domain.Gateways.connect_gateway(gateway)
-
-      attrs = %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => []
-      }
-
-      ref = push(socket, "create_flow", attrs)
-      assert_reply ref, :error, %{reason: :offline}
-    end
-
-    test "returns error when gateway is offline", %{
-      dns_resource: resource,
-      socket: socket
-    } do
-      attrs = %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => []
-      }
-
-      ref = push(socket, "create_flow", attrs)
-      assert_reply ref, :error, %{reason: :offline}
-    end
-
-    test "returns error when client has no policy allowing access to resource", %{
-      account: account,
-      socket: socket
-    } do
-      resource = Fixtures.Resources.create_resource(account: account)
-
-      gateway = Fixtures.Gateways.create_gateway(account: account)
-      :ok = Domain.Gateways.connect_gateway(gateway)
-
-      attrs = %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => []
-      }
-
-      ref = push(socket, "create_flow", attrs)
-      assert_reply ref, :error, %{reason: :not_found}
-    end
-
-    test "returns error when flow is not authorized due to failing conditions", %{
-      account: account,
-      client: client,
-      actor_group: actor_group,
-      gateway_group: gateway_group,
-      gateway: gateway,
-      socket: socket
-    } do
-      resource =
-        Fixtures.Resources.create_resource(
-          account: account,
-          connections: [%{gateway_group_id: gateway_group.id}]
-        )
-
-      Fixtures.Policies.create_policy(
-        account: account,
-        actor_group: actor_group,
-        resource: resource,
-        conditions: [
-          %{
-            property: :remote_ip_location_region,
-            operator: :is_not_in,
-            values: [client.last_seen_remote_ip_location_region]
-          }
-        ]
-      )
-
-      attrs = %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => []
-      }
-
-      :ok = Domain.Gateways.connect_gateway(gateway)
-
-      ref = push(socket, "create_flow", attrs)
-
-      assert_reply ref, :error, %{
-        reason: :forbidden,
-        violated_properties: [:remote_ip_location_region]
-      }
-    end
-
-    test "broadcasts create_flow to the gateways and then returns connect message", %{
-      dns_resource: resource,
-      gateway_group_token: gateway_group_token,
-      gateway: gateway,
-      client: client,
-      socket: socket
-    } do
-      gateway_id = gateway.id
-      gateway_public_key = gateway.public_key
-      resource_id = resource.id
-      client_id = client.id
-
-      :ok = Domain.Gateways.connect_gateway(gateway)
-      Domain.PubSub.subscribe(Domain.Tokens.socket_id(gateway_group_token))
-
-      attrs = %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => []
-      }
-
-      ref = push(socket, "create_flow", attrs)
-
-      assert_receive {:authorize_flow, {channel_pid, socket_ref}, payload, _opentelemetry_ctx}
-
-      assert %{
-               resource_id: ^resource_id,
-               client_id: ^client_id,
-               flow_id: flow_id,
-               authorization_expires_at: authorization_expires_at,
-               ice_credentials:
-                 %{
-                   client: %{username: client_ice_username, password: client_ice_password},
-                   gateway: %{username: gateway_ice_username, password: gateway_ice_password}
-                 } = ice_credentials,
-               preshared_key: preshared_key
-             } = payload
-
-      assert String.length(client_ice_username) == 4
-      assert String.length(client_ice_password) == 22
-
-      assert String.length(gateway_ice_username) == 4
-      assert String.length(gateway_ice_password) == 22
-
-      flow = Domain.Repo.get(Domain.Flows.Flow, flow_id)
-      assert authorization_expires_at == flow.expires_at
-
-      otel_ctx = {OpenTelemetry.Ctx.new(), OpenTelemetry.Tracer.start_span("connect")}
-
-      send(
-        channel_pid,
-        {:connect, socket_ref, resource_id, gateway_id, gateway.public_key, preshared_key,
-         ice_credentials, otel_ctx}
-      )
-
-      assert_reply ref, :ok, %{
-        resource_id: ^resource_id,
-        preshared_key: ^preshared_key,
-        ice_credentials: ^ice_credentials,
-        gateway_id: ^gateway_id,
-        gateway_public_key: ^gateway_public_key
-      }
-    end
-
-    test "works with service accounts", %{
-      account: account,
-      dns_resource: resource,
-      gateway_group_token: gateway_group_token,
-      gateway: gateway,
-      actor_group: actor_group
-    } do
-      actor = Fixtures.Actors.create_actor(type: :service_account, account: account)
-      client = Fixtures.Clients.create_client(account: account, actor: actor)
-      Fixtures.Actors.create_membership(account: account, actor: actor, group: actor_group)
-
-      identity = Fixtures.Auth.create_identity(account: account, actor: actor)
-      subject = Fixtures.Auth.create_subject(account: account, actor: actor, identity: identity)
-
-      {:ok, _reply, socket} =
-        API.Client.Socket
-        |> socket("client:#{client.id}", %{
-          opentelemetry_ctx: OpenTelemetry.Ctx.new(),
-          opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test"),
-          client: client,
-          subject: subject
-        })
-        |> subscribe_and_join(API.Client.Channel, "client")
-
-      :ok = Domain.Gateways.connect_gateway(gateway)
-      Phoenix.PubSub.subscribe(Domain.PubSub, Domain.Tokens.socket_id(gateway_group_token))
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => []
-      })
-
-      assert_receive {:authorize_flow, _refs, _payload, _opentelemetry_ctx}
-    end
-
-    test "selects compatible gateway versions", %{
-      account: account,
-      gateway_group: gateway_group,
-      dns_resource: resource,
-      subject: subject,
-      client: client
-    } do
-      client = %{client | last_seen_version: "1.1.55"}
-
-      gateway =
-        Fixtures.Gateways.create_gateway(
-          account: account,
-          group: gateway_group,
-          context:
-            Fixtures.Auth.build_context(
-              type: :gateway_group,
-              user_agent: "Linux/24.04 connlib/1.0.412"
-            )
-        )
-
-      :ok = Domain.Gateways.connect_gateway(gateway)
-
-      {:ok, _reply, socket} =
-        API.Client.Socket
-        |> socket("client:#{client.id}", %{
-          opentelemetry_ctx: OpenTelemetry.Ctx.new(),
-          opentelemetry_span_ctx: OpenTelemetry.Tracer.start_span("test"),
-          client: client,
-          subject: subject
-        })
-        |> subscribe_and_join(API.Client.Channel, "client")
-
-      ref =
-        push(socket, "create_flow", %{
-          "resource_id" => resource.id,
-          "connected_gateway_ids" => []
-        })
-
-      assert_reply ref, :error, %{reason: :not_found}
-
-      gateway =
-        Fixtures.Gateways.create_gateway(
-          account: account,
-          group: gateway_group,
-          context:
-            Fixtures.Auth.build_context(
-              type: :gateway_group,
-              user_agent: "Linux/24.04 connlib/1.1.11"
-            )
-        )
-
-      :ok = Domain.Gateways.connect_gateway(gateway)
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => []
-      })
-
-      assert_receive {:authorize_flow, _refs, _payload, _opentelemetry_ctx}
-    end
-
-    test "prefers connected gateways", %{
-      account: account,
-      gateway_group: gateway_group,
-      dns_resource: resource,
-      socket: socket
-    } do
-      gateway1 = Fixtures.Gateways.create_gateway(account: account, group: gateway_group)
-      :ok = Domain.Gateways.connect_gateway(gateway1)
-
-      gateway2 = Fixtures.Gateways.create_gateway(account: account, group: gateway_group)
-      :ok = Domain.Gateways.connect_gateway(gateway2)
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => [gateway1.id]
-      })
-
-      assert_receive {:authorize_flow, _refs, %{flow_id: flow_id}, _opentelemetry_ctx}
-      assert flow = Domain.Repo.get(Domain.Flows.Flow, flow_id)
-      assert flow.gateway_id == gateway1.id
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => [gateway2.id]
-      })
-
-      assert_receive {:authorize_flow, _refs, %{flow_id: flow_id}, _opentelemetry_ctx}
-      assert flow = Domain.Repo.get(Domain.Flows.Flow, flow_id)
-      assert flow.gateway_id == gateway2.id
-    end
-
-    test "ice credentials are deterministic by client-gateway public keys", %{
-      account: account,
-      gateway_group: gateway_group,
-      dns_resource: resource,
-      socket: socket
-    } do
-      gateway1 = Fixtures.Gateways.create_gateway(account: account, group: gateway_group)
-      :ok = Domain.Gateways.connect_gateway(gateway1)
-
-      gateway2 = Fixtures.Gateways.create_gateway(account: account, group: gateway_group)
-      :ok = Domain.Gateways.connect_gateway(gateway2)
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => [gateway1.id]
-      })
-
-      assert_receive {:authorize_flow, _refs, %{ice_credentials: ice_credentials1}, _}
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => [gateway1.id]
-      })
-
-      assert_receive {:authorize_flow, _refs, %{ice_credentials: ^ice_credentials1}, _}
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => [gateway2.id]
-      })
-
-      assert_receive {:authorize_flow, _refs, %{ice_credentials: ice_credentials2}, _}
-      assert ice_credentials2 != ice_credentials1
-    end
-
-    test "preshared key is distinct per flow", %{
-      account: account,
-      gateway_group: gateway_group,
-      dns_resource: resource,
-      socket: socket
-    } do
-      gateway = Fixtures.Gateways.create_gateway(account: account, group: gateway_group)
-      :ok = Domain.Gateways.connect_gateway(gateway)
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => [gateway.id]
-      })
-
-      assert_receive {:authorize_flow, _refs, %{preshared_key: preshared_key1}, _}
-
-      push(socket, "create_flow", %{
-        "resource_id" => resource.id,
-        "connected_gateway_ids" => [gateway.id]
-      })
-
-      assert_receive {:authorize_flow, _refs, %{preshared_key: preshared_key2}, _}
-      assert preshared_key2 != preshared_key1
     end
   end
 

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -687,6 +687,260 @@ defmodule API.Gateway.ChannelTest do
     end
   end
 
+  describe "handle_info/2 :authorize_flow" do
+    test "pushes authorize_flow message", %{
+      client: client,
+      resource: resource,
+      socket: socket
+    } do
+      channel_pid = self()
+      socket_ref = make_ref()
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      preshared_key = "PSK"
+      flow_id = Ecto.UUID.generate()
+
+      ice_credentials = %{
+        client: %{username: "A", password: "B"},
+        gateway: %{username: "C", password: "D"}
+      }
+
+      otel_ctx = {OpenTelemetry.Ctx.new(), OpenTelemetry.Tracer.start_span("connect")}
+
+      send(
+        socket.channel_pid,
+        {:authorize_flow, {channel_pid, socket_ref},
+         %{
+           client_id: client.id,
+           resource_id: resource.id,
+           flow_id: flow_id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key
+         }, otel_ctx}
+      )
+
+      assert_push "authorize_flow", payload
+
+      assert is_binary(payload.ref)
+      assert payload.flow_id == flow_id
+      assert payload.actor == %{id: client.actor_id}
+
+      assert payload.resource == %{
+               address: resource.address,
+               id: resource.id,
+               name: resource.name,
+               type: :dns,
+               filters: [
+                 %{protocol: :tcp, port_range_end: 80, port_range_start: 80},
+                 %{protocol: :tcp, port_range_end: 433, port_range_start: 433},
+                 %{protocol: :udp, port_range_start: 100, port_range_end: 200},
+                 %{protocol: :icmp}
+               ]
+             }
+
+      assert payload.client == %{
+               id: client.id,
+               peer: %{
+                 ipv4: client.ipv4,
+                 ipv6: client.ipv6,
+                 persistent_keepalive: 25,
+                 preshared_key: preshared_key,
+                 public_key: client.public_key
+               }
+             }
+
+      assert payload.ice_credentials == ice_credentials
+
+      assert DateTime.from_unix!(payload.expires_at) ==
+               DateTime.truncate(expires_at, :second)
+    end
+
+    test "subscribes for flow expiration event", %{
+      account: account,
+      client: client,
+      resource: resource,
+      socket: socket,
+      subject: subject
+    } do
+      channel_pid = self()
+      socket_ref = make_ref()
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      otel_ctx = {OpenTelemetry.Ctx.new(), OpenTelemetry.Tracer.start_span("connect")}
+      preshared_key = "PSK"
+
+      ice_credentials = %{
+        client: %{username: "A", password: "B"},
+        gateway: %{username: "C", password: "D"}
+      }
+
+      flow =
+        Fixtures.Flows.create_flow(
+          account: account,
+          subject: subject,
+          client: client,
+          resource: resource
+        )
+
+      send(
+        socket.channel_pid,
+        {:authorize_flow, {channel_pid, socket_ref},
+         %{
+           client_id: client.id,
+           resource_id: resource.id,
+           flow_id: flow.id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key
+         }, otel_ctx}
+      )
+
+      assert_push "authorize_flow", %{}
+
+      {:ok, [_flow]} = Domain.Flows.expire_flows_for(resource, subject)
+
+      assert_push "reject_access", %{
+        flow_id: flow_id,
+        client_id: client_id,
+        resource_id: resource_id
+      }
+
+      assert flow_id == flow.id
+      assert client_id == client.id
+      assert resource_id == resource.id
+    end
+
+    test "subscribes for resource events", %{
+      account: account,
+      client: client,
+      resource: resource,
+      relay: relay,
+      socket: socket,
+      subject: subject
+    } do
+      channel_pid = self()
+      socket_ref = make_ref()
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      otel_ctx = {OpenTelemetry.Ctx.new(), OpenTelemetry.Tracer.start_span("connect")}
+      preshared_key = "PSK"
+
+      ice_credentials = %{
+        client: %{username: "A", password: "B"},
+        gateway: %{username: "C", password: "D"}
+      }
+
+      stamp_secret = Ecto.UUID.generate()
+      :ok = Domain.Relays.connect_relay(relay, stamp_secret)
+
+      flow =
+        Fixtures.Flows.create_flow(
+          account: account,
+          subject: subject,
+          client: client,
+          resource: resource
+        )
+
+      send(
+        socket.channel_pid,
+        {:authorize_flow, {channel_pid, socket_ref},
+         %{
+           client_id: client.id,
+           resource_id: resource.id,
+           flow_id: flow.id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key
+         }, otel_ctx}
+      )
+
+      assert_push "authorize_flow", %{}
+
+      {:ok, resource} =
+        Domain.Resources.update_resource(resource, %{"name" => Ecto.UUID.generate()}, subject)
+
+      assert_push "resource_updated", payload
+
+      assert payload == %{
+               address: resource.address,
+               id: resource.id,
+               name: resource.name,
+               type: :dns,
+               filters: [
+                 %{protocol: :tcp, port_range_end: 80, port_range_start: 80},
+                 %{protocol: :tcp, port_range_end: 433, port_range_start: 433},
+                 %{protocol: :udp, port_range_start: 100, port_range_end: 200},
+                 %{protocol: :icmp}
+               ]
+             }
+    end
+  end
+
+  describe "handle_in/3 flow_authorized" do
+    test "forwards reply to the client channel", %{
+      client: client,
+      resource: resource,
+      gateway: gateway,
+      socket: socket
+    } do
+      channel_pid = self()
+      socket_ref = make_ref()
+      flow_id = Ecto.UUID.generate()
+      expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
+      preshared_key = "PSK"
+      gateway_id = gateway.id
+      gateway_public_key = gateway.public_key
+      resource_id = resource.id
+
+      ice_credentials = %{
+        client: %{username: "A", password: "B"},
+        gateway: %{username: "C", password: "D"}
+      }
+
+      otel_ctx = {OpenTelemetry.Ctx.new(), OpenTelemetry.Tracer.start_span("authorize_flow")}
+
+      send(
+        socket.channel_pid,
+        {:authorize_flow, {channel_pid, socket_ref},
+         %{
+           client_id: client.id,
+           resource_id: resource.id,
+           flow_id: flow_id,
+           authorization_expires_at: expires_at,
+           ice_credentials: ice_credentials,
+           preshared_key: preshared_key
+         }, otel_ctx}
+      )
+
+      assert_push "authorize_flow", %{ref: ref}
+      push_ref = push(socket, "flow_authorized", %{"ref" => ref})
+
+      assert_reply push_ref, :ok
+
+      assert_receive {
+        :connect,
+        ^socket_ref,
+        ^resource_id,
+        ^gateway_id,
+        ^gateway_public_key,
+        ^preshared_key,
+        ^ice_credentials,
+        {_opentelemetry_ctx, opentelemetry_span_ctx}
+      }
+
+      assert elem(opentelemetry_span_ctx, 1) == otel_ctx |> elem(1) |> elem(1)
+    end
+
+    test "pushes an error when ref is invalid", %{
+      socket: socket
+    } do
+      push_ref =
+        push(socket, "flow_authorized", %{
+          "ref" => "foo"
+        })
+
+      assert_reply push_ref, :error, %{reason: :invalid_ref}
+    end
+  end
+
   describe "handle_in/3 connection_ready" do
     test "forwards RFC session description to the client channel", %{
       client: client,

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -887,6 +887,7 @@ defmodule API.Gateway.ChannelTest do
       flow_id = Ecto.UUID.generate()
       expires_at = DateTime.utc_now() |> DateTime.add(30, :second)
       preshared_key = "PSK"
+      gateway_group_id = gateway.group_id
       gateway_id = gateway.id
       gateway_public_key = gateway.public_key
       resource_id = resource.id
@@ -920,6 +921,7 @@ defmodule API.Gateway.ChannelTest do
         :connect,
         ^socket_ref,
         ^resource_id,
+        ^gateway_group_id,
         ^gateway_id,
         ^gateway_public_key,
         ^preshared_key,

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -854,8 +854,12 @@ defmodule API.Gateway.ChannelTest do
 
       assert_push "authorize_flow", %{}
 
-      {:ok, resource} =
-        Domain.Resources.update_resource(resource, %{"name" => Ecto.UUID.generate()}, subject)
+      {:updated, resource} =
+        Domain.Resources.update_or_replace_resource(
+          resource,
+          %{"name" => Ecto.UUID.generate()},
+          subject
+        )
 
       assert_push "resource_updated", payload
 

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -740,13 +740,10 @@ defmodule API.Gateway.ChannelTest do
 
       assert payload.client == %{
                id: client.id,
-               peer: %{
-                 ipv4: client.ipv4,
-                 ipv6: client.ipv6,
-                 persistent_keepalive: 25,
-                 preshared_key: preshared_key,
-                 public_key: client.public_key
-               }
+               ipv4: client.ipv4,
+               ipv6: client.ipv6,
+               preshared_key: preshared_key,
+               public_key: client.public_key
              }
 
       assert payload.ice_credentials == ice_credentials

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -746,7 +746,8 @@ defmodule API.Gateway.ChannelTest do
                public_key: client.public_key
              }
 
-      assert payload.ice_credentials == ice_credentials
+      assert payload.client_ice_credentials == ice_credentials.client
+      assert payload.gateway_ice_credentials == ice_credentials.gateway
 
       assert DateTime.from_unix!(payload.expires_at) ==
                DateTime.truncate(expires_at, :second)

--- a/elixir/apps/domain/lib/domain/crypto.ex
+++ b/elixir/apps/domain/lib/domain/crypto.ex
@@ -3,6 +3,7 @@ defmodule Domain.Crypto do
 
   def psk do
     random_token(@wg_psk_length, encoder: :base64)
+    |> String.slice(0, @wg_psk_length)
   end
 
   def random_token(length \\ 16, opts \\ []) do

--- a/elixir/apps/domain/test/domain/crypto_test.exs
+++ b/elixir/apps/domain/test/domain/crypto_test.exs
@@ -4,7 +4,7 @@ defmodule Domain.CryptoTest do
 
   describe "psk/0" do
     test "it returns a string of proper length" do
-      assert 44 == String.length(psk())
+      assert 32 == String.length(psk())
     end
   end
 


### PR DESCRIPTION
TODOs:
- [x] Switch to sending messages instead of replies
- [ ] Do not hide pre-filtered resources and render them with an error instead (in case we will want to expose that on a client later)
- [x] Figure out how to generate PSK so that it stays across WS connections