### PR TITLE
docs(gateway): add changelog entry for #7479

### DIFF
--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -24,6 +24,10 @@ export default function Gateway() {
           improving performance. The number of threads can be controlled with
           `FIREZONE_NUM_TUN_THREADS` and defaults to 2.
         </ChangeItem>
+        <ChangeItem pull="7479">
+          Fixes an issue where SSH connections involving NAT64 failed to
+          establish.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.1" date={new Date("2024-11-15")}>
         <ChangeItem pull="7263">


### PR DESCRIPTION
The issue is now fixed and `git pull` from `github.com` as a resource now works as expected.