### PR TITLE
build(rust): depend on our `boringtun` fork

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/cloudflare/boringtun?branch=master#64a2fc7c63e5f5a9aa5b8e1fbcefd504778ad118"
+source = "git+https://github.com/firezone/boringtun?branch=master#b07142b38d51095ab7d7830db42d5f7e91c2bacf"
 dependencies = [
  "aead",
  "base64 0.13.1",
@@ -632,7 +632,7 @@ dependencies = [
  "ip_network",
  "ip_network_table",
  "libc",
- "nix 0.25.1",
+ "nix 0.29.0",
  "parking_lot",
  "rand_core 0.6.4",
  "ring",
@@ -3805,18 +3805,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "nix"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -77,7 +77,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", branch = "main" }
-boringtun = { git = "https://github.com/cloudflare/boringtun", branch = "master" }
+boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -439,19 +439,6 @@ where
             .get_established_mut(&connection)
             .ok_or(Error::NotConnected)?;
 
-        let packet_len = packet.packet().len();
-        let max_len = if self.mode.is_client() {
-            ip_packet::PACKET_SIZE
-        } else {
-            ip_packet::PACKET_SIZE + ip_packet::NAT46_OVERHEAD
-        };
-
-        // TODO: This is a it of a hack, we should compile-time enforce this.
-        if packet_len > max_len {
-            tracing::warn!("Packet is too large; max={max_len}, actual={packet_len}");
-            return Ok(None);
-        }
-
         // Encode the packet with an offset of 4 bytes, in case we need to wrap it in a channel-data message.
         let Some(packet_len) = conn
             .encapsulate(packet.packet(), &mut buffer.inner[4..], now)?


### PR DESCRIPTION
This switches our dependency on `boringtun` over to our fork at https://github.com/firezone/boringtun. The idea of the fork is to carefully only patch selective parts such that upstream things later is still possible. The complete diff can be seen here: https://github.com/cloudflare/boringtun/compare/master...firezone:boringtun:master

So far, the only patches in the fork are dependency bumps, linter fixes, adjustments to log levels and the removal of panics when the destination buffer is too small.