### PR TITLE
chore(apple/macOS): Add dedicated xcconfig for standalone distribution

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -102,7 +102,7 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
 
           # Copy xcconfig
-          cp Firezone/xcconfig/release.xcconfig Firezone/xcconfig/config.xcconfig
+          cp Firezone/xcconfig/app_store.xcconfig Firezone/xcconfig/config.xcconfig
 
           # App Store Connect requires a new build version on each upload and it must be an integer.
           # See https://developer.apple.com/documentation/xcode/build-settings-reference#Current-Project-Version

--- a/swift/apple/Firezone/Firezone.entitlements
+++ b/swift/apple/Firezone/Firezone.entitlements
@@ -4,7 +4,8 @@
 <dict>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
-		<string>packet-tunnel-provider</string>
+    <!-- "-systemextension" is needed for standalone distribution -->
+		<string>packet-tunnel-provider$(PACKET_TUNNEL_PROVIDER_SUFFIX)</string>
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>

--- a/swift/apple/Firezone/xcconfig/app_store.xcconfig
+++ b/swift/apple/Firezone/xcconfig/app_store.xcconfig
@@ -1,4 +1,4 @@
-// Apple Developer account-specific configuration
+// Apple Developer account-specific configuration for App Store distribution
 DEVELOPMENT_TEAM = 47R2M6779T
 PRODUCT_BUNDLE_IDENTIFIER = dev.firezone.firezone
 APP_GROUP_ID[sdk=macosx*] = 47R2M6779T.dev.firezone.firezone

--- a/swift/apple/Firezone/xcconfig/standalone.xcconfig
+++ b/swift/apple/Firezone/xcconfig/standalone.xcconfig
@@ -1,0 +1,12 @@
+// Apple Developer account-specific configuration for Standalone distribution
+DEVELOPMENT_TEAM = 47R2M6779T
+PRODUCT_BUNDLE_IDENTIFIER = dev.firezone.firezone
+APP_GROUP_ID[sdk=macosx*] = 47R2M6779T.dev.firezone.firezone
+APP_GROUP_ID_PRE_1_4_0[sdk=macosx*] = 47R2M6779T.group.dev.firezone.firezone
+APP_GROUP_ID[sdk=iphoneos*] = group.dev.firezone.firezone
+APP_GROUP_ID_PRE_1_4_0[sdk=iphoneos*] = group.dev.firezone.firezone
+CODE_SIGN_STYLE = Manual
+CODE_SIGN_IDENTITY = Developer ID Application: Firezone, Inc. (47R2M6779T)
+MACOS_APP_PROVISIONING_PROFILE_IDENTIFIER = 734b5163-46a4-4676-9ee7-01f25ec968e7
+MACOS_NE_PROVISIONING_PROFILE_IDENTIFIER = 6c0eee5f-00fd-40ab-ba6c-6ae83c59d19d
+PACKET_TUNNEL_PROVIDER_SUFFIX = -systemextension

--- a/swift/apple/FirezoneNetworkExtension/FirezoneNetworkExtension.entitlements
+++ b/swift/apple/FirezoneNetworkExtension/FirezoneNetworkExtension.entitlements
@@ -4,7 +4,8 @@
 <dict>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
-		<string>packet-tunnel-provider</string>
+    <!-- "-systemextension" is needed for standalone distribution -->
+		<string>packet-tunnel-provider$(PACKET_TUNNEL_PROVIDER_SUFFIX)</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>


### PR DESCRIPTION
Standalone distribution requires using a different signing identity (certificate), set of provisioning profiles, and (annoyingly) requires the `-systemextension` suffix for our network extension capabilities.

This PR prepares the Xcode environment for building a Standalone app in CI that will be notarized by matching certificates and provisioning profiles in our Apple Developer account.