### PR TITLE
ci: Add macos-15 to Rust unit tests

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -80,6 +80,7 @@ jobs:
             ubuntu-24.04,
             macos-13,
             macos-14,
+            macos-15,
             windows-2019,
             windows-2022,
           ]


### PR DESCRIPTION
We try to unit test on each major platform we support in CI to reduce the possibility a specific OS has issues with our unit tests. Now that macos-15 is available in GitHub CI, it would be a good idea to add it to the mix.