### PR TITLE
chore(rust): don't panic in fallible functions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 dependencies = [
  "backtrace",
 ]
@@ -1049,6 +1049,7 @@ name = "connlib-client-android"
 version = "1.3.8"
 dependencies = [
  "android_log-sys",
+ "anyhow",
  "backoff",
  "connlib-client-shared",
  "connlib-model",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -70,6 +70,7 @@ unused_async = "warn"
 wildcard_enum_match_arm = "warn" # Ensures we match on all combinations of `Poll`, preventing erroneous suspensions.
 redundant_else = "warn"
 redundant_clone = "warn"
+unwrap_in_result = "warn"
 
 [workspace.lints.rustdoc]
 private-intra-doc-links = "allow" # We don't publish any of our docs but want to catch dead links.

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -369,7 +369,9 @@ fn create_tun_device() -> io::Result<()> {
         return Ok(());
     }
 
-    let parent_dir = path.parent().unwrap();
+    let parent_dir = path
+        .parent()
+        .expect("const-declared path always has a parent");
     fs::create_dir_all(parent_dir)?;
     let permissions = fs::Permissions::from_mode(0o751);
     fs::set_permissions(parent_dir, permissions)?;

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -259,15 +259,11 @@ impl Tun {
     }
 
     // Moves packets from the Internet towards the user
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "Fn signature must align with other platform implementations"
-    )]
     fn write(&self, bytes: &[u8]) -> io::Result<usize> {
         let len = bytes
             .len()
             .try_into()
-            .expect("Packet length should fit into u16");
+            .map_err(|_| io::Error::other("Packet too large; length does not fit into u16"))?;
 
         let Ok(mut pkt) = self.session.allocate_send_packet(len) else {
             // Ring buffer is full, just drop the packet since we're at the IP layer

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -11,7 +11,6 @@ use std::{
     os::windows::process::CommandExt,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    str::FromStr,
     sync::Arc,
     task::{ready, Context, Poll},
 };
@@ -225,10 +224,12 @@ impl Tun {
         let wintun = unsafe { wintun::load_from_path(path) }?;
 
         // Create wintun adapter
-        let uuid = uuid::Uuid::from_str(TUNNEL_UUID)
-            .expect("static UUID should always parse correctly")
-            .as_u128();
-        let adapter = match Adapter::create(&wintun, TUNNEL_NAME, TUNNEL_NAME, Some(uuid)) {
+        let adapter = match Adapter::create(
+            &wintun,
+            TUNNEL_NAME,
+            TUNNEL_NAME,
+            Some(TUNNEL_UUID.as_u128()),
+        ) {
             Ok(x) => x,
             Err(error) => {
                 tracing::error!(error = std_dyn_err(&error), "Failed in `Adapter::create`");

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -11,6 +11,7 @@ use std::{
     path::PathBuf,
     ptr::null,
 };
+use uuid::Uuid;
 use windows::Win32::NetworkManagement::{
     IpHelper::{GetAdaptersAddresses, MIB_IPFORWARD_TABLE2},
     Ndis::NET_LUID_LH,
@@ -33,7 +34,7 @@ pub const CREATE_NO_WINDOW: u32 = 0x08000000;
 /// A UUID we generated at dev time for our tunnel.
 ///
 /// This ends up in registry keys and tunnel management.
-pub const TUNNEL_UUID: &str = "e9245bc1-b8c1-44ca-ab1d-c6aad4f13b9c";
+pub const TUNNEL_UUID: Uuid = Uuid::from_u128(0xe924_5bc1_b8c1_44ca_ab1d_c6aa_d4f1_3b9c);
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]
 pub enum DnsControlMethod {

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["lib", "cdylib"]
 doc = false
 
 [dependencies]
+anyhow = "1.0.93"
 backoff = "0.4.0"
 connlib-client-shared = { workspace = true }
 connlib-model = { workspace = true }

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -4,9 +4,10 @@
 // ecosystem, so it's used here for consistency.
 
 use crate::tun::Tun;
+use anyhow::{Context as _, Result};
 use backoff::ExponentialBackoffBuilder;
 use connlib_client_shared::{Callbacks, DisconnectError, Session, V4RouteList, V6RouteList};
-use connlib_model::{ResourceId, ResourceView};
+use connlib_model::ResourceView;
 use firezone_logging::std_dyn_err;
 use firezone_telemetry::{Telemetry, ANDROID_DSN};
 use ip_network::{Ipv4Network, Ipv6Network};
@@ -17,11 +18,11 @@ use jni::{
     JNIEnv, JavaVM,
 };
 use phoenix_channel::get_user_agent;
+use phoenix_channel::LoginUrl;
 use phoenix_channel::PhoenixChannel;
-use phoenix_channel::{LoginUrl, LoginUrlError};
 use secrecy::{Secret, SecretString};
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
-use std::{collections::BTreeSet, io, net::IpAddr, os::fd::AsRawFd, path::Path, sync::Arc};
+use std::{io, net::IpAddr, os::fd::AsRawFd, path::Path, sync::Arc};
 use std::{
     net::{Ipv4Addr, Ipv6Addr},
     os::fd::RawFd,
@@ -291,34 +292,12 @@ fn catch_and_throw<F: FnOnce(&mut JNIEnv) -> R, R>(env: &mut JNIEnv, f: F) -> Op
         .ok()
 }
 
-#[derive(Debug, Error)]
-enum ConnectError {
-    #[error("Failed to access {name:?}: {source}")]
-    StringInvalid {
-        name: &'static str,
-        source: jni::errors::Error,
-    },
-    #[error("Failed to get Java VM: {0}")]
-    GetJavaVmFailed(#[source] jni::errors::Error),
-    #[error(transparent)]
-    ConnectFailed(#[from] DisconnectError),
-    #[error(transparent)]
-    InvalidLoginUrl(#[from] LoginUrlError<url::ParseError>),
-    #[error("Unable to create tokio runtime: {0}")]
-    UnableToCreateRuntime(#[from] io::Error),
-    #[error(transparent)]
-    CallbackError(#[from] CallbackError),
-}
-
 macro_rules! string_from_jstring {
     ($env:expr, $j:ident) => {
         String::from(
             ($env)
                 .get_string(&($j))
-                .map_err(|source| ConnectError::StringInvalid {
-                    name: stringify!($j),
-                    source,
-                })?,
+                .with_context(|| format!("Failed to get string {} from JNIEnv", stringify!($j)))?,
         )
     };
 }
@@ -337,7 +316,7 @@ fn connect(
     log_filter: JString,
     callback_handler: GlobalRef,
     device_info: JString,
-) -> Result<SessionWrapper, ConnectError> {
+) -> Result<SessionWrapper> {
     let api_url = string_from_jstring!(env, api_url);
     let secret = SecretString::from(string_from_jstring!(env, token));
     let device_id = string_from_jstring!(env, device_id);
@@ -346,7 +325,8 @@ fn connect(
     let log_dir = string_from_jstring!(env, log_dir);
     let log_filter = string_from_jstring!(env, log_filter);
     let device_info = string_from_jstring!(env, device_info);
-    let device_info = serde_json::from_str(&device_info).unwrap();
+    let device_info =
+        serde_json::from_str(&device_info).context("Failed to deserialize `DeviceInfo`")?;
 
     let telemetry = Telemetry::default();
     telemetry.start(&api_url, env!("CARGO_PKG_VERSION"), ANDROID_DSN);
@@ -355,7 +335,7 @@ fn connect(
     install_rustls_crypto_provider();
 
     let callbacks = CallbackHandler {
-        vm: env.get_java_vm().map_err(ConnectError::GetJavaVmFailed)?,
+        vm: env.get_java_vm()?,
         callback_handler,
         handle,
     };
@@ -476,8 +456,6 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_di
     });
 }
 
-///
-///
 /// # Safety
 /// session_ptr should have been obtained from `connect` function, and shouldn't be dropped with disconnect
 /// at any point before or during operation of this function.
@@ -490,14 +468,11 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_se
 ) {
     let disabled_resources = String::from(
         env.get_string(&disabled_resources)
-            .map_err(|source| ConnectError::StringInvalid {
-                name: "disabled_resources",
-                source,
-            })
             .expect("Invalid string returned from android client"),
     );
-    let disabled_resources: BTreeSet<ResourceId> =
-        serde_json::from_str(&disabled_resources).unwrap();
+    let disabled_resources = serde_json::from_str(&disabled_resources)
+        .expect("Failed to deserialize disabled resource IDs");
+
     tracing::debug!("disabled resource: {disabled_resources:?}");
     let session = &*(session_ptr as *const SessionWrapper);
     session.inner.set_disabled_resources(disabled_resources);
@@ -521,13 +496,9 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_se
 ) {
     let dns = String::from(
         env.get_string(&dns_list)
-            .map_err(|source| ConnectError::StringInvalid {
-                name: "dns_list",
-                source,
-            })
             .expect("Invalid string returned from android client"),
     );
-    let dns: Vec<IpAddr> = serde_json::from_str(&dns).unwrap();
+    let dns = serde_json::from_str::<Vec<IpAddr>>(&dns).expect("Failed to deserialize DNS IPs");
     let session = &*(session_ptr as *const SessionWrapper);
     session.inner.set_dns(dns);
 }

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -4,6 +4,7 @@
 mod make_writer;
 mod tun;
 
+use anyhow::Context;
 use anyhow::Result;
 use backoff::ExponentialBackoffBuilder;
 use connlib_client_shared::{Callbacks, DisconnectError, Session, V4RouteList, V6RouteList};
@@ -199,7 +200,8 @@ impl WrappedSession {
         install_rustls_crypto_provider();
 
         let secret = SecretString::from(token);
-        let device_info = serde_json::from_str(&device_info).unwrap();
+        let device_info =
+            serde_json::from_str(&device_info).context("Failed to deserialize `DeviceInfo`")?;
 
         let url = LoginUrl::client(
             api_url.as_str(),

--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -1,5 +1,7 @@
 //! A SANS-IO connectivity library for wireguard connections formed by ICE.
 
+#![cfg_attr(test, allow(clippy::unwrap_in_result))]
+
 mod allocation;
 mod backoff;
 mod candidate_set;

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -245,8 +245,11 @@ impl GatewayState {
             now,
         )?;
 
-        self.allow_access(client_id, ipv4, ipv6, expires_at, resource, None, now)
-            .expect("Should never fail without a `DnsResourceNatEntry`");
+        let result = self.allow_access(client_id, ipv4, ipv6, expires_at, resource, None, now);
+        debug_assert!(
+            result.is_ok(),
+            "`allow_access` should never fail without a `DnsResourceEntry`"
+        );
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -34,6 +34,7 @@ mod peer_store;
 mod proptest;
 mod sockets;
 #[cfg(all(test, feature = "proptest"))]
+#[allow(clippy::unwrap_in_result)]
 mod tests;
 mod utils;
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -452,7 +452,7 @@ impl ClientOnGateway {
 
         self.permanent_translations
             .get_mut(&ip)
-            .expect("inconsistent state")
+            .context("No translation state for outgoing packet")?
             .on_incoming_traffic(now);
 
         packet.update_checksum();

--- a/rust/headless-client/src/ipc_service/windows.rs
+++ b/rust/headless-client/src/ipc_service/windows.rs
@@ -57,7 +57,7 @@ impl ProcessToken {
     fn is_elevated(&self) -> Result<bool> {
         let mut elevation = TOKEN_ELEVATION::default();
         let token_elevation_sz = u32::try_from(size_of::<TOKEN_ELEVATION>())
-            .expect("`TOKEN_ELEVATION` size should fit into a u32");
+            .context("Failed to convert `TOKEN_ELEVATION` to u32")?;
         let mut return_size = 0u32;
         // SAFETY: Docs say nothing about threads or safety <https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-gettokeninformation>
         // The type of `elevation` varies based on the 2nd parameter, but we hard-coded that.

--- a/rust/logging/src/file.rs
+++ b/rust/logging/src/file.rs
@@ -107,11 +107,10 @@ impl Appender {
 
     // Inspired from `tracing-appender/src/rolling.rs`.
     fn create_new_writer(&self) -> io::Result<(fs::File, String)> {
-        let format = time::format_description::parse(TIME_FORMAT)
-            .expect("static format description should always be parsable");
+        let format = time::format_description::parse(TIME_FORMAT).map_err(io::Error::other)?;
         let date = OffsetDateTime::now_utc()
             .format(&format)
-            .expect("formatting a timestamp should always be possible");
+            .map_err(|_| io::Error::other("Failed to format timestamp"))?;
 
         let filename = format!("{LOG_FILE_BASE_NAME}.{date}.{}", self.file_extension);
 


### PR DESCRIPTION
"Just let it crash" is terrible advice for software that is shipped to end users. Where possible, we should use proper error handling and only fail the current function / task that is active, e.g. drop a particular packet instead of failing all of connlib. We more or less already do that.

Activating the clippy lint `unwrap_in_result` surfaced a few more places where we panic despite being in a function that is fallible already. These cases can easily be converted to not panic and return an error instead.