### PR TITLE
chore(connlib): discard packets from smoltcp if > MTU

### DIFF
--- a/rust/dns-over-tcp/src/stub_device.rs
+++ b/rust/dns-over-tcp/src/stub_device.rs
@@ -64,7 +64,7 @@ impl<'a> smoltcp::phy::TxToken for SmolTxToken<'a> {
         let max_len = ip_packet::PACKET_SIZE;
 
         if len > max_len {
-            tracing::warn!("Packets larger than {max_len} are not supported");
+            tracing::warn!("Packets larger than {max_len} are not supported; len={len}");
 
             let mut buf = Vec::with_capacity(len);
             return f(&mut buf);

--- a/rust/dns-over-tcp/src/stub_device.rs
+++ b/rust/dns-over-tcp/src/stub_device.rs
@@ -61,6 +61,15 @@ impl<'a> smoltcp::phy::TxToken for SmolTxToken<'a> {
     where
         F: FnOnce(&mut [u8]) -> R,
     {
+        let max_len = ip_packet::PACKET_SIZE;
+
+        if len > max_len {
+            tracing::warn!("Packets larger than {max_len} are not supported");
+
+            let mut buf = Vec::with_capacity(len);
+            return f(&mut buf);
+        }
+
         let mut ip_packet_buf = IpPacketBuf::new();
         let result = f(ip_packet_buf.buf());
 


### PR DESCRIPTION
This should really never happen but is a defense in depth measure to ensure we never attempt to send packets through the tunnel that are larger than our interface MTU.

Raising a warning will alert us through Sentry in case this does happen.