### PR TITLE
ci: checkout tags for release builds

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -27,6 +27,8 @@ jobs:
     name: build-release
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true # Otherwise we cannot embed the correct version into the build.
       - uses: ./.github/actions/setup-android
       - name: Bundle and sign release
         env:

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -29,6 +29,8 @@ jobs:
         working-directory: ./swift/apple
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true # Otherwise we cannot embed the correct version into the build.
       - uses: ./.github/actions/setup-rust
         with:
           targets: aarch64-apple-darwin aarch64-apple-ios x86_64-apple-darwin

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -64,6 +64,8 @@ jobs:
       UPLOAD_SCRIPT: ../../scripts/build/tauri-upload-${{ matrix.os }}.sh
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true # Otherwise we cannot embed the correct version into the build.
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri-v2


### PR DESCRIPTION
In the Rust code, we use `git describe` to determine the current version of the code. This only works if tags are actually checked out. To save time, the `actions/checkout` action by default only does a shallow-clone of depth 1 without any tags. Due to that, all events in Sentry just show up as a commit hash.