### PR TITLE
chore(android): Bump kotlin-android and firebase-bom

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -215,7 +215,7 @@ dependencies {
     androidTestImplementation("androidx.fragment:fragment-testing:1.8.5")
 
     // Import the BoM for the Firebase platform
-    implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
+    implementation(platform("com.google.firebase:firebase-bom:33.8.0"))
 
     // Add the dependencies for the Crashlytics and Analytics libraries
     // When using the BoM, you don't specify versions in Firebase library dependencies

--- a/kotlin/android/build.gradle.kts
+++ b/kotlin/android/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
 
 plugins {
     id("org.mozilla.rust-android-gradle.rust-android") version "0.9.5" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
     id("com.android.application") version "8.8.0" apply false
     id("com.google.firebase.appdistribution") version "5.1.0" apply false
     id("com.google.dagger.hilt.android") version "2.55" apply false


### PR DESCRIPTION
The new firebase-bom is incompatible with older kotlin android buildscript plugin versions.

Supersedes #7928 