### PR TITLE
refactor(gui-client): add more context to connection failures

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -218,7 +218,7 @@ impl Drop for Tun {
 
 impl Tun {
     #[tracing::instrument(level = "debug")]
-    pub fn new(mtu: u32) -> Result<Self> {
+    fn new(mtu: u32) -> Result<Self> {
         let path = ensure_dll().context("Failed to ensure `wintun.dll` is in place")?;
         // SAFETY: we're loading a DLL from disk and it has arbitrary C code in it. There's no perfect way to prove it's safe.
         let wintun = unsafe { wintun::load_from_path(path.clone()) }

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -224,18 +224,12 @@ impl Tun {
         let wintun = unsafe { wintun::load_from_path(path) }?;
 
         // Create wintun adapter
-        let adapter = match Adapter::create(
+        let adapter = Adapter::create(
             &wintun,
             TUNNEL_NAME,
             TUNNEL_NAME,
             Some(TUNNEL_UUID.as_u128()),
-        ) {
-            Ok(x) => x,
-            Err(error) => {
-                tracing::error!(error = std_dyn_err(&error), "Failed in `Adapter::create`");
-                return Err(error)?;
-            }
-        };
+        )?;
         let iface_idx = adapter.get_adapter_index()?;
 
         set_iface_config(adapter.get_luid(), mtu)?;

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -217,7 +217,6 @@ impl Drop for Tun {
 }
 
 impl Tun {
-    #[tracing::instrument(level = "debug")]
     fn new(mtu: u32) -> Result<Self> {
         let path = ensure_dll().context("Failed to ensure `wintun.dll` is in place")?;
         // SAFETY: we're loading a DLL from disk and it has arbitrary C code in it. There's no perfect way to prove it's safe.

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -9,7 +9,7 @@ use firezone_bin_shared::{
     platform::{tcp_socket_factory, udp_socket_factory, DnsControlMethod},
     TunDeviceManager, TOKEN_ENV_KEY,
 };
-use firezone_logging::{anyhow_dyn_err, std_dyn_err, telemetry_span};
+use firezone_logging::{anyhow_dyn_err, telemetry_span};
 use firezone_telemetry::Telemetry;
 use futures::{
     future::poll_fn,
@@ -480,12 +480,7 @@ impl<'a> Handler<'a> {
                 // Warning: Connection errors don't bubble to callers of `handle_ipc_msg`.
                 let token = secrecy::SecretString::from(token);
                 let result = self.connect_to_firezone(&api_url, token);
-                if let Err(error) = &result {
-                    tracing::error!(
-                        error = std_dyn_err(error),
-                        "Failed to connect connlib session"
-                    );
-                }
+
                 self.ipc_tx
                     .send(&ServerMsg::ConnectResult(result))
                     .await


### PR DESCRIPTION
Adding more context to these errors makes it easier to identify, which of the operations fails. In addition, we remove some usages of the "log and return" anti-pattern to avoid duplicate reports of the same issue.