### PR TITLE
chore(website): fully apply prettier formatting

### DIFF
--- a/website/src/app/blog/page.tsx
+++ b/website/src/app/blog/page.tsx
@@ -22,7 +22,7 @@ export default function Page() {
           </p>
         </div>
       </div>
-      <Posts/>
+      <Posts />
     </section>
   );
 }

--- a/website/src/app/blog/sans-io/readme.mdx
+++ b/website/src/app/blog/sans-io/readme.mdx
@@ -648,7 +648,6 @@ on drafts of this post.
     [this article](/kb/architecture/tech-stack) in our architecture docs.
 
 [^2]: Technically, a thread-per-core runtime could allow non-`'static` `Future`s.
-
 [^3]:
     `boringtun` does call `Instant::now` internally and is thus unfortunately
     partly impure, see https://github.com/cloudflare/boringtun/issues/391.

--- a/website/src/app/manifest.webmanifest
+++ b/website/src/app/manifest.webmanifest
@@ -1,19 +1,19 @@
 {
-    "name": "Firezone",
-    "short_name": "Firezone",
-    "icons": [
-        {
-            "src": "/images/android-chrome-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/images/android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png"
-        }
-    ],
-    "theme_color": "#331700",
-    "background_color": "#331700",
-    "display": "standalone"
+  "name": "Firezone",
+  "short_name": "Firezone",
+  "icons": [
+    {
+      "src": "/images/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#331700",
+  "background_color": "#331700",
+  "display": "standalone"
 }

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -22,19 +22,19 @@ export default function GUI({ title }: { title: string }) {
       </Unreleased>
       <Entry version="1.3.9" date={new Date("2024-10-09")}>
         <ChangeItem enable={title === "Linux GUI"} pull="6987">
-          Fixes a crash on startup caused by incorrect permissions on the ID file.
+          Fixes a crash on startup caused by incorrect permissions on the ID
+          file.
         </ChangeItem>
         <ChangeItem enable={title === "Windows"}>
           This is a maintenance release with no user-facing changes.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.8" date={new Date("2024-10-08")}>
-        <ChangeItem pull="6874">
-          Fixes the GUI shutting down slowly.
-        </ChangeItem>
+        <ChangeItem pull="6874">Fixes the GUI shutting down slowly.</ChangeItem>
         <ChangeItem enable={title === "Windows"} pull="6931">
-          Mitigates an issue where `ipconfig` and WSL weren't aware of Firezone DNS resolvers.
-          Users may need to restart WSL after signing in to Firezone.
+          Mitigates an issue where `ipconfig` and WSL weren't aware of Firezone
+          DNS resolvers. Users may need to restart WSL after signing in to
+          Firezone.
         </ChangeItem>
       </Entry>
       <Entry version="1.3.7" date={new Date("2024-10-02")}>

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -11,14 +11,14 @@ export default function Gateway() {
   return (
     <Entries href={href} arches={arches} title="Gateway">
       <Unreleased>
-          <ChangeItem pull="6960">
-            Separates CIDR and DNS resources filters, preventing filters
-            from one applying to the other.
-          </ChangeItem>
-          <ChangeItem pull="6941">
-            Implements support for the new control protocol; delivering faster
-            and more robust connection establishment.
-          </ChangeItem>
+        <ChangeItem pull="6960">
+          Separates CIDR and DNS resources filters, preventing filters from one
+          applying to the other.
+        </ChangeItem>
+        <ChangeItem pull="6941">
+          Implements support for the new control protocol; delivering faster and
+          more robust connection establishment.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.3.2" date={new Date("2024-10-02")}>
         <ChangeItem pull="6733">

--- a/website/src/components/CustomerTestimonials/index.tsx
+++ b/website/src/components/CustomerTestimonials/index.tsx
@@ -75,9 +75,7 @@ const TestimonialBox = ({
 }: TestimonialBoxProps) => {
   return (
     <div className="shrink-0 p-6 md:p-8 bg-[#1B1B1D] flex flex-col rounded-2xl justify-between w-fit lg:max-w-[320px] xl:max-w-[340px] lg:min-h-[320px] h-fit">
-      <FaQuoteLeft
-        className="absolute text-white/10 -translate-y-1/3 -z-1 w-10 h-10 sm:h-12 md:h-12 md:w-12"
-      />
+      <FaQuoteLeft className="absolute text-white/10 -translate-y-1/3 -z-1 w-10 h-10 sm:h-12 md:h-12 md:w-12" />
       <p
         className={`text-md  ${fontSize === "md" ? "lg:text-md" : "lg:text-lg"}
          tracking-wide font-light mb-6 break-keep italic text-neutral-50 z-10`}
@@ -111,7 +109,6 @@ const TestimonialBox = ({
 };
 
 export default function CustomerTestimonials() {
-
   return (
     <section className="bg-neutral-950 py-24 flex justify-center">
       <div className="relative flex flex-col lg:flex-row items-start lg:items-center justify-center max-w-screen-2xl">


### PR DESCRIPTION
Not sure why CI isn't picking up on this but running `prettier --write website/src/**` produces these formatting changes for me.