### PR TITLE
chore(rust): remove JSON logging

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2146,7 +2146,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-log",
- "tracing-stackdriver",
  "tracing-subscriber",
 ]
 

--- a/rust/logging/Cargo.toml
+++ b/rust/logging/Cargo.toml
@@ -16,7 +16,6 @@ time = { workspace = true, features = ["formatting"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-log = { workspace = true }
-tracing-stackdriver = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Nobody looks at these logs, writing them uses unnecessary CPU + storage on users devices. It also means we have 1 background thread less because we need one less non-blocking writer.