### PR TITLE
test(connlib): reduce number of duplicate IPs

### DIFF
--- a/rust/connlib/tunnel/src/tests/sim_net.rs
+++ b/rust/connlib/tunnel/src/tests/sim_net.rs
@@ -4,7 +4,6 @@ use connlib_model::{ClientId, GatewayId, RelayId};
 use firezone_relay::{AddressFamily, IpStack};
 use ip_network::{IpNetwork, Ipv4Network};
 use ip_network_table::IpNetworkTable;
-use itertools::Itertools as _;
 use prop::sample;
 use proptest::prelude::*;
 use snownet::Transmit;
@@ -308,13 +307,10 @@ pub(crate) fn dual_ip_stack() -> impl Strategy<Value = IpStack> {
 ///
 /// This uses the `TEST-NET-3` (`203.0.113.0/24`) address space reserved for documentation and examples in [RFC5737](https://datatracker.ietf.org/doc/html/rfc5737).
 pub(crate) fn host_ip4s() -> impl Strategy<Value = Ipv4Addr> {
-    let ips = Ipv4Network::new(Ipv4Addr::new(203, 0, 113, 0), 24)
-        .unwrap()
-        .hosts()
-        .take(100)
-        .collect_vec();
+    const FIRST: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 0);
+    const LAST: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 255);
 
-    sample::select(ips)
+    (FIRST.to_bits()..=LAST.to_bits()).prop_map(Ipv4Addr::from_bits)
 }
 
 /// A [`Strategy`] of [`Ipv6Addr`]s used for routing packets between hosts within our test.
@@ -323,5 +319,5 @@ pub(crate) fn host_ip4s() -> impl Strategy<Value = Ipv4Addr> {
 pub(crate) fn host_ip6s() -> impl Strategy<Value = Ipv6Addr> {
     const HOST_SUBNET: u16 = 0x1010;
 
-    documentation_ip6s(HOST_SUBNET, 100)
+    documentation_ip6s(HOST_SUBNET)
 }

--- a/rust/connlib/tunnel/src/tests/sim_net.rs
+++ b/rust/connlib/tunnel/src/tests/sim_net.rs
@@ -2,9 +2,8 @@ use crate::tests::buffered_transmits::BufferedTransmits;
 use crate::tests::strategies::documentation_ip6s;
 use connlib_model::{ClientId, GatewayId, RelayId};
 use firezone_relay::{AddressFamily, IpStack};
-use ip_network::{IpNetwork, Ipv4Network};
+use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
-use prop::sample;
 use proptest::prelude::*;
 use snownet::Transmit;
 use std::{


### PR DESCRIPTION
For our test-suite, we need to sample a unique, non-overlapping IP for each component that is being simulated (client, gateways and relays). These are sampled from a predefined range.

Currently, we only consider the first 100 IPs of this range and pick it from an allocated `Vec`. This isn't ideal for performance and increases the likelihood of two hosts having the same IP. IPv4 and IPv6 addresses can also just be represented as numbers. Instead of sampling a random IP from a list, we can simply sample a random number between the first and last address of the particular IP network to achieve the same effect.