### PR TITLE
chore(connlib): remove old `mock` feature

### DIFF
--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -9,9 +9,6 @@ name = "connlib"
 crate-type = ["lib", "cdylib"]
 doc = false
 
-[features]
-mock = ["connlib-client-shared/mock"]
-
 [dependencies]
 backoff = "0.4.0"
 connlib-client-shared = { workspace = true }

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -4,9 +4,6 @@ name = "connlib-client-apple"
 version = "1.3.7"
 edition = "2021"
 
-[features]
-mock = ["connlib-client-shared/mock"]
-
 [build-dependencies]
 swift-bridge-build = "0.1.57"
 

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -3,9 +3,6 @@ name = "connlib-client-shared"
 version = "0.1.0"
 edition = "2021"
 
-[features]
-mock = ["connlib-model/mock"]
-
 [dependencies]
 anyhow = "1.0.82"
 backoff = { workspace = true }

--- a/rust/connlib/model/Cargo.toml
+++ b/rust/connlib/model/Cargo.toml
@@ -3,10 +3,6 @@ name = "connlib-model"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[features]
-mock = []
-
 [dependencies]
 boringtun = { workspace = true }
 domain = { workspace = true }


### PR DESCRIPTION
This is so stale, it definitely needs to go in the bin.