### PR TITLE
chore(infra): Reduce gateway size to e2-micro for prod

### DIFF
--- a/terraform/environments/production/gateways.tf
+++ b/terraform/environments/production/gateways.tf
@@ -2,7 +2,7 @@
 locals {
   gateways_region         = local.region
   gateways_zone           = local.availability_zone
-  gateways_instance_type  = "n1-standard-1"
+  gateways_instance_type  = "e2-micro"
   gateways_instance_count = 2
 }
 


### PR DESCRIPTION
`e2-micro` is what we use for Relays and should be more than capable to use for our internal prod Gateways for accessing the prod env.

Cost savings is about 3-4x vs `n1-standard-1`.