### PR TITLE
chore(ci): remove unused env var

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -20,7 +20,6 @@ defaults:
 env:
   RUSTFLAGS: "-Dwarnings"
   RUSTDOCFLAGS: "-D warnings"
-  SENTRY_ENVIRONMENT: "production"
 
 jobs:
   build-gui:


### PR DESCRIPTION
`SENTRY_ENVIRONMENT` is only read at run time, not at build time, and we override the environment in our code anyway, so this env var was doing nothing.