### PR TITLE
chore(rust): capture backtraces for panics

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1815,6 +1815,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "firezone-bin-shared"
 version = "0.1.0"
 dependencies = [
@@ -5319,8 +5331,10 @@ dependencies = [
  "httpdate",
  "reqwest",
  "rustls 0.22.4",
+ "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
+ "sentry-debug-images",
  "sentry-panic",
  "sentry-tracing",
  "tokio",
@@ -5379,6 +5393,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentry-debug-images"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc6b25e945fcaa5e97c43faee0267eebda9f18d4b09a251775d8fef1086238a"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
+]
+
+[[package]]
 name = "sentry-panic"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5394,6 +5419,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
 dependencies = [
+ "sentry-backtrace",
  "sentry-core",
  "tracing-core",
  "tracing-subscriber",

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.7.1"
-sentry = { version = "0.34.0", default-features = false, features = ["contexts", "panic", "reqwest", "rustls", "tracing"] }
+sentry = { version = "0.34.0", default-features = false, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing"] }
 sentry-anyhow = "0.34.0"
 tracing = { workspace = true }
 


### PR DESCRIPTION
Sentry by default has an integration to capture stacktraces for panics, we just need to enable it. Here is what this looks like: https://firezone-inc.sentry.io/issues/6013299023

Resolves: #7132.