### PR TITLE
fix(connlib): don't add new relays after nomination

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6898,6 +6898,7 @@ dependencies = [
  "hex",
  "hex-display",
  "ip-packet",
+ "itertools 0.13.0",
  "once_cell",
  "rand 0.8.5",
  "secrecy",

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -11,6 +11,7 @@ bytes = "1.7.1"
 hex = "0.4.0"
 hex-display = "0.3.0"
 ip-packet = { workspace = true }
+itertools = "0.13"
 once_cell = "1.17.1"
 rand = "0.8"
 secrecy = { workspace = true }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1111,18 +1111,16 @@ fn add_local_candidate_to_all<TId, RId>(
     let initial_connections = connections
         .initial
         .iter_mut()
-        .flat_map(|(id, c)| Some((*id, &mut c.agent, c.relay?)));
+        .flat_map(|(cid, c)| Some((*cid, &mut c.agent, c.relay?, c.span.enter())));
     let established_connections = connections
         .established
         .iter_mut()
-        .flat_map(|(id, c)| Some((*id, &mut c.agent, c.relay?)));
+        .flat_map(|(cid, c)| Some((*cid, &mut c.agent, c.relay?, c.span.enter())));
 
-    for (cid, agent, _) in initial_connections
+    for (cid, agent, _, _guard) in initial_connections
         .chain(established_connections)
-        .filter(|(_, _, selected_relay)| *selected_relay == rid)
+        .filter(|(_, _, selected_relay, _)| *selected_relay == rid)
     {
-        let _span = info_span!("connection", %cid).entered();
-
         add_local_candidate(cid, agent, candidate.clone(), pending_events);
     }
 }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -749,6 +749,13 @@ where
 
         for (rid, event) in allocation_events {
             match event {
+                CandidateEvent::New(candidate)
+                    if candidate.kind() == CandidateKind::ServerReflexive =>
+                {
+                    for (cid, agent, _span) in self.connections.agents_mut() {
+                        add_local_candidate(cid, agent, candidate.clone(), &mut self.pending_events)
+                    }
+                }
                 CandidateEvent::New(candidate) => {
                     for (cid, agent, _span) in self.connections.connecting_agents_by_relay_mut(rid)
                     {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1047,14 +1047,6 @@ where
         initial_connections.chain(pending_connections)
     }
 
-    fn relay(&mut self, id: TId) -> Option<RId> {
-        let maybe_initial_connection = self.initial.get_mut(&id).and_then(|i| i.relay);
-        let maybe_established_connection =
-            self.established.get_mut(&id).and_then(|c| c.state.relay());
-
-        maybe_initial_connection.or(maybe_established_connection)
-    }
-
     fn agents_mut(
         &mut self,
     ) -> impl Iterator<Item = (TId, &mut IceAgent, tracing::span::Entered<'_>)> {
@@ -1487,19 +1479,6 @@ where
             last_incoming: now,
         };
         apply_default_stun_timings(agent);
-    }
-
-    fn relay(&self) -> Option<RId> {
-        let peer_socket = match self {
-            Self::Connecting { relay, .. } => return *relay,
-            Self::Failed => return None,
-            Self::Idle { peer_socket } | Self::Connected { peer_socket, .. } => peer_socket,
-        };
-
-        match peer_socket {
-            PeerSocket::Relay { relay, .. } => Some(*relay),
-            PeerSocket::Direct { .. } => None,
-        }
     }
 }
 


### PR DESCRIPTION
When relays reboot or get redeployed, the portal sends us new relays to use and or relays we should discontinue using. To be more efficient with battery and network usage, `connlib` only ever samples a single relay out of all existing ones for a particular connection.

In case of a network topology where we need to use relays, there are situations we can end up in:

- The client connects to the gateway's relay, i.e. to the port the gateway allocated on the relay.
- The gateway connects to the client's relay, i.e to the port the client allocated on the relay.

When we detect that a relay is down, the party that allocated the port will now immediately (once #6666 is merged). The other party needs to wait until it receives the invalidated candidates from its peer. Invalidating that candidate will also invalidate the currently nominated socket and fail the connection. In theory at least. That only works if there are no other candidates available to try.

This is where this patch becomes important. Say we have the following setup:

- Client samples relay A.
- Gateway samples relay B.
- The nominated candidate pair is "client server-reflexive <=> relay B", i.e. the client talks to the allocated port on the gateway.

Next:

1. Client and portal get network-partitioned.
2. Relay B disappears.
3. Relay C appears.
4. Relay A reboots.
5. Client reconnects.

At this point, the client is told by the portal to use relays A & C. Note that relay A rebooted and thus the allocation previously present on the client is no longer valid. With #6666, we will detect this by comparing credentials & IPs. The gateway is being told about the same relays and as part of that, tests that relay B is still there. It learns that it isn't, invalidates the candidates which fails the connection to the client (but only locally!).

Meanwhile, as part of the regular `init` procedure, the client made a new allocation with relays A & C. Because it had previously selected relay A for the connection with the gateway, the new candidates are added to the agent, forming new pairs. The gateway has already given up on this connection however so it won't ever answer these STUN requests.

Concurrently, the gateway's invalidated candidates arrive the client. They however don't fail the connection because the client is probing the newly added candidates. This creates a state mismatch between the client and gateway that is only resolved after the candidates start timing out, adding an additional delay during which the connection isn't working.

With this PR, we prevent this from happening by only ever adding new candidates while we are still in the nomination process of a socket. In theory, there exists a race condition in which we nominate a relay candidate first and then miss out on a server-reflexive candidate not being added. In practice, this won't happen because:

- Our host candidates are always available first.
- We learn server-reflexive candidates already as part of the initial BINDING, before creating the allocation.
- We learn server-reflexive candidates from all relays, not just the one that has been assigned.

Related: #6666.