### PR TITLE
chore(rust): don't pass errors as values for debug logs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2131,6 +2131,7 @@ dependencies = [
  "nu-ansi-term 0.50.1",
  "rand 0.8.5",
  "sentry-tracing",
+ "thiserror",
  "time",
  "tracing",
  "tracing-appender",

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use ::backoff::backoff::Backoff;
 use bytecodec::{DecodeExt as _, EncodeExt as _};
-use firezone_logging::std_dyn_err;
+use firezone_logging::{err_with_sources, std_dyn_err};
 use hex_display::HexDisplayExt as _;
 use rand::random;
 use std::{
@@ -1227,7 +1227,7 @@ impl ChannelBindings {
     fn try_decode<'p>(&mut self, packet: &'p [u8], now: Instant) -> Option<(SocketAddr, &'p [u8])> {
         let (channel_number, payload) = crate::channel_data::decode(packet)
             .inspect_err(|e| {
-                tracing::debug!(error = std_dyn_err(e), "Malformed channel data message")
+                tracing::debug!("Malformed channel data message: {}", err_with_sources(e))
             })
             .ok()?;
         let Some(channel) = self.inner.get_mut(&channel_number) else {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -9,7 +9,7 @@ use boringtun::noise::{Tunn, TunnResult};
 use boringtun::x25519::PublicKey;
 use boringtun::{noise::rate_limiter::RateLimiter, x25519::StaticSecret};
 use core::fmt;
-use firezone_logging::std_dyn_err;
+use firezone_logging::err_with_sources;
 use hex_display::HexDisplayExt;
 use ip_packet::{
     ConvertibleIpv4Packet, ConvertibleIpv6Packet, IpPacket, IpPacketBuf, MAX_DATAGRAM_PAYLOAD,
@@ -336,7 +336,7 @@ where
         let candidate = match Candidate::from_sdp_string(&candidate) {
             Ok(c) => c,
             Err(e) => {
-                tracing::debug!(error = std_dyn_err(&e), "Failed to parse candidate");
+                tracing::debug!("Failed to parse candidate: {}", err_with_sources(&e));
                 return;
             }
         };
@@ -372,7 +372,7 @@ where
         let candidate = match Candidate::from_sdp_string(&candidate) {
             Ok(c) => c,
             Err(e) => {
-                tracing::debug!(error = std_dyn_err(&e), "Failed to parse candidate");
+                tracing::debug!("Failed to parse candidate: {}", err_with_sources(&e));
                 return;
             }
         };

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -1,6 +1,6 @@
 use crate::{device_channel::Device, dns, sockets::Sockets};
 use domain::base::Message;
-use firezone_logging::{std_dyn_err, telemetry_span};
+use firezone_logging::{err_with_sources, std_dyn_err, telemetry_span};
 use futures::{
     future::{self, Either},
     stream, Stream, StreamExt,
@@ -352,7 +352,7 @@ async fn tun_send_recv(
         {
             Either::Left((Some(Command::SendPacket(p)), _)) => {
                 if let Err(e) = device.write(p) {
-                    tracing::debug!(error = std_dyn_err(&e), "Failed to write TUN packet");
+                    tracing::debug!("Failed to write TUN packet: {}", err_with_sources(&e));
                 };
             }
             Either::Left((Some(Command::UpdateTun(tun)), _)) => {

--- a/rust/dns-over-tcp/src/server.rs
+++ b/rust/dns-over-tcp/src/server.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use anyhow::{Context as _, Result};
 use domain::{base::Message, dep::octseq::OctetsInto as _};
-use firezone_logging::anyhow_dyn_err;
 use ip_packet::IpPacket;
 use smoltcp::{
     iface::{Interface, PollResult, SocketSet},
@@ -188,7 +187,7 @@ impl Server {
                         });
                     }
                     Err(e) => {
-                        tracing::debug!(error = anyhow_dyn_err(&e), "Error on receiving DNS query");
+                        tracing::debug!("Error on receiving DNS query: {e:#}");
                         socket.abort();
                         break;
                     }

--- a/rust/logging/Cargo.toml
+++ b/rust/logging/Cargo.toml
@@ -18,5 +18,8 @@ tracing-log = "0.2"
 tracing-stackdriver = { version = "0.11.0" }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
+[dev-dependencies]
+thiserror = "1"
+
 [lints]
 workspace = true

--- a/rust/logging/src/err_with_sources.rs
+++ b/rust/logging/src/err_with_sources.rs
@@ -1,10 +1,9 @@
 use core::fmt;
 use std::error::Error;
 
-pub fn err_with_sources(e: &(impl Error + 'static)) -> ErrorWithSources<'_> {
-    ErrorWithSources {
-        e: e as &(dyn Error + 'static),
-    }
+/// Returns a [`fmt::Display`] adapter that prints the error and all its sources.
+pub fn err_with_sources<'a>(e: &'a (dyn Error + 'static)) -> ErrorWithSources<'a> {
+    ErrorWithSources { e }
 }
 
 pub struct ErrorWithSources<'a> {

--- a/rust/logging/src/err_with_sources.rs
+++ b/rust/logging/src/err_with_sources.rs
@@ -1,0 +1,50 @@
+use core::fmt;
+use std::error::Error;
+
+pub fn err_with_sources(e: &(impl Error + 'static)) -> ErrorWithSources<'_> {
+    ErrorWithSources {
+        e: e as &(dyn Error + 'static),
+    }
+}
+
+pub struct ErrorWithSources<'a> {
+    e: &'a (dyn Error + 'static),
+}
+
+impl<'a> fmt::Display for ErrorWithSources<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.e)?;
+
+        for cause in anyhow::Chain::new(self.e).skip(1) {
+            write!(f, ": {}", cause)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prints_errors_with_sources() {
+        let error = Error3(Error2(Error1));
+
+        let display = err_with_sources(&error);
+
+        assert_eq!(display.to_string(), "Argh: Failed to do the thing: oh no!");
+    }
+
+    #[derive(thiserror::Error, Debug)]
+    #[error("oh no!")]
+    struct Error1;
+
+    #[derive(thiserror::Error, Debug)]
+    #[error("Failed to do the thing")]
+    struct Error2(#[source] Error1);
+
+    #[derive(thiserror::Error, Debug)]
+    #[error("Argh")]
+    struct Error3(#[source] Error2);
+}

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -3,6 +3,7 @@ pub mod file;
 mod format;
 #[macro_use]
 mod unwrap_or;
+mod err_with_sources;
 
 use sentry_tracing::EventFilter;
 use tracing::{subscriber::DefaultGuard, Subscriber};

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -14,6 +14,7 @@ use tracing_subscriber::{
 };
 
 pub use dyn_err::{anyhow_dyn_err, std_dyn_err};
+pub use err_with_sources::{err_with_sources, ErrorWithSources};
 pub use format::Format;
 
 /// Registers a global subscriber with stdout logging and `additional_layer`

--- a/rust/logging/src/unwrap_or.rs
+++ b/rust/logging/src/unwrap_or.rs
@@ -26,7 +26,7 @@ macro_rules! unwrap_or_debug {
             Err(e) => {
                 let error: &dyn ::std::error::Error = e.as_ref();
 
-                ::tracing::debug!(error, $($arg)*)
+                ::tracing::debug!($($arg)*, $crate::err_with_sources(error))
             }
         }
     };
@@ -43,7 +43,7 @@ macro_rules! unwrap_or_trace {
             Err(e) => {
                 let error: &dyn ::std::error::Error = e.as_ref();
 
-                ::tracing::debug!(error, $($arg)*)
+                ::tracing::debug!($($arg)*, $crate::err_with_sources(error))
             }
         }
     };

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -13,7 +13,7 @@ use std::{io, mem};
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
 use base64::Engine;
-use firezone_logging::{std_dyn_err, telemetry_span};
+use firezone_logging::{err_with_sources, std_dyn_err, telemetry_span};
 use futures::future::BoxFuture;
 use futures::{FutureExt, SinkExt, StreamExt};
 use heartbeat::{Heartbeat, MissedLastHeartbeat};
@@ -415,7 +415,7 @@ where
                         let socket_factory = self.socket_factory.clone();
                         let socket_addresses = self.socket_addresses();
 
-                        tracing::debug!(error = std_dyn_err(&e), ?backoff, max_elapsed_time = ?self.reconnect_backoff.max_elapsed_time, "Reconnecting to portal on transient client error");
+                        tracing::debug!(?backoff, max_elapsed_time = ?self.reconnect_backoff.max_elapsed_time, "Reconnecting to portal on transient client error: {}", err_with_sources(&e));
 
                         self.state = State::Connecting(Box::pin(async move {
                             tokio::time::sleep(backoff).await;


### PR DESCRIPTION
Our logging library `tracing` supports structured logging. Structured logging means we can include values within a `tracing::Event` without having to immediately format it as a string. Processing these values - such as errors - as their original type allows the various `tracing` layers to capture and represent them as they see fit.

One of these layers is responsible for sending ERROR and WARN events to Sentry, as part of which `std::error::Error` values get automatically captured as so-called "sentry exceptions".

Unfortunately, there is a caveat: If an `std::error::Error` value is included in an event that does not get mapped to an exception, the `error` field is completely lost. See https://github.com/getsentry/sentry-rust/issues/702 for details.

To work around this, we introduce a `err_with_sources` adapter that an error and all its sources together into a string. For all `tracing::debug!` statements, we then use this to report these errors.

It is really unfortunate that we have to do this and cannot use the same mechanism, regardless of the log level. However, until this is fixed upstream, this will do and gives us better information in the log submitted to Sentry.