### PR TITLE
chore(rust): record tracing WARNs as Sentry exceptions

### DIFF
--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -100,8 +100,7 @@ where
 {
     sentry_tracing::layer()
         .event_filter(move |md| match *md.level() {
-            tracing::Level::ERROR => EventFilter::Exception,
-            tracing::Level::WARN => EventFilter::Event,
+            tracing::Level::ERROR | tracing::Level::WARN => EventFilter::Exception,
             tracing::Level::INFO => EventFilter::Breadcrumb,
             tracing::Level::TRACE if md.target() == "telemetry" => {
                 // rand::random generates floats in the range of [0, 1).


### PR DESCRIPTION
It appears that I have misunderstood the documentation of `sentry-tracing`. When a message gets logged as an event (rather than an "exception") `std::error::Error`s attached as tracing `Value`s do not get recorded. It doesn't really matter whether we record our events as exceptions or messages. We should ideally look at all of them and particularly noisy ones can be muted forever in Sentry so we don't end up in a "boy who cried wolf" situation. Therefore, this PR changes our event filter to also submit WARNs as exceptions to make sure they get logged accordingly.

Resolves: #7161.
Related: https://github.com/getsentry/sentry-rust/issues/702.