### PR TITLE
fix(ci): Fix typo when moving final DMG into place

### DIFF
--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -123,5 +123,5 @@ echo "Disk image created at $dmg_path"
 
 # Move to final location the uploader expects
 if [[ -n "${ARTIFACT_PATH:-}" ]]; then
-    mv "$package_path" "$ARTIFACT_PATH"
+    mv "$dmg_path" "$ARTIFACT_PATH"
 fi


### PR DESCRIPTION
The customized DMG needs to be moved to `ARTIFACT_PATH`. Currently, this is set to the intermediate `$package_path`.