### PR TITLE
fix(telemetry): disable for unofficial environments

### DIFF
--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -60,8 +60,11 @@ impl Telemetry {
         let environment = match api_url {
             "wss://api.firezone.dev" | "wss://api.firezone.dev/" => "production",
             "wss://api.firez.one" | "wss://api.firez.one/" => "staging",
-            "ws://api:8081" | "ws://api:8081/" => "docker-compose",
-            _ => "self-hosted",
+            _ => {
+                tracing::debug!(%api_url, "Telemetry won't start in unofficial environment");
+
+                return;
+            }
         };
 
         tracing::info!("Starting telemetry");


### PR DESCRIPTION
On the one hand, learning about in which edgecases our software fails is useful and thus having telemetry also active for self-hosted users is beneficial. On the other hand, we have neither control nor a contact to those self-hosted and whatever they are doing might spam our Sentry account with errors that we can't do anything about.

To mitigate this, we disable telemetry for self-hosted users with the next release.

Once we have more resources, we can consider enabling this again.