### PR TITLE
fix(connlib): don't fail NAT64 on invalid IPv4 DSCP value

### DIFF
--- a/rust/ip-packet/src/nat64.rs
+++ b/rust/ip-packet/src/nat64.rs
@@ -32,7 +32,7 @@ pub fn translate_in_place(buf: &mut [u8], src: Ipv4Addr, dst: Ipv4Addr) -> Resul
         //    addition, if the translator is at an administrative boundary, the
         //    filtering and update considerations of [RFC2475] may be
         //    applicable.
-        dscp: Ipv4Dscp::try_new(ipv6_header.traffic_class)?,
+        dscp: Ipv4Dscp::try_new(ipv6_header.traffic_class).unwrap_or(Ipv4Dscp::ZERO),
 
         // Total Length:  Payload length value from the IPv6 header, plus the
         //    size of the IPv4 header.


### PR DESCRIPTION
As per the RFC, the IPv6 traffic class should be 1-to-1 translated to the IPv4 DSCP value. However, it appears that not all values here are valid. In particular, when attempting to reach GitHub over IPv6, we receive an IPv6 packet that has a traffic class value of 72 which is out-of-range for the IPv4 DSCP value, resulting in the following error on the Gateway:

```
Failed to translate packet: NAT64 failed: Error '72' is too big to be a 'IPv4 DSCP (Differentiated Services Code Point)' (maximum allowed value is '63')
```

The bigger scope of this issue is that this causes the ICMP packets returned to the client to be dropped which means that `ssh` spawned by `git` doesn't learn that the IPv6 address assigned by Firezone is not actually routable.

Related: #7476.