### PR TITLE
chore(apple): log all `connect` errors on the connlib-side

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use backoff::ExponentialBackoffBuilder;
 use connlib_client_shared::{Callbacks, DisconnectError, Session, V4RouteList, V6RouteList};
 use connlib_model::ResourceView;
+use firezone_logging::anyhow_dyn_err;
 use firezone_telemetry::Telemetry;
 use firezone_telemetry::APPLE_DSN;
 use ip_network::{Ipv4Network, Ipv6Network};
@@ -266,7 +267,11 @@ impl WrappedSession {
 }
 
 fn err_to_string(result: Result<WrappedSession>) -> Result<WrappedSession, String> {
-    result.map_err(|e| format!("{e:#}"))
+    result.map_err(|e| {
+        tracing::error!(error = anyhow_dyn_err(&e), "Failed to create session");
+
+        format!("{e:#}")
+    })
 }
 
 /// Installs the `ring` crypto provider for rustls.


### PR DESCRIPTION
We don't have Sentry yet in the native Apple client, meaning we don't yet learn about errors returned from the `connect` call. Normally, logging and returning an error is an anti-pattern. We are okay with that in this case until we can report these errors in the native Apple client.