### PR TITLE
docs(rust/gui-client/linux): clarify supported Ubuntu versions

### DIFF
--- a/website/src/app/kb/client-apps/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/client-apps/linux-gui-client/readme.mdx
@@ -14,9 +14,9 @@ present to authenticate with your identity provider interactively.
 
 ## Prerequisites
 
-- Ubuntu **20.04** or **22.04**. Other distributions may work, but are not
-  officially supported.
 - **x86-64** or **ARM64** CPU architecture
+- Ubuntu **20.04** or **22.04**. (For ARM64, only 22.04) Other distributions may work, but are not
+  officially supported.
 - **systemd-resolved**. Ubuntu already uses this by default.
 
 ## Installation

--- a/website/src/app/kb/client-apps/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/client-apps/linux-gui-client/readme.mdx
@@ -15,8 +15,8 @@ present to authenticate with your identity provider interactively.
 ## Prerequisites
 
 - **x86-64** or **ARM64** CPU architecture
-- Ubuntu **20.04** or **22.04**. (For ARM64, only 22.04) Other distributions may work, but are not
-  officially supported.
+- Ubuntu **20.04** or **22.04**. (For ARM64, only 22.04) Other distributions may
+  work, but are not officially supported.
 - **systemd-resolved**. Ubuntu already uses this by default.
 
 ## Installation


### PR DESCRIPTION
Ubuntu 20.04 ARM doesn't work because we're building on 22.04 in CI against a newer glibc