### PR TITLE
feat(apple): Show sysex & VPN install errors

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -8,9 +8,6 @@
 import SwiftUI
 import Combine
 
-#if os(macOS)
-import SystemExtensions
-#endif
 
 @MainActor
 final class GrantVPNViewModel: ObservableObject {
@@ -33,23 +30,19 @@ final class GrantVPNViewModel: ObservableObject {
 
 #if os(macOS)
   func installSystemExtensionButtonTapped() {
-    Task {
+    Task.detached { [weak self] in
+      guard let self else { return }
+
       do {
         try await store.installSystemExtension()
 
         // The window has a tendency to go to the background after installing
         // the system extension
-        NSApp.activate(ignoringOtherApps: true)
+        await NSApp.activate(ignoringOtherApps: true)
 
       } catch {
-        if let error = error as? OSSystemExtensionError,
-           case OSSystemExtensionError.requestSuperseded = error { // Code 12
-          // This will happen if the user repeatedly clicks the `Enable` button
-          // before actually enabling it in system settings.
-          Log.info("\(#function): Request superseded: \(error)")
-        } else {
-          Log.error(error)
-        }
+        Log.error(error)
+        await macOSAlert.show(for: error)
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -297,6 +297,7 @@ public final class MenuBar: NSObject, ObservableObject {
         try await model.store.grantVPNPermission()
       } catch {
         Log.error(error)
+        await macOSAlert.show(for: error)
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
@@ -1,0 +1,130 @@
+//
+//  macOSAlert.swift
+//  (c) 2024 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+import SystemExtensions
+import AppKit
+
+@MainActor
+struct macOSAlert {
+  static func show(for error: OSSystemExtensionError) {
+    let messageText: String? =
+    switch error.code {
+
+    // Code 1
+    case .unknown:
+      """
+      An unknown error occurred. Please try enabling the system extension again.
+      If the issue persists, contact your administrator.
+      """
+
+    // Code 2
+    case .missingEntitlement:
+      """
+      The system extension appears to be missing an entitlement. Please try
+      downloading and installing Firezone again.
+      """
+
+    // Code 3
+    case .unsupportedParentBundleLocation:
+      """
+      Please ensure Firezone.app is launched from the /Applications folder
+      and try again.
+      """
+
+    // Code 4
+    case .extensionNotFound:
+      """
+      The Firezone.app bundle seems corrupt. Please try downloading and
+      installing Firezone again.
+      """
+
+    // Code 5
+    case .extensionMissingIdentifier:
+      """
+      The system extension is missing its bundle identifier. Please try
+      downloading and installing Firezone again.
+      """
+
+    // Code 6
+    case .duplicateExtensionIdentifer:
+      """
+      The system extension appears to have been installed already. Please try
+      completely removing Firezone and all Firezone-related system extensions
+      and try again.
+      """
+
+    // Code 7
+    case .unknownExtensionCategory:
+      """
+      The system extension doesn't belong to any recognizable category.
+      Please contact your adminstrator for assistance.
+      """
+
+    // Code 8
+    case .codeSignatureInvalid:
+      """
+      The system extension contains an invalid code signature. Please ensure
+      your macOS version is up to date and system integrity protection (SIP)
+      is enabled and functioning properly.
+      """
+
+    // Code 9
+    case .validationFailed:
+      """
+      The system extension unexpectedly failed validation. Please try updating
+      to the latest version and contact your administrator if this issue
+      persists.
+      """
+
+    // Code 10
+    case .forbiddenBySystemPolicy:
+      """
+      The FirezoneNetworkExtension was blocked from loading by a system policy.
+      This will prevent Firezone from functioning. Please contact your
+      administrator for assistance.
+
+      Team ID: 47R2M6779T
+      Extension Identifier: dev.firezone.firezone.network-extension
+      """
+
+    // Code 11
+    case .requestCanceled:
+      // This will happen if the user cancels
+      nil
+
+    // Code 12
+    case .requestSuperseded:
+      // This will happen if the user repeatedly clicks "Enable ..."
+      nil
+
+    // Code 13
+    case .authorizationRequired:
+      // This happens the first time we try to install the system extension.
+      // The user is prompted but we still get this.
+      nil
+
+    default:
+      "\(error)"
+    }
+
+    // Only show alert if we have something to tell the user about
+    guard let messageText else { return }
+
+    let alert = NSAlert()
+    alert.messageText = messageText
+    alert.alertStyle = .critical
+    let _ = alert.runModal()
+  }
+
+  static func show(for error: Error) {
+    if let error = error as? OSSystemExtensionError {
+      show(for: error)
+    }
+  }
+}
+
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
@@ -138,7 +138,7 @@ struct macOSAlert {
       case .unknownExtensionCategory:
         return """
         The system extension doesn't belong to any recognizable category.
-        Please contact your adminstrator for assistance.
+        Please contact your administrator for assistance.
         """
 
         // Code 8
@@ -163,7 +163,7 @@ struct macOSAlert {
         The FirezoneNetworkExtension was blocked from loading by a system policy.
         This will prevent Firezone from functioning. Please contact your
         administrator for assistance.
-        
+
         Team ID: 47R2M6779T
         Extension Identifier: dev.firezone.firezone.network-extension
         """

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/macOSAlert.swift
@@ -3,127 +3,191 @@
 //  (c) 2024 Firezone, Inc.
 //  LICENSE: Apache-2.0
 //
+//  A helper to display alerts that aim to be actionable by the end-user.
 
 #if os(macOS)
 import SystemExtensions
 import AppKit
+import NetworkExtension
 
 @MainActor
 struct macOSAlert {
-  static func show(for error: OSSystemExtensionError) {
-    let messageText: String? =
-    switch error.code {
-
-    // Code 1
-    case .unknown:
-      """
-      An unknown error occurred. Please try enabling the system extension again.
-      If the issue persists, contact your administrator.
-      """
-
-    // Code 2
-    case .missingEntitlement:
-      """
-      The system extension appears to be missing an entitlement. Please try
-      downloading and installing Firezone again.
-      """
-
-    // Code 3
-    case .unsupportedParentBundleLocation:
-      """
-      Please ensure Firezone.app is launched from the /Applications folder
-      and try again.
-      """
-
-    // Code 4
-    case .extensionNotFound:
-      """
-      The Firezone.app bundle seems corrupt. Please try downloading and
-      installing Firezone again.
-      """
-
-    // Code 5
-    case .extensionMissingIdentifier:
-      """
-      The system extension is missing its bundle identifier. Please try
-      downloading and installing Firezone again.
-      """
-
-    // Code 6
-    case .duplicateExtensionIdentifer:
-      """
-      The system extension appears to have been installed already. Please try
-      completely removing Firezone and all Firezone-related system extensions
-      and try again.
-      """
-
-    // Code 7
-    case .unknownExtensionCategory:
-      """
-      The system extension doesn't belong to any recognizable category.
-      Please contact your adminstrator for assistance.
-      """
-
-    // Code 8
-    case .codeSignatureInvalid:
-      """
-      The system extension contains an invalid code signature. Please ensure
-      your macOS version is up to date and system integrity protection (SIP)
-      is enabled and functioning properly.
-      """
-
-    // Code 9
-    case .validationFailed:
-      """
-      The system extension unexpectedly failed validation. Please try updating
-      to the latest version and contact your administrator if this issue
-      persists.
-      """
-
-    // Code 10
-    case .forbiddenBySystemPolicy:
-      """
-      The FirezoneNetworkExtension was blocked from loading by a system policy.
-      This will prevent Firezone from functioning. Please contact your
-      administrator for assistance.
-
-      Team ID: 47R2M6779T
-      Extension Identifier: dev.firezone.firezone.network-extension
-      """
-
-    // Code 11
-    case .requestCanceled:
-      // This will happen if the user cancels
-      nil
-
-    // Code 12
-    case .requestSuperseded:
-      // This will happen if the user repeatedly clicks "Enable ..."
-      nil
-
-    // Code 13
-    case .authorizationRequired:
-      // This happens the first time we try to install the system extension.
-      // The user is prompted but we still get this.
-      nil
-
-    default:
-      "\(error)"
+  static func show(for error: Error) {
+    if let error = error as? OSSystemExtensionError,
+       // Expected in normal operation
+       error.code != .requestCanceled,
+       error.code != .requestSuperseded,
+       error.code != .authorizationRequired
+    {
+      alert(message(for: error))
     }
 
-    // Only show alert if we have something to tell the user about
-    guard let messageText else { return }
+    if let error = error as? NEVPNError {
+      alert(message(for: error))
+    }
+  }
 
+  private static func alert(_ messageText: String) {
     let alert = NSAlert()
     alert.messageText = messageText
     alert.alertStyle = .critical
     let _ = alert.runModal()
   }
 
-  static func show(for error: Error) {
-    if let error = error as? OSSystemExtensionError {
-      show(for: error)
-    }
+  // NEVPNError
+  private static func message(for error: NEVPNError) -> String {
+    return {
+      switch error.code {
+
+      // Code 1
+      case .configurationDisabled:
+        return """
+        The VPN configuration appears to be disabled. Please remove the Firezone
+        VPN configuration in System Settings and try again.
+        """
+
+      // Code 2
+      case .configurationInvalid:
+        return """
+        The VPN configuration appears to be invalid. Please remove the Firezone
+        VPN configuration in System Settings and try again.
+        """
+
+      // Code 3
+      case .connectionFailed:
+        return """
+        The VPN connection failed. Try signing in again.
+        """
+
+      // Code 4
+      case .configurationStale:
+        return """
+        The VPN configuration appears to be stale. Please remove the Firezone
+        VPN configuration in System Settings and try again.
+        """
+
+      // Code 5
+      case .configurationReadWriteFailed:
+        return """
+        Could not read or write the VPN configuration. Try removing the Firezone
+        VPN configuration from System Settings if this issue persists.
+        """
+
+      // Code 6
+      case .configurationUnknown:
+        return """
+        An unknown VPN configuration error occurred. Try removing the Firezone
+        VPN configuration from System Settings if this issue persists.
+        """
+
+      @unknown default:
+        return "\(error)"
+      }
+    }()
+  }
+
+  // OSSystemExtensionError
+  private static func message(for error: OSSystemExtensionError) -> String {
+    return {
+      switch error.code {
+
+        // Code 1
+      case .unknown:
+        return """
+        An unknown error occurred. Please try enabling the system extension again.
+        If the issue persists, contact your administrator.
+        """
+
+        // Code 2
+      case .missingEntitlement:
+        return """
+        The system extension appears to be missing an entitlement. Please try
+        downloading and installing Firezone again.
+        """
+
+        // Code 3
+      case .unsupportedParentBundleLocation:
+        return """
+        Please ensure Firezone.app is launched from the /Applications folder
+        and try again.
+        """
+
+        // Code 4
+      case .extensionNotFound:
+        return """
+        The Firezone.app bundle seems corrupt. Please try downloading and
+        installing Firezone again.
+        """
+
+        // Code 5
+      case .extensionMissingIdentifier:
+        return """
+        The system extension is missing its bundle identifier. Please try
+        downloading and installing Firezone again.
+        """
+
+        // Code 6
+      case .duplicateExtensionIdentifer:
+        return """
+        The system extension appears to have been installed already. Please try
+        completely removing Firezone and all Firezone-related system extensions
+        and try again.
+        """
+
+        // Code 7
+      case .unknownExtensionCategory:
+        return """
+        The system extension doesn't belong to any recognizable category.
+        Please contact your adminstrator for assistance.
+        """
+
+        // Code 8
+      case .codeSignatureInvalid:
+        return """
+        The system extension contains an invalid code signature. Please ensure
+        your macOS version is up to date and system integrity protection (SIP)
+        is enabled and functioning properly.
+        """
+
+        // Code 9
+      case .validationFailed:
+        return """
+        The system extension unexpectedly failed validation. Please try updating
+        to the latest version and contact your administrator if this issue
+        persists.
+        """
+
+        // Code 10
+      case .forbiddenBySystemPolicy:
+        return """
+        The FirezoneNetworkExtension was blocked from loading by a system policy.
+        This will prevent Firezone from functioning. Please contact your
+        administrator for assistance.
+        
+        Team ID: 47R2M6779T
+        Extension Identifier: dev.firezone.firezone.network-extension
+        """
+
+        // Code 11
+      case .requestCanceled:
+        // This will happen if the user cancels
+        fallthrough
+
+        // Code 12
+      case .requestSuperseded:
+        // This will happen if the user repeatedly clicks "Enable ..."
+        fallthrough
+
+        // Code 13
+      case .authorizationRequired:
+        // This happens the first time we try to install the system extension.
+        // The user is prompted but we still get this.
+        fallthrough
+
+      @unknown default:
+        return "\(error)"
+      }
+    }()
   }
 }
 


### PR DESCRIPTION
When installing the System Extension or VPN configuration, certain errors can occur.

Some of these are due to user error and we should further advise the user how to remedy.

For others, they aren't really actionable, and we silently ignore or quietly log them.

Resolves: #7714 