### PR TITLE
chore(relay): downgrade log on missing allocation for REFRESH

### DIFF
--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -603,7 +603,7 @@ where
         // TODO: Verify that this is the correct error code.
         let Some(allocation) = self.allocations.get_mut(&sender) else {
             let (error_response, msg) = make_error_response(AllocationMismatch, &request);
-            tracing::warn!(target: "relay", "{msg}: Sender doesn't have an allocation");
+            tracing::info!(target: "relay", "{msg}: Sender doesn't have an allocation");
 
             return Err(error_response);
         };


### PR DESCRIPTION
Attempting to refresh an allocation is the only idempotent way in TURN to test whether one has an active allocation. As such, logging this on WARN is too aggressive.

Resolves: #7481.