### PR TITLE
refactor(connlib): use millisecond precision for `smoltcp`

### DIFF
--- a/rust/dns-over-tcp/src/client.rs
+++ b/rust/dns-over-tcp/src/client.rs
@@ -288,9 +288,9 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
     }
 
     fn smol_now(&self, now: Instant) -> smoltcp::time::Instant {
-        let seconds_since_startup = now.duration_since(self.created_at).as_secs();
+        let millis_since_startup = now.duration_since(self.created_at).as_millis();
 
-        smoltcp::time::Instant::from_secs(seconds_since_startup as i64)
+        smoltcp::time::Instant::from_millis(millis_since_startup as i64)
     }
 
     fn sample_unique_ports(&mut self, num_ports: usize) -> Result<impl Iterator<Item = u16>> {

--- a/rust/dns-over-tcp/src/client.rs
+++ b/rust/dns-over-tcp/src/client.rs
@@ -4,7 +4,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{codec, create_tcp_socket, interface::create_interface, stub_device::InMemoryDevice};
+use crate::{
+    codec, create_tcp_socket, interface::create_interface, stub_device::InMemoryDevice,
+    time::smol_now,
+};
 use anyhow::{anyhow, bail, Context as _, Result};
 use domain::{base::Message, dep::octseq::OctetsInto};
 use ip_packet::IpPacket;
@@ -217,9 +220,11 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
             return;
         };
 
-        let result = self
-            .interface
-            .poll(self.smol_now(now), &mut self.device, &mut self.sockets);
+        let result = self.interface.poll(
+            smol_now(self.created_at, now),
+            &mut self.device,
+            &mut self.sockets,
+        );
 
         if result == PollResult::None && self.pending_queries_by_remote.is_empty() {
             return;
@@ -280,17 +285,11 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
     }
 
     pub fn poll_timeout(&mut self) -> Option<Instant> {
-        let now = self.smol_now(self.last_now);
+        let now = smol_now(self.created_at, self.last_now);
 
         let poll_in = self.interface.poll_delay(now, &self.sockets)?;
 
         Some(self.last_now + Duration::from(poll_in))
-    }
-
-    fn smol_now(&self, now: Instant) -> smoltcp::time::Instant {
-        let millis_since_startup = now.duration_since(self.created_at).as_millis();
-
-        smoltcp::time::Instant::from_millis(millis_since_startup as i64)
     }
 
     fn sample_unique_ports(&mut self, num_ports: usize) -> Result<impl Iterator<Item = u16>> {

--- a/rust/dns-over-tcp/src/lib.rs
+++ b/rust/dns-over-tcp/src/lib.rs
@@ -3,6 +3,7 @@ mod codec;
 mod interface;
 mod server;
 mod stub_device;
+mod time;
 
 pub use client::{Client, QueryResult};
 pub use server::{Server, SocketHandle};

--- a/rust/dns-over-tcp/src/server.rs
+++ b/rust/dns-over-tcp/src/server.rs
@@ -4,7 +4,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{codec, create_tcp_socket, interface::create_interface, stub_device::InMemoryDevice};
+use crate::{
+    codec, create_tcp_socket, interface::create_interface, stub_device::InMemoryDevice,
+    time::smol_now,
+};
 use anyhow::{Context as _, Result};
 use domain::{base::Message, dep::octseq::OctetsInto as _};
 use ip_packet::IpPacket;
@@ -153,9 +156,11 @@ impl Server {
     pub fn handle_timeout(&mut self, now: Instant) {
         self.last_now = now;
 
-        let result = self
-            .interface
-            .poll(self.smol_now(now), &mut self.device, &mut self.sockets);
+        let result = self.interface.poll(
+            smol_now(self.created_at, now),
+            &mut self.device,
+            &mut self.sockets,
+        );
 
         if result == PollResult::None {
             return;
@@ -184,7 +189,7 @@ impl Server {
     }
 
     pub fn poll_timeout(&mut self) -> Option<Instant> {
-        let now = self.smol_now(self.last_now);
+        let now = smol_now(self.created_at, self.last_now);
 
         let poll_in = self.interface.poll_delay(now, &self.sockets)?;
 
@@ -199,12 +204,6 @@ impl Server {
     /// Returns queries received from a DNS client.
     pub fn poll_queries(&mut self) -> Option<Query> {
         self.received_queries.pop_front()
-    }
-
-    fn smol_now(&self, now: Instant) -> smoltcp::time::Instant {
-        let millis_since_startup = now.duration_since(self.created_at).as_millis();
-
-        smoltcp::time::Instant::from_millis(millis_since_startup as i64)
     }
 }
 

--- a/rust/dns-over-tcp/src/server.rs
+++ b/rust/dns-over-tcp/src/server.rs
@@ -202,9 +202,9 @@ impl Server {
     }
 
     fn smol_now(&self, now: Instant) -> smoltcp::time::Instant {
-        let seconds_since_startup = now.duration_since(self.created_at).as_secs();
+        let millis_since_startup = now.duration_since(self.created_at).as_millis();
 
-        smoltcp::time::Instant::from_secs(seconds_since_startup as i64)
+        smoltcp::time::Instant::from_millis(millis_since_startup as i64)
     }
 }
 

--- a/rust/dns-over-tcp/src/time.rs
+++ b/rust/dns-over-tcp/src/time.rs
@@ -1,0 +1,8 @@
+use std::time::Instant;
+
+/// Computes an instance of [`smoltcp::time::Instant`] based on a given starting point and the current time.
+pub fn smol_now(boot: Instant, now: Instant) -> smoltcp::time::Instant {
+    let millis_since_startup = now.duration_since(boot).as_millis();
+
+    smoltcp::time::Instant::from_millis(millis_since_startup as i64)
+}


### PR DESCRIPTION
Although it didn't cause any problems, I've found reading the logs of `smoltcp` to be a bit confusing with only a precision of 1s.