### PR TITLE
chore(snownet): don't log missing attribute for binding requests

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1103,7 +1103,9 @@ impl Allocation {
     #[cfg(not(test))]
     fn check_message_integrity(&self, message: &Message<Attribute>) -> bool {
         let Some(mi) = message.get_attribute::<MessageIntegrity>() else {
-            tracing::debug!("Message does not have a `MessageIntegrity` attribute");
+            if message.method() != BINDING {
+                tracing::debug!("Message does not have a `MessageIntegrity` attribute");
+            }
 
             return false;
         };


### PR DESCRIPTION
STUN binding requests & responses are not authenticated on purpose because they are so easy to fulfill that having to perform the computational work to check the authentication is more work than actually just sending the request. With #7819, we send STUN binding requests more often because they are used as keep-alives to the relay. This spams the debug log because we see

> Message does not have a `MessageIntegrity` attribute

for every BINDING response. This information isn't interesting for BINDING responses because those will never have a `MessageIntegrity` attribute.