### PR TITLE
fix(apple): Ensure resources are updated on MainActor

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SessionView.swift
@@ -49,7 +49,7 @@ public final class SessionViewModel: ObservableObject {
 
         if status == .connected {
           store.beginUpdatingResources { resources in
-            self.resources = resources
+            Task { await MainActor.run { self.resources = resources } }
           }
         } else {
           store.endUpdatingResources()


### PR DESCRIPTION
This fixes a bug introduced in db655dd171 that could lead to a crash or undefined behavior because it potentially updates resources (a `@Published` object) from a background thread.

UI updates must occur on the main thread only.