### PR TITLE
ci: Remove deprecated macos-12 tests from GitHub CI

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -78,7 +78,6 @@ jobs:
         runs-on: [
           ubuntu-22.04,
           ubuntu-24.04,
-          macos-12,
           macos-13,
           macos-14,
           windows-2019,


### PR DESCRIPTION
- https://github.com/actions/runner-images/issues/10721
- https://github.com/firezone/firezone/actions/runs/11669446546/job/32494632762?pr=7258