### PR TITLE
test: reduce number of local rejects for generating IPs

### DIFF
--- a/rust/connlib/tunnel/src/tests/strategies.rs
+++ b/rust/connlib/tunnel/src/tests/strategies.rs
@@ -135,19 +135,11 @@ pub(crate) fn relays(
 /// We make sure to always have at least 1 IPv4 and 1 IPv6 DNS server.
 pub(crate) fn dns_servers() -> impl Strategy<Value = BTreeSet<SocketAddr>> {
     let ip4_dns_servers = collection::btree_set(
-        non_reserved_ipv4()
-            .prop_filter("must be addressable IP", |ip| {
-                !ip.is_unspecified() && !ip.is_multicast() && !ip.is_broadcast()
-            })
-            .prop_map(|ip| SocketAddr::from((ip, 53))),
+        non_reserved_ipv4().prop_map(|ip| SocketAddr::from((ip, 53))),
         1..4,
     );
     let ip6_dns_servers = collection::btree_set(
-        non_reserved_ipv6()
-            .prop_filter("must be addressable IP", |ip| {
-                !ip.is_unspecified() && !ip.is_multicast()
-            })
-            .prop_map(|ip| SocketAddr::from((ip, 53))),
+        non_reserved_ipv6().prop_map(|ip| SocketAddr::from((ip, 53))),
         1..4,
     );
 
@@ -172,6 +164,9 @@ fn non_reserved_ipv4() -> impl Strategy<Value = Ipv4Addr> {
         .prop_filter("must not be in IPv4 resources range", |ip| {
             !IPV4_RESOURCES.contains(*ip)
         })
+        .prop_filter("must be addressable IP", |ip| {
+            !ip.is_unspecified() && !ip.is_multicast() && !ip.is_broadcast()
+        })
 }
 
 fn non_reserved_ipv6() -> impl Strategy<Value = Ipv6Addr> {
@@ -181,6 +176,9 @@ fn non_reserved_ipv6() -> impl Strategy<Value = Ipv6Addr> {
         })
         .prop_filter("must not be in IPv6 resources range", |ip| {
             !IPV6_RESOURCES.contains(*ip)
+        })
+        .prop_filter("must be addressable IP", |ip| {
+            !ip.is_unspecified() && !ip.is_multicast()
         })
 }
 


### PR DESCRIPTION
When generating random input data in property-based tests, we have to ensure that the data conforms to certain criteria. For example, IP addresses must not be multicast or unspecified addresses and they must not be within our reserved IP ranges.

Currently, we ensure this using "filtering" which is a pretty poor technique [0]. To improve on this, we refactor the generation of IPs to automatically exclude all IPs within certain ranges. On very big test-runs (i.e. > 30000 test cases), too many local rejections lead to the test suite being aborted early.

[0]: https://proptest-rs.github.io/proptest/proptest/tutorial/filtering.html