### PR TITLE
refactor(apple): Downgrade onSetInterfaceConfig when tunnelStopped

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -388,7 +388,8 @@ extension Adapter: CallbackHandlerDelegate {
 
         networkSettings.apply()
       case .tunnelStopped:
-        Log.error(AdapterError.invalidState(self.state))
+        // Callback was processed after tunnel stopped; nothing to do
+        Log.debug("\(AdapterError.invalidState(self.state))")
       }
     }
   }


### PR DESCRIPTION
This log isn't actionable. These callbacks are processed in a queue, so if they get delayed for whatever reason, it's possible this callback can be processed after the tunnel has stopped.