### PR TITLE
fix(website): Use expected event names

### DIFF
--- a/website/src/components/Analytics/GoogleAds.tsx
+++ b/website/src/components/Analytics/GoogleAds.tsx
@@ -25,10 +25,6 @@ export default function GoogleAds() {
           Number(formData.submissionValues["0-2/numberofemployees"]) * 5;
 
         sendGTMEvent({
-          event: "gtm.js",
-        });
-
-        sendGTMEvent({
           event: "gtm.formSubmit",
           conversionValue: value,
         });

--- a/website/src/components/Analytics/GoogleAds.tsx
+++ b/website/src/components/Analytics/GoogleAds.tsx
@@ -25,7 +25,11 @@ export default function GoogleAds() {
           Number(formData.submissionValues["0-2/numberofemployees"]) * 5;
 
         sendGTMEvent({
-          event: "hubspot-sales-form-submitted",
+          event: "gtm.js",
+        });
+
+        sendGTMEvent({
+          event: "gtm.formSubmit",
           conversionValue: value,
         });
       }


### PR DESCRIPTION
Turns out that when using a custom event trigger, the event name doesn't match what's sent for `sendGTMEvent`. Google tag manager expects `gtm.formSubmission` instead. 🙃 