### PR TITLE
ci: Skip package testing on main

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -103,6 +103,8 @@ jobs:
         run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.FIREZONE_GUI_VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
         shell: bash
+        env:
+          SKIP_PACKAGE_TEST: "${{ github.ref_name == 'main' }}"
         run: ${{ env.RENAME_SCRIPT }}
       - name: Upload debug symbols to Sentry
         if: ${{ github.ref_name == 'main' }}

--- a/scripts/build/tauri-rename-linux.sh
+++ b/scripts/build/tauri-rename-linux.sh
@@ -34,22 +34,24 @@ make_hash "$BINARY_DEST_PATH.dwp"
 make_hash "$BINARY_DEST_PATH.deb"
 make_hash "$BINARY_DEST_PATH.rpm"
 
-# Test the deb package, since this script is the easiest place to get a release build
-DEB_PATH=$(realpath "$BINARY_DEST_PATH.deb")
-sudo apt-get install "$DEB_PATH"
+if [[ ! "$SKIP_PACKAGE_TEST" == "true" ]]; then
+    # Test the deb package, since this script is the easiest place to get a release build
+    DEB_PATH=$(realpath "$BINARY_DEST_PATH.deb")
+    sudo apt-get install "$DEB_PATH"
 
-# Debug-print the files. The icons and both binaries should be in here
-dpkg --listfiles firezone-client-gui
-# Print the deps
-dpkg --info "$DEB_PATH"
+    # Debug-print the files. The icons and both binaries should be in here
+    dpkg --listfiles firezone-client-gui
+    # Print the deps
+    dpkg --info "$DEB_PATH"
 
-# Confirm that both binaries and at least one icon were installed
-which firezone-client-gui firezone-client-ipc
-stat /usr/share/icons/hicolor/512x512/apps/firezone-client-gui.png
+    # Confirm that both binaries and at least one icon were installed
+    which firezone-client-gui firezone-client-ipc
+    stat /usr/share/icons/hicolor/512x512/apps/firezone-client-gui.png
 
-# Make sure the binary got built, packaged, and installed, and at least
-# knows its own name
-firezone-client-gui --help | grep "Usage: firezone-client-gui"
+    # Make sure the binary got built, packaged, and installed, and at least
+    # knows its own name
+    firezone-client-gui --help | grep "Usage: firezone-client-gui"
 
-# Make sure the IPC service is running
-systemctl status "$SERVICE_NAME" || debug_exit
+    # Make sure the IPC service is running
+    systemctl status "$SERVICE_NAME" || debug_exit
+fi

--- a/scripts/build/tauri-rename-windows.sh
+++ b/scripts/build/tauri-rename-windows.sh
@@ -18,9 +18,11 @@ make_hash "$BINARY_DEST_PATH.exe"
 make_hash "$BINARY_DEST_PATH.msi"
 make_hash "$BINARY_DEST_PATH.pdb"
 
-# Test-install the MSI package, since it already exists here
-msiexec //i "$BINARY_DEST_PATH.msi" //log install.log //qn
-# For debugging
-cat install.log
-# Make sure the IPC service is running
-sc query FirezoneClientIpcService | grep RUNNING
+if [[ ! "$SKIP_PACKAGE_TEST" == "true" ]]; then
+    # Test-install the MSI package, since it already exists here
+    msiexec //i "$BINARY_DEST_PATH.msi" //log install.log //qn
+    # For debugging
+    cat install.log
+    # Make sure the IPC service is running
+    sc query FirezoneClientIpcService | grep RUNNING
+fi


### PR DESCRIPTION
Since these are already run on PRs, it doesn't make sense to run them again on `main` considering this step takes 1-2 minutes on the slowest CI job in the pipeline, thus slowing down the entire pipeline.