### PR TITLE
refactor(connlib): spawn dedicated threads for UDP sockets

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6444,6 +6444,7 @@ dependencies = [
  "gat-lending-iterator",
  "ip-packet",
  "lockfree-object-pool",
+ "parking_lot",
  "quinn-udp",
  "socket2",
  "tokio",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2483,6 +2483,7 @@ dependencies = [
  "firezone-logging",
  "firezone-relay",
  "firezone-telemetry",
+ "flume",
  "futures",
  "futures-bounded",
  "gat-lending-iterator",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2167,6 +2167,7 @@ dependencies = [
  "firezone-logging",
  "flume",
  "futures",
+ "gat-lending-iterator",
  "hex-literal",
  "ip-packet",
  "ip_network",
@@ -2484,6 +2485,7 @@ dependencies = [
  "firezone-telemetry",
  "futures",
  "futures-bounded",
+ "gat-lending-iterator",
  "glob",
  "hex",
  "ip-packet",
@@ -2723,6 +2725,12 @@ checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "gat-lending-iterator"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9af1174056216fca07a0c9585aed69d46aefb1107721ea30c379660329443c7"
 
 [[package]]
 name = "gdk"
@@ -6430,8 +6438,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "derive_more 1.0.0",
  "firezone-logging",
+ "gat-lending-iterator",
  "ip-packet",
+ "lockfree-object-pool",
  "quinn-udp",
  "socket2",
  "tokio",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -120,6 +120,7 @@ proptest = "1.6.0"
 proptest-state-machine = "0.3.1"
 quinn-udp = { version = "0.5.8", features = ["fast-apple-datapath"] }
 rand = "0.8.5"
+gat-lending-iterator = "0.1.6"
 rand_core = "0.6.4"
 rangemap = "1.5.1"
 rayon = "1.10.0"

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -12,6 +12,7 @@ axum = { workspace = true, features = ["http1", "tokio"] }
 clap = { workspace = true, features = ["derive", "env"] }
 firezone-logging = { workspace = true }
 futures = { workspace = true, features = ["std", "async-await"] }
+gat-lending-iterator = { workspace = true }
 hex-literal = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true, features = ["serde"] }

--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
 use firezone_bin_shared::{TunDeviceManager, platform::udp_socket_factory};
+use gat_lending_iterator::LendingIterator as _;
 use ip_network::Ipv4Network;
 use ip_packet::Ecn;
 use socket_factory::DatagramOut;
@@ -51,8 +52,7 @@ async fn no_packet_loops_udp() {
         .unwrap();
 
     let task = std::future::poll_fn(|cx| {
-        let mut buf = [0u8; 1000];
-        let result = std::task::ready!(socket.poll_recv_from(&mut buf, cx));
+        let result = std::task::ready!(socket.poll_recv_from(cx));
 
         let _response = result.unwrap().next().unwrap();
 

--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -52,13 +52,9 @@ async fn no_packet_loops_udp() {
         .await
         .unwrap();
 
-    let task = std::future::poll_fn(|cx| {
-        let result = std::task::ready!(socket.poll_recv_from(cx));
-
-        let _response = result.unwrap().next().unwrap();
-
-        std::task::Poll::Ready(())
-    });
+    let task = async {
+        socket.recv_from().await.unwrap().next().unwrap();
+    };
 
     tokio::time::timeout(Duration::from_secs(10), task)
         .await

--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -49,6 +49,7 @@ async fn no_packet_loops_udp() {
             segment_size: None,
             ecn: Ecn::NonEct,
         })
+        .await
         .unwrap();
 
     let task = std::future::poll_fn(|cx| {

--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -33,7 +33,7 @@ async fn no_packet_loops_udp() {
         .unwrap();
 
     // Make a socket.
-    let mut socket =
+    let socket =
         udp_socket_factory(&SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))).unwrap();
 
     std::future::poll_fn(|cx| socket.poll_send_ready(cx))

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -20,6 +20,7 @@ firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
 futures = { workspace = true }
 futures-bounded = { workspace = true }
+gat-lending-iterator = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }
 ip-packet = { workspace = true }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -18,6 +18,7 @@ dns-over-tcp = { workspace = true }
 dns-types = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
+flume = { workspace = true, features = ["async"] }
 futures = { workspace = true }
 futures-bounded = { workspace = true }
 gat-lending-iterator = { workspace = true }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -8,6 +8,7 @@ use anyhow::{Context as _, Result};
 use firezone_logging::{telemetry_event, telemetry_span};
 use futures::FutureExt as _;
 use futures_bounded::FuturesTupleSet;
+use gat_lending_iterator::LendingIterator;
 use gso_queue::GsoQueue;
 use ip_packet::{Ecn, IpPacket, MAX_FZ_PAYLOAD};
 use nameserver_set::NameserverSet;
@@ -71,18 +72,12 @@ struct DnsQueryMetaData {
 
 pub(crate) struct Buffers {
     ip: Vec<IpPacket>,
-    udp4: Vec<u8>,
-    udp6: Vec<u8>,
 }
 
 impl Default for Buffers {
     fn default() -> Self {
-        const ONE_MB: usize = 1024 * 1024;
-
         Self {
             ip: Vec::with_capacity(MAX_INBOUND_PACKET_BATCH),
-            udp4: vec![0; ONE_MB],
-            udp6: vec![0; ONE_MB],
         }
     }
 }
@@ -171,17 +166,14 @@ impl Io {
         Result<
             Input<
                 impl Iterator<Item = IpPacket> + use<'b>,
-                impl Iterator<Item = DatagramIn<'b>> + use<'b>,
+                impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>,
             >,
         >,
     > {
         ready!(self.flush(cx)?);
         ready!(self.nameservers.poll(cx));
 
-        if let Poll::Ready(network) =
-            self.sockets
-                .poll_recv_from(&mut buffers.udp4, &mut buffers.udp6, cx)
-        {
+        if let Poll::Ready(network) = self.sockets.poll_recv_from(cx) {
             return Poll::Ready(Ok(Input::Network(
                 network
                     .context("Failed to receive from UDP sockets")?
@@ -480,11 +472,7 @@ mod tests {
         assert!(timeout.duration_since(now) < Duration::from_millis(100));
     }
 
-    static mut DUMMY_BUF: Buffers = Buffers {
-        ip: Vec::new(),
-        udp4: Vec::new(),
-        udp6: Vec::new(),
-    };
+    static mut DUMMY_BUF: Buffers = Buffers { ip: Vec::new() };
 
     /// Helper functions to make the test more concise.
     impl Io {
@@ -503,7 +491,7 @@ mod tests {
             &mut self,
         ) -> Input<
             impl Iterator<Item = IpPacket> + use<>,
-            impl Iterator<Item = DatagramIn<'static>> + use<>,
+            impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>>,
         > {
             poll_fn(|cx| {
                 self.poll(
@@ -522,7 +510,7 @@ mod tests {
             Result<
                 Input<
                     impl Iterator<Item = IpPacket> + use<>,
-                    impl Iterator<Item = DatagramIn<'static>> + use<>,
+                    impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>,
                 >,
             >,
         > {

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -113,7 +113,7 @@ impl Io {
         nameservers.evaluate();
 
         Self {
-            outbound_packet_buffer: VecDeque::with_capacity(10), // It is unlikely that we process more than 10 packets after 1 GRO call.
+            outbound_packet_buffer: VecDeque::default(),
             timeout: None,
             sockets,
             nameservers,

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -103,7 +103,7 @@ impl Io {
         nameservers: BTreeSet<IpAddr>,
     ) -> Self {
         let mut sockets = Sockets::default();
-        sockets.rebind(udp_socket_factory.as_ref()); // Bind sockets on startup. Must happen within a tokio runtime context.
+        sockets.rebind(udp_socket_factory.clone()); // Bind sockets on startup.
 
         let mut nameservers = NameserverSet::new(
             nameservers,
@@ -325,7 +325,7 @@ impl Io {
     }
 
     pub fn reset(&mut self) {
-        self.sockets.rebind(self.udp_socket_factory.as_ref());
+        self.sockets.rebind(self.udp_socket_factory.clone());
         self.gso_queue.clear();
         self.dns_queries = FuturesTupleSet::new(DNS_QUERY_TIMEOUT, 1000);
         self.nameservers.evaluate();

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -10,6 +10,7 @@ use bimap::BiMap;
 use chrono::Utc;
 use connlib_model::{ClientId, GatewayId, PublicKey, ResourceId, ResourceView};
 use dns_types::DomainName;
+use gat_lending_iterator::LendingIterator;
 use io::{Buffers, Io};
 use ip_network::{Ipv4Network, Ipv6Network};
 use ip_packet::Ecn;
@@ -186,10 +187,10 @@ impl ClientTunnel {
 
                     continue;
                 }
-                Poll::Ready(io::Input::Network(packets)) => {
+                Poll::Ready(io::Input::Network(mut packets)) => {
                     let now = Instant::now();
 
-                    for received in packets {
+                    while let Some(received) = packets.next() {
                         self.packet_counter.add(
                             1,
                             &[
@@ -317,11 +318,11 @@ impl GatewayTunnel {
 
                     continue;
                 }
-                Poll::Ready(io::Input::Network(packets)) => {
+                Poll::Ready(io::Input::Network(mut packets)) => {
                     let now = Instant::now();
                     let utc_now = Utc::now();
 
-                    for received in packets {
+                    while let Some(received) = packets.next() {
                         self.packet_counter.add(
                             1,
                             &[

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -162,13 +162,10 @@ impl ThreadedUdpSocket {
         let (error_tx, error_rx) = flume::bounded(0);
 
         std::thread::Builder::new()
-            .name(
-                match addr {
-                    SocketAddr::V4(_) => "UDP send/recv IPv4",
-                    SocketAddr::V6(_) => "UDP send/recv IPv6",
-                }
-                .to_owned(),
-            )
+            .name(match addr {
+                SocketAddr::V4(_) => "UDP IPv4".to_owned(),
+                SocketAddr::V6(_) => "UDP IPv6".to_owned(),
+            })
             .spawn(move || {
                 tokio::runtime::Builder::new_current_thread()
                     .enable_all()

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -156,8 +156,8 @@ impl ThreadedUdpSocket {
     fn new(sf: &dyn SocketFactory<UdpSocket>, addr: SocketAddr) -> io::Result<Self> {
         let mut socket = sf(&addr)?;
 
-        let (outbound_tx, outbound_rx) = flume::bounded(100);
-        let (inbound_tx, inbound_rx) = flume::bounded(100);
+        let (outbound_tx, outbound_rx) = flume::bounded(10);
+        let (inbound_tx, inbound_rx) = flume::bounded(10);
 
         std::thread::Builder::new()
             .name(

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -159,48 +159,56 @@ impl ThreadedUdpSocket {
         let (outbound_tx, outbound_rx) = flume::bounded(100);
         let (inbound_tx, inbound_rx) = flume::bounded(100);
 
-        std::thread::spawn(|| {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to spawn tokio runtime on UDP thread")
-                .block_on(async move {
-                    loop {
-                        match futures::future::select(
-                            outbound_rx.recv_async(),
-                            std::future::poll_fn(|cx| socket.poll_recv_from(cx)),
-                        )
-                        .await
-                        {
-                            futures::future::Either::Left((Ok(datagram), _)) => {
-                                if let Err(e) = socket.send(datagram).await {
-                                    tracing::debug!("Failed to send datagram: {e:#}")
-                                };
-                            }
-                            futures::future::Either::Left((
-                                Err(flume::RecvError::Disconnected),
-                                _,
-                            )) => {
-                                tracing::debug!(
-                                    "Channel for outbound datagrams closed; exiting UDP thread"
-                                );
-                                break;
-                            }
-                            futures::future::Either::Right((Ok(datagrams), _)) => {
-                                if inbound_tx.send_async(datagrams).await.is_err() {
+        std::thread::Builder::new()
+            .name(
+                match addr {
+                    SocketAddr::V4(_) => "UDP send/recv IPv4",
+                    SocketAddr::V6(_) => "UDP send/recv IPv6",
+                }
+                .to_owned(),
+            )
+            .spawn(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("Failed to spawn tokio runtime on UDP thread")
+                    .block_on(async move {
+                        loop {
+                            match futures::future::select(
+                                outbound_rx.recv_async(),
+                                std::future::poll_fn(|cx| socket.poll_recv_from(cx)),
+                            )
+                            .await
+                            {
+                                futures::future::Either::Left((Ok(datagram), _)) => {
+                                    if let Err(e) = socket.send(datagram).await {
+                                        tracing::debug!("Failed to send datagram: {e:#}")
+                                    };
+                                }
+                                futures::future::Either::Left((
+                                    Err(flume::RecvError::Disconnected),
+                                    _,
+                                )) => {
                                     tracing::debug!(
-                                        "Channel for inbound datagrams closed; exiting UDP thread"
+                                        "Channel for outbound datagrams closed; exiting UDP thread"
                                     );
                                     break;
                                 }
-                            }
-                            futures::future::Either::Right((Err(e), _)) => {
-                                tracing::debug!("Failed to receive from socket: {e:#}")
+                                futures::future::Either::Right((Ok(datagrams), _)) => {
+                                    if inbound_tx.send_async(datagrams).await.is_err() {
+                                        tracing::debug!(
+                                        "Channel for inbound datagrams closed; exiting UDP thread"
+                                    );
+                                        break;
+                                    }
+                                }
+                                futures::future::Either::Right((Err(e), _)) => {
+                                    tracing::debug!("Failed to receive from socket: {e:#}")
+                                }
                             }
                         }
-                    }
-                })
-        });
+                    })
+            })?;
 
         Ok(Self {
             outbound_tx: outbound_tx.into_sink(),

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -1,12 +1,16 @@
 use anyhow::Result;
+use bytes::BytesMut;
+use futures::{SinkExt, StreamExt, ready};
 use gat_lending_iterator::LendingIterator;
-use socket_factory::{DatagramIn, DatagramOut, SocketFactory, UdpSocket};
+use socket_factory::{DatagramIn, DatagramSegmentIter, SocketFactory, UdpSocket};
 use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
-    ops::Deref,
-    task::{Context, Poll, Waker, ready},
+    task::{Context, Poll, Waker},
 };
+
+type DatagramOut =
+    socket_factory::DatagramOut<lockfree_object_pool::SpinLockOwnedReusable<BytesMut>>;
 
 const UNSPECIFIED_V4_SOCKET: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 const UNSPECIFIED_V6_SOCKET: SocketAddrV6 = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0);
@@ -15,18 +19,20 @@ const UNSPECIFIED_V6_SOCKET: SocketAddrV6 = SocketAddrV6::new(Ipv6Addr::UNSPECIF
 pub(crate) struct Sockets {
     waker: Option<Waker>,
 
-    socket_v4: Option<UdpSocket>,
-    socket_v6: Option<UdpSocket>,
+    socket_v4: Option<ThreadedUdpSocket>,
+    socket_v6: Option<ThreadedUdpSocket>,
 }
 
 impl Sockets {
     pub fn rebind(&mut self, socket_factory: &dyn SocketFactory<UdpSocket>) {
-        self.socket_v4 = socket_factory(&SocketAddr::V4(UNSPECIFIED_V4_SOCKET))
-            .inspect_err(|e| tracing::info!("Failed to bind IPv4 socket: {e}"))
-            .ok();
-        self.socket_v6 = socket_factory(&SocketAddr::V6(UNSPECIFIED_V6_SOCKET))
-            .inspect_err(|e| tracing::info!("Failed to bind IPv6 socket: {e}"))
-            .ok();
+        self.socket_v4 =
+            ThreadedUdpSocket::new(socket_factory, SocketAddr::V4(UNSPECIFIED_V4_SOCKET))
+                .inspect_err(|e| tracing::info!("Failed to bind IPv4 socket: {e}"))
+                .ok();
+        self.socket_v6 =
+            ThreadedUdpSocket::new(socket_factory, SocketAddr::V6(UNSPECIFIED_V6_SOCKET))
+                .inspect_err(|e| tracing::info!("Failed to bind IPv6 socket: {e}"))
+                .ok();
 
         if let Some(waker) = self.waker.take() {
             waker.wake();
@@ -48,22 +54,19 @@ impl Sockets {
         Poll::Ready(())
     }
 
-    pub fn poll_send_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        if let Some(socket) = self.socket_v4.as_ref() {
+    pub fn poll_send_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if let Some(socket) = self.socket_v4.as_mut() {
             ready!(socket.poll_send_ready(cx))?;
         }
 
-        if let Some(socket) = self.socket_v6.as_ref() {
+        if let Some(socket) = self.socket_v6.as_mut() {
             ready!(socket.poll_send_ready(cx))?;
         }
 
         Poll::Ready(Ok(()))
     }
 
-    pub fn send<B>(&mut self, datagram: DatagramOut<B>) -> Result<()>
-    where
-        B: Deref<Target: bytes::Buf>,
-    {
+    pub fn send(&mut self, datagram: DatagramOut) -> Result<()> {
         let socket = match datagram.dst {
             SocketAddr::V4(dst) => self.socket_v4.as_mut().ok_or_else(|| {
                 io::Error::new(
@@ -89,11 +92,11 @@ impl Sockets {
     ) -> Poll<Result<impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>>> {
         let mut iter = PacketIter::new();
 
-        if let Some(Poll::Ready(packets)) = self.socket_v4.as_ref().map(|s| s.poll_recv_from(cx)) {
+        if let Some(Poll::Ready(packets)) = self.socket_v4.as_mut().map(|s| s.poll_recv_from(cx)) {
             iter.ip4 = Some(packets?);
         }
 
-        if let Some(Poll::Ready(packets)) = self.socket_v6.as_ref().map(|s| s.poll_recv_from(cx)) {
+        if let Some(Poll::Ready(packets)) = self.socket_v6.as_mut().map(|s| s.poll_recv_from(cx)) {
             iter.ip6 = Some(packets?);
         }
 
@@ -140,5 +143,91 @@ where
         }
 
         None
+    }
+}
+
+struct ThreadedUdpSocket {
+    outbound_tx: flume::r#async::SendSink<'static, DatagramOut>,
+    inbound_rx: flume::r#async::RecvStream<'static, DatagramSegmentIter>,
+}
+
+impl ThreadedUdpSocket {
+    #[expect(clippy::unwrap_in_result, reason = "We unwrap in the new thread.")]
+    fn new(sf: &dyn SocketFactory<UdpSocket>, addr: SocketAddr) -> io::Result<Self> {
+        let mut socket = sf(&addr)?;
+
+        let (outbound_tx, outbound_rx) = flume::bounded(100);
+        let (inbound_tx, inbound_rx) = flume::bounded(100);
+
+        std::thread::spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to spawn tokio runtime on UDP thread")
+                .block_on(async move {
+                    loop {
+                        match futures::future::select(
+                            outbound_rx.recv_async(),
+                            std::future::poll_fn(|cx| socket.poll_recv_from(cx)),
+                        )
+                        .await
+                        {
+                            futures::future::Either::Left((Ok(datagram), _)) => {
+                                if let Err(e) = socket.send(datagram).await {
+                                    tracing::debug!("Failed to send datagram: {e:#}")
+                                };
+                            }
+                            futures::future::Either::Left((
+                                Err(flume::RecvError::Disconnected),
+                                _,
+                            )) => {
+                                tracing::debug!(
+                                    "Channel for outbound datagrams closed; exiting UDP thread"
+                                );
+                                break;
+                            }
+                            futures::future::Either::Right((Ok(datagrams), _)) => {
+                                if inbound_tx.send_async(datagrams).await.is_err() {
+                                    tracing::debug!(
+                                        "Channel for inbound datagrams closed; exiting UDP thread"
+                                    );
+                                    break;
+                                }
+                            }
+                            futures::future::Either::Right((Err(e), _)) => {
+                                tracing::debug!("Failed to receive from socket: {e:#}")
+                            }
+                        }
+                    }
+                })
+        });
+
+        Ok(Self {
+            outbound_tx: outbound_tx.into_sink(),
+            inbound_rx: inbound_rx.into_stream(),
+        })
+    }
+
+    fn poll_send_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.outbound_tx
+            .poll_ready_unpin(cx)
+            .map_err(io::Error::other)
+    }
+
+    fn send(&mut self, datagram: DatagramOut) -> io::Result<()> {
+        self.outbound_tx
+            .start_send_unpin(datagram)
+            .map_err(io::Error::other)
+    }
+
+    fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<DatagramSegmentIter>> {
+        let Some(iter) = ready!(self.inbound_rx.poll_next_unpin(cx)) else {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "UDP recv thread stopped",
+            )));
+        };
+
+        Poll::Ready(Ok(iter))
     }
 }

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -172,7 +172,7 @@ impl ThreadedUdpSocket {
                     .build()
                     .expect("Failed to spawn tokio runtime on UDP thread")
                     .block_on(async move {
-                        let mut socket = match sf(&addr) {
+                        let socket = match sf(&addr) {
                             Ok(s) => {
                                 let _ = error_tx.send(Ok(()));
 

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -12,6 +12,7 @@ firezone-logging = { workspace = true }
 gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
 lockfree-object-pool = { workspace = true }
+parking_lot = { workspace = true }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true }
 tokio = { workspace = true, features = ["net"] }

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -7,9 +7,15 @@ license = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }
+derive_more = { workspace = true, features = ["debug"] }
 firezone-logging = { workspace = true }
+gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
+lockfree-object-pool = { workspace = true }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true }
 tokio = { workspace = true, features = ["net"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+derive_more = { workspace = true, features = ["deref"] }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -1,13 +1,15 @@
 use anyhow::{Context as _, Result};
 use bytes::Buf as _;
 use firezone_logging::err_with_src;
+use gat_lending_iterator::LendingIterator;
 use ip_packet::Ecn;
-use quinn_udp::Transmit;
+use quinn_udp::{EcnCodepoint, Transmit};
 use std::collections::HashMap;
-use std::fmt;
+use std::io::IoSliceMut;
 use std::ops::Deref;
+use std::sync::Arc;
+use std::{fmt, io};
 use std::{
-    io::{self, IoSliceMut},
     net::{IpAddr, SocketAddr},
     task::{Context, Poll, ready},
 };
@@ -147,6 +149,9 @@ pub struct UdpSocket {
     /// A cache of source IPs by their destination IPs.
     src_by_dst_cache: HashMap<IpAddr, IpAddr>,
 
+    /// A buffer pool for batches of incoming UDP packets.
+    buffer_pool: Arc<lockfree_object_pool::MutexObjectPool<Vec<u8>>>,
+
     port: u16,
 }
 
@@ -160,6 +165,10 @@ impl UdpSocket {
             inner,
             source_ip_resolver: Box::new(|_| Ok(None)),
             src_by_dst_cache: Default::default(),
+            buffer_pool: Arc::new(lockfree_object_pool::MutexObjectPool::new(
+                || vec![0u8; u16::MAX as usize],
+                |_| {},
+            )),
         })
     }
 
@@ -212,75 +221,32 @@ pub struct DatagramOut<B> {
 }
 
 impl UdpSocket {
-    pub fn poll_recv_from<'b>(
+    pub fn poll_recv_from(
         &self,
-        buffer: &'b mut [u8],
         cx: &mut Context<'_>,
-    ) -> Poll<Result<impl Iterator<Item = DatagramIn<'b>> + fmt::Debug + use<'b>>> {
+    ) -> Poll<Result<impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + fmt::Debug + use<>>>
+    {
         const NUM_BUFFERS: usize = 10;
-
         let Self {
             port, inner, state, ..
         } = self;
 
-        let mut bufs = split_buffer_equal::<NUM_BUFFERS>(buffer).map(IoSliceMut::new);
+        let mut bufs = std::array::from_fn::<_, NUM_BUFFERS, _>(|_| self.buffer_pool.pull_owned());
         let mut meta = std::array::from_fn::<_, NUM_BUFFERS, _>(|_| quinn_udp::RecvMeta::default());
 
         loop {
             ready!(inner.poll_recv_ready(cx)).context("Failed to poll UDP socket for readiness")?;
 
-            if let Ok(len) = inner.try_io(Interest::READABLE, || {
-                state.recv((&inner).into(), &mut bufs, &mut meta)
+            if let Ok(_len) = inner.try_io(Interest::READABLE, || {
+                state.recv(
+                    (&inner).into(),
+                    &mut bufs.each_mut().map(|b| IoSliceMut::new(b)),
+                    &mut meta,
+                )
             }) {
-                let bufs = split_buffer_equal::<NUM_BUFFERS>(buffer);
-                let port = *port;
+                // Note: We don't need to use `len` here because the iterator will stop once it encounteres `meta.len == 0`.
 
-                let datagrams = bufs.into_iter().zip(meta).take(len).flat_map(move |(buffer, meta)| {
-                    if meta.len == 0 {
-                        return None;
-                    }
-
-                    let Some(local_ip) = meta.dst_ip else {
-                        tracing::warn!("Skipping packet without local IP");
-                        return None;
-                    };
-
-                    match meta.stride.cmp(&meta.len) {
-                        std::cmp::Ordering::Equal | std::cmp::Ordering::Less => {}
-                        std::cmp::Ordering::Greater => {
-                            tracing::warn!("stride ({}) is larger than buffer len ({})", meta.stride, meta.len);
-
-                            return None;
-                        }
-                    }
-
-                    let local = SocketAddr::new(local_ip, port);
-
-                    let segment_size = meta.stride;
-                    let num_packets = meta.len / segment_size;
-                    let trailing_bytes = meta.len % segment_size;
-
-                    tracing::trace!(target: "wire::net::recv", src = %meta.addr, dst = %local, ecn = ?meta.ecn, %num_packets, %segment_size, %trailing_bytes);
-
-                    let iter = buffer[..meta.len]
-                        .chunks(meta.stride)
-                        .map(move |packet| DatagramIn {
-                            local,
-                            from: meta.addr,
-                            packet,
-                            ecn: match meta.ecn {
-                                Some(quinn_udp::EcnCodepoint::Ce) => Ecn::Ce,
-                                Some(quinn_udp::EcnCodepoint::Ect0) => Ecn::Ect0,
-                                Some(quinn_udp::EcnCodepoint::Ect1) => Ecn::Ect1,
-                                None => Ecn::NonEct,
-                            },
-                        });
-
-                    Some(iter)
-                })
-                .flatten();
-
-                return Poll::Ready(Ok(datagrams));
+                return Poll::Ready(Ok(DatagramSegmentIter::new(bufs, meta, *port)));
             }
         }
     }
@@ -464,16 +430,173 @@ impl UdpSocket {
     }
 }
 
-fn split_buffer_equal<const N: usize>(s: &mut [u8]) -> [&mut [u8]; N] {
-    let chunk_size = s.len() / N;
-    let mut chunks: [&mut [u8]; N] = std::array::from_fn(|_| [].as_mut());
+/// An iterator that segments a given buffer into individual datagrams.
+///
+/// This iterator is generic over its buffer to allow easier testing without a buffer pool.
+#[derive(derive_more::Debug)]
+struct DatagramSegmentIter<B, const N: usize> {
+    #[debug(skip)]
+    buffers: [B; N],
+    metas: [quinn_udp::RecvMeta; N],
 
-    let mut rest = s;
-    for chunk in &mut chunks {
-        let (head, tail) = rest.split_at_mut(chunk_size);
-        *chunk = head;
-        rest = tail;
+    port: u16,
+
+    buf_index: usize,
+    segment_index: usize,
+
+    total_bytes: usize,
+    num_packets: usize,
+}
+
+impl<B, const N: usize> DatagramSegmentIter<B, N> {
+    fn new(buffers: [B; N], metas: [quinn_udp::RecvMeta; N], port: u16) -> Self {
+        let total_bytes = metas.iter().map(|m| m.len).sum::<usize>();
+        let num_packets = metas
+            .iter()
+            .map(|meta| {
+                if meta.len == 0 {
+                    return 0;
+                }
+
+                meta.len / meta.stride
+            })
+            .sum::<usize>();
+
+        Self {
+            buffers,
+            metas,
+            port,
+            buf_index: 0,
+            segment_index: 0,
+            total_bytes,
+            num_packets,
+        }
     }
+}
 
-    chunks
+impl<B, const N: usize> LendingIterator for DatagramSegmentIter<B, N>
+where
+    B: Deref<Target = Vec<u8>> + 'static,
+{
+    type Item<'a> = DatagramIn<'a>;
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        loop {
+            if self.buf_index >= N {
+                return None;
+            }
+
+            let buf = &self.buffers[self.buf_index];
+            let meta = &self.metas[self.buf_index];
+
+            if meta.len == 0 {
+                self.buf_index += 1;
+                continue;
+            }
+
+            let Some(local_ip) = meta.dst_ip else {
+                tracing::warn!("Skipping packet without local IP");
+
+                self.buf_index += 1;
+                continue;
+            };
+
+            match meta.stride.cmp(&meta.len) {
+                std::cmp::Ordering::Equal | std::cmp::Ordering::Less => {}
+                std::cmp::Ordering::Greater => {
+                    tracing::warn!(
+                        "stride ({}) is larger than buffer len ({})",
+                        meta.stride,
+                        meta.len
+                    );
+
+                    self.buf_index += 1;
+                    continue;
+                }
+            }
+
+            if self.segment_index >= meta.len {
+                self.buf_index += 1;
+                self.segment_index = 0;
+                continue;
+            }
+
+            let local = SocketAddr::new(local_ip, self.port);
+
+            let segment_size = meta.stride;
+
+            tracing::trace!(target: "wire::net::recv", num_p = %self.num_packets, tot_b = %self.total_bytes, src = %meta.addr, dst = %local, ecn = ?meta.ecn, len = %segment_size);
+
+            let segment_start = self.segment_index;
+            let segment_end = std::cmp::min(segment_start + segment_size, meta.len);
+
+            self.segment_index += segment_size;
+
+            return Some(DatagramIn {
+                local,
+                from: meta.addr,
+                packet: &buf[segment_start..segment_end],
+                ecn: match meta.ecn {
+                    Some(EcnCodepoint::Ce) => Ecn::Ce,
+                    Some(EcnCodepoint::Ect0) => Ecn::Ect0,
+                    Some(EcnCodepoint::Ect1) => Ecn::Ect1,
+                    None => Ecn::NonEct,
+                },
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gat_lending_iterator::LendingIterator as _;
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    #[derive(derive_more::Deref)]
+    struct DummyBuffer(Vec<u8>);
+
+    #[test]
+    fn datagram_iter_segments_buffer_correctly() {
+        let mut iter = DatagramSegmentIter::new(
+            [
+                DummyBuffer(b"foobar1foobar2foobar3foobar4foobar5foo                 ".to_vec()),
+                DummyBuffer(b"baz1baz2baz3baz4baz5foo       ".to_vec()),
+                DummyBuffer(b"".to_vec()),
+            ],
+            [
+                quinn_udp::RecvMeta {
+                    addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+                    stride: 7,
+                    len: 38,
+                    ecn: None,
+                },
+                quinn_udp::RecvMeta {
+                    addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    dst_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+                    stride: 4,
+                    len: 23,
+                    ecn: None,
+                },
+                quinn_udp::RecvMeta::default(),
+            ],
+            0,
+        );
+
+        assert_eq!(iter.next().unwrap().packet, b"foobar1");
+        assert_eq!(iter.next().unwrap().packet, b"foobar2");
+        assert_eq!(iter.next().unwrap().packet, b"foobar3");
+        assert_eq!(iter.next().unwrap().packet, b"foobar4");
+        assert_eq!(iter.next().unwrap().packet, b"foobar5");
+        assert_eq!(iter.next().unwrap().packet, b"foo");
+        assert_eq!(iter.next().unwrap().packet, b"baz1");
+        assert_eq!(iter.next().unwrap().packet, b"baz2");
+        assert_eq!(iter.next().unwrap().packet, b"baz3");
+        assert_eq!(iter.next().unwrap().packet, b"baz4");
+        assert_eq!(iter.next().unwrap().packet, b"baz5");
+        assert_eq!(iter.next().unwrap().packet, b"foo");
+        assert!(iter.next().is_none());
+    }
 }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -231,19 +231,24 @@ impl UdpSocket {
             port, inner, state, ..
         } = self;
 
+        // Stack-allocate arrays for buffers and meta. The size is implied from the const-generic default on `DatagramSegmentIter`.
         let mut bufs = std::array::from_fn(|_| self.buffer_pool.pull_owned());
         let mut meta = std::array::from_fn(|_| quinn_udp::RecvMeta::default());
 
         loop {
             ready!(inner.poll_recv_ready(cx)).context("Failed to poll UDP socket for readiness")?;
 
-            if let Ok(_len) = inner.try_io(Interest::READABLE, || {
-                state.recv(
-                    (&inner).into(),
-                    &mut bufs.each_mut().map(|b| IoSliceMut::new(b)),
-                    &mut meta,
-                )
-            }) {
+            let recv = || {
+                // Fancy std-functions ahead: `each_mut` transforms our array into an array of references to our items and `map` allows us to create an `IoSliceMut` out of each element.
+                // `state.recv` requires us to pass `IoSliceMut` but later on, we need the original buffer again because `DatagramSegmentIter` needs to own them.
+                // That is why we cannot just create an `IoSliceMut` to begin with.
+                let mut bufs = bufs.each_mut().map(|b| IoSliceMut::new(b));
+                let socket = (&inner).into();
+
+                state.recv(socket, &mut bufs, &mut meta)
+            };
+
+            if let Ok(_len) = inner.try_io(Interest::READABLE, recv) {
                 // Note: We don't need to use `len` here because the iterator will stop once it encounteres `meta.len == 0`.
 
                 return Poll::Ready(Ok(DatagramSegmentIter::new(bufs, meta, *port)));
@@ -428,9 +433,22 @@ impl UdpSocket {
     }
 }
 
-/// An iterator that segments a given buffer into individual datagrams.
+/// An iterator that segments an array of buffers into individual datagrams.
 ///
-/// This iterator is generic over its buffer to allow easier testing without a buffer pool.
+/// This iterator is generic over its buffer type and the number of buffers to allow easier testing without a buffer pool.
+///
+/// This implementation might look like dark arts but it is actually quite simple.
+/// Its design is driven by two main ideas:
+///
+/// - We want the return a single `Iterator`-like type from a `recv` call on the socket.
+/// - We want to avoid copying buffers around.
+///
+/// To achieve this, this type doesn't implement `Iterator` but `LendingIterator` instead.
+/// A `LendingIterator` adds a lifetime to the `Item` type, allowing us to return a reference to something the iterator owns.
+///
+/// Composing `LendingIterator`s itself is difficult which is why we implement the entire segmentation of the buffers within a single type.
+/// When [`quinn_udp`] returns us the buffers, it will have populated the [`quinn_udp::RecvMeta`]s accordingly.
+/// Thus, our main job within this iterator is to loop over the `buffers` and `meta` pair-wise, inspect the `meta` and segment the data within the buffer accordingly.
 #[derive(derive_more::Debug)]
 pub struct DatagramSegmentIter<
     const N: usize = 10,

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -434,7 +434,7 @@ impl UdpSocket {
 ///
 /// This iterator is generic over its buffer to allow easier testing without a buffer pool.
 #[derive(derive_more::Debug)]
-struct DatagramSegmentIter<B, const N: usize> {
+struct DatagramSegmentIter<const N: usize, B = lockfree_object_pool::MutexOwnedReusable<Vec<u8>>> {
     #[debug(skip)]
     buffers: [B; N],
     metas: [quinn_udp::RecvMeta; N],
@@ -448,7 +448,7 @@ struct DatagramSegmentIter<B, const N: usize> {
     num_packets: usize,
 }
 
-impl<B, const N: usize> DatagramSegmentIter<B, N> {
+impl<B, const N: usize> DatagramSegmentIter<N, B> {
     fn new(buffers: [B; N], metas: [quinn_udp::RecvMeta; N], port: u16) -> Self {
         let total_bytes = metas.iter().map(|m| m.len).sum::<usize>();
         let num_packets = metas
@@ -474,7 +474,7 @@ impl<B, const N: usize> DatagramSegmentIter<B, N> {
     }
 }
 
-impl<B, const N: usize> LendingIterator for DatagramSegmentIter<B, N>
+impl<B, const N: usize> LendingIterator for DatagramSegmentIter<N, B>
 where
     B: Deref<Target = Vec<u8>> + 'static,
 {

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -226,7 +226,7 @@ impl UdpSocket {
         std::future::poll_fn(|cx| self.poll_recv_from(cx)).await
     }
 
-    pub fn poll_recv_from(&self, cx: &mut Context<'_>) -> Poll<Result<DatagramSegmentIter>> {
+    fn poll_recv_from(&self, cx: &mut Context<'_>) -> Poll<Result<DatagramSegmentIter>> {
         let Self {
             port, inner, state, ..
         } = self;

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -24,6 +24,9 @@ export default function Android() {
           Fixes a performance regression that could lead to packet drops under
           high load.
         </ChangeItem>
+        <ChangeItem pull="7590">
+          Improves performance by moving UDP sockets to a dedicated thread.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-03-15")}>
         <ChangeItem pull="8445">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -19,7 +19,11 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7590">
+          Improves performance by moving UDP sockets to a dedicated thread.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.8" date={new Date("2025-03-21")}>
         <ChangeItem pull="8477">
           Fixes an issue where the app would not auto-connect on launch.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -27,6 +27,9 @@ export default function GUI({ os }: { os: OS }) {
             Applies the search domain configured in the admin portal, if any.
           </ChangeItem>
         )}
+        <ChangeItem pull="7590">
+          Improves performance by moving UDP sockets to a dedicated thread.
+        </ChangeItem>
       </Entry>
       <Entry version="1.4.8" date={new Date("2025-03-10")}>
         <ChangeItem pull="8286">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -34,6 +34,9 @@ export default function Gateway() {
           Improves performance by defaulting to only 1 TUN thread on single-core
           systems.
         </ChangeItem>
+        <ChangeItem pull="7590">
+          Improves performance by moving UDP sockets to a dedicated thread.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-03-10")}>
         <ChangeItem pull="8124">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -16,6 +16,9 @@ export default function Headless({ os }: { os: OS }) {
             high load.
           </ChangeItem>
         )}
+        <ChangeItem pull="7590">
+          Improves performance by moving UDP sockets to a dedicated thread.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-03-14")}>
         {os === OS.Windows && (


### PR DESCRIPTION
Correctly implementing asynchronous IO is notoriously hard. In order to not drop packets in the process, one has to ensure a given socket is ready to accept packets, buffer them if it is not case, suspend everything else until the socket is ready and then continue.

Until now, we did this because it was the only option to run the UDP sockets on the same thread as the actual packet processing. That in turn was motivated by wanting to pass around references of the received packets for processing. Rust's borrow-checker does not allow to pass references between threads which forced us to have the sockets on the same thread as the packet processing.

Like we already did in other places in `connlib`, this can be solved through the use of buffer pools. Using a buffer pool, we can use heap allocations to store the received packets without having to make a new allocation every time we read new packets. Instead, we can have a dedicated thread that is connected to `connlib`'s packet processing thread via two channels (one for inbound and one for outbound packets). These channels are bounded, which ensures backpressure is maintained in case one of the two threads lags behind. These bounds also mean that we have at most N buffers from the buffer pool in-flight (where N is the capacity of the channel).

Within those dedicated threads, we can then use `async/await` notation to suspend the entire task when a socket isn't ready for sending.

Resolves: #8000