### PR TITLE
fix(apple/macOS): Don't allow empty `WindowGroup`

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -45,6 +45,8 @@ struct FirezoneApp: App {
       if let menuBar = appDelegate.menuBar {
         // menuBar will be initialized by this point
         AppView(model: appViewModel).environmentObject(menuBar)
+      } else {
+        ProgressView("Loading...")
       }
     }
     .handlesExternalEvents(


### PR DESCRIPTION
On macOS 12, returning an empty body for a `WindowGroup` can cause the app UI to crash with the following error:

```
*** Assertion failure in void _NSWindowSetFrameIvar(NSWindow *, NSRect)(), NSWindow.m:935
```

Since the `menuBar` is not initialized when the app initializes, this conditional can return an empty body in a race condition.

Even though we're winding down support for macOS 12, it would be good to fix this logic bug.