### PR TITLE
chore(connlib): better error reporting for invalid IP packets

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -47,10 +47,10 @@ impl Device {
             )));
         }
 
-        let packet = IpPacket::new(ip_packet, n).ok_or_else(|| {
+        let packet = IpPacket::new(ip_packet, n).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "received bytes are not an IP packet",
+                format!("Failed to parse IP packet: {e:#}"),
             )
         })?;
 

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -324,6 +324,8 @@ pub fn ipv6_translated(ip: Ipv6Addr) -> Option<Ipv4Addr> {
 
 impl IpPacket {
     pub fn new(buf: IpPacketBuf, len: usize) -> Result<Self> {
+        anyhow::ensure!(len <= PACKET_SIZE, "Packet too large (len: {len})");
+
         Ok(match buf.inner[NAT46_OVERHEAD] >> 4 {
             4 => IpPacket::Ipv4(ConvertibleIpv4Packet::new(buf, len)?),
             6 => IpPacket::Ipv6(ConvertibleIpv6Packet::new(buf, len)?),

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -168,7 +168,7 @@ impl ConvertibleIpv4Packet {
             start: NAT46_OVERHEAD,
             len,
         };
-        Ipv4HeaderSlice::from_slice(this.packet()).context("Invalid IPv4 header")?;
+        Ipv4Slice::from_slice(this.packet()).context("Invalid IPv4 packet")?;
 
         Ok(this)
     }
@@ -249,7 +249,7 @@ impl ConvertibleIpv6Packet {
             len,
         };
 
-        Ipv6HeaderSlice::from_slice(this.packet()).context("Invalid IPv6 header")?;
+        Ipv6Slice::from_slice(this.packet()).context("Invalid IPv6 packet")?;
 
         Ok(this)
     }


### PR DESCRIPTION
Currently, we don't report very detailed errors when we fail to parse certain IP packets. With this patch, we use `Result` in more places and also extend the validation of IP packets to:

a) enforce a length of at most 1280 bytes. This should already be the case due to our MTU but bad things may happen if that is off for some reason
b) validate the entire IP packet instead of just its header