### PR TITLE
chore(rust): use new `try_send` APIs in `quinn-udp`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4972,10 +4972,11 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -288,7 +288,7 @@ impl UdpSocket {
 
         self.inner
             .async_io(Interest::WRITABLE, || {
-                self.state.send((&self.inner).into(), &transmit)
+                self.state.try_send((&self.inner).into(), &transmit)
             })
             .await?;
 
@@ -315,7 +315,7 @@ impl UdpSocket {
         };
 
         self.inner.try_io(Interest::WRITABLE, || {
-            self.state.send((&self.inner).into(), &transmit)
+            self.state.try_send((&self.inner).into(), &transmit)
         })
     }
 


### PR DESCRIPTION
With the recent lobbying effort in `quinn-udp`, we were able to get `try_send` APIs for the UDP socket that doesn't silence any errors while sending datagrams. Originally, the reasoning in `quinn-udp` was that because UDP is an unreliable protocol anyway, errors don't need to be surfaced because there must be upper-level mechanisms for retrying messages. Whilst that is true, getting immediate feedback that something isn't working can also be very beneficial. For example, if you don't have proper IPv6 connectivity on a socket, the syscall will immediately fail with `DestinationUnreachable`.

Within Firezone, we use these UDP sockets to send all kinds of messages, including DNS queries to upstream servers. In case that doesn't work, failing instantly allows us to send a SERVFAIL error back to the OS right away instead of having to wait for a timeout.

Additionally, `quinn-udp` logs these send errors on WARN which cause unnecessary noise in Sentry.

Resolves: #6353.