### PR TITLE
chore(gateway): bump log severity

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -453,7 +453,7 @@ fn handle_p2p_control_packet(
             };
 
             if !peer.is_allowed(req.resource) {
-                tracing::debug!(cid = %peer.id(), resource = %req.resource, "Received `AssignedIpsEvent` for resource that is not allowed");
+                tracing::warn!(cid = %peer.id(), resource = %req.resource, "Received `AssignedIpsEvent` for resource that is not allowed");
 
                 let packet = dns_resource_nat::domain_status(
                     req.resource,


### PR DESCRIPTION
This log should only ever happen if clients are buggy or someone is using a custom client. Thus worth a `warn`.

Follow-up from #6941.