### PR TITLE
refactor: merge `on_update_routes` and `on_set_interface_config`

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -118,22 +118,16 @@ class TunnelService : VpnService() {
                 addressIPv4: String,
                 addressIPv6: String,
                 dnsAddresses: String,
-            ) {
-                // init tunnel config
-                tunnelDnsAddresses = moshi.adapter<MutableList<String>>().fromJson(dnsAddresses)!!
-                tunnelIpv4Address = addressIPv4
-                tunnelIpv6Address = addressIPv6
-
-                buildVpnService()
-            }
-
-            override fun onUpdateRoutes(
                 routes4JSON: String,
                 routes6JSON: String,
             ) {
+                // init tunnel config
+                tunnelDnsAddresses = moshi.adapter<MutableList<String>>().fromJson(dnsAddresses)!!
                 val routes4 = moshi.adapter<MutableList<Cidr>>().fromJson(routes4JSON)!!
                 val routes6 = moshi.adapter<MutableList<Cidr>>().fromJson(routes6JSON)!!
 
+                tunnelIpv4Address = addressIPv4
+                tunnelIpv6Address = addressIPv6
                 tunnelRoutes.clear()
                 tunnelRoutes.addAll(routes4)
                 tunnelRoutes.addAll(routes6)

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/callback/ConnlibCallback.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/callback/ConnlibCallback.kt
@@ -6,9 +6,6 @@ interface ConnlibCallback {
         addressIPv4: String,
         addressIPv6: String,
         dnsAddresses: String,
-    )
-
-    fun onUpdateRoutes(
         routes4JSON: String,
         routes6JSON: String,
     )

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -205,31 +205,20 @@ impl Callbacks for CallbackHandler {
                     source,
                 })?;
 
-            {
-                let name = "onSetInterfaceConfig";
-                env.call_method(
-                    &self.callback_handler,
-                    name,
-                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
-                    &[
-                        JValue::from(&tunnel_address_v4),
-                        JValue::from(&tunnel_address_v6),
-                        JValue::from(&dns_addresses),
-                    ],
-                )
-                .map_err(|source| CallbackError::CallMethodFailed { name, source })?;
-            }
-
-            {
-                let name = "onUpdateRoutes";
-                env.call_method(
-                    &self.callback_handler,
-                    name,
-                    "(Ljava/lang/String;Ljava/lang/String;)V",
-                    &[JValue::from(&route_list_4), JValue::from(&route_list_6)],
-                )
-                .map_err(|source| CallbackError::CallMethodFailed { name, source })?;
-            }
+            let name = "onSetInterfaceConfig";
+            env.call_method(
+                &self.callback_handler,
+                name,
+                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                &[
+                    JValue::from(&tunnel_address_v4),
+                    JValue::from(&tunnel_address_v6),
+                    JValue::from(&dns_addresses),
+                    JValue::from(&route_list_4),
+                    JValue::from(&route_list_6),
+                ],
+            )
+            .map_err(|source| CallbackError::CallMethodFailed { name, source })?;
 
             Ok(())
         })

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -129,6 +129,8 @@ impl Callbacks for CallbackHandler {
         tunnel_address_v4: Ipv4Addr,
         tunnel_address_v6: Ipv6Addr,
         dns_addresses: Vec<IpAddr>,
+        route_list_4: Vec<Ipv4Network>,
+        route_list_6: Vec<Ipv6Network>,
     ) {
         let dns_addresses = match serde_json::to_string(&dns_addresses) {
             Ok(dns_addresses) => dns_addresses,
@@ -137,24 +139,21 @@ impl Callbacks for CallbackHandler {
                 return;
             }
         };
-
-        self.inner.on_set_interface_config(
-            tunnel_address_v4.to_string(),
-            tunnel_address_v6.to_string(),
-            dns_addresses,
-        );
-    }
-
-    fn on_update_routes(&self, route_list_4: Vec<Ipv4Network>, route_list_6: Vec<Ipv6Network>) {
         match (
+            serde_json::to_string(&dns_addresses),
             serde_json::to_string(&V4RouteList::new(route_list_4)),
             serde_json::to_string(&V6RouteList::new(route_list_6)),
         ) {
-            (Ok(route_list_4), Ok(route_list_6)) => {
+            (Ok(dns_addresses), Ok(route_list_4), Ok(route_list_6)) => {
+                self.inner.on_set_interface_config(
+                    tunnel_address_v4.to_string(),
+                    tunnel_address_v6.to_string(),
+                    dns_addresses,
+                );
                 self.inner.on_update_routes(route_list_4, route_list_6);
             }
-            (Err(e), _) | (_, Err(e)) => {
-                tracing::error!(error = std_dyn_err(&e), "Failed to serialize route list");
+            (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {
+                tracing::error!(error = std_dyn_err(&e), "Failed to serialize to JSON");
             }
         }
     }

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -89,8 +89,8 @@ mod ffi {
             tunnelAddressIPv4: String,
             tunnelAddressIPv6: String,
             dnsAddresses: String,
-            routeList4: String,
-            routeList6: String,
+            routeListv4: String,
+            routeListv6: String,
         );
 
         #[swift_bridge(swift_name = "onUpdateResources")]
@@ -128,8 +128,8 @@ impl Callbacks for CallbackHandler {
         tunnel_address_v4: Ipv4Addr,
         tunnel_address_v6: Ipv6Addr,
         dns_addresses: Vec<IpAddr>,
-        route_list_4: Vec<Ipv4Network>,
-        route_list_6: Vec<Ipv6Network>,
+        route_list_v4: Vec<Ipv4Network>,
+        route_list_v6: Vec<Ipv6Network>,
     ) {
         let dns_addresses = match serde_json::to_string(&dns_addresses) {
             Ok(dns_addresses) => dns_addresses,
@@ -140,8 +140,8 @@ impl Callbacks for CallbackHandler {
         };
         match (
             serde_json::to_string(&dns_addresses),
-            serde_json::to_string(&V4RouteList::new(route_list_4)),
-            serde_json::to_string(&V6RouteList::new(route_list_6)),
+            serde_json::to_string(&V4RouteList::new(route_list_v4)),
+            serde_json::to_string(&V6RouteList::new(route_list_v6)),
         ) {
             (Ok(dns_addresses), Ok(route_list_4), Ok(route_list_6)) => {
                 self.inner.on_set_interface_config(

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -89,10 +89,9 @@ mod ffi {
             tunnelAddressIPv4: String,
             tunnelAddressIPv6: String,
             dnsAddresses: String,
+            routeList4: String,
+            routeList6: String,
         );
-
-        #[swift_bridge(swift_name = "onUpdateRoutes")]
-        fn on_update_routes(&self, routeList4: String, routeList6: String);
 
         #[swift_bridge(swift_name = "onUpdateResources")]
         fn on_update_resources(&self, resourceList: String);
@@ -149,8 +148,9 @@ impl Callbacks for CallbackHandler {
                     tunnel_address_v4.to_string(),
                     tunnel_address_v6.to_string(),
                     dns_addresses,
+                    route_list_4,
+                    route_list_6,
                 );
-                self.inner.on_update_routes(route_list_4, route_list_6);
             }
             (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {
                 tracing::error!(error = std_dyn_err(&e), "Failed to serialize to JSON");

--- a/rust/connlib/clients/shared/src/callbacks.rs
+++ b/rust/connlib/clients/shared/src/callbacks.rs
@@ -9,10 +9,15 @@ pub trait Callbacks: Clone + Send + Sync {
     /// The first time this is called, the Resources list is also ready,
     /// the routes are also ready, and the Client can consider the tunnel
     /// to be ready for incoming traffic.
-    fn on_set_interface_config(&self, _: Ipv4Addr, _: Ipv6Addr, _: Vec<IpAddr>) {}
-
-    /// Called when the route list changes.
-    fn on_update_routes(&self, _: Vec<Ipv4Network>, _: Vec<Ipv6Network>) {}
+    fn on_set_interface_config(
+        &self,
+        _: Ipv4Addr,
+        _: Ipv6Addr,
+        _: Vec<IpAddr>,
+        _: Vec<Ipv4Network>,
+        _: Vec<Ipv6Network>,
+    ) {
+    }
 
     /// Called when the resource list changes.
     ///

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -166,9 +166,10 @@ where
             firezone_tunnel::ClientEvent::TunInterfaceUpdated(config) => {
                 let dns_servers = config.dns_by_sentinel.left_values().copied().collect();
 
-                self.callbacks
-                    .on_set_interface_config(config.ip4, config.ip6, dns_servers);
-                self.callbacks.on_update_routes(
+                self.callbacks.on_set_interface_config(
+                    config.ip4,
+                    config.ip6,
+                    dns_servers,
                     Vec::from_iter(config.ipv4_routes),
                     Vec::from_iter(config.ipv6_routes),
                 );

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -85,12 +85,10 @@ pub enum ConnlibMsg {
         ipv4: Ipv4Addr,
         ipv6: Ipv6Addr,
         dns: Vec<IpAddr>,
+        ipv4_routes: Vec<Ipv4Network>,
+        ipv6_routes: Vec<Ipv6Network>,
     },
     OnUpdateResources(Vec<ResourceView>),
-    OnUpdateRoutes {
-        ipv4: Vec<Ipv4Network>,
-        ipv6: Vec<Ipv6Network>,
-    },
 }
 
 #[derive(Clone)]
@@ -117,14 +115,14 @@ impl Callbacks for CallbackHandler {
         ipv6_routes: Vec<Ipv6Network>,
     ) {
         self.cb_tx
-            .try_send(ConnlibMsg::OnSetInterfaceConfig { ipv4, ipv6, dns })
-            .expect("Should be able to send OnSetInterfaceConfig");
-        self.cb_tx
-            .try_send(ConnlibMsg::OnUpdateRoutes {
-                ipv4: ipv4_routes,
-                ipv6: ipv6_routes,
+            .try_send(ConnlibMsg::OnSetInterfaceConfig {
+                ipv4,
+                ipv6,
+                dns,
+                ipv4_routes,
+                ipv6_routes,
             })
-            .expect("Should be able to send messages");
+            .expect("Should be able to send OnSetInterfaceConfig");
     }
 
     fn on_update_resources(&self, resources: Vec<ResourceView>) {

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -108,10 +108,23 @@ impl Callbacks for CallbackHandler {
             .expect("should be able to send OnDisconnect");
     }
 
-    fn on_set_interface_config(&self, ipv4: Ipv4Addr, ipv6: Ipv6Addr, dns: Vec<IpAddr>) {
+    fn on_set_interface_config(
+        &self,
+        ipv4: Ipv4Addr,
+        ipv6: Ipv6Addr,
+        dns: Vec<IpAddr>,
+        ipv4_routes: Vec<Ipv4Network>,
+        ipv6_routes: Vec<Ipv6Network>,
+    ) {
         self.cb_tx
             .try_send(ConnlibMsg::OnSetInterfaceConfig { ipv4, ipv6, dns })
             .expect("Should be able to send OnSetInterfaceConfig");
+        self.cb_tx
+            .try_send(ConnlibMsg::OnUpdateRoutes {
+                ipv4: ipv4_routes,
+                ipv6: ipv6_routes,
+            })
+            .expect("Should be able to send messages");
     }
 
     fn on_update_resources(&self, resources: Vec<ResourceView>) {
@@ -119,12 +132,6 @@ impl Callbacks for CallbackHandler {
         self.cb_tx
             .try_send(ConnlibMsg::OnUpdateResources(resources))
             .expect("Should be able to send OnUpdateResources");
-    }
-
-    fn on_update_routes(&self, ipv4: Vec<Ipv4Network>, ipv6: Vec<Ipv6Network>) {
-        self.cb_tx
-            .try_send(ConnlibMsg::OnUpdateRoutes { ipv4, ipv6 })
-            .expect("Should be able to send messages");
     }
 }
 

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -153,6 +153,6 @@ mod tests {
     // Make sure it's okay to store a bunch of these to mitigate #5880
     #[test]
     fn callback_msg_size() {
-        assert_eq!(std::mem::size_of::<ConnlibMsg>(), 56)
+        assert_eq!(std::mem::size_of::<ConnlibMsg>(), 96)
     }
 }

--- a/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
+++ b/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
@@ -20,9 +20,10 @@ public protocol CallbackHandlerDelegate: AnyObject {
   func onSetInterfaceConfig(
     tunnelAddressIPv4: String,
     tunnelAddressIPv6: String,
-    dnsAddresses: [String]
+    dnsAddresses: [String],
+    routeListv4: String,
+    routeListv6: String
   )
-  func onUpdateRoutes(routeList4: String, routeList6: String)
   func onUpdateResources(resourceList: String)
   func onDisconnect(error: String)
 }
@@ -33,7 +34,9 @@ public class CallbackHandler {
   func onSetInterfaceConfig(
     tunnelAddressIPv4: RustString,
     tunnelAddressIPv6: RustString,
-    dnsAddresses: RustString
+    dnsAddresses: RustString,
+    routeListv4: RustString,
+    routeListv6: RustString
   ) {
     Log.log(
       """
@@ -41,6 +44,8 @@ public class CallbackHandler {
           IPv4: \(tunnelAddressIPv4.toString())
           IPv6: \(tunnelAddressIPv6.toString())
           DNS: \(dnsAddresses.toString())
+          IPv4 routes:  \(routeListv4.toString())
+          IPv6 routes: \(routeListv6.toString())
       """)
 
     let dnsData = dnsAddresses.toString().data(using: .utf8)!
@@ -49,13 +54,10 @@ public class CallbackHandler {
     delegate?.onSetInterfaceConfig(
       tunnelAddressIPv4: tunnelAddressIPv4.toString(),
       tunnelAddressIPv6: tunnelAddressIPv6.toString(),
-      dnsAddresses: dnsArray
+      dnsAddresses: dnsArray,
+      routeListv4: routeListv4.toString(),
+      routeListv6: routeListv6.toString()
     )
-  }
-
-  func onUpdateRoutes(routeList4: RustString, routeList6: RustString) {
-    Log.log("CallbackHandler.onUpdateRoutes: \(routeList4) \(routeList6)")
-    delegate?.onUpdateRoutes(routeList4: routeList4.toString(), routeList6: routeList6.toString())
   }
 
   func onUpdateResources(resourceList: RustString) {


### PR DESCRIPTION
For a while now, `connlib` has been calling these two callbacks right after each other because the internal event already bundles all the information about the TUN device. With this PR, we merge the two callback functions also in layers above `connlib` itself.

Resolves: #6182.