### PR TITLE
fix: Add openssl-dev build req to rust Dockerfile

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -10,6 +10,7 @@ ARG PACKAGE
 FROM rust:${RUST_VERSION}-alpine${ALPINE_VERSION} AS chef
 
 ARG CARGO_CHEF_VERSION
+# openssl-dev can be removed after https://github.com/tauri-apps/tauri/pull/12445 is shipped
 RUN set -xe \
     && apk add --no-cache musl-dev openssl-dev \
     && cargo install cargo-chef --locked --version=${CARGO_CHEF_VERSION} \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -11,7 +11,7 @@ FROM rust:${RUST_VERSION}-alpine${ALPINE_VERSION} AS chef
 
 ARG CARGO_CHEF_VERSION
 RUN set -xe \
-    && apk add --no-cache musl-dev  \
+    && apk add --no-cache musl-dev openssl-dev \
     && cargo install cargo-chef --locked --version=${CARGO_CHEF_VERSION} \
     && rm -rf $CARGO_HOME/registry/
 


### PR DESCRIPTION
#7808 introduced a minor bug that prevented the rust Docker images from building locally, in `debug` builds. Adding `openssl-dev` to the builder's container fixes the issue.

```
cargo:warning=Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge. If OpenSSL is installed and this crate had trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the compilation process. See stderr section below for further information.
```