### PR TITLE
fix(infra): Filter out WebSocket upgrade from latency alerting

### DIFF
--- a/terraform/modules/google-cloud/ops/main.tf
+++ b/terraform/modules/google-cloud/ops/main.tf
@@ -431,7 +431,8 @@ resource "google_monitoring_alert_policy" "load_balancer_latency_policy" {
     display_name = "Load balancer latency"
 
     condition_threshold {
-      filter          = "resource.type = \"https_lb_rule\" AND metric.type = \"loadbalancing.googleapis.com/https/backend_latencies\""
+      # Filter out HTTP 101 responses (switching protocols) to prevent WebSocket connections from triggering the alert
+      filter          = "metric.labels.response_code != \"101\" AND resource.type = \"https_lb_rule\" AND metric.type = \"loadbalancing.googleapis.com/https/backend_latencies\""
       comparison      = "COMPARISON_GT"
       threshold_value = 1000
       duration        = "0s"


### PR DESCRIPTION
We were getting lots of false-positive latency alerts that were due to the WebSocket upgrade. This prevents those from occurring.