### PR TITLE
refactor(gui-client): reduce warning to debug

### DIFF
--- a/rust/gui-client/src-common/src/deep_link/windows.rs
+++ b/rust/gui-client/src-common/src/deep_link/windows.rs
@@ -70,7 +70,7 @@ async fn bind_to_pipe(pipe_path: &str) -> Result<named_pipe::NamedPipeServer, su
         match create_pipe_server(pipe_path) {
             Ok(server) => return Ok(server),
             Err(e) => {
-                tracing::warn!(
+                tracing::debug!(
                     error = std_dyn_err(&e),
                     "`create_pipe_server` failed, sleeping... (attempt {i}/{NUM_ITERS})"
                 );


### PR DESCRIPTION
Windows has some funny behaviour where creating the deep-link server sometimes fails and we have to try again. Currently, each of these operations is logged as a warning when it would actually succeed later. These create unnecessary Sentry alerts.

If we run out of attempts to create the deep-link server (currently 10), the entire function fails which will be logged as an error further down. The last 500 INFO and DEBUG logs will be captured as breadcrumbs together with the event, meaning we still get to see those error messages on why it failed to create the deep-link server.

Resolves: #7238.