### PR TITLE
chore(connlib): submit DEBUG events as breadcrumbs

### DIFF
--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -76,9 +76,8 @@ pub fn test_global(directives: &str) {
 ///
 /// ## Events
 ///
-/// - error events are reported as sentry exceptions
-/// - warn events are reported as sentry messages
-/// - info events are captured as breadcrumbs (and submitted together with warns & errors)
+/// - error and warn events are reported as sentry exceptions
+/// - info and debug events are captured as breadcrumbs (and submitted together with warns & errors)
 ///
 /// ## Telemetry events
 ///
@@ -101,7 +100,7 @@ where
     sentry_tracing::layer()
         .event_filter(move |md| match *md.level() {
             tracing::Level::ERROR | tracing::Level::WARN => EventFilter::Exception,
-            tracing::Level::INFO => EventFilter::Breadcrumb,
+            tracing::Level::INFO | tracing::Level::DEBUG => EventFilter::Breadcrumb,
             tracing::Level::TRACE if md.target() == "telemetry" => {
                 // rand::random generates floats in the range of [0, 1).
                 if rand::random::<f32>() < 0.01 {

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -70,6 +70,7 @@ impl Telemetry {
                 // We can't get the release number ourselves because we don't know if we're embedded in a GUI Client or a Headless Client.
                 release: Some(release.into()),
                 traces_sample_rate: 0.1,
+                max_breadcrumbs: 500,
                 ..Default::default()
             },
         ));


### PR DESCRIPTION
This should give us much more context for a particular error without having to bother a customer with sending us the logs / digging for them ourselves in our staging or production environment.

Resolves: #7176.