### PR TITLE
fix(portal): Fix sign_up/sign_in email templates

### DIFF
--- a/elixir/apps/domain/lib/domain/mailer/auth_email/sign_in_link.html.eex
+++ b/elixir/apps/domain/lib/domain/mailer/auth_email/sign_in_link.html.eex
@@ -99,7 +99,7 @@
                     <div role="separator" style="line-height: 16px">&zwj;</div>
                     <div>
                       <a
-                        href={@sign_in_url}
+                        href="<%= @sign_in_url %>"
                         target="_blank"
                         style="display: inline-block; border-radius: 4px; background-color: #5e00d6; padding: 16px 24px; font-size: 16px; font-weight: 600; line-height: 1; color: #f6f6f6; text-decoration: none"
                       >

--- a/elixir/apps/domain/lib/domain/mailer/auth_email/sign_up_link.html.eex
+++ b/elixir/apps/domain/lib/domain/mailer/auth_email/sign_up_link.html.eex
@@ -95,7 +95,7 @@
                     <p></p>
                     <div>
                       <a
-                        href={@sign_in_form_url}
+                        href="<%= @sign_in_form_url %>"
                         style="display: inline-block; border-radius: 4px; background-color: #5e00d6; padding: 16px 24px; font-size: 16px; font-weight: 600; line-height: 1; color: #f6f6f6; text-decoration: none"
                       >
                         <!--[if mso]>
@@ -155,7 +155,7 @@
                           Sign In URL
                         </th>
                         <td style="padding: 16px 24px;">
-                          <a href={@sign_in_form_url}><%= @sign_in_form_url %></a>
+                          <a href="<%= @sign_in_form_url %>"><%= @sign_in_form_url %></a>
                         </td>
                       </tr>
                     </table>


### PR DESCRIPTION
Why:

* Two of the email templates using an `<a>` tag were not properly interpolating a view variable.  This happened when the templates were moved from the `web` app using `.heex` files to the `domain` app using `.eex` files.

Fixes #7294