### PR TITLE
ci: assert that integration tests don't produce warnings

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -143,25 +143,25 @@ jobs:
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 
       - name: Ensure Client emitted no warnings
-        run: docker compose logs client | grep "WARN" && exit 1
+        run: docker compose logs client | grep --quiet --invert "WARN"
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client
 
       - name: Ensure Relay-1 emitted no warnings
-        run: docker compose logs relay-1 | grep "WARN" && exit 1
+        run: docker compose logs relay-1 | grep --quiet --invert "WARN"
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
 
       - name: Ensure Relay-2 emitted no warnings
-        run: docker compose logs relay-2 | grep "WARN" && exit 1
+        run: docker compose logs relay-2 | grep --quiet --invert "WARN"
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2
 
       - name: Ensure Gateway emitted no warnings
-        run: docker compose logs gateway | grep "WARN" && exit 1
+        run: docker compose logs gateway | grep --quiet --invert "WARN"
       - name: Show Gateway logs
         if: "!cancelled()"
         run: docker compose logs gateway

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -142,18 +142,30 @@ jobs:
 
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 
+      - name: Ensure Client emitted no warnings
+        run: docker compose logs client | grep -q "WARN" && exit 1
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client
+
+      - name: Ensure Relay-1 emitted no warnings
+        run: docker compose logs relay-1 | grep -q "WARN" && exit 1
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
+
+      - name: Ensure Relay-2 emitted no warnings
+        run: docker compose logs relay-2 | grep -q "WARN" && exit 1
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2
+
+      - name: Ensure Gateway emitted no warnings
+        run: docker compose logs gateway | grep -q "WARN" && exit 1
       - name: Show Gateway logs
         if: "!cancelled()"
         run: docker compose logs gateway
+
       - name: Show API logs
         if: "!cancelled()"
         run: docker compose logs api

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -143,25 +143,25 @@ jobs:
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 
       - name: Ensure Client emitted no warnings
-        run: docker compose logs client | grep -q "WARN" && exit 1
+        run: docker compose logs client | grep "WARN" && exit 1
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client
 
       - name: Ensure Relay-1 emitted no warnings
-        run: docker compose logs relay-1 | grep -q "WARN" && exit 1
+        run: docker compose logs relay-1 | grep "WARN" && exit 1
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
 
       - name: Ensure Relay-2 emitted no warnings
-        run: docker compose logs relay-2 | grep -q "WARN" && exit 1
+        run: docker compose logs relay-2 | grep "WARN" && exit 1
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2
 
       - name: Ensure Gateway emitted no warnings
-        run: docker compose logs gateway | grep -q "WARN" && exit 1
+        run: docker compose logs gateway | grep "WARN" && exit 1
       - name: Show Gateway logs
         if: "!cancelled()"
         run: docker compose logs gateway


### PR DESCRIPTION
Would have allowed us to detect https://github.com/rust-netlink/netlink-packet-route/issues/140 earlier.