### PR TITLE
fix(gateway): don't warn about disconnected peer after DNS query

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -292,7 +292,7 @@ impl GatewayState {
         now: Instant,
     ) -> anyhow::Result<()> {
         let Some(peer) = self.peers.get_mut(&req.client) else {
-            tracing::debug!(client = %req.client, "Client disconnected while we were resolving a domain");
+            tracing::debug!(client = %req.client, domain = %req.domain, "Client disconnected whilst we were resolving a domain");
 
             return Ok(());
         };


### PR DESCRIPTION
Setting up the DNS resource NAT for a client is asynchronous because we have to resolve the DNS name. If the client disconnects in the meantime, there is nothing we can do about that so we should just discard the result.

The actual timing of this is quite bizarre though because we receive the event for setting up a DNS resource NAT _via_ the tunnel and the ICE timeout is something like ~10s. When we assume that receiving such an event also means that we are still exchanging STUN messages, then it would mean that resolving the domain took longer than 10s.