### PR TITLE
fix(portal): Catch seat limit error in API fallback controller

### DIFF
--- a/elixir/apps/api/lib/api/controllers/error_json.ex
+++ b/elixir/apps/api/lib/api/controllers/error_json.ex
@@ -1,4 +1,8 @@
 defmodule API.ErrorJSON do
+  def render(_template, %{reason: reason} = _assigns) do
+    %{error: %{reason: reason}}
+  end
+
   def render(template, _assigns) do
     %{error: %{reason: Phoenix.Controller.status_message_from_template(template)}}
   end

--- a/elixir/apps/api/lib/api/controllers/fallback_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/fallback_controller.ex
@@ -36,6 +36,13 @@ defmodule API.FallbackController do
     |> render(:error, reason: "Seat Limit Reached")
   end
 
+  def call(conn, {:error, :service_accounts_limit_reached}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: API.ErrorJSON)
+    |> render(:error, reason: "Service Accounts Limit Reached")
+  end
+
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/elixir/apps/api/lib/api/controllers/fallback_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/fallback_controller.ex
@@ -29,6 +29,13 @@ defmodule API.FallbackController do
     |> render(:"422")
   end
 
+  def call(conn, {:error, :seats_limit_reached}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: API.ErrorJSON)
+    |> render(:error, reason: "Seat Limit Reached")
+  end
+
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)


### PR DESCRIPTION
Why:

* The fallback controller in the API was not catching `{:error, :seat_limit_reached}` being returned and was then generating a 500 response when this happened.  This commit adds the condition in the fallback controller and adds a new template for a more specific error message in the returned JSON.