### PR TITLE
fix(portal): API clients 'show' page should always be in settings

### DIFF
--- a/elixir/apps/web/lib/web/live/actors/components.ex
+++ b/elixir/apps/web/lib/web/live/actors/components.ex
@@ -45,7 +45,7 @@ defmodule Web.Actors.Components do
   def actor_name_and_role(assigns) do
     ~H"""
     <.link
-      navigate={~p"/#{@account}/actors/#{@actor}"}
+      navigate={actor_show_url(@account, @actor)}
       class={["text-accent-500 hover:underline", @class]}
     >
       <%= @actor.name %>
@@ -55,6 +55,9 @@ defmodule Web.Actors.Components do
     </span>
     <span :if={@actor.type == :service_account} class={["text-xs", @class]}>
       (service account)
+    </span>
+    <span :if={@actor.type == :api_client} class={["text-xs", @class]}>
+      (api client)
     </span>
     """
   end
@@ -189,5 +192,13 @@ defmodule Web.Actors.Components do
 
   def next_step_path(_other, account) do
     ~p"/#{account}/actors/users/new"
+  end
+
+  def actor_show_url(account, %Domain.Actors.Actor{type: :api_client} = actor) do
+    ~p"/#{account}/settings/api_clients/#{actor}"
+  end
+
+  def actor_show_url(account, actor) do
+    ~p"/#{account}/actors/#{actor}"
   end
 end

--- a/elixir/apps/web/test/web/live/actors/index_test.exs
+++ b/elixir/apps/web/test/web/live/actors/index_test.exs
@@ -144,4 +144,25 @@ defmodule Web.Live.Actors.IndexTest do
       assert String.contains?(row["last signed in"], "1 hour ago")
     end)
   end
+
+  test "renders proper URL for API client 'show' page", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    api_client = Fixtures.Actors.create_actor(type: :api_client, account: account)
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/actors")
+
+    items =
+      lv
+      |> element("#actors")
+      |> render()
+      |> Floki.find("a[href*=\"api_clients/#{api_client.id}\"]")
+
+    assert length(items) == 1
+  end
 end


### PR DESCRIPTION
Why:

* The portal currently shows API clients in the Actors index list.  Each Actor in the list has a link to their own 'show' page.  Prior to this commit, selecting an API client from the list would result an error. While API clients are technically an Actor, they aren't quite the same as all other Actors because they are only used to configure the portal for a given account.  Because of this, they don't have the same information to show as all other Actors.  This commit sets the 'show' URL for API clients to the 'settings' page to show the proper info for the API client.

Fixes: #7370 