### PR TITLE
chore(gui-client): don't warn on sign-out while raising tunnel

### DIFF
--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -442,7 +442,7 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
                     Status::Quitting => tracing::error!("Can't cancel sign-in while already quitting"),
                     Status::TunnelReady{..} => tracing::error!("Can't cancel sign-in, the tunnel is already up. This is a logic error in the code."),
                     Status::WaitingForTunnel { .. } => {
-                        tracing::warn!(
+                        tracing::debug!(
                             "Connlib is already raising the tunnel, calling `sign_out` anyway"
                         );
                         self.sign_out().await?;


### PR DESCRIPTION
All warnings triggered events in Sentry. This particular warning is of no concern, it simply means that the user clicked on "Sign out" while we were trying to set up the tunnel.

Resolves: #7250.