### PR TITLE
refactor(connlib): clarify TUN and network input functions

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -405,7 +405,12 @@ impl ClientState {
         self.peers.get(gateway_id).is_some()
     }
 
-    pub(crate) fn encapsulate(
+    /// Handles packets received on the TUN device.
+    ///
+    /// Most of these packets will be application traffic that needs to be encrypted and sent through a WireGuard tunnel.
+    /// Some of it may be processed directly, for example DNS queries.
+    /// In that case, this function will return `None` and you should call [`ClientState::handle_timeout`] next to fully advance the internal state.
+    pub(crate) fn handle_tun_input(
         &mut self,
         packet: IpPacket,
         now: Instant,
@@ -460,7 +465,13 @@ impl ClientState {
         Some(transmit)
     }
 
-    pub(crate) fn decapsulate(
+    /// Handles UDP packets received on the network interface.
+    ///
+    /// Most of these packets will be WireGuard encrypted IP packets and will thus yield an [`IpPacket`].
+    /// Some of them will however be handled internally, for example, TURN control packets exchanged with relays.
+    ///
+    /// In case this function returns `None`, you should call [`ClientState::handle_timeout`] next to fully advance the internal state.
+    pub(crate) fn handle_network_input(
         &mut self,
         local: SocketAddr,
         from: SocketAddr,

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -177,7 +177,8 @@ impl GatewayState {
         self.node.public_key()
     }
 
-    pub(crate) fn encapsulate(
+    /// Handles packets received on the TUN device.
+    pub(crate) fn handle_tun_input(
         &mut self,
         packet: IpPacket,
         now: Instant,
@@ -210,7 +211,13 @@ impl GatewayState {
         Some(transmit)
     }
 
-    pub(crate) fn decapsulate(
+    /// Handles UDP packets received on the network interface.
+    ///
+    /// Most of these packets will be WireGuard encrypted IP packets and will thus yield an [`IpPacket`].
+    /// Some of them will however be handled internally, for example, TURN control packets exchanged with relays.
+    ///
+    /// In case this function returns `None`, you should call [`GatewayState::handle_timeout`] next to fully advance the internal state.
+    pub(crate) fn handle_network_input(
         &mut self,
         local: SocketAddr,
         from: SocketAddr,

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -143,7 +143,7 @@ impl ClientTunnel {
                     let now = Instant::now();
                     let Some(enc_packet) =
                         self.role_state
-                            .encapsulate(packet, now, &mut self.encrypt_buf)
+                            .handle_tun_input(packet, now, &mut self.encrypt_buf)
                     else {
                         self.role_state.handle_timeout(now);
                         continue;
@@ -158,7 +158,7 @@ impl ClientTunnel {
                     let now = Instant::now();
 
                     for received in packets {
-                        let Some(packet) = self.role_state.decapsulate(
+                        let Some(packet) = self.role_state.handle_network_input(
                             received.local,
                             received.from,
                             received.packet,
@@ -247,7 +247,7 @@ impl GatewayTunnel {
                     let now = Instant::now();
                     let Some(enc_packet) =
                         self.role_state
-                            .encapsulate(packet, now, &mut self.encrypt_buf)
+                            .handle_tun_input(packet, now, &mut self.encrypt_buf)
                     else {
                         self.role_state.handle_timeout(now, Utc::now());
                         continue;
@@ -263,7 +263,7 @@ impl GatewayTunnel {
                     let utc_now = Utc::now();
 
                     for received in packets {
-                        let Some(packet) = self.role_state.decapsulate(
+                        let Some(packet) = self.role_state.handle_network_input(
                             received.local,
                             received.from,
                             received.packet,

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -155,13 +155,16 @@ impl ClientTunnel {
                     continue;
                 }
                 Poll::Ready(io::Input::Network(packets)) => {
+                    let now = Instant::now();
+
                     for received in packets {
                         let Some(packet) = self.role_state.decapsulate(
                             received.local,
                             received.from,
                             received.packet,
-                            Instant::now(),
+                            now,
                         ) else {
+                            self.role_state.handle_timeout(now);
                             continue;
                         };
 
@@ -256,13 +259,17 @@ impl GatewayTunnel {
                     continue;
                 }
                 Poll::Ready(io::Input::Network(packets)) => {
+                    let now = Instant::now();
+                    let utc_now = Utc::now();
+
                     for received in packets {
                         let Some(packet) = self.role_state.decapsulate(
                             received.local,
                             received.from,
                             received.packet,
-                            Instant::now(),
+                            now,
                         ) else {
+                            self.role_state.handle_timeout(now, utc_now);
                             continue;
                         };
 

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -149,7 +149,7 @@ impl SimClient {
             }
         }
 
-        let Some(enc_packet) = self.sut.encapsulate(packet, now, &mut self.enc_buffer) else {
+        let Some(enc_packet) = self.sut.handle_tun_input(packet, now, &mut self.enc_buffer) else {
             self.sut.handle_timeout(now); // If we handled the packet internally, make sure to advance state.
             return None;
         };
@@ -158,10 +158,12 @@ impl SimClient {
     }
 
     pub(crate) fn receive(&mut self, transmit: Transmit, now: Instant) {
-        let Some(packet) =
-            self.sut
-                .decapsulate(transmit.dst, transmit.src.unwrap(), &transmit.payload, now)
-        else {
+        let Some(packet) = self.sut.handle_network_input(
+            transmit.dst,
+            transmit.src.unwrap(),
+            &transmit.payload,
+            now,
+        ) else {
             self.sut.handle_timeout(now);
             return;
         };

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -162,6 +162,7 @@ impl SimClient {
             self.sut
                 .decapsulate(transmit.dst, transmit.src.unwrap(), &transmit.payload, now)
         else {
+            self.sut.handle_timeout(now);
             return;
         };
 

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -45,10 +45,12 @@ impl SimGateway {
         now: Instant,
         utc_now: DateTime<Utc>,
     ) -> Option<Transmit<'static>> {
-        let Some(packet) =
-            self.sut
-                .decapsulate(transmit.dst, transmit.src.unwrap(), &transmit.payload, now)
-        else {
+        let Some(packet) = self.sut.handle_network_input(
+            transmit.dst,
+            transmit.src.unwrap(),
+            &transmit.payload,
+            now,
+        ) else {
             self.sut.handle_timeout(now, utc_now);
             return None;
         };
@@ -84,7 +86,7 @@ impl SimGateway {
 
             let transmit = self
                 .sut
-                .encapsulate(response, now, &mut self.enc_buffer)?
+                .handle_tun_input(response, now, &mut self.enc_buffer)?
                 .to_transmit(&self.enc_buffer)
                 .into_owned();
 
@@ -130,7 +132,7 @@ impl SimGateway {
         .expect("src and dst are taken from incoming packet");
         let transmit = self
             .sut
-            .encapsulate(echo_response, now, &mut self.enc_buffer)?
+            .handle_tun_input(echo_response, now, &mut self.enc_buffer)?
             .to_transmit(&self.enc_buffer)
             .into_owned();
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -497,9 +497,9 @@ impl TunnelTest {
 
         for (_, gateway) in self.gateways.iter_mut() {
             while let Some(transmit) = gateway.poll_transmit(now) {
-                let Some(reply) =
-                    gateway.exec_mut(|g| g.receive(global_dns_records, transmit, now))
-                else {
+                let Some(reply) = gateway.exec_mut(|g| {
+                    g.receive(global_dns_records, transmit, now, self.flux_capacitor.now())
+                }) else {
                     continue;
                 };
 


### PR DESCRIPTION
Within `connlib`, the `encapsulate` and `decapsulate` functions on `ClientState` and `GatewayState` are the entrypoint for sending and receiving network traffic. For example, IP packets read from the TUN device are processed using these functions.

Not all packets / traffic passed to these functions is meant to be encrypted. Some of it is TURN traffic with relays, some of it is DNS traffic that we intercept.

To clarify this, we rename these functions to `handle_tun_input` and `handle_network_input`.

As part of this clarification, we also call `handle_timeout` in case we don't emit a decrypted IP packet when handling network input. Once we support DNS over TCP (#6944), some IP packets sent through the tunnel will originate from DNS servers that we forwarded queries to. In that case, those responses will be handled by `connlib`'s internal TCP stack and thus not produce a decrypted IP packet. To correctly, advance the state in this case, we mirror what we already do for `handle_tun_input` and call `handle_timeout` if `handle_network_input` yields `None`.