### PR TITLE
Revert "refactor(apple): Use `kSecUseDataProtectionKeychain` for token"

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
@@ -49,17 +49,13 @@ public struct Token: CustomStringConvertible {
 
       return try Keychain.update(
         query: query,
-        attributesToUpdate: [
-          kSecValueData: data,
-          kSecUseDataProtectionKeychain: true
-        ]
+        attributesToUpdate: [kSecValueData: data]
       )
     }
 
     let query = Token.query.merging([
       kSecClass: kSecClassGenericPassword,
-      kSecValueData: data,
-      kSecUseDataProtectionKeychain: true
+      kSecValueData: data
     ]) { (_, new) in new }
 
     try Keychain.add(query: query)


### PR DESCRIPTION
After reading through this [Apple technical note](https://developer.apple.com/documentation/technotes/tn3137-on-mac-keychains), it's clear that we want to actually omit this key from our keychain queries.

The reason is because:

- on iOS, this will be already set (there is no other option)
- on macOS, the data protection keychain is *unavailable* from system extensions

After testing, it appears that the original issue that PR sought to fix was actually fixed by always installing the correct system extension version: #7759.

Reverts firezone/firezone#7756