### PR TITLE
ci: add `@tauri-apps/*` to dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -131,6 +131,10 @@ updates:
     directory: rust/gui-client/
     schedule:
       interval: monthly
+    groups:
+      tauri:
+        patterns:
+          - "@tauri-apps/*"
   - package-ecosystem: npm
     directory: elixir/apps/web/assets/
     schedule:


### PR DESCRIPTION
These packages need to be grouped together for the NPM ecosystem.