### PR TITLE
fix(infra): Rotate naming to taint old Relay instances

### DIFF
--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -46,7 +46,7 @@ locals {
 # Create networks
 resource "google_compute_network" "network" {
   project = module.google-cloud-project.project.project_id
-  name    = "relay"
+  name    = "relays"
 
   routing_mode = "GLOBAL"
 

--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -46,7 +46,7 @@ locals {
 # Create networks
 resource "google_compute_network" "network" {
   project = module.google-cloud-project.project.project_id
-  name    = "relay"
+  name    = "relays"
 
   routing_mode = "GLOBAL"
 

--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -60,7 +60,7 @@ resource "google_compute_network" "network" {
 resource "google_compute_subnetwork" "subnetwork" {
   for_each = local.subnet_ip_cidr_ranges
   project  = module.google-cloud-project.project.project_id
-  name     = "relay-${each.key}"
+  name     = "relays-${each.key}"
   region   = each.key
   network  = google_compute_network.network.self_link
 

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -147,7 +147,7 @@ resource "google_compute_instance_template" "application" {
 
   project = var.project_id
 
-  name_prefix = "${local.application_name}-${each.key}-"
+  name_prefix = "${local.application_name}-template-${each.key}-"
 
   description = "This template is used to create ${local.application_name} instances using Terraform."
 


### PR DESCRIPTION
The Relay instance template is sticking around because none of its inputs have changed, so we bump its name.