### PR TITLE
chore(rust/gui-client): fix missing favicon and make GUI logs quieter

### DIFF
--- a/rust/gui-client/src-common/src/auth.rs
+++ b/rust/gui-client/src-common/src/auth.rs
@@ -102,9 +102,9 @@ impl Auth {
             ),
             Ok(Some(SessionAndToken { session, token: _ })) => {
                 this.state = State::SignedIn(session);
-                tracing::info!("Reloaded token from disk, starting in signed-in state.");
+                tracing::debug!("Reloaded token from disk, starting in signed-in state.");
             }
-            Ok(None) => tracing::info!("No token on disk, starting in signed-out state."),
+            Ok(None) => tracing::debug!("No token on disk, starting in signed-out state."),
         }
 
         Ok(this)

--- a/rust/gui-client/src-common/src/ipc.rs
+++ b/rust/gui-client/src-common/src/ipc.rs
@@ -28,7 +28,7 @@ impl Drop for Client {
 
 impl Client {
     pub async fn new(ctlr_tx: tokio::sync::mpsc::Sender<Event>) -> Result<Self> {
-        tracing::info!(
+        tracing::debug!(
             client_pid = std::process::id(),
             "Connecting to IPC service..."
         );

--- a/rust/gui-client/src-common/src/logging.rs
+++ b/rust/gui-client/src-common/src/logging.rs
@@ -59,7 +59,7 @@ pub fn setup(directives: &str) -> Result<Handles> {
     let subscriber = Registry::default().with(layer.with_filter(filter));
     set_global_default(subscriber)?;
     if let Err(error) = output_vt100::try_init() {
-        tracing::warn!(
+        tracing::debug!(
             ?error,
             "Failed to init vt100 terminal colors (expected in release builds and in CI)"
         );

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -445,7 +445,7 @@ async fn run_controller(
     log_filter_reloader: LogFilterReloader,
     updates_rx: mpsc::Receiver<Option<updates::Notification>>,
 ) -> Result<(), Error> {
-    tracing::info!("Entered `run_controller`");
+    tracing::debug!("Entered `run_controller`");
     let (ipc_tx, ipc_rx) = mpsc::channel(1);
     let ipc_client = ipc::Client::new(ipc_tx).await?;
     let tray = system_tray::Tray::new(app.tray_handle());

--- a/rust/gui-client/src/about.html
+++ b/rust/gui-client/src/about.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
     <link rel="stylesheet" href="output.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>About Firezone</title>

--- a/rust/gui-client/src/settings.html
+++ b/rust/gui-client/src/settings.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
     <link rel="stylesheet" href="output.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Settings</title>

--- a/rust/gui-client/src/welcome.html
+++ b/rust/gui-client/src/welcome.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
     <link rel="stylesheet" href="output.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Welcome to Firezone</title>

--- a/rust/headless-client/src/ipc_service/ipc/linux.rs
+++ b/rust/headless-client/src/ipc_service/ipc/linux.rs
@@ -36,7 +36,7 @@ pub async fn connect_to_service(id: ServiceId) -> Result<ClientStream, Error> {
         .peer_cred()
         .context("Couldn't get PID of UDS server")
         .map_err(Error::Other)?;
-    tracing::info!(
+    tracing::debug!(
         uid = cred.uid(),
         gid = cred.gid(),
         pid = cred.pid(),

--- a/rust/headless-client/src/ipc_service/ipc/windows.rs
+++ b/rust/headless-client/src/ipc_service/ipc/windows.rs
@@ -39,7 +39,7 @@ pub(crate) async fn connect_to_service(id: ServiceId) -> Result<ClientStream, Er
     unsafe { GetNamedPipeServerProcessId(handle, &mut server_pid) }
         .context("Couldn't get PID of named pipe server")
         .map_err(Error::Other)?;
-    tracing::info!(?server_pid, "Made IPC connection");
+    tracing::debug!(?server_pid, "Made IPC connection");
     Ok(stream)
 }
 
@@ -65,7 +65,7 @@ impl Server {
             .bind_to_pipe()
             .await
             .context("Couldn't bind to named pipe")?;
-        tracing::info!(
+        tracing::debug!(
             server_pid = std::process::id(),
             "Listening for GUI to connect over IPC..."
         );
@@ -80,7 +80,7 @@ impl Server {
         // from Tokio, so it should be valid.
         unsafe { GetNamedPipeClientProcessId(handle, &mut client_pid) }
             .context("Couldn't get PID of named pipe client")?;
-        tracing::info!(?client_pid, "Accepted IPC connection");
+        tracing::debug!(?client_pid, "Accepted IPC connection");
         Ok(server)
     }
 


### PR DESCRIPTION
Closes #6821

Before

<img width="570" alt="image" src="https://github.com/user-attachments/assets/1a86b828-3416-43e9-a70c-dc50d112b2d9">

After

<img width="566" alt="image" src="https://github.com/user-attachments/assets/9fc6fd66-70aa-4305-8a67-d77517d040ae">
