### PR TITLE
chore(ops): Update CPU utilization alert threshold

### DIFF
--- a/terraform/modules/google-cloud/ops/main.tf
+++ b/terraform/modules/google-cloud/ops/main.tf
@@ -212,7 +212,7 @@ resource "google_monitoring_alert_policy" "instances_high_cpu_policy" {
       filter     = "resource.type = \"gce_instance\" AND metric.type = \"compute.googleapis.com/instance/cpu/utilization\" AND metadata.user_labels.managed_by = \"terraform\""
       comparison = "COMPARISON_GT"
 
-      threshold_value = 0.8
+      threshold_value = 0.9
       duration        = "60s"
 
       trigger {


### PR DESCRIPTION
The PR updates the threshold for CPU utilization monitoring alerts.  This is being done to avoid notification fatigue.  This is not intended to ignore any issue that might cause the CPU utilization to be high, but rather make sure we don't miss other important alerts that might come through while we try to solve the underlying CPU utilization issues.