### PR TITLE
fix(apple): Make sign in error modal async

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/AuthClient.swift
@@ -10,6 +10,7 @@ import Foundation
 enum AuthClientError: Error {
   case invalidCallbackURL
   case randomNumberGenerationFailure(errorStatus: Int32)
+  case invalidAuthURL
 
   var description: String {
     switch self {
@@ -24,6 +25,10 @@ enum AuthClientError: Error {
       If this issue persists, contact your administrator.
 
       Code: \(errorStatus)
+      """
+    case .invalidAuthURL:
+      return """
+      The provided Auth URL seems invalid. Please double-check your settings.
       """
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
@@ -18,7 +18,10 @@ struct WebAuthSession {
     guard let authURL = store.authURL(),
           let authClient = try? AuthClient(authURL: authURL),
           let url = try? authClient.build()
-    else { fatalError("authURL must be valid!") }
+    else {
+      // Should never get here because we perform URL validation on input, but handle this just in case
+      throw AuthClientError.invalidAuthURL
+    }
 
     let anchor = PresentationAnchor()
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -265,19 +265,12 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func signInButtonTapped() {
-    Task.detached {
+    Task {
       do {
         try await WebAuthSession.signIn(store: self.model.store)
       } catch {
         Log.error(error)
-
-        let alert = await NSAlert()
-        await MainActor.run {
-          alert.messageText = "Error signing in"
-          alert.informativeText = error.localizedDescription
-          alert.alertStyle = .warning
-          _ = alert.runModal()
-        }
+        await macOSAlert.show(for: error)
       }
     }
   }


### PR DESCRIPTION
So it turns out we can get around the whole modal-blocking issue by wrapping the `runModal()` call in `withCheckedContinuation`.

The key takeaway here is that `withCheckedContinuation` can be used to wrap calls that can block I/O, marking them async, and allowing the Task executor to do other useful work. This can even take place on on the main thread.

Bear in mind `withCheckedContinuation` (and friends) *will not* prevent blocking the task executor if the code being called is CPU-bottlenecked in nature, such as calculating prime numbers or something. In those cases, even `Task.detached` will cause Sentry to report `App Hanging` alerts.

In short, only `Task.detached` when the I/O-related work to perform does not depend on the current context and can be executed completely independently of the parent, such as downloading image files in the background or something.