### PR TITLE
fix(rust): fallback to `CARGO_PKG_VERSION` if git is unavailable

### DIFF
--- a/rust/bin-shared/src/lib.rs
+++ b/rust/bin-shared/src/lib.rs
@@ -57,7 +57,7 @@ macro_rules! git_version {
     ($regex:literal) => {
         $crate::__reexport::git_version!(
             args = ["--always", "--dirty=-modified", "--tags", "--match", $regex],
-            fallback = "unknown"
+            fallback = env!("CARGO_PKG_VERSION")
         )
     };
 }


### PR DESCRIPTION
When building inside a docker container, like we do for the headless-client and gateway, the `.git` directory is not available. Thus, determining what our current version is fails and gets reported as "unknown". We are now also using this for Sentry which is not very helpful if all errors are categorised under the same version.

In case somebody builds a gateway / client from source, we will have the full version available. Most users will use our docker containers though, meaning the version will only always be for a full release.

Resolves: #7184.