### PR TITLE
chore(website): Increase cache revalidation to 1 hour

### DIFF
--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -4,8 +4,8 @@ import { get } from "@vercel/edge-config";
 // Cache responses
 export const dynamic = "force-static";
 
-// Revalidate cache every 60 seconds
-export const revalidate = 60;
+// Revalidate cache at most every hour
+export const revalidate = 3600;
 
 export async function GET(_req: NextRequest) {
   const versions = {


### PR DESCRIPTION
Why:

Reduces the number of edge functions that need to run, and thus reducing the likelihood this endpoint will timeout due to slow edge function startup.