### PR TITLE
fix(portal): Remove extra space before a link

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -166,9 +166,11 @@ defmodule Web.Sites.Show do
       <:content flash={@flash}>
         <.flash :if={@gateways_metadata.count == 1} kind={:info} style="wide" class="mb-2">
           Deploy at least one more gateway to ensure
-          <.website_link path="/kb/deploy/gateways" fragment="deploy-multiple-gateways">
-            high availability
-          </.website_link>.
+          <span class="inline-flex">
+            <.website_link path="/kb/deploy/gateways" fragment="deploy-multiple-gateways">
+              high availability
+            </.website_link>.
+          </span>
         </.flash>
 
         <div class="relative overflow-x-auto">


### PR DESCRIPTION
<img width="394" alt="Screenshot 2024-10-14 at 4 49 09 PM" src="https://github.com/user-attachments/assets/1f1f3eba-96a5-49c6-b05b-d28439041a56">
