### PR TITLE
fix(connlib): don't add host candidates multiple times

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -744,7 +744,7 @@ where
     fn add_local_as_host_candidate(&mut self, local: SocketAddr) -> Result<(), Error> {
         let host_candidate = Candidate::host(local, Protocol::Udp)?;
 
-        if self.shared_candidates.insert(host_candidate.clone()) {
+        if !self.shared_candidates.insert(host_candidate.clone()) {
             return Ok(());
         }
 


### PR DESCRIPTION
We introduced a boolean bug in #7163 that causes us to attempt to add host candidates much more often than necessary. This spams the logs on DEBUG level but was otherwise not harmful.