### PR TITLE
refactor(connlib): track UDP DNS query source in query meta data

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -63,18 +63,21 @@ pub(crate) struct RecursiveResponse {
 }
 
 impl RecursiveQuery {
-    pub(crate) fn via_udp(server: SocketAddr, message: Message<&[u8]>) -> Self {
+    pub(crate) fn via_udp(source: SocketAddr, server: SocketAddr, message: Message<&[u8]>) -> Self {
         Self {
             server,
             message: message.octets_into(),
-            transport: Transport::Udp,
+            transport: Transport::Udp { source },
         }
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Transport {
-    Udp,
+    Udp {
+        /// The original source we received the DNS query on.
+        source: SocketAddr,
+    },
 }
 
 /// Tells the Client how to reply to a single DNS query

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -217,7 +217,7 @@ impl Io {
 
     pub fn send_dns_query(&mut self, query: dns::RecursiveQuery) {
         match query.transport {
-            dns::Transport::Udp => {
+            dns::Transport::Udp { .. } => {
                 let factory = self.udp_socket_factory.clone();
                 let server = query.server;
                 let bind_addr = match query.server {
@@ -227,7 +227,7 @@ impl Io {
                 let meta = DnsQueryMetaData {
                     query: query.message.clone(),
                     server,
-                    transport: dns::Transport::Udp,
+                    transport: query.transport,
                 };
 
                 if self


### PR DESCRIPTION
When performing recursive DNS queries over UDP, `connlib` needs to remember the original source socket a particular query came from in order to send the response back to the correct socket. Until now, this was tracked in a separate `HashMap`, indexed by upstream server and query ID.

When DNS queries are being retried, they may be resent using the same query ID, causing "Unknown query" logs if the retry happens on a shorter interval than the timeout of our recursive query.

We are already tracking a bunch of meta data along-side the actual query, meaning we can just as easily add the original source socket to that as well.

Once we add TCP DNS queries, we will need to track the handle of the TCP socket in a similar manner.