### PR TITLE
fix(portal): Fix update API endpoint for resources

### DIFF
--- a/elixir/apps/api/lib/api/controllers/resource_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/resource_controller.ex
@@ -92,7 +92,7 @@ defmodule API.ResourceController do
     subject = conn.assigns.subject
     attrs = set_param_defaults(params)
 
-    with {:ok, resource} <- Resources.fetch_resource_by_id_or_persistent_id(id, subject) do
+    with {:ok, resource} <- Resources.fetch_active_resource_by_id_or_persistent_id(id, subject) do
       case Resources.update_or_replace_resource(resource, attrs, subject) do
         {:updated, updated_resource} ->
           render(conn, :show, resource: updated_resource)

--- a/elixir/apps/domain/lib/domain/resources.ex
+++ b/elixir/apps/domain/lib/domain/resources.ex
@@ -43,6 +43,26 @@ defmodule Domain.Resources do
     end
   end
 
+  def fetch_active_resource_by_id_or_persistent_id(id, %Auth.Subject{} = subject, opts \\ []) do
+    required_permissions =
+      {:one_of,
+       [
+         Authorizer.manage_resources_permission(),
+         Authorizer.view_available_resources_permission()
+       ]}
+
+    with :ok <- Auth.ensure_has_permissions(subject, required_permissions),
+         true <- Repo.valid_uuid?(id) do
+      Resource.Query.not_deleted()
+      |> Resource.Query.by_id_or_persistent_id(id)
+      |> Authorizer.for_subject(Resource, subject)
+      |> Repo.fetch(Resource.Query, opts)
+    else
+      false -> {:error, :not_found}
+      other -> other
+    end
+  end
+
   def fetch_and_authorize_resource_by_id(id, %Auth.Subject{} = subject, opts \\ []) do
     with :ok <-
            Auth.ensure_has_permissions(subject, Authorizer.view_available_resources_permission()),


### PR DESCRIPTION
Why:

* The API endpoint for updating Resources was using `Resources.fetch_resource_by_id_or_persistent_id`, however that function was fetching all Resources, which included deleted Resources. In order to prevent an API user from attempting to update a Resource that is deleted, a new function was added to fetch active Resources only.

Fixes: #7492 