### PR TITLE
chore(connlib): bump severity of several logs

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -924,7 +924,7 @@ impl ClientState {
                 let known_sockets = &mut self.tcp_dns_sockets_by_upstream_and_query_id;
 
                 let Some(source) = known_sockets.remove(&(server, qid)) else {
-                    tracing::debug!(?known_sockets, %server, %qid, "Failed to find TCP socket handle for query result");
+                    tracing::warn!(?known_sockets, %server, %qid, "Failed to find TCP socket handle for query result");
 
                     continue;
                 };
@@ -953,7 +953,7 @@ impl ClientState {
         let (datagram, message) = match parse_udp_dns_message(&packet) {
             Ok((datagram, message)) => (datagram, message),
             Err(e) => {
-                tracing::trace!(
+                tracing::warn!(
                     error = anyhow_dyn_err(&e),
                     ?packet,
                     "Failed to parse DNS query"
@@ -999,11 +999,7 @@ impl ClientState {
         let message = query.message;
 
         let Some(upstream) = self.dns_mapping.get_by_left(&query.local.ip()) else {
-            tracing::debug!("Received TCP packet for non-sentinel IP");
-            debug_assert!(
-                false,
-                "We only dispatch packets to sentinel IPs to the TCP DNS server"
-            );
+            // This is highly-unlikely but might be possible if our DNS mapping changes whilst the TCP DNS server is processing a request.
             return;
         };
         let server = upstream.address();
@@ -1021,9 +1017,9 @@ impl ClientState {
                     match self.tcp_dns_client.send_query(server, message.clone()) {
                         Ok(()) => {}
                         Err(e) => {
-                            tracing::debug!(
+                            tracing::warn!(
                                 error = anyhow_dyn_err(&e),
-                                "Failed to send recursive TCP DNS quer"
+                                "Failed to send recursive TCP DNS query"
                             );
 
                             self.tcp_dns_server
@@ -1438,7 +1434,7 @@ impl ClientState {
 }
 
 fn parse_udp_dns_message(packet: &IpPacket) -> anyhow::Result<(UdpSlice, Message<&[u8]>)> {
-    let datagram = packet.as_udp().context("Only DNS over UDP is supported")?;
+    let datagram = packet.as_udp().context("Not a UDP packet")?;
     let port = datagram.destination_port();
 
     anyhow::ensure!(

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -274,7 +274,7 @@ impl StubResolver {
         match self.try_handle(message) {
             Ok(s) => s,
             Err(e) => {
-                tracing::trace!(error = anyhow_dyn_err(&e), "Failed to handle DNS query");
+                tracing::warn!(error = anyhow_dyn_err(&e), "Failed to handle DNS query");
 
                 ResolveStrategy::LocalResponse(servfail(message))
             }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -317,7 +317,7 @@ impl GatewayState {
             )
             .map(|()| dns_resource_nat::NatStatus::Active)
             .unwrap_or_else(|e| {
-                tracing::debug!(
+                tracing::warn!(
                     error = anyhow_dyn_err(&e),
                     "Failed to setup DNS resource NAT"
                 );


### PR DESCRIPTION
Now that we have Sentry integrated with `tracing`, using `warn!` logs a bit more liberally allows us to detect edge-cases that customers might run into.

All the logs touched in this PR represent some kind of problem that it would be good to know about.