### PR TITLE
chore(connlib): use tcp and udp packets for proptests

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -105,8 +105,9 @@ jobs:
           cargo test --all-features ${{ steps.setup-rust.outputs.packages }} -- --include-ignored --nocapture
 
           # Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
-          rg --count --no-ignore SendPacketToCidrResource $TESTCASES_DIR
-          rg --count --no-ignore SendPacketToDnsResource $TESTCASES_DIR
+          rg --count --no-ignore SendIcmpPacket $TESTCASES_DIR
+          rg --count --no-ignore SendUdpPacket $TESTCASES_DIR
+          rg --count --no-ignore SendTcpPayload $TESTCASES_DIR
           rg --count --no-ignore SendDnsQueries $TESTCASES_DIR
           rg --count --no-ignore "Performed IP-NAT46" $TESTCASES_DIR
           rg --count --no-ignore "Performed IP-NAT64" $TESTCASES_DIR

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -109,6 +109,9 @@ jobs:
           rg --count --no-ignore SendUdpPacket $TESTCASES_DIR
           rg --count --no-ignore SendTcpPayload $TESTCASES_DIR
           rg --count --no-ignore SendDnsQueries $TESTCASES_DIR
+          rg --count --no-ignore "Packet for DNS resource" $TESTCASES_DIR
+          rg --count --no-ignore "Packet for CIDR resource" $TESTCASES_DIR
+          rg --count --no-ignore "Packet for internet resource" $TESTCASES_DIR
           rg --count --no-ignore "Performed IP-NAT46" $TESTCASES_DIR
           rg --count --no-ignore "Performed IP-NAT64" $TESTCASES_DIR
 

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -105,8 +105,8 @@ jobs:
           cargo test --all-features ${{ steps.setup-rust.outputs.packages }} -- --include-ignored --nocapture
 
           # Poor man's test coverage testing: Grep the generated logs for specific patterns / lines.
-          rg --count --no-ignore SendICMPPacketToCidrResource $TESTCASES_DIR
-          rg --count --no-ignore SendICMPPacketToDnsResource $TESTCASES_DIR
+          rg --count --no-ignore SendPacketToCidrResource $TESTCASES_DIR
+          rg --count --no-ignore SendPacketToDnsResource $TESTCASES_DIR
           rg --count --no-ignore SendDnsQueries $TESTCASES_DIR
           rg --count --no-ignore "Performed IP-NAT46" $TESTCASES_DIR
           rg --count --no-ignore "Performed IP-NAT64" $TESTCASES_DIR

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -111,7 +111,7 @@ jobs:
           rg --count --no-ignore SendDnsQueries $TESTCASES_DIR
           rg --count --no-ignore "Packet for DNS resource" $TESTCASES_DIR
           rg --count --no-ignore "Packet for CIDR resource" $TESTCASES_DIR
-          rg --count --no-ignore "Packet for internet resource" $TESTCASES_DIR
+          rg --count --no-ignore "Packet for Internet resource" $TESTCASES_DIR
           rg --count --no-ignore "Performed IP-NAT46" $TESTCASES_DIR
           rg --count --no-ignore "Performed IP-NAT64" $TESTCASES_DIR
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -795,7 +795,7 @@ impl ClientState {
             .resolve_resource_by_ip(&destination)
             .filter(|resource| self.is_resource_enabled(resource))
             .inspect(
-                |resource| tracing::trace!(target: "tunnel_test", %destination, %resource, "Packet for DNS resource"),
+                |resource| tracing::trace!(target: "tunnel_test_coverage", %destination, %resource, "Packet for DNS resource"),
             );
 
         // We don't need to filter from here because resources are removed from the active_cidr_resources as soon as they are disabled.
@@ -804,7 +804,7 @@ impl ClientState {
             .longest_match(destination)
             .map(|(_, res)| res.id)
             .inspect(
-                |resource| tracing::trace!(target: "tunnel_test", %destination, %resource, "Packet for CIDR resource"),
+                |resource| tracing::trace!(target: "tunnel_test_coverage", %destination, %resource, "Packet for CIDR resource"),
             );
 
         maybe_dns_resource_id
@@ -812,7 +812,7 @@ impl ClientState {
             .or(self.internet_resource)
             .inspect(|r| {
                 if Some(*r) == self.internet_resource {
-                    tracing::trace!(target: "tunnel_test", %destination, "Packet for Internet resource")
+                    tracing::trace!(target: "tunnel_test_coverage", %destination, "Packet for Internet resource")
                 }
             })
     }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -795,7 +795,7 @@ impl ClientState {
             .resolve_resource_by_ip(&destination)
             .filter(|resource| self.is_resource_enabled(resource))
             .inspect(
-                |resource| tracing::trace!(%destination, %resource, "Packet for DNS resource"),
+                |resource| tracing::trace!(target: "tunnel_test", %destination, %resource, "Packet for DNS resource"),
             );
 
         // We don't need to filter from here because resources are removed from the active_cidr_resources as soon as they are disabled.
@@ -804,7 +804,7 @@ impl ClientState {
             .longest_match(destination)
             .map(|(_, res)| res.id)
             .inspect(
-                |resource| tracing::trace!(%destination, %resource, "Packet for CIDR resource"),
+                |resource| tracing::trace!(target: "tunnel_test", %destination, %resource, "Packet for CIDR resource"),
             );
 
         maybe_dns_resource_id
@@ -812,7 +812,7 @@ impl ClientState {
             .or(self.internet_resource)
             .inspect(|r| {
                 if Some(*r) == self.internet_resource {
-                    tracing::trace!(%destination, "Packet for internet resource")
+                    tracing::trace!(target: "tunnel_test", %destination, "Packet for Internet resource")
                 }
             })
     }

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -195,7 +195,7 @@ fn init_logging(
 
 fn log_file_filter() -> EnvFilter {
     let default_filter =
-        "debug,firezone_tunnel=trace,firezone_tunnel::tests=debug,tunnel_test=trace,ip_packet=trace".to_owned();
+        "debug,firezone_tunnel=trace,firezone_tunnel::tests=debug,tunnel_test_coverage=trace,ip_packet=trace".to_owned();
     let env_filter = std::env::var("RUST_LOG").unwrap_or_default();
 
     EnvFilter::new([default_filter, env_filter].join(","))

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -29,8 +29,6 @@ mod sut;
 mod transition;
 
 type QueryId = u16;
-type IcmpSeq = u16;
-type IcmpIdentifier = u16;
 
 #[test]
 #[expect(clippy::print_stdout, clippy::print_stderr)]

--- a/rust/connlib/tunnel/src/tests.rs
+++ b/rust/connlib/tunnel/src/tests.rs
@@ -195,7 +195,7 @@ fn init_logging(
 
 fn log_file_filter() -> EnvFilter {
     let default_filter =
-        "debug,firezone_tunnel=trace,firezone_tunnel::tests=debug,ip_packet=trace".to_owned();
+        "debug,firezone_tunnel=trace,firezone_tunnel::tests=debug,tunnel_test=trace,ip_packet=trace".to_owned();
     let env_filter = std::env::var("RUST_LOG").unwrap_or_default();
 
     EnvFilter::new([default_filter, env_filter].join(","))

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -103,7 +103,7 @@ pub(crate) fn assert_tcp_packets_properties(
     );
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn assert_packets_properties<T, U>(
     ref_client: &RefClient,
     sent_requests: &HashMap<(T, U), IpPacket>,

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -1,13 +1,14 @@
 use super::{
     sim_client::{RefClient, SimClient},
     sim_gateway::SimGateway,
+    transition::{Destination, RequestFrom},
 };
-use crate::tests::reference::ResourceDst;
 use connlib_model::{DomainName, GatewayId};
 use ip_packet::IpPacket;
 use itertools::Itertools;
 use std::{
     collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, VecDeque},
+    hash::Hash,
     marker::PhantomData,
     net::IpAddr,
     sync::atomic::{AtomicBool, Ordering},
@@ -21,66 +22,147 @@ use tracing_subscriber::Layer;
 ///     - For CIDR resources, that is the actual CIDR resource IP.
 ///     - For DNS resources, the IP must match one of the resolved IPs for the domain.
 /// 3. For DNS resources, the mapping of proxy IP to actual resource IP must be stable.
+
 pub(crate) fn assert_icmp_packets_properties(
     ref_client: &RefClient,
     sim_client: &SimClient,
-    sim_gateways: HashMap<GatewayId, &SimGateway>,
+    sim_gateway: HashMap<GatewayId, &SimGateway>,
     global_dns_records: &BTreeMap<DomainName, BTreeSet<IpAddr>>,
 ) {
-    let unexpected_icmp_replies = find_unexpected_entries(
-        &ref_client
-            .expected_icmp_handshakes
-            .values()
-            .flatten()
-            .collect(),
+    let received_icmp_requests = sim_gateway
+        .iter()
+        .map(|(g, s)| (*g, &s.received_icmp_requests))
+        .collect();
+
+    assert_packets_properties(
+        ref_client,
+        &sim_client.sent_icmp_requests,
+        &received_icmp_requests,
+        &ref_client.expected_icmp_handshakes,
         &sim_client.received_icmp_replies,
-        |(_, (_, seq_a, id_a)), (seq_b, id_b)| seq_a == seq_b && id_a == id_b,
+        "ICMP",
+        global_dns_records,
+    );
+}
+
+/// Asserts the following properties for all UDP handshakes:
+/// 1. An UDP request on the client MUST result in an UDP response using the flipped src & dst IP and sport and dport.
+/// 2. An UDP request on the gateway MUST target the intended resource:
+///     - For CIDR resources, that is the actual CIDR resource IP.
+///     - For DNS resources, the IP must match one of the resolved IPs for the domain.
+/// 3. For DNS resources, the mapping of proxy IP to actual resource IP must be stable.
+
+pub(crate) fn assert_udp_packets_properties(
+    ref_client: &RefClient,
+    sim_client: &SimClient,
+    sim_gateway: HashMap<GatewayId, &SimGateway>,
+    global_dns_records: &BTreeMap<DomainName, BTreeSet<IpAddr>>,
+) {
+    let received_udp_requests = sim_gateway
+        .iter()
+        .map(|(g, s)| (*g, &s.received_udp_requests))
+        .collect();
+
+    assert_packets_properties(
+        ref_client,
+        &sim_client.sent_udp_requests,
+        &received_udp_requests,
+        &ref_client.expected_udp_handshakes,
+        &sim_client.received_udp_replies,
+        "UDP",
+        global_dns_records,
+    );
+}
+
+/// Asserts the following properties for all TCP handshakes:
+/// 1. An TCP request on the client MUST result in an TCP response using the flipped src & dst IP and sport and dport.
+/// 2. An TCP request on the gateway MUST target the intended resource:
+///     - For CIDR resources, that is the actual CIDR resource IP.
+///     - For DNS resources, the IP must match one of the resolved IPs for the domain.
+/// 3. For DNS resources, the mapping of proxy IP to actual resource IP must be stable.
+
+pub(crate) fn assert_tcp_packets_properties(
+    ref_client: &RefClient,
+    sim_client: &SimClient,
+    sim_gateway: HashMap<GatewayId, &SimGateway>,
+    global_dns_records: &BTreeMap<DomainName, BTreeSet<IpAddr>>,
+) {
+    let received_tcp_requests = sim_gateway
+        .iter()
+        .map(|(g, s)| (*g, &s.received_tcp_requests))
+        .collect();
+
+    assert_packets_properties(
+        ref_client,
+        &sim_client.sent_tcp_requests,
+        &received_tcp_requests,
+        &ref_client.expected_tcp_handshakes,
+        &sim_client.received_tcp_replies,
+        "TCP",
+        global_dns_records,
+    );
+}
+
+pub(crate) fn assert_packets_properties<T, U>(
+    ref_client: &RefClient,
+    sent_requests: &HashMap<(T, U), IpPacket>,
+    received_requests: &HashMap<GatewayId, &BTreeMap<u64, IpPacket>>,
+    expected_handshakes: &BTreeMap<GatewayId, BTreeMap<u64, (Destination, T, U)>>,
+    received_replies: &BTreeMap<(T, U), IpPacket>,
+    packet_protocol: &str,
+    global_dns_records: &BTreeMap<DomainName, BTreeSet<IpAddr>>,
+) where
+    T: Copy + std::fmt::Debug,
+    U: Copy + std::fmt::Debug,
+    (T, U): RequestFrom + Hash + Eq + Ord,
+{
+    let unexpected_replies = find_unexpected_entries(
+        &expected_handshakes.values().flatten().collect(),
+        received_replies,
+        |(_, (_, t_a, u_a)), b| (*t_a, *u_a).request_from() == *b,
     );
 
-    if !unexpected_icmp_replies.is_empty() {
-        tracing::error!(target: "assertions", ?unexpected_icmp_replies, "❌ Unexpected ICMP replies on client");
+    if !unexpected_replies.is_empty() {
+        tracing::error!(target: "assertions", ?unexpected_replies, "❌ Unexpected {packet_protocol} replies on client");
     }
 
-    for (gid, expected_icmp_handshakes) in ref_client.expected_icmp_handshakes.iter() {
-        let gateway = sim_gateways.get(gid).unwrap();
+    for (gid, expected_handshakes) in expected_handshakes.iter() {
+        let received_requests = received_requests.get(gid).unwrap();
 
-        let num_expected_handshakes = expected_icmp_handshakes.len();
-        let num_actual_handshakes = gateway.received_icmp_requests.len();
+        let num_expected_handshakes = expected_handshakes.len();
+        let num_actual_handshakes = received_requests.len();
 
         if num_expected_handshakes != num_actual_handshakes {
-            tracing::error!(target: "assertions", %num_expected_handshakes, %num_actual_handshakes, %gid, "❌ Unexpected ICMP requests");
+            tracing::error!(target: "assertions", %num_expected_handshakes, %num_actual_handshakes, %gid, "❌ Unexpected {packet_protocol} requests");
         } else {
-            tracing::info!(target: "assertions", %num_expected_handshakes, %gid, "✅ Performed the expected ICMP handshakes");
+            tracing::info!(target: "assertions", %num_expected_handshakes, %gid, "✅ Performed the expected {packet_protocol} handshakes");
         }
     }
 
     let mut mapping = HashMap::new();
 
-    // Assert properties of the individual ICMP handshakes per gateway.
+    // Assert properties of the individual handshakes per gateway.
     // Due to connlib's implementation of NAT64, we cannot match the packets sent by the client to the packets arriving at the resource by port or ICMP identifier.
     // Thus, we rely on the _order_ here which is why the packets are indexed by gateway in the `RefClient`.
-    for (gateway, expected_icmp_handshakes) in &ref_client.expected_icmp_handshakes {
-        let received_icmp_requests = &sim_gateways.get(gateway).unwrap().received_icmp_requests;
-
-        for (payload, (resource_dst, seq, identifier)) in expected_icmp_handshakes {
+    for (gateway, expected_handshakes) in expected_handshakes {
+        let received_requests = received_requests.get(gateway).unwrap();
+        for (payload, (resource_dst, t, u)) in expected_handshakes {
             let _guard =
-                tracing::info_span!(target: "assertions", "icmp", %seq, %identifier).entered();
+                tracing::info_span!(target: "assertions", "packet", packet_protocol, ?t, ?u)
+                    .entered();
 
-            let Some(client_sent_request) = sim_client.sent_icmp_requests.get(&(*seq, *identifier))
-            else {
-                tracing::error!(target: "assertions", "❌ Missing ICMP request on client");
+            let Some(client_sent_request) = sent_requests.get(&(*t, *u).request_from()) else {
+                tracing::error!(target: "assertions", "❌ Missing {packet_protocol} request on client");
                 continue;
             };
-            let Some(client_received_reply) =
-                sim_client.received_icmp_replies.get(&(*seq, *identifier))
-            else {
-                tracing::error!(target: "assertions", "❌ Missing ICMP reply on client");
+            let Some(client_received_reply) = received_replies.get(&(*t, *u)) else {
+                tracing::error!(target: "assertions", "❌ Missing {packet_protocol} reply on client");
                 continue;
             };
             assert_correct_src_and_dst_ips(client_sent_request, client_received_reply);
 
-            let Some(gateway_received_request) = received_icmp_requests.get(payload) else {
-                tracing::error!(target: "assertions", "❌ Missing ICMP request on gateway");
+            let Some(gateway_received_request) = received_requests.get(payload) else {
+                tracing::error!(target: "assertions", "❌ Missing {packet_protocol} request on gateway");
                 continue;
             };
 
@@ -89,19 +171,19 @@ pub(crate) fn assert_icmp_packets_properties(
                 let actual = gateway_received_request.source();
 
                 if expected != actual {
-                    tracing::error!(target: "assertions", %expected, %actual, "❌ Unexpected request source");
+                    tracing::error!(target: "assertions", %expected, %actual, "❌ Unexpected {packet_protocol} request source");
                 }
             }
 
             match resource_dst {
-                ResourceDst::Cidr(resource_dst) => {
+                Destination::IpAddr(resource_dst) => {
                     assert_destination_is_cdir_resource(gateway_received_request, resource_dst)
                 }
-                ResourceDst::Dns(domain) => {
+                Destination::DomainName { name, .. } => {
                     assert_destination_is_dns_resource(
                         gateway_received_request,
                         global_dns_records,
-                        domain,
+                        name,
                     );
 
                     assert_proxy_ip_mapping_is_stable(
@@ -109,9 +191,6 @@ pub(crate) fn assert_icmp_packets_properties(
                         gateway_received_request,
                         &mut mapping,
                     )
-                }
-                ResourceDst::Internet(resource_dst) => {
-                    assert_destination_is_cdir_resource(gateway_received_request, resource_dst)
                 }
             }
         }
@@ -324,11 +403,11 @@ fn assert_proxy_ip_mapping_is_stable(
 fn find_unexpected_entries<'a, E, K, V>(
     expected: &VecDeque<E>,
     actual: &'a BTreeMap<K, V>,
-    is_equal: impl Fn(&E, &K) -> bool,
+    is_expected: impl Fn(&E, &K) -> bool,
 ) -> Vec<&'a V> {
     actual
         .iter()
-        .filter(|(k, _)| !expected.iter().any(|e| is_equal(e, k)))
+        .filter(|(k, _)| !expected.iter().any(|e| is_expected(e, k)))
         .map(|(_, v)| v)
         .collect()
 }

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -1,10 +1,10 @@
 use super::{
-    reference::{private_key, PrivateKey, ResourceDst},
+    reference::{private_key, PrivateKey},
     sim_net::{any_ip_stack, any_port, host, Host},
     sim_relay::{map_explode, SimRelay},
     strategies::latency,
-    transition::{DnsQuery, DnsTransport},
-    IcmpIdentifier, IcmpSeq, QueryId,
+    transition::{DPort, Destination, DnsQuery, DnsTransport, Identifier, SPort, Seq},
+    QueryId,
 };
 use crate::{
     client::{CidrResource, DnsResource, InternetResource, Resource},
@@ -12,6 +12,7 @@ use crate::{
     DomainName,
 };
 use crate::{proptest::*, ClientState};
+use anyhow::anyhow;
 use bimap::BiMap;
 use connlib_model::{ClientId, GatewayId, RelayId, ResourceId};
 use domain::{
@@ -55,8 +56,14 @@ pub(crate) struct SimClient {
     pub(crate) sent_tcp_dns_queries: HashSet<(SocketAddr, QueryId)>,
     pub(crate) received_tcp_dns_responses: BTreeSet<(SocketAddr, QueryId)>,
 
-    pub(crate) sent_icmp_requests: HashMap<(u16, u16), IpPacket>,
-    pub(crate) received_icmp_replies: BTreeMap<(u16, u16), IpPacket>,
+    pub(crate) sent_icmp_requests: HashMap<(Seq, Identifier), IpPacket>,
+    pub(crate) received_icmp_replies: BTreeMap<(Seq, Identifier), IpPacket>,
+
+    pub(crate) sent_tcp_requests: HashMap<(SPort, DPort), IpPacket>,
+    pub(crate) received_tcp_replies: BTreeMap<(SPort, DPort), IpPacket>,
+
+    pub(crate) sent_udp_requests: HashMap<(SPort, DPort), IpPacket>,
+    pub(crate) received_udp_replies: BTreeMap<(SPort, DPort), IpPacket>,
 
     pub(crate) tcp_dns_client: dns_over_tcp::Client,
 
@@ -79,6 +86,10 @@ impl SimClient {
             received_tcp_dns_responses: Default::default(),
             sent_icmp_requests: Default::default(),
             received_icmp_replies: Default::default(),
+            sent_tcp_requests: Default::default(),
+            received_tcp_replies: Default::default(),
+            sent_udp_requests: Default::default(),
+            received_udp_replies: Default::default(),
             enc_buffer: Default::default(),
             ipv4_routes: Default::default(),
             ipv6_routes: Default::default(),
@@ -177,19 +188,7 @@ impl SimClient {
         packet: IpPacket,
         now: Instant,
     ) -> Option<snownet::Transmit<'static>> {
-        if let Some(icmp) = packet.as_icmpv4() {
-            if let Icmpv4Type::EchoRequest(echo) = icmp.icmp_type() {
-                self.sent_icmp_requests
-                    .insert((echo.seq, echo.id), packet.clone());
-            }
-        }
-
-        if let Some(icmp) = packet.as_icmpv6() {
-            if let Icmpv6Type::EchoRequest(echo) = icmp.icmp_type() {
-                self.sent_icmp_requests
-                    .insert((echo.seq, echo.id), packet.clone());
-            }
-        }
+        self.update_sent_requests(&packet).ok()?;
 
         let Some(enc_packet) = self.sut.handle_tun_input(packet, now, &mut self.enc_buffer) else {
             self.sut.handle_timeout(now); // If we handled the packet internally, make sure to advance state.
@@ -197,6 +196,43 @@ impl SimClient {
         };
 
         Some(enc_packet.to_transmit(&self.enc_buffer).into_owned())
+    }
+
+    fn update_sent_requests(&mut self, packet: &IpPacket) -> anyhow::Result<()> {
+        if let Some(icmp) = packet.as_icmpv4() {
+            if let Icmpv4Type::EchoRequest(echo) = icmp.icmp_type() {
+                self.sent_icmp_requests
+                    .insert((Seq(echo.seq), Identifier(echo.id)), packet.clone());
+                return Ok(());
+            }
+        }
+
+        if let Some(icmp) = packet.as_icmpv6() {
+            if let Icmpv6Type::EchoRequest(echo) = icmp.icmp_type() {
+                self.sent_icmp_requests
+                    .insert((Seq(echo.seq), Identifier(echo.id)), packet.clone());
+                return Ok(());
+            }
+        }
+
+        if let Some(tcp) = packet.as_tcp() {
+            self.sent_tcp_requests.insert(
+                (SPort(tcp.source_port()), DPort(tcp.destination_port())),
+                packet.clone(),
+            );
+            return Ok(());
+        }
+
+        if let Some(udp) = packet.as_udp() {
+            self.sent_udp_requests.insert(
+                (SPort(udp.source_port()), DPort(udp.destination_port())),
+                packet.clone(),
+            );
+
+            return Ok(());
+        }
+
+        Err(anyhow!("Unhandled packet"))
     }
 
     pub(crate) fn receive(&mut self, transmit: Transmit, now: Instant) {
@@ -215,29 +251,6 @@ impl SimClient {
 
     /// Process an IP packet received on the client.
     pub(crate) fn on_received_packet(&mut self, packet: IpPacket) {
-        if let Some(icmp) = packet.as_icmpv4() {
-            if let Icmpv4Type::EchoReply(echo) = icmp.icmp_type() {
-                self.received_icmp_replies
-                    .insert((echo.seq, echo.id), packet.clone());
-
-                return;
-            }
-        }
-
-        if let Some(icmp) = packet.as_icmpv6() {
-            if let Icmpv6Type::EchoReply(echo) = icmp.icmp_type() {
-                self.received_icmp_replies
-                    .insert((echo.seq, echo.id), packet.clone());
-
-                return;
-            }
-        }
-
-        if self.tcp_dns_client.accepts(&packet) {
-            self.tcp_dns_client.handle_inbound(packet);
-            return;
-        }
-
         if let Some(udp) = packet.as_udp() {
             if udp.source_port() == 53 {
                 let message = Message::from_slice(udp.payload())
@@ -254,6 +267,41 @@ impl SimClient {
                     .insert((upstream, message.header().id()), packet.clone());
                 self.handle_dns_response(message);
 
+                return;
+            }
+
+            self.received_udp_replies.insert(
+                (SPort(udp.source_port()), DPort(udp.destination_port())),
+                packet.clone(),
+            );
+            return;
+        }
+
+        if self.tcp_dns_client.accepts(&packet) {
+            self.tcp_dns_client.handle_inbound(packet);
+            return;
+        }
+
+        if let Some(tcp) = packet.as_tcp() {
+            self.received_tcp_replies.insert(
+                (SPort(tcp.source_port()), DPort(tcp.destination_port())),
+                packet.clone(),
+            );
+            return;
+        }
+
+        if let Some(icmp) = packet.as_icmpv4() {
+            if let Icmpv4Type::EchoReply(echo) = icmp.icmp_type() {
+                self.received_icmp_replies
+                    .insert((Seq(echo.seq), Identifier(echo.id)), packet.clone());
+                return;
+            }
+        }
+
+        if let Some(icmp) = packet.as_icmpv6() {
+            if let Icmpv6Type::EchoReply(echo) = icmp.icmp_type() {
+                self.received_icmp_replies
+                    .insert((Seq(echo.seq), Identifier(echo.id)), packet.clone());
                 return;
             }
         }
@@ -376,7 +424,18 @@ pub struct RefClient {
     /// The expected ICMP handshakes.
     #[derivative(Debug = "ignore")]
     pub(crate) expected_icmp_handshakes:
-        BTreeMap<GatewayId, BTreeMap<u64, (ResourceDst, IcmpSeq, IcmpIdentifier)>>,
+        BTreeMap<GatewayId, BTreeMap<u64, (Destination, Seq, Identifier)>>,
+
+    /// The expected UDP handshakes.
+    #[derivative(Debug = "ignore")]
+    pub(crate) expected_udp_handshakes:
+        BTreeMap<GatewayId, BTreeMap<u64, (Destination, SPort, DPort)>>,
+
+    /// The expected TCP handshakes.
+    #[derivative(Debug = "ignore")]
+    pub(crate) expected_tcp_handshakes:
+        BTreeMap<GatewayId, BTreeMap<u64, (Destination, SPort, DPort)>>,
+
     /// The expected UDP DNS handshakes.
     #[derivative(Debug = "ignore")]
     pub(crate) expected_udp_dns_handshakes: VecDeque<(SocketAddr, QueryId)>,
@@ -518,99 +577,76 @@ impl RefClient {
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(dst, resource))]
-    pub(crate) fn on_icmp_packet_to_internet(
+    pub(crate) fn on_icmp_packet(
         &mut self,
         src: IpAddr,
-        dst: IpAddr,
-        seq: u16,
-        identifier: u16,
+        dst: Destination,
+        seq: Seq,
+        identifier: Identifier,
         payload: u64,
         gateway_by_resource: impl Fn(ResourceId) -> Option<GatewayId>,
     ) {
-        tracing::Span::current().record("dst", tracing::field::display(dst));
-
-        // Second, if we are not yet connected, check if we have a resource for this IP.
-        let Some(rid) = self.active_internet_resource() else {
-            tracing::debug!("No internet resource");
-            return;
-        };
-        tracing::Span::current().record("resource", tracing::field::display(rid));
-
-        let Some(gateway) = gateway_by_resource(rid) else {
-            tracing::error!("No gateway for resource");
-            return;
-        };
-
-        if self.is_connected_to_internet(rid) && self.is_tunnel_ip(src) {
-            tracing::debug!("Connected to Internet resource, expecting packet to be routed");
-            self.expected_icmp_handshakes
-                .entry(gateway)
-                .or_default()
-                .insert(payload, (ResourceDst::Internet(dst), seq, identifier));
-            return;
-        }
-
-        // If we have a resource, the first packet will initiate a connection to the gateway.
-        tracing::debug!("Not connected to resource, expecting to trigger connection intent");
-        self.connected_internet_resource = true;
+        self.on_packet(
+            src,
+            dst.clone(),
+            (dst, seq, identifier),
+            |ref_client| &mut ref_client.expected_icmp_handshakes,
+            payload,
+            gateway_by_resource,
+        );
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(dst, resource))]
-    pub(crate) fn on_icmp_packet_to_cidr(
+    pub(crate) fn on_udp_packet(
         &mut self,
         src: IpAddr,
-        dst: IpAddr,
-        seq: u16,
-        identifier: u16,
+        dst: Destination,
+        sport: SPort,
+        dport: DPort,
         payload: u64,
         gateway_by_resource: impl Fn(ResourceId) -> Option<GatewayId>,
     ) {
-        tracing::Span::current().record("dst", tracing::field::display(dst));
-
-        // Second, if we are not yet connected, check if we have a resource for this IP.
-        let Some(rid) = self.cidr_resource_by_ip(dst) else {
-            tracing::debug!("No resource corresponds to IP");
-            return;
-        };
-        tracing::Span::current().record("resource", tracing::field::display(rid));
-
-        if self.disabled_resources.contains(&rid) {
-            return;
-        }
-
-        let Some(gateway) = gateway_by_resource(rid) else {
-            tracing::error!("No gateway for resource");
-            return;
-        };
-
-        if self.is_connected_to_internet_or_cidr(rid) && self.is_tunnel_ip(src) {
-            tracing::debug!("Connected to CIDR resource, expecting packet to be routed");
-            self.expected_icmp_handshakes
-                .entry(gateway)
-                .or_default()
-                .insert(payload, (ResourceDst::Cidr(dst), seq, identifier));
-            return;
-        }
-
-        // If we have a resource, the first packet will initiate a connection to the gateway.
-        tracing::debug!("Not connected to resource, expecting to trigger connection intent");
-        self.connect_to_internet_or_cidr_resource(rid, gateway);
+        self.on_packet(
+            src,
+            dst.clone(),
+            (dst, sport, dport),
+            |ref_client| &mut ref_client.expected_udp_handshakes,
+            payload,
+            gateway_by_resource,
+        );
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(dst, resource))]
-    pub(crate) fn on_icmp_packet_to_dns(
+    pub(crate) fn on_tcp_packet(
         &mut self,
         src: IpAddr,
-        dst: DomainName,
-        seq: u16,
-        identifier: u16,
+        dst: Destination,
+        sport: SPort,
+        dport: DPort,
         payload: u64,
         gateway_by_resource: impl Fn(ResourceId) -> Option<GatewayId>,
     ) {
-        tracing::Span::current().record("dst", tracing::field::display(&dst));
+        self.on_packet(
+            src,
+            dst.clone(),
+            (dst, sport, dport),
+            |ref_client| &mut ref_client.expected_tcp_handshakes,
+            payload,
+            gateway_by_resource,
+        );
+    }
 
-        let Some(resource) = self.dns_resource_by_domain(&dst) else {
-            tracing::debug!("No resource corresponds to IP");
+    #[tracing::instrument(level = "debug", skip_all, fields(dst, resource))]
+    pub(crate) fn on_packet<E>(
+        &mut self,
+        src: IpAddr,
+        dst: Destination,
+        packet_id: E,
+        map: impl FnOnce(&mut Self) -> &mut BTreeMap<GatewayId, BTreeMap<u64, E>>,
+        payload: u64,
+        gateway_by_resource: impl Fn(ResourceId) -> Option<GatewayId>,
+    ) {
+        let Some(resource) = self.resource(&dst) else {
             return;
         };
 
@@ -621,28 +657,40 @@ impl RefClient {
             return;
         };
 
-        if self
-            .connected_dns_resources
-            .contains(&(resource, dst.clone()))
-            && self.is_tunnel_ip(src)
-        {
+        if self.is_connected_to_resource(resource, &dst) && self.is_tunnel_ip(src) {
             tracing::debug!("Connected to DNS resource, expecting packet to be routed");
-            self.expected_icmp_handshakes
+            map(self)
                 .entry(gateway)
                 .or_default()
-                .insert(payload, (ResourceDst::Dns(dst), seq, identifier));
+                .insert(payload, packet_id);
             return;
         }
 
-        debug_assert!(
-            self.dns_records.iter().any(|(name, _)| name == &dst),
-            "Should only sample ICMPs to domains that we resolved"
-        );
+        if let Destination::DomainName { name: dst, .. } = &dst {
+            debug_assert!(
+                self.dns_records.iter().any(|(name, _)| name == dst),
+                "Should only sample ICMPs to domains that we resolved"
+            );
+        }
 
         tracing::debug!("Not connected to resource, expecting to trigger connection intent");
-        if !self.disabled_resources.contains(&resource) {
-            self.connected_dns_resources.insert((resource, dst));
-            self.connected_gateways.insert(gateway);
+        self.connect_to_resource(resource, dst, gateway);
+    }
+
+    fn connect_to_resource(
+        &mut self,
+        resource: ResourceId,
+        destination: Destination,
+        gateway: GatewayId,
+    ) {
+        match destination {
+            Destination::DomainName { name, .. } => {
+                if !self.disabled_resources.contains(&resource) {
+                    self.connected_dns_resources.insert((resource, name));
+                    self.connected_gateways.insert(gateway);
+                }
+            }
+            Destination::IpAddr(_) => self.connect_to_internet_or_cidr_resource(resource, gateway),
         }
     }
 
@@ -703,6 +751,19 @@ impl RefClient {
             .collect_vec()
     }
 
+    fn is_connected_to_resource(&self, resource: ResourceId, destination: &Destination) -> bool {
+        if self.is_connected_to_internet_or_cidr(resource) {
+            return true;
+        }
+
+        let Destination::DomainName { name, .. } = destination else {
+            return false;
+        };
+
+        self.connected_dns_resources
+            .contains(&(resource, name.clone()))
+    }
+
     fn is_connected_to_internet(&self, id: ResourceId) -> bool {
         self.active_internet_resource() == Some(id) && self.connected_internet_resource
     }
@@ -731,6 +792,23 @@ impl RefClient {
         (is_known_host || is_dns_resource) && is_suppported_type
     }
 
+    fn resource(&self, destination: &Destination) -> Option<ResourceId> {
+        match destination {
+            Destination::DomainName { name, .. } => {
+                if let Some(id) = self.dns_resource_by_domain(name) {
+                    return Some(id);
+                }
+            }
+            Destination::IpAddr(addr) => {
+                if let Some(id) = self.cidr_resource_by_ip(*addr) {
+                    return Some(id);
+                }
+            }
+        }
+
+        self.active_internet_resource()
+    }
+
     pub(crate) fn dns_resource_by_domain(&self, domain: &DomainName) -> Option<ResourceId> {
         self.resources
             .iter()
@@ -751,12 +829,35 @@ impl RefClient {
     }
 
     /// An ICMP packet is valid if we didn't yet send an ICMP packet with the same seq, identifier and payload.
-    pub(crate) fn is_valid_icmp_packet(&self, seq: &u16, identifier: &u16, payload: &u64) -> bool {
+    pub(crate) fn is_valid_icmp_packet(
+        &self,
+        seq: &Seq,
+        identifier: &Identifier,
+        payload: &u64,
+    ) -> bool {
         self.expected_icmp_handshakes.values().flatten().all(
-            |(existig_payload, (_, existing_seq, existing_identifer))| {
+            |(existig_payload, (_, existing_seq, existing_identifier))| {
                 existing_seq != seq
-                    && existing_identifer != identifier
+                    && existing_identifier != identifier
                     && existig_payload != payload
+            },
+        )
+    }
+
+    /// An UDP packet is valid if we didn't yet send an UDP packet with the same sport, dport and payload.
+    pub(crate) fn is_valid_udp_packet(&self, sport: &SPort, dport: &DPort, payload: &u64) -> bool {
+        self.expected_udp_handshakes.values().flatten().all(
+            |(existig_payload, (_, existing_sport, existing_dport))| {
+                existing_dport != dport && existing_sport != sport && existig_payload != payload
+            },
+        )
+    }
+
+    /// An TCP packet is valid if we didn't yet send an TCP packet with the same sport, dport and payload.
+    pub(crate) fn is_valid_tcp_packet(&self, sport: &SPort, dport: &DPort, payload: &u64) -> bool {
+        self.expected_tcp_handshakes.values().flatten().all(
+            |(existig_payload, (_, existing_sport, existing_dport))| {
+                existing_dport != dport && existing_sport != sport && existig_payload != payload
             },
         )
     }
@@ -991,6 +1092,8 @@ fn ref_client(
                     connected_dns_resources: Default::default(),
                     connected_internet_resource: Default::default(),
                     expected_icmp_handshakes: Default::default(),
+                    expected_udp_handshakes: Default::default(),
+                    expected_tcp_handshakes: Default::default(),
                     expected_udp_dns_handshakes: Default::default(),
                     expected_tcp_dns_handshakes: Default::default(),
                     disabled_resources: Default::default(),

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -575,7 +575,6 @@ impl RefClient {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(dst, resource))]
     pub(crate) fn on_icmp_packet(
         &mut self,
         src: IpAddr,
@@ -595,7 +594,6 @@ impl RefClient {
         );
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(dst, resource))]
     pub(crate) fn on_udp_packet(
         &mut self,
         src: IpAddr,
@@ -615,7 +613,6 @@ impl RefClient {
         );
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(dst, resource))]
     pub(crate) fn on_tcp_packet(
         &mut self,
         src: IpAddr,

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -158,7 +158,7 @@ impl SimGateway {
             }
         }
 
-        if let Some(reply) = ip_packet::make::ehco_reply(packet.clone()) {
+        if let Some(reply) = ip_packet::make::echo_reply(packet.clone()) {
             self.request_received(&packet);
             let transmit = self
                 .sut
@@ -189,13 +189,13 @@ impl SimGateway {
     fn request_received(&mut self, packet: &IpPacket) {
         if let Some(udp) = packet.as_udp() {
             let packet_id = u64::from_be_bytes(*udp.payload().first_chunk().unwrap());
-            tracing::debug!(%packet_id, "Received request");
+            tracing::debug!(%packet_id, "Received UDP request");
             self.received_udp_requests.insert(packet_id, packet.clone());
         }
 
         if let Some(tcp) = packet.as_tcp() {
             let packet_id = u64::from_be_bytes(*tcp.payload().first_chunk().unwrap());
-            tracing::debug!(%packet_id, "Received request");
+            tracing::debug!(%packet_id, "Received TCP request");
             self.received_tcp_requests.insert(packet_id, packet.clone());
         }
     }

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -27,6 +27,12 @@ pub(crate) struct SimGateway {
     /// The received ICMP packets, indexed by our custom ICMP payload.
     pub(crate) received_icmp_requests: BTreeMap<u64, IpPacket>,
 
+    /// The received UDP packets, indexed by our custom UDP payload.
+    pub(crate) received_udp_requests: BTreeMap<u64, IpPacket>,
+
+    /// The received TCP packets, indexed by our custom TCP payload.
+    pub(crate) received_tcp_requests: BTreeMap<u64, IpPacket>,
+
     udp_dns_server_resources: HashMap<SocketAddr, UdpDnsServerResource>,
     tcp_dns_server_resources: HashMap<SocketAddr, TcpDnsServerResource>,
 }
@@ -40,6 +46,8 @@ impl SimGateway {
             enc_buffer: Default::default(),
             udp_dns_server_resources: Default::default(),
             tcp_dns_server_resources: Default::default(),
+            received_udp_requests: Default::default(),
+            received_tcp_requests: Default::default(),
         }
     }
 
@@ -112,12 +120,20 @@ impl SimGateway {
 
         if let Some(icmp) = packet.as_icmpv4() {
             if let Icmpv4Type::EchoRequest(echo) = icmp.icmp_type() {
+                let packet_id = u64::from_be_bytes(*icmp.payload().first_chunk().unwrap());
+                tracing::debug!(%packet_id, "Received ICMP request");
+                self.received_icmp_requests
+                    .insert(packet_id, packet.clone());
                 return self.handle_icmp_request(&packet, echo, icmp.payload(), now);
             }
         }
 
         if let Some(icmp) = packet.as_icmpv6() {
             if let Icmpv6Type::EchoRequest(echo) = icmp.icmp_type() {
+                let packet_id = u64::from_be_bytes(*icmp.payload().first_chunk().unwrap());
+                tracing::debug!(%packet_id, "Received ICMP request");
+                self.received_icmp_requests
+                    .insert(packet_id, packet.clone());
                 return self.handle_icmp_request(&packet, echo, icmp.payload(), now);
             }
         }
@@ -125,6 +141,7 @@ impl SimGateway {
         if let Some(udp) = packet.as_udp() {
             let socket = SocketAddr::new(packet.destination(), udp.destination_port());
 
+            // NOTE: we can make this assumption because port 53 is excluded from non-dns query packets
             if let Some(server) = self.udp_dns_server_resources.get_mut(&socket) {
                 server.handle_input(packet);
                 return None;
@@ -134,10 +151,22 @@ impl SimGateway {
         if let Some(tcp) = packet.as_tcp() {
             let socket = SocketAddr::new(packet.destination(), tcp.destination_port());
 
+            // NOTE: we can make this assumption because port 53 is excluded from non-dns query packets
             if let Some(server) = self.tcp_dns_server_resources.get_mut(&socket) {
                 server.handle_input(packet);
                 return None;
             }
+        }
+
+        if let Some(reply) = ip_packet::make::ehco_reply(packet.clone()) {
+            self.request_received(&packet);
+            let transmit = self
+                .sut
+                .handle_tun_input(reply, now, &mut self.enc_buffer)?
+                .to_transmit(&self.enc_buffer)
+                .into_owned();
+
+            return Some(transmit);
         }
 
         tracing::error!(?packet, "Unhandled packet");
@@ -157,6 +186,20 @@ impl SimGateway {
         )
     }
 
+    fn request_received(&mut self, packet: &IpPacket) {
+        if let Some(udp) = packet.as_udp() {
+            let packet_id = u64::from_be_bytes(*udp.payload().first_chunk().unwrap());
+            tracing::debug!(%packet_id, "Received request");
+            self.received_udp_requests.insert(packet_id, packet.clone());
+        }
+
+        if let Some(tcp) = packet.as_tcp() {
+            let packet_id = u64::from_be_bytes(*tcp.payload().first_chunk().unwrap());
+            tracing::debug!(%packet_id, "Received request");
+            self.received_tcp_requests.insert(packet_id, packet.clone());
+        }
+    }
+
     fn handle_icmp_request(
         &mut self,
         packet: &IpPacket,
@@ -164,11 +207,6 @@ impl SimGateway {
         payload: &[u8],
         now: Instant,
     ) -> Option<Transmit<'static>> {
-        let echo_id = u64::from_be_bytes(*payload.first_chunk().unwrap());
-        self.received_icmp_requests.insert(echo_id, packet.clone());
-
-        tracing::debug!(%echo_id, "Received ICMP request");
-
         let echo_response = ip_packet::make::icmp_reply_packet(
             packet.destination(),
             packet.source(),

--- a/rust/connlib/tunnel/src/tests/strategies.rs
+++ b/rust/connlib/tunnel/src/tests/strategies.rs
@@ -151,7 +151,7 @@ fn cidr_resource_outside_reserved_ranges(
 ) -> impl Strategy<Value = CidrResource> {
     cidr_resource(any_ip_network(8), sites.prop_map(|s| vec![s]))
         .prop_filter(
-            "tests doesn't support yet CIDR resources overlapping DNS resources",
+            "tests doesn't support CIDR resources overlapping DNS resources",
             |r| {
                 // This works because CIDR resources' host mask is always <8 while IP resource is 21
                 let is_ip4_reserved = IpNetwork::V4(IPV4_RESOURCES)

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -350,7 +350,19 @@ impl TunnelTest {
         assert_icmp_packets_properties(
             ref_client,
             sim_client,
-            sim_gateways,
+            &sim_gateways,
+            &ref_state.global_dns_records,
+        );
+        assert_udp_packets_properties(
+            ref_client,
+            sim_client,
+            &sim_gateways,
+            &ref_state.global_dns_records,
+        );
+        assert_tcp_packets_properties(
+            ref_client,
+            sim_client,
+            &sim_gateways,
             &ref_state.global_dns_records,
         );
         assert_udp_dns_packets_properties(ref_client, sim_client);

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -18,7 +18,6 @@ use std::{
 /// The possible transitions of the state machine.
 #[derive(Clone, derivative::Derivative)]
 #[derivative(Debug)]
-#[expect(clippy::large_enum_variant)]
 pub(crate) enum Transition {
     /// Activate a resource on the client.
     ActivateResource(Resource),
@@ -117,7 +116,7 @@ pub(crate) struct SPort(pub u16);
 pub(crate) struct DPort(pub u16);
 
 #[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub(crate) enum Destination {
     DomainName {
         resolved_ip: sample::Selector,
@@ -182,7 +181,7 @@ impl PacketDestination {
     }
 }
 
-#[allow(private_bounds)]
+#[expect(private_bounds)]
 pub(crate) fn icmp_to_destination<I, D>(
     src: impl Strategy<Value = I>,
     dst: impl Strategy<Value = D>,

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -182,7 +182,7 @@ impl PacketDestination {
 }
 
 #[expect(private_bounds)]
-pub(crate) fn icmp_to_destination<I, D>(
+pub(crate) fn icmp_packet<I, D>(
     src: impl Strategy<Value = I>,
     dst: impl Strategy<Value = D>,
 ) -> impl Strategy<Value = Transition>
@@ -210,7 +210,7 @@ where
 }
 
 #[expect(private_bounds)]
-pub(crate) fn udp_to_destination<I, D>(
+pub(crate) fn udp_packet<I, D>(
     src: impl Strategy<Value = I>,
     dst: impl Strategy<Value = D>,
 ) -> impl Strategy<Value = Transition>
@@ -238,7 +238,7 @@ where
 }
 
 #[expect(private_bounds)]
-pub(crate) fn tcp_to_destination<I, D>(
+pub(crate) fn tcp_packet<I, D>(
     src: impl Strategy<Value = I>,
     dst: impl Strategy<Value = D>,
 ) -> impl Strategy<Value = Transition>

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -209,7 +209,7 @@ where
         })
 }
 
-#[allow(private_bounds)]
+#[expect(private_bounds)]
 pub(crate) fn udp_to_destination<I, D>(
     src: impl Strategy<Value = I>,
     dst: impl Strategy<Value = D>,

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -133,18 +133,18 @@ enum PacketDestination {
     IpAddr(IpAddr),
 }
 
-pub(crate) trait RequestFrom {
-    fn request_from(self) -> Self;
+pub(crate) trait ReplyTo {
+    fn reply_to(self) -> Self;
 }
 
-impl RequestFrom for (SPort, DPort) {
-    fn request_from(self) -> Self {
+impl ReplyTo for (SPort, DPort) {
+    fn reply_to(self) -> Self {
         (SPort(self.1 .0), DPort(self.0 .0))
     }
 }
 
-impl RequestFrom for (Seq, Identifier) {
-    fn request_from(self) -> Self {
+impl ReplyTo for (Seq, Identifier) {
+    fn reply_to(self) -> Self {
         self
     }
 }

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -25,7 +25,7 @@ pub(crate) enum Transition {
     DeactivateResource(ResourceId),
     /// Client-side disable resource
     DisableResources(BTreeSet<ResourceId>),
-    /// Send an ICMP packet to non-resource IP.
+    /// Send an ICMP packet to destination (IP resource, DNS resource or IP non-resource).
     SendIcmpPacket {
         src: IpAddr,
         dst: Destination,
@@ -41,7 +41,7 @@ pub(crate) enum Transition {
         dport: DPort,
         payload: u64,
     },
-    /// Send an TCP payload to non-resource IP.
+    /// Send an TCP payload to destination (IP resource, DNS resource or IP non-resource).
     SendTcpPayload {
         src: IpAddr,
         dst: Destination,
@@ -237,7 +237,7 @@ where
         )
 }
 
-#[allow(private_bounds)]
+#[expect(private_bounds)]
 pub(crate) fn tcp_to_destination<I, D>(
     src: impl Strategy<Value = I>,
     dst: impl Strategy<Value = D>,

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -33,7 +33,7 @@ pub(crate) enum Transition {
         identifier: Identifier,
         payload: u64,
     },
-    /// Send an UDP packet to non-resource IP.
+    /// Send an UDP packet to destination (IP resource, DNS resource or IP non-resource).
     SendUdpPacket {
         src: IpAddr,
         dst: Destination,

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -98,7 +98,7 @@ pub fn icmp_reply_packet(
     }
 }
 
-pub fn ehco_reply(mut req: IpPacket) -> Option<IpPacket> {
+pub fn echo_reply(mut req: IpPacket) -> Option<IpPacket> {
     if !req.is_udp() && !req.is_tcp() {
         return None;
     }

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -98,6 +98,36 @@ pub fn icmp_reply_packet(
     }
 }
 
+pub fn ehco_reply(mut req: IpPacket) -> Option<IpPacket> {
+    if !req.is_udp() && !req.is_tcp() {
+        return None;
+    }
+
+    if let Some(mut packet) = req.as_tcp_mut() {
+        let original_src = packet.get_source_port();
+        let original_dst = packet.get_destination_port();
+
+        packet.set_source_port(original_dst);
+        packet.set_destination_port(original_src);
+    }
+
+    if let Some(mut packet) = req.as_udp_mut() {
+        let original_src = packet.get_source_port();
+        let original_dst = packet.get_destination_port();
+
+        packet.set_source_port(original_dst);
+        packet.set_destination_port(original_src);
+    }
+
+    let original_src = req.source();
+    let original_dst = req.destination();
+
+    req.set_dst(original_src);
+    req.set_src(original_dst);
+
+    Some(req)
+}
+
 pub fn tcp_packet<IP>(
     saddr: IP,
     daddr: IP,

--- a/rust/ip-packet/src/tcp_header_slice_mut.rs
+++ b/rust/ip-packet/src/tcp_header_slice_mut.rs
@@ -13,6 +13,14 @@ impl<'a> TcpHeaderSliceMut<'a> {
         Ok(Self { slice })
     }
 
+    pub fn get_source_port(&self) -> u16 {
+        u16::from_be_bytes([self.slice[0], self.slice[1]])
+    }
+
+    pub fn get_destination_port(&self) -> u16 {
+        u16::from_be_bytes([self.slice[2], self.slice[3]])
+    }
+
     pub fn set_source_port(&mut self, src: u16) {
         // Safety: Slice it at least of length 20 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 0, src.to_be_bytes()) };

--- a/rust/ip-packet/src/udp_header_slice_mut.rs
+++ b/rust/ip-packet/src/udp_header_slice_mut.rs
@@ -13,6 +13,14 @@ impl<'a> UdpHeaderSliceMut<'a> {
         Ok(Self { slice })
     }
 
+    pub fn get_source_port(&self) -> u16 {
+        u16::from_be_bytes([self.slice[0], self.slice[1]])
+    }
+
+    pub fn get_destination_port(&self) -> u16 {
+        u16::from_be_bytes([self.slice[2], self.slice[3]])
+    }
+
     pub fn set_source_port(&mut self, src: u16) {
         // Safety: Slice it at least of length 8 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 0, src.to_be_bytes()) };


### PR DESCRIPTION
Currently, tests only send ICMP packets back and forth, to expand our coverage and later on permit us cover filters and resource picking this PR implements sending UDP and TCP packets as part of that logic too.

To make this PR simpler in this stage TCP packets don't track an actual TCP connection, just that they are forwarded back and forth, this will be fixed in a future PR by emulating TCP sockets.

We also unify how we handle CIDR/DNS/Non Resources to reduce the number of transitions.

Fixes #7003