### PR TITLE
refactor(connlib): introduce dedicated `Resource` model

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2470,7 +2470,6 @@ dependencies = [
  "ip_network_table",
  "itertools 0.13.0",
  "lru",
- "phoenix-channel",
  "proptest",
  "proptest-state-machine",
  "rand 0.8.5",

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -41,7 +41,6 @@ uuid = { version = "1.10", default-features = false, features = ["std", "v4"] }
 derivative = "2.2.0"
 firezone-relay = { workspace = true, features = ["proptest"] }
 ip-packet = { workspace = true, features = ["proptest"] }
-phoenix-channel = { workspace = true }
 proptest-state-machine = "0.3"
 rand = "0.8"
 serde_json = "1.0"

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -81,7 +81,7 @@ impl ClientTunnel {
         self.role_state.set_resources(
             resources
                 .into_iter()
-                .map(Resource::from_description)
+                .filter_map(Resource::from_description)
                 .collect(),
         );
 
@@ -108,8 +108,11 @@ impl ClientTunnel {
 
     /// Adds a the given resource to the tunnel.
     pub fn add_resource(&mut self, resource: ResourceDescription) {
-        self.role_state
-            .add_resource(Resource::from_description(resource));
+        let Some(resource) = Resource::from_description(resource) else {
+            return;
+        };
+
+        self.role_state.add_resource(resource);
 
         self.role_state
             .buffered_events

--- a/rust/connlib/tunnel/src/client/resource.rs
+++ b/rust/connlib/tunnel/src/client/resource.rs
@@ -66,13 +66,14 @@ pub struct InternetResource {
 }
 
 impl Resource {
-    pub fn from_description(resource: ResourceDescription) -> Self {
+    pub fn from_description(resource: ResourceDescription) -> Option<Self> {
         match resource {
-            ResourceDescription::Dns(i) => Resource::Dns(DnsResource::from_description(i)),
-            ResourceDescription::Cidr(i) => Resource::Cidr(CidrResource::from_description(i)),
+            ResourceDescription::Dns(i) => Some(Resource::Dns(DnsResource::from_description(i))),
+            ResourceDescription::Cidr(i) => Some(Resource::Cidr(CidrResource::from_description(i))),
             ResourceDescription::Internet(i) => {
-                Resource::Internet(InternetResource::from_description(i))
+                Some(Resource::Internet(InternetResource::from_description(i)))
             }
+            ResourceDescription::Unknown => None,
         }
     }
 

--- a/rust/connlib/tunnel/src/client/resource.rs
+++ b/rust/connlib/tunnel/src/client/resource.rs
@@ -1,0 +1,205 @@
+//! Internal model of resources as used by connlib's client code.
+
+use std::collections::BTreeSet;
+
+use connlib_model::{
+    CidrResourceView, DnsResourceView, InternetResourceView, ResourceId, ResourceStatus,
+    ResourceView, Site,
+};
+use ip_network::IpNetwork;
+use itertools::Itertools as _;
+
+use crate::messages::client::{
+    ResourceDescription, ResourceDescriptionCidr, ResourceDescriptionDns,
+    ResourceDescriptionInternet,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Resource {
+    Dns(DnsResource),
+    Cidr(CidrResource),
+    Internet(InternetResource),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DnsResource {
+    /// Resource's id.
+    pub id: ResourceId,
+    /// Internal resource's domain name.
+    pub address: String,
+    /// Name of the resource.
+    ///
+    /// Used only for display.
+    pub name: String,
+
+    pub address_description: Option<String>,
+    pub sites: Vec<Site>,
+}
+
+/// Description of a resource that maps to a CIDR.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CidrResource {
+    /// Resource's id.
+    pub id: ResourceId,
+    /// CIDR that this resource points to.
+    pub address: IpNetwork,
+    /// Name of the resource.
+    ///
+    /// Used only for display.
+    pub name: String,
+
+    pub address_description: Option<String>,
+    pub sites: Vec<Site>,
+}
+
+/// Description of an internet resource.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct InternetResource {
+    /// Name of the resource.
+    ///
+    /// Used only for display.
+    pub name: String,
+    /// Resource's id.
+    pub id: ResourceId,
+    /// Sites for the internet resource
+    pub sites: Vec<Site>,
+}
+
+impl Resource {
+    pub fn from_description(resource: ResourceDescription) -> Self {
+        match resource {
+            ResourceDescription::Dns(i) => Resource::Dns(DnsResource::from_description(i)),
+            ResourceDescription::Cidr(i) => Resource::Cidr(CidrResource::from_description(i)),
+            ResourceDescription::Internet(i) => {
+                Resource::Internet(InternetResource::from_description(i))
+            }
+        }
+    }
+
+    #[cfg(all(feature = "proptest", test))]
+    pub fn into_dns(self) -> Option<DnsResource> {
+        match self {
+            Resource::Dns(d) => Some(d),
+            Resource::Cidr(_) | Resource::Internet(_) => None,
+        }
+    }
+
+    pub fn address_string(&self) -> Option<String> {
+        match self {
+            Resource::Dns(d) => Some(d.address.clone()),
+            Resource::Cidr(c) => Some(c.address.to_string()),
+            Resource::Internet(_) => None,
+        }
+    }
+
+    pub fn sites_string(&self) -> String {
+        self.sites().iter().map(|s| &s.name).join("|")
+    }
+
+    pub fn id(&self) -> ResourceId {
+        match self {
+            Resource::Dns(r) => r.id,
+            Resource::Cidr(r) => r.id,
+            Resource::Internet(r) => r.id,
+        }
+    }
+
+    pub fn sites(&self) -> BTreeSet<&Site> {
+        match self {
+            Resource::Dns(r) => BTreeSet::from_iter(r.sites.iter()),
+            Resource::Cidr(r) => BTreeSet::from_iter(r.sites.iter()),
+            Resource::Internet(r) => BTreeSet::from_iter(r.sites.iter()),
+        }
+    }
+
+    /// What the GUI clients should show as the user-friendly display name, e.g. `Firezone GitHub`
+    pub fn name(&self) -> &str {
+        match self {
+            Resource::Dns(r) => &r.name,
+            Resource::Cidr(r) => &r.name,
+            Resource::Internet(_) => "Internet",
+        }
+    }
+
+    pub fn has_different_address(&self, other: &Resource) -> bool {
+        match (self, other) {
+            (Resource::Dns(dns_a), Resource::Dns(dns_b)) => dns_a.address != dns_b.address,
+            (Resource::Cidr(cidr_a), Resource::Cidr(cidr_b)) => cidr_a.address != cidr_b.address,
+            (Resource::Internet(_), Resource::Internet(_)) => false,
+            _ => true,
+        }
+    }
+
+    pub fn with_status(self, status: ResourceStatus) -> ResourceView {
+        match self {
+            Resource::Dns(r) => ResourceView::Dns(r.with_status(status)),
+            Resource::Cidr(r) => ResourceView::Cidr(r.with_status(status)),
+            Resource::Internet(r) => ResourceView::Internet(r.with_status(status)),
+        }
+    }
+}
+
+impl CidrResource {
+    pub fn from_description(resource: ResourceDescriptionCidr) -> Self {
+        Self {
+            id: resource.id,
+            address: resource.address,
+            name: resource.name,
+            address_description: resource.address_description,
+            sites: resource.sites,
+        }
+    }
+
+    pub fn with_status(self, status: ResourceStatus) -> CidrResourceView {
+        CidrResourceView {
+            id: self.id,
+            address: self.address,
+            name: self.name,
+            address_description: self.address_description,
+            sites: self.sites,
+            status,
+        }
+    }
+}
+
+impl InternetResource {
+    pub fn from_description(resource: ResourceDescriptionInternet) -> Self {
+        Self {
+            name: resource.name,
+            id: resource.id,
+            sites: resource.sites,
+        }
+    }
+
+    pub fn with_status(self, status: ResourceStatus) -> InternetResourceView {
+        InternetResourceView {
+            name: self.name,
+            id: self.id,
+            sites: self.sites,
+            status,
+        }
+    }
+}
+
+impl DnsResource {
+    pub fn from_description(resource: ResourceDescriptionDns) -> Self {
+        Self {
+            id: resource.id,
+            address: resource.address,
+            name: resource.name,
+            address_description: resource.address_description,
+            sites: resource.sites,
+        }
+    }
+
+    pub fn with_status(self, status: ResourceStatus) -> DnsResourceView {
+        DnsResourceView {
+            id: self.id,
+            address: self.address,
+            name: self.name,
+            address_description: self.address_description,
+            sites: self.sites,
+            status,
+        }
+    }
+}

--- a/rust/connlib/tunnel/src/messages/client.rs
+++ b/rust/connlib/tunnel/src/messages/client.rs
@@ -67,6 +67,8 @@ pub enum ResourceDescription {
     Dns(ResourceDescriptionDns),
     Cidr(ResourceDescriptionCidr),
     Internet(ResourceDescriptionInternet),
+    #[serde(other)]
+    Unknown, // Important for forwards-compatibility with future resource types.
 }
 
 #[derive(Debug, Deserialize)]
@@ -192,6 +194,43 @@ mod tests {
                 "some_other": [
                     "field"
                 ]
+            }
+        ]"#;
+
+        serde_json::from_str::<Vec<ResourceDescription>>(resources).unwrap();
+    }
+
+    #[test]
+    fn can_deserialize_unknown_resource() {
+        let resources = r#"[
+            {
+                "id": "73037362-715d-4a83-a749-f18eadd970e6",
+                "type": "cidr",
+                "name": "172.172.0.0/16",
+                "address": "172.172.0.0/16",
+                "address_description": "cidr resource",
+                "gateway_groups": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}]
+            },
+            {
+                "id": "03000143-e25e-45c7-aafb-144990e57dcd",
+                "type": "dns",
+                "name": "gitlab.mycorp.com",
+                "address": "gitlab.mycorp.com",
+                "address_description": "dns resource",
+                "gateway_groups": [{"name": "test", "id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"}]
+            },
+            {
+                "id": "1106047c-cd5d-4151-b679-96b93da7383b",
+                "type": "internet",
+                "name": "Internet Resource",
+                "gateway_groups": [{"name": "test", "id": "eb94482a-94f4-47cb-8127-14fb3afa5516"}],
+                "not": "relevant",
+                "some_other": [
+                    "field"
+                ]
+            },
+            {
+                "type": "what_is_this",
             }
         ]"#;
 

--- a/rust/connlib/tunnel/src/messages/client.rs
+++ b/rust/connlib/tunnel/src/messages/client.rs
@@ -3,12 +3,8 @@
 use crate::messages::{
     GatewayResponse, Interface, Key, Relay, RelaysPresence, RequestConnection, ReuseConnection,
 };
-use connlib_model::{
-    CidrResourceView, DnsResourceView, GatewayId, InternetResourceView, ResourceId, ResourceStatus,
-    ResourceView, Site, SiteId,
-};
+use connlib_model::{GatewayId, ResourceId, Site, SiteId};
 use ip_network::IpNetwork;
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, net::IpAddr};
 
@@ -29,19 +25,6 @@ pub struct ResourceDescriptionDns {
     pub sites: Vec<Site>,
 }
 
-impl ResourceDescriptionDns {
-    pub fn with_status(self, status: ResourceStatus) -> DnsResourceView {
-        DnsResourceView {
-            id: self.id,
-            address: self.address,
-            name: self.name,
-            address_description: self.address_description,
-            sites: self.sites,
-            status,
-        }
-    }
-}
-
 /// Description of a resource that maps to a CIDR.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ResourceDescriptionCidr {
@@ -57,19 +40,6 @@ pub struct ResourceDescriptionCidr {
     pub address_description: Option<String>,
     #[serde(rename = "gateway_groups")]
     pub sites: Vec<Site>,
-}
-
-impl ResourceDescriptionCidr {
-    pub fn with_status(self, status: ResourceStatus) -> CidrResourceView {
-        CidrResourceView {
-            id: self.id,
-            address: self.address,
-            name: self.name,
-            address_description: self.address_description,
-            sites: self.sites,
-            status,
-        }
-    }
 }
 
 fn internet_resource_name() -> String {
@@ -91,107 +61,12 @@ pub struct ResourceDescriptionInternet {
     pub sites: Vec<Site>,
 }
 
-impl ResourceDescriptionInternet {
-    pub fn with_status(self, status: ResourceStatus) -> InternetResourceView {
-        InternetResourceView {
-            name: self.name,
-            id: self.id,
-            sites: self.sites,
-            status,
-        }
-    }
-}
-
-impl ResourceDescription {
-    pub fn address_string(&self) -> Option<String> {
-        match self {
-            ResourceDescription::Dns(d) => Some(d.address.clone()),
-            ResourceDescription::Cidr(c) => Some(c.address.to_string()),
-            ResourceDescription::Internet(_) => None,
-        }
-    }
-
-    pub fn sites_string(&self) -> String {
-        self.sites().iter().map(|s| &s.name).join("|")
-    }
-
-    pub fn id(&self) -> ResourceId {
-        match self {
-            ResourceDescription::Dns(r) => r.id,
-            ResourceDescription::Cidr(r) => r.id,
-            ResourceDescription::Internet(r) => r.id,
-        }
-    }
-
-    pub fn sites(&self) -> BTreeSet<&Site> {
-        match self {
-            ResourceDescription::Dns(r) => BTreeSet::from_iter(r.sites.iter()),
-            ResourceDescription::Cidr(r) => BTreeSet::from_iter(r.sites.iter()),
-            ResourceDescription::Internet(r) => BTreeSet::from_iter(r.sites.iter()),
-        }
-    }
-
-    pub fn sites_mut(&mut self) -> &mut Vec<Site> {
-        match self {
-            ResourceDescription::Dns(r) => &mut r.sites,
-            ResourceDescription::Cidr(r) => &mut r.sites,
-            ResourceDescription::Internet(r) => &mut r.sites,
-        }
-    }
-
-    /// What the GUI clients should show as the user-friendly display name, e.g. `Firezone GitHub`
-    pub fn name(&self) -> &str {
-        match self {
-            ResourceDescription::Dns(r) => &r.name,
-            ResourceDescription::Cidr(r) => &r.name,
-            ResourceDescription::Internet(_) => "Internet",
-        }
-    }
-
-    pub fn has_different_address(&self, other: &ResourceDescription) -> bool {
-        match (self, other) {
-            (ResourceDescription::Dns(dns_a), ResourceDescription::Dns(dns_b)) => {
-                dns_a.address != dns_b.address
-            }
-            (ResourceDescription::Cidr(cidr_a), ResourceDescription::Cidr(cidr_b)) => {
-                cidr_a.address != cidr_b.address
-            }
-            (ResourceDescription::Internet(_), ResourceDescription::Internet(_)) => false,
-            _ => true,
-        }
-    }
-
-    pub fn with_status(self, status: ResourceStatus) -> ResourceView {
-        match self {
-            ResourceDescription::Dns(r) => ResourceView::Dns(r.with_status(status)),
-            ResourceDescription::Cidr(r) => ResourceView::Cidr(r.with_status(status)),
-            ResourceDescription::Internet(r) => ResourceView::Internet(r.with_status(status)),
-        }
-    }
-}
-
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResourceDescription {
     Dns(ResourceDescriptionDns),
     Cidr(ResourceDescriptionCidr),
     Internet(ResourceDescriptionInternet),
-}
-
-impl ResourceDescription {
-    pub fn into_dns(self) -> Option<ResourceDescriptionDns> {
-        match self {
-            ResourceDescription::Dns(d) => Some(d),
-            ResourceDescription::Cidr(_) | ResourceDescription::Internet(_) => None,
-        }
-    }
-
-    pub fn into_cidr(self) -> Option<ResourceDescriptionCidr> {
-        match self {
-            ResourceDescription::Cidr(c) => Some(c),
-            ResourceDescription::Dns(_) | ResourceDescription::Internet(_) => None,
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Clone)]

--- a/rust/connlib/tunnel/src/messages/client.rs
+++ b/rust/connlib/tunnel/src/messages/client.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, net::IpAddr};
 
 /// Description of a resource that maps to a DNS record.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Deserialize)]
 pub struct ResourceDescriptionDns {
     /// Resource's id.
     pub id: ResourceId,
@@ -26,7 +26,7 @@ pub struct ResourceDescriptionDns {
 }
 
 /// Description of a resource that maps to a CIDR.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Deserialize)]
 pub struct ResourceDescriptionCidr {
     /// Resource's id.
     pub id: ResourceId,
@@ -47,7 +47,7 @@ fn internet_resource_name() -> String {
 }
 
 /// Description of an internet resource.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Deserialize)]
 pub struct ResourceDescriptionInternet {
     /// Name of the resource.
     ///
@@ -61,7 +61,7 @@ pub struct ResourceDescriptionInternet {
     pub sites: Vec<Site>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResourceDescription {
     Dns(ResourceDescriptionDns),
@@ -69,7 +69,7 @@ pub enum ResourceDescription {
     Internet(ResourceDescriptionInternet),
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
+#[derive(Debug, Deserialize)]
 pub struct InitClient {
     pub interface: Interface,
     #[serde(default)]
@@ -78,12 +78,12 @@ pub struct InitClient {
     pub relays: Vec<Relay>,
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
+#[derive(Debug, Deserialize)]
 pub struct ConfigUpdate {
     pub interface: Interface,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize)]
 pub struct ConnectionDetails {
     pub resource_id: ResourceId,
     pub gateway_id: GatewayId,
@@ -92,7 +92,7 @@ pub struct ConnectionDetails {
     pub site_id: SiteId,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize)]
 pub struct Connect {
     pub gateway_payload: GatewayResponse,
     pub resource_id: ResourceId,
@@ -102,7 +102,7 @@ pub struct Connect {
 
 // These messages are the messages that can be received
 // by a client.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 pub enum IngressMessages {
     Init(InitClient),
@@ -119,7 +119,7 @@ pub enum IngressMessages {
     RelaysPresence(RelaysPresence),
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize)]
 pub struct GatewaysIceCandidates {
     /// The list of gateway IDs these candidates will be broadcast to.
     pub gateway_ids: Vec<GatewayId>,
@@ -127,7 +127,7 @@ pub struct GatewaysIceCandidates {
     pub candidates: BTreeSet<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize)]
 pub struct GatewayIceCandidates {
     /// Gateway's id the ice candidates are from
     pub gateway_id: GatewayId,
@@ -136,7 +136,7 @@ pub struct GatewayIceCandidates {
 }
 
 /// The replies that can arrive from the channel by a client
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum ReplyMessages {
     ConnectionDetails(ConnectionDetails),
@@ -144,7 +144,7 @@ pub enum ReplyMessages {
 }
 
 // These messages can be sent from a client to a control pane
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 // enum_variant_names: These are the names in the portal!
 pub enum EgressMessages {

--- a/rust/connlib/tunnel/src/messages/client.rs
+++ b/rust/connlib/tunnel/src/messages/client.rs
@@ -230,7 +230,7 @@ mod tests {
                 ]
             },
             {
-                "type": "what_is_this",
+                "type": "what_is_this"
             }
         ]"#;
 
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn can_deserialize_ice_candidates_message() {
-        let json = r#"{"topic":"client","event":"ice_candidates","payload":{"gateway_ids":["b3d34a15-55ab-40df-994b-a838e75d65d7"],"candidates":["candidate:7031633958891736544 1 udp 50331391 35.244.108.190 53909 typ relay"]},"ref":6}"#;
+        let json = r#"{"topic":"client","event":"ice_candidates","payload":{"gateway_id":"b3d34a15-55ab-40df-994b-a838e75d65d7","candidates":["candidate:7031633958891736544 1 udp 50331391 35.244.108.190 53909 typ relay"]},"ref":6}"#;
 
         let message = serde_json::from_str::<IngressMessages>(json).unwrap();
 
@@ -261,32 +261,24 @@ mod tests {
     #[test]
     fn can_deserialize_connect_reply() {
         let json = r#"{
-            "ref": 0,
-            "topic": "client",
-            "event": "phx_reply",
-            "payload": {
-                "status": "ok",
-                "response": {
-                    "resource_id": "ea6570d1-47c7-49d2-9dc3-efff1c0c9e0b",
-                    "gateway_public_key": "dvy0IwyxAi+txSbAdT7WKgf7K4TekhKzrnYwt5WfbSM=",
-                    "gateway_payload": {
-                       "ConnectionAccepted":{
-                          "domain_response":{
-                             "address":[
-                                "2607:f8b0:4008:804::200e",
-                                "142.250.64.206"
-                             ],
-                             "domain":"google.com"
-                          },
-                          "ice_parameters":{
-                             "username":"tGeqOjtGuPzPpuOx",
-                             "password":"pMAxxTgHHSdpqHRzHGNvuNsZinLrMxwe"
-                          }
-                       }
-                    },
-                    "persistent_keepalive": 25
-                }
-            }
+            "resource_id": "ea6570d1-47c7-49d2-9dc3-efff1c0c9e0b",
+            "gateway_public_key": "dvy0IwyxAi+txSbAdT7WKgf7K4TekhKzrnYwt5WfbSM=",
+            "gateway_payload": {
+               "ConnectionAccepted":{
+                  "domain_response":{
+                     "address":[
+                        "2607:f8b0:4008:804::200e",
+                        "142.250.64.206"
+                     ],
+                     "domain":"google.com"
+                  },
+                  "ice_parameters":{
+                     "username":"tGeqOjtGuPzPpuOx",
+                     "password":"pMAxxTgHHSdpqHRzHGNvuNsZinLrMxwe"
+                  }
+               }
+            },
+            "persistent_keepalive": 25
         }"#;
 
         let message = serde_json::from_str::<ReplyMessages>(json).unwrap();
@@ -298,18 +290,10 @@ mod tests {
     fn can_deserialize_connection_details_reply() {
         let json = r#"
             {
-                "ref":null,
-                "topic":"client",
-                "event": "phx_reply",
-                "payload": {
-                    "response": {
-                        "resource_id": "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3",
-                        "gateway_id": "73037362-715d-4a83-a749-f18eadd970e6",
-                        "gateway_remote_ip": "172.28.0.1",
-                        "gateway_group_id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"
-                    },
-                    "status":"ok"
-                }
+                "resource_id": "f16ecfa0-a94f-4bfd-a2ef-1cc1f2ef3da3",
+                "gateway_id": "73037362-715d-4a83-a749-f18eadd970e6",
+                "gateway_remote_ip": "172.28.0.1",
+                "gateway_group_id": "bf56f32d-7b2c-4f5d-a784-788977d014a4"
             }"#;
 
         let message = serde_json::from_str::<ReplyMessages>(json).unwrap();

--- a/rust/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/connlib/tunnel/src/messages/gateway.rs
@@ -15,7 +15,7 @@ use std::{
 pub type Filters = Vec<Filter>;
 
 /// Description of a resource that maps to a DNS record.
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ResourceDescriptionDns {
     /// Resource's id.
     pub id: ResourceId,
@@ -30,7 +30,7 @@ pub struct ResourceDescriptionDns {
 }
 
 /// Description of a resource that maps to a CIDR.
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ResourceDescriptionCidr {
     /// Resource's id.
     pub id: ResourceId,
@@ -45,12 +45,12 @@ pub struct ResourceDescriptionCidr {
 }
 
 /// Description of an Internet resource.
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ResourceDescriptionInternet {
     pub id: ResourceId,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResourceDescription {
     Dns(ResourceDescriptionDns),
@@ -104,14 +104,14 @@ impl ResourceDescription {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ClientPayload {
     pub ice_parameters: Offer,
     pub domain: Option<ResolveRequest>,
 }
 
 // TODO: Should this have a resource?
-#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct InitGateway {
     pub interface: Interface,
     pub config: Config,
@@ -125,14 +125,14 @@ pub struct Config {
     pub ipv6_masquerade_enabled: bool,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Client {
     pub id: ClientId,
     pub payload: ClientPayload,
     pub peer: Peer,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct RequestConnection {
     pub resource: ResourceDescription,
     pub client: Client,
@@ -142,12 +142,12 @@ pub struct RequestConnection {
     pub expires_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RemoveResource {
     pub id: ResourceId,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct AllowAccess {
     pub client_id: ClientId,
     pub resource: ResourceDescription,
@@ -162,7 +162,7 @@ pub struct AllowAccess {
     pub client_ipv6: Ipv6Addr,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct RejectAccess {
     pub client_id: ClientId,
     pub resource_id: ResourceId,
@@ -170,7 +170,7 @@ pub struct RejectAccess {
 
 // These messages are the messages that can be received
 // either by a client or a gateway by the client.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "snake_case", tag = "event", content = "payload")]
 pub enum IngressMessages {
     RequestConnection(RequestConnection),
@@ -184,7 +184,7 @@ pub enum IngressMessages {
 }
 
 /// A client's ice candidate message.
-#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Clone)]
 pub struct ClientsIceCandidates {
     /// Client's id the ice candidates are meant for
     pub client_ids: Vec<ClientId>,
@@ -193,7 +193,7 @@ pub struct ClientsIceCandidates {
 }
 
 /// A client's ice candidate message.
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ClientIceCandidates {
     /// Client's id the ice candidates came from
     pub client_id: ClientId,

--- a/rust/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/connlib/tunnel/src/messages/gateway.rs
@@ -221,8 +221,6 @@ pub struct ConnectionReady {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::messages::Turn;
-    use phoenix_channel::PhoenixMessage;
 
     #[test]
     fn can_deserialize_udp_filter() {
@@ -317,8 +315,8 @@ mod tests {
     }
 
     #[test]
-    fn request_connection_message() {
-        let message = r#"{
+    fn can_deserialize_request_connection_messages() {
+        let json = r#"{
             "ref": null,
             "topic": "gateway",
             "event": "request_connection",
@@ -368,13 +366,15 @@ mod tests {
                 ]
             }
         }"#;
-        // TODO: We are just testing we can deserialize for now.
-        let _: PhoenixMessage<IngressMessages, ()> = serde_json::from_str(message).unwrap();
+
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
+
+        assert!(matches!(message, IngressMessages::RequestConnection(_)));
     }
 
     #[test]
-    fn request_connection_with_payload() {
-        let message = r#"{
+    fn can_deserialize_legacy_request_connection_message() {
+        let json = r#"{
   "event": "request_connection",
   "ref": null,
   "topic": "gateway",
@@ -460,223 +460,45 @@ mod tests {
     "flow_id": "b944e68a-c936-4a81-bd8d-88c45efdcb2c"
   }
 }"#;
-        let _: PhoenixMessage<IngressMessages, ()> = serde_json::from_str(message).unwrap();
+
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
+
+        assert!(matches!(message, IngressMessages::RequestConnection(_)));
     }
 
     #[test]
-    fn invalidate_ice_candidates_message() {
-        let msg = r#"{"event":"invalidate_ice_candidates","ref":null,"topic":"gateway","payload":{"candidates":["candidate:7854631899965427361 1 udp 1694498559 172.28.0.100 47717 typ srflx"],"client_id":"2b1524e6-239e-4570-bc73-70a188e12101"}}"#;
-        let expected = IngressMessages::InvalidateIceCandidates(ClientIceCandidates {
-            client_id: "2b1524e6-239e-4570-bc73-70a188e12101".parse().unwrap(),
-            candidates: vec![
-                "candidate:7854631899965427361 1 udp 1694498559 172.28.0.100 47717 typ srflx"
-                    .to_owned(),
-            ],
-        });
+    fn can_deserialize_invalidate_ice_candidates_message() {
+        let json = r#"{"event":"invalidate_ice_candidates","ref":null,"topic":"gateway","payload":{"candidates":["candidate:7854631899965427361 1 udp 1694498559 172.28.0.100 47717 typ srflx"],"client_id":"2b1524e6-239e-4570-bc73-70a188e12101"}}"#;
 
-        let actual = serde_json::from_str::<IngressMessages>(msg).unwrap();
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
 
-        assert_eq!(actual, expected);
+        assert!(matches!(
+            message,
+            IngressMessages::InvalidateIceCandidates(_)
+        ));
     }
 
     #[test]
-    fn init_phoenix_message() {
-        let m = PhoenixMessage::new_message(
-            "gateway",
-            IngressMessages::Init(InitGateway {
-                interface: Interface {
-                    ipv4: "100.115.164.78".parse().unwrap(),
-                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                    upstream_dns: vec![],
-                },
-                config: Config {
-                    ipv4_masquerade_enabled: true,
-                    ipv6_masquerade_enabled: true,
-                },
-                relays: vec![],
-            }),
-            None,
-        );
+    fn can_deserialize_init_message() {
+        let json = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
 
-        let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message =
-            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
-        assert_eq!(m, ingress_message);
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
+
+        assert!(matches!(message, IngressMessages::Init(_)));
     }
 
     #[test]
-    fn additional_fields_are_ignore() {
-        let m = PhoenixMessage::new_message(
-            "gateway",
-            IngressMessages::Init(InitGateway {
-                interface: Interface {
-                    ipv4: "100.115.164.78".parse().unwrap(),
-                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                    upstream_dns: vec![],
-                },
-                config: Config {
-                    ipv4_masquerade_enabled: true,
-                    ipv6_masquerade_enabled: true,
-                },
-                relays: vec![],
-            }),
-            None,
-        );
+    fn can_deserialize_resource_updated_message() {
+        let json = r#"{"event":"resource_updated","ref":null,"topic":"gateway","payload":{"id":"57f9ebbb-21d5-4f9f-bf86-b25122fc7a43","name":"?.httpbin","type":"dns","address":"?.httpbin","filters":[{"protocol":"icmp"},{"protocol":"tcp"}]}}"#;
 
-        let message = r#"{"event":"init","ref":null,"topic":"gateway","irrelevant":"field","payload":{"more":"info","interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true,"ignored":"field"}}}"#;
-        let ingress_message =
-            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
-        assert_eq!(m, ingress_message);
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
+
+        assert!(matches!(message, IngressMessages::ResourceUpdated(_)));
     }
 
     #[test]
-    fn additional_null_fields_are_ignored() {
-        let m = PhoenixMessage::new_message(
-            "gateway",
-            IngressMessages::Init(InitGateway {
-                interface: Interface {
-                    ipv4: "100.115.164.78".parse().unwrap(),
-                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                    upstream_dns: vec![],
-                },
-                config: Config {
-                    ipv4_masquerade_enabled: true,
-                    ipv6_masquerade_enabled: true,
-                },
-                relays: vec![],
-            }),
-            None,
-        );
-
-        let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":null,"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message =
-            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
-        assert_eq!(m, ingress_message);
-    }
-
-    #[test]
-    fn additional_number_fields_are_ignored() {
-        let m = PhoenixMessage::new_message(
-            "gateway",
-            IngressMessages::Init(InitGateway {
-                interface: Interface {
-                    ipv4: "100.115.164.78".parse().unwrap(),
-                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                    upstream_dns: vec![],
-                },
-                config: Config {
-                    ipv4_masquerade_enabled: true,
-                    ipv6_masquerade_enabled: true,
-                },
-                relays: vec![],
-            }),
-            None,
-        );
-
-        let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":0.3,"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message =
-            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
-        assert_eq!(m, ingress_message);
-    }
-
-    #[test]
-    fn additional_boolean_fields_are_ignored() {
-        let m = PhoenixMessage::new_message(
-            "gateway",
-            IngressMessages::Init(InitGateway {
-                interface: Interface {
-                    ipv4: "100.115.164.78".parse().unwrap(),
-                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                    upstream_dns: vec![],
-                },
-                config: Config {
-                    ipv4_masquerade_enabled: true,
-                    ipv6_masquerade_enabled: true,
-                },
-                relays: vec![],
-            }),
-            None,
-        );
-
-        let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":true,"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message =
-            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
-        assert_eq!(m, ingress_message);
-    }
-
-    #[test]
-    fn additional_object_fields_are_ignored() {
-        let m = PhoenixMessage::new_message(
-            "gateway",
-            IngressMessages::Init(InitGateway {
-                interface: Interface {
-                    ipv4: "100.115.164.78".parse().unwrap(),
-                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                    upstream_dns: vec![],
-                },
-                config: Config {
-                    ipv4_masquerade_enabled: true,
-                    ipv6_masquerade_enabled: true,
-                },
-                relays: vec![],
-            }),
-            None,
-        );
-
-        let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":{"ignored":"field"},"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message =
-            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
-        assert_eq!(m, ingress_message);
-    }
-
-    #[test]
-    fn additional_array_fields_are_ignored() {
-        let m = PhoenixMessage::new_message(
-            "gateway",
-            IngressMessages::Init(InitGateway {
-                interface: Interface {
-                    ipv4: "100.115.164.78".parse().unwrap(),
-                    ipv6: "fd00:2021:1111::2c:f6ab".parse().unwrap(),
-                    upstream_dns: vec![],
-                },
-                config: Config {
-                    ipv4_masquerade_enabled: true,
-                    ipv6_masquerade_enabled: true,
-                },
-                relays: vec![],
-            }),
-            None,
-        );
-
-        let message = r#"{"event":"init","ref":null,"topic":"gateway","payload":{"additional":[true,false],"interface":{"ipv6":"fd00:2021:1111::2c:f6ab","ipv4":"100.115.164.78"},"config":{"ipv4_masquerade_enabled":true,"ipv6_masquerade_enabled":true}}}"#;
-        let ingress_message =
-            serde_json::from_str::<PhoenixMessage<IngressMessages, ()>>(message).unwrap();
-        assert_eq!(m, ingress_message);
-    }
-
-    #[test]
-    fn resource_updated() {
-        let message = r#"{"event":"resource_updated","ref":null,"topic":"gateway","payload":{"id":"57f9ebbb-21d5-4f9f-bf86-b25122fc7a43","name":"?.httpbin","type":"dns","address":"?.httpbin","filters":[{"protocol":"icmp"},{"protocol":"tcp"}]}}"#;
-        let m =
-            IngressMessages::ResourceUpdated(ResourceDescription::Dns(ResourceDescriptionDns {
-                id: "57f9ebbb-21d5-4f9f-bf86-b25122fc7a43".parse().unwrap(),
-                address: "?.httpbin".to_string(),
-                name: "?.httpbin".to_string(),
-                filters: vec![
-                    Filter::Icmp,
-                    Filter::Tcp(PortRange {
-                        port_range_end: 65535,
-                        port_range_start: 0,
-                    }),
-                ],
-            }));
-        let ingress_message = serde_json::from_str::<IngressMessages>(message).unwrap();
-        assert_eq!(m, ingress_message);
-    }
-
-    #[test]
-    fn relays_presence() {
-        let message = r#"
+    fn can_deserialize_relays_presence_message() {
+        let json = r#"
         {
             "event": "relays_presence",
             "ref": null,
@@ -699,22 +521,9 @@ mod tests {
             }
         }
         "#;
-        let expected = IngressMessages::RelaysPresence(RelaysPresence {
-            disconnected_ids: vec![
-                "e95f9517-2152-4677-a16a-fbb2687050a3".parse().unwrap(),
-                "b0724bd1-a8cc-4faf-88cd-f21159cfec47".parse().unwrap(),
-            ],
-            connected: vec![Relay::Turn(Turn {
-                id: "0a133356-7a9e-4b9a-b413-0d95a5720fd8".parse().unwrap(),
-                expires_at: DateTime::from_timestamp(1719367575, 0).unwrap(),
-                addr: "172.28.0.101:3478".parse().unwrap(),
-                username: "1719367575:ZQHcVGkdnfgGmcP1".to_owned(),
-                password: "ZWYiBeFHOJyYq0mcwAXjRpcuXIJJpzWlOXVdxwttrWg".to_owned(),
-            })],
-        });
 
-        let ingress_message = serde_json::from_str::<IngressMessages>(message).unwrap();
+        let message = serde_json::from_str::<IngressMessages>(json).unwrap();
 
-        assert_eq!(ingress_message, expected);
+        assert!(matches!(message, IngressMessages::RelaysPresence(_)));
     }
 }

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -7,9 +7,9 @@ use super::sim_net::{Host, HostId, RoutingTable};
 use super::sim_relay::SimRelay;
 use super::stub_portal::StubPortal;
 use super::transition::DnsQuery;
+use crate::client::Resource;
 use crate::dns::is_subdomain;
 use crate::gateway::DnsResourceNatEntry;
-use crate::messages::client::ResourceDescription;
 use crate::tests::assertions::*;
 use crate::tests::flux_capacitor::FluxCapacitor;
 use crate::tests::transition::Transition;
@@ -121,7 +121,7 @@ impl TunnelTest {
                 state.client.exec_mut(|c| {
                     // Flush DNS.
                     match &resource {
-                        ResourceDescription::Dns(r) => {
+                        Resource::Dns(r) => {
                             c.dns_records.retain(|domain, _| {
                                 if is_subdomain(domain, &r.address) {
                                     return false;
@@ -130,8 +130,8 @@ impl TunnelTest {
                                 true
                             });
                         }
-                        ResourceDescription::Cidr(_) => {}
-                        ResourceDescription::Internet(_) => {}
+                        Resource::Cidr(_) => {}
+                        Resource::Internet(_) => {}
                     }
 
                     c.sut.add_resource(resource);

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -1,11 +1,11 @@
 use crate::{
-    client::{IPV4_RESOURCES, IPV6_RESOURCES},
+    client::{Resource, IPV4_RESOURCES, IPV6_RESOURCES},
     proptest::{host_v4, host_v6},
 };
 use connlib_model::RelayId;
 
 use super::sim_net::{any_ip_stack, any_port, Host};
-use crate::messages::{client::ResourceDescription, DnsServer};
+use crate::messages::DnsServer;
 use connlib_model::{DomainName, ResourceId};
 use domain::base::Rtype;
 use prop::collection;
@@ -21,7 +21,7 @@ use std::{
 #[expect(clippy::large_enum_variant)]
 pub(crate) enum Transition {
     /// Activate a resource on the client.
-    ActivateResource(ResourceDescription),
+    ActivateResource(Resource),
     /// Deactivate a resource on the client.
     DeactivateResource(ResourceId),
     /// Client-side disable resource


### PR DESCRIPTION
Following up from #6919, this PR introduces a dedicated, internal model for resources as to how the client uses them. This separation serves several purposes:

1. It allows us to introduce an `Unknown` resource type, ensuring forwards-compatibility with future resource types.
2. It allows us to remove trait implementations like `PartialEq` or `PartialOrd` from the message types. With #6732, the messages will include types like `SecretKey`s which cannot be compared.
3. A decoupling of serialisation and domain models is good practice in general and has long been overdue.