### PR TITLE
build(rust): configure `cargo cross` to passthrough `GITHUB_SHA`

### DIFF
--- a/rust/Cross.toml
+++ b/rust/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = ["GITHUB_SHA"] # Allows binaries to embed the current SHA on CI.


### PR DESCRIPTION
Our relays aren't semver-versioned like other components. So for the version reported to Sentry, we use the current Git SHA. This one is only available as an ENV variable because we are building within a docker container using `cargo cross`. By default, no env variables are passed through to the container. To fix this, we need to add a configuration file that explicitly opts-in to the necessary ENV variable.