### PR TITLE
chore(gui-client): don't warn when tray menu updates fail

### DIFF
--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -60,8 +60,8 @@ pub trait GuiIntegration {
     /// Also opens non-URLs
     fn open_url<P: AsRef<str>>(&self, url: P) -> Result<()>;
 
-    fn set_tray_icon(&mut self, icon: system_tray::Icon) -> Result<()>;
-    fn set_tray_menu(&mut self, app_state: system_tray::AppState) -> Result<()>;
+    fn set_tray_icon(&mut self, icon: system_tray::Icon);
+    fn set_tray_menu(&mut self, app_state: system_tray::AppState);
     fn show_notification(&self, title: &str, body: &str) -> Result<()>;
     fn show_update_notification(&self, ctlr_tx: CtlrTx, title: &str, url: url::Url) -> Result<()>;
 
@@ -593,8 +593,7 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
             IpcServerMsg::TerminatingGracefully => {
                 tracing::info!("Caught TerminatingGracefully");
                 self.integration
-                    .set_tray_icon(system_tray::icon_terminating())
-                    .ok();
+                    .set_tray_icon(system_tray::icon_terminating());
                 Err(Error::IpcServiceTerminating)?
             }
             IpcServerMsg::TunnelReady => {
@@ -747,12 +746,10 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
             system_tray::ConnlibState::SignedOut
         };
 
-        if let Err(e) = self.integration.set_tray_menu(system_tray::AppState {
+        self.integration.set_tray_menu(system_tray::AppState {
             connlib,
             release: self.release.clone(),
-        }) {
-            tracing::debug!("Failed to set new tray menu: {e:#}")
-        };
+        });
     }
 
     /// If we're in the `RetryingConnection` state, use the token to retry the Portal connection

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -79,11 +79,11 @@ impl GuiIntegration for TauriIntegration {
         Ok(self.app.shell().open(url.as_ref(), None)?)
     }
 
-    fn set_tray_icon(&mut self, icon: common::system_tray::Icon) -> Result<()> {
-        self.tray.set_icon(icon)
+    fn set_tray_icon(&mut self, icon: common::system_tray::Icon) {
+        self.tray.set_icon(icon);
     }
 
-    fn set_tray_menu(&mut self, app_state: common::system_tray::AppState) -> Result<()> {
+    fn set_tray_menu(&mut self, app_state: common::system_tray::AppState) {
         self.tray.update(app_state)
     }
 

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -89,10 +89,7 @@ impl Tray {
             self.app
                 .run_on_main_thread(move || {
                     if let Err(error) = update(handle, &app, &menu) {
-                        tracing::error!(
-                            error = anyhow_dyn_err(&error),
-                            "Error while updating tray icon"
-                        );
+                        tracing::debug!("Error while updating tray menu: {error:#}");
                     }
                 })
                 .context("Failed to update tray icon")?;

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -116,7 +116,7 @@ impl Tray {
         self.app
             .run_on_main_thread(move || {
                 if let Err(e) = handle.set_icon(Some(icon_to_tauri_icon(&icon))) {
-                    tracing::warn!(error = std_dyn_err(&e), "Failed to set tray icon")
+                    tracing::debug!("Failed to set tray icon: {e:#}")
                 }
             })
             .context("Failed to run closure for updating tray icon on main thread")?;

--- a/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/system_tray.rs
@@ -86,9 +86,10 @@ impl Tray {
             tracing::debug!("Skipping redundant menu update");
         } else {
             self.run_on_main_thread(move || {
-                if let Err(error) = update(handle, &app, &menu) {
-                    tracing::debug!("Error while updating tray menu: {error:#}");
-                }
+                firezone_logging::unwrap_or_debug!(
+                    update(handle, &app, &menu),
+                    "Error while updating tray menu: {}"
+                );
             });
         }
         self.set_icon(new_icon);
@@ -109,9 +110,11 @@ impl Tray {
         let handle = self.handle.clone();
         self.last_icon_set = icon.clone();
         self.run_on_main_thread(move || {
-            if let Err(e) = handle.set_icon(Some(icon_to_tauri_icon(&icon))) {
-                tracing::debug!("Failed to set tray icon: {e:#}")
-            }
+            let result = handle
+                .set_icon(Some(icon_to_tauri_icon(&icon)))
+                .context("Failed to set tray icon");
+
+            firezone_logging::unwrap_or_debug!(result, "{}");
         });
     }
 


### PR DESCRIPTION
Windows appears to randomly fail to update the tray menu. There is nothing we can do about that. Hence, we downgrade these errors to debug and make the functions infallible, reducing the complexity for the caller.