### PR TITLE
build(deps): Use Package.resolved dir for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,7 +120,7 @@ updates:
           - com.google.firebase:firebase-analytics-ktx
 
   - package-ecosystem: swift
-    directory: swift/apple/FirezoneKit/
+    directory: swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
     schedule:
       interval: monthly
   - package-ecosystem: npm


### PR DESCRIPTION
We don't use the `Package.swift` in `FirezoneKit` because it only applies to that module. Instead, we use Xcode's package management which tracks things in `swift/apple/Firezone.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`.