### PR TITLE
refactor(connlib): reset authorized resources on roaming

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1376,9 +1376,13 @@ impl ClientState {
     pub(crate) fn reset(&mut self, now: Instant) {
         tracing::info!("Resetting network state");
 
-        self.node.reset(now);
+        self.node.reset(now); // Clear all network connections.
+        self.peers.clear(); // Clear all state associated with Gateways.
+
+        self.resources_gateways.clear(); // Clear Resource <> Gateway mapping (we will re-create this as new flows are authorized).
+
         self.recently_connected_gateways.clear(); // Ensure we don't have sticky gateways when we roam.
-        self.dns_resource_nat_by_gateway.clear();
+        self.dns_resource_nat_by_gateway.clear(); // Clear all state related to DNS resource NATs.
         self.drain_node_events();
 
         // Resetting the client will trigger a failed `QueryResult` for each one that is in-progress.

--- a/rust/connlib/tunnel/src/peer_store.rs
+++ b/rust/connlib/tunnel/src/peer_store.rs
@@ -100,6 +100,11 @@ where
     pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut P> {
         self.peer_by_id.values_mut()
     }
+
+    pub(crate) fn clear(&mut self) {
+        self.id_by_ip = IpNetworkTable::new();
+        self.peer_by_id.clear();
+    }
 }
 
 pub(crate) trait Peer {


### PR DESCRIPTION
When a Firezone client roams, the host app sends a "reset" command to `connlib`. At present, this "reset" command clears the network connection state and therefore restarts ICE. As part of that, the tunnel key also gets rotated yet which resources have already been authorized is retained.

This isn't a problem per se because the client's identity is determined by the "Firezone ID" which persists even across restarts of a Client. For the Gateway however, a roamed Client and a restarted Client are indistinguishable as in both cases, the tunnel public key and ICE credentials change.

Instead of only clearing the connection-specific state, we now also throw away all the ACL state that is associated with connections, i.e. which Resource already got authorized on the Gateway. As a result - with this change - Clients will emit another "connection intent" to the portal upon roaming, triggering a new authorization of this flow with a Gateway.

There isn't any particular need for doing this except that lingering state can be a nasty source of bugs. With the now idempotent control protocol, it is pretty easy to re-request these authorisations. Overall, this makes `connlib` more resilient and easier to reason about.