### PR TITLE
chore(infra): Bump terraform to 1.10

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,7 +3,7 @@
 nodejs 20.14.0
 elixir 1.17.2-otp-27
 erlang 27.0.1
-terraform 1.9.7
+terraform 1.10.4
 
 # Used for static analysis
 python 3.11.9

--- a/terraform/environments/production/versions.tf
+++ b/terraform/environments/production/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.9.0"
+  required_version = "~> 1.10.0"
 
   required_providers {
     random = {

--- a/terraform/environments/staging/versions.tf
+++ b/terraform/environments/staging/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.9.0"
+  required_version = "~> 1.10.0"
 
   required_providers {
     random = {


### PR DESCRIPTION
Caught some [weird CI errors](https://github.com/firezone/firezone/actions/runs/12754884373/job/35551006515) about terraform 1.9.8 cache being corrupted, so I thought I'd go ahead and bump TF to the latest stable version.

