### PR TITLE
test(connlib): spend less time shrinking useless things

### DIFF
--- a/rust/connlib/model/src/lib.rs
+++ b/rust/connlib/model/src/lib.rs
@@ -28,8 +28,8 @@ pub struct ResourceId(Uuid);
 pub struct RelayId(Uuid);
 
 impl RelayId {
-    pub fn from_u128(v: u128) -> Self {
-        Self(Uuid::from_u128(v))
+    pub fn from_u8(v: u8) -> Self {
+        Self(Uuid::from_u128(v as u128))
     }
 }
 
@@ -46,14 +46,18 @@ impl ResourceId {
         ResourceId(Uuid::new_v4())
     }
 
+    pub fn from_u8(v: u8) -> Self {
+        Self(Uuid::from_u128(v as u128))
+    }
+
     pub fn from_u128(v: u128) -> Self {
         Self(Uuid::from_u128(v))
     }
 }
 
 impl GatewayId {
-    pub fn from_u128(v: u128) -> Self {
-        Self(Uuid::from_u128(v))
+    pub fn from_u8(v: u8) -> Self {
+        Self(Uuid::from_u128(v as u128))
     }
 }
 
@@ -69,8 +73,8 @@ impl FromStr for ClientId {
 }
 
 impl ClientId {
-    pub fn from_u128(v: u128) -> Self {
-        Self(Uuid::from_u128(v))
+    pub fn from_u8(v: u8) -> Self {
+        Self(Uuid::from_u128(v as u128))
     }
 }
 
@@ -168,8 +172,8 @@ impl FromStr for SiteId {
 }
 
 impl SiteId {
-    pub fn from_u128(v: u128) -> Self {
-        Self(Uuid::from_u128(v))
+    pub fn from_u8(v: u8) -> Self {
+        Self(Uuid::from_u128(v as u128))
     }
 }
 

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -746,8 +746,8 @@ mod tests {
     #[test]
     fn prioritises_non_wildcard_over_wildcard_domain() {
         let mut resolver = StubResolver::new(BTreeMap::default());
-        let wc = ResourceId::from_u128(0);
-        let non_wc = ResourceId::from_u128(1);
+        let wc = ResourceId::from_u8(0);
+        let non_wc = ResourceId::from_u8(1);
 
         resolver.add_resource(wc, "**.example.com".to_owned());
         resolver.add_resource(non_wc, "foo.example.com".to_owned());

--- a/rust/connlib/tunnel/src/p2p_control.rs
+++ b/rust/connlib/tunnel/src/p2p_control.rs
@@ -115,7 +115,7 @@ pub mod dns_resource_nat {
         #[test]
         fn max_payload_length_assigned_ips() {
             let assigned_ips = AssignedIps {
-                resource: ResourceId::from_u128(100),
+                resource: ResourceId::from_u8(100),
                 domain: longest_domain_possible(),
                 proxy_ips: eight_proxy_ips(),
             };
@@ -129,7 +129,7 @@ pub mod dns_resource_nat {
         #[test]
         fn assigned_ips_serde_roundtrip() {
             let packet = assigned_ips(
-                ResourceId::from_u128(101),
+                ResourceId::from_u8(101),
                 domain("example.com"),
                 eight_proxy_ips(),
             );
@@ -137,7 +137,7 @@ pub mod dns_resource_nat {
             let slice = packet.as_fz_p2p_control().unwrap();
             let assigned_ips = decode_assigned_ips(slice).unwrap();
 
-            assert_eq!(assigned_ips.resource, ResourceId::from_u128(101));
+            assert_eq!(assigned_ips.resource, ResourceId::from_u8(101));
             assert_eq!(assigned_ips.domain, domain("example.com"));
             assert_eq!(assigned_ips.proxy_ips, eight_proxy_ips())
         }
@@ -145,7 +145,7 @@ pub mod dns_resource_nat {
         #[test]
         fn domain_status_serde_roundtrip() {
             let packet = domain_status(
-                ResourceId::from_u128(101),
+                ResourceId::from_u8(101),
                 domain("example.com"),
                 NatStatus::Active,
             );
@@ -153,7 +153,7 @@ pub mod dns_resource_nat {
             let slice = packet.as_fz_p2p_control().unwrap();
             let domain_status = decode_domain_status(slice).unwrap();
 
-            assert_eq!(domain_status.resource, ResourceId::from_u128(101));
+            assert_eq!(domain_status.resource, ResourceId::from_u8(101));
             assert_eq!(domain_status.domain, domain("example.com"));
             assert_eq!(domain_status.status, NatStatus::Active)
         }
@@ -170,7 +170,7 @@ pub mod dns_resource_nat {
             let slice = packet.as_fz_p2p_control().unwrap();
             let domain_status = decode_domain_status(slice).unwrap();
 
-            assert_eq!(domain_status.resource, ResourceId::from_u128(101));
+            assert_eq!(domain_status.resource, ResourceId::from_u8(101));
             assert_eq!(domain_status.domain, domain("example.com"));
             assert_eq!(domain_status.status, NatStatus::Inactive);
         }

--- a/rust/connlib/tunnel/src/proptest.rs
+++ b/rust/connlib/tunnel/src/proptest.rs
@@ -89,23 +89,23 @@ pub fn site() -> impl Strategy<Value = Site> + Clone {
 }
 
 pub fn resource_id() -> impl Strategy<Value = ResourceId> + Clone {
-    any::<u128>().prop_map(ResourceId::from_u128)
+    any::<u8>().prop_map(ResourceId::from_u8)
 }
 
 pub fn gateway_id() -> impl Strategy<Value = GatewayId> + Clone {
-    any::<u128>().prop_map(GatewayId::from_u128)
+    any::<u8>().prop_map(GatewayId::from_u8)
 }
 
 pub fn client_id() -> impl Strategy<Value = ClientId> {
-    any::<u128>().prop_map(ClientId::from_u128)
+    any::<u8>().prop_map(ClientId::from_u8)
 }
 
 pub fn relay_id() -> impl Strategy<Value = RelayId> {
-    any::<u128>().prop_map(RelayId::from_u128)
+    any::<u8>().prop_map(RelayId::from_u8)
 }
 
 pub fn site_id() -> impl Strategy<Value = SiteId> + Clone {
-    any::<u128>().prop_map(SiteId::from_u128)
+    any::<u8>().prop_map(SiteId::from_u8)
 }
 
 pub fn site_name() -> impl Strategy<Value = String> + Clone {

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -759,7 +759,7 @@ fn select_host_v6(hosts: &[Ipv6Network]) -> impl Strategy<Value = Ipv6Addr> {
 }
 
 pub(crate) fn private_key() -> impl Strategy<Value = PrivateKey> {
-    any::<[u8; 32]>().prop_map(PrivateKey)
+    any::<u8>().prop_map(|k| PrivateKey([k; 32]))
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]

--- a/rust/gui-client/src-common/src/system_tray.rs
+++ b/rust/gui-client/src-common/src/system_tray.rs
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     fn no_resources_invalid_favorite() {
         let resources = vec![];
-        let favorites = HashSet::from([ResourceId::from_u128(42)]);
+        let favorites = HashSet::from([ResourceId::from_u8(42)]);
         let disabled_resources = Default::default();
         let input = signed_in(resources, favorites, disabled_resources);
         let actual = input.into_menu();


### PR DESCRIPTION
When `proptest` finds an error, it attempts to shrink the inputs to the most minimal one. Currently, some of our inputs have extremely large input spaces, i.e. all IDs are u128 and the private keys are u256. Exploring the entire space of these inputs is pretty useless. Instead, `proptest` should spend its time shrinking other things, like removing transitions, reducing DNS records, changing IPs etc.

To achieve this, we sample all IDs from a u8 and cast them to a u128. A u8 still gives us 128 clients / gateways which we don't have in the test. For the private key, we generate a single u8 and use it for all byte-positions.