### PR TITLE
chore(gui-client): don't emit error when reading 0 bytes

### DIFF
--- a/rust/gui-client/src-common/src/deep_link.rs
+++ b/rust/gui-client/src-common/src/deep_link.rs
@@ -170,7 +170,7 @@ mod tests {
         let expected_url = url::Url::parse(&format!("bogus-test-schema://{id}"))?;
         super::open(&expected_url).await?;
 
-        let bytes = server_task.await??;
+        let bytes = server_task.await??.unwrap();
         let s = std::str::from_utf8(bytes.expose_secret())?;
         let url = url::Url::parse(s)?;
         assert_eq!(url, expected_url);

--- a/rust/gui-client/src-common/src/deep_link/linux.rs
+++ b/rust/gui-client/src-common/src/deep_link/linux.rs
@@ -58,7 +58,7 @@ impl Server {
     /// Await one incoming deep link
     ///
     /// To match the Windows API, this consumes the `Server`.
-    pub async fn accept(self) -> Result<Secret<Vec<u8>>> {
+    pub async fn accept(self) -> Result<Option<Secret<Vec<u8>>>> {
         tracing::debug!("deep_link::accept");
         let (mut stream, _) = self.listener.accept().await?;
         tracing::debug!("Accepted Unix domain socket connection");
@@ -71,14 +71,14 @@ impl Server {
             .await
             .context("failed to read incoming deep link over Unix socket stream")?;
         if bytes.is_empty() {
-            bail!("Got zero bytes from the deep link socket - probably a 2nd instance was blocked");
+            return Ok(None);
         }
         let bytes = Secret::new(bytes);
         tracing::debug!(
             len = bytes.expose_secret().len(),
             "Got data from Unix domain socket"
         );
-        Ok(bytes)
+        Ok(Some(bytes))
     }
 }
 

--- a/rust/gui-client/src-common/src/deep_link/macos.rs
+++ b/rust/gui-client/src-common/src/deep_link/macos.rs
@@ -12,7 +12,7 @@ impl Server {
         Ok(Self {})
     }
 
-    pub(crate) async fn accept(self) -> Result<Secret<Vec<u8>>> {
+    pub(crate) async fn accept(self) -> Result<Option<Secret<Vec<u8>>>> {
         futures::future::pending().await
     }
 }

--- a/rust/gui-client/src-common/src/deep_link/windows.rs
+++ b/rust/gui-client/src-common/src/deep_link/windows.rs
@@ -40,7 +40,7 @@ impl Server {
     /// I assume this is based on the underlying Windows API.
     /// I tried re-using the server and it acted strange. The official Tokio
     /// examples are not clear on this.
-    pub async fn accept(mut self) -> Result<Secret<Vec<u8>>> {
+    pub async fn accept(mut self) -> Result<Option<Secret<Vec<u8>>>> {
         self.inner
             .connect()
             .await
@@ -58,7 +58,7 @@ impl Server {
         let bytes = Secret::new(bytes);
 
         self.inner.disconnect().ok();
-        Ok(bytes)
+        Ok(Some(bytes))
     }
 }
 

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -449,10 +449,9 @@ async fn accept_deep_links(mut server: deep_link::Server, ctlr_tx: CtlrTx) -> Re
                     .await
                     .ok();
             }
-            Err(error) => tracing::error!(
-                error = anyhow_dyn_err(&error),
-                "error while accepting deep link"
-            ),
+            Err(error) => {
+                tracing::warn!(error = anyhow_dyn_err(&error), "Failed to accept deep link")
+            }
         }
         // We re-create the named pipe server every time we get a link, because of an oddity in the Windows API.
         server = deep_link::Server::new().await?;


### PR DESCRIPTION
The deep-link server of the GUI client runs in a loop and accepts one connection after another. It can sometimes happen that after accepting a connection, we end up reading 0 bytes. This isn't an error worth reporting, we simply loop around and try again.

Resolves: #7257.