### PR TITLE
refactor(gui-client): capture error sources when connect fails

### DIFF
--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -500,7 +500,7 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
                 Ok(flow) => Ok(flow),
                 // Handles <https://github.com/firezone/firezone/issues/6547> more gracefully so we can still export logs even if we crashed right after sign-in
                 Err(Error::ConnectToFirezoneFailed(error)) => {
-                    tracing::error!(error = std_dyn_err(&error), "Failed to connect to Firezone");
+                    tracing::error!("Failed to connect to Firezone: {error}");
                     self.sign_out().await?;
                     Ok(ControlFlow::Continue(()))
                 }
@@ -644,7 +644,7 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
                 }
                 Ok(())
             }
-            Err(msg) => Err(Error::ConnectToFirezoneFailed(msg)),
+            Err(IpcServiceError::Other(error)) => Err(Error::ConnectToFirezoneFailed(error)),
         }
     }
 

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -631,7 +631,7 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
                 }
                 Ok(())
             }
-            Err(IpcServiceError::PortalConnection(error)) => {
+            Err(IpcServiceError::Io(error)) => {
                 // This is typically something like, we don't have Internet access so we can't
                 // open the PhoenixChannel's WebSocket.
                 tracing::info!(

--- a/rust/gui-client/src-common/src/errors.rs
+++ b/rust/gui-client/src-common/src/errors.rs
@@ -1,12 +1,12 @@
 use crate::{self as common, deep_link};
 use anyhow::Result;
-use firezone_headless_client::{ipc, IpcServiceError, FIREZONE_GROUP};
+use firezone_headless_client::{ipc, FIREZONE_GROUP};
 
 // TODO: Replace with `anyhow` gradually per <https://github.com/firezone/firezone/pull/3546#discussion_r1477114789>
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failed to connect to Firezone for non-Portal-related reason")]
-    ConnectToFirezoneFailed(IpcServiceError),
+    #[error("Failed to connect to Firezone")]
+    ConnectToFirezoneFailed(String),
     #[error("Deep-link module error: {0}")]
     DeepLink(#[from] deep_link::Error),
     #[error("Logging module error: {0}")]


### PR DESCRIPTION
When `connlib` fails to establish a session, the GUI client currently only captures the top-level error within `connect_to_firezone` because it uses `.to_string()` for all errors. Unfortunately, that doesn't print any of the sources of an error.

To conveniently capture all sources, we can use `anyhow` and its alternate formatting using `format!("{e:#}")` (notice the `#`). Not all errors within `connect_to_firezone` should be captured like this however. Certain IO errors, in particular when trying to resolve the domain of the portal, need to be captured separately because they may resolve by themselves if we gain connectivity again. This is important, otherwise we discard the users token when they boot-up a machine without internet access yet Firezone is auto-starting.

To make this more ergonomic, we trim down `IpcServiceError` to two variants: The IO variant we need to special-case and everything else. This allows us to create `From` impls which "do the right thing" by capturing more error information using `anyhow`'s alternate formatting.

