### PR TITLE
refactor(gateway): start telemetry earlier

### DIFF
--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -38,7 +38,6 @@ fn main() {
         .expect("Calling `install_default` only once per process should always succeed");
 
     let cli = Cli::parse();
-
     let mut telemetry = Telemetry::default();
     if cli.is_telemetry_allowed() {
         telemetry.start(

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -32,13 +32,13 @@ mod eventloop;
 
 const ID_PATH: &str = "/var/lib/firezone/gateway_id";
 
-#[tokio::main]
-async fn main() {
+fn main() {
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Calling `install_default` only once per process should always succeed");
 
     let cli = Cli::parse();
+
     let mut telemetry = Telemetry::default();
     if cli.is_telemetry_allowed() {
         telemetry.start(
@@ -48,19 +48,22 @@ async fn main() {
         );
     }
 
-    // Enforce errors only being printed on a single line using the technique recommended in the anyhow docs:
-    // https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations
-    //
-    // By default, `anyhow` prints a stacktrace when it exits.
-    // That looks like a "crash" but we "just" exit with a fatal error.
-    if let Err(e) = try_main(cli, &mut telemetry).await {
-        tracing::error!(error = anyhow_dyn_err(&e));
-        telemetry.stop_on_crash().await;
+    let runtime = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
 
-        std::process::exit(1);
+    match runtime.block_on(try_main(cli, &mut telemetry)) {
+        Ok(()) => runtime.block_on(telemetry.stop()),
+        Err(e) => {
+            // Enforce errors only being printed on a single line using the technique recommended in the anyhow docs:
+            // https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations
+            //
+            // By default, `anyhow` prints a stacktrace when it exits.
+            // That looks like a "crash" but we "just" exit with a fatal error.
+            tracing::error!(error = anyhow_dyn_err(&e));
+            runtime.block_on(telemetry.stop_on_crash());
+
+            std::process::exit(1);
+        }
     }
-
-    telemetry.stop().await
 }
 
 async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {


### PR DESCRIPTION
By removing the use of the `#[tokio::main]`, we can ensure that telemetry is initialised as early as possible.