### PR TITLE
fix(apple): Move status observer setup to `init()`

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -139,6 +139,10 @@ public class TunnelManager {
   public static let bundleIdentifier: String = "\(Bundle.main.bundleIdentifier!).network-extension"
   private let bundleDescription = "Firezone"
 
+  init() {
+    encoder.outputFormat = .binary
+  }
+
   // Initialize and save a new VPN profile in system Preferences
   func create() async throws {
     let protocolConfiguration = NETunnelProviderProtocol()
@@ -150,7 +154,6 @@ public class TunnelManager {
     protocolConfiguration.serverAddress = settings.apiURL
     manager.localizedDescription = bundleDescription
     manager.protocolConfiguration = protocolConfiguration
-    encoder.outputFormat = .binary
 
     // Save the new VPN profile to System Preferences and reload it,
     // which should update our status from invalid -> disconnected.

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -141,6 +141,9 @@ public class TunnelManager {
 
   init() {
     encoder.outputFormat = .binary
+
+    // Hook up status updates
+    setupTunnelObservers()
   }
 
   // Initialize and save a new VPN profile in system Preferences
@@ -205,9 +208,6 @@ public class TunnelManager {
           break
         }
       }
-
-      // Hook up status updates
-      setupTunnelObservers()
 
       // If no tunnel configuration was found, update state to
       // prompt user to create one.


### PR DESCRIPTION
This is a very minor regression caused by #7555. We didn't bind the status update observer until after the VPN profile was created. In practice this didn't cause an issue because the status never changes until a VPN profile is created, but still thought it's good to fix.

The JSON encoder is now configured in the `init()` as well like any other instance variable should be.