### PR TITLE
revert(infra): Billing budget (PR #7836)

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -38,11 +38,10 @@ provider "google-beta" {}
 module "google-cloud-project" {
   source = "../../modules/google-cloud/project"
 
-  id                    = "firezone-prod"
-  name                  = "Production Environment"
-  organization_id       = "335836213177"
-  billing_account_id    = "0199BA-489CDD-F385C8"
-  billing_budget_amount = var.billing_budget_amount
+  id                 = "firezone-prod"
+  name               = "Production Environment"
+  organization_id    = "335836213177"
+  billing_account_id = "0199BA-489CDD-F385C8"
 
   auto_create_network = false
 }

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -97,8 +97,3 @@ variable "portal_image_tag" {
   type    = string
   default = null
 }
-
-variable "billing_budget_amount" {
-  type        = number
-  description = "Monthly budget in USD for billing alerts"
-}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -44,11 +44,10 @@ provider "google-beta" {}
 module "google-cloud-project" {
   source = "../../modules/google-cloud/project"
 
-  id                    = "firezone-staging"
-  name                  = "Staging Environment"
-  organization_id       = "335836213177"
-  billing_account_id    = "01DFC9-3D6951-579BE1"
-  billing_budget_amount = var.billing_budget_amount
+  id                 = "firezone-staging"
+  name               = "Staging Environment"
+  organization_id    = "335836213177"
+  billing_account_id = "01DFC9-3D6951-579BE1"
 
   auto_create_network = false
 }

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -75,8 +75,3 @@ variable "workos_client_id" {
 variable "workos_base_url" {
   type = string
 }
-
-variable "billing_budget_amount" {
-  type        = number
-  description = "Monthly budget in USD for billing alerts"
-}

--- a/terraform/modules/google-cloud/project/main.tf
+++ b/terraform/modules/google-cloud/project/main.tf
@@ -36,19 +36,3 @@ resource "google_project_service" "serviceusage" {
 
   disable_on_destroy = false
 }
-
-resource "google_billing_budget" "budget" {
-  billing_account = var.billing_account_id
-  display_name    = "Firezone Budget"
-
-  amount {
-    specified_amount {
-      currency_code = "USD"
-      units         = var.billing_budget_amount
-    }
-  }
-
-  threshold_rules {
-    threshold_percent = 0.5
-  }
-}

--- a/terraform/modules/google-cloud/project/variables.tf
+++ b/terraform/modules/google-cloud/project/variables.tf
@@ -6,11 +6,6 @@ variable "billing_account_id" {
   description = "ID of a Google Cloud Billing Account which will be used to pay for resources"
 }
 
-variable "billing_budget_amount" {
-  type        = number
-  description = "Monthly budget for the billing account in USD"
-}
-
 variable "name" {
   description = "Name of a Google Cloud Project"
 }


### PR DESCRIPTION
This is causing issues applying because our CI terraform IAM user doesn't have the `Billing Account Administrator` role.

Rather than granting such a sensitive role to our CI pipeline, I'm suggesting we create the billing budget outside the scope of the terraform config tracked in this repo.

If we want it to be tracked as code, I would propose maybe we have a separate (private) repository with a separate token / IAM permissions that we can monitor separately.

For the time being, I'll plan to manually create this budget in the UI.

Reverts: #7836 