### PR TITLE
fix(gui-client): retry connlib messages using backoff

### DIFF
--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -15,7 +15,7 @@ use firezone_telemetry::Telemetry;
 use futures::{
     future::poll_fn,
     task::{Context, Poll},
-    Future as _, SinkExt as _, Stream as _, TryFutureExt,
+    Future as _, SinkExt as _, Stream as _,
 };
 use phoenix_channel::LoginUrl;
 use secrecy::SecretString;

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -75,6 +75,7 @@ pub struct CliCommon {
 /// i.e. callbacks
 // The names are CamelCase versions of the connlib callbacks.
 #[expect(clippy::enum_variant_names)]
+#[derive(Debug, Clone)]
 pub enum ConnlibMsg {
     OnDisconnect {
         error_msg: String,


### PR DESCRIPTION
Whenever system state needs to change, such as DNS servers, tunnel IP configuration or resources, `connlib` emits a message to the hosting app. `connlib` expects that these changes are applied and there is no way of communicating back that this failed. This is by design because `connlib` can't do anything about these kind of failures.

In the worst case, when the host app can't fulfill the request, it should shutdown or otherwise have the user initiate a retry. It could also be that an encountered failure is just a temporary situation. For these problems, we implement a retry mechanism that for applying the state described in the message from connlib.

We use an exponential backoff in order to give it more time with each failure. This should increase the likelihood of things working in case the system is overloaded / too slow which I believe is the root cause for #7962.

Fixes: #7962