### PR TITLE
fix: don't exit TUN thread on errors

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -41,6 +41,8 @@ impl Device {
         let n = std::task::ready!(tun.poll_read(ip_packet.buf(), cx))?;
 
         if n == 0 {
+            self.tun = None;
+
             return Poll::Ready(Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
                 "device is closed",

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -379,10 +379,9 @@ async fn tun_send_recv(
             }
             Either::Right((Err(e), _)) => {
                 tracing::debug!(
-                    error = std_dyn_err(&e),
-                    "Failed to read packet from TUN device"
+                    "Failed to read packet from TUN device: {}",
+                    err_with_sources(&e)
                 );
-                return;
             }
         };
     }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -1,6 +1,6 @@
 use crate::{device_channel::Device, dns, sockets::Sockets};
 use domain::base::Message;
-use firezone_logging::{err_with_sources, std_dyn_err, telemetry_event, telemetry_span};
+use firezone_logging::{err_with_sources, telemetry_event, telemetry_span};
 use futures::{
     future::{self, Either},
     stream, Stream, StreamExt,


### PR DESCRIPTION
I noticed that in case there is an error when reading from the TUN device, we currently exit that thread and we don't have a mechanism at the moment to restart it. Discarding the thread also means we can no longer send new instances of `Tun` into it.

Instead of exiting the thread, we now just log the error and continue. In case the error was caused by the FD being closed, we discard the instance of `Tun` and wait for a new one.