### PR TITLE
refactor(rust): consistently record errors as `tracing::Value`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "bimap",
  "chrono",
  "connlib-model",
+ "firezone-logging",
  "firezone-telemetry",
  "firezone-tunnel",
  "ip_network",
@@ -2040,6 +2041,7 @@ dependencies = [
  "difference",
  "env_logger",
  "firezone-bin-shared",
+ "firezone-logging",
  "futures",
  "hex",
  "hex-display",
@@ -5699,6 +5701,7 @@ dependencies = [
 name = "socket-factory"
 version = "0.1.0"
 dependencies = [
+ "firezone-logging",
  "quinn-udp",
  "socket2",
  "tokio",

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -9,6 +9,7 @@ description = "Firezone-specific modules shared between binaries."
 anyhow = "1.0.82"
 axum = { version = "0.7.7", default-features = false, features = ["http1", "tokio"] }
 clap = { version = "4.5.19", features = ["derive", "env"] }
+firezone-logging = { workspace = true }
 futures = "0.3"
 git-version = "0.3.9"
 ip_network = { version = "0.4", default-features = false, features = ["serde"] }
@@ -19,7 +20,6 @@ tracing = { workspace = true }
 tun = { workspace = true }
 
 [dev-dependencies]
-firezone-logging = { workspace = true }
 hex-literal = "0.4.1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -2,6 +2,7 @@
 
 use crate::FIREZONE_MARK;
 use anyhow::{anyhow, Context as _, Result};
+use firezone_logging::std_dyn_err;
 use futures::TryStreamExt;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use libc::{
@@ -257,7 +258,7 @@ async fn add_route(route: &IpNetwork, idx: u32, handle: &Handle) {
         return;
     }
 
-    tracing::warn!(%route, "Failed to add route: {err}");
+    tracing::warn!(error = std_dyn_err(&err), %route, "Failed to add route");
 }
 
 async fn remove_route(route: &IpNetwork, idx: u32, handle: &Handle) {
@@ -279,7 +280,7 @@ async fn remove_route(route: &IpNetwork, idx: u32, handle: &Handle) {
         return;
     }
 
-    tracing::warn!(%route, "Failed to remove route: {err}");
+    tracing::warn!(error = std_dyn_err(&err), %route, "Failed to remove route");
 }
 
 #[derive(Debug)]

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -139,7 +139,7 @@ fn add_route(route: IpNetwork, iface_idx: u32) {
         return;
     }
 
-    tracing::warn!(%route, "Failed to add route: {e}");
+    tracing::warn!(error = as_dyn_err(&e), %route, "Failed to add route");
 }
 
 // It's okay if this blocks until the route is removed in the OS.
@@ -159,7 +159,7 @@ fn remove_route(route: IpNetwork, iface_idx: u32) {
         return;
     }
 
-    tracing::warn!(%route, "Failed to remove route: {e}")
+    tracing::warn!(error = as_dyn_err(&e), %route, "Failed to remove route")
 }
 
 fn forward_entry(route: IpNetwork, iface_idx: u32) -> MIB_IPFORWARD_ROW2 {

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -1,6 +1,7 @@
 use crate::windows::{CREATE_NO_WINDOW, TUNNEL_UUID};
 use crate::TUNNEL_NAME;
 use anyhow::{Context as _, Result};
+use firezone_logging::std_dyn_err;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ring::digest;
 use std::{
@@ -139,7 +140,7 @@ fn add_route(route: IpNetwork, iface_idx: u32) {
         return;
     }
 
-    tracing::warn!(error = as_dyn_err(&e), %route, "Failed to add route");
+    tracing::warn!(error = std_dyn_err(&e), %route, "Failed to add route");
 }
 
 // It's okay if this blocks until the route is removed in the OS.
@@ -159,7 +160,7 @@ fn remove_route(route: IpNetwork, iface_idx: u32) {
         return;
     }
 
-    tracing::warn!(error = as_dyn_err(&e), %route, "Failed to remove route")
+    tracing::warn!(error = std_dyn_err(&e), %route, "Failed to remove route")
 }
 
 fn forward_entry(route: IpNetwork, iface_idx: u32) -> MIB_IPFORWARD_ROW2 {

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -137,7 +137,7 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
 
         // Safety: The `entry` is initialised.
         if let Err(e) = unsafe { DeleteIpForwardEntry2(entry) }.ok() {
-            tracing::warn!("Failed to remove routing entry: {e}");
+            tracing::warn!(error = as_dyn_err(&e), "Failed to remove routing entry");
             continue;
         };
 
@@ -200,7 +200,7 @@ impl Drop for RoutingTableEntry {
 
         // Safety: The entry we stored is valid.
         if let Err(e) = unsafe { DeleteIpForwardEntry2(&self.entry) }.ok() {
-            tracing::warn!("Failed to delete routing entry: {e}");
+            tracing::warn!(error = as_dyn_err(&e), "Failed to delete routing entry");
             return;
         };
 

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -1,5 +1,6 @@
 use crate::TUNNEL_NAME;
 use anyhow::{Context as _, Result};
+use firezone_logging::std_dyn_err;
 use known_folders::{get_known_folder_path, KnownFolder};
 use socket_factory::{TcpSocket, UdpSocket};
 use std::{
@@ -137,7 +138,7 @@ fn delete_all_routing_entries_matching(addr: IpAddr) -> io::Result<()> {
 
         // Safety: The `entry` is initialised.
         if let Err(e) = unsafe { DeleteIpForwardEntry2(entry) }.ok() {
-            tracing::warn!(error = as_dyn_err(&e), "Failed to remove routing entry");
+            tracing::warn!(error = std_dyn_err(&e), "Failed to remove routing entry");
             continue;
         };
 
@@ -200,7 +201,7 @@ impl Drop for RoutingTableEntry {
 
         // Safety: The entry we stored is valid.
         if let Err(e) = unsafe { DeleteIpForwardEntry2(&self.entry) }.ok() {
-            tracing::warn!(error = as_dyn_err(&e), "Failed to delete routing entry");
+            tracing::warn!(error = std_dyn_err(&e), "Failed to delete routing entry");
             return;
         };
 

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.82"
 backoff = { workspace = true }
 bimap = "0.6"
 connlib-model = { workspace = true }
+firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
 firezone-tunnel = { workspace = true }
 ip_network = { version = "0.4", default-features = false }

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -1,6 +1,7 @@
 use crate::{callbacks::Callbacks, PHOENIX_TOPIC};
 use anyhow::Result;
 use connlib_model::ResourceId;
+use firezone_logging::{anyhow_dyn_err, std_dyn_err};
 use firezone_tunnel::messages::{client::*, *};
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel, PublicKeyParam};
@@ -91,7 +92,7 @@ where
                     continue;
                 }
                 Poll::Ready(Err(e)) => {
-                    tracing::warn!("Tunnel error: {e}");
+                    tracing::warn!(error = std_dyn_err(&e), "Tunnel error");
                     continue;
                 }
                 Poll::Pending => {}
@@ -300,7 +301,7 @@ where
                     gateway_public_key.0.into(),
                     Instant::now(),
                 ) {
-                    tracing::warn!("Failed to accept connection: {e}");
+                    tracing::warn!(error = anyhow_dyn_err(&e), "Failed to accept connection");
                 }
             }
             ReplyMessages::Connect(Connect {
@@ -332,7 +333,10 @@ where
                 ) {
                     Ok(()) => {}
                     Err(e) => {
-                        tracing::warn!("Failed to request new connection: {e}");
+                        tracing::warn!(
+                            error = anyhow_dyn_err(&e),
+                            "Failed to request new connection"
+                        );
                     }
                 };
             }

--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -3,6 +3,7 @@ pub use crate::serde_routelist::{V4RouteList, V6RouteList};
 pub use callbacks::{Callbacks, DisconnectError};
 pub use connlib_model::StaticSecret;
 pub use eventloop::Eventloop;
+use firezone_logging::std_dyn_err;
 pub use firezone_tunnel::messages::client::{
     ResourceDescription, {IngressMessages, ReplyMessages},
 };
@@ -159,7 +160,7 @@ async fn connect_supervisor<CB>(
                 telemetry::capture_error(&e);
             }
 
-            tracing::error!("connlib failed: {e}");
+            tracing::error!(error = std_dyn_err(&e), "connlib failed");
             callbacks.on_disconnect(&e);
         }
         Err(e) => {

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -8,6 +8,7 @@ backoff = "0.4.0"
 boringtun = { workspace = true }
 bytecodec = "0.4.15"
 bytes = "1.7.1"
+firezone-logging = { workspace = true }
 hex = "0.4.0"
 hex-display = "0.3.0"
 ip-packet = { workspace = true }
@@ -20,9 +21,6 @@ str0m = { workspace = true }
 stun_codec = "0.3.4"
 thiserror = "1"
 tracing = { workspace = true }
-
-[dev-dependencies]
-firezone-logging = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -8,6 +8,7 @@ use boringtun::noise::{Tunn, TunnResult};
 use boringtun::x25519::PublicKey;
 use boringtun::{noise::rate_limiter::RateLimiter, x25519::StaticSecret};
 use core::fmt;
+use firezone_logging::std_dyn_err;
 use hex_display::HexDisplayExt;
 use ip_packet::{
     ConvertibleIpv4Packet, ConvertibleIpv6Packet, IpPacket, IpPacketBuf, MAX_DATAGRAM_PAYLOAD,
@@ -328,7 +329,7 @@ where
         let candidate = match Candidate::from_sdp_string(&candidate) {
             Ok(c) => c,
             Err(e) => {
-                tracing::debug!("Failed to parse candidate: {e}");
+                tracing::debug!(error = std_dyn_err(&e), "Failed to parse candidate");
                 return;
             }
         };
@@ -369,7 +370,7 @@ where
         let candidate = match Candidate::from_sdp_string(&candidate) {
             Ok(c) => c,
             Err(e) => {
-                tracing::debug!("Failed to parse candidate: {e}");
+                tracing::debug!(error = std_dyn_err(&e), "Failed to parse candidate");
                 return;
             }
         };

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -10,6 +10,7 @@ use domain::{
     },
     dep::octseq::OctetsInto,
 };
+use firezone_logging::{anyhow_dyn_err, std_dyn_err};
 use itertools::Itertools;
 use pattern::{Candidate, Pattern};
 use std::io;
@@ -178,7 +179,7 @@ impl StubResolver {
         let parsed_pattern = match Pattern::new(&pattern) {
             Ok(p) => p,
             Err(e) => {
-                tracing::warn!(%pattern, "Domain pattern is not valid: {e}");
+                tracing::warn!(error = std_dyn_err(&e), %pattern, "Domain pattern is not valid");
                 return false;
             }
         };
@@ -273,7 +274,7 @@ impl StubResolver {
         match self.try_handle(message) {
             Ok(s) => s,
             Err(e) => {
-                tracing::trace!("Failed to handle DNS query: {e:#}");
+                tracing::trace!(error = anyhow_dyn_err(&e), "Failed to handle DNS query");
 
                 ResolveStrategy::LocalResponse(servfail(message))
             }
@@ -390,7 +391,7 @@ pub fn is_subdomain(name: &DomainName, resource: &str) -> bool {
     let pattern = match Pattern::new(resource) {
         Ok(p) => p,
         Err(e) => {
-            tracing::warn!(%resource, "Unable to parse pattern: {e}");
+            tracing::warn!(error = std_dyn_err(&e), %resource, "Unable to parse pattern");
             return false;
         }
     };

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use boringtun::x25519::PublicKey;
 use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, DomainName, RelayId, ResourceId};
+use firezone_logging::{anyhow_dyn_err, std_dyn_err};
 use ip_network::{Ipv4Network, Ipv6Network};
 use ip_packet::{FzP2pControlSlice, IpPacket};
 use secrecy::{ExposeSecret as _, Secret};
@@ -106,7 +107,7 @@ impl GatewayState {
         let transmit = self
             .node
             .encapsulate(cid, packet, now, buffer)
-            .inspect_err(|e| tracing::debug!(%cid, "Failed to encapsulate: {e}"))
+            .inspect_err(|e| tracing::debug!(error = std_dyn_err(e), %cid, "Failed to encapsulate"))
             .ok()??;
 
         Some(transmit)
@@ -131,7 +132,7 @@ impl GatewayState {
             packet,
             now,
         )
-        .inspect_err(|e| tracing::debug!(%from, num_bytes = %packet.len(), "Failed to decapsulate incoming packet: {e}"))
+        .inspect_err(|e| tracing::debug!(error = std_dyn_err(e), %from, num_bytes = %packet.len(), "Failed to decapsulate incoming packet"))
         .ok()??;
 
         let Some(peer) = self.peers.get_mut(&cid) else {
@@ -257,7 +258,7 @@ impl GatewayState {
         };
 
         if let Err(e) = peer.refresh_translation(name.clone(), resource_id, resolved_ips, now) {
-            tracing::warn!(rid = %resource_id, %name, "Failed to refresh DNS resource IP translations: {e:#}");
+            tracing::warn!(error = anyhow_dyn_err(&e), rid = %resource_id, %name, "Failed to refresh DNS resource IP translations");
         };
     }
 
@@ -316,7 +317,10 @@ impl GatewayState {
             )
             .map(|()| dns_resource_nat::NatStatus::Active)
             .unwrap_or_else(|e| {
-                tracing::debug!("Failed to setup DNS resource NAT: {e:#}");
+                tracing::debug!(
+                    error = anyhow_dyn_err(&e),
+                    "Failed to setup DNS resource NAT"
+                );
 
                 dns_resource_nat::NatStatus::Inactive
             });
@@ -490,7 +494,7 @@ fn encrypt_packet<'a>(
 ) -> Option<Transmit<'a>> {
     let encrypted_packet = node
         .encapsulate(cid, packet, now, buffer)
-        .inspect_err(|e| tracing::debug!(%cid, "Failed to encapsulate: {e}"))
+        .inspect_err(|e| tracing::debug!(error = std_dyn_err(e), %cid, "Failed to encapsulate"))
         .ok()??;
 
     Some(encrypted_packet.to_transmit(buffer))

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -1,5 +1,6 @@
 use crate::{device_channel::Device, dns, sockets::Sockets};
 use domain::base::Message;
+use firezone_logging::std_dyn_err;
 use futures::{
     future::{self, Either},
     stream, Stream, StreamExt,
@@ -348,7 +349,7 @@ async fn tun_send_recv(
         {
             Either::Left((Some(Command::SendPacket(p)), _)) => {
                 if let Err(e) = device.write(p) {
-                    tracing::debug!("Failed to write TUN packet: {e}");
+                    tracing::debug!(error = std_dyn_err(&e), "Failed to write TUN packet");
                 };
             }
             Either::Left((Some(Command::UpdateTun(tun)), _)) => {
@@ -365,7 +366,10 @@ async fn tun_send_recv(
                 };
             }
             Either::Right((Err(e), _)) => {
-                tracing::debug!("Failed to read packet from TUN device: {e}");
+                tracing::debug!(
+                    error = std_dyn_err(&e),
+                    "Failed to read packet from TUN device"
+                );
                 return;
             }
         };

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -1,3 +1,4 @@
+use firezone_logging::std_dyn_err;
 use socket_factory::{DatagramIn, DatagramOut, SocketFactory, UdpSocket};
 use std::{
     io,
@@ -19,10 +20,10 @@ pub(crate) struct Sockets {
 impl Sockets {
     pub fn rebind(&mut self, socket_factory: &dyn SocketFactory<UdpSocket>) {
         self.socket_v4 = socket_factory(&SocketAddr::V4(UNSPECIFIED_V4_SOCKET))
-            .inspect_err(|e| tracing::warn!("Failed to bind IPv4 socket: {e}"))
+            .inspect_err(|e| tracing::warn!(error = std_dyn_err(e), "Failed to bind IPv4 socket"))
             .ok();
         self.socket_v6 = socket_factory(&SocketAddr::V6(UNSPECIFIED_V6_SOCKET))
-            .inspect_err(|e| tracing::warn!("Failed to bind IPv6 socket: {e}"))
+            .inspect_err(|e| tracing::warn!(error = std_dyn_err(e), "Failed to bind IPv6 socket"))
             .ok();
 
         if let Some(waker) = self.waker.take() {

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -18,6 +18,7 @@ use connlib_model::{ClientId, DomainName, GatewayId, RelayId};
 use domain::base::iana::{Class, Rcode};
 use domain::base::{Message, MessageBuilder, Record, Rtype, ToName as _, Ttl};
 use domain::rdata::AllRecordData;
+use firezone_logging::anyhow_dyn_err;
 use secrecy::ExposeSecret as _;
 use snownet::Transmit;
 use std::collections::BTreeSet;
@@ -512,7 +513,7 @@ impl TunnelTest {
                         c.handle_dns_response(message.for_slice())
                     }
                     Err(e) => {
-                        tracing::error!("TCP DNS query failed: {e:#}");
+                        tracing::error!(error = anyhow_dyn_err(&e), "TCP DNS query failed");
                     }
                 }
             }

--- a/rust/dns-over-tcp/Cargo.toml
+++ b/rust/dns-over-tcp/Cargo.toml
@@ -7,6 +7,7 @@ description = "User-space implementation of DNS over TCP."
 [dependencies]
 anyhow = "1.0"
 domain = { workspace = true }
+firezone-logging = { workspace = true }
 ip-packet = { workspace = true }
 itertools = "0.13"
 rand = "0.8"
@@ -15,7 +16,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 firezone-bin-shared = { workspace = true }
-firezone-logging = { workspace = true }
 futures = "0.3"
 ip_network = { version = "0.4", default-features = false }
 tokio = { workspace = true, features = ["process", "rt", "macros"] }

--- a/rust/dns-over-tcp/src/server.rs
+++ b/rust/dns-over-tcp/src/server.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use anyhow::{Context as _, Result};
 use domain::{base::Message, dep::octseq::OctetsInto as _};
+use firezone_logging::anyhow_dyn_err;
 use ip_packet::IpPacket;
 use smoltcp::{
     iface::{Interface, PollResult, SocketSet},
@@ -187,7 +188,7 @@ impl Server {
                         });
                     }
                     Err(e) => {
-                        tracing::debug!("Error on receiving DNS query: {e}");
+                        tracing::debug!(error = anyhow_dyn_err(&e), "Error on receiving DNS query");
                         socket.abort();
                         break;
                     }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -7,6 +7,7 @@ use firezone_bin_shared::{
     linux::{tcp_socket_factory, udp_socket_factory},
     TunDeviceManager,
 };
+use firezone_logging::anyhow_dyn_err;
 use firezone_tunnel::messages::Interface;
 use firezone_tunnel::{GatewayTunnel, IPV4_PEERS, IPV6_PEERS};
 use phoenix_channel::get_user_agent;
@@ -42,7 +43,7 @@ async fn main() {
     // By default, `anyhow` prints a stacktrace when it exits.
     // That looks like a "crash" but we "just" exit with a fatal error.
     if let Err(e) = try_main().await {
-        tracing::error!("{e:#}");
+        tracing::error!(error = anyhow_dyn_err(&e));
         std::process::exit(1);
     }
 }
@@ -143,14 +144,14 @@ async fn update_device_task(
             .set_ips(next_interface.ipv4, next_interface.ipv6)
             .await
         {
-            tracing::warn!("Failed to set interface: {e:#}");
+            tracing::warn!(error = anyhow_dyn_err(&e), "Failed to set interface");
         }
 
         if let Err(e) = tun_device
             .set_routes(vec![IPV4_PEERS], vec![IPV6_PEERS])
             .await
         {
-            tracing::warn!("Failed to set routes: {e:#}");
+            tracing::warn!(error = anyhow_dyn_err(&e), "Failed; to set routes");
         };
     }
 }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -12,6 +12,7 @@ use firezone_bin_shared::{
 use firezone_headless_client::{
     device_id, signals, CallbackHandler, CliCommon, ConnlibMsg, DnsController,
 };
+use firezone_logging::LogUnwrap;
 use firezone_telemetry::Telemetry;
 use futures::{FutureExt as _, StreamExt as _};
 use phoenix_channel::get_user_agent;
@@ -156,6 +157,9 @@ fn main() -> Result<()> {
         arch = std::env::consts::ARCH,
         git_version = firezone_bin_shared::git_version!("headless-client-*")
     );
+
+    anyhow::Result::<()>::Err(anyhow::Error::msg("foo").context("bar").context("baz"))
+        .log_unwrap_debug("Something failed");
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/rust/logging/src/dyn_err.rs
+++ b/rust/logging/src/dyn_err.rs
@@ -1,0 +1,9 @@
+use std::error::Error;
+
+pub fn std_dyn_err(e: &(impl Error + 'static)) -> &(dyn Error + 'static) {
+    e as &(dyn Error + 'static)
+}
+
+pub fn anyhow_dyn_err(e: &anyhow::Error) -> &(dyn Error + 'static) {
+    e.as_ref()
+}

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -1,3 +1,4 @@
+mod dyn_err;
 pub mod file;
 mod format;
 mod log_unwrap;
@@ -9,6 +10,7 @@ use tracing_subscriber::{
     Registry,
 };
 
+pub use dyn_err::{anyhow_dyn_err, std_dyn_err};
 pub use format::Format;
 pub use log_unwrap::LogUnwrap;
 

--- a/rust/logging/src/log_unwrap.rs
+++ b/rust/logging/src/log_unwrap.rs
@@ -1,23 +1,33 @@
+use std::error::Error;
+
 pub trait LogUnwrap {
+    #[track_caller]
     fn log_unwrap_debug(&self, msg: &str);
+    #[track_caller]
     fn log_unwrap_trace(&self, msg: &str);
 }
 
 impl LogUnwrap for anyhow::Result<()> {
+    #[track_caller]
     fn log_unwrap_debug(&self, msg: &str) {
         match self {
             Ok(()) => {}
             Err(e) => {
-                tracing::debug!("{msg}: {e:#}")
+                let error: &dyn Error = e.as_ref();
+
+                tracing::debug!(error, "{msg}")
             }
         }
     }
 
+    #[track_caller]
     fn log_unwrap_trace(&self, msg: &str) {
         match self {
             Ok(()) => {}
             Err(e) => {
-                tracing::trace!("{msg}: {e:#}")
+                let error: &dyn Error = e.as_ref();
+
+                tracing::trace!(error, "{msg}")
             }
         }
     }

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 backoff = "0.4.0"
 base64 = "0.22.1"
+firezone-logging = { workspace = true }
 futures = "0.3.29"
 hex = "0.4"
 libc = "0.2"
@@ -28,7 +29,6 @@ uuid = { version = "1.10", default-features = false, features = ["std", "v4"] }
 hostname = "0.4.0"
 
 [dev-dependencies]
-firezone-logging = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "tracing"] }
 
 [lints]

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -12,6 +12,7 @@ bytes = "1.7.1"
 clap = { version = "4.5.19", features = ["derive", "env"] }
 derive_more = { version = "1.0.0", features = ["from"] }
 firezone-bin-shared = { workspace = true }
+firezone-logging = { workspace = true }
 futures = "0.3.29"
 hex = "0.4.3"
 hex-display = "0.3.0"

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -12,6 +12,7 @@ use crate::{ClientSocket, IpStack, PeerSocket};
 use anyhow::Result;
 use bytecodec::EncodeExt;
 use core::fmt;
+use firezone_logging::std_dyn_err;
 use hex_display::HexDisplayExt as _;
 use opentelemetry::metrics::{Counter, UpDownCounter};
 use opentelemetry::KeyValue;
@@ -782,7 +783,7 @@ where
             .value()
             .parse::<Uuid>()
             .map_err(|e| {
-                tracing::debug!(target: "relay", "failed to parse nonce: {e}");
+                tracing::debug!(target: "relay", error = std_dyn_err(&e), "failed to parse nonce");
 
                 self.make_error_response(Unauthorized, request, ResponseErrorLevel::Warn)
             })?;

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+firezone-logging = { workspace = true }
 quinn-udp = "0.5.2"
 socket2 = { workspace = true }
 tokio = { version = "1.39", features = ["net"] }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -1,3 +1,4 @@
+use firezone_logging::std_dyn_err;
 use std::collections::HashMap;
 use std::fmt;
 use std::{
@@ -330,8 +331,9 @@ impl UdpSocket {
                 Ok(src_ip) => src_ip,
                 Err(e) => {
                     tracing::trace!(
+                        error = std_dyn_err(&e),
                         dst = %dst.ip(),
-                        "No available interface for packet: {e}"
+                        "No available interface for packet"
                     );
                     return Ok(None); // Not an error because we log it above already.
                 }


### PR DESCRIPTION
Our logging library, `tracing` supports structured logging. This is useful because it preserves the more than just the string representation of a value and thus allows the active logging backend(s) to capture more information for a particular value.

In the case of errors, this is especially useful because it allows us to capture the sources of a particular error.

Unfortunately, recording an error as a tracing value is a bit cumbersome because `tracing::Value` is only implemented for `&dyn std::error::Error`. Casting an error to this is quite verbose. To make it easier, we introduce two utility functions in `firezone-logging`:

- `std_dyn_err`
- `anyhow_dyn_err`

Tracking errors as correct `tracing::Value`s will be especially helpful once we enable Sentry's `tracing` integration: https://docs.rs/sentry-tracing/latest/sentry_tracing/#tracking-errors