### PR TITLE
chore(gui-client): reuse release-version constant

### DIFF
--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -63,7 +63,7 @@ pub(crate) fn run() -> Result<()> {
             let mut telemetry = telemetry::Telemetry::default();
             telemetry.start(
                 settings.api_url.as_ref(),
-                concat!("gui-client@", env!("CARGO_PKG_VERSION")),
+                firezone_gui_client_common::RELEASE,
                 telemetry::GUI_DSN,
             );
             // Don't fix the log filter for smoke tests


### PR DESCRIPTION
This constant already defines the same string: https://github.com/firezone/firezone/blob/36f5eee99d98aadb1fd29ae0247af502d7e48023/rust/gui-client/src-common/src/lib.rs#L19