### PR TITLE
ci: fix potential drift between release tag and binaries

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -82,6 +82,26 @@ jobs:
           echo -n "$FIREBASE_APP_DISTRIBUTION_CREDENTIALS" > $FIREBASE_CREDENTIALS_PATH
           ./gradlew appDistributionUploadRelease uploadCrashlyticsSymbolFileRelease
 
+  update-release-draft:
+    name: update-release-draft
+    needs: build_release
+    runs-on: ubuntu-22.04
+    env:
+      # mark:next-android-version
+      RELEASE_NAME: android-client-1.4.1
+    steps:
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
+        id: update-release-draft
+        with:
+          config-name: release-drafter-android-client.yml
+          tag: ${{ env.RELEASE_NAME }}
+          version: ${{ env.RELEASE_NAME }}
+          name: ${{ env.RELEASE_NAME }}
+          commitish: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build_debug:
     # Android SDK tools hardware accel is available only on Linux runners
     runs-on: ubuntu-22.04

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -104,3 +104,23 @@ jobs:
           # Swift benefits heavily from build cache, so aggressively write a new one
           # on each build on `main` and attempt to restore it in PR builds with broader restore-key.
           key: ${{ steps.cache.outputs.cache-primary-key }}
+
+  update-release-draft:
+    name: update-release-draft
+    needs: build
+    runs-on: ubuntu-22.04
+    env:
+      # mark:next-apple-version
+      RELEASE_NAME: macos-client-1.4.1
+    steps:
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
+        id: update-release-draft
+        with:
+          config-name: release-drafter-macos-client.yml
+          tag: ${{ env.RELEASE_NAME}}
+          version: ${{ env.RELEASE_NAME}}
+          name: ${{ env.RELEASE_NAME}}
+          commitish: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -125,3 +125,23 @@ jobs:
           TAG_NAME: gui-client-${{ env.FIREZONE_GUI_VERSION }}
         shell: bash
         run: ${{ env.UPLOAD_SCRIPT }}
+
+  update-release-draft:
+    name: update-release-draft
+    needs: build-gui
+    runs-on: ubuntu-22.04
+    env:
+      # mark:next-gui-version
+      RELEASE_NAME: gui-client-1.4.1
+    steps:
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
+        id: update-release-draft
+        with:
+          config-name: release-drafter-gui-client.yml
+          tag: ${{ env.RELEASE_NAME }}
+          version: ${{ env.RELEASE_NAME }}
+          name: ${{ env.RELEASE_NAME }}
+          commitish: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # mark:next-gui-version
-      RELEASE_NAME: gui-client-1.4.1
+      RELEASE_NAME: gui-client-1.4.2
     steps:
       - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           tag: ${{ matrix.release_name }}
           version: ${{ matrix.release_name }}
           name: ${{ matrix.release_name }}
+          commitish: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,6 @@ jobs:
           # mark:next-headless-version
           - release_name: headless-client-1.4.1
             config_name: release-drafter-headless-client.yml
-          # mark:next-gui-version
-          - release_name: gui-client-1.4.1
-            config_name: release-drafter-gui-client.yml
-          # mark:next-apple-version
-          - release_name: macos-client-1.4.1
-            config_name: release-drafter-macos-client.yml
-          # mark:next-android-version
-          - release_name: android-client-1.4.1
-            config_name: release-drafter-android-client.yml
 
     steps:
       - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0


### PR DESCRIPTION
Recently, we changed that we only upload binaries to the draft releases when we actively call the workflow. This means that we may potentially have a drift between:

- The commit that gets tagged as the release.
- The commit from which the binaries got built.

To ensure that this doesn't drift, we only update the draft releases whenever we actually uploaded new binaries to them. In addition, we instruct `release-drafter` to set the target of the release to the commit SHA from when it was triggered. As a result, it is much less error prone that these may drift apart. I believe the only race condition here could be if somebody publishes a release between the time the binaries get uploaded and we update the release draft, i.e. when GitHub hasn't fully finished CI yet.