### PR TITLE
fix(connlib): don't log warnings for unreachable errors

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -92,6 +92,13 @@ where
                 Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::WouldBlock => {
                     continue;
                 }
+                Poll::Ready(Err(e))
+                    if e.kind() == io::ErrorKind::NetworkUnreachable
+                        || e.kind() == io::ErrorKind::HostUnreachable =>
+                {
+                    // Network unreachable most likely means we don't have IPv4 or IPv6 connectivity.
+                    continue;
+                }
                 Poll::Ready(Err(e)) => {
                     telemetry_event!("Tunnel error: {}", err_with_src(&e));
                     continue;

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -79,6 +79,13 @@ impl Eventloop {
                 Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::WouldBlock => {
                     continue;
                 }
+                Poll::Ready(Err(e))
+                    if e.kind() == io::ErrorKind::NetworkUnreachable
+                        || e.kind() == io::ErrorKind::HostUnreachable =>
+                {
+                    // Network unreachable most likely means we don't have IPv4 or IPv6 connectivity.
+                    continue;
+                }
                 Poll::Ready(Err(e)) => {
                     telemetry_event!("Tunnel error: {}", err_with_src(&e));
                     continue;


### PR DESCRIPTION
When a Gateway or Client is running in an environment without IPv4 or IPv6 connectivity, our initial probes for sending packets to the relays will fail with network unreachable. That isn't a very big concern and happens a lot in the wild. There is no need to report these as telemetry events.

Resolves: #7514.