### PR TITLE
ci: upload debug symbols to Sentry

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -33,17 +33,14 @@ jobs:
             arch: x86_64
             os: linux
             pkg-extension: deb
-            syms-extension: dwp
           - runs-on: ubuntu-22.04-arm
             arch: aarch64
             os: linux
             pkg-extension: deb
-            syms-extension: dwp
           - runs-on: windows-2019
             arch: x86_64
             os: windows
             pkg-extension: msi
-            syms-extension: pdb
     env:
       # mark:next-gui-version
       ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.3.13_${{ matrix.arch }}
@@ -107,12 +104,6 @@ jobs:
       - name: Rename artifacts and compute SHA256
         shell: bash
         run: ${{ env.RENAME_SCRIPT }}
-      - name: Upload debug symbols
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.ARTIFACT_DST }}-syms
-          path: ${{ env.ARTIFACT_SRC }}.${{ matrix.syms-extension }}
-          if-no-files-found: error
       - name: Upload debug symbols to Sentry
         run: |
           sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -105,6 +105,7 @@ jobs:
         shell: bash
         run: ${{ env.RENAME_SCRIPT }}
       - name: Upload debug symbols to Sentry
+        if: ${{ github.ref_name == 'main' }}
         run: |
           sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
           sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -71,6 +71,10 @@ jobs:
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
         timeout-minutes: 10
+      - uses: matbour/setup-sentry-cli@v2
+        with:
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          organization: firezone-inc
       - name: Install pnpm deps
         run: pnpm install
       - name: Install AzureSignTool
@@ -109,6 +113,10 @@ jobs:
           name: ${{ env.ARTIFACT_DST }}-syms
           path: ${{ env.ARTIFACT_SRC }}.${{ matrix.syms-extension }}
           if-no-files-found: error
+      - name: Upload debug symbols to Sentry
+        run: |
+          sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
+          sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target
       - name: Upload package
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
In order to display better stacktraces when Firezone crashes, Sentry needs debug symbols for our binaries. Debug symbols on Sentry are retained for 90 days after they have been last used [0]. We can thus simply upload them every time we build a binary on `main`.

For the moment, this only uploads them for the GUI client. Debug symbols for the Android and Apple clients will be done in separate PRs.


[0]: https://docs.sentry.io/platforms/native/data-management/debug-files/#retention-policy