### PR TITLE
feat(rust/gui-client/windows): sign the IPC service exe

### DIFF
--- a/rust/gui-client/src-tauri/tauri.windows.conf.json
+++ b/rust/gui-client/src-tauri/tauri.windows.conf.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "beforeBundleCommand": "bash -c '../../scripts/build/sign.sh ../target/release/Firezone.exe'"
+    "beforeBundleCommand": "bash -c '../../scripts/build/sign.sh ../target/release/Firezone.exe ../target/release/firezone-client-ipc.exe'"
   },
   "package": {
     "productName": "Firezone"

--- a/scripts/build/sign.sh
+++ b/scripts/build/sign.sh
@@ -6,11 +6,14 @@ if ! command -v AzureSignTool &>/dev/null; then
     exit
 fi
 
-AzureSignTool sign \
-    --azure-key-vault-url "$AZURE_KEY_VAULT_URI" \
-    --azure-key-vault-client-id "$AZURE_CLIENT_ID" \
-    --azure-key-vault-tenant-id "$AZURE_TENANT_ID" \
-    --azure-key-vault-client-secret "$AZURE_CLIENT_SECRET" \
-    --azure-key-vault-certificate "$AZURE_CERT_NAME" \
-    --timestamp-rfc3161 "http://timestamp.digicert.com" \
-    --verbose "$1"
+for exe in "$@"
+do
+    AzureSignTool sign \
+        --azure-key-vault-url "$AZURE_KEY_VAULT_URI" \
+        --azure-key-vault-client-id "$AZURE_CLIENT_ID" \
+        --azure-key-vault-tenant-id "$AZURE_TENANT_ID" \
+        --azure-key-vault-client-secret "$AZURE_CLIENT_SECRET" \
+        --azure-key-vault-certificate "$AZURE_CERT_NAME" \
+        --timestamp-rfc3161 "http://timestamp.digicert.com" \
+        --verbose "$exe"
+done

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -18,7 +18,7 @@ export default function GUI({ title }: { title: string }) {
         <ChangeItem enable={title === "Linux GUI"}>
           This is a maintenance release with no user-facing changes.
         </ChangeItem>
-        <ChangeItem enable={title === "Windows"}>
+        <ChangeItem enable={title === "Windows"} pull="7009">
           The IPC service `firezone-client-ipc.exe` is now signed.
         </ChangeItem>
       </Unreleased>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,7 +14,14 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem enable={title === "Linux GUI"}>
+          This is a maintenance release with no user-facing changes.
+        </ChangeItem>
+        <ChangeItem enable={title === "Windows"}>
+          The IPC service `firezone-client-ipc.exe` is now signed.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.3.9" date={new Date("2024-10-09")}>
         <ChangeItem enable={title === "Linux GUI"} pull="6987">
           Fixes a crash on startup caused by incorrect permissions on the ID file.


### PR DESCRIPTION
Closes #7008.

We already signed the GUI exe and the entire MSI package, but when adding the IPC service we overlooked that one. 
This PR:
- Modifies the signing script to accept multiple EXEs
- Modifies the Tauri bundle command to sign both exes
- Updates the changelog
![image](https://github.com/user-attachments/assets/ba58c540-dd0c-42b4-ba62-9c96fc4682c5)
