### PR TITLE
build(deps): switch to `quinn-udp` release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4953,8 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
-source = "git+https://github.com/quinn-rs/quinn?branch=main#31a0440009afd5a7e29101410aa9d3da2d1f8077"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -83,7 +83,7 @@ output_vt100 = "0.1"
 png = "0.17.13"
 proptest = "1"
 proptest-state-machine = "0.3"
-quinn-udp = { version = "0.5.7", features = ["fast-apple-datapath"] }
+quinn-udp = { version = "0.5.8", features = ["fast-apple-datapath"] }
 rand = "0.8.5"
 rand_core = "0.6.4"
 rangemap = "1.5.1"
@@ -177,7 +177,6 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", branch = "main" }
-quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" }
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.


### PR DESCRIPTION
The less Git-dependencies the better.