### PR TITLE
fix(infra): Update gcp cloud armor rules

### DIFF
--- a/terraform/modules/google-cloud/apps/elixir/network.tf
+++ b/terraform/modules/google-cloud/apps/elixir/network.tf
@@ -68,23 +68,12 @@ resource "google_compute_security_policy" "default" {
   rule {
     description = "block sanctioned countries"
 
-    action   = "deny(451)"
+    action   = "deny(403)"
     priority = "101"
 
     match {
       expr {
-        expression = <<EOT
-          request.path.matches(\"/sign_up\") && (\
-          origin.region_code == 'RU' || \
-          origin.region_code == 'BY' || \
-          origin.region_code == 'KP' || \
-          origin.region_code == 'IR' || \
-          origin.region_code == 'SY' || \
-          origin.region_code == 'CU' || \
-          origin.region_code == 'VE' || \
-          origin.region_code == 'XC' || \
-          origin.region_code == 'XD')"
-        EOT
+        expression = "request.path.matches('/sign_up') && !origin.region_code.matches('^RU|BY|KP|IR|SY|CU|VE|XC|XD$')"
       }
     }
   }


### PR DESCRIPTION
The expression for one of the rules was not able to be applied due to invalid characters (`\n`) and even once the invalid characters were removed there is a limit of 5 subexpressions, but the previous expression contained 10.

Along with the expression change, the `deny(451)` is not allowed.  The only `deny` codes allowed are `403`, `404`, `502`