### PR TITLE
ci: lint Rust dependencies using `cargo deny`

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -50,9 +50,11 @@ jobs:
         id: setup-rust
       - uses: ./.github/actions/setup-tauri-v2
         timeout-minutes: 5
-      - uses: taiki-e/install-action@cargo-udeps
+      - uses: taiki-e/install-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tool: cargo-udeps,cargo-deny
       - run: |
           rustup install --no-self-update nightly-2024-09-01 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
           cargo +nightly-2024-09-01 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
@@ -64,11 +66,8 @@ jobs:
       - run: cargo clippy --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
         name: "cargo clippy"
         shell: bash
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          log-level: warn
-          manifest-path: ./rust/Cargo.toml
-          command: check --hide-inclusion-graph
+      - run: cargo deny check --hide-inclusion-graph
+        shell: bash
   test:
     name: test-${{ matrix.runs-on }}
     strategy:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -64,7 +64,11 @@ jobs:
       - run: cargo clippy --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
         name: "cargo clippy"
         shell: bash
-
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          log-level: warn
+          manifest-path: ./rust/Cargo.toml
+          command: check --hide-inclusion-graph
   test:
     name: test-${{ matrix.runs-on }}
     strategy:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -448,15 +448,11 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
  "tower 0.5.1",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -477,7 +473,6 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5680,16 +5675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
-dependencies = [
- "itoa 1.0.11",
- "serde",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6988,7 +6973,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -448,6 +448,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
  "tower 0.5.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,9 @@ members = [
 
 resolver = "2"
 
+[workspace.package]
+license = "Apache-2.0"
+
 [workspace.dependencies]
 atomicwrites = "0.4.4"
 boringtun = { version = "0.6", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,23 +29,116 @@ resolver = "2"
 license = "Apache-2.0"
 
 [workspace.dependencies]
+anyhow = "1.0.93"
+arboard = { version = "3.4.0", default-features = false }
+async-trait = { version = "0.1", default-features = false }
 atomicwrites = "0.4.4"
-boringtun = { version = "0.6", default-features = false }
-chrono = { version = "0.4", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
-swift-bridge = "0.1.57"
+axum = { version = "0.7.7", default-features = false }
 backoff = { version = "0.4", features = ["tokio"] }
-tracing = { version = "0.1.40" }
-tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" } # Contains `dbg!` but for `tracing`.
-tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
-secrecy = "0.8"
-str0m = { version = "0.6.3", default-features = false, features = ["sha1"] }
-futures-bounded = "0.2.1"
-domain = { version = "0.10", features = ["serde"] }
+base64 = { version = "0.22.1", default-features = false }
+bimap = "0.6"
+boringtun = { version = "0.6", default-features = false }
+bytecodec = "0.4.15"
+bytes = { version = "1.7.1", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
+clap = "4.5.21"
+derivative = "2.2.0"
+derive_more = "1.0.0"
+difference = "2.0.0"
+dirs = "5.0.1"
+divan = "0.1.14"
 dns-lookup = "2.0"
-tokio-tungstenite = "0.23.1"
+domain = { version = "0.10", features = ["serde"] }
+either = "1"
+env_logger = "0.11.3"
+etherparse = "0.16"
+futures = { version = "0.3.31", default-features = false }
+futures-bounded = "0.2.1"
+futures-util = { version = "0.3", default-features = false }
+glob = "0.3.1"
+hex = "0.4.3"
+hex-display = "0.3.0"
+hex-literal = "0.4.1"
+humantime = "2.1"
+ip_network = { version = "0.4", default-features = false }
+ip_network_table = { version = "0.2", default-features = false }
+itertools = "0.13"
+jni = "0.21.1"
+keyring = "3.2.1"
+known-folders = "1.2.0"
+libc = "0.2.150"
+log = "0.4"
+lru = "0.12.5"
+mio = "1.0.1"
+native-dialog = "0.7.0"
+nix = "0.29.0"
+nu-ansi-term = "0.50"
+once_cell = "1.17.1"
+opentelemetry = "0.26.0"
+opentelemetry-otlp = "0.26.0"
+opentelemetry_sdk = "0.26.0"
+os_info = { version = "3", default-features = false }
+output_vt100 = "0.1"
+png = "0.17.13"
+proptest = "1"
+proptest-state-machine = "0.3"
+quinn-udp = "0.5.2"
+rand = "0.8.5"
+rand_core = "0.6.4"
+rangemap = "1.5.1"
+reqwest = { version = "0.12.5", default-features = false }
 rtnetlink = { version = "0.14.1", default-features = false, features = ["tokio_socket"] }
-tokio = "1.41"
 rustls = { version = "0.23.10", default-features = false, features = ["ring"] }
+sadness-generator = "0.6.0"
+secrecy = "0.8"
+semver = "1.0.22"
+sentry = { version = "0.34.0", default-features = false }
+sentry-anyhow = "0.34.0"
+sentry-tracing = "0.34.0"
+serde = "1.0.210"
+serde_json = "1.0.132"
+serde_variant = "0.1.3"
+sha2 = "0.10.8"
+smallvec = "1.13.2"
+smbios-lib = "0.9.2"
+smoltcp = { version = "0.11", default-features = false }
+static_assertions = "1.1.0"
+str0m = { version = "0.6.3", default-features = false, features = ["sha1"] }
+stun_codec = "0.3.4"
+subprocess = "0.2.9"
+subtle = "2.5.0"
+swift-bridge = "0.1.57"
+swift-bridge-build = "0.1.57"
+tauri = "2.0.3"
+tauri-build = "2.0.1"
+tauri-plugin-dialog = "2.0.1"
+tauri-plugin-notification = "2.0.1"
+tauri-plugin-shell = "2.0.2"
+tauri-runtime = "2.1.0"
+tauri-utils = "2.0.1"
+tempfile = "3.13.0"
+test-case = "3.3.1"
+test-strategy = "0.4.0"
+thiserror = "1.0.68"
+time = "0.3.36"
+tokio = "1.41"
+tokio-stream = "0.1.16"
+tokio-tungstenite = "0.23.1"
+tokio-util = "0.7.11"
+tracing = { version = "0.1.40" }
+tracing-appender = "0.2.3"
+tracing-core = "0.1.31"
+tracing-log = "0.2.0"
+tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" } # Contains `dbg!` but for `tracing`.
+tracing-opentelemetry = "0.27.0"
+tracing-stackdriver = "0.11.0"
+tracing-subscriber = { version = "0.3.17", features = ["parking_lot"] }
+trackable = "1.3.0"
+url = "2.5.2"
+uuid = "1.10.0"
+windows = "0.58.0"
+winreg = "0.52.0"
+zip = { version = "2", default-features = false }
 
 connlib-client-android = { path = "connlib/clients/android" }
 connlib-client-apple = { path = "connlib/clients/apple" }
@@ -53,6 +146,8 @@ connlib-client-shared = { path = "connlib/clients/shared" }
 firezone-bin-shared = { path = "bin-shared" }
 firezone-logging = { path = "logging" }
 firezone-telemetry = { path = "telemetry" }
+firezone-headless-client = { path = "headless-client" }
+firezone-gui-client-common = { path = "gui-client/src-common" }
 snownet = { path = "connlib/snownet" }
 dns-over-tcp = { path = "dns-over-tcp" }
 firezone-relay = { path = "relay" }

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = { workspace = true }
 axum = { workspace = true, features = ["http1", "tokio"] }
 clap = { workspace = true, features = ["derive", "env"] }
 firezone-logging = { workspace = true }
-futures = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await"] }
 hex-literal = { workspace = true }
 ip_network = { workspace = true, features = ["serde"] }
 socket-factory = { workspace = true }

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -25,8 +25,8 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { workspace = true }
-netlink-packet-core = { version = "0.7", default-features = false }
-netlink-packet-route = { version = "0.19", default-features = false }
+netlink-packet-core = { version = "0.7" }
+netlink-packet-route = { version = "0.19" }
 nix = { workspace = true, features = ["socket"] }
 rtnetlink = { workspace = true }
 zbus = "4.4" # Can't use `zbus`'s `tokio` feature here, or it will break toast popups all the way over in `gui-client`.

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -7,15 +7,15 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.82"
-axum = { version = "0.7.7", default-features = false, features = ["http1", "tokio"] }
-clap = { version = "4.5.21", features = ["derive", "env"] }
+anyhow = { workspace = true }
+axum = { workspace = true, features = ["http1", "tokio"] }
+clap = { workspace = true, features = ["derive", "env"] }
 firezone-logging = { workspace = true }
-futures = "0.3"
-hex-literal = "0.4.1"
-ip_network = { version = "0.4", default-features = false, features = ["serde"] }
+futures = { workspace = true }
+hex-literal = { workspace = true }
+ip_network = { workspace = true, features = ["serde"] }
 socket-factory = { workspace = true }
-thiserror = "1.0.68"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "rt", "sync"] }
 tracing = { workspace = true }
 tun = { workspace = true }
@@ -24,24 +24,24 @@ tun = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 netlink-packet-core = { version = "0.7", default-features = false }
 netlink-packet-route = { version = "0.19", default-features = false }
-nix = { version = "0.29.0", features = ["socket"] }
+nix = { workspace = true, features = ["socket"] }
 rtnetlink = { workspace = true }
 zbus = "4.4" # Can't use `zbus`'s `tokio` feature here, or it will break toast popups all the way over in `gui-client`.
 
 [target.'cfg(windows)'.dependencies]
-known-folders = "1.2.0"
+known-folders = { workspace = true }
 ring = "0.17"
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }
 windows-core = "0.58.0"
 windows-implement = "0.58.0"
 wintun = "0.5.0"
-winreg = "0.52.0"
+winreg = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.58.0"
+workspace = true
 features = [
   # For implementing COM interfaces
   "implement",

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -3,6 +3,7 @@ name = "firezone-bin-shared"
 version = "0.1.0"
 edition = "2021"
 description = "Firezone-specific modules shared between binaries."
+license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -3,6 +3,7 @@ name = "connlib-client-android"
 # mark:next-android-version
 version = "1.3.8"
 edition = "2021"
+license = { workspace = true }
 
 [lib]
 name = "connlib"

--- a/rust/connlib/clients/android/Cargo.toml
+++ b/rust/connlib/clients/android/Cargo.toml
@@ -11,28 +11,28 @@ crate-type = ["lib", "cdylib"]
 doc = false
 
 [dependencies]
-anyhow = "1.0.93"
-backoff = "0.4.0"
+anyhow = { workspace = true }
+backoff = { workspace = true }
 connlib-client-shared = { workspace = true }
 connlib-model = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
-ip_network = "0.4"
-jni = { version = "0.21.1", features = ["invocation"] }
-libc = "0.2"
-log = "0.4"
+ip_network = { workspace = true }
+jni = { workspace = true, features = ["invocation"] }
+libc = { workspace = true }
+log = { workspace = true }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
-serde_json = "1"
+serde_json = { workspace = true }
 socket-factory = { workspace = true }
-thiserror = "1"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing = { workspace = true, features = ["std", "attributes"] }
-tracing-appender = "0.2"
+tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 tun = { workspace = true }
-url = "2.5.2"
+url = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.3.1"

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -6,29 +6,29 @@ edition = "2021"
 license = { workspace = true }
 
 [build-dependencies]
-swift-bridge-build = "0.1.57"
+swift-bridge-build = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.86"
-backoff = "0.4.0"
+anyhow = { workspace = true }
+backoff = { workspace = true }
 connlib-client-shared = { workspace = true }
 connlib-model = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
-ip_network = "0.4"
-libc = "0.2"
+ip_network = { workspace = true }
+libc = { workspace = true }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
-serde_json = "1"
+serde_json = { workspace = true }
 socket-factory = { workspace = true }
 swift-bridge = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing = { workspace = true }
-tracing-appender = "0.2"
-tracing-subscriber = "0.3"
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true }
 tun = { workspace = true }
-url = "2.5.2"
+url = { workspace = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 oslog = { version = "0.2.0", default-features = false }

--- a/rust/connlib/clients/apple/Cargo.toml
+++ b/rust/connlib/clients/apple/Cargo.toml
@@ -3,6 +3,7 @@ name = "connlib-client-apple"
 # mark:next-apple-version
 version = "1.3.10"
 edition = "2021"
+license = { workspace = true }
 
 [build-dependencies]
 swift-bridge-build = "0.1.57"

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -5,28 +5,28 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.82"
+anyhow = { workspace = true }
 backoff = { workspace = true }
-bimap = "0.6"
+bimap = { workspace = true }
 connlib-model = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-tunnel = { workspace = true }
-ip_network = { version = "0.4", default-features = false }
+ip_network = { workspace = true }
 phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
+serde = { workspace = true, default-features = false, features = ["std", "derive"] }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
-thiserror = "1.0.68"
-time = { version = "0.3.36", features = ["formatting"] }
+thiserror = { workspace = true }
+time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true, features = ["rt", "sync"] }
 tracing = { workspace = true, features = ["std", "attributes"] }
 tun = { workspace = true }
-url = { version = "2.4.1", features = ["serde"] }
+url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 chrono = { workspace = true }
-serde_json = { version = "1.0", features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
 
 [lints]
 workspace = true

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -2,6 +2,7 @@
 name = "connlib-client-shared"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 
 [dependencies]
 anyhow = "1.0.82"

--- a/rust/connlib/clients/shared/Cargo.toml
+++ b/rust/connlib/clients/shared/Cargo.toml
@@ -14,7 +14,7 @@ firezone-tunnel = { workspace = true }
 ip_network = { workspace = true }
 phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
-serde = { workspace = true, default-features = false, features = ["std", "derive"] }
+serde = { workspace = true, features = ["std", "derive"] }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/connlib/model/Cargo.toml
+++ b/rust/connlib/model/Cargo.toml
@@ -7,12 +7,12 @@ license = { workspace = true }
 [dependencies]
 boringtun = { workspace = true }
 domain = { workspace = true }
-ip_network = { version = "0.4", default-features = false, features = ["serde"] }
-serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
-uuid = { version = "1.10", default-features = false, features = ["std", "v4", "serde"] }
+ip_network = { workspace = true, features = ["serde"] }
+serde = { workspace = true, default-features = false, features = ["derive", "std"] }
+uuid = { workspace = true, default-features = false, features = ["std", "v4", "serde"] }
 
 [dev-dependencies]
-itertools = "0.13"
+itertools = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/connlib/model/Cargo.toml
+++ b/rust/connlib/model/Cargo.toml
@@ -2,6 +2,7 @@
 name = "connlib-model"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 
 [dependencies]
 boringtun = { workspace = true }

--- a/rust/connlib/model/Cargo.toml
+++ b/rust/connlib/model/Cargo.toml
@@ -8,8 +8,8 @@ license = { workspace = true }
 boringtun = { workspace = true }
 domain = { workspace = true }
 ip_network = { workspace = true, features = ["serde"] }
-serde = { workspace = true, default-features = false, features = ["derive", "std"] }
-uuid = { workspace = true, default-features = false, features = ["std", "v4", "serde"] }
+serde = { workspace = true, features = ["derive", "std"] }
+uuid = { workspace = true, features = ["std", "v4", "serde"] }
 
 [dev-dependencies]
 itertools = { workspace = true }

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -2,6 +2,7 @@
 name = "snownet"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 
 [dependencies]
 backoff = "0.4.0"

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -5,22 +5,22 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-backoff = "0.4.0"
+backoff = { workspace = true }
 boringtun = { workspace = true }
-bytecodec = "0.4.15"
-bytes = "1.7.1"
+bytecodec = { workspace = true }
+bytes = { workspace = true }
 firezone-logging = { workspace = true }
-hex = "0.4.0"
-hex-display = "0.3.0"
+hex = { workspace = true }
+hex-display = { workspace = true }
 ip-packet = { workspace = true }
-itertools = "0.13"
-once_cell = "1.17.1"
-rand = "0.8"
+itertools = { workspace = true }
+once_cell = { workspace = true }
+rand = { workspace = true }
 secrecy = { workspace = true }
-sha2 = "0.10.8"
+sha2 = { workspace = true }
 str0m = { workspace = true }
-stun_codec = "0.3.4"
-thiserror = "1"
+stun_codec = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -2,6 +2,7 @@
 name = "firezone-tunnel"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -25,13 +25,13 @@ hex = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
 ip_network_table = { workspace = true }
-itertools = { workspace = true, default-features = false, features = ["use_std"] }
+itertools = { workspace = true, features = ["use_std"] }
 lru = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }
 rangemap = { workspace = true }
 secrecy = { workspace = true, features = ["serde"] }
-serde = { workspace = true, default-features = false, features = ["derive", "std"] }
+serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
@@ -41,7 +41,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 tun = { workspace = true }
-uuid = { workspace = true, default-features = false, features = ["std", "v4"] }
+uuid = { workspace = true, features = ["std", "v4"] }
 
 [dev-dependencies]
 derivative = { workspace = true }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -5,53 +5,53 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
-base64 = { version = "0.22", default-features = false, features = ["std"] }
-bimap = "0.6"
+anyhow = { workspace = true }
+base64 = { workspace = true, features = ["std"] }
+bimap = { workspace = true }
 boringtun = { workspace = true }
-bytes = { version = "1.7", default-features = false, features = ["std"] }
+bytes = { workspace = true, features = ["std"] }
 chrono = { workspace = true }
 connlib-model = { workspace = true }
-derivative = "2.2.0"
-divan = { version = "0.1.14", optional = true }
+derivative = { workspace = true }
+divan = { workspace = true, optional = true }
 dns-over-tcp = { workspace = true }
 domain = { workspace = true }
 firezone-logging = { workspace = true }
-futures = { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
-futures-bounded = "0.2.4"
-futures-util = { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }
-glob = "0.3.1"
-hex = "0.4.3"
+futures = { workspace = true, features = ["std", "async-await", "executor"] }
+futures-bounded = { workspace = true }
+futures-util = { workspace = true, features = ["std", "async-await", "async-await-macro"] }
+glob = { workspace = true }
+hex = { workspace = true }
 ip-packet = { workspace = true }
-ip_network = { version = "0.4", default-features = false }
-ip_network_table = { version = "0.2", default-features = false }
-itertools = { version = "0.13", default-features = false, features = ["use_std"] }
-lru = "0.12.5"
-proptest = { version = "1", optional = true }
-rand = "0.8.5"
-rangemap = "1.5.1"
+ip_network = { workspace = true }
+ip_network_table = { workspace = true }
+itertools = { workspace = true, default-features = false, features = ["use_std"] }
+lru = { workspace = true }
+proptest = { workspace = true, optional = true }
+rand = { workspace = true }
+rangemap = { workspace = true }
 secrecy = { workspace = true, features = ["serde"] }
-serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
-serde_json = "1.0"
+serde = { workspace = true, default-features = false, features = ["derive", "std"] }
+serde_json = { workspace = true }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
 socket2 = { workspace = true }
-thiserror = { version = "1.0", default-features = false }
+thiserror = { workspace = true }
 tokio = { workspace = true }
-tokio-util = "0.7.12"
+tokio-util = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 tun = { workspace = true }
-uuid = { version = "1.10", default-features = false, features = ["std", "v4"] }
+uuid = { workspace = true, default-features = false, features = ["std", "v4"] }
 
 [dev-dependencies]
-derivative = "2.2.0"
+derivative = { workspace = true }
 firezone-relay = { workspace = true, features = ["proptest"] }
 ip-packet = { workspace = true, features = ["proptest"] }
-proptest-state-machine = "0.3"
-rand = "0.8"
-test-case = "3.3.1"
-test-strategy = "0.4.0"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+proptest-state-machine = { workspace = true }
+rand = { workspace = true }
+test-case = { workspace = true }
+test-strategy = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[bench]]
 name = "divan"

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -1,0 +1,304 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# The graph table configures how the dependency graph is constructed and thus
+# which crates the checks are performed against
+[graph]
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  #"x86_64-unknown-linux-musl",
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory databases are cloned/fetched into
+#db-path = "$CARGO_HOME/advisory-dbs"
+# The url(s) of the advisory databases to use
+#db-urls = ["https://github.com/rustsec/advisory-db"]
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+  "RUSTSEC-2020-0095",
+  "RUSTSEC-2024-0384",
+  "RUSTSEC-2024-0370",
+  "RUSTSEC-2024-0388",
+  #"RUSTSEC-0000-0000",
+  #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+  #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+  #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+]
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MPL-2.0",
+  "ISC",
+  "0BSD",
+  "Unicode-DFS-2016",
+  "BSL-1.0",
+  "Zlib",
+  "OpenSSL",
+]
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  #{ allow = ["Zlib"], crate = "adler32" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+[[licenses.clarify]]
+# The package spec the clarification applies to
+crate = "ring"
+# The SPDX expression for the license requirements of the crate
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+  # Each entry is a crate relative path, and the (opaque) hash of its contents
+  { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[licenses.private]
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = true
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+  #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "deny"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overridden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overridden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+  #"ansi_term@0.11.0",
+  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+]
+# List of crates to deny
+deny = [
+  #"ansi_term@0.11.0",
+  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#crate = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+  "base64",
+  "bitflags",
+  "cocoa",
+  "cocoa-foundation",
+  "core-foundation",
+  "core-graphics",
+  "core-graphics-types",
+  "derive_more",
+  "getrandom",
+  "hashbrown",
+  "heck",
+  "hermit-abi",
+  "indexmap",
+  "itertools",
+  "itoa",
+  "libloading",
+  "nix",
+  "nu-ansi-term",
+  "phf",
+  "phf_codegen",
+  "phf_generator",
+  "phf_macros",
+  "phf_shared",
+  "proc-macro-crate",
+  "quick-xml",
+  "rand",
+  "rand_chacha",
+  "rand_core",
+  "raw-window-handle",
+  "regex-automata",
+  "regex-syntax",
+  "rustls",
+  "syn",
+  "sync_wrapper",
+  "tauri-winrt-notification",
+  "toml",
+  "toml_edit",
+  "tower",
+  "trackable",
+  "wasi",
+  "windows",
+  "windows-core",
+  "windows-implement",
+  "windows-interface",
+  "windows-result",
+  "windows-sys",
+  "windows-targets",
+  "windows_aarch64_gnullvm",
+  "windows_aarch64_msvc",
+  "windows_i686_gnu",
+  "windows_i686_msvc",
+  "windows_x86_64_gnu",
+  "windows_x86_64_gnullvm",
+  "windows_x86_64_msvc",
+  "winnow",
+  "winreg",
+  #"ansi_term@0.11.0",
+  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+  #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+  #{ crate = "ansi_term@0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "allow"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = []
+# 1 or more gitlab.com organizations to allow git sources for
+gitlab = []
+# 1 or more bitbucket.org organizations to allow git sources for
+bitbucket = []

--- a/rust/dns-over-tcp/Cargo.toml
+++ b/rust/dns-over-tcp/Cargo.toml
@@ -6,18 +6,18 @@ description = "User-space implementation of DNS over TCP."
 license = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 domain = { workspace = true }
 firezone-logging = { workspace = true }
 ip-packet = { workspace = true }
-itertools = "0.13"
-rand = "0.8"
-smoltcp = { version = "0.11", default-features = false, features = ["std", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-tcp"] }
+itertools = { workspace = true }
+rand = { workspace = true }
+smoltcp = { workspace = true, features = ["std", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-tcp"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
 firezone-bin-shared = { workspace = true }
-futures = "0.3"
-ip_network = { version = "0.4", default-features = false }
+futures = { workspace = true }
+ip_network = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt", "macros"] }
 tun = { workspace = true }

--- a/rust/dns-over-tcp/Cargo.toml
+++ b/rust/dns-over-tcp/Cargo.toml
@@ -3,6 +3,7 @@ name = "dns-over-tcp"
 version = "0.1.0"
 edition = "2021"
 description = "User-space implementation of DNS over TCP."
+license = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -3,6 +3,7 @@ name = "firezone-gateway"
 # mark:next-gateway-version
 version = "1.4.2"
 edition = "2021"
+license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -7,40 +7,40 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.82"
-async-trait = { version = "0.1", default-features = false }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 backoff = { workspace = true }
 boringtun = { workspace = true }
 chrono = { workspace = true }
-clap = "4.5.21"
+clap = { workspace = true }
 connlib-model = { workspace = true }
 dns-lookup = { workspace = true }
 domain = { workspace = true }
-either = "1"
+either = { workspace = true }
 firezone-bin-shared = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
 firezone-tunnel = { workspace = true }
-futures = "0.3.29"
+futures = { workspace = true }
 futures-bounded = { workspace = true }
 ip-packet = { workspace = true }
-ip_network = { version = "0.4", default-features = false }
-libc = { version = "0.2", default-features = false, features = ["std", "const-extern-fn", "extra_traits"] }
+ip_network = { workspace = true }
+libc = { workspace = true, default-features = false, features = ["std", "const-extern-fn", "extra_traits"] }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0", default-features = false, features = ["std", "derive"] }
+serde = { workspace = true, default-features = false, features = ["std", "derive"] }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
-static_assertions = "1.1.0"
+static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread", "fs", "signal"] }
 tracing = { workspace = true }
-tracing-subscriber = "0.3.17"
-url = { version = "2.5.2", default-features = false }
-uuid = { version = "1.10.0", features = ["v4"] }
+tracing-subscriber = { workspace = true }
+url = { workspace = true, default-features = false }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-serde_json = { version = "1.0", default-features = false, features = ["std"] }
+serde_json = { workspace = true, default-features = false, features = ["std"] }
 
 [lints]
 workspace = true

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -25,22 +25,22 @@ futures = { workspace = true }
 futures-bounded = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
-libc = { workspace = true, default-features = false, features = ["std", "const-extern-fn", "extra_traits"] }
+libc = { workspace = true, features = ["std", "const-extern-fn", "extra_traits"] }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
-serde = { workspace = true, default-features = false, features = ["std", "derive"] }
+serde = { workspace = true, features = ["std", "derive"] }
 snownet = { workspace = true }
 socket-factory = { workspace = true }
 static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread", "fs", "signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-url = { workspace = true, default-features = false }
+url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-serde_json = { workspace = true, default-features = false, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
 
 [lints]
 workspace = true

--- a/rust/gui-client/src-common/Cargo.toml
+++ b/rust/gui-client/src-common/Cargo.toml
@@ -3,6 +3,7 @@ name = "firezone-gui-client-common"
 # mark:next-gui-version
 version = "1.3.14"
 edition = "2021"
+license = { workspace = true }
 
 [dependencies]
 anyhow = { version = "1.0" }

--- a/rust/gui-client/src-common/Cargo.toml
+++ b/rust/gui-client/src-common/Cargo.toml
@@ -6,50 +6,43 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-anyhow = { version = "1.0" }
-arboard = { version = "3.4.0", default-features = false }
+anyhow = { workspace = true }
+arboard = { workspace = true }
 atomicwrites = { workspace = true }
 connlib-model = { workspace = true }
 firezone-bin-shared = { workspace = true }
-firezone-headless-client = { path = "../../headless-client" }
+firezone-headless-client = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
-futures = { version = "0.3", default-features = false }
-hex = "0.4.3"
-native-dialog = "0.7.0"
-output_vt100 = "0.1"
-png = "0.17.13" # `png` is mostly free since we already need it for Tauri
-rand = "0.8.5"
-reqwest = { version = "0.12.5", default-features = false, features = ["stream", "rustls-tls"] }
-sadness-generator = "0.6.0"
+futures = { workspace = true }
+hex = { workspace = true }
+native-dialog = { workspace = true }
+output_vt100 = { workspace = true }
+png = { workspace = true } # `png` is mostly free since we already need it for Tauri
+rand = { workspace = true }
+reqwest = { workspace = true, features = ["stream", "rustls-tls"] }
+sadness-generator = { workspace = true }
 secrecy = { workspace = true }
-semver = { version = "1.0.22", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-subtle = "2.5.0"
-thiserror = { version = "1.0", default-features = false }
-time = { version = "0.3.36", features = ["formatting"] }
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+subtle = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-log = "0.2"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-url = { version = "2.5.2" }
-uuid = { version = "1.10.0", features = ["v4"] }
-zip = { version = "2", features = ["deflate", "time"], default-features = false }
-
-[dependencies.keyring]
-version = "3.2.1"
-features = [
-  "crypto-rust", # Don't rely on OpenSSL
-  "sync-secret-service", # Can't use Tokio because of <https://github.com/hwchen/keyring-rs/issues/132>
-  "windows-native", # Yes, really, we must actually explicitly ask for every platform. Otherwise it defaults to an in-memory mock store. Really. That's really how `keyring` 3.x is designed.
-]
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+url = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+zip = { workspace = true, features = ["deflate", "time"] }
+keyring = { workspace = true, features = ["crypto-rust", "sync-secret-service", "windows-native"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-dirs = "5.0.1"
+dirs = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winreg = "0.52.0"
+winreg = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/gui-client/src-common/Cargo.toml
+++ b/rust/gui-client/src-common/Cargo.toml
@@ -16,6 +16,7 @@ firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+keyring = { workspace = true, features = ["crypto-rust", "sync-secret-service", "windows-native"] }
 native-dialog = { workspace = true }
 output_vt100 = { workspace = true }
 png = { workspace = true } # `png` is mostly free since we already need it for Tauri
@@ -36,7 +37,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 zip = { workspace = true, features = ["deflate", "time"] }
-keyring = { workspace = true, features = ["crypto-rust", "sync-secret-service", "windows-native"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dirs = { workspace = true }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -6,6 +6,7 @@ description = "Firezone"
 edition = "2021"
 default-run = "firezone-gui-client"
 authors = ["Firezone, Inc."]
+license = { workspace = true }
 
 [build-dependencies]
 anyhow = { version = "1.0.89" }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -9,47 +9,47 @@ authors = ["Firezone, Inc."]
 license = { workspace = true }
 
 [build-dependencies]
-anyhow = { version = "1.0.89" }
-tauri-build = { version = "2.0.1", features = [] }
+anyhow = { workspace = true }
+tauri-build = { workspace = true, features = [] }
 
 [dependencies]
-anyhow = { version = "1.0.89" }
+anyhow = { workspace = true }
 atomicwrites = { workspace = true }
 chrono = { workspace = true }
-clap = { version = "4.5.21", features = ["derive", "env"] }
+clap = { workspace = true, features = ["derive", "env"] }
 connlib-client-shared = { workspace = true }
 connlib-model = { workspace = true }
 firezone-bin-shared = { workspace = true }
-firezone-gui-client-common = { path = "../src-common" }
-firezone-headless-client = { path = "../../headless-client" }
+firezone-gui-client-common = { workspace = true }
+firezone-headless-client = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
-futures = "0.3.31"
-native-dialog = "0.7.0"
-rand = "0.8.5"
+futures = { workspace = true }
+native-dialog = { workspace = true }
+rand = { workspace = true }
 rustls = { workspace = true }
-sadness-generator = "0.6.0"
+sadness-generator = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.132"
-subtle = "2.5.0"
-tauri = { version = "2.0.3", features = ["tray-icon", "image-png"] }
-tauri-plugin-dialog = "2.0.1"
-tauri-plugin-notification = "2.0.1"
-tauri-plugin-shell = "2.0.2"
-tauri-runtime = "2.1.0"
-tauri-utils = "2.0.1"
-thiserror = "1.0.68"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+subtle = { workspace = true }
+tauri = { workspace = true, features = ["tray-icon", "image-png"] }
+tauri-plugin-dialog = { workspace = true }
+tauri-plugin-notification = { workspace = true }
+tauri-plugin-shell = { workspace = true }
+tauri-runtime = { workspace = true }
+tauri-utils = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["signal", "time", "macros", "rt", "rt-multi-thread"] }
-tokio-util = { version = "0.7.11", features = ["codec"] }
+tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-url = { version = "2.5.2", features = ["serde"] }
-uuid = { version = "1.10.0", features = ["v4"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+url = { workspace = true, features = ["serde"] }
+uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-dirs = "5.0.1"
-nix = { version = "0.29.0", features = ["user"] }
+dirs = { workspace = true }
+nix = { workspace = true, features = ["user"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 
@@ -57,7 +57,7 @@ nix = { version = "0.29.0", features = ["user"] }
 tauri-winrt-notification = "0.6.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
-version = "0.58.0"
+workspace = true
 features = [
   "Win32_Foundation",
   "Win32_System_Threading",

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -8,63 +8,63 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0" }
+anyhow = { workspace = true }
 atomicwrites = { workspace = true } # Needed to safely backup `/etc/resolv.conf` and write the device ID on behalf of `gui-client`
-backoff = "0.4.0"
-clap = { version = "4.5", features = ["derive", "env", "string"] }
+backoff = { workspace = true }
+clap = { workspace = true, features = ["derive", "env", "string"] }
 connlib-client-shared = { workspace = true }
 connlib-model = { workspace = true }
 firezone-bin-shared = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
-futures = "0.3.30"
-humantime = "2.1"
+futures = { workspace = true }
+humantime = { workspace = true }
 ip-packet = { workspace = true }
-ip_network = { version = "0.4", default-features = false }
+ip_network = { workspace = true }
 phoenix-channel = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.132"
-serde_variant = "0.1.3"
-smbios-lib = "0.9.2"
-thiserror = { version = "1.0", default-features = false }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+serde_variant = { workspace = true }
+smbios-lib = { workspace = true }
+thiserror = { workspace = true }
 # This actually relies on many other features in Tokio, so this will probably
 # fail to build outside the workspace. <https://github.com/firezone/firezone/pull/4328#discussion_r1540342142>
 tokio = { workspace = true, features = ["macros", "signal", "process", "time", "rt-multi-thread", "fs"] }
-tokio-stream = "0.1.16"
-tokio-util = { version = "0.7.11", features = ["codec"] }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-url = { version = "2.5.2", default-features = false }
-uuid = { version = "1.10", default-features = false, features = ["std", "v4", "serde"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+url = { workspace = true, default-features = false }
+uuid = { workspace = true, default-features = false, features = ["std", "v4", "serde"] }
 
 [dev-dependencies]
-tempfile = "3.13.0"
+tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 mutants = "0.0.3" # Needed to mark functions as exempt from `cargo-mutants` testing
 
 [target.'cfg(target_os = "linux")'.dependencies]
-dirs = "5.0.1"
-libc = "0.2.150"
-nix = { version = "0.29.0", features = ["fs", "user", "socket"] }
+dirs = { workspace = true }
+libc = { workspace = true }
+nix = { workspace = true, features = ["fs", "user", "socket"] }
 resolv-conf = "0.7.0"
 rtnetlink = { workspace = true }
 sd-notify = "0.4.2" # This is a pure Rust re-implementation, so it isn't vulnerable to CVE-2024-3094
 
 [target.'cfg(target_os = "macos")'.dependencies]
-dirs = "5.0.1"
+dirs = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 ipconfig = "0.3.2"
-itertools = "0.13.0"
-known-folders = "1.2.0"
+itertools = { workspace = true }
+known-folders = { workspace = true }
 windows-service = "0.7.0"
-winreg = "0.52.0"
+winreg = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.58.0"
+workspace = true
 features = [
   # For DNS control and route control
   "Win32_Foundation",

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -4,6 +4,7 @@ name = "firezone-headless-client"
 version = "1.3.8"
 edition = "2021"
 authors = ["Firezone, Inc."]
+license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -36,8 +36,8 @@ tokio-stream = { workspace = true }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-url = { workspace = true, default-features = false }
-uuid = { workspace = true, default-features = false, features = ["std", "v4", "serde"] }
+url = { workspace = true }
+uuid = { workspace = true, features = ["std", "v4", "serde"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/rust/ip-packet/Cargo.toml
+++ b/rust/ip-packet/Cargo.toml
@@ -11,14 +11,14 @@ license = { workspace = true }
 proptest = ["dep:proptest"]
 
 [dependencies]
-anyhow = "1.0.86"
-etherparse = "0.16"
-proptest = { version = "1", optional = true }
-thiserror = "1"
-tracing = "0.1"
+anyhow = { workspace= true}
+etherparse = { workspace = true }
+proptest = { workspace = true, optional = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-test-strategy = "0.4.0"
+test-strategy = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/ip-packet/Cargo.toml
+++ b/rust/ip-packet/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Firezone, Inc."]
 publish = false
+license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/rust/ip-packet/Cargo.toml
+++ b/rust/ip-packet/Cargo.toml
@@ -11,7 +11,7 @@ license = { workspace = true }
 proptest = ["dep:proptest"]
 
 [dependencies]
-anyhow = { workspace= true}
+anyhow = { workspace = true }
 etherparse = { workspace = true }
 proptest = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/rust/logging/Cargo.toml
+++ b/rust/logging/Cargo.toml
@@ -8,19 +8,19 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
-nu-ansi-term = { version = "0.50" }
-rand = "0.8"
-sentry-tracing = "0.34.0"
-time = { version = "0.3.36", features = ["formatting"] }
+anyhow = { workspace = true }
+nu-ansi-term = { workspace = true }
+rand = { workspace = true }
+sentry-tracing = { workspace = true }
+time = { workspace = true, features = ["formatting"] }
 tracing = { workspace = true }
-tracing-appender = { version = "0.2.2" }
-tracing-log = "0.2"
-tracing-stackdriver = { version = "0.11.0" }
+tracing-appender = { workspace = true }
+tracing-log = { workspace = true }
+tracing-stackdriver = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]
-thiserror = "1"
+thiserror = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/logging/Cargo.toml
+++ b/rust/logging/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Firezone, Inc."]
 publish = false
+license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -6,25 +6,25 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-backoff = "0.4.0"
-base64 = "0.22.1"
+backoff = { workspace = true }
+base64 = { workspace = true }
 firezone-logging = { workspace = true }
-futures = "0.3.29"
-hex = "0.4"
-libc = "0.2"
-os_info = { version = "3", default-features = false }
-rand_core = "0.6.4"
+futures = { workspace = true }
+hex = { workspace = true }
+libc = { workspace = true }
+os_info = { workspace = true }
+rand_core = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.132"
-sha2 = "0.10.8"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 socket-factory = { workspace = true }
-thiserror = "1.0.68"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["net", "time"] }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 tracing = { workspace = true }
-url = "2.5.2"
-uuid = { version = "1.10", default-features = false, features = ["std", "v4"] }
+url = { workspace = true }
+uuid = { workspace = true, default-features = false, features = ["std", "v4"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 hostname = "0.4.0"

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -2,6 +2,7 @@
 name = "phoenix-channel"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { workspace = true, features = ["net", "time"] }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 tracing = { workspace = true }
 url = { workspace = true }
-uuid = { workspace = true, default-features = false, features = ["std", "v4"] }
+uuid = { workspace = true, features = ["std", "v4"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 hostname = "0.4.0"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -5,49 +5,49 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.82"
-backoff = "0.4"
-base64 = "0.22.1"
-bytecodec = "0.4.15"
-bytes = "1.7.1"
-clap = { version = "4.5.21", features = ["derive", "env"] }
-derive_more = { version = "1.0.0", features = ["from"] }
+anyhow = { workspace = true }
+backoff = { workspace = true }
+base64 = { workspace = true }
+bytecodec = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
+derive_more = { workspace = true, features = ["from"] }
 firezone-bin-shared = { workspace = true }
 firezone-logging = { workspace = true }
-futures = "0.3.29"
-hex = "0.4.3"
-hex-display = "0.3.0"
-mio = { version = "1.0.1", features = ["net"] }
-once_cell = "1.17.1"
-opentelemetry = { version = "0.26.0", features = ["metrics"] }
-opentelemetry-otlp = { version = "0.26.0", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio"] }
-phoenix-channel = { path = "../phoenix-channel" }
-proptest = { version = "1", optional = true }
-rand = "0.8.5"
+futures = { workspace = true }
+hex = { workspace = true }
+hex-display = { workspace = true }
+mio = { workspace = true, features = ["net"] }
+once_cell = { workspace = true }
+opentelemetry = { workspace = true, features = ["metrics"] }
+opentelemetry-otlp = { workspace = true, features = ["metrics"] }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
+phoenix-channel = { workspace = true }
+proptest = { workspace = true, optional = true }
+rand = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
-serde = { version = "1.0.210", features = ["derive"] }
-sha2 = "0.10.8"
-smallvec = "1.13.2"
+serde = { workspace = true, features = ["derive"] }
+sha2 = { workspace = true }
+smallvec = { workspace = true }
 socket-factory = { workspace = true }
 socket2 = { workspace = true }
-stun_codec = "0.3.4"
-thiserror = "1.0.68"
+stun_codec = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time", "signal"] }
 tracing = { workspace = true, features = ["log"] }
-tracing-core = "0.1.31"
-tracing-opentelemetry = "0.27.0"
-tracing-stackdriver = { version = "0.11.0", features = ["opentelemetry"] }
+tracing-core = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+tracing-stackdriver = { workspace = true, features = ["opentelemetry"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json", "fmt"] }
-trackable = "1.3.0"
-url = "2.5.2"
-uuid = { version = "1.10.0", features = ["v4"] }
+trackable = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-difference = "2.0.0"
-env_logger = "0.11.3"
-test-strategy = "0.4.0"
+difference = { workspace = true }
+env_logger = { workspace = true }
+test-strategy = { workspace = true }
 
 [[test]]
 name = "regression"

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -2,6 +2,7 @@
 name = "firezone-relay"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 
 [dependencies]
 anyhow = "1.0.82"

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -2,6 +2,7 @@
 name = "socket-factory"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 
 [dependencies]
 firezone-logging = { workspace = true }

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 
 [dependencies]
 firezone-logging = { workspace = true }
-quinn-udp = "0.5.2"
+quinn-udp = { workspace = true }
 socket2 = { workspace = true }
-tokio = { version = "1.41", features = ["net"] }
-tracing = "0.1"
+tokio = { workspace = true, features = ["net"] }
+tracing = { workspace = true }

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-sentry = { version = "0.34.0", default-features = false, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing"] }
-sentry-anyhow = "0.34.0"
+sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing"] }
+sentry-anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-thiserror = "1.0.68"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 
 [lints]

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -2,6 +2,7 @@
 name = "firezone-telemetry"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 
 [dependencies]
 sentry = { version = "0.34.0", default-features = false, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing"] }

--- a/rust/tests/gui-smoke-test/Cargo.toml
+++ b/rust/tests/gui-smoke-test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gui-smoke-test"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 
 [dependencies]
 anyhow = { version = "1.0" }

--- a/rust/tests/gui-smoke-test/Cargo.toml
+++ b/rust/tests/gui-smoke-test/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-anyhow = { version = "1.0" }
-clap = { version = "4.5", features = ["derive"] }
-subprocess = "0.2.9"
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+subprocess = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/rust/tests/http-test-server/Cargo.toml
+++ b/rust/tests/http-test-server/Cargo.toml
@@ -7,7 +7,7 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-axum = { workspace = true, features = ["http1", "tokio"] }
+axum = { workspace = true, features = ["http1", "tokio", "query"] }
 futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["net"] }

--- a/rust/tests/http-test-server/Cargo.toml
+++ b/rust/tests/http-test-server/Cargo.toml
@@ -6,10 +6,10 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
-axum = { version = "0.7.7", features = ["http1", "tokio"] }
-futures = "0.3"
-serde = { version = "1", features = ["derive"] }
+anyhow = { workspace = true }
+axum = { workspace = true, features = ["http1", "tokio"] }
+futures = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["net"] }
 
 [lints]

--- a/rust/tests/http-test-server/Cargo.toml
+++ b/rust/tests/http-test-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "http-test-server"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/rust/tun/Cargo.toml
+++ b/rust/tun/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(target_family = "unix")'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 tokio = { workspace = true }
 
 [lints]

--- a/rust/tun/Cargo.toml
+++ b/rust/tun/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tun"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(target_family = "unix")'.dependencies]

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -58,7 +58,7 @@
           ];
 
           mkShellWithRustVersion = rustVersion: pkgs.mkShell {
-            packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.nodePackages.pnpm cargo-udeps pkgs.cargo-sort ];
+            packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.nodePackages.pnpm cargo-udeps pkgs.cargo-sort pkgs.cargo-deny pkgs.cargo-autoinherit ];
             buildInputs = packages ++ [
               (rustVersion.override {
                 extensions = [ "rust-src" "rust-analyzer" ];


### PR DESCRIPTION
One of Rust's promises is "if it compiles, it works". However, there are certain situations in which this isn't true. In particular, when using dynamic typing patterns where trait objects are downcast to concrete types, having two versions of the same dependency can silently break things.

This happened in #7379 where I forgot to patch a certain Sentry dependency. A similar problem exists with our `tracing-stackdriver` dependency (see #7241).

Lastly, duplicate dependencies increase the compile-times of a project, so we should aim for having as few duplicate versions of a particular dependency as possible in our dependency graph.

This PR introduces `cargo deny`, a linter for Rust dependencies. In addition to linting for duplicate dependencies, it also enforces that all dependencies are compatible with an allow-list of licenses and it warns when a dependency is referred to from multiple crates without introducing a workspace dependency. Thanks to existing tooling (https://github.com/mainmatter/cargo-autoinherit), transitioning all dependencies to workspace dependencies was quite easy.

Resolves: #7241.