### PR TITLE
chore(infra): Remove project owners that are no longer owners

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,8 +1,6 @@
 locals {
   project_owners = [
-    "a@firezone.dev",
     "bmanifold@firezone.dev",
-    "gabriel@firezone.dev",
     "jamil@firezone.dev",
   ]
 


### PR DESCRIPTION
Now Terraform is receiving a 400 from the Google API because these users don't exist... 🙃.

Hopefully the cycle was broken by the last PR and this one succeeds.