### PR TITLE
fix(apple/macOS): Handle outdated system extensions

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -38,8 +38,9 @@ public class AppViewModel: ObservableObject {
 
 #if os(macOS)
         try await self.store.checkedIfInstalled()
+        let isInstalled = self.store.systemExtensionStatus == .installed
 
-        if !self.store.isInstalled || self.store.status == .invalid {
+        if !isInstalled || self.store.status == .invalid {
 
           // Show the main Window if VPN permission needs to be granted
           AppViewModel.WindowDefinition.main.openWindow()
@@ -106,10 +107,10 @@ public struct AppView: View {
       }
     }
 #elseif os(macOS)
-    switch (model.store.isInstalled, model.status) {
-    case (_, nil):
+    switch (model.store.systemExtensionStatus, model.status) {
+    case (nil, nil):
       ProgressView()
-    case (false, _), (_, .invalid):
+    case (.needsInstall, _), (_, .invalid):
       GrantVPNView(model: GrantVPNViewModel(store: model.store))
     default:
       FirstTimeView()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -18,11 +18,13 @@ final class GrantVPNViewModel: ObservableObject {
   init(store: Store) {
     self.store = store
 
-    store.$isInstalled
+#if os(macOS)
+    store.$systemExtensionStatus
       .receive(on: DispatchQueue.main)
-      .sink(receiveValue: { [weak self] isInstalled in
-        self?.isInstalled = isInstalled
+      .sink(receiveValue: { [weak self] status in
+        self?.isInstalled = status == .installed
       }).store(in: &cancellables)
+#endif
   }
 
   func installSystemExtensionButtonTapped() {


### PR DESCRIPTION
When a user launches the macOS app, we check if the system extension is installed. If it was, we assumed it would function properly.

However, an older version of the extension can be installed from our current app version, so we would erroneously consider the extension as "installed" even though it needed to be updated.

To fix this, we introduced an enum for tracking the system extension state with `installed`, `needsReplacement`, and `needsInstall` states. These track whether the extension is up-to-date, needs upgrade (or downgrade), or needs to be approved and enabled by the user altogether respectively.

Importantly, this also gracefully handles downgrades, not just upgrades since we already return a `.replace` action in our request callback that the system calls when installing an extension with the same bundle ID as one that exists.