### PR TITLE
fix(website): remove duplicate tailwind rule

### DIFF
--- a/website/src/app/pricing/plan_table.tsx
+++ b/website/src/app/pricing/plan_table.tsx
@@ -636,7 +636,7 @@ export default function PlanTable() {
             <Link href="https://app.firezone.dev/sign_up">
               <button
                 type="button"
-                className="md:text-lg md:py-2.5 text-sm sm:px-5 px-2.5 py-1.5 text-primary-450 font-semibold tracking-tight rounded duration-50 hover:ring-2 transition transform shadow-lg border border-primary-450 hover:ring-2 hover:ring-primary-200"
+                className="md:text-lg md:py-2.5 text-sm sm:px-5 px-2.5 py-1.5 text-primary-450 font-semibold tracking-tight rounded duration-50 hover:ring-2 transition transform shadow-lg border border-primary-450 hover:ring-primary-200"
               >
                 Sign up
               </button>
@@ -646,7 +646,7 @@ export default function PlanTable() {
             <Link href="https://app.firezone.dev/sign_up">
               <button
                 type="button"
-                className="md:text-lg md:py-2.5 text-sm sm:px-5 px-2.5 py-1.5 text-primary-450 font-semibold tracking-tight rounded duration-50 hover:ring-2 transition transform shadow-lg border border-primary-450 hover:ring-2 hover:ring-primary-200"
+                className="md:text-lg md:py-2.5 text-sm sm:px-5 px-2.5 py-1.5 text-primary-450 font-semibold tracking-tight rounded duration-50 hover:ring-2 transition transform shadow-lg border border-primary-450 hover:ring-primary-200"
               >
                 Sign up
               </button>


### PR DESCRIPTION
My editor complained that the `hover:ring-2` class was applied twice for these elements.