### PR TITLE
ci: tag merged image with branch name

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -391,6 +391,7 @@ jobs:
           images: ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image.name }}
           tags: |
             type=raw,value=latest
+            type=raw,value={{branch}}
             type=raw,value=${{ inputs.sha }}
             ${{ matrix.image.version && format('type=raw,value={0}', matrix.image.version) }}
             ${{ matrix.image.version && format('type=raw,value={0}-{1}', matrix.image.version, inputs.sha) }}


### PR DESCRIPTION
In #7389, we started tagging the built images with the branch name in addition to other tags such as `latest` and the version number. That wasn't enough unfortunately because we also need to tag the merged manifest image that bundles the different architectures together as only that one actually gets pushed to the registry.