### PR TITLE
fix(ci): Only trigger Apple artifact uploads on `workflow_dispatch` trigger

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -71,7 +71,7 @@ jobs:
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
       - run: ${{ matrix.upload-script }}
-        if: "${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         env:
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"


### PR DESCRIPTION
Unfortunately Apple's API doesn't expect to be hit this frequently and also doesn't respond with obvious errors when we ask too much of it.

Because of this, we move the App Store connect upload back to manual trigger only, and update the standalone upload to GitHub releases to the same because it needs to hit Apple's notary service API.