### PR TITLE
Revert "fix(website): Use expected event names"

### DIFF
--- a/website/src/components/Analytics/GoogleAds.tsx
+++ b/website/src/components/Analytics/GoogleAds.tsx
@@ -25,7 +25,7 @@ export default function GoogleAds() {
           Number(formData.submissionValues["0-2/numberofemployees"]) * 5;
 
         sendGTMEvent({
-          event: "gtm.formSubmit",
+          event: "hubspot-sales-form-submitted",
           conversionValue: value,
         });
       }


### PR DESCRIPTION
This was correct. There's just a delay in the Google Tag manager <-> Ads configuration sync...
SMH

Reverts firezone/firezone#7156