### PR TITLE
refactor(connlib): clarify design of p2p control protocol

### DIFF
--- a/rust/ip-packet/src/fz_p2p_control.rs
+++ b/rust/ip-packet/src/fz_p2p_control.rs
@@ -12,3 +12,16 @@ pub const ADDR: Ipv6Addr = Ipv6Addr::UNSPECIFIED;
 ///
 /// `0xFF` is reserved and should thus never appear as real-world traffic.
 pub const IP_NUMBER: IpNumber = IpNumber(0xFF);
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct EventType(u8);
+
+impl EventType {
+    pub const fn new(ty: u8) -> Self {
+        Self(ty)
+    }
+
+    pub fn into_u8(self) -> u8 {
+        self.0
+    }
+}

--- a/rust/ip-packet/src/fz_p2p_control_slice.rs
+++ b/rust/ip-packet/src/fz_p2p_control_slice.rs
@@ -1,5 +1,7 @@
 use etherparse::LenSource;
 
+use crate::FzP2pEventType;
+
 pub struct FzP2pControlSlice<'a> {
     slice: &'a [u8],
 }
@@ -20,8 +22,8 @@ impl<'a> FzP2pControlSlice<'a> {
         Ok(Self { slice })
     }
 
-    pub fn message_type(&self) -> u8 {
-        self.slice[0]
+    pub fn event_type(&self) -> FzP2pEventType {
+        FzP2pEventType::new(self.slice[0])
     }
 
     pub fn payload(&self) -> &[u8] {

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -15,6 +15,7 @@ mod tcp_header_slice_mut;
 mod udp_header_slice_mut;
 
 pub use etherparse::*;
+pub use fz_p2p_control::EventType as FzP2pEventType;
 pub use fz_p2p_control_slice::FzP2pControlSlice;
 
 #[cfg(all(test, feature = "proptest"))]


### PR DESCRIPTION
This incorporates the feedback from #6939 after a discussion with @conectado. We agreed that the protocol should be more event-based, where each message has its own event type. Events MAY appear in pairs or other cardinality combinations, meaning semantically they could be seen as requests and responses. In general though, due to the unreliable nature of IP, it is better to view them as events. Events are typically designed to be idempotent which is important to make this protocol work. Using events also means it is not as easy to fall into the "trap" of modelling requests / responses on the control protocol level.