### PR TITLE
chore: publish GUI client 1.3.10

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -46,19 +46,19 @@ jobs:
             syms-extension: pdb
     env:
       # mark:next-gui-version
-      ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.3.10_${{ matrix.arch }}
+      ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.3.11_${{ matrix.arch }}
       # mark:next-gui-version
-      ARTIFACT_DST: firezone-client-gui-${{ matrix.os }}_1.3.10_${{ matrix.arch }}
+      ARTIFACT_DST: firezone-client-gui-${{ matrix.os }}_1.3.11_${{ matrix.arch }}
       AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
       # mark:next-gui-version
-      BINARY_DEST_PATH: firezone-client-gui-${{ matrix.os }}_1.3.10_${{ matrix.arch }}
+      BINARY_DEST_PATH: firezone-client-gui-${{ matrix.os }}_1.3.11_${{ matrix.arch }}
       # Seems like there's no way to de-dupe env vars that depend on each other
       # mark:next-gui-version
-      FIREZONE_GUI_VERSION: 1.3.10
+      FIREZONE_GUI_VERSION: 1.3.11
       RENAME_SCRIPT: ../../scripts/build/tauri-rename-${{ matrix.os }}.sh
       TARGET_DIR: ../target
       UPLOAD_SCRIPT: ../../scripts/build/tauri-upload-${{ matrix.os }}.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           - release_name: headless-client-1.3.5
             config_name: release-drafter-headless-client.yml
           # mark:next-gui-version
-          - release_name: gui-client-1.3.10
+          - release_name: gui-client-1.3.11
             config_name: release-drafter-gui-client.yml
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gui-client"
-version = "1.3.10"
+version = "1.3.11"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gui-client-common"
-version = "1.3.10"
+version = "1.3.11"
 dependencies = [
  "anyhow",
  "arboard",

--- a/rust/gui-client/src-common/Cargo.toml
+++ b/rust/gui-client/src-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gui-client-common"
 # mark:next-gui-version
-version = "1.3.10"
+version = "1.3.11"
 edition = "2021"
 
 [dependencies]

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gui-client"
 # mark:next-gui-version
-version = "1.3.10"
+version = "1.3.11"
 description = "Firezone"
 edition = "2021"
 default-run = "firezone-gui-client"

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -21,14 +21,14 @@
 current-apple-version = 1.3.6
 current-android-version = 1.3.5
 current-gateway-version = 1.4.0
-current-gui-version = 1.3.9
+current-gui-version = 1.3.10
 current-headless-version = 1.3.4
 
 # Tracks the next version to release for each platform
 next-apple-version = 1.3.7
 next-android-version = 1.3.6
 next-gateway-version = 1.4.1
-next-gui-version = 1.3.10
+next-gui-version = 1.3.11
 next-headless-version = 1.3.5
 
 # macOS uses a slightly different sed syntax

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -10,7 +10,7 @@ module.exports = [
     source: "/dl/firezone-client-gui-windows/latest/x86_64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.3.9/firezone-client-gui-windows_1.3.9_x86_64.msi",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.3.10/firezone-client-gui-windows_1.3.10_x86_64.msi",
     permanent: false,
   },
   /*
@@ -22,14 +22,14 @@ module.exports = [
     source: "/dl/firezone-client-gui-linux/latest/x86_64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.3.9/firezone-client-gui-linux_1.3.9_x86_64.deb",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.3.10/firezone-client-gui-linux_1.3.10_x86_64.deb",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-gui-linux/latest/aarch64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.3.9/firezone-client-gui-linux_1.3.9_aarch64.deb",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.3.10/firezone-client-gui-linux_1.3.10_aarch64.deb",
     permanent: false,
   },
   {

--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -15,7 +15,7 @@ export async function GET(_req: NextRequest) {
     // mark:current-android-version
     android: "1.3.5",
     // mark:current-gui-version
-    gui: "1.3.9",
+    gui: "1.3.10",
     // mark:current-headless-version
     headless: "1.3.4",
     // mark:current-gateway-version

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,7 +14,8 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased>
+      <Unreleased></Unreleased>
+      <Entry version="1.3.10" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
         <ChangeItem enable={title === "Windows"} pull="7009">
           The IPC service `firezone-client-ipc.exe` is now signed.
@@ -29,7 +30,7 @@ export default function GUI({ title }: { title: string }) {
           Fixes an issue where Firezone would fail to establish connections to
           Gateways and the user had to sign-out and in again.
         </ChangeItem>
-      </Unreleased>
+      </Entry>
       <Entry version="1.3.9" date={new Date("2024-10-09")}>
         <ChangeItem enable={title === "Linux GUI"} pull="6987">
           Fixes a crash on startup caused by incorrect permissions on the ID file.


### PR DESCRIPTION
We've successfully published release 1.3.10 for the GUI client: https://github.com/firezone/firezone/releases/tag/gui-client-1.3.10.

This PR bumps the versions for development going forward.