### PR TITLE
refactor(gui-client): return error to TypeScript from commands

### DIFF
--- a/rust/gui-client/src-tauri/src/client/settings.rs
+++ b/rust/gui-client/src-tauri/src/client/settings.rs
@@ -2,12 +2,11 @@
 //! advanced settings and code for manipulating diagnostic logs.
 
 use crate::client::gui::Managed;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use firezone_gui_client_common::{
     controller::{ControllerRequest, CtlrTx},
     settings::{save, AdvancedSettings},
 };
-use firezone_logging::std_dyn_err;
 use std::time::Duration;
 use tokio::sync::oneshot;
 
@@ -52,16 +51,14 @@ pub(crate) async fn get_advanced_settings(
     managed: tauri::State<'_, Managed>,
 ) -> Result<AdvancedSettings, String> {
     let (tx, rx) = oneshot::channel();
-    if let Err(error) = managed
+
+    managed
         .ctlr_tx
         .send(ControllerRequest::GetAdvancedSettings(tx))
         .await
-    {
-        tracing::error!(
-            error = std_dyn_err(&error),
-            "couldn't request advanced settings from controller task"
-        );
-    }
+        .context("couldn't request advanced settings from controller task")
+        .map_err(|e| e.to_string())?;
+
     rx.await.map_err(|_| {
         "Couldn't get settings from `Controller`, maybe the program is crashing".to_string()
     })

--- a/rust/gui-client/src-tauri/src/client/welcome.rs
+++ b/rust/gui-client/src-tauri/src/client/welcome.rs
@@ -1,17 +1,17 @@
 //! Everything related to the Welcome window
 
 use crate::client::gui::Managed;
+use anyhow::Context;
 use firezone_gui_client_common::controller::ControllerRequest;
-use firezone_logging::std_dyn_err;
 
-// Tauri requires a `Result` here, maybe in case the managed state can't be retrieved
 #[tauri::command]
-pub(crate) async fn sign_in(managed: tauri::State<'_, Managed>) -> anyhow::Result<(), String> {
-    if let Err(error) = managed.ctlr_tx.send(ControllerRequest::SignIn).await {
-        tracing::error!(
-            error = std_dyn_err(&error),
-            "Couldn't request `Controller` to begin signing in"
-        );
-    }
+pub(crate) async fn sign_in(managed: tauri::State<'_, Managed>) -> Result<(), String> {
+    managed
+        .ctlr_tx
+        .send(ControllerRequest::SignIn)
+        .await
+        .context("Failed to send `SignIn` command")
+        .map_err(|e| e.to_string())?;
+
     Ok(())
 }

--- a/rust/gui-client/src/welcome.ts
+++ b/rust/gui-client/src/welcome.ts
@@ -4,13 +4,8 @@ const signInBtn = <HTMLButtonElement>(
   document.getElementById("sign-in")
 );
 
-async function sign_in() {
+signInBtn.addEventListener("click", async (_e) => {
   console.log("Signing in...");
-  invoke("sign_in")
-    .then(() => {})
-    .catch((e: Error) => {
-      console.error(e);
-    });
-}
 
-signInBtn.addEventListener("click", (_e) => sign_in());
+  await invoke("sign_in");
+});


### PR DESCRIPTION
Within the Tauri client, we invoke commands from TypeScript on the Rust side. These commands can sometimes fail, which is why these commands return a `Result`.

Most of our commands actually only send messages through a channel to an event-loop. This can only fail if the other side of the channel is closed, which should(?) only happen if the program is shutting down or some part of it crashed. Regardless, these errors can directly be forwarded to the TypeScript code where they will get caught and logged to the browser console.

In the future, we can install Sentry's TypeScript client in the GUI code to automatically report errors on the TypeScript side too.

Resolves: #7256.