### PR TITLE
fix(connlib): blackhole DNS HTTPS type queries for resources

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -291,6 +291,11 @@ impl StubResolver {
 
                 vec![AllRecordData::Ptr(domain::rdata::Ptr::new(fqdn))]
             }
+            (Rtype::HTTPS, Some(_)) => {
+                anyhow::bail!(
+                    "HTTPs record query for resource {domain} discarding as we can't mangle it"
+                );
+            }
             _ => {
                 return Ok(ControlFlow::Break(ResolveStrategy::ForwardQuery {
                     upstream,

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -293,7 +293,7 @@ impl StubResolver {
             }
             (Rtype::HTTPS, Some(_)) => {
                 anyhow::bail!(
-                    "HTTPs record query for resource {domain} discarding as we can't mangle it"
+                    "Discarding HTTPS record query for resource {domain} because we can't mangle it"
                 );
             }
             _ => {

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -9,6 +9,16 @@ export default function Apple() {
       href="https://apps.apple.com/us/app/firezone/id6443661826"
       title="macOS / iOS"
     >
+      {/*
+      <Entry version="1.3.4" date={new Date(todo)}>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem pull="{todo}">
+            Fixes a bug where HTTPs queries for resources where forwarded without intercepting,
+            causing in iOS an issue where browsers would use the real IP instead of our proxy IP.
+          </ChangeItem>
+        </ul>
+      </Entry>
+      */}
       <Entry version="1.3.3" date={new Date("2024-09-19")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6765">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -12,7 +12,7 @@ export default function Apple() {
       {/*
       <Entry version="1.3.4" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="{todo}">
+          <ChangeItem pull="6788">
             Fixes a bug where HTTPs queries for resources where forwarded without intercepting,
             causing in iOS an issue where browsers would use the real IP instead of our proxy IP.
           </ChangeItem>


### PR DESCRIPTION
Fix #6781
Fix #6375

The problem was that browsers in iOS(and possible other OSes) queries for A, AAAA and HTTPS, and we correctly intercept A and AAAA.

Correctly intercepting HTTPS queries is more tricky since we need the server's alpn, before this PR we were just forwarding those and then the response back but the problem with that is that it'd return the real IP for the service instead of our proxy IP.

So to quickly fix this we simply blackhole the query so the browser never use that response.

In the future an improvement over this would be to intercept the response instead of the query and mangle the ips there.
