### PR TITLE
fix(connlib): send all unwritten packets before reading new ones

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2239,6 +2239,7 @@ dependencies = [
  "test-strategy",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tun",

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -37,6 +37,7 @@ socket-factory = { workspace = true }
 socket2 = { workspace = true }
 thiserror = { version = "1.0", default-features = false }
 tokio = { workspace = true }
+tokio-util = "0.7.12"
 tracing = { workspace = true, features = ["attributes"] }
 tun = { workspace = true }
 uuid = { version = "1.10", default-features = false, features = ["std", "v4"] }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -120,7 +120,7 @@ impl ClientTunnel {
             }
 
             if let Some(packet) = self.role_state.poll_packets() {
-                self.io.send_tun(packet)?;
+                self.io.send_tun(packet);
                 continue;
             }
 
@@ -177,7 +177,7 @@ impl ClientTunnel {
                             continue;
                         };
 
-                        self.io.send_tun(packet)?;
+                        self.io.send_tun(packet);
                     }
 
                     continue;
@@ -282,7 +282,7 @@ impl GatewayTunnel {
                             continue;
                         };
 
-                        self.io.send_tun(packet)?;
+                        self.io.send_tun(packet);
                     }
 
                     continue;


### PR DESCRIPTION
With the parallelisation of TUN and UDP operations, we lost backpressure: Packets can now be read quicker from the UDP sockets than they can be sent out the TUN device, causing packet loss in extremely high-throughput situations.

To avoid this, we don't directly send packets into the channel to the TUN device thread. This channel is bounded, meaning sending can fail if reading UDP packets is faster than writing packets to the TUN device.

Due to GRO, we may read multiple UDP packets in one go, requiring us to write multiple IP packets to the TUN device as part of a single iteration in the event-loop. Thus, we cannot know, how much space we need in the channel for outgoing IP packets.

By introducing a dedicated buffer, we can temporarily hold on to all of these packets and on the next call to `poll`, we flush them out into the channel. If the channel is full, we will suspend and only continue once there is space in the channel. This behaviour restores backpressue because we won't read UDP packets from the socket unless we have space to write the corresponding packet to the TUN device.

UDP itself actually doesn't have any backpressure, instead the packets will simply get dropped once the receive buffer overflows. The UDP packets however carry encrypted IP packets, meaning whatever protocol sits inside these packets will detect the packet loss and should throttle their sending-pace accordingly.