### PR TITLE
refactor(windows): de-duplicate Win32 error codes

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -28,7 +28,6 @@ use windows::Win32::{
     },
     Networking::WinSock::{ADDRESS_FAMILY, AF_INET, AF_INET6},
 };
-use windows_core::HRESULT;
 use wintun::Adapter;
 
 /// The ring buffer size used for Wintun.

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -430,6 +430,9 @@ fn try_set_ip(luid: NET_LUID_LH, ip: IpAddr) -> Result<()> {
     // Safety: Docs don't mention anything about safety other than having to use `InitializeUnicastIpAddressEntry` and we did that.
     match unsafe { CreateUnicastIpAddressEntry(&row) }.ok() {
         Ok(()) => {}
+        Err(e) if e.code() == NOT_SUPPORTED => {
+            tracing::debug!(%ip, "IP stack not supported");
+        }
         Err(e) if e.code() == OBJECT_EXISTS => {}
         Err(e) => {
             return Err(anyhow::Error::new(e).context("Failed to create `UnicastIpAddressEntry`"))

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -77,9 +77,6 @@ impl TunDeviceManager {
             .luid
             .context("Cannot set IPs prior to creating an adapter")?;
 
-        tracing::debug!("Setting our IPv4 = {}", ipv4);
-        tracing::debug!("Setting our IPv6 = {}", ipv6);
-
         // SAFETY: Both NET_LUID_LH unions should be the same. We're just copying out
         // the u64 value and re-wrapping it, since wintun doesn't refer to the windows
         // crate's version of NET_LUID_LH.
@@ -403,6 +400,8 @@ fn try_set_mtu(luid: NET_LUID_LH, family: ADDRESS_FAMILY, mtu: u32) -> Result<()
 }
 
 fn try_set_ip(luid: NET_LUID_LH, ip: IpAddr) -> Result<()> {
+    tracing::debug!(%ip, "Setting tunnel interface IP");
+
     // Safety: Docs don't mention anything in regards to safety of this function.
     let mut row = unsafe {
         let mut row: MIB_UNICASTIPADDRESS_ROW = std::mem::zeroed();

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -50,7 +50,7 @@ pub const TUNNEL_UUID: Uuid = Uuid::from_u128(0xe924_5bc1_b8c1_44ca_ab1d_c6aa_d4
 ///
 /// ## Adding new codes
 ///
-/// We create the error codes using the [`HRESULT::from_win32`] constructor which sets these bits correctly.
+/// We create the error codes using the [`windows_core::HRESULT::from_win32`] constructor which sets these bits correctly.
 /// The doctests make sure we actually construct the error that we'll see in logs.
 /// Being able to search for these with full-text search is important for maintenance.
 pub mod error {

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -48,17 +48,34 @@ pub const TUNNEL_UUID: Uuid = Uuid::from_u128(0xe924_5bc1_b8c1_44ca_ab1d_c6aa_d4
 /// - The "7" indicates the facility. In our case, this means Win32 APIs.
 /// - The last 4 numbers (i.e. 16 bit) are the actual error code.
 ///
-pub(crate) mod error {
+/// ## Adding new codes
+///
+/// We create the error codes using the [`HRESULT::from_win32`] constructor which sets these bits correctly.
+/// The doctests make sure we actually construct the error that we'll see in logs.
+/// Being able to search for these with full-text search is important for maintenance.
+pub mod error {
     use windows_core::HRESULT;
 
     /// Win32 error code objects that don't exist (like network adapters).
-    pub(crate) const NOT_FOUND: HRESULT = HRESULT::from_win32(0x80070490);
+    ///
+    /// ```
+    /// assert_eq!(firezone_bin_shared::windows::error::NOT_FOUND.0 as u32, 0x80070490)
+    /// ```
+    pub const NOT_FOUND: HRESULT = HRESULT::from_win32(0x0490);
 
     /// Win32 error code for objects that already exist (like routing table entries).
-    pub(crate) const OBJECT_EXISTS: HRESULT = HRESULT::from_win32(0x80071392);
+    ///
+    /// ```
+    /// assert_eq!(firezone_bin_shared::windows::error::OBJECT_EXISTS.0 as u32, 0x80071392)
+    /// ```
+    pub const OBJECT_EXISTS: HRESULT = HRESULT::from_win32(0x1392);
 
     /// Win32 error code for unsupported operations (like setting an IPv6 address without an IPv6 stack).
-    pub(crate) const NOT_SUPPORTED: HRESULT = HRESULT::from_win32(0x80070032);
+    ///
+    /// ```
+    /// assert_eq!(firezone_bin_shared::windows::error::NOT_SUPPORTED.0 as u32, 0x80070032)
+    /// ```
+    pub const NOT_SUPPORTED: HRESULT = HRESULT::from_win32(0x0032);
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]


### PR DESCRIPTION
The errors returned from Win32 API calls are currently duplicated in several places. To makes it error-prone to handle them correctly. With this PR, we de-duplicate this and add proper docs and links for further reading to them.

We also fix a case where we would currently fail to set IP addresses for our tunnel interface if the IP stack is not supported.