### PR TITLE
chore(connlib): reduce log level for non-udp DNS queries

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -658,7 +658,7 @@ impl ClientState {
                 ControlFlow::Continue((packet, dest))
             }
             Err(e) => {
-                tracing::debug!(?packet, "Failed to handle DNS query: {e:#}");
+                tracing::trace!(?packet, "Failed to handle DNS query: {e:#}");
                 ControlFlow::Break(())
             }
         }


### PR DESCRIPTION
This can actually happen more often than we first suspected, i.e. when an application requests TCP DNS in addition to UDP.