### PR TITLE
feat(apple): Show UI alerts for sign in failures

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -16,6 +16,7 @@ struct FirezoneApp: App {
   @StateObject var favorites: Favorites
   @StateObject var appViewModel: AppViewModel
   @StateObject var store: Store
+  @StateObject private var errorHandler = GlobalErrorHandler()
 
   init() {
     // Initialize Telemetry as early as possible
@@ -35,7 +36,7 @@ struct FirezoneApp: App {
   var body: some Scene {
 #if os(iOS)
     WindowGroup {
-      AppView(model: appViewModel)
+      AppView(model: appViewModel).environmentObject(errorHandler)
     }
 #elseif os(macOS)
     WindowGroup(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -271,7 +271,7 @@ public class VPNConfigurationManager {
     Telemetry.setEnvironmentOrClose(settings.apiURL)
   }
 
-  func start(token: String? = nil) {
+  func start(token: String? = nil) throws {
     var options: [String: NSObject] = [:]
 
     // Pass token if provided
@@ -285,11 +285,7 @@ public class VPNConfigurationManager {
       options.merge(["id": id as NSObject]) { _, n in n }
     }
 
-    do {
-      try session()?.startTunnel(options: options)
-    } catch {
-      Log.error(error)
-    }
+    try session()?.startTunnel(options: options)
   }
 
   func stop(clearToken: Bool = false) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthClient.swift
@@ -9,10 +9,24 @@ import Foundation
 
 enum AuthClientError: Error {
   case invalidCallbackURL
-  case invalidStateReturnedInCallback(expected: String, got: String)
-  case authResponseError(Error)
-  case sessionFailure(Error)
   case randomNumberGenerationFailure(errorStatus: Int32)
+
+  var description: String {
+    switch self {
+    case .invalidCallbackURL:
+      return """
+      Invalid callback URL. Please try signing in again.
+      If this issue persists, contact your administrator.
+      """
+    case .randomNumberGenerationFailure(let errorStatus):
+      return """
+      Could not generate secure sign in params. Please try signing in again.
+      If this issue persists, contact your administrator.
+
+      Code: \(errorStatus)
+      """
+    }
+  }
 }
 
 struct AuthClient {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
@@ -36,6 +36,11 @@ struct WebAuthSession {
         do {
           try await store.signIn(authResponse: authResponse)
         } catch {
+          let alert = NSAlert()
+          alert.messageText = error.localizedDescription
+          alert.alertStyle = .warning
+          let _ = alert.runModal()
+
           Log.error(error)
         }
       }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -173,14 +173,14 @@ public final class Store: ObservableObject {
     return URL(string: settings.authBaseURL)
   }
 
-  func start(token: String? = nil) async throws {
+  private func start(token: String? = nil) throws {
     guard status == .disconnected
     else {
       Log.log("\(#function): Already connected")
       return
     }
 
-    self.vpnConfigurationManager.start(token: token)
+    try self.vpnConfigurationManager.start(token: token)
   }
 
   func stop(clearToken: Bool = false) {
@@ -198,7 +198,7 @@ public final class Store: ObservableObject {
     try await self.vpnConfigurationManager.saveAuthResponse(authResponse)
 
     // Bring the tunnel up and send it a token to start
-    self.vpnConfigurationManager.start(token: authResponse.token)
+    try self.vpnConfigurationManager.start(token: authResponse.token)
   }
 
   func signOut() async throws {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -55,7 +55,10 @@ public final class Store: ObservableObject {
   private func initNotifications() {
     // Finish initializing notification binding
     sessionNotification.signInHandler = {
-      WebAuthSession.signIn(store: self)
+      Task.detached {
+        do { try await WebAuthSession.signIn(store: self) }
+        catch { Log.error(error) }
+      }
     }
 
     sessionNotification.$decision

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -55,7 +55,7 @@ public class AppViewModel: ObservableObject {
         if vpnConfigurationStatus == .disconnected {
 
           // Try to connect on start
-          await self.store.vpnConfigurationManager.start()
+          try await self.store.vpnConfigurationManager.start()
         }
       } catch {
         Log.error(error)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GlobalErrorHandler.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GlobalErrorHandler.swift
@@ -1,0 +1,33 @@
+//
+//  GlobalErrorHandler.swift
+//  (c) 2024 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+// A utility class for responding to errors raised in the view hierarchy.
+
+import SwiftUI
+
+public class ErrorAlert: Identifiable {
+  var title: String
+  var error: Error
+
+  public init(title: String = "An error occurred", error: Error) {
+    self.title = title
+    self.error = error
+  }
+}
+
+public class GlobalErrorHandler: ObservableObject {
+  @Published var currentAlert: ErrorAlert?
+
+  public init() {}
+
+  public func handle(_ errorAlert: ErrorAlert) {
+    currentAlert = errorAlert
+  }
+
+  public func clear() {
+    currentAlert = nil
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -261,7 +261,21 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func signInButtonTapped() {
-    WebAuthSession.signIn(store: model.store)
+    Task.detached {
+      do {
+        try await WebAuthSession.signIn(store: self.model.store)
+      } catch {
+        Log.error(error)
+
+        let alert = await NSAlert()
+        await MainActor.run {
+          alert.messageText = "Error signing in"
+          alert.informativeText = error.localizedDescription
+          alert.alertStyle = .warning
+          let _ = alert.runModal()
+        }
+      }
+    }
   }
 
   @objc private func signOutButtonTapped() {


### PR DESCRIPTION
On Apple, we will silently fail if the tunnel fails to start. This adds a simple `NSAlert` modal (macOS) or `Alert` popup (iOS) that must be dismissed before continuing if the tunnel fails to come up, so that the user has a chance of understanding why.

The vast majority of the time this fails due to DNS lookup errors while starting connlib.

Related: #7004
Supersedes: #7814