### PR TITLE
ci(rust): increase number of proptest runs

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -116,7 +116,7 @@ jobs:
           # Needed to create tunnel interfaces in unit tests
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
-          PROPTEST_CASES: 1000 # Default is only 256.
+          PROPTEST_CASES: 2000 # Default is only 256.
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
           TESTCASES_DIR: "connlib/tunnel/testcases"
 


### PR DESCRIPTION
Our tests are pretty fast now, meaning we can afford running more permutations. This makes it less likely to encounter flakes in the "coverage" tests where we grep for certain log lines to ensure that the tests hit certain code paths.