### PR TITLE
fix(rust/gui-client): strip exes

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -173,6 +173,7 @@ jobs:
             image_name: http-test-server
     env:
       BINARY_DEST_PATH: ${{ matrix.name.artifact }}_${{ matrix.name.version }}_${{ matrix.arch.shortname }}
+      SENTRY_ENVIRONMENT: "production"
     outputs:
       client_image: ${{ steps.image-name.outputs.client_image }}
       relay_image: ${{ steps.image-name.outputs.relay_image }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -20,6 +20,7 @@ defaults:
 env:
   RUSTFLAGS: "-Dwarnings"
   RUSTDOCFLAGS: "-D warnings"
+  SENTRY_ENVIRONMENT: "production"
 
 jobs:
   build-gui:

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -109,4 +109,4 @@ strip = "none"
 [profile.release.package.firezone-gui-client]
 debug = "full"
 split-debuginfo = "packed"
-strip = "none"
+strip = true

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -191,8 +191,11 @@ impl<I: GuiIntegration> Controller<I> {
         // Start telemetry
         {
             let environment = self.advanced_settings.api_url.to_string();
-            self.telemetry
-                .start(environment.clone(), firezone_bin_shared::git_version!("gui-client-*"), firezone_telemetry::GUI_DSN);
+            self.telemetry.start(
+                environment.clone(),
+                firezone_bin_shared::git_version!("gui-client-*"),
+                firezone_telemetry::GUI_DSN,
+            );
             self.ipc_client
                 .send_msg(&IpcClientMsg::StartTelemetry { environment })
                 .await?;

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -192,7 +192,7 @@ impl<I: GuiIntegration> Controller<I> {
         {
             let environment = self.advanced_settings.api_url.to_string();
             self.telemetry
-                .start(environment.clone(), firezone_telemetry::GUI_DSN);
+                .start(environment.clone(), firezone_bin_shared::git_version!("gui-client-*"), firezone_telemetry::GUI_DSN);
             self.ipc_client
                 .send_msg(&IpcClientMsg::StartTelemetry { environment })
                 .await?;

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -60,7 +60,11 @@ pub(crate) fn run() -> Result<()> {
             // Can't check elevation here because the Windows CI is always elevated
             let settings = common::settings::load_advanced_settings().unwrap_or_default();
             let telemetry = telemetry::Telemetry::default();
-            telemetry.start(settings.api_url.to_string(), firezone_bin_shared::git_version!("gui-client-*"), telemetry::GUI_DSN);
+            telemetry.start(
+                settings.api_url.to_string(),
+                firezone_bin_shared::git_version!("gui-client-*"),
+                telemetry::GUI_DSN,
+            );
             // Don't fix the log filter for smoke tests
             let common::logging::Handles {
                 logger: _logger,
@@ -88,7 +92,11 @@ fn run_gui(cli: Cli) -> Result<()> {
     let mut settings = common::settings::load_advanced_settings().unwrap_or_default();
     let telemetry = telemetry::Telemetry::default();
     // In the future telemetry will be opt-in per organization, that's why this isn't just at the top of `main`
-    telemetry.start(settings.api_url.to_string(), firezone_bin_shared::git_version!("gui-client-*"), telemetry::GUI_DSN);
+    telemetry.start(
+        settings.api_url.to_string(),
+        firezone_bin_shared::git_version!("gui-client-*"),
+        telemetry::GUI_DSN,
+    );
     fix_log_filter(&mut settings)?;
     let common::logging::Handles {
         logger: _logger,

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -60,7 +60,7 @@ pub(crate) fn run() -> Result<()> {
             // Can't check elevation here because the Windows CI is always elevated
             let settings = common::settings::load_advanced_settings().unwrap_or_default();
             let telemetry = telemetry::Telemetry::default();
-            telemetry.start(settings.api_url.to_string(), telemetry::GUI_DSN);
+            telemetry.start(settings.api_url.to_string(), firezone_bin_shared::git_version!("gui-client-*"), telemetry::GUI_DSN);
             // Don't fix the log filter for smoke tests
             let common::logging::Handles {
                 logger: _logger,
@@ -88,7 +88,7 @@ fn run_gui(cli: Cli) -> Result<()> {
     let mut settings = common::settings::load_advanced_settings().unwrap_or_default();
     let telemetry = telemetry::Telemetry::default();
     // In the future telemetry will be opt-in per organization, that's why this isn't just at the top of `main`
-    telemetry.start(settings.api_url.to_string(), telemetry::GUI_DSN);
+    telemetry.start(settings.api_url.to_string(), firezone_bin_shared::git_version!("gui-client-*"), telemetry::GUI_DSN);
     fix_log_filter(&mut settings)?;
     let common::logging::Handles {
         logger: _logger,

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -500,7 +500,7 @@ impl<'a> Handler<'a> {
             }
             ClientMsg::StartTelemetry { environment } => self
                 .telemetry
-                .start(environment, firezone_telemetry::IPC_SERVICE_DSN),
+                .start(environment, firezone_bin_shared::git_version!("gui-client-*"), firezone_telemetry::IPC_SERVICE_DSN),
             ClientMsg::StopTelemetry => self.telemetry.stop(),
         }
         Ok(())

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -498,9 +498,11 @@ impl<'a> Handler<'a> {
 
                 session.connlib.set_disabled_resources(disabled_resources);
             }
-            ClientMsg::StartTelemetry { environment } => self
-                .telemetry
-                .start(environment, firezone_bin_shared::git_version!("gui-client-*"), firezone_telemetry::IPC_SERVICE_DSN),
+            ClientMsg::StartTelemetry { environment } => self.telemetry.start(
+                environment,
+                firezone_bin_shared::git_version!("gui-client-*"),
+                firezone_telemetry::IPC_SERVICE_DSN,
+            ),
             ClientMsg::StopTelemetry => self.telemetry.stop(),
         }
         Ok(())

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -116,7 +116,11 @@ fn main() -> Result<()> {
     let token_env_var = cli.token.take().map(SecretString::from);
     let cli = cli;
     let telemetry = Telemetry::default();
-    telemetry.start(cli.api_url.to_string(), firezone_bin_shared::git_version!("headless-client-*"), firezone_telemetry::HEADLESS_DSN);
+    telemetry.start(
+        cli.api_url.to_string(),
+        firezone_bin_shared::git_version!("headless-client-*"),
+        firezone_telemetry::HEADLESS_DSN,
+    );
 
     // Docs indicate that `remove_var` should actually be marked unsafe
     // SAFETY: We haven't spawned any other threads, this code should be the first

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -116,7 +116,7 @@ fn main() -> Result<()> {
     let token_env_var = cli.token.take().map(SecretString::from);
     let cli = cli;
     let telemetry = Telemetry::default();
-    telemetry.start(cli.api_url.to_string(), firezone_telemetry::HEADLESS_DSN);
+    telemetry.start(cli.api_url.to_string(), firezone_bin_shared::git_version!("headless-client-*"), firezone_telemetry::HEADLESS_DSN);
 
     // Docs indicate that `remove_var` should actually be marked unsafe
     // SAFETY: We haven't spawned any other threads, this code should be the first

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -42,7 +42,7 @@ impl Clone for Telemetry {
 }
 
 impl Telemetry {
-    pub fn start(&self, environment: String, dsn: Dsn) {
+    pub fn start(&self, environment: String, release: &'static str, dsn: Dsn) {
         // Since it's `arc_swap` and not `Option`, there is a TOCTOU here,
         // but in practice it should never trigger
         if self.inner.load().is_some() {
@@ -53,7 +53,7 @@ impl Telemetry {
             dsn.0,
             sentry::ClientOptions {
                 environment: Some(environment.into()),
-                release: sentry::release_name!(),
+                release: Some(release.into()),
                 traces_sample_rate: 1.0,
                 ..Default::default()
             },

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -86,6 +86,8 @@ impl Telemetry {
 mod tests {
     use super::*;
 
+    const ENV: &str = "unit test";
+
     // To avoid problems with global mutable state, we run unrelated tests in the same test case.
     #[test]
     fn sentry() {
@@ -113,7 +115,7 @@ mod tests {
             // Expect no telemetry because the telemetry module needs to be enabled before it can do anything
             negative_error("X7X4CKH3");
 
-            tele.start("test".to_string(), HEADLESS_DSN);
+            tele.start("test".to_string(), ENV, HEADLESS_DSN);
             // Expect telemetry because the user opted in.
             sentry::add_breadcrumb(sentry::Breadcrumb {
                 ty: "test_crumb".into(),
@@ -126,7 +128,7 @@ mod tests {
             // Expect no telemetry because the user opted back out.
             negative_error("2RSIYAPX");
 
-            tele.start("test".to_string(), HEADLESS_DSN);
+            tele.start("test".to_string(), ENV, HEADLESS_DSN);
             // Cycle one more time to be sure.
             error("S672IOBZ");
             tele.stop();
@@ -140,12 +142,12 @@ mod tests {
             {
                 let tele = Telemetry::default();
                 negative_error("4H7HFTNX");
-                tele.start("test".to_string(), HEADLESS_DSN);
+                tele.start("test".to_string(), ENV, HEADLESS_DSN);
             }
             {
                 negative_error("GF46D6IL");
                 let tele = Telemetry::default();
-                tele.start("test".to_string(), HEADLESS_DSN);
+                tele.start("test".to_string(), ENV, HEADLESS_DSN);
                 error("OKOEUKSW");
             }
         }

--- a/scripts/build/tauri-rename-ubuntu.sh
+++ b/scripts/build/tauri-rename-ubuntu.sh
@@ -13,7 +13,6 @@ ls ../target/release ../target/release/bundle/deb
 
 # Used for release artifact
 # In release mode the name comes from tauri.conf.json
-# Using a glob for the source, there will only be one exe and one deb anyway
 cp ../target/release/firezone-client-gui "$BINARY_DEST_PATH"
 cp ../target/release/firezone-gui-client.dwp "$BINARY_DEST_PATH.dwp"
 cp ../target/release/bundle/deb/firezone-client-gui.deb "$BINARY_DEST_PATH.deb"


### PR DESCRIPTION
The notes on 651ea3ae00e said that stripping would prevent the debug symbols from being generated, which doesn't make much sense. This was 6 months ago, so maybe it was a compiler bug that got fixed or something.

The .dwp files still seem to be generated fine with stripping enabled, and the exe is much smaller, so we'll get a fair comparison between the size of the Tauri Client and the Iced or GTK+ Clients.

Zipped package sizes from CI:
- Linux aarch64 - 12.6 to 9.48 MB
- Linux x86_64 - 13.2 to 10.1 MB
- Windows x86_64 - 8.88 to 8.88 MB

Maybe we were already stripping it on Windows.