### PR TITLE
chore(connlib): introduce custom logging format

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2438,6 +2438,7 @@ dependencies = [
 name = "firezone-logging"
 version = "0.1.0"
 dependencies = [
+ "nu-ansi-term",
  "time",
  "tracing",
  "tracing-appender",

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -140,9 +140,12 @@ fn init_logging(log_dir: &Path, log_filter: String) -> firezone_logging::file::H
         .with(file_layer)
         .with(
             tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .without_time()
-                .with_level(false)
+                .event_format(
+                    firezone_logging::Format::new()
+                        .without_ansi()
+                        .without_timestamp()
+                        .without_level(),
+                )
                 .with_writer(make_writer::MakeWriter::new("connlib")),
         )
         .with(firezone_logging::filter(&log_filter))

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -160,9 +160,12 @@ fn init_logging(
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .without_time()
-                .with_level(false)
+                .event_format(
+                    firezone_logging::Format::new()
+                        .without_ansi()
+                        .without_timestamp()
+                        .without_level(),
+                )
                 .with_writer(make_writer::MakeWriter::new(
                     "dev.firezone.firezone",
                     "connlib",

--- a/rust/gtk-client/Cargo.lock
+++ b/rust/gtk-client/Cargo.lock
@@ -1453,6 +1453,7 @@ dependencies = [
 name = "firezone-logging"
 version = "0.1.0"
 dependencies = [
+ "nu-ansi-term",
  "time",
  "tracing",
  "tracing-appender",

--- a/rust/logging/Cargo.toml
+++ b/rust/logging/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nu-ansi-term = { version = "0.46" }
 time = { version = "0.3.36", features = ["formatting"] }
 tracing = { workspace = true }
 tracing-appender = { version = "0.2.2" }

--- a/rust/logging/src/format.rs
+++ b/rust/logging/src/format.rs
@@ -1,3 +1,7 @@
+//! Defines our custom event format.
+//!
+//! Inspired by `Compact` in <https://github.com/tokio-rs/tracing/blob/tracing-subscriber-0.3.18/tracing-subscriber/src/fmt/format/mod.rs>.
+
 use std::{fmt, io, num::NonZeroU8};
 
 use nu_ansi_term::{Color, Style};

--- a/rust/logging/src/format.rs
+++ b/rust/logging/src/format.rs
@@ -1,0 +1,174 @@
+use std::{fmt, io, num::NonZeroU8};
+
+use nu_ansi_term::{Color, Style};
+use time::format_description::well_known::{
+    iso8601::{Config, EncodedConfig, TimePrecision},
+    Iso8601,
+};
+use tracing::{Event, Level, Subscriber};
+use tracing_log::NormalizeEvent as _;
+use tracing_subscriber::{
+    fmt::{format::Writer, FmtContext, FormatEvent, FormatFields, FormattedFields},
+    registry::LookupSpan,
+};
+
+/// A custom [`FormatEvent`] implementation for [`tracing-subscriber`] that renders compact, yet informative logs.
+///
+/// Most importantly, we log:
+///
+/// - ISO8601 timestamp
+/// - The log level
+/// - The log target
+/// - The actual message
+/// - All fields, including the fields of all active spans
+///
+/// Most importantly, the actual span-name is not logged.
+pub(crate) struct CompactNoSpans;
+
+const TIMESTAMP_FORMAT_CONFIG: EncodedConfig = Config::DEFAULT
+    .set_time_precision(TimePrecision::Second {
+        decimal_digits: Some({
+            // Safety: 3 > 0
+            unsafe { NonZeroU8::new_unchecked(3) }
+        }),
+    })
+    .encode();
+
+impl<S, N> FormatEvent<S, N> for CompactNoSpans
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let normalized_meta = event.normalized_metadata();
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+
+        if writer.has_ansi_escapes() {
+            let style = Style::new().dimmed();
+            write!(writer, "{}", style.prefix())?;
+
+            ::time::OffsetDateTime::now_utc()
+                .format_into(
+                    &mut IoWriteAdapter::new(&mut writer),
+                    &Iso8601::<TIMESTAMP_FORMAT_CONFIG>,
+                )
+                .map_err(|_| fmt::Error)?;
+
+            write!(writer, "{} ", style.suffix())?;
+        } else {
+            ::time::OffsetDateTime::now_utc()
+                .format_into(
+                    &mut IoWriteAdapter::new(&mut writer),
+                    &Iso8601::<TIMESTAMP_FORMAT_CONFIG>,
+                )
+                .map_err(|_| fmt::Error)?;
+
+            writer.write_char(' ')?;
+        }
+
+        let fmt_level = FmtLevel::new(meta.level(), writer.has_ansi_escapes());
+
+        write!(writer, "{} ", fmt_level)?;
+
+        let dimmed = if writer.has_ansi_escapes() {
+            Style::new().dimmed()
+        } else {
+            Style::new()
+        };
+
+        write!(
+            writer,
+            "{}{}",
+            dimmed.paint(meta.target()),
+            dimmed.paint(":")
+        )?;
+        writer.write_char(' ')?;
+
+        ctx.format_fields(writer.by_ref(), event)?;
+
+        for span in ctx
+            .event_scope()
+            .into_iter()
+            .flat_map(tracing_subscriber::registry::Scope::from_root)
+        {
+            let exts = span.extensions();
+            if let Some(fields) = exts.get::<FormattedFields<N>>() {
+                if !fields.is_empty() {
+                    write!(writer, " {}", fields.fields)?;
+                }
+            }
+        }
+        writeln!(writer)
+    }
+}
+
+/// An adapter to go from [`io::Write`] to [`fmt::Write`] that assumes all bytes are UTF-8 strings.
+struct IoWriteAdapter<'a> {
+    fmt_write: &'a mut dyn fmt::Write,
+}
+
+impl<'a> IoWriteAdapter<'a> {
+    fn new(fmt_write: &'a mut dyn fmt::Write) -> Self {
+        Self { fmt_write }
+    }
+}
+
+impl io::Write for IoWriteAdapter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let s = match std::str::from_utf8(buf) {
+            Ok(s) => s,
+            Err(e) => return Err(io::Error::other(e)),
+        };
+        self.fmt_write.write_str(s).map_err(io::Error::other)?;
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct FmtLevel<'a> {
+    level: &'a Level,
+    ansi: bool,
+}
+
+impl<'a> FmtLevel<'a> {
+    pub(crate) fn new(level: &'a Level, ansi: bool) -> Self {
+        Self { level, ansi }
+    }
+}
+
+const TRACE_STR: &str = "TRACE";
+const DEBUG_STR: &str = "DEBUG";
+const INFO_STR: &str = " INFO";
+const WARN_STR: &str = " WARN";
+const ERROR_STR: &str = "ERROR";
+
+impl<'a> fmt::Display for FmtLevel<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.ansi {
+            match *self.level {
+                Level::TRACE => write!(f, "{}", Color::Purple.paint(TRACE_STR)),
+                Level::DEBUG => write!(f, "{}", Color::Blue.paint(DEBUG_STR)),
+                Level::INFO => write!(f, "{}", Color::Green.paint(INFO_STR)),
+                Level::WARN => write!(f, "{}", Color::Yellow.paint(WARN_STR)),
+                Level::ERROR => write!(f, "{}", Color::Red.paint(ERROR_STR)),
+            }
+        } else {
+            match *self.level {
+                Level::TRACE => f.pad(TRACE_STR),
+                Level::DEBUG => f.pad(DEBUG_STR),
+                Level::INFO => f.pad(INFO_STR),
+                Level::WARN => f.pad(WARN_STR),
+                Level::ERROR => f.pad(ERROR_STR),
+            }
+        }
+    }
+}

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod file;
+mod format;
 
 use tracing::subscriber::DefaultGuard;
 use tracing_log::LogTracer;
@@ -16,7 +17,7 @@ where
 
     let subscriber = Registry::default()
         .with(additional_layer)
-        .with(fmt::layer())
+        .with(fmt::layer().event_format(crate::format::CompactNoSpans))
         .with(filter(&directives));
     tracing::subscriber::set_global_default(subscriber).expect("Could not set global default");
     LogTracer::init().unwrap();

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -8,6 +8,8 @@ use tracing_subscriber::{
     Registry,
 };
 
+pub use format::Format;
+
 /// Registers a global subscriber with stdout logging and `additional_layer`
 pub fn setup_global_subscriber<L>(additional_layer: L)
 where
@@ -17,7 +19,7 @@ where
 
     let subscriber = Registry::default()
         .with(additional_layer)
-        .with(fmt::layer().event_format(crate::format::CompactNoSpans))
+        .with(fmt::layer().event_format(Format::new()))
         .with(filter(&directives));
     tracing::subscriber::set_global_default(subscriber).expect("Could not set global default");
     LogTracer::init().unwrap();


### PR DESCRIPTION
This PR introduces a custom logging format for all Rust-components. It is more or less a copy of `tracing_subscriber::fmt::format::Compact` with the main difference that span-names don't get logged.

Spans are super useful because they allow us to record contextual values, like the current connection ID, for a certain scope. What is IMO less useful about them is that in the default formatter configuration, active spans cause a right-drift of the actual log message.

The actual log message is still what most accurately describes, what `connlib` is currently doing. Spans only add contextual information that the reader may use for further understand what is happening. This optional nature of the utility of spans IMO means that they should come _after_ the actual log message.

Resolves: #7014.