### PR TITLE
refactor(connlib): remove unused branch in `match`

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -268,10 +268,6 @@ impl StubResolver {
         Some(domain.clone())
     }
 
-    fn knows_resource(&self, resource: &ResourceId) -> bool {
-        self.dns_resources.values().contains(resource)
-    }
-
     /// Processes the incoming DNS query.
     ///
     /// Any errors will result in an immediate `SERVFAIL` response.
@@ -323,9 +319,6 @@ impl StubResolver {
         let maybe_resource = self.match_resource_linear(&domain);
 
         let resource_records = match (qtype, maybe_resource) {
-            (_, Some(resource)) if !self.knows_resource(&resource) => {
-                return Ok(ResolveStrategy::Recurse)
-            }
             (Rtype::A, Some(resource)) => self.get_or_assign_a_records(domain.clone(), resource),
             (Rtype::AAAA, Some(resource)) => {
                 self.get_or_assign_aaaa_records(domain.clone(), resource)


### PR DESCRIPTION
When deciding what to do with a certain DNS query, we check whether the domain name in question corresponds to any of the (wildcard) DNS resource addresses. If yes, we resolve it to the resource ID of that resource. The source of those resource IDs is the `dns_resources` map.

If we have looked up a `ResourceId` in that map, it is impossible for it to not be "known" which means the branch deleted in this PR is completely redundant and already covered by the catch-all branch where `maybe_resource` is `None`.