### PR TITLE
fix(website): Wait for edge config to return deployed_sha

### DIFF
--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -8,11 +8,7 @@ export const dynamic = "force-static";
 export const revalidate = 60;
 
 export async function GET(_req: NextRequest) {
-  return NextResponse.json(versions());
-}
-
-async function versions() {
-  return {
+  const versions = {
     portal: await get("deployed_sha"),
     // mark:current-apple-version
     apple: "1.3.6",
@@ -25,4 +21,6 @@ async function versions() {
     // mark:current-gateway-version
     gateway: "1.3.2",
   };
+
+  return NextResponse.json(versions);
 }

--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -11,9 +11,9 @@ export async function GET(_req: NextRequest) {
   return NextResponse.json(versions());
 }
 
-function versions() {
+async function versions() {
   return {
-    portal: get("deployed_sha"),
+    portal: await get("deployed_sha"),
     // mark:current-apple-version
     apple: "1.3.6",
     // mark:current-android-version


### PR DESCRIPTION
#7136 introduced a bug where the portal's deployed_sha is now blank because we don't `await` its response.