### PR TITLE
chore(snownet): log ignored candidate

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -352,7 +352,7 @@ where
         };
 
         let Some((agent, relay)) = self.connections.connecting_agent_mut(cid) else {
-            tracing::debug!("Unknown connection or socket has already been nominated");
+            tracing::debug!(ignored_candidate = %candidate, "Unknown connection or socket has already been nominated");
             return;
         };
 


### PR DESCRIPTION
Once we've finished ICE and nominated a socket, we ignore future candidates for the same connection (see #6876). To make this log a bit more helpful, we now log the candidate that we are ignoring on this connection.