### PR TITLE
fix(portal): Fix show page errors when entity was created by API

### DIFF
--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -8,7 +8,8 @@ defmodule Web.Groups.Show do
            Actors.fetch_group_by_id(id, socket.assigns.subject,
              preload: [
                provider: [],
-               created_by_identity: [:actor]
+               created_by_identity: [:actor],
+               created_by_actor: []
              ]
            ) do
       socket =

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -10,6 +10,7 @@ defmodule Web.Policies.Show do
                actor_group: [:provider],
                resource: [],
                created_by_identity: :actor,
+               created_by_actor: [],
                replaced_by_policy: [:actor_group, :resource],
                replaces_policy: [:actor_group, :resource]
              ]

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -5,7 +5,10 @@ defmodule Web.Sites.Show do
   def mount(%{"id" => id}, _session, socket) do
     with {:ok, group} <-
            Gateways.fetch_group_by_id(id, socket.assigns.subject,
-             preload: [created_by_identity: [:actor]]
+             preload: [
+               created_by_identity: [:actor],
+               created_by_actor: []
+             ]
            ) do
       if connected?(socket) do
         :ok = Gateways.subscribe_to_gateways_presence_in_group(group)

--- a/elixir/apps/web/test/web/live/groups/show_test.exs
+++ b/elixir/apps/web/test/web/live/groups/show_test.exs
@@ -89,6 +89,31 @@ defmodule Web.Live.Groups.ShowTest do
     assert table["created"] =~ "by #{actor.name}"
   end
 
+  test "renders group details when created by API", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    actor = Fixtures.Actors.create_actor(type: :api_client, account: account)
+    subject = Fixtures.Auth.create_subject(account: account, actor: actor)
+    group = Fixtures.Actors.create_group(account: account, subject: subject)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/groups/#{group}")
+
+    table =
+      lv
+      |> element("#group")
+      |> render()
+      |> vertical_table_to_map()
+
+    assert table["name"] == group.name
+    assert around_now?(table["created"])
+    assert table["created"] =~ "by #{actor.name}"
+  end
+
   test "renders name of actor that created group", %{
     account: account,
     actor: actor,

--- a/elixir/apps/web/test/web/live/policies/show_test.exs
+++ b/elixir/apps/web/test/web/live/policies/show_test.exs
@@ -222,6 +222,37 @@ defmodule Web.Live.Policies.ShowTest do
     assert table["conditions"] =~ "provider(s)"
   end
 
+  test "renders policy details when created by API", %{
+    account: account,
+    identity: identity,
+    resource: resource,
+    conn: conn
+  } do
+    actor = Fixtures.Actors.create_actor(type: :api_client, account: account)
+    subject = Fixtures.Auth.create_subject(account: account, actor: actor)
+
+    policy =
+      Fixtures.Policies.create_policy(account: account, subject: subject, resource: resource)
+      |> Domain.Repo.preload(:actor_group)
+      |> Domain.Repo.preload(:resource)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/policies/#{policy}")
+
+    table =
+      lv
+      |> element("#policy")
+      |> render()
+      |> vertical_table_to_map()
+
+    assert table["group"] =~ policy.actor_group.name
+    assert table["resource"] =~ policy.resource.name
+    assert table["description"] =~ policy.description
+    assert table["created"] =~ actor.name
+  end
+
   test "renders logs table", %{
     account: account,
     identity: identity,

--- a/elixir/apps/web/test/web/live/sites/show_test.exs
+++ b/elixir/apps/web/test/web/live/sites/show_test.exs
@@ -110,6 +110,30 @@ defmodule Web.Live.Sites.ShowTest do
     assert table["created"] =~ actor.name
   end
 
+  test "renders group details when group created by API", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    actor = Fixtures.Actors.create_actor(type: :api_client, account: account)
+    subject = Fixtures.Auth.create_subject(account: account, actor: actor)
+    group = Fixtures.Gateways.create_group(account: account, subject: subject)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/sites/#{group}")
+
+    table =
+      lv
+      |> element("#group")
+      |> render()
+      |> vertical_table_to_map()
+
+    assert table["name"] =~ group.name
+    assert table["created"] =~ actor.name
+  end
+
   test "renders online gateways table", %{
     account: account,
     identity: identity,


### PR DESCRIPTION
Why:

* A handful of 'show' pages were throwing errors for entities created using the API.  The reason was due to the fact that the `created_by_actor` was not being preloaded and when the details on the show page were being rendered.  This commit updates the various pages to preload the `created_by_actor` to allow for both API created entities and UI created entities.