### PR TITLE
refactor(snownet): only initiate a single WireGuard session

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1824,7 +1824,9 @@ where
 
                     tracing::info!(?old, new = ?remote_socket, duration_since_intent = ?self.duration_since_intent(now), "Updating remote socket");
 
-                    self.force_handshake(allocations, transmits, now);
+                    if self.agent.controlling() {
+                        self.force_handshake(allocations, transmits, now);
+                    }
                 }
                 IceAgentEvent::IceRestart(_) | IceAgentEvent::IceConnectionStateChange(_) => {}
             }


### PR DESCRIPTION
To reduce the TTFB, we immediately force a WireGuard handshake as soon as ICE completes. Currently, both the client and the gateway do this which is somewhat counter-productive as there can only be one active session.

With this patch, only the client will force a new WireGuard handshake as soon as ICE completes.