### PR TITLE
fix(android): Bump AGP to 8.7.0 to fix build on macOS

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -238,6 +238,7 @@ cargo {
     prebuiltToolchains = true
     module = "../../../rust/connlib/clients/android"
     libname = "connlib"
+    verbose = true
     targets =
         listOf(
             "arm64",

--- a/kotlin/android/app/src/main/java/dev/firezone/android/core/presentation/MainActivity.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/core/presentation/MainActivity.kt
@@ -1,19 +1,9 @@
 /* Licensed under Apache 2.0 (C) 2024 Firezone, Inc. */
 package dev.firezone.android.core.presentation
 
-import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
 import dev.firezone.android.R
 
 @AndroidEntryPoint
-internal class MainActivity : AppCompatActivity(R.layout.activity_main) {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
-
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        super.onBackPressed()
-    }
-}
+internal class MainActivity : AppCompatActivity(R.layout.activity_main)

--- a/kotlin/android/build.gradle.kts
+++ b/kotlin/android/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
 plugins {
     id("org.mozilla.rust-android-gradle.rust-android") version "0.9.4" apply false
     id("org.jetbrains.kotlin.android") version "1.8.22" apply false
-    id("com.android.application") version "8.6.1" apply false
+    id("com.android.application") version "8.7.0" apply false
     id("com.google.firebase.appdistribution") version "5.0.0" apply false
     id("com.google.dagger.hilt.android") version "2.52" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false


### PR DESCRIPTION
Bumps AGP to 8.7.0 to fix the following error with recent versions of Android Studio / gradle:

```
Caused by: java.io.IOException: Cannot run program "rustc" (in directory "/Users/jamil/Developer/firezone/firezone/kotlin/android/app"): error=2, No such file or directory
        at net.rubygrapefruit.platform.internal.DefaultProcessLauncher.start(DefaultProcessLauncher.java:25)
        ... 7 more
Caused by: java.io.IOException: error=2, No such file or directory
```

Also removes dead code and enables verbose output to make it easier to catch problems like this in the future.