### PR TITLE
refactor(connlib): track srvflx candidates separately

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1,6 +1,6 @@
 use crate::{
     backoff::{self, ExponentialBackoff},
-    node::{CandidateEvent, SessionId, Transmit},
+    node::{SessionId, Transmit},
     ringbuffer::RingBuffer,
     utils::earliest,
     EncryptedPacket,
@@ -89,6 +89,12 @@ pub struct Allocation {
     last_now: Instant,
 
     credentials: Option<Credentials>,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum CandidateEvent {
+    New(Candidate),
+    Invalid(Candidate),
 }
 
 #[derive(Debug, Clone)]

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -70,7 +70,7 @@ pub struct Allocation {
     allocation_lifetime: Option<(Instant, Duration)>,
 
     buffered_transmits: VecDeque<Transmit<'static>>,
-    events: VecDeque<CandidateEvent>,
+    events: VecDeque<Event>,
 
     sent_requests: BTreeMap<
         TransactionId,
@@ -92,7 +92,7 @@ pub struct Allocation {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum CandidateEvent {
+pub(crate) enum Event {
     New(Candidate),
     Invalid(Candidate),
 }
@@ -655,7 +655,7 @@ impl Allocation {
         // TODO: Clean up unused channels
     }
 
-    pub fn poll_event(&mut self) -> Option<CandidateEvent> {
+    pub fn poll_event(&mut self) -> Option<Event> {
         self.events.pop_front()
     }
 
@@ -828,11 +828,11 @@ impl Allocation {
         tracing::info!(active_socket = ?self.active_socket, "Invalidating allocation");
 
         if let Some(candidate) = self.ip4_allocation.take() {
-            self.events.push_back(CandidateEvent::Invalid(candidate))
+            self.events.push_back(Event::Invalid(candidate))
         }
 
         if let Some(candidate) = self.ip6_allocation.take() {
-            self.events.push_back(CandidateEvent::Invalid(candidate))
+            self.events.push_back(Event::Invalid(candidate))
         }
 
         self.channel_bindings.clear();
@@ -1048,17 +1048,17 @@ fn authenticate(message: Message<Attribute>, credentials: &Credentials) -> Messa
 fn update_candidate(
     maybe_new: Option<Candidate>,
     maybe_current: &mut Option<Candidate>,
-    events: &mut VecDeque<CandidateEvent>,
+    events: &mut VecDeque<Event>,
 ) {
     match (maybe_new, &maybe_current) {
         (Some(new), Some(current)) if &new != current => {
-            events.push_back(CandidateEvent::New(new.clone()));
-            events.push_back(CandidateEvent::Invalid(current.clone()));
+            events.push_back(Event::New(new.clone()));
+            events.push_back(Event::Invalid(current.clone()));
             *maybe_current = Some(new);
         }
         (Some(new), None) => {
             *maybe_current = Some(new.clone());
-            events.push_back(CandidateEvent::New(new));
+            events.push_back(Event::New(new));
         }
         _ => {}
     }
@@ -1927,14 +1927,14 @@ mod tests {
         let next_event = allocation.poll_event();
         assert_eq!(
             next_event,
-            Some(CandidateEvent::New(
+            Some(Event::New(
                 Candidate::server_reflexive(PEER1, PEER1, Protocol::Udp).unwrap()
             ))
         );
         let next_event = allocation.poll_event();
         assert_eq!(
             next_event,
-            Some(CandidateEvent::New(
+            Some(Event::New(
                 Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()
             ))
         );
@@ -1979,13 +1979,13 @@ mod tests {
 
         assert_eq!(
             allocation.poll_event(),
-            Some(CandidateEvent::Invalid(
+            Some(Event::Invalid(
                 Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()
             ))
         );
         assert_eq!(
             allocation.poll_event(),
-            Some(CandidateEvent::Invalid(
+            Some(Event::Invalid(
                 Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp).unwrap()
             ))
         );
@@ -2310,8 +2310,8 @@ mod tests {
         assert_eq!(
             iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>(),
             vec![
-                CandidateEvent::Invalid(Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()),
-                CandidateEvent::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp).unwrap()),
             ]
         )
     }
@@ -2330,8 +2330,8 @@ mod tests {
         assert_eq!(
             iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>(),
             vec![
-                CandidateEvent::Invalid(Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()),
-                CandidateEvent::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp).unwrap()),
             ]
         )
     }
@@ -2362,8 +2362,8 @@ mod tests {
         assert_eq!(
             iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>(),
             vec![
-                CandidateEvent::Invalid(Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()),
-                CandidateEvent::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp).unwrap()),
             ]
         );
         assert_eq!(
@@ -2451,10 +2451,10 @@ mod tests {
         assert_eq!(
             events,
             vec![
-                CandidateEvent::New(
+                Event::New(
                     Candidate::server_reflexive(PEER2_IP4, PEER2_IP4, Protocol::Udp).unwrap()
                 ),
-                CandidateEvent::New(
+                Event::New(
                     Candidate::server_reflexive(PEER2_IP6, PEER2_IP6, Protocol::Udp).unwrap()
                 )
             ]

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -227,15 +227,10 @@ impl Allocation {
         allocation
     }
 
-    pub fn current_candidates(&self) -> impl Iterator<Item = Candidate> {
-        [
-            self.ip4_srflx_candidate.clone(),
-            self.ip6_srflx_candidate.clone(),
-            self.ip4_allocation.clone(),
-            self.ip6_allocation.clone(),
-        ]
-        .into_iter()
-        .flatten()
+    pub fn current_relay_candidates(&self) -> impl Iterator<Item = Candidate> {
+        [self.ip4_allocation.clone(), self.ip6_allocation.clone()]
+            .into_iter()
+            .flatten()
     }
 
     /// Refresh this allocation.
@@ -1990,9 +1985,8 @@ mod tests {
         );
         assert!(allocation.poll_event().is_none());
         assert_eq!(
-            allocation.current_candidates().collect::<Vec<_>>(),
-            vec![Candidate::server_reflexive(PEER1, PEER1, Protocol::Udp).unwrap()],
-            "server-reflexive candidate should still be valid after refresh"
+            allocation.current_relay_candidates().collect::<Vec<_>>(),
+            vec![],
         )
     }
 

--- a/rust/connlib/snownet/src/candidate_set.rs
+++ b/rust/connlib/snownet/src/candidate_set.rs
@@ -1,0 +1,28 @@
+use std::collections::HashSet;
+
+use itertools::Itertools;
+use str0m::Candidate;
+
+/// Custom "set" implementation for [`Candidate`]s based on a [`HashSet`] with an enforced ordering when iterating.
+#[derive(Debug, Default)]
+pub struct CandidateSet {
+    inner: HashSet<Candidate>,
+}
+
+impl CandidateSet {
+    pub fn insert(&mut self, c: Candidate) -> bool {
+        self.inner.insert(c)
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.clear()
+    }
+
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "We are guaranteeing a stable ordering"
+    )]
+    pub fn iter(&self) -> impl Iterator<Item = &Candidate> {
+        self.inner.iter().sorted_by_key(|c| c.prio())
+    }
+}

--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod allocation;
 mod backoff;
+mod candidate_set;
 mod channel_data;
 mod index;
 mod node;

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1,4 +1,4 @@
-use crate::allocation::{Allocation, CandidateEvent, RelaySocket, Socket};
+use crate::allocation::{self, Allocation, RelaySocket, Socket};
 use crate::candidate_set::CandidateSet;
 use crate::index::IndexLfsr;
 use crate::ringbuffer::RingBuffer;
@@ -904,18 +904,18 @@ where
             tracing::trace!(%rid, ?event);
 
             match event {
-                CandidateEvent::New(candidate)
+                allocation::Event::New(candidate)
                     if candidate.kind() == CandidateKind::ServerReflexive =>
                 {
                     self.shared_candidates.insert(candidate);
                 }
-                CandidateEvent::New(candidate) => {
+                allocation::Event::New(candidate) => {
                     for (cid, agent, _span) in self.connections.connecting_agents_by_relay_mut(rid)
                     {
                         add_local_candidate(cid, agent, candidate.clone(), &mut self.pending_events)
                     }
                 }
-                CandidateEvent::Invalid(candidate) => {
+                allocation::Event::Invalid(candidate) => {
                     for (cid, agent, _span) in self.connections.agents_mut() {
                         remove_local_candidate(cid, agent, &candidate, &mut self.pending_events);
                     }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -709,9 +709,7 @@ where
         agent.handle_timeout(now);
 
         if self.allocations.is_empty() {
-            tracing::warn!(
-                "No TURN servers connected; connection will very likely fail to establish"
-            );
+            tracing::warn!("No TURN servers connected; connection may fail to establish");
         }
 
         Connection {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1,4 +1,4 @@
-use crate::allocation::{Allocation, RelaySocket, Socket};
+use crate::allocation::{Allocation, CandidateEvent, RelaySocket, Socket};
 use crate::candidate_set::CandidateSet;
 use crate::index::IndexLfsr;
 use crate::ringbuffer::RingBuffer;
@@ -1553,12 +1553,6 @@ impl<'a> Transmit<'a> {
             payload: Cow::Owned(self.payload.into_owned()),
         }
     }
-}
-
-#[derive(Debug, PartialEq)]
-pub(crate) enum CandidateEvent {
-    New(Candidate),
-    Invalid(Candidate),
 }
 
 struct InitialConnection<RId> {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1123,10 +1123,7 @@ where
             return;
         };
 
-        for candidate in allocation
-            .current_candidates()
-            .filter(|c| c.kind() == CandidateKind::Relayed)
-        {
+        for candidate in allocation.current_relay_candidates() {
             add_local_candidate(connection, agent, candidate, &mut self.pending_events);
         }
     }
@@ -1391,10 +1388,7 @@ fn invalidate_allocation_candidates<TId, RId>(
     RId: Copy + Eq + Hash + PartialEq + Ord + fmt::Debug + fmt::Display,
 {
     for (cid, agent, _guard) in connections.agents_mut() {
-        for candidate in allocation
-            .current_candidates()
-            .filter(|c| c.kind() == CandidateKind::Relayed)
-        {
+        for candidate in allocation.current_relay_candidates() {
             remove_local_candidate(cid, agent, &candidate, pending_events);
         }
     }


### PR DESCRIPTION
As part of maintaining an allocation, we also perform STUN with our relays to discover our server-reflexive address. At the moment, these candidates are scoped to an `Allocation`. This is unnecessarily restrictive. Similar to host candidates, server-reflexive candidate entirely depend on the socket you send data from and are thus independent of the allocation's state.

During normal operation, this doesn't really matter because all relay traffic is sent through the same sockets so all `Allocation`s end up with the same server-reflexive candidates. Where this does matter is when we disconnect from relay's for one reason or another (for example: #7162). The fact that all but host-candidates are scoped to `Allocation`s means that without `Allocation`s, we cannot make any new connections, not even direct ones. This is unnecessarily restrictive and causes bugs within `Allocation` to have a bigger blast radius than necessary.

With this PR, we keep server-reflexive candidates in the same set as host candidates. This allows us to at least establish direct connections in case something is wrong with the relays or our state tracking of relays on the client side.