### PR TITLE
ci: reference GitHub actions by hash

### DIFF
--- a/.github/actions/create-sentry-release/action.yml
+++ b/.github/actions/create-sentry-release/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "version=$version" >> $GITHUB_OUTPUT
       shell: bash
 
-    - uses: getsentry/action-release@v1
+    - uses: getsentry/action-release@1841d945bad68068f92f796114d0fa534129764d # v1.8.0
       env:
         SENTRY_AUTH_TOKEN: ${{ inputs.sentry_token }}
         SENTRY_ORG: firezone-inc

--- a/.github/actions/gcp-docker-login/action.yml
+++ b/.github/actions/gcp-docker-login/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - id: auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
       with:
         token_format: access_token
         workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions"
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: gcloud --quiet config set project ${{ inputs.project }}
     - name: Login to Google Artifact Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:
         registry: "us-east1-docker.pkg.dev"
         username: oauth2accesstoken

--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -8,21 +8,21 @@ runs:
       with:
         targets: armv7-linux-androideabi aarch64-linux-android x86_64-linux-android i686-linux-android
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
       with:
         distribution: temurin
         java-version: 17
 
-    - uses: gradle/actions/setup-gradle@v4
+    - uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
 
-    - uses: android-actions/setup-android@v3
+    - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
     - name: Install NDK
       run: sdkmanager "ndk;27.2.12479018" # Must match `kotlin/android/app/build.gradle.kts`
       shell: bash
 
     - name: Validate Gradle wrapper
-      uses: gradle/actions/wrapper-validation@v4
+      uses: gradle/actions/wrapper-validation@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
 
     - run: touch local.properties
       shell: bash

--- a/.github/actions/setup-elixir/action.yml
+++ b/.github/actions/setup-elixir/action.yml
@@ -17,8 +17,8 @@ runs:
   steps:
     - name: Tool Versions
       id: versions
-      uses: marocchino/tool-versions-action@v1.2.0
-    - uses: erlef/setup-beam@v1
+      uses: marocchino/tool-versions-action@18a164fa2b0db1cc1edf7305fcb17ace36d1c306 # v1.2.0
+    - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
       id: setup-beam
       with:
         otp-version: ${{ steps.versions.outputs.erlang }}
@@ -29,7 +29,7 @@ runs:
       run: |
         mix local.hex --force
         mix local.rebar --force
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       name: Restore Elixir Deps Cache
       id: cache
       with:
@@ -47,7 +47,7 @@ runs:
       shell: bash
       working-directory: ./elixir
       run: mix deps.compile --skip-umbrella-children
-    - uses: actions/cache/save@v4
+    - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       name: Save Elixir Deps Cache
       if: ${{ github.ref_name == 'main' }}
       with:

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -8,9 +8,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
       with:
         version: 9.3
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -36,7 +36,7 @@ runs:
     # Setup sccache, works well for most Rust components
     - if: ${{ inputs.cache_backend == 'sccache' }}
       id: auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
       with:
         workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions"
         service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
@@ -48,13 +48,13 @@ runs:
         echo "SCCACHE_GCS_RW_MODE=READ_WRITE" >> $GITHUB_ENV
       shell: bash
     - if: ${{ inputs.cache_backend == 'sccache' }}
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
     - if: ${{ inputs.cache_backend == 'sccache' }}
       run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
       shell: bash
 
     - if: ${{ inputs.cache_backend == 'github' }}
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       with:
         save-if: ${{ github.ref_name == 'main' }}
         key: ${{ inputs.key }}
@@ -75,7 +75,7 @@ runs:
         echo "RUST_TOOLCHAIN=$RUST_TOOLCHAIN" >> $GITHUB_ENV
       shell: bash
       working-directory: ./rust
-    - uses: dtolnay/rust-toolchain@master
+    - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # v1
       with:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
         components: rustfmt,clippy

--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -28,7 +28,7 @@ runs:
       if: ${{ runner.os == 'Linux' && inputs.runtime == 'true' }}
       run: sudo apt-get --yes install at-spi2-core xvfb
       shell: bash
-    - uses: actions/cache@v4
+    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' }}
       id: cache-webview2-installer
       with:

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -71,11 +71,11 @@ jobs:
               APPLICATION_NAME=api
               GIT_SHA=${{ inputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.sha }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
         with:
           # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
@@ -88,7 +88,7 @@ jobs:
           project: firezone-staging
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         with:
           images: ${{ steps.login.outputs.registry }}/firezone/${{matrix.image_name }}
           tags: |
@@ -101,7 +101,7 @@ jobs:
           echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
       - name: Build and push control plane images
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
         with:
           build-args: ${{ matrix.build-args }}
           target: ${{ matrix.target }}
@@ -179,7 +179,7 @@ jobs:
       gateway_image: ${{ steps.image-name.outputs.gateway_image }}
       http_test_server_image: ${{ steps.image-name.outputs.http-test-server_image }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.sha }}
       - uses: ./.github/actions/setup-rust
@@ -189,7 +189,7 @@ jobs:
           cache_backend: github
           # Cache needs to be scoped per OS version and target since cross seems to clobber the cache
           key: ubuntu-22.04-${{ matrix.arch.target }}
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@c87777c3160ce0cfd8fc286df47224d2449cb76b # v2.47.11
         with:
           tool: cross
         env:
@@ -234,7 +234,7 @@ jobs:
       - name: Authenticate to Google Cloud
         id: auth
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && contains(fromJSON('["gateway", "client"]'), matrix.name.image_name) }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
         with:
           workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions"
           service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
@@ -251,9 +251,9 @@ jobs:
             ${BINARY_DEST_PATH}.sha256sum.txt \
             gs://firezone-staging-artifacts/firezone-${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
         with:
           # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
@@ -275,7 +275,7 @@ jobs:
           echo "MAJOR_MINOR_VERSION=${MAJOR_MINOR_VERSION}" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         with:
           images: ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }}
           # We only version client and gateway
@@ -295,7 +295,7 @@ jobs:
           echo "CACHE_TAG=$CACHE_TAG" >> "$GITHUB_ENV"
       - name: Build Docker images
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
         with:
           platforms: ${{ matrix.arch.platform }}
           build-args: |
@@ -315,7 +315,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${{ matrix.name.image_name }}/${digest#sha256:}"
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           overwrite: true
           name: ${{ matrix.image_prefix && format('{0}-', matrix.image_prefix) || '' }}${{ matrix.name.image_name }}-${{ inputs.sha }}-digest-${{ matrix.arch.shortname }}
@@ -352,7 +352,7 @@ jobs:
             version: 1.0.6
           - name: http-test-server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.sha }}
       - uses: ./.github/actions/gcp-docker-login
@@ -360,7 +360,7 @@ jobs:
         with:
           project: firezone-staging
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: ${{ matrix.image_prefix && format('{0}-', matrix.image_prefix) || '' }}${{ matrix.image.name }}-${{ inputs.sha }}-digest-*
           merge-multiple: true
@@ -368,7 +368,7 @@ jobs:
       - name: Display structure of downloaded artifacts
         run: ls -R /tmp/digests
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
         with:
           # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
@@ -386,7 +386,7 @@ jobs:
           echo "MAJOR_MINOR_VERSION=${MAJOR_MINOR_VERSION}" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         with:
           images: ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image.name }}
           tags: |

--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -29,16 +29,16 @@ jobs:
           #   working-directory: 'swift/apple'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
         with:
           working-directory: ${{ matrix.working-directory }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/_deploy_production.yml
+++ b/.github/workflows/_deploy_production.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         image: [domain, api, web, gateway, relay, client]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Login to staging registry
         uses: ./.github/actions/gcp-docker-login
         id: login-staging
@@ -50,7 +50,7 @@ jobs:
         with:
           project: firezone-prod
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
         with:
           # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
@@ -68,7 +68,7 @@ jobs:
             $SOURCE_TAG
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
         with:
           workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions"
           service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
@@ -114,18 +114,18 @@ jobs:
       TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
       TF_WORKSPACE: "production"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Tool Versions
         id: versions
-        uses: marocchino/tool-versions-action@v1.2.0
-      - uses: hashicorp/setup-terraform@v3
+        uses: marocchino/tool-versions-action@18a164fa2b0db1cc1edf7305fcb17ace36d1c306 # v1.2.0
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ steps.versions.outputs.terraform }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
       - name: Upload Configuration
-        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.3.2
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
         id: apply-upload
         with:
           workspace: ${{ env.TF_WORKSPACE }}
@@ -133,7 +133,7 @@ jobs:
           # https://app.terraform.io/app/firezone/workspaces/production/settings/general
           directory: "./"
       - name: Create Plan Run
-        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.3.2
+        uses: hashicorp/tfc-workflows-github/actions/create-run@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
         id: apply-run
         env:
           TF_VAR_image_tag: '"${{ inputs.tag }}"'
@@ -141,7 +141,7 @@ jobs:
           workspace: ${{ env.TF_WORKSPACE }}
           configuration_version: ${{ steps.apply-upload.outputs.configuration_version_id }}
       - name: Apply
-        uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.3.2
+        uses: hashicorp/tfc-workflows-github/actions/apply-run@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
         if: fromJSON(steps.apply-run.outputs.payload).data.attributes.actions.IsConfirmable
         id: apply
         with:
@@ -162,20 +162,20 @@ jobs:
       matrix:
         image: [domain, api, web, relay]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Login to staging registry
         uses: ./.github/actions/gcp-docker-login
         id: login-staging
         with:
           project: firezone-staging
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
         with:
           # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -26,7 +26,7 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-elixir
         with:
           mix_env: ${{ env.MIX_ENV }}
@@ -44,7 +44,7 @@ jobs:
           mix_test="mix test --warnings-as-errors --exclude flaky:true --exclude acceptance:true"
           $mix_test || $mix_test --failed
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
         if:
           ${{ github.event.pull_request.head.repo.full_name == github.repository
           && (success() || failure()) }}
@@ -63,14 +63,14 @@ jobs:
       MIX_ENV: dev
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-elixir
         id: setup-beam
         with:
           mix_env: ${{ env.MIX_ENV }}
       - name: Compile Application
         run: mix compile --warnings-as-errors
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         name: Restore PLT cache
         id: plt_cache
         with:
@@ -82,7 +82,7 @@ jobs:
       - name: Create PLTs
         if: ${{ steps.plt_cache.outputs.cache-hit != 'true' }}
         run: mix dialyzer --plt
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: ${{ github.ref_name == 'main' }}
         name: Save PLT cache
         with:
@@ -100,7 +100,7 @@ jobs:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-elixir
         with:
           mix_env: ${{ env.MIX_ENV }}
@@ -141,7 +141,7 @@ jobs:
           --health-cmd pg_isready --health-interval 10s --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-elixir
         with:
           mix_env: ${{ env.MIX_ENV }}
@@ -203,8 +203,8 @@ jobs:
           - 8200:8200/tcp
         options: --cap-add=IPC_LOCK
     steps:
-      - uses: actions/checkout@v4
-      - uses: nanasess/setup-chromedriver@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: nanasess/setup-chromedriver@e93e57b843c0c92788f22483f1a31af8ee48db25 # v2.3.0
       - run: |
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &
@@ -216,7 +216,7 @@ jobs:
       - name: Compile Application
         run: mix compile --warnings-as-errors
       # Front-End deps cache
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         name: pnpm Web Deps Cache
         id: pnpm-web-deps-cache
         env:
@@ -232,7 +232,7 @@ jobs:
         run: |
           cd apps/web
           mix assets.setup
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         name: Save pnpm Deps Cache
         if: ${{ github.ref_name == 'main' }}
         env:
@@ -244,7 +244,7 @@ jobs:
             elixir/tailwind-*
           key: ubuntu-22.04-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/pnpm-lock.yaml') }}
       # Front-End build cache, it rarely changes so we cache it aggressively too
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         name: Web Assets Cache
         id: pnpm-web-build-cache
         env:
@@ -259,7 +259,7 @@ jobs:
         run: |
           cd apps/web
           mix assets.build
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         name: Save Web Assets Cache
         if: ${{ github.ref_name == 'main' }}
         env:
@@ -292,12 +292,12 @@ jobs:
         if:
           ${{ github.event.pull_request.head.repo.full_name == github.repository
           && always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: screenshots-${{ matrix.MIX_TEST_PARTITION }}
           path: elixir/apps/web/screenshots
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
         if:
           ${{ github.event.pull_request.head.repo.full_name == github.repository
           && (success() || failure()) }}

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -110,7 +110,7 @@ jobs:
           - name: relay-graceful-shutdown
           - name: systemd/dns-systemd-resolved
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -16,7 +16,7 @@ jobs:
     # Android SDK tools hardware accel is available only on Linux runners
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-android
       - name: Run linter
         run: ./gradlew spotlessCheck
@@ -39,7 +39,7 @@ jobs:
             build-command: "./gradlew assembleRelease"
             output-path: app/build/outputs/apk/release/app-release.apk
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-tags: true # Otherwise we cannot embed the correct version into the build.
       - uses: ./.github/actions/setup-android
@@ -57,7 +57,7 @@ jobs:
         run: |
           ./gradlew testReleaseUnitTest
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: Android ${{ matrix.package-type }}
           path: |
@@ -87,13 +87,13 @@ jobs:
     runs-on: ubuntu-22.04
     name: build-debug
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-android
       - name: Build debug APK
         run: |
           ./gradlew assembleDebug
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: Android debug APK
           path: |

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -27,7 +27,7 @@ jobs:
           ]
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-rust
         id: setup-rust
       - run: cargo bench ${{ steps.setup-rust.outputs.bench-packages }}
@@ -45,12 +45,12 @@ jobs:
         runs-on: [ubuntu-22.04, macos-14, windows-2022]
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-rust
         id: setup-rust
       - uses: ./.github/actions/setup-tauri-v2
         timeout-minutes: 5
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@c87777c3160ce0cfd8fc286df47224d2449cb76b # v2.47.11
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -85,11 +85,11 @@ jobs:
           ]
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-rust
         id: setup-rust
       - uses: ./.github/actions/setup-tauri-v2
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@c87777c3160ce0cfd8fc286df47224d2449cb76b # v2.47.11
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -140,7 +140,7 @@ jobs:
         working-directory: ./rust/gui-client
       # The Windows client ignores RUST_LOG because it uses a settings file instead
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri-v2
@@ -158,7 +158,7 @@ jobs:
         run: pnpm vite build
       - name: Build client
         run: cargo build -p firezone-gui-client --all-targets
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@c87777c3160ce0cfd8fc286df47224d2449cb76b # v2.47.11
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -177,7 +177,7 @@ jobs:
         test: [linux-group, token-path]
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-tauri-v2
         timeout-minutes: 5

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -18,14 +18,14 @@ jobs:
             echo "PR title too long. Please keep it under 64 characters."
             exit 1
           fi
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 #v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   version-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check version is up to date
         run: |
           make -f scripts/Makefile version
@@ -42,8 +42,8 @@ jobs:
   link-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: lycheeverse/lychee-action@v2.2.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374 # v2.2.0
         with:
           fail: true
           args: --offline --verbose --no-progress **/*.md
@@ -51,11 +51,11 @@ jobs:
   global-linter:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.11"
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         name: Restore Python Cache
         id: cache
         with:
@@ -64,7 +64,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install -r .github/requirements.txt
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20
       - name: Install dependencies
@@ -76,7 +76,7 @@ jobs:
         run: |
           pre-commit install --config .github/pre-commit-config.yaml
           SKIP=no-commit-to-branch pre-commit run --all-files --config .github/pre-commit-config.yaml
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: ${{ steps.cache.outputs.cache-hit != 'true'}}
         name: Save Python Cache
         with:

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -39,13 +39,13 @@ jobs:
             # mark:next-apple-version
             release-name: macos-client-1.4.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-tags: true # Otherwise we cannot embed the correct version into the build.
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.rust-targets }}
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         name: Restore Swift DerivedData Cache
         id: cache
         with:
@@ -83,7 +83,7 @@ jobs:
           PLATFORM: "${{ matrix.platform }}"
       - name: Setup sentry CLI
         if: ${{ github.ref_name == 'main' }}
-        uses: matbour/setup-sentry-cli@v2
+        uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           organization: firezone-inc
@@ -95,7 +95,7 @@ jobs:
           rm -f "${{ runner.temp }}/dmg/Applications"
 
           sentry-cli debug-files upload --log-level info --project apple-client --include-sources ${{ runner.temp }}
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: ${{ steps.cache.outputs.cache-hit != 'true'}}
         name: Save Swift DerivedData Cache
         with:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -60,7 +60,7 @@ jobs:
       TARGET_DIR: ../target
       UPLOAD_SCRIPT: ../../scripts/build/tauri-upload-${{ matrix.os }}.sh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-tags: true # Otherwise we cannot embed the correct version into the build.
       - uses: ./.github/actions/setup-node
@@ -68,7 +68,7 @@ jobs:
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
         timeout-minutes: 10
-      - uses: matbour/setup-sentry-cli@v2
+      - uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           organization: firezone-inc
@@ -110,14 +110,14 @@ jobs:
           sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
           sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ env.ARTIFACT_DST }}-pkg
           path: ${{ env.ARTIFACT_SRC }}.${{ matrix.pkg-extension }}
           if-no-files-found: error
       - name: Upload rpm package
         if: ${{ runner.os == 'Linux' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ env.ARTIFACT_DST }}-rpm
           path: ${{ env.ARTIFACT_SRC }}.rpm

--- a/.github/workflows/_terraform.yml
+++ b/.github/workflows/_terraform.yml
@@ -13,14 +13,14 @@ jobs:
       TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
       TF_WORKSPACE: "staging"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Tool Versions
         id: versions
-        uses: marocchino/tool-versions-action@v1.2.0
-      - uses: hashicorp/setup-terraform@v3
+        uses: marocchino/tool-versions-action@18a164fa2b0db1cc1edf7305fcb17ace36d1c306 # v1.2.0
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ steps.versions.outputs.terraform }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Validate cloud-init
         run: |
           sudo apt-get update
@@ -32,7 +32,7 @@ jobs:
         working-directory: terraform
         run: |
           terraform fmt --check --recursive
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         with:
           filters: |
@@ -40,7 +40,7 @@ jobs:
               - 'terraform/**'
       - if: steps.changes.outputs.terraform == 'true'
         name: Upload Configuration
-        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.3.2
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
         id: plan-upload
         with:
           workspace: ${{ env.TF_WORKSPACE }}
@@ -50,7 +50,7 @@ jobs:
           speculative: true
       - if: steps.changes.outputs.terraform == 'true'
         name: Create Plan Run
-        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.3.2
+        uses: hashicorp/tfc-workflows-github/actions/create-run@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
         id: plan-run
         env:
           TF_VAR_image_tag: '"${{ github.sha }}"'
@@ -60,12 +60,12 @@ jobs:
           plan_only: true
       - if: steps.changes.outputs.terraform == 'true'
         name: Get Plan Output
-        uses: hashicorp/tfc-workflows-github/actions/plan-output@v1.3.2
+        uses: hashicorp/tfc-workflows-github/actions/plan-output@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
         id: plan-output
         with:
           plan: ${{ fromJSON(steps.plan-run.outputs.payload).data.relationships.plan.data.id }}
       - name: Update PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: plan-comment
         if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.terraform == 'true' }}
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,18 +57,18 @@ jobs:
       TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
       TF_WORKSPACE: "staging"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Tool Versions
         id: versions
-        uses: marocchino/tool-versions-action@v1.2.0
-      - uses: hashicorp/setup-terraform@v3
+        uses: marocchino/tool-versions-action@18a164fa2b0db1cc1edf7305fcb17ace36d1c306 # v1.2.0
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ steps.versions.outputs.terraform }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
       - name: Upload Configuration
-        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.3.2
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
         id: apply-upload
         with:
           workspace: ${{ env.TF_WORKSPACE }}
@@ -76,7 +76,7 @@ jobs:
           # https://app.terraform.io/app/firezone/workspaces/staging/settings/general
           directory: "./"
       - name: Create Plan Run
-        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.3.2
+        uses: hashicorp/tfc-workflows-github/actions/create-run@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
         id: apply-run
         env:
           TF_VAR_image_tag: '"${{ github.sha }}"'
@@ -84,7 +84,7 @@ jobs:
           workspace: ${{ env.TF_WORKSPACE }}
           configuration_version: ${{ steps.apply-upload.outputs.configuration_version_id }}
       - name: Apply
-        uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.3.2
+        uses: hashicorp/tfc-workflows-github/actions/apply-run@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
         if: fromJSON(steps.apply-run.outputs.payload).data.attributes.actions.IsConfirmable
         id: apply
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             config_name: release-drafter-android-client.yml
 
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         # Only draft releases on merges to main
         if: ${{ github.ref_name == 'main' }}
         id: update-release-draft
@@ -172,7 +172,7 @@ jobs:
           - relayed-udp-client2server
           - relayed-udp-server2client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
@@ -200,7 +200,7 @@ jobs:
           ./scripts/tests/perf/${{ matrix.test_name }}.sh
           jq '{ "${{ matrix.test_name }}": { "throughput": { "value": .end.sum_received.bits_per_second } } }' ./${{ matrix.test_name }}.json > ./${{ matrix.test_name }}.bmf.json
       - name: "Save performance test results: ${{ matrix.test_name }}"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           overwrite: true
           name: ${{ matrix.test_name }}-${{ github.sha }}-iperf3results
@@ -240,10 +240,10 @@ jobs:
       pull-requests: write
       checks: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: bencherdev/bencher@main
       - name: Download performance test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: "*-${{ github.sha }}-iperf3results"
           merge-multiple: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,13 @@ jobs:
       # Needed to login to GCP
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
           project: firezone-staging
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
           echo "major_version=$MAJOR_VERSION" >> "$GITHUB_OUTPUT"
           echo "major_minor_version=$MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
         with:
           # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
           # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
@@ -79,7 +79,7 @@ jobs:
             $SOURCE_TAG
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
         with:
           workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions"
           service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -25,7 +25,7 @@ jobs:
           - component: macos-client
             projects: apple-client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: ./.github/actions/create-sentry-release


### PR DESCRIPTION
To improve supply-chain security, reference all GitHub actions using the hash of the released tag. GitHub recommends to do this for third-party actions (https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). In order to make our CI more deterministic, I opted to do it for all our actions. This means any change to our workflow configuration requires a source code change and thus passing CI on our end.

Dependabot will automatically issue PRs for these actions and update the comment with the new version next to them.

Resolves: #2497.