### PR TITLE
refactor(connlib): allow passing `IpAddr` as well as `IpNetwork`

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -388,11 +388,8 @@ impl ClientState {
         let Some((fqdn, ips)) = self.stub_resolver.get_fqdn(resource_ip) else {
             return;
         };
-        self.peers.add_ips_with_resource(
-            &gateway_id,
-            &ips.iter().copied().map_into().collect_vec(),
-            &resource_id,
-        );
+        self.peers
+            .add_ips_with_resource(&gateway_id, ips.iter().copied(), &resource_id);
         self.buffered_events.push_back(ClientEvent::RequestAccess {
             resource_id,
             gateway_id,
@@ -582,7 +579,7 @@ impl ClientState {
 
         if self.peers.get(&gateway_id).is_some() {
             self.peers
-                .add_ips_with_resource(&gateway_id, &ips, &resource_id);
+                .add_ips_with_resource(&gateway_id, ips.into_iter(), &resource_id);
 
             self.buffered_events.push_back(ClientEvent::RequestAccess {
                 resource_id,
@@ -597,7 +594,7 @@ impl ClientState {
             &[],
         );
         self.peers
-            .add_ips_with_resource(&gateway_id, &ips, &resource_id);
+            .add_ips_with_resource(&gateway_id, ips.into_iter(), &resource_id);
 
         let offer = self.node.new_connection(
             gateway_id,

--- a/rust/connlib/tunnel/src/peer_store.rs
+++ b/rust/connlib/tunnel/src/peer_store.rs
@@ -25,14 +25,16 @@ impl PeerStore<GatewayId, GatewayOnClient> {
     pub(crate) fn add_ips_with_resource(
         &mut self,
         id: &GatewayId,
-        ips: &[IpNetwork],
+        ips: impl Iterator<Item = impl Into<IpNetwork>>,
         resource: &ResourceId,
     ) {
         for ip in ips {
-            let Some(peer) = self.add_ip(id, ip) else {
+            let ip = ip.into();
+
+            let Some(peer) = self.add_ip(id, &ip) else {
                 continue;
             };
-            peer.insert_id(ip, resource);
+            peer.insert_id(&ip, resource);
         }
     }
 }


### PR DESCRIPTION
We call the `add_ips_with_resource` function with a list of `IpAddr` or `IpNetwork`s. To make this more ergonomic for the caller, we can accept an iterator that converts the items on the fly.