### PR TITLE
fix(snownet): don't allow duplicate server-reflexive candidates

### DIFF
--- a/rust/connlib/snownet/src/candidate_set.rs
+++ b/rust/connlib/snownet/src/candidate_set.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use itertools::Itertools;
-use str0m::Candidate;
+use str0m::{Candidate, CandidateKind};
 
 /// Custom "set" implementation for [`Candidate`]s based on a [`HashSet`] with an enforced ordering when iterating.
 #[derive(Debug, Default)]
@@ -21,6 +21,23 @@ impl CandidateSet {
             return false;
         }
 
+        if new.kind() == CandidateKind::ServerReflexive {
+            self.inner.retain(|current| {
+                if current.kind() != CandidateKind::ServerReflexive {
+                    return true; // Non-server-reflexive candidates are always kept (i.e. host candidates)
+                }
+
+                // Candidates of different IP version are also kept.
+                let is_ip_version_different = current.addr().is_ipv4() != new.addr().is_ipv4();
+
+                if !is_ip_version_different {
+                    tracing::debug!(%current, %new, "Replacing server-reflexive candidate");
+                }
+
+                is_ip_version_different
+            });
+        }
+
         self.inner.insert(new)
     }
 
@@ -34,5 +51,50 @@ impl CandidateSet {
     )]
     pub fn iter(&self) -> impl Iterator<Item = &Candidate> {
         self.inner.iter().sorted_by_key(|c| c.prio())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    use str0m::net::Protocol;
+
+    const SOCK_ADDR_IP4_BASE: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 10);
+    const SOCK_ADDR1: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234);
+    const SOCK_ADDR2: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5678);
+
+    const SOCK_ADDR_IP6_BASE: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 10);
+    const SOCK_ADDR3: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1234);
+    const SOCK_ADDR4: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5678);
+
+    #[test]
+    fn only_allows_one_server_reflexive_candidate_per_ip_family() {
+        let mut set = CandidateSet::default();
+
+        let host1 = Candidate::host(SOCK_ADDR_IP4_BASE, Protocol::Udp).unwrap();
+        let host2 = Candidate::host(SOCK_ADDR_IP6_BASE, Protocol::Udp).unwrap();
+
+        assert!(set.insert(host1.clone()));
+        assert!(set.insert(host2.clone()));
+
+        let c1 =
+            Candidate::server_reflexive(SOCK_ADDR1, SOCK_ADDR_IP4_BASE, Protocol::Udp).unwrap();
+        let c2 =
+            Candidate::server_reflexive(SOCK_ADDR2, SOCK_ADDR_IP4_BASE, Protocol::Udp).unwrap();
+        let c3 =
+            Candidate::server_reflexive(SOCK_ADDR3, SOCK_ADDR_IP6_BASE, Protocol::Udp).unwrap();
+        let c4 =
+            Candidate::server_reflexive(SOCK_ADDR4, SOCK_ADDR_IP6_BASE, Protocol::Udp).unwrap();
+
+        assert!(set.insert(c1));
+        assert!(set.insert(c2.clone()));
+        assert!(set.insert(c3));
+        assert!(set.insert(c4.clone()));
+
+        assert_eq!(
+            set.iter().cloned().collect::<Vec<_>>(),
+            vec![c2, c4, host1, host2]
+        );
     }
 }

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -11,7 +11,12 @@ export default function Android() {
       title="Android"
     >
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7334">
+          Fixes an issue where symmetric NATs would generate unnecessary
+          candidate for hole-punching.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.7" date={new Date("2024-11-08")}>
         <ChangeItem pull="7263">
           Mitigates a crash in case the maximum packet size is not respected.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -11,7 +11,12 @@ export default function Apple() {
       title="macOS / iOS"
     >
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7334">
+          Fixes an issue where symmetric NATs would generate unnecessary
+          candidate for hole-punching.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.3.9" date={new Date("2024-11-08")}>
         <ChangeItem pull="7288">
           Fixes an issue where network roaming would cause Firezone to become

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,7 +14,12 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries href={href} arches={arches} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7334">
+          Fixes an issue where symmetric NATs would generate unnecessary
+          candidate for hole-punching.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.3.12" date={new Date("2024-11-08")}>
         <ChangeItem pull="7288">
           Fixes an issue where network roaming would cause Firezone to become

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -14,6 +14,10 @@ export default function Gateway() {
         <ChangeItem pull="7263">
           Mitigates a crash in case the maximum packet size is not respected.
         </ChangeItem>
+        <ChangeItem pull="7334">
+          Fixes an issue where symmetric NATs would generate unnecessary
+          candidate for hole-punching.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.0" date={new Date("2024-11-04")}>
         <ChangeItem pull="6960">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -11,7 +11,12 @@ export default function Headless() {
   return (
     <Entries href={href} arches={arches} title="Linux headless">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7334">
+          Fixes an issue where symmetric NATs would generate unnecessary
+          candidate for hole-punching.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.3.6" date={new Date("2024-11-08")}>
         <ChangeItem pull="7263">
           Mitigates a crash in case the maximum packet size is not respected.


### PR DESCRIPTION
In #7163, we introduced a shared cache of server-reflexive candidates within a `snownet::Node`. What we unfortunately overlooked is that if a node (i.e. a client or a gateway) is behind symmetric NAT, then we will repeatedly create "new" server-reflexive candiates, thereby filling up this cache.

This cache is used to initialise the agents with local candidates, which manifests in us sending dozens if not hundreds of candidates to the other party. Whilst not harmful in itself, it does create quite a lot of spam. To fix this, we introduce a limit of only keeping around 1 server-reflexive candidate per IP version, i.e. only 1 IPv4 and IPv6 address.

At present, `connlib` only supports a single egress interface meaning for now, we are fine with making this assumption.

In case we encounter a new candidate of the same kind and same IP version, we evict the old one and replace it with the new one. Thus, for subsequent connections, only the new candidate is used.