### PR TITLE
fix(apple/macOS): Don't report errors for missing SC keys

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
@@ -105,9 +105,11 @@ class SystemConfigurationResolvers {
 
       // kSCStatusNoKey indicates the key is missing, which is expected if the
       // interface has no DNS configuration.
-      if code != kSCStatusNoKey {
-        Log.error(SystemConfigurationError.unableToCopyValue(path: path, code: code))
+      if code == kSCStatusNoKey {
+        return nil
       }
+
+      Log.error(SystemConfigurationError.unableToCopyValue(path: path, code: code))
 
       return nil
     }

--- a/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/SystemConfigurationResolvers.swift
@@ -102,7 +102,13 @@ class SystemConfigurationResolvers {
     guard let result = SCDynamicStoreCopyValue(dynamicStore, path as CFString)
     else {
       let code = SCError()
-      Log.error(SystemConfigurationError.unableToCopyValue(path: path, code: code))
+
+      // kSCStatusNoKey indicates the key is missing, which is expected if the
+      // interface has no DNS configuration.
+      if code != kSCStatusNoKey {
+        Log.error(SystemConfigurationError.unableToCopyValue(path: path, code: code))
+      }
+
       return nil
     }
 


### PR DESCRIPTION
These are expected to be missing if a particular network interface has no DNS configuration.