### PR TITLE
chore(connlib): introduce `telemetry` log target

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2019,6 +2019,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "nu-ansi-term 0.50.1",
+ "rand 0.8.5",
  "sentry-tracing",
  "time",
  "tracing",

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -379,7 +379,9 @@ impl ClientState {
                         }
                     })
                     .unwrap_or_else(|e| {
-                        tracing::debug!(error = std_dyn_err(&e), "Recursive UDP DNS query failed");
+                        let error = std_dyn_err(&e);
+                        tracing::debug!(error, "Recursive UDP DNS query failed");
+                        tracing::trace!(target: "telemetry", error, "Recursive UDP DNS query failed");
 
                         dns::servfail(response.query.for_slice_ref())
                     });
@@ -395,7 +397,9 @@ impl ClientState {
                         tracing::trace!("Received recursive TCP DNS response");
                     })
                     .unwrap_or_else(|e| {
-                        tracing::debug!(error = std_dyn_err(&e), "Recursive TCP DNS query failed");
+                        let error = std_dyn_err(&e);
+                        tracing::debug!(error, "Recursive TCP DNS query failed");
+                        tracing::trace!(target: "telemetry", error, "Recursive TCP DNS query failed");
 
                         dns::servfail(response.query.for_slice_ref())
                     });

--- a/rust/logging/Cargo.toml
+++ b/rust/logging/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 nu-ansi-term = { version = "0.50" }
+rand = "0.8"
 sentry-tracing = "0.34.0"
 time = { version = "0.3.36", features = ["formatting"] }
 tracing = { workspace = true }


### PR DESCRIPTION
With #7105, all ERROR events from `tracing` get logged as exceptions in Sentry and all WARN events get logged as "messages". We don't want to fill up the user's harddrive with logs which means we have to be somewhat conservative, what gets logged on INFO and above (with INFO being the default log level). There are certain events though where it would be useful to know, how often they happen because too many of them can indicate a problem.

To solve this problem, we introduce a dedicated `telemetry` log target that the tracing-sentry integration layer watches for. Events for the `telemetry` log target that gets logged on TRACE will be sampled at a rate of 1% and submitted as messages to Sentry.