### PR TITLE
fix(gui-client): don't hard-fail if update-desktop-database doesn't exist

### DIFF
--- a/rust/gui-client/src-common/src/deep_link/linux.rs
+++ b/rust/gui-client/src-common/src/deep_link/linux.rs
@@ -145,7 +145,7 @@ Categories=Network;
         }
         Err(e) if e.kind() == ErrorKind::NotFound => {
             // This is not an Ubuntu machine, so this executable won't exist.
-            tracing::debug!("Could not find update-desktop-database command, ignoring");
+            tracing::debug!("Could not find {update_desktop_database} command, ignoring");
         }
         Err(e) => {
             return Err(e).with_context(|| format!("failed to run `{update_desktop_database}`"));


### PR DESCRIPTION
Currently the gui client exits if `update-desktop-database` cannot be executed after deep-links were registered. On non-Ubuntu systems (or more generally non-Debian) this will fail since the command does not exist and prevent the gui-client from starting. 

This PR just ignores any command-not-found error, ensuring the command still has to succeed on debian/ubuntu machines.
