### PR TITLE
test(connlib): assert resource status as part of `tunnel_test`

### DIFF
--- a/rust/connlib/model/src/view.rs
+++ b/rust/connlib/model/src/view.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -11,6 +12,16 @@ pub enum ResourceStatus {
     Unknown,
     Online,
     Offline,
+}
+
+impl fmt::Display for ResourceStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResourceStatus::Unknown => write!(f, "unknown"),
+            ResourceStatus::Online => write!(f, "online"),
+            ResourceStatus::Offline => write!(f, "offline"),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1462,6 +1462,7 @@ impl ClientState {
             .insert(new_resource.id(), new_resource.clone());
 
         if !self.is_resource_enabled(&(new_resource.id())) {
+            self.emit_resources_changed(); // We still have a new resource but it is disabled, let the client know.
             return;
         }
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1553,7 +1553,6 @@ impl ClientState {
         let Some(peer) = peer_by_resource_mut(&self.resources_gateways, &mut self.peers, id) else {
             return;
         };
-        let gateway_id = peer.id();
 
         // First we remove the id from all allowed ips
         for (_, resources) in peer
@@ -1570,13 +1569,6 @@ impl ClientState {
 
         // We remove all empty allowed ips entry since there's no resource that corresponds to it
         peer.allowed_ips.retain(|_, r| !r.is_empty());
-
-        // If there's no allowed ip left we remove the whole peer because there's no point on keeping it around
-        if peer.allowed_ips.is_empty() {
-            self.peers.remove(&gateway_id);
-            self.update_site_status_by_gateway(&gateway_id, ResourceStatus::Unknown);
-            // TODO: should we have a Node::remove_connection?
-        }
 
         self.resources_gateways.remove(&id);
     }

--- a/rust/connlib/tunnel/src/client/resource.rs
+++ b/rust/connlib/tunnel/src/client/resource.rs
@@ -113,6 +113,11 @@ impl Resource {
         }
     }
 
+    /// Returns the [`Site`] of a [`Resource`] if there is exactly one site.
+    pub fn site(&self) -> Result<&Site, itertools::ExactlyOneError<impl Iterator<Item = &Site>>> {
+        self.sites().into_iter().exactly_one()
+    }
+
     /// What the GUI clients should show as the user-friendly display name, e.g. `Firezone GitHub`
     pub fn name(&self) -> &str {
         match self {

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -104,6 +104,31 @@ pub(crate) fn assert_tcp_packets_properties(
     );
 }
 
+pub(crate) fn assert_resource_status(ref_client: &RefClient, sim_client: &SimClient) {
+    let expected_status_map = &ref_client.expected_resource_status();
+    let actual_status_map = &sim_client.resource_status;
+
+    if expected_status_map != actual_status_map {
+        for (resource, expected_status) in expected_status_map {
+            match actual_status_map.get(resource) {
+                Some(actual_status) if actual_status != expected_status => {
+                    tracing::error!(target: "assertions", %expected_status, %actual_status, %resource, "Resource status doesn't match");
+                }
+                Some(_) => {}
+                None => {
+                    tracing::error!(target: "assertions", %expected_status, %resource, "Missing resource status");
+                }
+            }
+        }
+
+        for (resource, actual_status) in actual_status_map {
+            if expected_status_map.get(resource).is_none() {
+                tracing::error!(target: "assertions", %actual_status, %resource, "Unexpected resource status");
+            }
+        }
+    }
+}
+
 #[expect(clippy::too_many_arguments)]
 fn assert_packets_properties<T, U>(
     ref_client: &RefClient,

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -364,10 +364,6 @@ impl ReferenceState {
                 for query in queries {
                     state.client.exec_mut(|client| {
                         client.on_dns_query(query);
-
-                        if let Some(resource) = client.dns_query_via_resource(query) {
-                            client.connect_to_internet_or_cidr_resource(resource);
-                        }
                     });
                 }
             }

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use crate::{proptest::*, ClientState};
 use bimap::BiMap;
-use connlib_model::{ClientId, GatewayId, RelayId, ResourceId};
+use connlib_model::{ClientId, GatewayId, RelayId, ResourceId, ResourceStatus, SiteId};
 use domain::{
     base::{iana::Opcode, Message, MessageBuilder, Question, Rtype, ToName},
     rdata::AllRecordData,
@@ -48,6 +48,8 @@ pub(crate) struct SimClient {
 
     pub(crate) ipv4_routes: BTreeSet<Ipv4Network>,
     pub(crate) ipv6_routes: BTreeSet<Ipv6Network>,
+
+    pub(crate) resource_status: BTreeMap<ResourceId, ResourceStatus>,
 
     pub(crate) sent_udp_dns_queries: HashMap<(SocketAddr, QueryId), IpPacket>,
     pub(crate) received_udp_dns_responses: BTreeMap<(SocketAddr, QueryId), IpPacket>,
@@ -89,6 +91,7 @@ impl SimClient {
             received_udp_replies: Default::default(),
             ipv4_routes: Default::default(),
             ipv6_routes: Default::default(),
+            resource_status: Default::default(),
             tcp_dns_client,
         }
     }
@@ -433,6 +436,10 @@ pub struct RefClient {
     #[debug(skip)]
     pub(crate) disabled_resources: BTreeSet<ResourceId>,
 
+    /// The [`ResourceStatus`] of each site.
+    #[debug(skip)]
+    site_status: BTreeMap<SiteId, ResourceStatus>,
+
     /// The expected ICMP handshakes.
     #[debug(skip)]
     pub(crate) expected_icmp_handshakes:
@@ -525,6 +532,10 @@ impl RefClient {
     pub(crate) fn reset_connections(&mut self) {
         self.connected_cidr_resources.clear();
         self.connected_internet_resource = false;
+
+        for status in self.site_status.values_mut() {
+            *status = ResourceStatus::Unknown;
+        }
     }
 
     pub(crate) fn add_internet_resource(&mut self, r: InternetResource) {
@@ -573,6 +584,21 @@ impl RefClient {
                 Resource::Internet(i) => self.add_internet_resource(i),
             }
         }
+    }
+
+    pub(crate) fn expected_resource_status(&self) -> BTreeMap<ResourceId, ResourceStatus> {
+        self.resources
+            .iter()
+            .filter_map(|r| {
+                let status = self
+                    .site_status
+                    .get(&r.site().ok()?.id)
+                    .copied()
+                    .unwrap_or(ResourceStatus::Unknown);
+
+                Some((r.id(), status))
+            })
+            .collect()
     }
 
     pub(crate) fn is_tunnel_ip(&self, ip: IpAddr) -> bool {
@@ -657,6 +683,7 @@ impl RefClient {
         gateway_by_resource: impl Fn(ResourceId) -> Option<GatewayId>,
     ) {
         let Some(resource) = self.resource_by_dst(&dst) else {
+            tracing::warn!("Unknown resource");
             return;
         };
 
@@ -670,6 +697,7 @@ impl RefClient {
         tracing::Span::current().record("gateway", tracing::field::display(gateway));
 
         self.connect_to_resource(resource, dst);
+        self.set_resource_online(resource);
 
         if !self.is_tunnel_ip(src) {
             return;
@@ -688,6 +716,19 @@ impl RefClient {
             Destination::DomainName { .. } => {}
             Destination::IpAddr(_) => self.connect_to_internet_or_cidr_resource(resource),
         }
+    }
+
+    fn set_resource_online(&mut self, resource: ResourceId) {
+        let Some(Ok(site)) = self
+            .resources
+            .iter()
+            .find_map(|r| (r.id() == resource).then_some(r.site()))
+        else {
+            tracing::error!(%resource, "Unknown resource or multi-site resource");
+            return;
+        };
+
+        self.site_status.insert(site.id, ResourceStatus::Online);
     }
 
     fn is_connected_to_internet_or_cidr(&self, resource: ResourceId) -> bool {
@@ -728,6 +769,7 @@ impl RefClient {
 
         if let Some(resource) = self.dns_query_via_resource(query) {
             self.connect_to_internet_or_cidr_resource(resource);
+            self.set_resource_online(resource);
         }
     }
 
@@ -1060,6 +1102,7 @@ fn ref_client(
                     resources: Default::default(),
                     ipv4_routes: Default::default(),
                     ipv6_routes: Default::default(),
+                    site_status: Default::default(),
                 }
             },
         )

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -690,11 +690,11 @@ impl RefClient {
         }
     }
 
-    pub(crate) fn is_connected_to_internet_or_cidr(&self, resource: ResourceId) -> bool {
+    fn is_connected_to_internet_or_cidr(&self, resource: ResourceId) -> bool {
         self.is_connected_to_cidr(resource) || self.is_connected_to_internet(resource)
     }
 
-    pub(crate) fn connect_to_internet_or_cidr_resource(&mut self, resource: ResourceId) {
+    fn connect_to_internet_or_cidr_resource(&mut self, resource: ResourceId) {
         if self.internet_resource.is_some_and(|r| r == resource) {
             self.connected_internet_resource = true;
             return;
@@ -725,6 +725,10 @@ impl RefClient {
                     .push_back((query.dns_server, query.query_id));
             }
         }
+
+        if let Some(resource) = self.dns_query_via_resource(query) {
+            self.connect_to_internet_or_cidr_resource(resource);
+        }
     }
 
     pub(crate) fn ipv4_cidr_resource_dsts(&self) -> Vec<Ipv4Network> {
@@ -745,7 +749,7 @@ impl RefClient {
         self.active_internet_resource() == Some(id) && self.connected_internet_resource
     }
 
-    pub(crate) fn is_connected_to_cidr(&self, id: ResourceId) -> bool {
+    fn is_connected_to_cidr(&self, id: ResourceId) -> bool {
         self.connected_cidr_resources.contains(&id)
     }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -372,6 +372,7 @@ impl TunnelTest {
         assert_tcp_dns(ref_client, sim_client);
         assert_dns_servers_are_valid(ref_client, sim_client);
         assert_routes_are_valid(ref_client, sim_client);
+        assert_resource_status(ref_client, sim_client);
     }
 }
 
@@ -754,8 +755,13 @@ impl TunnelTest {
                 };
             }
 
-            ClientEvent::ResourcesChanged { .. } => {
-                tracing::warn!("Unimplemented");
+            ClientEvent::ResourcesChanged { resources } => {
+                self.client.exec_mut(|c| {
+                    c.resource_status = resources
+                        .into_iter()
+                        .map(|r| (r.id(), r.status()))
+                        .collect();
+                });
             }
             ClientEvent::TunInterfaceUpdated(config) => {
                 if self.client.inner().dns_mapping() == &config.dns_by_sentinel


### PR DESCRIPTION
In order to ensure that the "site status" in the UIs is always up-to-date, we model the resource status as part of `tunnel_test`. This should cover even the most bizarre combinations of adding, removing, disabling and enabling resources interleaved with sending packets, resetting connections etc.

Fixes: #7761.