### PR TITLE
refactor(connlib): remove "known hosts" feature

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -220,7 +220,7 @@ impl ClientState {
             sites_status: Default::default(),
             gateways_site: Default::default(),
             mangled_dns_queries: Default::default(),
-            stub_resolver: StubResolver::new(),
+            stub_resolver: Default::default(),
             disabled_resources: Default::default(),
             buffered_transmits: Default::default(),
             internet_resource: None,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -205,11 +205,7 @@ impl PendingFlow {
 }
 
 impl ClientState {
-    pub(crate) fn new(
-        known_hosts: BTreeMap<String, Vec<IpAddr>>,
-        seed: [u8; 32],
-        now: Instant,
-    ) -> Self {
+    pub(crate) fn new(seed: [u8; 32], now: Instant) -> Self {
         Self {
             resources_gateways: Default::default(),
             active_cidr_resources: IpNetworkTable::new(),
@@ -224,7 +220,7 @@ impl ClientState {
             sites_status: Default::default(),
             gateways_site: Default::default(),
             mangled_dns_queries: Default::default(),
-            stub_resolver: StubResolver::new(known_hosts),
+            stub_resolver: StubResolver::new(),
             disabled_resources: Default::default(),
             buffered_transmits: Default::default(),
             internet_resource: None,
@@ -1979,7 +1975,7 @@ mod tests {
 
     impl ClientState {
         pub fn for_test() -> ClientState {
-            ClientState::new(BTreeMap::new(), rand::random(), Instant::now())
+            ClientState::new(rand::random(), Instant::now())
         }
     }
 

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -45,8 +45,6 @@ pub struct StubResolver {
     ip_provider: IpProvider,
     /// All DNS resources we know about, indexed by the glob pattern they match against.
     dns_resources: BTreeMap<Pattern, ResourceId>,
-    /// Fixed dns name that will be resolved to fixed ip addrs, similar to /etc/hosts
-    known_hosts: KnownHosts,
 }
 
 /// A query that needs to be forwarded to an upstream DNS server for resolution.
@@ -108,57 +106,13 @@ pub(crate) enum ResolveStrategy {
     Recurse,
 }
 
-struct KnownHosts {
-    fqdn_to_ips: BTreeMap<DomainName, Vec<IpAddr>>,
-    ips_to_fqdn: BTreeMap<IpAddr, DomainName>,
-}
-
-impl KnownHosts {
-    fn new(hosts: BTreeMap<String, Vec<IpAddr>>) -> KnownHosts {
-        KnownHosts {
-            fqdn_to_ips: fqdn_to_ips_for_known_hosts(&hosts),
-            ips_to_fqdn: ips_to_fqdn_for_known_hosts(&hosts),
-        }
-    }
-
-    fn get_records(
-        &self,
-        qtype: Rtype,
-        domain: &DomainName,
-    ) -> Option<Vec<AllRecordData<Vec<u8>, DomainName>>> {
-        match qtype {
-            Rtype::A => {
-                let ips = self.fqdn_to_ips.get::<DomainName>(domain)?;
-
-                Some(to_a_records(ips.iter().copied()))
-            }
-
-            Rtype::AAAA => {
-                let ips = self.fqdn_to_ips.get::<DomainName>(domain)?;
-
-                Some(to_aaaa_records(ips.iter().copied()))
-            }
-            Rtype::PTR => {
-                let ip = reverse_dns_addr(&domain.to_string())?;
-                let fqdn = self.ips_to_fqdn.get(&ip)?;
-
-                Some(vec![AllRecordData::Ptr(domain::rdata::Ptr::new(
-                    fqdn.clone(),
-                ))])
-            }
-            _ => None,
-        }
-    }
-}
-
 impl StubResolver {
-    pub(crate) fn new(known_hosts: BTreeMap<String, Vec<IpAddr>>) -> StubResolver {
+    pub(crate) fn new() -> StubResolver {
         StubResolver {
             fqdn_to_ips: Default::default(),
             ips_to_fqdn: Default::default(),
             ip_provider: IpProvider::for_resources(),
             dns_resources: Default::default(),
-            known_hosts: KnownHosts::new(known_hosts),
         }
     }
 
@@ -310,11 +264,6 @@ impl StubResolver {
             return Ok(ResolveStrategy::LocalResponse(payload));
         }
 
-        if let Some(records) = self.known_hosts.get_records(qtype, &domain) {
-            let response = build_dns_with_answer(message, domain, records)?;
-            return Ok(ResolveStrategy::LocalResponse(response));
-        }
-
         // `match_resource` is `O(N)` which we deem fine for DNS queries.
         let maybe_resource = self.match_resource_linear(&domain);
 
@@ -446,29 +395,6 @@ fn get_v6(ip: IpAddr) -> Option<Ipv6Addr> {
         IpAddr::V4(_) => None,
         IpAddr::V6(v6) => Some(v6),
     }
-}
-
-fn fqdn_to_ips_for_known_hosts(
-    hosts: &BTreeMap<String, Vec<IpAddr>>,
-) -> BTreeMap<DomainName, Vec<IpAddr>> {
-    hosts
-        .iter()
-        .filter_map(|(d, a)| DomainName::vec_from_str(d).ok().map(|d| (d, a.clone())))
-        .collect()
-}
-
-fn ips_to_fqdn_for_known_hosts(
-    hosts: &BTreeMap<String, Vec<IpAddr>>,
-) -> BTreeMap<IpAddr, DomainName> {
-    hosts
-        .iter()
-        .filter_map(|(d, a)| {
-            DomainName::vec_from_str(d)
-                .ok()
-                .map(|d| a.iter().map(move |a| (*a, d.clone())))
-        })
-        .flatten()
-        .collect()
 }
 
 mod pattern {
@@ -743,7 +669,7 @@ mod tests {
 
     #[test]
     fn prioritises_non_wildcard_over_wildcard_domain() {
-        let mut resolver = StubResolver::new(BTreeMap::default());
+        let mut resolver = StubResolver::new();
         let wc = ResourceId::from_u128(0);
         let non_wc = ResourceId::from_u128(1);
 
@@ -764,7 +690,7 @@ mod tests {
 
     #[test]
     fn query_for_doh_canary_domain_records_nx_domain() {
-        let mut resolver = StubResolver::new(BTreeMap::default());
+        let mut resolver = StubResolver::new();
 
         let mut builder = MessageBuilder::new_vec().question();
         builder
@@ -797,7 +723,7 @@ mod benches {
     fn match_domain_linear<const NUM_RES: u128>(bencher: divan::Bencher) {
         bencher
             .with_inputs(|| {
-                let mut resolver = StubResolver::new(BTreeMap::default());
+                let mut resolver = StubResolver::new();
                 let mut rng = rand::thread_rng();
 
                 for n in 0..NUM_RES {

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -106,8 +106,8 @@ pub(crate) enum ResolveStrategy {
     Recurse,
 }
 
-impl StubResolver {
-    pub(crate) fn new() -> StubResolver {
+impl Default for StubResolver {
+    fn default() -> Self {
         StubResolver {
             fqdn_to_ips: Default::default(),
             ips_to_fqdn: Default::default(),
@@ -115,7 +115,9 @@ impl StubResolver {
             dns_resources: Default::default(),
         }
     }
+}
 
+impl StubResolver {
     /// Attempts to resolve an IP to a given resource.
     ///
     /// Semantically, this is like a PTR query, i.e. we check whether we handed out this IP as part of answering a DNS query for one of our resources.
@@ -669,7 +671,7 @@ mod tests {
 
     #[test]
     fn prioritises_non_wildcard_over_wildcard_domain() {
-        let mut resolver = StubResolver::new();
+        let mut resolver = StubResolver::default();
         let wc = ResourceId::from_u128(0);
         let non_wc = ResourceId::from_u128(1);
 
@@ -690,7 +692,7 @@ mod tests {
 
     #[test]
     fn query_for_doh_canary_domain_records_nx_domain() {
-        let mut resolver = StubResolver::new();
+        let mut resolver = StubResolver::default();
 
         let mut builder = MessageBuilder::new_vec().question();
         builder
@@ -723,7 +725,7 @@ mod benches {
     fn match_domain_linear<const NUM_RES: u128>(bencher: divan::Bencher) {
         bencher
             .with_inputs(|| {
-                let mut resolver = StubResolver::new();
+                let mut resolver = StubResolver::default();
                 let mut rng = rand::thread_rng();
 
                 for n in 0..NUM_RES {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -12,7 +12,7 @@ use io::{Buffers, Io};
 use ip_network::{Ipv4Network, Ipv6Network};
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
@@ -87,7 +87,7 @@ impl ClientTunnel {
     ) -> Self {
         Self {
             io: Io::new(tcp_socket_factory, udp_socket_factory),
-            role_state: ClientState::new(BTreeMap::default(), rand::random(), Instant::now()),
+            role_state: ClientState::new(rand::random(), Instant::now()),
             buffers: Buffers::default(),
         }
     }

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -198,16 +198,6 @@ fn assert_packets_properties<T, U>(
     }
 }
 
-pub(crate) fn assert_known_hosts_are_valid(ref_client: &RefClient, sim_client: &SimClient) {
-    for (record, actual) in &sim_client.dns_records {
-        if let Some(expected) = ref_client.known_hosts.get(&record.to_string()) {
-            if actual != expected {
-                tracing::error!(target: "assertions", ?actual, ?expected, "❌ Unexpected known-hosts");
-            }
-        }
-    }
-}
-
 pub(crate) fn assert_dns_servers_are_valid(ref_client: &RefClient, sim_client: &SimClient) {
     let expected = ref_client.expected_dns_servers();
     let actual = sim_client.effective_dns_servers();

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -664,12 +664,6 @@ impl ReferenceState {
         self.global_dns_records
             .domains_iter()
             .map(|d| (d.clone(), self.global_dns_records.domain_rtypes(&d)))
-            .chain(self.client.inner().known_hosts.keys().map(|h| {
-                (
-                    DomainName::vec_from_str(h).unwrap(),
-                    vec![Rtype::A, Rtype::AAAA],
-                )
-            }))
             .collect()
     }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -370,7 +370,6 @@ impl TunnelTest {
         );
         assert_udp_dns_packets_properties(ref_client, sim_client);
         assert_tcp_dns(ref_client, sim_client);
-        assert_known_hosts_are_valid(ref_client, sim_client);
         assert_dns_servers_are_valid(ref_client, sim_client);
         assert_routes_are_valid(ref_client, sim_client);
     }


### PR DESCRIPTION
Ever since #7289, we no longer issue any DNS queries to `connlib` when we reconnect to the portal. Thus, the back-then conceived feature of "known hosts" that allowed us to resolve that DNS query without having an upstream receiver is no longer needed.