### PR TITLE
fix(apple): Fix retain cycle in Log.swift

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -196,6 +196,8 @@ private final class LogWriter {
 
     jsonData.append(newLineData)
 
-    workQueue.async { self.handle.write(jsonData) }
+    workQueue.async { [weak self] in
+      self?.handle.write(jsonData)
+    }
   }
 }


### PR DESCRIPTION
The previous developer introduced a retain cycle in Log.swift by strongly capturing `self` inside an async closure.