### PR TITLE
build(rust): don't strip release binaries

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -189,8 +189,6 @@ tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdr
 tracing = "0.1.40"
 
 [profile.release]
-strip = true
-
 # Full link-time optimization. Reduces binaries by up to 3x on some platforms.
 lto = "fat"
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -196,9 +196,6 @@ lto = "fat"
 # at the expense of compilation time
 codegen-units = 1
 
-[profile.bench]
-strip = false # Frame pointers are necessary for profiling; `strip=true` appears to remove them.
-
 # Override build settings just for the GUI client, so we get a pdb/dwp
 # Cargo ignores profile settings if they're not in the workspace's Cargo.toml
 [profile.dev.package.firezone-gui-client]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -204,9 +204,7 @@ strip = false # Frame pointers are necessary for profiling; `strip=true` appears
 [profile.dev.package.firezone-gui-client]
 debug = "full"
 split-debuginfo = "packed"
-strip = "none"
 
 [profile.release.package.firezone-gui-client]
 debug = "full"
 split-debuginfo = "packed"
-strip = "none"

--- a/rust/README.md
+++ b/rust/README.md
@@ -33,7 +33,7 @@ Resulting in, e.g.
 The recommended way for benchmarking any of the Rust components is Linux' `perf` utility.
 For example, to attach to a running application, do:
 
-1. Ensure the binary you are profiling is compiled with the `bench` profile.
+1. Ensure the binary you are profiling is compiled with the `release` profile.
 1. `sudo perf perf record -g --freq 10000 --pid $(pgrep <your-binary>)`.
 1. Run the speed test or whatever load-inducing task you want to measure.
 1. `sudo perf script > profile.perf`


### PR DESCRIPTION
Stripping the release binaries makes stacktraces completely useless.