### PR TITLE
fix(connlib): answer `use-application-dns.net` with NXDOMAIN

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -25,6 +25,9 @@ const DNS_PORT: u16 = 53;
 ///
 /// Responding to queries for this domain with NXDOMAIN will disable DoH.
 /// See <https://support.mozilla.org/en-US/kb/canary-domain-use-application-dnsnet>.
+/// For Chrome and other Chrome-based browsers, this is not required as
+/// Chrome will automatically disable DoH if your server(s) don't support
+/// it. See https://www.chromium.org/developers/dns-over-https/#faq
 static DOH_CANARY_DOMAIN: LazyLock<DomainName> =
     LazyLock::new(|| DomainName::vec_from_str("use-application-dns.net").unwrap());
 

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -27,7 +27,7 @@ const DNS_PORT: u16 = 53;
 /// See <https://support.mozilla.org/en-US/kb/canary-domain-use-application-dnsnet>.
 /// For Chrome and other Chrome-based browsers, this is not required as
 /// Chrome will automatically disable DoH if your server(s) don't support
-/// it. See https://www.chromium.org/developers/dns-over-https/#faq
+/// it. See <https://www.chromium.org/developers/dns-over-https/#faq>.
 static DOH_CANARY_DOMAIN: LazyLock<DomainName> =
     LazyLock::new(|| DomainName::vec_from_str("use-application-dns.net").unwrap());
 


### PR DESCRIPTION
Firefox uses this so-called canary domain `use-application-dns.net` to detect, whether it should use DoH for its DNS queries. If answered with a server error or without records, Firefox disables DoH as long as it only its "Default protection" is enabled. If a user forces DoH, this hint from the network is ignored.

See https://support.mozilla.org/en-US/kb/canary-domain-use-application-dnsnet for details.

I tested this on MacOS and Firefox does indeed instantly disable DoH. A default installation of Chrome doesn't use DoH for me.

Related: #6375.