### PR TITLE
ci: Add fixes for upload script

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -20,7 +20,6 @@ jobs:
             rust-targets: aarch64-apple-ios
             build-script: scripts/build/ios-appstore.sh
             upload-script: scripts/upload/app-store-connect.sh
-            should-upload: "${{ github.event_name == 'workflow_dispatch' }}"
             artifact-file: "Firezone.ipa"
             platform: iOS
 
@@ -28,7 +27,6 @@ jobs:
             rust-targets: aarch64-apple-darwin x86_64-apple-darwin
             build-script: scripts/build/macos-appstore.sh
             upload-script: scripts/upload/app-store-connect.sh
-            should-upload: "${{ github.event_name == 'workflow_dispatch' }}"
             artifact-file: "Firezone.pkg"
             platform: macOS
 
@@ -36,7 +34,6 @@ jobs:
             rust-targets: aarch64-apple-darwin x86_64-apple-darwin
             build-script: scripts/build/macos-standalone.sh
             upload-script: scripts/upload/github-release.sh
-            shoud-upload: "${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}"
             # mark:next-apple-version
             artifact-file: "firezone-macos-client-1.4.0.dmg"
             # mark:next-apple-version
@@ -74,7 +71,7 @@ jobs:
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
       - run: ${{ matrix.upload-script }}
-        if: ${{ matrix.should-upload }}
+        if: "${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}"
         env:
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -20,6 +20,7 @@ jobs:
             rust-targets: aarch64-apple-ios
             build-script: scripts/build/ios-appstore.sh
             upload-script: scripts/upload/app-store-connect.sh
+            should-upload: "${{ github.event_name == 'workflow_dispatch' }}"
             artifact-file: "Firezone.ipa"
             platform: iOS
 
@@ -27,6 +28,7 @@ jobs:
             rust-targets: aarch64-apple-darwin x86_64-apple-darwin
             build-script: scripts/build/macos-appstore.sh
             upload-script: scripts/upload/app-store-connect.sh
+            should-upload: "${{ github.event_name == 'workflow_dispatch' }}"
             artifact-file: "Firezone.pkg"
             platform: macOS
 
@@ -34,6 +36,7 @@ jobs:
             rust-targets: aarch64-apple-darwin x86_64-apple-darwin
             build-script: scripts/build/macos-standalone.sh
             upload-script: scripts/upload/github-release.sh
+            shoud-upload: "${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}"
             # mark:next-apple-version
             artifact-file: "firezone-macos-client-1.4.0.dmg"
             # mark:next-apple-version
@@ -71,7 +74,7 @@ jobs:
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
       - run: ${{ matrix.upload-script }}
-        if: ${{ github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && contains(github.event.head_commit.modified, 'elixir/VERSION')) }}
+        if: ${{ matrix.should-upload }}
         env:
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -8,8 +8,8 @@ jobs:
     name: ${{ matrix.job_name }}
     runs-on: macos-15
     permissions:
-      contents: read
-      id-token: "write"
+      contents: write
+      id-token: write
     env:
       XCODE_VERSION: "16.2"
     strategy:
@@ -71,13 +71,14 @@ jobs:
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
       - run: ${{ matrix.upload-script }}
-        if: "${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}"
         env:
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          REPOSITORY: ${{ github.repository }}
           RELEASE_NAME: "${{ matrix.release-name }}"
           PLATFORM: "${{ matrix.platform }}"
       - uses: actions/cache/save@v4

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -8,7 +8,7 @@ jobs:
     name: ${{ matrix.job_name }}
     runs-on: macos-15
     permissions:
-      contents: write
+      contents: write # for attaching the build artifacts to the release
       id-token: write
     env:
       XCODE_VERSION: "16.2"
@@ -78,7 +78,6 @@ jobs:
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          REPOSITORY: ${{ github.repository }}
           RELEASE_NAME: "${{ matrix.release-name }}"
           PLATFORM: "${{ matrix.platform }}"
       - uses: actions/cache/save@v4

--- a/scripts/upload/github-release.sh
+++ b/scripts/upload/github-release.sh
@@ -2,7 +2,7 @@
 
 # Uploads built packages to a GitHub release
 
-set -euox pipefail
+set -euo pipefail
 
 # Only clobber existing release assets if the release is a draft
 is_draft=$(gh release view "$RELEASE_NAME" --json isDraft --jq '.isDraft' | tr -d '\n')
@@ -17,5 +17,4 @@ sha256sum "$ARTIFACT_PATH" >"$ARTIFACT_PATH.sha256sum.txt"
 gh release upload "$RELEASE_NAME" \
     "$ARTIFACT_PATH" \
     "$ARTIFACT_PATH.sha256sum.txt" \
-    $clobber \
-    --repo "$REPOSITORY"
+    $clobber

--- a/scripts/upload/github-release.sh
+++ b/scripts/upload/github-release.sh
@@ -17,4 +17,5 @@ sha256sum "$ARTIFACT_PATH" >"$ARTIFACT_PATH.sha256sum.txt"
 gh release upload "$RELEASE_NAME" \
     "$ARTIFACT_PATH" \
     "$ARTIFACT_PATH.sha256sum.txt" \
-    $clobber
+    $clobber \
+    --repo "$REPOSITORY"

--- a/scripts/upload/github-release.sh
+++ b/scripts/upload/github-release.sh
@@ -17,5 +17,4 @@ sha256sum "$ARTIFACT_PATH" >"$ARTIFACT_PATH.sha256sum.txt"
 gh release upload "$RELEASE_NAME" \
     "$ARTIFACT_PATH" \
     "$ARTIFACT_PATH.sha256sum.txt" \
-    $clobber \
-    --repo "$GITHUB_REPOSITORY"
+    $clobber

--- a/scripts/upload/github-release.sh
+++ b/scripts/upload/github-release.sh
@@ -2,7 +2,7 @@
 
 # Uploads built packages to a GitHub release
 
-set -euo pipefail
+set -euox pipefail
 
 # Only clobber existing release assets if the release is a draft
 is_draft=$(gh release view "$RELEASE_NAME" --json isDraft --jq '.isDraft' | tr -d '\n')


### PR DESCRIPTION
- Attaching the standalone client needs to happen on `main` runs, like the other clients
- GitHub can't seem to find the release. I suspect the `GITHUB_REPOSITORY` var is unneeded.