### PR TITLE
feat(apple): Add Sentry reporting to Swift codebase

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -10,41 +10,26 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  create_gateway_sentry_release:
-    if: ${{ startsWith(github.event.release.name, 'gateway') }}
+  create_sentry_release:
+    name: create_${{ matrix.component }}_sentry_release
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - component: gateway
+            projects: gateway
+          - component: gui-client
+            projects: gui-client-gui gui-client-ipc-service
+          - component: headless-client
+            projects: headless-client
+          - component: macos-client
+            projects: apple-client apple-macos
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/create-sentry-release
         with:
-          component: gateway
-          projects: gateway
-          sentry_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
-  create_gui-client_sentry_release:
-    if: ${{ startsWith(github.event.release.name, 'gui-client') }}
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/create-sentry-release
-        with:
-          component: gui-client
-          projects: gui-client-gui gui-client-ipc-service
-          sentry_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
-  create_headless-client_sentry_release:
-    if: ${{ startsWith(github.event.release.name, 'headless-client') }}
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/create-sentry-release
-        with:
-          component: headless-client
-          projects: headless-client
+          component: ${{ matrix.component }}
+          projects: ${{ matrix.projects }}
           sentry_token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -23,12 +23,13 @@ jobs:
           - component: headless-client
             projects: headless-client
           - component: macos-client
-            projects: apple-client apple-macos
+            projects: apple-client
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/create-sentry-release
+        if: ${{ startsWith(github.event.release.name, matrix.component) }}
         with:
           component: ${{ matrix.component }}
           projects: ${{ matrix.projects }}

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		6FE93AFB2A738D7E002D278A /* NetworkSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE93AFA2A738D7E002D278A /* NetworkSettings.swift */; };
 		794C38152970A2660029F38F /* FirezoneKit in Frameworks */ = {isa = PBXBuildFile; productRef = 794C38142970A2660029F38F /* FirezoneKit */; };
 		79756C6629704A7A0018E2D5 /* FirezoneKit in Frameworks */ = {isa = PBXBuildFile; productRef = 79756C6529704A7A0018E2D5 /* FirezoneKit */; };
+		8D4087D52D24653B005B2BAF /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 8D4087D42D24653B005B2BAF /* Sentry */; };
+		8D4087D92D246541005B2BAF /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 8D4087D82D246541005B2BAF /* Sentry */; };
+		8D4087DD2D246651005B2BAF /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 8D4087DC2D246651005B2BAF /* Sentry */; };
 		8D41B9A52D15DD6800D16065 /* TunnelLogArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D41B9A42D15DD6800D16065 /* TunnelLogArchive.swift */; };
 		8D41B9A62D15DD6800D16065 /* TunnelLogArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D41B9A42D15DD6800D16065 /* TunnelLogArchive.swift */; };
 		8D5047F52CE6AA1E009802E9 /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D5047F32CE6AA1E009802E9 /* libresolv.9.tbd */; };
@@ -129,6 +132,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8D4087D52D24653B005B2BAF /* Sentry in Frameworks */,
 				8DC08BD42B297B8200675F46 /* libresolv.tbd in Frameworks */,
 				8DC08BCB2B296C4500675F46 /* libresolv.9.tbd in Frameworks */,
 				794C38152970A2660029F38F /* FirezoneKit in Frameworks */,
@@ -145,6 +149,7 @@
 				8D5047F82CE6AA22009802E9 /* FirezoneKit in Frameworks */,
 				8DC9FB852CF5A738001BCE6A /* NetworkExtension.framework in Frameworks */,
 				8D5047FA2CE6AA2E009802E9 /* SystemConfiguration.framework in Frameworks */,
+				8D4087D92D246541005B2BAF /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -154,6 +159,7 @@
 			files = (
 				05D3BB2128FDE9C000BC3727 /* NetworkExtension.framework in Frameworks */,
 				79756C6629704A7A0018E2D5 /* FirezoneKit in Frameworks */,
+				8D4087DD2D246651005B2BAF /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -276,6 +282,7 @@
 			name = FirezoneNetworkExtensioniOS;
 			packageProductDependencies = (
 				794C38142970A2660029F38F /* FirezoneKit */,
+				8D4087D42D24653B005B2BAF /* Sentry */,
 			);
 			productName = FirezoneNetworkExtensioniOS;
 			productReference = 05CF1CF0290B1CEE00CF4755 /* dev.firezone.firezone.network-extension.appex */;
@@ -298,6 +305,7 @@
 			name = FirezoneNetworkExtensionmacOS;
 			packageProductDependencies = (
 				8D5047F72CE6AA22009802E9 /* FirezoneKit */,
+				8D4087D82D246541005B2BAF /* Sentry */,
 			);
 			productName = FirezoneNetworkExtensionStandalonemacOS;
 			productReference = 8D5047E32CE6A8F4009802E9 /* dev.firezone.firezone.network-extension.systemextension */;
@@ -323,6 +331,7 @@
 			name = Firezone;
 			packageProductDependencies = (
 				79756C6529704A7A0018E2D5 /* FirezoneKit */,
+				8D4087DC2D246651005B2BAF /* Sentry */,
 			);
 			productName = Firezone;
 			productReference = 8DCC021928D512AC007E12D2 /* Firezone.app */;
@@ -361,6 +370,7 @@
 			);
 			mainGroup = 8DCC021028D512AC007E12D2;
 			packageReferences = (
+				8D4087C72D2464D6005B2BAF /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			productRefGroup = 8DCC021A28D512AC007E12D2 /* Products */;
 			projectDirPath = "";
@@ -986,6 +996,17 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		8D4087C72D2464D6005B2BAF /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.42.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		794C38142970A2660029F38F /* FirezoneKit */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -994,6 +1015,21 @@
 		79756C6529704A7A0018E2D5 /* FirezoneKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FirezoneKit;
+		};
+		8D4087D42D24653B005B2BAF /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8D4087C72D2464D6005B2BAF /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+		8D4087D82D246541005B2BAF /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8D4087C72D2464D6005B2BAF /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+		8D4087DC2D246651005B2BAF /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8D4087C72D2464D6005B2BAF /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 		8D5047F72CE6AA22009802E9 /* FirezoneKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "c1404acfa3a71e42aa789c6d5564da59d4377569",
+        "version" : "8.42.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -84,6 +84,10 @@ struct FirezoneApp: App {
         try await FirezoneId.migrate()
 
         try await FirezoneId.createIfMissing()
+
+        // Hydrate telemetry userId with our firezone id
+        let id = try await FirezoneId.load()
+        Telemetry.setFirezoneId(id?.uuid.uuidString)
       }
 
       if let store = store {

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -18,6 +18,9 @@ struct FirezoneApp: App {
   @StateObject var store: Store
 
   init() {
+    // Initialize Telemetry as early as possible
+    Telemetry.start()
+
     let favorites = Favorites()
     let store = Store()
     _favorites = StateObject(wrappedValue: favorites)

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -83,11 +83,10 @@ struct FirezoneApp: App {
         // Can be removed once all clients >= 1.4.0
         try await FirezoneId.migrate()
 
-        try await FirezoneId.createIfMissing()
+        let id = try await FirezoneId.createIfMissing()
 
         // Hydrate telemetry userId with our firezone id
-        let id = try await FirezoneId.load()
-        Telemetry.setFirezoneId(id?.uuid.uuidString)
+        Telemetry.setFirezoneId(id.uuid.uuidString)
       }
 
       if let store = store {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -50,9 +50,9 @@ public final class Log {
     logWriter?.write(severity: .warning, message: message)
   }
 
-  public static func error(_ err: Error, _ message: String? = nil) {
-    self.logger.error("\(message ?? err.localizedDescription, privacy: .public)")
-    logWriter?.write(severity: .error, message: message ?? err.localizedDescription)
+  public static func error(_ err: Error) {
+    self.logger.error("\(err.localizedDescription, privacy: .public)")
+    logWriter?.write(severity: .error, message: err.localizedDescription)
     Telemetry.capture(err)
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -50,9 +50,10 @@ public final class Log {
     logWriter?.write(severity: .warning, message: message)
   }
 
-  public static func error(_ message: String) {
-    self.logger.error("\(message, privacy: .public)")
-    logWriter?.write(severity: .error, message: message)
+  public static func error(_ err: Error, _ message: String? = nil) {
+    self.logger.error("\(message ?? err.localizedDescription, privacy: .public)")
+    logWriter?.write(severity: .error, message: message ?? err.localizedDescription)
+    Telemetry.capture(err)
   }
 
   // Returns the size in bytes of the provided directory, calculated by summing

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -7,6 +7,17 @@
 import Foundation
 
 public struct SharedAccess {
+  public enum Error: Swift.Error {
+    case unableToWriteToFile(URL, Swift.Error)
+
+    var localizedDescription: String {
+      switch self {
+      case .unableToWriteToFile(let url, let error):
+        return "Unable to write to \(url): \(error)"
+      }
+    }
+  }
+
   public static var baseFolderURL: URL {
     guard
       let url = FileManager.default.containerURL(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -1,0 +1,50 @@
+//
+//  Telemetry.swift
+//  (c) 2024 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+import Sentry
+
+public enum Telemetry {
+  public static func start() {
+    SentrySDK.start { options in
+
+      // Different Sentry projects for macOS and iOS
+#if os(macOS)
+      options.dsn = "https://5420feea6f18a799f28a34f30cdcd555@o4507971108339712.ingest.us.sentry.io/4508564061224960"
+#elseif os(iOS)
+      options.dsn = "https://617b332660d27526eb96e39571b62f27@o4507971108339712.ingest.us.sentry.io/4508564070989824"
+#endif
+
+      options.releaseName = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+      options.environment = "entrypoint" // will be reconfigured in TunnelManager
+
+#if DEBUG
+      options.debug = true
+#endif
+    }
+  }
+
+  public static func setEnvironmentOrClose(_ apiURLString: String) {
+    var environment: String?
+
+    if apiURLString.starts(with: "wss://api.firezone.dev") {
+      environment = "production"
+    } else if apiURLString.starts(with: "wss://api.firez.one") {
+      environment = "staging"
+    }
+
+    guard let environment
+    else {
+      // Disable Sentry in unknown environments
+      SentrySDK.close()
+
+      return
+    }
+
+    SentrySDK.configureScope { configuration in
+      configuration.setEnvironment(environment)
+    }
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -17,8 +17,8 @@ public enum Telemetry {
   public static func start() {
     SentrySDK.start { options in
       options.dsn = "https://66c71f83675f01abfffa8eb977bcbbf7@o4507971108339712.ingest.us.sentry.io/4508175177023488"
-      options.releaseName = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
       options.environment = "entrypoint" // will be reconfigured in TunnelManager
+      options.releaseName = releaseName()
 
 #if DEBUG
       // https://docs.sentry.io/platforms/apple/guides/ios/configuration/options/#debug
@@ -77,5 +77,24 @@ public enum Telemetry {
 
       configuration.setUser(user)
     }
+  }
+
+  private static func releaseName() -> String {
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    var prefix: String = ""
+
+#if os(iOS)
+    prefix = "ios-appstore-"
+#else
+    // Apps from the app store have a receipt file
+    if let receiptURL = Bundle.main.appStoreReceiptURL,
+       FileManager.default.fileExists(atPath: receiptURL.path) {
+      prefix = "macos-appstore-"
+    } else {
+      prefix = "macos-standalone-"
+    }
+#endif
+
+    return "\(prefix)\(version ?? "unknown")"
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -16,18 +16,12 @@ public enum Telemetry {
 
   public static func start() {
     SentrySDK.start { options in
-
-      // Different Sentry projects for macOS and iOS
-#if os(macOS)
-      options.dsn = "https://5420feea6f18a799f28a34f30cdcd555@o4507971108339712.ingest.us.sentry.io/4508564061224960"
-#elseif os(iOS)
-      options.dsn = "https://617b332660d27526eb96e39571b62f27@o4507971108339712.ingest.us.sentry.io/4508564070989824"
-#endif
-
+      options.dsn = "https://66c71f83675f01abfffa8eb977bcbbf7@o4507971108339712.ingest.us.sentry.io/4508175177023488"
       options.releaseName = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
       options.environment = "entrypoint" // will be reconfigured in TunnelManager
 
 #if DEBUG
+      // https://docs.sentry.io/platforms/apple/guides/ios/configuration/options/#debug
       options.debug = true
 #endif
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -80,21 +80,19 @@ public enum Telemetry {
   }
 
   private static func releaseName() -> String {
-    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-    var prefix: String = ""
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"]
+    as? String ?? "unknown"
 
 #if os(iOS)
-    prefix = "ios-appstore-"
+    return "ios-appstore-\(version)"
 #else
     // Apps from the app store have a receipt file
     if let receiptURL = Bundle.main.appStoreReceiptURL,
        FileManager.default.fileExists(atPath: receiptURL.path) {
-      prefix = "macos-appstore-"
-    } else {
-      prefix = "macos-standalone-"
+      return "macos-appstore-\(version)"
     }
-#endif
 
-    return "\(prefix)\(version ?? "unknown")"
+    return "macos-client-\(version)"
+#endif
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -55,6 +55,10 @@ public enum Telemetry {
     }
   }
 
+  public static func capture(_ err: Error) {
+    SentrySDK.capture(error: err)
+  }
+
   public static func setFirezoneId(_ id: String?) {
     self.userId = id
     updateUser()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -172,6 +172,9 @@ public class TunnelManager {
           }
           let status = manager.connection.status
 
+          // Configure our Sentry environment
+          Telemetry.setEnvironmentOrClose(settings.apiURL)
+
           // Share what we found with our caller
           callback(status, settings, actorName)
 
@@ -238,6 +241,9 @@ public class TunnelManager {
 
     try await manager.saveToPreferences()
     try await manager.loadFromPreferences()
+
+    // Reconfigure our Telemetry environment in case it changed
+    Telemetry.setEnvironmentOrClose(settings.apiURL)
   }
 
   func start(token: String? = nil) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -17,7 +17,7 @@ enum TunnelManagerError: Error {
   case decodeIPCDataFailed
   case invalidStatusChange
 
-  var description: String {
+  var localizedDescription: String {
     switch self {
     case .cannotSaveIfMissing:
       return "Manager doesn't seem initialized. Can't save settings."

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -20,6 +20,7 @@ public enum TunnelManagerKeys {
   static let actorName = "actorName"
   static let authBaseURL = "authBaseURL"
   static let apiURL = "apiURL"
+  public static let accountSlug = "accountSlug"
   public static let logFilter = "logFilter"
   public static let internetResourceEnabled = "internetResourceEnabled"
 }
@@ -172,8 +173,11 @@ public class TunnelManager {
           }
           let status = manager.connection.status
 
-          // Configure our Sentry environment
+          // Configure our Telemetry environment
           Telemetry.setEnvironmentOrClose(settings.apiURL)
+          Telemetry.setAccountSlug(
+            providerConfiguration[TunnelManagerKeys.accountSlug]
+          )
 
           // Share what we found with our caller
           callback(status, settings, actorName)
@@ -197,7 +201,7 @@ public class TunnelManager {
     }
   }
 
-  func saveActorName(_ actorName: String?) async throws {
+  func saveAuthResponse(_ authResponse: AuthResponse) async throws {
     guard let manager = manager,
           let protocolConfiguration = manager.protocolConfiguration as? NETunnelProviderProtocol,
           var providerConfiguration = protocolConfiguration.providerConfiguration
@@ -206,7 +210,8 @@ public class TunnelManager {
       throw TunnelManagerError.cannotSaveIfMissing
     }
 
-    providerConfiguration[TunnelManagerKeys.actorName] = actorName
+    providerConfiguration[TunnelManagerKeys.actorName] = authResponse.actorName
+    providerConfiguration[TunnelManagerKeys.accountSlug] = authResponse.accountSlug
     protocolConfiguration.providerConfiguration = providerConfiguration
     manager.protocolConfiguration = protocolConfiguration
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthResponse.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthResponse.swift
@@ -10,11 +10,9 @@ struct AuthResponse {
   // The user associated with this authResponse.
   let actorName: String
 
+  // The account slug of the account the user signed in to.
+  let accountSlug: String
+
   // The opaque auth token
   let token: String
-
-  init(token: String, actorName: String) {
-    self.actorName = actorName
-    self.token = token
-  }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneId.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneId.swift
@@ -91,12 +91,17 @@ public struct FirezoneId {
     try await firezoneId.save()
   }
 
-  public static func createIfMissing() async throws {
-    guard try await load() == nil
-    else { return } // New firezone-id already saved in Keychain
+  public static func createIfMissing() async throws -> FirezoneId {
+    guard let id = try await load()
+    else {
+      let id = FirezoneId(UUID())
+      try await id.save()
 
-    let firezoneId = FirezoneId(UUID())
-    try await firezoneId.save()
+      return id
+    }
+
+    // New firezone-id already saved in Keychain
+    return id
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneId.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneId.swift
@@ -15,7 +15,7 @@ public struct FirezoneId {
     kSecAttrDescription: "Firezone device id",
   ]
 
-  private var uuid: UUID
+  public var uuid: UUID
 
   public init(_ uuid: UUID? = nil) {
     self.uuid = uuid ?? UUID()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -97,9 +97,9 @@ public class SessionNotification: NSObject {
         )
         UNUserNotificationCenter.current().add(request) { error in
           if let error = error {
-            Log.error("\(#function): Error requesting notification: \(error)")
+            Log.error(error)
           } else {
-            Log.error("\(#function): Successfully requested notification")
+            Log.debug("\(#function): Successfully requested notification")
           }
         }
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
@@ -32,7 +32,13 @@ struct WebAuthSession {
         return
       }
 
-      Task { try await store.signIn(authResponse: authResponse) }
+      Task {
+        do {
+          try await store.signIn(authResponse: authResponse)
+        } catch {
+          Log.error(error)
+        }
+      }
     }
 
     // Apple weirdness, doesn't seem to be actually used in macOS

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -126,7 +126,7 @@ public final class Store: ObservableObject {
     DispatchQueue.main.async { self.actorName = authResponse.actorName }
 
     try await TunnelManager.shared.saveSettings(settings)
-    try await TunnelManager.shared.saveActorName(authResponse.actorName)
+    try await TunnelManager.shared.saveAuthResponse(authResponse)
 
     // Bring the tunnel up and send it a token to start
     TunnelManager.shared.start(token: authResponse.token)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -163,7 +163,7 @@ public final class Store: ObservableObject {
         try await TunnelManager.shared.saveSettings(newSettings)
         DispatchQueue.main.async { self.settings = newSettings }
       } catch {
-        Log.error("\(#function): \(error)")
+        Log.error(error)
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -21,7 +21,7 @@ final class GrantVPNViewModel: ObservableObject {
       do {
         try await store.createVPNProfile()
       } catch {
-        Log.error("\(#function): \(error)")
+        Log.error(error)
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -293,7 +293,7 @@ public final class MenuBar: NSObject, ObservableObject {
       do {
         try await model.store.createVPNProfile()
       } catch {
-        Log.error("\(#function): \(error)")
+        Log.error(error)
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -10,6 +10,13 @@ import SwiftUI
 
 enum SettingsViewError: Error {
   case logFolderIsUnavailable
+
+  var description: String {
+    switch self {
+    case .logFolderIsUnavailable:
+      return "Log folder is unavailable."
+    }
+  }
 }
 
 @MainActor
@@ -47,7 +54,7 @@ public final class SettingsViewModel: ObservableObject {
       do {
         try await store.save(settings)
       } catch {
-        Log.error("Error saving settings to tunnel store: \(error)")
+        Log.error(error)
       }
     }
   }
@@ -67,8 +74,6 @@ public final class SettingsViewModel: ObservableObject {
     Log.log("\(#function)")
 
     guard let logFilesFolderURL = SharedAccess.logFolderURL else {
-      Log.error("\(#function): Log folder is unavailable")
-
       return "Unknown"
     }
 
@@ -90,7 +95,7 @@ public final class SettingsViewModel: ObservableObject {
       return byteCountFormatter.string(fromByteCount: Int64(totalSize))
 
     } catch {
-      Log.error("\(#function): \(error)")
+      Log.error(error)
 
       return "Unknown"
     }
@@ -135,7 +140,7 @@ extension FileManager {
         let resourceValues = try url.resourceValues(forKeys: resourceKeys)
         handler(url, resourceValues)
       } catch {
-        Log.error("Unable to get resource value for '\(url)': \(error)")
+        Log.error(error)
       }
     }
   }
@@ -598,7 +603,7 @@ public struct SettingsView: View {
               window.contentViewController?.presentingViewController?.dismiss(self)
             }
           } catch {
-            Log.error("\(#function): \(error)")
+            Log.error(error)
 
             let alert = NSAlert()
             alert.messageText = "Error exporting logs: \(error.localizedDescription)"

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 enum SettingsViewError: Error {
   case logFolderIsUnavailable
 
-  var description: String {
+  var localizedDescription: String {
     switch self {
     case .logFolderIsUnavailable:
       return "Log folder is unavailable."
@@ -116,6 +116,17 @@ public final class SettingsViewModel: ObservableObject {
 }
 
 extension FileManager {
+  enum FileManagerError: Error {
+    case invalidURL(URL, Error)
+
+    var localizedDescription: String {
+      switch self {
+      case .invalidURL(let url, let error):
+        return "Unable to get resource value for '\(url)': \(error)"
+      }
+    }
+  }
+
   func forEachFileUnder(
     _ dirURL: URL,
     including resourceKeys: Set<URLResourceKey>,
@@ -140,7 +151,7 @@ extension FileManager {
         let resourceValues = try url.resourceValues(forKeys: resourceKeys)
         handler(url, resourceValues)
       } catch {
-        Log.error(error)
+        Log.error(FileManagerError.invalidURL(url, error))
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -14,7 +14,7 @@ class UpdateChecker {
   enum UpdateError: Error {
     case invalidVersion(String)
 
-    var description: String {
+    var localizedDescription: String {
       switch self {
       case .invalidVersion(let version):
         return "Invalid version: \(version)"

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -11,6 +11,17 @@ import UserNotifications
 import Cocoa
 
 class UpdateChecker {
+  enum UpdateError: Error {
+    case invalidVersion(String)
+
+    var description: String {
+      switch self {
+      case .invalidVersion(let version):
+        return "Invalid version: \(version)"
+      }
+    }
+  }
+
   private var timer: Timer?
   private let notificationAdapter: NotificationAdapter = NotificationAdapter()
   private let versionCheckUrl: URL = URL(string: "https://www.firezone.dev/api/releases")!
@@ -36,12 +47,13 @@ class UpdateChecker {
           guard let self = self else { return }
 
           if let error = error {
-            Log.error("Error fetching version manifest: \(error)")
+            Log.error(error)
             return
           }
 
           guard let versionInfo = VersionInfo.from(data: data)  else {
-            Log.error("No data or failed to decode data")
+            let attemptedVersion = String(data: data ?? Data(), encoding: .utf8) ?? ""
+            Log.error(UpdateError.invalidVersion(attemptedVersion))
             return
           }
 
@@ -89,9 +101,9 @@ private class NotificationAdapter: NSObject, UNUserNotificationCenterDelegate {
 
     notificationCenter.delegate = self
     notificationCenter.requestAuthorization(options: [.sound, .badge, .alert]) { _, error in
-	  if let error = error {
-	    Log.error("Failed to request authorization for notifications: \(error)")
-	  }
+      if let error = error {
+        Log.error(error)
+      }
     }
 
   }
@@ -114,7 +126,7 @@ private class NotificationAdapter: NSObject, UNUserNotificationCenterDelegate {
 
     UNUserNotificationCenter.current().add(request) { error in
       if let error = error {
-        Log.error("\(#function): Error requesting notification: \(error)")
+        Log.error(error)
       }
     }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -8,16 +8,25 @@ import Foundation
 import NetworkExtension
 import OSLog
 
-public enum AdapterError: Error {
+enum AdapterError: Error {
   /// Failure to perform an operation in such state.
-  case invalidState
+  case invalidState(AdapterState)
 
   /// connlib failed to start
   case connlibConnectError(String)
+
+  var description: String {
+    switch self {
+    case .invalidState(let state):
+      return "Adapter is in an invalid state: \(state)"
+    case .connlibConnectError(let error):
+      return "connlib failed to start: \(error)"
+    }
+  }
 }
 
 /// Enum representing internal state of the  adapter
-private enum AdapterState: CustomStringConvertible {
+enum AdapterState: CustomStringConvertible {
   case tunnelStarted(session: WrappedSession)
   case tunnelStopped
 
@@ -118,14 +127,10 @@ class Adapter {
   public func start() async throws {
     Log.log("Adapter.start")
     guard case .tunnelStopped = self.state else {
-      throw AdapterError.invalidState
+      throw AdapterError.invalidState(self.state)
     }
 
     callbackHandler.delegate = self
-
-    if connlibLogFolderPath.isEmpty {
-      Log.error("Cannot get shared log folder for connlib")
-    }
 
     Log.log("Adapter.start: Starting connlib")
     do {
@@ -377,8 +382,7 @@ extension Adapter: CallbackHandlerDelegate {
         networkSettings.dnsAddresses = dnsAddresses
         networkSettings.apply()
       case .tunnelStopped:
-        Log.error(
-          "\(#function): Unexpected state: \(self.state)")
+        Log.error(AdapterError.invalidState(self.state))
       }
     }
   }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -15,7 +15,7 @@ enum AdapterError: Error {
   /// connlib failed to start
   case connlibConnectError(String)
 
-  var description: String {
+  var localizedDescription: String {
     switch self {
     case .invalidState(let state):
       return "Adapter is in an invalid state: \(state)"

--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -53,9 +53,7 @@ class NetworkSettings {
 
     packetTunnelProvider?.setTunnelNetworkSettings(tunnelNetworkSettings) { error in
       if let error = error {
-        Log.error(
-          "\(#function): Error occurred while applying network settings! Error: \(error.localizedDescription)"
-        )
+        Log.error(error)
       }
 
       completionHandler?()

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -47,6 +47,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // initialize the id here too.
         try await FirezoneId.createIfMissing()
 
+        // Hydrate the telemetry userId with our firezone id
+        let id = try await FirezoneId.load()
+        Telemetry.setFirezoneId(id?.uuid.uuidString)
+
         let passedToken = options?["token"] as? String
         let keychainToken = try await Token.load()
 
@@ -82,6 +86,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
               "providerConfiguration.logFilter"))
           return
         }
+
+        // Hydrate telemetry account slug
+        Telemetry.setAccountSlug(
+          providerConfiguration[TunnelManagerKeys.accountSlug]
+        )
 
         let internetResourceEnabled: Bool = if let internetResourceEnabledJSON = providerConfiguration[TunnelManagerKeys.internetResourceEnabled]?.data(using: .utf8) {
           (try? JSONDecoder().decode(Bool.self, from: internetResourceEnabledJSON )) ?? false

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -45,11 +45,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         // The tunnel can come up without the app having been launched first, so
         // initialize the id here too.
-        try await FirezoneId.createIfMissing()
+        let id = try await FirezoneId.createIfMissing()
 
         // Hydrate the telemetry userId with our firezone id
-        let id = try await FirezoneId.load()
-        Telemetry.setFirezoneId(id?.uuid.uuidString)
+        Telemetry.setFirezoneId(id.uuid.uuidString)
 
         let passedToken = options?["token"] as? String
         let keychainToken = try await Token.load()
@@ -134,8 +133,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         try String(reason.rawValue).write(
           to: SharedAccess.providerStopReasonURL, atomically: true, encoding: .utf8)
       } catch {
-        Log.warning(
-          "\(#function): Couldn't write provider stop reason to file. Notification won't work.")
+        Log.error(
+          SharedAccess.Error.unableToWriteToFile(
+            SharedAccess.providerStopReasonURL,
+            error
+          )
+        )
       }
       #if os(iOS)
         // iOS notifications should be shown from the tunnel process

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -24,6 +24,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
   private var logExportState: LogExportState = .idle
 
+  override init() {
+    // Initialize Telemetry as early as possible
+    Telemetry.start()
+
+    super.init()
+  }
+
   override func startTunnel(
     options: [String: NSObject]?,
     completionHandler: @escaping (Error?) -> Void
@@ -61,6 +68,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             PacketTunnelProviderError.savedProtocolConfigurationIsInvalid("serverAddress"))
           return
         }
+
+        // Reconfigure our Telemetry environment now that we know the API URL
+        Telemetry.setEnvironmentOrClose(apiURL)
 
         guard
           let providerConfiguration = (protocolConfiguration as? NETunnelProviderProtocol)?

--- a/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
@@ -14,7 +14,7 @@ class SystemConfigurationResolvers {
     case failedToCreateDynamicStore
     case unableToRetrieveNetworkServices
 
-    var description: String {
+    var localizedDescription: String {
       switch self {
       case .failedToCreateDynamicStore:
         return "Failed to create dynamic store"

--- a/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
@@ -10,6 +10,19 @@ import Foundation
 import SystemConfiguration
 
 class SystemConfigurationResolvers {
+  enum SystemConfigurationError: Error {
+    case failedToCreateDynamicStore
+    case unableToRetrieveNetworkServices
+
+    var description: String {
+      switch self {
+      case .failedToCreateDynamicStore:
+        return "Failed to create dynamic store"
+      case .unableToRetrieveNetworkServices:
+        return "Unable to retrieve network services"
+      }
+    }
+  }
   private var dynamicStore: SCDynamicStore?
 
   // Arbitrary name for the connection to the store
@@ -18,7 +31,7 @@ class SystemConfigurationResolvers {
   init() {
     guard let dynamicStore = SCDynamicStoreCreate(nil, storeName, nil, nil)
     else {
-      Log.error("\(#function): Failed to create dynamic store")
+      Log.error(SystemConfigurationError.failedToCreateDynamicStore)
       self.dynamicStore = nil
       return
     }
@@ -47,7 +60,7 @@ class SystemConfigurationResolvers {
     let interfaceSearchKey = "Setup:/Network/Service/.*/Interface" as CFString
     guard let services = SCDynamicStoreCopyKeyList(dynamicStore, interfaceSearchKey) as? [String]
     else {
-      Log.error("\(#function): Unable to retrieve network services")
+      Log.error(SystemConfigurationError.unableToRetrieveNetworkServices)
       return []
     }
 

--- a/swift/apple/PrivacyInfo.xcprivacy
+++ b/swift/apple/PrivacyInfo.xcprivacy
@@ -2,8 +2,50 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <!-- BEGIN Sentry -->
+  <key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false />
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false />
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false />
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false />
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false />
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false />
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+  <!-- END Sentry -->
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
+    <!-- BEGIN various connlib syscalls -->
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
@@ -12,6 +54,33 @@
 				<string>3B52.1</string>
 			</array>
 		</dict>
+    <!-- END various connlib syscalls -->
+    <!-- BEGIN Sentry -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+    <!-- END Sentry -->
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Adds Sentry SDK to the Swift codebase. Currently error captures are implemented and happen during `Log.error` calls.

Fixes #7560 