### PR TITLE
fix(telemetry): use `package@version` notation for releases

### DIFF
--- a/.github/actions/create-sentry-release/action.yml
+++ b/.github/actions/create-sentry-release/action.yml
@@ -27,6 +27,6 @@ runs:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_ORG: firezone-inc
       with:
-        version: ${{ steps.version.outputs.version }}
+        version: ${{ inputs.component }}@${{ steps.version.outputs.version }}
         projects: ${{ inputs.projects }}
         set_commits: auto

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -41,6 +41,12 @@ mod tun;
 /// (IoT devices, point-of-sale devices, etc), so try to reconnect for 30 days.
 const MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24 * 30);
 
+/// The Sentry release.
+///
+/// This module is only responsible for the connlib part of the Android app.
+/// Bugs within the Android app itself may use the same DSN but a different component as part of the version string.
+const RELEASE: &str = concat!("connlib-android@", env!("CARGO_PKG_VERSION"));
+
 pub struct CallbackHandler {
     vm: JavaVM,
     callback_handler: GlobalRef,
@@ -331,7 +337,7 @@ fn connect(
         serde_json::from_str(&device_info).context("Failed to deserialize `DeviceInfo`")?;
 
     let mut telemetry = Telemetry::default();
-    telemetry.start(&api_url, env!("CARGO_PKG_VERSION"), ANDROID_DSN);
+    telemetry.start(&api_url, RELEASE, ANDROID_DSN);
     telemetry.set_firezone_id(device_id.clone());
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -41,6 +41,12 @@ use tun::Tun;
 /// Hopefully we aren't down for more than 24 hours.
 const MAX_PARTITION_TIME: Duration = Duration::from_secs(60 * 60 * 24);
 
+/// The Sentry release.
+///
+/// This module is only responsible for the connlib part of the MacOS/iOS app.
+/// Bugs within the MacOS/iOS app itself may use the same DSN but a different component as part of the version string.
+const RELEASE: &str = concat!("connlib-apple@", env!("CARGO_PKG_VERSION"));
+
 #[swift_bridge::bridge]
 mod ffi {
     extern "Rust" {
@@ -238,7 +244,7 @@ impl WrappedSession {
         device_info: String,
     ) -> Result<Self> {
         let mut telemetry = Telemetry::default();
-        telemetry.start(&api_url, env!("CARGO_PKG_VERSION"), APPLE_DSN);
+        telemetry.start(&api_url, RELEASE, APPLE_DSN);
         telemetry.set_firezone_id(device_id.clone());
 
         init_logging(log_dir.into(), log_filter)?;

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
     if cli.is_telemetry_allowed() {
         telemetry.start(
             cli.api_url.as_str(),
-            env!("CARGO_PKG_VERSION"),
+            concat!("gateway@", env!("CARGO_PKG_VERSION")),
             firezone_telemetry::GATEWAY_DSN,
         );
     }

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -220,13 +220,11 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
     pub async fn main_loop(mut self) -> Result<(), Error> {
         let account_slug = self.auth.session().map(|s| s.account_slug.to_owned());
 
-        // Start telemetry
+        // Tell IPC service to start telemetry.
         {
             const VERSION: &str = env!("CARGO_PKG_VERSION");
 
             let environment = self.advanced_settings.api_url.to_string();
-            self.telemetry
-                .start(&environment, VERSION, firezone_telemetry::GUI_DSN);
             if let Some(account_slug) = account_slug.clone() {
                 self.telemetry.set_account_slug(account_slug);
             }

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -222,8 +222,6 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
 
         // Tell IPC service to start telemetry.
         {
-            const VERSION: &str = env!("CARGO_PKG_VERSION");
-
             let environment = self.advanced_settings.api_url.to_string();
             if let Some(account_slug) = account_slug.clone() {
                 self.telemetry.set_account_slug(account_slug);
@@ -232,7 +230,7 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
             self.ipc_client
                 .send_msg(&IpcClientMsg::StartTelemetry {
                     environment,
-                    version: VERSION.to_owned(),
+                    release: crate::RELEASE.to_string(),
                     account_slug,
                 })
                 .await?;

--- a/rust/gui-client/src-common/src/lib.rs
+++ b/rust/gui-client/src-common/src/lib.rs
@@ -11,3 +11,9 @@ pub mod settings;
 pub mod system_tray;
 pub mod updates;
 pub mod uptime;
+
+/// The Sentry "release" we are part of.
+///
+/// IPC service and GUI client are always bundled into a single release.
+/// Hence, we have a single constant for IPC service and GUI client.
+pub const RELEASE: &str = concat!("gui-client@", env!("CARGO_PKG_VERSION"));

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -64,7 +64,7 @@ pub(crate) fn run() -> Result<()> {
             let mut telemetry = telemetry::Telemetry::default();
             telemetry.start(
                 settings.api_url.as_ref(),
-                env!("CARGO_PKG_VERSION"),
+                concat!("gui-client@", env!("CARGO_PKG_VERSION")),
                 telemetry::GUI_DSN,
             );
             // Don't fix the log filter for smoke tests
@@ -96,7 +96,7 @@ fn run_gui(cli: Cli) -> Result<()> {
     // In the future telemetry will be opt-in per organization, that's why this isn't just at the top of `main`
     telemetry.start(
         settings.api_url.as_ref(),
-        env!("CARGO_PKG_VERSION"),
+        firezone_gui_client_common::RELEASE,
         telemetry::GUI_DSN,
     );
     // Get the device ID before starting Tokio, so that all the worker threads will inherit the correct scope.

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -98,7 +98,7 @@ pub enum ClientMsg {
     SetDisabledResources(BTreeSet<ResourceId>),
     StartTelemetry {
         environment: String,
-        version: String,
+        release: String,
         account_slug: Option<String>,
     },
     StopTelemetry,
@@ -554,11 +554,11 @@ impl<'a> Handler<'a> {
             }
             ClientMsg::StartTelemetry {
                 environment,
-                version,
+                release,
                 account_slug,
             } => {
                 self.telemetry
-                    .start(&environment, &version, firezone_telemetry::IPC_SERVICE_DSN);
+                    .start(&environment, &release, firezone_telemetry::IPC_SERVICE_DSN);
 
                 if let Some(account_slug) = account_slug {
                     self.telemetry.set_account_slug(account_slug);

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -159,7 +159,7 @@ fn main() -> Result<()> {
     if cli.is_telemetry_allowed() {
         telemetry.start(
             cli.api_url.as_ref(),
-            VERSION,
+            &format!("headless-client@{VERSION}"),
             firezone_telemetry::HEADLESS_DSN,
         );
     }


### PR DESCRIPTION
In order for Sentry to parse our releases as semver, they need to be in the form of `package@version` [0]. Without this, the feature of "Mark this issue as resolved in the _next_ version" doesn't work properly because Sentry compares the versions as to when it first saw them vs parsing the semver string itself. We test versions prior to releasing them, meaning Sentry learns about a 1.4.0 version before it is actually released. This causes false-positive "regressions" even though they are fixed in a later (as per semver) release.

This create some redundancy with the different DSNs that we are already using. I think it would make sense to consider merging the two projects we have for the GUI client for example. That is really just one project that happens to run as two binaries.

For all other projects, I think the separation still makes sense because we e.g. may add Sentry to the "host" applications of Android and MacOS/iOS as well. For those, we would reuse the DSN and thus funnel the issues into the same Sentry project.

As per Sentry's docs, releases are organisation-wide and therefore need a package identifier to be grouped correctly.

[0]: https://docs.sentry.io/platforms/javascript/configuration/releases/#bind-the-version