### PR TITLE
chore: bump client versions to 1.4.0

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -154,9 +154,9 @@ jobs:
             artifact: firezone-client-headless-linux
             image_name: client
             # mark:next-headless-version
-            release_name: headless-client-1.3.8
+            release_name: headless-client-1.4.0
             # mark:next-headless-version
-            version: 1.3.8
+            version: 1.4.0
           - package: firezone-relay
             artifact: firezone-relay
             image_name: relay

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -43,19 +43,19 @@ jobs:
             pkg-extension: msi
     env:
       # mark:next-gui-version
-      ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.3.14_${{ matrix.arch }}
+      ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.4.0_${{ matrix.arch }}
       # mark:next-gui-version
-      ARTIFACT_DST: firezone-client-gui-${{ matrix.os }}_1.3.14_${{ matrix.arch }}
+      ARTIFACT_DST: firezone-client-gui-${{ matrix.os }}_1.4.0_${{ matrix.arch }}
       AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
       # mark:next-gui-version
-      BINARY_DEST_PATH: firezone-client-gui-${{ matrix.os }}_1.3.14_${{ matrix.arch }}
+      BINARY_DEST_PATH: firezone-client-gui-${{ matrix.os }}_1.4.0_${{ matrix.arch }}
       # Seems like there's no way to de-dupe env vars that depend on each other
       # mark:next-gui-version
-      FIREZONE_GUI_VERSION: 1.3.14
+      FIREZONE_GUI_VERSION: 1.4.0
       RENAME_SCRIPT: ../../scripts/build/tauri-rename-${{ matrix.os }}.sh
       TARGET_DIR: ../target
       UPLOAD_SCRIPT: ../../scripts/build/tauri-upload-${{ matrix.os }}.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
           - release_name: gateway-1.4.2
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
-          - release_name: headless-client-1.3.8
+          - release_name: headless-client-1.4.0
             config_name: release-drafter-headless-client.yml
           # mark:next-gui-version
-          - release_name: gui-client-1.3.14
+          - release_name: gui-client-1.4.0
             config_name: release-drafter-gui-client.yml
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
             ARTIFACT=client
             # mark:next-headless-version
-            VERSION="1.3.8"
+            VERSION="1.4.0"
           else
             echo "Shouldn't have gotten here. Exiting."
             exit 1

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         targetSdk = 35
         versionCode = (System.currentTimeMillis() / 1000 / 10).toInt()
         // mark:next-android-version
-        versionName = "1.3.8"
+        versionName = "1.4.0"
         multiDexEnabled = true
         testInstrumentationRunner = "dev.firezone.android.core.HiltTestRunner"
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1033,7 +1033,7 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "connlib-client-android"
-version = "1.3.8"
+version = "1.4.0"
 dependencies = [
  "android_log-sys",
  "anyhow",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "connlib-client-apple"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gui-client"
-version = "1.3.14"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gui-client-common"
-version = "1.3.14"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-headless-client"
-version = "1.3.8"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "atomicwrites",

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "connlib-client-android"
 # mark:next-android-version
-version = "1.3.8"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "connlib-client-apple"
 # mark:next-apple-version
-version = "1.3.10"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 

--- a/rust/gui-client/src-common/Cargo.toml
+++ b/rust/gui-client/src-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gui-client-common"
 # mark:next-gui-version
-version = "1.3.14"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gui-client"
 # mark:next-gui-version
-version = "1.3.14"
+version = "1.4.0"
 description = "Firezone"
 edition = { workspace = true }
 default-run = "firezone-gui-client"

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-headless-client"
 # mark:next-headless-version
-version = "1.3.8"
+version = "1.4.0"
 edition = { workspace = true }
 authors = ["Firezone, Inc."]
 license = { workspace = true }

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -598,7 +598,7 @@ impl<'a> Handler<'a> {
             // The IPC service must use the GUI's version number, not the Headless Client's.
             // But refactoring to separate the IPC service from the Headless Client will take a while.
             // mark:next-gui-version
-            get_user_agent(None, "1.3.14"),
+            get_user_agent(None, "1.4.0"),
             "client",
             (),
             || {

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -25,11 +25,11 @@ current-gui-version = 1.3.13
 current-headless-version = 1.3.7
 
 # Tracks the next version to release for each platform
-next-apple-version = 1.3.10
-next-android-version = 1.3.8
+next-apple-version = 1.4.0
+next-android-version = 1.4.0
 next-gateway-version = 1.4.2
-next-gui-version = 1.3.14
-next-headless-version = 1.3.8
+next-gui-version = 1.4.0
+next-headless-version = 1.4.0
 
 # macOS uses a slightly different sed syntax
 ifeq ($(shell uname),Darwin)

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -583,7 +583,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/debug";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.3.10;
+				MARKETING_VERSION = 1.4.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
@@ -626,7 +626,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/release";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.3.10;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
@@ -695,7 +695,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/debug";
-				MARKETING_VERSION = 1.3.10;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
@@ -733,7 +733,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/release";
-				MARKETING_VERSION = 1.3.10;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
@@ -899,7 +899,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.3.10;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -950,7 +950,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.3.10;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
In order to release the new control protocol to users, we need to bump the versions of the clients to 1.4.0. The portal has a version gate to only select gateways with version >= 1.4.0 for clients >= 1.4.0. Thus, bumping these versions can only happen once testing has completed and the gateway has actually been released as 1.4.0.