### PR TITLE
feat(connlib): utilise GSO for UDP sockets

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4935,9 +4935,8 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
+version = "0.5.7"
+source = "git+https://github.com/quinn-rs/quinn?branch=main#9386cde871c750464073772409615e90344b80e9"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -7771,7 +7770,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -82,7 +82,7 @@ output_vt100 = "0.1"
 png = "0.17.13"
 proptest = "1"
 proptest-state-machine = "0.3"
-quinn-udp = { version = "0.5.2", features = ["fast-apple-datapath"] }
+quinn-udp = { version = "0.5.7", features = ["fast-apple-datapath"] }
 rand = "0.8.5"
 rand_core = "0.6.4"
 rangemap = "1.5.1"
@@ -176,6 +176,7 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", branch = "main" }
+quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" }
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -82,7 +82,7 @@ output_vt100 = "0.1"
 png = "0.17.13"
 proptest = "1"
 proptest-state-machine = "0.3"
-quinn-udp = "0.5.2"
+quinn-udp = { version = "0.5.2", features = ["fast-apple-datapath"] }
 rand = "0.8.5"
 rand_core = "0.6.4"
 rangemap = "1.5.1"

--- a/rust/bin-shared/src/tun_device_manager.rs
+++ b/rust/bin-shared/src/tun_device_manager.rs
@@ -104,6 +104,7 @@ mod tests {
                 packet: Cow::Borrowed(&hex_literal::hex!(
                     "000100002112A4420123456789abcdef01234567"
                 )),
+                segment_size: None,
             })
             .unwrap();
 

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -9,6 +9,7 @@ use ::backoff::backoff::Backoff;
 use bytecodec::{DecodeExt as _, EncodeExt as _};
 use firezone_logging::{err_with_src, std_dyn_err};
 use hex_display::HexDisplayExt as _;
+use ip_packet::MAX_DATAGRAM_PAYLOAD;
 use rand::random;
 use std::{
     borrow::Cow,
@@ -766,10 +767,10 @@ impl Allocation {
     pub fn encode_to_encrypted_packet(
         &self,
         peer: SocketAddr,
-        buffer: &mut [u8],
+        mut buffer: [u8; MAX_DATAGRAM_PAYLOAD],
+        buffer_len: usize,
         now: Instant,
     ) -> Option<EncryptedPacket> {
-        let buffer_len = buffer.len();
         let packet_len = buffer_len - 4;
 
         let channel_number = self.channel_bindings.connected_channel_to_peer(peer, now)?;
@@ -780,6 +781,7 @@ impl Allocation {
             dst: self.active_socket?,
             packet_start: 0,
             packet_len: buffer_len,
+            buffer,
         })
     }
 

--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -17,7 +17,7 @@ pub use allocation::RelaySocket;
 #[allow(deprecated)] // Rust bug: `expect` doesn't seem to work on imports?
 pub use node::{Answer, Offer};
 pub use node::{
-    Client, ClientNode, Credentials, EncryptBuffer, EncryptedPacket, Error, Event, NoTurnServers,
-    Node, Server, ServerNode, Transmit, HANDSHAKE_TIMEOUT,
+    Client, ClientNode, Credentials, EncryptedPacket, Error, Event, NoTurnServers, Node, Server,
+    ServerNode, Transmit, HANDSHAKE_TIMEOUT,
 };
 pub use stats::{ConnectionStats, NodeStats};

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1510,14 +1510,20 @@ impl EncryptedPacket {
         Transmit {
             src: self.src,
             dst: self.dst,
-            payload: Cow::Borrowed(
-                &self.buffer[self.packet_start..(self.packet_start + self.packet_len)],
-            ),
+            payload: Cow::Borrowed(self.payload()),
         }
+    }
+
+    pub fn src(&self) -> Option<SocketAddr> {
+        self.src
     }
 
     pub fn dst(&self) -> SocketAddr {
         self.dst
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.buffer[self.packet_start..(self.packet_start + self.packet_len)]
     }
 }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -28,7 +28,7 @@ use crate::ClientEvent;
 use domain::base::Message;
 use lru::LruCache;
 use secrecy::{ExposeSecret as _, Secret};
-use snownet::{ClientNode, EncryptBuffer, NoTurnServers, RelaySocket, Transmit};
+use snownet::{ClientNode, NoTurnServers, RelaySocket, Transmit};
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -298,14 +298,13 @@ impl ClientState {
         &mut self,
         packet: IpPacket,
         now: Instant,
-        buffer: &mut EncryptBuffer,
     ) -> Option<snownet::EncryptedPacket> {
         let non_dns_packet = match self.try_handle_dns(packet, now) {
             ControlFlow::Break(()) => return None,
             ControlFlow::Continue(non_dns_packet) => non_dns_packet,
         };
 
-        self.encapsulate(non_dns_packet, now, buffer)
+        self.encapsulate(non_dns_packet, now)
     }
 
     /// Handles UDP packets received on the network interface.
@@ -410,12 +409,7 @@ impl ClientState {
         }
     }
 
-    fn encapsulate(
-        &mut self,
-        packet: IpPacket,
-        now: Instant,
-        buffer: &mut EncryptBuffer,
-    ) -> Option<snownet::EncryptedPacket> {
+    fn encapsulate(&mut self, packet: IpPacket, now: Instant) -> Option<snownet::EncryptedPacket> {
         let dst = packet.destination();
 
         if is_definitely_not_a_resource(dst) {
@@ -448,7 +442,7 @@ impl ClientState {
 
         let transmit = self
             .node
-            .encapsulate(gid, packet, now, buffer)
+            .encapsulate(gid, packet, now)
             .inspect_err(|e| tracing::debug!(%gid, "Failed to encapsulate: {}", err_with_src(e)))
             .ok()??;
 
@@ -917,14 +911,12 @@ impl ClientState {
 
             // Check if the client wants to emit any packets.
             if let Some(packet) = self.tcp_dns_client.poll_outbound() {
-                let mut buffer = snownet::EncryptBuffer::new();
-
                 // All packets from the TCP DNS client _should_ go through the tunnel.
-                let Some(encryped_packet) = self.encapsulate(packet, now, &mut buffer) else {
+                let Some(encryped_packet) = self.encapsulate(packet, now) else {
                     continue;
                 };
 
-                let transmit = encryped_packet.to_transmit(&buffer).into_owned();
+                let transmit = encryped_packet.to_transmit().into_owned();
                 self.buffered_transmits.push_back(transmit);
                 continue;
             }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -12,7 +12,7 @@ use firezone_logging::{anyhow_dyn_err, telemetry_span};
 use ip_network::{Ipv4Network, Ipv6Network};
 use ip_packet::{FzP2pControlSlice, IpPacket};
 use secrecy::{ExposeSecret as _, Secret};
-use snownet::{Credentials, EncryptBuffer, NoTurnServers, RelaySocket, ServerNode, Transmit};
+use snownet::{Credentials, NoTurnServers, RelaySocket, ServerNode, Transmit};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::{Duration, Instant};
@@ -84,7 +84,6 @@ impl GatewayState {
         &mut self,
         packet: IpPacket,
         now: Instant,
-        buffer: &mut EncryptBuffer,
     ) -> Result<Option<snownet::EncryptedPacket>> {
         let dst = packet.destination();
 
@@ -102,7 +101,7 @@ impl GatewayState {
 
         let Some(encrypted_packet) = self
             .node
-            .encapsulate(cid, packet, now, buffer)
+            .encapsulate(cid, packet, now)
             .context("Failed to encapsulate")?
         else {
             return Ok(None);
@@ -144,14 +143,12 @@ impl GatewayState {
                 return Ok(None);
             };
 
-            let mut buffer = EncryptBuffer::new();
-            let Some(transmit) =
-                encrypt_packet(immediate_response, cid, &mut self.node, &mut buffer, now)?
+            let Some(transmit) = encrypt_packet(immediate_response, cid, &mut self.node, now)?
             else {
                 return Ok(None);
             };
 
-            self.buffered_transmits.push_back(transmit.into_owned());
+            self.buffered_transmits.push_back(transmit);
 
             return Ok(None);
         }
@@ -340,13 +337,11 @@ impl GatewayState {
 
         let packet = dns_resource_nat::domain_status(req.resource, req.domain, nat_status)?;
 
-        let mut buffer = EncryptBuffer::new();
-        let Some(transmit) = encrypt_packet(packet, req.client, &mut self.node, &mut buffer, now)?
-        else {
+        let Some(transmit) = encrypt_packet(packet, req.client, &mut self.node, now)? else {
             return Ok(());
         };
 
-        self.buffered_transmits.push_back(transmit.into_owned());
+        self.buffered_transmits.push_back(transmit);
 
         Ok(())
     }
@@ -505,21 +500,20 @@ fn handle_p2p_control_packet(
     None
 }
 
-fn encrypt_packet<'a>(
+fn encrypt_packet(
     packet: IpPacket,
     cid: ClientId,
     node: &mut ServerNode<ClientId, RelayId>,
-    buffer: &'a mut EncryptBuffer,
     now: Instant,
-) -> Result<Option<Transmit<'a>>> {
+) -> Result<Option<Transmit<'static>>> {
     let Some(encrypted_packet) = node
-        .encapsulate(cid, packet, now, buffer)
+        .encapsulate(cid, packet, now)
         .context("Failed to encapsulate packet")?
     else {
         return Ok(None);
     };
 
-    Ok(Some(encrypted_packet.to_transmit(buffer)))
+    Ok(Some(encrypted_packet.to_transmit().into_owned()))
 }
 
 /// Opaque request struct for when a domain name needs to be resolved.

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -141,9 +141,7 @@ impl Io {
             Input<impl Iterator<Item = IpPacket> + use<'b>, impl Iterator<Item = DatagramIn<'b>>>,
         >,
     > {
-        if self.gso_queue.should_force_flush() {
-            ready!(self.flush_send_queue(cx)?);
-        }
+        ready!(self.flush_send_queue(cx)?);
 
         if let Poll::Ready(network) =
             self.sockets
@@ -195,9 +193,6 @@ impl Io {
                 return Poll::Ready(Ok(Input::Timeout(deadline)));
             }
         }
-
-        // If we don't have anything else to do, flush all packets.
-        ready!(self.flush_send_queue(cx)?);
 
         Poll::Pending
     }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -154,9 +154,7 @@ impl Io {
             self.inbound_packet_rx
                 .poll_recv_many(cx, &mut buffers.ip, MAX_INBOUND_PACKET_BATCH)
         {
-            if num_packets > 0 {
-                return Poll::Ready(Ok(Input::Device(buffers.ip.drain(..num_packets))));
-            }
+            return Poll::Ready(Ok(Input::Device(buffers.ip.drain(..num_packets))));
         }
 
         match self.dns_queries.poll_unpin(cx) {

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -124,7 +124,7 @@ impl Io {
             tcp_socket_factory,
             udp_socket_factory,
             dns_queries: FuturesTupleSet::new(DNS_QUERY_TIMEOUT, 1000),
-            gso_queue: GsoQueue::new(socket_factory::MAX_GSO_SEGMENTS),
+            gso_queue: GsoQueue::new(),
         }
     }
 

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -103,13 +103,16 @@ impl Io {
         let (outbound_packet_tx, outbound_packet_rx) = mpsc::channel(IP_CHANNEL_SIZE);
         let (tun_tx, tun_rx) = mpsc::channel(10);
 
-        std::thread::spawn(|| {
-            futures::executor::block_on(tun_send_recv(
-                tun_rx,
-                outbound_packet_rx,
-                inbound_packet_tx,
-            ))
-        });
+        std::thread::Builder::new()
+            .name("connlib-tun-send-recv".to_string())
+            .spawn(|| {
+                futures::executor::block_on(tun_send_recv(
+                    tun_rx,
+                    outbound_packet_rx,
+                    inbound_packet_tx,
+                ))
+            })
+            .expect("Failed to spawn tun_send_recv thread");
 
         Self {
             tun_tx,

--- a/rust/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/connlib/tunnel/src/io/gso_queue.rs
@@ -8,8 +8,6 @@ use std::{
 use bytes::BytesMut;
 use socket_factory::DatagramOut;
 
-const ONE_MB: usize = 1024 * 1024;
-
 /// Holds UDP datagrams that we need to send, indexed by src, dst and segment size.
 ///
 /// Calling [`Io::send_network`](super::Io::send_network) will copy the provided payload into this buffer.
@@ -25,15 +23,6 @@ impl GsoQueue {
             max_segments,
             inner: Default::default(),
         }
-    }
-
-    /// Checks if the [`GsoQueue`] needs to be force-flushed.
-    ///
-    /// If our send queue grows beyond 1MB, force flushing before accepting any more work by reading new packets.
-    /// If not, we allow the event-loop to do other stuff.
-    /// This allows us to handle bursts of packets at once and batching them up into a single syscall.
-    pub fn should_force_flush(&self) -> bool {
-        self.inner.values().any(|b| b.inner.len() >= ONE_MB)
     }
 
     pub fn handle_timeout(&mut self, now: Instant) {

--- a/rust/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/connlib/tunnel/src/io/gso_queue.rs
@@ -1,0 +1,181 @@
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
+
+use bytes::BytesMut;
+use socket_factory::DatagramOut;
+
+const ONE_MB: usize = 1024 * 1024;
+
+/// Holds UDP datagrams that we need to send, indexed by src, dst and segment size.
+///
+/// Calling [`Io::send_network`](super::Io::send_network) will copy the provided payload into this buffer.
+/// The buffer is then flushed using GSO in a single syscall.
+pub struct GsoQueue {
+    max_segments: usize,
+    inner: BTreeMap<Key, DatagramBuffer>,
+}
+
+impl GsoQueue {
+    pub fn new(max_segments: usize) -> Self {
+        Self {
+            max_segments,
+            inner: Default::default(),
+        }
+    }
+
+    /// Checks if the [`GsoQueue`] needs to be force-flushed.
+    ///
+    /// If our send queue grows beyond 1MB, force flushing before accepting any more work by reading new packets.
+    /// If not, we allow the event-loop to do other stuff.
+    /// This allows us to handle bursts of packets at once and batching them up into a single syscall.
+    pub fn should_force_flush(&self) -> bool {
+        self.inner.values().any(|b| b.inner.len() >= ONE_MB)
+    }
+
+    pub fn handle_timeout(&mut self, now: Instant) {
+        self.inner.retain(|_, b| {
+            if !b.is_empty() {
+                return true;
+            }
+
+            now.duration_since(b.last_access) < Duration::from_secs(60)
+        })
+    }
+
+    pub fn enqueue(
+        &mut self,
+        src: Option<SocketAddr>,
+        dst: SocketAddr,
+        payload: &[u8],
+        now: Instant,
+    ) {
+        self.inner
+            .entry(Key {
+                src,
+                dst,
+                segment_size: payload.len(),
+            })
+            .or_insert_with(|| DatagramBuffer::new(now))
+            .extend(payload, now);
+    }
+
+    pub fn datagrams(&mut self) -> impl Iterator<Item = DatagramOut<'static>> + '_ {
+        self.inner
+            .iter_mut()
+            .filter(|(_, b)| !b.is_empty())
+            .flat_map(|(key, buffer)| {
+                let max_length = self.max_segments * key.segment_size;
+                let buffer = &mut buffer.inner;
+
+                std::iter::from_fn(move || {
+                    if buffer.is_empty() {
+                        return None;
+                    }
+
+                    let packet = if buffer.len() > max_length {
+                        buffer.split_to(max_length)
+                    } else {
+                        buffer.split()
+                    };
+
+                    Some(DatagramOut {
+                        src: key.src,
+                        dst: key.dst,
+                        packet: Cow::Owned(packet.freeze().into()),
+                        segment_size: Some(key.segment_size),
+                    })
+                })
+            })
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.clear()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Copy)]
+struct Key {
+    src: Option<SocketAddr>,
+    dst: SocketAddr,
+    segment_size: usize,
+}
+
+struct DatagramBuffer {
+    inner: BytesMut,
+    last_access: Instant,
+}
+
+impl DatagramBuffer {
+    pub fn new(now: Instant) -> Self {
+        Self {
+            inner: Default::default(),
+            last_access: now,
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub(crate) fn extend(&mut self, payload: &[u8], now: Instant) {
+        self.inner.extend_from_slice(payload);
+        self.last_access = now;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    use super::*;
+
+    #[test]
+    fn send_queue_gcs_after_1_minute() {
+        let now = Instant::now();
+        let mut send_queue = GsoQueue::new(100);
+
+        send_queue.enqueue(None, DST, b"foobar", now);
+        for _entry in send_queue.datagrams() {}
+
+        send_queue.handle_timeout(now + Duration::from_secs(60));
+
+        assert_eq!(send_queue.inner.len(), 0);
+    }
+
+    #[test]
+    fn does_not_gc_unsent_items() {
+        let now = Instant::now();
+        let mut send_queue = GsoQueue::new(100);
+
+        send_queue.enqueue(None, DST, b"foobar", now);
+
+        send_queue.handle_timeout(now + Duration::from_secs(60));
+
+        assert_eq!(send_queue.inner.len(), 1);
+    }
+
+    #[test]
+    fn returns_at_most_max_segments_per_iteration() {
+        let now = Instant::now();
+        let mut send_queue = GsoQueue::new(2);
+
+        send_queue.enqueue(None, DST, b"test1", now);
+        send_queue.enqueue(None, DST, b"test2", now);
+        send_queue.enqueue(None, DST, b"test3", now);
+
+        let datagram = send_queue.datagrams().next().unwrap();
+        assert_eq!(datagram.packet.as_ref(), b"test1test2");
+
+        let datagram = send_queue.datagrams().next().unwrap();
+        assert_eq!(datagram.packet.as_ref(), b"test3");
+
+        let datagram = send_queue.datagrams().next();
+        assert!(datagram.is_none());
+    }
+
+    const DST: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1234));
+}

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -148,7 +148,7 @@ impl ClientTunnel {
                         continue;
                     };
 
-                    self.io.send_encrypted_packet(enc_packet)?;
+                    self.io.send_encrypted_packet(enc_packet);
 
                     continue;
                 }
@@ -244,7 +244,7 @@ impl GatewayTunnel {
                         continue;
                     };
 
-                    self.io.send_encrypted_packet(enc_packet)?;
+                    self.io.send_encrypted_packet(enc_packet);
 
                     continue;
                 }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -278,7 +278,10 @@ impl UdpSocket {
     }
 
     pub fn send(&mut self, datagram: DatagramOut) -> io::Result<()> {
-        tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, num_bytes = %datagram.packet.len());
+        let segment_size = datagram.segment_size.unwrap_or(datagram.packet.len());
+        let num_packets = datagram.packet.len() / segment_size;
+
+        tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, %num_packets, %segment_size);
 
         self.try_send(datagram)?;
 

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -280,8 +280,9 @@ impl UdpSocket {
     pub fn send(&mut self, datagram: DatagramOut) -> io::Result<()> {
         let segment_size = datagram.segment_size.unwrap_or(datagram.packet.len());
         let num_packets = datagram.packet.len() / segment_size;
+        let trailing_bytes = datagram.packet.len() % segment_size;
 
-        tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, %num_packets, %segment_size);
+        tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, %num_packets, %segment_size, %trailing_bytes);
 
         self.try_send(datagram)?;
 

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -15,6 +15,8 @@ use std::collections::hash_map::Entry;
 use std::pin::Pin;
 use tokio::io::Interest;
 
+pub const MAX_GSO_SEGMENTS: usize = quinn_udp::BATCH_SIZE;
+
 pub trait SocketFactory<S>: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}
 
 impl<F, S> SocketFactory<S> for F where F: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -15,8 +15,6 @@ use std::collections::hash_map::Entry;
 use std::pin::Pin;
 use tokio::io::Interest;
 
-pub const MAX_GSO_SEGMENTS: usize = quinn_udp::BATCH_SIZE;
-
 pub trait SocketFactory<S>: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}
 
 impl<F, S> SocketFactory<S> for F where F: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -279,9 +279,8 @@ impl UdpSocket {
     pub fn send(&mut self, datagram: DatagramOut) -> io::Result<()> {
         let segment_size = datagram.segment_size.unwrap_or(datagram.packet.len());
         let num_packets = datagram.packet.len() / segment_size;
-        let trailing_bytes = datagram.packet.len() % segment_size;
 
-        tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, %num_packets, %segment_size, %trailing_bytes);
+        tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, %num_packets, %segment_size);
 
         self.try_send(datagram)?;
 

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -16,6 +16,10 @@ export default function Android() {
           Fixes an issue where symmetric NATs would generate unnecessary
           candidate for hole-punching.
         </ChangeItem>
+        <ChangeItem pull="7210">
+          Adds support for GSO (Generic Segmentation Offload), delivering
+          throughput improvements of up to 60%.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.7" date={new Date("2024-11-08")}>
         <ChangeItem pull="7263">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -16,6 +16,10 @@ export default function Apple() {
           Fixes an issue where symmetric NATs would generate unnecessary
           candidate for hole-punching.
         </ChangeItem>
+        <ChangeItem pull="7210">
+          Adds support for GSO (Generic Segmentation Offload), delivering
+          throughput improvements of up to 60%.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.3.9" date={new Date("2024-11-08")}>
         <ChangeItem pull="7288">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,7 +14,12 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7210">
+          Adds support for GSO (Generic Segmentation Offload), delivering
+          throughput improvements of up to 60%.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.3.13" date={new Date("2024-11-15")}>
         <ChangeItem pull="7334">
           Fixes an issue where symmetric NATs would generate unnecessary

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -10,7 +10,12 @@ export default function Gateway() {
 
   return (
     <Entries href={href} arches={arches} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7210">
+          Adds support for GSO (Generic Segmentation Offload), delivering
+          throughput improvements of up to 60%.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.1" date={new Date("2024-11-15")}>
         <ChangeItem pull="7263">
           Mitigates a crash in case the maximum packet size is not respected.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -15,6 +15,10 @@ export default function Headless() {
         <ChangeItem pull="7350">
           Allows disabling telemetry by setting `FIREZONE_NO_TELEMETRY=true`.
         </ChangeItem>
+        <ChangeItem pull="7210">
+          Adds support for GSO (Generic Segmentation Offload), delivering
+          throughput improvements of up to 60%.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.3.7" date={new Date("2024-11-15")}>
         <ChangeItem pull="7334">


### PR DESCRIPTION
## Context

At present, `connlib` sends UDP packets one at a time. Sending a packet requires us to make a syscall which is quite expensive. Under load, i.e. during a speedtest, syscalls account for over 50% of our CPU time [0]. In order to improve this situation, we need to somehow make use of GSO (generic segmentation offload). With GSO, we can send multiple packets to the same destination in a single syscall.

The tricky question here is, how can we achieve having multiple UDP packets ready at once so we can send them in a single syscall? Our TUN interface only feeds us packets one at a time and `connlib`'s state machine is single-threaded. Additionally, we currently only have a single `EncryptBuffer` in which the to-be-sent datagram sits.

## 1. Stack-allocating encrypted IP packets

As a first step, we get rid of the single `EncryptBuffer` and instead stack-allocate each encrypted IP packet. Due to our small MTU, these packets are only around 1300 bytes. Stack-allocating that requires a few memcpy's but those are in the single-digit % range in the terms of CPU time performance hit. That is nothing compared to how much time we are spending on UDP syscalls. With the `EncryptBuffer` out the way, we can now "freely" move around the `EncryptedPacket` structs and - technically - we can have multiple of them at the same time.

## 2. Implementing GSO

The GSO interface allows you to pass multiple packets **of the same length and for the same destination** in a single syscall, meaning we cannot just batch-up arbitrary UDP packets. Counterintuitively, making use of GSO requires us to do more copying: In particular, we change the interface of `Io` such that "sending" a packet performs essentially a lookup of a `BytesMut`-buffer by destination and packet length and appends the payload to that packet.

## 3. Batch-read IP packets

In order to actually perform GSO, we need to process more than a single IP packet in one event-loop tick. We achieve this by batch-reading up to 50 IP packets from the mpsc-channel that connects `connlib`'s main event-loop with the dedicated thread that reads and writes to the TUN device. These reads and writes happen concurrently to `connlib`'s packet processing. Thus, it is likely that by the time `connlib` is ready to process another IP packet, multiple have been read from the device and are sitting in the channel. Batch-processing these IP packets means that the buffers in our `GsoQueue` are more likely to contain more than a single datagram.

Imagine you are running a file upload. The OS will send many packets to the same destination IP and likely max MTU to the TUN device. It is likely, that we read 10-20 of these packets in one batch (i.e. within a single "tick" of the event-loop). All packets will be appended to the same buffer in the `GsoQueue` and on the next event-loop tick, they will all be flushed out in a single syscall.

## Results

Overall, this results in a significant reduction of syscalls for sending UDP message. In [1], we spend only a total of 16% of our CPU time in `udpv6_sendmsg` whereas in [0] (main), we spent a total of 34%. Do note that these numbers are relative to the total CPU time spent per program run and thus can't be compared directly (i.e. you cannot just do 34 - 16 and say we now spend 18% less time sending UDP packets). Nevertheless, this appears to be a great improvement.

In terms of throughput, we achieve a ~60% improvement in our benchmark suite. That one is running on localhost though so it might not necessarily be reflect like that in a real network.

[0]: https://share.firefox.dev/4hvoPju
[1]: https://share.firefox.dev/4frhCPv