### PR TITLE
chore(telemetry): use same DSN for GUI and IPC service

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -19,7 +19,7 @@ jobs:
           - component: gateway
             projects: gateway
           - component: gui-client
-            projects: gui-client-gui gui-client-ipc-service
+            projects: gui-client
           - component: headless-client
             projects: headless-client
           - component: macos-client

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -565,7 +565,7 @@ impl<'a> Handler<'a> {
                 account_slug,
             } => {
                 self.telemetry
-                    .start(&environment, &release, firezone_telemetry::IPC_SERVICE_DSN);
+                    .start(&environment, &release, firezone_telemetry::GUI_DSN);
 
                 if let Some(account_slug) = account_slug {
                     self.telemetry.set_account_slug(account_slug);

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -14,7 +14,6 @@ pub const APPLE_DSN: Dsn = Dsn("https://66c71f83675f01abfffa8eb977bcbbf7@o450797
 pub const GATEWAY_DSN: Dsn = Dsn("https://f763102cc3937199ec483fbdae63dfdc@o4507971108339712.ingest.us.sentry.io/4508162914451456");
 pub const GUI_DSN: Dsn = Dsn("https://2e17bf5ed24a78c0ac9e84a5de2bd6fc@o4507971108339712.ingest.us.sentry.io/4508008945549312");
 pub const HEADLESS_DSN: Dsn = Dsn("https://bc27dca8bb37be0142c48c4f89647c13@o4507971108339712.ingest.us.sentry.io/4508010028728320");
-pub const IPC_SERVICE_DSN: Dsn = Dsn("https://0590b89fd4479494a1e7ffa4dc705001@o4507971108339712.ingest.us.sentry.io/4508008896069632");
 pub const RELAY_DSN: Dsn = Dsn("https://9d5f664d8f8f7f1716d4b63a58bcafd5@o4507971108339712.ingest.us.sentry.io/4508373298970624");
 
 #[derive(Default)]


### PR DESCRIPTION
The application-split itself doesn't really warrant having two different Sentry projects.

1. The location of the panic / log already tells us, which component is failing.
2. Both of the projects are built with Rust so the same "platform" setting applies.
3. Reducing the number of Sentry projects makes things easier to manage.
4. The binaries are started as independent processes, so the two Sentry contexts don't interfere.

What we should keep in mind is that one instance of an application will now log into Sentry twice using the same DSN. I _think_ this means that the number of sessions listed in Sentry will be double the number of actual client-runs. The same is true for the Apple client though and once we integrate Sentry for Android, the same will apply there so relative to each other, those numbers still make sense.