### PR TITLE
refactor(windows): don't fail install on missing IPC service

### DIFF
--- a/rust/headless-client/src/ipc_service/windows.rs
+++ b/rust/headless-client/src/ipc_service/windows.rs
@@ -4,7 +4,7 @@ use firezone_bin_shared::platform::DnsControlMethod;
 use firezone_telemetry::Telemetry;
 use futures::channel::mpsc;
 use std::{
-    ffi::{c_void, OsString},
+    ffi::{c_void, OsStr, OsString},
     mem::size_of,
     time::Duration,
 };
@@ -155,7 +155,7 @@ pub(crate) fn install_ipc_service() -> Result<()> {
 
     // Un-install existing one first if needed
     if let Err(e) =
-        uninstall_ipc_service(name).with_context(|| format!("Failed to uninstall `{name}`"))
+        uninstall_ipc_service(&service_manager, name).with_context(|| format!("Failed to uninstall `{name}`"))
     {
         tracing::debug!("{e:#}");
     }
@@ -178,7 +178,7 @@ pub(crate) fn install_ipc_service() -> Result<()> {
     Ok(())
 }
 
-fn uninstall_ipc_service(name: impl AsRef<OsStr>) -> Result<()> {
+fn uninstall_ipc_service(service_manager: &ServiceManager, name: impl AsRef<OsStr>) -> Result<()> {
     let service_access = ServiceAccess::DELETE;
     let service = service_manager.open_service(name, service_access)?;
     service.delete()?;

--- a/rust/headless-client/src/ipc_service/windows.rs
+++ b/rust/headless-client/src/ipc_service/windows.rs
@@ -151,18 +151,18 @@ pub(crate) fn install_ipc_service() -> Result<()> {
     let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
 
-    let name = OsString::from("FirezoneClientIpcServiceDebug");
+    let name = "FirezoneClientIpcServiceDebug";
 
     // Un-install existing one first if needed
+    if let Err(e) =
+        uninstall_ipc_service(name).with_context(|| format!("Failed to uninstall `{name}`"))
     {
-        let service_access = ServiceAccess::DELETE;
-        let service = service_manager.open_service(&name, service_access)?;
-        service.delete()?;
+        tracing::debug!("{e:#}");
     }
 
     let executable_path = std::env::current_exe()?;
     let service_info = ServiceInfo {
-        name,
+        name: OsString::from(name),
         display_name: OsString::from("Firezone Client IPC (Debug)"),
         service_type: ServiceType::OWN_PROCESS,
         start_type: ServiceStartType::AutoStart,
@@ -175,6 +175,14 @@ pub(crate) fn install_ipc_service() -> Result<()> {
     };
     let service = service_manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG)?;
     service.set_description("Description")?;
+    Ok(())
+}
+
+fn uninstall_ipc_service(name: impl AsRef<OsStr>) -> Result<()> {
+    let service_access = ServiceAccess::DELETE;
+    let service = service_manager.open_service(name, service_access)?;
+    service.delete()?;
+
     Ok(())
 }
 

--- a/rust/headless-client/src/ipc_service/windows.rs
+++ b/rust/headless-client/src/ipc_service/windows.rs
@@ -154,8 +154,8 @@ pub(crate) fn install_ipc_service() -> Result<()> {
     let name = "FirezoneClientIpcServiceDebug";
 
     // Un-install existing one first if needed
-    if let Err(e) =
-        uninstall_ipc_service(&service_manager, name).with_context(|| format!("Failed to uninstall `{name}`"))
+    if let Err(e) = uninstall_ipc_service(&service_manager, name)
+        .with_context(|| format!("Failed to uninstall `{name}`"))
     {
         tracing::debug!("{e:#}");
     }


### PR DESCRIPTION
In order to test changes to the IPC service on Windows more easily, the IPC service binary offers an `install` command that installs a new "Debug" IPC service. Prior to that, the previous is uninstalled.

This doesn't work if one doesn't have a previous "Debug" IPC service so the `install` command only works for devs that have at least run it once with that part of the function commented out. To improve this Dev UX, we don't abort if we can't uninstall the previous one.