### PR TITLE
refactor(connlib): only log actual updates to the allocation

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -563,20 +563,18 @@ impl Allocation {
                 }
 
                 self.allocation_lifetime = Some((now, lifetime));
-                let updated_ip4 = update_candidate(
+                update_candidate(
                     maybe_ip4_relay_candidate,
                     &mut self.ip4_allocation,
                     &mut self.events,
                 );
-                let updated_ip6 = update_candidate(
+                update_candidate(
                     maybe_ip6_relay_candidate,
                     &mut self.ip6_allocation,
                     &mut self.events,
                 );
 
-                if updated_ip4 || updated_ip6 {
-                    self.log_update(now);
-                }
+                self.log_update(now);
 
                 while let Some(peer) = self.buffered_channel_bindings.dequeue() {
                     debug_assert!(

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -885,7 +885,7 @@ impl Allocation {
     }
 
     fn log_update(&self, now: Instant) {
-        tracing::info!(
+        tracing::debug!(
             srflx_ip4 = ?self.ip4_srflx_candidate.as_ref().map(|c| c.addr()),
             srflx_ip6 = ?self.ip6_srflx_candidate.as_ref().map(|c| c.addr()),
             relay_ip4 = ?self.ip4_allocation.as_ref().map(|c| c.addr()),


### PR DESCRIPTION
With #7819, these log messages appear at a ~10x higher rate than before - a day's worth of these would be over 3,000 messages. For BINDING requests, these only matter if the candidates change, therefore we can make the logging conditional to that.