### PR TITLE
chore(snownet): unset parent span

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -576,7 +576,9 @@ where
             },
             possible_sockets: BTreeSet::default(),
             relay,
-            span: info_span!("connection", %cid),
+            last_outgoing: now,
+            last_incoming: now,
+            span: info_span!(parent: tracing::Span::none(), "connection", %cid),
         }
     }
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -576,8 +576,6 @@ where
             },
             possible_sockets: BTreeSet::default(),
             relay,
-            last_outgoing: now,
-            last_incoming: now,
             span: info_span!(parent: tracing::Span::none(), "connection", %cid),
         }
     }


### PR DESCRIPTION
When constructing a span, any currently set span will automatically be set as the parent. In the case of the `connection` span, this was the `accept_answer` or `new_connection` span from the client  / gateway. Those are not meant to be re-activated every time we enter the `connection` span.

By setting an explicit parent, we avoid that.

Unfortunately, this means that this span will never have a parent, even if other spans are active whilst we enter this one. We enter this one in the hot-path, which is why it is being constructed ahead of time.

