### PR TITLE
ci: Remove DMG staging directory to prevent Sentry walks

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           # Remove the /Applications symlink in the DMG staging directory so Sentry doesn't
           # attempt to walk it.
-          rm "$dmg_dir/Applications"
+          rm "${{ runner.temp }}/dmg/Applications"
 
           sentry-cli debug-files upload --log-level info --project apple-client --include-sources ${{ runner.temp }}
       - uses: actions/cache/save@v4

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           # Remove the /Applications symlink in the DMG staging directory so Sentry doesn't
           # attempt to walk it.
-          rm "${{ runner.temp }}/dmg/Applications"
+          rm -f "${{ runner.temp }}/dmg/Applications"
 
           sentry-cli debug-files upload --log-level info --project apple-client --include-sources ${{ runner.temp }}
       - uses: actions/cache/save@v4

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -70,7 +70,7 @@ jobs:
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
-          RUNNER_TEMP: "${{ runner.temp }}"
+          TEMP_DIR: "${{ runner.temp }}"
       - run: ${{ matrix.upload-script }}
         if: "${{ github.event_name == 'workflow_dispatch' }}"
         env:
@@ -90,6 +90,10 @@ jobs:
       - name: Upload debug symbols to Sentry
         if: ${{ github.ref_name == 'main' }}
         run: |
+          # Remove the /Applications symlink in the DMG staging directory so Sentry doesn't
+          # attempt to walk it.
+          rm "$dmg_dir/Applications"
+
           sentry-cli debug-files upload --log-level info --project apple-client --include-sources ${{ runner.temp }}
       - uses: actions/cache/save@v4
         if: ${{ steps.cache.outputs.cache-hit != 'true'}}

--- a/scripts/build/ios-appstore.sh
+++ b/scripts/build/ios-appstore.sh
@@ -9,7 +9,7 @@ source "./scripts/build/lib.sh"
 # Define needed variables
 app_profile_id=8da59aa3-e8da-4a8c-9902-2d540324d92c
 ne_profile_id=0fccb78a-97c0-41b9-8c54-9c995280ea8e
-temp_dir="${RUNNER_TEMP:-$(mktemp -d)}"
+temp_dir="${TEMP_DIR:-$(mktemp -d)}"
 archive_path="$temp_dir/Firezone.xcarchive"
 export_options_plist_path="$temp_dir/ExportOptions.plist"
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}

--- a/scripts/build/macos-appstore.sh
+++ b/scripts/build/macos-appstore.sh
@@ -9,7 +9,7 @@ source "./scripts/build/lib.sh"
 # Define needed variables
 app_profile_id=2bf20e38-81ea-40d0-91e5-330cf58f52d9
 ne_profile_id=2c683d1a-4479-451c-9ee6-ae7d4aca5c93
-temp_dir="${RUNNER_TEMP:-$(mktemp -d)}"
+temp_dir="${TEMP_DIR:-$(mktemp -d)}"
 package_path="$temp_dir/Firezone.pkg"
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}
 project_file=swift/apple/Firezone.xcodeproj

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -84,6 +84,10 @@ hdiutil create \
     -format UDRW \
     "$package_path"
 
+# Remove dmg_dir to prevent sentry-cli debug-files upload from searching
+# the /Applications symlink recursively.
+rm -rf "$dmg_dir"
+
 # Mount disk image for customization
 mount_dir=$(hdiutil attach "$package_path" -readwrite -noverify -noautoopen | grep -o "/Volumes/.*")
 

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -10,7 +10,7 @@ source "./scripts/build/lib.sh"
 app_profile_id=c5d97f71-de80-4dfc-80f8-d0a4393ff082
 ne_profile_id=153db941-2136-4d6c-96ef-52f748521e78
 notarize=${NOTARIZE:-"false"}
-temp_dir="${RUNNER_TEMP:-$(mktemp -d)}"
+temp_dir="${TEMP_DIR:-$(mktemp -d)}"
 dmg_dir="$temp_dir/dmg"
 dmg_path="$temp_dir/Firezone.dmg"
 package_path="$temp_dir/package.dmg"
@@ -83,10 +83,6 @@ hdiutil create \
     -ov \
     -format UDRW \
     "$package_path"
-
-# Remove dmg_dir to prevent sentry-cli debug-files upload from searching
-# the /Applications symlink recursively.
-rm -rf "$dmg_dir"
 
 # Mount disk image for customization
 mount_dir=$(hdiutil attach "$package_path" -readwrite -noverify -noautoopen | grep -o "/Volumes/.*")


### PR DESCRIPTION
`sentry-cli debug-files upload` offers no option to exclude certain files or directories when recursively searching the given path. Thus, we need to remove this staging directory to prevent it from recursively walking the directory and inevitably erroring out when it hits a path it doesn't have access to.