### PR TITLE
fix(portal): Add provider_identifier to identities email unique index

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20241214030516_change_identity_email_unique_index.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20241214030516_change_identity_email_unique_index.exs
@@ -1,0 +1,27 @@
+defmodule Domain.Repo.Migrations.ChangeIdentityEmailUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    drop(
+      index(:auth_identities, [:account_id, :provider_id, :email],
+        name: :auth_identities_account_id_provider_id_email_idx,
+        where: "deleted_at IS NULL",
+        unique: true
+      )
+    )
+
+    # We include provider_identifier in the index because it's possible
+    # for two identities in the same provider to share an email address.
+    #
+    # This can happen for example if the IdP allows auth methods on their
+    # end tied to a single OIDC connector with Firezone. Examples of IdPs
+    # that do this are Authelia, Auth0, Keycloak and likely others.
+    create(
+      index(:auth_identities, [:account_id, :provider_id, :email, :provider_identifier],
+        name: :auth_identities_acct_id_provider_id_email_prov_ident_unique_idx,
+        where: "deleted_at IS NULL",
+        unique: true
+      )
+    )
+  end
+end


### PR DESCRIPTION
It's possible for two of the same emails to exist within the same provider, so we need to add `provider_identifier` to the unique index to enforce uniqueness properly.

Refs https://firezonehq.slack.com/archives/C04HRQTFY0Z/p1734131256450379