### PR TITLE
refactor(apple): Use `kSecUseDataProtectionKeychain` for token

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
@@ -49,13 +49,17 @@ public struct Token: CustomStringConvertible {
 
       return try Keychain.update(
         query: query,
-        attributesToUpdate: [kSecValueData: data]
+        attributesToUpdate: [
+          kSecValueData: data,
+          kSecUseDataProtectionKeychain: true
+        ]
       )
     }
 
     let query = Token.query.merging([
       kSecClass: kSecClassGenericPassword,
-      kSecValueData: data
+      kSecValueData: data,
+      kSecUseDataProtectionKeychain: true
     ]) { (_, new) in new }
 
     try Keychain.add(query: query)


### PR DESCRIPTION
This will force the macOS Keychain to behave like the iOS Keychain. To be honest, Apple's documentation is very much lacking in this regard, but some research suggests this is both heavily recommended by Apple and that it enables the Keychain operation to benefit from Apple's security hardware in their Macs.

In my local testing, it also seems to make keychain operations more reliable when SIP is disabled, but that could be a fluke given the number of variables at play.

https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain

Draft because stacked.