### PR TITLE
fix(gui-client): don't fail on missing `update-desktop-database`

### DIFF
--- a/rust/gui-client/src-common/src/deep_link/linux.rs
+++ b/rust/gui-client/src-common/src/deep_link/linux.rs
@@ -145,7 +145,7 @@ Categories=Network;
         }
         Err(e) if e.kind() == ErrorKind::NotFound => {
             // This is not an Ubuntu machine, so this executable won't exist.
-            tracing::debug!("Could not find update-desktop-database command, ignoring");
+            tracing::debug!("Could not find {update_desktop_database} command, ignoring");
         }
         Err(e) => {
             return Err(e).with_context(|| format!("failed to run `{update_desktop_database}`"));

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -36,6 +36,12 @@ export default function GUI({ title }: { title: string }) {
             Disables URO/GRO due to hardware / driver bugs.
           </ChangeItem>
         )}
+        {title == "Linux GUI" && (
+          <ChangeItem pull="7822">
+            Makes the runtime dependency on `update-desktop-database` optional,
+            thus improving compatibility on non-Ubuntu systems.
+          </ChangeItem>
+        )}
       </Unreleased>
       <Entry version="1.4.0" date={new Date("2024-12-13")}>
         <ChangeItem pull="7210">


### PR DESCRIPTION
Currently the GUI Client exits if `update-desktop-database` cannot be executed after deep-links were registered. On non-Ubuntu systems (or more generally non-Debian) this will fail since the command does not exist and prevent the GUI Client from starting. 

This PR just ignores any command-not-found error, ensuring the command still has to succeed on Debian/Ubuntu machines.
