### PR TITLE
chore(connlib): increase snownet's idle timeout to 8 hours

### DIFF
--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -15,6 +15,7 @@ use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::task::JoinHandle;
 use tun::Tun;
@@ -136,6 +137,7 @@ where
         tcp_socket_factory,
         udp_socket_factory,
         BTreeMap::from([(portal.server_host().to_owned(), portal.resolved_addresses())]),
+        Duration::from_secs(8 * 60 * 60),
     );
 
     let mut eventloop = Eventloop::new(tunnel, callbacks, portal, rx);

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1497,7 +1497,7 @@ where
     }
 
     fn idle_timeout(&self) -> Instant {
-        const MAX_IDLE: Duration = Duration::from_secs(5 * 60);
+        const MAX_IDLE: Duration = Duration::from_secs(8 * 60 * 60);
 
         self.last_incoming.max(self.last_outgoing) + MAX_IDLE
     }

--- a/rust/connlib/snownet/tests/lib.rs
+++ b/rust/connlib/snownet/tests/lib.rs
@@ -76,12 +76,14 @@ fn only_generate_candidate_event_after_answer() {
     let mut alice = ClientNode::<u64, u64>::new(
         StaticSecret::random_from_rng(rand::thread_rng()),
         rand::random(),
+        Duration::from_secs(8 * 60 * 60),
     );
     alice.add_local_host_candidate(local_candidate).unwrap();
 
     let mut bob = ServerNode::<u64, u64>::new(
         StaticSecret::random_from_rng(rand::thread_rng()),
         rand::random(),
+        Duration::from_secs(8 * 60 * 60),
     );
 
     let offer = alice.new_connection(1, Instant::now(), Instant::now());
@@ -109,10 +111,12 @@ fn alice_and_bob() -> (ClientNode<u64, u64>, ServerNode<u64, u64>) {
     let alice = ClientNode::new(
         StaticSecret::random_from_rng(rand::thread_rng()),
         rand::random(),
+        Duration::from_secs(8 * 60 * 60),
     );
     let bob = ServerNode::new(
         StaticSecret::random_from_rng(rand::thread_rng()),
         rand::random(),
+        Duration::from_secs(8 * 60 * 60),
     );
 
     (alice, bob)

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -267,6 +267,7 @@ impl ClientState {
         private_key: impl Into<StaticSecret>,
         known_hosts: BTreeMap<String, Vec<IpAddr>>,
         seed: [u8; 32],
+        idle_timeout: Duration,
     ) -> Self {
         Self {
             awaiting_connection_details: Default::default(),
@@ -278,7 +279,7 @@ impl ClientState {
             buffered_events: Default::default(),
             tun_config: Default::default(),
             buffered_packets: Default::default(),
-            node: ClientNode::new(private_key.into(), seed),
+            node: ClientNode::new(private_key.into(), seed, idle_timeout),
             system_resolvers: Default::default(),
             sites_status: Default::default(),
             gateways_site: Default::default(),
@@ -1549,6 +1550,7 @@ mod tests {
                 StaticSecret::random_from_rng(OsRng),
                 BTreeMap::new(),
                 rand::random(),
+                Duration::from_secs(8 * 60 * 60),
             )
         }
     }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -141,10 +141,14 @@ pub struct GatewayState {
 }
 
 impl GatewayState {
-    pub(crate) fn new(private_key: impl Into<StaticSecret>, seed: [u8; 32]) -> Self {
+    pub(crate) fn new(
+        private_key: impl Into<StaticSecret>,
+        seed: [u8; 32],
+        idle_timeout: Duration,
+    ) -> Self {
         Self {
             peers: Default::default(),
-            node: ServerNode::new(private_key.into(), seed),
+            node: ServerNode::new(private_key.into(), seed, idle_timeout),
             next_expiry_resources_check: Default::default(),
             buffered_events: VecDeque::default(),
         }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
     task::{ready, Context, Poll},
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tun::Tun;
 use utils::turn;
@@ -85,10 +85,11 @@ impl ClientTunnel {
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
         known_hosts: BTreeMap<String, Vec<IpAddr>>,
+        idle_timeout: Duration,
     ) -> Self {
         Self {
             io: Io::new(tcp_socket_factory, udp_socket_factory),
-            role_state: ClientState::new(private_key, known_hosts, rand::random()),
+            role_state: ClientState::new(private_key, known_hosts, rand::random(), idle_timeout),
             ip4_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
             ip6_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
             encrypt_buf: EncryptBuffer::new(MAX_DATAGRAM_PAYLOAD),
@@ -180,10 +181,11 @@ impl GatewayTunnel {
         private_key: StaticSecret,
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
+        idle_timeout: Duration,
     ) -> Self {
         Self {
             io: Io::new(tcp_socket_factory, udp_socket_factory),
-            role_state: GatewayState::new(private_key, rand::random()),
+            role_state: GatewayState::new(private_key, rand::random(), idle_timeout),
             ip4_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
             ip6_read_buf: Box::new([0u8; MAX_UDP_SIZE]),
             encrypt_buf: EncryptBuffer::new(MAX_DATAGRAM_PAYLOAD),

--- a/rust/connlib/tunnel/src/proptest.rs
+++ b/rust/connlib/tunnel/src/proptest.rs
@@ -14,6 +14,7 @@ use proptest::{
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     ops::Range,
+    time::Duration,
 };
 
 pub fn resource(
@@ -126,6 +127,13 @@ pub fn resource_name() -> impl Strategy<Value = String> {
 
 pub fn domain_label() -> impl Strategy<Value = String> {
     any_with::<String>("[a-z]{3,6}".into())
+}
+
+pub fn idle_timeout() -> impl Strategy<Value = Duration> {
+    prop_oneof![
+        Just(Duration::from_secs(5 * 60)),
+        Just(Duration::from_secs(8 * 60 * 60)),
+    ]
 }
 
 pub fn domain_name(depth: Range<usize>) -> impl Strategy<Value = String> {

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -15,7 +15,7 @@ use snownet::{EncryptBuffer, Transmit};
 use std::{
     collections::{BTreeMap, BTreeSet},
     net::IpAddr,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 /// Simulation state for a particular client.
@@ -144,8 +144,9 @@ impl RefGateway {
     /// Initialize the [`GatewayState`].
     ///
     /// This simulates receiving the `init` message from the portal.
-    pub(crate) fn init(self, id: GatewayId) -> SimGateway {
-        SimGateway::new(id, GatewayState::new(self.key, self.key.0)) // Cheating a bit here by reusing the key as seed.
+    pub(crate) fn init(self, id: GatewayId, idle_timeout: Duration) -> SimGateway {
+        SimGateway::new(id, GatewayState::new(self.key, self.key.0, idle_timeout))
+        // Cheating a bit here by reusing the key as seed.
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -296,7 +296,7 @@ impl TunnelTest {
                 state.relays = online; // Override all relays.
             }
             Transition::Idle => {
-                const IDLE_DURATION: Duration = Duration::from_secs(6 * 60); // Ensure idling twice in a row puts us in the 10-15 minute window where TURN data channels are cooling down.
+                const IDLE_DURATION: Duration = Duration::from_secs(8 * 60 * 60); // Ensure idling twice in a row puts us in the 10-15 minute window where TURN data channels are cooling down.
                 let cut_off = state.flux_capacitor.now::<Instant>() + IDLE_DURATION;
 
                 while state.flux_capacitor.now::<Instant>() <= cut_off {

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -82,8 +82,8 @@ pub(crate) enum Transition {
     /// To avoid having to model that, we partition all of them but reconnect them within the same transition.
     PartitionRelaysFromPortal,
 
-    /// Idle connlib for a while, forcing connection to auto-close.
-    Idle,
+    IdleGateway,
+    IdleClient,
 }
 
 #[derive(Debug, Clone)]

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -14,10 +14,10 @@ use futures::channel::mpsc;
 use futures::{future, StreamExt, TryFutureExt};
 use phoenix_channel::PhoenixChannel;
 use secrecy::{Secret, SecretString};
-use std::convert::Infallible;
 use std::path::Path;
 use std::pin::pin;
 use std::sync::Arc;
+use std::{convert::Infallible, time::Duration};
 use tokio::io::AsyncWriteExt;
 use tokio::signal::ctrl_c;
 use tracing_subscriber::layer;
@@ -110,6 +110,7 @@ async fn run(login: LoginUrl, private_key: StaticSecret) -> Result<Infallible> {
         private_key,
         Arc::new(tcp_socket_factory),
         Arc::new(udp_socket_factory),
+        Duration::from_secs(8 * 60 * 60),
     );
     let portal = PhoenixChannel::connect(
         Secret::new(login),


### PR DESCRIPTION
Related to #6778

This is still a work in progress, I'm not sure if exposing the timeout to higher-layers is the way to go but I've done it to include the testing where clients and gatewawys might have different timeouts.

The reason the PR is not finished yet is that I expected the test to fail in this case:

* Gateway gets a 5 minutes timeout
* Client gets an 8 hours timeout
* Client create a connection
* Gateway idle timeout
* Client believes the connection is still open and tries to send a packet
* As expected this last step should fail(on either timeout we reset connections for the reference) however, in the reference this should establish a connection and in reality the client do have a connection still so it won't trigger a connection
* Client sends another packet, this should go through in the reference and fail in the simulation

So far, I haven't been able to reproduce this case!