### PR TITLE
fix(gui-client): Include rust files when replacing version sentinels

### DIFF
--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -579,9 +579,10 @@ impl<'a> Handler<'a> {
         // Synchronous DNS resolution here
         let portal = PhoenixChannel::disconnected(
             Secret::new(url),
-            // The IPC service must use the GUI's version number, not the Headless Client's. But refactoring to separate the IPC service from the Headless Client will take a while.
+            // The IPC service must use the GUI's version number, not the Headless Client's.
+            // But refactoring to separate the IPC service from the Headless Client will take a while.
             // mark:next-gui-version
-            get_user_agent(None, "1.3.10"),
+            get_user_agent(None, "1.3.12"),
             "client",
             (),
             ExponentialBackoffBuilder::default()

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -68,6 +68,7 @@ gui-version:
 	@find website -type f -name "route.ts" -exec sed $(SEDARG) -e '/mark:current-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(current-gui-version)/g;}' {} \;
 	@find .github -type f -exec sed $(SEDARG) -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(next-gui-version)/g;}' {} \;
 	@find rust -path rust/gui-client/node_modules -prune -o -name "Cargo.toml" -exec sed $(SEDARG) -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(next-gui-version)/;}' {} \;
+	@find rust -path rust/gui-client/node_modules -prune -o -name "*.rs" -exec sed $(SEDARG) -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/$(next-gui-version)/;}' {} \;
 	@cd rust && cargo update --workspace
 
 headless-version:


### PR DESCRIPTION
Fixes an issue where the ipc_service was stuck reporting 1.3.10.