### PR TITLE
fix(connlib): apply timeout to WebSocket connection to portal

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -13,7 +13,10 @@ export default function Android() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="7263">
-            Mitigates a crash in case the maximum packet size is not respected.
+          Mitigates a crash in case the maximum packet size is not respected.
+        </ChangeItem>
+        <ChangeItem pull="7265">
+          Prevents re-connections to the portal from hanging for longer than 5s.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.3.6" date={new Date("2024-10-31")}>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -15,6 +15,9 @@ export default function Apple() {
         <ChangeItem pull="7263">
             Mitigates a crash in case the maximum packet size is not respected.
           </ChangeItem>
+          <ChangeItem pull="7265">
+            Prevents re-connections to the portal from hanging for longer than 5s.
+          </ChangeItem>
       </Unreleased>
       <Entry version="1.3.7" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -15,7 +15,12 @@ export default function GUI({ title }: { title: string }) {
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
-        <ChangeItem pull="7263">Mitigates a crash in case the maximum packet size is not respected.</ChangeItem>
+        <ChangeItem pull="7263">
+          Mitigates a crash in case the maximum packet size is not respected.
+        </ChangeItem>
+        <ChangeItem pull="7265">
+          Prevents re-connections to the portal from hanging for longer than 5s.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.3.10" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -13,7 +13,10 @@ export default function Headless() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="7263">
-            Mitigates a crash in case the maximum packet size is not respected.
+          Mitigates a crash in case the maximum packet size is not respected.
+        </ChangeItem>
+        <ChangeItem pull="7265">
+          Prevents re-connections to the portal from hanging for longer than 5s.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.3.5" date={new Date("2024-10-31")}>


### PR DESCRIPTION
The issue in #7254 and #7200 appears to be that eventually, we fail to connect to the portal because we stop re-trying, i.e. the socket connect appears to hang forever. Perhaps there is race condition somewhere in how we resolve DNS / flush DNS servers etc. Regardless of that, connecting to the portal should never take more than 5s so timing out after that ensures we retry the connection.

Resolves: #7254.
Resolves: #7200.