### PR TITLE
fix(gateway): don't return error when client disconnected

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -90,10 +90,10 @@ impl GatewayState {
             return Ok(None);
         }
 
-        let peer = self
-            .peers
-            .peer_by_ip_mut(dst)
-            .context("Couldn't find connection by IP")?;
+        let Some(peer) = self.peers.peer_by_ip_mut(dst) else {
+            tracing::debug!(%dst, "Unknown client, perhaps already disconnected?");
+            return Ok(None);
+        };
         let cid = peer.id();
 
         let packet = peer


### PR DESCRIPTION
When a client disconnects, we clear up the connection on the gateway. There might still be packets arriving from resources that we then cannot route. This isn't worth returning an error.