### PR TITLE
ci: set branch name as docker tag for images

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -281,6 +281,7 @@ jobs:
           # We only version client and gateway
           tags: |
             type=raw,value=latest
+            type=raw,value={{branch}}
             type=raw,value=${{ inputs.sha }}
             ${{ matrix.name.version && format('type=raw,value={0}', matrix.name.version) }}
             ${{ matrix.name.version && format('type=raw,value={0}-{1}', matrix.name.version, inputs.sha) }}


### PR DESCRIPTION
Our `docker-compose` file references the images using the `main` tag. However, doing a `docker compose pull` fails because the `main` tag doesn't exist for the client, gateway and relay images.

In order for this tag to exist, we need to instruct the `docker/metadata-action` to generate a tag for the current branch.