### PR TITLE
fix(rust): don't start all log files with `connlib.`

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -139,7 +139,7 @@ fn init_logging(log_dir: &Path, log_filter: String) -> Result<()> {
     }
 
     let (log_filter, reload_handle) = reload::Layer::new(log_filter);
-    let (file_layer, handle) = firezone_logging::file::layer(log_dir);
+    let (file_layer, handle) = firezone_logging::file::layer(log_dir, "connlib");
 
     let subscriber = tracing_subscriber::registry()
         .with(log_filter)

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -193,7 +193,7 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<()> {
 
     let (env_filter, reload_handle) = tracing_subscriber::reload::Layer::new(env_filter);
 
-    let (file_layer, handle) = firezone_logging::file::layer(&log_dir);
+    let (file_layer, handle) = firezone_logging::file::layer(&log_dir, "connlib");
 
     let subscriber = tracing_subscriber::registry()
         .with(env_filter)

--- a/rust/gui-client/src-common/src/logging.rs
+++ b/rust/gui-client/src-common/src/logging.rs
@@ -52,7 +52,7 @@ pub fn setup(directives: &str) -> Result<Handles> {
     let log_path = known_dirs::logs().context("Can't compute app log dir")?;
 
     std::fs::create_dir_all(&log_path).map_err(Error::CreateDirAll)?;
-    let (layer, logger) = firezone_logging::file::layer(&log_path);
+    let (layer, logger) = firezone_logging::file::layer(&log_path, "gui-client");
     let (filter, reloader) = reload::Layer::new(firezone_logging::try_filter(directives)?);
     let subscriber = Registry::default()
         .with(layer.with_filter(filter))

--- a/rust/headless-client/src/clear_logs.rs
+++ b/rust/headless-client/src/clear_logs.rs
@@ -67,6 +67,11 @@ fn choose_logs_to_delete(paths: &[PathBuf]) -> Vec<&Path> {
             // Don't delete files if we can't parse their stems as UTF-8.
             let stem = path.file_stem()?.to_str()?;
 
+            if !stem.ends_with(".log") {
+                // Delete any non-log files like crash dumps.
+                return Some(path.as_path());
+            }
+
             (stem < most_recent_stem).then_some(path.as_path())
         })
         .collect()

--- a/rust/headless-client/src/clear_logs.rs
+++ b/rust/headless-client/src/clear_logs.rs
@@ -67,11 +67,6 @@ fn choose_logs_to_delete(paths: &[PathBuf]) -> Vec<&Path> {
             // Don't delete files if we can't parse their stems as UTF-8.
             let stem = path.file_stem()?.to_str()?;
 
-            if !stem.ends_with(".log") {
-                // Delete any non-log files like crash dumps.
-                return Some(path.as_path());
-            }
-
             (stem < most_recent_stem).then_some(path.as_path())
         })
         .collect()
@@ -109,8 +104,6 @@ mod tests {
                 "/bogus/connlib.2024-08-06-14-21-13.log",
                 "/bogus/connlib.2024-08-06-14-51-19.jsonl",
                 "/bogus/connlib.2024-08-06-14-51-19.log",
-                "/bogus/crash.2024-07-22-21-16-20.dmp",
-                "/bogus/last_crash.dmp",
             ]
             .into_iter()
             .map(Path::new)

--- a/rust/headless-client/src/clear_logs.rs
+++ b/rust/headless-client/src/clear_logs.rs
@@ -66,10 +66,7 @@ fn choose_logs_to_delete(paths: &[PathBuf]) -> Vec<&Path> {
         .filter_map(|path| {
             // Don't delete files if we can't parse their stems as UTF-8.
             let stem = path.file_stem()?.to_str()?;
-            if !stem.starts_with("connlib.") {
-                // Delete any non-log files like crash dumps.
-                return Some(path.as_path());
-            }
+
             (stem < most_recent_stem).then_some(path.as_path())
         })
         .collect()

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -666,7 +666,7 @@ fn setup_logging(
     std::fs::create_dir_all(&log_dir)
         .context("We should have permissions to create our log dir")?;
 
-    let (layer, handle) = firezone_logging::file::layer(&log_dir);
+    let (layer, handle) = firezone_logging::file::layer(&log_dir, "ipc-service");
 
     let directives = get_log_filter().context("Couldn't read log filter")?;
     let (filter, reloader) = reload::Layer::new(firezone_logging::try_filter(&directives)?);

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -137,7 +137,7 @@ fn main() -> Result<()> {
         .common
         .log_dir
         .as_deref()
-        .map(firezone_logging::file::layer)
+        .map(|dir| firezone_logging::file::layer(dir, "firezone-headless-client"))
         .unzip();
     firezone_logging::setup_global_subscriber(layer).context("Failed to set up logging")?;
 


### PR DESCRIPTION
At present, the file logger for all Rust code starts each logfile with `connlib.`. This is very confusing when exporting the logs from the GUI client because even the logs from the client itself will start with `connlib.`. To fix this, we make the base file name of the log file configurable.