### PR TITLE
feat(relay): add Sentry crash reporting

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2151,6 +2151,7 @@ dependencies = [
  "env_logger",
  "firezone-bin-shared",
  "firezone-logging",
+ "firezone-telemetry",
  "futures",
  "hex",
  "hex-display",

--- a/rust/relay/Cargo.toml
+++ b/rust/relay/Cargo.toml
@@ -14,6 +14,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 derive_more = { workspace = true, features = ["from"] }
 firezone-bin-shared = { workspace = true }
 firezone-logging = { workspace = true }
+firezone-telemetry = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 hex-display = { workspace = true }

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -4,12 +4,13 @@ use anyhow::{anyhow, bail, Context, Result};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use firezone_bin_shared::http_health_check;
-use firezone_logging::std_dyn_err;
+use firezone_logging::{anyhow_dyn_err, sentry_layer, std_dyn_err};
 use firezone_relay::sockets::Sockets;
 use firezone_relay::{
     sockets, AddressFamily, AllocationPort, ChannelData, ClientSocket, Command, IpStack,
     PeerSocket, Server, Sleep,
 };
+use firezone_telemetry::{Telemetry, RELAY_DSN};
 use futures::{future, FutureExt};
 use phoenix_channel::{Event, LoginUrl, NoParams, PhoenixChannel};
 use rand::rngs::StdRng;
@@ -88,6 +89,16 @@ struct Args {
 
     #[command(flatten)]
     health_check: http_health_check::HealthCheckArgs,
+
+    /// Disable sentry.io crash-reporting agent.
+    #[arg(long, env = "FIREZONE_NO_TELEMETRY", default_value_t = false)]
+    no_telemetry: bool,
+}
+
+impl Args {
+    fn is_telemetry_allowed(&self) -> bool {
+        !self.no_telemetry
+    }
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
@@ -97,14 +108,39 @@ enum LogFormat {
     GoogleCloud,
 }
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<()> {
+fn main() {
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Calling `install_default` only once per process should always succeed");
 
     let args = Args::parse();
 
+    let mut telemetry = Telemetry::default();
+    if args.is_telemetry_allowed() {
+        telemetry.start(
+            args.api_url.as_str(),
+            option_env!("GITHUB_SHA").unwrap_or("unknown"),
+            RELAY_DSN,
+        );
+    }
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build tokio runtime");
+
+    match runtime.block_on(try_main(args)) {
+        Ok(()) => runtime.block_on(telemetry.stop()),
+        Err(e) => {
+            tracing::error!(error = anyhow_dyn_err(&e));
+            runtime.block_on(telemetry.stop_on_crash());
+
+            std::process::exit(1);
+        }
+    }
+}
+
+async fn try_main(args: Args) -> Result<()> {
     setup_tracing(&args)?;
 
     let public_addr = match (args.public_ip4_addr, args.public_ip6_addr) {
@@ -198,6 +234,7 @@ fn setup_tracing(args: &Args) -> Result<()> {
         None => tracing_subscriber::registry()
             .with(log_layer(args))
             .with(env_filter())
+            .with(sentry_layer())
             .into(),
         Some(endpoint) => {
             let metadata = make_otel_metadata();
@@ -237,6 +274,7 @@ fn setup_tracing(args: &Args) -> Result<()> {
                 .with(log_layer(args))
                 .with(tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("relay")))
                 .with(env_filter())
+                .with(sentry_layer())
                 .into()
         }
     };

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -16,6 +16,7 @@ pub const GATEWAY_DSN: Dsn = Dsn("https://f763102cc3937199ec483fbdae63dfdc@o4507
 pub const GUI_DSN: Dsn = Dsn("https://2e17bf5ed24a78c0ac9e84a5de2bd6fc@o4507971108339712.ingest.us.sentry.io/4508008945549312");
 pub const HEADLESS_DSN: Dsn = Dsn("https://bc27dca8bb37be0142c48c4f89647c13@o4507971108339712.ingest.us.sentry.io/4508010028728320");
 pub const IPC_SERVICE_DSN: Dsn = Dsn("https://0590b89fd4479494a1e7ffa4dc705001@o4507971108339712.ingest.us.sentry.io/4508008896069632");
+pub const RELAY_DSN: Dsn = Dsn("https://9d5f664d8f8f7f1716d4b63a58bcafd5@o4507971108339712.ingest.us.sentry.io/4508373298970624");
 
 #[derive(Default)]
 pub struct Telemetry {


### PR DESCRIPTION
In addition to monitoring clients and gateways, it is also useful to monitor relays in the same way. This gives us alerts on ERROR and WARN messages logged by the relay as well as panics.