### PR TITLE
fix(telemetry): dispose previous session when starting new one

### DIFF
--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{borrow::Cow, sync::Arc, time::Duration};
 
 use sentry::protocol::SessionStatus;
 
@@ -50,7 +50,14 @@ impl Telemetry {
             }
         };
 
-        if self.inner.is_some() {
+        if self
+            .inner
+            .as_ref()
+            .and_then(|i| i.options().environment.as_ref())
+            .is_some_and(|env| env == environment)
+        {
+            tracing::debug!("Telemetry already initialised");
+
             return;
         }
 

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -38,10 +38,6 @@ impl Drop for Telemetry {
 
 impl Telemetry {
     pub fn start(&mut self, api_url: &str, release: &str, dsn: Dsn) {
-        if self.inner.is_some() {
-            return;
-        }
-
         // Can't use URLs as `environment` directly, because Sentry doesn't allow slashes in environments.
         // <https://docs.sentry.io/platforms/rust/configuration/environments/>
         let environment = match api_url {
@@ -53,6 +49,10 @@ impl Telemetry {
                 return;
             }
         };
+
+        if self.inner.is_some() {
+            return;
+        }
 
         tracing::info!("Starting telemetry");
         let inner = sentry::init((


### PR DESCRIPTION
For persistent applications like the IPC service, it is possible that telemetry gets initialised with different parameters depending on what the user logs in with. Currently, only the first one is persisted and all consecutive ones are ignored, leading to events that may be wrongly tagged for a certain user / environment.

To fix this, we only skip the init if we are still in the same environment. Otherwise, the close the previous session and initialise a new one.

Fixes: #7525.