### PR TITLE
chore(gui-client): don't double log errors

### DIFF
--- a/rust/gui-client/src-common/src/errors.rs
+++ b/rust/gui-client/src-common/src/errors.rs
@@ -61,7 +61,6 @@ pub fn show_error_dialog(error: &Error) -> Result<()> {
         Error::UserNotInFirezoneGroup => format!("You are not a member of the group `{FIREZONE_GROUP}`. Try `sudo usermod -aG {FIREZONE_GROUP} $USER` and then reboot"),
         Error::Other(error) => error.to_string(),
     };
-    tracing::error!(?user_friendly_error_msg);
 
     // I tried the Tauri dialogs and for some reason they don't show our
     // app icon.


### PR DESCRIPTION
This line leads to duplicate events in Sentry, we already log the error passed to this function on every call-site.