### PR TITLE
refactor(rust/gui-client): change how default settings are initialized

### DIFF
--- a/rust/gui-client/src-common/src/settings.rs
+++ b/rust/gui-client/src-common/src/settings.rs
@@ -21,27 +21,27 @@ pub struct AdvancedSettings {
 }
 
 #[cfg(debug_assertions)]
-impl Default for AdvancedSettings {
-    fn default() -> Self {
-        Self {
-            auth_base_url: Url::parse("https://app.firez.one").unwrap(),
-            api_url: Url::parse("wss://api.firez.one").unwrap(),
-            favorite_resources: Default::default(),
-            internet_resource_enabled: Default::default(),
-            log_filter: "firezone_gui_client=debug,info".to_string(),
-        }
-    }
+mod defaults {
+    pub(crate) const AUTH_BASE_URL: &str = "https://app.firez.one";
+    pub(crate) const API_URL: &str = "wss://api.firez.one";
+    pub(crate) const LOG_FILTER: &str = "firezone_gui_client=debug,info";
 }
 
 #[cfg(not(debug_assertions))]
+mod defaults {
+    pub(crate) const AUTH_BASE_URL: &str = "https://app.firezone.dev";
+    pub(crate) const API_URL: &str = "wss://api.firezone.dev";
+    pub(crate) const LOG_FILTER: &str = "info";
+}
+
 impl Default for AdvancedSettings {
     fn default() -> Self {
         Self {
-            auth_base_url: Url::parse("https://app.firezone.dev").unwrap(),
-            api_url: Url::parse("wss://api.firezone.dev").unwrap(),
+            auth_base_url: Url::parse(defaults::AUTH_BASE_URL).unwrap(),
+            api_url: Url::parse(defaults::API_URL).unwrap(),
             favorite_resources: Default::default(),
             internet_resource_enabled: Default::default(),
-            log_filter: "info".to_string(),
+            log_filter: defaults::LOG_FILTER.to_string(),
         }
     }
 }


### PR DESCRIPTION
This makes it easier to add more fields to the settings without writing them twice

This is factored out from https://github.com/firezone/firezone/pull/6782