### PR TITLE
feat(connlib): implement idempotent control protocol for gateway

### DIFF
--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -1259,7 +1259,7 @@ defmodule API.Client.ChannelTest do
       assert client_id == client.id
       assert resource_id == resource.id
       assert authorization_expires_at == socket.assigns.subject.expires_at
-      assert String.length(preshared_key) == 32
+      assert String.length(preshared_key) == 44
     end
 
     test "returns online gateway connected to an internet resource", %{
@@ -1314,7 +1314,7 @@ defmodule API.Client.ChannelTest do
       assert client_id == client.id
       assert resource_id == resource.id
       assert authorization_expires_at == socket.assigns.subject.expires_at
-      assert String.length(preshared_key) == 32
+      assert String.length(preshared_key) == 44
     end
 
     test "broadcasts authorize_flow to the gateway and flow_created to the client", %{

--- a/elixir/apps/domain/lib/domain/crypto.ex
+++ b/elixir/apps/domain/lib/domain/crypto.ex
@@ -3,7 +3,6 @@ defmodule Domain.Crypto do
 
   def psk do
     random_token(@wg_psk_length, encoder: :base64)
-    |> String.slice(0, @wg_psk_length)
   end
 
   def random_token(length \\ 16, opts \\ []) do

--- a/elixir/apps/domain/test/domain/crypto_test.exs
+++ b/elixir/apps/domain/test/domain/crypto_test.exs
@@ -4,7 +4,7 @@ defmodule Domain.CryptoTest do
 
   describe "psk/0" do
     test "it returns a string of proper length" do
-      assert 32 == String.length(psk())
+      assert 44 == String.length(psk())
     end
   end
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -52,9 +52,7 @@ pub type GatewayTunnel = Tunnel<GatewayState>;
 pub type ClientTunnel = Tunnel<ClientState>;
 
 pub use client::ClientState;
-pub use gateway::{
-    DnsResourceNatEntry, GatewayState, PendingSetupNatRequest, IPV4_PEERS, IPV6_PEERS,
-};
+pub use gateway::{DnsResourceNatEntry, GatewayState, ResolveDnsRequest, IPV4_PEERS, IPV6_PEERS};
 pub use utils::turn;
 
 /// [`Tunnel`] glues together connlib's [`Io`] component and the respective (pure) state of a client or gateway.
@@ -353,7 +351,7 @@ pub struct TunConfig {
     pub ipv6_routes: BTreeSet<Ipv6Network>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum GatewayEvent {
     AddedIceCandidates {
         conn_id: ClientId,
@@ -368,7 +366,7 @@ pub enum GatewayEvent {
         conn_id: ClientId,
         resource_id: ResourceId,
     },
-    ResolveDns(PendingSetupNatRequest),
+    ResolveDns(ResolveDnsRequest),
 }
 
 fn fmt_routes<T>(routes: &BTreeSet<T>, f: &mut fmt::Formatter) -> fmt::Result

--- a/rust/connlib/tunnel/src/messages.rs
+++ b/rust/connlib/tunnel/src/messages.rs
@@ -143,7 +143,6 @@ pub struct DomainResponse {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ConnectionAccepted {
     pub ice_parameters: Answer,
-    pub domain_response: Option<DomainResponse>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -155,6 +154,12 @@ pub struct ResourceAccepted {
 pub enum GatewayResponse {
     ConnectionAccepted(ConnectionAccepted),
     ResourceAccepted(ResourceAccepted),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+pub struct IceCredentials {
+    pub username: String,
+    pub password: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -450,6 +450,10 @@ impl ClientOnGateway {
         Ok(Some(packet))
     }
 
+    pub(crate) fn is_allowed(&self, resource: ResourceId) -> bool {
+        self.resources.contains_key(&resource)
+    }
+
     fn ensure_allowed_src(&self, packet: &IpPacket) -> anyhow::Result<()> {
         let src = packet.source();
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -202,31 +202,37 @@ impl ClientOnGateway {
             })
             .collect_vec();
 
-        self.assign_translations(name, resource_id, &resolved_ips, proxy_ips, now)?;
+        self.setup_nat(name, resource_id, &resolved_ips, proxy_ips, now)?;
 
         Ok(())
     }
 
+    /// Setup the NAT for a particular domain within a wildcard DNS resource.
     #[tracing::instrument(level = "debug", skip_all, fields(cid = %self.id))]
-    pub(crate) fn assign_translations(
+    pub(crate) fn setup_nat(
         &mut self,
         name: DomainName,
         resource_id: ResourceId,
-        mapped_ips: &[IpAddr],
+        resolved_ips: &[IpAddr],
         proxy_ips: Vec<IpAddr>,
         now: Instant,
     ) -> Result<()> {
-        let Some(ResourceOnGateway::Dns {
+        let resource = self
+            .resources
+            .get_mut(&resource_id)
+            .context("Unknown resource")?;
+
+        let ResourceOnGateway::Dns {
             address, domains, ..
-        }) = self.resources.get_mut(&resource_id)
+        } = resource
         else {
-            bail!("Cannot assign translation for non-DNS resource")
+            bail!("Cannot setup NAT for non-DNS resource")
         };
 
         anyhow::ensure!(crate::dns::is_subdomain(&name, address));
 
-        let mapped_ipv4 = mapped_ipv4(mapped_ips);
-        let mapped_ipv6 = mapped_ipv6(mapped_ips);
+        let mapped_ipv4 = mapped_ipv4(resolved_ips);
+        let mapped_ipv6 = mapped_ipv6(resolved_ips);
 
         let ipv4_maps = proxy_ips
             .iter()
@@ -249,7 +255,9 @@ impl ClientOnGateway {
             );
         }
 
-        domains.insert(name, mapped_ips.to_vec());
+        tracing::debug!(domain = %name, ?resolved_ips, ?proxy_ips, "Set up DNS resource NAT");
+
+        domains.insert(name, resolved_ips.to_vec());
         self.recalculate_filters();
 
         Ok(())
@@ -330,6 +338,8 @@ impl ClientOnGateway {
         resource: crate::messages::gateway::ResourceDescription,
         expires_at: Option<DateTime<Utc>>,
     ) {
+        tracing::info!(client = %self.id, resource = %resource.id(), expires = ?expires_at.map(|e| e.to_rfc3339()), "Allowing access to resource");
+
         match self.resources.entry(resource.id()) {
             hash_map::Entry::Vacant(v) => {
                 v.insert(ResourceOnGateway::new(resource, expires_at));
@@ -1104,7 +1114,7 @@ mod tests {
         let mut peer = ClientOnGateway::new(client_id(), source_v4_addr(), source_v6_addr());
         peer.add_resource(foo_dns_resource(), None);
         peer.add_resource(bar_cidr_resource(), None);
-        peer.assign_translations(
+        peer.setup_nat(
             foo_name().parse().unwrap(),
             resource_id(),
             &[foo_real_ip().into()],
@@ -1165,7 +1175,7 @@ mod tests {
         let mut peer = ClientOnGateway::new(client_id(), source_v4_addr(), source_v6_addr());
         peer.add_resource(foo_dns_resource(), None);
         peer.add_resource(internet_resource(), None);
-        peer.assign_translations(
+        peer.setup_nat(
             foo_name().parse().unwrap(),
             resource_id(),
             &[foo_real_ip().into()],

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -375,7 +375,14 @@ impl TunnelTest {
                     continue;
                 };
 
-                on_gateway_event(*id, event, &mut self.client, now);
+                on_gateway_event(
+                    *id,
+                    event,
+                    &mut self.client,
+                    gateway,
+                    &ref_state.global_dns_records,
+                    now,
+                );
                 continue 'outer;
             }
             if let Some(event) = self.client.exec_mut(|c| c.sut.poll_event()) {
@@ -764,35 +771,33 @@ impl TunnelTest {
 
                 let client_id = self.client.inner().id;
 
-                let answer = gateway
-                    .exec_mut(|g| {
-                        let answer = g.sut.accept(
-                            client_id,
-                            snownet::Offer {
-                                session_key: preshared_key.expose_secret().0.into(),
-                                credentials: snownet::Credentials {
-                                    username: offer.username,
-                                    password: offer.password,
-                                },
+                let answer = gateway.exec_mut(|g| {
+                    let answer = g.sut.accept(
+                        client_id,
+                        snownet::Offer {
+                            session_key: preshared_key.expose_secret().0.into(),
+                            credentials: snownet::Credentials {
+                                username: offer.username,
+                                password: offer.password,
                             },
-                            self.client.inner().sut.public_key(),
+                        },
+                        self.client.inner().sut.public_key(),
+                        now,
+                    );
+                    g.sut
+                        .allow_access(
+                            self.client.inner().id,
+                            self.client.inner().sut.tunnel_ip4().unwrap(),
+                            self.client.inner().sut.tunnel_ip6().unwrap(),
+                            None,
+                            resource.clone(),
+                            maybe_entry,
                             now,
-                        );
-                        g.sut
-                            .allow_access(
-                                self.client.inner().id,
-                                self.client.inner().sut.tunnel_ip4().unwrap(),
-                                self.client.inner().sut.tunnel_ip6().unwrap(),
-                                None,
-                                resource.clone(),
-                                maybe_entry,
-                                now,
-                            )
-                            .unwrap();
+                        )
+                        .unwrap();
 
-                        anyhow::Ok(answer)
-                    })
-                    .unwrap();
+                    answer
+                });
 
                 self.client
                     .exec_mut(|c| {
@@ -885,6 +890,8 @@ fn on_gateway_event(
     src: GatewayId,
     event: GatewayEvent,
     client: &mut Host<SimClient>,
+    gateway: &mut Host<SimGateway>,
+    global_dns_records: &BTreeMap<DomainName, BTreeSet<IpAddr>>,
     now: Instant,
 ) {
     match event {
@@ -899,5 +906,21 @@ fn on_gateway_event(
             }
         }),
         GatewayEvent::RefreshDns { .. } => todo!(),
+        GatewayEvent::ResolveDns(r) => {
+            let resolved_ips = global_dns_records
+                .get(r.domain())
+                .cloned()
+                .unwrap_or_default();
+
+            gateway.exec_mut(|g| {
+                g.sut
+                    .handle_pending_setup_nat_request_completed(
+                        r,
+                        Vec::from_iter(resolved_ips),
+                        now,
+                    )
+                    .unwrap()
+            })
+        }
     }
 }

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -914,11 +914,7 @@ fn on_gateway_event(
 
             gateway.exec_mut(|g| {
                 g.sut
-                    .handle_pending_setup_nat_request_completed(
-                        r,
-                        Vec::from_iter(resolved_ips),
-                        now,
-                    )
+                    .handle_domain_resolved(r, Vec::from_iter(resolved_ips), now)
                     .unwrap()
             })
         }

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -15,6 +15,10 @@ export default function Gateway() {
             Separates CIDR and DNS resources filters, preventing filters
             from one applying to the other.
           </ChangeItem>
+          <ChangeItem pull="6941">
+            Implements support for the new control protocol; delivering faster
+            and more robust connection establishment.
+          </ChangeItem>
       </Unreleased>
       <Entry version="1.3.2" date={new Date("2024-10-02")}>
         <ChangeItem pull="6733">


### PR DESCRIPTION
This PR implements the new idempotent control protocol for the gateway. We retain backwards-compatibility with old clients to allow admins to perform a disruption-free update to the latest version.

With this new control protocol, we are moving the responsibility of exchanging the proxy IPs we assigned to DNS resources to a p2p protocol between client and gateway. As a result, wildcard DNS resources only get authorized on the first access. Accessing a new domain within the same resource will thus no longer require a roundtrip to the portal.

Overall, users will see a greatly decreased connection setup latency. On top of that, the new protocol will allow us to more easily implement packet buffering which will be another UX boost for Firezone.