### PR TITLE
fix(portal): Update IDP sync error notification threshold

### DIFF
--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
@@ -864,12 +864,14 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
         end)
       end
 
-      {:ok, pid} = Task.Supervisor.start_link()
-      assert execute(%{task_supervisor: pid}) == :ok
+      for _n <- 1..10 do
+        {:ok, pid} = Task.Supervisor.start_link()
+        assert execute(%{task_supervisor: pid}) == :ok
+      end
 
       assert_email_sent(fn email ->
         assert email.subject == "Firezone Identity Provider Sync Error"
-        assert email.text_body =~ "failed to sync 1 times"
+        assert email.text_body =~ "failed to sync 10 times"
       end)
 
       cancel_bypass_expectations_check(bypass)

--- a/elixir/apps/domain/test/domain/auth/adapters/jumpcloud/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/jumpcloud/jobs/sync_directory_test.exs
@@ -582,12 +582,14 @@ defmodule Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectoryTest do
         end)
       end
 
-      {:ok, pid} = Task.Supervisor.start_link()
-      assert execute(%{task_supervisor: pid}) == :ok
+      for _n <- 1..10 do
+        {:ok, pid} = Task.Supervisor.start_link()
+        assert execute(%{task_supervisor: pid}) == :ok
+      end
 
       assert_email_sent(fn email ->
         assert email.subject == "Firezone Identity Provider Sync Error"
-        assert email.text_body =~ "failed to sync 1 times"
+        assert email.text_body =~ "failed to sync 10 times"
       end)
 
       cancel_bypass_expectations_check(bypass)

--- a/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/jobs/sync_directory_test.exs
@@ -500,12 +500,14 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
         end)
       end
 
-      {:ok, pid} = Task.Supervisor.start_link()
-      assert execute(%{task_supervisor: pid}) == :ok
+      for _n <- 1..10 do
+        {:ok, pid} = Task.Supervisor.start_link()
+        assert execute(%{task_supervisor: pid}) == :ok
+      end
 
       assert_email_sent(fn email ->
         assert email.subject == "Firezone Identity Provider Sync Error"
-        assert email.text_body =~ "failed to sync 1 times"
+        assert email.text_body =~ "failed to sync 10 times"
       end)
 
       cancel_bypass_expectations_check(bypass)

--- a/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/sync_directory_test.exs
@@ -812,12 +812,14 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
         end)
       end
 
-      {:ok, pid} = Task.Supervisor.start_link()
-      assert execute(%{task_supervisor: pid}) == :ok
+      for _n <- 1..10 do
+        {:ok, pid} = Task.Supervisor.start_link()
+        assert execute(%{task_supervisor: pid}) == :ok
+      end
 
       assert_email_sent(fn email ->
         assert email.subject == "Firezone Identity Provider Sync Error"
-        assert email.text_body =~ "failed to sync 1 times"
+        assert email.text_body =~ "failed to sync 10 times"
       end)
 
       cancel_bypass_expectations_check(bypass)


### PR DESCRIPTION
Why:

* Instead of sending a notification to users when an identity provider in their account fails to sync 1 time, we've now decided to wait until the sync failures have reached 10 times to account for various anomalies that might occur with any given identity providers API.