### PR TITLE
chore(rust): ban the use of `.unwrap` except in tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2175,6 +2175,7 @@ dependencies = [
  "socket2",
  "stun_codec",
  "test-strategy",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-core",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -71,6 +71,7 @@ wildcard_enum_match_arm = "warn" # Ensures we match on all combinations of `Poll
 redundant_else = "warn"
 redundant_clone = "warn"
 unwrap_in_result = "warn"
+unwrap_used = "warn"
 
 [workspace.lints.rustdoc]
 private-intra-doc-links = "allow" # We don't publish any of our docs but want to catch dead links.

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -11,6 +11,7 @@ axum = { version = "0.7.7", default-features = false, features = ["http1", "toki
 clap = { version = "4.5.19", features = ["derive", "env"] }
 firezone-logging = { workspace = true }
 futures = "0.3"
+hex-literal = "0.4.1"
 ip_network = { version = "0.4", default-features = false, features = ["serde"] }
 socket-factory = { workspace = true }
 thiserror = "1.0.68"
@@ -19,7 +20,6 @@ tracing = { workspace = true }
 tun = { workspace = true }
 
 [dev-dependencies]
-hex-literal = "0.4.1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/rust/bin-shared/benches/tunnel.rs
+++ b/rust/bin-shared/benches/tunnel.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use anyhow::Result;
 
 fn main() -> Result<()> {

--- a/rust/bin-shared/src/lib.rs
+++ b/rust/bin-shared/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 pub mod http_health_check;
 
 mod network_changes;

--- a/rust/bin-shared/src/network_changes/windows.rs
+++ b/rust/bin-shared/src/network_changes/windows.rs
@@ -64,6 +64,7 @@
 
 use crate::platform::DnsControlMethod;
 use anyhow::{anyhow, Context as _, Result};
+use firezone_logging::anyhow_dyn_err;
 use std::thread;
 use tokio::sync::{
     mpsc::{self, error::TrySendError},
@@ -257,7 +258,12 @@ impl<'a> Drop for Listener<'a> {
     // we crash the GUI process before we can get back to the main thread
     // and drop the DNS listeners
     fn drop(&mut self) {
-        self.close_dont_drop().unwrap();
+        if let Err(e) = self.close_dont_drop() {
+            tracing::error!(
+                error = anyhow_dyn_err(&e),
+                "Failed to close `Listener` gracefully"
+            );
+        }
     }
 }
 

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -438,7 +438,7 @@ fn dll_already_exists(path: &Path, dll_bytes: &DllBytes) -> bool {
         return false;
     }
 
-    let expected = ring::test::from_hex(dll_bytes.expected_sha256).unwrap();
+    let expected = dll_bytes.expected_sha256;
     let actual = digest::digest(&digest::SHA256, &buf);
     expected == actual.as_ref()
 }
@@ -457,14 +457,16 @@ struct DllBytes {
     /// Bytes embedded in the client with `include_bytes`
     pub bytes: &'static [u8],
     /// Expected SHA256 hash
-    pub expected_sha256: &'static str,
+    pub expected_sha256: [u8; 32],
 }
 
 #[cfg(target_arch = "x86_64")]
 fn wintun_bytes() -> DllBytes {
     DllBytes {
         bytes: include_bytes!("../wintun/bin/amd64/wintun.dll"),
-        expected_sha256: "e5da8447dc2c320edc0fc52fa01885c103de8c118481f683643cacc3220dafce",
+        expected_sha256: hex_literal::hex!(
+            "e5da8447dc2c320edc0fc52fa01885c103de8c118481f683643cacc3220dafce"
+        ),
     }
 }
 
@@ -472,6 +474,8 @@ fn wintun_bytes() -> DllBytes {
 fn wintun_bytes() -> DllBytes {
     DllBytes {
         bytes: include_bytes!("../wintun/bin/arm64/wintun.dll"),
-        expected_sha256: "f7ba89005544be9d85231a9e0d5f23b2d15b3311667e2dad0debd344918a3f80",
+        expected_sha256: hex_literal::hex!(
+            "f7ba89005544be9d85231a9e0d5f23b2d15b3311667e2dad0debd344918a3f80"
+        ),
     }
 }

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -1,7 +1,7 @@
 use crate::windows::{CREATE_NO_WINDOW, TUNNEL_UUID};
 use crate::TUNNEL_NAME;
 use anyhow::{Context as _, Result};
-use firezone_logging::std_dyn_err;
+use firezone_logging::{anyhow_dyn_err, std_dyn_err};
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ring::digest;
 use std::{
@@ -426,7 +426,19 @@ fn dll_already_exists(path: &Path, dll_bytes: &DllBytes) -> bool {
         Ok(x) => x,
     };
 
-    let actual_len = usize::try_from(f.metadata().unwrap().len()).unwrap();
+    let actual_len = match file_length(&f) {
+        Err(e) => {
+            tracing::warn!(
+                error = anyhow_dyn_err(&e),
+                path = %path.display(),
+                "Failed to get file length"
+            );
+
+            return false;
+        }
+        Ok(l) => l,
+    };
+
     let expected_len = dll_bytes.bytes.len();
     // If the dll is 100 MB instead of 0.5 MB, this allows us to skip a 100 MB read
     if actual_len != expected_len {
@@ -441,6 +453,13 @@ fn dll_already_exists(path: &Path, dll_bytes: &DllBytes) -> bool {
     let expected = dll_bytes.expected_sha256;
     let actual = digest::digest(&digest::SHA256, &buf);
     expected == actual.as_ref()
+}
+
+fn file_length(f: &std::fs::File) -> Result<usize> {
+    let len = f.metadata().context("Failed to read metadata")?.len();
+    let len = usize::try_from(len).context("File length doesn't fit into usize")?;
+
+    Ok(len)
 }
 
 /// Returns the absolute path for installing and loading `wintun.dll`

--- a/rust/bin-shared/tests/network_notifiers.rs
+++ b/rust/bin-shared/tests/network_notifiers.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use firezone_bin_shared::{new_dns_notifier, new_network_notifier, platform::DnsControlMethod};
 use futures::future::FutureExt as _;
 use std::time::Duration;

--- a/rust/connlib/model/src/lib.rs
+++ b/rust/connlib/model/src/lib.rs
@@ -3,6 +3,8 @@
 //! This includes types provided by external crates, i.e. [boringtun] to make sure that
 //! we are using the same version across our own crates.
 
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 mod view;
 
 pub use boringtun::x25519::PublicKey;

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -225,7 +225,8 @@ impl Allocation {
             channel_bindings: Default::default(),
             last_now: now,
             buffered_channel_bindings: RingBuffer::new(100),
-            software: Software::new(format!("snownet; session={session_id}")).unwrap(),
+            software: Software::new(format!("snownet; session={session_id}"))
+                .expect("description has less then 128 chars"),
         };
 
         allocation.send_binding_requests();
@@ -1119,7 +1120,7 @@ fn make_channel_bind_request(
     );
 
     message.add_attribute(XorPeerAddress::new(target));
-    message.add_attribute(ChannelNumber::new(channel).unwrap());
+    message.add_attribute(ChannelNumber::new(channel).expect("channel number out of range")); // Panic is fine here, because we control the channel number within this module.
     message.add_attribute(software);
 
     message

--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -1,6 +1,7 @@
 //! A SANS-IO connectivity library for wireguard connections formed by ICE.
 
 #![cfg_attr(test, allow(clippy::unwrap_in_result))]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod allocation;
 mod backoff;

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -34,8 +34,10 @@ pub(crate) const DNS_PORT: u16 = 53;
 /// For Chrome and other Chrome-based browsers, this is not required as
 /// Chrome will automatically disable DoH if your server(s) don't support
 /// it. See <https://www.chromium.org/developers/dns-over-https/#faq>.
-static DOH_CANARY_DOMAIN: LazyLock<DomainName> =
-    LazyLock::new(|| DomainName::vec_from_str("use-application-dns.net").unwrap());
+static DOH_CANARY_DOMAIN: LazyLock<DomainName> = LazyLock::new(|| {
+    DomainName::vec_from_str("use-application-dns.net")
+        .expect("static domain name should always parse")
+});
 
 pub struct StubResolver {
     fqdn_to_ips: HashMap<DomainName, Vec<IpAddr>>,
@@ -797,6 +799,7 @@ mod tests {
 }
 
 #[cfg(feature = "divan")]
+#[allow(clippy::unwrap_used)]
 mod benches {
     use super::*;
     use rand::{distributions::DistString, seq::IteratorRandom, Rng};

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -3,6 +3,8 @@
 //! This is both the wireguard and ICE implementation that should work in tandem.
 //! [Tunnel] is the main entry-point for this crate.
 
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 use crate::messages::{Offer, ResolveRequest, SecretKey};
 use bimap::BiMap;
 use chrono::Utc;

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -60,7 +60,7 @@ async fn main() {
 }
 
 async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
-    firezone_logging::setup_global_subscriber(layer::Identity::default());
+    firezone_logging::setup_global_subscriber(layer::Identity::default())?;
 
     let firezone_id = get_firezone_id(cli.firezone_id).await
         .context("Couldn't read FIREZONE_ID or write it to disk: Please provide it through the env variable or provide rw access to /var/lib/firezone/")?;
@@ -109,7 +109,7 @@ async fn get_firezone_id(env_id: Option<String>) -> Result<String> {
     }
 
     let id_path = Path::new(ID_PATH);
-    tokio::fs::create_dir_all(id_path.parent().unwrap()).await?;
+    tokio::fs::create_dir_all(id_path.parent().context("Missing parent")?).await?;
     let mut id_file = tokio::fs::File::create(id_path).await?;
     let id = Uuid::new_v4().to_string();
     id_file.write_all(id.as_bytes()).await?;

--- a/rust/gui-client/src-common/src/lib.rs
+++ b/rust/gui-client/src-common/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 pub mod auth;
 pub mod compositor;
 pub mod controller;

--- a/rust/gui-client/src-common/src/settings.rs
+++ b/rust/gui-client/src-common/src/settings.rs
@@ -38,8 +38,8 @@ mod defaults {
 impl Default for AdvancedSettings {
     fn default() -> Self {
         Self {
-            auth_base_url: Url::parse(defaults::AUTH_BASE_URL).unwrap(),
-            api_url: Url::parse(defaults::API_URL).unwrap(),
+            auth_base_url: Url::parse(defaults::AUTH_BASE_URL).expect("static URL is a valid URL"),
+            api_url: Url::parse(defaults::API_URL).expect("static URL is a valid URL"),
             favorite_resources: Default::default(),
             internet_resource_enabled: Default::default(),
             log_filter: defaults::LOG_FILTER.to_string(),

--- a/rust/gui-client/src-tauri/src/client/debug_commands.rs
+++ b/rust/gui-client/src-tauri/src/client/debug_commands.rs
@@ -34,7 +34,7 @@ pub fn run(cmd: Cmd) -> Result<()> {
 
 fn set_autostart(enabled: bool) -> Result<()> {
     firezone_headless_client::setup_stdout_logging()?;
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(crate::client::gui::set_autostart(enabled))?;
     Ok(())
 }

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -150,7 +150,9 @@ pub(crate) fn run(
                 // Per https://tauri.app/v1/guides/features/system-tray/#preventing-the-app-from-closing
                 // Closing the window fully seems to deallocate it or something.
 
-                window.hide().unwrap();
+                if let Err(e) = window.hide() {
+                    tracing::warn!(error = std_dyn_err(&e), "Failed to hide window")
+                };
                 api.prevent_close();
             }
         })
@@ -260,10 +262,10 @@ pub(crate) fn run(
                         }
                         Ok(Err(error)) => {
                             tracing::error!(error = std_dyn_err(&error), "run_controller returned an error");
-                            errors::show_error_dialog(&error).unwrap();
-
+                            if let Err(e) = errors::show_error_dialog(&error) {
+                                tracing::error!(error = anyhow_dyn_err(&e), "Failed to show error dialog");
+                            }
                             telemetry.stop_on_crash().await;
-
                             1
                         }
                         Ok(Ok(_)) => {

--- a/rust/gui-client/src-tauri/src/main.rs
+++ b/rust/gui-client/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod client;
 

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -381,10 +381,8 @@ impl<'a> Handler<'a> {
                     tracing::info!(
                         "Caught SIGINT / SIGTERM / Ctrl+C while an IPC client is connected"
                     );
-                    self.ipc_tx
-                        .send(&ServerMsg::TerminatingGracefully)
-                        .await
-                        .unwrap();
+                    // Ignore the result here because we're terminating anyway.
+                    let _ = self.ipc_tx.send(&ServerMsg::TerminatingGracefully).await;
                     break HandlerOk::ServiceTerminating;
                 }
             }

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -8,6 +8,8 @@
 //! Tauri deb bundler to pick it up easily.
 //! Otherwise we would just make it a normal binary crate.
 
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 use anyhow::{Context as _, Result};
 use connlib_client_shared::Callbacks;
 use connlib_model::ResourceView;

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -1,5 +1,7 @@
 //! The headless Client, AKA standalone Client
 
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 use anyhow::{anyhow, Context as _, Result};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
@@ -152,7 +154,7 @@ fn main() -> Result<()> {
         .as_deref()
         .map(firezone_logging::file::layer)
         .unzip();
-    firezone_logging::setup_global_subscriber(layer);
+    firezone_logging::setup_global_subscriber(layer).context("Failed to set up logging")?;
 
     tracing::info!(arch = std::env::consts::ARCH, version = VERSION);
 

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 pub mod make;
 
 mod fz_p2p_control;
@@ -9,6 +11,7 @@ mod ipv6_header_slice_mut;
 mod nat46;
 mod nat64;
 #[cfg(feature = "proptest")]
+#[allow(clippy::unwrap_used)]
 pub mod proptest;
 mod slice_utils;
 mod tcp_header_slice_mut;

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -32,6 +32,7 @@ smallvec = "1.13.2"
 socket-factory = { workspace = true }
 socket2 = { workspace = true }
 stun_codec = "0.3.4"
+thiserror = "1.0.68"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "signal"] }
 tracing = { workspace = true, features = ["log"] }
 tracing-core = "0.1.31"

--- a/rust/relay/src/auth.rs
+++ b/rust/relay/src/auth.rs
@@ -11,7 +11,8 @@ use stun_codec::rfc5389::attributes::{MessageIntegrity, Realm, Username};
 use uuid::Uuid;
 
 // TODO: Upstream a const constructor to `stun-codec`.
-pub static FIREZONE: Lazy<Realm> = Lazy::new(|| Realm::new("firezone".to_owned()).unwrap());
+pub static FIREZONE: Lazy<Realm> =
+    Lazy::new(|| Realm::new("firezone".to_owned()).expect("static realm is less than 128 chars"));
 
 pub(crate) trait MessageIntegrityExt {
     fn verify(
@@ -91,11 +92,15 @@ impl Nonces {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub(crate) enum Error {
+    #[error("expired")]
     Expired,
+    #[error("invalid password")]
     InvalidPassword,
+    #[error("invalid username")]
     InvalidUsername,
+    #[error("invalid nonce")]
     InvalidNonce,
 }
 

--- a/rust/relay/src/lib.rs
+++ b/rust/relay/src/lib.rs
@@ -1,9 +1,12 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 mod net_ext;
 mod server;
 mod sleep;
 
 pub mod auth;
 #[cfg(feature = "proptest")]
+#[allow(clippy::unwrap_used)]
 pub mod proptest;
 pub mod sockets;
 

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -1025,7 +1025,11 @@ where
 
             self.add_nonce(new_nonce);
 
-            message.add_attribute(Nonce::new(new_nonce.to_string()).unwrap());
+            message.add_attribute(
+                Nonce::new(new_nonce.to_string()).expect(
+                    "UUIDs are valid nonces because they are less than 128 characters long",
+                ),
+            );
             message.add_attribute((*FIREZONE).clone());
         }
 

--- a/rust/relay/src/server/client_message.rs
+++ b/rust/relay/src/server/client_message.rs
@@ -2,6 +2,7 @@ use crate::auth::{generate_password, split_username, systemtime_from_unix, FIREZ
 use crate::server::channel_data::ChannelData;
 use crate::server::UDP_TRANSPORT;
 use crate::Attribute;
+use anyhow::{Context, Result};
 use bytecodec::DecodeExt;
 use secrecy::SecretString;
 use std::io;
@@ -162,7 +163,7 @@ impl Allocate {
         username: Username,
         relay_secret: &SecretString,
         nonce: Uuid,
-    ) -> Self {
+    ) -> Result<Self> {
         let (requested_transport, nonce, message_integrity) = Self::make_attributes(
             transaction_id,
             &lifetime,
@@ -170,9 +171,9 @@ impl Allocate {
             relay_secret,
             nonce,
             None,
-        );
+        )?;
 
-        Self {
+        Ok(Self {
             transaction_id,
             message_integrity: Some(message_integrity),
             requested_transport,
@@ -182,7 +183,7 @@ impl Allocate {
             requested_address_family: None, // IPv4 is the default.
             additional_address_family: None,
             software: None,
-        }
+        })
     }
 
     pub fn new_authenticated_udp_ip6(
@@ -191,7 +192,7 @@ impl Allocate {
         username: Username,
         relay_secret: &SecretString,
         nonce: Uuid,
-    ) -> Self {
+    ) -> Result<Self> {
         let requested_address_family = RequestedAddressFamily::new(AddressFamily::V6);
 
         let (requested_transport, nonce, message_integrity) = Self::make_attributes(
@@ -201,9 +202,9 @@ impl Allocate {
             relay_secret,
             nonce,
             Some(requested_address_family.clone()),
-        );
+        )?;
 
-        Self {
+        Ok(Self {
             transaction_id,
             message_integrity: Some(message_integrity),
             requested_transport,
@@ -213,7 +214,7 @@ impl Allocate {
             requested_address_family: Some(requested_address_family),
             additional_address_family: None,
             software: None,
-        }
+        })
     }
 
     pub fn new_unauthenticated_udp(
@@ -250,9 +251,9 @@ impl Allocate {
         relay_secret: &SecretString,
         nonce: Uuid,
         requested_address_family: Option<RequestedAddressFamily>,
-    ) -> (RequestedTransport, Nonce, MessageIntegrity) {
+    ) -> Result<(RequestedTransport, Nonce, MessageIntegrity)> {
         let requested_transport = RequestedTransport::new(UDP_TRANSPORT);
-        let nonce = Nonce::new(nonce.as_hyphenated().to_string()).expect("len(uuid) < 128");
+        let nonce = Nonce::new(nonce.as_hyphenated().to_string()).context("Invalid nonce")?;
 
         let mut message =
             Message::<Attribute>::new(MessageClass::Request, ALLOCATE, transaction_id);
@@ -268,15 +269,15 @@ impl Allocate {
             message.add_attribute(lifetime.clone());
         }
 
-        let (expiry, salt) = split_username(username.name()).expect("a valid username");
+        let (expiry, salt) = split_username(username.name())?;
         let expiry_systemtime = systemtime_from_unix(expiry);
 
         let password = generate_password(relay_secret, expiry_systemtime, salt);
 
         let message_integrity =
-            MessageIntegrity::new_long_term_credential(&message, username, &FIREZONE, &password)
-                .unwrap();
-        (requested_transport, nonce, message_integrity)
+            MessageIntegrity::new_long_term_credential(&message, username, &FIREZONE, &password)?;
+
+        Ok((requested_transport, nonce, message_integrity))
     }
 
     pub fn parse(message: &Message<Attribute>) -> Result<Self, Message<Attribute>> {
@@ -359,8 +360,8 @@ impl Refresh {
         username: Username,
         relay_secret: &SecretString,
         nonce: Uuid,
-    ) -> Self {
-        let nonce = Nonce::new(nonce.as_hyphenated().to_string()).expect("len(uuid) < 128");
+    ) -> Result<Self> {
+        let nonce = Nonce::new(nonce.as_hyphenated().to_string()).context("Invalid nonce")?;
 
         let mut message = Message::<Attribute>::new(MessageClass::Request, REFRESH, transaction_id);
         message.add_attribute(username.clone());
@@ -370,23 +371,22 @@ impl Refresh {
             message.add_attribute(lifetime.clone());
         }
 
-        let (expiry, salt) = split_username(username.name()).expect("a valid username");
+        let (expiry, salt) = split_username(username.name())?;
         let expiry_systemtime = systemtime_from_unix(expiry);
 
         let password = generate_password(relay_secret, expiry_systemtime, salt);
 
         let message_integrity =
-            MessageIntegrity::new_long_term_credential(&message, &username, &FIREZONE, &password)
-                .unwrap();
+            MessageIntegrity::new_long_term_credential(&message, &username, &FIREZONE, &password)?;
 
-        Self {
+        Ok(Self {
             transaction_id,
             message_integrity: Some(message_integrity),
             lifetime,
             username: Some(username),
             nonce: Some(nonce),
             software: None,
-        }
+        })
     }
 
     pub fn parse(message: &Message<Attribute>) -> Self {
@@ -450,8 +450,8 @@ impl ChannelBind {
         username: Username,
         relay_secret: &SecretString,
         nonce: Uuid,
-    ) -> Self {
-        let nonce = Nonce::new(nonce.as_hyphenated().to_string()).expect("len(uuid) < 128");
+    ) -> Result<Self> {
+        let nonce = Nonce::new(nonce.as_hyphenated().to_string()).context("Invalid nonce")?;
 
         let mut message =
             Message::<Attribute>::new(MessageClass::Request, CHANNEL_BIND, transaction_id);
@@ -460,16 +460,15 @@ impl ChannelBind {
         message.add_attribute(xor_peer_address.clone());
         message.add_attribute(nonce.clone());
 
-        let (expiry, salt) = split_username(username.name()).expect("a valid username");
+        let (expiry, salt) = split_username(username.name())?;
         let expiry_systemtime = systemtime_from_unix(expiry);
 
         let password = generate_password(relay_secret, expiry_systemtime, salt);
 
         let message_integrity =
-            MessageIntegrity::new_long_term_credential(&message, &username, &FIREZONE, &password)
-                .unwrap();
+            MessageIntegrity::new_long_term_credential(&message, &username, &FIREZONE, &password)?;
 
-        Self {
+        Ok(Self {
             transaction_id,
             channel_number,
             message_integrity: Some(message_integrity),
@@ -477,7 +476,7 @@ impl ChannelBind {
             username: Some(username),
             nonce: Some(nonce),
             software: None,
-        }
+        })
     }
 
     pub fn parse(message: &Message<Attribute>) -> Result<Self, Message<Attribute>> {
@@ -584,12 +583,14 @@ impl CreatePermission {
 /// Computes the effective lifetime of an allocation.
 fn compute_effective_lifetime(requested_lifetime: Option<&Lifetime>) -> Lifetime {
     let Some(requested) = requested_lifetime else {
-        return Lifetime::new(DEFAULT_ALLOCATION_LIFETIME).unwrap();
+        return Lifetime::new(DEFAULT_ALLOCATION_LIFETIME)
+            .expect("Default lifetime is less than 0xFFFF_FFFF");
     };
 
     let effective_lifetime = requested.lifetime().min(MAX_ALLOCATION_LIFETIME);
 
-    Lifetime::new(effective_lifetime).unwrap()
+    Lifetime::new(effective_lifetime)
+        .expect("lifetime is at most MAX_ALLOCATION_LIFETIME which is less than 0xFFFF_FFFF")
 }
 
 fn bad_request(message: &Message<Attribute>) -> Message<Attribute> {

--- a/rust/relay/tests/regression.rs
+++ b/rust/relay/tests/regression.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use bytecodec::{DecodeExt, EncodeExt};
 use firezone_relay::{
     AddressFamily, Allocate, AllocationPort, Attribute, Binding, ChannelBind, ChannelData,
@@ -61,7 +63,8 @@ fn deallocate_once_time_expired(
                 valid_username(&username_salt),
                 secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [
@@ -121,7 +124,8 @@ fn unauthenticated_allocate_triggers_authentication(
                 valid_username(&username_salt),
                 &secret,
                 first_nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [
@@ -165,7 +169,8 @@ fn when_refreshed_in_time_allocation_does_not_expire(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [
@@ -198,7 +203,8 @@ fn when_refreshed_in_time_allocation_does_not_expire(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [send_message(
@@ -243,7 +249,8 @@ fn when_receiving_lifetime_0_for_existing_allocation_then_delete(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [
@@ -275,7 +282,8 @@ fn when_receiving_lifetime_0_for_existing_allocation_then_delete(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [
@@ -315,36 +323,45 @@ fn freeing_allocation_clears_all_channels(
     let secret = server.auth_secret().to_owned();
 
     let _ = server.server.handle_client_message(
-        ClientMessage::Allocate(Allocate::new_authenticated_udp_implicit_ip4(
-            allocate_transaction_id,
-            None,
-            valid_username(&username_salt),
-            &secret,
-            nonce,
-        )),
+        ClientMessage::Allocate(
+            Allocate::new_authenticated_udp_implicit_ip4(
+                allocate_transaction_id,
+                None,
+                valid_username(&username_salt),
+                &secret,
+                nonce,
+            )
+            .unwrap(),
+        ),
         ClientSocket::new(source),
         now,
     );
     let _ = server.server.handle_client_message(
-        ClientMessage::ChannelBind(ChannelBind::new(
-            channel_bind_transaction_id,
-            channel,
-            XorPeerAddress::new(peer.into()),
-            valid_username(&username_salt),
-            &secret,
-            nonce,
-        )),
+        ClientMessage::ChannelBind(
+            ChannelBind::new(
+                channel_bind_transaction_id,
+                channel,
+                XorPeerAddress::new(peer.into()),
+                valid_username(&username_salt),
+                &secret,
+                nonce,
+            )
+            .unwrap(),
+        ),
         ClientSocket::new(source),
         now,
     );
     let _ = server.server.handle_client_message(
-        ClientMessage::Refresh(Refresh::new(
-            refresh_transaction_id,
-            Some(Lifetime::new(Duration::ZERO).unwrap()),
-            valid_username(&username_salt),
-            &secret,
-            nonce,
-        )),
+        ClientMessage::Refresh(
+            Refresh::new(
+                refresh_transaction_id,
+                Some(Lifetime::new(Duration::ZERO).unwrap()),
+                valid_username(&username_salt),
+                &secret,
+                nonce,
+            )
+            .unwrap(),
+        ),
         ClientSocket::new(source),
         now,
     );
@@ -387,7 +404,8 @@ fn ping_pong_relay(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [
@@ -422,7 +440,8 @@ fn ping_pong_relay(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [send_message(
@@ -496,7 +515,8 @@ fn allows_rebind_channel_after_expiry(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [
@@ -531,7 +551,8 @@ fn allows_rebind_channel_after_expiry(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [send_message(
@@ -566,7 +587,8 @@ fn allows_rebind_channel_after_expiry(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [send_message(
@@ -614,7 +636,8 @@ fn ping_pong_ip6_relay(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [
@@ -649,7 +672,8 @@ fn ping_pong_ip6_relay(
                 valid_username(&username_salt),
                 &secret,
                 nonce,
-            ),
+            )
+            .unwrap(),
             now,
         ),
         [send_message(

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -83,10 +83,12 @@ impl Telemetry {
             scope.set_tag("api_url", api_url);
             let ctx = sentry::integrations::contexts::utils::device_context();
             scope.set_context("device", ctx);
-            let ctx = sentry::integrations::contexts::utils::os_context().unwrap();
-            scope.set_context("os", ctx);
             let ctx = sentry::integrations::contexts::utils::rust_context();
             scope.set_context("rust", ctx);
+
+            if let Some(ctx) = sentry::integrations::contexts::utils::os_context() {
+                scope.set_context("os", ctx);
+            }
         });
         self.inner.replace(inner);
         sentry::start_session();


### PR DESCRIPTION
Using the clippy lint `unwrap_used`, we can automatically lint against all uses of `.unwrap()` on `Result` and `Option`. This turns up quite a few results actually. In most cases, they are invariants that can't actually be hit. For these, we change them to `Option`. In other cases, they can actually be hit. For example, if the user supplies an invalid log-filter.

Activating this lint ensures the compiler will yell at us every time we use `.unwrap` to double-check whether we do indeed want to panic here.

Resolves: #7292.