### PR TITLE
fix(infra): Inline sentry logging config

### DIFF
--- a/elixir/apps/domain/lib/domain/application.ex
+++ b/elixir/apps/domain/lib/domain/application.ex
@@ -8,7 +8,14 @@ defmodule Domain.Application do
     _ = OpentelemetryLoggerMetadata.setup()
     _ = OpentelemetryEcto.setup([:domain, :repo])
 
-    Logger.add_handlers(:logger)
+    # Configure Sentry to capture Logger messages
+    :logger.add_handler(:sentry, Sentry.LoggerHandler, %{
+      config: %{
+        level: :warning,
+        metadata: :all,
+        capture_log_messages: true
+      }
+    })
 
     # Can be uncommented when this bug is fixed: https://github.com/open-telemetry/opentelemetry-erlang-contrib/issues/327
     # _ = OpentelemetryFinch.setup()

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -232,17 +232,6 @@ config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
   metadata: :all
 
-config :logger, :logger, [
-  {:handler, :sentry, Sentry.LoggerHandler,
-   %{
-     config: %{
-       level: :warning,
-       metadata: :all,
-       capture_log_messages: true
-     }
-   }}
-]
-
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 


### PR DESCRIPTION
It appears that something is initializing the Sentry.LoggerHandler before we try to load it when starting:

```
Invalid logger handler config: {:logger,
 {:invalid_handler, {:function_not_exported, {Sentry.LoggerHandler, :log, 2}}}}
```

This doesn't seem to actually inhibit the Sentry logger at all, presumably because it initializes just fine in the application start callback.

Instead of defining the config in the `config/` directory, we can pass it directly to `:logger` on start which solves the above issue.