### PR TITLE
fix(connlib): prevent time from going backwards

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -341,16 +341,16 @@ mod tests {
 
     #[tokio::test]
     async fn timer_is_reset_after_it_fires() {
-        let now = Instant::now();
         let mut io = Io::for_test();
 
-        io.reset_timeout(now + Duration::from_secs(1));
+        let deadline = Instant::now() + Duration::from_secs(1);
+        io.reset_timeout(deadline);
 
         let Input::Timeout(timeout) = io.next().await else {
             panic!("Unexpected result");
         };
 
-        assert_eq!(timeout, now + Duration::from_secs(1));
+        assert!(timeout >= deadline, "timer expire after deadline");
 
         let poll = io.poll_test();
 


### PR DESCRIPTION
On a high level, `connlib` is a state machine that gets driven by a custom event-loop. For time-related actions, the state machine computes, when it would like to be woken next. The event-loop sets a timer for that value and emits this value when the timer fires.

There is an edge-case where this may result in the time going backwards within the state machine. Specifically, if - for whatever reason - the state machine emits a time value that is in the past, the timer in the `Io` component will fire right away **but the `deadline` will point to the time in the past**.

The only thing we are actually interested in is that the timer fires at all. Instead of passing back the deadline of the timer, we fetch the _current_ time and pass that back to the state machine as the current input. This ensures that we never jump back in time because Rust guarantees for calls to `Instant::now` to be monotonic. (https://doc.rust-lang.org/std/time/struct.Instant.html#:~:text=a%20measurement%20of%20a%20monotonically%20nondecreasing%20clock.)