### PR TITLE
build(deps): Bump cargo gradle plugin to fix `pipes` issue

### DIFF
--- a/kotlin/android/README.md
+++ b/kotlin/android/README.md
@@ -63,6 +63,15 @@ locally.
 
 1. Perform a test build: `./gradlew assembleDebug`.
 
+If you get errors about `rustc` or `cargo` not being found, it can help to
+explicitly specify the path to these in your shell environment. For example:
+
+```
+# ~/.zprofile or ~/.bash_profile
+export RUST_ANDROID_GRADLE_RUSTC_COMMAND=$HOME/.cargo/bin/rustc
+export RUST_ANDROID_GRADLE_CARGO_COMMAND=$HOME/.cargo/bin/cargo
+```
+
 # Release Setup
 
 We release from GitHub CI, so this shouldn't be necessary. But if you're looking

--- a/kotlin/android/build.gradle.kts
+++ b/kotlin/android/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id("org.mozilla.rust-android-gradle.rust-android") version "0.9.4" apply false
+    id("org.mozilla.rust-android-gradle.rust-android") version "0.9.5" apply false
     id("org.jetbrains.kotlin.android") version "1.8.22" apply false
     id("com.android.application") version "8.7.2" apply false
     id("com.google.firebase.appdistribution") version "5.0.0" apply false


### PR DESCRIPTION
This fixes a recent issue regarding the `pipes` module being deprecated in python3.

Docs are also updated to fix an intermittent issue I sometimes hit with the plugin not finding my `rustc` or `cargo`.

https://github.com/mozilla/rust-android-gradle/releases/tag/v0.9.5