### PR TITLE
refactor(website): better changelog writing UX

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -2,6 +2,7 @@ import ChangeItem from "./ChangeItem";
 import Entries from "./Entries";
 import Entry from "./Entry";
 import Link from "next/link";
+import Unreleased from "./Unreleased";
 
 export default function Android() {
   return (
@@ -10,16 +11,14 @@ export default function Android() {
       title="Android"
     >
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      {/*
-      <Entry version="1.3.4" date={new Date(todo)}>
+      <Unreleased>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6809">
             Fixes a bug where non-wildcard DNS resources were not prioritised
             over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
           </ChangeItem>
         </ul>
-      </Entry>
-      */}
+      </Unreleased>
       <Entry version="1.3.3" date={new Date("2024-09-24")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6707">

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -12,176 +12,147 @@ export default function Android() {
     >
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6809">
-            Fixes a bug where non-wildcard DNS resources were not prioritised
-            over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6809">
+          Fixes a bug where non-wildcard DNS resources were not prioritised over
+          wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.3.3" date={new Date("2024-09-24")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6707">
-            Resetting the settings now resets the list of favorited Resources,
-            too.
-          </ChangeItem>
-          <ChangeItem pull="6765">
-            Fixes a bug where DNS PTR queries by the system did not get
-            answered.
-          </ChangeItem>
-          <ChangeItem pull="6722">
-            Fixes a routing bug when one of several overlapping CIDR resources
-            gets disabled / removed.
-          </ChangeItem>
-          <ChangeItem pull="6788">
-            Fixes an issue where some browsers may fail to route DNS Resources
-            correctly.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6707">
+          Resetting the settings now resets the list of favorited Resources,
+          too.
+        </ChangeItem>
+        <ChangeItem pull="6765">
+          Fixes a bug where DNS PTR queries by the system did not get answered.
+        </ChangeItem>
+        <ChangeItem pull="6722">
+          Fixes a routing bug when one of several overlapping CIDR resources
+          gets disabled / removed.
+        </ChangeItem>
+        <ChangeItem pull="6788">
+          Fixes an issue where some browsers may fail to route DNS Resources
+          correctly.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-09-05")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6605">
-            Fixes another bug where the tunnel would immediately disconnect
-            after connecting.
-          </ChangeItem>
-          <ChangeItem pull="6518">
-            Minor improvements to the look of the internet resource and makes
-            the Internet resource off by default.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6605">
+          Fixes another bug where the tunnel would immediately disconnect after
+          connecting.
+        </ChangeItem>
+        <ChangeItem pull="6518">
+          Minor improvements to the look of the internet resource and makes the
+          Internet resource off by default.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-08-31")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6517">
-            Fixes a bug where the tunnel would immediately disconnect after
-            connecting.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6517">
+          Fixes a bug where the tunnel would immediately disconnect after
+          connecting.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6424">
-            Fixes a bug where packets would be lost when a connection is first
-            established to a gateway, due to routes being updated with no actual
-            change.
-          </ChangeItem>
-          <ChangeItem pull="6405">
-            Shows the Git SHA corresponding to the build on the Settings -&gt;
-            Advanced screen.
-          </ChangeItem>
-          <ChangeItem pull="6495">
-            Fixes a bug where the Firezone tunnel wasn't shutdown properly if
-            you disconnect the VPN in system settings.
-          </ChangeItem>
-          <ChangeItem pull="6434">
-            Adds the Internet Resource feature.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6424">
+          Fixes a bug where packets would be lost when a connection is first
+          established to a gateway, due to routes being updated with no actual
+          change.
+        </ChangeItem>
+        <ChangeItem pull="6405">
+          Shows the Git SHA corresponding to the build on the Settings -&gt;
+          Advanced screen.
+        </ChangeItem>
+        <ChangeItem pull="6495">
+          Fixes a bug where the Firezone tunnel wasn't shutdown properly if you
+          disconnect the VPN in system settings.
+        </ChangeItem>
+        <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>
       </Entry>
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="5901">
-            Implements glob-like matching of domains for DNS resources.
-          </ChangeItem>
-          <ChangeItem pull="6361">
-            Connections to Gateways are now sticky for the duration of the
-            Client's session. This fixes potential issues maintaining long-lived
-            TCP connections to Gateways in a high-availability setup.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="5901">
+          Implements glob-like matching of domains for DNS resources.
+        </ChangeItem>
+        <ChangeItem pull="6361">
+          Connections to Gateways are now sticky for the duration of the
+          Client's session. This fixes potential issues maintaining long-lived
+          TCP connections to Gateways in a high-availability setup.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.6" date={new Date("2024-08-13")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6276">
-            Fixes a bug where relayed connections failed to establish after an
-            idle period.
-          </ChangeItem>
-          <ChangeItem pull="6277">
-            Fixes a bug where restrictive NATs caused connectivity problems.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6276">
+          Fixes a bug where relayed connections failed to establish after an
+          idle period.
+        </ChangeItem>
+        <ChangeItem pull="6277">
+          Fixes a bug where restrictive NATs caused connectivity problems.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-08-10")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6107">
-            Adds the ability to mark Resources as favorites.
-          </ChangeItem>
-          <ChangeItem pull="6181">
-            Improves reliability of DNS resolution of non-resources.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6107">
+          Adds the ability to mark Resources as favorites.
+        </ChangeItem>
+        <ChangeItem pull="6181">
+          Improves reliability of DNS resolution of non-resources.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.4" date={new Date("2024-08-02")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Fixes{" "}
-            <Link
-              href="https://github.com/firezone/firezone/pull/6143"
-              className="text-accent-500 underline hover:no-underline"
-            >
-              an issue
-            </Link>{" "}
-            where DNS queries could time out on some networks.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Fixes{" "}
+          <Link
+            href="https://github.com/firezone/firezone/pull/6143"
+            className="text-accent-500 underline hover:no-underline"
+          >
+            an issue
+          </Link>{" "}
+          where DNS queries could time out on some networks.
+        </li>
       </Entry>
       <Entry version="1.1.3" date={new Date("2024-07-06")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Fixes{" "}
-            <Link
-              href="https://github.com/firezone/firezone/issues/5781"
-              className="text-accent-500 underline hover:no-underline"
-            >
-              an issue
-            </Link>{" "}
-            where the app would crash if IPv6 scopes were present in the DNS
-            servers discovered on the local system.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Fixes{" "}
+          <Link
+            href="https://github.com/firezone/firezone/issues/5781"
+            className="text-accent-500 underline hover:no-underline"
+          >
+            an issue
+          </Link>{" "}
+          where the app would crash if IPv6 scopes were present in the DNS
+          servers discovered on the local system.
+        </li>
       </Entry>
       <Entry version="1.1.2" date={new Date("2024-07-03")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Prevents Firezone's stub resolver from intercepting DNS record types
-            besides A, AAAA, and PTR. These are now forwarded to your upstream
-            DNS resolver.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Prevents Firezone's stub resolver from intercepting DNS record types
+          besides A, AAAA, and PTR. These are now forwarded to your upstream DNS
+          resolver.
+        </li>
       </Entry>
       <Entry version="1.1.1" date={new Date("2024-06-29")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Fixes an issue that could cause Resources to be unreachable a few
-            hours after roaming networks.
-          </li>
-          <li className="pl-2">
-            Reduces noise in logs for the default log level.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Fixes an issue that could cause Resources to be unreachable a few
+          hours after roaming networks.
+        </li>
+        <li className="pl-2">
+          Reduces noise in logs for the default log level.
+        </li>
       </Entry>
       <Entry version="1.1.0" date={new Date("2024-06-27")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Introduces the new DNS routing system supported by 1.1.0 Gateways
-            which results in much more stable connections for DNS Resources,
-            especially when wildcards are used.
-          </li>
-          <li className="pl-2">
-            Improves reliability when roaming between networks.
-          </li>
-          <li className="pl-2">
-            Closes idle connections to Gateways that have not seen traffic for
-            more than 5 minutes which reduces power consumption when not
-            accessing Resources.
-          </li>
-          <li className="pl-2">
-            Updates log file endings to JSONL and adds syslog-style logs for
-            easier readability.
-          </li>
-          <li className="pl-2">Fixes various crashes.</li>
-        </ul>
+        <li className="pl-2">
+          Introduces the new DNS routing system supported by 1.1.0 Gateways
+          which results in much more stable connections for DNS Resources,
+          especially when wildcards are used.
+        </li>
+        <li className="pl-2">
+          Improves reliability when roaming between networks.
+        </li>
+        <li className="pl-2">
+          Closes idle connections to Gateways that have not seen traffic for
+          more than 5 minutes which reduces power consumption when not accessing
+          Resources.
+        </li>
+        <li className="pl-2">
+          Updates log file endings to JSONL and adds syslog-style logs for
+          easier readability.
+        </li>
+        <li className="pl-2">Fixes various crashes.</li>
         <p>
           <strong>Note:</strong> Client versions 1.1.x are incompatible with
           Gateways running 1.0.x.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -13,168 +13,137 @@ export default function Apple() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
 
       <Unreleased>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6809">
-            Fixes a bug where non-wildcard DNS resources were not prioritised
-            over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6809">
+          Fixes a bug where non-wildcard DNS resources were not prioritised over
+          wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.3.4" date={new Date("2024-09-25")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6788">
-            Fixes an issue where some browsers may fail to route DNS Resources
-            correctly.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6788">
+          Fixes an issue where some browsers may fail to route DNS Resources
+          correctly.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.3" date={new Date("2024-09-19")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6765">
-            Fixes a bug where DNS PTR queries by the system did not get
-            answered.
-          </ChangeItem>
-          <ChangeItem pull="6722">
-            Fixes a routing bug when one of several overlapping CIDR resources
-            gets disabled / removed.
-          </ChangeItem>
-          <ChangeItem>
-            Improves logging for DNS queries when{" "}
-            <code>firezone_tunnel=trace</code> log level is used.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6765">
+          Fixes a bug where DNS PTR queries by the system did not get answered.
+        </ChangeItem>
+        <ChangeItem pull="6722">
+          Fixes a routing bug when one of several overlapping CIDR resources
+          gets disabled / removed.
+        </ChangeItem>
+        <ChangeItem>
+          Improves logging for DNS queries when{" "}
+          <code>firezone_tunnel=trace</code> log level is used.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-09-18")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6632">
-            (macOS) Fixes a bug where the addressDescription wasn't fully
-            displayed in the macOS menu bar if it exceeded a certain length.
-          </ChangeItem>
-          <ChangeItem pull="6679">
-            (macOS) Displays a notification when a new version is available.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6632">
+          (macOS) Fixes a bug where the addressDescription wasn't fully
+          displayed in the macOS menu bar if it exceeded a certain length.
+        </ChangeItem>
+        <ChangeItem pull="6679">
+          (macOS) Displays a notification when a new version is available.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6521">
-            Gracefully handles cases where the device's local interface
-            IPv4/IPv6 address or local network gateway changes while the client
-            is connected.
-          </ChangeItem>
-          <ChangeItem pull="6518">
-            Minor improvements to the look of the internet resource and makes
-            the Internet resource off by default.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6521">
+          Gracefully handles cases where the device's local interface IPv4/IPv6
+          address or local network gateway changes while the client is
+          connected.
+        </ChangeItem>
+        <ChangeItem pull="6518">
+          Minor improvements to the look of the internet resource and makes the
+          Internet resource off by default.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6434">
-            Adds the Internet Resource feature.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>
       </Entry>
       <Entry version="1.2.1" date={new Date("2024-08-22")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6406">
-            Shows the Git SHA corresponding to the build on the Settings -&gt;
-            Advanced screen.
-          </ChangeItem>
-          <ChangeItem pull="6424">
-            Fixes a bug where packets would be lost when a connection is first
-            established to a Gateway due to routes being updated with no actual
-            change.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6406">
+          Shows the Git SHA corresponding to the build on the Settings -&gt;
+          Advanced screen.
+        </ChangeItem>
+        <ChangeItem pull="6424">
+          Fixes a bug where packets would be lost when a connection is first
+          established to a Gateway due to routes being updated with no actual
+          change.
+        </ChangeItem>
       </Entry>
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="5901">
-            Implements glob-like matching of domains for DNS resources.
-          </ChangeItem>
-          <ChangeItem pull="6186">
-            Adds the ability to mark Resources as favorites.
-          </ChangeItem>
-          <ChangeItem pull="6361">
-            Connections to Gateways are now sticky for the duration of the
-            Client's session. This fixes potential issues maintaining long-lived
-            TCP connections to Gateways in a high-availability setup.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="5901">
+          Implements glob-like matching of domains for DNS resources.
+        </ChangeItem>
+        <ChangeItem pull="6186">
+          Adds the ability to mark Resources as favorites.
+        </ChangeItem>
+        <ChangeItem pull="6361">
+          Connections to Gateways are now sticky for the duration of the
+          Client's session. This fixes potential issues maintaining long-lived
+          TCP connections to Gateways in a high-availability setup.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-08-13")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6276">
-            Fixes a bug where relayed connections failed to establish after an
-            idle period.
-          </ChangeItem>
-          <ChangeItem pull="6277">
-            Fixes a bug where restrictive NATs caused connectivity problems.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6276">
+          Fixes a bug where relayed connections failed to establish after an
+          idle period.
+        </ChangeItem>
+        <ChangeItem pull="6277">
+          Fixes a bug where restrictive NATs caused connectivity problems.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.4" date={new Date("2024-08-10")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6181">
-            Improves reliability of DNS resolution of non-resources.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6181">
+          Improves reliability of DNS resolution of non-resources.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.3" date={new Date("2024-08-02")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Fixes{" "}
-            <Link
-              href="https://github.com/firezone/firezone/pull/6143"
-              className="text-accent-500 underline hover:no-underline"
-            >
-              an issue
-            </Link>{" "}
-            where DNS queries could time out on some networks.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Fixes{" "}
+          <Link
+            href="https://github.com/firezone/firezone/pull/6143"
+            className="text-accent-500 underline hover:no-underline"
+          >
+            an issue
+          </Link>{" "}
+          where DNS queries could time out on some networks.
+        </li>
       </Entry>
       <Entry version="1.1.2" date={new Date("2024-07-03")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Prevents Firezone's stub resolver from intercepting DNS record types
-            besides A, AAAA, and PTR. These are now forwarded to your upstream
-            DNS resolver.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Prevents Firezone's stub resolver from intercepting DNS record types
+          besides A, AAAA, and PTR. These are now forwarded to your upstream DNS
+          resolver.
+        </li>
       </Entry>
       <Entry version="1.1.1" date={new Date("2024-06-29")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Fixes an issue that could cause Resources to be unreachable a few
-            hours after roaming networks.
-          </li>
-          <li className="pl-2">
-            Reduces noise in logs for the default log level.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Fixes an issue that could cause Resources to be unreachable a few
+          hours after roaming networks.
+        </li>
+        <li className="pl-2">
+          Reduces noise in logs for the default log level.
+        </li>
       </Entry>
       <Entry version="1.1.0" date={new Date("2024-06-27")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Introduces the new DNS routing system supported by 1.1.0 Gateways
-            which results in much more stable connections for DNS Resources,
-            especially when wildcards are used.
-          </li>
-          <li className="pl-2">
-            Improves reliability when roaming between networks.
-          </li>
-          <li className="pl-2">
-            Closes idle connections to Gateways that have not seen traffic for
-            more than 5 minutes which reduces power consumption when not
-            accessing Resources.
-          </li>
-          <li className="pl-2">
-            Updates log file endings to JSONL and adds syslog-style logs for
-            easier readability.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Introduces the new DNS routing system supported by 1.1.0 Gateways
+          which results in much more stable connections for DNS Resources,
+          especially when wildcards are used.
+        </li>
+        <li className="pl-2">
+          Improves reliability when roaming between networks.
+        </li>
+        <li className="pl-2">
+          Closes idle connections to Gateways that have not seen traffic for
+          more than 5 minutes which reduces power consumption when not accessing
+          Resources.
+        </li>
+        <li className="pl-2">
+          Updates log file endings to JSONL and adds syslog-style logs for
+          easier readability.
+        </li>
         <p>
           <strong>Note:</strong> Client versions 1.1.x are incompatible with
           Gateways running 1.0.x.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Entry from "./Entry";
 import Entries from "./Entries";
 import ChangeItem from "./ChangeItem";
+import Unreleased from "./Unreleased";
 
 export default function Apple() {
   return (
@@ -10,16 +11,15 @@ export default function Apple() {
       title="macOS / iOS"
     >
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      {/*
-      <Entry version="1.3.5" date={new Date(todo)}>
+
+      <Unreleased>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6809">
             Fixes a bug where non-wildcard DNS resources were not prioritised
             over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
           </ChangeItem>
         </ul>
-      </Entry>
-      */}
+      </Unreleased>
       <Entry version="1.3.4" date={new Date("2024-09-25")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6788">

--- a/website/src/components/Changelog/Entries.tsx
+++ b/website/src/components/Changelog/Entries.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { ReactElement, ReactNode } from "react";
 import Entry from "./Entry";
 import Link from "next/link";
+import Unreleased from "./Unreleased";
 
 function Latest({
   arches,
@@ -122,16 +123,12 @@ export default function Entries({
   title: string;
   children: React.ReactNode;
 }) {
-  const childrenArray = React.Children.toArray(children).filter(
-    (e) => e != null
-  );
+  const childrenArray = React.Children.toArray(children)
+    .filter((child) => React.isValidElement(child))
+    .filter((child) => child.type != Unreleased);
 
   const firstEntry = childrenArray[0];
   const previousEntries = childrenArray.slice(1);
-
-  if (!React.isValidElement(firstEntry)) {
-    throw new Error("First child is not a valid React element");
-  }
 
   const { version, date, children: firstEntryChildren } = firstEntry.props;
 

--- a/website/src/components/Changelog/Entries.tsx
+++ b/website/src/components/Changelog/Entries.tsx
@@ -122,7 +122,10 @@ export default function Entries({
   title: string;
   children: React.ReactNode;
 }) {
-  const childrenArray = React.Children.toArray(children);
+  const childrenArray = React.Children.toArray(children).filter(
+    (e) => e != null
+  );
+
   const firstEntry = childrenArray[0];
   const previousEntries = childrenArray.slice(1);
 

--- a/website/src/components/Changelog/Entry.tsx
+++ b/website/src/components/Changelog/Entry.tsx
@@ -25,7 +25,7 @@ export default function Entry({
         <time dateTime={date.toDateString()}>{utcDateString}</time>
       </td>
       <td className="px-2 py-1 sm:px-3 sm:py-1.5 md:px-4 md:py-2 lg:px-6 lg:py-4">
-        {children}
+        <ul className="list-disc space-y-2 pl-4 mb-4">{children}</ul>
       </td>
     </tr>
   );

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -16,269 +16,222 @@ export default function GUI({ title }: { title: string }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased></Unreleased>
       <Entry version="1.3.6" date={new Date("2024-09-25")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6809">
-            Fixes a bug where non-wildcard DNS resources were not prioritised
-            over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6809">
+          Fixes a bug where non-wildcard DNS resources were not prioritised over
+          wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.5" date={new Date("2024-09-25")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6788">
-            Fixes an issue where some browsers may fail to route DNS Resources
-            correctly.
-          </ChangeItem>
-          <ChangeItem enable={title === "Linux GUI"} pull="6780">
-            Fixes a bug where the Linux Clients didn't work on ZFS filesystems.
-          </ChangeItem>
-          <ChangeItem pull="6795">
-            Fixes a bug where auto-sign-in with an expired token would cause a
-            "Couldn't send Disconnect" error message.
-          </ChangeItem>
-          <ChangeItem enable={title === "Windows"} pull="6810">
-            Fixes a bug where roaming from Ethernet to WiFi would cause Firezone
-            to fail to connect to the portal.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6788">
+          Fixes an issue where some browsers may fail to route DNS Resources
+          correctly.
+        </ChangeItem>
+        <ChangeItem enable={title === "Linux GUI"} pull="6780">
+          Fixes a bug where the Linux Clients didn't work on ZFS filesystems.
+        </ChangeItem>
+        <ChangeItem pull="6795">
+          Fixes a bug where auto-sign-in with an expired token would cause a
+          "Couldn't send Disconnect" error message.
+        </ChangeItem>
+        <ChangeItem enable={title === "Windows"} pull="6810">
+          Fixes a bug where roaming from Ethernet to WiFi would cause Firezone
+          to fail to connect to the portal.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.4" date={new Date("2024-09-19")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6765">
-            Fixes a bug where DNS PTR queries by the system did not get
-            answered.
-          </ChangeItem>
-          <ChangeItem pull="6722">
-            Fixes a routing bug when one of several overlapping CIDR resources
-            gets disabled / removed.
-          </ChangeItem>
-          <ChangeItem>
-            Improves logging for DNS queries when{" "}
-            <code>firezone_tunnel=trace</code> log level is used.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6765">
+          Fixes a bug where DNS PTR queries by the system did not get answered.
+        </ChangeItem>
+        <ChangeItem pull="6722">
+          Fixes a routing bug when one of several overlapping CIDR resources
+          gets disabled / removed.
+        </ChangeItem>
+        <ChangeItem>
+          Improves logging for DNS queries when{" "}
+          <code>firezone_tunnel=trace</code> log level is used.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.3" date={new Date("2024-09-13")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem enable={title === "Windows"} pull="6681">
-            Fixes a bug where sign-in fails if IPv6 is disabled.
-          </ChangeItem>
-        </ul>
+        <ChangeItem enable={title === "Windows"} pull="6681">
+          Fixes a bug where sign-in fails if IPv6 is disabled.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-09-06")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6624">
-            Fixes a bug that took down the tunnel when internet resource was
-            missing.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6624">
+          Fixes a bug that took down the tunnel when internet resource was
+          missing.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6518">
-            Minor improvements to the look of the internet resource and makes
-            the Internet resource off by default.
-          </ChangeItem>
-          <ChangeItem pull="6584">
-            Prevents routing loops for some Windows installation when the
-            Internet resource was on, taking down network connections.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6518">
+          Minor improvements to the look of the internet resource and makes the
+          Internet resource off by default.
+        </ChangeItem>
+        <ChangeItem pull="6584">
+          Prevents routing loops for some Windows installation when the Internet
+          resource was on, taking down network connections.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6434">
-            Adds the Internet Resource feature.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>
       </Entry>
       <Entry version="1.2.2" date={new Date("2024-08-29")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6432">
-            Shows an orange dot on the tray icon when an update is ready to
-            download.
-          </ChangeItem>
-          <ChangeItem pull="6449">Checks for updates once a day</ChangeItem>
-          <ChangeItem enable={title === "Windows"} pull="6472">
-            Fixes an issue where Split DNS didn't work for domain-joined Windows
-            machines
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6432">
+          Shows an orange dot on the tray icon when an update is ready to
+          download.
+        </ChangeItem>
+        <ChangeItem pull="6449">Checks for updates once a day</ChangeItem>
+        <ChangeItem enable={title === "Windows"} pull="6472">
+          Fixes an issue where Split DNS didn't work for domain-joined Windows
+          machines
+        </ChangeItem>
       </Entry>
       <Entry version="1.2.1" date={new Date("2024-08-27")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6414">
-            Waits for Internet to connect to Firezone if there's no Internet at
-            startup and you're already signed in.
-          </ChangeItem>
-          <ChangeItem pull="6455">
-            Fixes a false positive warning log at startup about DNS interception
-            being disabled.
-          </ChangeItem>
-          <ChangeItem pull="6458">
-            Fixes a bug where we considered our own startup to be a network
-            change event, which may interfere with access to DNS Resources.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6414">
+          Waits for Internet to connect to Firezone if there's no Internet at
+          startup and you're already signed in.
+        </ChangeItem>
+        <ChangeItem pull="6455">
+          Fixes a false positive warning log at startup about DNS interception
+          being disabled.
+        </ChangeItem>
+        <ChangeItem pull="6458">
+          Fixes a bug where we considered our own startup to be a network change
+          event, which may interfere with access to DNS Resources.
+        </ChangeItem>
       </Entry>
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="5901">
-            Implements glob-like matching of domains for DNS resources.
-          </ChangeItem>
-          <ChangeItem enable={title === "Windows"} pull="6280">
-            Fixes a bug where the "Clear Logs" button did not clear the IPC
-            service logs.
-          </ChangeItem>
-          <ChangeItem enable={title === "Windows"} pull="6308">
-            Fixes a bug where the GUI could not run if the user is Administrator
-          </ChangeItem>
-          <ChangeItem pull="6351">
-            The log filter on the IPC service is now reloaded immediately when
-            you change the setting in the GUI.
-          </ChangeItem>
-          <ChangeItem pull="6361">
-            Connections to Gateways are now sticky for the duration of the
-            Client's session to fix issues with long-lived TCP connections.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="5901">
+          Implements glob-like matching of domains for DNS resources.
+        </ChangeItem>
+        <ChangeItem enable={title === "Windows"} pull="6280">
+          Fixes a bug where the "Clear Logs" button did not clear the IPC
+          service logs.
+        </ChangeItem>
+        <ChangeItem enable={title === "Windows"} pull="6308">
+          Fixes a bug where the GUI could not run if the user is Administrator
+        </ChangeItem>
+        <ChangeItem pull="6351">
+          The log filter on the IPC service is now reloaded immediately when you
+          change the setting in the GUI.
+        </ChangeItem>
+        <ChangeItem pull="6361">
+          Connections to Gateways are now sticky for the duration of the
+          Client's session to fix issues with long-lived TCP connections.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.12" date={new Date("2024-08-13")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6226">
-            Fixes a bug where clearing the log files would delete the current
-            logfile, preventing logs from being written.
-          </ChangeItem>
-          <ChangeItem pull="6276">
-            Fixes a bug where relayed connections failed to establish after an
-            idle period.
-          </ChangeItem>
-          <ChangeItem pull="6277">
-            Fixes a bug where restrictive NATs caused connectivity problems.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6226">
+          Fixes a bug where clearing the log files would delete the current
+          logfile, preventing logs from being written.
+        </ChangeItem>
+        <ChangeItem pull="6276">
+          Fixes a bug where relayed connections failed to establish after an
+          idle period.
+        </ChangeItem>
+        <ChangeItem pull="6277">
+          Fixes a bug where restrictive NATs caused connectivity problems.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.11" date={new Date("2024-08-09")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6233">
-            Fixes an issue where the IPC service can panic during DNS
-            resolution.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6233">
+          Fixes an issue where the IPC service can panic during DNS resolution.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.10" date={new Date("2024-08-08")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="5923">
-            Adds the ability to mark Resources as favorites.
-          </ChangeItem>
-          <ChangeItem enable={title === "Linux GUI"} pull="6163">
-            Supports using `etc-resolv-conf` DNS control method, or disabling
-            DNS control
-          </ChangeItem>
-          <ChangeItem pull="6181">
-            Improves reliability of DNS resolution of non-resources.
-          </ChangeItem>
-          <ChangeItem enable={title === "Windows"} pull="6163">
-            Supports disabling DNS control
-          </ChangeItem>
-          <ChangeItem pull="6184">
-            Mitigates a bug where the IPC service can panic if an internal
-            channel fills up
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="5923">
+          Adds the ability to mark Resources as favorites.
+        </ChangeItem>
+        <ChangeItem enable={title === "Linux GUI"} pull="6163">
+          Supports using `etc-resolv-conf` DNS control method, or disabling DNS
+          control
+        </ChangeItem>
+        <ChangeItem pull="6181">
+          Improves reliability of DNS resolution of non-resources.
+        </ChangeItem>
+        <ChangeItem enable={title === "Windows"} pull="6163">
+          Supports disabling DNS control
+        </ChangeItem>
+        <ChangeItem pull="6184">
+          Mitigates a bug where the IPC service can panic if an internal channel
+          fills up
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.9" date={new Date("2024-08-02")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6143">
-            Fixes an issue where DNS queries could time out on some networks.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6143">
+          Fixes an issue where DNS queries could time out on some networks.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.8" date={new Date("2024-08-01")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem enable={title === "Linux GUI"} pull="5978">
-            Adds network roaming support.
-          </ChangeItem>
-          <ChangeItem enable={title === "Windows"} pull="6051">
-            Fixes "Element not found" error when setting routes.
-          </ChangeItem>
-          <ChangeItem pull="6017">
-            Removes keyboard accelerators, which were not working.
-          </ChangeItem>
-          <ChangeItem pull="6071">
-            Puts angle brackets around hyperlinks in the menu.
-          </ChangeItem>
-        </ul>
+        <ChangeItem enable={title === "Linux GUI"} pull="5978">
+          Adds network roaming support.
+        </ChangeItem>
+        <ChangeItem enable={title === "Windows"} pull="6051">
+          Fixes "Element not found" error when setting routes.
+        </ChangeItem>
+        <ChangeItem pull="6017">
+          Removes keyboard accelerators, which were not working.
+        </ChangeItem>
+        <ChangeItem pull="6071">
+          Puts angle brackets around hyperlinks in the menu.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.7" date={new Date("2024-07-17")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem enable={title === "Linux GUI"} pull="5848">
-            Stops the GUI and prompts you to re-launch it if you update Firezone
-            while the GUI is running.
-          </ChangeItem>
-          <ChangeItem enable={title === "Windows"} pull="5375">
-            Improves sign-in speed and fixes a DNS leak
-          </ChangeItem>
-        </ul>
+        <ChangeItem enable={title === "Linux GUI"} pull="5848">
+          Stops the GUI and prompts you to re-launch it if you update Firezone
+          while the GUI is running.
+        </ChangeItem>
+        <ChangeItem enable={title === "Windows"} pull="5375">
+          Improves sign-in speed and fixes a DNS leak
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.6" date={new Date("2024-07-12")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="5795">
-            Unexpected IPC service stops are now reported as "IPC connection
-            closed".
-          </ChangeItem>
-          <ChangeItem enable={title === "Windows"} pull="5827">
-            Fixes a bug where DNS could stop working when you sign out.
-          </ChangeItem>
-          <ChangeItem pull="5817">
-            Shows different tray icons when signed out, signing in, and signed
-            in.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="5795">
+          Unexpected IPC service stops are now reported as "IPC connection
+          closed".
+        </ChangeItem>
+        <ChangeItem enable={title === "Windows"} pull="5827">
+          Fixes a bug where DNS could stop working when you sign out.
+        </ChangeItem>
+        <ChangeItem pull="5817">
+          Shows different tray icons when signed out, signing in, and signed in.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-07-08")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem enable={title === "Linux GUI"} pull="5793">
-            The Linux GUI Client is now built for both x86-64 and ARM64.
-          </ChangeItem>
-          <ChangeItem enable={title === "Windows"}>
-            This is a maintenance release with no user-facing changes.
-          </ChangeItem>
-        </ul>
+        <ChangeItem enable={title === "Linux GUI"} pull="5793">
+          The Linux GUI Client is now built for both x86-64 and ARM64.
+        </ChangeItem>
+        <ChangeItem enable={title === "Windows"}>
+          This is a maintenance release with no user-facing changes.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.4" date={new Date("2024-07-05")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="5700">
-            Fixes an issue where a stale DNS cache could prevent traffic from
-            routing to DNS Resources if they were updated while the Client was
-            signed in.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="5700">
+          Fixes an issue where a stale DNS cache could prevent traffic from
+          routing to DNS Resources if they were updated while the Client was
+          signed in.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.3" date={new Date("2024-07-03")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Prevents Firezone's stub resolver from intercepting DNS record types
-            besides A, AAAA, and PTR. These are now forwarded to your upstream
-            DNS resolver.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Prevents Firezone's stub resolver from intercepting DNS record types
+          besides A, AAAA, and PTR. These are now forwarded to your upstream DNS
+          resolver.
+        </li>
       </Entry>
       <Entry version="1.1.2" date={new Date("2024-06-29")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
+        <li className="pl-2">
+          Fixes an issue that could cause Resources to be unreachable a few
+          hours after roaming networks.
+        </li>
+        <li className="pl-2">
+          Reduces noise in logs for the default log level.
+        </li>
+        {title === "Windows" && (
           <li className="pl-2">
-            Fixes an issue that could cause Resources to be unreachable a few
-            hours after roaming networks.
+            Substantially reduces memory usage for the IPC service.
           </li>
-          <li className="pl-2">
-            Reduces noise in logs for the default log level.
-          </li>
-          {title === "Windows" && (
-            <li className="pl-2">
-              Substantially reduces memory usage for the IPC service.
-            </li>
-          )}
-        </ul>
+        )}
       </Entry>
       <Entry version="1.1.1" date={new Date("2024-06-27")}>
         {title === "Windows" ? (
@@ -288,31 +241,29 @@ export default function GUI({ title }: { title: string }) {
         )}
       </Entry>
       <Entry version="1.1.0" date={new Date("2024-06-27")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
+        <li className="pl-2">
+          Introduces the new DNS routing system supported by 1.1.0 Gateways
+          which results in much more stable connections for DNS Resources,
+          especially when wildcards are used.
+        </li>
+        <li className="pl-2">
+          Improves reliability when roaming between networks.
+        </li>
+        <li className="pl-2">
+          Closes idle connections to Gateways that have not seen traffic for
+          more than 5 minutes which reduces power consumption when not accessing
+          Resources.
+        </li>
+        <li className="pl-2">
+          Updates log file endings to JSONL and adds syslog-style logs for
+          easier readability.
+        </li>
+        {title === "Windows" && (
           <li className="pl-2">
-            Introduces the new DNS routing system supported by 1.1.0 Gateways
-            which results in much more stable connections for DNS Resources,
-            especially when wildcards are used.
+            Fixes a hang that could occur when the Client is quit, preventing it
+            from opening again.
           </li>
-          <li className="pl-2">
-            Improves reliability when roaming between networks.
-          </li>
-          <li className="pl-2">
-            Closes idle connections to Gateways that have not seen traffic for
-            more than 5 minutes which reduces power consumption when not
-            accessing Resources.
-          </li>
-          <li className="pl-2">
-            Updates log file endings to JSONL and adds syslog-style logs for
-            easier readability.
-          </li>
-          {title === "Windows" && (
-            <li className="pl-2">
-              Fixes a hang that could occur when the Client is quit, preventing
-              it from opening again.
-            </li>
-          )}
-        </ul>
+        )}
         <p>
           <strong>Note:</strong> Client versions 1.1.x are incompatible with
           Gateways running 1.0.x.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Entry from "./Entry";
 import Entries from "./Entries";
 import ChangeItem from "./ChangeItem";
+import Unreleased from "./Unreleased";
 
 export default function GUI({ title }: { title: string }) {
   const href =
@@ -13,12 +14,7 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      {/*
-      <Entry version="1.3.7" date={new Date(todo)}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-        </ul>
-      </Entry>
-      */}
+      <Unreleased></Unreleased>
       <Entry version="1.3.6" date={new Date("2024-09-25")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6809">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -2,6 +2,7 @@ import Entry from "./Entry";
 import Entries from "./Entries";
 import Link from "next/link";
 import ChangeItem from "./ChangeItem";
+import Unreleased from "./Unreleased";
 
 export default function Gateway() {
   const href = "/dl/firezone-gateway/:version/:arch";
@@ -9,6 +10,7 @@ export default function Gateway() {
 
   return (
     <Entries href={href} arches={arches} title="Gateway">
+      <Unreleased></Unreleased>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6563">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -12,72 +12,56 @@ export default function Gateway() {
     <Entries href={href} arches={arches} title="Gateway">
       <Unreleased></Unreleased>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6563">
-            Removes unnecessary packet buffers for a minor performance increase.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6563">
+          Removes unnecessary packet buffers for a minor performance increase.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6434">
-            Adds support for routing the Internet Resource for Clients.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6434">
+          Adds support for routing the Internet Resource for Clients.
+        </ChangeItem>
       </Entry>
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="5901">
-            Implements glob-like matching of domains for DNS resources.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="5901">
+          Implements glob-like matching of domains for DNS resources.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-08-13")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6276">
-            Fixes a bug where relayed connections failed to establish after an
-            idle period.
-          </ChangeItem>
-          <ChangeItem pull="6277">
-            Fixes a bug where restrictive NATs caused connectivity problems.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6276">
+          Fixes a bug where relayed connections failed to establish after an
+          idle period.
+        </ChangeItem>
+        <ChangeItem pull="6277">
+          Fixes a bug where restrictive NATs caused connectivity problems.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.4" date={new Date("2024-08-08")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Removes `FIREZONE_ENABLE_MASQUERADE` env variable. Masquerading is
-            now always enabled unconditionally.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Removes `FIREZONE_ENABLE_MASQUERADE` env variable. Masquerading is now
+          always enabled unconditionally.
+        </li>
       </Entry>
       <Entry version="1.1.3" date={new Date("2024-08-02")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Fixes{" "}
-            <Link
-              className="text-accent-500 underline hover:no-underline"
-              href="https://github.com/firezone/firezone/pull/6117"
-            >
-              an issue
-            </Link>{" "}
-            where Gateways could become unresponsive after new versions of the
-            Firezone infrastructure was deployed.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Fixes{" "}
+          <Link
+            className="text-accent-500 underline hover:no-underline"
+            href="https://github.com/firezone/firezone/pull/6117"
+          >
+            an issue
+          </Link>{" "}
+          where Gateways could become unresponsive after new versions of the
+          Firezone infrastructure was deployed.
+        </li>
       </Entry>
       <Entry version="1.1.2" date={new Date("2024-06-29")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">Reduces log noise for the default log level.</li>
-        </ul>
+        <li className="pl-2">Reduces log noise for the default log level.</li>
       </Entry>
       <Entry version="1.1.1" date={new Date("2024-06-27")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Fixes a minor connectivity issue that could occur for some DNS
-            Resources.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Fixes a minor connectivity issue that could occur for some DNS
+          Resources.
+        </li>
       </Entry>
       <Entry version="1.1.0" date={new Date("2024-06-19")}>
         <p className="mb-2 md:mb-4">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -13,152 +13,122 @@ export default function Headless() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased></Unreleased>
       <Entry version="1.3.3" date={new Date("2024-09-25")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6809">
-            Fixes a bug where non-wildcard DNS resources were not prioritised
-            over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6809">
+          Fixes a bug where non-wildcard DNS resources were not prioritised over
+          wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.2" date={new Date("2024-09-25")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6765">
-            Fixes a bug where DNS PTR queries by the system did not get
-            answered.
-          </ChangeItem>
-          <ChangeItem pull="6722">
-            Fixes a routing bug when one of several overlapping CIDR resources
-            gets disabled / removed.
-          </ChangeItem>
-          <ChangeItem pull="6780">
-            Fixes a bug where the Linux Clients didn't work on ZFS filesystems.
-          </ChangeItem>
-          <ChangeItem pull="6788">
-            Fixes an issue where some browsers may fail to route DNS Resources
-            correctly.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6765">
+          Fixes a bug where DNS PTR queries by the system did not get answered.
+        </ChangeItem>
+        <ChangeItem pull="6722">
+          Fixes a routing bug when one of several overlapping CIDR resources
+          gets disabled / removed.
+        </ChangeItem>
+        <ChangeItem pull="6780">
+          Fixes a bug where the Linux Clients didn't work on ZFS filesystems.
+        </ChangeItem>
+        <ChangeItem pull="6788">
+          Fixes an issue where some browsers may fail to route DNS Resources
+          correctly.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6563">
-            Removes unnecessary packet buffers for a minor performance increase.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6563">
+          Removes unnecessary packet buffers for a minor performance increase.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6434">
-            Adds the Internet Resource feature.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>
       </Entry>
       <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="5901">
-            Implements glob-like matching of domains for DNS resources.
-          </ChangeItem>
-          <ChangeItem pull="6361">
-            Connections to Gateways are now sticky for the duration of the
-            Client's session to fix issues with long-lived TCP connections.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="5901">
+          Implements glob-like matching of domains for DNS resources.
+        </ChangeItem>
+        <ChangeItem pull="6361">
+          Connections to Gateways are now sticky for the duration of the
+          Client's session to fix issues with long-lived TCP connections.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.7" date={new Date("2024-08-13")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6276">
-            Fixes a bug where relayed connections failed to establish after an
-            idle period.
-          </ChangeItem>
-          <ChangeItem pull="6277">
-            Fixes a bug where restrictive NATs caused connectivity problems.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6276">
+          Fixes a bug where relayed connections failed to establish after an
+          idle period.
+        </ChangeItem>
+        <ChangeItem pull="6277">
+          Fixes a bug where restrictive NATs caused connectivity problems.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.6" date={new Date("2024-08-09")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6233">
-            Fixes an issue where the IPC service can panic during DNS
-            resolution.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6233">
+          Fixes an issue where the IPC service can panic during DNS resolution.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-08-08")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6163">
-            Uses `systemd-resolved` DNS control by default on Linux
-          </ChangeItem>
-          <ChangeItem pull="6184">
-            Mitigates a bug where the Client can panic if an internal channel
-            fills up
-          </ChangeItem>
-          <ChangeItem pull="6181">
-            Improves reliability of DNS resolution of non-resources.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6163">
+          Uses `systemd-resolved` DNS control by default on Linux
+        </ChangeItem>
+        <ChangeItem pull="6184">
+          Mitigates a bug where the Client can panic if an internal channel
+          fills up
+        </ChangeItem>
+        <ChangeItem pull="6181">
+          Improves reliability of DNS resolution of non-resources.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.4" date={new Date("2024-08-02")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <ChangeItem pull="6143">
-            Fixes an issue where DNS queries could time out on some networks.
-          </ChangeItem>
-        </ul>
+        <ChangeItem pull="6143">
+          Fixes an issue where DNS queries could time out on some networks.
+        </ChangeItem>
       </Entry>
       <Entry version="1.1.3" date={new Date("2024-07-05")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Fixes an{" "}
-            <Link
-              href="https://github.com/firezone/firezone/pull/5700"
-              className="text-accent-500 underline hover:no-underline"
-            >
-              issue
-            </Link>{" "}
-            where a stale DNS cache could prevent traffic from routing to DNS
-            Resources if they were updated while the Client was signed in.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Fixes an{" "}
+          <Link
+            href="https://github.com/firezone/firezone/pull/5700"
+            className="text-accent-500 underline hover:no-underline"
+          >
+            issue
+          </Link>{" "}
+          where a stale DNS cache could prevent traffic from routing to DNS
+          Resources if they were updated while the Client was signed in.
+        </li>
       </Entry>
       <Entry version="1.1.2" date={new Date("2024-07-03")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Prevents Firezone's stub resolver from intercepting DNS record types
-            besides A, AAAA, and PTR. These are now forwarded to your upstream
-            DNS resolver.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Prevents Firezone's stub resolver from intercepting DNS record types
+          besides A, AAAA, and PTR. These are now forwarded to your upstream DNS
+          resolver.
+        </li>
       </Entry>
       <Entry version="1.1.1" date={new Date("2024-06-29")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Fixes an issue that could cause Resources to be unreachable a few
-            hours after roaming networks.
-          </li>
-          <li className="pl-2">
-            Reduces noise in logs for the default log level.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Fixes an issue that could cause Resources to be unreachable a few
+          hours after roaming networks.
+        </li>
+        <li className="pl-2">
+          Reduces noise in logs for the default log level.
+        </li>
       </Entry>
       <Entry version="1.1.0" date={new Date("2024-06-27")}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-          <li className="pl-2">
-            Introduces the new DNS routing system supported by 1.1.0 Gateways
-            which results in much more stable connections for DNS Resources,
-            especially when wildcards are used.
-          </li>
-          <li className="pl-2">
-            Improves reliability when roaming between networks.
-          </li>
-          <li className="pl-2">
-            Closes idle connections to Gateways that have not seen traffic for
-            more than 5 minutes which reduces power consumption when not
-            accessing Resources.
-          </li>
-          <li className="pl-2">
-            Updates log file endings to JSONL and adds syslog-style logs for
-            easier readability.
-          </li>
-        </ul>
+        <li className="pl-2">
+          Introduces the new DNS routing system supported by 1.1.0 Gateways
+          which results in much more stable connections for DNS Resources,
+          especially when wildcards are used.
+        </li>
+        <li className="pl-2">
+          Improves reliability when roaming between networks.
+        </li>
+        <li className="pl-2">
+          Closes idle connections to Gateways that have not seen traffic for
+          more than 5 minutes which reduces power consumption when not accessing
+          Resources.
+        </li>
+        <li className="pl-2">
+          Updates log file endings to JSONL and adds syslog-style logs for
+          easier readability.
+        </li>
         <p>
           <strong>Note:</strong> Client versions 1.1.x are incompatible with
           Gateways running 1.0.x.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -2,6 +2,7 @@ import ChangeItem from "./ChangeItem";
 import Entry from "./Entry";
 import Entries from "./Entries";
 import Link from "next/link";
+import Unreleased from "./Unreleased";
 
 export default function Headless() {
   const href = "/dl/firezone-client-headless-linux/:version/:arch";
@@ -10,12 +11,7 @@ export default function Headless() {
   return (
     <Entries href={href} arches={arches} title="Linux headless">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      {/*
-      <Entry version="1.3.4" date={new Date(todo)}>
-        <ul className="list-disc space-y-2 pl-4 mb-4">
-        </ul>
-      </Entry>
-      */}
+      <Unreleased></Unreleased>
       <Entry version="1.3.3" date={new Date("2024-09-25")}>
         <ul className="list-disc space-y-2 pl-4 mb-4">
           <ChangeItem pull="6809">

--- a/website/src/components/Changelog/Unreleased.tsx
+++ b/website/src/components/Changelog/Unreleased.tsx
@@ -3,5 +3,5 @@ export default function Unreleased({
 }: {
   children?: React.ReactNode;
 }) {
-  return <></>;
+  return null;
 }

--- a/website/src/components/Changelog/Unreleased.tsx
+++ b/website/src/components/Changelog/Unreleased.tsx
@@ -1,0 +1,7 @@
+export default function Unreleased({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  return <></>;
+}


### PR DESCRIPTION
Currently, our changelog components have a lot of duplication. Additionally, keeping a "commented out" `Entry` around leads to many merge conflicts because the formatter doesn't pick up code within comments.

To fix this, we introduce an `Unreleased` components that doesn't render its children. Furthermore, we move the `<ul>` into the `Entry` components to avoid duplicating it for every changelog entry.