### PR TITLE
refactor(gateway): improve logging for filtered traffic

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -4,14 +4,14 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::Instant;
 
 use crate::client::{IPV4_RESOURCES, IPV6_RESOURCES};
+use crate::messages::gateway::Filters;
 use crate::messages::gateway::ResourceDescription;
-use crate::messages::{gateway::Filter, gateway::Filters};
 use chrono::{DateTime, Utc};
 use connlib_model::{ClientId, DomainName, GatewayId, ResourceId};
+use filter_engine::FilterEngine;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_network_table::IpNetworkTable;
 use ip_packet::IpPacket;
-use rangemap::RangeInclusiveSet;
 
 use crate::utils::network_contains_network;
 use crate::GatewayEvent;
@@ -19,85 +19,8 @@ use crate::GatewayEvent;
 use anyhow::{bail, Context, Result};
 use nat_table::{NatTable, TranslateIncomingResult};
 
+mod filter_engine;
 mod nat_table;
-
-#[derive(Debug)]
-enum FilterEngine {
-    PermitAll,
-    PermitSome(AllowRules),
-}
-
-#[derive(Debug)]
-struct AllowRules {
-    udp: RangeInclusiveSet<u16>,
-    tcp: RangeInclusiveSet<u16>,
-    icmp: bool,
-}
-
-impl FilterEngine {
-    fn is_allowed(&self, packet: &IpPacket) -> bool {
-        match self {
-            FilterEngine::PermitAll => true,
-            FilterEngine::PermitSome(filter_engine) => filter_engine.is_allowed(packet),
-        }
-    }
-
-    fn with_filters<'a>(filters: impl Iterator<Item = &'a Filters> + Clone) -> FilterEngine {
-        // Empty filters means permit all
-        if filters.clone().any(|f| f.is_empty()) {
-            return Self::PermitAll;
-        }
-
-        let mut allow_rules = AllowRules::new();
-        allow_rules.add_filters(filters.flatten());
-
-        Self::PermitSome(allow_rules)
-    }
-}
-
-impl AllowRules {
-    fn new() -> AllowRules {
-        AllowRules {
-            udp: RangeInclusiveSet::new(),
-            tcp: RangeInclusiveSet::new(),
-            icmp: false,
-        }
-    }
-
-    fn is_allowed(&self, packet: &IpPacket) -> bool {
-        if let Some(tcp) = packet.as_tcp() {
-            return self.tcp.contains(&tcp.destination_port());
-        }
-
-        if let Some(udp) = packet.as_udp() {
-            return self.udp.contains(&udp.destination_port());
-        }
-
-        if packet.is_icmp() || packet.is_icmpv6() {
-            return self.icmp;
-        }
-
-        false
-    }
-
-    fn add_filters<'a>(&mut self, filters: impl IntoIterator<Item = &'a Filter>) {
-        for filter in filters {
-            match filter {
-                Filter::Udp(range) => {
-                    self.udp
-                        .insert(range.port_range_start..=range.port_range_end);
-                }
-                Filter::Tcp(range) => {
-                    self.tcp
-                        .insert(range.port_range_start..=range.port_range_end);
-                }
-                Filter::Icmp => {
-                    self.icmp = true;
-                }
-            }
-        }
-    }
-}
 
 /// The state of one gateway on a client.
 pub(crate) struct GatewayOnClient {
@@ -893,7 +816,9 @@ mod tests {
 #[cfg(all(test, feature = "proptest"))]
 mod proptests {
     use super::*;
-    use crate::messages::gateway::{PortRange, ResourceDescription, ResourceDescriptionCidr};
+    use crate::messages::gateway::{
+        Filter, PortRange, ResourceDescription, ResourceDescriptionCidr,
+    };
     use crate::proptest::*;
     use ip_packet::make::{icmp_request_packet, tcp_packet, udp_packet};
     use itertools::Itertools as _;
@@ -903,6 +828,7 @@ mod proptests {
         sample::select,
         strategy::{Just, Strategy},
     };
+    use rangemap::RangeInclusiveSet;
     use std::{collections::BTreeSet, ops::RangeInclusive};
     use test_strategy::Arbitrary;
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -329,13 +329,13 @@ impl ClientOnGateway {
             return Ok(());
         }
 
-        if !self
+        let (_, filter) = self
             .filters
             .longest_match(dst)
-            .is_some_and(|(_, filter)| filter.is_allowed(packet))
-        {
-            return Err(anyhow::Error::new(DstNotAllowed(dst)));
-        };
+            .context("No filter")
+            .context(DstNotAllowed(dst))?;
+
+        filter.apply(packet).context(DstNotAllowed(dst))?;
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/peer/filter_engine.rs
+++ b/rust/connlib/tunnel/src/peer/filter_engine.rs
@@ -1,0 +1,84 @@
+use ip_packet::IpPacket;
+use rangemap::RangeInclusiveSet;
+
+use crate::messages::gateway::{Filter, Filters};
+
+#[derive(Debug)]
+pub(crate) enum FilterEngine {
+    PermitAll,
+    PermitSome(AllowRules),
+}
+
+#[derive(Debug)]
+pub(crate) struct AllowRules {
+    udp: RangeInclusiveSet<u16>,
+    tcp: RangeInclusiveSet<u16>,
+    icmp: bool,
+}
+
+impl FilterEngine {
+    pub(crate) fn is_allowed(&self, packet: &IpPacket) -> bool {
+        match self {
+            FilterEngine::PermitAll => true,
+            FilterEngine::PermitSome(filter_engine) => filter_engine.is_allowed(packet),
+        }
+    }
+
+    pub(crate) fn with_filters<'a>(
+        filters: impl Iterator<Item = &'a Filters> + Clone,
+    ) -> FilterEngine {
+        // Empty filters means permit all
+        if filters.clone().any(|f| f.is_empty()) {
+            return Self::PermitAll;
+        }
+
+        let mut allow_rules = AllowRules::new();
+        allow_rules.add_filters(filters.flatten());
+
+        Self::PermitSome(allow_rules)
+    }
+}
+
+impl AllowRules {
+    fn new() -> AllowRules {
+        AllowRules {
+            udp: RangeInclusiveSet::new(),
+            tcp: RangeInclusiveSet::new(),
+            icmp: false,
+        }
+    }
+
+    fn is_allowed(&self, packet: &IpPacket) -> bool {
+        if let Some(tcp) = packet.as_tcp() {
+            return self.tcp.contains(&tcp.destination_port());
+        }
+
+        if let Some(udp) = packet.as_udp() {
+            return self.udp.contains(&udp.destination_port());
+        }
+
+        if packet.is_icmp() || packet.is_icmpv6() {
+            return self.icmp;
+        }
+
+        false
+    }
+
+    fn add_filters<'a>(&mut self, filters: impl IntoIterator<Item = &'a Filter>) {
+        for filter in filters {
+            match filter {
+                Filter::Udp(range) => {
+                    self.udp
+                        .insert(range.port_range_start..=range.port_range_end);
+                }
+                Filter::Tcp(range) => {
+                    self.tcp
+                        .insert(range.port_range_start..=range.port_range_end);
+                }
+                Filter::Icmp => {
+                    self.icmp = true;
+                }
+            }
+        }
+    }
+}

--- a/rust/connlib/tunnel/src/peer/filter_engine.rs
+++ b/rust/connlib/tunnel/src/peer/filter_engine.rs
@@ -16,11 +16,27 @@ pub(crate) struct AllowRules {
     icmp: bool,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Filtered {
+    #[error("TCP port {offending_port} not in allowed range {allowed_ports:?}")]
+    Tcp {
+        allowed_ports: RangeInclusiveSet<u16>,
+        offending_port: u16,
+    },
+    #[error("UDP port {offending_port} not in allowed range {allowed_ports:?}")]
+    Udp {
+        allowed_ports: RangeInclusiveSet<u16>,
+        offending_port: u16,
+    },
+    #[error("ICMP not allowed")]
+    Icmp,
+}
+
 impl FilterEngine {
-    pub(crate) fn is_allowed(&self, packet: &IpPacket) -> bool {
+    pub(crate) fn apply(&self, packet: &IpPacket) -> Result<(), Filtered> {
         match self {
-            FilterEngine::PermitAll => true,
-            FilterEngine::PermitSome(filter_engine) => filter_engine.is_allowed(packet),
+            FilterEngine::PermitAll => Ok(()),
+            FilterEngine::PermitSome(filter_engine) => filter_engine.apply(packet),
         }
     }
 
@@ -48,20 +64,38 @@ impl AllowRules {
         }
     }
 
-    fn is_allowed(&self, packet: &IpPacket) -> bool {
-        if let Some(tcp) = packet.as_tcp() {
-            return self.tcp.contains(&tcp.destination_port());
+    fn apply(&self, packet: &IpPacket) -> Result<(), Filtered> {
+        if let Some(dest_port) = packet.as_tcp().map(|tcp| tcp.destination_port()) {
+            if self.tcp.contains(&dest_port) {
+                return Ok(());
+            }
+
+            return Err(Filtered::Tcp {
+                allowed_ports: self.tcp.clone(),
+                offending_port: dest_port,
+            });
         }
 
-        if let Some(udp) = packet.as_udp() {
-            return self.udp.contains(&udp.destination_port());
+        if let Some(dest_port) = packet.as_udp().map(|udp| udp.destination_port()) {
+            if self.udp.contains(&dest_port) {
+                return Ok(());
+            }
+
+            return Err(Filtered::Udp {
+                allowed_ports: self.udp.clone(),
+                offending_port: dest_port,
+            });
         }
 
         if packet.is_icmp() || packet.is_icmpv6() {
-            return self.icmp;
+            if self.icmp {
+                return Ok(());
+            }
+
+            return Err(Filtered::Icmp);
         }
 
-        false
+        Ok(())
     }
 
     fn add_filters<'a>(&mut self, filters: impl IntoIterator<Item = &'a Filter>) {
@@ -80,5 +114,29 @@ impl AllowRules {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn print_filtered() {
+        let mut allowed_ports = RangeInclusiveSet::new();
+        allowed_ports.insert(10..=150);
+        allowed_ports.insert(1024..=30000);
+        allowed_ports.insert(45231..=50100);
+
+        assert_eq!(
+            format!(
+                "{}",
+                Filtered::Tcp {
+                    allowed_ports,
+                    offending_port: 443
+                }
+            ),
+            "TCP port 443 not in allowed range {10..=150, 1024..=30000, 45231..=50100}"
+        );
     }
 }


### PR DESCRIPTION
When the Gateway's filter-engine drops a packet, we currently only log "destination not allowed". This could happen either because we don't have a filter (i.e. the resource is not allowed) or because the TCP / UDP port or ICMP traffic is not allowed. To make debugging easier, we now include that information in the error message.

Resolves: #7875.