### PR TITLE
refactor(connlib): use Win32 APIs instead of `netsh` to set IPs

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -408,7 +408,7 @@ fn try_set_mtu(luid: NET_LUID_LH, family: ADDRESS_FAMILY, mtu: u32) -> Result<()
 fn try_set_ip(luid: NET_LUID_LH, ip: IpAddr) -> Result<()> {
     const ERROR_OBJECT_ALREADY_EXISTS: HRESULT = HRESULT::from_win32(0x80071392);
 
-    // Safety: Docs mention anything in regards to safety of this function.
+    // Safety: Docs don't mention anything in regards to safety of this function.
     let mut row = unsafe {
         let mut row: MIB_UNICASTIPADDRESS_ROW = std::mem::zeroed();
         InitializeUnicastIpAddressEntry(&mut row);

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -89,7 +89,7 @@ impl TunDeviceManager {
         };
 
         try_set_ip(luid, IpAddr::V4(ipv4)).context("Failed to set IPv4 address")?;
-        try_set_ip(luid, IpAddr::V6(ipv6)).context("Failed to set IPv4 address")?;
+        try_set_ip(luid, IpAddr::V6(ipv6)).context("Failed to set IPv6 address")?;
 
         Ok(())
     }


### PR DESCRIPTION
This should be faster and hopefully more reliable.