### PR TITLE
ci: Upload Rust symbols to Sentry for Apple

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -95,7 +95,7 @@ jobs:
           rm -f "${{ runner.temp }}/dmg/Applications"
 
           sentry-cli debug-files upload --log-level info --project apple-client --include-sources ${{ runner.temp }}
-          sentry-cli debug-files upload --log-level info --project apple-client ./rust/target
+          sentry-cli debug-files upload --log-level info --project apple-client --include-sources ./rust/target
       - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: ${{ steps.cache.outputs.cache-hit != 'true'}}
         name: Save Swift DerivedData Cache

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -95,6 +95,7 @@ jobs:
           rm -f "${{ runner.temp }}/dmg/Applications"
 
           sentry-cli debug-files upload --log-level info --project apple-client --include-sources ${{ runner.temp }}
+          sentry-cli debug-files upload --log-level info --project apple-client ./rust/target
       - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: ${{ steps.cache.outputs.cache-hit != 'true'}}
         name: Save Swift DerivedData Cache


### PR DESCRIPTION
In addition to the Swift symbols, we also need the symbols from the Rust build of connlib.