### PR TITLE
chore(infra): Use `numeric` instead of `number`

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -146,7 +146,7 @@ resource "random_string" "subnet_suffix" {
   length  = 8
   special = false
   upper   = false
-  number  = true
+  numeric = true
 }
 
 resource "google_compute_subnetwork" "subnetwork" {

--- a/terraform/modules/google-cloud/apps/relay/variables.tf
+++ b/terraform/modules/google-cloud/apps/relay/variables.tf
@@ -19,7 +19,7 @@ variable "instances" {
 
 variable "base_cidr_block" {
   type        = string
-  default     = "10.129.0.0/16"
+  default     = "10.200.0.0/16"
   description = "The base CIDR block for subnets."
 }
 


### PR DESCRIPTION
`number` is deprecated for the built-in `random_string` resource.