### PR TITLE
fix(infra): Use computed cidrsubnet for Relays

### DIFF
--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -9,252 +9,211 @@ module "relays" {
   #  - /website/src/app/kb/architecture/tech-stack/readme.mdx
   instances = {
     "africa-south1" = {
-      cidr_range = "10.129.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["africa-south1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["africa-south1-a"]
     }
     "asia-east1" = {
-      cidr_range = "10.130.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-east1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-east1-a"]
     }
     "asia-east2" = {
-      cidr_range = "10.131.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-east2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-east2-a"]
     }
     "asia-northeast1" = {
-      cidr_range = "10.132.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-northeast1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-northeast1-a"]
     }
     "asia-northeast2" = {
-      cidr_range = "10.133.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-northeast2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-northeast2-a"]
     }
     "asia-northeast3" = {
-      cidr_range = "10.134.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-northeast3-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-northeast3-a"]
     }
     "asia-south1" = {
-      cidr_range = "10.135.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-south1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-south1-a"]
     }
     "asia-south2" = {
-      cidr_range = "10.136.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-south2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-south2-a"]
     }
     "asia-southeast1" = {
-      cidr_range = "10.137.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-southeast1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-southeast1-a"]
     }
     "asia-southeast2" = {
-      cidr_range = "10.138.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-southeast2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-southeast2-a"]
     }
     "australia-southeast1" = {
-      cidr_range = "10.139.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["australia-southeast1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["australia-southeast1-a"]
     }
     "australia-southeast2" = {
-      cidr_range = "10.140.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["australia-southeast2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["australia-southeast2-a"]
     }
     "europe-central2" = {
-      cidr_range = "10.141.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-central2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-central2-a"]
     }
     "europe-north1" = {
-      cidr_range = "10.142.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-north1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-north1-a"]
     }
     "europe-southwest1" = {
-      cidr_range = "10.143.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-southwest1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-southwest1-a"]
     }
     "europe-west1" = {
-      cidr_range = "10.144.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west1-b"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west1-b"]
     }
     "europe-west2" = {
-      cidr_range = "10.145.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west2-a"]
     }
     "europe-west3" = {
-      cidr_range = "10.146.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west3-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west3-a"]
     }
     "europe-west4" = {
-      cidr_range = "10.147.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west4-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west4-a"]
     }
     "europe-west6" = {
-      cidr_range = "10.148.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west6-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west6-a"]
     }
     "europe-west8" = {
-      cidr_range = "10.149.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west8-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west8-a"]
     }
     "europe-west9" = {
-      cidr_range = "10.150.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west9-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west9-a"]
     }
     "europe-west10" = {
-      cidr_range = "10.151.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west10-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west10-a"]
     }
     "europe-west12" = {
-      cidr_range = "10.152.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west12-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west12-a"]
     }
     "me-central1" = {
-      cidr_range = "10.153.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["me-central1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["me-central1-a"]
     }
     # Fails with:
     # Access to the region is unavailable. Please contact our sales team at https://cloud.google.com/contact for further assistance."
     # "me-central2" = {
-    #   cidr_range = "10.154.1.0/24"
-    #   type       = "e2-micro"
+    #       #   type       = "e2-micro"
     #   replicas   = 1
     #   zones      = ["me-central2-a"]
     # }
     "me-west1" = {
-      cidr_range = "10.155.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["me-west1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["me-west1-a"]
     }
     "northamerica-northeast1" = {
-      cidr_range = "10.156.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["northamerica-northeast1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["northamerica-northeast1-a"]
     }
     "northamerica-northeast2" = {
-      cidr_range = "10.157.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["northamerica-northeast2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["northamerica-northeast2-a"]
     }
     "northamerica-south1" = {
-      cidr_range = "10.158.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["northamerica-south1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["northamerica-south1-a"]
     }
     "southamerica-east1" = {
-      cidr_range = "10.159.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["southamerica-east1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["southamerica-east1-a"]
     }
     "southamerica-west1" = {
-      cidr_range = "10.160.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["southamerica-west1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["southamerica-west1-a"]
     }
     "us-central1" = {
-      cidr_range = "10.161.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-central1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-central1-a"]
     }
     "us-east1" = {
-      cidr_range = "10.162.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-east1-b"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-east1-b"]
     }
     "us-east4" = {
-      cidr_range = "10.163.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-east4-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-east4-a"]
     }
     "us-east5" = {
-      cidr_range = "10.164.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-east5-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-east5-a"]
     }
     "us-south1" = {
-      cidr_range = "10.165.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-south1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-south1-a"]
     }
     "us-west1" = {
-      cidr_range = "10.166.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-west1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-west1-a"]
     }
     "us-west2" = {
-      cidr_range = "10.167.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-west2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-west2-a"]
     }
     "us-west3" = {
-      cidr_range = "10.168.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-west3-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-west3-a"]
     }
     "us-west4" = {
-      cidr_range = "10.169.1.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-west4-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-west4-a"]
     }
   }
 

--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -4,252 +4,211 @@ module "relays" {
   project_id = module.google-cloud-project.project.project_id
   instances = {
     "africa-south1" = {
-      cidr_range = "10.129.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["africa-south1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["africa-south1-a"]
     }
     "asia-east1" = {
-      cidr_range = "10.130.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-east1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-east1-a"]
     }
     "asia-east2" = {
-      cidr_range = "10.131.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-east2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-east2-a"]
     }
     "asia-northeast1" = {
-      cidr_range = "10.132.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-northeast1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-northeast1-a"]
     }
     "asia-northeast2" = {
-      cidr_range = "10.133.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-northeast2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-northeast2-a"]
     }
     "asia-northeast3" = {
-      cidr_range = "10.134.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-northeast3-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-northeast3-a"]
     }
     "asia-south1" = {
-      cidr_range = "10.135.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-south1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-south1-a"]
     }
     "asia-south2" = {
-      cidr_range = "10.136.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-south2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-south2-a"]
     }
     "asia-southeast1" = {
-      cidr_range = "10.137.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-southeast1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-southeast1-a"]
     }
     "asia-southeast2" = {
-      cidr_range = "10.138.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["asia-southeast2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["asia-southeast2-a"]
     }
     "australia-southeast1" = {
-      cidr_range = "10.139.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["australia-southeast1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["australia-southeast1-a"]
     }
     "australia-southeast2" = {
-      cidr_range = "10.140.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["australia-southeast2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["australia-southeast2-a"]
     }
     "europe-central2" = {
-      cidr_range = "10.141.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-central2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-central2-a"]
     }
     "europe-north1" = {
-      cidr_range = "10.142.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-north1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-north1-a"]
     }
     "europe-southwest1" = {
-      cidr_range = "10.143.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-southwest1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-southwest1-a"]
     }
     "europe-west1" = {
-      cidr_range = "10.144.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west1-b"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west1-b"]
     }
     "europe-west2" = {
-      cidr_range = "10.145.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west2-a"]
     }
     "europe-west3" = {
-      cidr_range = "10.146.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west3-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west3-a"]
     }
     "europe-west4" = {
-      cidr_range = "10.147.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west4-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west4-a"]
     }
     "europe-west6" = {
-      cidr_range = "10.148.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west6-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west6-a"]
     }
     "europe-west8" = {
-      cidr_range = "10.149.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west8-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west8-a"]
     }
     "europe-west9" = {
-      cidr_range = "10.150.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west9-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west9-a"]
     }
     "europe-west10" = {
-      cidr_range = "10.151.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west10-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west10-a"]
     }
     "europe-west12" = {
-      cidr_range = "10.152.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["europe-west12-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["europe-west12-a"]
     }
     "me-central1" = {
-      cidr_range = "10.153.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["me-central1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["me-central1-a"]
     }
     # Fails with:
     # Access to the region is unavailable. Please contact our sales team at https://cloud.google.com/contact for further assistance."
     # "me-central2" = {
-    #   cidr_range = "10.154.2.0/24"
     #   type       = "e2-micro"
     #   replicas   = 1
     #   zones      = ["me-central2-a"]
     # }
     "me-west1" = {
-      cidr_range = "10.155.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["me-west1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["me-west1-a"]
     }
     "northamerica-northeast1" = {
-      cidr_range = "10.156.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["northamerica-northeast1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["northamerica-northeast1-a"]
     }
     "northamerica-northeast2" = {
-      cidr_range = "10.157.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["northamerica-northeast2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["northamerica-northeast2-a"]
     }
     "northamerica-south1" = {
-      cidr_range = "10.158.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["northamerica-south1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["northamerica-south1-a"]
     }
     "southamerica-east1" = {
-      cidr_range = "10.159.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["southamerica-east1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["southamerica-east1-a"]
     }
     "southamerica-west1" = {
-      cidr_range = "10.160.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["southamerica-west1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["southamerica-west1-a"]
     }
     "us-central1" = {
-      cidr_range = "10.161.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-central1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-central1-a"]
     }
     "us-east1" = {
-      cidr_range = "10.162.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-east1-b"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-east1-b"]
     }
     "us-east4" = {
-      cidr_range = "10.163.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-east4-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-east4-a"]
     }
     "us-east5" = {
-      cidr_range = "10.164.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-east5-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-east5-a"]
     }
     "us-south1" = {
-      cidr_range = "10.165.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-south1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-south1-a"]
     }
     "us-west1" = {
-      cidr_range = "10.166.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-west1-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-west1-a"]
     }
     "us-west2" = {
-      cidr_range = "10.167.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-west2-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-west2-a"]
     }
     "us-west3" = {
-      cidr_range = "10.168.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-west3-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-west3-a"]
     }
     "us-west4" = {
-      cidr_range = "10.169.2.0/24"
-      type       = "e2-micro"
-      replicas   = 1
-      zones      = ["us-west4-a"]
+      type     = "e2-micro"
+      replicas = 1
+      zones    = ["us-west4-a"]
     }
   }
   container_registry      = module.google-artifact-registry.url

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -50,6 +50,12 @@ locals {
       value = var.api_url
     }
   ], var.application_environment_variables)
+
+  # Generate persistent CIDR blocks based on state tracking
+  instance_cidr_blocks = {
+    for region, instance in var.instances :
+    region => cidrsubnet(var.base_cidr_block, var.subnet_size, index(region, keys(var.instances)))
+  }
 }
 
 # Fetch most recent COS image
@@ -140,7 +146,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 
   project = var.project_id
 
-  name   = "relays-${each.key}"
+  name   = "relays-${each.key}-${local.instance_cidr_blocks[each.key]}"
   region = each.key
 
   network = google_compute_network.network.self_link
@@ -151,7 +157,7 @@ resource "google_compute_subnetwork" "subnetwork" {
   }
 
   stack_type               = "IPV4_IPV6"
-  ip_cidr_range            = each.value.cidr_range
+  ip_cidr_range            = local.instance_cidr_blocks[each.key]
   ipv6_access_type         = "EXTERNAL"
   private_ip_google_access = true
 }

--- a/terraform/modules/google-cloud/apps/relay/variables.tf
+++ b/terraform/modules/google-cloud/apps/relay/variables.tf
@@ -18,6 +18,18 @@ variable "instances" {
   description = "List deployment locations for the application."
 }
 
+variable "base_cidr_block" {
+  type        = string
+  default     = "10.129.0.0/16"
+  description = "The base CIDR block for subnets."
+}
+
+variable "subnet_size" {
+  description = "Subnet mask size for each region."
+  type        = number
+  default     = 24
+}
+
 ################################################################################
 ## Container Registry
 ################################################################################

--- a/terraform/modules/google-cloud/apps/relay/variables.tf
+++ b/terraform/modules/google-cloud/apps/relay/variables.tf
@@ -24,10 +24,10 @@ variable "base_cidr_block" {
   description = "The base CIDR block for subnets."
 }
 
-variable "subnet_size" {
-  description = "Subnet mask size for each region."
+variable "extension_bits" {
   type        = number
-  default     = 24
+  default     = 8
+  description = "Number of bits to extend the base CIDR block by."
 }
 
 ################################################################################

--- a/terraform/modules/google-cloud/apps/relay/variables.tf
+++ b/terraform/modules/google-cloud/apps/relay/variables.tf
@@ -9,10 +9,9 @@ variable "project_id" {
 
 variable "instances" {
   type = map(object({
-    cidr_range = string
-    type       = string
-    replicas   = number
-    zones      = list(string)
+    type     = string
+    replicas = number
+    zones    = list(string)
   }))
 
   description = "List deployment locations for the application."


### PR DESCRIPTION
When a Relay's instances are updated / changed, the contained subnetwork's `name` and `ip_cidr_range` need to be updated to something else because we are using the `create_before_destroy` lifecycle configuration for the Relays module.

To fix this, we need to make sure that when recreating Relays, we use a unique `name` and `ip_cidr_range` for the new instances so as not to conflict with existing ones.

To handle this, we use a computed state-tracked value for `ip_cidr_range` that will automatically adjust to the number of Relay regions we have and it will be incremented each time the Relays are recreated. Then we update the `name` to include this range to ensure we never have a subnet name that conflicts with an existing one.