### PR TITLE
chore(connlib): only send some tunnel errors to Sentry

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -1,7 +1,7 @@
 use crate::{callbacks::Callbacks, PHOENIX_TOPIC};
 use anyhow::Result;
 use connlib_model::ResourceId;
-use firezone_logging::{anyhow_dyn_err, std_dyn_err};
+use firezone_logging::{anyhow_dyn_err, err_with_sources, std_dyn_err, telemetry_event};
 use firezone_tunnel::messages::{client::*, *};
 use firezone_tunnel::ClientTunnel;
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel, PublicKeyParam};
@@ -92,7 +92,8 @@ where
                     continue;
                 }
                 Poll::Ready(Err(e)) => {
-                    tracing::warn!(error = std_dyn_err(&e), "Tunnel error");
+                    tracing::debug!("Tunnel error: {}", err_with_sources(&e));
+                    telemetry_event!(error = std_dyn_err(&e), "Tunnel error");
                     continue;
                 }
                 Poll::Pending => {}


### PR DESCRIPTION
Errors from the tunnel can potentially happen on a per-packet basis. In order to not flood Sentry, reduce the log-level down to `debug` and only report 1% of all errors. We did the same thing for the gateway in #7299.