### PR TITLE
ci: split installation test for GUI client into separate script

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -51,6 +51,7 @@ jobs:
       # mark:next-gui-version
       FIREZONE_GUI_VERSION: 1.4.1
       RENAME_SCRIPT: ../../scripts/build/tauri-rename-${{ matrix.os }}.sh
+      TEST_INSTALL_SCRIPT: ../../scripts/tests/gui-client-install-${{ matrix.os }}-${{ matrix.pkg-extension }}.sh
       TARGET_DIR: ../target
       UPLOAD_SCRIPT: ../../scripts/build/tauri-upload-${{ matrix.os }}.sh
     steps:
@@ -90,28 +91,32 @@ jobs:
         shell: bash
         run: ../../scripts/build/sign.sh ../target/release/bundle/msi/Firezone_${{ env.FIREZONE_GUI_VERSION }}_x64_en-US.msi
       - name: Rename artifacts and compute SHA256
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
         shell: bash
         run: ${{ env.RENAME_SCRIPT }}
-      - name: Upload debug symbols to Sentry
-        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
-        run: |
-          sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
-          sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target
-      - name: Upload package
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+      - name: Upload deb / msi package
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ env.ARTIFACT_DST }}-pkg
           path: ${{ env.ARTIFACT_SRC }}.${{ matrix.pkg-extension }}
           if-no-files-found: error
       - name: Upload rpm package
-        if: "${{ runner.os == 'Linux' && github.event_name == 'workflow_dispatch' }}"
+        if: "${{ runner.os == 'Linux' }}"
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ env.ARTIFACT_DST }}-rpm
           path: ${{ env.ARTIFACT_SRC }}.rpm
           if-no-files-found: error
+      - name: Test installation
+        # if: "${{ github.event_name == 'workflow_dispatch' }}"
+        shell: bash
+        run: ${{ env.TEST_INSTALL_SCRIPT }}
+
+      - name: Upload debug symbols to Sentry
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        run: |
+          sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
+          sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target
+
       - name: Upload Release Assets
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         env:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -112,7 +112,7 @@ jobs:
         run: ${{ env.TEST_INSTALL_SCRIPT }}
 
       - name: Upload debug symbols to Sentry
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         run: |
           sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
           sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -107,7 +107,7 @@ jobs:
           path: ${{ env.ARTIFACT_SRC }}.rpm
           if-no-files-found: error
       - name: Test installation
-        # if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         shell: bash
         run: ${{ env.TEST_INSTALL_SCRIPT }}
 

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -94,7 +94,7 @@ jobs:
         shell: bash
         run: ${{ env.RENAME_SCRIPT }}
       - name: Upload debug symbols to Sentry
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         run: |
           sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
           sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target
@@ -113,7 +113,7 @@ jobs:
           path: ${{ env.ARTIFACT_SRC }}.rpm
           if-no-files-found: error
       - name: Upload Release Assets
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}

--- a/scripts/build/tauri-rename-linux.sh
+++ b/scripts/build/tauri-rename-linux.sh
@@ -4,13 +4,6 @@
 
 set -euox pipefail
 
-SERVICE_NAME=firezone-client-ipc
-
-function debug_exit() {
-    systemctl status "$SERVICE_NAME"
-    exit 1
-}
-
 # For debugging
 ls "$TARGET_DIR/release" "$TARGET_DIR/release/bundle/deb"
 
@@ -33,23 +26,3 @@ make_hash "$BINARY_DEST_PATH"
 make_hash "$BINARY_DEST_PATH.dwp"
 make_hash "$BINARY_DEST_PATH.deb"
 make_hash "$BINARY_DEST_PATH.rpm"
-
-# Test the deb package, since this script is the easiest place to get a release build
-DEB_PATH=$(realpath "$BINARY_DEST_PATH.deb")
-sudo apt-get install "$DEB_PATH"
-
-# Debug-print the files. The icons and both binaries should be in here
-dpkg --listfiles firezone-client-gui
-# Print the deps
-dpkg --info "$DEB_PATH"
-
-# Confirm that both binaries and at least one icon were installed
-which firezone-client-gui firezone-client-ipc
-stat /usr/share/icons/hicolor/512x512/apps/firezone-client-gui.png
-
-# Make sure the binary got built, packaged, and installed, and at least
-# knows its own name
-firezone-client-gui --help | grep "Usage: firezone-client-gui"
-
-# Make sure the IPC service is running
-systemctl status "$SERVICE_NAME" || debug_exit

--- a/scripts/build/tauri-rename-windows.sh
+++ b/scripts/build/tauri-rename-windows.sh
@@ -17,10 +17,3 @@ function make_hash() {
 make_hash "$BINARY_DEST_PATH.exe"
 make_hash "$BINARY_DEST_PATH.msi"
 make_hash "$BINARY_DEST_PATH.pdb"
-
-# Test-install the MSI package, since it already exists here
-msiexec //i "$BINARY_DEST_PATH.msi" //log install.log //qn
-# For debugging
-cat install.log
-# Make sure the IPC service is running
-sc query FirezoneClientIpcService | grep RUNNING

--- a/scripts/tests/gui-client-install-linux-deb.sh
+++ b/scripts/tests/gui-client-install-linux-deb.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Runs from `rust/gui-client` or `rust/tauri-client`
+
+set -euox pipefail
+
+SERVICE_NAME=firezone-client-ipc
+
+function debug_exit() {
+    systemctl status "$SERVICE_NAME"
+    exit 1
+}
+
+# Test the deb package, since this script is the easiest place to get a release build
+DEB_PATH=$(realpath "$BINARY_DEST_PATH.deb")
+sudo apt-get install "$DEB_PATH"
+
+# Debug-print the files. The icons and both binaries should be in here
+dpkg --listfiles firezone-client-gui
+# Print the deps
+dpkg --info "$DEB_PATH"
+
+# Confirm that both binaries and at least one icon were installed
+which firezone-client-gui firezone-client-ipc
+stat /usr/share/icons/hicolor/512x512/apps/firezone-client-gui.png
+
+# Make sure the binary got built, packaged, and installed, and at least
+# knows its own name
+firezone-client-gui --help | grep "Usage: firezone-client-gui"
+
+# Make sure the IPC service is running
+systemctl status "$SERVICE_NAME" || debug_exit

--- a/scripts/tests/gui-client-install-windows-msi.sh
+++ b/scripts/tests/gui-client-install-windows-msi.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+# Test-install the MSI package, since it already exists here
+msiexec //i "$BINARY_DEST_PATH.msi" //log install.log //qn
+# For debugging
+cat install.log
+# Make sure the IPC service is running
+sc query FirezoneClientIpcService | grep RUNNING


### PR DESCRIPTION
In #7795, we optimised our CI pipeline to only test the installation of the GUI client whenever we actually upload to the draft release. This trigger has been moved to `workflow_dispatch`, meaning no CI builds neither from PRs nor `main` perform these steps.

This makes it difficult to test GUI client binaries from PRs because they also no longer get uploaded to the artifacts of the CI run on the PR.

To fix this, we split the testing away from the rename script and unconditionally run the rename script, which allows us to also always upload the binaries to the CI artifacts.

Finally, uploading to the draft releases is only done when we explicitly trigger the workflow from `main`. This is a defense-in-depth measure: We should never publish a code to a release that hasn't been merged to `main`.