### PR TITLE
fix(relay): reduce number of warnings

### DIFF
--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -561,9 +561,9 @@ where
             match self.sigterm.poll_recv(cx) {
                 Poll::Ready(Some(())) => {
                     if self.shutting_down {
-                        // Received a repeated SIGTERM whilst shutting down
+                        tracing::info!("Forcing shutdown on repeated SIGTERM");
 
-                        return Poll::Ready(Err(anyhow!("Forcing shutdown on repeated SIGTERM")));
+                        return Poll::Ready(Ok(()));
                     }
 
                     tracing::info!(active_allocations = %self.server.num_allocations(), "Received SIGTERM, initiating graceful shutdown");

--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -1233,7 +1233,7 @@ fn derive_relay_addresses(
             // For now, we will just partially satisfy the request.
             // We expect clients to gracefully handle this by only extracting the relay addresses they receive.
 
-            tracing::warn!(target: "relay", "Partially fulfilling allocation using only an IPv4 address");
+            tracing::debug!(target: "relay", "Partially fulfilling allocation using only an IPv4 address");
 
             Ok((ip4.into(), None))
         }
@@ -1242,7 +1242,7 @@ fn derive_relay_addresses(
             // For now, we will just partially satisfy the request.
             // We expect clients to gracefully handle this by only extracting the relay addresses they receive.
 
-            tracing::warn!(target: "relay", "Partially fulfilling allocation using only an IPv6 address");
+            tracing::debug!(target: "relay", "Partially fulfilling allocation using only an IPv6 address");
 
             Ok((ip6.into(), None))
         }


### PR DESCRIPTION
With this PR, we reduce some of the warnings emitted by the relay. If we can only partially fulfill an allocation, we now only emit a warning.

Similarly, if we receive a repeated SIGTERM signal, we shut down successfully (i.e. exit with code 0) instead of failing the event-loop. During normal operation, we wait for all allocations to expire before we shut down. On CI however, the relay gets shutdown much earlier so this would generate unnecessary errors.

Receiving another SIGTERM is a user-initiated action so we shouldn't fail as a result but instead just comply with it.