### PR TITLE
revert: include span fields in breadcrumb messages

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5505,9 +5505,9 @@ dependencies = [
  "httpdate",
  "reqwest",
  "rustls 0.22.4",
- "sentry-backtrace 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-backtrace",
  "sentry-contexts",
- "sentry-core 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-core",
  "sentry-debug-images",
  "sentry-panic",
  "sentry-tracing",
@@ -5519,11 +5519,12 @@ dependencies = [
 [[package]]
 name = "sentry-anyhow"
 version = "0.34.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#5570b24018347683e0523cd50dce226861fe99cb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d672bfd1ed4e90978435f3c0704edb71a7a9d86403657839d518cd6aa278aff5"
 dependencies = [
  "anyhow",
- "sentry-backtrace 0.34.0 (git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release)",
- "sentry-core 0.34.0 (git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release)",
+ "sentry-backtrace",
+ "sentry-core",
 ]
 
 [[package]]
@@ -5535,18 +5536,7 @@ dependencies = [
  "backtrace",
  "once_cell",
  "regex",
- "sentry-core 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sentry-backtrace"
-version = "0.34.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#5570b24018347683e0523cd50dce226861fe99cb"
-dependencies = [
- "backtrace",
- "once_cell",
- "regex",
- "sentry-core 0.34.0 (git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release)",
+ "sentry-core",
 ]
 
 [[package]]
@@ -5559,7 +5549,7 @@ dependencies = [
  "libc",
  "os_info",
  "rustc_version",
- "sentry-core 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-core",
  "uname",
 ]
 
@@ -5571,19 +5561,7 @@ checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
- "sentry-types 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "sentry-core"
-version = "0.34.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#5570b24018347683e0523cd50dce226861fe99cb"
-dependencies = [
- "once_cell",
- "rand 0.8.5",
- "sentry-types 0.34.0 (git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release)",
+ "sentry-types",
  "serde",
  "serde_json",
 ]
@@ -5596,7 +5574,7 @@ checksum = "8fc6b25e945fcaa5e97c43faee0267eebda9f18d4b09a251775d8fef1086238a"
 dependencies = [
  "findshlibs",
  "once_cell",
- "sentry-core 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-core",
 ]
 
 [[package]]
@@ -5605,17 +5583,18 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
 dependencies = [
- "sentry-backtrace 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sentry-core 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry-backtrace",
+ "sentry-core",
 ]
 
 [[package]]
 name = "sentry-tracing"
 version = "0.34.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#5570b24018347683e0523cd50dce226861fe99cb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
 dependencies = [
- "sentry-backtrace 0.34.0 (git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release)",
- "sentry-core 0.34.0 (git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release)",
+ "sentry-backtrace",
+ "sentry-core",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -5625,22 +5604,6 @@ name = "sentry-types"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
-dependencies = [
- "debugid",
- "hex",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "thiserror",
- "time",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.34.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#5570b24018347683e0523cd50dce226861fe99cb"
 dependencies = [
  "debugid",
  "hex",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -85,8 +85,6 @@ ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" }
 proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "main" }
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.26" } # Waiting for release.
-sentry-tracing = { git = "https://github.com/thomaseizinger/sentry-rust", branch = "bundled-changes-waiting-for-release" }
-sentry-anyhow = { git = "https://github.com/thomaseizinger/sentry-rust", branch = "bundled-changes-waiting-for-release" }
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -114,7 +114,9 @@ impl Telemetry {
 
         // Sentry uses blocking IO for flushing ..
         let _ = tokio::task::spawn_blocking(move || {
-            if !inner.flush(Some(Duration::from_secs(5))) {
+            // `flush`'s return value is flipped from the docs
+            // <https://github.com/getsentry/sentry-rust/issues/677>
+            if inner.flush(Some(Duration::from_secs(5))) {
                 tracing::error!("Failed to flush telemetry events to sentry.io");
                 return;
             };


### PR DESCRIPTION
Reverts #7379.

Unfortunately, this doesn't actually work because those fields are only recorded as part of spans that get sampled, see https://github.com/getsentry/sentry-rust/issues/617#issuecomment-2487058619. If we were to start recording all spans, we'd have a massive overhead and send lots of spans to Sentry.