### PR TITLE
ci: allow unmaintained gtk crates

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -73,6 +73,19 @@ ignore = [
   "RUSTSEC-2020-0095", # `difference` is unmaintained
   "RUSTSEC-2024-0384", # `instant` is unmaintained
   "RUSTSEC-2024-0370", # `proc-macro-error` is unmaintained
+
+  # `gtk-rs` crates are unmaintained
+  "RUSTSEC-2024-0411",
+  "RUSTSEC-2024-0412",
+  "RUSTSEC-2024-0413",
+  "RUSTSEC-2024-0414",
+  "RUSTSEC-2024-0415",
+  "RUSTSEC-2024-0416",
+  "RUSTSEC-2024-0417",
+  "RUSTSEC-2024-0418",
+  "RUSTSEC-2024-0419",
+  "RUSTSEC-2024-0420",
+  "RUSTSEC-2024-0421",
   #"RUSTSEC-0000-0000",
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -241,7 +241,6 @@ skip = [
   "raw-window-handle",
   "regex-automata",
   "regex-syntax",
-  "rustls",
   "syn",
   "sync_wrapper",
   "tauri-winrt-notification",


### PR DESCRIPTION
Tauri still depends on GTK3 which is now officially unmaintained (https://github.com/rustsec/advisory-db/pull/2164). I've asked the Tauri team for a position on it (https://github.com/tauri-apps/tauri/issues/11942). In the meantime, we'll have to allow the use of these unmaintained crates to unblock CI.