### PR TITLE
fix(apple): Prevent dupe resources timer scheduling

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -163,8 +163,7 @@ public final class Store: ObservableObject {
   func beginUpdatingResources(callback: @escaping (ResourceList) -> Void) {
     Log.log("\(#function)")
 
-    guard self.resourcesTimer == nil
-    else {
+    if self.resourcesTimer != nil {
       // Prevent duplicate timer scheduling. This will happen if the system sends us two .connected status updates
       // in a row, which can happen occasionally.
       return

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -163,6 +163,13 @@ public final class Store: ObservableObject {
   func beginUpdatingResources(callback: @escaping (ResourceList) -> Void) {
     Log.log("\(#function)")
 
+    guard self.resourcesTimer == nil
+    else {
+      // Prevent duplicate timer scheduling. This will happen if the system sends us two .connected status updates
+      // in a row, which can happen occasionally.
+      return
+    }
+
     // Define the Timer's closure
     let updateResources: @Sendable (Timer) -> Void = { _ in
       Task.detached { [weak self] in


### PR DESCRIPTION
If we receive two `.connected` status change updates from the system in a row, we'll incorrectly schedule an additional timer, and the handle to the first one will be lost.

This causes a memory leak because we'll then never call the first timer's `invalidate()` function in the `endUpdatingResources` call.