### PR TITLE
refactor(apple): Make IPC calls async, bubbling errors

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -164,7 +164,7 @@ public final class Store: ObservableObject {
       Task {
         do {
           let resources = try await self.vpnConfigurationManager.fetchResources()
-          callback(resources)
+          await callback(resources)
         } catch {
           Log.error(error)
         }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -276,9 +276,7 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func signOutButtonTapped() {
-    Task.detached { [weak self] in
-      try await self?.model.store.signOut()
-    }
+    do { try self.model.store.signOut() } catch { Log.error(error) }
   }
 
   @objc private func grantPermissionMenuItemTapped() {
@@ -340,11 +338,9 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func quitButtonTapped() {
-    Task.detached { [weak self] in
-      guard let self else { return }
-
-      await self.model.store.stop()
-      await NSApp.terminate(self)
+    Task {
+      do { try self.model.store.stop() } catch { Log.error(error) }
+      NSApp.terminate(self)
     }
   }
 
@@ -809,8 +805,15 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc private func internetResourceToggle(_ sender: NSMenuItem) {
-    self.model.store.toggleInternetResource(enabled: !model.store.internetResourceEnabled())
-    sender.title = internetResourceToggleTitle()
+    Task {
+      do {
+        try await self.model.store.toggleInternetResource(enabled: !model.store.internetResourceEnabled())
+      } catch {
+        Log.error(error)
+      }
+
+      sender.title = internetResourceToggleTitle()
+    }
   }
 
   @objc private func resourceURLTapped(_ sender: AnyObject?) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -245,7 +245,13 @@ struct ToggleInternetResourceButton: View {
   var body: some View {
     Button(
       action: {
-        model.store.toggleInternetResource(enabled: !model.isInternetResourceEnabled())
+        Task {
+          do {
+            try await model.store.toggleInternetResource(enabled: !model.isInternetResourceEnabled())
+          } catch {
+            Log.error(error)
+          }
+        }
       },
       label: {
         HStack {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -49,7 +49,7 @@ public final class SessionViewModel: ObservableObject {
 
         if status == .connected {
           store.beginUpdatingResources { resources in
-            Task { await MainActor.run { self.resources = resources } }
+            self.resources = resources
           }
         } else {
           store.endUpdatingResources()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -50,13 +50,17 @@ public final class SettingsViewModel: ObservableObject {
   }
 
   func saveSettings() {
-      if [.connected, .connecting, .reasserting].contains(store.status) {
-        Task.detached { [weak self] in
-          do { try await self?.store.signOut() } catch { Log.error(error) }
+    Task {
+      do {
+        if [.connected, .connecting, .reasserting].contains(store.status) {
+          try self.store.signOut()
         }
-      }
 
-      store.save(settings)
+        try await store.save(settings)
+      } catch {
+        Log.error(error)
+      }
+    }
   }
 
   // Calculates the total size of our logs by summing the size of the

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
@@ -118,9 +118,7 @@ struct iOSNavigationView<Content: View>: View { // swiftlint:disable:this type_n
   }
 
   private func signOutButtonTapped() {
-    Task {
-      try await model.store.signOut()
-    }
+    do { try model.store.signOut() } catch { Log.error(error) }
   }
 }
 #endif


### PR DESCRIPTION
`fetchResources` is an IPC call, and we can use `withCheckedThrowingContinuation` like the others to yield while we wait for the provider to respond.

The particular sentry issue related to this isn't because we are necessarily blocking the task thread, rather, I suspect it's when applying the fetched Resources to the UI that we're slow. There isn't much we can do about this, but this PR will only help.

Because we're using a timer that fires off a closure to do this, we still use a `callback` inside the timer to actually set the Resources on the main `Store`, which updates the UI.

Unfortunately refactoring these IPC calls lead to somewhat of a ball of yarn, so the best way to summarize the spirit of this PR is:

- Ensure IPC calls use `withCheckedThrowingContinuation` where possible
- Thusly, marking these functions `async throws`
- Bubble these errors up the view where we can ultimately decide what to do with them
- Keep VPN state management and conditional logic based on `NEVPNStatus` in the vpnConfigurationManager