### PR TITLE
chore(rust): correctly disable ANSI escapes globally

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -143,9 +143,9 @@ fn init_logging(log_dir: &Path, log_filter: EnvFilter) -> firezone_logging::file
         .with(file_layer)
         .with(
             tracing_subscriber::fmt::layer()
+                .with_ansi(false)
                 .event_format(
                     firezone_logging::Format::new()
-                        .without_ansi()
                         .without_timestamp()
                         .without_level(),
                 )

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -178,9 +178,9 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<firezone_logging
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
+                .with_ansi(false)
                 .event_format(
                     firezone_logging::Format::new()
-                        .without_ansi()
                         .without_timestamp()
                         .without_level(),
                 )

--- a/rust/gui-client/src-common/src/logging.rs
+++ b/rust/gui-client/src-common/src/logging.rs
@@ -12,7 +12,7 @@ use std::{
 use tokio::task::spawn_blocking;
 use tracing::subscriber::set_global_default;
 use tracing_log::LogTracer;
-use tracing_subscriber::{fmt, layer::SubscriberExt, reload, Layer, Registry};
+use tracing_subscriber::{layer::SubscriberExt, reload, Layer, Registry};
 
 /// If you don't store `Handles` in a variable, the file logger handle will drop immediately,
 /// resulting in empty log files.
@@ -55,7 +55,6 @@ pub fn setup(directives: &str) -> Result<Handles> {
 
     std::fs::create_dir_all(&log_path).map_err(Error::CreateDirAll)?;
     let (layer, logger) = firezone_logging::file::layer(&log_path);
-    let layer = layer.and_then(fmt::layer());
     let (filter, reloader) = reload::Layer::new(firezone_logging::try_filter(directives)?);
     let subscriber = Registry::default()
         .with(layer.with_filter(filter))

--- a/rust/gui-client/src-common/src/logging.rs
+++ b/rust/gui-client/src-common/src/logging.rs
@@ -59,7 +59,6 @@ pub fn setup(directives: &str) -> Result<Handles> {
     let subscriber = Registry::default()
         .with(layer.with_filter(filter))
         .with(firezone_logging::sentry_layer());
-
     set_global_default(subscriber)?;
     if let Err(error) = output_vt100::try_init() {
         tracing::debug!(

--- a/rust/gui-client/src-common/src/logging.rs
+++ b/rust/gui-client/src-common/src/logging.rs
@@ -59,6 +59,7 @@ pub fn setup(directives: &str) -> Result<Handles> {
     let subscriber = Registry::default()
         .with(layer.with_filter(filter))
         .with(firezone_logging::sentry_layer());
+
     set_global_default(subscriber)?;
     if let Err(error) = output_vt100::try_init() {
         tracing::debug!(

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -138,7 +138,9 @@ pub fn setup_stdout_logging() -> Result<LogFilterReloader> {
     let directives = ipc_service::get_log_filter().context("Can't read log filter")?;
     let (filter, reloader) =
         tracing_subscriber::reload::Layer::new(firezone_logging::try_filter(&directives)?);
-    let layer = fmt::layer().with_filter(filter);
+    let layer = fmt::layer()
+        .event_format(firezone_logging::Format::new())
+        .with_filter(filter);
     let subscriber = Registry::default().with(layer);
     set_global_default(subscriber)?;
     Ok(reloader)

--- a/rust/logging/src/file.rs
+++ b/rust/logging/src/file.rs
@@ -39,8 +39,9 @@ where
 
     let (appender_fmt, handle_fmt) = new_appender(log_dir.to_path_buf(), "log");
     let layer_fmt = tracing_subscriber::fmt::layer()
+        .with_ansi(false)
         .with_writer(appender_fmt)
-        .event_format(crate::Format::new().without_ansi())
+        .event_format(crate::Format::new())
         .boxed();
 
     let handle = Handle {

--- a/rust/logging/src/format.rs
+++ b/rust/logging/src/format.rs
@@ -28,7 +28,6 @@ use tracing_subscriber::{
 ///
 /// Most importantly, the actual span-name is not logged.
 pub struct Format {
-    ansi: bool,
     time: bool,
     level: bool,
 }
@@ -36,16 +35,8 @@ pub struct Format {
 impl Format {
     pub fn new() -> Self {
         Self {
-            ansi: true,
             time: true,
             level: true,
-        }
-    }
-
-    pub fn without_ansi(self) -> Self {
-        Self {
-            ansi: false,
-            ..self
         }
     }
 
@@ -94,7 +85,7 @@ where
         let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
 
         if self.time {
-            if self.ansi {
+            if writer.has_ansi_escapes() {
                 let style = Style::new().dimmed();
                 write!(writer, "{}", style.prefix())?;
 
@@ -119,12 +110,12 @@ where
         }
 
         if self.level {
-            let fmt_level = FmtLevel::new(meta.level(), self.ansi);
+            let fmt_level = FmtLevel::new(meta.level(), writer.has_ansi_escapes());
 
             write!(writer, "{} ", fmt_level)?;
         }
 
-        let dimmed = if self.ansi {
+        let dimmed = if writer.has_ansi_escapes() {
             Style::new().dimmed()
         } else {
             Style::new()


### PR DESCRIPTION
I think I finally understood and correctly traced, where the use of ANSI escape codes came from. It turns out, the `with_ansi` switch on `tracing_subscriber::fmt::Layer` is what you want to toggle. From there, it trickles down to the `Writer` which we can then test for in our `Format`.

Resolves: #7284.