### PR TITLE
test(windows): increase grace-period for timer `Io` timer

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -369,7 +369,13 @@ mod tests {
             panic!("Unexpected result");
         };
 
-        assert!(timeout.duration_since(now) < Duration::from_millis(1));
+        let grace_period = if cfg!(windows) {
+            Duration::from_millis(100)
+        } else {
+            Duration::from_millis(1)
+        };
+
+        assert!(timeout.duration_since(now) < grace_period);
     }
 
     static mut DUMMY_BUF: Buffers = Buffers {


### PR DESCRIPTION
Windows' timer granularity isn't as good as the one from Unix platforms. To ensure this test isn't flaky, we increase the grace-period for Windows runners.

See https://github.com/firezone/firezone/actions/runs/12862968520/job/35858749736?pr=7808.