### PR TITLE
fix(telemetry): remove need for tracking our own user state

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5508,7 +5508,7 @@ dependencies = [
 [[package]]
 name = "sentry"
 version = "0.35.0"
-source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#fd92a324630069138d079959367b8ad0bf7c642b"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -5527,7 +5527,7 @@ dependencies = [
 [[package]]
 name = "sentry-backtrace"
 version = "0.35.0"
-source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#fd92a324630069138d079959367b8ad0bf7c642b"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -5538,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "sentry-contexts"
 version = "0.35.0"
-source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#fd92a324630069138d079959367b8ad0bf7c642b"
 dependencies = [
  "hostname",
  "libc",
@@ -5551,7 +5551,7 @@ dependencies = [
 [[package]]
 name = "sentry-core"
 version = "0.35.0"
-source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#fd92a324630069138d079959367b8ad0bf7c642b"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -5563,7 +5563,7 @@ dependencies = [
 [[package]]
 name = "sentry-debug-images"
 version = "0.35.0"
-source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#fd92a324630069138d079959367b8ad0bf7c642b"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -5573,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "sentry-panic"
 version = "0.35.0"
-source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#fd92a324630069138d079959367b8ad0bf7c642b"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5582,7 +5582,7 @@ dependencies = [
 [[package]]
 name = "sentry-tracing"
 version = "0.35.0"
-source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#fd92a324630069138d079959367b8ad0bf7c642b"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5593,7 +5593,7 @@ dependencies = [
 [[package]]
 name = "sentry-types"
 version = "0.35.0"
-source = "git+https://github.com/getsentry/sentry-rust?branch=master#caa746df4e5362f7be341e21cb186bb1ea351cd3"
+source = "git+https://github.com/getsentry/sentry-rust?branch=master#fd92a324630069138d079959367b8ad0bf7c642b"
 dependencies = [
  "debugid",
  "hex",
@@ -7779,7 +7779,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -20,9 +20,6 @@ pub const RELAY_DSN: Dsn = Dsn("https://9d5f664d8f8f7f1716d4b63a58bcafd5@o450797
 #[derive(Default)]
 pub struct Telemetry {
     inner: Option<sentry::ClientInitGuard>,
-
-    account_slug: Option<String>,
-    firezone_id: Option<String>,
 }
 
 impl Drop for Telemetry {
@@ -68,8 +65,6 @@ impl Telemetry {
             sentry::end_session();
             drop(inner);
 
-            self.account_slug = None;
-            self.firezone_id = None;
             set_current_user(None);
         }
 
@@ -107,8 +102,6 @@ impl Telemetry {
         });
         self.inner.replace(inner);
         sentry::start_session();
-
-        self.update_user_context();
     }
 
     /// Flushes events to sentry.io and drops the guard
@@ -140,28 +133,24 @@ impl Telemetry {
     }
 
     pub fn set_account_slug(&mut self, slug: String) {
-        self.account_slug = Some(slug);
-        self.update_user_context();
+        self.update_user(|user| {
+            user.other.insert("account_slug".to_owned(), slug.into());
+        });
     }
 
     pub fn set_firezone_id(&mut self, id: String) {
-        self.firezone_id = Some(id);
-        self.update_user_context();
+        self.update_user(|user| {
+            user.id = Some(id);
+        });
     }
 
-    fn update_user_context(&self) {
-        let mut user = sentry::User {
-            id: self.firezone_id.clone(),
-            ..Default::default()
-        };
+    fn update_user(&mut self, update: impl FnOnce(&mut sentry::User)) {
+        sentry::Hub::main().configure_scope(|scope| {
+            let mut user = scope.user().cloned().unwrap_or_default();
+            update(&mut user);
 
-        user.other.extend(
-            self.account_slug
-                .clone()
-                .map(|slug| ("account_slug".to_owned(), slug.into())),
-        );
-
-        set_current_user(Some(user));
+            scope.set_user(Some(user));
+        });
     }
 }
 


### PR DESCRIPTION
Previously, we needed to track our own user state in order to set the whole thing in Sentry. That was necessary because Sentry didn't allow us to _retrieve_ the current user of the scope but always required the full user to be set. This was changed https://github.com/getsentry/sentry-rust/pull/715, which allows us to remove some of that code and hopefully mitigating any sort of lingering state when it comes to telemetry sessions.