### PR TITLE
fix(ci): Wait up to 20 seconds in E2E tests in CI for HTML element changes

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Run Acceptance Tests
         env:
           MIX_TEST_PARTITION: ${{ matrix.MIX_TEST_PARTITION }}
-          E2E_DEFAULT_WAIT_SECONDS: 5
+          E2E_DEFAULT_WAIT_SECONDS: 20
         run: |
           mix test --only acceptance:true \
                    --partitions=${{ env.MIX_TEST_PARTITIONS }} \


### PR DESCRIPTION
Fixes an intermittent issue where a slow runner could cause the 5s timeout to be hit when waiting for the Email OTP request submission to go through.

https://github.com/firezone/firezone/actions/runs/12111072265/job/33762401305?pr=7445#step:16:1654