### PR TITLE
docs(gui-client): add troubleshooting for Windows ACL issues

### DIFF
--- a/website/src/app/kb/client-apps/windows-client/readme.mdx
+++ b/website/src/app/kb/client-apps/windows-client/readme.mdx
@@ -111,24 +111,46 @@ In the Start Menu, search for "Windows Powershell". Open it and run this
 command:
 
 ```pwsh
-Get-Service -Name FirezoneClientIpcService
+Get-CIMInstance -Class Win32_Service -Filter "name ='FirezoneClientIpcService' " | Format-Table Name,State,StartName
 ```
 
-Good output
+#### Good output
 
 ```text
-Status   Name               DisplayName
-------   ----               -----------
-Running  FirezoneClientI... Firezone Client IPC
+Name                     State   StartName
+----                     -----   ---------
+FirezoneClientIpcService Running LocalSystem
 ```
 
-Bad output
+#### Bad output (not running)
 
 ```text
-Status   Name               DisplayName
-------   ----               -----------
-Stopped  FirezoneClientI... Firezone Client IPC
+Name                     State   StartName
+----                     -----   ---------
+FirezoneClientIpcService Stopped LocalSystem
 ```
+
+Solution: Start the Firezone IPC service.
+Go to:
+
+- `services.msc`
+- Right-click on `Firzone Client IPC`, select `Start`
+
+#### Bad output (wrong user)
+
+```text
+Name                     State   StartName
+----                     -----   ---------
+FirezoneClientIpcService Stopped NT AUTHORITY\NetworkService
+```
+
+Solution: Configure the Firezone IPC service to run as the "LocalSystem" user.
+Go to:
+
+- `services.msc`
+- Right-click on `Firzone Client IPC`, select `Permissions`
+- Switch to the tab `Log On`
+- Select `Local System Account`
 
 ### Check if Firezone is controlling DNS
 

--- a/website/src/app/kb/client-apps/windows-client/readme.mdx
+++ b/website/src/app/kb/client-apps/windows-client/readme.mdx
@@ -152,6 +152,35 @@ Go to:
 - Switch to the tab `Log On`
 - Select `Local System Account`
 
+### Check if necessary registry keys have the right permissions
+
+In the Start Menu, search for "Windows Powershell". Open it and run this
+command:
+
+```pwsh
+@("HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip", "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6") | ForEach-Object { Get-Acl $_ | Select-Object -ExpandProperty Access | Where-Object IdentityReference -match "SYSTEM" }
+```
+
+Good output:
+
+```text
+RegistryRights    : FullControl
+AccessControlType : Allow
+IdentityReference : NT AUTHORITY\SYSTEM
+IsInherited       : False
+InheritanceFlags  : ContainerInherit
+PropagationFlags  : None
+
+RegistryRights    : FullControl
+AccessControlType : Allow
+IdentityReference : NT AUTHORITY\SYSTEM
+IsInherited       : False
+InheritanceFlags  : ContainerInherit
+PropagationFlags  : None
+```
+
+The "RegistryRights" must be `FullControl`.
+
 ### Check if Firezone is controlling DNS
 
 In the Start Menu, search for "Windows Powershell". Open it and run this


### PR DESCRIPTION
In case the IPC service is run as a user that is different from the local SYSTEM user, WinTUN will have issues booting up the adapter correctly.