### PR TITLE
fix(portal): Partial index only when email is not null

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20241126185037_add_identity_email_unique_index.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20241126185037_add_identity_email_unique_index.exs
@@ -5,7 +5,7 @@ defmodule Domain.Repo.Migrations.AddIdentityEmailUniqueIndex do
     create(
       index(:auth_identities, [:account_id, :provider_id, :email],
         name: :auth_identities_account_id_provider_id_email_idx,
-        where: "deleted_at IS NULL",
+        where: "deleted_at IS NULL AND email IS NOT NULL",
         unique: true
       )
     )


### PR DESCRIPTION
Fixes this migration error on prod:

```
ERROR:  duplicate key value violates unique constraint "auth_identities_account_id_provider_id_email_idx
```

Using this query, it looks like many `email` nulls are the culprit:

```sql
SELECT 
    account_id, 
    provider_id, 
    email,
    COUNT(*) AS duplicate_count
FROM 
    auth_identities
WHERE 
    deleted_at IS NULL
GROUP BY 
    account_id, 
    provider_id, 
    email
HAVING 
    COUNT(*) > 1;
```


<img width="802" alt="Screenshot 2024-12-13 at 4 01 32 PM" src="https://github.com/user-attachments/assets/4995c748-4691-42e7-931d-f59933f0ae80" />
