### PR TITLE
fix(portal): Update log level for failed component version fetch

### DIFF
--- a/elixir/apps/domain/lib/domain/component_versions.ex
+++ b/elixir/apps/domain/lib/domain/component_versions.ex
@@ -66,11 +66,11 @@ defmodule Domain.ComponentVersions do
         {:ok, Enum.into(versions, [])}
 
       {:ok, response} ->
-        Logger.error("Can't fetch Firezone versions", reason: inspect(response))
+        Logger.warning("Can't fetch Firezone versions", reason: inspect(response))
         {:error, {response.status, response.body}}
 
       {:error, reason} ->
-        Logger.error("Can't fetch Firezone versions", reason: inspect(reason))
+        Logger.warning("Can't fetch Firezone versions", reason: inspect(reason))
         {:error, reason}
     end
   end

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -79,11 +79,11 @@ config :domain, Domain.ComponentVersions,
   firezone_releases_url: "https://www.firezone.dev/api/releases",
   fetch_from_url: true,
   versions: [
-    apple: "1.3.6",
-    android: "1.3.5",
-    gateway: "1.3.2",
-    gui: "1.3.8",
-    headless: "1.3.4"
+    apple: "1.3.8",
+    android: "1.3.6",
+    gateway: "1.4.0",
+    gui: "1.3.11",
+    headless: "1.3.5"
   ]
 
 config :domain, Domain.Cluster,


### PR DESCRIPTION
Why:

* The Firezone website is hosting the component versions at the moment
      and due to how Vercel works, occassionally a request will
      timeout when being made to the /api/versions endpoint.  This had been
      throwing an error in the elixir logs and triggering an alert, but
      because there is always a default set of component version values in
      the elixir app there isn't really a need for an error/alert.  With
      that in mind the log level will be set to `warning` rather than
      `error`.
      
Closes #7233