### PR TITLE
fix(rust/telemetry): report correct environment when missing trailing slash

### DIFF
--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -52,10 +52,8 @@ impl Telemetry {
         // Can't use URLs as `environment` directly, because Sentry doesn't allow slashes in environments.
         // <https://docs.sentry.io/platforms/rust/configuration/environments/>
         let environment = match api_url {
-            "wss://api.firezone.dev" => "production",
-            "wss://api.firezone.dev/" => "production",
-            "wss://api.firez.one" => "staging",
-            "wss://api.firez.one/" => "staging",
+            "wss://api.firezone.dev" | "wss://api.firezone.dev/" => "production",
+            "wss://api.firez.one" | "wss://api.firez.one/" => "staging",
             _ => "self-hosted",
         };
 

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -52,7 +52,9 @@ impl Telemetry {
         // Can't use URLs as `environment` directly, because Sentry doesn't allow slashes in environments.
         // <https://docs.sentry.io/platforms/rust/configuration/environments/>
         let environment = match api_url {
+            "wss://api.firezone.dev" => "production",
             "wss://api.firezone.dev/" => "production",
+            "wss://api.firez.one" => "staging",
             "wss://api.firez.one/" => "staging",
             _ => "self-hosted",
         };


### PR DESCRIPTION
Closes #6928