### PR TITLE
fix(apple/ios): Expose IPHONEOS_DEPLOYMENT_TARGET to tell rustc our iOS version

### DIFF
--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -13,6 +13,7 @@ cmd=${1:-""}
 for var in $(env | awk -F= '{print $1}'); do
     if [[ "$var" != "HOME" ]] &&
         [[ "$var" != "MACOSX_DEPLOYMENT_TARGET" ]] &&
+        [[ "$var" != "IPHONEOS_DEPLOYMENT_TARGET" ]] &&
         [[ "$var" != "USER" ]] &&
         [[ "$var" != "LOGNAME" ]] &&
         [[ "$var" != "TERM" ]] &&


### PR DESCRIPTION
Fixes a similar issue as #7443 where we were deleting the `IPHONEOS_DEPLOYMENT_TARGET` variable in our Rust build script, which caused lots of warnings about building for a different OS than being linked against.