### PR TITLE
fix(apple): Don't try to sign in if user cancels

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
@@ -22,12 +22,14 @@ struct WebAuthSession {
 
     let anchor = PresentationAnchor()
 
-    let authResponse = try await withCheckedThrowingContinuation { continuation in
+    let authResponse: AuthResponse? = try await withCheckedThrowingContinuation { continuation in
       let session = ASWebAuthenticationSession(url: url, callbackURLScheme: scheme) { returnedURL, error in
         do {
           if let error = error as? ASWebAuthenticationSessionError,
              error.code == .canceledLogin {
             // User canceled sign in
+            continuation.resume(returning: nil)
+            return
           } else if let error = error {
             throw error
           }
@@ -50,7 +52,9 @@ struct WebAuthSession {
       session.start()
     }
 
-    try await store.signIn(authResponse: authResponse)
+    if let authResponse {
+      try await store.signIn(authResponse: authResponse)
+    }
   }
 }
 


### PR DESCRIPTION
This fixes a minor regression introduced in f779fe9667  where we would incorrectly show an error dialog if the user cancels sign in because the `authResponse` is invalid.