### PR TITLE
docs: Add note on resource address match order

### DIFF
--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -51,15 +51,18 @@ From there, you can select the type of Resource you want to create:
 When multiple Resources' addresses overlap, the Resource with the more specific
 address will be used.
 
-For CIDR Resources, this means the Resource with the
-longest prefix length will be used.
+For CIDR Resources, this means the Resource with the longest prefix length will
+be used.
 
 For DNS Resources, the more specific match will be used according to the
 following rules:
 
-- Resources without wildcards are always prioritized over wildcard domains: For example, `app.example.com` is checked before `*.example.com`.
-- Single-char wildcards (`?`) take priority over label wildcards (`*`): For example, `???.example.com` is checked before `*.example.com`.
-- Label wildcards (`*`) take priority over catch-all wildcards (`**`): For example, `*.example.com` is checked before `**.example.com`.
+- Resources without wildcards are always prioritized over wildcard domains: For
+  example, `app.example.com` is checked before `*.example.com`.
+- Single-char wildcards (`?`) take priority over label wildcards (`*`): For
+  example, `???.example.com` is checked before `*.example.com`.
+- Label wildcards (`*`) take priority over catch-all wildcards (`**`): For
+  example, `*.example.com` is checked before `**.example.com`.
 
 ### Address description
 

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -55,9 +55,9 @@ longest prefix length will be used.
 For DNS Resources, the more specific match will be used according to the
 following rules:
 
-- Resources without wildcards are always prioritized over wildcard domains
-- Single-char wildcards (`?`) take priority over label wildcards (`*`)
-- Label wildcards (`*`) take priority over catch-all wildcards (`**`)
+- Resources without wildcards are always prioritized over wildcard domains: For example, `app.example.com` is checked before `*.example.com`.
+- Single-char wildcards (`?`) take priority over label wildcards (`*`): For example, `???.example.com` is checked before `*.example.com`.
+- Label wildcards (`*`) take priority over catch-all wildcards (`**`): For example, `*.example.com` is checked before `**.example.com`.
 
 ### Address description
 

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -56,7 +56,7 @@ shorter one. For example: `10.0.0.0/16` is more specific than `10.0.0.0/8`. IP
 Resources are essentially addresses with `/32` prefix and thus always more
 specific than any other CIDR. be used.
 
-For DNS Resources, more specific loosly translates to less wildcards. In
+For DNS Resources, more specific loosely translates to less wildcards. In
 particular: following rules:
 
 - Resources without wildcards are always prioritized over wildcard domains: For

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -51,10 +51,10 @@ From there, you can select the type of Resource you want to create:
 When multiple Resources' addresses overlap, the Resource with the more specific
 address will be used.
 
-For CIDR Resources, this means the Resource with the longest prefix length will
+For CIDR Resources, an address with a longer prefix is more specific than a shorter one. For example: `10.0.0.0/16` is more specific than `10.0.0.0/8`. IP Resources are essentially addresses with `/32` prefix and thus always more specific than any other CIDR.
 be used.
 
-For DNS Resources, the more specific match will be used according to the
+For DNS Resources, more specific loosly translates to less wildcards. In particular:
 following rules:
 
 - Resources without wildcards are always prioritized over wildcard domains: For

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -51,11 +51,13 @@ From there, you can select the type of Resource you want to create:
 When multiple Resources' addresses overlap, the Resource with the more specific
 address will be used.
 
-For CIDR Resources, an address with a longer prefix is more specific than a shorter one. For example: `10.0.0.0/16` is more specific than `10.0.0.0/8`. IP Resources are essentially addresses with `/32` prefix and thus always more specific than any other CIDR.
-be used.
+For CIDR Resources, an address with a longer prefix is more specific than a
+shorter one. For example: `10.0.0.0/16` is more specific than `10.0.0.0/8`. IP
+Resources are essentially addresses with `/32` prefix and thus always more
+specific than any other CIDR. be used.
 
-For DNS Resources, more specific loosly translates to less wildcards. In particular:
-following rules:
+For DNS Resources, more specific loosly translates to less wildcards. In
+particular: following rules:
 
 - Resources without wildcards are always prioritized over wildcard domains: For
   example, `app.example.com` is checked before `*.example.com`.

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -46,6 +46,19 @@ From there, you can select the type of Resource you want to create:
   Resource.
 </Alert>
 
+#### Routing order for overlapping addresses
+
+When multiple Resources' addresses overlap, the Resource with the more specific
+address will be used. For CIDR Resources, this means the Resource with the
+longest prefix length will be used.
+
+For DNS Resources, the more specific match will be used according to the
+following rules:
+
+- Resources without wildcards are always prioritized over wildcard domains
+- Single-char wildcards (`?`) take priority over label wildcards (`*`)
+- Label wildcards (`*`) take priority over catch-all wildcards (`**`)
+
 ### Address description
 
 When creating a Resource, you'll be given the option to add an

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -49,7 +49,9 @@ From there, you can select the type of Resource you want to create:
 #### Routing order for overlapping addresses
 
 When multiple Resources' addresses overlap, the Resource with the more specific
-address will be used. For CIDR Resources, this means the Resource with the
+address will be used.
+
+For CIDR Resources, this means the Resource with the
 longest prefix length will be used.
 
 For DNS Resources, the more specific match will be used according to the

--- a/website/src/app/kb/deploy/resources/readme.mdx
+++ b/website/src/app/kb/deploy/resources/readme.mdx
@@ -54,10 +54,10 @@ address will be used.
 For CIDR Resources, an address with a longer prefix is more specific than a
 shorter one. For example: `10.0.0.0/16` is more specific than `10.0.0.0/8`. IP
 Resources are essentially addresses with `/32` prefix and thus always more
-specific than any other CIDR. be used.
+specific than any other CIDR.
 
 For DNS Resources, more specific loosely translates to less wildcards. In
-particular: following rules:
+particular:
 
 - Resources without wildcards are always prioritized over wildcard domains: For
   example, `app.example.com` is checked before `*.example.com`.


### PR DESCRIPTION
Documents how overlapping addresses are matched.

Draft until #6809 is merged and published.