### PR TITLE
fix(gui-client): graceful shutdown of IPC service on Windows

### DIFF
--- a/rust/headless-client/src/ipc_service/windows.rs
+++ b/rust/headless-client/src/ipc_service/windows.rs
@@ -4,12 +4,9 @@ use firezone_bin_shared::platform::DnsControlMethod;
 use firezone_logging::anyhow_dyn_err;
 use firezone_telemetry::Telemetry;
 use futures::channel::mpsc;
-use futures::future::{self, Either};
-use futures::StreamExt;
 use std::{
     ffi::{c_void, OsString},
     mem::size_of,
-    pin::pin,
     time::Duration,
 };
 use windows::{


### PR DESCRIPTION
When the IPC service is shutdown gracefully (i.e. purposely), we send a `TerminatingGracefully` message of the IPC channel. This allows the GUI to handle this case differently from the a crash.

On Linux, this is achieved by reacting to signals that are sent to the IPC process. Windows however doesn't send any signals to services. Instead, we get an event that we are being shutdown.

Currently, this event is handled separately from the signal handler and the signal handler does nothing on Windows. To make this more uniform and allow graceful shutdown of the IPC service on Windows, we introduce a 2nd constructor to the `Terminate` signal abstraction that is already hooked up with the correct logic here.