### PR TITLE
fix(apple): Expose `MACOSX_DEPLOYMENT_TARGET` in rust apple build script to signal to rustc which macOS to target

### DIFF
--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -12,6 +12,7 @@ cmd=${1:-""}
 # into our highly evolved Rust-based build system.
 for var in $(env | awk -F= '{print $1}'); do
     if [[ "$var" != "HOME" ]] &&
+        [[ "$var" != "MACOSX_DEPLOYMENT_TARGET" ]] &&
         [[ "$var" != "USER" ]] &&
         [[ "$var" != "LOGNAME" ]] &&
         [[ "$var" != "TERM" ]] &&


### PR DESCRIPTION
`MACOSX_DEPLOYMENT_TARGET` is a standard env var read by gcc and rustc that determines which version of macOS to target binaries for. This variable was being removed inadvertently in our rust build script.

Exposing this var fixes a slew of warnings about object files being built for a newer macOS target than being linked that were showing up in Xcode for some time now.

Hasn't caused any issues thus far from what I can tell, but possibly related to #7442 