### PR TITLE
refactor(gui-client): more detailed tray menu update errors

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -126,8 +126,15 @@ impl Tray {
 }
 
 fn update(handle: tauri::tray::TrayIcon, app: &AppHandle, menu: &Menu) -> Result<()> {
-    handle.set_tooltip(Some(TOOLTIP))?;
-    handle.set_menu(Some(build_app_state(app, menu)?))?;
+    let menu = build_app_state(app, menu).context("Failed to build tray menu")?;
+
+    handle
+        .set_tooltip(Some(TOOLTIP))
+        .context("Failed to set tooltip")?;
+    handle
+        .set_menu(Some(menu))
+        .context("Failed to set tray menu")?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Just adding a bit more context to see which particular operation fails.