### PR TITLE
fix(portal): Throttle reqs/sec and scheduled frequency on Okta sync jobs

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
@@ -105,6 +105,9 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     headers = headers ++ [{"Authorization", "Bearer #{api_token}"}]
     request = Finch.build(:get, uri, headers)
 
+    # Crude request throttle
+    :timer.sleep(:timer.seconds(1))
+
     with {:ok, %Finch.Response{headers: headers, body: response, status: status}}
          when status in 200..299 <- Finch.request(request, @pool_name),
          {:ok, list} <- Jason.decode(response) do

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
@@ -105,7 +105,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     headers = headers ++ [{"Authorization", "Bearer #{api_token}"}]
     request = Finch.build(:get, uri, headers)
 
-    # Crude request throttle
+    # Crude request throttle, revisit for https://github.com/firezone/firezone/issues/6793
     :timer.sleep(:timer.seconds(1))
 
     with {:ok, %Finch.Response{headers: headers, body: response, status: status}}

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/jobs/sync_directory.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/jobs/sync_directory.ex
@@ -1,7 +1,7 @@
 defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectory do
   use Domain.Jobs.Job,
     otp_app: :domain,
-    every: :timer.minutes(5),
+    every: :timer.minutes(20),
     executor: Domain.Jobs.Executors.Concurrent
 
   alias Domain.Auth.Adapter.OpenIDConnect.DirectorySync


### PR DESCRIPTION
Why:

* Our current Okta sync job has no throttle, which has caused an issue with customers that have other applications hitting their Okta API by going over their API rate limits.  By throttling the requests per second and by lowering the frequency of how often the job runs we should hopefully aleviate any Okta API rate limiting issues.  This will come at the expense of syncs taking longer and not happening as often, however, this tradeoff seems worthwhile to ensure Firezone isn't hindering a customers use of their Okta API.

Closes: #6748 