### PR TITLE
chore(connlib): downgrade warning about missing DNS servers

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1721,7 +1721,7 @@ fn effective_dns_servers(
         .peekable();
 
     if dns_servers.peek().is_none() {
-        tracing::warn!("No system default DNS servers available! Can't initialize resolver. DNS interception will be disabled.");
+        tracing::info!("No system default DNS servers available! Can't initialize resolver. DNS resources won't work.");
         return Vec::new();
     }
 


### PR DESCRIPTION
There is nothing we can do if the user doesn't have any DNS servers defined. The default log level is INFO so a user reading the logs will still come across this message in case they are trying to debug what is happening.

Long term, problems like these would probably warrant some kind of notification channel from `connlib` to the GUI where we can display messages to the user.