### PR TITLE
fix(windows): only consider online adapters

### DIFF
--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -22,6 +22,9 @@ export default function GUI({ title }: { title: string }) {
           <ChangeItem pull="6795">
             Fixes a bug where auto-sign-in with an expired token would cause a "Couldn't send Disconnect" error message.
           </ChangeItem>
+          <ChangeItem enable={title === "Windows"} pull="6810">
+            Fixes a bug where roaming from Ethernet to WiFi would cause Firezone to fail to connect to the portal.
+          </ChangeItem>
         </ul>
       </Entry
       */}


### PR DESCRIPTION
When deciding which interface we are going to use for connecting to the portal API, we need to filter through all adapters on Windows and exclude our own TUN adapter to avoid routing loops. In addition, we also need to filter for only online adapters, otherwise we might pick one that is not actually routable.

Resolves: #6802.