### PR TITLE
chore: remove WireGuard keepalive

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -733,7 +733,7 @@ where
                 self.private_key.clone(),
                 remote,
                 Some(key),
-                self.mode.is_client().then_some(25), // 25 is the default of the kernel implementation.
+                None,
                 self.index.next(),
                 Some(self.rate_limiter.clone()),
                 self.rng.next_u64(),


### PR DESCRIPTION
Contrary to my prior belief, we don't actually need the WireGuard _persistent_ keep-alive. The in-built timers from WireGuard will automatically send keep-alive messages in case no organic reply is sent for a particular request.

All NAT bindings along the network path are already kept open using the STUN bindings sent on all candidate pairs. Even on idle connections, we send those every 60s. Well-behaved NATs are meant to keep confirmed UDP bindings open for at least 120s. Even if not, the worst-case here is that a connection which does not send any(!) application traffic is cut.