### PR TITLE
chore(infra): Deny connections from US-sanctioned countries with HTTP 403

### DIFF
--- a/terraform/modules/google-cloud/apps/elixir/network.tf
+++ b/terraform/modules/google-cloud/apps/elixir/network.tf
@@ -74,7 +74,7 @@ resource "google_compute_security_policy" "default" {
     match {
       expr {
         # Required by US law due to sanctions.
-        expression = "request.path.matches('/sign_up') && origin.region_code.matches('^RU|BY|KP|IR|SY|CU|VE|XC|XD|SD|MM$')"
+        expression = "origin.region_code.matches('^RU|BY|KP|IR|SY|CU|VE|XC|XD|SD|MM$')"
       }
     }
   }


### PR DESCRIPTION
Implementing the remainder of the legally required block. Will be applied on Dec 9th, as we notified customers.