### PR TITLE
chore(ci): use Vite bundler correctly in GUI smoke test

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -151,14 +151,15 @@ jobs:
         timeout-minutes: 5
         with:
           runtime: true
+        # These steps must be synchronized with build.sh and build.bat in `rust/gui-client`
       - name: pnpm install
         run: |
           pnpm install
           cp "node_modules/flowbite/dist/flowbite.min.js" "src/"
-      - name: Compile TypeScript
-        run: pnpm tsc
       - name: Compile Tailwind
         run: pnpm tailwindcss -i src/input.css -o src/output.css
+      - name: Run Vite bundler
+        run: pnpm vite build
       - name: Build client
         run: cargo build -p firezone-gui-client --all-targets
       - uses: taiki-e/install-action@v2

--- a/rust/gui-client/build.sh
+++ b/rust/gui-client/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# These steps must be synchronized with `gui-smoke-test` in `_rust.yml`.
 
 set -euo pipefail
 


### PR DESCRIPTION
Closes #7171 

If the assets aren't bundled, Tauri will warn about it in `tracing`, that will get sent to Sentry, and then it will be interpreted as an error.

Timeline to prove that this fixes the false positive error in Sentry, all times UTC on October 29th:

- 21:01:26 - Most recent events in Sentry as of 21:20:19
- 21:11:09 - Restarted CI while CD is quiet
- 21:14:01 - First smoke test begins
- 21:19:39 - Last smoke test ends