### PR TITLE
test(connlib): drain all `Transmit`s at the end of `advance`

### DIFF
--- a/rust/connlib/tunnel/src/tests/buffered_transmits.rs
+++ b/rust/connlib/tunnel/src/tests/buffered_transmits.rs
@@ -89,6 +89,12 @@ impl BufferedTransmits {
         Some(next.value)
     }
 
+    pub(crate) fn drain(&mut self) -> impl Iterator<Item = (Transmit<'static>, Instant)> + '_ {
+        self.inner
+            .drain()
+            .map(|Reverse(ByTime { at, value })| (value, at))
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -492,7 +492,7 @@ impl TunnelTest {
             });
 
             if let Some(transmit) = buffered_transmits.pop(now) {
-                self.dispatch_transmit(transmit);
+                self.dispatch_transmit(transmit, now);
                 continue;
             }
 
@@ -510,6 +510,10 @@ impl TunnelTest {
             }
 
             self.flux_capacitor.large_tick(); // Large tick to more quickly advance to potential next timeout.
+        }
+
+        for (transmit, at) in buffered_transmits.drain() {
+            self.dispatch_transmit(transmit, at);
         }
     }
 
@@ -619,12 +623,11 @@ impl TunnelTest {
     /// It takes a [`Transmit`] and checks, which host accepts it, i.e. has configured the correct IP address.
     ///
     /// Currently, the network topology of our tests are a single subnet without NAT.
-    fn dispatch_transmit(&mut self, transmit: Transmit<'static>) {
+    fn dispatch_transmit(&mut self, transmit: Transmit<'static>, at: Instant) {
         let src = transmit
             .src
             .expect("`src` should always be set in these tests");
         let dst = transmit.dst;
-        let now = self.flux_capacitor.now();
 
         let Some(host) = self.network.host_by_ip(dst.ip()) else {
             tracing::error!("Unhandled packet: {src} -> {dst}");
@@ -641,7 +644,7 @@ impl TunnelTest {
                     return;
                 }
 
-                self.client.receive(transmit, now);
+                self.client.receive(transmit, at);
             }
             HostId::Gateway(id) => {
                 if self.drop_direct_client_traffic && self.client.is_sender(src.ip()) {
@@ -653,13 +656,13 @@ impl TunnelTest {
                 self.gateways
                     .get_mut(&id)
                     .expect("unknown gateway")
-                    .receive(transmit, now);
+                    .receive(transmit, at);
             }
             HostId::Relay(id) => {
                 self.relays
                     .get_mut(&id)
                     .expect("unknown relay")
-                    .receive(transmit, now);
+                    .receive(transmit, at);
             }
             HostId::Stale => {
                 tracing::debug!(%dst, "Dropping packet because host roamed away or is offline");


### PR DESCRIPTION
Within our test suite, we "spin" for several (simulated) seconds after each state transition to allow for packets being sent between the different nodes. The test suite simulates different latencies by delaying the delivery of some of these packets.

`connlib` has several timers for sending packets, i.e. STUN bindings, WG keep-alives etc. These timers never end so we cannot simply spin "until we no longer want to send any packets". Currently, we simply hard-stop after a few seconds and drop the remaining packets and move on to the next state transition.

At present, this isn't an issue because only our ICE agent adheres to the simulated time advancement. `boringtun` is still impure and thus we usually don't get to see any of the WireGuard packets like keep-alives and session timeouts etc in our tests. The STUN messages are pretty resilient to retransmissions so the current packet drop doesn't matter.

In the process of adopting our boringtun fork (https://github.com/firezone/boringtun) where we will eventually fix the time impurity, dropping some of these packets caused problems.

To fix this, we now drain all remaining packets that are sitting in the "yet-to-be-delivered" buffer. These packets are delivered to an "inbox" that is per-host, meaning the host (i.e. client, gateway or relay) will still perceive the incoming packet with the correct latency.

We extract this functionality from #7120 because it is generally useful.