### PR TITLE
fix(apple/macOS): Show signed out directly on MainActor

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -96,17 +96,21 @@ public class SessionNotification: NSObject {
   // In macOS, use a Cocoa alert.
   // This gets called from the app side.
   @MainActor
-  func showSignedOutAlertmacOS() {
+  func showSignedOutAlertmacOS() async {
     let alert = NSAlert()
     alert.messageText = "Your Firezone session has ended"
     alert.informativeText = "Please sign in again to reconnect"
     alert.addButton(withTitle: "Sign In")
     alert.addButton(withTitle: "Cancel")
     NSApp.activate(ignoringOtherApps: true)
-    let response = alert.runModal()
-    if response == NSApplication.ModalResponse.alertFirstButtonReturn {
-      Log.log("\(#function): 'Sign In' clicked in notification")
-      signInHandler()
+
+    await withCheckedContinuation { continuation in
+      let response = alert.runModal()
+      if response == NSApplication.ModalResponse.alertFirstButtonReturn {
+        Log.log("\(#function): 'Sign In' clicked in notification")
+        signInHandler()
+      }
+      continuation.resume()
     }
   }
 #endif


### PR DESCRIPTION
`NSAlert`'s `runModal` method blocks the current thread until the user takes action. When we do this via `await MainActor.run { ... }` from within a `Task`, Sentry correctly detects this as blocking the executor thread.

See https://github.com/getsentry/sentry-cocoa/issues/2643

As such, to show `NSAlert`s from within `Tasks` in Swift, we need to wrap them with `withCheckedContinuation` to signal to the Task executor we are yielding. Sentry won't complain if these are only blocking the UI thread, which is unavoidable (and by design with `NSAlert`).

Since handling VPN status change events already occurs within a `Task` in `VPNConfigurationManager` and we can't get around that, we mark the handler called from there as `async` and add a fourth parameter, an `NEProviderStopReason` which needs to be read from the tunnel process via IPC when we encounter a `disconnected` state. This is needed because the status change events we get from the system only include the status and not the reason.

If the reason is `authenticationCanceled`, we run the modal.