### PR TITLE
chore(rust): use latest `main` of `smoltcp`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5681,8 +5681,7 @@ dependencies = [
 [[package]]
 name = "smoltcp"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1a996951e50b5971a2c8c0fa05a381480d70a933064245c4a223ddc87ccc97"
+source = "git+https://github.com/smoltcp-rs/smoltcp?branch=main#7acf1ac71bdd709df4bbe2a44c559077ebe45f7f"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -75,6 +75,7 @@ redundant_clone = "warn"
 private-intra-doc-links = "allow" # We don't publish any of our docs but want to catch dead links.
 
 [patch.crates-io]
+smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", branch = "main" }
 boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.

--- a/rust/dns-over-tcp/src/client.rs
+++ b/rust/dns-over-tcp/src/client.rs
@@ -10,7 +10,7 @@ use domain::{base::Message, dep::octseq::OctetsInto};
 use ip_packet::IpPacket;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use smoltcp::{
-    iface::{Interface, SocketSet},
+    iface::{Interface, PollResult, SocketSet},
     socket::tcp::{self, Socket},
 };
 
@@ -211,13 +211,13 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             return;
         };
 
-        let changed = self.interface.poll(
+        let result = self.interface.poll(
             smoltcp::time::Instant::from(now),
             &mut self.device,
             &mut self.sockets,
         );
 
-        if !changed && self.pending_queries_by_remote.is_empty() {
+        if result == PollResult::None && self.pending_queries_by_remote.is_empty() {
             return;
         }
 

--- a/rust/dns-over-tcp/src/server.rs
+++ b/rust/dns-over-tcp/src/server.rs
@@ -9,7 +9,7 @@ use anyhow::{Context as _, Result};
 use domain::{base::Message, dep::octseq::OctetsInto as _};
 use ip_packet::IpPacket;
 use smoltcp::{
-    iface::{Interface, SocketSet},
+    iface::{Interface, PollResult, SocketSet},
     socket::tcp,
     wire::IpEndpoint,
 };
@@ -146,13 +146,13 @@ impl Server {
     ///
     /// Typical for a sans-IO design, `handle_timeout` will work through all local buffers and process them as much as possible.
     pub fn handle_timeout(&mut self, now: Instant) {
-        let changed = self.interface.poll(
+        let result = self.interface.poll(
             smoltcp::time::Instant::from(now),
             &mut self.device,
             &mut self.sockets,
         );
 
-        if !changed {
+        if result == PollResult::None {
             return;
         }
 

--- a/rust/dns-over-tcp/src/stub_device.rs
+++ b/rust/dns-over-tcp/src/stub_device.rs
@@ -77,10 +77,10 @@ pub(crate) struct SmolRxToken {
 }
 
 impl smoltcp::phy::RxToken for SmolRxToken {
-    fn consume<R, F>(mut self, f: F) -> R
+    fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
-        f(self.packet.packet_mut())
+        f(self.packet.packet())
     }
 }

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -789,7 +789,7 @@ impl IpPacket {
         }
     }
 
-    pub fn packet_mut(&mut self) -> &mut [u8] {
+    fn packet_mut(&mut self) -> &mut [u8] {
         match self {
             IpPacket::Ipv4(v4) => v4.packet_mut(),
             IpPacket::Ipv6(v6) => v6.packet_mut(),


### PR DESCRIPTION
The last released version of `smoltcp` is `0.11.0`. That version is almost a year old. Since then, an important "bug" got fixed in the IPv6 handling code of `smoltcp`.

In order to route packets to our interface, we define a dummy IPv4 and IPv6 address and create catch-all routes with our interface as the gateway. Together with `set_any_ip(true)`, the makes `smoltcp` accept any packet we pass it to. This is necessary because we don't directly connect `smoltcp` to the TUN device but rather have an `InMemoryDevice` where we explicitly feed certain packets to it.

In the last released version, `smoltcp` only performs the above logic for IPv4. For IPv6, the additional check for "do we have a route that this packet matches" doesn't exist and thus no IPv6 traffic is accepted by `smoltcp`.

Extracted out of #6944.