### PR TITLE
chore(gui-client): downgrade warning to debug

### DIFF
--- a/rust/headless-client/src/ipc_service/ipc.rs
+++ b/rust/headless-client/src/ipc_service/ipc.rs
@@ -145,11 +145,9 @@ pub async fn connect_to_service(id: ServiceId) -> Result<(ClientRead, ClientWrit
                 return Ok((rx, tx));
             }
             Err(error) => {
-                tracing::debug!(
-                    error = std_dyn_err(&error),
-                    "Couldn't connect to IPC service, will sleep and try again"
-                );
+                tracing::debug!("Couldn't connect to IPC service: {error}");
                 last_err = Some(error);
+
                 // This won't come up much for humans but it helps the automated
                 // tests pass
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/rust/headless-client/src/ipc_service/ipc.rs
+++ b/rust/headless-client/src/ipc_service/ipc.rs
@@ -1,6 +1,5 @@
 use crate::{IpcClientMsg, IpcServerMsg};
 use anyhow::{Context as _, Result};
-use firezone_logging::std_dyn_err;
 use tokio::io::{ReadHalf, WriteHalf};
 use tokio_util::{
     bytes::BytesMut,
@@ -275,5 +274,12 @@ mod tests {
             }
         }
         Ok(())
+    }
+
+    #[test]
+    fn error_logs_all_anyhow_sources_on_display() {
+        let err = Error::Other(anyhow::anyhow!("foo").context("bar").context("baz"));
+
+        assert_eq!(err.to_string(), "baz: bar: foo");
     }
 }

--- a/rust/headless-client/src/ipc_service/ipc.rs
+++ b/rust/headless-client/src/ipc_service/ipc.rs
@@ -145,7 +145,7 @@ pub async fn connect_to_service(id: ServiceId) -> Result<(ClientRead, ClientWrit
                 return Ok((rx, tx));
             }
             Err(error) => {
-                tracing::warn!(
+                tracing::debug!(
                     error = std_dyn_err(&error),
                     "Couldn't connect to IPC service, will sleep and try again"
                 );

--- a/rust/headless-client/src/ipc_service/ipc.rs
+++ b/rust/headless-client/src/ipc_service/ipc.rs
@@ -33,7 +33,7 @@ pub enum Error {
     #[error("Permission denied")]
     PermissionDenied,
 
-    #[error(transparent)]
+    #[error("{0:#}")] // Use alternate display here to log entire chain of errors.
     Other(anyhow::Error),
 }
 


### PR DESCRIPTION
With a retry-mechanism in place, there is no need to log a warning when `connect_to_service` fails. Instead, we just log this as on DEBUG and continue trying. If it fails after all attempts, the entire function will bail out and we will receive a Sentry event from error handling higher up the callstack.