### PR TITLE
ci: create Sentry release on publish

### DIFF
--- a/.github/actions/create-sentry-release/action.yml
+++ b/.github/actions/create-sentry-release/action.yml
@@ -1,0 +1,30 @@
+---
+name: "Create Sentry release"
+description: "Creates a Sentry release for projects from a particular Git tag"
+inputs:
+  component:
+    description: "The component to create a release for"
+    required: true
+  projects:
+    description: "The Sentry projects to create a release for"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract version from release
+      id: version
+      run: |
+        version=${{ github.event.release.name }}
+        version=${version#${{ inputs.component }}-}
+        echo "version=$version" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - uses: getsentry/action-release@v1
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: firezone-inc
+      with:
+        version: ${{ steps.version.outputs.version }}
+        projects: ${{ inputs.projects }}
+        set_commits: auto

--- a/.github/actions/create-sentry-release/action.yml
+++ b/.github/actions/create-sentry-release/action.yml
@@ -5,14 +5,16 @@ inputs:
   component:
     description: "The component to create a release for"
     required: true
+    # e.g. "gateway", "gui-client", "headless-client", ...
   projects:
     description: "The Sentry projects to create a release for"
     required: true
+    # Must be space-separated.
 
 runs:
   using: "composite"
   steps:
-    - name: Extract version from release
+    - name: Extract semantic version from release name
       id: version
       run: |
         version=${{ github.event.release.name }}

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ startsWith(github.event.release.name, 'gui-client') }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/create-sentry-release

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ startsWith(github.event.release.name, 'gateway') }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/create-sentry-release
@@ -38,7 +38,7 @@ jobs:
     if: ${{ startsWith(github.event.release.name, 'headless-client') }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/create-sentry-release

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,0 +1,47 @@
+name: Create Sentry releases
+run-name: Triggered by ${{ github.actor }}
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: "publish-production-${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
+jobs:
+  create_gateway_sentry_release:
+    if: ${{ startsWith(github.event.release.name, 'gateway') }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/create-sentry-release
+        with:
+          component: gateway
+          projects: gateway
+
+  create_gui-client_sentry_release:
+    if: ${{ startsWith(github.event.release.name, 'gui-client') }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/create-sentry-release
+        with:
+          component: gui-client
+          projects: gui-client-gui gui-client-ipc-service
+
+  create_headless-client_sentry_release:
+    if: ${{ startsWith(github.event.release.name, 'headless-client') }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/create-sentry-release
+        with:
+          component: headless-client
+          projects: headless-client


### PR DESCRIPTION
Explicitly creating the Sentry release allows us to associate the commits since the last release with the new one. This might help us to identify potential sources of regressions. For the current releases, I've set them manually to ensure that this automation has something to pick up on for the next release.

The releases will already exists prior to this because they are automatically created when a client / gateway first logs in with a certain version.

What this does it mark it as "finalized" and set the commit range accordingly.

Resolves: #7358.