### PR TITLE
refactor(apple): Remove useless `Task.detached`

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -113,7 +113,7 @@ struct FirezoneApp: App {
           string: "x-apple.systempreferences:com.apple.preferences.softwareupdate"
         )
 
-        NSWorkspace.shared.open(softwareUpdateURL!)
+        Task { await NSWorkspace.shared.openAsync(softwareUpdateURL!) }
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Extensions/NSWorkspace.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Extensions/NSWorkspace.swift
@@ -1,0 +1,21 @@
+//
+//  NSWorkspace.swift
+//  (c) 2024 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+
+#if os(macOS)
+import AppKit
+
+@MainActor
+public extension NSWorkspace {
+  func openAsync(_ url: URL) async {
+    let configuration = NSWorkspace.OpenConfiguration()
+    return await withCheckedContinuation { continuation in
+      open(url, configuration: configuration) { _, _ in
+        continuation.resume()
+      }
+    }
+  }
+}
+#endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -282,6 +282,12 @@ public class VPNConfigurationManager {
   }
 
   func start(token: String? = nil) throws {
+    guard let session = session()
+    else { throw VPNConfigurationManagerError.managerNotInitialized }
+
+    guard session.status == .disconnected
+    else { throw VPNConfigurationManagerError.invalidStatus(session.status) }
+
     var options: [String: NSObject] = [:]
 
     // Pass token if provided

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -277,23 +277,11 @@ public class VPNConfigurationManager {
     try await manager.saveToPreferences()
     try await manager.loadFromPreferences()
 
-    // Sign out if connected when settings change
-    if let session = session(),
-       [.connected, .connecting, .reasserting].contains(session.status) {
-      try signOut()
-    }
-
     // Reconfigure our Telemetry environment in case it changed
     Telemetry.setEnvironmentOrClose(settings.apiURL)
   }
 
   func start(token: String? = nil) throws {
-    guard let session = session()
-    else { throw VPNConfigurationManagerError.managerNotInitialized }
-
-    guard session.status == .disconnected
-    else { throw VPNConfigurationManagerError.invalidStatus(session.status) }
-
     var options: [String: NSObject] = [:]
 
     // Pass token if provided

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -277,6 +277,12 @@ public class VPNConfigurationManager {
     try await manager.saveToPreferences()
     try await manager.loadFromPreferences()
 
+    // Sign out if connected when settings change
+    if let session = session(),
+       [.connected, .connecting, .reasserting].contains(session.status) {
+      try signOut()
+    }
+
     // Reconfigure our Telemetry environment in case it changed
     Telemetry.setEnvironmentOrClose(settings.apiURL)
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/AppView.swift
@@ -87,8 +87,8 @@ public class AppViewModel: ObservableObject {
       .store(in: &cancellables)
   }
 
-  func updateNotificationDecision(to newStatus: UNAuthorizationStatus) async {
-    await MainActor.run { self.decision = newStatus }
+  func updateNotificationDecision(to newStatus: UNAuthorizationStatus) {
+    self.decision = newStatus
   }
 }
 
@@ -111,7 +111,7 @@ public struct AppView: View {
       GrantNotificationsView(model: GrantNotificationsViewModel(
         sessionNotification: model.sessionNotification,
         onDecisionChanged: { decision in
-          await model.updateNotificationDecision(to: decision)
+          model.updateNotificationDecision(to: decision)
         }
       ))
     case (.disconnected, _):

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantNotificationsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantNotificationsView.swift
@@ -23,21 +23,17 @@ public final class GrantNotificationsViewModel: ObservableObject {
   }
 
   func grantNotificationButtonTapped(errorHandler: GlobalErrorHandler) {
-    Task.detached { [weak self] in
-      guard let self else { return }
-
+    Task {
       do {
         let decision = try await sessionNotification.askUserForNotificationPermissions()
         await onDecisionChanged(decision)
       } catch {
         Log.error(error)
 
-        await MainActor.run {
-          errorHandler.handle(ErrorAlert(
-            title: "Error granting notifications",
-            error: error
-          ))
-        }
+        errorHandler.handle(ErrorAlert(
+          title: "Error granting notifications",
+          error: error
+        ))
       }
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -29,15 +29,13 @@ final class GrantVPNViewModel: ObservableObject {
 
 #if os(macOS)
   func installSystemExtensionButtonTapped() {
-    Task.detached { [weak self] in
-      guard let self else { return }
-
+    Task {
       do {
         try await store.installSystemExtension()
 
         // The window has a tendency to go to the background after installing
         // the system extension
-        await NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate(ignoringOtherApps: true)
 
       } catch {
         Log.error(error)
@@ -48,15 +46,13 @@ final class GrantVPNViewModel: ObservableObject {
 
   func grantPermissionButtonTapped() {
     Log.log("\(#function)")
-    Task.detached { [weak self] in
-      guard let self else { return }
-
+    Task {
       do {
         try await store.grantVPNPermission()
 
         // The window has a tendency to go to the background after allowing the
         // VPN configuration
-        await NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate(ignoringOtherApps: true)
       } catch {
         Log.error(error)
         await macOSAlert.show(for: error)
@@ -68,22 +64,18 @@ final class GrantVPNViewModel: ObservableObject {
 #if os(iOS)
   func grantPermissionButtonTapped(errorHandler: GlobalErrorHandler) {
     Log.log("\(#function)")
-    Task.detached { [weak self] in
-      guard let self else { return }
-
+    Task {
       do {
         try await store.grantVPNPermission()
       } catch {
         Log.error(error)
 
-        await MainActor.run {
-          errorHandler.handle(
-            ErrorAlert(
-              title: "Error installing VPN configuration",
-              error: error
-            )
+        errorHandler.handle(
+          ErrorAlert(
+            title: "Error installing VPN configuration",
+            error: error
           )
-        }
+        )
       }
     }
   }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -37,13 +37,16 @@ public final class MenuBar: NSObject, ObservableObject {
 
   @ObservedObject var model: SessionViewModel
 
-  private var signedOutIcon: NSImage?
-  private var signedInConnectedIcon: NSImage?
-  private var signedOutIconNotification: NSImage?
-  private var signedInConnectedIconNotification: NSImage?
+  private lazy var signedOutIcon = NSImage(named: "MenuBarIconSignedOut")
+  private lazy var signedInConnectedIcon = NSImage(named: "MenuBarIconSignedInConnected")
+  private lazy var signedOutIconNotification = NSImage(named: "MenuBarIconSignedOutNotification")
+  private lazy var signedInConnectedIconNotification = NSImage(named: "MenuBarIconSignedInConnectedNotification")
 
-  private var connectingAnimationImages: [NSImage?] = [nil, nil, nil]
-
+  private lazy var connectingAnimationImages = [
+    NSImage(named: "MenuBarIconConnecting1"),
+    NSImage(named: "MenuBarIconConnecting2"),
+    NSImage(named: "MenuBarIconConnecting3")
+  ]
   private var connectingAnimationImageIndex: Int = 0
   private var connectingAnimationTimer: Timer?
 
@@ -57,26 +60,6 @@ public final class MenuBar: NSObject, ObservableObject {
 
     createMenu()
     setupObservers()
-
-    Task {
-      self.signedOutIcon = await loadImage(named: "MenuBarIconSignedOut")
-      self.signedInConnectedIcon = await loadImage(named: "MenuBarIconSignedInConnected")
-      self.signedOutIconNotification = await loadImage(named: "MenuBarIconSignedOutNotification")
-      self.signedInConnectedIconNotification = await loadImage(named: "MenuBarIconSignedInConnectedNotification")
-      let image1 = await loadImage(named: "MenuBarIconConnecting1")
-      let image2 = await loadImage(named: "MenuBarIconConnecting2")
-      let image3 = await loadImage(named: "MenuBarIconConnecting3")
-      self.connectingAnimationImages = [
-        image1, image2, image3
-      ]
-    }
-  }
-
-  // NSImage() synchronously loads images from disk. This can be slow on busy drives.
-  private func loadImage(named: String) async -> NSImage? {
-    return await withCheckedContinuation { continuation in
-      continuation.resume(returning: NSImage(named: named))
-    }
   }
 
   func showMenu() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -621,16 +621,14 @@ public struct SettingsView: View {
           return
         }
 
-        Task.detached {
+        Task {
           do {
             try await LogExporter.export(
               to: destinationURL,
               with: model.store.vpnConfigurationManager
             )
 
-            await MainActor.run {
-              window.contentViewController?.presentingViewController?.dismiss(self)
-            }
+            window.contentViewController?.presentingViewController?.dismiss(self)
           } catch {
             if let error = error as? VPNConfigurationManagerError,
                case VPNConfigurationManagerError.noIPCData = error {
@@ -639,15 +637,10 @@ public struct SettingsView: View {
               Log.error(error)
             }
 
-            let alert = await NSAlert()
-            await MainActor.run {
-              alert.messageText = "Error exporting logs: \(error.localizedDescription)"
-              alert.alertStyle = .critical
-              _ = alert.runModal()
-            }
+            await macOSAlert.show(for: error)
           }
 
-          await MainActor.run { self.isExportingLogs = false }
+          self.isExportingLogs = false
         }
       }
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -182,8 +182,13 @@ private class NotificationAdapter: NSObject, UNUserNotificationCenterDelegate {
       return
     }
 
-    Task.detached {
-      NSWorkspace.shared.open(UpdateChecker.downloadURL())
+    // Must be explicitly run from a MainActor context
+    Task {
+      await MainActor.run {
+        Task {
+          await NSWorkspace.shared.openAsync(UpdateChecker.downloadURL())
+        }
+      }
     }
 
     completionHandler()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/WelcomeView.swift
@@ -38,18 +38,16 @@ struct WelcomeView: View {
         """).multilineTextAlignment(.center)
           .padding(.bottom, 10)
         Button("Sign in") {
-          Task.detached {
+          Task {
             do {
               try await WebAuthSession.signIn(store: model.store)
             } catch {
               Log.error(error)
 
-              await MainActor.run {
-                self.errorHandler.handle(ErrorAlert(
-                  title: "Error signing in",
-                  error: error
-                ))
-              }
+              self.errorHandler.handle(ErrorAlert(
+                title: "Error signing in",
+                error: error
+              ))
             }
           }
         }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
@@ -73,20 +73,18 @@ struct iOSNavigationView<Content: View>: View { // swiftlint:disable:this type_n
       } else {
         Button(
           action: {
-            Task.detached {
+            Task {
               do {
                 try await WebAuthSession.signIn(store: model.store)
               } catch {
                 Log.error(error)
 
-                await MainActor.run {
-                  self.errorHandler.handle(
-                    ErrorAlert(
-                      title: "Error signing in",
-                      error: error
-                    )
+                self.errorHandler.handle(
+                  ErrorAlert(
+                    title: "Error signing in",
+                    error: error
                   )
-                }
+                )
               }
             }
           },


### PR DESCRIPTION
Whether we execute a task on the main thread or a background thread doesn't affect whether the thread is "hung" as reported by Sentry.

Instead, our options for fixing these are:

- Try to use an async version of the underlying API (the [async version](https://developer.apple.com/documentation/appkit/nsworkspace/open(_:configuration:completionhandler:)) of `open` for example)
- If there is none, and the call could potentially block (most likely to do disk IO contention), at least schedule this on a new thread using `Task.detached` but with `.background` priority so that it will avoid blocking any other execution.

The main takeaway here is that unfortunately, under some conditions, Sentry will _always_ report an "App Hanging" alert since it's constantly monitoring all threads for paused execution longer than 2000ms.

We'll probably end up letting some of these slide (pausing a background or worker thread isn't necessarily a UX issue), but pausing the UI thread is.

Luckily, we're able to use async APIs for most things. The remaining things (like working with log files over IPC) we use a `Task.detached` for.