### PR TITLE
ci: Don't enable more swap space

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -73,12 +73,6 @@ jobs:
         shell: bash
         # AzureSignTool >= 5 needs .NET 8. windows-2019 runner only has .NET 7.
         run: dotnet tool install --global AzureSignTool --version 4.0.1
-      - name: Check if swap needed
-        if: ${{ runner.os == 'Linux' }}
-        run: free -m
-      - name: Enable swap
-        if: ${{ runner.os == 'Linux' }}
-        run: sudo fallocate -l 8G /swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile && free -m
       - name: Build release exe and MSI / deb
         env:
           CARGO_PROFILE_RELEASE_LTO: thin # Fat LTO is getting too slow / RAM-hungry on Tauri builds


### PR DESCRIPTION
It seems that runners consistently have a 4 GB swapfile enabled now, so this seems to be unneeded and causing a conflict with the Ubuntu-22.04-arm runner which amusingly [uses the same path](https://github.com/firezone/firezone/actions/runs/12895498951/job/35956521688).