### PR TITLE
fix(connlib): match exact domains before wildcard ones

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -481,6 +481,7 @@ mod pattern {
 
     impl Ord for Pattern {
         fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            // Iterate over characters in reverse order so that e.g. `*.example.com` and `subdomain.example.com` will compare the `example.com` suffix
             let mut self_rev = self.original.chars().rev();
             let mut other_rev = other.original.chars().rev();
 

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -605,6 +605,22 @@ mod tests {
 
         assert!(!matches);
     }
+
+    #[test]
+    fn prioritises_non_wildcard_over_wildcard_domain() {
+        let mut resolver = StubResolver::new(BTreeMap::default());
+        let wc = ResourceId::from_u128(0);
+        let non_wc = ResourceId::from_u128(1);
+
+        resolver.add_resource(wc, "**.example.com".to_owned());
+        resolver.add_resource(non_wc, "foo.example.com".to_owned());
+
+        let resource_id = resolver
+            .match_resource_linear(&"foo.example.com".parse().unwrap())
+            .unwrap();
+
+        assert_eq!(resource_id, non_wc);
+    }
 }
 
 #[cfg(feature = "divan")]

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -25,7 +25,7 @@ pub struct StubResolver {
     ips_to_fqdn: HashMap<IpAddr, (DomainName, ResourceId)>,
     ip_provider: IpProvider,
     /// All DNS resources we know about, indexed by the glob pattern they match against.
-    dns_resources: HashMap<Pattern, ResourceId>,
+    dns_resources: BTreeMap<Pattern, ResourceId>,
     /// Fixed dns name that will be resolved to fixed ip addrs, similar to /etc/hosts
     known_hosts: KnownHosts,
 }
@@ -443,15 +443,79 @@ mod pattern {
     use super::*;
     use std::{convert::Infallible, fmt, str::FromStr};
 
-    #[derive(Debug, PartialEq, Eq, Hash)]
+    #[derive(Eq)]
     pub struct Pattern {
         inner: glob::Pattern,
         original: String,
     }
 
+    impl std::hash::Hash for Pattern {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.original.hash(state)
+        }
+    }
+
+    impl fmt::Debug for Pattern {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_tuple("Pattern").field(&self.original).finish()
+        }
+    }
+
+    impl PartialEq for Pattern {
+        fn eq(&self, other: &Self) -> bool {
+            self.original == other.original
+        }
+    }
+
     impl fmt::Display for Pattern {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             self.original.fmt(f)
+        }
+    }
+
+    impl PartialOrd for Pattern {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Ord for Pattern {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            let mut self_rev = self.original.chars().rev();
+            let mut other_rev = other.original.chars().rev();
+
+            loop {
+                let self_next = self_rev.next();
+                let other_next = other_rev.next();
+
+                match (self_next, other_next) {
+                    (Some(self_char), Some(other_char)) if self_char == other_char => {
+                        continue;
+                    }
+                    // `*` > `?`
+                    (Some('*'), Some('?')) => break std::cmp::Ordering::Greater,
+                    (Some('?'), Some('*')) => break std::cmp::Ordering::Less,
+
+                    // Domains that only differ in wildcard come later
+                    (Some('*') | Some('?'), None | Some('.')) => break std::cmp::Ordering::Greater,
+                    (None | Some('.'), Some('*') | Some('?')) => break std::cmp::Ordering::Less,
+
+                    // `*` | `?` > non-wildcard
+                    (Some('*') | Some('?'), Some(_)) => break std::cmp::Ordering::Greater,
+                    (Some(_), Some('*') | Some('?')) => break std::cmp::Ordering::Less,
+
+                    // non-wildcard lexically
+                    (Some(self_char), Some(other_char)) => {
+                        break self_char.cmp(&other_char).reverse(); // Reverse because we compare from right to left.
+                    }
+
+                    // Shorter domains come first
+                    (Some(_), None) => break std::cmp::Ordering::Greater,
+                    (None, Some(_)) => break std::cmp::Ordering::Less,
+
+                    (None, None) => break std::cmp::Ordering::Equal,
+                }
+            }
         }
     }
 
@@ -502,6 +566,43 @@ mod pattern {
 
         fn from_str(s: &str) -> Result<Self, Self::Err> {
             Ok(Self(s.replace('.', "/")))
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::collections::BTreeSet;
+
+        use super::*;
+
+        #[test]
+        fn pattern_ordering() {
+            let patterns = BTreeSet::from([
+                Pattern::new("**.example.com").unwrap(),
+                Pattern::new("bar.example.com").unwrap(),
+                Pattern::new("foo.example.com").unwrap(),
+                Pattern::new("example.com").unwrap(),
+                Pattern::new("*ample.com").unwrap(),
+                Pattern::new("*.bar.example.com").unwrap(),
+                Pattern::new("?.example.com").unwrap(),
+                Pattern::new("*.com").unwrap(),
+                Pattern::new("*.example.com").unwrap(),
+            ]);
+
+            assert_eq!(
+                Vec::from_iter(patterns),
+                vec![
+                    Pattern::new("example.com").unwrap(), // Shorter domains first.
+                    Pattern::new("bar.example.com").unwrap(), // Lexical-ordering by default.
+                    Pattern::new("*.bar.example.com").unwrap(), // Lexically takes priority over specific match.
+                    Pattern::new("foo.example.com").unwrap(),   // Most specific next.
+                    Pattern::new("?.example.com").unwrap(),     // Single-wildcard second.
+                    Pattern::new("*.example.com").unwrap(),     // Star-wildcard third.
+                    Pattern::new("**.example.com").unwrap(),    // Double-star wildcard last.
+                    Pattern::new("*ample.com").unwrap(), // Specific match takes priority over wildcard.
+                    Pattern::new("*.com").unwrap(),      // Wildcards after all non-wildcards.
+                ]
+            )
         }
     }
 }

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -14,7 +14,8 @@ export default function Android() {
       <Entry version="1.3.4" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6809">
-            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+            Fixes a bug where non-wildcard DNS resources were not prioritised
+            over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
           </ChangeItem>
         </ul>
       </Entry>

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -13,6 +13,9 @@ export default function Android() {
       {/*
       <Entry version="1.3.4" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem pull="6809">
+            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+          </ChangeItem>
         </ul>
       </Entry>
       */}

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -14,7 +14,8 @@ export default function Apple() {
       <Entry version="1.3.5" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6809">
-            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+            Fixes a bug where non-wildcard DNS resources were not prioritised
+            over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
           </ChangeItem>
         </ul>
       </Entry>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -13,6 +13,9 @@ export default function Apple() {
       {/*
       <Entry version="1.3.5" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem pull="6809">
+            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+          </ChangeItem>
         </ul>
       </Entry>
       */}

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -16,6 +16,9 @@ export default function GUI({ title }: { title: string }) {
       {/*
       <Entry version="1.3.6" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem pull="6809">
+            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+          </ChangeItem>
         </ul>
       </Entry>
       */}
@@ -33,10 +36,8 @@ export default function GUI({ title }: { title: string }) {
             "Couldn't send Disconnect" error message.
           </ChangeItem>
           <ChangeItem enable={title === "Windows"} pull="6810">
-            Fixes a bug where roaming from Ethernet to WiFi would cause Firezone to fail to connect to the portal.
-          </ChangeItem>
-          <ChangeItem pull="6809">
-            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+            Fixes a bug where roaming from Ethernet to WiFi would cause Firezone
+            to fail to connect to the portal.
           </ChangeItem>
         </ul>
       </Entry>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -35,6 +35,9 @@ export default function GUI({ title }: { title: string }) {
           <ChangeItem enable={title === "Windows"} pull="6810">
             Fixes a bug where roaming from Ethernet to WiFi would cause Firezone to fail to connect to the portal.
           </ChangeItem>
+          <ChangeItem pull="6809">
+            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+          </ChangeItem>
         </ul>
       </Entry>
       <Entry version="1.3.4" date={new Date("2024-09-19")}>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -17,7 +17,8 @@ export default function GUI({ title }: { title: string }) {
       <Entry version="1.3.6" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6809">
-            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+            Fixes a bug where non-wildcard DNS resources were not prioritised
+            over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
           </ChangeItem>
         </ul>
       </Entry>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -14,7 +14,8 @@ export default function Headless() {
       <Entry version="1.3.3" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6809">
-            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+            Fixes a bug where non-wildcard DNS resources were not prioritised
+            over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
           </ChangeItem>
         </ul>
       </Entry>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -13,6 +13,9 @@ export default function Headless() {
       {/*
       <Entry version="1.3.3" date={new Date(todo)}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
+          <ChangeItem pull="6809">
+            Fixes a bug where non-wildcard DNS resources were not prioritised over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+          </ChangeItem>
         </ul>
       </Entry>
       */}


### PR DESCRIPTION
Currently, the order in which connlib matches against the patterns of DNS resources is not specified. We simply iterate over all patterns and take the first one that matches. Due to the iteration order of `HashMap`s, this also isn't deterministic.

With this patch, we introduce a defined order in which we attempt to match a particular domain against the defined DNS resources:

- Resources without wildcards are always prioritised over wildcard domains
- Single-char wildcards (`?`) take priority over label wildcards (`*`)
- Label wildcards (`*`) take priority over catch-all wildcards (`**`)

By matching against the DNS resources in a defined order, we ensure that DNS resources that overlap always resolve to the most specific resource.