### PR TITLE
refactor(apple): `Adapter.start` doesn't need `async`

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -127,7 +127,7 @@ class Adapter {
   }
 
   /// Start the tunnel.
-  public func start() async throws {
+  public func start() throws {
     Log.log("Adapter.start")
     guard case .tunnelStopped = self.state else {
       throw AdapterError.invalidState(self.state)


### PR DESCRIPTION
This function is called from `PacketTunnelProvider.startTunnel`, which already uses the `completionHandler` approach for returning to the caller when the tunnel start operation is completed.

Thus `async / await` here is redundant and unnecessary.