### PR TITLE
chore(gui-client): log entire error when connlib fails

### DIFF
--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -539,7 +539,7 @@ impl<I: GuiIntegration> Controller<I> {
                         "To access resources, sign in again.",
                     )?;
                 } else {
-                    tracing::error!(?error_msg, "Disconnected");
+                    tracing::error!("Connlib disconnected: {error_msg}");
                     native_dialog::MessageDialog::new()
                         .set_title("Firezone Error")
                         .set_text(&error_msg)


### PR DESCRIPTION
The `error_msg` here is already a user-friendly string because we are also showing it to the user in an error message. These can be entirely different errors so we should display them as different messages. This will allow Sentry to group them together correctly.