### PR TITLE
docs(rust/client/windows): known issue, DNS Resources don't work inside WSL

### DIFF
--- a/website/src/app/kb/client-apps/windows-client/readme.mdx
+++ b/website/src/app/kb/client-apps/windows-client/readme.mdx
@@ -198,5 +198,7 @@ the tunnel, and a GUI which allows the user to control Firezone.
   Resources within your browser.
 - Firezone does not register itself with Windows as a VPN
   [#2875](https://github.com/firezone/firezone/issues/2875)
+- **WSL**: DNS Resources do not work in WSL yet
+  [#6777](https://github.com/firezone/firezone/issues/6777)
 
 <SupportOptions />


### PR DESCRIPTION
#6777 includes a workaround that isn't quite good enough to publish, and some theory on how we can fix it.