### PR TITLE
chore(gateway): report more tunnel errors to event-loop

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -101,8 +101,10 @@ impl GatewayState {
 
         let packet = peer
             .encapsulate(packet, now)
-            .inspect_err(|e| tracing::debug!(%cid, "Failed to encapsulate: {e:#}"))
-            .ok()??;
+            .inspect_err(
+                |e| tracing::debug!(error = anyhow_dyn_err(e), %cid, "Failed to encapsulate"),
+            )
+            .ok()?;
 
         let transmit = self
             .node

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -4,11 +4,11 @@ use crate::messages::{
 use crate::utils::earliest;
 use crate::{p2p_control, GatewayEvent};
 use crate::{peer::ClientOnGateway, peer_store::PeerStore};
-use anyhow::Context;
+use anyhow::{Context, Result};
 use boringtun::x25519::PublicKey;
 use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, DomainName, RelayId, ResourceId};
-use firezone_logging::{anyhow_dyn_err, std_dyn_err, telemetry_span};
+use firezone_logging::{anyhow_dyn_err, telemetry_span};
 use ip_network::{Ipv4Network, Ipv6Network};
 use ip_packet::{FzP2pControlSlice, IpPacket};
 use secrecy::{ExposeSecret as _, Secret};
@@ -85,34 +85,30 @@ impl GatewayState {
         packet: IpPacket,
         now: Instant,
         buffer: &mut EncryptBuffer,
-    ) -> Option<snownet::EncryptedPacket> {
+    ) -> Result<Option<snownet::EncryptedPacket>> {
         let dst = packet.destination();
 
-        if !is_client(dst) {
-            return None;
-        }
+        anyhow::ensure!(is_client(dst), "Packet not destined for a client");
 
-        let Some(peer) = self.peers.peer_by_ip_mut(dst) else {
-            tracing::trace!(%dst, "Couldn't find connection by IP");
-
-            return None;
-        };
+        let peer = self
+            .peers
+            .peer_by_ip_mut(dst)
+            .context("Couldn't find connection by IP")?;
         let cid = peer.id();
 
         let packet = peer
-            .encapsulate(packet, now)
-            .inspect_err(
-                |e| tracing::debug!(error = anyhow_dyn_err(e), %cid, "Failed to encapsulate"),
-            )
-            .ok()?;
+            .translate_inbound(packet, now)
+            .context("Failed to translate packet")?;
 
-        let transmit = self
+        let Some(encrypted_packet) = self
             .node
             .encapsulate(cid, packet, now, buffer)
-            .inspect_err(|e| tracing::debug!(error = std_dyn_err(e), %cid, "Failed to encapsulate"))
-            .ok()??;
+            .context("Failed to encapsulate")?
+        else {
+            return Ok(None);
+        };
 
-        Some(transmit)
+        Ok(Some(encrypted_packet))
     }
 
     /// Handles UDP packets received on the network interface.
@@ -127,40 +123,44 @@ impl GatewayState {
         from: SocketAddr,
         packet: &[u8],
         now: Instant,
-    ) -> Option<IpPacket> {
-        let (cid, packet) = self.node.decapsulate(
-            local,
-            from,
-            packet,
-            now,
-        )
-        .inspect_err(|e| tracing::debug!(error = std_dyn_err(e), %from, num_bytes = %packet.len(), "Failed to decapsulate incoming packet"))
-        .ok()??;
-
-        let Some(peer) = self.peers.get_mut(&cid) else {
-            tracing::warn!(%cid, "Couldn't find connection by ID");
-
-            return None;
+    ) -> Result<Option<IpPacket>> {
+        let Some((cid, packet)) = self
+            .node
+            .decapsulate(local, from, packet, now)
+            .context("Failed to decapsulate")?
+        else {
+            return Ok(None);
         };
 
+        let peer = self
+            .peers
+            .get_mut(&cid)
+            .context("Failed to find connection by ID")?;
+
         if let Some(fz_p2p_control) = packet.as_fz_p2p_control() {
-            let response =
-                handle_p2p_control_packet(fz_p2p_control, peer, &mut self.buffered_events)?;
+            let Some(immediate_response) =
+                handle_p2p_control_packet(fz_p2p_control, peer, &mut self.buffered_events)
+            else {
+                return Ok(None);
+            };
 
             let mut buffer = EncryptBuffer::new();
-            let transmit = encrypt_packet(response, cid, &mut self.node, &mut buffer, now)?;
+            let Some(transmit) =
+                encrypt_packet(immediate_response, cid, &mut self.node, &mut buffer, now)?
+            else {
+                return Ok(None);
+            };
 
             self.buffered_transmits.push_back(transmit.into_owned());
 
-            return None;
+            return Ok(None);
         }
 
         let packet = peer
-            .decapsulate(packet, now)
-            .inspect_err(|e| tracing::debug!(%cid, "Invalid packet: {e:#}"))
-            .ok()?;
+            .translate_outbound(packet, now)
+            .context("Failed to translate packet")?;
 
-        Some(packet)
+        Ok(Some(packet))
     }
 
     pub fn cleanup_connection(&mut self, id: &ClientId) {
@@ -338,7 +338,7 @@ impl GatewayState {
         let packet = dns_resource_nat::domain_status(req.resource, req.domain, nat_status);
 
         let mut buffer = EncryptBuffer::new();
-        let Some(transmit) = encrypt_packet(packet, req.client, &mut self.node, &mut buffer, now)
+        let Some(transmit) = encrypt_packet(packet, req.client, &mut self.node, &mut buffer, now)?
         else {
             return Ok(());
         };
@@ -501,13 +501,15 @@ fn encrypt_packet<'a>(
     node: &mut ServerNode<ClientId, RelayId>,
     buffer: &'a mut EncryptBuffer,
     now: Instant,
-) -> Option<Transmit<'a>> {
-    let encrypted_packet = node
+) -> Result<Option<Transmit<'a>>> {
+    let Some(encrypted_packet) = node
         .encapsulate(cid, packet, now, buffer)
-        .inspect_err(|e| tracing::debug!(error = std_dyn_err(e), %cid, "Failed to encapsulate"))
-        .ok()??;
+        .context("Failed to encapsulate packet")?
+    else {
+        return Ok(None);
+    };
 
-    Some(encrypted_packet.to_transmit(buffer))
+    Ok(Some(encrypted_packet.to_transmit(buffer)))
 }
 
 /// Opaque request struct for when a domain name needs to be resolved.

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -428,7 +428,11 @@ impl ClientOnGateway {
         Ok(packet)
     }
 
-    pub fn decapsulate(&mut self, packet: IpPacket, now: Instant) -> anyhow::Result<IpPacket> {
+    pub fn translate_outbound(
+        &mut self,
+        packet: IpPacket,
+        now: Instant,
+    ) -> anyhow::Result<IpPacket> {
         self.ensure_allowed_src(&packet)?;
         self.ensure_allowed_dst(&packet)?;
 
@@ -437,7 +441,11 @@ impl ClientOnGateway {
         Ok(packet)
     }
 
-    pub fn encapsulate(&mut self, packet: IpPacket, now: Instant) -> anyhow::Result<IpPacket> {
+    pub fn translate_inbound(
+        &mut self,
+        packet: IpPacket,
+        now: Instant,
+    ) -> anyhow::Result<IpPacket> {
         let Some((proto, ip)) = self.nat_table.translate_incoming(&packet, now)? else {
             return Ok(packet);
         };
@@ -1128,7 +1136,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.decapsulate(pkt, Instant::now()).is_ok());
+        assert!(peer.translate_outbound(pkt, Instant::now()).is_ok());
 
         let pkt = ip_packet::make::udp_packet(
             source_v4_addr(),
@@ -1139,7 +1147,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.decapsulate(pkt, Instant::now()).is_err());
+        assert!(peer.translate_outbound(pkt, Instant::now()).is_err());
 
         let pkt = ip_packet::make::udp_packet(
             source_v4_addr(),
@@ -1150,7 +1158,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.decapsulate(pkt, Instant::now()).is_err());
+        assert!(peer.translate_outbound(pkt, Instant::now()).is_err());
 
         let pkt = ip_packet::make::udp_packet(
             source_v4_addr(),
@@ -1161,7 +1169,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.decapsulate(pkt, Instant::now()).is_ok());
+        assert!(peer.translate_outbound(pkt, Instant::now()).is_ok());
     }
 
     #[test]
@@ -1187,7 +1195,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.decapsulate(pkt, Instant::now()).is_ok());
+        assert!(peer.translate_outbound(pkt, Instant::now()).is_ok());
 
         let pkt = ip_packet::make::udp_packet(
             source_v4_addr(),
@@ -1198,7 +1206,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.decapsulate(pkt, Instant::now()).is_err());
+        assert!(peer.translate_outbound(pkt, Instant::now()).is_err());
 
         let pkt = ip_packet::make::udp_packet(
             source_v4_addr(),
@@ -1209,7 +1217,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.decapsulate(pkt, Instant::now()).is_ok());
+        assert!(peer.translate_outbound(pkt, Instant::now()).is_ok());
     }
 
     fn foo_dns_resource() -> crate::messages::gateway::ResourceDescription {

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -437,18 +437,12 @@ impl ClientOnGateway {
         Ok(packet)
     }
 
-    pub fn encapsulate(
-        &mut self,
-        packet: IpPacket,
-        now: Instant,
-    ) -> anyhow::Result<Option<IpPacket>> {
+    pub fn encapsulate(&mut self, packet: IpPacket, now: Instant) -> anyhow::Result<IpPacket> {
         let Some((proto, ip)) = self.nat_table.translate_incoming(&packet, now)? else {
-            return Ok(Some(packet));
+            return Ok(packet);
         };
 
-        let Some(mut packet) = packet.translate_source(self.ipv4, self.ipv6, proto, ip) else {
-            return Ok(None);
-        };
+        let mut packet = packet.translate_source(self.ipv4, self.ipv6, proto, ip)?;
 
         self.permanent_translations
             .get_mut(&ip)
@@ -457,7 +451,7 @@ impl ClientOnGateway {
 
         packet.update_checksum();
 
-        Ok(Some(packet))
+        Ok(packet)
     }
 
     pub(crate) fn is_allowed(&self, resource: ResourceId) -> bool {

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -60,7 +60,9 @@ impl SimGateway {
         let Some(packet) = self
             .sut
             .handle_network_input(transmit.dst, transmit.src.unwrap(), &transmit.payload, now)
-            .unwrap()
+            .inspect_err(|e| tracing::warn!("{e:#}"))
+            .ok()
+            .flatten()
         else {
             self.sut.handle_timeout(now, utc_now);
             return None;

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -57,12 +57,11 @@ impl SimGateway {
         now: Instant,
         utc_now: DateTime<Utc>,
     ) -> Option<Transmit<'static>> {
-        let Some(packet) = self.sut.handle_network_input(
-            transmit.dst,
-            transmit.src.unwrap(),
-            &transmit.payload,
-            now,
-        ) else {
+        let Some(packet) = self
+            .sut
+            .handle_network_input(transmit.dst, transmit.src.unwrap(), &transmit.payload, now)
+            .unwrap()
+        else {
             self.sut.handle_timeout(now, utc_now);
             return None;
         };
@@ -91,7 +90,8 @@ impl SimGateway {
             .filter_map(|packet| {
                 Some(
                     self.sut
-                        .handle_tun_input(packet, now, &mut self.enc_buffer)?
+                        .handle_tun_input(packet, now, &mut self.enc_buffer)
+                        .unwrap()?
                         .to_transmit(&self.enc_buffer)
                         .into_owned(),
                 )
@@ -162,7 +162,8 @@ impl SimGateway {
             self.request_received(&packet);
             let transmit = self
                 .sut
-                .handle_tun_input(reply, now, &mut self.enc_buffer)?
+                .handle_tun_input(reply, now, &mut self.enc_buffer)
+                .unwrap()?
                 .to_transmit(&self.enc_buffer)
                 .into_owned();
 
@@ -217,7 +218,8 @@ impl SimGateway {
         .expect("src and dst are taken from incoming packet");
         let transmit = self
             .sut
-            .handle_tun_input(echo_response, now, &mut self.enc_buffer)?
+            .handle_tun_input(echo_response, now, &mut self.enc_buffer)
+            .unwrap()?
             .to_transmit(&self.enc_buffer)
             .into_owned();
 

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -4,7 +4,7 @@ use connlib_model::DomainName;
 use connlib_model::{ClientId, ResourceId};
 #[cfg(not(target_os = "windows"))]
 use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
-use firezone_logging::{anyhow_dyn_err, std_dyn_err, telemetry_span};
+use firezone_logging::{anyhow_dyn_err, std_dyn_err, telemetry_event, telemetry_span};
 use firezone_tunnel::messages::gateway::{
     AllowAccess, ClientIceCandidates, ClientsIceCandidates, ConnectionReady, EgressMessages,
     IngressMessages, RejectAccess, RequestConnection,
@@ -79,6 +79,7 @@ impl Eventloop {
                 }
                 Poll::Ready(Err(e)) => {
                     tracing::debug!(error = std_dyn_err(&e), "Tunnel error");
+                    telemetry_event!(error = std_dyn_err(&e), "Tunnel error");
                     continue;
                 }
                 Poll::Pending => {}


### PR DESCRIPTION
Currently, the Gateway's state machine functions for processing packets use type-signature that only return `Option`. Any errors while processing packets are logged internally. This makes it difficult to consistently log these errors.

We refactor these functions to return `Result<Option<T>>` in most cases, indicating that they may fail for various reasons and also sometimes succeed without producing an output.

This allows us to consistently log these errors in the event-loop. Logging them on WARN or ERROR would be too spammy though. In order to still be alerted about some of these, we use the `telemetry_event!` macro which samples them at a rate of 1%. This will alert us about cases that happen often and allows us to handle them explicitly.

Once this is deployed to staging, I will monitor the alerts in Sentry to ensure we won't get spammed with events from customers on the next release.