### PR TITLE
fix(infra): Fix subnet numbering across all regions

### DIFF
--- a/terraform/environments/production/portal.tf
+++ b/terraform/environments/production/portal.tf
@@ -50,7 +50,7 @@ resource "google_compute_subnetwork" "apps" {
 
   stack_type = "IPV4_IPV6"
 
-  ip_cidr_range = "10.128.0.0/20"
+  ip_cidr_range = "10.2.2.0/20"
   region        = local.region
   network       = module.google-cloud-vpc.id
 

--- a/terraform/environments/staging/portal.tf
+++ b/terraform/environments/staging/portal.tf
@@ -50,7 +50,7 @@ resource "google_compute_subnetwork" "apps" {
 
   stack_type = "IPV4_IPV6"
 
-  ip_cidr_range = "10.128.0.0/20"
+  ip_cidr_range = "10.2.2.0/20"
   region        = local.region
   network       = module.google-cloud-vpc.id
 

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -150,8 +150,8 @@ resource "random_string" "name_suffix" {
 resource "random_integer" "numbering_offset" {
   min = 0
 
-  # 10.129.0.0 - 10.255.255.255 is 32512 /24 subnets
-  max = 32512 - length(var.instances)
+  # 10.128.0.0/9 is 2^(32-9) / 2^(32-24) = 32,768 /24 networks
+  max = 32767 - length(var.instances)
 
   keepers = {
     image_tag = var.image_tag

--- a/terraform/modules/google-cloud/apps/relay/variables.tf
+++ b/terraform/modules/google-cloud/apps/relay/variables.tf
@@ -19,13 +19,13 @@ variable "instances" {
 
 variable "base_cidr_block" {
   type        = string
-  default     = "10.200.0.0/16"
+  default     = "10.128.0.0/9"
   description = "The base CIDR block for subnets. Must not overlap with existing subnet."
 }
 
 variable "extension_bits" {
   type        = number
-  default     = 8
+  default     = 15
   description = "Number of bits to extend the base CIDR block by."
 }
 


### PR DESCRIPTION
#7733 fixed the randomness generation, but didn't fix the numbering. According to [GCP docs](https://cloud.google.com/vpc/docs/subnets), we can use virtually any RFC 1918 space for this.

This PR updates our numbering scheme to use the `10.128.0.0/9` space for Relay subnets and changes the elixir app to use `10.2.2.0/20` to prevent collisions.