### PR TITLE
fix(gui-client): don't fail on repeated deep-links

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -86,6 +86,9 @@ ignore = [
   "RUSTSEC-2024-0419",
   "RUSTSEC-2024-0420",
   "RUSTSEC-2024-0421",
+
+  "RUSTSEC-2024-0429", # `glib`, need to wait for tauri to upgrade
+
   #"RUSTSEC-0000-0000",
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish

--- a/rust/gui-client/src-common/src/auth.rs
+++ b/rust/gui-client/src-common/src/auth.rs
@@ -170,10 +170,12 @@ impl Auth {
     /// Returns a valid token.
     /// Performs I/O.
     ///
-    /// Errors if we don't have any ongoing flow, or if the response is invalid
-    pub(crate) fn handle_response(&mut self, resp: Response) -> Result<SecretString, Error> {
-        let req = self.ongoing_request().ok_or(Error::NoInflightRequest)?;
-
+    /// Errors if the response is invalid.
+    pub(crate) fn handle_response(
+        &mut self,
+        req: &Request,
+        resp: Response,
+    ) -> Result<SecretString, Error> {
         if !secure_equality(&resp.state, &req.state) {
             self.sign_out()?;
             return Err(Error::StatesDontMatch);

--- a/rust/gui-client/src-common/src/auth.rs
+++ b/rust/gui-client/src-common/src/auth.rs
@@ -446,7 +446,7 @@ mod tests {
             assert!(state.token().unwrap().is_none());
 
             // User clicks "Sign In", build a fake server response
-            let req = state.start_sign_in().unwrap().unwrap();
+            let req = state.start_sign_in().unwrap();
             let resp = Response {
                 account_slug: "firezone".into(),
                 actor_name: actor_name.into(),
@@ -474,7 +474,7 @@ mod tests {
             // Accidentally sign in again, this can happen if the user holds the systray menu open while a sign in is succeeding.
             // For now, we treat that like signing out and back in immediately, so it wipes the old token.
             // TODO: That sounds wrong.
-            assert!(state.start_sign_in().unwrap().is_some());
+            assert!(state.start_sign_in().is_some());
             assert!(state.token().unwrap().is_none());
 
             // Sign out again, now the token is gone

--- a/rust/gui-client/src-common/src/auth.rs
+++ b/rust/gui-client/src-common/src/auth.rs
@@ -474,7 +474,7 @@ mod tests {
             // Accidentally sign in again, this can happen if the user holds the systray menu open while a sign in is succeeding.
             // For now, we treat that like signing out and back in immediately, so it wipes the old token.
             // TODO: That sounds wrong.
-            assert!(state.start_sign_in().is_some());
+            assert!(state.start_sign_in().is_ok());
             assert!(state.token().unwrap().is_none());
 
             // Sign out again, now the token is gone

--- a/rust/gui-client/src-common/src/auth.rs
+++ b/rust/gui-client/src-common/src/auth.rs
@@ -154,7 +154,7 @@ impl Auth {
     ///
     /// Returns parameters used to make a URL for the web browser to open
     /// May return Ok(None) if we're already signed in
-    pub fn start_sign_in(&mut self) -> Result<Option<&Request>, Error> {
+    pub fn start_sign_in(&mut self) -> Result<&Request, Error> {
         self.sign_out()?;
         self.state = State::NeedResponse(Request {
             nonce: generate_nonce(),
@@ -162,7 +162,7 @@ impl Auth {
         });
         let request = self.ongoing_request().ok_or(Error::NoInflightRequest)?;
 
-        Ok(Some(request))
+        Ok(request)
     }
 
     /// Complete an ongoing sign-in flow using parameters from a deep link

--- a/rust/gui-client/src-common/src/auth.rs
+++ b/rust/gui-client/src-common/src/auth.rs
@@ -22,8 +22,6 @@ pub enum Error {
     DeleteFile(std::io::Error),
     #[error(transparent)]
     Keyring(#[from] keyring::Error),
-    #[error("No in-flight request")]
-    NoInflightRequest,
     #[error("session file path has no parent, this should be impossible")]
     PathWrong,
     #[error("Couldn't read session file: {0}")]
@@ -160,7 +158,9 @@ impl Auth {
             nonce: generate_nonce(),
             state: generate_nonce(),
         });
-        let request = self.ongoing_request().ok_or(Error::NoInflightRequest)?;
+        let State::NeedResponse(request) = &self.state else {
+            unreachable!("We just set `self.state`")
+        };
 
         Ok(request)
     }

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -739,7 +739,7 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
                 Status::WaitingForPortal { .. } => system_tray::ConnlibState::WaitingForPortal,
                 Status::WaitingForTunnel { .. } => system_tray::ConnlibState::WaitingForTunnel,
             }
-        } else if self.auth.ongoing_request().is_ok() {
+        } else if self.auth.ongoing_request().is_some() {
             // Signing in, waiting on deep link callback
             system_tray::ConnlibState::WaitingForBrowser
         } else {

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -374,10 +374,15 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
             deep_link::parse_auth_callback(url).context("Couldn't parse scheme request")?;
 
         tracing::info!("Received deep link over IPC");
+
+        let req = self
+            .auth
+            .ongoing_request()
+            .ok_or(Error::NoInflightRequest)?;
         // Uses `std::fs`
         let token = self
             .auth
-            .handle_response(auth_response)
+            .handle_response(req, auth_response)
             .context("Couldn't handle auth response")?;
         self.start_session(token).await?;
         Ok(())

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -375,10 +375,11 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
 
         tracing::info!("Received deep link over IPC");
 
-        let req = self
-            .auth
-            .ongoing_request()
-            .ok_or(Error::NoInflightRequest)?;
+        let Some(req) = self.auth.ongoing_request() else {
+            tracing::debug!("No pending auth request");
+            return Ok(());
+        };
+
         // Uses `std::fs`
         let token = self
             .auth

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -437,17 +437,16 @@ impl<'a, I: GuiIntegration> Controller<'a, I> {
                 }
             }
             Req::SignIn | Req::SystemTrayMenu(TrayMenuEvent::SignIn) => {
-                if let Some(req) = self
+                let req = self
                     .auth
                     .start_sign_in()
-                    .context("Couldn't start sign-in flow")?
-                {
-                    let url = req.to_url(&self.advanced_settings.auth_base_url);
-                    self.refresh_system_tray_menu();
-                    self.integration.open_url(url.expose_secret())
-                        .context("Couldn't open auth page")?;
-                    self.integration.set_welcome_window_visible(false)?;
-                }
+                    .context("Couldn't start sign-in flow")?;
+
+                let url = req.to_url(&self.advanced_settings.auth_base_url);
+                self.refresh_system_tray_menu();
+                self.integration.open_url(url.expose_secret())
+                    .context("Couldn't open auth page")?;
+                self.integration.set_welcome_window_visible(false)?;
             }
             Req::SystemTrayMenu(TrayMenuEvent::AddFavorite(resource_id)) => {
                 self.advanced_settings.favorite_resources.insert(resource_id);


### PR DESCRIPTION
Firezone's authentication scheme uses deep-links to transfer the secret token via the login-flow using the browser to the application. Such a deep-link can be opened multiple times, even if we are already signed in. In such a case, and in any other where we don't have a pending sign-in request, we currently generate an error.

This is unnecessary as we can simply discard the token received from the deep-link.