### PR TITLE
chore(infra): Disable debug log for otel

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/templates/cloud-init.yaml
+++ b/terraform/modules/google-cloud/apps/relay/templates/cloud-init.yaml
@@ -56,9 +56,6 @@ write_files:
             - set(attributes["exported_instrumentation_version"], attributes["instrumentation_version"])
             - delete_key(attributes, "instrumentation_version")
       service:
-        telemetry:
-          logs:
-            level: "debug"
         pipelines:
           traces:
             receivers: [otlp]


### PR DESCRIPTION
In the relay's `cloud-init.yaml`, we've overridden the `telemetry` service log filter to be `debug`.

This results in this log being printed to Cloud Logging every 1s, for _every_ relay:

```
2025-01-26T23:00:35.066Z	debug	memorylimiter/memorylimiter.go:200	Currently used memory.	{"kind": "processor", "name": "memory_limiter", "pipeline": "logs", "cur_mem_mib": 31}
```

These logs are consuming over half of our total log count, which accounts for over half our Cloud Monitoring cost -- the second highest cost in our GCP account.

This PR removes the override so that the relay app has the same `otel-collector` log level as the Elixir, the default (presumably `info`).

