### PR TITLE
docs(blog): remove src field from `Transmit`

### DIFF
--- a/website/src/app/blog/sans-io/readme.mdx
+++ b/website/src/app/blog/sans-io/readme.mdx
@@ -155,7 +155,6 @@ abstraction. Meet `Transmit`:
 
 ```rust
 pub struct Transmit {
-    src: SocketAddr,
     dst: SocketAddr,
     payload: Vec<u8>
 }


### PR DESCRIPTION
Update the `Transmit` type to remove src field.
This was done in reference to this https://github.com/firezone/sans-io-blog-example/issues/3.