### PR TITLE
fix(telemetry): include span attributes in breadcrumbs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1047,7 +1047,7 @@ dependencies = [
  "libc",
  "log",
  "phoenix-channel",
- "rustls 0.23.19",
+ "rustls",
  "secrecy",
  "serde_json",
  "socket-factory",
@@ -1074,7 +1074,7 @@ dependencies = [
  "libc",
  "oslog",
  "phoenix-channel",
- "rustls 0.23.19",
+ "rustls",
  "secrecy",
  "serde_json",
  "socket-factory",
@@ -1961,7 +1961,7 @@ dependencies = [
  "ip_network",
  "libc",
  "phoenix-channel",
- "rustls 0.23.19",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -1995,7 +1995,7 @@ dependencies = [
  "native-dialog",
  "nix 0.29.0",
  "rand 0.8.5",
- "rustls 0.23.19",
+ "rustls",
  "sadness-generator",
  "secrecy",
  "serde",
@@ -2085,7 +2085,7 @@ dependencies = [
  "phoenix-channel",
  "resolv-conf",
  "rtnetlink",
- "rustls 0.23.19",
+ "rustls",
  "sd-notify",
  "secrecy",
  "serde",
@@ -2150,7 +2150,7 @@ dependencies = [
  "phoenix-channel",
  "proptest",
  "rand 0.8.5",
- "rustls 0.23.19",
+ "rustls",
  "secrecy",
  "serde",
  "sha2",
@@ -2991,7 +2991,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.19",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3458,7 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4895,7 +4895,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.19",
+ "rustls",
  "socket2",
  "thiserror",
  "tokio",
@@ -4912,7 +4912,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash",
- "rustls 0.23.19",
+ "rustls",
  "slab",
  "thiserror",
  "tinyvec",
@@ -5145,7 +5145,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.19",
+ "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -5262,20 +5262,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -5481,13 +5467,12 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
+version = "0.35.0"
+source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
 dependencies = [
  "httpdate",
  "reqwest",
- "rustls 0.22.4",
+ "rustls",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -5501,9 +5486,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
+version = "0.35.0"
+source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -5513,9 +5497,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
+version = "0.35.0"
+source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
 dependencies = [
  "hostname",
  "libc",
@@ -5527,9 +5510,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
+version = "0.35.0"
+source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -5540,9 +5522,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc6b25e945fcaa5e97c43faee0267eebda9f18d4b09a251775d8fef1086238a"
+version = "0.35.0"
+source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -5551,9 +5532,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
+version = "0.35.0"
+source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5561,9 +5541,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
+version = "0.35.0"
+source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5573,9 +5552,8 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
+version = "0.35.0"
+source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
 dependencies = [
  "debugid",
  "hex",
@@ -6772,7 +6750,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.19",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6796,7 +6774,7 @@ checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.19",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -6966,9 +6944,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -6990,9 +6968,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7001,9 +6979,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -7163,7 +7141,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.19",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror",
@@ -7313,7 +7291,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "once_cell",
- "rustls 0.23.19",
+ "rustls",
  "rustls-pki-types",
  "url",
  "webpki-roots",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5468,7 +5468,7 @@ dependencies = [
 [[package]]
 name = "sentry"
 version = "0.35.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -5487,7 +5487,7 @@ dependencies = [
 [[package]]
 name = "sentry-backtrace"
 version = "0.35.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -5498,7 +5498,7 @@ dependencies = [
 [[package]]
 name = "sentry-contexts"
 version = "0.35.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
 dependencies = [
  "hostname",
  "libc",
@@ -5511,7 +5511,7 @@ dependencies = [
 [[package]]
 name = "sentry-core"
 version = "0.35.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "sentry-debug-images"
 version = "0.35.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -5533,7 +5533,7 @@ dependencies = [
 [[package]]
 name = "sentry-panic"
 version = "0.35.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5542,7 +5542,7 @@ dependencies = [
 [[package]]
 name = "sentry-tracing"
 version = "0.35.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5553,7 +5553,7 @@ dependencies = [
 [[package]]
 name = "sentry-types"
 version = "0.35.0"
-source = "git+https://github.com/thomaseizinger/sentry-rust?branch=bundled-changes-waiting-for-release#ea87597eba6b54243c44734726b1c3d2b65d7412"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
 dependencies = [
  "debugid",
  "hex",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -153,9 +153,6 @@ name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "arbitrary"
@@ -2179,7 +2176,6 @@ name = "firezone-telemetry"
 version = "0.1.0"
 dependencies = [
  "sentry",
- "sentry-anyhow",
  "thiserror",
  "tokio",
  "tracing",
@@ -5501,17 +5497,6 @@ dependencies = [
  "tokio",
  "ureq",
  "webpki-roots",
-]
-
-[[package]]
-name = "sentry-anyhow"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d672bfd1ed4e90978435f3c0704edb71a7a9d86403657839d518cd6aa278aff5"
-dependencies = [
- "anyhow",
- "sentry-backtrace",
- "sentry-core",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -91,8 +91,8 @@ rustls = { version = "0.23.10", default-features = false, features = ["ring"] }
 sadness-generator = "0.6.0"
 secrecy = "0.8"
 semver = "1.0.22"
-sentry = { version = "0.34.0", default-features = false }
-sentry-tracing = "0.34.0"
+sentry = { version = "0.35.0", default-features = false }
+sentry-tracing = "0.35.0"
 serde = "1.0.210"
 serde_json = "1.0.133"
 serde_variant = "0.1.3"
@@ -181,6 +181,8 @@ ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" }
 proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "main" }
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.26" } # Waiting for release.
+sentry = { git = "https://github.com/thomaseizinger/sentry-rust", branch = "bundled-changes-waiting-for-release" }
+sentry-tracing = { git = "https://github.com/thomaseizinger/sentry-rust", branch = "bundled-changes-waiting-for-release" }
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -92,7 +92,6 @@ sadness-generator = "0.6.0"
 secrecy = "0.8"
 semver = "1.0.22"
 sentry = { version = "0.34.0", default-features = false }
-sentry-anyhow = "0.34.0"
 sentry-tracing = "0.34.0"
 serde = "1.0.210"
 serde_json = "1.0.133"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -181,8 +181,8 @@ ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch
 proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" }
 proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "main" }
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.26" } # Waiting for release.
-sentry = { git = "https://github.com/thomaseizinger/sentry-rust", branch = "bundled-changes-waiting-for-release" }
-sentry-tracing = { git = "https://github.com/thomaseizinger/sentry-rust", branch = "bundled-changes-waiting-for-release" }
+sentry = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
+sentry-tracing = { git = "https://github.com/getsentry/sentry-rust", branch = "master" }
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -6,7 +6,6 @@ license = { workspace = true }
 
 [dependencies]
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing"] }
-sentry-anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
 use sentry::protocol::SessionStatus;
-pub use sentry_anyhow::capture_anyhow;
 
 pub struct Dsn(&'static str);
 

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -120,9 +120,7 @@ impl Telemetry {
 
         // Sentry uses blocking IO for flushing ..
         let _ = tokio::task::spawn_blocking(move || {
-            // `flush`'s return value is flipped from the docs
-            // <https://github.com/getsentry/sentry-rust/issues/677>
-            if inner.flush(Some(Duration::from_secs(5))) {
+            if !inner.flush(Some(Duration::from_secs(5))) {
                 tracing::error!("Failed to flush telemetry events to sentry.io");
                 return;
             };


### PR DESCRIPTION
This is another attempt at fixing #7386. Previous PR was #7379. The difference is, this time it works! In the following screenshot, `handle_input` is a currently active span.

![image](https://github.com/user-attachments/assets/0845d566-8ca7-4ba2-8786-9c5819cdfd48)

I had to make some patches to Sentry, most notably:

- https://github.com/getsentry/sentry-rust/pull/708
- https://github.com/getsentry/sentry-rust/pull/712

The way we configure Sentry is quite tricky:

First and foremost, we need to understand that the `tracing` adapter for Sentry has a `span_filter` configuration. When a span gets filtered out there, the rest of `sentry-tracing` never sees the data in that span. Thus, in order to capture variables from spans, we need to have a fairly generous span filter. In this PR, we change this span filter to include all spans except those on TRACE level.

Secondly, by default, the Sentry SDK doesn't send any spans to the backend, i.e. the sampling rate is 0. Previously, we set the sampling rate to 1.0 because the `span_filter` was already filtering out all non-telemetry spans. A telemetry span is a concept that we invented. It is a span that gets sampled at _creation_ time with a probability of 1%. This is useful because creating a lot of spans is also expensive, so we don't want to do it e.g. on a per-packet basis. With just these configuration options, we now have a problem: We don't want to submit all spans to Sentry but we need the `span_filter` to allow all spans otherwise we can't capture the contextual fields from the span in breadcrumbs. Luckily, the Sentry SDK has another configuration option: `traces_sampler`.

The `traces_sampler` gets to compute a sampling rate for each individual span. This allows us to discard all spans from being sent to Sentry unless they are `telemetry` spans.

Resolves: #7386.