### PR TITLE
chore(rust): remove hickory dependencies

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,8 +34,6 @@ backoff = { version = "0.4", features = ["tokio"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
-hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63", features = ["tokio-runtime"] }
-hickory-proto = { git = "https://github.com/hickory-dns/hickory-dns", rev = "a3669bd80f3f7b97f0c301c15f1cba6368d97b63" }
 str0m = { version = "0.6.2", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.10", features = ["serde"] }


### PR DESCRIPTION
These were still defined from a time when we made use of `hickory` for DNS resolution.