### PR TITLE
fix(gui-client): retry connlib messages using backoff

### DIFF
--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -121,7 +121,7 @@ fn activate(dns_config: &[IpAddr]) -> Result<()> {
     // using QUIC, HTTP/2, or even HTTP/1.1, and so they won't resolve the DNS
     // again unless you let that connection time out:
     // <https://github.com/firezone/firezone/issues/3113#issuecomment-1882096111>
-    tracing::info!("Activating DNS control...");
+    tracing::info!(nameservers = ?dns_config, "Activating DNS control...");
 
     let hklm = winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE);
 

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -121,7 +121,7 @@ fn activate(dns_config: &[IpAddr]) -> Result<()> {
     // using QUIC, HTTP/2, or even HTTP/1.1, and so they won't resolve the DNS
     // again unless you let that connection time out:
     // <https://github.com/firezone/firezone/issues/3113#issuecomment-1882096111>
-    tracing::info!(nameservers = ?dns_config, "Activating DNS control...");
+    tracing::info!(nameservers = ?dns_config, "Activating DNS control");
 
     let hklm = winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE);
 

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -360,6 +360,11 @@ impl<'a> Handler<'a> {
         loop {
             match poll_fn(|cx| self.next_event(cx, signals)).await {
                 Event::Callback(msg) => {
+                    // Attempt to change the system's state as per the message from connlib.
+                    // We can safely retry these because they are by design idempotent:
+                    // There is no difference between us attempting to apply the same message multiple times
+                    // and connlib sending us the same message multiple times.
+
                     let mut backoff = backoff::ExponentialBackoffBuilder::new()
                         .with_initial_interval(Duration::from_millis(100))
                         .with_max_elapsed_time(Some(Duration::from_secs(10)))

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -15,7 +15,7 @@ use firezone_telemetry::Telemetry;
 use futures::{
     future::poll_fn,
     task::{Context, Poll},
-    Future as _, SinkExt as _, Stream as _, TryFutureExt,
+    Future as _, SinkExt as _, Stream as _,
 };
 use phoenix_channel::LoginUrl;
 use secrecy::SecretString;

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -75,6 +75,7 @@ pub struct CliCommon {
 /// i.e. callbacks
 // The names are CamelCase versions of the connlib callbacks.
 #[expect(clippy::enum_variant_names)]
+#[derive(Debug, Clone)]
 pub enum ConnlibMsg {
     OnDisconnect {
         error_msg: String,

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -27,7 +27,12 @@ export default function GUI({ title }: { title: string }) {
   return (
     <Entries downloadLinks={downloadLinks} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="7971">
+          Introduces a retry mechanism in case routing rules or DNS settings
+          fail to apply.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.2" date={new Date("2025-01-30")}>
         {title == "Linux GUI" && (
           <ChangeItem>


### PR DESCRIPTION
Whenever system state needs to change, such as DNS servers, tunnel IP configuration or resources, `connlib` emits a message to the hosting app. `connlib` expects that these changes are applied and there is no way of communicating back that this failed. This is by design because `connlib` can't do anything about these kind of failures.

In the worst case, when the host app can't fulfill the request, it should shutdown or otherwise have the user initiate a retry. It could also be that an encountered failure is just a temporary situation. For these problems, we implement a retry mechanism that for applying the state described in the message from connlib.

We use an exponential backoff in order to give it more time with each failure. This should increase the likelihood of things working in case the system is overloaded / too slow which I believe is the root cause for #7962.

Fixes: #7962