### PR TITLE
fix(gateway): filter packets not destined for a client

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -88,7 +88,9 @@ impl GatewayState {
     ) -> Result<Option<snownet::EncryptedPacket>> {
         let dst = packet.destination();
 
-        anyhow::ensure!(is_client(dst), "Packet not destined for a client");
+        if !is_client(dst) {
+            return Ok(None);
+        }
 
         let peer = self
             .peers


### PR DESCRIPTION
This causes unnecessary logs higher up the stack.