### PR TITLE
feat(connlib): validate integrity of all relay responses

### DIFF
--- a/rust/relay/src/server/client_message.rs
+++ b/rust/relay/src/server/client_message.rs
@@ -109,6 +109,16 @@ impl ClientMessage<'_> {
             ClientMessage::ChannelData(_) => None,
         }
     }
+
+    pub fn username(&self) -> Option<&Username> {
+        match self {
+            ClientMessage::ChannelData(_) | ClientMessage::Binding(_) => None,
+            ClientMessage::Allocate(request) => request.username(),
+            ClientMessage::Refresh(request) => request.username(),
+            ClientMessage::ChannelBind(request) => request.username(),
+            ClientMessage::CreatePermission(request) => request.username(),
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
In order to avoid processing of responses of relays that somehow got altered on the network path, we now use the client's `password` as a shared secret for the relay to also authenticate its responses. This means that not all message can be authenticated. In particular, BINDING requests will still be unauthenticated.

Performing this validation now requires every component that crafts input to the `Allocation` to include a valid `MessageIntegrity` attribute. This is somewhat problematic for the regression tests of the relay and the unit tests of `Allocation`. In both cases, we implement workarounds so we don't have to actually compute a valid `MessageIntegrity`. This is deemed acceptable because:

- Both of these are just tests.
- We do test the validation path using `tunnel_test` because there we run an actual relay.