### PR TITLE
refactor(gui-client): simplify error handling of `gui::run`

### DIFF
--- a/rust/gui-client/src-common/src/deep_link.rs
+++ b/rust/gui-client/src-common/src/deep_link.rs
@@ -23,16 +23,9 @@ mod imp;
 #[path = "deep_link/windows.rs"]
 mod imp;
 
-#[cfg_attr(target_os = "linux", allow(dead_code))]
-#[cfg_attr(target_os = "macos", allow(dead_code))]
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
-    // This one is not `anyhow` since we catch it in the caller
-    #[error("named pipe server couldn't start listening, we are probably the second instance")]
-    CantListen,
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
-}
+#[error("named pipe server couldn't start listening, we are probably the second instance")]
+pub struct CantListen;
 
 pub use imp::{open, register, Server};
 

--- a/rust/gui-client/src-common/src/errors.rs
+++ b/rust/gui-client/src-common/src/errors.rs
@@ -1,12 +1,9 @@
-use crate::deep_link;
 use anyhow::Result;
 use firezone_headless_client::ipc;
 
 // TODO: Replace with `anyhow` gradually per <https://github.com/firezone/firezone/pull/3546#discussion_r1477114789>
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Deep-link module error: {0}")]
-    DeepLink(#[from] deep_link::Error),
     #[error("IPC service not found")]
     IpcNotFound,
     #[error("IPC closed")]
@@ -34,10 +31,6 @@ impl Error {
     // messages in the log which only need to be used for `git grep`.
     pub fn user_friendly_msg(&self) -> String {
         match self {
-            Error::DeepLink(deep_link::Error::CantListen) => {
-                "Firezone is already running. If it's not responding, force-stop it.".to_string()
-            }
-            Error::DeepLink(deep_link::Error::Other(error)) => error.to_string(),
             Error::IpcNotFound => {
                 "Couldn't find Firezone IPC service. Is the service running?".to_string()
             }

--- a/rust/gui-client/src-common/src/errors.rs
+++ b/rust/gui-client/src-common/src/errors.rs
@@ -15,8 +15,6 @@ pub enum Error {
     IpcRead(#[source] anyhow::Error),
     #[error("IPC service terminating")]
     IpcServiceTerminating,
-    #[error("WebViewNotInstalled")]
-    WebViewNotInstalled,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -36,13 +34,19 @@ impl Error {
     // messages in the log which only need to be used for `git grep`.
     pub fn user_friendly_msg(&self) -> String {
         match self {
-            Error::WebViewNotInstalled => "Firezone cannot start because WebView2 is not installed. Follow the instructions at <https://www.firezone.dev/kb/client-apps/windows-client>.".to_string(),
-            Error::DeepLink(deep_link::Error::CantListen) => "Firezone is already running. If it's not responding, force-stop it.".to_string(),
+            Error::DeepLink(deep_link::Error::CantListen) => {
+                "Firezone is already running. If it's not responding, force-stop it.".to_string()
+            }
             Error::DeepLink(deep_link::Error::Other(error)) => error.to_string(),
-            Error::IpcNotFound => "Couldn't find Firezone IPC service. Is the service running?".to_string(),
+            Error::IpcNotFound => {
+                "Couldn't find Firezone IPC service. Is the service running?".to_string()
+            }
             Error::IpcClosed => "IPC connection closed".to_string(),
             Error::IpcRead(_) => "IPC read failure".to_string(),
-            Error::IpcServiceTerminating => "The Firezone IPC service is terminating. Please restart the GUI Client.".to_string(),
+            Error::IpcServiceTerminating => {
+                "The Firezone IPC service is terminating. Please restart the GUI Client."
+                    .to_string()
+            }
             Error::Other(error) => error.to_string(),
         }
     }

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -131,7 +131,7 @@ fn run_gui(cli: Cli) -> Result<()> {
             }
 
             common::errors::show_error_dialog(anyhow.to_string())?;
-            tracing::error!(error = anyhow_dyn_err(&anyhow), "{anyhow:#}");
+            tracing::error!(error = anyhow_dyn_err(&anyhow), "GUI failed");
 
             Err(anyhow)
         }

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -336,7 +336,7 @@ async fn smoke_test(ctlr_tx: CtlrTx) -> Result<()> {
         })
         .await
         .context("Failed to send `ExportLogs` request")?;
-    let (tx, rx) = oneshot::channel();
+    let (tx, rx) = tokio::sync::oneshot::channel();
     ctlr_tx
         .send(ControllerRequest::ClearLogs(tx))
         .await

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -173,130 +173,122 @@ pub(crate) fn run(
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_opener::init())
         .setup(move |app| {
-            let setup_inner = move || {
-                // Check for updates
+            // Check for updates
+            tokio::spawn(async move {
+                if let Err(error) = updates::checker_task(updates_tx, cli.debug_update_check).await
+                {
+                    tracing::error!(error = anyhow_dyn_err(&error), "Error in updates::checker_task");
+                }
+            });
+
+            if let Some(client::Cmd::SmokeTest) = &cli.command {
+                let ctlr_tx = ctlr_tx.clone();
                 tokio::spawn(async move {
-                    if let Err(error) = updates::checker_task(updates_tx, cli.debug_update_check).await
-                    {
-                        tracing::error!(error = anyhow_dyn_err(&error), "Error in updates::checker_task");
+                    if let Err(error) = smoke_test(ctlr_tx).await {
+                        tracing::error!(error = anyhow_dyn_err(&error), "Error during smoke test, crashing on purpose so a dev can see our stacktraces");
+                        unsafe { sadness_generator::raise_segfault() }
                     }
                 });
-
-                if let Some(client::Cmd::SmokeTest) = &cli.command {
-                    let ctlr_tx = ctlr_tx.clone();
-                    tokio::spawn(async move {
-                        if let Err(error) = smoke_test(ctlr_tx).await {
-                            tracing::error!(error = anyhow_dyn_err(&error), "Error during smoke test, crashing on purpose so a dev can see our stacktraces");
-                            unsafe { sadness_generator::raise_segfault() }
-                        }
-                    });
-                }
-
-                tracing::debug!(cli.no_deep_links);
-                if !cli.no_deep_links {
-                    // The single-instance check is done, so register our exe
-                    // to handle deep links
-                    let exe = tauri_utils::platform::current_exe().context("Can't find our own exe path")?;
-                    deep_link::register(exe).context("Failed to register deep link handler")?;
-                    tokio::spawn(accept_deep_links(deep_link_server, ctlr_tx.clone()));
-                }
-
-                if let Some(failure) = cli.fail_on_purpose() {
-                    let ctlr_tx = ctlr_tx.clone();
-                    tokio::spawn(async move {
-                        let delay = 5;
-                        tracing::warn!(
-                            "Will crash / error / panic on purpose in {delay} seconds to test error handling."
-                        );
-                        tokio::time::sleep(Duration::from_secs(delay)).await;
-                        tracing::warn!("Crashing / erroring / panicking on purpose");
-                        ctlr_tx.send(ControllerRequest::Fail(failure)).await?;
-                        Ok::<_, anyhow::Error>(())
-                    });
-                }
-
-                if let Some(delay) = cli.quit_after {
-                    let ctlr_tx = ctlr_tx.clone();
-                    tokio::spawn(async move {
-                        tracing::warn!("Will quit gracefully in {delay} seconds.");
-                        tokio::time::sleep(Duration::from_secs(delay)).await;
-                        tracing::warn!("Quitting gracefully due to `--quit-after`");
-                        ctlr_tx.send(ControllerRequest::SystemTrayMenu(firezone_gui_client_common::system_tray::Event::Quit)).await?;
-                        Ok::<_, anyhow::Error>(())
-                    });
-                }
-
-                assert_eq!(
-                    firezone_bin_shared::BUNDLE_ID,
-                    app.handle().config().identifier,
-                    "BUNDLE_ID should match bundle ID in tauri.conf.json"
-                );
-
-                let tray = system_tray::Tray::new(app.handle().clone(), |app, event| match handle_system_tray_event(app, event) {
-                    Ok(_) => {}
-                    Err(e) => tracing::error!("{e}"),
-                })?;
-                let integration = TauriIntegration { app: app.handle().clone(), tray };
-
-                let app_handle = app.handle().clone();
-                let _ctlr_task = tokio::spawn(async move {
-                    let result = AssertUnwindSafe(Controller::start(
-                        ctlr_tx,
-                        integration,
-                        ctlr_rx,
-                        advanced_settings,
-                        reloader,
-                        &mut telemetry,
-                        updates_rx,
-                    )).catch_unwind().await;
-
-                    // See <https://github.com/tauri-apps/tauri/issues/8631>
-                    // This should be the ONLY place we call `app.exit` or `app_handle.exit`,
-                    // because it exits the entire process without dropping anything.
-                    //
-                    // This seems to be a platform limitation that Tauri is unable to hide
-                    // from us. It was the source of much consternation at time of writing.
-
-                    let exit_code = match result {
-                        Err(_panic) => {
-                            // The panic will have been recorded already by Sentry's panic hook.
-                            telemetry.stop_on_crash().await;
-
-                            1
-                        }
-                        Ok(Err(error)) => {
-                            tracing::error!(error = std_dyn_err(&error), "run_controller returned an error");
-                            if let Err(e) = errors::show_error_dialog(error.user_friendly_msg()) {
-                                tracing::error!(error = anyhow_dyn_err(&e), "Failed to show error dialog");
-                            }
-                            telemetry.stop_on_crash().await;
-                            1
-                        }
-                        Ok(Ok(_)) => {
-                            telemetry.stop().await;
-
-                            0
-                        }
-                    };
-
-                    // But due to a limit in `tao` we cannot return from the event loop and must call `std::process::exit` (or Tauri's wrapper), so we explicitly flush here.
-                    // TODO: This limit may not exist in Tauri v2
-
-                    tracing::info!(?exit_code);
-                    app_handle.exit(exit_code);
-                    // In Tauri v1, calling `App::exit` internally exited the process.
-                    // In Tauri v2, that doesn't happen, but `App::run` still doesn't return, so we have to bail out of the process manually.
-                    std::process::exit(exit_code);
-                });
-                Ok(())
-            };
-
-            let result = setup_inner();
-            if let Err(error) = &result {
-                tracing::error!(error, "Tauri setup failed");
             }
 
-            result
+            tracing::debug!(cli.no_deep_links);
+            if !cli.no_deep_links {
+                // The single-instance check is done, so register our exe
+                // to handle deep links
+                let exe = tauri_utils::platform::current_exe().context("Can't find our own exe path")?;
+                deep_link::register(exe).context("Failed to register deep link handler")?;
+                tokio::spawn(accept_deep_links(deep_link_server, ctlr_tx.clone()));
+            }
+
+            if let Some(failure) = cli.fail_on_purpose() {
+                let ctlr_tx = ctlr_tx.clone();
+                tokio::spawn(async move {
+                    let delay = 5;
+                    tracing::warn!(
+                        "Will crash / error / panic on purpose in {delay} seconds to test error handling."
+                    );
+                    tokio::time::sleep(Duration::from_secs(delay)).await;
+                    tracing::warn!("Crashing / erroring / panicking on purpose");
+                    ctlr_tx.send(ControllerRequest::Fail(failure)).await?;
+                    Ok::<_, anyhow::Error>(())
+                });
+            }
+
+            if let Some(delay) = cli.quit_after {
+                let ctlr_tx = ctlr_tx.clone();
+                tokio::spawn(async move {
+                    tracing::warn!("Will quit gracefully in {delay} seconds.");
+                    tokio::time::sleep(Duration::from_secs(delay)).await;
+                    tracing::warn!("Quitting gracefully due to `--quit-after`");
+                    ctlr_tx.send(ControllerRequest::SystemTrayMenu(firezone_gui_client_common::system_tray::Event::Quit)).await?;
+                    Ok::<_, anyhow::Error>(())
+                });
+            }
+
+            assert_eq!(
+                firezone_bin_shared::BUNDLE_ID,
+                app.handle().config().identifier,
+                "BUNDLE_ID should match bundle ID in tauri.conf.json"
+            );
+
+            let tray = system_tray::Tray::new(app.handle().clone(), |app, event| match handle_system_tray_event(app, event) {
+                Ok(_) => {}
+                Err(e) => tracing::error!("{e}"),
+            })?;
+            let integration = TauriIntegration { app: app.handle().clone(), tray };
+
+            let app_handle = app.handle().clone();
+            let _ctlr_task = tokio::spawn(async move {
+                let result = AssertUnwindSafe(Controller::start(
+                    ctlr_tx,
+                    integration,
+                    ctlr_rx,
+                    advanced_settings,
+                    reloader,
+                    &mut telemetry,
+                    updates_rx,
+                )).catch_unwind().await;
+
+                // See <https://github.com/tauri-apps/tauri/issues/8631>
+                // This should be the ONLY place we call `app.exit` or `app_handle.exit`,
+                // because it exits the entire process without dropping anything.
+                //
+                // This seems to be a platform limitation that Tauri is unable to hide
+                // from us. It was the source of much consternation at time of writing.
+
+                let exit_code = match result {
+                    Err(_panic) => {
+                        // The panic will have been recorded already by Sentry's panic hook.
+                        telemetry.stop_on_crash().await;
+
+                        1
+                    }
+                    Ok(Err(error)) => {
+                        tracing::error!(error = std_dyn_err(&error), "run_controller returned an error");
+                        if let Err(e) = errors::show_error_dialog(error.user_friendly_msg()) {
+                            tracing::error!(error = anyhow_dyn_err(&e), "Failed to show error dialog");
+                        }
+                        telemetry.stop_on_crash().await;
+                        1
+                    }
+                    Ok(Ok(_)) => {
+                        telemetry.stop().await;
+
+                        0
+                    }
+                };
+
+                // But due to a limit in `tao` we cannot return from the event loop and must call `std::process::exit` (or Tauri's wrapper), so we explicitly flush here.
+                // TODO: This limit may not exist in Tauri v2
+
+                tracing::info!(?exit_code);
+                app_handle.exit(exit_code);
+                // In Tauri v1, calling `App::exit` internally exited the process.
+                // In Tauri v2, that doesn't happen, but `App::run` still doesn't return, so we have to bail out of the process manually.
+                std::process::exit(exit_code);
+            });
+
+            Ok(())
         });
     let app = app.build(tauri::generate_context!());
 

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -289,25 +289,9 @@ pub(crate) fn run(
             });
 
             Ok(())
-        });
-    let app = app.build(tauri::generate_context!());
-
-    let app = match app {
-        Ok(x) => x,
-        Err(error) => {
-            tracing::error!(
-                error = std_dyn_err(&error),
-                "Failed to build Tauri app instance"
-            );
-            #[expect(clippy::wildcard_enum_match_arm)]
-            match error {
-                tauri::Error::Runtime(tauri_runtime::Error::CreateWebview(_)) => {
-                    return Err(Error::WebViewNotInstalled);
-                }
-                error => Err(anyhow::Error::from(error).context("Tauri error"))?,
-            }
-        }
-    };
+        })
+        .build(tauri::generate_context!())
+        .context("Failed to build Tauri app instance")?;
 
     app.run(|_app_handle, event| {
         if let tauri::RunEvent::ExitRequested { api, .. } = event {

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -12,8 +12,7 @@ use common::system_tray::Event as TrayMenuEvent;
 use firezone_gui_client_common::{
     self as common,
     controller::{Controller, ControllerRequest, CtlrTx, GuiIntegration},
-    deep_link,
-    errors::{self, Error},
+    deep_link, errors,
     settings::AdvancedSettings,
     updates,
 };
@@ -117,15 +116,13 @@ impl GuiIntegration for TauriIntegration {
 }
 
 /// Runs the Tauri GUI and returns on exit or unrecoverable error
-///
-/// Still uses `thiserror` so we can catch the deep_link `CantListen` error
 #[instrument(skip_all)]
 pub(crate) fn run(
     cli: client::Cli,
     advanced_settings: AdvancedSettings,
     reloader: LogFilterReloader,
     mut telemetry: telemetry::Telemetry,
-) -> Result<(), Error> {
+) -> Result<()> {
     // Needed for the deep link server
     let rt = tokio::runtime::Runtime::new().context("Couldn't start Tokio runtime")?;
     let _guard = rt.enter();

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -23,7 +23,7 @@ use futures::FutureExt;
 use secrecy::{ExposeSecret as _, SecretString};
 use std::{panic::AssertUnwindSafe, str::FromStr, time::Duration};
 use tauri::Manager;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tracing::instrument;
 
 pub(crate) mod system_tray;


### PR DESCRIPTION
At present, the GUI client uses a monolithic `Error` enum that represents all kinds of errors. Some of them are unused (see #7956). Others are only used during startup, like the `deep_link` and `WebViewNotInstalled` variants. This makes it difficult to write correct error handling code.

In addition to remove certain variants in #7965, this PR refactors the `run::gui` function to not depend on this `Error` at all. Instead, we use `anyhow::Result` and probe for particular errors that we want to special-case. This is a bit less type-safe because there is no source code-level connection between the source site that emits an error and the error handling code.

In the worst case, any regression here is "just" a slight degradation in UX: We will show a generic error dialog instead of a tailored message. This risk is deemed acceptable in exchange for an easier to understand control flow.