### PR TITLE
fix(connlib): don't drop unsent datagrams

### DIFF
--- a/rust/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/connlib/tunnel/src/io/gso_queue.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    mem,
     net::SocketAddr,
     sync::Arc,
     time::{Duration, Instant},
@@ -80,12 +81,12 @@ impl GsoQueue {
     ) -> impl Iterator<Item = DatagramOut<lockfree_object_pool::SpinLockOwnedReusable<BytesMut>>> + '_
     {
         self.inner
-            .drain()
+            .iter_mut()
             .filter(|(_, b)| !b.is_empty())
             .map(|(key, buffer)| DatagramOut {
                 src: key.src,
                 dst: key.dst,
-                packet: buffer.inner,
+                packet: mem::replace(&mut buffer.inner, self.buffer_pool.pull_owned()),
                 segment_size: Some(key.segment_size),
             })
     }

--- a/rust/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/connlib/tunnel/src/io/gso_queue.rs
@@ -149,5 +149,22 @@ mod tests {
         assert_eq!(send_queue.inner.len(), 1);
     }
 
+    #[test]
+    fn dropping_datagram_iterator_does_not_drop_items() {
+        let now = Instant::now();
+        let mut send_queue = GsoQueue::new();
+
+        send_queue.enqueue(None, DST, b"foobar", now);
+
+        let datagrams = send_queue.datagrams();
+        drop(datagrams);
+
+        let datagrams = send_queue.datagrams().collect::<Vec<_>>();
+
+        assert_eq!(datagrams.len(), 1);
+        assert_eq!(datagrams[0].dst, DST);
+        assert_eq!(datagrams[0].packet.as_ref(), b"foobar");
+    }
+
     const DST: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1234));
 }


### PR DESCRIPTION
We introduced a regression in `connlib` in #7749 whereby queued but unsent datagrams got dropped in case the socket was not ready to send more data.

This happens because within `Io`, we pull each datagram one by one from the iterator: https://github.com/firezone/firezone/blob/e60ec7144cfb38c9fbbc26cd3d28e1f41665dc58/rust/connlib/tunnel/src/io.rs#L178-L188

This function will send datagrams for as long as the socket is ready and drop the iterator afterwards. This means the returned iterator MUST BE lazy and "cancel-safe". This was the case prior to #7749 because `datagrams` function used `iter_mut` and only cut off the to be sent bytes when the next item got pulled from iterator. With #7749, the entire `HashMap` got drained, thus dropping packets if `Io` didn't manage to process the iterator in full.