### PR TITLE
chore(apple): Make update download URL compatible with upcoming standalone macOS release

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/AppInfoPlistConstants.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/AppInfoPlistConstants.swift
@@ -7,6 +7,15 @@
 import Foundation
 
 struct AppInfoPlistConstants {
+  static func isAppStore() -> Bool {
+    if let receiptURL = Bundle.main.appStoreReceiptURL,
+       FileManager.default.fileExists(atPath: receiptURL.path) {
+      return true
+    }
+
+    return false
+  }
+
   static var gitSha: String {
     guard let gitSha = Bundle.main.object(forInfoDictionaryKey: "GitSha") as? String,
           !gitSha.isEmpty

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Bundle.swift
@@ -1,12 +1,12 @@
 //
-//  AppInfoPlistConstants.swift
+//  Bundle.swift
 //  (c) 2024 Firezone, Inc.
 //  LICENSE: Apache-2.0
 //
 
 import Foundation
 
-struct AppInfoPlistConstants {
+enum BundleHelper {
   static func isAppStore() -> Bool {
     if let receiptURL = Bundle.main.appStoreReceiptURL,
        FileManager.default.fileExists(atPath: receiptURL.path) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -21,7 +21,7 @@ public struct SharedAccess {
   public static var baseFolderURL: URL {
     guard
       let url = FileManager.default.containerURL(
-        forSecurityApplicationGroupIdentifier: AppInfoPlistConstants.appGroupId)
+        forSecurityApplicationGroupIdentifier: BundleHelper.appGroupId)
     else {
       fatalError("Shared folder unavailable")
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -95,7 +95,7 @@ public enum Telemetry {
     return "ios-appstore-\(version)"
 #else
     // Apps from the app store have a receipt file
-    if AppInfoPlistConstants.isAppStore() {
+    if BundleHelper.isAppStore() {
       return "macos-appstore-\(version)"
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -95,8 +95,7 @@ public enum Telemetry {
     return "ios-appstore-\(version)"
 #else
     // Apps from the app store have a receipt file
-    if let receiptURL = Bundle.main.appStoreReceiptURL,
-       FileManager.default.fileExists(atPath: receiptURL.path) {
+    if AppInfoPlistConstants.isAppStore() {
       return "macos-appstore-\(version)"
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneId.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/FirezoneId.swift
@@ -11,7 +11,7 @@ public struct FirezoneId {
   private static let query: [CFString: Any] = [
     kSecAttrLabel: "Firezone id",
     kSecAttrAccount: "2",
-    kSecAttrService: AppInfoPlistConstants.appGroupId,
+    kSecAttrService: BundleHelper.appGroupId,
     kSecAttrDescription: "Firezone device id",
   ]
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
@@ -11,7 +11,7 @@ public struct Token: CustomStringConvertible {
   private static let query: [CFString: Any] = [
     kSecAttrLabel: "Firezone token",
     kSecAttrAccount: "1",
-    kSecAttrService: AppInfoPlistConstants.appGroupId,
+    kSecAttrService: BundleHelper.appGroupId,
     kSecAttrDescription: "Firezone access token",
   ]
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -308,7 +308,7 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func updateAvailableButtonTapped() {
-    NSWorkspace.shared.open(appStoreLink)
+    NSWorkspace.shared.open(UpdateChecker.downloadURL())
   }
 
   @objc private func documentationButtonTapped() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -373,7 +373,7 @@ public struct SettingsView: View {
         }
         Spacer()
         HStack {
-          Text("Build: \(AppInfoPlistConstants.gitSha)")
+          Text("Build: \(BundleHelper.gitSha)")
             .textSelection(.enabled)
             .foregroundColor(.gray)
           Spacer()
@@ -447,7 +447,7 @@ public struct SettingsView: View {
         }
         Spacer()
         HStack {
-          Text("Build: \(AppInfoPlistConstants.gitSha)")
+          Text("Build: \(BundleHelper.gitSha)")
             .textSelection(.enabled)
             .foregroundColor(.gray)
           Spacer()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -73,9 +73,15 @@ class UpdateChecker {
 
         task.resume()
     }
-}
 
-public let appStoreLink = URL(string: "https://apps.apple.com/app/firezone/id6443661826")!
+  static func downloadURL() -> URL {
+    if AppInfoPlistConstants.isAppStore() {
+      return URL(string: "https://apps.apple.com/app/firezone/id6443661826")!
+    }
+
+    return URL(string: "https://www.firezone.dev/dl/firezone-client-macos/latest")!
+  }
+}
 
 private class NotificationAdapter: NSObject, UNUserNotificationCenterDelegate {
   private var lastNotifiedVersion: SemVerString?
@@ -140,7 +146,7 @@ private class NotificationAdapter: NSObject, UNUserNotificationCenterDelegate {
         return
       }
 
-      NSWorkspace.shared.open(appStoreLink)
+      NSWorkspace.shared.open(UpdateChecker.downloadURL())
 
       completionHandler()
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -75,7 +75,7 @@ class UpdateChecker {
     }
 
   static func downloadURL() -> URL {
-    if AppInfoPlistConstants.isAppStore() {
+    if BundleHelper.isAppStore() {
       return URL(string: "https://apps.apple.com/app/firezone/id6443661826")!
     }
 

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -3,6 +3,18 @@
 module.exports = [
   /*
    *
+   * macOS Client
+   *
+   */
+  {
+    source: "/dl/firezone-client-macos/latest",
+    destination:
+      // mark:current-apple-version
+      "https://www.github.com/firezone/firezone/releases/download/macos-client-1.3.9/firezone-macos-client-1.3.9.dmg",
+    permanent: false,
+  },
+  /*
+   *
    * Android Client
    *
    */

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -4,6 +4,11 @@ import { NextResponse, NextRequest } from "next/server";
 // more than once. See https://github.com/vercel/next.js/issues/66891
 const versionedRedirects = [
   {
+    source: /^\/dl\/firezone-client-macos\/(\d+\.\d+\.\d+)$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/macos-client-:version/firezone-macos-client-:version.dmg",
+  },
+  {
     source: /^\/dl\/firezone-client-android\/(\d+\.\d+\.\d+)$/,
     destination:
       "https://www.github.com/firezone/firezone/releases/download/android-client-:version/firezone-android-client-:version.apk",


### PR DESCRIPTION
- Updates Apple download URL to point to app store or website depending on package type
- Refactors `AppInfoPlistConstants` to `BundleHelper` to better name what it does