### PR TITLE
revert: Add tauri release build to CI

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -96,26 +96,30 @@ jobs:
         shell: bash
         run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.FIREZONE_GUI_VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         shell: bash
         run: ${{ env.RENAME_SCRIPT }}
       - name: Upload debug symbols to Sentry
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         run: |
           sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
           sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target
       - name: Upload package
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ env.ARTIFACT_DST }}-pkg
           path: ${{ env.ARTIFACT_SRC }}.${{ matrix.pkg-extension }}
           if-no-files-found: error
       - name: Upload rpm package
-        if: ${{ runner.os == 'Linux' }}
+        if: "${{ runner.os == 'Linux' && github.event_name == 'workflow_dispatch' }}"
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ env.ARTIFACT_DST }}-rpm
           path: ${{ env.ARTIFACT_SRC }}.rpm
           if-no-files-found: error
       - name: Upload Release Assets
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  tauri:
+    uses: ./.github/workflows/_tauri.yml
+    secrets: inherit
+
   build-artifacts:
     needs: update-release-draft
     uses: ./.github/workflows/_build_artifacts.yml


### PR DESCRIPTION
Reverts the portion of #7795 that removed Tauri release builds from running in PRs.