### PR TITLE
wip: track Rust memory usage

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2126,6 +2126,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "tracking-allocator",
  "url",
  "uuid",
  "windows 0.58.0",
@@ -7332,6 +7333,13 @@ checksum = "ebeb235c5847e2f82cfe0f07eb971d1e5f6804b18dac2ae16349cc604380f82f"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "tracking-allocator"
+version = "0.1.0"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "tests/gui-smoke-test",
   "tests/http-test-server",
   "tun",
+  "tracking-allocator",
 ]
 
 resolver = "2"
@@ -160,6 +161,7 @@ firezone-tunnel = { path = "connlib/tunnel" }
 phoenix-channel = { path = "phoenix-channel" }
 ip-packet = { path = "ip-packet" }
 socket-factory = { path = "socket-factory" }
+tracking-allocator = { path = "tracking-allocator" }
 tun = { path = "tun" }
 socket2 = { version = "0.5" }
 

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -17,6 +17,7 @@ connlib-model = { workspace = true }
 firezone-bin-shared = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
+tracking-allocator = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
 ip-packet = { workspace = true }

--- a/rust/tracking-allocator/Cargo.toml
+++ b/rust/tracking-allocator/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tracking-allocator"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/tracking-allocator/src/lib.rs
+++ b/rust/tracking-allocator/src/lib.rs
@@ -1,0 +1,39 @@
+//! A proxy allocator that logs a warning when a certain threshold is reached.
+//!
+//! Inspired by <https://www.reddit.com/r/rust/comments/8z83wc/comment/e2h4dp9>.
+
+use std::alloc::{GlobalAlloc, Layout};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub struct TrackingAllocator<A> {
+    inner: A,
+    current: AtomicUsize,
+}
+
+unsafe impl<A> GlobalAlloc for TrackingAllocator<A>
+where
+    A: GlobalAlloc,
+{
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        self.current.fetch_add(l.size(), Ordering::SeqCst);
+        self.inner.alloc(l)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, l: Layout) {
+        self.current.fetch_sub(l.size(), Ordering::SeqCst);
+        self.inner.dealloc(ptr, l);
+    }
+}
+
+impl<A> TrackingAllocator<A> {
+    pub const fn new(inner: A) -> Self {
+        TrackingAllocator {
+            inner,
+            current: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn get(&self) -> usize {
+        self.current.load(Ordering::SeqCst)
+    }
+}


### PR DESCRIPTION
PoC for how we can track memory usage in Rust. Using this, we could for example log a WARN once the memory usage goes above a certain threshold (and thus receive a Sentry alert) as a result.

Open questions:

- How to ensure this doesn't spam the log / Sentry
- What is a useful limit?
- Why does this not report the same as the process memory usage? My OS says the process uses 35MB but this only returns ~5.7 MB.