### PR TITLE
fix(connlib): make time within `boringtun` deterministic

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -504,12 +504,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -614,10 +608,10 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/firezone/boringtun?branch=master#b07142b38d51095ab7d7830db42d5f7e91c2bacf"
+source = "git+https://github.com/firezone/boringtun?branch=master#2adc2637783c5955b8687604207d5999abce9740"
 dependencies = [
  "aead",
- "base64 0.13.1",
+ "base64 0.22.1",
  "blake2",
  "chacha20poly1305",
  "hex",
@@ -627,7 +621,7 @@ dependencies = [
  "libc",
  "nix 0.29.0",
  "parking_lot",
- "rand_core 0.6.4",
+ "rand 0.8.5",
  "ring",
  "tracing",
  "untrusted",

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1810,8 +1810,6 @@ where
             return;
         }
 
-        // TODO: `boringtun` is impure because it calls `Instant::now`.
-
         if now >= self.next_wg_timer_update {
             self.next_wg_timer_update = now + self.wg_timer;
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -13,7 +13,7 @@ use hex_display::HexDisplayExt;
 use ip_packet::{ConvertibleIpv4Packet, ConvertibleIpv6Packet, IpPacket, IpPacketBuf};
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
-use rand::{random, Rng, SeedableRng};
+use rand::{random, Rng, RngCore, SeedableRng};
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 use secrecy::{ExposeSecret, Secret};
 use sha2::Digest;
@@ -161,7 +161,7 @@ where
     RId: Copy + Eq + Hash + PartialEq + Ord + fmt::Debug + fmt::Display,
     T: Mode,
 {
-    pub fn new(seed: [u8; 32]) -> Self {
+    pub fn new(seed: [u8; 32], now: Instant) -> Self {
         let mut rng = StdRng::from_seed(seed);
         let private_key = StaticSecret::random_from_rng(&mut rng);
         let public_key = &(&private_key).into();
@@ -174,7 +174,7 @@ where
             public_key: *public_key,
             mode: T::new(),
             index,
-            rate_limiter: Arc::new(RateLimiter::new(public_key, HANDSHAKE_RATE_LIMIT)),
+            rate_limiter: Arc::new(RateLimiter::new_at(public_key, HANDSHAKE_RATE_LIMIT, now)),
             shared_candidates: Default::default(),
             buffered_transmits: VecDeque::default(),
             next_rate_limiter_reset: None,
@@ -200,7 +200,7 @@ where
     /// - we change our IP or port
     ///
     /// `snownet` cannot control which IP / port we are binding to, thus upper layers MUST ensure that a new IP / port is allocated after calling [`Node::reset`].
-    pub fn reset(&mut self) {
+    pub fn reset(&mut self, now: Instant) {
         self.allocations.clear();
 
         self.buffered_transmits.clear();
@@ -222,7 +222,11 @@ where
 
         self.private_key = StaticSecret::random_from_rng(&mut self.rng);
         self.public_key = (&self.private_key).into();
-        self.rate_limiter = Arc::new(RateLimiter::new(&self.public_key, HANDSHAKE_RATE_LIMIT));
+        self.rate_limiter = Arc::new(RateLimiter::new_at(
+            &self.public_key,
+            HANDSHAKE_RATE_LIMIT,
+            now,
+        ));
         self.session_id = SessionId::new(self.public_key);
 
         tracing::debug!(%num_connections, "Closed all connections as part of reconnecting");
@@ -297,9 +301,9 @@ where
         self.public_key
     }
 
-    pub fn connection_id(&self, key: PublicKey) -> Option<TId> {
+    pub fn connection_id(&self, key: PublicKey, now: Instant) -> Option<TId> {
         self.connections.iter_established().find_map(|(id, c)| {
-            (c.remote_pub_key == key && c.tunnel.time_since_last_handshake().is_some())
+            (c.remote_pub_key == key && c.tunnel.time_since_last_handshake_at(now).is_some())
                 .then_some(id)
         })
     }
@@ -572,7 +576,7 @@ where
             let next_reset = *self.next_rate_limiter_reset.get_or_insert(now);
 
             if now >= next_reset {
-                self.rate_limiter.reset_count();
+                self.rate_limiter.reset_count_at(now);
                 self.next_rate_limiter_reset = Some(now + Duration::from_secs(1));
             }
         }
@@ -725,13 +729,15 @@ where
 
         Connection {
             agent,
-            tunnel: Tunn::new(
+            tunnel: Tunn::new_at(
                 self.private_key.clone(),
                 remote,
                 Some(key),
                 Some(25), // 25 is the default of the kernel implementation.
                 self.index.next(),
                 Some(self.rate_limiter.clone()),
+                self.rng.next_u64(),
+                now,
             ),
             wg_timer: DEFAULT_WG_TIMER,
             next_wg_timer_update: now,
@@ -878,7 +884,7 @@ where
                 continue;
             }
 
-            let handshake_complete_before_decapsulate = conn.wg_handshake_complete();
+            let handshake_complete_before_decapsulate = conn.wg_handshake_complete(now);
 
             let control_flow = conn.decapsulate(
                 packet,
@@ -887,7 +893,7 @@ where
                 now,
             );
 
-            let handshake_complete_after_decapsulate = conn.wg_handshake_complete();
+            let handshake_complete_after_decapsulate = conn.wg_handshake_complete(now);
 
             // I can't think of a better way to detect this ...
             if !handshake_complete_before_decapsulate && handshake_complete_after_decapsulate {
@@ -1751,8 +1757,8 @@ where
         from_nominated || self.possible_sockets.contains(addr)
     }
 
-    fn wg_handshake_complete(&self) -> bool {
-        self.tunnel.time_since_last_handshake().is_some()
+    fn wg_handshake_complete(&self, now: Instant) -> bool {
+        self.tunnel.time_since_last_handshake_at(now).is_some()
     }
 
     fn duration_since_intent(&self, now: Instant) -> Duration {
@@ -1821,7 +1827,7 @@ where
 
             let mut buf = [0u8; MAX_SCRATCH_SPACE];
 
-            match self.tunnel.update_timers(&mut buf) {
+            match self.tunnel.update_timers_at(&mut buf, now) {
                 TunnResult::Done => {}
                 TunnResult::Err(WireGuardError::ConnectionExpired) => {
                     tracing::info!("Connection failed (wireguard tunnel expired)");
@@ -1979,7 +1985,7 @@ where
     ) -> Result<Option<&'b [u8]>, Error> {
         let _guard = self.span.enter();
 
-        let len = match self.tunnel.encapsulate(packet, buffer) {
+        let len = match self.tunnel.encapsulate_at(packet, buffer, now) {
             TunnResult::Done => return Ok(None),
             TunnResult::Err(e) => return Err(Error::Encapsulate(e)),
             TunnResult::WriteToNetwork(packet) => packet.len(),
@@ -2004,7 +2010,10 @@ where
         let _guard = self.span.enter();
         let mut ip_packet = IpPacketBuf::new();
 
-        let control_flow = match self.tunnel.decapsulate(None, packet, ip_packet.buf()) {
+        let control_flow = match self
+            .tunnel
+            .decapsulate_at(None, packet, ip_packet.buf(), now)
+        {
             TunnResult::Done => ControlFlow::Break(Ok(())),
             TunnResult::Err(e) => ControlFlow::Break(Err(Error::Decapsulate(e))),
 
@@ -2044,7 +2053,8 @@ where
                         buffered.push(bytes.to_owned());
 
                         while let TunnResult::WriteToNetwork(packet) =
-                            self.tunnel.decapsulate(None, &[], self.buffer.as_mut())
+                            self.tunnel
+                                .decapsulate_at(None, &[], self.buffer.as_mut(), now)
                         {
                             buffered.push(packet.to_owned());
                         }
@@ -2059,7 +2069,8 @@ where
                         ));
 
                         while let TunnResult::WriteToNetwork(packet) =
-                            self.tunnel.decapsulate(None, &[], self.buffer.as_mut())
+                            self.tunnel
+                                .decapsulate_at(None, &[], self.buffer.as_mut(), now)
                         {
                             transmits.extend(make_owned_transmit(
                                 *peer_socket,
@@ -2099,8 +2110,9 @@ where
 
         let mut buf = [0u8; MAX_SCRATCH_SPACE];
 
-        let TunnResult::WriteToNetwork(bytes) =
-            self.tunnel.format_handshake_initiation(&mut buf, false)
+        let TunnResult::WriteToNetwork(bytes) = self
+            .tunnel
+            .format_handshake_initiation_at(&mut buf, false, now)
         else {
             return;
         };

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -219,7 +219,7 @@ impl ClientState {
             buffered_events: Default::default(),
             tun_config: Default::default(),
             buffered_packets: Default::default(),
-            node: ClientNode::new(seed),
+            node: ClientNode::new(seed, now),
             system_resolvers: Default::default(),
             sites_status: Default::default(),
             gateways_site: Default::default(),
@@ -1377,10 +1377,10 @@ impl ClientState {
         self.buffered_events.pop_front()
     }
 
-    pub(crate) fn reset(&mut self) {
+    pub(crate) fn reset(&mut self, now: Instant) {
         tracing::info!("Resetting network state");
 
-        self.node.reset();
+        self.node.reset(now);
         self.recently_connected_gateways.clear(); // Ensure we don't have sticky gateways when we roam.
         self.dns_resource_nat_by_gateway.clear();
         self.drain_node_events();

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -64,10 +64,10 @@ impl DnsResourceNatEntry {
 }
 
 impl GatewayState {
-    pub(crate) fn new(seed: [u8; 32]) -> Self {
+    pub(crate) fn new(seed: [u8; 32], now: Instant) -> Self {
         Self {
             peers: Default::default(),
-            node: ServerNode::new(seed),
+            node: ServerNode::new(seed, now),
             next_expiry_resources_check: Default::default(),
             buffered_events: VecDeque::default(),
             buffered_transmits: VecDeque::default(),

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -97,7 +97,7 @@ impl ClientTunnel {
     }
 
     pub fn reset(&mut self) {
-        self.role_state.reset();
+        self.role_state.reset(Instant::now());
         self.io.reset();
     }
 
@@ -191,7 +191,7 @@ impl GatewayTunnel {
     ) -> Self {
         Self {
             io: Io::new(tcp_socket_factory, udp_socket_factory),
-            role_state: GatewayState::new(rand::random()),
+            role_state: GatewayState::new(rand::random(), Instant::now()),
             buffers: Buffers::default(),
         }
     }

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -259,8 +259,8 @@ impl RefGateway {
     /// Initialize the [`GatewayState`].
     ///
     /// This simulates receiving the `init` message from the portal.
-    pub(crate) fn init(self, id: GatewayId) -> SimGateway {
-        SimGateway::new(id, GatewayState::new(self.key.0)) // Cheating a bit here by reusing the key as seed.
+    pub(crate) fn init(self, id: GatewayId, now: Instant) -> SimGateway {
+        SimGateway::new(id, GatewayState::new(self.key.0, now)) // Cheating a bit here by reusing the key as seed.
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -60,7 +60,7 @@ impl TunnelTest {
             .iter()
             .map(|(gid, gateway)| {
                 let gateway = gateway.map(
-                    |ref_gateway, _, _| ref_gateway.init(*gid),
+                    |ref_gateway, _, _| ref_gateway.init(*gid, flux_capacitor.now()),
                     debug_span!("gateway", %gid),
                 );
 
@@ -248,7 +248,7 @@ impl TunnelTest {
                     .add_host(state.client.inner().id, &state.client));
 
                 state.client.exec_mut(|c| {
-                    c.sut.reset();
+                    c.sut.reset(now);
 
                     // In prod, we reconnect to the portal and receive a new `init` message.
                     c.update_relays(iter::empty(), state.relays.iter(), now);


### PR DESCRIPTION
At present, the WireGuard implementation within `boringtun` is impure with regards to time due to calls to `Instant::now` and `Instant::elapsed`. This makes it impossible to exhaustively test time-related features because time cannot be advanced arbitrarily. The rest of `connlib` is implemented in a sans-IO fashion where time is controlled from the outside via `Instant` parameters on every function that requires access to the current time.

With this PR, we update to the latest version of our `boringtun` fork at https://github.com/firezone/boringtun which introduces pure equivalents of all functions that require access to the current time _and_ also implements the missing handshake-delay jitter feature (see https://github.com/firezone/boringtun/issues/19).

This is a pretty safe upgrade as the production code doesn't really change and time advances at the same rate as before. To ensure this passes our test-suite, I ran 50_000 iterations locally.