### PR TITLE
ci: group all android navigation libs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,8 +71,7 @@ updates:
           - androidx.lifecycle:lifecycle-livedata-ktx
       navigation:
         patterns:
-          - androidx.navigation:navigation-fragment-ktx
-          - androidx.navigation:navigation-ui-ktx
+          - androidx.navigation:navigation-*
       hilt:
         patterns:
           - androidx.hilt:hilt-compiler


### PR DESCRIPTION
Fixes some dependabot groups that weren't grouped.