### PR TITLE
fix(infra): Use naming_suffix in instance_group_manager

### DIFF
--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -353,15 +353,15 @@ module "relays" {
       zones    = ["us-west4-a"]
     }
   }
-  network                         = google_compute_network.network.self_link
-  instance_template_naming_suffix = random_string.naming_suffix.result
-  container_registry              = module.google-artifact-registry.url
-  image_repo                      = module.google-artifact-registry.repo
-  image                           = "relay"
-  image_tag                       = local.relay_image_tag
-  observability_log_level         = "info,hyper=off,h2=warn,tower=warn"
-  application_name                = "relay"
-  application_version             = replace(local.relay_image_tag, ".", "-")
+  network                 = google_compute_network.network.self_link
+  naming_suffix           = random_string.naming_suffix.result
+  container_registry      = module.google-artifact-registry.url
+  image_repo              = module.google-artifact-registry.repo
+  image                   = "relay"
+  image_tag               = local.relay_image_tag
+  observability_log_level = "info,hyper=off,h2=warn,tower=warn"
+  application_name        = "relay"
+  application_version     = replace(local.relay_image_tag, ".", "-")
   application_environment_variables = [
     {
       name  = "FIREZONE_TELEMETRY"

--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -348,15 +348,15 @@ module "relays" {
       zones    = ["us-west4-a"]
     }
   }
-  network                         = google_compute_network.network.self_link
-  instance_template_naming_suffix = random_string.naming_suffix.result
-  container_registry              = module.google-artifact-registry.url
-  image_repo                      = module.google-artifact-registry.repo
-  image                           = "relay"
-  image_tag                       = var.image_tag
-  observability_log_level         = "info,hyper=off,h2=warn,tower=warn"
-  application_name                = "relay"
-  application_version             = replace(var.image_tag, ".", "-")
+  network                 = google_compute_network.network.self_link
+  naming_suffix           = random_string.naming_suffix.result
+  container_registry      = module.google-artifact-registry.url
+  image_repo              = module.google-artifact-registry.repo
+  image                   = "relay"
+  image_tag               = var.image_tag
+  observability_log_level = "info,hyper=off,h2=warn,tower=warn"
+  application_name        = "relay"
+  application_version     = replace(var.image_tag, ".", "-")
   application_environment_variables = [
     {
       name  = "FIREZONE_TELEMETRY"

--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -147,7 +147,7 @@ resource "google_compute_instance_template" "application" {
 
   project = var.project_id
 
-  name_prefix = "${local.application_name}-${each.key}-${var.instance_template_naming_suffix}-"
+  name_prefix = "${local.application_name}-${each.key}-${var.naming_suffix}-"
 
   description = "This template is used to create ${local.application_name} instances using Terraform."
 
@@ -302,7 +302,7 @@ resource "google_compute_region_instance_group_manager" "application" {
 
   project = var.project_id
 
-  name = "${local.application_name}-group-${each.key}"
+  name = "${local.application_name}-group-${each.key}-${var.naming_suffix}"
 
   base_instance_name = local.application_name
 

--- a/terraform/modules/google-cloud/apps/relay/variables.tf
+++ b/terraform/modules/google-cloud/apps/relay/variables.tf
@@ -23,10 +23,10 @@ variable "network" {
   description = "ID of a Google Cloud Network"
 }
 
-# Ensure instance group template is recreated when this value is changed.
-variable "instance_template_naming_suffix" {
+# Ensure instances are recreated when this is changed.
+variable "naming_suffix" {
   type        = string
-  description = "Suffix to append to the name of the instance group template."
+  description = "Suffix to append to the name of resources."
 }
 
 ################################################################################


### PR DESCRIPTION
Google still had lingering Relay instance groups and subnets around from a previous deployment that were deleted in the UI and gone, but then popped back up.

Theoretically, the instance groups should be deleted because there is no current Terraform config matching them. This change will ensure that instance groups also get rolled over based on the naming suffix introduced in #7870.

Related: #7870