### PR TITLE
chore(connlib): use proxy ip to match filters instead of translated

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -382,7 +382,7 @@ impl ClientOnGateway {
         for (addr, TranslationState { resource_id, .. }) in &self.permanent_translations {
             let mut filter_engine = FilterEngine::empty();
             // Empty filters means permit all
-            let filters = self.resources.get(&resource_id).unwrap().filters();
+            let filters = self.resources.get(resource_id).unwrap().filters();
 
             if filters.is_empty() {
                 filter_engine.permit_all();

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -21,9 +21,8 @@ export default function Gateway() {
           always-on, low-power mode instead of closing them.
         </ChangeItem>
         <ChangeItem pull="6960">
-          Applies DNS and CIDR resources filters separatedly, preventing
-          DNS resources with resovled IPs overlapping with CIDR having the CIDR
-          filters applied.
+          Separates CIDR and DNS resources filters, preventing filters
+          from one applying to the other.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -10,7 +10,14 @@ export default function Gateway() {
 
   return (
     <Entries href={href} arches={arches} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <Entry version="1.3.3" date={todo}>
+          <ChangeItem pull="6960">
+            Separates CIDR and DNS resources filters, preventing filters
+            from one applying to the other.
+          </ChangeItem>
+        </Entry>
+      </Unreleased>
       <Entry version="1.3.2" date={new Date("2024-10-02")}>
         <ChangeItem pull="6733">
           Reduces log level of the "Couldn't find connection by IP" message so
@@ -19,10 +26,6 @@ export default function Gateway() {
         <ChangeItem pull="6845">
           Fixes connectivity issues on idle connections by entering an
           always-on, low-power mode instead of closing them.
-        </ChangeItem>
-        <ChangeItem pull="6960">
-          Separates CIDR and DNS resources filters, preventing filters
-          from one applying to the other.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -20,6 +20,11 @@ export default function Gateway() {
           Fixes connectivity issues on idle connections by entering an
           always-on, low-power mode instead of closing them.
         </ChangeItem>
+        <ChangeItem pull="6960">
+          Applies DNS and CIDR resources filters separatedly, preventing
+          DNS resources with resovled IPs overlapping with CIDR having the CIDR
+          filters applied.
+        </ChangeItem>
       </Entry>
       <Entry version="1.3.1" date={new Date("2024-09-05")}>
         <ChangeItem pull="6563">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -11,12 +11,10 @@ export default function Gateway() {
   return (
     <Entries href={href} arches={arches} title="Gateway">
       <Unreleased>
-        <Entry version="1.3.3" date={todo}>
           <ChangeItem pull="6960">
             Separates CIDR and DNS resources filters, preventing filters
             from one applying to the other.
           </ChangeItem>
-        </Entry>
       </Unreleased>
       <Entry version="1.3.2" date={new Date("2024-10-02")}>
         <ChangeItem pull="6733">


### PR DESCRIPTION
Previously, when a gateway checked if a packet was allowed through, it used the real IP of the DNS resource that the client was trying to communicate with.

The problem with this was that if there's an overlapping CIDR resource with the real IP this would allow a user to send packets using the filters for that resource instead of the DNS resource filters.

This can be confusing for users as packet can flow unexpectedly to the resources even if the filter doesn't permit it, so we use the IP of the packet before we translate it to the real IP to match the filters.

This doesn't change the security of this feature as a user can just change the IP of the packet with the dst of the DNS or the cidr resource according to what they need. 

Fixes #6806