### PR TITLE
fix(apple): Don't log certain security errors in debug

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -113,7 +113,7 @@ public final class Log {
       return false
     }
 #endif
-    
+
     return true
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -105,9 +105,6 @@ public final class Log {
   // because these happen often due to code signing requirements.
   private static func shouldCaptureError(_ err: Error) -> Bool {
 #if DEBUG
-    if let _ = err as? FirezoneKit.KeychainError {
-      return false
-    }
     if let err = err as? VPNConfigurationManagerError,
        case VPNConfigurationManagerError.noIPCData = err {
       return false

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -53,7 +53,10 @@ public final class Log {
   public static func error(_ err: Error) {
     self.logger.error("\(err.localizedDescription, privacy: .public)")
     logWriter?.write(severity: .error, message: err.localizedDescription)
-    Telemetry.capture(err)
+
+    if shouldCaptureError(err) {
+      Telemetry.capture(err)
+    }
   }
 
   // Returns the size in bytes of the provided directory, calculated by summing
@@ -96,6 +99,22 @@ public final class Log {
     else { return }
 
     try FileManager.default.removeItem(at: directory)
+  }
+
+  // Don't capture certain kinds of IPC and security errors in DEBUG builds
+  // because these happen often due to code signing requirements.
+  private static func shouldCaptureError(_ err: Error) -> Bool {
+#if DEBUG
+    if let _ = err as? FirezoneKit.KeychainError {
+      return false
+    }
+    if let err = err as? VPNConfigurationManagerError,
+       case VPNConfigurationManagerError.noIPCData = err {
+      return false
+    }
+#endif
+    
+    return true
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -16,6 +16,7 @@ enum VPNConfigurationManagerError: Error {
   case cannotLoad
   case decodeIPCDataFailed
   case invalidStatusChange
+  case noIPCData
 
   var localizedDescription: String {
     switch self {
@@ -27,6 +28,8 @@ enum VPNConfigurationManagerError: Error {
       return "NEVPNStatusDidChange notification doesn't seem to be valid."
     case .cannotLoad:
       return "Could not load VPN configurations!"
+    case .noIPCData:
+      return "No IPC data returned from the XPC connection!"
     }
   }
 }
@@ -369,7 +372,7 @@ public class VPNConfigurationManager {
           guard let data = data
           else {
             continuation
-              .resume(throwing: VPNConfigurationManagerError.decodeIPCDataFailed)
+              .resume(throwing: VPNConfigurationManagerError.noIPCData)
 
             return
           }
@@ -399,7 +402,7 @@ public class VPNConfigurationManager {
         ) { data in
           guard let data = data
           else {
-            errorHandler(VPNConfigurationManagerError.decodeIPCDataFailed)
+            errorHandler(VPNConfigurationManagerError.noIPCData)
 
             return
           }


### PR DESCRIPTION
When building / testing the Apple clients locally, OS code signing and security requirements can cause certain types of errors to throw.

We still want to see these in the console, but not necessary capture them to Sentry.