### PR TITLE
docs(maintainers): suggest always keeping a draft entry open

### DIFF
--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -36,6 +36,7 @@ Given that `main` is tested:
     1. New version numbers
     1. Release notes
     1. Release date
+    1. Empty draft entry
 1. Update the known issues in `website/src/app/kb/client-apps/*`
 1. When the PR merges, the website will now redirect to the new version(s).
 


### PR DESCRIPTION
This reduces merge conflicts when 2 PRs both want to make the first change to a draft entry