### PR TITLE
chore(rust): remove unused deps from workspace

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -49,9 +49,6 @@ connlib-client-android = { path = "connlib/clients/android" }
 connlib-client-apple = { path = "connlib/clients/apple" }
 connlib-client-shared = { path = "connlib/clients/shared" }
 firezone-bin-shared = { path = "bin-shared" }
-firezone-gateway = { path = "gateway" }
-firezone-headless-client = { path = "headless-client" }
-firezone-gui-client = { path = "gui-client/src-tauri" }
 firezone-logging = { path = "logging" }
 firezone-telemetry = { path = "telemetry" }
 snownet = { path = "connlib/snownet" }


### PR DESCRIPTION
These crates are leaves and don't need to be deps