### PR TITLE
fix(ci): Reduce log level for android upload release workflow

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -71,7 +71,7 @@ jobs:
           FIREBASE_APP_TESTERS: ${{ vars.FIREBASE_APP_TESTERS }}
         run: |
           echo -n "$FIREBASE_APP_DISTRIBUTION_CREDENTIALS" > $FIREBASE_CREDENTIALS_PATH
-          ./gradlew --info appDistributionUploadRelease uploadCrashlyticsSymbolFileRelease
+          ./gradlew appDistributionUploadRelease uploadCrashlyticsSymbolFileRelease
 
   build_debug:
     # Android SDK tools hardware accel is available only on Linux runners


### PR DESCRIPTION
Reduces the likelihood we log something sensitive.