### PR TITLE
feat(connlib): implement TRACE logging for DNS

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -147,7 +147,7 @@ fn parse_dns_response(packet: &IpPacket) -> Option<(Rtype, ParsedName<&[u8]>, St
 
             Some(data)
         })
-        .join(",");
+        .join(" | ");
     let id = message.header().id();
 
     Some((qtype, qname, records, rcode, id))

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -1,6 +1,11 @@
+use domain::base::iana::Rcode;
+use domain::base::{Message, ParsedName, Rtype};
+use domain::rdata::AllRecordData;
 use ip_packet::{IpPacket, IpPacketBuf};
+use itertools::Itertools;
 use std::io;
 use std::task::{Context, Poll, Waker};
+use tracing::Level;
 use tun::Tun;
 
 pub struct Device {
@@ -49,12 +54,24 @@ impl Device {
             )
         })?;
 
+        if tracing::event_enabled!(target: "wire::dns::qry", Level::TRACE) {
+            if let Some((qtype, qname, qid)) = parse_dns_query(&packet) {
+                tracing::trace!(target: "wire::dns::qry", %qid, "{:5} {qname}", qtype.to_string());
+            }
+        }
+
         tracing::trace!(target: "wire::dev::recv", dst = %packet.destination(), src = %packet.source(), bytes = %packet.packet().len());
 
         Poll::Ready(Ok(packet))
     }
 
     pub fn write(&self, packet: IpPacket) -> io::Result<usize> {
+        if tracing::event_enabled!(target: "wire::dns::res", Level::TRACE) {
+            if let Some((qtype, qname, records, rcode, qid)) = parse_dns_response(&packet) {
+                tracing::trace!(target: "wire::dns::res", %qid, %rcode, "{:5} {qname} => [{records}]", qtype.to_string());
+            }
+        }
+
         tracing::trace!(target: "wire::dev::send", dst = %packet.destination(), src = %packet.source(), bytes = %packet.packet().len());
 
         match packet {
@@ -74,4 +91,64 @@ impl Device {
 
 fn io_error_not_initialized() -> io::Error {
     io::Error::new(io::ErrorKind::NotConnected, "device is not initialized yet")
+}
+
+fn parse_dns_query(packet: &IpPacket) -> Option<(Rtype, ParsedName<&[u8]>, u16)> {
+    let udp = packet.as_udp()?;
+    if udp.destination_port() != crate::dns::DNS_PORT {
+        return None;
+    }
+
+    let message = &Message::from_slice(udp.payload()).ok()?;
+
+    if message.header().qr() {
+        return None;
+    }
+
+    let question = message.sole_question().ok()?;
+
+    let qtype = question.qtype();
+    let qname = question.into_qname();
+    let id = message.header().id();
+
+    Some((qtype, qname, id))
+}
+
+#[expect(clippy::type_complexity)]
+fn parse_dns_response(packet: &IpPacket) -> Option<(Rtype, ParsedName<&[u8]>, String, Rcode, u16)> {
+    let udp = packet.as_udp()?;
+    if udp.source_port() != crate::dns::DNS_PORT {
+        return None;
+    }
+
+    let message = &Message::from_slice(udp.payload()).ok()?;
+
+    if !message.header().qr() {
+        return None;
+    }
+
+    let question = message.sole_question().ok()?;
+
+    let qtype = question.qtype();
+    let qname = question.into_qname();
+    let rcode = message.header().rcode();
+
+    let record_section = message.answer().ok()?;
+
+    let records = record_section
+        .into_iter()
+        .filter_map(|r| {
+            let data = r
+                .ok()?
+                .into_any_record::<AllRecordData<_, _>>()
+                .ok()?
+                .data()
+                .clone();
+
+            Some(data)
+        })
+        .join(",");
+    let id = message.header().id();
+
+    Some((qtype, qname, records, rcode, id))
 }

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -19,7 +19,7 @@ const DNS_TTL: u32 = 1;
 const REVERSE_DNS_ADDRESS_END: &str = "arpa";
 const REVERSE_DNS_ADDRESS_V4: &str = "in-addr";
 const REVERSE_DNS_ADDRESS_V6: &str = "ip6";
-const DNS_PORT: u16 = 53;
+pub(crate) const DNS_PORT: u16 = 53;
 
 /// The DNS over HTTPS canary domain used by Firefox to check whether DoH can be enabled by default.
 ///

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -733,7 +733,7 @@ impl IpPacket {
         }
     }
 
-    fn is_udp(&self) -> bool {
+    pub fn is_udp(&self) -> bool {
         self.next_header() == IpNumber::UDP
     }
 


### PR DESCRIPTION
When debugging DNS-related issues, it is useful to see all DNS queries that go into `connlib` and the responses that we generate. Analogous to the `wire::net` and `wire::dev` TRACE logs, we introduce `wire::dns` which logs incoming queries and the responses on TRACE. The output looks like this:

```
2024-10-02T00:16:47.522847Z TRACE wire::dns::qry: A     caldav.fastmail.com qid=55845
2024-10-02T00:16:47.522926Z TRACE wire::dns::qry: AAAA  caldav.fastmail.com qid=56277
2024-10-02T00:16:47.531347Z TRACE wire::dns::res: AAAA  caldav.fastmail.com => [] qid=56277 rcode=NOERROR
2024-10-02T00:16:47.538984Z TRACE wire::dns::res: A     caldav.fastmail.com => [103.168.172.46 | 103.168.172.61] qid=55845 rcode=NOERROR
2024-10-02T00:16:47.580237Z TRACE wire::dns::qry: HTTPS cloudflare-dns.com qid=21518
2024-10-02T00:16:47.580338Z TRACE wire::dns::qry: A     example.org qid=35459
2024-10-02T00:16:47.580364Z TRACE wire::dns::qry: AAAA  example.org qid=60073
2024-10-02T00:16:47.580699Z TRACE wire::dns::qry: AAAA  ipv4only.arpa qid=17280
2024-10-02T00:16:47.580782Z TRACE wire::dns::qry: A     ipv4only.arpa qid=47215
2024-10-02T00:16:47.581134Z TRACE wire::dns::qry: A     detectportal.firefox.com qid=34970
2024-10-02T00:16:47.581261Z TRACE wire::dns::qry: AAAA  detectportal.firefox.com qid=39505
2024-10-02T00:16:47.609502Z TRACE wire::dns::res: AAAA  example.org => [2606:2800:21f:cb07:6820:80da:af6b:8b2c] qid=60073 rcode=NOERROR
2024-10-02T00:16:47.609640Z TRACE wire::dns::res: AAAA  ipv4only.arpa => [] qid=17280 rcode=NOERROR
2024-10-02T00:16:47.610407Z TRACE wire::dns::res: A     ipv4only.arpa => [192.0.0.170 | 192.0.0.171] qid=47215 rcode=NOERROR
2024-10-02T00:16:47.617952Z TRACE wire::dns::res: HTTPS cloudflare-dns.com => [1  alpn=h3,h2 ipv4hint=104.16.248.249,104.16.249.249 ipv6hint=2606:4700::6810:f8f9,2606:4700::6810:f9f9] qid=21518 rcode=NOERROR
2024-10-02T00:16:47.631124Z TRACE wire::dns::res: A     example.org => [93.184.215.14] qid=35459 rcode=NOERROR
2024-10-02T00:16:47.640286Z TRACE wire::dns::res: AAAA  detectportal.firefox.com => [detectportal.prod.mozaws.net. | prod.detectportal.prod.cloudops.mozgcp.net. | 2600:1901:0:38d7::] qid=39505 rcode=NOERROR
2024-10-02T00:16:47.641332Z TRACE wire::dns::res: A     detectportal.firefox.com => [detectportal.prod.mozaws.net. | prod.detectportal.prod.cloudops.mozgcp.net. | 34.107.221.82] qid=34970 rcode=NOERROR
2024-10-02T00:16:48.737608Z TRACE wire::dns::qry: AAAA  myfiles.fastmail.com qid=52965
2024-10-02T00:16:48.737710Z TRACE wire::dns::qry: A     myfiles.fastmail.com qid=5114
2024-10-02T00:16:48.745282Z TRACE wire::dns::res: AAAA  myfiles.fastmail.com => [] qid=52965 rcode=NOERROR
2024-10-02T00:16:49.027932Z TRACE wire::dns::res: A     myfiles.fastmail.com => [103.168.172.46 | 103.168.172.61] qid=5114 rcode=NOERROR
2024-10-02T00:16:49.190054Z TRACE wire::dns::qry: HTTPS github.com qid=64696
2024-10-02T00:16:49.190171Z TRACE wire::dns::qry: A     github.com qid=11912
2024-10-02T00:16:49.190502Z TRACE wire::dns::res: A     github.com => [100.96.0.1 | 100.96.0.2 | 100.96.0.3 | 100.96.0.4] qid=11912 rcode=NOERROR
2024-10-02T00:16:49.190619Z TRACE wire::dns::qry: A     github.com qid=63366
2024-10-02T00:16:49.190730Z TRACE wire::dns::res: A     github.com => [100.96.0.1 | 100.96.0.2 | 100.96.0.3 | 100.96.0.4] qid=63366 rcode=NOERROR
```

As with the other filters, seeing both queries and responses can be achieved with `RUST_LOG=wire::dns=trace`. If you are only interested in the responses, you can activate a more specific log filter using `RUST_LOG=wire::dns::res=trace`. All responses also print the original query that they are answering.

Resolves: #6862.