### PR TITLE
chore(telemetry): capture Firezone ID and account in user ctx

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -182,12 +182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,7 +2188,6 @@ dependencies = [
 name = "firezone-telemetry"
 version = "0.1.0"
 dependencies = [
- "arc-swap",
  "sentry",
  "sentry-anyhow",
  "thiserror",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2013,6 +2013,7 @@ dependencies = [
  "firezone-headless-client",
  "firezone-logging",
  "firezone-telemetry",
+ "futures",
  "native-dialog",
  "nix 0.29.0",
  "rand 0.8.5",

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -350,6 +350,7 @@ fn connect(
 
     let mut telemetry = Telemetry::default();
     telemetry.start(&api_url, env!("CARGO_PKG_VERSION"), ANDROID_DSN);
+    telemetry.set_firezone_id(device_id.clone());
 
     let handle = init_logging(&PathBuf::from(log_dir), log_filter);
     install_rustls_crypto_provider();

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -348,7 +348,7 @@ fn connect(
     let device_info = string_from_jstring!(env, device_info);
     let device_info = serde_json::from_str(&device_info).unwrap();
 
-    let telemetry = Telemetry::default();
+    let mut telemetry = Telemetry::default();
     telemetry.start(&api_url, env!("CARGO_PKG_VERSION"), ANDROID_DSN);
 
     let handle = init_logging(&PathBuf::from(log_dir), log_filter);
@@ -469,7 +469,7 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_di
 ) {
     let session = session_ptr as *mut SessionWrapper;
     catch_and_throw(&mut env, |_| {
-        let session = Box::from_raw(session);
+        let mut session = Box::from_raw(session);
 
         session.runtime.block_on(session.telemetry.stop());
         session.inner.disconnect();

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -193,7 +193,7 @@ impl WrappedSession {
         callback_handler: ffi::CallbackHandler,
         device_info: String,
     ) -> Result<Self> {
-        let telemetry = Telemetry::default();
+        let mut telemetry = Telemetry::default();
         telemetry.start(&api_url, env!("CARGO_PKG_VERSION"), APPLE_DSN);
 
         let logger = init_logging(log_dir.into(), log_filter)?;
@@ -264,7 +264,7 @@ impl WrappedSession {
         self.inner.set_disabled_resources(disabled_resources)
     }
 
-    fn disconnect(self) {
+    fn disconnect(mut self) {
         self.runtime.block_on(self.telemetry.stop());
         self.inner.disconnect();
     }

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -195,6 +195,7 @@ impl WrappedSession {
     ) -> Result<Self> {
         let mut telemetry = Telemetry::default();
         telemetry.start(&api_url, env!("CARGO_PKG_VERSION"), APPLE_DSN);
+        telemetry.set_firezone_id(device_id.clone());
 
         let logger = init_logging(log_dir.into(), log_filter)?;
         install_rustls_crypto_provider();

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
         .expect("Calling `install_default` only once per process should always succeed");
 
     let cli = Cli::parse();
-    let telemetry = Telemetry::default();
+    let mut telemetry = Telemetry::default();
     if cli.is_telemetry_allowed() {
         telemetry.start(
             cli.api_url.as_str(),

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -53,17 +53,18 @@ async fn main() {
     //
     // By default, `anyhow` prints a stacktrace when it exits.
     // That looks like a "crash" but we "just" exit with a fatal error.
-    if let Err(e) = try_main(cli).await {
+    if let Err(e) = try_main(cli, &mut telemetry).await {
         tracing::error!(error = anyhow_dyn_err(&e));
         std::process::exit(1);
     }
 }
 
-async fn try_main(cli: Cli) -> Result<()> {
+async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
     firezone_logging::setup_global_subscriber(layer::Identity::default());
 
     let firezone_id = get_firezone_id(cli.firezone_id).await
         .context("Couldn't read FIREZONE_ID or write it to disk: Please provide it through the env variable or provide rw access to /var/lib/firezone/")?;
+    telemetry.set_firezone_id(firezone_id.clone());
 
     let login = LoginUrl::gateway(
         cli.api_url,

--- a/rust/gui-client/src-common/src/auth.rs
+++ b/rust/gui-client/src-common/src/auth.rs
@@ -73,9 +73,15 @@ pub(crate) struct Response {
 }
 
 #[derive(Default, Deserialize, Serialize)]
-pub(crate) struct Session {
+pub struct Session {
     pub(crate) account_slug: String,
     pub(crate) actor_name: String,
+}
+
+impl Session {
+    pub fn account_slug(&self) -> &str {
+        &self.account_slug
+    }
 }
 
 struct SessionAndToken {
@@ -118,7 +124,7 @@ impl Auth {
     }
 
     /// Returns the session iff we are signed in.
-    pub(crate) fn session(&self) -> Option<&Session> {
+    pub fn session(&self) -> Option<&Session> {
         match &self.state {
             State::SignedIn(x) => Some(x),
             State::NeedResponse(_) | State::SignedOut => None,
@@ -234,7 +240,6 @@ impl Auth {
         match std::fs::read_to_string(session_data_path()?) {
             Ok(x) => {
                 session = serde_json::from_str(&x).map_err(|_| Error::Serde)?;
-                firezone_telemetry::set_account_slug(session.account_slug.to_string());
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(Error::ReadFile(e)),

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -231,6 +231,11 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
             self.refresh_system_tray_menu()?;
         }
 
+        if let Some(session) = self.auth.session() {
+            self.telemetry
+                .set_account_slug(session.account_slug().to_owned());
+        }
+
         if !ran_before::get().await? {
             self.integration.set_welcome_window_visible(true)?;
         }

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -41,7 +41,7 @@ pub struct Controller<'a, I: GuiIntegration> {
     release: Option<updates::Release>,
     rx: mpsc::Receiver<ControllerRequest>,
     status: Status,
-    telemetry: &'a Telemetry,
+    telemetry: &'a mut Telemetry,
     updates_rx: mpsc::Receiver<Option<updates::Notification>>,
     uptime: crate::uptime::Tracker,
 }
@@ -52,7 +52,7 @@ pub struct Builder<'a, I: GuiIntegration> {
     pub integration: I,
     pub log_filter_reloader: LogFilterReloader,
     pub rx: mpsc::Receiver<ControllerRequest>,
-    pub telemetry: &'a Telemetry,
+    pub telemetry: &'a mut Telemetry,
     pub updates_rx: mpsc::Receiver<Option<updates::Notification>>,
 }
 

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -26,7 +26,7 @@ mod ran_before;
 
 pub type CtlrTx = mpsc::Sender<ControllerRequest>;
 
-pub struct Controller<I: GuiIntegration> {
+pub struct Controller<'a, I: GuiIntegration> {
     /// Debugging-only settings like API URL, auth URL, log filter
     advanced_settings: AdvancedSettings,
     // Sign-in state with the portal / deep links
@@ -41,23 +41,23 @@ pub struct Controller<I: GuiIntegration> {
     release: Option<updates::Release>,
     rx: mpsc::Receiver<ControllerRequest>,
     status: Status,
-    telemetry: Telemetry,
+    telemetry: &'a Telemetry,
     updates_rx: mpsc::Receiver<Option<updates::Notification>>,
     uptime: crate::uptime::Tracker,
 }
 
-pub struct Builder<I: GuiIntegration> {
+pub struct Builder<'a, I: GuiIntegration> {
     pub advanced_settings: AdvancedSettings,
     pub ctlr_tx: CtlrTx,
     pub integration: I,
     pub log_filter_reloader: LogFilterReloader,
     pub rx: mpsc::Receiver<ControllerRequest>,
-    pub telemetry: Telemetry,
+    pub telemetry: &'a Telemetry,
     pub updates_rx: mpsc::Receiver<Option<updates::Notification>>,
 }
 
-impl<I: GuiIntegration> Builder<I> {
-    pub async fn build(self) -> Result<Controller<I>> {
+impl<'a, I: GuiIntegration> Builder<'a, I> {
+    pub async fn build(self) -> Result<Controller<'a, I>> {
         let Builder {
             advanced_settings,
             ctlr_tx,
@@ -203,7 +203,7 @@ impl Status {
     }
 }
 
-impl<I: GuiIntegration> Controller<I> {
+impl<'a, I: GuiIntegration> Controller<'a, I> {
     pub async fn main_loop(mut self) -> Result<(), Error> {
         // Start telemetry
         {

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ firezone-gui-client-common = { path = "../src-common" }
 firezone-headless-client = { path = "../../headless-client" }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
+futures = "0.3.31"
 native-dialog = "0.7.0"
 rand = "0.8.5"
 rustls = { workspace = true }

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -61,7 +61,7 @@ pub(crate) fn run() -> Result<()> {
         Some(Cmd::SmokeTest) => {
             // Can't check elevation here because the Windows CI is always elevated
             let settings = common::settings::load_advanced_settings().unwrap_or_default();
-            let telemetry = telemetry::Telemetry::default();
+            let mut telemetry = telemetry::Telemetry::default();
             telemetry.start(
                 settings.api_url.as_ref(),
                 env!("CARGO_PKG_VERSION"),
@@ -92,7 +92,7 @@ pub(crate) fn run() -> Result<()> {
 // Can't `instrument` this because logging isn't running when we enter it.
 fn run_gui(cli: Cli) -> Result<()> {
     let mut settings = common::settings::load_advanced_settings().unwrap_or_default();
-    let telemetry = telemetry::Telemetry::default();
+    let mut telemetry = telemetry::Telemetry::default();
     // In the future telemetry will be opt-in per organization, that's why this isn't just at the top of `main`
     telemetry.start(
         settings.api_url.as_ref(),

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -123,7 +123,7 @@ pub(crate) fn run(
     cli: client::Cli,
     advanced_settings: AdvancedSettings,
     reloader: LogFilterReloader,
-    telemetry: telemetry::Telemetry,
+    mut telemetry: telemetry::Telemetry,
 ) -> Result<(), Error> {
     // Needed for the deep link server
     let rt = tokio::runtime::Runtime::new().context("Couldn't start Tokio runtime")?;
@@ -245,7 +245,7 @@ pub(crate) fn run(
                         ctlr_rx,
                         advanced_settings,
                         reloader,
-                        &telemetry,
+                        &mut telemetry,
                         updates_rx,
                     )).catch_unwind().await;
 
@@ -476,7 +476,7 @@ async fn run_controller(
     rx: mpsc::Receiver<ControllerRequest>,
     advanced_settings: AdvancedSettings,
     log_filter_reloader: LogFilterReloader,
-    telemetry: &telemetry::Telemetry,
+    telemetry: &mut telemetry::Telemetry,
     updates_rx: mpsc::Receiver<Option<updates::Notification>>,
 ) -> Result<(), Error> {
     tracing::debug!("Entered `run_controller`");

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -245,7 +245,7 @@ pub(crate) fn run(
                         ctlr_rx,
                         advanced_settings,
                         reloader,
-                        telemetry.clone(),
+                        &telemetry,
                         updates_rx,
                     )).catch_unwind().await;
 
@@ -476,7 +476,7 @@ async fn run_controller(
     rx: mpsc::Receiver<ControllerRequest>,
     advanced_settings: AdvancedSettings,
     log_filter_reloader: LogFilterReloader,
-    telemetry: telemetry::Telemetry,
+    telemetry: &telemetry::Telemetry,
     updates_rx: mpsc::Receiver<Option<updates::Notification>>,
 ) -> Result<(), Error> {
     tracing::debug!("Entered `run_controller`");

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -211,7 +211,7 @@ fn run_smoke_test() -> Result<()> {
             &mut server,
             &mut dns_controller,
             &log_filter_reloader,
-            telemetry,
+            &telemetry,
         )
         .await?
         .run(&mut signals)
@@ -253,7 +253,7 @@ async fn ipc_listen(
             &mut server,
             &mut dns_controller,
             log_filter_reloader,
-            telemetry.clone(),
+            &telemetry,
         ));
         let Some(handler) = poll_fn(|cx| {
             if let Poll::Ready(()) = signals.poll_recv(cx) {
@@ -285,7 +285,7 @@ struct Handler<'a> {
     last_connlib_start_instant: Option<Instant>,
     log_filter_reloader: &'a LogFilterReloader,
     session: Option<Session>,
-    telemetry: Telemetry, // Handle to the sentry.io telemetry module
+    telemetry: &'a Telemetry, // Handle to the sentry.io telemetry module
     tun_device: TunDeviceManager,
 }
 
@@ -316,7 +316,7 @@ impl<'a> Handler<'a> {
         server: &mut IpcServer,
         dns_controller: &'a mut DnsController,
         log_filter_reloader: &'a LogFilterReloader,
-        telemetry: Telemetry,
+        telemetry: &'a Telemetry,
     ) -> Result<Self> {
         dns_controller.deactivate()?;
         let (ipc_rx, ipc_tx) = server

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -128,7 +128,7 @@ fn main() -> Result<()> {
     // and we need to recover. <https://github.com/firezone/firezone/issues/4899>
     dns_controller.deactivate()?;
 
-    let telemetry = Telemetry::default();
+    let mut telemetry = Telemetry::default();
     telemetry.start(
         cli.api_url.as_ref(),
         VERSION,

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -20,7 +20,6 @@ use phoenix_channel::LoginUrl;
 use phoenix_channel::PhoenixChannel;
 use secrecy::{Secret, SecretString};
 use std::{
-    collections::BTreeMap,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -175,15 +174,7 @@ fn main() -> Result<()> {
         Some(id) => id,
         None => device_id::get_or_create().context("Could not get `firezone_id` from CLI, could not read it from disk, could not generate it and save it to disk")?.id,
     };
-    firezone_telemetry::configure_scope(|scope| {
-        scope.set_context(
-            "firezone",
-            firezone_telemetry::Context::Other(BTreeMap::from([(
-                "id".to_string(),
-                firezone_id.clone().into(),
-            )])),
-        )
-    });
+    telemetry.set_firezone_id(firezone_id.clone());
 
     let url = LoginUrl::client(
         cli.api_url,

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-arc-swap = "1.7.1"
 sentry = { version = "0.34.0", default-features = false, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing"] }
 sentry-anyhow = "0.34.0"
 tokio = { workspace = true, features = ["rt"] }

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -39,14 +39,6 @@ pub struct Telemetry {
     inner: ArcSwapOption<sentry::ClientInitGuard>,
 }
 
-impl Clone for Telemetry {
-    fn clone(&self) -> Self {
-        Self {
-            inner: ArcSwapOption::new(self.inner.load().clone()),
-        }
-    }
-}
-
 impl Telemetry {
     pub fn start(&self, api_url: &str, release: &str, dsn: Dsn) {
         // Since it's `arc_swap` and not `Option`, there is a TOCTOU here,

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
 pub use sentry::{
-    add_breadcrumb, capture_error, capture_message, configure_scope, end_session,
-    end_session_with_status,
+    add_breadcrumb, capture_error, capture_message, end_session, end_session_with_status,
     types::protocol::v7::{Context, SessionStatus},
     Breadcrumb, Hub, Level,
 };
@@ -38,6 +37,7 @@ pub struct Telemetry {
     inner: Option<sentry::ClientInitGuard>,
 
     account_slug: Option<String>,
+    firezone_id: Option<String>,
 }
 
 impl Telemetry {
@@ -114,12 +114,22 @@ impl Telemetry {
         self.update_user_context();
     }
 
+    pub fn set_firezone_id(&mut self, id: String) {
+        self.firezone_id = Some(id);
+        self.update_user_context();
+    }
+
     fn update_user_context(&self) {
         let mut user = sentry::User::default();
 
         if let Some(account_slug) = self.account_slug.clone() {
             user.other
                 .insert("account_slug".to_string(), account_slug.into());
+        }
+
+        if let Some(firezone_id) = self.firezone_id.clone() {
+            user.other
+                .insert("firezone_id".to_string(), firezone_id.into());
         }
 
         sentry::Hub::main().configure_scope(|scope| scope.set_user(Some(user)));

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -120,17 +120,16 @@ impl Telemetry {
     }
 
     fn update_user_context(&self) {
-        let mut user = sentry::User::default();
+        let mut user = sentry::User {
+            id: self.firezone_id.clone(),
+            ..Default::default()
+        };
 
-        if let Some(account_slug) = self.account_slug.clone() {
-            user.other
-                .insert("account_slug".to_string(), account_slug.into());
-        }
-
-        if let Some(firezone_id) = self.firezone_id.clone() {
-            user.other
-                .insert("firezone_id".to_string(), firezone_id.into());
-        }
+        user.other.extend(
+            self.account_slug
+                .clone()
+                .map(|slug| ("account_slug".to_owned(), slug.into())),
+        );
 
         sentry::Hub::main().configure_scope(|scope| scope.set_user(Some(user)));
     }


### PR DESCRIPTION
Sentry has a feature called the "User context" which allows us to assign events to individual users. This in turn will give us statistics in Sentry, how many users are affected by a certain issue.

Unfortunately, Sentry's user context cannot be built-up step-by-step but has to be set as a whole. To achieve this, we need to slightly refactor `Telemetry` to not be `clone`d and instead passed around by mutable reference.

Resolves: #7248.
Related: https://github.com/getsentry/sentry-rust/issues/706.