### PR TITLE
fix(infra): Make staging relays match prod exactly

### DIFF
--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -96,8 +96,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 module "relays" {
-  count = var.relay_token != null ? 1 : 0
-
+  count      = var.relay_token != null ? 1 : 0
   source     = "../../modules/google-cloud/apps/relay"
   project_id = module.google-cloud-project.project.project_id
 
@@ -387,23 +386,18 @@ module "relays" {
 
 # Allow SSH access using IAP for relays
 resource "google_compute_firewall" "relays-ssh-ipv4" {
-  count = length(module.relays) > 0 ? 1 : 0
-
+  count   = length(module.relays) > 0 ? 1 : 0
   project = module.google-cloud-project.project.project_id
-
   name    = "relays-ssh-ipv4"
   network = google_compute_network.network.self_link
-
   allow {
     protocol = "tcp"
     ports    = [22]
   }
-
   allow {
     protocol = "udp"
     ports    = [22]
   }
-
   allow {
     protocol = "sctp"
     ports    = [22]

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -22,6 +22,10 @@ locals {
   iap_ipv4_ranges = [
     "35.235.240.0/20"
   ]
+
+  gateway_image_tag = var.gateway_image_tag != null ? var.gateway_image_tag : var.image_tag
+  relay_image_tag   = var.relay_image_tag != null ? var.relay_image_tag : var.image_tag
+  portal_image_tag  = var.portal_image_tag != null ? var.portal_image_tag : var.image_tag
 }
 
 terraform {

--- a/terraform/environments/staging/outputs.tf
+++ b/terraform/environments/staging/outputs.tf
@@ -15,3 +15,15 @@ output "demo_postgresql_connection_url" {
 output "image_tag" {
   value = var.image_tag
 }
+
+output "gateway_image_tag" {
+  value = local.gateway_image_tag
+}
+
+output "relay_image_tag" {
+  value = local.relay_image_tag
+}
+
+output "portal_image_tag" {
+  value = local.portal_image_tag
+}

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -75,3 +75,27 @@ variable "workos_client_id" {
 variable "workos_base_url" {
   type = string
 }
+
+# Version overrides
+#
+#
+# This section should be used to bind a specific version of the Firezone component
+# (eg. during rollback) to ensure it's not replaced by a new one until a manual action
+#
+# To update them go to Terraform Cloud and change/delete the following variables,
+# if they are unset `var.image_tag` will be used.
+
+variable "relay_image_tag" {
+  type    = string
+  default = null
+}
+
+variable "gateway_image_tag" {
+  type    = string
+  default = null
+}
+
+variable "portal_image_tag" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
There are two places relating to Relays where our production infra has drifted from staging:

- We have a "Relays are down" alarm on prod that we don't on staging
- We allow overriding the image tag to deploy via an input var on prod (this can be set from the TF cloud UI)

This PR fixes that, and also updates the production TF config whitespace to match staging exactly for easier diffs.