### PR TITLE
chore: mark Apple apps 1.3.7 as published

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -18,7 +18,7 @@
 # the relevant versions in order to push to a newly drafted release.
 
 # Tracks the current version to use for generating download links and changelogs
-current-apple-version = 1.3.6
+current-apple-version = 1.3.7
 current-android-version = 1.3.5
 current-gateway-version = 1.4.0
 current-gui-version = 1.3.9

--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -11,7 +11,7 @@ export async function GET(_req: NextRequest) {
   const versions = {
     portal: await get("deployed_sha"),
     // mark:current-apple-version
-    apple: "1.3.6",
+    apple: "1.3.7",
     // mark:current-android-version
     android: "1.3.5",
     // mark:current-gui-version

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -11,7 +11,8 @@ export default function Apple() {
       title="macOS / iOS"
     >
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased>
+      <Unreleased></Unreleased>
+      <Entry version="1.3.7" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
         <ChangeItem pull="7152">
           Adds always-on error reporting using sentry.io.
@@ -20,7 +21,7 @@ export default function Apple() {
           Fixes an issue where Firezone would fail to establish connections to
           Gateways and the user had to sign-out and in again.
         </ChangeItem>
-      </Unreleased>
+      </Entry>
       <Entry version="1.3.6" date={new Date("2024-10-02")}>
         <ChangeItem pull="6831">
           Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is


### PR DESCRIPTION
As soon as this version hits the app stores, we can merge this.
