### PR TITLE
refactor(snownet): re-implement backoff to only tick on timeout

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6039,7 +6039,6 @@ dependencies = [
 name = "snownet"
 version = "0.1.0"
 dependencies = [
- "backoff",
  "boringtun",
  "bytecodec",
  "bytes",

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -5,7 +5,6 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-backoff = { workspace = true }
 boringtun = { workspace = true }
 bytecodec = { workspace = true }
 bytes = { workspace = true }

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1025,6 +1025,8 @@ impl Allocation {
     }
 
     fn send_binding_requests(&mut self, now: Instant) {
+        tracing::debug!(relay_socket = ?self.server, "Sending BINDING requests to pick active socket");
+
         if let Some(v4) = self.server.as_v4() {
             self.queue(
                 (*v4).into(),


### PR DESCRIPTION
For all STUN and TURN messages that are being sent from `connlib`, we implement a retransmit strategy with an exponential backoff if we don't hear from the relay within a given amount of time. For this, we are currently using the `backoff` crate.

For our purposes, this crate is a bit unergonomic. In particular, it has a mutable `next_backoff` function as well as internal dependency on a "clock". As a consequence, we need to

a) always make sure the clock of an `ExponentialBackoff` is pointing to the current time
b) only call `next_backoff` when we want to resend a message

Within the sans-IO design of `connlib`, time-related functions are handled within `handle_timeout` which is being passed a `now: Instant` parameter. Instead of ticking over to the next backoff, what we need from our backoff module are answers to the questions:

- Is the backoff expired?
- When should the next retry happen?
- What is the current waiting interval?

In addition, we want the backoff module to "tick over" to the next trigger when the time passes the current one, i.e. we want to issue the command: "This is the current time, update your internal state."

By re-implementing this ourselves, we can avoid this additional state tracking of `last_now`, thus simplifying the implementation.