### PR TITLE
fix(connlib): reintroduce device-ID hashing

### DIFF
--- a/rust/phoenix-channel/src/login_url.rs
+++ b/rust/phoenix-channel/src/login_url.rs
@@ -55,6 +55,7 @@ impl LoginUrl {
         public_key: [u8; 32],
         device_info: DeviceInfo,
     ) -> Result<Self, LoginUrlError<E>> {
+        let external_id = hex::encode(sha2::Sha256::digest(device_id));
         let device_name = device_name
             .or(get_host_name())
             .unwrap_or_else(|| Uuid::new_v4().to_string());
@@ -64,7 +65,7 @@ impl LoginUrl {
             firezone_token,
             "client",
             Some(public_key),
-            Some(device_id),
+            Some(external_id),
             Some(device_name),
             None,
             None,


### PR DESCRIPTION
As part of iterating on the correct approach in #6857, we at some point removed the hashing of the Firezone-generated device ID. This will break customers because all of the device IDs as seen by the portal are changing.

We've since settled on a different approach for device verification. To not break anyone, we are re-introducing hashing of the device ID.

Related: #6857.