### PR TITLE
chore(relay): downgrade allocation mismatch warn on CHANNEL_BIND

### DIFF
--- a/rust/relay/src/server.rs
+++ b/rust/relay/src/server.rs
@@ -655,7 +655,7 @@ where
         let Some(allocation) = self.allocations.get_mut(&sender) else {
             let (error_response, msg) = make_error_response(AllocationMismatch, &request);
 
-            tracing::warn!(target: "relay", "{msg}: Sender doesn't have an allocation");
+            tracing::info!(target: "relay", "{msg}: Sender doesn't have an allocation");
 
             return Err(error_response);
         };


### PR DESCRIPTION
This code-path is handled gracefully in `connlib`, no need to issue a warning here.