### PR TITLE
chore(relay): don't warn on existing allocation

### DIFF
--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -482,7 +482,7 @@ where
             Span::current().record("allocation", display(&allocation.port));
             let (error_response, msg) = make_error_response(AllocationMismatch, &request);
 
-            tracing::warn!(target: "relay", "{msg}: Client already has an allocation");
+            tracing::debug!(target: "relay", "{msg}: Client already has an allocation");
 
             return Err(error_response);
         }


### PR DESCRIPTION
A client may have lost its state and therefore "probe" the relay whether or not is still has an allocation. If it does, it will react to the error, delete it and make a new one. This is no reason to print a warning on the relay side.