### PR TITLE
fix(apple): don't pass completionHandler to IPC if we're not going to call it

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -293,7 +293,7 @@ public class TunnelManager {
   func updateInternetResourceState() {
     guard session()?.status == .connected else { return }
 
-    try? session()?.sendProviderMessage(encoder.encode(TunnelMessage.internetResourceEnabled(internetResourceEnabled))) { _ in }
+    try? session()?.sendProviderMessage(encoder.encode(TunnelMessage.internetResourceEnabled(internetResourceEnabled)))
   }
 
   func toggleInternetResource(enabled: Bool) {


### PR DESCRIPTION
If we pass a `completionHandler` to `sendProviderMessage`, the Network Extension framework will expect that completion handler to be called.

Probably doesn't cause any issue as-is, but it would be better to be correct here.