### PR TITLE
fix(telemetry): flush sentry.io events in dedicated task

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "sentry",
  "sentry-anyhow",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -470,8 +470,8 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_di
     catch_and_throw(&mut env, |_| {
         let session = Box::from_raw(session);
 
+        session.runtime.block_on(session.telemetry.stop());
         session.inner.disconnect();
-        session.telemetry.stop();
     });
 }
 

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -92,11 +92,6 @@ mod ffi {
 /// This is used by the apple client to interact with our code.
 pub struct WrappedSession {
     inner: Session,
-
-    #[expect(
-        dead_code,
-        reason = "Runtime must be kept alive until Session is dropped"
-    )]
     runtime: Runtime,
 
     #[expect(
@@ -265,8 +260,8 @@ impl WrappedSession {
     }
 
     fn disconnect(self) {
+        self.runtime.block_on(self.telemetry.stop());
         self.inner.disconnect();
-        self.telemetry.stop();
     }
 }
 

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -139,7 +139,6 @@ pub(crate) fn run(
         ctlr_tx: ctlr_tx.clone(),
         inject_faults: cli.inject_faults,
     };
-
     let (tray_tx, tray_rx) = oneshot::channel();
     let app = tauri::Builder::default()
         .manage(managed)
@@ -277,7 +276,7 @@ pub(crate) fn run(
                     // In a normal Rust application, Sentry's guard would flush on drop: https://docs.sentry.io/platforms/rust/configuration/draining/
                     // But due to a limit in `tao` we cannot return from the event loop and must call `std::process::exit` (or Tauri's wrapper), so we explicitly flush here.
                     // TODO: This limit may not exist in Tauri v2
-                    telemetry.stop();
+                    telemetry.stop().await;
 
                     tracing::info!(?exit_code);
                     app_handle.exit(exit_code);

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -527,7 +527,9 @@ impl<'a> Handler<'a> {
                 firezone_bin_shared::git_version!("gui-client-*"),
                 firezone_telemetry::IPC_SERVICE_DSN,
             ),
-            ClientMsg::StopTelemetry => self.telemetry.stop(),
+            ClientMsg::StopTelemetry => {
+                self.telemetry.stop().await;
+            }
         }
         Ok(())
     }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -327,7 +327,8 @@ fn main() -> Result<()> {
             tracing::error!(?error, "network notifier");
         }
 
-        telemetry.stop(); // Stop telemetry before dropping session. `connlib` needs to be active for this, otherwise we won't be able to resolve the DNS name for sentry.
+        telemetry.stop().await; // Stop telemetry before dropping session. `connlib` needs to be active for this, otherwise we won't be able to resolve the DNS name for sentry.
+
         session.disconnect();
 
         result

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2021"
 arc-swap = "1.7.1"
 sentry = { version = "0.34.0", default-features = false, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing"] }
 sentry-anyhow = "0.34.0"
+tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
 thiserror = "1.0.63"
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
`sentry`'s transport layer appears to be using blocking IO for flushing events. Performing blocking IO within a future that is running on a worker-thread of tokio causes this operation to hang and eventually time-out after 5 seconds. As a result, many events - especially traces - don't get flushed to sentry when an app is being shut down.

To fix this, we make `Telemetry::stop` an `async fn` and offload the flushing to a task on tokio's thread-pool for blocking IO.