### PR TITLE
chore(connlib): downgrade warning when disconnecting from relay

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -569,7 +569,7 @@ where
         self.allocations
             .retain(|rid, allocation| match allocation.can_be_freed() {
                 Some(e) => {
-                    tracing::warn!(%rid, "Disconnecting from relay; {e}");
+                    tracing::info!(%rid, "Disconnecting from relay; {e}");
 
                     false
                 }


### PR DESCRIPTION
There are several reasons why we can disconnect from a relay at runtime:

- STUN is blocked
- We have invalid credentials
- The TURN server is not protocol-conform

The first two are very much possible in production and there is nothing we can do about them. When relays reboot, their credentials change and if the Internet connection of a user / gateway gets cut, we may disconnect from the relay because the messages get lost.

The last one should never happen if we are connected to our own relays. Firezone can be self-hosted so ultimately, we don't have control over what we are talking to. That error however is more of a safe-guard for `connlib` itself to disconnect from the server as soon as it detects that it is behaving weirdly.

None of these reasons are worth reporting to Sentry as a problem because they aren't really fixable as such. It is more important that the user sees them in the logs if they decide to dig into them which they will still do on INFO level.