### PR TITLE
chore(gateway): lower "Tunnel error" to debug

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -77,7 +77,7 @@ impl Eventloop {
                     continue;
                 }
                 Poll::Ready(Err(e)) => {
-                    tracing::warn!(error = std_dyn_err(&e), "Tunnel error");
+                    tracing::debug!(error = std_dyn_err(&e), "Tunnel error");
                     continue;
                 }
                 Poll::Pending => {}


### PR DESCRIPTION
This is spamming Sentry and we have almost reached our rate limit for the amounts of events ingested.