### PR TITLE
chore(portal): Remove redundant uniqueness index on auth_identities

### DIFF
--- a/elixir/apps/domain/lib/domain/auth.ex
+++ b/elixir/apps/domain/lib/domain/auth.ex
@@ -399,7 +399,7 @@ defmodule Domain.Auth do
     |> Repo.insert(
       conflict_target:
         {:unsafe_fragment,
-         ~s/(account_id, provider_id, provider_identifier) WHERE deleted_at IS NULL/},
+         ~s/(account_id, provider_id, email, provider_identifier) WHERE deleted_at IS NULL/},
       on_conflict: {:replace, [:provider_state]},
       returning: true
     )

--- a/elixir/apps/domain/priv/repo/migrations/20241215234628_update_auth_identities_provider_identifier_idx.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20241215234628_update_auth_identities_provider_identifier_idx.exs
@@ -1,0 +1,14 @@
+defmodule Domain.Repo.Migrations.UpdateAuthIdentitiesProviderIdentifierIdx do
+  use Ecto.Migration
+
+  def change do
+    # created in 20230425101110_create_auth_identities; covered by previous migration
+    drop(
+      index(:auth_identities, [:account_id, :provider_id, :provider_identifier],
+        name: :auth_identities_account_id_provider_id_provider_identifier_idx,
+        where: "deleted_at IS NULL",
+        unique: true
+      )
+    )
+  end
+end


### PR DESCRIPTION
With the index created as part of #7392, this index is now redundant.