### PR TITLE
ci: Push to Firebase on merge to main

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -49,7 +49,7 @@ jobs:
           path: |
             ./kotlin/android/app/build/outputs/bundle/*
       - name: Upload release
-        if: ${{ github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && contains(github.event.head_commit.modified, 'elixir/VERSION')) }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}
         env:
           FIREBASE_APP_DISTRIBUTION_CREDENTIALS: ${{ secrets.FIREBASE_APP_DISTRIBUTION_CREDENTIALS }}
           FIREBASE_CREDENTIALS_PATH: firebase-credentials.json


### PR DESCRIPTION
Updates the Android workflow to match the new Swift workflow behavior to push release builds on merges to `main`.