### PR TITLE
chore: set simpler default log filters

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -277,7 +277,7 @@ defmodule Web.Sites.NewToken do
         "--env #{key}=\"#{value}\""
       end),
       "--env FIREZONE_NAME=$(hostname)",
-      "--env RUST_LOG=str0m=warn,info",
+      "--env RUST_LOG=info",
       "#{Domain.Config.fetch_env!(:domain, :docker_registry)}/gateway:1"
     ]
     |> List.flatten()
@@ -316,7 +316,7 @@ defmodule Web.Sites.NewToken do
 
   defp manual_command_env(env) do
     """
-    RUST_LOG=str0m=warn,info
+    RUST_LOG=info
     #{Enum.map_join(env, "\n", fn {key, value} -> "#{key}=#{value}" end)}
     """
   end

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -11,9 +11,9 @@ FROM rust:${RUST_VERSION}-alpine${ALPINE_VERSION} AS chef
 
 ARG CARGO_CHEF_VERSION
 RUN set -xe \
-  && apk add --no-cache musl-dev  \
-  && cargo install cargo-chef --locked --version=${CARGO_CHEF_VERSION} \
-  && rm -rf $CARGO_HOME/registry/
+    && apk add --no-cache musl-dev  \
+    && cargo install cargo-chef --locked --version=${CARGO_CHEF_VERSION} \
+    && rm -rf $CARGO_HOME/registry/
 
 ## See https://github.com/LukeMathWalker/cargo-chef/issues/231.
 COPY rust-toolchain.toml rust-toolchain.toml
@@ -37,7 +37,7 @@ COPY --from=planner /build/recipe.json .
 
 ARG PACKAGE
 RUN set -xe \
-  && cargo chef cook --recipe-path recipe.json --bin ${PACKAGE}
+    && cargo chef cook --recipe-path recipe.json --bin ${PACKAGE}
 
 COPY . .
 
@@ -48,9 +48,9 @@ RUN cargo build -p ${PACKAGE} $([ -n "${TARGET}" ] && "--target ${TARGET}")
 FROM alpine:${ALPINE_VERSION} AS runtime_base
 
 ENV LANG=C.UTF-8 \
-  TERM=xterm \
-  RUST_BACKTRACE=1 \
-  RUST_LOG=str0m=warn,info
+    TERM=xterm \
+    RUST_BACKTRACE=1 \
+    RUST_LOG=info
 
 WORKDIR /bin
 

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -41,11 +41,11 @@ pub mod platform;
 
 /// Default log filter for the IPC service
 #[cfg(debug_assertions)]
-const SERVICE_RUST_LOG: &str = "firezone_headless_client=debug,firezone_tunnel=debug,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,boringtun=debug,snownet=debug,str0m=info,info";
+const SERVICE_RUST_LOG: &str = "debug";
 
 /// Default log filter for the IPC service
 #[cfg(not(debug_assertions))]
-const SERVICE_RUST_LOG: &str = "str0m=warn,info";
+const SERVICE_RUST_LOG: &str = "info";
 
 #[derive(clap::Parser)]
 #[command(author, version, about, long_about = None)]

--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -7,7 +7,7 @@ FIREZONE_NAME=${FIREZONE_NAME:-$hostname}
 FIREZONE_ID=${FIREZONE_ID:-}
 FIREZONE_TOKEN=${FIREZONE_TOKEN:-}
 FIREZONE_API_URL=${FIREZONE_API_URL:-wss://api.firezone.dev}
-RUST_LOG=${RUST_LOG:-str0m=warn,info}
+RUST_LOG=${RUST_LOG:-info}
 
 # Can be used to download a specific version of the gateway from a custom URL
 FIREZONE_VERSION=${FIREZONE_VERSION:-latest}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -68,15 +68,14 @@ struct Settings: Equatable {
       Settings(
         authBaseURL: "https://app.firez.one",
         apiURL: "wss://api.firez.one",
-        logFilter:
-          "firezone_tunnel=debug,phoenix_channel=debug,connlib_shared=debug,connlib_client_shared=debug,snownet=debug,str0m=info,warn",
+        logFilter: "debug",
         internetResourceEnabled: nil
       )
     #else
       Settings(
         authBaseURL: "https://app.firezone.dev",
         apiURL: "wss://api.firezone.dev",
-        logFilter: "str0m=warn,info",
+        logFilter: "info",
         internetResourceEnabled: nil
       )
     #endif

--- a/website/src/app/kb/automate/docker-compose/readme.mdx
+++ b/website/src/app/kb/automate/docker-compose/readme.mdx
@@ -32,7 +32,7 @@ services:
 
       # Configure log output. Other options are "trace", "debug", "info", "warn", "error", and "off".
       # See https://docs.rs/env_logger/latest/env_logger/ for more information.
-      - RUST_LOG=str0m=warn,info
+      - RUST_LOG=info
 
       # Human-friendly name to use for this Gateway in the admin portal.
       # $(hostname) is used by default if not set.


### PR DESCRIPTION
Follow-up from #6985 to simplify our log filters everywhere. If any of this doesn't fit, we should adjust the things here:

https://github.com/firezone/firezone/blob/17ea827c03579a3516f7abf6184a557ec32cd48b/rust/logging/src/lib.rs#L32-L40