### PR TITLE
ci: don't reference old Sentry project name

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -114,8 +114,7 @@ jobs:
       - name: Upload debug symbols to Sentry
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         run: |
-          sentry-cli debug-files upload --log-level info --project gui-client-gui --include-sources ../target
-          sentry-cli debug-files upload --log-level info --project gui-client-ipc-service --include-sources ../target
+          sentry-cli debug-files upload --log-level info --project gui-client --include-sources ../target
 
       - name: Upload Release Assets
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"


### PR DESCRIPTION
We have recently merged the two Sentry projects for the GUI client into just one, i.e. both the GUI client and its IPC service use the same DSN to report errors.

What we forgot to change is that these are also referenced in the CI workflow when we upload debug symbols.