### PR TITLE
fix(ci): Run PR title check on PR edit

### DIFF
--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -1,6 +1,8 @@
 name: Static Analysis
 on:
   workflow_call:
+  pull_request:
+    types: [edited]
 
 jobs:
   pr-lint:


### PR DESCRIPTION
If the PR title violates the length check, editing it and re-running the job wouldn't fix it because the original title was still referenced.

To fix this, we introduce a trigger for this check that runs specifically on PR edit.