### PR TITLE
fix(portal): Minor UI consistency fixes for resource/group select

### DIFF
--- a/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
+++ b/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
@@ -202,7 +202,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
             "mt-2 pb-1 px-1 space-y-0.5 z-20",
             "w-full bg-white",
             input_border_class(),
-            "border border-gray-200 rounded-lg",
+            "border border-gray-200 rounded shadow",
             "overflow-hidden"
           ]}
           role="listbox"
@@ -213,7 +213,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
             "max-h-72",
             "overflow-y-auto overflow-x-hidden"
           ]}>
-            <div class="bg-white p-2 sticky top-0 z-40">
+            <div class="bg-white p-2 sticky top-2 z-40">
               <input
                 name={"search_query-#{@id}"}
                 id={"select-" <> @id <> "-search-input"}
@@ -232,7 +232,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
             <div>
               <div class={[
                 "hidden only:block",
-                "py-2 px-4",
+                "py-2 px-2",
                 "text-sm text-neutral-400"
               ]}>
                 <%= if @no_search_results == [] do %>

--- a/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
+++ b/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
@@ -165,8 +165,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
           autocomplete={false}
           class={[
             input_class(),
-            not @disabled && "cursor-pointer",
-            @disabled && "cursor-not-allowed",
+            @disabled && "cursor-not-allowed" || "cursor-pointer",
             @errors != [] && input_has_errors_class()
           ]}
           value={@value_name}

--- a/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
+++ b/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
@@ -213,7 +213,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
             "max-h-72",
             "overflow-y-auto overflow-x-hidden"
           ]}>
-            <div class="bg-white p-2 sticky top-2 z-40">
+            <div class="bg-white p-2 sticky top-1 z-40">
               <input
                 name={"search_query-#{@id}"}
                 id={"select-" <> @id <> "-search-input"}

--- a/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
+++ b/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
@@ -181,7 +181,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
         <div
           class={[
             "absolute top-1/2 end-2 -translate-y-1/2",
-            @disabled && "cursor-not-allowed" || "cursor-pointer",
+            @disabled && "cursor-not-allowed" || "cursor-pointer"
           ]}
           phx-click={
             unless @disabled do

--- a/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
+++ b/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
@@ -181,8 +181,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
         <div
           class={[
             "absolute top-1/2 end-2 -translate-y-1/2",
-            not @disabled && "cursor-pointer",
-            @disabled && "cursor-not-allowed"
+            @disabled && "cursor-not-allowed" || "cursor-pointer",
           ]}
           phx-click={
             unless @disabled do

--- a/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
+++ b/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
@@ -165,7 +165,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
           autocomplete={false}
           class={[
             input_class(),
-            @disabled && "cursor-not-allowed" || "cursor-pointer",
+            (@disabled && "cursor-not-allowed") || "cursor-pointer",
             @errors != [] && input_has_errors_class()
           ]}
           value={@value_name}
@@ -181,7 +181,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
         <div
           class={[
             "absolute top-1/2 end-2 -translate-y-1/2",
-            @disabled && "cursor-not-allowed" || "cursor-pointer"
+            (@disabled && "cursor-not-allowed") || "cursor-pointer"
           ]}
           phx-click={
             unless @disabled do

--- a/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
+++ b/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
@@ -166,6 +166,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
           class={[
             input_class(),
             not @disabled && "cursor-pointer",
+            @disabled && "cursor-not-allowed",
             @errors != [] && input_has_errors_class()
           ]}
           value={@value_name}
@@ -181,14 +182,17 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
         <div
           class={[
             "absolute top-1/2 end-2 -translate-y-1/2",
-            not @disabled && "cursor-pointer"
+            not @disabled && "cursor-pointer",
+            @disabled && "cursor-not-allowed"
           ]}
           phx-click={
-            JS.toggle_class("hidden",
-              to: "#select-#{@id}-dropdown"
-            )
-            |> JS.toggle_attribute({"aria-expanded", "true", "false"}, to: "##{@id}-input")
-            |> JS.focus(to: "#select-" <> @id <> "-search-input")
+            unless @disabled do
+              JS.toggle_class("hidden",
+                to: "#select-#{@id}-dropdown"
+              )
+              |> JS.toggle_attribute({"aria-expanded", "true", "false"}, to: "##{@id}-input")
+              |> JS.focus(to: "#select-" <> @id <> "-search-input")
+            end
           }
         >
           <.icon name="hero-chevron-up-down" class="w-5 h-5" />

--- a/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
+++ b/elixir/apps/web/lib/web/components/form_components/select_with_groups.ex
@@ -265,7 +265,7 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
                       "block",
                       "w-full py-2 px-4",
                       "text-sm text-neutral-800",
-                      "rounded-lg",
+                      "rounded",
                       "hover:bg-neutral-100",
                       "focus:outline-none focus:bg-neutral-100",
                       value != @value && "cursor-pointer",
@@ -280,14 +280,21 @@ defmodule Web.Components.FormComponents.SelectWithGroups do
                       checked={value == @value}
                       class="hidden"
                     />
-                    <div>
-                      <div class={["flex items center"]}>
-                        <div class={["text-gray-800"]}>
-                          <%= render_slot(@option, slot_assigns) %>
-                        </div>
-                        <div :if={value == @value} class="ml-auto">
-                          <.icon name="hero-check" class="w-4 h-4" />
-                        </div>
+                    <div
+                      phx-click={
+                        JS.toggle_class("hidden",
+                          to: "#select-#{@id}-dropdown"
+                        )
+                        |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+                        |> JS.focus(to: "#select-" <> @id <> "-search-input")
+                      }
+                      class={["flex items-center"]}
+                    >
+                      <div class={["text-gray-800"]}>
+                        <%= render_slot(@option, slot_assigns) %>
+                      </div>
+                      <div :if={value == @value} class="ml-auto">
+                        <.icon name="hero-check" class="w-4 h-4" />
                       </div>
                     </div>
                   </label>

--- a/elixir/apps/web/lib/web/live/policies/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies/edit.ex
@@ -146,7 +146,7 @@ defmodule Web.Policies.Edit do
                   </:no_options>
 
                   <:no_search_results>
-                    No resources found. Try a different search query or create a new one <.link
+                    No Resources found. Try a different search query or create a new one <.link
                       navigate={~p"/#{@account}/resources/new"}
                       class={link_style()}
                     >here</.link>.

--- a/elixir/apps/web/lib/web/live/policies/edit.ex
+++ b/elixir/apps/web/lib/web/live/policies/edit.ex
@@ -124,7 +124,7 @@ defmodule Web.Policies.Edit do
                     <% end %>
 
                     <span :if={resource.gateway_groups == []} class="text-red-800">
-                      (not connected to any Sites)
+                      (not connected to any Site)
                     </span>
                     <span
                       :if={length(resource.gateway_groups) > 0}

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -135,7 +135,7 @@ defmodule Web.Policies.New do
                   </:no_options>
 
                   <:no_search_results>
-                    No resources found. Try a different search query or create a new one <.link
+                    No Resources found. Try a different search query or create a new one <.link
                       navigate={~p"/#{@account}/resources/new"}
                       class={link_style()}
                     >here</.link>.

--- a/elixir/apps/web/lib/web/live/policies/new.ex
+++ b/elixir/apps/web/lib/web/live/policies/new.ex
@@ -113,7 +113,7 @@ defmodule Web.Policies.New do
                     <% end %>
 
                     <span :if={resource.gateway_groups == []} class="text-red-800">
-                      (not connected to any Sites)
+                      (not connected to any Site)
                     </span>
                     <span
                       :if={length(resource.gateway_groups) > 0}


### PR DESCRIPTION
- [x] Spacing consistency
- [x] Border radius consistency
- [x] Minor grammar
- [x] Dismiss select when item is selected
- [x] Add shadow to stand out from rest of form
- [x] Prevent from opening when disabled
- [x] Use `cursor-not-allowed` when disabled for consistency with other form elements


Before


<img width="670" alt="Screenshot 2024-09-27 at 5 01 38 PM" src="https://github.com/user-attachments/assets/79e3a4c6-4d23-4edd-93b2-149acc58c37b">



After


<img width="677" alt="Screenshot 2024-09-27 at 5 11 48 PM" src="https://github.com/user-attachments/assets/e1453c05-fed7-4d87-a176-6f6ce1267488">



