### PR TITLE
fix(apple): Initialize NSAlert on the main thread

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -108,6 +108,7 @@ public class SessionNotification: NSObject {
 #elseif os(macOS)
   // In macOS, use a Cocoa alert.
   // This gets called from the app side.
+  @MainActor
   func showSignedOutAlertmacOS() {
     let alert = NSAlert()
     alert.messageText = "Your Firezone session has ended"


### PR DESCRIPTION
All UI operations must take place on the main thread. Swift doesn't protect us from this unfortunately for Cocoa APIs like `NSAlert`.