### PR TITLE
fix(relay): buffer packets in case IO is busy

### DIFF
--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -16,10 +16,11 @@ use phoenix_channel::{Event, LoginUrl, NoParams, PhoenixChannel};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use secrecy::{Secret, SecretString};
+use std::borrow::Cow;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use std::task::Poll;
+use std::task::{ready, Poll};
 use std::time::{Duration, Instant};
 use tokio::signal::unix;
 use tracing::{level_filters::LevelFilter, Subscriber};
@@ -418,6 +419,8 @@ where
                 return Poll::Ready(Ok(()));
             }
 
+            ready!(self.sockets.flush(cx))?;
+
             // Priority 1: Execute the pending commands of the server.
             if let Some(next_command) = self.server.next_command() {
                 match next_command {
@@ -425,7 +428,7 @@ where
                         if let Err(e) = self.sockets.try_send(
                             self.server.listen_port(),
                             recipient.into_socket(),
-                            &payload,
+                            Cow::Owned(payload),
                         ) {
                             tracing::warn!(target: "relay", error = std_dyn_err(&e), %recipient, "Failed to send message");
                         }
@@ -493,10 +496,11 @@ where
                             .expect("valid ChannelData if we should relay it")
                             .data(); // When relaying data from a client to peer, we need to forward only the channel-data's payload.
 
-                        if let Err(e) =
-                            self.sockets
-                                .try_send(port.value(), peer.into_socket(), payload)
-                        {
+                        if let Err(e) = self.sockets.try_send(
+                            port.value(),
+                            peer.into_socket(),
+                            Cow::Borrowed(payload),
+                        ) {
                             tracing::warn!(target: "relay", error = std_dyn_err(&e), %peer, "Failed to relay data to peer");
                         }
                     };
@@ -521,7 +525,7 @@ where
                         if let Err(e) = self.sockets.try_send(
                             self.server.listen_port(), // Packets coming in from peers always go out on the TURN port
                             client.into_socket(),
-                            &self.buffer[..total_length],
+                            Cow::Borrowed(&self.buffer[..total_length]),
                         ) {
                             tracing::warn!(target: "relay", error = std_dyn_err(&e), %client, "Failed to relay data to client");
                         };


### PR DESCRIPTION
At present, the relay's event-loop simply drops a UDP packet in case the socket is not ready for writing. This is terrible for throughput because it means the encapsulated packet within the WG payload needs to be retransmitted by the source after a timeout. To avoid this, we instead buffer the packet and suspend the event loop until it has been correctly flushed out. This may still cause packet loss because the receive buffer may overflow in the meantime. However, there is nothing we can do about that because UDP itself doesn't have any backpressure.

The relay listens on many sockets at once via a separate worker thread and an `mio` event-loop. In addition to the current subscription to readable event, we now also subscribe to writable events.

At the very top of the relay's event-loop, we insert a `flush` function that ensures all buffered packets have been written out and - in case writing a packet fails - suspends the event-loop with a waker. If we receive a new event for write-readiness, we wake the waker which will trigger a new call to `Eventloop::poll` where we again try to flush the pending packet. We don't bother with tracking exactly, which socket sent the write-readiness and which socket we have still pending packets in. Instead, we suspend the entire event-loop until all pending packets have been flushed.

Resolves: #7519.