### PR TITLE
fix(connlib): don't pull new GSO buffer unless we need it

### DIFF
--- a/rust/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/connlib/tunnel/src/io/gso_queue.rs
@@ -55,7 +55,6 @@ impl GsoQueue {
         payload: &[u8],
         now: Instant,
     ) {
-        let buffer = self.buffer_pool.pull_owned();
         let segment_size = payload.len();
 
         debug_assert!(
@@ -70,7 +69,7 @@ impl GsoQueue {
                 segment_size,
             })
             .or_insert_with(|| DatagramBuffer {
-                inner: buffer,
+                inner: self.buffer_pool.pull_owned(),
                 last_access: now,
             })
             .extend(payload, now);


### PR DESCRIPTION
When we are queuing a new UDP payload for sending, we always immediately pulled a new buffer even though we might already have on allocated for this particular segment length. This causes an unnecessary spike in memory when we are under load.