### PR TITLE
chore(snownet): fast-path using `PartialEq`

### DIFF
--- a/rust/connlib/snownet/src/candidate_set.rs
+++ b/rust/connlib/snownet/src/candidate_set.rs
@@ -10,8 +10,18 @@ pub struct CandidateSet {
 }
 
 impl CandidateSet {
-    pub fn insert(&mut self, c: Candidate) -> bool {
-        self.inner.insert(c)
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "We don't care about the ordering."
+    )]
+    pub fn insert(&mut self, new: Candidate) -> bool {
+        // Hashing a `Candidate` takes longer than checking a handful of entries using their `PartialEq` implementation.
+        // This function is in the hot-path so it needs to be fast ...
+        if self.inner.iter().any(|c| c == &new) {
+            return false;
+        }
+
+        self.inner.insert(new)
     }
 
     pub fn clear(&mut self) {


### PR DESCRIPTION
Counter-intuitively, doing a linear search across all local candidates and checking for equality is faster than hashing the candidate. This is because a `Candidate` actually has quite a few fields and we call this function in the hot-path of packet processing; from `snownet`'s perspective, each packet might come from a different local socket so we have to test for each packet, whether or not we already know about this socket.

Using `PartialEq` instead of hashing every candidate saves about 1% in the during a speedtest.