### PR TITLE
chore(infra): Set auto_create_network = false

### DIFF
--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -49,6 +49,8 @@ module "google-cloud-project" {
   organization_id       = "335836213177"
   billing_account_id    = "01DFC9-3D6951-579BE1"
   billing_budget_amount = var.billing_budget_amount
+
+  auto_create_network = false
 }
 
 # Grant owner access to the project


### PR DESCRIPTION
Strangely, this is set in `production` but not `staging`. This variable determines whether to keep the `Default` network or not.

Since we create our own network resources, I don't think we need this to be `true`.