### PR TITLE
fix(gui-client): don't share log-directives via file system

### DIFF
--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -371,7 +371,7 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
     async fn handle_request(&mut self, req: ControllerRequest) -> Result<(), Error> {
         match req {
             Req::ApplySettings(settings) => {
-                let filter = firezone_logging::try_filter(&self.advanced_settings.log_filter)
+                let filter = firezone_logging::try_filter(&settings.log_filter)
                         .context("Couldn't parse new log filter directives")?;
                 self.advanced_settings = *settings;
                 self.log_filter_reloader

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -205,12 +205,6 @@ impl Status {
 
 impl<'a, I: GuiIntegration> Controller<'a, I> {
     pub async fn main_loop(mut self) -> Result<(), Error> {
-        self.ipc_client
-            .send_msg(&IpcClientMsg::ApplyLogFilter {
-                directives: self.advanced_settings.log_filter.clone(),
-            })
-            .await?;
-
         let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
 
         // Start telemetry

--- a/rust/gui-client/src-common/src/settings.rs
+++ b/rust/gui-client/src-common/src/settings.rs
@@ -2,12 +2,11 @@
 //! advanced settings and code for manipulating diagnostic logs.
 
 use anyhow::{Context as _, Result};
-use atomicwrites::{AtomicFile, OverwriteBehavior};
 use connlib_model::ResourceId;
 use firezone_headless_client::known_dirs;
-use firezone_logging::std_dyn_err;
+
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, io::Write, path::PathBuf};
+use std::{collections::HashSet, path::PathBuf};
 use url::Url;
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -65,21 +64,12 @@ pub async fn save(settings: &AdvancedSettings) -> Result<()> {
     let dir = path
         .parent()
         .context("settings path should have a parent")?;
+
     tokio::fs::create_dir_all(dir).await?;
     tokio::fs::write(&path, serde_json::to_string(settings)?).await?;
-    // Don't create the dir for the log filter file, that's the IPC service's job.
-    // If it isn't there for some reason yet, just log an error and move on.
-    let log_filter_path = known_dirs::ipc_log_filter().context("`ipc_log_filter` failed")?;
-    let f = AtomicFile::new(&log_filter_path, OverwriteBehavior::AllowOverwrite);
-    // Note: Blocking file write in async function
-    if let Err(error) = f.write(|f| f.write_all(settings.log_filter.as_bytes())) {
-        tracing::error!(
-            error = std_dyn_err(&error),
-            ?log_filter_path,
-            "Couldn't write log filter file for IPC service"
-        );
-    }
+
     tracing::debug!(?path, "Saved settings");
+
     Ok(())
 }
 

--- a/rust/gui-client/src-common/src/settings.rs
+++ b/rust/gui-client/src-common/src/settings.rs
@@ -4,7 +4,6 @@
 use anyhow::{Context as _, Result};
 use connlib_model::ResourceId;
 use firezone_headless_client::known_dirs;
-
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, path::PathBuf};
 use url::Url;

--- a/rust/headless-client/src/known_dirs.rs
+++ b/rust/headless-client/src/known_dirs.rs
@@ -7,9 +7,9 @@
 //!
 //! I wanted the ProgramData folder on Windows, which `dirs` alone doesn't provide.
 
+use anyhow::{Context as _, Result};
 use std::path::PathBuf;
 
-use anyhow::{Context as _, Result};
 pub use platform::{ipc_service_config, ipc_service_logs, logs, runtime, session, settings};
 
 #[cfg(target_os = "linux")]

--- a/rust/headless-client/src/known_dirs.rs
+++ b/rust/headless-client/src/known_dirs.rs
@@ -7,6 +7,9 @@
 //!
 //! I wanted the ProgramData folder on Windows, which `dirs` alone doesn't provide.
 
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result};
 pub use platform::{ipc_service_config, ipc_service_logs, logs, runtime, session, settings};
 
 #[cfg(target_os = "linux")]
@@ -20,6 +23,12 @@ pub mod platform;
 #[cfg(target_os = "windows")]
 #[path = "known_dirs/windows.rs"]
 pub mod platform;
+
+pub fn ipc_log_filter() -> Result<PathBuf> {
+    Ok(ipc_service_config()
+        .context("Failed to compute `ipc_service_config` directory")?
+        .join("log-filter"))
+}
 
 #[cfg(test)]
 mod tests {

--- a/rust/headless-client/src/known_dirs.rs
+++ b/rust/headless-client/src/known_dirs.rs
@@ -8,7 +8,6 @@
 //! I wanted the ProgramData folder on Windows, which `dirs` alone doesn't provide.
 
 pub use platform::{ipc_service_config, ipc_service_logs, logs, runtime, session, settings};
-use std::path::PathBuf;
 
 #[cfg(target_os = "linux")]
 #[path = "known_dirs/linux.rs"]
@@ -21,10 +20,6 @@ pub mod platform;
 #[cfg(target_os = "windows")]
 #[path = "known_dirs/windows.rs"]
 pub mod platform;
-
-pub fn ipc_log_filter() -> Option<PathBuf> {
-    Some(ipc_service_config()?.join("log-filter"))
-}
 
 #[cfg(test)]
 mod tests {

--- a/rust/headless-client/src/known_dirs/linux.rs
+++ b/rust/headless-client/src/known_dirs/linux.rs
@@ -1,11 +1,9 @@
 use firezone_bin_shared::BUNDLE_ID;
 use std::path::PathBuf;
 
-/// Path for IPC service config that either the IPC service or GUI can write
+/// Path for IPC service config that the IPC service can write
 ///
-/// e.g. the device ID should only be written by the IPC service, and
-/// the log filter should only be written by the GUI. No file should be written
-/// by both programs. All writes should use `atomicwrites`.
+/// All writes should use `atomicwrites`.
 ///
 /// On Linux, `/var/lib/$BUNDLE_ID/config/firezone-id`
 ///

--- a/rust/headless-client/src/known_dirs/windows.rs
+++ b/rust/headless-client/src/known_dirs/windows.rs
@@ -2,11 +2,9 @@ use firezone_bin_shared::{platform::app_local_data_dir, BUNDLE_ID};
 use known_folders::{get_known_folder_path, KnownFolder};
 use std::path::PathBuf;
 
-/// Path for IPC service config that either the IPC service or GUI can write
+/// Path for IPC service config that the IPC service can write
 ///
-/// e.g. the device ID should only be written by the IPC service, and
-/// the log filter should only be written by the GUI. No file should be written
-/// by both programs. All writes should use `atomicwrites`.
+/// All writes should use `atomicwrites`.
 ///
 /// On Windows, `C:/ProgramData/$BUNDLE_ID/config`
 pub fn ipc_service_config() -> Option<PathBuf> {

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use connlib_client_shared::Callbacks;
 use connlib_model::ResourceView;
 use firezone_bin_shared::platform::DnsControlMethod;
@@ -127,7 +127,7 @@ impl Callbacks for CallbackHandler {
 
 /// Sets up logging for stdout only, with INFO level by default
 pub fn setup_stdout_logging() -> Result<LogFilterReloader> {
-    let directives = ipc_service::get_log_filter().context("Can't read log filter")?;
+    let directives = ipc_service::get_log_filter();
     let (filter, reloader) =
         tracing_subscriber::reload::Layer::new(firezone_logging::try_filter(&directives)?);
     let layer = fmt::layer()

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use connlib_client_shared::Callbacks;
 use connlib_model::ResourceView;
 use firezone_bin_shared::platform::DnsControlMethod;
@@ -127,7 +127,7 @@ impl Callbacks for CallbackHandler {
 
 /// Sets up logging for stdout only, with INFO level by default
 pub fn setup_stdout_logging() -> Result<LogFilterReloader> {
-    let directives = ipc_service::get_log_filter();
+    let directives = ipc_service::get_log_filter().context("Can't read log filter")?;
     let (filter, reloader) =
         tracing_subscriber::reload::Layer::new(firezone_logging::try_filter(&directives)?);
     let layer = fmt::layer()


### PR DESCRIPTION
At present, the GUI client shares the current log-directives with the IPC service via the file system. Supposedly, this has been done to allow the IPC service to start back up with the same log filter as before. This behaviour appears to be buggy though as we are receiving a fair number of error reports where this file is not writable.

Instead of relying on the file system to communicate, we send the current log-directives to the IPC service as soon as we start up. The IPC service then uses the file system as a cache that log string and re-apply it on the next startup. This way, no two programs need to read / write the same file. The IPC service runs with higher privileges, so this should resolve the permission errors we are seeing in Sentry.