### PR TITLE
chore(infra): Revert relay regions to test prod-like deploy

### DIFF
--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -1,341 +1,105 @@
-locals {
-  subnet_ip_cidr_ranges = {
-    "africa-south1"           = "10.240.0.0/24",
-    "asia-east1"              = "10.240.1.0/24",
-    "asia-east2"              = "10.240.2.0/24",
-    "asia-northeast1"         = "10.240.3.0/24",
-    "asia-northeast2"         = "10.240.4.0/24",
-    "asia-northeast3"         = "10.240.5.0/24",
-    "asia-south1"             = "10.240.6.0/24",
-    "asia-south2"             = "10.240.7.0/24",
-    "asia-southeast1"         = "10.240.8.0/24",
-    "asia-southeast2"         = "10.240.9.0/24",
-    "australia-southeast1"    = "10.240.10.0/24",
-    "australia-southeast2"    = "10.240.11.0/24",
-    "europe-central2"         = "10.240.12.0/24",
-    "europe-north1"           = "10.240.13.0/24",
-    "europe-southwest1"       = "10.240.14.0/24",
-    "europe-west1"            = "10.240.15.0/24",
-    "europe-west2"            = "10.240.16.0/24",
-    "europe-west3"            = "10.240.17.0/24",
-    "europe-west4"            = "10.240.18.0/24",
-    "europe-west6"            = "10.240.19.0/24",
-    "europe-west8"            = "10.240.20.0/24",
-    "europe-west9"            = "10.240.21.0/24",
-    "europe-west10"           = "10.240.22.0/24",
-    "europe-west12"           = "10.240.23.0/24",
-    "me-central1"             = "10.240.24.0/24",
-    "me-west1"                = "10.240.25.0/24",
-    "northamerica-northeast1" = "10.240.26.0/24",
-    "northamerica-northeast2" = "10.240.27.0/24",
-    "northamerica-south1"     = "10.240.28.0/24",
-    "southamerica-east1"      = "10.240.29.0/24",
-    "southamerica-west1"      = "10.240.30.0/24",
-    "us-central1"             = "10.240.31.0/24",
-    "us-east1"                = "10.240.32.0/24",
-    "us-east4"                = "10.240.33.0/24",
-    "us-east5"                = "10.240.34.0/24",
-    "us-south1"               = "10.240.35.0/24",
-    "us-west1"                = "10.240.36.0/24",
-    "us-west2"                = "10.240.37.0/24",
-    "us-west3"                = "10.240.38.0/24",
-    "us-west4"                = "10.240.39.0/24"
-  }
-}
-
-# Create networks
-resource "google_compute_network" "network" {
-  project = module.google-cloud-project.project.project_id
-  name    = "relays"
-
-  routing_mode = "GLOBAL"
-
-  auto_create_subnetworks = false
-
-  depends_on = [
-    google_project_service.compute
-  ]
-}
-
-resource "google_compute_subnetwork" "subnetwork" {
-  for_each = local.subnet_ip_cidr_ranges
-  project  = module.google-cloud-project.project.project_id
-  name     = "relay-${each.key}"
-  region   = each.key
-  network  = google_compute_network.network.self_link
-
-  log_config {
-    aggregation_interval = "INTERVAL_10_MIN"
-    metadata             = "INCLUDE_ALL_METADATA"
-  }
-
-  stack_type = "IPV4_IPV6"
-
-  # Sequentially numbered /24s given an offset
-  ip_cidr_range            = each.value
-  ipv6_access_type         = "EXTERNAL"
-  private_ip_google_access = true
-}
-
 module "relays" {
   count = var.relay_token != null ? 1 : 0
 
   source     = "../../modules/google-cloud/apps/relay"
   project_id = module.google-cloud-project.project.project_id
 
-  # Remember to update the following published documentation when this changes:
+  # TODO: Remember to update the following published documentation when this changes:
   #  - /website/src/app/kb/deploy/gateways/readme.mdx
   #  - /website/src/app/kb/architecture/tech-stack/readme.mdx
   instances = {
-    "africa-south1" = {
-      subnet   = google_compute_subnetwork.subnetwork["africa-south1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["africa-south1-a"]
-    }
     "asia-east1" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-east1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-east1-a"]
+      cidr_range = "10.129.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["asia-east1-c"]
     }
-    "asia-east2" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-east2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-east2-a"]
-    }
-    "asia-northeast1" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-northeast1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-northeast1-a"]
-    }
-    "asia-northeast2" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-northeast2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-northeast2-a"]
-    }
-    "asia-northeast3" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-northeast3"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-northeast3-a"]
-    }
+
     "asia-south1" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-south1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-south1-a"]
+      cidr_range = "10.130.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["asia-south1-c"]
     }
-    "asia-south2" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-south2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-south2-a"]
-    }
-    "asia-southeast1" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-southeast1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-southeast1-a"]
-    }
-    "asia-southeast2" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-southeast2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-southeast2-a"]
-    }
+
     "australia-southeast1" = {
-      subnet   = google_compute_subnetwork.subnetwork["australia-southeast1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["australia-southeast1-a"]
+      cidr_range = "10.131.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["australia-southeast1-c"]
     }
-    "australia-southeast2" = {
-      subnet   = google_compute_subnetwork.subnetwork["australia-southeast2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["australia-southeast2-a"]
-    }
-    "europe-central2" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-central2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-central2-a"]
-    }
-    "europe-north1" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-north1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-north1-a"]
-    }
-    "europe-southwest1" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-southwest1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-southwest1-a"]
-    }
+
     "europe-west1" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west1-b"]
+      cidr_range = "10.132.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["europe-west1-d"]
     }
-    "europe-west2" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west2-a"]
-    }
-    "europe-west3" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west3"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west3-a"]
-    }
-    "europe-west4" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west4"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west4-a"]
-    }
-    "europe-west6" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west6"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west6-a"]
-    }
-    "europe-west8" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west8"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west8-a"]
-    }
-    "europe-west9" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west9"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west9-a"]
-    }
-    "europe-west10" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west10"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west10-a"]
-    }
-    "europe-west12" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west12"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west12-a"]
-    }
-    "me-central1" = {
-      subnet   = google_compute_subnetwork.subnetwork["me-central1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["me-central1-a"]
-    }
-    # Fails with:
-    # Access to the region is unavailable. Please contact our sales team at https://cloud.google.com/contact for further assistance."
-    # "me-central2" = {
+
+    # "me-central1" = {
+    #   cidr_range = "10.133.0.0/24"
     #   type       = "e2-micro"
-    #   replicas   = 1
-    #   zones      = ["me-central2-a"]
+    #   replicas   = 2
+    #   zones      ["me-central1-a"]
     # }
-    "me-west1" = {
-      subnet   = google_compute_subnetwork.subnetwork["me-west1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["me-west1-a"]
-    }
-    "northamerica-northeast1" = {
-      subnet   = google_compute_subnetwork.subnetwork["northamerica-northeast1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["northamerica-northeast1-a"]
-    }
-    "northamerica-northeast2" = {
-      subnet   = google_compute_subnetwork.subnetwork["northamerica-northeast2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["northamerica-northeast2-a"]
-    }
-    "northamerica-south1" = {
-      subnet   = google_compute_subnetwork.subnetwork["northamerica-south1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["northamerica-south1-a"]
-    }
+
     "southamerica-east1" = {
-      subnet   = google_compute_subnetwork.subnetwork["southamerica-east1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["southamerica-east1-a"]
+      cidr_range = "10.134.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["southamerica-east1-c"]
     }
-    "southamerica-west1" = {
-      subnet   = google_compute_subnetwork.subnetwork["southamerica-west1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["southamerica-west1-a"]
-    }
+
     "us-central1" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-central1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-central1-a"]
+      cidr_range = "10.135.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-central1-f"]
     }
+
     "us-east1" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-east1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-east1-b"]
+      cidr_range = "10.136.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-east1-c"]
     }
-    "us-east4" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-east4"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-east4-a"]
-    }
-    "us-east5" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-east5"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-east5-a"]
-    }
-    "us-south1" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-south1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-south1-a"]
-    }
-    "us-west1" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-west1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-west1-a"]
-    }
+
     "us-west2" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-west2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-west2-a"]
+      cidr_range = "10.137.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-west2-b"]
     }
-    "us-west3" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-west3"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-west3-a"]
+
+    "europe-central2" = {
+      cidr_range = "10.138.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["europe-central2-c"]
     }
-    "us-west4" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-west4"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-west4-a"]
+
+    "europe-north1" = {
+      cidr_range = "10.139.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["europe-north1-c"]
+    }
+
+    "europe-west2" = {
+      cidr_range = "10.140.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["europe-west2-c"]
+    }
+
+    "us-east4" = {
+      cidr_range = "10.141.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-east4-c"]
     }
   }
-  network            = google_compute_network.network.self_link
+
   container_registry = module.google-artifact-registry.url
 
   image_repo = module.google-artifact-registry.repo
@@ -381,7 +145,7 @@ resource "google_compute_firewall" "relays-ssh-ipv4" {
   project = module.google-cloud-project.project.project_id
 
   name    = "relays-ssh-ipv4"
-  network = google_compute_network.network.self_link
+  network = module.relays[0].network
 
   allow {
     protocol = "tcp"

--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -1,384 +1,157 @@
-locals {
-  subnet_ip_cidr_ranges = {
-    "africa-south1"           = "10.240.0.0/24",
-    "asia-east1"              = "10.240.1.0/24",
-    "asia-east2"              = "10.240.2.0/24",
-    "asia-northeast1"         = "10.240.3.0/24",
-    "asia-northeast2"         = "10.240.4.0/24",
-    "asia-northeast3"         = "10.240.5.0/24",
-    "asia-south1"             = "10.240.6.0/24",
-    "asia-south2"             = "10.240.7.0/24",
-    "asia-southeast1"         = "10.240.8.0/24",
-    "asia-southeast2"         = "10.240.9.0/24",
-    "australia-southeast1"    = "10.240.10.0/24",
-    "australia-southeast2"    = "10.240.11.0/24",
-    "europe-central2"         = "10.240.12.0/24",
-    "europe-north1"           = "10.240.13.0/24",
-    "europe-southwest1"       = "10.240.14.0/24",
-    "europe-west1"            = "10.240.15.0/24",
-    "europe-west2"            = "10.240.16.0/24",
-    "europe-west3"            = "10.240.17.0/24",
-    "europe-west4"            = "10.240.18.0/24",
-    "europe-west6"            = "10.240.19.0/24",
-    "europe-west8"            = "10.240.20.0/24",
-    "europe-west9"            = "10.240.21.0/24",
-    "europe-west10"           = "10.240.22.0/24",
-    "europe-west12"           = "10.240.23.0/24",
-    "me-central1"             = "10.240.24.0/24",
-    "me-west1"                = "10.240.25.0/24",
-    "northamerica-northeast1" = "10.240.26.0/24",
-    "northamerica-northeast2" = "10.240.27.0/24",
-    "northamerica-south1"     = "10.240.28.0/24",
-    "southamerica-east1"      = "10.240.29.0/24",
-    "southamerica-west1"      = "10.240.30.0/24",
-    "us-central1"             = "10.240.31.0/24",
-    "us-east1"                = "10.240.32.0/24",
-    "us-east4"                = "10.240.33.0/24",
-    "us-east5"                = "10.240.34.0/24",
-    "us-south1"               = "10.240.35.0/24",
-    "us-west1"                = "10.240.36.0/24",
-    "us-west2"                = "10.240.37.0/24",
-    "us-west3"                = "10.240.38.0/24",
-    "us-west4"                = "10.240.39.0/24"
-  }
-}
-
-# Create networks
-resource "google_compute_network" "network" {
-  project = module.google-cloud-project.project.project_id
-  name    = "relays"
-
-  routing_mode = "GLOBAL"
-
-  auto_create_subnetworks = false
-
-  depends_on = [
-    google_project_service.compute
-  ]
-}
-
-resource "google_compute_subnetwork" "subnetwork" {
-  for_each = local.subnet_ip_cidr_ranges
-  project  = module.google-cloud-project.project.project_id
-  name     = "relays-${each.key}"
-  region   = each.key
-  network  = google_compute_network.network.self_link
-
-  log_config {
-    aggregation_interval = "INTERVAL_10_MIN"
-    metadata             = "INCLUDE_ALL_METADATA"
-  }
-
-  stack_type = "IPV4_IPV6"
-
-  # Sequentially numbered /24s given an offset
-  ip_cidr_range            = each.value
-  ipv6_access_type         = "EXTERNAL"
-  private_ip_google_access = true
-}
-
 module "relays" {
-  count      = var.relay_token != null ? 1 : 0
+  count = var.relay_token != null ? 1 : 0
+
   source     = "../../modules/google-cloud/apps/relay"
   project_id = module.google-cloud-project.project.project_id
+
   instances = {
-    "africa-south1" = {
-      subnet   = google_compute_subnetwork.subnetwork["africa-south1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["africa-south1-a"]
-    }
     "asia-east1" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-east1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-east1-a"]
+      cidr_range = "10.129.0.0/24"
+      type       = "e2-micro"
+      replicas   = 1
+      zones      = ["asia-east1-a"]
     }
-    "asia-east2" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-east2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-east2-a"]
-    }
-    "asia-northeast1" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-northeast1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-northeast1-a"]
-    }
-    "asia-northeast2" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-northeast2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-northeast2-a"]
-    }
-    "asia-northeast3" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-northeast3"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-northeast3-a"]
-    }
+
     "asia-south1" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-south1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-south1-a"]
+      cidr_range = "10.130.0.0/24"
+      type       = "e2-micro"
+      replicas   = 1
+      zones      = ["asia-south1-a"]
     }
-    "asia-south2" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-south2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-south2-a"]
-    }
-    "asia-southeast1" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-southeast1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-southeast1-a"]
-    }
-    "asia-southeast2" = {
-      subnet   = google_compute_subnetwork.subnetwork["asia-southeast2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["asia-southeast2-a"]
-    }
+
     "australia-southeast1" = {
-      subnet   = google_compute_subnetwork.subnetwork["australia-southeast1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["australia-southeast1-a"]
+      cidr_range = "10.131.0.0/24"
+      type       = "e2-micro"
+      replicas   = 1
+      zones      = ["australia-southeast1-a"]
     }
-    "australia-southeast2" = {
-      subnet   = google_compute_subnetwork.subnetwork["australia-southeast2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["australia-southeast2-a"]
-    }
-    "europe-central2" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-central2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-central2-a"]
-    }
-    "europe-north1" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-north1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-north1-a"]
-    }
-    "europe-southwest1" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-southwest1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-southwest1-a"]
-    }
+
     "europe-west1" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west1-b"]
+      cidr_range = "10.132.0.0/24"
+      type       = "e2-micro"
+      replicas   = 1
+      zones      = ["europe-west1-d"]
     }
-    "europe-west2" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west2-a"]
-    }
-    "europe-west3" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west3"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west3-a"]
-    }
-    "europe-west4" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west4"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west4-a"]
-    }
-    "europe-west6" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west6"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west6-a"]
-    }
-    "europe-west8" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west8"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west8-a"]
-    }
-    "europe-west9" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west9"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west9-a"]
-    }
-    "europe-west10" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west10"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west10-a"]
-    }
-    "europe-west12" = {
-      subnet   = google_compute_subnetwork.subnetwork["europe-west12"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["europe-west12-a"]
-    }
-    "me-central1" = {
-      subnet   = google_compute_subnetwork.subnetwork["me-central1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["me-central1-a"]
-    }
-    # Fails with:
-    # Access to the region is unavailable. Please contact our sales team at https://cloud.google.com/contact for further assistance."
-    # "me-central2" = {
-    #   type       = "e2-micro"
+
+    # "me-central1" = {
+    #   cidr_range = "10.133.0.0/24"
+    #   type       = "n2-standard-2"
     #   replicas   = 1
-    #   zones      = ["me-central2-a"]
+    #   zones      = ["me-central1-a"]
     # }
-    "me-west1" = {
-      subnet   = google_compute_subnetwork.subnetwork["me-west1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["me-west1-a"]
-    }
-    "northamerica-northeast1" = {
-      subnet   = google_compute_subnetwork.subnetwork["northamerica-northeast1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["northamerica-northeast1-a"]
-    }
-    "northamerica-northeast2" = {
-      subnet   = google_compute_subnetwork.subnetwork["northamerica-northeast2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["northamerica-northeast2-a"]
-    }
-    "northamerica-south1" = {
-      subnet   = google_compute_subnetwork.subnetwork["northamerica-south1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["northamerica-south1-a"]
-    }
+
     "southamerica-east1" = {
-      subnet   = google_compute_subnetwork.subnetwork["southamerica-east1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["southamerica-east1-a"]
+      cidr_range = "10.134.0.0/24"
+      type       = "e2-micro"
+      replicas   = 1
+      zones      = ["southamerica-east1-b"]
     }
-    "southamerica-west1" = {
-      subnet   = google_compute_subnetwork.subnetwork["southamerica-west1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["southamerica-west1-a"]
-    }
+
     "us-central1" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-central1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-central1-a"]
+      cidr_range = "10.135.0.0/24"
+      type       = "e2-micro"
+      replicas   = 1
+      zones      = ["us-central1-b"]
     }
+
     "us-east1" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-east1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-east1-b"]
+      cidr_range = "10.136.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-east1-d"]
     }
-    "us-east4" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-east4"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-east4-a"]
-    }
-    "us-east5" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-east5"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-east5-a"]
-    }
-    "us-south1" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-south1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-south1-a"]
-    }
-    "us-west1" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-west1"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-west1-a"]
-    }
+
     "us-west2" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-west2"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-west2-a"]
+      cidr_range = "10.137.0.0/24"
+      type       = "e2-micro"
+      replicas   = 2
+      zones      = ["us-west2-b"]
     }
-    "us-west3" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-west3"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-west3-a"]
+
+    "europe-central2" = {
+      cidr_range = "10.138.0.0/24"
+      type       = "e2-micro"
+      replicas   = 1
+      zones      = ["europe-central2-c"]
     }
-    "us-west4" = {
-      subnet   = google_compute_subnetwork.subnetwork["us-west4"].self_link
-      type     = "e2-micro"
-      replicas = 1
-      zones    = ["us-west4-a"]
+
+    "europe-north1" = {
+      cidr_range = "10.139.0.0/24"
+      type       = "e2-micro"
+      replicas   = 1
+      zones      = ["europe-north1-c"]
+    }
+
+    "europe-west2" = {
+      cidr_range = "10.140.0.0/24"
+      type       = "e2-micro"
+      replicas   = 1
+      zones      = ["europe-west2-c"]
     }
   }
-  network                 = google_compute_network.network.self_link
-  container_registry      = module.google-artifact-registry.url
-  image_repo              = module.google-artifact-registry.repo
-  image                   = "relay"
-  image_tag               = var.image_tag
+
+  container_registry = module.google-artifact-registry.url
+
+  image_repo = module.google-artifact-registry.repo
+  image      = "relay"
+  image_tag  = var.image_tag
+
   observability_log_level = "info,hyper=off,h2=warn,tower=warn"
-  application_name        = "relay"
-  application_version     = replace(var.image_tag, ".", "-")
+
+  application_name    = "relay"
+  application_version = replace(var.image_tag, ".", "-")
   application_environment_variables = [
     {
       name  = "FIREZONE_TELEMETRY"
       value = "true"
     }
   ]
+
   health_check = {
-    name                = "health"
-    protocol            = "TCP"
-    port                = 8080
-    initial_delay_sec   = 60
+    name     = "health"
+    protocol = "TCP"
+    port     = 8080
+
+    initial_delay_sec = 60
+
     check_interval_sec  = 15
     timeout_sec         = 10
     healthy_threshold   = 1
     unhealthy_threshold = 3
+
     http_health_check = {
       request_path = "/healthz"
     }
   }
+
   api_url = "wss://api.${local.tld}"
   token   = var.relay_token
 }
 
 # Allow SSH access using IAP for relays
 resource "google_compute_firewall" "relays-ssh-ipv4" {
-  count   = length(module.relays) > 0 ? 1 : 0
+  count = length(module.relays) > 0 ? 1 : 0
+
   project = module.google-cloud-project.project.project_id
+
   name    = "relays-ssh-ipv4"
   network = module.google-cloud-vpc.id
+
   allow {
     protocol = "tcp"
     ports    = [22]
   }
+
   allow {
     protocol = "udp"
     ports    = [22]
   }
+
   allow {
     protocol = "sctp"
     ports    = [22]
   }
+
   # Only allows connections using IAP
   source_ranges = local.iap_ipv4_ranges
   target_tags   = module.relays[0].target_tags

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -121,6 +121,40 @@ resource "google_project_iam_member" "cloudtrace" {
   member = "serviceAccount:${google_service_account.application.email}"
 }
 
+# Create network
+resource "google_compute_network" "network" {
+  project = var.project_id
+  name    = "relays"
+
+  routing_mode = "GLOBAL"
+
+  auto_create_subnetworks = false
+
+  depends_on = [
+    google_project_service.compute
+  ]
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  for_each = var.instances
+
+  project = var.project_id
+
+  name   = "relays-${each.key}"
+  region = each.key
+
+  network = google_compute_network.network.self_link
+
+  log_config {
+    aggregation_interval = "INTERVAL_10_MIN"
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+
+  stack_type               = "IPV4_IPV6"
+  ip_cidr_range            = each.value.cidr_range
+  ipv6_access_type         = "EXTERNAL"
+  private_ip_google_access = true
+}
 
 resource "google_compute_reservation" "relay_reservation" {
   for_each = var.instances
@@ -147,7 +181,7 @@ resource "google_compute_instance_template" "application" {
 
   project = var.project_id
 
-  name_prefix = "${local.application_name}-template-${each.key}-"
+  name_prefix = "${local.application_name}-${each.key}-"
 
   description = "This template is used to create ${local.application_name} instances using Terraform."
 
@@ -184,7 +218,7 @@ resource "google_compute_instance_template" "application" {
   }
 
   network_interface {
-    subnetwork = var.instances[each.key].subnet
+    subnetwork = google_compute_subnetwork.subnetwork[each.key].self_link
 
     stack_type = "IPV4_IPV6"
 
@@ -362,7 +396,7 @@ resource "google_compute_firewall" "stun-turn-ipv4" {
   project = var.project_id
 
   name    = "${local.application_name}-firewall-lb-to-instances-ipv4"
-  network = var.network
+  network = google_compute_network.network.self_link
 
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["app-${local.application_name}"]
@@ -377,7 +411,7 @@ resource "google_compute_firewall" "stun-turn-ipv6" {
   project = var.project_id
 
   name    = "${local.application_name}-firewall-lb-to-instances-ipv6"
-  network = var.network
+  network = google_compute_network.network.self_link
 
   source_ranges = ["::/0"]
   target_tags   = ["app-${local.application_name}"]
@@ -393,7 +427,7 @@ resource "google_compute_firewall" "http-health-checks" {
   project = var.project_id
 
   name    = "${local.application_name}-healthcheck"
-  network = var.network
+  network = google_compute_network.network.self_link
 
   source_ranges = local.google_health_check_ip_ranges
   target_tags   = ["app-${local.application_name}"]
@@ -409,7 +443,7 @@ resource "google_compute_firewall" "ingress-ipv4" {
   project = var.project_id
 
   name      = "${local.application_name}-ingress-ipv4"
-  network   = var.network
+  network   = google_compute_network.network.self_link
   direction = "INGRESS"
 
   target_tags   = ["app-${local.application_name}"]
@@ -424,7 +458,7 @@ resource "google_compute_firewall" "ingress-ipv6" {
   project = var.project_id
 
   name      = "${local.application_name}-ingress-ipv6"
-  network   = var.network
+  network   = google_compute_network.network.self_link
   direction = "INGRESS"
 
   target_tags   = ["app-${local.application_name}"]
@@ -440,7 +474,7 @@ resource "google_compute_firewall" "egress-ipv4" {
   project = var.project_id
 
   name      = "${local.application_name}-egress-ipv4"
-  network   = var.network
+  network   = google_compute_network.network.self_link
   direction = "EGRESS"
 
   target_tags        = ["app-${local.application_name}"]
@@ -455,7 +489,7 @@ resource "google_compute_firewall" "egress-ipv6" {
   project = var.project_id
 
   name      = "${local.application_name}-egress-ipv6"
-  network   = var.network
+  network   = google_compute_network.network.self_link
   direction = "EGRESS"
 
   target_tags        = ["app-${local.application_name}"]

--- a/terraform/modules/google-cloud/apps/relay/outputs.tf
+++ b/terraform/modules/google-cloud/apps/relay/outputs.tf
@@ -9,3 +9,7 @@ output "target_tags" {
 output "instances" {
   value = var.instances
 }
+
+output "network" {
+  value = google_compute_network.network.self_link
+}

--- a/terraform/modules/google-cloud/apps/relay/variables.tf
+++ b/terraform/modules/google-cloud/apps/relay/variables.tf
@@ -9,18 +9,13 @@ variable "project_id" {
 
 variable "instances" {
   type = map(object({
-    subnet   = string
-    type     = string
-    replicas = number
-    zones    = list(string)
+    cidr_range = string
+    type       = string
+    replicas   = number
+    zones      = list(string)
   }))
 
   description = "List deployment locations for the application."
-}
-
-variable "network" {
-  type        = string
-  description = "ID of a Google Cloud Network"
 }
 
 ################################################################################


### PR DESCRIPTION
Since we know we now have the Relay configuration we want (and works), this PR rolls back staging to how it was pre-Relay region changes, so we can test that a single `terraform apply` on prod will deploy without any errors.