### PR TITLE
test(connlib): don't waste shrinking time & cycles on IDs

### DIFF
--- a/rust/connlib/tunnel/src/proptest.rs
+++ b/rust/connlib/tunnel/src/proptest.rs
@@ -79,7 +79,9 @@ pub fn internet_resource(
 
 pub fn address_description() -> impl Strategy<Value = Option<String>> {
     prop_oneof![
-        any_with::<String>("[a-z]{4,10}".into()).prop_map(Some),
+        any_with::<String>("[a-z]{4,10}".into())
+            .prop_map(Some)
+            .no_shrink(),
         Just(None),
     ]
 }
@@ -89,31 +91,31 @@ pub fn site() -> impl Strategy<Value = Site> + Clone {
 }
 
 pub fn resource_id() -> impl Strategy<Value = ResourceId> + Clone {
-    any::<u128>().prop_map(ResourceId::from_u128)
+    any::<u128>().prop_map(ResourceId::from_u128).no_shrink()
 }
 
 pub fn gateway_id() -> impl Strategy<Value = GatewayId> + Clone {
-    any::<u128>().prop_map(GatewayId::from_u128)
+    any::<u128>().prop_map(GatewayId::from_u128).no_shrink()
 }
 
 pub fn client_id() -> impl Strategy<Value = ClientId> {
-    any::<u128>().prop_map(ClientId::from_u128)
+    any::<u128>().prop_map(ClientId::from_u128).no_shrink()
 }
 
 pub fn relay_id() -> impl Strategy<Value = RelayId> {
-    any::<u128>().prop_map(RelayId::from_u128)
+    any::<u128>().prop_map(RelayId::from_u128).no_shrink()
 }
 
 pub fn site_id() -> impl Strategy<Value = SiteId> + Clone {
-    any::<u128>().prop_map(SiteId::from_u128)
+    any::<u128>().prop_map(SiteId::from_u128).no_shrink()
 }
 
 pub fn site_name() -> impl Strategy<Value = String> + Clone {
-    any_with::<String>("[a-z]{4,10}".into())
+    any_with::<String>("[a-z]{4,10}".into()).no_shrink()
 }
 
 pub fn resource_name() -> impl Strategy<Value = String> {
-    any_with::<String>("[a-z]{4,10}".into())
+    any_with::<String>("[a-z]{4,10}".into()).no_shrink()
 }
 
 pub fn domain_label() -> impl Strategy<Value = String> {

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -761,7 +761,7 @@ fn select_host_v6(hosts: &[Ipv6Network]) -> impl Strategy<Value = Ipv6Addr> {
 }
 
 pub(crate) fn private_key() -> impl Strategy<Value = PrivateKey> {
-    any::<[u8; 32]>().prop_map(PrivateKey)
+    any::<[u8; 32]>().prop_map(PrivateKey).no_shrink()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
When `proptest` discovers a test failure, it will attempt to "shrink" the input to identify, what exactly causes the issue. How this is done depends on the data type but mostly performs things such as binary search to be efficient. Not every input within our tests is relevant for a failure. For example, which ID we have sampled for a client or a gateway doesn't at all affect whether or not the test will fail. `proptest` doesn't know that though so it will still happily spend shrinking time and cycles on figuring out the minimal difference in IDs (which is 1 because they have to be different). This is a huge waste of time for no benefit. We are getting much more value out of `proptest` if it tries to adjust other things such as the transitions involved in a test, how many gateways and relays there are etc.

By marking the strategies for the IDs and private keys with `no_shrink`, we can achieve that.