### PR TITLE
chore(snownet): print error code for unhandled message

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -443,7 +443,7 @@ impl Allocation {
                 _ => {}
             }
 
-            tracing::warn!(error = %error.reason_phrase(), "TURN request failed");
+            tracing::warn!(error = %error.reason_phrase(), code = %error.code(), "TURN request failed");
 
             return true;
         }


### PR DESCRIPTION
All our logic for handling errors is based on the error code. Even though there should be a 1:1 mapping between error code and reason phrase, I am seeing odd reports in Sentry for a case that we should be handling but aren't.