### PR TITLE
chore: Hide internal commands/flags in headless clients

### DIFF
--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -63,13 +63,13 @@ struct Cli {
     ///
     /// Returns 1 if the configuration is wrong. Mostly non-destructive but may
     /// write a device ID to disk if one is not found.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     check: bool,
 
     /// Connect to the Firezone network and initialize, then exit
     ///
     /// Use this to check how fast you can connect.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     exit: bool,
 
     /// Friendly name for this client to display in the UI.
@@ -102,6 +102,7 @@ impl Cli {
 }
 
 #[derive(clap::Subcommand, Clone, Copy)]
+#[clap(hide = true)]
 enum Cmd {
     Standalone,
 }

--- a/website/src/app/kb/client-apps/linux-client/readme.mdx
+++ b/website/src/app/kb/client-apps/linux-client/readme.mdx
@@ -153,12 +153,9 @@ sudo mv /etc/resolv.conf.before-firezone /etc/resolv.conf
 Usage: firezone-headless-client [OPTIONS] [COMMAND]
 
 Commands:
-  standalone
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-      --check
-          Check the configuration and return 0 before connecting to the API
       --token-path <TOKEN_PATH>
           A filesystem path where the token can be found [env: FIREZONE_TOKEN_PATH=] [default: /etc/dev.firezone.client/token]
       --firezone-name <FIREZONE_NAME>

--- a/website/src/app/kb/client-apps/windows-headless-client/readme.mdx
+++ b/website/src/app/kb/client-apps/windows-headless-client/readme.mdx
@@ -92,7 +92,6 @@ Error: Command-line args for the headless Client
 Usage: firezone-client-headless-windows_1.4.2_x86_64.exe [OPTIONS] [COMMAND]
 
 Commands:
-  standalone
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -113,16 +112,6 @@ Options:
           Maximum length of time to retry connecting to the portal if we're having internet issues or it's down. Accepts human times. e.g. "5m" or "1h" or "30d"
 
           [env: MAX_PARTITION_TIME=]
-
-      --check
-          Check the configuration and return 0 before connecting to the API
-
-          Returns 1 if the configuration is wrong. Mostly non-destructive but may write a device ID to disk if one is not found.
-
-      --exit
-          Connect to the Firezone network and initialize, then exit
-
-          Use this to check how fast you can connect.
 
       --firezone-name <FIREZONE_NAME>
           Friendly name for this client to display in the UI

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -31,7 +31,12 @@ export default function Headless({ title }: { title: string }) {
   return (
     <Entries downloadLinks={downloadLinks} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8055">
+          Hides the <code>--check</code> and <code>--exit</code> CLI options
+          from the help output. These are only used internally.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.2" date={new Date("2025-02-10")}>
         <ChangeItem pull="8041">
           Publishes the headless client for Windows.


### PR DESCRIPTION
These are just noise for the user and only used internally in Firezone.