### PR TITLE
fix(portal): Only configure Sentry.LoggerHandler once

### DIFF
--- a/elixir/apps/api/lib/api/application.ex
+++ b/elixir/apps/api/lib/api/application.ex
@@ -6,8 +6,6 @@ defmodule API.Application do
     _ = :opentelemetry_cowboy.setup()
     _ = OpentelemetryPhoenix.setup(adapter: :cowboy2)
 
-    Logger.add_handlers(:api)
-
     children = [
       API.Endpoint
     ]

--- a/elixir/apps/domain/lib/domain/application.ex
+++ b/elixir/apps/domain/lib/domain/application.ex
@@ -8,7 +8,7 @@ defmodule Domain.Application do
     _ = OpentelemetryLoggerMetadata.setup()
     _ = OpentelemetryEcto.setup([:domain, :repo])
 
-    Logger.add_handlers(:domain)
+    Logger.add_handlers(:logger)
 
     # Can be uncommented when this bug is fixed: https://github.com/open-telemetry/opentelemetry-erlang-contrib/issues/327
     # _ = OpentelemetryFinch.setup()

--- a/elixir/apps/web/lib/web/application.ex
+++ b/elixir/apps/web/lib/web/application.ex
@@ -7,8 +7,6 @@ defmodule Web.Application do
     _ = :opentelemetry_cowboy.setup()
     _ = OpentelemetryPhoenix.setup(adapter: :cowboy2)
 
-    Logger.add_handlers(:web)
-
     children = [
       Web.Endpoint
     ]

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -12,17 +12,6 @@ import Config
 ##### Domain ##################
 ###############################
 
-config :domain, :logger, [
-  {:handler, :domain, Sentry.LoggerHandler,
-   %{
-     config: %{
-       level: :warning,
-       metadata: :all,
-       capture_log_messages: true
-     }
-   }}
-]
-
 config :domain, ecto_repos: [Domain.Repo]
 config :domain, generators: [binary_id: true, context_app: :domain]
 
@@ -127,17 +116,6 @@ config :domain, web_external_url: "http://localhost:13000"
 ###############################
 ##### Web #####################
 ###############################
-
-config :web, :logger, [
-  {:handler, :web, Sentry.LoggerHandler,
-   %{
-     config: %{
-       level: :warning,
-       metadata: :all,
-       capture_log_messages: true
-     }
-   }}
-]
 
 config :web, ecto_repos: [Domain.Repo]
 config :web, generators: [binary_id: true, context_app: :domain]
@@ -253,6 +231,17 @@ config :logger, level: String.to_atom(System.get_env("LOG_LEVEL", "info"))
 config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
   metadata: :all
+
+config :logger, :logger, [
+  {:handler, :sentry, Sentry.LoggerHandler,
+   %{
+     config: %{
+       level: :warning,
+       metadata: :all,
+       capture_log_messages: true
+     }
+   }}
+]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason


### PR DESCRIPTION
The applications within our umbrella are all joined into a single Erlang cluster, and logger configuration is applied already to the entire umbrella.

As such, registering the Sentry log handler in each application's startup routine triggers duplicate handlers to be registered for the cluster, resulting in warnings like this in GCP:

```
Event dropped due to being a duplicate of a previously-captured event.
```

As such, we can move the log handler configuration to the top-level `:logger` key, under the `:logger` subkey for configuring a single handler. We then load this handler config in the `domain` app only and it applies to the entire cluster.