### PR TITLE
refactor(portal): `Authorized Sessions` -> `Recent Connections`

### DIFF
--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -38,6 +38,7 @@ defmodule Web.Actors.Show do
         |> assign_live_table("flows",
           query_module: Flows.Flow.Query,
           sortable_fields: [],
+          hide_filters: [:expiration],
           callback: &handle_flows_update!/2
         )
         |> assign_live_table("groups",
@@ -510,9 +511,9 @@ defmodule Web.Actors.Show do
     </.section>
 
     <.section>
-      <:title>Authorized Sessions</:title>
+      <:title>Recent Connections</:title>
       <:help>
-        Authorized sessions opened by this Actor to access a Resource.
+        Recent connections opened by this Actor to access a Resource.
       </:help>
       <:content>
         <.live_table
@@ -526,9 +527,6 @@ defmodule Web.Actors.Show do
         >
           <:col :let={flow} label="authorized" class="xl:w-1/12">
             <.relative_datetime datetime={flow.inserted_at} />
-          </:col>
-          <:col :let={flow} label="expires" class="xl:w-1/12">
-            <.relative_datetime datetime={flow.expires_at} />
           </:col>
           <:col :let={flow} label="policy" class="w-3/12">
             <.link navigate={~p"/#{@account}/policies/#{flow.policy_id}"} class={[link_style()]}>

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -29,6 +29,7 @@ defmodule Web.Clients.Show do
         |> assign_live_table("flows",
           query_module: Flows.Flow.Query,
           sortable_fields: [],
+          hide_filters: [:expiration],
           callback: &handle_flows_update!/2
         )
 
@@ -288,9 +289,9 @@ defmodule Web.Clients.Show do
     </.section>
 
     <.section>
-      <:title>Authorized Sessions</:title>
+      <:title>Recent Connections</:title>
       <:help>
-        Authorized sessions opened by this Client to access a Resource.
+        Recent connections opened by this Client to access a Resource.
       </:help>
       <:content>
         <.live_table
@@ -304,9 +305,6 @@ defmodule Web.Clients.Show do
         >
           <:col :let={flow} label="authorized">
             <.relative_datetime datetime={flow.inserted_at} />
-          </:col>
-          <:col :let={flow} label="expires">
-            <.relative_datetime datetime={flow.expires_at} />
           </:col>
           <:col :let={flow} label="remote ip" class="w-3/12">
             <%= flow.client_remote_ip %>

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -31,6 +31,7 @@ defmodule Web.Policies.Show do
         |> assign_live_table("flows",
           query_module: Flows.Flow.Query,
           sortable_fields: [],
+          hide_filters: [:expiration],
           callback: &handle_flows_update!/2
         )
 
@@ -237,9 +238,9 @@ defmodule Web.Policies.Show do
     </.section>
 
     <.section>
-      <:title>Authorized Sessions</:title>
+      <:title>Recent Connections</:title>
       <:help>
-        Authorized sessions opened by Actors to access the Resources governed by this Policy.
+        Recent connections opened by Actors to access the Resources governed by this Policy.
       </:help>
       <:content>
         <.live_table
@@ -253,9 +254,6 @@ defmodule Web.Policies.Show do
         >
           <:col :let={flow} label="authorized">
             <.relative_datetime datetime={flow.inserted_at} />
-          </:col>
-          <:col :let={flow} label="expires">
-            <.relative_datetime datetime={flow.expires_at} />
           </:col>
           <:col :let={flow} label="client, actor" class="w-3/12">
             <.link navigate={~p"/#{@account}/clients/#{flow.client_id}"} class={link_style()}>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -33,6 +33,7 @@ defmodule Web.Resources.Show do
         |> assign_live_table("flows",
           query_module: Flows.Flow.Query,
           sortable_fields: [],
+          hide_filters: [:expiration],
           callback: &handle_flows_update!/2
         )
         |> assign_live_table("policies",
@@ -325,9 +326,9 @@ defmodule Web.Resources.Show do
     </.section>
 
     <.section>
-      <:title>Authorized Sessions</:title>
+      <:title>Recent Connections</:title>
       <:help>
-        Authorized sessions opened by Actors to access this Resource.
+        Recent connections opened by Actors to access this Resource.
       </:help>
       <:content>
         <.live_table
@@ -341,9 +342,6 @@ defmodule Web.Resources.Show do
         >
           <:col :let={flow} label="authorized">
             <.relative_datetime datetime={flow.inserted_at} />
-          </:col>
-          <:col :let={flow} label="expires">
-            <.relative_datetime datetime={flow.expires_at} />
           </:col>
           <:col :let={flow} label="policy">
             <.link navigate={~p"/#{@account}/policies/#{flow.policy_id}"} class={[link_style()]}>

--- a/elixir/apps/web/test/web/live/actors/show_test.exs
+++ b/elixir/apps/web/test/web/live/actors/show_test.exs
@@ -135,7 +135,6 @@ defmodule Web.Live.Actors.ShowTest do
       |> table_to_map()
 
     assert row["authorized"]
-    assert row["expires"]
     assert row["policy"] =~ flow.policy.actor_group.name
     assert row["policy"] =~ flow.policy.resource.name
 
@@ -175,7 +174,6 @@ defmodule Web.Live.Actors.ShowTest do
       |> table_to_map()
 
     assert row["authorized"]
-    assert row["expires"]
     assert row["policy"] =~ flow.policy.actor_group.name
     assert row["policy"] =~ flow.policy.resource.name
 
@@ -216,7 +214,6 @@ defmodule Web.Live.Actors.ShowTest do
       |> table_to_map()
 
     assert row["authorized"]
-    assert row["expires"]
     assert row["policy"] =~ flow.policy.actor_group.name
     assert row["policy"] =~ flow.policy.resource.name
 

--- a/elixir/apps/web/test/web/live/clients/show_test.exs
+++ b/elixir/apps/web/test/web/live/clients/show_test.exs
@@ -205,7 +205,6 @@ defmodule Web.Live.Clients.ShowTest do
       |> table_to_map()
 
     assert row["authorized"]
-    assert row["expires"]
     assert row["remote ip"] == to_string(client.last_seen_remote_ip)
     assert row["policy"] =~ flow.policy.actor_group.name
     assert row["policy"] =~ flow.policy.resource.name
@@ -241,7 +240,6 @@ defmodule Web.Live.Clients.ShowTest do
       |> table_to_map()
 
     assert row["authorized"]
-    assert row["expires"]
     assert row["remote ip"] == to_string(client.last_seen_remote_ip)
     assert row["policy"] =~ flow.policy.actor_group.name
     assert row["policy"] =~ flow.policy.resource.name
@@ -278,7 +276,6 @@ defmodule Web.Live.Clients.ShowTest do
       |> table_to_map()
 
     assert row["authorized"]
-    assert row["expires"]
     assert row["remote ip"] == to_string(client.last_seen_remote_ip)
     assert row["policy"] =~ flow.policy.actor_group.name
     assert row["policy"] =~ flow.policy.resource.name

--- a/elixir/apps/web/test/web/live/policies/show_test.exs
+++ b/elixir/apps/web/test/web/live/policies/show_test.exs
@@ -281,7 +281,6 @@ defmodule Web.Live.Policies.ShowTest do
       |> table_to_map()
 
     assert row["authorized"]
-    assert row["expires"]
     assert row["client, actor"] =~ flow.client.name
     assert row["client, actor"] =~ "owned by #{flow.client.actor.name}"
     assert row["client, actor"] =~ to_string(flow.client_remote_ip)

--- a/elixir/apps/web/test/web/live/resources/show_test.exs
+++ b/elixir/apps/web/test/web/live/resources/show_test.exs
@@ -294,7 +294,6 @@ defmodule Web.Live.Resources.ShowTest do
       |> table_to_map()
 
     assert row["authorized"]
-    assert row["expires"]
     assert row["policy"] =~ flow.policy.actor_group.name
     assert row["policy"] =~ flow.policy.resource.name
 


### PR DESCRIPTION
We've gotten feedback recently that the expiration field causes confusion among auditors who assume it has actual security relevance.

In reality, this is simply the maximum amount of time a connection between Client and Gateway will stay alive for, and it has no relation to "sessions" from a security perspective. As such, it's removed, and the table renamed "Recent connections" to better name what these are.

The `expiration` column is also removed because this is not actionable by the admin or end-user. In nearly all cases, the connection will have been "expired" by some other means naturally, such as toggling Firezone on/off or a policy or resource change. In other words, we do not rely on this `expiration` field to enforce any security-related timeout.

Fixes #7712 