### PR TITLE
fix(connlib): attempt to detect runtime shutdown within TUN task

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7202,6 +7202,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "tun"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "flume",
  "futures",
  "ip-packet",

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -26,7 +26,6 @@ use std::{
     fs, io,
     os::{fd::RawFd, unix::fs::PermissionsExt},
 };
-use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
 use tun::ioctl;
 use tun::unix::TunFd;
@@ -313,7 +312,7 @@ impl Tun {
         let outbound_capacity_waker = Arc::new(AtomicWaker::new());
 
         for n in 0..num_threads {
-            let fd = AsyncFd::new(open_tun()?)?;
+            let fd = open_tun()?;
             let outbound_rx = outbound_rx.clone().into_stream();
             let inbound_tx = inbound_tx.clone();
             let outbound_capacity_waker = outbound_capacity_waker.clone();
@@ -331,7 +330,7 @@ impl Tun {
                             outbound_capacity_waker,
                             read,
                             write,
-                        ));
+                        ))?;
 
                     io::Result::Ok(())
                 })

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -320,19 +320,17 @@ impl Tun {
             std::thread::Builder::new()
                 .name(format!("TUN send/recv {n}/{num_threads}"))
                 .spawn(move || {
-                    tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()?
-                        .block_on(tun::unix::send_recv_tun(
+                    firezone_logging::unwrap_or_warn!(
+                        tun::unix::send_recv_tun(
                             fd,
                             inbound_tx,
                             outbound_rx,
                             outbound_capacity_waker,
                             read,
                             write,
-                        ))?;
-
-                    io::Result::Ok(())
+                        ),
+                        "Failed to send / recv from TUN device"
+                    )
                 })
                 .map_err(io::Error::other)?;
         }

--- a/rust/connlib/clients/android/src/tun.rs
+++ b/rust/connlib/clients/android/src/tun.rs
@@ -71,19 +71,17 @@ impl Tun {
             .spawn({
                 let outbound_capacity_waker = outbound_capacity_waker.clone();
                 || {
-                    tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()?
-                        .block_on(tun::unix::send_recv_tun(
+                    firezone_logging::unwrap_or_warn!(
+                        tun::unix::send_recv_tun(
                             fd,
                             inbound_tx,
                             outbound_rx.into_stream(),
                             outbound_capacity_waker,
                             read,
                             write,
-                        ))?;
-
-                    io::Result::Ok(())
+                        ),
+                        "Failed to send / recv from TUN device"
+                    )
                 }
             })
             .map_err(io::Error::other)?;

--- a/rust/connlib/clients/android/src/tun.rs
+++ b/rust/connlib/clients/android/src/tun.rs
@@ -3,7 +3,6 @@ use ip_packet::{IpPacket, IpPacketBuf};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::{io, os::fd::RawFd};
-use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
 use tun::ioctl;
 use tun::unix::TunFd;
@@ -61,8 +60,6 @@ impl Tun {
         // Safety: We are forwarding the safety requirements to the caller.
         let fd = unsafe { TunFd::new(fd) };
 
-        let fd = AsyncFd::new(fd)?;
-
         let (inbound_tx, inbound_rx) = mpsc::channel(1000);
         let (outbound_tx, outbound_rx) = flume::bounded(1000); // flume is an MPMC channel, therefore perfect for workstealing outbound packets.
         let outbound_capacity_waker = Arc::new(AtomicWaker::new());
@@ -84,7 +81,7 @@ impl Tun {
                             outbound_capacity_waker,
                             read,
                             write,
-                        ));
+                        ))?;
 
                     io::Result::Ok(())
                 }

--- a/rust/connlib/clients/apple/src/tun.rs
+++ b/rust/connlib/clients/apple/src/tun.rs
@@ -7,7 +7,6 @@ use std::{
     io,
     os::fd::{AsRawFd as _, RawFd},
 };
-use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
 
 #[derive(Debug)]
@@ -24,8 +23,6 @@ impl Tun {
         set_non_blocking(fd)?;
         let name = name(fd)?;
 
-        let fd = AsyncFd::new(fd)?;
-
         let (inbound_tx, inbound_rx) = mpsc::channel(1000);
         let (outbound_tx, outbound_rx) = flume::bounded(1000); // flume is an MPMC channel, therefore perfect for workstealing outbound packets.
         let outbound_capacity_waker = Arc::new(AtomicWaker::new());
@@ -34,7 +31,7 @@ impl Tun {
             .name("TUN send/recv".to_owned())
             .spawn({
                 let outbound_capacity_waker = outbound_capacity_waker.clone();
-                || {
+                move || {
                     tokio::runtime::Builder::new_current_thread()
                         .enable_all()
                         .build()?
@@ -45,7 +42,7 @@ impl Tun {
                             outbound_capacity_waker,
                             read,
                             write,
-                        ));
+                        ))?;
 
                     io::Result::Ok(())
                 }

--- a/rust/connlib/clients/apple/src/tun.rs
+++ b/rust/connlib/clients/apple/src/tun.rs
@@ -32,19 +32,17 @@ impl Tun {
             .spawn({
                 let outbound_capacity_waker = outbound_capacity_waker.clone();
                 move || {
-                    tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()?
-                        .block_on(tun::unix::send_recv_tun(
+                    firezone_logging::unwrap_or_warn!(
+                        tun::unix::send_recv_tun(
                             fd,
                             inbound_tx,
                             outbound_rx.into_stream(),
                             outbound_capacity_waker,
                             read,
                             write,
-                        ))?;
-
-                    io::Result::Ok(())
+                        ),
+                        "Failed to send / recv from TUN device"
+                    )
                 }
             })
             .map_err(io::Error::other)?;

--- a/rust/tun/Cargo.toml
+++ b/rust/tun/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 
 [dependencies]
 ip-packet = { workspace = true }
+anyhow = { workspace = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 libc = { workspace = true }

--- a/rust/tun/Cargo.toml
+++ b/rust/tun/Cargo.toml
@@ -6,8 +6,8 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ip-packet = { workspace = true }
 anyhow = { workspace = true }
+ip-packet = { workspace = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 libc = { workspace = true }

--- a/rust/tun/src/unix.rs
+++ b/rust/tun/src/unix.rs
@@ -83,6 +83,11 @@ pub async fn send_recv_tun<T>(
                 };
             }
             Either::Right((Err(e), _)) => {
+                if is_rt_shutdown_err(&e) {
+                    tracing::debug!("Runtime is shutting down; exiting TUN read/write task");
+                    return;
+                }
+
                 tracing::warn!("Failed to read from TUN FD: {e}");
                 continue;
             }
@@ -104,4 +109,20 @@ pub async fn send_recv_tun<T>(
             }
         }
     }
+}
+
+/// Checks if the cause of an IO error is due to the tokio runtime shutting down.
+///
+/// Inspired from <https://github.com/tokio-rs/tokio/blob/9d42b977df149363c11257c77c465efe4ce288ee/tokio/src/process/unix/pidfd_reaper.rs#L98-L109>.
+#[allow(deprecated)]
+fn is_rt_shutdown_err(err: &io::Error) -> bool {
+    let Some(inner) = err.get_ref() else {
+        return false;
+    };
+
+    // Using `Error::description()` is more efficient than `format!("{inner}")`,
+    // so we use it here even if it is deprecated.
+    err.kind() == io::ErrorKind::Other
+        && inner.source().is_none()
+        && inner.description() == "A Tokio 1.x context was found, but it is being shutdown."
 }

--- a/rust/tun/src/unix.rs
+++ b/rust/tun/src/unix.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context as _, Result};
 use futures::future::Either;
 use futures::task::AtomicWaker;
 use futures::StreamExt as _;
@@ -36,79 +37,89 @@ impl Drop for TunFd {
     }
 }
 
-/// Concurrently reads and writes packets to the given TUN file-descriptor using the provided function pointers for the actual syscall.
+/// Creates a new current-thread [`tokio`] runtime and concurrently reads and writes packets to the given TUN file-descriptor using the provided function pointers for the actual syscall.
+///
+/// This function will block until failure and is therefore intended to be called from a new thread.
 ///
 /// - Every packet received on `outbound_rx` channel will be written to the file descriptor using the `write` syscall.
 /// - Every packet read using the `read` syscall will be sent into the `inbound_tx` channel.
 /// - Every time we read a packet from `outbound_rx`, we notify `outbound_capacity_waker` about the newly gained capacity.
 /// - In case any of the channels close, we exit the task.
 /// - IO errors are not fallible.
-pub async fn send_recv_tun<T>(
+pub fn send_recv_tun<T>(
     fd: T,
     inbound_tx: mpsc::Sender<IpPacket>,
     mut outbound_rx: flume::r#async::RecvStream<'static, IpPacket>,
     outbound_capacity_waker: Arc<AtomicWaker>,
     read: impl Fn(RawFd, &mut IpPacketBuf) -> io::Result<usize>,
     write: impl Fn(RawFd, &IpPacket) -> io::Result<usize>,
-) -> io::Result<()>
+) -> Result<()>
 where
     T: AsRawFd,
 {
-    let fd = AsyncFd::new(fd)?;
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("Failed to create runtime")?
+        .block_on(async move {
+            let fd = AsyncFd::new(fd)?;
 
-    loop {
-        let next_inbound_packet = pin!(fd.async_io(tokio::io::Interest::READABLE, |fd| {
-            let mut ip_packet_buf = IpPacketBuf::new();
+            loop {
+                let next_inbound_packet = pin!(fd.async_io(tokio::io::Interest::READABLE, |fd| {
+                    let mut ip_packet_buf = IpPacketBuf::new();
 
-            let len = read(fd.as_raw_fd(), &mut ip_packet_buf)?;
+                    let len = read(fd.as_raw_fd(), &mut ip_packet_buf)?;
 
-            if len == 0 {
-                return Ok(None);
+                    if len == 0 {
+                        return Ok(None);
+                    }
+
+                    let packet = IpPacket::new(ip_packet_buf, len)
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+                    Ok(Some(packet))
+                }));
+                let next_outbound_packet = pin!(outbound_rx.next());
+
+                match futures::future::select(next_outbound_packet, next_inbound_packet).await {
+                    Either::Right((Ok(None), _)) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::NotConnected,
+                            "TUN file descriptor is closed",
+                        ));
+                    }
+                    Either::Right((Ok(Some(packet)), _)) => {
+                        if inbound_tx.send(packet).await.is_err() {
+                            tracing::debug!("Inbound packet receiver gone, shutting down task");
+
+                            break;
+                        };
+                    }
+                    Either::Right((Err(e), _)) => {
+                        tracing::warn!("Failed to read from TUN FD: {e}");
+                        continue;
+                    }
+                    Either::Left((Some(packet), _)) => {
+                        if let Err(e) = fd
+                            .async_io(tokio::io::Interest::WRITABLE, |fd| {
+                                write(fd.as_raw_fd(), &packet)
+                            })
+                            .await
+                        {
+                            tracing::warn!("Failed to write to TUN FD: {e}");
+                        };
+
+                        outbound_capacity_waker.wake(); // We wrote a packet, notify about the new capacity.
+                    }
+                    Either::Left((None, _)) => {
+                        tracing::debug!("Outbound packet sender gone, shutting down task");
+                        break;
+                    }
+                }
             }
 
-            let packet = IpPacket::new(ip_packet_buf, len)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-
-            Ok(Some(packet))
-        }));
-        let next_outbound_packet = pin!(outbound_rx.next());
-
-        match futures::future::select(next_outbound_packet, next_inbound_packet).await {
-            Either::Right((Ok(None), _)) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotConnected,
-                    "TUN file descriptor is closed",
-                ));
-            }
-            Either::Right((Ok(Some(packet)), _)) => {
-                if inbound_tx.send(packet).await.is_err() {
-                    tracing::debug!("Inbound packet receiver gone, shutting down task");
-
-                    break;
-                };
-            }
-            Either::Right((Err(e), _)) => {
-                tracing::warn!("Failed to read from TUN FD: {e}");
-                continue;
-            }
-            Either::Left((Some(packet), _)) => {
-                if let Err(e) = fd
-                    .async_io(tokio::io::Interest::WRITABLE, |fd| {
-                        write(fd.as_raw_fd(), &packet)
-                    })
-                    .await
-                {
-                    tracing::warn!("Failed to write to TUN FD: {e}");
-                };
-
-                outbound_capacity_waker.wake(); // We wrote a packet, notify about the new capacity.
-            }
-            Either::Left((None, _)) => {
-                tracing::debug!("Outbound packet sender gone, shutting down task");
-                break;
-            }
-        }
-    }
+            Ok(())
+        })?;
 
     Ok(())
 }


### PR DESCRIPTION
Reading and writing to the TUN device within `connlib` happens in a separate thread. The task running within these threads is connected to the rest of `connlib` via channels. When the application shuts down, these threads also need to exit. Currently, we attempt to detect this from within the task when these channels close. It appears that there is a race condition here because we first attempt to read from the TUN device before reading from the channels. We treat read & write errors on the TUN device as non-fatal so we loop around and attempt to read from it again, causing an infinite-loop and log spam.

To fix this, we swap the order in which we evaluate the two concurrent tasks: The first task to be polled is now the channel for outbound packets and only if that one is empty, we attempt to read new packets from the TUN device. This is also better from a backpressure point of view: We should attempt to flush out our local buffers of already processed packets before taking on "new work".

As a defense-in-depth strategy, we also attempt to detect the particular error from the tokio runtime when it is being shut down and exit the task.

Resolves: #7601.
Related: https://github.com/tokio-rs/tokio/issues/7056.