### PR TITLE
fix(linux): don't fail on unsupported IP version

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -261,6 +261,11 @@ async fn add_route(route: &IpNetwork, idx: u32, handle: &Handle) {
         return;
     }
 
+    // On systems without support for a certain IP version (i.e. no IPv6), attempting to add a route may result in "Not supported (os error 95)".
+    if matches!(&err, NetlinkError(err) if err.raw_code() == -libc::EOPNOTSUPP) {
+        return;
+    }
+
     tracing::warn!(error = std_dyn_err(&err), %route, "Failed to add route");
 }
 


### PR DESCRIPTION
Firezone always attempts to handle IPv4 and IPv6. On Linux systems without an IPv6 stack, attempts to add an IPv6 route may fail with "Not supported (os error 95)". We don't need the IPv6 routes on those systems as we will never receive IPv6 traffic. Therefore, we can safely ignore these errors and not log them.