### PR TITLE
docs: Tune prosewrap to preserve for non-website docs

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -8,9 +8,17 @@
   "overrides": [
     {
       "files": ["website/**/*.md", "website/**/*.mdx"],
-      "excludedFiles": "website/src/app/blog/**/*",
       "options": {
         "proseWrap": "always"
+      }
+    },
+    {
+      "files": [
+        "website/src/app/blog/**/*.md",
+        "website/src/app/blog/**/*.mdx"
+      ],
+      "options": {
+        "proseWrap": "preserve"
       }
     }
   ]

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,15 +4,13 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": false,
-  "proseWrap": "always",
+  "proseWrap": "preserve",
   "overrides": [
     {
-      "files": [
-        "website/src/app/blog/**/*.md",
-        "website/src/app/blog/**/*.mdx"
-      ],
+      "files": ["website/**/*.md", "website/**/*.mdx"],
+      "excludedFiles": "website/src/app/blog/**/*",
       "options": {
-        "proseWrap": "preserve"
+        "proseWrap": "always"
       }
     }
   ]


### PR DESCRIPTION
Keeps from auto-formatting the component specific md files.