### PR TITLE
chore(connlib): remove outdated log

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -251,8 +251,6 @@ where
                 self.tunnel.set_new_interface_config(interface);
                 self.tunnel.set_resources(resources);
                 self.tunnel.update_relays(BTreeSet::default(), relays);
-
-                tracing::info!("Firezone Started!");
             }
             IngressMessages::ResourceCreatedOrUpdated(resource) => {
                 self.tunnel.add_resource(resource);


### PR DESCRIPTION
This log is currently printed after we receive the `init` message from the client. It is a left-over from early days of connlib where receiving `init` itself already triggered all kinds of actions.

These days, we are mostly just updating state. In addition, `init` can be received multiple times during a client's session which is somewhat confusing when you see multiple "Firezone started" logs.