### PR TITLE
feat(gui-client): track "IPC not found" error inside `anyhow`

### DIFF
--- a/rust/gui-client/src-common/src/errors.rs
+++ b/rust/gui-client/src-common/src/errors.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
-use firezone_headless_client::ipc;
 
 // TODO: Replace with `anyhow` gradually per <https://github.com/firezone/firezone/pull/3546#discussion_r1477114789>
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("IPC service not found")]
-    IpcNotFound,
     #[error("IPC closed")]
     IpcClosed,
     #[error("IPC read failed")]
@@ -16,24 +13,12 @@ pub enum Error {
     Other(#[from] anyhow::Error),
 }
 
-impl From<ipc::Error> for Error {
-    fn from(value: ipc::Error) -> Self {
-        match value {
-            ipc::Error::NotFound(_) => Self::IpcNotFound,
-            ipc::Error::Other(error) => Self::Other(error),
-        }
-    }
-}
-
 impl Error {
     // Decision to put the error strings here: <https://github.com/firezone/firezone/pull/3464#discussion_r1473608415>
     // This message gets shown to users in the GUI and could be localized, unlike
     // messages in the log which only need to be used for `git grep`.
     pub fn user_friendly_msg(&self) -> String {
         match self {
-            Error::IpcNotFound => {
-                "Couldn't find Firezone IPC service. Is the service running?".to_string()
-            }
             Error::IpcClosed => "IPC connection closed".to_string(),
             Error::IpcRead(_) => "IPC read failure".to_string(),
             Error::IpcServiceTerminating => {

--- a/rust/gui-client/src-common/src/ipc.rs
+++ b/rust/gui-client/src-common/src/ipc.rs
@@ -1,8 +1,5 @@
 use anyhow::{Context as _, Result};
-use firezone_headless_client::{
-    ipc::{self, Error},
-    IpcClientMsg,
-};
+use firezone_headless_client::{ipc, IpcClientMsg};
 use futures::SinkExt;
 use secrecy::{ExposeSecret, SecretString};
 use std::net::IpAddr;
@@ -15,7 +12,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub async fn new() -> Result<(Self, ipc::ClientRead), ipc::Error> {
+    pub async fn new() -> Result<(Self, ipc::ClientRead)> {
         tracing::debug!(
             client_pid = std::process::id(),
             "Connecting to IPC service..."
@@ -38,19 +35,14 @@ impl Client {
         Ok(())
     }
 
-    pub async fn connect_to_firezone(
-        &mut self,
-        api_url: &str,
-        token: SecretString,
-    ) -> Result<(), Error> {
+    pub async fn connect_to_firezone(&mut self, api_url: &str, token: SecretString) -> Result<()> {
         let token = token.expose_secret().clone();
         self.send_msg(&IpcClientMsg::Connect {
             api_url: api_url.to_string(),
             token,
         })
         .await
-        .context("Couldn't send Connect message")
-        .map_err(Error::Other)?;
+        .context("Couldn't send Connect message")?;
         Ok(())
     }
 

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -132,7 +132,7 @@ fn run_gui(cli: Cli) -> Result<()> {
             }
 
             if let Some(error) = anyhow.root_cause().downcast_ref::<ipc::NotFound>() {
-                tracing::info!("{error}");
+                tracing::info!("{anyhow:#}");
                 common::errors::show_error_dialog(
                     "Couldn't find Firezone IPC service. Is the service running?".to_string(),
                 )?;

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -3,6 +3,7 @@ use clap::{Args, Parser};
 use firezone_gui_client_common::{
     self as common, controller::Failure, deep_link, settings::AdvancedSettings,
 };
+use firezone_headless_client::ipc;
 use firezone_logging::anyhow_dyn_err;
 use firezone_telemetry as telemetry;
 use tracing::instrument;
@@ -126,6 +127,14 @@ fn run_gui(cli: Cli) -> Result<()> {
                 common::errors::show_error_dialog(
                     "Firezone is already running. If it's not responding, force-stop it."
                         .to_string(),
+                )?;
+                return Err(anyhow);
+            }
+
+            if let Some(error) = anyhow.root_cause().downcast_ref::<ipc::NotFound>() {
+                tracing::info!("{error}");
+                common::errors::show_error_dialog(
+                    "Couldn't find Firezone IPC service. Is the service running?".to_string(),
                 )?;
                 return Err(anyhow);
             }

--- a/rust/headless-client/src/ipc_service/ipc.rs
+++ b/rust/headless-client/src/ipc_service/ipc.rs
@@ -24,15 +24,9 @@ pub type ClientWrite = FramedWrite<WriteHalf<ClientStream>, Encoder<IpcClientMsg
 pub(crate) type ServerRead = FramedRead<ReadHalf<ServerStream>, Decoder<IpcClientMsg>>;
 pub(crate) type ServerWrite = FramedWrite<WriteHalf<ServerStream>, Encoder<IpcServerMsg>>;
 
-// pub so that the GUI can display a human-friendly message
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Couldn't find IPC service `{0}`")]
-    NotFound(String),
-
-    #[error("{0:#}")] // Use alternate display here to log entire chain of errors.
-    Other(anyhow::Error),
-}
+#[error("Couldn't find IPC service `{0}`")]
+pub struct NotFound(String);
 
 /// A name that both the server and client can use to find each other
 ///
@@ -128,7 +122,7 @@ impl<E: serde::Serialize> tokio_util::codec::Encoder<&E> for Encoder<E> {
 /// Connect to the IPC service
 ///
 /// Public because the GUI Client will need it
-pub async fn connect_to_service(id: ServiceId) -> Result<(ClientRead, ClientWrite), Error> {
+pub async fn connect_to_service(id: ServiceId) -> Result<(ClientRead, ClientWrite)> {
     // This is how ChatGPT recommended, and I couldn't think of any more clever
     // way before I asked it.
     let mut last_err = None;
@@ -272,12 +266,5 @@ mod tests {
             }
         }
         Ok(())
-    }
-
-    #[test]
-    fn error_logs_all_anyhow_sources_on_display() {
-        let err = Error::Other(anyhow::anyhow!("foo").context("bar").context("baz"));
-
-        assert_eq!(err.to_string(), "baz: bar: foo");
     }
 }


### PR DESCRIPTION
Instead of a typed chain of errors through multiple layers, we introduce a dedicated `NotFound` error inside the `ipc` module that we can retrieve as the root cause.