### PR TITLE
fix(snownet): implement STUN keepalive with relays

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5917,6 +5917,7 @@ dependencies = [
  "boringtun",
  "bytecodec",
  "bytes",
+ "derive_more 1.0.0",
  "firezone-logging",
  "hex",
  "hex-display",

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -9,6 +9,7 @@ backoff = { workspace = true }
 boringtun = { workspace = true }
 bytecodec = { workspace = true }
 bytes = { workspace = true }
+derive_more = { workspace = true, features = ["debug"] }
 firezone-logging = { workspace = true }
 hex = { workspace = true }
 hex-display = { workspace = true }

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -2238,27 +2238,6 @@ mod tests {
     }
 
     #[test]
-    fn failed_refresh_resets_allocation_lifetime() {
-        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
-
-        let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input_ip4(
-            &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
-            Instant::now(),
-        );
-
-        allocation.advance_to_next_timeout();
-
-        let refresh = allocation.next_message().unwrap();
-        allocation.handle_test_input_ip4(&allocation_mismatch(&refresh), Instant::now());
-
-        let allocate = allocation.next_message().unwrap();
-        allocation.handle_test_input_ip4(&server_error(&allocate), Instant::now()); // These ones are not retried.
-
-        assert_eq!(allocation.poll_timeout(), None);
-    }
-
-    #[test]
     fn when_refreshed_with_no_allocation_after_failed_response_tries_to_allocate() {
         let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
 
@@ -2836,12 +2815,6 @@ mod tests {
         /// Wrapper around `handle_input` that always sets `RELAY` and `PEER1`.
         fn handle_test_input_ip4(&mut self, packet: &[u8], now: Instant) -> bool {
             self.handle_input(RELAY_V4.into(), PEER1, packet, now)
-        }
-
-        fn advance_to_next_timeout(&mut self) {
-            if let Some(next) = self.poll_timeout() {
-                self.handle_timeout(next)
-            }
         }
 
         fn refresh_with_same_credentials(&mut self) {

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -2203,21 +2203,18 @@ mod tests {
 
     #[test]
     fn allocation_is_refreshed_after_half_its_lifetime() {
-        let mut allocation = Allocation::for_test_ip4(Instant::now()).with_binding_response(PEER1);
+        let mut now = Instant::now();
+        let mut allocation = Allocation::for_test_ip4(now).with_binding_response(PEER1);
 
         let allocate = allocation.next_message().unwrap();
 
-        let received_at = Instant::now();
-
         allocation.handle_test_input_ip4(
             &allocate_response(&allocate, &[RELAY_ADDR_IP4, RELAY_ADDR_IP6]),
-            received_at,
+            now,
         );
 
-        let refresh_at = allocation.poll_timeout().unwrap();
-        assert_eq!(refresh_at, received_at + (ALLOCATION_LIFETIME / 2));
-
-        allocation.handle_timeout(refresh_at);
+        now += ALLOCATION_LIFETIME / 2;
+        allocation.handle_timeout(now);
 
         let refresh = iter::from_fn(|| allocation.next_message()).find(|m| m.method() == REFRESH);
         assert!(refresh.is_some());

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -697,7 +697,11 @@ impl Allocation {
 
             // If we have an active socket (i.e. successfully sent at least 1 BINDING request)
             // and we just timed out a message, invalidate the allocation.
-            if !queued && self.active_socket.is_some() {
+            if !queued
+                && self
+                    .active_socket
+                    .is_some_and(|s| s.same_ip_version_as(dst))
+            {
                 self.active_socket = None; // The socket seems to no longer be reachable.
                 self.invalidate_allocation();
             }
@@ -1124,6 +1128,10 @@ impl ActiveSocket {
             addr,
             next_binding: now + BINDING_INTERVAL,
         }
+    }
+
+    fn same_ip_version_as(&self, dst: SocketAddr) -> bool {
+        self.addr.is_ipv4() == dst.is_ipv4()
     }
 
     fn handle_timeout(&mut self, now: Instant) -> Option<SocketAddr> {


### PR DESCRIPTION
Firezone Clients and Gateways create an allocation with a given set of Relays as soon as they start up. If no traffic is being secured and thus no connections are established between them, NAT bindings between Clients / Gateways and the Relays may expire. Typically, these bindings last for 120s. Allocations are only refreshed every 5 min (after 50% of their lifetime has passed). 

After a NAT binding is expired, the next UDP message passing through the NAT may allocate a new port, thus changing the 3-tuple of the sender. TURN identifies clients by their 3-tuple. Therefore, without a proactive keepalive, TURN clients lose access to their allocation and need to create one under the new port.

To fix this, we implement a scheduled STUN binding request every 25s once we have chosen a socket (IPv4 or IPv6) for a given relay.

Resolves: #7802.