### PR TITLE
fix(connlib): limit batch size on mobile platforms to 25

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -25,7 +25,17 @@ use tun::Tun;
 ///
 /// Reading IP packets from the channel in batches allows us to process (i.e. encrypt) them as a batch.
 /// UDP datagrams of the same size and destination can then be sent in a single syscall using GSO.
-const MAX_INBOUND_PACKET_BATCH: usize = 100;
+///
+/// On mobile platforms, we are memory-constrained and thus cannot afford to process big batches of packets.
+/// Thus, we limit the batch-size there to 25.
+const MAX_INBOUND_PACKET_BATCH: usize = {
+    if cfg!(any(target_os = "ios", target_os = "android")) {
+        25
+    } else {
+        100
+    }
+};
+
 const MAX_UDP_SIZE: usize = (1 << 16) - 1;
 
 /// Bundles together all side-effects that connlib needs to have access to.


### PR DESCRIPTION
The batch size effects how many packets we process one at a time. It also effects the worst-case size of a single buffer as all packets may be of the same size and thus need to be appended to the same buffer.

On mobile, we can't afford to allocate all of these so we reduce the batch-size there.