### PR TITLE
fix(infra): Rotate random vars on each image version

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -50,12 +50,6 @@ locals {
       value = var.api_url
     }
   ], var.application_environment_variables)
-
-  # Generate persistent CIDR blocks based on state tracking
-  instance_cidr_blocks = {
-    for region, instance in var.instances :
-    region => cidrsubnet(var.base_cidr_block, var.extension_bits, index(keys(var.instances), region))
-  }
 }
 
 # Fetch most recent COS image
@@ -142,11 +136,27 @@ resource "google_compute_network" "network" {
 }
 
 # Subnet names must be unique across all regions
-resource "random_string" "subnet_suffix" {
+resource "random_string" "name_suffix" {
   length  = 8
   special = false
   upper   = false
   numeric = true
+
+  keepers = {
+    image_tag = var.image_tag
+  }
+}
+
+resource "random_integer" "numbering_offset" {
+  description = "Subnet numbering offset for relay instances to reduce the chance of collision."
+  min         = 0
+
+  # 10.129.0.0 - 10.255.255.255 is 32512 /24 subnets
+  max = 32512 - length(var.instances)
+
+  keepers = {
+    image_tag = var.image_tag
+  }
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
@@ -154,7 +164,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 
   project = var.project_id
 
-  name   = "relays-${each.key}-${random_string.subnet_suffix.result}"
+  name   = "relays-${each.key}-${random_string.name_suffix.result}"
   region = each.key
 
   network = google_compute_network.network.self_link
@@ -164,8 +174,14 @@ resource "google_compute_subnetwork" "subnetwork" {
     metadata             = "INCLUDE_ALL_METADATA"
   }
 
-  stack_type               = "IPV4_IPV6"
-  ip_cidr_range            = local.instance_cidr_blocks[each.key]
+  stack_type = "IPV4_IPV6"
+
+  # Sequentially numbered /24s given an offset
+  ip_cidr_range = cidrsubnet(
+    var.base_cidr_block,
+    var.extension_bits,
+    random_integer.numbering_offset + index(keys(var.instances), each.key)
+  )
   ipv6_access_type         = "EXTERNAL"
   private_ip_google_access = true
 }

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -148,8 +148,7 @@ resource "random_string" "name_suffix" {
 }
 
 resource "random_integer" "numbering_offset" {
-  description = "Subnet numbering offset for relay instances to reduce the chance of collision."
-  min         = 0
+  min = 0
 
   # 10.129.0.0 - 10.255.255.255 is 32512 /24 subnets
   max = 32512 - length(var.instances)

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -179,7 +179,7 @@ resource "google_compute_subnetwork" "subnetwork" {
   ip_cidr_range = cidrsubnet(
     var.base_cidr_block,
     var.extension_bits,
-    random_integer.numbering_offset + index(keys(var.instances), each.key)
+    random_integer.numbering_offset.result + index(keys(var.instances), each.key)
   )
   ipv6_access_type         = "EXTERNAL"
   private_ip_google_access = true

--- a/terraform/modules/google-cloud/apps/relay/variables.tf
+++ b/terraform/modules/google-cloud/apps/relay/variables.tf
@@ -20,7 +20,7 @@ variable "instances" {
 variable "base_cidr_block" {
   type        = string
   default     = "10.200.0.0/16"
-  description = "The base CIDR block for subnets."
+  description = "The base CIDR block for subnets. Must not overlap with existing subnet."
 }
 
 variable "extension_bits" {


### PR DESCRIPTION
The random vars introduced in #7730 don't actually rotate on each recreation. This PR fixes that and uses a random subnet offset to ensure the subnets are rotated each time the image tag changes.