### PR TITLE
refactor(gui-client): simplify IPC message handling code

### DIFF
--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -540,12 +540,7 @@ impl<I: GuiIntegration> Controller<'_, I> {
                 }
                 Err(error) => Err(error),
             },
-            Err(error) => {
-                // IPC errors are always fatal
-                tracing::error!(error = anyhow_dyn_err(&error), "IPC read failure");
-
-                Err(Error::IpcRead)
-            }
+            Err(error) => Err(Error::IpcRead(error)),
         }
     }
 

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -539,10 +539,7 @@ impl<I: GuiIntegration> Controller<'_, I> {
                 })?;
             }
             IpcServerMsg::ConnectResult(result) => {
-                return self
-                    .handle_connect_result(result)
-                    .await
-                    .map(|_| ControlFlow::Continue(()))
+                self.handle_connect_result(result).await?;
             }
             IpcServerMsg::DisconnectedGracefully => {
                 if let Status::Quitting = self.status {

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -39,7 +39,7 @@ pub struct Controller<'a, I: GuiIntegration> {
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
     ctlr_tx: CtlrTx,
     ipc_client: ipc::Client,
-    ipc_rx: ipc::MsgStream,
+    ipc_rx: ipc::ClientRead,
     integration: I,
     log_filter_reloader: LogFilterReloader,
     /// A release that's ready to download

--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -39,7 +39,7 @@ pub struct Controller<'a, I: GuiIntegration> {
     clear_logs_callback: Option<oneshot::Sender<Result<(), String>>>,
     ctlr_tx: CtlrTx,
     ipc_client: ipc::Client,
-    ipc_rx: ReceiverStream<Result<IpcServerMsg>>,
+    ipc_rx: ipc::MsgStream,
     integration: I,
     log_filter_reloader: LogFilterReloader,
     /// A release that's ready to download
@@ -191,8 +191,7 @@ impl<I: GuiIntegration> Controller<'_, I> {
     ) -> Result<(), Error> {
         tracing::debug!("Starting new instance of `Controller`");
 
-        let (ipc_tx, ipc_rx) = mpsc::channel(1);
-        let ipc_client = ipc::Client::new(ipc_tx).await?;
+        let (ipc_client, ipc_rx) = ipc::Client::new().await?;
 
         let dns_notifier = new_dns_notifier().await?.boxed();
         let network_notifier = new_network_notifier().await?.boxed();
@@ -203,7 +202,7 @@ impl<I: GuiIntegration> Controller<'_, I> {
             clear_logs_callback: None,
             ctlr_tx,
             ipc_client,
-            ipc_rx: ReceiverStream::new(ipc_rx),
+            ipc_rx,
             integration,
             log_filter_reloader,
             release: None,

--- a/rust/gui-client/src-common/src/errors.rs
+++ b/rust/gui-client/src-common/src/errors.rs
@@ -5,8 +5,6 @@ use firezone_headless_client::ipc;
 // TODO: Replace with `anyhow` gradually per <https://github.com/firezone/firezone/pull/3546#discussion_r1477114789>
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failed to connect to Firezone")]
-    ConnectToFirezoneFailed(String),
     #[error("Deep-link module error: {0}")]
     DeepLink(#[from] deep_link::Error),
     #[error("Logging module error: {0}")]
@@ -42,7 +40,6 @@ impl Error {
     // messages in the log which only need to be used for `git grep`.
     pub fn user_friendly_msg(&self) -> String {
         match self {
-            Error::ConnectToFirezoneFailed(_) => self.to_string(),
             Error::WebViewNotInstalled => "Firezone cannot start because WebView2 is not installed. Follow the instructions at <https://www.firezone.dev/kb/client-apps/windows-client>.".to_string(),
             Error::DeepLink(deep_link::Error::CantListen) => "Firezone is already running. If it's not responding, force-stop it.".to_string(),
             Error::DeepLink(deep_link::Error::Other(error)) => error.to_string(),

--- a/rust/gui-client/src-common/src/errors.rs
+++ b/rust/gui-client/src-common/src/errors.rs
@@ -16,7 +16,7 @@ pub enum Error {
     #[error("IPC closed")]
     IpcClosed,
     #[error("IPC read failed")]
-    IpcRead,
+    IpcRead(#[source] anyhow::Error),
     #[error("IPC service terminating")]
     IpcServiceTerminating,
     #[error("Failed to connect to portal")]
@@ -48,7 +48,7 @@ impl Error {
             Error::DeepLink(deep_link::Error::Other(error)) => error.to_string(),
             Error::IpcNotFound => "Couldn't find Firezone IPC service. Is the service running?".to_string(),
             Error::IpcClosed => "IPC connection closed".to_string(),
-            Error::IpcRead => "IPC read failure".to_string(),
+            Error::IpcRead(_) => "IPC read failure".to_string(),
             Error::IpcServiceTerminating => "The Firezone IPC service is terminating. Please restart the GUI Client.".to_string(),
             Error::Logging(_) => "Logging error".to_string(),
             Error::PortalConnection(_) => "Couldn't connect to the Firezone Portal. Are you connected to the Internet?".to_string(),

--- a/rust/gui-client/src-common/src/ipc.rs
+++ b/rust/gui-client/src-common/src/ipc.rs
@@ -8,7 +8,6 @@ use secrecy::{ExposeSecret, SecretString};
 use std::net::IpAddr;
 
 pub enum Event {
-    Closed,
     Message(IpcServerMsg),
     ReadFailed(anyhow::Error),
 }
@@ -41,7 +40,6 @@ impl Client {
                 };
                 ctlr_tx.send(event).await?;
             }
-            ctlr_tx.send(Event::Closed).await?;
             Ok(())
         });
         Ok(Self { task, tx })

--- a/rust/headless-client/src/ipc_service/ipc.rs
+++ b/rust/headless-client/src/ipc_service/ipc.rs
@@ -19,7 +19,7 @@ pub mod platform;
 pub(crate) use platform::Server;
 use platform::{ClientStream, ServerStream};
 
-pub(crate) type ClientRead = FramedRead<ReadHalf<ClientStream>, Decoder<IpcServerMsg>>;
+pub type ClientRead = FramedRead<ReadHalf<ClientStream>, Decoder<IpcServerMsg>>;
 pub type ClientWrite = FramedWrite<WriteHalf<ClientStream>, Encoder<IpcClientMsg>>;
 pub(crate) type ServerRead = FramedRead<ReadHalf<ServerStream>, Decoder<IpcClientMsg>>;
 pub(crate) type ServerWrite = FramedWrite<WriteHalf<ServerStream>, Encoder<IpcServerMsg>>;


### PR DESCRIPTION
At present, the GUI client uses a separate task for reading messages from the IPC connection and forwards them to another channel. The other end of this channel is then used within the controller to actually react to IPC messages.

We can simplify this by removing the intermediary task and processing the messages from the IPC connection directly.