### PR TITLE
chore: mark Android app version 1.3.6 as published

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -19,7 +19,7 @@
 
 # Tracks the current version to use for generating download links and changelogs
 current-apple-version = 1.3.6
-current-android-version = 1.3.5
+current-android-version = 1.3.6
 current-gateway-version = 1.4.0
 current-gui-version = 1.3.9
 current-headless-version = 1.3.4

--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -13,7 +13,7 @@ export async function GET(_req: NextRequest) {
     // mark:current-apple-version
     apple: "1.3.6",
     // mark:current-android-version
-    android: "1.3.5",
+    android: "1.3.6",
     // mark:current-gui-version
     gui: "1.3.9",
     // mark:current-headless-version

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -11,7 +11,8 @@ export default function Android() {
       title="Android"
     >
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased>
+      <Unreleased></Unreleased>
+      <Entry version="1.3.6" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
         <ChangeItem pull="7151">
           Adds always-on error reporting using sentry.io.
@@ -24,7 +25,7 @@ export default function Android() {
           Fixes an issue where Firezone would fail to establish connections to
           Gateways and the user had to sign-out and in again.
         </ChangeItem>
-      </Unreleased>
+      </Entry>
       <Entry version="1.3.5" date={new Date("2024-10-03")}>
         <ChangeItem pull="6831">
           Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is


### PR DESCRIPTION
As soon as this version hits the app store, we can merge this.