### PR TITLE
fix(portal): Fix outdated gateway notification to respect enable/disable status

### DIFF
--- a/elixir/apps/domain/lib/domain/accounts.ex
+++ b/elixir/apps/domain/lib/domain/accounts.ex
@@ -27,6 +27,7 @@ defmodule Domain.Accounts do
   def all_active_accounts_by_subscription_name_pending_notification!(subscription_name) do
     Account.Query.not_disabled()
     |> Account.Query.by_stripe_product_name(subscription_name)
+    |> Account.Query.by_notification_enabled("outdated_gateway")
     |> Account.Query.by_notification_last_notified("outdated_gateway", 24)
     |> Repo.all()
   end

--- a/elixir/apps/domain/lib/domain/accounts/account/query.ex
+++ b/elixir/apps/domain/lib/domain/accounts/account/query.ex
@@ -55,6 +55,18 @@ defmodule Domain.Accounts.Account.Query do
     end
   end
 
+  def by_notification_enabled(queryable, notification) do
+    where(
+      queryable,
+      [accounts: accounts],
+      fragment(
+        "(?->'notifications'->?->>'enabled') = 'true'",
+        accounts.config,
+        ^notification
+      )
+    )
+  end
+
   def by_notification_last_notified(queryable, notification, hours) do
     interval = Duration.new!(hour: hours)
 

--- a/elixir/apps/domain/test/domain/notifications/jobs/outdated_gateways_test.exs
+++ b/elixir/apps/domain/test/domain/notifications/jobs/outdated_gateways_test.exs
@@ -5,8 +5,19 @@ defmodule Domain.Notifications.Jobs.OutdatedGatewaysTest do
 
   describe "execute/1" do
     setup do
+      account_attrs = %{
+        config: %{
+          notifications: %{
+            outdated_gateway: %{
+              enabled: true,
+              last_notified: nil
+            }
+          }
+        }
+      }
+
       account =
-        Fixtures.Accounts.create_account()
+        Fixtures.Accounts.create_account(account_attrs)
         |> Fixtures.Accounts.change_to_enterprise()
 
       gateway_group = Fixtures.Gateways.create_group(account: account)


### PR DESCRIPTION
Realized the enable/disable setting wasn't being respected for the outdated gateway notification.  This PR should fix that issue.