### PR TITLE
fix(connlib): also apply timeout to TLS connection

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -18,6 +18,9 @@ export default function Android() {
         <ChangeItem pull="7265">
           Prevents re-connections to the portal from hanging for longer than 5s.
         </ChangeItem>
+        <ChangeItem pull="7283">
+          Prevents TLS handshake with the portal from hanging for longer than 5s.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.3.6" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -11,7 +11,11 @@ export default function Apple() {
       title="macOS / iOS"
     >
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7283">
+          Prevents TLS handshake with the portal from hanging for longer than 5s.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.3.8" date={new Date("2024-11-05")}>
         <ChangeItem pull="7263">
           Mitigates a crash in case the maximum packet size is not respected.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,7 +14,11 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7283">
+          Prevents TLS handshake with the portal from hanging for longer than 5s.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.3.11" date={new Date("2024-11-05")}>
         <ChangeItem pull="7263">
           Mitigates a crash in case the maximum packet size is not respected.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -14,6 +14,9 @@ export default function Gateway() {
         <ChangeItem pull="7263">
             Mitigates a crash in case the maximum packet size is not respected.
         </ChangeItem>
+        <ChangeItem pull="7283">
+          Prevents TLS handshake with the portal from hanging for longer than 5s.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.0" date={new Date("2024-11-04")}>
         <ChangeItem pull="6960">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -18,6 +18,9 @@ export default function Headless() {
         <ChangeItem pull="7265">
           Prevents re-connections to the portal from hanging for longer than 5s.
         </ChangeItem>
+        <ChangeItem pull="7283">
+          Prevents TLS handshake with the portal from hanging for longer than 5s.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.3.5" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>


### PR DESCRIPTION
In #7265, we introduced a timeout for the DNS resolution socket creation when (re)-connecting to the portal. It appears that this wasn't enough and we also need to apply a timeout to the TLS handshake as I've just hit this issue while testing in my Windows VM.

Resolves: #7254.