### PR TITLE
docs: refer to correct way how to disable gateway telemetry

### DIFF
--- a/website/src/app/kb/deploy/gateways/readme.mdx
+++ b/website/src/app/kb/deploy/gateways/readme.mdx
@@ -161,7 +161,7 @@ automate this.
 
 By default, Gateways will run a https://sentry.io crash-reporting agent. If
 you'd like to opt-out of this, set the environment variable
-`FIREZONE_NO_TELEMETRY=1`.
+`FIREZONE_NO_TELEMETRY=true`.
 
 <NextStep href="/kb/deploy/resources">Next: Create Resources</NextStep>
 

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -30,7 +30,7 @@ export default function Gateway() {
         </ChangeItem>
         <ChangeItem pull="7103">
           Adds on-by-default error reporting using sentry.io. Disable by setting
-          `FIREZONE_NO_TELEMETRY=1`.
+          `FIREZONE_NO_TELEMETRY=true`.
         </ChangeItem>
         <ChangeItem pull="7164">
           Fixes an issue where the Gateway would fail to accept connections and


### PR DESCRIPTION
Shame on me for not actually testing this when I built it. `clap` requires you to explicitly spell out `true` or `false`.