### PR TITLE
chore(infra): Update otel-collector image to 0.119.0

### DIFF
--- a/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
+++ b/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
@@ -53,8 +53,8 @@ write_files:
       [Service]
       TimeoutStartSec=0
       Restart=always
-      ExecStartPre=/usr/bin/docker pull otel/opentelemetry-collector-contrib:0.97.0
-      ExecStart=/usr/bin/docker run --rm -u 2000 --name=otel-collector --network host --volume /etc/otelcol-contrib/:/etc/otelcol-contrib/ otel/opentelemetry-collector-contrib:0.97.0
+      ExecStartPre=/usr/bin/docker pull otel/opentelemetry-collector-contrib:0.119.0
+      ExecStart=/usr/bin/docker run --rm -u 2000 --name=otel-collector --network host --volume /etc/otelcol-contrib/:/etc/otelcol-contrib/ otel/opentelemetry-collector-contrib:0.119.0
       ExecStop=/usr/bin/docker stop otel-collector
       ExecStopPost=/usr/bin/docker rm otel-collector
 

--- a/terraform/modules/google-cloud/apps/relay/templates/cloud-init.yaml
+++ b/terraform/modules/google-cloud/apps/relay/templates/cloud-init.yaml
@@ -80,8 +80,8 @@ write_files:
       [Service]
       TimeoutStartSec=0
       Restart=always
-      ExecStartPre=/usr/bin/docker pull otel/opentelemetry-collector-contrib:0.97.0
-      ExecStart=/usr/bin/docker run --rm -u 2000 --name=otel-collector --network host --volume /etc/otelcol-contrib/:/etc/otelcol-contrib/ otel/opentelemetry-collector-contrib:0.97.0
+      ExecStartPre=/usr/bin/docker pull otel/opentelemetry-collector-contrib:0.119.0
+      ExecStart=/usr/bin/docker run --rm -u 2000 --name=otel-collector --network host --volume /etc/otelcol-contrib/:/etc/otelcol-contrib/ otel/opentelemetry-collector-contrib:0.119.0
       ExecStop=/usr/bin/docker stop otel-collector
       ExecStopPost=/usr/bin/docker rm otel-collector
 


### PR DESCRIPTION
We are quite a few versions behind.

The changelog lists a good amount of [Breaking API changes](https://github.com/open-telemetry/opentelemetry-collector/releases), but rather than enumerate all of those, or forever stay on the same (ancient) version, I thought it would be a good idea to flex the upgrade muscle here and see where it lands us on staging.