### PR TITLE
feat(infra): Add billing budget alerts to infra

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -38,10 +38,11 @@ provider "google-beta" {}
 module "google-cloud-project" {
   source = "../../modules/google-cloud/project"
 
-  id                 = "firezone-prod"
-  name               = "Production Environment"
-  organization_id    = "335836213177"
-  billing_account_id = "0199BA-489CDD-F385C8"
+  id                    = "firezone-prod"
+  name                  = "Production Environment"
+  organization_id       = "335836213177"
+  billing_account_id    = "0199BA-489CDD-F385C8"
+  billing_budget_amount = var.billing_budget_amount
 
   auto_create_network = false
 }

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -97,3 +97,8 @@ variable "portal_image_tag" {
   type    = string
   default = null
 }
+
+variable "billing_budget_amount" {
+  type        = number
+  description = "Monthly budget in USD for billing alerts"
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -44,10 +44,11 @@ provider "google-beta" {}
 module "google-cloud-project" {
   source = "../../modules/google-cloud/project"
 
-  id                 = "firezone-staging"
-  name               = "Staging Environment"
-  organization_id    = "335836213177"
-  billing_account_id = "01DFC9-3D6951-579BE1"
+  id                    = "firezone-staging"
+  name                  = "Staging Environment"
+  organization_id       = "335836213177"
+  billing_account_id    = "01DFC9-3D6951-579BE1"
+  billing_budget_amount = var.billing_budget_amount
 }
 
 # Grant owner access to the project

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -75,3 +75,8 @@ variable "workos_client_id" {
 variable "workos_base_url" {
   type = string
 }
+
+variable "billing_budget_amount" {
+  type        = number
+  description = "Monthly budget in USD for billing alerts"
+}

--- a/terraform/modules/google-cloud/project/main.tf
+++ b/terraform/modules/google-cloud/project/main.tf
@@ -52,4 +52,3 @@ resource "google_billing_budget" "budget" {
     threshold_percent = 0.5
   }
 }
-

--- a/terraform/modules/google-cloud/project/main.tf
+++ b/terraform/modules/google-cloud/project/main.tf
@@ -36,3 +36,20 @@ resource "google_project_service" "serviceusage" {
 
   disable_on_destroy = false
 }
+
+resource "google_billing_budget" "budget" {
+  billing_account = var.billing_account_id
+  display_name    = "Firezone Budget"
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units         = var.billing_budget_amount
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+}
+

--- a/terraform/modules/google-cloud/project/variables.tf
+++ b/terraform/modules/google-cloud/project/variables.tf
@@ -6,6 +6,11 @@ variable "billing_account_id" {
   description = "ID of a Google Cloud Billing Account which will be used to pay for resources"
 }
 
+variable "billing_budget_amount" {
+  type        = number
+  description = "Monthly budget for the billing account in USD"
+}
+
 variable "name" {
   description = "Name of a Google Cloud Project"
 }


### PR DESCRIPTION
To help prevent surprises with unexpected cloud bills, we add a billing budget amount that will trigger when the 50% threshold is hit.

The exact amount is considered secret and is set via variables that are already added in HCP staging and prod envs.