### PR TITLE
fix(connlib): use a buffer pool for the GSO queue

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2234,6 +2234,7 @@ dependencies = [
  "ip_network",
  "ip_network_table",
  "itertools 0.13.0",
+ "lockfree-object-pool",
  "lru",
  "proptest",
  "proptest-state-machine",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5936,6 +5936,7 @@ dependencies = [
 name = "socket-factory"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "firezone-logging",
  "quinn-udp",
  "socket2",

--- a/rust/bin-shared/src/tun_device_manager.rs
+++ b/rust/bin-shared/src/tun_device_manager.rs
@@ -20,7 +20,6 @@ mod tests {
     use ip_network::Ipv4Network;
     use socket_factory::DatagramOut;
     use std::{
-        borrow::Cow,
         net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},
         time::Duration,
     };
@@ -101,9 +100,7 @@ mod tests {
             .send(DatagramOut {
                 src: None,
                 dst: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(141, 101, 90, 0), 3478)), // stun.cloudflare.com,
-                packet: Cow::Borrowed(&hex_literal::hex!(
-                    "000100002112A4420123456789abcdef01234567"
-                )),
+                packet: hex_literal::hex!("000100002112A4420123456789abcdef01234567").as_ref(),
                 segment_size: None,
             })
             .unwrap();

--- a/rust/bin-shared/src/tun_device_manager.rs
+++ b/rust/bin-shared/src/tun_device_manager.rs
@@ -100,7 +100,7 @@ mod tests {
             .send(DatagramOut {
                 src: None,
                 dst: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(141, 101, 90, 0), 3478)), // stun.cloudflare.com,
-                packet: hex_literal::hex!("000100002112A4420123456789abcdef01234567").as_ref(),
+                packet: &hex_literal::hex!("000100002112A4420123456789abcdef01234567").as_ref(),
                 segment_size: None,
             })
             .unwrap();

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -26,6 +26,7 @@ ip-packet = { workspace = true }
 ip_network = { workspace = true }
 ip_network_table = { workspace = true }
 itertools = { workspace = true, features = ["use_std"] }
+lockfree-object-pool = { workspace = true }
 lru = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }

--- a/rust/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/connlib/tunnel/src/io/gso_queue.rs
@@ -1,11 +1,10 @@
 use std::{
-    borrow::Cow,
     collections::BTreeMap,
     net::SocketAddr,
     time::{Duration, Instant},
 };
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use socket_factory::DatagramOut;
 
 use super::MAX_INBOUND_PACKET_BATCH;
@@ -60,14 +59,14 @@ impl GsoQueue {
             .extend(payload, now);
     }
 
-    pub fn datagrams(&mut self) -> impl Iterator<Item = DatagramOut<'static>> + '_ {
+    pub fn datagrams(&mut self) -> impl Iterator<Item = DatagramOut<Bytes>> + '_ {
         self.inner
             .iter_mut()
             .filter(|(_, b)| !b.is_empty())
             .map(|(key, buffer)| DatagramOut {
                 src: key.src,
                 dst: key.dst,
-                packet: Cow::Owned(buffer.inner.split().freeze().into()),
+                packet: buffer.inner.split().freeze(),
                 segment_size: Some(key.segment_size),
             })
     }

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -57,7 +57,10 @@ impl Sockets {
         Poll::Ready(Ok(()))
     }
 
-    pub fn send(&mut self, datagram: DatagramOut) -> io::Result<()> {
+    pub fn send<B>(&mut self, datagram: DatagramOut<B>) -> io::Result<()>
+    where
+        B: bytes::Buf,
+    {
         let socket = match datagram.dst {
             SocketAddr::V4(dst) => self.socket_v4.as_mut().ok_or_else(|| {
                 io::Error::new(

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -2,6 +2,7 @@ use socket_factory::{DatagramIn, DatagramOut, SocketFactory, UdpSocket};
 use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    ops::Deref,
     task::{ready, Context, Poll, Waker},
 };
 
@@ -59,7 +60,7 @@ impl Sockets {
 
     pub fn send<B>(&mut self, datagram: DatagramOut<B>) -> io::Result<()>
     where
-        B: bytes::Buf,
+        B: Deref<Target: bytes::Buf>,
     {
         let socket = match datagram.dst {
             SocketAddr::V4(dst) => self.socket_v4.as_mut().ok_or_else(|| {

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -61,11 +61,11 @@ pub const MAX_UDP_PAYLOAD: usize = MAX_IP_PAYLOAD - etherparse::UdpHeader::LEN;
 pub const MAX_FZ_PAYLOAD: usize =
     MAX_IP_SIZE + WG_OVERHEAD + NAT46_OVERHEAD + DATA_CHANNEL_OVERHEAD;
 /// Wireguard has a 32-byte overhead (4b message type + 4b receiver idx + 8b packet counter + 16b AEAD tag)
-const WG_OVERHEAD: usize = 32;
+pub const WG_OVERHEAD: usize = 32;
 /// In order to do NAT46 without copying, we need 20 extra byte in the buffer (IPv6 packets are 20 byte bigger than IPv4).
 pub(crate) const NAT46_OVERHEAD: usize = 20;
 /// TURN's data channels have a 4 byte overhead.
-const DATA_CHANNEL_OVERHEAD: usize = 4;
+pub const DATA_CHANNEL_OVERHEAD: usize = 4;
 
 macro_rules! for_both {
     ($this:ident, |$name:ident| $body:expr) => {

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -5,6 +5,7 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+bytes = { workspace = true }
 firezone-logging = { workspace = true }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -1,7 +1,9 @@
+use bytes::Buf as _;
 use firezone_logging::std_dyn_err;
 use quinn_udp::Transmit;
 use std::collections::HashMap;
 use std::fmt;
+use std::ops::Deref;
 use std::{
     io::{self, IoSliceMut},
     net::{IpAddr, SocketAddr},
@@ -276,12 +278,12 @@ impl UdpSocket {
 
     pub fn send<B>(&mut self, datagram: DatagramOut<B>) -> io::Result<()>
     where
-        B: bytes::Buf,
+        B: Deref<Target: bytes::Buf>,
     {
         let Some(transmit) = self.prepare_transmit(
             datagram.dst,
             datagram.src.map(|s| s.ip()),
-            datagram.packet.chunk(),
+            datagram.packet.deref().chunk(),
             datagram.segment_size,
         )?
         else {


### PR DESCRIPTION
Within `connlib`, we read batches of IP packets and process them at once. Each encrypted packet is appended to a buffer shared with other packets of the same length. Once the batch is successfully processed, all of these buffers are written out using GSO to the network. This allows UDP operations to be much more efficient because not every packet has to traverse the entire syscall hierarchy of the operating system.

Until now, these buffers got re-allocated on every batch. This is pretty wasteful and leads to a lot of repeated allocations. Measurements show that most of the time, we only have a handful of packets with different segments lengths _per batch_. For example, just booting up the headless-client and running a speedtest showed that only 5 of these buffers are were needed at one time.

By introducing a buffer pool, we can reuse these buffers between batches and avoid reallocating them.

Related: #7747.