### PR TITLE
build(deps): Group tauri dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,23 @@ updates:
     schedule:
       interval: weekly
     groups:
+      tauri:
+        # See https://github.com/tauri-apps/tauri/blob/dev/Cargo.toml
+        patterns:
+          - tauri
+          - tauri-runtime
+          - tauri-runtime-wry
+          - tauri-macros
+          - tauri-utils
+          - tauri-build
+          - tauri-codegen
+          - tauri-plugin
+          - tauri-schema-generator
+          - tauri-schema-worker
+          - tauri-cli
+          - tauri-bundler
+          - tauri-macos-sign
+          - tauri-driver
       netlink:
         patterns:
           - rtnetlink


### PR DESCRIPTION
Groups tauri updates related to the core packages together.