### PR TITLE
Revert "ci: Consolidate templates for release drafter"

### DIFF
--- a/.github/release-drafter-gateway.yml
+++ b/.github/release-drafter-gateway.yml
@@ -1,0 +1,57 @@
+tag-prefix: "gateway-"
+autolabeler:
+  - label: "area/ci"
+    title:
+      - "/^ci/i"
+  - label: "kind/test"
+    title:
+      - "/^test/i"
+  - label: "kind/feature"
+    title:
+      - "/^feat/i"
+  - label: "kind/bug"
+    title:
+      - "/^fix/i"
+      - "/^bug/i"
+  - label: "kind/refactor"
+    title:
+      - "/^refactor/i"
+  - label: "kind/chore"
+    title:
+      - "/^chore/i"
+  - label: "kind/docs"
+    title:
+      - "/^docs/i"
+  - label: "kind/security"
+    title:
+      - "/^security/i"
+  - label: "dependencies"
+    title:
+      - "/^deps/i"
+categories:
+  - title: "✨ Features"
+    labels:
+      - "kind/feature"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "kind/bug"
+  - title: "🧰 Maintenance"
+    label:
+      - "area/ci"
+      - "kind/test"
+      - "kind/refactor"
+      - "kind/chore"
+      - "kind/cleanup"
+      - "dependencies"
+  - title: "📝 Documentation"
+    label: "kind/docs"
+  - title: "🔐 Security"
+    label: "kind/security"
+exclude-labels:
+  - "skip-changelog"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: >
+  Please see our
+  [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)
+  for more details.

--- a/.github/release-drafter-gui-client.yml
+++ b/.github/release-drafter-gui-client.yml
@@ -1,0 +1,57 @@
+tag-prefix: "gui-client-"
+autolabeler:
+  - label: "area/ci"
+    title:
+      - "/^ci/i"
+  - label: "kind/test"
+    title:
+      - "/^test/i"
+  - label: "kind/feature"
+    title:
+      - "/^feat/i"
+  - label: "kind/bug"
+    title:
+      - "/^fix/i"
+      - "/^bug/i"
+  - label: "kind/refactor"
+    title:
+      - "/^refactor/i"
+  - label: "kind/chore"
+    title:
+      - "/^chore/i"
+  - label: "kind/docs"
+    title:
+      - "/^docs/i"
+  - label: "kind/security"
+    title:
+      - "/^security/i"
+  - label: "dependencies"
+    title:
+      - "/^deps/i"
+categories:
+  - title: "✨ Features"
+    labels:
+      - "kind/feature"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "kind/bug"
+  - title: "🧰 Maintenance"
+    label:
+      - "area/ci"
+      - "kind/test"
+      - "kind/refactor"
+      - "kind/chore"
+      - "kind/cleanup"
+      - "dependencies"
+  - title: "📝 Documentation"
+    label: "kind/docs"
+  - title: "🔐 Security"
+    label: "kind/security"
+exclude-labels:
+  - "skip-changelog"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: >
+  Please see our
+  [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)
+  for more details.

--- a/.github/release-drafter-headless-client.yml
+++ b/.github/release-drafter-headless-client.yml
@@ -1,0 +1,57 @@
+tag-prefix: "headless-client-"
+autolabeler:
+  - label: "area/ci"
+    title:
+      - "/^ci/i"
+  - label: "kind/test"
+    title:
+      - "/^test/i"
+  - label: "kind/feature"
+    title:
+      - "/^feat/i"
+  - label: "kind/bug"
+    title:
+      - "/^fix/i"
+      - "/^bug/i"
+  - label: "kind/refactor"
+    title:
+      - "/^refactor/i"
+  - label: "kind/chore"
+    title:
+      - "/^chore/i"
+  - label: "kind/docs"
+    title:
+      - "/^docs/i"
+  - label: "kind/security"
+    title:
+      - "/^security/i"
+  - label: "dependencies"
+    title:
+      - "/^deps/i"
+categories:
+  - title: "✨ Features"
+    labels:
+      - "kind/feature"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "kind/bug"
+  - title: "🧰 Maintenance"
+    label:
+      - "area/ci"
+      - "kind/test"
+      - "kind/refactor"
+      - "kind/chore"
+      - "kind/cleanup"
+      - "dependencies"
+  - title: "📝 Documentation"
+    label: "kind/docs"
+  - title: "🔐 Security"
+    label: "kind/security"
+exclude-labels:
+  - "skip-changelog"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: >
+  Please see our
+  [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)
+  for more details.

--- a/.github/release-drafter-macos-client.yml
+++ b/.github/release-drafter-macos-client.yml
@@ -1,3 +1,4 @@
+tag-prefix: "macos-client-"
 template: >
   Please see our
   [changelog](https://www.firezone.dev/changelog?utm_source=github-releases)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     secrets: inherit
 
   update-release-draft:
-    name: update-release-draft-${{ matrix.job_suffix }}
+    name: update-release-draft-${{ matrix.config_name }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -48,16 +48,16 @@ jobs:
         include:
           # mark:next-gateway-version
           - release_name: gateway-1.4.3
-            job_suffix: gateway
+            config_name: release-drafter-gateway.yml
           # mark:next-headless-version
           - release_name: headless-client-1.4.1
-            job_suffix: headless-client
+            config_name: release-drafter-headless-client.yml
           # mark:next-gui-version
           - release_name: gui-client-1.4.1
-            job_suffix: gui-client
+            config_name: release-drafter-gui-client.yml
           # mark:next-apple-version
           - release_name: macos-client-1.4.0
-            job_suffix: macos-client
+            config_name: release-drafter-macos-client.yml
 
     steps:
       - uses: release-drafter/release-drafter@v6
@@ -65,6 +65,7 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         id: update-release-draft
         with:
+          config-name: ${{ matrix.config_name }}
           tag: ${{ matrix.release_name }}
           version: ${{ matrix.release_name }}
           name: ${{ matrix.release_name }}


### PR DESCRIPTION
Reverts firezone/firezone#7597

Release drafter unfortunately gets confused if multiple releases share the same config name