### PR TITLE
refactor(gui-client): downgrade temporary error

### DIFF
--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -627,7 +627,7 @@ impl<I: GuiIntegration> Controller<I> {
             Err(IpcServiceError::PortalConnection(error)) => {
                 // This is typically something like, we don't have Internet access so we can't
                 // open the PhoenixChannel's WebSocket.
-                tracing::warn!(
+                tracing::info!(
                     error,
                     "Failed to connect to Firezone Portal, will try again when the network changes"
                 );


### PR DESCRIPTION
If we only temporarily fail to connect to the portal, we don't need to report this as a warning.

Resolves: #7251.