### PR TITLE
refactor(connlib): expose `&mut TRoleState` for direct access

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -131,7 +131,6 @@ impl ClientTunnel {
 
     pub fn set_resource_offline(&mut self, id: ResourceId) {
         self.role_state.set_resource_offline(id);
-        self.role_state.on_connection_failed(id);
     }
 
     pub fn add_ice_candidate(&mut self, conn_id: GatewayId, ice_candidate: String) {
@@ -342,7 +341,8 @@ impl ClientState {
             self.sites_status.insert(*id, ResourceStatus::Offline);
         }
 
-        self.emit_resources_changed()
+        self.on_connection_failed(id);
+        self.emit_resources_changed();
     }
 
     pub(crate) fn public_key(&self) -> PublicKey {

--- a/rust/connlib/tunnel/src/client/resource.rs
+++ b/rust/connlib/tunnel/src/client/resource.rs
@@ -140,6 +140,18 @@ impl Resource {
     }
 }
 
+impl TryFrom<ResourceDescription> for Resource {
+    type Error = UnknownResourceType;
+
+    fn try_from(value: ResourceDescription) -> Result<Self, Self::Error> {
+        Self::from_description(value).ok_or(UnknownResourceType)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Unknown resource type")]
+pub struct UnknownResourceType;
+
 impl CidrResource {
     pub fn from_description(resource: ResourceDescriptionCidr) -> Self {
         Self {

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -15,7 +15,6 @@ use snownet::{EncryptBuffer, RelaySocket, ServerNode};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::{Duration, Instant};
-use tun::Tun;
 
 pub const IPV4_PEERS: Ipv4Network = match Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 0), 11) {
     Ok(n) => n,
@@ -30,10 +29,6 @@ pub const IPV6_PEERS: Ipv6Network =
 const EXPIRE_RESOURCES_INTERVAL: Duration = Duration::from_secs(1);
 
 impl GatewayTunnel {
-    pub fn set_tun(&mut self, tun: Box<dyn Tun>) {
-        self.io.set_tun(tun);
-    }
-
     /// Accept a connection request from a client.
     #[expect(deprecated, reason = "Will be deleted together with deprecated API")]
     pub fn accept(

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -12,6 +12,7 @@ use connlib_model::{
 use io::Io;
 use ip_network::{Ipv4Network, Ipv6Network};
 use ip_packet::MAX_DATAGRAM_PAYLOAD;
+use snownet::EncryptBuffer;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -22,7 +23,6 @@ use std::{
     time::Instant,
 };
 use tun::Tun;
-use utils::turn;
 
 mod client;
 mod device_channel;
@@ -56,7 +56,7 @@ pub type ClientTunnel = Tunnel<ClientState>;
 
 pub use client::ClientState;
 pub use gateway::{DnsResourceNatEntry, GatewayState, IPV4_PEERS, IPV6_PEERS};
-use snownet::EncryptBuffer;
+pub use utils::turn;
 
 /// [`Tunnel`] glues together connlib's [`Io`] component and the respective (pure) state of a client or gateway.
 ///
@@ -76,6 +76,16 @@ pub struct Tunnel<TRoleState> {
 
     /// Buffer for encrypting a single packet.
     encrypt_buf: EncryptBuffer,
+}
+
+impl<TRoleState> Tunnel<TRoleState> {
+    pub fn state_mut(&mut self) -> &mut TRoleState {
+        &mut self.role_state
+    }
+
+    pub fn set_tun(&mut self, tun: Box<dyn Tun>) {
+        self.io.set_tun(tun);
+    }
 }
 
 impl ClientTunnel {

--- a/rust/connlib/tunnel/src/messages.rs
+++ b/rust/connlib/tunnel/src/messages.rs
@@ -101,6 +101,18 @@ pub struct Answer {
     pub password: String,
 }
 
+#[expect(deprecated)]
+impl From<Answer> for snownet::Answer {
+    fn from(val: Answer) -> Self {
+        snownet::Answer {
+            credentials: snownet::Credentials {
+                username: val.username,
+                password: val.password,
+            },
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Offer {
     pub username: String,

--- a/rust/connlib/tunnel/src/messages.rs
+++ b/rust/connlib/tunnel/src/messages.rs
@@ -4,6 +4,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use chrono::{serde::ts_seconds, DateTime, Utc};
 use connlib_model::{GatewayId, RelayId, ResourceId};
 use ip_network::IpNetwork;
+use secrecy::{ExposeSecret, Secret};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -117,6 +118,20 @@ impl From<Answer> for snownet::Answer {
 pub struct Offer {
     pub username: String,
     pub password: String,
+}
+
+#[expect(deprecated)]
+impl Offer {
+    // Not a very clean API but it is deprecated anyway.
+    pub fn into_snownet_offer(self, key: Secret<Key>) -> snownet::Offer {
+        snownet::Offer {
+            session_key: Secret::new(key.expose_secret().0),
+            credentials: snownet::Credentials {
+                username: self.username,
+                password: self.password,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Hash, PartialEq, Eq)]

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -132,7 +132,7 @@ impl TunnelTest {
             }
             Transition::DisableResources(resources) => state
                 .client
-                .exec_mut(|c| c.sut.set_disabled_resource(resources)),
+                .exec_mut(|c| c.sut.set_disabled_resources(resources)),
             Transition::SendICMPPacketToNonResourceIp {
                 src,
                 dst,

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -661,23 +661,17 @@ impl TunnelTest {
                 let resource = portal.map_client_resource_to_gateway_resource(resource_id);
 
                 gateway.exec_mut(|g| {
-                    g.sut.allow_access(
-                        self.client.inner().id,
-                        self.client.inner().sut.tunnel_ip4().unwrap(),
-                        self.client.inner().sut.tunnel_ip6().unwrap(),
-                        None,
-                        resource.clone(),
-                    );
-                    if let Some(entry) = maybe_entry {
-                        g.sut
-                            .create_dns_resource_nat_entry(
-                                self.client.inner().id,
-                                resource.id(),
-                                entry,
-                                now,
-                            )
-                            .unwrap()
-                    };
+                    g.sut
+                        .allow_access(
+                            self.client.inner().id,
+                            self.client.inner().sut.tunnel_ip4().unwrap(),
+                            self.client.inner().sut.tunnel_ip6().unwrap(),
+                            None,
+                            resource.clone(),
+                            maybe_entry,
+                            now,
+                        )
+                        .unwrap();
                 });
             }
             ClientEvent::ResourcesChanged { .. } => {
@@ -734,23 +728,17 @@ impl TunnelTest {
                             self.client.inner().sut.public_key(),
                             now,
                         );
-                        g.sut.allow_access(
-                            self.client.inner().id,
-                            self.client.inner().sut.tunnel_ip4().unwrap(),
-                            self.client.inner().sut.tunnel_ip6().unwrap(),
-                            None,
-                            resource.clone(),
-                        );
-                        if let Some(entry) = maybe_entry {
-                            g.sut
-                                .create_dns_resource_nat_entry(
-                                    self.client.inner().id,
-                                    resource.id(),
-                                    entry,
-                                    now,
-                                )
-                                .unwrap()
-                        };
+                        g.sut
+                            .allow_access(
+                                self.client.inner().id,
+                                self.client.inner().sut.tunnel_ip4().unwrap(),
+                                self.client.inner().sut.tunnel_ip6().unwrap(),
+                                None,
+                                resource.clone(),
+                                maybe_entry,
+                                now,
+                            )
+                            .unwrap();
 
                         anyhow::Ok(answer)
                     })


### PR DESCRIPTION
Currently, we have a lot of stupid code to forward data from the `{Client,Gateway}Tunnel` interface to `{Client,Gateway}State`. Recent refactorings such as #6919 made it possible to get rid of this forwarding layer by directly exposing `&mut TRoleState`.

To maintain some type-privacy, several functions are made generic to accept `impl Into` or `impl TryInto`.