### PR TITLE
fix(website): Use relative hrefs for downloads on changelog

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -11,7 +11,7 @@ export default function Android() {
       title: "Download on Google Play",
     },
     {
-      href: "https://www.firezone.dev/dl/firezone-client-android/:version",
+      href: "/dl/firezone-client-android/:version",
       title: "Download APK",
     },
   ];

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -11,7 +11,7 @@ export default function Apple() {
       title: "Download on App Store for macOS and iOS",
     },
     {
-      href: "https://www.firezone.dev/dl/firezone-client-macos/latest",
+      href: "/dl/firezone-client-macos/:version",
       title: "Download standalone package for macOS",
     },
   ];

--- a/website/src/components/Changelog/Entries.tsx
+++ b/website/src/components/Changelog/Entries.tsx
@@ -47,7 +47,7 @@ function Latest({
           {downloadLinks.map((link) => (
             <Link
               key={link.href}
-              href={new URL(link.href.replace(":version", version))}
+              href={{ pathname: link.href.replace(":version", version) }}
               className="hover:no-underline underline text-accent-500 mr-2"
             >
               {link.title}

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,17 +10,17 @@ export default function GUI({ title }: { title: string }) {
       ? [
           {
             title: "Download for x86_64",
-            href: "https://www.firezone.dev/dl/firezone-client-gui-windows/:version/x86_64",
+            href: "/dl/firezone-client-gui-windows/:version/x86_64",
           },
         ]
       : [
           {
             title: "Download for x86_64",
-            href: "https://www.firezone.dev/dl/firezone-client-gui-linux/:version/x86_64",
+            href: "/dl/firezone-client-gui-linux/:version/x86_64",
           },
           {
             title: "Download for aarch64",
-            href: "https://www.firezone.dev/dl/firezone-client-gui-linux/:version/aarch64",
+            href: "/dl/firezone-client-gui-linux/:version/aarch64",
           },
         ];
 

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -7,15 +7,15 @@ import Unreleased from "./Unreleased";
 export default function Gateway() {
   const downloadLinks = [
     {
-      href: "https://www.firezone.dev/dl/firezone-gateway/:version/x86_64",
+      href: "/dl/firezone-gateway/:version/x86_64",
       title: "Download for x86_64",
     },
     {
-      href: "https://www.firezone.dev/dl/firezone-gateway/:version/aarch64",
+      href: "/dl/firezone-gateway/:version/aarch64",
       title: "Download for aarch64",
     },
     {
-      href: "https://www.firezone.dev/dl/firezone-gateway/:version/armv7",
+      href: "/dl/firezone-gateway/:version/armv7",
       title: "Download for armv7",
     },
   ];

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -7,15 +7,15 @@ import Unreleased from "./Unreleased";
 export default function Headless() {
   const downloadLinks = [
     {
-      href: "https://www.firezone.dev/dl/firezone-client-headless-linux/:version/x86_64",
+      href: "/dl/firezone-client-headless-linux/:version/x86_64",
       title: "Download for x86_64",
     },
     {
-      href: "https://www.firezone.dev/dl/firezone-client-headless-linux/:version/aarch64",
+      href: "/dl/firezone-client-headless-linux/:version/aarch64",
       title: "Download for aarch64",
     },
     {
-      href: "https://www.firezone.dev/dl/firezone-client-headless-linux/:version/armv7",
+      href: "/dl/firezone-client-headless-linux/:version/armv7",
       title: "Download for armv7",
     },
   ];

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -62,6 +62,8 @@ const versionedRedirects = [
 
 export const config = {
   matcher: [
+    "/dl/firezone-client-macos/(\\d+).(\\d+).(\\d+)",
+    "/dl/firezone-client-android/(\\d+).(\\d+).(\\d+)",
     "/dl/firezone-client-gui-windows/(\\d+).(\\d+).(\\d+)/x86_64",
     "/dl/firezone-client-gui-linux/(\\d+).(\\d+).(\\d+)/x86_64",
     "/dl/firezone-client-gui-linux/(\\d+).(\\d+).(\\d+)/aarch64",


### PR DESCRIPTION
These weren't being loaded correctly for Android and Apple, and are now updated to use relative paths.