### PR TITLE
build(deps): bump `wintun` to `v0.5.1`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8426,8 +8426,9 @@ dependencies = [
 
 [[package]]
 name = "wintun"
-version = "0.5.0"
-source = "git+https://github.com/nulldotblack/wintun?branch=main#f196da9f72b9450de5b8d5462f444f25c2480d38"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da99be64b5aa3de869c16977994314d0759a698d9a73ab0a5b1d52e2282033ae"
 dependencies = [
  "c2rust-bitfields",
  "libloading 0.8.5",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8427,8 +8427,7 @@ dependencies = [
 [[package]]
 name = "wintun"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b196f9328341b035820c54beebca487823e2e20a5977f284f2af2a0ee8f04400"
+source = "git+https://github.com/nulldotblack/wintun?branch=main#f196da9f72b9450de5b8d5462f444f25c2480d38"
 dependencies = [
  "c2rust-bitfields",
  "libloading 0.8.5",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -184,6 +184,7 @@ str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.26" } # Waiting for release.
+wintun = { git = "https://github.com/nulldotblack/wintun", branch = "main" } # Waiting for release.
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -184,7 +184,6 @@ str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.26" } # Waiting for release.
-wintun = { git = "https://github.com/nulldotblack/wintun", branch = "main" } # Waiting for release.
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -39,7 +39,7 @@ ring = "0.17"
 uuid = { workspace = true, features = ["v4"] }
 windows-core = "0.58.0"
 windows-implement = "0.58.0"
-wintun = "0.5.0"
+wintun = "0.5.1"
 winreg = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows]

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -27,7 +27,14 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries downloadLinks={downloadLinks} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {title == "Windows" && (
+          <ChangeItem pull="7912">
+            Fixes an issue where the tunnel device could not be created,
+            resulting in an immediate sign-out after signing-in.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.4.1" date={new Date("2025-01-28")}>
         <ChangeItem pull="7551">
           Fixes an issue where large DNS responses were incorrectly discarded.


### PR DESCRIPTION
This updates `wintun` to include https://github.com/nulldotblack/wintun/pull/27. The error message of the linked Sentry issues in #7901 of "Unable to find matching {UUID}" is removed in that PR in favor of a Win32 function that converts the adapter name directly to the corresponding index and UUID instead of searching through the list of adapters.

Resolves: #7901.