### PR TITLE
refactor: downgrade errors when we cannot bind sockets

### DIFF
--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -1,4 +1,3 @@
-use firezone_logging::std_dyn_err;
 use socket_factory::{DatagramIn, DatagramOut, SocketFactory, UdpSocket};
 use std::{
     io,
@@ -20,10 +19,10 @@ pub(crate) struct Sockets {
 impl Sockets {
     pub fn rebind(&mut self, socket_factory: &dyn SocketFactory<UdpSocket>) {
         self.socket_v4 = socket_factory(&SocketAddr::V4(UNSPECIFIED_V4_SOCKET))
-            .inspect_err(|e| tracing::warn!(error = std_dyn_err(e), "Failed to bind IPv4 socket"))
+            .inspect_err(|e| tracing::info!("Failed to bind IPv4 socket: {e}"))
             .ok();
         self.socket_v6 = socket_factory(&SocketAddr::V6(UNSPECIFIED_V6_SOCKET))
-            .inspect_err(|e| tracing::warn!(error = std_dyn_err(e), "Failed to bind IPv6 socket"))
+            .inspect_err(|e| tracing::info!("Failed to bind IPv6 socket: {e}"))
             .ok();
 
         if let Some(waker) = self.waker.take() {


### PR DESCRIPTION
Most of the time, these errors are a result of a limited IP stack, for example IPv6 not being available. Reporting these as errors to Sentry is unnecessarily noisy.

If something else happens further down the line, the last 500 debug and info logs will be sent along with the error report so we will still see these in the breadcrumbs if an actual error happens later.

Resolves: #7245.