### PR TITLE
chore(phoenix-channel): print elapsed time on test failure

### DIFF
--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -101,7 +101,7 @@ mod tests {
         let elapsed = start.elapsed();
 
         assert!(result.is_ok());
-        assert!(elapsed >= INTERVAL);
+        assert!(elapsed >= INTERVAL, "Only suspended for {elapsed:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Related: #6953.