### PR TITLE
fix(apple/macOS): Memoize successful SCDynamicStoreCreate

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -58,6 +58,11 @@ class Adapter {
     private var gateways: [Network.NWEndpoint] = []
   #endif
 
+#if os(macOS)
+  /// Used for finding system DNS resolvers on macOS when network conditions have changed.
+  private let systemConfigurationResolvers = SystemConfigurationResolvers()
+#endif
+
   /// Track our last fetched DNS resolvers to know whether to tell connlib they've updated
   private var lastFetchedResolvers: [String] = []
 
@@ -453,7 +458,7 @@ extension Adapter: CallbackHandlerDelegate {
 
   private func getSystemDefaultResolvers(interfaceName: String?) -> [String] {
     #if os(macOS)
-      let resolvers = SystemConfigurationResolvers().getDefaultDNSServers(
+      let resolvers = self.systemConfigurationResolvers.getDefaultDNSServers(
         interfaceName: interfaceName)
     #elseif os(iOS)
       let resolvers = resetToSystemDNSGettingBindResolvers()

--- a/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
@@ -28,7 +28,7 @@ class SystemConfigurationResolvers {
   }
 
   /// We use a computed property to memoize the creation of SC Dynamic Store, since this
-  /// can fail in some circumstances to initalize, like because of allocation failures.
+  /// can fail in some circumstances to initialize, like because of allocation failures.
   private var _dynamicStore: SCDynamicStore?
   private var dynamicStore: SCDynamicStore? {
     get {


### PR DESCRIPTION
Under some conditions the call to SCDynamicStoreCreate can fail, presumably due to some kind of allocation failure. Once it succeeds, however, we can continue using the dynamic store for the lifetime of the Adapter instance.

So we memoize the result of this call so as not to allocate each time we need it.

See https://developer.apple.com/documentation/systemconfiguration/1437828-scdynamicstorecreate