### PR TITLE
refactor(apple): Clean up use of DispatchQueue.main

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
@@ -15,7 +15,7 @@ import AuthenticationServices
 struct WebAuthSession {
   private static let scheme = "firezone-fd0020211111"
 
-  static func signIn(store: Store) async {
+  static func signIn(store: Store) {
     guard let authURL = store.authURL(),
           let authClient = try? AuthClient(authURL: authURL),
           let url = try? authClient.build()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -50,7 +50,7 @@ public final class Store: ObservableObject {
   private func initNotifications() {
     // Finish initializing notification binding
     sessionNotification.signInHandler = {
-      Task { await WebAuthSession.signIn(store: self) }
+      WebAuthSession.signIn(store: self)
     }
 
     sessionNotification.$decision
@@ -93,17 +93,11 @@ public final class Store: ObservableObject {
     #endif
   }
 
-  func createVPNProfile() {
-    Task {
-      try await TunnelManager.shared.create()
+  func createVPNProfile() async throws {
+    try await TunnelManager.shared.create()
 
-      DispatchQueue.main.async { [weak self] in
-        guard let self else { return }
-
-        // Load the new settings and bind observers
-        self.loadTunnelManager()
-      }
-    }
+    // Load the new settings and bind observers
+    self.loadTunnelManager()
   }
 
   func authURL() -> URL? {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -17,7 +17,13 @@ final class GrantVPNViewModel: ObservableObject {
 
   func grantPermissionButtonTapped() {
     Log.app.log("\(#function)")
-    store.createVPNProfile()
+    Task {
+      do {
+        try await store.createVPNProfile()
+      } catch {
+        Log.app.error("\(#function): \(error)")
+      }
+    }
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -16,12 +16,12 @@ final class GrantVPNViewModel: ObservableObject {
   }
 
   func grantPermissionButtonTapped() {
-    Log.app.log("\(#function)")
+    Log.log("\(#function)")
     Task {
       do {
         try await store.createVPNProfile()
       } catch {
-        Log.app.error("\(#function): \(error)")
+        Log.error("\(#function): \(error)")
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -16,8 +16,14 @@ final class GrantVPNViewModel: ObservableObject {
   }
 
   func grantPermissionButtonTapped() {
-    Log.log("\(#function)")
-    store.createVPNProfile()
+    Log.app.log("\(#function)")
+    Task {
+      do {
+        try await store.createVPNProfile()
+      } catch {
+        Log.app.error("\(#function): \(error)")
+      }
+    }
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -273,7 +273,7 @@ public final class MenuBar: NSObject, ObservableObject {
 
   @objc private func signInButtonTapped() {
     NSApp.activate(ignoringOtherApps: true)
-    Task { await WebAuthSession.signIn(store: model.store) }
+    WebAuthSession.signIn(store: model.store)
   }
 
   @objc private func signOutButtonTapped() {
@@ -290,7 +290,11 @@ public final class MenuBar: NSObject, ObservableObject {
 
   @objc private func grantVPNPermissionButtonTapped() {
     Task {
-      model.store.createVPNProfile()
+      do {
+        try await model.store.createVPNProfile()
+      } catch {
+        Log.app.error("\(#function): \(error)")
+      }
     }
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -293,7 +293,7 @@ public final class MenuBar: NSObject, ObservableObject {
       do {
         try await model.store.createVPNProfile()
       } catch {
-        Log.app.error("\(#function): \(error)")
+        Log.error("\(#function): \(error)")
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/WelcomeView.swift
@@ -17,15 +17,12 @@ final class WelcomeViewModel: ObservableObject {
   }
 
   func signInButtonTapped() {
-    Task { await WebAuthSession.signIn(store: store) }
+    WebAuthSession.signIn(store: store)
   }
 }
 
 struct WelcomeView: View {
   @ObservedObject var model: WelcomeViewModel
-
-  // Debounce button taps
-  @State private var tapped = false
 
   var body: some View {
     VStack(
@@ -44,19 +41,8 @@ struct WelcomeView: View {
         """).multilineTextAlignment(.center)
           .padding(.bottom, 10)
         Button("Sign in") {
-          if !tapped {
-            tapped = true
-
-            DispatchQueue.main.async {
-              model.signInButtonTapped()
-            }
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-              tapped = false
-            }
-          }
+          model.signInButtonTapped()
         }
-        .disabled(tapped)
         .buttonStyle(.borderedProminent)
         .controlSize(.large)
         Spacer()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
@@ -54,7 +54,7 @@ struct iOSNavigationView<Content: View>: View {
         }
       } else {
         Button(action: {
-          Task { await WebAuthSession.signIn(store: model.store) }
+          WebAuthSession.signIn(store: model.store)
         }) {
           Label("Sign in", systemImage: "person.crop.circle.fill.badge.plus")
         }


### PR DESCRIPTION
In several places we were unnecessarily wrapping code in either a `Task` or `DispatchQueue.main.async` block.

The former is only needed if the API we're calling itself exposes an `async` function or we're running some long-running task.

The latter is typically used for UI updates.

At all other times it is preferable to simply use blocking functions and let the caller of these best determine how to execute them.