### PR TITLE
ci: Publish Gateway 1.4.0

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -165,9 +165,9 @@ jobs:
             artifact: firezone-gateway
             image_name: gateway
             # mark:next-gateway-version
-            release_name: gateway-1.4.0
+            release_name: gateway-1.4.1
             # mark:next-gateway-version
-            version: 1.4.0
+            version: 1.4.1
           - package: http-test-server
             artifact: http-test-server
             image_name: http-test-server
@@ -348,7 +348,7 @@ jobs:
           - name: relay
           - name: gateway
             # mark:next-gateway-version
-            version: 1.4.0
+            version: 1.4.1
           - name: client
             # mark:next-client-version
             version: 1.0.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         include:
           # mark:next-gateway-version
-          - release_name: gateway-1.4.0
+          - release_name: gateway-1.4.1
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
           - release_name: headless-client-1.3.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           if [[ "${{ github.event.release.name }}" =~ gateway* ]]; then
             ARTIFACT=gateway
             # mark:next-gateway-version
-            VERSION="1.4.0"
+            VERSION="1.4.1"
           elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
             ARTIFACT=client
             # mark:next-headless-version

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gateway"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gateway"
 # mark:next-gateway-version
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -20,14 +20,14 @@
 # Tracks the current version to use for generating download links and changelogs
 current-apple-version = 1.3.6
 current-android-version = 1.3.5
-current-gateway-version = 1.3.2
+current-gateway-version = 1.4.0
 current-gui-version = 1.3.9
 current-headless-version = 1.3.4
 
 # Tracks the next version to release for each platform
 next-apple-version = 1.3.7
 next-android-version = 1.3.6
-next-gateway-version = 1.4.0
+next-gateway-version = 1.4.1
 next-gui-version = 1.3.10
 next-headless-version = 1.3.5
 

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -62,21 +62,21 @@ module.exports = [
     source: "/dl/firezone-gateway/latest/x86_64",
     destination:
       // mark:current-gateway-version
-      "https://www.github.com/firezone/firezone/releases/download/gateway-1.3.2/firezone-gateway_1.3.2_x86_64",
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.4.0/firezone-gateway_1.4.0_x86_64",
     permanent: false,
   },
   {
     source: "/dl/firezone-gateway/latest/aarch64",
     destination:
       // mark:current-gateway-version
-      "https://www.github.com/firezone/firezone/releases/download/gateway-1.3.2/firezone-gateway_1.3.2_aarch64",
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.4.0/firezone-gateway_1.4.0_aarch64",
     permanent: false,
   },
   {
     source: "/dl/firezone-gateway/latest/armv7",
     destination:
       // mark:current-gateway-version
-      "https://www.github.com/firezone/firezone/releases/download/gateway-1.3.2/firezone-gateway_1.3.2_armv7",
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.4.0/firezone-gateway_1.4.0_armv7",
     permanent: false,
   },
   /*

--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -19,7 +19,7 @@ export async function GET(_req: NextRequest) {
     // mark:current-headless-version
     headless: "1.3.4",
     // mark:current-gateway-version
-    gateway: "1.3.2",
+    gateway: "1.4.0",
   };
 
   return NextResponse.json(versions);


### PR DESCRIPTION
Publish the 1.4.0 release so it's available at `/api/releases` and will send upgrade Gateway notifications.