### PR TITLE
refactor(apple): make panics on decoding errors more descriptive

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -250,13 +250,17 @@ impl WrappedSession {
     }
 
     fn set_dns(&mut self, dns_servers: String) {
-        self.inner
-            .set_dns(serde_json::from_str(&dns_servers).unwrap())
+        let dns_servers =
+            serde_json::from_str(&dns_servers).expect("Failed to deserialize DNS servers");
+
+        self.inner.set_dns(dns_servers)
     }
 
     fn set_disabled_resources(&mut self, disabled_resources: String) {
-        self.inner
-            .set_disabled_resources(serde_json::from_str(&disabled_resources).unwrap())
+        let disabled_resources = serde_json::from_str(&disabled_resources)
+            .expect("Failed to deserialize disabled resources");
+
+        self.inner.set_disabled_resources(disabled_resources)
     }
 
     fn disconnect(self) {


### PR DESCRIPTION
The communication between the native Apple client and `connlib` uses JSON encoding. The deserialisation of these should never fail because a particular version of `connlib` is always bundled with the native client. Thus, panicking here is justified.

In case it does ever happen, we improve the panic message with this patch.