### PR TITLE
fix(connlib): bind new channel to peer if needed

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1788,7 +1788,7 @@ mod tests {
     }
 
     #[test]
-    fn does_not_relay_to_with_unbound_channel() {
+    fn does_relay_to_with_bound_channel() {
         let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);
@@ -1810,7 +1810,7 @@ mod tests {
     }
 
     #[test]
-    fn does_relay_to_with_bound_channel() {
+    fn does_not_relay_to_with_unbound_channel() {
         let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1)
             .with_allocate_response(&[RELAY_ADDR_IP4]);

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1620,8 +1620,8 @@ mod tests {
         let channel = channel_bindings.new_channel_to_peer(PEER1, start).unwrap();
         channel_bindings.set_confirmed(channel, start + Duration::from_secs(1));
 
-        let mut packet = [&[0u8; 4] as &[u8], b"foobar"].concat();
-        crate::channel_data::encode_header_to_slice(&mut packet, channel, 0);
+        let mut packet = channel_data_packet_buffer(b"foobar");
+        crate::channel_data::encode_header_to_slice(&mut packet[..4], channel, 6);
         let (peer, payload) = channel_bindings
             .try_decode(&packet, start + Duration::from_secs(2))
             .unwrap();

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -2,7 +2,6 @@ use crate::{
     backoff::{self, ExponentialBackoff},
     node::{SessionId, Transmit},
     utils::earliest,
-    EncryptedPacket,
 };
 use ::backoff::backoff::Backoff;
 use bytecodec::{DecodeExt as _, EncodeExt as _};
@@ -11,7 +10,6 @@ use hex_display::HexDisplayExt as _;
 use rand::random;
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 use std::{
-    borrow::Cow,
     collections::{BTreeMap, VecDeque},
     net::{SocketAddr, SocketAddrV4, SocketAddrV6},
     time::{Duration, Instant},
@@ -763,40 +761,23 @@ impl Allocation {
         );
     }
 
-    pub fn encode_to_encrypted_packet(
+    pub fn encode_channel_data_header(
         &self,
         peer: SocketAddr,
-        mut buffer: lockfree_object_pool::SpinLockOwnedReusable<Vec<u8>>,
-        buffer_len: usize,
+        buffer: &mut [u8],
         now: Instant,
-    ) -> Option<EncryptedPacket> {
-        let packet_len = buffer_len - 4;
+    ) -> Option<EncodeOk> {
+        let payload_length = buffer.len() - 4;
 
         let channel_number = self.channel_bindings.connected_channel_to_peer(peer, now)?;
-        crate::channel_data::encode_header_to_slice(&mut buffer[..4], channel_number, packet_len);
+        crate::channel_data::encode_header_to_slice(
+            &mut buffer[..4],
+            channel_number,
+            payload_length,
+        );
 
-        Some(EncryptedPacket {
-            src: None,
-            dst: self.active_socket?,
-            packet_start: 0,
-            packet_len: buffer_len,
-            buffer,
-        })
-    }
-
-    pub fn encode_to_owned_transmit(
-        &mut self,
-        peer: SocketAddr,
-        packet: &[u8],
-        now: Instant,
-    ) -> Option<Transmit<'static>> {
-        let channel_number = self.channel_bindings.connected_channel_to_peer(peer, now)?;
-        let channel_data = crate::channel_data::encode(channel_number, packet);
-
-        Some(Transmit {
-            src: None,
-            dst: self.active_socket?,
-            payload: Cow::Owned(channel_data),
+        Some(EncodeOk {
+            socket: self.active_socket?,
         })
     }
 
@@ -1081,6 +1062,10 @@ impl Allocation {
         )
         .is_ok()
     }
+}
+
+pub struct EncodeOk {
+    pub socket: SocketAddr,
 }
 
 fn authenticate(message: Message<Attribute>, credentials: &Credentials) -> Message<Attribute> {
@@ -1511,6 +1496,8 @@ fn display_attr(attr: &Attribute) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::utils::channel_data_packet_buffer;
+
     use super::*;
     use std::{
         iter,
@@ -1624,7 +1611,8 @@ mod tests {
         let channel = channel_bindings.new_channel_to_peer(PEER1, start).unwrap();
         channel_bindings.set_confirmed(channel, start + Duration::from_secs(1));
 
-        let packet = crate::channel_data::encode(channel, b"foobar");
+        let mut packet = [&[0u8; 4] as &[u8], b"foobar"].concat();
+        crate::channel_data::encode_header_to_slice(&mut packet, channel, 0);
         let (peer, payload) = channel_bindings
             .try_decode(&packet, start + Duration::from_secs(2))
             .unwrap();
@@ -1641,7 +1629,8 @@ mod tests {
         let channel = channel_bindings.new_channel_to_peer(PEER1, start).unwrap();
         channel_bindings.set_confirmed(channel, start + Duration::from_secs(1));
 
-        let packet = crate::channel_data::encode(channel, b"foobar");
+        let mut packet = channel_data_packet_buffer(b"foobar");
+        crate::channel_data::encode_header_to_slice(&mut packet[..4], channel, 6);
         channel_bindings
             .try_decode(&packet, start + Duration::from_secs(2))
             .unwrap();
@@ -1800,13 +1789,12 @@ mod tests {
             Instant::now(),
         );
 
-        let transmit = allocation
-            .encode_to_owned_transmit(PEER2_IP4, b"foobar", Instant::now())
+        let mut buffer = channel_data_packet_buffer(b"foobar");
+        let encode_ok = allocation
+            .encode_channel_data_header(PEER2_IP4, &mut buffer, Instant::now())
             .unwrap();
 
-        assert_eq!(&transmit.payload[4..], b"foobar");
-        assert_eq!(transmit.src, None);
-        assert_eq!(transmit.dst, RELAY_V4.into());
+        assert_eq!(encode_ok.socket, RELAY_V4.into());
     }
 
     #[test]
@@ -1816,9 +1804,11 @@ mod tests {
             .with_allocate_response(&[RELAY_ADDR_IP4]);
         allocation.bind_channel(PEER2_IP4, Instant::now());
 
-        let message = allocation.encode_to_owned_transmit(PEER2_IP4, b"foobar", Instant::now());
+        let mut buffer = channel_data_packet_buffer(b"foobar");
+        let encode_ok =
+            allocation.encode_channel_data_header(PEER2_IP4, &mut buffer, Instant::now());
 
-        assert!(message.is_none())
+        assert!(encode_ok.is_none())
     }
 
     #[test]
@@ -2105,7 +2095,8 @@ mod tests {
             Instant::now(),
         );
 
-        let msg = allocation.encode_to_owned_transmit(PEER2_IP4, b"foobar", Instant::now());
+        let mut packet = channel_data_packet_buffer(b"foobar");
+        let msg = allocation.encode_channel_data_header(PEER2_IP4, &mut packet, Instant::now());
         assert!(msg.is_some(), "expect to have a channel to peer");
 
         allocation.refresh_with_same_credentials();
@@ -2113,7 +2104,8 @@ mod tests {
         let refresh = allocation.next_message().unwrap();
         allocation.handle_test_input_ip4(&allocation_mismatch(&refresh), Instant::now());
 
-        let msg = allocation.encode_to_owned_transmit(PEER2_IP4, b"foobar", Instant::now());
+        let mut packet = channel_data_packet_buffer(b"foobar");
+        let msg = allocation.encode_channel_data_header(PEER2_IP4, &mut packet, Instant::now());
         assert!(msg.is_none(), "expect to no longer have a channel to peer");
     }
 

--- a/rust/connlib/snownet/src/channel_data.rs
+++ b/rust/connlib/snownet/src/channel_data.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, BytesMut};
+use bytes::BufMut;
 use std::io;
 
 const HEADER_LEN: usize = 4;
@@ -36,14 +36,6 @@ pub fn decode(data: &[u8]) -> Result<(u16, &[u8]), io::Error> {
     Ok((channel_number, &payload[..length]))
 }
 
-pub fn encode(channel: u16, data: &[u8]) -> Vec<u8> {
-    debug_assert!(channel > 0x400);
-    debug_assert!(channel < 0x7FFF);
-    debug_assert!(data.len() <= u16::MAX as usize);
-
-    to_bytes(channel, data.len() as u16, data)
-}
-
 /// Encode the channel data header (number + length) to the given slice.
 ///
 /// Returns the total length of the packet (i.e. the encoded header + data).
@@ -58,14 +50,4 @@ pub fn encode_header_to_slice(mut slice: &mut [u8], channel: u16, payload_length
     slice.put_u16(payload_length as u16);
 
     HEADER_LEN + payload_length
-}
-
-fn to_bytes(channel: u16, len: u16, payload: &[u8]) -> Vec<u8> {
-    let mut message = BytesMut::with_capacity(HEADER_LEN + (len as usize));
-
-    message.put_u16(channel);
-    message.put_u16(len);
-    message.put_slice(payload);
-
-    message.freeze().into()
 }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -485,14 +485,13 @@ where
                 buffer,
             })),
             PeerSocket::Relay { relay, dest: peer } => {
-                let Some(allocation) = self.allocations.get(&relay) else {
+                let Some(allocation) = self.allocations.get_mut(&relay) else {
                     tracing::warn!(%relay, "No allocation");
                     return Ok(None);
                 };
                 let Some(encode_ok) =
                     allocation.encode_channel_data_header(peer, &mut buffer[..packet_end], now)
                 else {
-                    tracing::warn!(%peer, "No channel");
                     return Ok(None);
                 };
 

--- a/rust/connlib/snownet/src/utils.rs
+++ b/rust/connlib/snownet/src/utils.rs
@@ -8,3 +8,7 @@ pub fn earliest(left: Option<Instant>, right: Option<Instant>) -> Option<Instant
         (None, Some(right)) => Some(right),
     }
 }
+
+pub fn channel_data_packet_buffer(payload: &[u8]) -> Vec<u8> {
+    [&[0u8; 4] as &[u8], payload].concat()
+}


### PR DESCRIPTION
Initially, when we receive a new candidate from a remote peer, we bind a channel for each remote address on the relay that we sampled. This ensures that every possible communication path is actually functioning. In ICE, all candidates are tried against each other, meaning the remote will attempt to send from each of their candidates to every one of ours, including our relay candidates. To allow this traffic, a channel needs to be bound first.

For various reasons, an allocation might become stale or needs to be otherwise invalidated. In that case, all the channel bindings are lost but there might still be an active connection that wants to utilise them. In that case, we will see "No channel" warnings like https://firezone-inc.sentry.io/issues/6036662614/events/f8375883fd3243a4afbb27c36f253e23/.

To fix this, we use the attempt to encode a message for a channel as an intent to bind a new one. This is deemed safe because wanting to encode a message to a peer as a channel data message means we want such a channel to exist. The first message here is still dropped but that is better than not establishing the channel at all.