### PR TITLE
refactor(apple): Optionally capture in Log.error

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -50,11 +50,11 @@ public final class Log {
     logWriter?.write(severity: .warning, message: message)
   }
 
-  public static func error(_ err: Error) {
+  public static func error(_ err: Error, capture: Bool = true) {
     self.logger.error("\(err.localizedDescription, privacy: .public)")
     logWriter?.write(severity: .error, message: err.localizedDescription)
 
-    if shouldCaptureError(err) {
+    if capture && errorNotIgnored(err) {
       Telemetry.capture(err)
     }
   }
@@ -103,7 +103,7 @@ public final class Log {
 
   // Don't capture certain kinds of IPC and security errors in DEBUG builds
   // because these happen often due to code signing requirements.
-  private static func shouldCaptureError(_ err: Error) -> Bool {
+  private static func errorNotIgnored(_ err: Error) -> Bool {
 #if DEBUG
     if let err = err as? VPNConfigurationManagerError,
        case VPNConfigurationManagerError.noIPCData = err {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -54,7 +54,7 @@ public final class Log {
     self.logger.error("\(err.localizedDescription, privacy: .public)")
     logWriter?.write(severity: .error, message: err.localizedDescription)
 
-    if capture && errorNotIgnored(err) {
+    if capture && errorNotGloballyIgnored(err) {
       Telemetry.capture(err)
     }
   }
@@ -103,7 +103,7 @@ public final class Log {
 
   // Don't capture certain kinds of IPC and security errors in DEBUG builds
   // because these happen often due to code signing requirements.
-  private static func errorNotIgnored(_ err: Error) -> Bool {
+  private static func errorNotGloballyIgnored(_ err: Error) -> Bool {
 #if DEBUG
     if let err = err as? VPNConfigurationManagerError,
        case VPNConfigurationManagerError.noIPCData = err {


### PR DESCRIPTION
We want to write certain kinds of errors to the log files but not capture them to Sentry.

This refactors the previous logic to add an optional `capture` argument to the `Log.error` call so that we can control this from the context under which it's called. That way we can determine on a case by case basis whether to capture certain errors, or not.