### PR TITLE
revert: "chore(connlib): don't add routes for DNS sentinel servers"

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -815,6 +815,8 @@ impl ClientState {
             .map(|(ip, _)| ip)
             .chain(iter::once(IPV4_RESOURCES.into()))
             .chain(iter::once(IPV6_RESOURCES.into()))
+            .chain(iter::once(DNS_SENTINELS_V4.into()))
+            .chain(iter::once(DNS_SENTINELS_V6.into()))
             .chain(
                 self.internet_resource
                     .map(|_| Ipv4Network::DEFAULT_ROUTE.into()),
@@ -1841,7 +1843,9 @@ mod proptests {
             resource_routes
                 .into_iter()
                 .chain(iter::once(IPV4_RESOURCES.into()))
-                .chain(iter::once(IPV6_RESOURCES.into())),
+                .chain(iter::once(IPV6_RESOURCES.into()))
+                .chain(iter::once(DNS_SENTINELS_V4.into()))
+                .chain(iter::once(DNS_SENTINELS_V6.into())),
         )
     }
 

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -947,15 +947,25 @@ fn ref_client(
 }
 
 fn default_routes_v4() -> Vec<Ipv4Network> {
-    vec![Ipv4Network::new(Ipv4Addr::new(100, 96, 0, 0), 11).unwrap()]
+    vec![
+        Ipv4Network::new(Ipv4Addr::new(100, 96, 0, 0), 11).unwrap(),
+        Ipv4Network::new(Ipv4Addr::new(100, 100, 111, 0), 24).unwrap(),
+    ]
 }
 
 fn default_routes_v6() -> Vec<Ipv6Network> {
-    vec![Ipv6Network::new(
-        Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0x8000, 0, 0, 0, 0),
-        107,
-    )
-    .unwrap()]
+    vec![
+        Ipv6Network::new(
+            Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0x8000, 0, 0, 0, 0),
+            107,
+        )
+        .unwrap(),
+        Ipv6Network::new(
+            Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0x8000, 0x0100, 0x0100, 0x0111, 0),
+            120,
+        )
+        .unwrap(),
+    ]
 }
 
 fn known_hosts() -> impl Strategy<Value = BTreeMap<String, Vec<IpAddr>>> {


### PR DESCRIPTION
Reverts firezone/firezone#6755

The problem was that ipv6 dns sentinel range falls outside the dns resources ipv6 range..