### PR TITLE
chore(connlib): print GRO metadata in `wire::net::recv` log

### DIFF
--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -256,15 +256,17 @@ impl UdpSocket {
 
                 let local = SocketAddr::new(local_ip, *port);
 
+                let segment_size = meta.stride;
+                let num_packets = meta.len / segment_size;
+
+                tracing::trace!(target: "wire::net::recv", src = %meta.addr, dst = %local, %num_packets, %segment_size);
+
                 let iter = buffer[..meta.len]
                     .chunks(meta.stride)
                     .map(move |packet| DatagramIn {
                         local,
                         from: meta.addr,
                         packet,
-                    })
-                    .inspect(|r| {
-                        tracing::trace!(target: "wire::net::recv", src = %r.from, dst = %r.local, num_bytes = %r.packet.len());
                     });
 
                 return Poll::Ready(Ok(iter));

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -258,8 +258,9 @@ impl UdpSocket {
 
                 let segment_size = meta.stride;
                 let num_packets = meta.len / segment_size;
+                let trailing_bytes = meta.len % segment_size;
 
-                tracing::trace!(target: "wire::net::recv", src = %meta.addr, dst = %local, %num_packets, %segment_size);
+                tracing::trace!(target: "wire::net::recv", src = %meta.addr, dst = %local, %num_packets, %segment_size, %trailing_bytes);
 
                 let iter = buffer[..meta.len]
                     .chunks(meta.stride)

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -237,12 +237,7 @@ impl UdpSocket {
                 };
 
                 match meta.stride.cmp(&meta.len) {
-                    std::cmp::Ordering::Equal => {}
-                    std::cmp::Ordering::Less => {
-                        let num_packets = meta.len / meta.stride;
-
-                        tracing::trace!(%num_packets, size = %meta.stride, "Read packets using GRO");
-                    }
+                    std::cmp::Ordering::Equal | std::cmp::Ordering::Less => {}
                     std::cmp::Ordering::Greater => {
                         return Poll::Ready(Err(io::Error::new(
                             io::ErrorKind::InvalidData,


### PR DESCRIPTION
Previously, we printed only the size of each individual packet in the `wire::net` logs. This makes it impossible to tell whether or not GRO was used to receive this packet. The total number of bytes can still be computed by calculating `num_packets * segment_size + trailing_bytes`. Thus, the new log is strictly superior.