### PR TITLE
chore(rust): add `tracing-macros` dependency

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,7 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 swift-bridge = "0.1.57"
 backoff = { version = "0.4", features = ["tokio"] }
 tracing = { version = "0.1.40" }
+tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" } # Contains `dbg!` but for `tracing`.
 tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
 hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63", features = ["tokio-runtime"] }
@@ -82,6 +83,10 @@ ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "master" }
 proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "master" }
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "deps/bump-otel-0.23" } # Waiting for release.
+
+# Enforce `tracing-macros` to have released `tracing` version.
+[patch.'https://github.com/tokio-rs/tracing']
+tracing = "0.1"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
This crate contains a useful macro `dbg!` which acts mostly like `std::dbg!` but logs to `tracing` instead. Having it easily available as a dependency during development makes debugging easier, especially with `tunnel_test` which produces log-files per test-run.