### PR TITLE
refactor(apple): Downgrade DNS failures during `Adapter.start`

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -113,8 +113,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       completionHandler(error)
 
     } catch {
+      if let error = error as? AdapterError,
+         case AdapterError.connlibConnectError(let string) = error,
+         string.contains("nodename nor servname provided") {
+        // User likely tried to start the tunnel while offline
+        Log.warning("\(#function): \(error)")
+      } else {
+        Log.error(error)
+      }
 
-      Log.error(error)
       completionHandler(error)
     }
   }


### PR DESCRIPTION
If the user's device is offline or otherwise unable to resolve the API host while connecting connlib, we don't necessarily need to know about this in Sentry.