### PR TITLE
chore: make all Rust code compile on Windows

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -28,7 +28,7 @@ outputs:
     value: ${{
       (runner.os == 'Linux' && '--workspace') ||
       (runner.os == 'macOS' && '-p connlib-client-apple -p connlib-client-shared -p firezone-tunnel -p snownet') ||
-      (runner.os == 'Windows' && '--workspace') }}
+      (runner.os == 'Windows' && '-p connlib-client-shared -p connlib-model -p firezone-bin-shared -p firezone-gui-client -p firezone-gui-client-common -p firezone-headless-client -p firezone-logging -p firezone-telemetry -p firezone-tunnel -p gui-smoke-test -p http-test-server -p ip-packet -p phoenix-channel -p snownet -p socket-factory -p tun') }}
 
 runs:
   using: "composite"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -28,7 +28,7 @@ outputs:
     value: ${{
       (runner.os == 'Linux' && '--workspace') ||
       (runner.os == 'macOS' && '-p connlib-client-apple -p connlib-client-shared -p firezone-tunnel -p snownet') ||
-      (runner.os == 'Windows' && '-p connlib-client-shared -p connlib-model -p firezone-bin-shared -p firezone-gui-client -p firezone-gui-client-common -p firezone-headless-client -p firezone-logging -p firezone-telemetry -p firezone-tunnel -p gui-smoke-test -p http-test-server -p ip-packet -p phoenix-channel -p snownet -p socket-factory -p tun') }}
+      (runner.os == 'Windows' && '--workspace') }}
 
 runs:
   using: "composite"

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -3,6 +3,8 @@
 // However, this consideration has made it idiomatic for Java FFI in the Rust
 // ecosystem, so it's used here for consistency.
 
+#![cfg(unix)]
+
 use crate::tun::Tun;
 use anyhow::{Context as _, Result};
 use backoff::ExponentialBackoffBuilder;

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -1,5 +1,6 @@
 // Swift bridge generated code triggers this below
 #![allow(clippy::unnecessary_cast, improper_ctypes, non_camel_case_types)]
+#![cfg(unix)]
 
 mod make_writer;
 mod tun;

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 backoff = { workspace = true }
 boringtun = { workspace = true }
-caps = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 connlib-model = { workspace = true }
@@ -41,6 +40,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+caps = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true, features = ["std"] }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -87,8 +87,12 @@ fn main() -> ExitCode {
 #[cfg(target_os = "linux")]
 fn has_necessary_permissions() -> bool {
     let is_root = nix::unistd::Uid::current().is_root();
-    let has_net_admin =
-        caps::has_cap(None, caps::CapSet::Effective, caps::Capability::CAP_NET_ADMIN).is_ok_and(|b| b);
+    let has_net_admin = caps::has_cap(
+        None,
+        caps::CapSet::Effective,
+        caps::Capability::CAP_NET_ADMIN,
+    )
+    .is_ok_and(|b| b);
 
     is_root || has_net_admin
 }


### PR DESCRIPTION
Developing on Windows is much easier if all Rust code compiles without errors or warnings because you can "trust" your IDE that your code is error free if it says "0 errors; 0 warnings". We are not far off from achieving this!

Apart from the "graceful termination" feature in the relay, both the relay and gateway should actually also work on Windows just fine, thanks to the platform-agnostic abstractions we have been building up for the GUI and headless client.