### PR TITLE
fix(snownet): emit correct event on invalidating srflx candidate

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1402,7 +1402,7 @@ fn remove_local_candidate<TId>(
     TId: fmt::Display,
 {
     if candidate.kind() == CandidateKind::ServerReflexive {
-        pending_events.push_back(Event::NewIceCandidate {
+        pending_events.push_back(Event::InvalidateIceCandidate {
             connection: id,
             candidate: candidate.to_sdp_string(),
         });


### PR DESCRIPTION
This one has been lurking in the codebase for a while. Fortunately, it is not very critical because invalidation of server-reflexive addresses happens pretty rarely.