### PR TITLE
Revert 'fix(apple): Make Favorites load/save async'

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
@@ -1,51 +1,45 @@
 import Foundation
 
 public class Favorites: ObservableObject {
-  private let key = "favoriteResourceIDs"
+  private static let key = "favoriteResourceIDs"
   @Published private(set) var ids: Set<String>
 
-  public init () {
-    self.ids = Set()
-    Task { await self.ids = load() }
+  public init() {
+    ids = Favorites.load()
   }
 
   func contains(_ id: String) -> Bool {
     return ids.contains(id)
   }
 
-  func load() async -> Set<String> {
-    let ids = await withCheckedContinuation { continuation in
-      continuation.resume(returning: UserDefaults.standard.stringArray(forKey: key))
-    }
-
-    if let ids {
-      return Set(ids)
-    }
-
-    return Set()
-  }
-
   func reset() {
-    self.ids = Set()
-    Task { await save() }
+    objectWillChange.send()
+    ids = Set()
+    save()
   }
 
   func add(_ id: String) {
-    self.ids.insert(id)
-    Task { await save() }
+    objectWillChange.send()
+    ids.insert(id)
+    save()
   }
 
   func remove(_ id: String) {
-    self.ids.remove(id)
-    Task { await save() }
+    objectWillChange.send()
+    ids.remove(id)
+    save()
   }
 
-  private func save() async {
+  private func save() {
     // It's a run-time exception if we pass the `Set` directly here
     let ids = Array(ids)
-    await withCheckedContinuation { continuation in
-      UserDefaults.standard.set(ids, forKey: key)
-      continuation.resume()
+    UserDefaults.standard.set(ids, forKey: Favorites.key)
+  }
+
+  private static func load() -> Set<String> {
+    if let ids = UserDefaults.standard.stringArray(forKey: key) {
+      return Set(ids)
     }
+    return []
   }
 }


### PR DESCRIPTION
Turns out I was wrong about UserDefaults - they're persisted, but backed by an in-memory cache. The persisting is handled asynchronously, so this is unlikely to be the culprit of https://firezone-inc.sentry.io/issues/6225229650/?project=4508175177023488&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=1

More likely it has to do with some other synchronous I/O, so the search continues. Unfortunately we don't have great backtraces for this issue because it looks like the hang is happening outside the scope of our code, and seems to be macOS-only in low memory conditions.

Reverts firezone/firezone#8060