### PR TITLE
chore(android): simplify default log filter

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -85,8 +85,7 @@ android {
             buildConfigField(
                 "String",
                 "LOG_FILTER",
-                "\"connlib_client_android=debug,firezone_tunnel=debug,phoenix_channel=debug,connlib_shared=debug," +
-                    "boringtun=debug,snownet=debug,str0m=debug,connlib_client_shared=debug,info\"",
+                "\"debug\"",
             )
         }
 
@@ -126,7 +125,7 @@ android {
 
             buildConfigField("String", "AUTH_BASE_URL", "\"https://app.firezone.dev\"")
             buildConfigField("String", "API_URL", "\"wss://api.firezone.dev\"")
-            buildConfigField("String", "LOG_FILTER", "\"str0m=warn,info\"")
+            buildConfigField("String", "LOG_FILTER", "\"info\"")
             firebaseAppDistribution {
                 serviceCredentialsFile = System.getenv("FIREBASE_CREDENTIALS_PATH")
                 artifactType = "AAB"


### PR DESCRIPTION
With the introduction of `firezone-logging`, we provide a default filter that silences irrelevant crates: https://github.com/firezone/firezone/blob/17ea827c03579a3516f7abf6184a557ec32cd48b/rust/logging/src/lib.rs#L32-L40. Thus, it is safe to just set the default filter to `info` for production and `debug` for development.