### PR TITLE
fix(connlib): clear all in-flight upstream DNS queries on reset

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -204,7 +204,7 @@ impl Io {
         self.outbound_packet_buffer.push_back(packet);
     }
 
-    pub fn rebind_sockets(&mut self) {
+    pub fn reset(&mut self) {
         self.sockets.rebind(self.udp_socket_factory.as_ref());
         self.gso_queue.clear();
     }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -207,6 +207,7 @@ impl Io {
     pub fn reset(&mut self) {
         self.sockets.rebind(self.udp_socket_factory.as_ref());
         self.gso_queue.clear();
+        self.dns_queries = FuturesTupleSet::new(DNS_QUERY_TIMEOUT, 1000);
     }
 
     pub fn reset_timeout(&mut self, timeout: Instant) {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -98,7 +98,7 @@ impl ClientTunnel {
 
     pub fn reset(&mut self) {
         self.role_state.reset();
-        self.io.rebind_sockets();
+        self.io.reset();
     }
 
     pub fn poll_next_event(&mut self, cx: &mut Context<'_>) -> Poll<std::io::Result<ClientEvent>> {


### PR DESCRIPTION
When a Firezone Client roams, we reset all network connections and rebind our local sockets. Doing that enables us to start from a clean state and establish new connections to Gateways. What we are currently not clearing are in-flight DNS queries. Those are all very likely to fail because our network connection is changing. There is no point in us keeping those around. Additionally, as part of roaming, it may also be that our upstream DNS server changes and thus, we may suddenly receive a response from a DNS server that we no longer know about.

Clear all in-flight DNS queries on reset solves this.