### PR TITLE
fix: replace panics with `Result` for IP packets

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -385,7 +385,7 @@ impl ClientState {
                     });
 
                 self.try_queue_udp_dns_response(server, source, &message)
-                    .log_unwrap_debug("Failed to queue UDP DNS response");
+                    .log_unwrap_warn("Failed to queue UDP DNS response");
             }
             (dns::Transport::Tcp { source }, result) => {
                 let message = result
@@ -400,7 +400,7 @@ impl ClientState {
 
                 self.tcp_dns_server
                     .send_message(source, message)
-                    .log_unwrap_debug("Failed to send TCP DNS response");
+                    .log_unwrap_warn("Failed to send TCP DNS response");
             }
         }
     }

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -44,7 +44,9 @@ pub fn fz_p2p_control(header: [u8; 8], control_payload: &[u8]) -> Result<IpPacke
             crate::fz_p2p_control::IP_NUMBER,
             &payload_buf,
         )
-        .expect("Buffer should be big enough");
+        .with_context(|| {
+            format!("Buffer should be big enough; ip_payload_size={ip_payload_size}")
+        })?;
     let ip_packet = IpPacket::new(packet_buf, packet_size).context("Unable to create IP packet")?;
 
     Ok(ip_packet)

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -1,7 +1,7 @@
 //! Factory module for making all kinds of packets.
 
 use crate::{IpPacket, IpPacketBuf};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use etherparse::PacketBuilder;
 use std::net::IpAddr;
 
@@ -58,7 +58,7 @@ pub fn icmp_request_packet(
     seq: u16,
     identifier: u16,
     payload: &[u8],
-) -> Result<IpPacket, IpVersionMismatch> {
+) -> Result<IpPacket> {
     match (src, dst.into()) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
             let packet = PacketBuilder::ipv4(src.octets(), dst.octets(), 64)
@@ -72,7 +72,7 @@ pub fn icmp_request_packet(
 
             Ok(build!(packet, payload))
         }
-        _ => Err(IpVersionMismatch),
+        _ => bail!(IpVersionMismatch),
     }
 }
 
@@ -82,7 +82,7 @@ pub fn icmp_reply_packet(
     seq: u16,
     identifier: u16,
     payload: &[u8],
-) -> Result<IpPacket, IpVersionMismatch> {
+) -> Result<IpPacket> {
     match (src, dst.into()) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
             let packet = PacketBuilder::ipv4(src.octets(), dst.octets(), 64)
@@ -96,7 +96,7 @@ pub fn icmp_reply_packet(
 
             Ok(build!(packet, payload))
         }
-        _ => Err(IpVersionMismatch),
+        _ => bail!(IpVersionMismatch),
     }
 }
 
@@ -136,7 +136,7 @@ pub fn tcp_packet<IP>(
     sport: u16,
     dport: u16,
     payload: Vec<u8>,
-) -> Result<IpPacket, IpVersionMismatch>
+) -> Result<IpPacket>
 where
     IP: Into<IpAddr>,
 {
@@ -153,7 +153,7 @@ where
 
             Ok(build!(packet, payload))
         }
-        _ => Err(IpVersionMismatch),
+        _ => bail!(IpVersionMismatch),
     }
 }
 
@@ -163,7 +163,7 @@ pub fn udp_packet<IP>(
     sport: u16,
     dport: u16,
     payload: Vec<u8>,
-) -> Result<IpPacket, IpVersionMismatch>
+) -> Result<IpPacket>
 where
     IP: Into<IpAddr>,
 {
@@ -178,7 +178,7 @@ where
 
             Ok(build!(packet, payload))
         }
-        _ => Err(IpVersionMismatch),
+        _ => bail!(IpVersionMismatch),
     }
 }
 

--- a/rust/ip-packet/src/proptests.rs
+++ b/rust/ip-packet/src/proptests.rs
@@ -24,6 +24,7 @@ fn tcp_packet_v4() -> impl Strategy<Value = IpPacket> {
                 payload
             )
         })
+        .prop_map(|r: anyhow::Result<IpPacket>| r.unwrap())
 }
 
 fn tcp_packet_v6() -> impl Strategy<Value = IpPacket> {
@@ -40,6 +41,7 @@ fn tcp_packet_v6() -> impl Strategy<Value = IpPacket> {
                 payload
             )
         })
+        .prop_map(|r: anyhow::Result<IpPacket>| r.unwrap())
 }
 
 fn udp_packet_v4() -> impl Strategy<Value = IpPacket> {
@@ -56,6 +58,7 @@ fn udp_packet_v4() -> impl Strategy<Value = IpPacket> {
                 payload
             )
         })
+        .prop_map(|r: anyhow::Result<IpPacket>| r.unwrap())
 }
 
 fn udp_packet_v6() -> impl Strategy<Value = IpPacket> {
@@ -72,6 +75,7 @@ fn udp_packet_v6() -> impl Strategy<Value = IpPacket> {
                 payload
             )
         })
+        .prop_map(|r: anyhow::Result<IpPacket>| r.unwrap())
 }
 
 fn icmp_request_packet_v4() -> impl Strategy<Value = IpPacket> {
@@ -96,6 +100,7 @@ fn icmp_request_packet_v4() -> impl Strategy<Value = IpPacket> {
 
             build!(packet, EMPTY_PAYLOAD)
         })
+        .prop_map(|r: anyhow::Result<IpPacket>| r.unwrap())
 }
 
 fn icmp_reply_packet_v4() -> impl Strategy<Value = IpPacket> {
@@ -120,6 +125,7 @@ fn icmp_reply_packet_v4() -> impl Strategy<Value = IpPacket> {
 
             build!(packet, EMPTY_PAYLOAD)
         })
+        .prop_map(|r: anyhow::Result<IpPacket>| r.unwrap())
 }
 
 fn icmp_request_packet_v6() -> impl Strategy<Value = IpPacket> {
@@ -135,6 +141,7 @@ fn icmp_request_packet_v6() -> impl Strategy<Value = IpPacket> {
                 EMPTY_PAYLOAD
             )
         })
+        .prop_map(|r: anyhow::Result<IpPacket>| r.unwrap())
 }
 
 fn icmp_reply_packet_v6() -> impl Strategy<Value = IpPacket> {
@@ -150,6 +157,7 @@ fn icmp_reply_packet_v6() -> impl Strategy<Value = IpPacket> {
                 EMPTY_PAYLOAD
             )
         })
+        .prop_map(|r: anyhow::Result<IpPacket>| r.unwrap())
 }
 
 fn ipv4_options() -> impl Strategy<Value = Ipv4Options> {

--- a/rust/logging/src/log_unwrap.rs
+++ b/rust/logging/src/log_unwrap.rs
@@ -2,12 +2,26 @@ use std::error::Error;
 
 pub trait LogUnwrap {
     #[track_caller]
+    fn log_unwrap_warn(&self, msg: &str);
+    #[track_caller]
     fn log_unwrap_debug(&self, msg: &str);
     #[track_caller]
     fn log_unwrap_trace(&self, msg: &str);
 }
 
 impl LogUnwrap for anyhow::Result<()> {
+    #[track_caller]
+    fn log_unwrap_warn(&self, msg: &str) {
+        match self {
+            Ok(()) => {}
+            Err(e) => {
+                let error: &dyn Error = e.as_ref();
+
+                tracing::warn!(error, "{msg}")
+            }
+        }
+    }
+
     #[track_caller]
     fn log_unwrap_debug(&self, msg: &str) {
         match self {


### PR DESCRIPTION
My theory for this issue is that we receive a UDP DNS response from an upstream server that is bigger than our MTU and thus forwarding it fails.

This PR doesn't fix that issue by itself but only mitigates the actual panic. To properly fix the underlying issue, we need to parse the DNS message, truncate it and set the TC bit.

Related: #7121.