### PR TITLE
refactor(android): Fix Kotlin compile warnings

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/settings/ui/SettingsActivity.kt
@@ -94,7 +94,7 @@ internal class SettingsActivity : AppCompatActivity() {
         AlertDialog.Builder(this).apply {
             setTitle("Warning")
             setMessage("Changed settings will not be applied until you sign out and sign back in.")
-            setPositiveButton("Okay") { dialog, which ->
+            setPositiveButton("Okay") { _, _ ->
                 viewModel.onSaveSettingsCompleted()
             }
             create().show()

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -52,7 +52,7 @@ class TunnelService : VpnService() {
     private var tunnelRoutes: MutableList<Cidr> = mutableListOf()
     private var _tunnelResources: List<Resource> = emptyList()
     private var _tunnelState: State = State.DOWN
-    var resourceState: ResourceState = ResourceState.UNSET
+    private var resourceState: ResourceState = ResourceState.UNSET
 
     // For reacting to changes to the network
     private var networkCallback: NetworkMonitor? = null
@@ -259,7 +259,7 @@ class TunnelService : VpnService() {
         return resourceState
     }
 
-    fun internetResource(): Resource? {
+    private fun internetResource(): Resource? {
         return tunnelResources.firstOrNull { it.isInternetResource() }
     }
 
@@ -439,7 +439,6 @@ class TunnelService : VpnService() {
             DOWN,
         }
 
-        private const val TAG: String = "TunnelService"
         private const val SESSION_NAME: String = "Firezone Connection"
         private const val MTU: Int = 1280
 


### PR DESCRIPTION
Somehow these snuck in. I would turn on warnings-as-errors but we are using deprecated functions that don't have good replacements.