### PR TITLE
feat(portal): allow socket based postgres connections

### DIFF
--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -43,7 +43,7 @@ defmodule Domain.Config do
   end
 
   @doc """
-  Similar to `compile_config/2` but returns nil if the configuration is invalid.
+  Similar to `compile_config!/3` but returns nil if the configuration is invalid.
 
   This function does not resolve values from the database because it's intended use is during
   compilation and before application boot (in `config/runtime.exs`).
@@ -55,7 +55,7 @@ defmodule Domain.Config do
       {:ok, _source, value} ->
         value
 
-      {:error, reason} ->
+      {:error, _reason} ->
         nil
     end
   end

--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -42,6 +42,24 @@ defmodule Domain.Config do
     end
   end
 
+  @doc """
+  Similar to `compile_config/2` but returns nil if the configuration is invalid.
+
+  This function does not resolve values from the database because it's intended use is during
+  compilation and before application boot (in `config/runtime.exs`).
+
+  If you need to resolve values from the database, use `fetch_config/1` or `fetch_config!/1`.
+  """
+  def compile_config(module \\ Definitions, key, env_config \\ System.get_env()) do
+    case Fetcher.fetch_source_and_config(module, key, %{}, env_config) do
+      {:ok, _source, value} ->
+        value
+
+      {:error, reason} ->
+        nil
+    end
+  end
+
   def config_changeset(changeset, schema_key, config_key \\ nil) do
     config_key = config_key || schema_key
 

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -120,6 +120,7 @@ defmodule Domain.Config.Definitions do
        ]},
       {"Instrumentation",
        [
+         :healthz_port,
          :instrumentation_client_logs_enabled,
          :instrumentation_client_logs_bucket,
          :telemetry_metrics_reporter,
@@ -473,6 +474,19 @@ defmodule Domain.Config.Definitions do
   ##############################################
   ## Telemetry
   ##############################################
+
+  @doc """
+  The port for the internal healthz endpoint.
+  """
+  defconfig(:healthz_port, :integer,
+    default: 4000,
+    changeset: fn changeset, key ->
+      Ecto.Changeset.validate_number(changeset, key,
+        greater_than: 0,
+        less_than_or_equal_to: 65_535
+      )
+    end
+  )
 
   @doc """
   Enable or disable the Firezone telemetry collection.

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -61,6 +61,7 @@ defmodule Domain.Config.Definitions do
       {"Database",
        [
          :database_host,
+         :database_socket_dir,
          :database_port,
          :database_name,
          :database_user,
@@ -254,6 +255,11 @@ defmodule Domain.Config.Definitions do
   PostgreSQL host.
   """
   defconfig(:database_host, :string, default: "postgres")
+
+  @doc """
+  PostgreSQL socket directory (takes precedence over hostname).
+  """
+  defconfig(:database_socket_dir, :string, default: nil)
 
   @doc """
   PostgreSQL port.

--- a/elixir/apps/domain/lib/domain/telemetry.ex
+++ b/elixir/apps/domain/lib/domain/telemetry.ex
@@ -13,7 +13,8 @@ defmodule Domain.Telemetry do
 
     children = [
       # We start a /healthz endpoint that is used for liveness probes
-      {Bandit, plug: Telemetry.HealthzPlug, scheme: :http, port: Keyword.get(config, :healthz_port)},
+      {Bandit,
+       plug: Telemetry.HealthzPlug, scheme: :http, port: Keyword.get(config, :healthz_port)},
 
       # Telemetry poller will execute the given period measurements
       # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics

--- a/elixir/apps/domain/lib/domain/telemetry.ex
+++ b/elixir/apps/domain/lib/domain/telemetry.ex
@@ -13,7 +13,7 @@ defmodule Domain.Telemetry do
 
     children = [
       # We start a /healthz endpoint that is used for liveness probes
-      {Bandit, plug: Telemetry.HealthzPlug, scheme: :http, port: 4000},
+      {Bandit, plug: Telemetry.HealthzPlug, scheme: :http, port: Keyword.get(config, :healthz_port)},
 
       # Telemetry poller will execute the given period measurements
       # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -37,7 +37,7 @@ config :domain, Domain.Gateways,
   gateway_ipv4_masquerade: true,
   gateway_ipv6_masquerade: true
 
-config :domain, Domain.Telemetry, metrics_reporter: nil
+config :domain, Domain.Telemetry, metrics_reporter: nil, healthz_port: 4000
 
 config :domain, Domain.Analytics,
   mixpanel_token: nil,

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -211,7 +211,9 @@ if config_env() == :prod do
       otlp_endpoint: System.get_env("OTLP_ENDPOINT")
   end
 
-  config :domain, Domain.Telemetry, metrics_reporter: compile_config!(:telemetry_metrics_reporter)
+  config :domain, Domain.Telemetry,
+    healthz_port: compile_config!(:healthz_port),
+    metrics_reporter: compile_config!(:telemetry_metrics_reporter)
 
   if telemetry_metrics_reporter = compile_config!(:telemetry_metrics_reporter) do
     config :domain, telemetry_metrics_reporter, compile_config!(:telemetry_metrics_reporter_opts)

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -1,22 +1,31 @@
 import Config
 
 if config_env() == :prod do
-  import Domain.Config, only: [compile_config!: 1]
+  import Domain.Config, only: [compile_config!: 1, compile_config: 1]
 
   ###############################
   ##### Domain ##################
   ###############################
 
-  config :domain, Domain.Repo,
-    database: compile_config!(:database_name),
-    username: compile_config!(:database_user),
-    hostname: compile_config!(:database_host),
-    port: compile_config!(:database_port),
-    password: compile_config!(:database_password),
-    pool_size: compile_config!(:database_pool_size),
-    ssl: compile_config!(:database_ssl_enabled),
-    ssl_opts: compile_config!(:database_ssl_opts),
-    parameters: compile_config!(:database_parameters)
+  config :domain,
+         Domain.Repo,
+         [
+           {:database, compile_config!(:database_name)},
+           {:username, compile_config!(:database_user)},
+           {:port, compile_config!(:database_port)},
+           {:pool_size, compile_config!(:database_pool_size)},
+           {:ssl, compile_config!(:database_ssl_enabled)},
+           {:ssl_opts, compile_config!(:database_ssl_opts)},
+           {:parameters, compile_config!(:database_parameters)}
+         ] ++
+           if(compile_config(:database_password),
+             do: [{:password, compile_config!(:database_password)}],
+             else: []
+           ) ++
+           if(compile_config(:database_socket_dir),
+             do: [{:socket_dir, compile_config!(:database_socket_dir)}],
+             else: [{:hostname, compile_config!(:database_host)}]
+           )
 
   config :domain, Domain.Tokens,
     key_base: compile_config!(:tokens_key_base),


### PR DESCRIPTION
This allows connections to the postgresql database via the standard socket, which - opposed to TCP sockets - allows `peer` authentication based on local unix users. This removes the need for a password and is much simpler to deploy when running components locally.

In the current form, `DATABASE_SOCKET_DIR` takes precedence over hostname, if the environment variable is present. I found that `compile_config!` somehow enforces a value to be present which is explicitly not what I want for some of these values (i think). I'd be glad if anyone with more elixir experience can guide me as to how I can make this more idiomatic.
