### PR TITLE
fix(apple): only initialise global logger once

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -178,7 +178,7 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<firezone_logging
 
     let (file_layer, handle) = firezone_logging::file::layer(&log_dir);
 
-    tracing_subscriber::registry()
+    let subscriber = tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
@@ -193,8 +193,9 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<firezone_logging
                 )),
         )
         .with(file_layer)
-        .with(env_filter)
-        .try_init()?;
+        .with(env_filter);
+
+    firezone_logging::init(subscriber)?;
 
     Ok(handle)
 }

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -173,6 +173,9 @@ impl Callbacks for CallbackHandler {
 }
 
 fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<firezone_logging::file::Handle> {
+    let env_filter =
+        firezone_logging::try_filter(&log_filter).context("Failed to parse log-filter")?;
+
     let (file_layer, handle) = firezone_logging::file::layer(&log_dir);
 
     tracing_subscriber::registry()
@@ -190,7 +193,7 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<firezone_logging
                 )),
         )
         .with(file_layer)
-        .with(firezone_logging::try_filter(&log_filter).context("Failed to parse log-filter")?)
+        .with(env_filter)
         .try_init()?;
 
     Ok(handle)

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -169,6 +169,12 @@ impl Callbacks for CallbackHandler {
     }
 }
 
+/// Initialises a global logger with the specified log filter.
+///
+/// A global logger can only be set once, hence this function uses `static` state to check whether a logger has already been set.
+/// If so, the new `log_filter` will be applied to the existing logger but a different `log_dir` won't have any effect.
+///
+/// From within the FFI module, we have no control over our memory lifecycle and we may get initialised multiple times within the same process.
 fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<()> {
     static LOGGER_STATE: OnceLock<(
         firezone_logging::file::Handle,


### PR DESCRIPTION
From within the FFI code, we have no control over the lifecycle of the host application and `connect` may be called multiple times from within the same process. Therefore, we cannot rely on the global logger state to **not** be set when `connect` gets called.

To fix this, we cache the handles for the file logger and a reload-handle for the log filter in a `static` variable. This allows us to apply the new log-filter of a repeated `connect` call to the existing logger, even if `connect` is called multiple times from the same process.