### PR TITLE
chore: release Gateway, headless-client and GUI client

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -154,9 +154,9 @@ jobs:
             artifact: firezone-client-headless-linux
             image_name: client
             # mark:next-headless-version
-            release_name: headless-client-1.4.1
+            release_name: headless-client-1.4.2
             # mark:next-headless-version
-            version: 1.4.1
+            version: 1.4.2
           - package: firezone-relay
             artifact: firezone-relay
             image_name: relay

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -164,9 +164,9 @@ jobs:
             artifact: firezone-gateway
             image_name: gateway
             # mark:next-gateway-version
-            release_name: gateway-1.4.3
+            release_name: gateway-1.4.4
             # mark:next-gateway-version
-            version: 1.4.3
+            version: 1.4.4
           - package: http-test-server
             artifact: http-test-server
             image_name: http-test-server
@@ -346,7 +346,7 @@ jobs:
           - name: relay
           - name: gateway
             # mark:next-gateway-version
-            version: 1.4.3
+            version: 1.4.4
           - name: client
             # mark:next-client-version
             version: 1.0.6

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -37,19 +37,19 @@ jobs:
             pkg-extension: msi
     env:
       # mark:next-gui-version
-      ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.4.1_${{ matrix.arch }}
+      ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.4.2_${{ matrix.arch }}
       # mark:next-gui-version
-      ARTIFACT_DST: firezone-client-gui-${{ matrix.os }}_1.4.1_${{ matrix.arch }}
+      ARTIFACT_DST: firezone-client-gui-${{ matrix.os }}_1.4.2_${{ matrix.arch }}
       AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
       # mark:next-gui-version
-      BINARY_DEST_PATH: firezone-client-gui-${{ matrix.os }}_1.4.1_${{ matrix.arch }}
+      BINARY_DEST_PATH: firezone-client-gui-${{ matrix.os }}_1.4.2_${{ matrix.arch }}
       # Seems like there's no way to de-dupe env vars that depend on each other
       # mark:next-gui-version
-      FIREZONE_GUI_VERSION: 1.4.1
+      FIREZONE_GUI_VERSION: 1.4.2
       RENAME_SCRIPT: ../../scripts/build/tauri-rename-${{ matrix.os }}.sh
       TEST_INSTALL_SCRIPT: ../../scripts/tests/gui-client-install-${{ matrix.os }}-${{ matrix.pkg-extension }}.sh
       TARGET_DIR: ../target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           - release_name: headless-client-1.4.1
             config_name: release-drafter-headless-client.yml
           # mark:next-gui-version
-          - release_name: gui-client-1.4.1
+          - release_name: gui-client-1.4.2
             config_name: release-drafter-gui-client.yml
           # mark:next-apple-version
           - release_name: macos-client-1.4.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           - release_name: gateway-1.4.3
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
-          - release_name: headless-client-1.4.1
+          - release_name: headless-client-1.4.2
             config_name: release-drafter-headless-client.yml
           # mark:next-gui-version
           - release_name: gui-client-1.4.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         include:
           # mark:next-gateway-version
-          - release_name: gateway-1.4.3
+          - release_name: gateway-1.4.4
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
           - release_name: headless-client-1.4.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           if [[ "${{ github.event.release.name }}" =~ gateway* ]]; then
             ARTIFACT=gateway
             # mark:next-gateway-version
-            VERSION="1.4.3"
+            VERSION="1.4.4"
           elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
             ARTIFACT=client
             # mark:next-headless-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
             ARTIFACT=client
             # mark:next-headless-version
-            VERSION="1.4.1"
+            VERSION="1.4.2"
           else
             echo "Shouldn't have gotten here. Exiting."
             exit 1

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gateway"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gui-client"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gui-client-common"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-headless-client"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "atomicwrites",

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gateway"
 # mark:next-gateway-version
-version = "1.4.3"
+version = "1.4.4"
 edition = { workspace = true }
 license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/gui-client/src-common/Cargo.toml
+++ b/rust/gui-client/src-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gui-client-common"
 # mark:next-gui-version
-version = "1.4.1"
+version = "1.4.2"
 edition = { workspace = true }
 license = { workspace = true }
 

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gui-client"
 # mark:next-gui-version
-version = "1.4.1"
+version = "1.4.2"
 description = "Firezone"
 edition = { workspace = true }
 default-run = "firezone-gui-client"

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-headless-client"
 # mark:next-headless-version
-version = "1.4.1"
+version = "1.4.2"
 edition = { workspace = true }
 authors = ["Firezone, Inc."]
 license = { workspace = true }

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -611,7 +611,7 @@ impl<'a> Handler<'a> {
             // The IPC service must use the GUI's version number, not the Headless Client's.
             // But refactoring to separate the IPC service from the Headless Client will take a while.
             // mark:next-gui-version
-            get_user_agent(None, "1.4.1"),
+            get_user_agent(None, "1.4.2"),
             "client",
             (),
             || {

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -22,14 +22,14 @@ current-apple-version = 1.4.0
 current-android-version = 1.4.0
 current-gateway-version = 1.4.2
 current-gui-version = 1.4.1
-current-headless-version = 1.4.0
+current-headless-version = 1.4.1
 
 # Tracks the next version to release for each platform
 next-apple-version = 1.4.1
 next-android-version = 1.4.1
 next-gateway-version = 1.4.3
 next-gui-version = 1.4.2
-next-headless-version = 1.4.1
+next-headless-version = 1.4.2
 
 # macOS uses a slightly different sed syntax
 ifeq ($(shell uname),Darwin)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -20,14 +20,14 @@
 # Tracks the current version to use for generating download links and changelogs
 current-apple-version = 1.4.0
 current-android-version = 1.4.0
-current-gateway-version = 1.4.2
+current-gateway-version = 1.4.3
 current-gui-version = 1.4.1
 current-headless-version = 1.4.1
 
 # Tracks the next version to release for each platform
 next-apple-version = 1.4.1
 next-android-version = 1.4.1
-next-gateway-version = 1.4.3
+next-gateway-version = 1.4.4
 next-gui-version = 1.4.2
 next-headless-version = 1.4.2
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -21,14 +21,14 @@
 current-apple-version = 1.4.0
 current-android-version = 1.4.0
 current-gateway-version = 1.4.2
-current-gui-version = 1.4.0
+current-gui-version = 1.4.1
 current-headless-version = 1.4.0
 
 # Tracks the next version to release for each platform
 next-apple-version = 1.4.1
 next-android-version = 1.4.1
 next-gateway-version = 1.4.3
-next-gui-version = 1.4.1
+next-gui-version = 1.4.2
 next-headless-version = 1.4.1
 
 # macOS uses a slightly different sed syntax

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -60,21 +60,21 @@ module.exports = [
     source: "/dl/firezone-client-headless-linux/latest/x86_64",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.0/firezone-client-headless-linux_1.4.0_x86_64",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.1/firezone-client-headless-linux_1.4.1_x86_64",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-headless-linux/latest/aarch64",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.0/firezone-client-headless-linux_1.4.0_aarch64",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.1/firezone-client-headless-linux_1.4.1_aarch64",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-headless-linux/latest/armv7",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.0/firezone-client-headless-linux_1.4.0_armv7",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.1/firezone-client-headless-linux_1.4.1_armv7",
     permanent: false,
   },
   /*

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -86,21 +86,21 @@ module.exports = [
     source: "/dl/firezone-gateway/latest/x86_64",
     destination:
       // mark:current-gateway-version
-      "https://www.github.com/firezone/firezone/releases/download/gateway-1.4.2/firezone-gateway_1.4.2_x86_64",
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.4.3/firezone-gateway_1.4.3_x86_64",
     permanent: false,
   },
   {
     source: "/dl/firezone-gateway/latest/aarch64",
     destination:
       // mark:current-gateway-version
-      "https://www.github.com/firezone/firezone/releases/download/gateway-1.4.2/firezone-gateway_1.4.2_aarch64",
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.4.3/firezone-gateway_1.4.3_aarch64",
     permanent: false,
   },
   {
     source: "/dl/firezone-gateway/latest/armv7",
     destination:
       // mark:current-gateway-version
-      "https://www.github.com/firezone/firezone/releases/download/gateway-1.4.2/firezone-gateway_1.4.2_armv7",
+      "https://www.github.com/firezone/firezone/releases/download/gateway-1.4.3/firezone-gateway_1.4.3_armv7",
     permanent: false,
   },
   /*

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -34,7 +34,7 @@ module.exports = [
     source: "/dl/firezone-client-gui-windows/latest/x86_64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.4.0/firezone-client-gui-windows_1.4.0_x86_64.msi",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.4.1/firezone-client-gui-windows_1.4.1_x86_64.msi",
     permanent: false,
   },
   /*
@@ -46,14 +46,14 @@ module.exports = [
     source: "/dl/firezone-client-gui-linux/latest/x86_64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.4.0/firezone-client-gui-linux_1.4.0_x86_64.deb",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.4.1/firezone-client-gui-linux_1.4.1_x86_64.deb",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-gui-linux/latest/aarch64",
     destination:
       // mark:current-gui-version
-      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.4.0/firezone-client-gui-linux_1.4.0_aarch64.deb",
+      "https://www.github.com/firezone/firezone/releases/download/gui-client-1.4.1/firezone-client-gui-linux_1.4.1_aarch64.deb",
     permanent: false,
   },
   {

--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -13,7 +13,7 @@ export async function GET(_req: NextRequest) {
     // mark:current-headless-version
     headless: "1.4.1",
     // mark:current-gateway-version
-    gateway: "1.4.2",
+    gateway: "1.4.3",
   };
 
   return NextResponse.json(versions, {

--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -9,7 +9,7 @@ export async function GET(_req: NextRequest) {
     // mark:current-android-version
     android: "1.4.0",
     // mark:current-gui-version
-    gui: "1.4.0",
+    gui: "1.4.1",
     // mark:current-headless-version
     headless: "1.4.0",
     // mark:current-gateway-version

--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -11,7 +11,7 @@ export async function GET(_req: NextRequest) {
     // mark:current-gui-version
     gui: "1.4.1",
     // mark:current-headless-version
-    headless: "1.4.0",
+    headless: "1.4.1",
     // mark:current-gateway-version
     gateway: "1.4.2",
   };

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -27,7 +27,8 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries downloadLinks={downloadLinks} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased>
+      <Unreleased></Unreleased>
+      <Entry version="1.4.1" date={new Date("2025-01-28")}>
         <ChangeItem pull="7551">
           Fixes an issue where large DNS responses were incorrectly discarded.
         </ChangeItem>
@@ -42,7 +43,7 @@ export default function GUI({ title }: { title: string }) {
             thus improving compatibility on non-Ubuntu systems.
           </ChangeItem>
         )}
-      </Unreleased>
+      </Entry>
       <Entry version="1.4.0" date={new Date("2024-12-13")}>
         <ChangeItem pull="7210">
           Adds support for GSO (Generic Segmentation Offload), delivering

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,8 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased>
+      <Unreleased></Unreleased>
+      <Entry version="1.4.3" date={new Date("2025-01-28")}>
         <ChangeItem pull="7567">
           Fixes an issue where ICMPv6's `PacketTooBig' errors were not correctly
           translated by the NAT64 module.
@@ -32,7 +33,7 @@ export default function Gateway() {
           `CAP_NET_ADMIN` capability. The check can be skipped with
           `--no-check`.
         </ChangeItem>
-      </Unreleased>
+      </Entry>
       <Entry version="1.4.2" date={new Date("2024-12-13")}>
         <ChangeItem pull="7210">
           Adds support for GSO (Generic Segmentation Offload), delivering

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -23,7 +23,8 @@ export default function Headless() {
   return (
     <Entries downloadLinks={downloadLinks} title="Linux headless">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased>
+      <Unreleased></Unreleased>
+      <Entry version="1.4.1" date={new Date("2025-01-28")}>
         <ChangeItem pull="7551">
           Fixes an issue where large DNS responses were incorrectly discarded.
         </ChangeItem>
@@ -31,7 +32,7 @@ export default function Headless() {
           BREAKING: Removes the positional token argument on the CLI. Use
           `FIREZONE_TOKEN` or `FIREZONE_TOKEN_PATH` env variables instead.
         </ChangeItem>
-      </Unreleased>
+      </Entry>
       <Entry version="1.4.0" date={new Date("2024-12-13")}>
         <ChangeItem pull="7350">
           Allows disabling telemetry by setting `FIREZONE_NO_TELEMETRY=true`.


### PR DESCRIPTION
This bumps the versions of Gateway, headless-client and the GUI client as well as updates the respective changelogs. These have been released today:

- https://github.com/firezone/firezone/releases/tag/gui-client-1.4.1
- https://github.com/firezone/firezone/releases/tag/gateway-1.4.3
- https://github.com/firezone/firezone/releases/tag/headless-client-1.4.1

It is all done in one PR to avoid merge conflicts within the updates of the Makefile.