### PR TITLE
chore(rust): bump `secrecy`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1330,6 +1330,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -5540,6 +5541,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -6441,11 +6443,10 @@ checksum = "4646d6f919800cd25c50edb49438a1381e2cd4833c027e75e8897981c50b8b5e"
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "ba079fa568d52545cd70b334b2ce6f88f62b8fc2bda9290f48a0578388a49331"
 dependencies = [
- "bytes",
  "serde",
  "zeroize",
 ]
@@ -6906,6 +6907,7 @@ dependencies = [
  "stun_codec",
  "thiserror",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,7 +34,7 @@ backoff = { version = "0.4", features = ["tokio"] }
 tracing = { version = "0.1.40" }
 tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" } # Contains `dbg!` but for `tracing`.
 tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
-secrecy = "0.8"
+secrecy = "0.10.2"
 str0m = { version = "0.6.2", default-features = false }
 futures-bounded = "0.2.1"
 domain = { version = "0.10", features = ["serde"] }

--- a/rust/connlib/shared/Cargo.toml
+++ b/rust/connlib/shared/Cargo.toml
@@ -21,7 +21,7 @@ os_info = { version = "3", default-features = false }
 phoenix-channel = { workspace = true }
 rand = { version = "0.8", default-features = false, features = ["std"] }
 rand_core = { version = "0.6.4", default-features = false, features = ["std"] }
-secrecy = { workspace = true, features = ["serde", "bytes"] }
+secrecy = { workspace = true, features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 thiserror = { version = "1.0", default-features = false }
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
 url = { version = "2.5.2", default-features = false }
 uuid = { version = "1.10", default-features = false, features = ["std", "v4", "serde"] }
+zeroize = "1.8.1"
 
 [dev-dependencies]
 tokio = { version = "1.39", features = ["macros", "rt"] }

--- a/rust/connlib/shared/src/messages/key.rs
+++ b/rust/connlib/shared/src/messages/key.rs
@@ -1,7 +1,8 @@
 use base64::{display::Base64Display, engine::general_purpose::STANDARD, Engine};
 use boringtun::x25519::PublicKey;
-use secrecy::{CloneableSecret, DebugSecret, Secret, SerializableSecret, Zeroize};
+use secrecy::{CloneableSecret, SecretBox, SerializableSecret};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::Zeroize;
 
 use std::{fmt, str::FromStr};
 
@@ -16,8 +17,6 @@ const KEY_SIZE: usize = 32;
 /// into an encoded string.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Key(pub [u8; KEY_SIZE]);
-
-impl DebugSecret for Key {}
 
 impl FromStr for Key {
     type Err = base64::DecodeError;
@@ -83,7 +82,7 @@ impl Serialize for Key {
 impl CloneableSecret for Key {}
 impl SerializableSecret for Key {}
 
-pub type SecretKey = Secret<Key>;
+pub type SecretKey = SecretBox<Key>;
 
 #[cfg(test)]
 mod test {

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -19,6 +19,7 @@ str0m = { workspace = true }
 stun_codec = "0.3.4"
 thiserror = "1"
 tracing = { workspace = true }
+zeroize = "1.8.1"
 
 [dev-dependencies]
 firezone-logging = { workspace = true }

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -22,6 +22,7 @@ tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 tracing = { workspace = true }
 url = "2.5.2"
 uuid = { version = "1.10", default-features = false, features = ["std", "v4"] }
+zeroize = "1.8.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 hostname = "0.4.0"

--- a/rust/phoenix-channel/src/login_url.rs
+++ b/rust/phoenix-channel/src/login_url.rs
@@ -1,9 +1,10 @@
 use base64::{engine::general_purpose::STANDARD, Engine};
-use secrecy::{CloneableSecret, ExposeSecret as _, SecretString, Zeroize};
+use secrecy::{CloneableSecret, ExposeSecret as _, SecretString};
 use sha2::Digest as _;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use url::Url;
 use uuid::Uuid;
+use zeroize::Zeroize;
 
 // From https://man7.org/linux/man-pages/man2/gethostname.2.html
 // SUSv2 guarantees that "Host names are limited to 255 bytes".


### PR DESCRIPTION
Closes #6842 (when finished)

`secrecy` 0.10 has big breaking changes from `0.8`, so this will be tricky.