### PR TITLE
test: Ensure relayed curl works after one refresh interval

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -108,6 +108,7 @@ jobs:
           - name: dns-nm
           - name: tcp-dns
           - name: relay-graceful-shutdown
+          - name: relayed-curl-after-refresh
           - name: systemd/dns-systemd-resolved
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/scripts/tests/relayed-curl-after-refresh.sh
+++ b/scripts/tests/relayed-curl-after-refresh.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source "./scripts/tests/lib.sh"
+
+# Arrange: Setup a relayed connection
+install_iptables_drop_rules
+
+# Arrange: Wait for one allocation refresh cycle
+sleep 315
+
+# Assert: Dataplane still works
+client_curl_resource "172.20.0.100/get"


### PR DESCRIPTION
Due to the strange findings in #7763, it might be a good idea to add an integration that ensures we can still relay data after one allocation refresh cycle.

Because we have longer tests in CI (e.g. the tauri builds regularly take 10-15 minutes), this shouldn't slow the pipeline down.