### PR TITLE
fix(apple/macos): Add app sandbox and entitlements to network extension

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2786,9 +2786,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3112,7 +3112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -3507,7 +3507,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]

--- a/swift/apple/FirezoneNetworkExtension/FirezoneNetworkExtension.entitlements
+++ b/swift/apple/FirezoneNetworkExtension/FirezoneNetworkExtension.entitlements
@@ -10,5 +10,11 @@
 	<array>
 		<string>$(APP_GROUP_ID)</string>
 	</array>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Apple [requires](https://github.com/firezone/firezone/actions/runs/12161693820/job/33916881718) network extensions on macOS to be sandboxed. Given this requirement, we must explicitly allow both the `com.apple.security.network.client` and `com.apple.security.network.security` entitlements for making outbound network requests and for opening sockets respectively.