### PR TITLE
chore(gateway): don't log errors for untranslatable packets

### DIFF
--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -978,6 +978,10 @@ pub enum UnsupportedProtocol {
     UnsupportedIcmpv6Type(Icmpv6Type),
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("Packet cannot be translated as part of NAT64/46")]
+pub struct ImpossibleTranslation;
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Certain packets cannot be translated as part of NAT64/46. The RFC says to "Silently drop" those. Currently, we log all errors that happens during the translation and don't follow this guideline.

Most of these "silently drop" errors are related to ICMP types that cannot be represented in the other version such as ICMPv6 Neighbor Solicitation.

To fix this, we introduce a new error type in the `ip_packet` module: `ImpossibleTranslation`. For convenience reasons, we carry that one through all layers as an `anyhow::Error` and test at the very top of the event-loop, whether the root-cause of the error is such a failed translation. If so, we ignore the error and move on. This isn't as type-safe as it could be but it is much easier to implement. Additionally, the risk of a bug here (i.e. if we stop emitting this error within the IP packet translation layer) is merely that the log will pop up again.

Resolves: #7516.