### PR TITLE
refactor(apple): Move Adapter workQueue to `.utility` QoS and remove unneeded asyncs

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -100,7 +100,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         self.adapter = adapter
 
 
-        try await adapter.start()
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+          adapter.start { error in
+            if let error {
+              continuation.resume(throwing: error)
+              return
+            }
+
+            continuation.resume()
+          }
+        }
 
         // Tell the system the tunnel is up, moving the tunnel manager status to
         // `connected`.


### PR DESCRIPTION
Sets the QoS of the connlib thread (and therefore tokio worker threads) to the [`.utility` level](https://developer.apple.com/documentation/dispatch/dispatchqos/1780791-utility).

> Utility tasks have a lower priority than default, user-initiated, and user-interactive tasks, but a higher priority than background tasks. Assign this quality-of-service class to tasks that do not prevent the user from continuing to use your app. For example, you might assign this class to long-running tasks whose progress the user does not follow actively.

See https://forums.developer.apple.com/forums/thread/107904

Also removes the async wrapper around the connlib callbacks. AFAIK connlib calls these from a single worker thread and doesn't need the callee to ensure ordering.

Splits the path update callback queue into its own dedicated queue. These aren't urgent and can take lower priority than the connlib processing thread or worker threads.


