### PR TITLE
fix(phoenix-channel/test/windows): account for 15 ms timing granularity

### DIFF
--- a/rust/phoenix-channel/src/heartbeat.rs
+++ b/rust/phoenix-channel/src/heartbeat.rs
@@ -88,16 +88,17 @@ mod tests {
     use futures::future::Either;
     use std::{future::poll_fn, time::Instant};
 
-    const INTERVAL: Duration = Duration::from_millis(30);
-    const TIMEOUT: Duration = Duration::from_millis(5);
+    const INTERVAL: Duration = Duration::from_millis(180);
+    // Windows won't allow Tokio to schedule any timer shorter than about 15 ms.
+    // If we only set 15 here, sometimes the timeout and heartbeat may both fall on a 30-ms tick, so it has to be longer.
+    const TIMEOUT: Duration = Duration::from_millis(30);
 
     #[tokio::test]
     async fn returns_heartbeat_after_interval() {
+        let start = Instant::now();
         let mut heartbeat = Heartbeat::new(INTERVAL, TIMEOUT, Arc::new(AtomicU64::new(0)));
         let id = poll_fn(|cx| heartbeat.poll(cx)).await.unwrap(); // Tick once at startup.
         heartbeat.maybe_handle_reply(id);
-
-        let start = Instant::now();
 
         let result = poll_fn(|cx| heartbeat.poll(cx)).await;
 


### PR DESCRIPTION
Closes #6953 

- Increases heartbeat in unit test from 5 ms to 30 ms to avoid timer aliasing on Windows
- Increases interval proportionally to 180 ms
- Corrects measurement of elapsed time for `returns_heartbeat_after_interval`. The first `heartbeat.poll` seems to consume a few ms, which can cause a false test failure