### PR TITLE
fix(gui-client): initialise `sentry-tracing` for IPC service

### DIFF
--- a/rust/clippy.toml
+++ b/rust/clippy.toml
@@ -1,7 +1,8 @@
 avoid-breaking-exported-api = false # We don't publish anything to crates.io, hence we don't need to worry about breaking Rust API changes.
 disallowed-methods = [
-    { path = "std::collections::HashMap::iter", reason = "HashMap has non-deterministic iteration order, use BTreeMap instead" },
-    { path = "std::collections::HashSet::iter", reason = "HashSet has non-deterministic iteration order, use BTreeSet instead" },
-    { path = "std::collections::HashMap::into_iter", reason = "HashMap has non-deterministic iteration order, use BTreeMap instead" },
-    { path = "std::collections::HashSet::into_iter", reason = "HashSet has non-deterministic iteration order, use BTreeSet instead" },
+  { path = "std::collections::HashMap::iter", reason = "HashMap has non-deterministic iteration order, use BTreeMap instead" },
+  { path = "std::collections::HashSet::iter", reason = "HashSet has non-deterministic iteration order, use BTreeSet instead" },
+  { path = "std::collections::HashMap::into_iter", reason = "HashMap has non-deterministic iteration order, use BTreeMap instead" },
+  { path = "std::collections::HashSet::into_iter", reason = "HashSet has non-deterministic iteration order, use BTreeSet instead" },
+  { path = "tracing::subscriber::set_global_default", reason = "Does not init `LogTracer`, use `firezone_logging::init` instead." },
 ]

--- a/rust/gui-client/src-common/src/logging.rs
+++ b/rust/gui-client/src-common/src/logging.rs
@@ -10,8 +10,6 @@ use std::{
     path::{Path, PathBuf},
 };
 use tokio::task::spawn_blocking;
-use tracing::subscriber::set_global_default;
-use tracing_log::LogTracer;
 use tracing_subscriber::{layer::SubscriberExt, reload, Layer, Registry};
 
 /// If you don't store `Handles` in a variable, the file logger handle will drop immediately,
@@ -59,15 +57,17 @@ pub fn setup(directives: &str) -> Result<Handles> {
     let subscriber = Registry::default()
         .with(layer.with_filter(filter))
         .with(firezone_logging::sentry_layer());
-    set_global_default(subscriber)?;
+    firezone_logging::init(subscriber)?;
+
     if let Err(error) = output_vt100::try_init() {
         tracing::debug!(
             error = std_dyn_err(&error),
             "Failed to init vt100 terminal colors (expected in release builds and in CI)"
         );
     }
-    LogTracer::init()?;
+
     tracing::debug!(?log_path, "Log path");
+
     Ok(Handles { logger, reloader })
 }
 

--- a/rust/gui-client/src-common/src/logging.rs
+++ b/rust/gui-client/src-common/src/logging.rs
@@ -66,7 +66,7 @@ pub fn setup(directives: &str) -> Result<Handles> {
         );
     }
 
-    tracing::debug!(?log_path, "Log path");
+    tracing::debug!(log_path = %log_path.display(), "Log path");
 
     Ok(Handles { logger, reloader })
 }

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -650,7 +650,7 @@ fn setup_logging(
         arch = std::env::consts::ARCH,
         // version = env!("CARGO_PKG_VERSION"), TODO: Fix once `ipc_service` is moved to `gui-client`.
         system_uptime_seconds = crate::uptime::get().map(|dur| dur.as_secs()),
-        ?directives
+        %directives
     );
 
     Ok((handle, reloader))

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -23,7 +23,6 @@ use std::{
     collections::BTreeSet, io, net::IpAddr, path::PathBuf, pin::pin, sync::Arc, time::Duration,
 };
 use tokio::{sync::mpsc, task::spawn_blocking, time::Instant};
-use tracing::subscriber::set_global_default;
 use tracing_subscriber::{layer::SubscriberExt, reload, EnvFilter, Layer, Registry};
 use url::Url;
 
@@ -644,7 +643,7 @@ fn setup_logging(
     let subscriber = Registry::default()
         .with(layer.with_filter(filter))
         .with(sentry_layer());
-    set_global_default(subscriber).context("`set_global_default` should always work)")?;
+    firezone_logging::init(subscriber)?;
 
     tracing::info!(
         arch = std::env::consts::ARCH,

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -20,7 +20,6 @@ use std::{
     path::PathBuf,
 };
 use tokio::sync::mpsc;
-use tracing::subscriber::set_global_default;
 use tracing_subscriber::{fmt, layer::SubscriberExt as _, EnvFilter, Layer as _, Registry};
 
 mod clear_logs;
@@ -142,7 +141,8 @@ pub fn setup_stdout_logging() -> Result<LogFilterReloader> {
         .event_format(firezone_logging::Format::new())
         .with_filter(filter);
     let subscriber = Registry::default().with(layer);
-    set_global_default(subscriber)?;
+    firezone_logging::init(subscriber)?;
+
     Ok(reloader)
 }
 

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -38,6 +38,16 @@ where
                 .event_format(Format::new())
                 .with_filter(try_filter(&directives).context("Failed to parse directives")?),
         );
+    init(subscriber)?;
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "This is the alternative function."
+)]
+pub fn init(subscriber: impl Subscriber + Send + Sync + 'static) -> Result<()> {
     tracing::subscriber::set_global_default(subscriber).context("Could not set global default")?;
     LogTracer::init().context("Failed to init LogTracer")?;
 
@@ -72,7 +82,7 @@ pub fn test(directives: &str) -> DefaultGuard {
 }
 
 pub fn test_global(directives: &str) {
-    tracing::subscriber::set_global_default(
+    init(
         tracing_subscriber::fmt()
             .with_test_writer()
             .with_env_filter(directives)


### PR DESCRIPTION
It was already a bit sus that we didn't receive as many errors in Sentry from the IPC service as from the GUI client. Turns out that we forgot to initialise our `sentry_layer` there. Additionally, we also didn't initialise the `LogTracer`, meaning we didn't capture logs from the `log` crate which is used by some of the dependencies, for example `wintun`.