### PR TITLE
fix(apple): Use Task.detached to open URLs

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -231,7 +231,7 @@ public final class Store: ObservableObject {
 
       do {
         try await self.vpnConfigurationManager.saveSettings(newSettings)
-        await DispatchQueue.main.async { self.settings = newSettings }
+        await MainActor.run { self.settings = newSettings }
       } catch {
         Log.error(error)
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -138,7 +138,9 @@ public extension AppViewModel {
         window.makeKeyAndOrderFront(self)
       } else {
         // Open new window
-        NSWorkspace.shared.open(externalEventOpenURL)
+        Task.detached {
+          NSWorkspace.shared.open(externalEventOpenURL)
+        }
       }
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -292,22 +292,34 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func adminPortalButtonTapped() {
-    let url = URL(string: model.store.settings.authBaseURL)!
-    NSWorkspace.shared.open(url)
+    guard let url = URL(string: model.store.settings.authBaseURL)
+    else { return }
+
+    Task.detached {
+      NSWorkspace.shared.open(url)
+    }
   }
 
   @objc private func updateAvailableButtonTapped() {
-    NSWorkspace.shared.open(UpdateChecker.downloadURL())
+    Task.detached {
+      NSWorkspace.shared.open(UpdateChecker.downloadURL())
+    }
   }
 
   @objc private func documentationButtonTapped() {
     let url = URL(string: "https://www.firezone.dev/kb?utm_source=macos-client")!
-    NSWorkspace.shared.open(url)
+
+    Task.detached {
+      NSWorkspace.shared.open(url)
+    }
   }
 
   @objc private func supportButtonTapped() {
     let url = URL(string: "https://www.firezone.dev/support?utm_source=macos-client")!
-    NSWorkspace.shared.open(url)
+
+    Task.detached {
+      NSWorkspace.shared.open(url)
+    }
   }
 
   @objc private func aboutButtonTapped() {
@@ -777,9 +789,11 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func resourceURLTapped(_ sender: AnyObject?) {
-    if let value = (sender as? NSMenuItem)?.title {
-      // URL has already been validated
-      NSWorkspace.shared.open(URL(string: value)!)
+    if let value = (sender as? NSMenuItem)?.title,
+       let url = URL(string: value) {
+      Task.detached {
+        NSWorkspace.shared.open(url)
+      }
     }
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -154,7 +154,9 @@ private class NotificationAdapter: NSObject, UNUserNotificationCenterDelegate {
         return
       }
 
+    Task.detached {
       NSWorkspace.shared.open(UpdateChecker.downloadURL())
+    }
 
       completionHandler()
   }


### PR DESCRIPTION
Opening URLs using `NSWorkspace.shared.open(url)` (which potentially launches the browser) is a blocking operation on Apple platforms. This will cause the UI to hang if called from a UI thread, so we need to avoid that with a Task.