### PR TITLE
feat(relay): make telemetry opt-in

### DIFF
--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -91,15 +91,9 @@ struct Args {
     #[command(flatten)]
     health_check: http_health_check::HealthCheckArgs,
 
-    /// Disable sentry.io crash-reporting agent.
-    #[arg(long, env = "FIREZONE_NO_TELEMETRY", default_value_t = false)]
-    no_telemetry: bool,
-}
-
-impl Args {
-    fn is_telemetry_allowed(&self) -> bool {
-        !self.no_telemetry
-    }
+    /// Enable sentry.io crash-reporting agent.
+    #[arg(long, env = "FIREZONE_TELEMETRY", default_value_t = false)]
+    telemetry: bool,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
@@ -117,7 +111,7 @@ fn main() {
     let args = Args::parse();
 
     let mut telemetry = Telemetry::default();
-    if args.is_telemetry_allowed() {
+    if args.telemetry {
         telemetry.start(
             args.api_url.as_str(),
             option_env!("GITHUB_SHA").unwrap_or("unknown"),

--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -110,6 +110,9 @@ module "relays" {
 
   application_name    = "relay"
   application_version = replace(local.relay_image_tag, ".", "-")
+  application_environment_variables = {
+    FIREZONE_TELEMETRY = "true"
+  }
 
   health_check = {
     name     = "health"

--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -112,7 +112,7 @@ module "relays" {
   application_version = replace(local.relay_image_tag, ".", "-")
   application_environment_variables = [
     {
-      name = "FIREZONE_TELEMETRY"
+      name  = "FIREZONE_TELEMETRY"
       value = "true"
     }
   ]

--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -110,9 +110,12 @@ module "relays" {
 
   application_name    = "relay"
   application_version = replace(local.relay_image_tag, ".", "-")
-  application_environment_variables = {
-    FIREZONE_TELEMETRY = "true"
-  }
+  application_environment_variables = [
+    {
+      name = "FIREZONE_TELEMETRY"
+      value = "true"
+    }
+  ]
 
   health_check = {
     name     = "health"

--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -100,9 +100,12 @@ module "relays" {
 
   application_name    = "relay"
   application_version = replace(var.image_tag, ".", "-")
-  application_environment_variables = {
-    FIREZONE_TELEMETRY = "true"
-  }
+  application_environment_variables = [
+    {
+      name = "FIREZONE_TELEMETRY"
+      value = "true"
+    }
+  ]
 
   health_check = {
     name     = "health"

--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -102,7 +102,7 @@ module "relays" {
   application_version = replace(var.image_tag, ".", "-")
   application_environment_variables = [
     {
-      name = "FIREZONE_TELEMETRY"
+      name  = "FIREZONE_TELEMETRY"
       value = "true"
     }
   ]

--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -100,6 +100,9 @@ module "relays" {
 
   application_name    = "relay"
   application_version = replace(var.image_tag, ".", "-")
+  application_environment_variables = {
+    FIREZONE_TELEMETRY = "true"
+  }
 
   health_check = {
     name     = "health"


### PR DESCRIPTION
Currently, telemetry via Sentry in our relay code is opt-out but won't actually activate for a portal instance that isn't our staging or production environment. However, this isn't enough to prevent alerts from relay instances that aren't ours. It turns out that some self-hosted customers don't realise that they have to change the portal URL to their self-hosted portal. Without changing that, the relay will attempt to authenticate to our production portal with an unknown token and error out with a 401, logging a false-positive to Sentry.