### PR TITLE
feat(connlib): buffer packets during ICE

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -338,9 +338,6 @@ where
             .get_established_mut(&connection)
             .ok_or(Error::NotConnected)?;
 
-        // Must bail early if we don't have a socket yet to avoid running into WG timeouts.
-        let socket = conn.socket().ok_or(Error::NotConnected)?;
-
         // Encode the packet with an offset of 4 bytes, in case we need to wrap it in a channel-data message.
         let Some(packet_len) = conn
             .encapsulate(packet.packet(), &mut buffer.inner[4..], now)?
@@ -353,7 +350,23 @@ where
         let packet_start = 4;
         let packet_end = 4 + packet_len;
 
-        match socket {
+        let socket = match &mut conn.state {
+            ConnectionState::Connecting { buffered, .. } => {
+                buffered.push(buffer.inner[packet_start..packet_end].to_vec());
+                let num_buffered = buffered.len();
+
+                let _guard = conn.span.enter();
+
+                tracing::debug!(%num_buffered, "ICE is still in progress, buffering WG handshake");
+
+                return Ok(None);
+            }
+            ConnectionState::Connected { peer_socket, .. } => peer_socket,
+            ConnectionState::Idle { peer_socket } => peer_socket,
+            ConnectionState::Failed => return Err(Error::NotConnected),
+        };
+
+        match *socket {
             PeerSocket::Direct {
                 dest: remote,
                 source,
@@ -1516,6 +1529,8 @@ enum ConnectionState<RId> {
         ///
         /// This can happen if the remote's WG session initiation arrives at our socket before we nominate it.
         /// A session initiation requires a response that we must not drop, otherwise the connection setup experiences unnecessary delays.
+        ///
+        /// It can also happen if we attempt to encapsulate a packet prior to the WireGuard handshake which triggers the creation of a WireGuard handshake initiation packet.
         buffered: RingBuffer<Vec<u8>>,
     },
     /// A socket has been nominated.
@@ -1777,6 +1792,10 @@ where
 
                     let old = match mem::replace(&mut self.state, ConnectionState::Failed) {
                         ConnectionState::Connecting { buffered, .. } => {
+                            let num_buffered = buffered.len();
+
+                            tracing::debug!(%num_buffered, "Flushing packets buffered during ICE");
+
                             transmits.extend(buffered.into_iter().flat_map(|packet| {
                                 make_owned_transmit(remote_socket, &packet, allocations, now)
                             }));

--- a/rust/connlib/snownet/src/ringbuffer.rs
+++ b/rust/connlib/snownet/src/ringbuffer.rs
@@ -36,6 +36,10 @@ impl<T: PartialEq> RingBuffer<T> {
         self.buffer.into_iter()
     }
 
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
     #[cfg(test)]
     fn inner(&self) -> (&[T], &[T]) {
         self.buffer.as_slices()


### PR DESCRIPTION
As part of #6732, we will be using the tunnel for the p2p control protocol to setup the DNS resource NAT on the gateway. These messages will be immediately queued after creating the connection, before ICE is finished. In order to avoid additional retries within `firezone_tunnel`, we directly attempt to encapsulate these packets.

`boringtun` internally has a buffer for these because prior to having a WireGuard session, we don't actually have the necessary keys to encrypt a packet. Thus, the packet passed here won't actually end up in the referenced buffer of the `Connecting` state. Instead, if we haven't already initiated a WireGuard handshake, attempting to encapsulate a packet will trigger a WireGuard handshake initiation and _that_ is the packet we need to buffer.

Dropping this packet would require us to wait until `boringtun` retransmits it as part of the handshake timeout, causing an unnecessary delay in the connection setup.