### PR TITLE
ci: Only upload Tauri builds on workflow_dispatch

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -66,7 +66,7 @@ jobs:
           STANDALONE_BUILD_CERT: "${{ secrets.APPLE_STANDALONE_BUILD_CERTIFICATE_BASE64 }}"
           STANDALONE_BUILD_CERT_PASS: "${{ secrets.APPLE_STANDALONE_BUILD_CERTIFICATE_P12_PASSWORD }}"
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
-          NOTARIZE: "${{ (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main') }}"
+          NOTARIZE: "${{ (github.event_name == 'workflow_dispatch' }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
@@ -82,13 +82,13 @@ jobs:
           RELEASE_NAME: "${{ matrix.release-name }}"
           PLATFORM: "${{ matrix.platform }}"
       - name: Setup sentry CLI
-        if: ${{ github.ref_name == 'main' }}
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           organization: firezone-inc
       - name: Upload debug symbols to Sentry
-        if: ${{ github.ref_name == 'main' }}
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         run: |
           # Remove the /Applications symlink in the DMG staging directory so Sentry doesn't
           # attempt to walk it.

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -66,7 +66,7 @@ jobs:
           STANDALONE_BUILD_CERT: "${{ secrets.APPLE_STANDALONE_BUILD_CERTIFICATE_BASE64 }}"
           STANDALONE_BUILD_CERT_PASS: "${{ secrets.APPLE_STANDALONE_BUILD_CERTIFICATE_P12_PASSWORD }}"
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
-          NOTARIZE: "${{ (github.event_name == 'workflow_dispatch' }}"
+          NOTARIZE: "${{ github.event_name == 'workflow_dispatch' }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -102,20 +102,23 @@ jobs:
         shell: bash
         run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.FIREZONE_GUI_VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         shell: bash
         run: ${{ env.RENAME_SCRIPT }}
       - name: Upload debug symbols to Sentry
-        if: ${{ github.ref_name == 'main' }}
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         run: |
           sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
           sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target
       - name: Upload package
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ env.ARTIFACT_DST }}-pkg
           path: ${{ env.ARTIFACT_SRC }}.${{ matrix.pkg-extension }}
           if-no-files-found: error
       - name: Upload rpm package
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         if: ${{ runner.os == 'Linux' }}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
@@ -123,8 +126,7 @@ jobs:
           path: ${{ env.ARTIFACT_SRC }}.rpm
           if-no-files-found: error
       - name: Upload Release Assets
-        # Only upload the GUI Client build to the drafted release on main builds
-        if: ${{ github.ref_name == 'main' }}
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -1,16 +1,7 @@
 name: Tauri
 on:
   workflow_call:
-    inputs:
-      release_tag:
-        required: false
-        type: string
   workflow_dispatch:
-
-permissions:
-  # For saving to release
-  contents: write
-  id-token: write
 
 defaults:
   run:
@@ -25,6 +16,9 @@ jobs:
   build-gui:
     name: build-gui-${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: write # for attaching the build artifacts to the release
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -102,23 +96,19 @@ jobs:
         shell: bash
         run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.FIREZONE_GUI_VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
         shell: bash
         run: ${{ env.RENAME_SCRIPT }}
       - name: Upload debug symbols to Sentry
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
         run: |
           sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
           sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target
       - name: Upload package
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ env.ARTIFACT_DST }}-pkg
           path: ${{ env.ARTIFACT_SRC }}.${{ matrix.pkg-extension }}
           if-no-files-found: error
       - name: Upload rpm package
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
         if: ${{ runner.os == 'Linux' }}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
@@ -126,7 +116,6 @@ jobs:
           path: ${{ env.ARTIFACT_SRC }}.rpm
           if-no-files-found: error
       - name: Upload Release Assets
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  tauri:
-    needs: update-release-draft
-    uses: ./.github/workflows/_tauri.yml
-    secrets: inherit
-
   build-artifacts:
     needs: update-release-draft
     uses: ./.github/workflows/_build_artifacts.yml


### PR DESCRIPTION
Similar to the Apple and Android clients, this PR updates the Linux and Windows GUI clients to upload to the GitHub drafted release on manual workflow triggers only.

This should save a few minutes off `main` builds as the extra package testing steps will now be skipped there.

Notably, the Gateway and Headless Client workflows are unchanged because (a) they are much faster to build / test and (b) we use the release builds for performance testing connlib, so we need them to run on `main`.