### PR TITLE
fix(rust/gui-client): fix the version reported by the IPC service to the portal

### DIFF
--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -546,7 +546,9 @@ impl<'a> Handler<'a> {
         let phoenix_span = transaction.start_child("phoenix", "Resolve DNS for PhoenixChannel");
         let portal = PhoenixChannel::disconnected(
             Secret::new(url),
-            get_user_agent(None, env!("CARGO_PKG_VERSION")),
+            // The IPC service must use the GUI's version number, not the Headless Client's. But refactoring to separate the IPC service from the Headless Client will take a while.
+            // mark:next-gui-version
+            get_user_agent(None, "1.3.10"),
             "client",
             (),
             ExponentialBackoffBuilder::default()

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -19,6 +19,9 @@ export default function GUI({ title }: { title: string }) {
         <ChangeItem enable={title === "Windows"} pull="7009">
           The IPC service `firezone-client-ipc.exe` is now signed.
         </ChangeItem>
+        <ChangeItem pull="7123">
+          Reports the version to the Portal correctly.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.3.9" date={new Date("2024-10-09")}>
         <ChangeItem enable={title === "Linux GUI"} pull="6987">


### PR DESCRIPTION
Closes #7122 

It had been reporting the Headless Client version, since the IPC service is built as part of the Headless Client crate. Now it's corrected from 1.3.5 to 1.3.10

<img width="417" alt="image" src="https://github.com/user-attachments/assets/b868de4a-3dce-42e3-ab4f-39a68c2ba48c">
