### PR TITLE
fix(ci): Populate elixir vsn from env at build time

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -251,7 +251,9 @@ RUN cd apps/web \
     && mix assets.deploy
 
 # Copy the rest of the application files and compile them
-RUN mix compile
+# mix doesn't know when GIT_SHA changes, so --force is needed to avoid
+# pulling in a cached version.
+RUN mix compile --force
 
 FROM elixir as builder
 

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -226,10 +226,10 @@ COPY apps/domain/mix.exs ./apps/domain/mix.exs
 COPY apps/web/mix.exs ./apps/web/mix.exs
 COPY apps/api/mix.exs ./apps/api/mix.exs
 COPY config config
-COPY sha.exs .
 
 # Fetch and compile the dependencies
 ARG MIX_ENV="prod"
+ARG GIT_SHA
 RUN mix deps.get --only ${MIX_ENV}
 RUN mix deps.compile --skip-umbrella-children
 
@@ -269,6 +269,7 @@ COPY rel rel
 
 ARG APPLICATION_NAME
 ARG MIX_ENV="prod"
+ARG GIT_SHA
 RUN mix release ${APPLICATION_NAME}
 
 # start a new build stage so that the final image will only contain
@@ -300,10 +301,6 @@ COPY --from=builder /app/_build/${MIX_ENV}/rel/${APPLICATION_NAME} ./
 
 # Allow the default user to write to the priv directory of some libraries
 RUN chmod -R ugo+rw /app/lib/tzdata-*/priv
-
-# Populate the SHA pointing to this build
-ARG GIT_SHA
-RUN echo ${GIT_SHA} > ./GIT_SHA
 
 # Change user to "default" to limit runtime privileges
 USER default

--- a/elixir/apps/api/mix.exs
+++ b/elixir/apps/api/mix.exs
@@ -79,7 +79,7 @@ defmodule API.MixProject do
   end
 
   defp version do
-    sha = System.get_env("GIT_SHA", "deadbeef")
+    sha = System.get_env("GIT_SHA", "deadbeef") |> String.trim()
     "0.1.0+#{sha}"
   end
 end

--- a/elixir/apps/api/mix.exs
+++ b/elixir/apps/api/mix.exs
@@ -79,11 +79,7 @@ defmodule API.MixProject do
   end
 
   defp version do
-    if Mix.env() == :prod do
-      sha = System.fetch_env!("GIT_SHA")
-      "0.1.0+#{sha}"
-    else
-      "0.1.0+deadbeef"
-    end
+    sha = System.get_env("GIT_SHA", "dev")
+    "0.1.0+#{sha}"
   end
 end

--- a/elixir/apps/api/mix.exs
+++ b/elixir/apps/api/mix.exs
@@ -79,7 +79,7 @@ defmodule API.MixProject do
   end
 
   defp version do
-    sha = System.get_env("GIT_SHA", "dev")
+    sha = System.get_env("GIT_SHA", "deadbeef")
     "0.1.0+#{sha}"
   end
 end

--- a/elixir/apps/api/mix.exs
+++ b/elixir/apps/api/mix.exs
@@ -2,11 +2,9 @@ defmodule API.MixProject do
   use Mix.Project
 
   def project do
-    {sha, _} = Code.eval_file(Path.join([__DIR__, "..", "..", "sha.exs"]))
-
     [
       app: :api,
-      version: "0.1.0+#{sha}",
+      version: version(),
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -78,5 +76,14 @@ defmodule API.MixProject do
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
+  end
+
+  defp version do
+    if Mix.env() == :prod do
+      sha = System.fetch_env!("GIT_SHA")
+      "0.1.0+#{sha}"
+    else
+      "0.1.0+deadbeef"
+    end
   end
 end

--- a/elixir/apps/domain/mix.exs
+++ b/elixir/apps/domain/mix.exs
@@ -112,7 +112,7 @@ defmodule Domain.MixProject do
   end
 
   defp version do
-    sha = System.get_env("GIT_SHA", "deadbeef")
+    sha = System.get_env("GIT_SHA", "deadbeef") |> String.trim()
     "0.1.0+#{sha}"
   end
 end

--- a/elixir/apps/domain/mix.exs
+++ b/elixir/apps/domain/mix.exs
@@ -2,11 +2,9 @@ defmodule Domain.MixProject do
   use Mix.Project
 
   def project do
-    {sha, _} = Code.eval_file(Path.join([__DIR__, "..", "..", "sha.exs"]))
-
     [
       app: :domain,
-      version: "0.1.0+#{sha}",
+      version: version(),
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -111,5 +109,14 @@ defmodule Domain.MixProject do
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
+  end
+
+  defp version do
+    if Mix.env() == :prod do
+      sha = System.fetch_env!("GIT_SHA")
+      "0.1.0+#{sha}"
+    else
+      "0.1.0+dev"
+    end
   end
 end

--- a/elixir/apps/domain/mix.exs
+++ b/elixir/apps/domain/mix.exs
@@ -112,7 +112,7 @@ defmodule Domain.MixProject do
   end
 
   defp version do
-    sha = System.get_env("GIT_SHA", "dev")
+    sha = System.get_env("GIT_SHA", "deadbeef")
     "0.1.0+#{sha}"
   end
 end

--- a/elixir/apps/domain/mix.exs
+++ b/elixir/apps/domain/mix.exs
@@ -112,11 +112,7 @@ defmodule Domain.MixProject do
   end
 
   defp version do
-    if Mix.env() == :prod do
-      sha = System.fetch_env!("GIT_SHA")
-      "0.1.0+#{sha}"
-    else
-      "0.1.0+dev"
-    end
+    sha = System.get_env("GIT_SHA", "dev")
+    "0.1.0+#{sha}"
   end
 end

--- a/elixir/apps/web/mix.exs
+++ b/elixir/apps/web/mix.exs
@@ -104,11 +104,7 @@ defmodule Web.MixProject do
   end
 
   defp version do
-    if Mix.env() == :prod do
-      sha = System.fetch_env!("GIT_SHA")
-      "0.1.0+#{sha}"
-    else
-      "0.1.0+dev"
-    end
+    sha = System.get_env("GIT_SHA", "dev")
+    "0.1.0+#{sha}"
   end
 end

--- a/elixir/apps/web/mix.exs
+++ b/elixir/apps/web/mix.exs
@@ -104,7 +104,7 @@ defmodule Web.MixProject do
   end
 
   defp version do
-    sha = System.get_env("GIT_SHA", "dev")
+    sha = System.get_env("GIT_SHA", "deadbeef")
     "0.1.0+#{sha}"
   end
 end

--- a/elixir/apps/web/mix.exs
+++ b/elixir/apps/web/mix.exs
@@ -2,11 +2,9 @@ defmodule Web.MixProject do
   use Mix.Project
 
   def project do
-    {sha, _} = Code.eval_file(Path.join([__DIR__, "..", "..", "sha.exs"]))
-
     [
       app: :web,
-      version: "0.1.0+#{sha}",
+      version: version(),
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -103,5 +101,14 @@ defmodule Web.MixProject do
       "phx.server": ["ecto.create --quiet", "ecto.migrate", "phx.server"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
+  end
+
+  defp version do
+    if Mix.env() == :prod do
+      sha = System.fetch_env!("GIT_SHA")
+      "0.1.0+#{sha}"
+    else
+      "0.1.0+dev"
+    end
   end
 end

--- a/elixir/apps/web/mix.exs
+++ b/elixir/apps/web/mix.exs
@@ -104,7 +104,7 @@ defmodule Web.MixProject do
   end
 
   defp version do
-    sha = System.get_env("GIT_SHA", "deadbeef")
+    sha = System.get_env("GIT_SHA", "deadbeef") |> String.trim()
     "0.1.0+#{sha}"
   end
 end

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -95,7 +95,7 @@ defmodule Firezone.MixProject do
   end
 
   defp version do
-    sha = System.get_env("GIT_SHA", "deadbeef")
+    sha = System.get_env("GIT_SHA", "deadbeef") |> String.trim()
     "0.1.0+#{sha}"
   end
 end

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -95,11 +95,7 @@ defmodule Firezone.MixProject do
   end
 
   defp version do
-    if Mix.env() == :prod do
-      sha = System.fetch_env!("GIT_SHA")
-      "0.1.0+#{sha}"
-    else
-      "0.1.0+deadbeef"
-    end
+    sha = System.get_env("GIT_SHA", "dev")
+    "0.1.0+#{sha}"
   end
 end

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -2,12 +2,10 @@ defmodule Firezone.MixProject do
   use Mix.Project
 
   def project do
-    {sha, _} = Code.eval_file(Path.join([__DIR__, "sha.exs"]))
-
     [
       name: :firezone,
       apps_path: "apps",
-      version: "0.1.0+#{sha}",
+      version: version(),
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
@@ -94,5 +92,14 @@ defmodule Firezone.MixProject do
         ]
       ]
     ]
+  end
+
+  defp version do
+    if Mix.env() == :prod do
+      sha = System.fetch_env!("GIT_SHA")
+      "0.1.0+#{sha}"
+    else
+      "0.1.0+deadbeef"
+    end
   end
 end

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -95,7 +95,7 @@ defmodule Firezone.MixProject do
   end
 
   defp version do
-    sha = System.get_env("GIT_SHA", "dev")
+    sha = System.get_env("GIT_SHA", "deadbeef")
     "0.1.0+#{sha}"
   end
 end

--- a/elixir/sha.exs
+++ b/elixir/sha.exs
@@ -1,7 +1,0 @@
-case File.read(Path.join([__DIR__, "GIT_SHA"])) do
-  {:ok, sha} ->
-    sha |> String.trim()
-
-  _ ->
-    "deadbeef"
-end


### PR DESCRIPTION
Dependabot's workflow is set up in such a way it seems that it can't find our `sha.exs` file.

This is a cleaner approach that doesn't rely on using external files for the application version.

Interesting note: `mix compile` will happily use the cached `version` even though it's computed from an env var, because `mix compile` uses file hash and mtime to know when to recompile.

See https://github.com/firezone/firezone/network/updates/942719116