### PR TITLE
refactor(gateway): don't treat filtered packets as errors

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -158,7 +158,7 @@ impl GatewayState {
             .translate_outbound(packet, now)
             .context("Failed to translate outbound packet")?;
 
-        Ok(Some(packet))
+        Ok(packet)
     }
 
     pub fn cleanup_connection(&mut self, id: &ClientId) {

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -271,8 +271,7 @@ impl ClientOnGateway {
         packet: IpPacket,
         now: Instant,
     ) -> anyhow::Result<IpPacket> {
-        self.ensure_allowed_src(&packet)?;
-        self.ensure_allowed_dst(&packet)?;
+        self.ensure_allowed(&packet)?;
 
         let packet = self.transform_network_to_tun(packet, now)?;
 
@@ -308,6 +307,13 @@ impl ClientOnGateway {
 
     pub(crate) fn is_allowed(&self, resource: ResourceId) -> bool {
         self.resources.contains_key(&resource)
+    }
+
+    fn ensure_allowed(&self, packet: &IpPacket) -> anyhow::Result<()> {
+        self.ensure_allowed_src(packet)?;
+        self.ensure_allowed_dst(packet)?;
+
+        Ok(())
     }
 
     fn ensure_allowed_src(&self, packet: &IpPacket) -> anyhow::Result<()> {

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -271,11 +271,13 @@ impl ClientOnGateway {
         packet: IpPacket,
         now: Instant,
     ) -> anyhow::Result<Option<IpPacket>> {
+        // Filtering a packet is not an error.
         if let Err(e) = self.ensure_allowed(&packet) {
             tracing::debug!(filtered_packet = ?packet, "{e:#}");
             return Ok(None);
         }
 
+        // Failing to transform is an error we want to know about further up.
         let packet = self.transform_network_to_tun(packet, now)?;
 
         Ok(Some(packet))

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -321,7 +321,7 @@ impl ClientOnGateway {
     }
 
     /// Check if an incoming packet arriving over the network is ok to be forwarded to the TUN device.
-    fn ensure_allowed_dst(&mut self, packet: &IpPacket) -> anyhow::Result<()> {
+    fn ensure_allowed_dst(&self, packet: &IpPacket) -> anyhow::Result<()> {
         let dst = packet.destination();
 
         // Note a Gateway with Internet resource should never get packets for other resources

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -663,7 +663,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.translate_outbound(pkt, Instant::now()).is_err());
+        assert!(peer
+            .translate_outbound(pkt, Instant::now())
+            .unwrap()
+            .is_none());
 
         let pkt = ip_packet::make::udp_packet(
             source_v4_addr(),
@@ -674,7 +677,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.translate_outbound(pkt, Instant::now()).is_err());
+        assert!(peer
+            .translate_outbound(pkt, Instant::now())
+            .unwrap()
+            .is_none());
 
         let pkt = ip_packet::make::udp_packet(
             source_v4_addr(),
@@ -721,7 +727,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(peer.translate_outbound(pkt, Instant::now()).is_err());
+        assert!(peer
+            .translate_outbound(pkt, Instant::now())
+            .unwrap()
+            .is_none());
 
         let pkt = ip_packet::make::udp_packet(
             source_v4_addr(),

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -270,12 +270,15 @@ impl ClientOnGateway {
         &mut self,
         packet: IpPacket,
         now: Instant,
-    ) -> anyhow::Result<IpPacket> {
-        self.ensure_allowed(&packet)?;
+    ) -> anyhow::Result<Option<IpPacket>> {
+        if let Err(e) = self.ensure_allowed(&packet) {
+            tracing::debug!(filtered_packet = ?packet, "{e:#}");
+            return Ok(None);
+        }
 
         let packet = self.transform_network_to_tun(packet, now)?;
 
-        Ok(packet)
+        Ok(Some(packet))
     }
 
     pub fn translate_inbound(


### PR DESCRIPTION
Filtering packets is part of a Gateway's day-to-day business. We don't want to treat those as errors further up as those might get reported to Sentry but it is still worth logging them on debug.