### PR TITLE
fix(gui-client): remove error about unexpected `TunnelReady`

### DIFF
--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -598,13 +598,6 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
                 Err(Error::IpcServiceTerminating)?
             }
             IpcServerMsg::TunnelReady => {
-                if self.auth.session().is_none() {
-                    // This could maybe happen if the user cancels the sign-in
-                    // before it completes. This is because the state machine
-                    // between the GUI, the IPC service, and connlib isn't  perfectly synced.
-                    tracing::error!("Got `TunnelReady` while signed out");
-                    return Ok(ControlFlow::Continue(()));
-                }
                 if let Status::WaitingForTunnel { start_instant } = self.status {
                     tracing::info!(elapsed = ?start_instant.elapsed(), "Tunnel ready");
                     self.status = Status::TunnelReady { resources: vec![] };

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -598,14 +598,17 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
                 Err(Error::IpcServiceTerminating)?
             }
             IpcServerMsg::TunnelReady => {
-                if let Status::WaitingForTunnel { start_instant } = self.status {
-                    tracing::info!(elapsed = ?start_instant.elapsed(), "Tunnel ready");
-                    self.status = Status::TunnelReady { resources: vec![] };
-                    self.integration.show_notification(
-                        "Firezone connected",
-                        "You are now signed in and able to access resources.",
-                    )?;
-                }
+                let Status::WaitingForTunnel { start_instant } = self.status else {
+                    // If we are not waiting for a tunnel, continue.
+                    return Ok(ControlFlow::Continue(()));
+                };
+
+                tracing::info!(elapsed = ?start_instant.elapsed(), "Tunnel ready");
+                self.status = Status::TunnelReady { resources: vec![] };
+                self.integration.show_notification(
+                    "Firezone connected",
+                    "You are now signed in and able to access resources.",
+                )?;
                 self.refresh_system_tray_menu();
             }
         }


### PR DESCRIPTION
The communication between the GUI client, the IPC service and `connlib` are asynchronous. As such, it may happen that the state machines run out of sync. Receiving a `TunnelReady` despite not being in the right state for that is no concern and can be handled gracefully.