### PR TITLE
refactor(apple): Downgrade `noIPCData` to warning for logs

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -92,7 +92,13 @@ public final class SettingsViewModel: ObservableObject {
       return byteCountFormatter.string(fromByteCount: Int64(totalSize))
 
     } catch {
-      Log.error(error)
+      if let error = error as? VPNConfigurationManagerError,
+         case VPNConfigurationManagerError.noIPCData = error {
+        // Will happen if the extension is not enabled
+        Log.error(error, capture: false)
+      } else {
+        Log.error(error)
+      }
 
       return "Unknown"
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -622,7 +622,12 @@ public struct SettingsView: View {
               window.contentViewController?.presentingViewController?.dismiss(self)
             }
           } catch {
-            Log.error(error)
+            if let error = error as? VPNConfigurationManagerError,
+               case VPNConfigurationManagerError.noIPCData = error {
+              Log.warning("\(#function): Error exporting logs: \(error). Is the XPC service running?")
+            } else {
+              Log.error(error)
+            }
 
             let alert = await NSAlert()
             await MainActor.run {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -95,7 +95,7 @@ public final class SettingsViewModel: ObservableObject {
       if let error = error as? VPNConfigurationManagerError,
          case VPNConfigurationManagerError.noIPCData = error {
         // Will happen if the extension is not enabled
-        Log.error(error, capture: false)
+        Log.warning("\(#function): Unable to count logs: \(error). Is the XPC service running?")
       } else {
         Log.error(error)
       }


### PR DESCRIPTION
If the system extension has not been enabled by the user, opening the `Settings -> Diagnostic Logs` pane will trigger this error. There's nothing we can do until they enable the system extension, so don't capture this particular case in Sentry.