### PR TITLE
refactor(apple/ios): Remove incorrect use of Task {}

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -313,23 +313,20 @@ extension Adapter {
       }
 
       if shouldFetchSystemResolvers(path: path) {
-        // Spawn a new thread to avoid blocking the UI on iOS
-        Task {
-          let resolvers = getSystemDefaultResolvers(
-            interfaceName: path.availableInterfaces.first?.name)
-
-          if lastFetchedResolvers != resolvers,
-            let jsonResolvers = try? String(
-              decoding: JSONEncoder().encode(resolvers), as: UTF8.self
-            ).intoRustString()
-          {
-
-            // Update connlib DNS
-            session.setDns(jsonResolvers)
-
-            // Update our state tracker
-            lastFetchedResolvers = resolvers
-          }
+        let resolvers = getSystemDefaultResolvers(
+          interfaceName: path.availableInterfaces.first?.name)
+        
+        if lastFetchedResolvers != resolvers,
+           let jsonResolvers = try? String(
+            decoding: JSONEncoder().encode(resolvers), as: UTF8.self
+           ).intoRustString()
+        {
+          
+          // Update connlib DNS
+          session.setDns(jsonResolvers)
+          
+          // Update our state tracker
+          lastFetchedResolvers = resolvers
         }
       }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -315,16 +315,16 @@ extension Adapter {
       if shouldFetchSystemResolvers(path: path) {
         let resolvers = getSystemDefaultResolvers(
           interfaceName: path.availableInterfaces.first?.name)
-        
+
         if lastFetchedResolvers != resolvers,
            let jsonResolvers = try? String(
             decoding: JSONEncoder().encode(resolvers), as: UTF8.self
            ).intoRustString()
         {
-          
+
           // Update connlib DNS
           session.setDns(jsonResolvers)
-          
+
           // Update our state tracker
           lastFetchedResolvers = resolvers
         }


### PR DESCRIPTION
This code doesn't make sense:

 - In the Adapter, we are not running on the main UI thread
 - In this callback, we are running on the `workQueue` anyway
 - `Task` is not how to spawn a new thread in Swift strictly speaking