### PR TITLE
feat(portal): Show clients peek on actors index

### DIFF
--- a/elixir/apps/domain/lib/domain/clients/client/query.ex
+++ b/elixir/apps/domain/lib/domain/clients/client/query.ex
@@ -48,6 +48,15 @@ defmodule Domain.Clients.Client.Query do
     |> distinct(true)
   end
 
+  def count_clients_by_actor_id(queryable \\ not_deleted()) do
+    queryable
+    |> group_by([clients: clients], clients.actor_id)
+    |> select([clients: clients], %{
+      actor_id: clients.actor_id,
+      count: count(clients.id)
+    })
+  end
+
   def returning_not_deleted(queryable) do
     select(queryable, [clients: clients], clients)
   end

--- a/elixir/apps/domain/lib/domain/repo/paginator.ex
+++ b/elixir/apps/domain/lib/domain/repo/paginator.ex
@@ -66,8 +66,8 @@ defmodule Domain.Repo.Paginator do
 
   def query(queryable, paginator_opts) do
     queryable
-    |> order_by_cursor_fields(paginator_opts)
     |> maybe_query_page(paginator_opts)
+    |> order_by_cursor_fields(paginator_opts)
     |> limit_page_size(paginator_opts)
   end
 

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -221,14 +221,58 @@ for actor <- other_actors do
       provider_identifier_confirmation: email
     })
 
-  identity
-  |> Ecto.Changeset.change(
-    created_by: :provider,
-    provider_id: oidc_provider.id,
-    provider_identifier: email,
-    provider_state: %{"claims" => %{"email" => email, "group" => "users"}}
-  )
-  |> Repo.update!()
+  identity =
+    identity
+    |> Ecto.Changeset.change(
+      created_by: :provider,
+      provider_id: oidc_provider.id,
+      provider_identifier: email,
+      provider_state: %{"claims" => %{"email" => email, "group" => "users"}}
+    )
+    |> Repo.update!()
+
+  context = %Auth.Context{
+    type: :browser,
+    user_agent: "Windows/10.0.22631 seeds/1",
+    remote_ip: {172, 28, 0, 100},
+    remote_ip_location_region: "UA",
+    remote_ip_location_city: "Kyiv",
+    remote_ip_location_lat: 50.4333,
+    remote_ip_location_lon: 30.5167
+  }
+
+  {:ok, token} =
+    Auth.create_token(identity, context, "n", nil)
+
+  {:ok, subject} = Auth.build_subject(token, context)
+
+  count = Enum.random([1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 240])
+
+  for i <- 0..count do
+    user_agent =
+      Enum.random([
+        "iOS/12.7 (iPhone) connlib/1.5.0",
+        "Android/14 connlib/1.4.1",
+        "Windows/10.0.22631 connlib/1.3.412",
+        "Ubuntu/22.4.0 connlib/1.2.2"
+      ])
+
+    client_name = String.split(user_agent, "/") |> List.first()
+
+    {:ok, _client} =
+      Domain.Clients.upsert_client(
+        %{
+          name: "My #{client_name} #{i}",
+          external_id: Ecto.UUID.generate(),
+          public_key: :crypto.strong_rand_bytes(32) |> Base.encode64(),
+          identifier_for_vendor: Ecto.UUID.generate()
+        },
+        %{
+          subject
+          | context: %{subject.context | user_agent: user_agent}
+        }
+      )
+  end
 end
 
 # Other Account Users
@@ -432,7 +476,7 @@ end
 {:ok, finance_group} = Actors.create_group(%{name: "Finance", type: :static}, admin_subject)
 
 {:ok, synced_group} =
-  Actors.create_group(%{name: "Synced Group with long name", type: :static}, admin_subject)
+  Actors.create_group(%{name: "Group:Synced Group with long name", type: :static}, admin_subject)
 
 for group <- [eng_group, finance_group, synced_group] do
   IO.puts("  Name: #{group.name}  ID: #{group.id}")
@@ -475,6 +519,25 @@ synced_group
 oidc_provider
 |> Ecto.Changeset.change(last_synced_at: DateTime.utc_now())
 |> Repo.update!()
+
+for name <- [
+      "Group:gcp-logging-viewers",
+      "Group:gcp-security-admins",
+      "Group:gcp-organization-admins",
+      "OU:Admins",
+      "OU:Product",
+      "Group:Engineering",
+      "Group:gcp-developers"
+    ] do
+  {:ok, group} = Actors.create_group(%{name: name, type: :static}, admin_subject)
+
+  group
+  |> Repo.preload(:memberships)
+  |> Actors.update_group(
+    %{memberships: [%{actor_id: admin_subject.actor.id}]},
+    admin_subject
+  )
+end
 
 IO.puts("")
 

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -967,13 +967,14 @@ defmodule Web.CoreComponents do
   attr :datetime, DateTime, default: nil
   attr :relative_to, DateTime, required: false
   attr :negative_class, :string, default: ""
+  attr :popover, :boolean, default: true
 
   def relative_datetime(assigns) do
     assigns =
       assign_new(assigns, :relative_to, fn -> DateTime.utc_now() end)
 
     ~H"""
-    <.popover :if={not is_nil(@datetime)}>
+    <.popover :if={not is_nil(@datetime) and @popover}>
       <:target>
         <span class={[
           "underline underline-offset-2 decoration-1 decoration-dotted",
@@ -987,6 +988,10 @@ defmodule Web.CoreComponents do
         <%= @datetime %>
       </:content>
     </.popover>
+    <span :if={not @popover}>
+      <%= Cldr.DateTime.Relative.to_string!(@datetime, Web.CLDR, relative_to: @relative_to)
+      |> String.capitalize() %>
+    </span>
     <span :if={is_nil(@datetime)}>
       Never
     </span>
@@ -1053,6 +1058,17 @@ defmodule Web.CoreComponents do
         <%= if @schema.online?, do: "Online", else: "Offline" %>
       </span>
     </span>
+    """
+  end
+
+  @doc """
+  Renders online or offline status using an `online?` field of the schema.
+  """
+  attr :schema, :any, required: true
+
+  def online_icon(assigns) do
+    ~H"""
+    <span :if={@schema.online?} class="inline-flex rounded-full h-2.5 w-2.5 bg-green-500"></span>
     """
   end
 
@@ -1459,10 +1475,11 @@ defmodule Web.CoreComponents do
   """
 
   attr :color, :string, default: "info"
+  attr :class, :string, default: nil
 
   def ping_icon(assigns) do
     ~H"""
-    <span class="relative flex h-2.5 w-2.5">
+    <span class={["relative flex h-2.5 w-2.5", @class]}>
       <span class={~w[
         animate-ping absolute inline-flex
         h-full w-full rounded-full opacity-50

--- a/elixir/apps/web/lib/web/components/navigation_components.ex
+++ b/elixir/apps/web/lib/web/components/navigation_components.ex
@@ -102,14 +102,18 @@ defmodule Web.NavigationComponents do
 
   def sidebar(assigns) do
     ~H"""
-    <aside class={~w[
-        fixed top-0 left-0 z-40
-        w-64 h-screen
-        pt-14 pb-8
-        transition-transform -translate-x-full
-        bg-white border-r border-neutral-200
-        lg:translate-x-0
-      ]} aria-label="Sidenav" id="drawer-navigation">
+    <aside
+      class={[
+        "fixed top-0 left-0 z-40 lg:z-10",
+        "w-64 h-screen",
+        "pt-14 pb-8",
+        "transition-transform -translate-x-full",
+        "bg-white border-r border-neutral-200",
+        "lg:translate-x-0"
+      ]}
+      aria-label="Sidenav"
+      id="drawer-navigation"
+    >
       <div class="overflow-y-auto py-1 px-2 h-full bg-white">
         <ul>
           <%= render_slot(@inner_block) %>

--- a/elixir/apps/web/lib/web/live/actors/index.ex
+++ b/elixir/apps/web/lib/web/live/actors/index.ex
@@ -95,27 +95,42 @@ defmodule Web.Actors.Index do
             </div>
           </:col>
 
-          <:col :let={actor} label="groups">
-            <.peek peek={@actor_groups[actor.id]}>
-              <:empty>
-                None
-              </:empty>
+          <:col :let={actor} label="groups" class="w-1/12">
+            <.popover placement="right">
+              <:target>
+                <.link
+                  navigate={~p"/#{@account}/actors/#{actor}?#groups"}
+                  class={[
+                    "hover:underline hover:decoration-line",
+                    "underline underline-offset-2 decoration-1 decoration-dotted"
+                  ]}
+                >
+                  <%= @actor_groups[actor.id].count %>
+                </.link>
+              </:target>
+              <:content>
+                <.peek peek={@actor_groups[actor.id]}>
+                  <:empty>
+                    None
+                  </:empty>
 
-              <:item :let={group}>
-                <div class="flex flex-wrap gap-y-2 mr-2">
-                  <.group account={@account} group={group} />
-                </div>
-              </:item>
+                  <:item :let={group}>
+                    <div class="flex flex-wrap gap-y-2 mr-2">
+                      <.group account={@account} group={group} />
+                    </div>
+                  </:item>
 
-              <:tail :let={count}>
-                <span class="inline-block whitespace-nowrap">
-                  and <%= count %> more.
-                </span>
-              </:tail>
-            </.peek>
+                  <:tail :let={count}>
+                    <span class="inline-block whitespace-nowrap">
+                      and <%= count %> more.
+                    </span>
+                  </:tail>
+                </.peek>
+              </:content>
+            </.popover>
           </:col>
 
-          <:col :let={actor} label="clients">
+          <:col :let={actor} label="clients" class="w-2/12">
             <.peek peek={@actor_clients[actor.id]}>
               <:empty>
                 None
@@ -125,7 +140,9 @@ defmodule Web.Actors.Index do
                 <div class="mr-2">
                   <.client_as_icon client={client} />
                   <div class="relative">
-                    <div class="absolute -inset-y-2.5 -right-1"><.online_icon schema={client} /></div>
+                    <div class="absolute -inset-y-2.5 -right-1">
+                      <.online_icon schema={client} />
+                    </div>
                   </div>
                 </div>
               </:item>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -502,7 +502,7 @@ defmodule Web.Actors.Show do
           </:col>
           <:empty>
             <div class="text-center text-neutral-500 p-4">
-              No clients to display. Clients are created automatically when a user signs in from an application.
+              Actor has not signed in from any Client.
             </div>
           </:empty>
         </.live_table>

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -1,6 +1,7 @@
 defmodule Web.Actors.Show do
   use Web, :live_view
   import Web.Actors.Components
+  import Web.Clients.Components
   alias Domain.{Accounts, Auth, Tokens, Flows, Clients}
   alias Domain.Actors
 
@@ -467,16 +468,42 @@ defmodule Web.Actors.Show do
           ordered_by={@order_by_table_id["clients"]}
           metadata={@clients_metadata}
         >
-          <:col :let={client} label="name">
-            <.link navigate={~p"/#{@account}/clients/#{client.id}"} class={[link_style()]}>
-              <%= client.name %>
-            </.link>
+          <:col :let={client} class="w-8">
+            <.popover placement="right">
+              <:target>
+                <.client_os_icon client={client} />
+              </:target>
+              <:content>
+                <.client_os_name_and_version client={client} />
+              </:content>
+            </.popover>
+          </:col>
+          <:col :let={client} field={{:clients, :name}} label="name">
+            <div class="flex items-center space-x-1">
+              <.link navigate={~p"/#{@account}/clients/#{client.id}"} class={[link_style()]}>
+                <%= client.name %>
+              </.link>
+              <.icon
+                :if={not is_nil(client.verified_at)}
+                name="hero-shield-check"
+                class="w-4 h-4"
+                title="Device attributes of this client are manually verified"
+              />
+            </div>
           </:col>
           <:col :let={client} label="status">
             <.connection_status schema={client} />
           </:col>
+          <:col :let={client} field={{:clients, :last_seen_at}} label="last started">
+            <.relative_datetime datetime={client.last_seen_at} />
+          </:col>
+          <:col :let={client} field={{:clients, :inserted_at}} label="created">
+            <.relative_datetime datetime={client.inserted_at} />
+          </:col>
           <:empty>
-            <div class="text-center text-neutral-500 p-4">No clients to display.</div>
+            <div class="text-center text-neutral-500 p-4">
+              No clients to display. Clients are created automatically when a user signs in from an application.
+            </div>
           </:empty>
         </.live_table>
       </:content>

--- a/elixir/apps/web/lib/web/live/clients/components.ex
+++ b/elixir/apps/web/lib/web/live/clients/components.ex
@@ -1,5 +1,6 @@
 defmodule Web.Clients.Components do
   use Web, :component_library
+  import Web.CoreComponents
 
   def client_os(assigns) do
     ~H"""
@@ -25,6 +26,31 @@ defmodule Web.Clients.Components do
     <span>
       <%= get_client_os_name_and_version(@client.last_seen_user_agent) %>
     </span>
+    """
+  end
+
+  def client_as_icon(assigns) do
+    ~H"""
+    <.popover placement="right">
+      <:target>
+        <.client_os_icon client={@client} />
+      </:target>
+      <:content>
+        <div>
+          <%= @client.name %>
+        </div>
+        <div>
+          <.client_os_name_and_version client={@client} />
+        </div>
+        <div>
+          <span>Last started:</span>
+          <.relative_datetime datetime={@client.last_seen_at} popover={false} />
+        </div>
+        <div>
+          <.connection_status schema={@client} />
+        </div>
+      </:content>
+    </.popover>
     """
   end
 

--- a/elixir/apps/web/lib/web/live/clients/index.ex
+++ b/elixir/apps/web/lib/web/live/clients/index.ex
@@ -111,7 +111,7 @@ defmodule Web.Clients.Index do
           </:col>
           <:empty>
             <div class="text-center text-neutral-500 p-4">
-              No clients to display. Clients are created automatically when a user signs in from an application.
+              No Actors have signed in from any Client.
             </div>
           </:empty>
         </.live_table>

--- a/elixir/apps/web/lib/web/live/clients/index.ex
+++ b/elixir/apps/web/lib/web/live/clients/index.ex
@@ -111,7 +111,7 @@ defmodule Web.Clients.Index do
           </:col>
           <:empty>
             <div class="text-center text-neutral-500 p-4">
-              No clients to display. Clients are created automatically when a user connects to a resource.
+              No clients to display. Clients are created automatically when a user signs in from an application.
             </div>
           </:empty>
         </.live_table>

--- a/elixir/apps/web/test/web/live/actors/index_test.exs
+++ b/elixir/apps/web/test/web/live/actors/index_test.exs
@@ -59,6 +59,8 @@ defmodule Web.Live.Actors.IndexTest do
   } do
     admin_actor = Fixtures.Actors.create_actor(account: account, type: :account_admin_user)
     Fixtures.Actors.create_membership(account: account, actor: admin_actor)
+    client = Fixtures.Clients.create_client(account: account, actor: admin_actor)
+    Domain.Clients.connect_client(client)
     admin_actor = Repo.preload(admin_actor, identities: [:provider], groups: [])
 
     user_actor = Fixtures.Actors.create_actor(account: account, type: :account_user)
@@ -84,14 +86,13 @@ defmodule Web.Live.Actors.IndexTest do
       |> render()
       |> table_to_map()
 
-    for {actor, name} <- [
-          {admin_actor, "#{admin_actor.name} (admin)"},
-          {user_actor, user_actor.name},
-          {service_account_actor, "#{service_account_actor.name} (service account)"}
+    for {actor, name, clients} <- [
+          {admin_actor, "#{admin_actor.name} (admin)", [client]},
+          {user_actor, user_actor.name, []},
+          {service_account_actor, "#{service_account_actor.name} (service account)", []}
         ] do
       with_table_row(rows, "name", name, fn row ->
         for identity <- actor.identities do
-          assert row["identifiers"] =~ identity.provider.name
           assert row["identifiers"] =~ identity.provider_identifier
         end
 
@@ -99,7 +100,14 @@ defmodule Web.Live.Actors.IndexTest do
           assert row["groups"] =~ group.name
         end
 
-        assert row["last signed in"] == "Never"
+        for client <- clients do
+          assert row["clients"] =~ client.name
+          assert row["clients"] =~ "Online"
+          assert row["clients"] =~ "Apple"
+          assert row["clients"] =~ "iOS 12.5"
+        end
+
+        assert row["last signed in"]
       end)
     end
   end

--- a/elixir/apps/web/test/web/live/actors/show_test.exs
+++ b/elixir/apps/web/test/web/live/actors/show_test.exs
@@ -70,8 +70,11 @@ defmodule Web.Live.Actors.ShowTest do
       |> render()
       |> table_to_map()
 
+    assert row[""] =~ "Apple iOS"
     assert row["name"] == client.name
     assert row["status"] == "Offline"
+    assert row["last started"]
+    assert row["created"]
   end
 
   test "updates clients table using presence events", %{

--- a/elixir/apps/web/test/web/live/clients/index_test.exs
+++ b/elixir/apps/web/test/web/live/clients/index_test.exs
@@ -48,7 +48,7 @@ defmodule Web.Live.Clients.IndexTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/clients")
 
-    assert html =~ "No clients to display"
+    assert html =~ "No Actors have signed in from any Client"
   end
 
   test "renders clients table", %{


### PR DESCRIPTION
We will show up to 5 recently started client icons and a status for them as a green dot badge (no dot when it's offline to keep things simple). Additional details are available on hover.

<img width="1415" alt="1" src="https://github.com/user-attachments/assets/1d48d08b-f024-4016-837a-3a2ac9a34718">
<img width="1413" alt="2" src="https://github.com/user-attachments/assets/101ff122-26e2-4282-ae1d-073b4eba9c56">

I also extended the `Clients` table on "Actor" view page to match the "Clients" index view.

Also closes #7096