### PR TITLE
fix(apple): Make clear logs and log size functions work across the IPC boundary

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -28,7 +28,7 @@ public final class Store: ObservableObject {
   // we could periodically update it if we need to.
   @Published private(set) var decision: UNAuthorizationStatus
 
-  private let tunnelManager: TunnelManager
+  public let tunnelManager: TunnelManager
   private var sessionNotification: SessionNotification
   private var cancellables: Set<AnyCancellable> = []
   private var resourcesTimer: Timer?

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -124,6 +124,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     completionHandler()
   }
 
+  // TODO: It would be helpful to be able to encapsulate Errors here. To do that
+  // we need to update TunnelMessage to encode/decode Result to and from Data.
   override func handleAppMessage(_ message: Data, completionHandler: ((Data?) -> Void)? = nil) {
     guard let tunnelMessage =  try? PropertyListDecoder().decode(TunnelMessage.self, from: message) else { return }
 

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -139,6 +139,38 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         resourceListJSON in
         completionHandler?(resourceListJSON?.data(using: .utf8))
       }
+    case .clearLogs:
+      clearLogs(completionHandler)
+    case .getLogFolderSize:
+      getLogFolderSize(completionHandler)
+    }
+  }
+
+  func clearLogs(_ completionHandler: ((Data?) -> Void)? = nil) {
+    Task {
+      do {
+        try Log.clear(in: SharedAccess.logFolderURL)
+      } catch {
+        Log.tunnel.error("Error clearing logs: \(error)")
+      }
+
+      completionHandler?(nil)
+    }
+  }
+
+  func getLogFolderSize(_ completionHandler: ((Data?) -> Void)? = nil) {
+    guard let logFolderURL = SharedAccess.logFolderURL
+    else {
+      completionHandler?(nil)
+
+      return
+    }
+
+    Task {
+      let size = await Log.size(of: logFolderURL)
+      let data = withUnsafeBytes(of: size) { Data($0) }
+
+      completionHandler?(data)
     }
   }
 }


### PR DESCRIPTION
The macOS client starting in 1.4.0 uses a system extension for its network extension package type. This process runs as root and does not have access to the app's Group Container folder for reading / writing log files directly, and vice-versa. This means the tunnel now writes its logs to a separate directory as the GUI app process.

Since the logging functions of clearing logs, calculating their size, and exporting them assume all the logs are in the same directory, we need to introduce IPC handlers to ensure the GUI app can conveniently still perform these functions when initiated by the user.

We already use the Network Extension API `sendProviderMessage` as our IPC mechanism for adhoc, bi-directional communication through the tunnel, so we add more handlers to this mechanism to support the logging functions summarized above.

In this PR we only fix the log size calculation and clear log functionality. Exporting logs is more involved and will be implemented in another dedicated PR.