### PR TITLE
chore(dev): Use `postgres:15` for docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Dependencies
   postgres:
-    image: postgres:15.5
+    image: postgres:15
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
This will ensure we're using the latest Postgres major, which should more closely track staging/prod.