### PR TITLE
fix(apple): Improve handling of VPN lifecycle events

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -93,10 +93,6 @@ struct FirezoneApp: App {
         menuBar = MenuBar(model: SessionViewModel(favorites: favorites, store: store))
       }
 
-      // Apple recommends installing the system extension as early as possible after app launch.
-      // See https://developer.apple.com/documentation/systemextensions/installing-system-extensions-and-drivers
-      SystemExtensionManager.shared.installSystemExtension(identifier: TunnelManager.bundleIdentifier)
-
       // SwiftUI will show the first window group, so close it on launch
       _ = AppViewModel.WindowDefinition.allCases.map { $0.window()?.close() }
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -26,7 +26,10 @@ enum LogExporter {
     case invalidFileHandle
   }
 
-  static func export(to archiveURL: URL) async throws {
+  static func export(
+    to archiveURL: URL,
+    with tunnelManager: TunnelManager
+  ) async throws {
     guard let logFolderURL = SharedAccess.logFolderURL
     else {
       throw ExportError.invalidSourceDirectory
@@ -50,7 +53,7 @@ enum LogExporter {
 
     // 3. Await tunnel log export from tunnel process
     try await withCheckedThrowingContinuation { continuation in
-      TunnelManager.shared.exportLogs(
+      tunnelManager.exportLogs(
         appender: { chunk in
           do {
             // Append each chunk to the archive

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -28,7 +28,7 @@ enum LogExporter {
 
   static func export(
     to archiveURL: URL,
-    with tunnelManager: TunnelManager
+    with vpnProfileManager: VPNProfileManager
   ) async throws {
     guard let logFolderURL = SharedAccess.logFolderURL
     else {
@@ -53,7 +53,7 @@ enum LogExporter {
 
     // 3. Await tunnel log export from tunnel process
     try await withCheckedThrowingContinuation { continuation in
-      tunnelManager.exportLogs(
+      vpnProfileManager.exportLogs(
         appender: { chunk in
           do {
             // Append each chunk to the archive

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -35,7 +35,7 @@ public enum Telemetry {
   public static func start() {
     SentrySDK.start { options in
       options.dsn = "https://66c71f83675f01abfffa8eb977bcbbf7@o4507971108339712.ingest.us.sentry.io/4508175177023488"
-      options.environment = "entrypoint" // will be reconfigured in TunnelManager
+      options.environment = "entrypoint" // will be reconfigured in VPNProfileManager
       options.releaseName = releaseName()
       options.dist = distributionType()
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/TunnelManager.swift
@@ -110,8 +110,6 @@ public enum TunnelMessage: Codable {
 }
 
 public class TunnelManager {
-  public static let shared = TunnelManager()
-
   // Expose closures that someone else can use to respond to events
   // for this manager.
   var statusChangeHandler: ((NEVPNStatus) async -> Void)?

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNProfileManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNProfileManager.swift
@@ -154,8 +154,19 @@ public class VPNProfileManager {
     // Save the new VPN profile to System Preferences and reload it,
     // which should update our status from nil -> disconnected.
     // If the user denied the operation, the status will be .invalid
-    try await manager.saveToPreferences()
-    try await manager.loadFromPreferences()
+    do {
+      try await manager.saveToPreferences()
+      try await manager.loadFromPreferences()
+    } catch let error as NSError {
+      guard error.domain == "NEVPNErrorDomain",
+            error.code == 5 // permission denied
+      else {
+        throw error
+      }
+
+      // Silence error when the user doesn't click "Allow" on the VPN
+      // permission dialog
+    }
 
     self.manager = manager
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNProfileManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNProfileManager.swift
@@ -157,18 +157,18 @@ public class VPNProfileManager {
     do {
       try await manager.saveToPreferences()
       try await manager.loadFromPreferences()
+      self.manager = manager
     } catch let error as NSError {
-      guard error.domain == "NEVPNErrorDomain",
-            error.code == 5 // permission denied
-      else {
-        throw error
+      if error.domain == "NEVPNErrorDomain" && error.code == 5 {
+        // Silence error when the user doesn't click "Allow" on the VPN
+        // permission dialog
+        Log.info("VPN permission was denied by the user")
+        
+        return
       }
 
-      // Silence error when the user doesn't click "Allow" on the VPN
-      // permission dialog
+      throw error
     }
-
-    self.manager = manager
   }
 
   func loadFromPreferences(vpnStateUpdateHandler: @escaping (NEVPNStatus, Settings?, String?) -> Void) async throws {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNProfileManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNProfileManager.swift
@@ -163,7 +163,7 @@ public class VPNProfileManager {
         // Silence error when the user doesn't click "Allow" on the VPN
         // permission dialog
         Log.info("VPN permission was denied by the user")
-        
+
         return
       }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -32,13 +32,13 @@ struct Settings: Equatable {
   static func fromProviderConfiguration(_ providerConfiguration: [String: Any]?) -> Settings {
     if let providerConfiguration = providerConfiguration as? [String: String] {
       return Settings(
-        authBaseURL: providerConfiguration[TunnelManagerKeys.authBaseURL]
+        authBaseURL: providerConfiguration[VPNProfileManagerKeys.authBaseURL]
           ?? Settings.defaultValue.authBaseURL,
-        apiURL: providerConfiguration[TunnelManagerKeys.apiURL]
+        apiURL: providerConfiguration[VPNProfileManagerKeys.apiURL]
           ?? Settings.defaultValue.apiURL,
-        logFilter: providerConfiguration[TunnelManagerKeys.logFilter]
+        logFilter: providerConfiguration[VPNProfileManagerKeys.logFilter]
           ?? Settings.defaultValue.logFilter,
-        internetResourceEnabled: getInternetResourceEnabled(internetResourceEnabled:  providerConfiguration[TunnelManagerKeys.internetResourceEnabled])
+        internetResourceEnabled: getInternetResourceEnabled(internetResourceEnabled:  providerConfiguration[VPNProfileManagerKeys.internetResourceEnabled])
       )
     } else {
       return Settings.defaultValue
@@ -54,10 +54,10 @@ struct Settings: Equatable {
   // Used for initializing a new providerConfiguration from Settings
   func toProviderConfiguration() -> [String: String] {
     return [
-      TunnelManagerKeys.authBaseURL: authBaseURL,
-      TunnelManagerKeys.apiURL: apiURL,
-      TunnelManagerKeys.logFilter: logFilter,
-      TunnelManagerKeys.internetResourceEnabled: String(data: try! JSONEncoder().encode(internetResourceEnabled) , encoding: .utf8)!,
+      VPNProfileManagerKeys.authBaseURL: authBaseURL,
+      VPNProfileManagerKeys.apiURL: apiURL,
+      VPNProfileManagerKeys.logFilter: logFilter,
+      VPNProfileManagerKeys.internetResourceEnabled: String(data: try! JSONEncoder().encode(internetResourceEnabled) , encoding: .utf8)!,
     ]
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -22,7 +22,7 @@ public final class Store: ObservableObject {
 
   // Enacapsulate Tunnel status here to make it easier for other components
   // to observe
-  @Published private(set) var status: NEVPNStatus
+  @Published private(set) var status: NEVPNStatus?
 
   // This is not currently updated after it is initialized, but
   // we could periodically update it if we need to.
@@ -35,7 +35,6 @@ public final class Store: ObservableObject {
 
   public init() {
     // Initialize all stored properties
-    self.status = .disconnected
     self.decision = .authorized
     self.settings = Settings.defaultValue
     self.sessionNotification = SessionNotification()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -60,7 +60,6 @@ public class AppViewModel: ObservableObject {
       .receive(on: DispatchQueue.main)
       .sink(receiveValue: { [weak self] status in
         guard let self = self else { return }
-        Log.log("Status: \(status)")
 
         self.status = status
       })
@@ -106,6 +105,8 @@ public struct AppView: View {
     }
 #elseif os(macOS)
     switch model.status {
+    case nil:
+      ProgressView()
     case .invalid:
       GrantVPNView(model: GrantVPNViewModel(store: model.store))
     default:

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -32,6 +32,30 @@ public class AppViewModel: ObservableObject {
     self.favorites = favorites
     self.store = store
 
+    Task {
+      do {
+        try await self.store.bindToVPNProfileUpdates()
+
+#if os(macOS)
+        if self.store.status == .invalid {
+
+          // Show the main Window if VPN permission needs to be granted
+          AppViewModel.WindowDefinition.main.openWindow()
+        } else {
+          AppViewModel.WindowDefinition.main.window()?.close()
+        }
+#endif
+
+        if self.store.status == .disconnected {
+
+          // Try to connect on start
+          self.store.vpnProfileManager.start()
+        }
+      } catch {
+        Log.error(error)
+      }
+    }
+
     store.$status
       .receive(on: DispatchQueue.main)
       .sink(receiveValue: { [weak self] status in
@@ -39,21 +63,6 @@ public class AppViewModel: ObservableObject {
         Log.log("Status: \(status)")
 
         self.status = status
-
-#if os(macOS)
-        Task {
-          let firezoneId = try FirezoneId.load()
-
-          if status == .invalid || firezoneId == nil {
-
-            // Show the Wecome view if VPN permission needs to be granted
-            // or it's the first time starting
-            AppViewModel.WindowDefinition.main.openWindow()
-          } else {
-            AppViewModel.WindowDefinition.main.window()?.close()
-          }
-        }
-#endif
       })
       .store(in: &cancellables)
 
@@ -96,7 +105,7 @@ public struct AppView: View {
       }
     }
 #elseif os(macOS)
-    switch model.store.status {
+    switch model.status {
     case .invalid:
       GrantVPNView(model: GrantVPNViewModel(store: model.store))
     default:

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -19,7 +19,7 @@ final class GrantVPNViewModel: ObservableObject {
     Log.log("\(#function)")
     Task {
       do {
-        try await store.createVPNProfile()
+        try await store.grantVPNPermissions()
       } catch {
         Log.error(error)
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -378,7 +378,7 @@ public final class MenuBar: NSObject, ObservableObject {
     // Update "Sign In" / "Sign Out" menu items
     switch status {
     case nil:
-      signInMenuItem.title = "Loading VPN configurations…"
+      signInMenuItem.title = "Loading VPN profiles from system settings…"
       signInMenuItem.action = nil
       signOutMenuItem.isHidden = true
       settingsMenuItem.target = nil

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -26,7 +26,7 @@ public final class MenuBar: NSObject, ObservableObject {
 
   private var cancellables: Set<AnyCancellable> = []
 
-  private var vpnStatus: NEVPNStatus = .disconnected
+  private var vpnStatus: NEVPNStatus?
 
   private var updateChecker: UpdateChecker = UpdateChecker()
   private var updateMenuDisplayed: Bool = false
@@ -316,9 +316,9 @@ public final class MenuBar: NSObject, ObservableObject {
     }
   }
 
-  private func updateAnimation(status: NEVPNStatus) {
+  private func updateAnimation(status: NEVPNStatus?) {
     switch status {
-    case .invalid, .disconnected:
+    case nil, .invalid, .disconnected:
       self.stopConnectingAnimation()
     case .connected:
       self.stopConnectingAnimation()
@@ -329,13 +329,13 @@ public final class MenuBar: NSObject, ObservableObject {
     }
   }
 
-  private func getStatusIcon(status: NEVPNStatus, notification: Bool) -> NSImage? {
+  private func getStatusIcon(status: NEVPNStatus?, notification: Bool) -> NSImage? {
     if status == .connecting || status == .disconnecting || status == .reasserting {
       return self.connectingAnimationImages.last!
     }
 
     switch status {
-    case .invalid, .disconnected:
+    case nil, .invalid, .disconnected:
       return notification ? self.signedOutIconNotification : self.signedOutIcon
     case .connected:
       return notification ? self.signedInConnectedIconNotification : self.signedInConnectedIcon
@@ -377,6 +377,11 @@ public final class MenuBar: NSObject, ObservableObject {
     let status = model.status
     // Update "Sign In" / "Sign Out" menu items
     switch status {
+    case nil:
+      signInMenuItem.title = "Loading VPN configurations…"
+      signInMenuItem.action = nil
+      signOutMenuItem.isHidden = true
+      settingsMenuItem.target = nil
     case .invalid:
       signInMenuItem.title = "Allow the VPN permission to sign in…"
       signInMenuItem.target = self
@@ -435,7 +440,7 @@ public final class MenuBar: NSObject, ObservableObject {
       resourcesUnavailableReasonMenuItem.target = nil
       resourcesUnavailableReasonMenuItem.title = "Disconnecting…"
       resourcesSeparatorMenuItem.isHidden = false
-    case .disconnected, .invalid:
+    case nil, .disconnected, .invalid:
       // We should never be in a state where the tunnel is
       // down but the user is signed in, but we have
       // code to handle it just for the sake of completion.

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -107,6 +107,8 @@ struct SessionView: View {
       case .loading:
         Text("Loading Resources...")
       }
+    case nil:
+      Text("Loading VPN profiles from system settings…")
     case .connecting:
       Text("Connecting...")
     case .disconnecting:

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -14,7 +14,7 @@ public final class SessionViewModel: ObservableObject {
   @Published private(set) var actorName: String? = nil
   @Published private(set) var favorites: Favorites
   @Published private(set) var resources: ResourceList = ResourceList.loading
-  @Published private(set) var status: NEVPNStatus = .disconnected
+  @Published private(set) var status: NEVPNStatus?
 
   let store: Store
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -81,7 +81,7 @@ public final class SettingsViewModel: ObservableObject {
 
     do {
 #if os(macOS)
-      let providerLogFolderSize = try await TunnelManager.shared.getLogFolderSize()
+      let providerLogFolderSize = try await store.tunnelManager.getLogFolderSize()
       let totalSize = logFolderSize + providerLogFolderSize
 #else
       let totalSize = logFolderSize
@@ -110,7 +110,7 @@ public final class SettingsViewModel: ObservableObject {
     try Log.clear(in: SharedAccess.logFolderURL)
 
 #if os(macOS)
-    try await TunnelManager.shared.clearLogs()
+    try await store.tunnelManager.clearLogs()
 #endif
   }
 }
@@ -608,7 +608,10 @@ public struct SettingsView: View {
 
         Task {
           do {
-            try await LogExporter.export(to: destinationURL)
+            try await LogExporter.export(
+              to: destinationURL,
+              with: model.store.tunnelManager
+            )
 
             await MainActor.run {
               window.contentViewController?.presentingViewController?.dismiss(self)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -81,7 +81,7 @@ public final class SettingsViewModel: ObservableObject {
 
     do {
 #if os(macOS)
-      let providerLogFolderSize = try await store.tunnelManager.getLogFolderSize()
+      let providerLogFolderSize = try await store.vpnProfileManager.getLogFolderSize()
       let totalSize = logFolderSize + providerLogFolderSize
 #else
       let totalSize = logFolderSize
@@ -110,7 +110,7 @@ public final class SettingsViewModel: ObservableObject {
     try Log.clear(in: SharedAccess.logFolderURL)
 
 #if os(macOS)
-    try await store.tunnelManager.clearLogs()
+    try await store.vpnProfileManager.clearLogs()
 #endif
   }
 }
@@ -610,7 +610,7 @@ public struct SettingsView: View {
           do {
             try await LogExporter.export(
               to: destinationURL,
-              with: model.store.tunnelManager
+              with: model.store.vpnProfileManager
             )
 
             await MainActor.run {

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -78,7 +78,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         guard
           let providerConfiguration = (protocolConfiguration as? NETunnelProviderProtocol)?
             .providerConfiguration as? [String: String],
-          let logFilter = providerConfiguration[TunnelManagerKeys.logFilter]
+          let logFilter = providerConfiguration[VPNProfileManagerKeys.logFilter]
         else {
           completionHandler(
             PacketTunnelProviderError.savedProtocolConfigurationIsInvalid(
@@ -87,7 +87,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         // Hydrate telemetry account slug
-        guard let accountSlug = providerConfiguration[TunnelManagerKeys.accountSlug]
+        guard let accountSlug = providerConfiguration[VPNProfileManagerKeys.accountSlug]
         else {
           // This can happen if the user deletes the VPN profile while it's
           // connected. The system will try to restart us with a fresh config
@@ -103,7 +103,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         Telemetry.accountSlug = accountSlug
 
-        let internetResourceEnabled: Bool = if let internetResourceEnabledJSON = providerConfiguration[TunnelManagerKeys.internetResourceEnabled]?.data(using: .utf8) {
+        let internetResourceEnabled: Bool = if let internetResourceEnabledJSON = providerConfiguration[VPNProfileManagerKeys.internetResourceEnabled]?.data(using: .utf8) {
           (try? JSONDecoder().decode(Bool.self, from: internetResourceEnabledJSON )) ?? false
         } else {
           false


### PR DESCRIPTION
On macOS, there are two steps the user needs to allow for the VPN profile to be active: enable the system extension and allow the VPN profile.

The system extension must be installed before the VPN profile can be allowed. This PR updates the flow so that the user is prompted to handle both of those serially. Before, we tried to install the system extension on launch and prompt the user to allow the profile at the same time.

This PR includes fixes to handle the edge cases where the user removes the profile and/or extension while the tunnel is connected. When that happens, the `NEVPNStatus` becomes `.invalid` and we replace the `Sign In` link in the Menubar with a prompt to restart the grant permissions flow. On iOS, the behavior is similar -- we move the view back to the GrantPermissionsView.

Lastly, some refactoring is included to use consistent naming for `VPNProfile` instead of `TunnelManager` to more closely match what Apple calls these things.