### PR TITLE
docs: add note on how to rotate client secret for windows code signing

### DIFF
--- a/.github/README_CI.md
+++ b/.github/README_CI.md
@@ -1,5 +1,11 @@
 # CI Tips and Tricks
 
+## Rotating signing secrets
+
+- Apple: see [../swift/apple/README.md](../swift/apple/README.md)
+- Android: see [../kotlin/android/README.md](../kotlin/android/README.md)
+- Windows: see [../rust/gui-client/README.md](../rust/gui-client/README.md)
+
 ## Batch-deleting workflow runs
 
 Manually disable the workflows to be cleaned up, then run this:

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -65,7 +65,7 @@ To do so, login to [the Azure portal](https://portal.azure.com) using your `@fir
 
 Then,
 
-- Go to the `Entra ID` service
+- Go to the `Microsoft Entra ID` service
 - Find and navigate to the `CodeSigning` app registration
 - Client on `client credentials`
 - Click `New client secret`

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -66,6 +66,8 @@ To do so, login to [the Azure portal](https://portal.azure.com) using your `@fir
 Then,
 
 - Go to the `Microsoft Entra ID` service
+- Click on `App Registrations`
+- Make sure the tab `All applications` is selected
 - Find and navigate to the `CodeSigning` app registration
 - Client on `client credentials`
 - Click `New client secret`

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -61,7 +61,7 @@ Renewing / issuing a new code signing certificate and associated Azure entities 
 
 Instead, you'll most likely simply need to rotate the Azure `CodeSigning` Application's client secret.
 
-To do so, login to the Azure portal using your `@firezoneprod.onmicrosoft.com` account.
+To do so, login to [the Azure portal](https://portal.azure.com) using your `@firezoneprod.onmicrosoft.com` account.
 
 Then,
 

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -65,7 +65,8 @@ To do so, login to [the Azure portal](https://portal.azure.com) using your `@fir
 
 Then,
 
-- Find and navigate to the `CodeSigning` app registration.
+- Go to the `Entra ID` service
+- Find and navigate to the `CodeSigning` app registration
 - Client on `client credentials`
 - Click `New client secret`
 - Note down the secret value. This should be entered into the GitHub repository's secrets as `AZURE_CLIENT_SECRET`.

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -62,8 +62,10 @@ Renewing / issuing a new code signing certificate and associated Azure entities 
 Instead, you'll most likely simply need to rotate the Azure `CodeSigning` Application's client secret.
 
 To do so, login to [the Azure portal](https://portal.azure.com) using your `@firezoneprod.onmicrosoft.com` account.
+Try to access it via the following [deep-link](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/51da0daa-39dd-4890-9018-e02609efc9c8).
+If that doesn't work:
 
-Then,
+
 
 - Go to the `Microsoft Entra ID` service
 - Click on `App Registrations`

--- a/rust/gui-client/README.md
+++ b/rust/gui-client/README.md
@@ -49,6 +49,27 @@ stat ../target/release/Firezone.exe
 stat ../target/release/bundle/msi/Firezone_0.0.0_x64_en-US.msi
 ```
 
+## Signing the Windows MSI in GitHub CI
+
+The MSI is signed in GitHub CI using the `firezone/firezone` repository's
+secrets. This was originally set up using these guides for inspiration:
+
+- https://melatonin.dev/blog/how-to-code-sign-windows-installers-with-an-ev-cert-on-github-actions/
+- https://support.globalsign.com/code-signing/code-signing-using-azure-key-vault
+
+Renewing / issuing a new code signing certificate and associated Azure entities is outside the scope of this section. Use the guides above if this needs to be done.
+
+Instead, you'll most likely simply need to rotate the Azure `CodeSigning` Application's client secret.
+
+To do so, login to the Azure portal using your `@firezoneprod.onmicrosoft.com` account.
+
+Then,
+
+- Find and navigate to the `CodeSigning` app registration.
+- Client on `client credentials`
+- Click `New client secret`
+- Note down the secret value. This should be entered into the GitHub repository's secrets as `AZURE_CLIENT_SECRET`.
+
 ## Running
 
 From this dir:


### PR DESCRIPTION
Moved the code signing to our US-based Azure account (firezoneprod.onmicrosoft.com)