### PR TITLE
fix(apple/macOS): Fetch providerStopReason over IPC on macOS

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -166,7 +166,21 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         exportLogs(completionHandler)
       }
+    case .consumeStopReason:
+      Task {
+        guard let completionHandler
+        else {
+          Log.tunnel.error(
+            "\(#function): Need a completion handler to consumeStopReason."
+          )
+
+          return
+        }
+
+        consumeStopReason(completionHandler)
+      }
     }
+
   }
 
   func clearLogs(_ completionHandler: ((Data?) -> Void)? = nil) {
@@ -240,6 +254,23 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
       self.logExportState = .inProgress(tunnelLogArchive)
       sendChunk(tunnelLogArchive)
+    }
+  }
+
+  func consumeStopReason(_ completionHandler: (Data?) -> Void) {
+    do {
+      let data = try Data(
+        contentsOf: SharedAccess.providerStopReasonURL
+      )
+
+      try? FileManager.default
+        .removeItem(at: SharedAccess.providerStopReasonURL)
+
+      completionHandler(data)
+    } catch {
+      Log.tunnel.error("\(#function): error reading stop reason: \(error)")
+
+      completionHandler(nil)
     }
   }
 }


### PR DESCRIPTION
Since we no longer have access to the tunnel's group container from the app process, we need to move reading the last VPN stop reason to an IPC call. This call is used to show an alert to the user when their connlib session has been disconnected due to 401: Unauthorized.

Fixes #7468 