### PR TITLE
chore(snownet): warn on exceeding number of candidate pairs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6027,8 +6027,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.6.2"
-source = "git+https://github.com/algesten/str0m?branch=main#7170c3a3a5ef2d9446ac7193b5d2faa79e577a2a"
+version = "0.6.3"
+source = "git+https://github.com/algesten/str0m?branch=main#423361be7784966eb907c2d32cbfb5e1ef478b8b"
 dependencies = [
  "combine",
  "crc",
@@ -6701,18 +6701,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { version = "0.1.40" }
 tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" } # Contains `dbg!` but for `tracing`.
 tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
 secrecy = "0.8"
-str0m = { version = "0.6.2", default-features = false }
+str0m = { version = "0.6.3", default-features = false, features = ["sha1"] }
 futures-bounded = "0.2.1"
 domain = { version = "0.10", features = ["serde"] }
 dns-lookup = "2.0"

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2186,7 +2186,6 @@ where
 
 fn new_agent() -> IceAgent {
     let mut agent = IceAgent::new();
-    agent.set_max_candidate_pairs(300);
     agent.set_timing_advance(Duration::ZERO);
     apply_default_stun_timings(&mut agent);
 


### PR DESCRIPTION
In the latest version, we added a warning log to str0m when the maximum number of candidate pairs is exceeded: https://github.com/algesten/str0m/pull/587.

We only ever add the candidates of a single relay to an agent (2 candidates), plus at most 2 server-reflexive candidates and at most 2 host candidates. Unless there is a bug like what we fixed in #7334, exceeding the default number of candidate _pairs_ (100) should never happen.

In case it does, the newly added `warn` log in `str0m` will trigger a Sentry alert.