### PR TITLE
fix(infra): Restore project owners to prevent cycle. Will delete later

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,6 +1,8 @@
 locals {
   project_owners = [
+    "a@firezone.dev",
     "bmanifold@firezone.dev",
+    "gabriel@firezone.dev",
     "jamil@firezone.dev",
   ]
 


### PR DESCRIPTION
Terraform is complaining about a cycle involved with deleting these project owners from the prod config.

https://app.terraform.io/app/firezone/workspaces/production/runs/run-7vhn8Yv5pksywBtd

Will restore them to get prod to deploy now, and then investigate the cycle more carefully afterward.