### PR TITLE
docs: List minimum supported macOS as 13

### DIFF
--- a/website/src/app/kb/client-apps/macos-client/readme.mdx
+++ b/website/src/app/kb/client-apps/macos-client/readme.mdx
@@ -6,7 +6,7 @@ Firezone supports macOS with a native client available in the macOS App Store.
 
 ## Prerequisites
 
-- **macOS 12** or higher
+- **macOS 13** or higher
 - **Intel x86-64 or Apple Silicon** CPU architecture
 
 ## Installation


### PR DESCRIPTION
macOS 12's SwiftUI framework is quite buggy, which leads to buttons and window layout bugs in the Firezone app.

Since virtually no customers are on macOS 12 and it's officially EOL, we'll be dropping support for it.

https://endoflife.date/macos

Refs https://firezonehq.slack.com/archives/C06L41XN05T/p1734360363455569

Refs #7531 