### PR TITLE
chore(connlib): don't panic on invalid IP packet from smoltcp

### DIFF
--- a/rust/dns-over-tcp/src/stub_device.rs
+++ b/rust/dns-over-tcp/src/stub_device.rs
@@ -73,7 +73,10 @@ impl<'a> smoltcp::phy::TxToken for SmolTxToken<'a> {
         let mut ip_packet_buf = IpPacketBuf::new();
         let result = f(ip_packet_buf.buf());
 
-        let mut ip_packet = IpPacket::new(ip_packet_buf, len).unwrap();
+        let Some(mut ip_packet) = IpPacket::new(ip_packet_buf, len) else {
+            tracing::warn!("Received invalid IP packet");
+            return result;
+        };
         ip_packet.update_checksum();
         self.outbound_packets.push_back(ip_packet);
 


### PR DESCRIPTION
`smoltcp` should never emit a buffer that isn't a valid IP packet but in case it does, we shouldn't panic as a result and instead just discard the packet.