### PR TITLE
fix(portal): Update Stripe event handler to only listen for certain update events

### DIFF
--- a/elixir/apps/domain/lib/domain/billing/event_handler.ex
+++ b/elixir/apps/domain/lib/domain/billing/event_handler.ex
@@ -170,8 +170,13 @@ defmodule Domain.Billing.EventHandler do
             }
           }
         },
-        "type" => "customer.subscription." <> _
-      }) do
+        "type" => "customer.subscription." <> event_type
+      })
+      when event_type in [
+             "created",
+             "resumed",
+             "updated"
+           ] do
     {:ok,
      %{
        "name" => product_name,


### PR DESCRIPTION
Why:

* Recently we had an issue where a customer's payment info was incorrectly entered, which caused the payment to not go through.  When something like this happens Stripe will send an update event with a pending_update section (which we do not use currently).  When the customer fixes the payment info, and payment goes through we get another update event with the correct subscription info, however, the previous update (with the pending section) then gets expired and a `pending_update_expired` event is sent to us.  We had been inadvertantly catching the event and updating the specified account with the info in the event (which happened to be the previous state of the subscription)

Fixes: #7352 