### PR TITLE
fix(telemetry): always clear previous Sentry session

### DIFF
--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use env::SELF_HOSTED;
+use env::ON_PREM;
 use sentry::protocol::SessionStatus;
 
 pub struct Dsn(&'static str);
@@ -23,7 +23,7 @@ mod env {
 
     pub const PRODUCTION: Cow<'static, str> = Cow::Borrowed("production");
     pub const STAGING: Cow<'static, str> = Cow::Borrowed("staging");
-    pub const SELF_HOSTED: Cow<'static, str> = Cow::Borrowed("self-hosted");
+    pub const ON_PREM: Cow<'static, str> = Cow::Borrowed("on-prem");
 }
 
 #[derive(Default)]
@@ -49,7 +49,7 @@ impl Telemetry {
         let environment = match api_url {
             "wss://api.firezone.dev" | "wss://api.firezone.dev/" => env::PRODUCTION,
             "wss://api.firez.one" | "wss://api.firez.one/" => env::STAGING,
-            _ => env::SELF_HOSTED,
+            _ => env::ON_PREM,
         };
 
         if self
@@ -73,7 +73,7 @@ impl Telemetry {
             set_current_user(None);
         }
 
-        if environment == SELF_HOSTED {
+        if environment == ON_PREM {
             tracing::debug!(%api_url, "Telemetry won't start in unofficial environment");
             return;
         }

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -15,6 +15,7 @@ pub const GATEWAY_DSN: Dsn = Dsn("https://f763102cc3937199ec483fbdae63dfdc@o4507
 pub const GUI_DSN: Dsn = Dsn("https://2e17bf5ed24a78c0ac9e84a5de2bd6fc@o4507971108339712.ingest.us.sentry.io/4508008945549312");
 pub const HEADLESS_DSN: Dsn = Dsn("https://bc27dca8bb37be0142c48c4f89647c13@o4507971108339712.ingest.us.sentry.io/4508010028728320");
 pub const RELAY_DSN: Dsn = Dsn("https://9d5f664d8f8f7f1716d4b63a58bcafd5@o4507971108339712.ingest.us.sentry.io/4508373298970624");
+pub const TESTING: Dsn = Dsn("https://55ef451fca9054179a11f5d132c02f45@o4507971108339712.ingest.us.sentry.io/4508792604852224");
 
 #[derive(Default)]
 pub struct Telemetry {
@@ -155,4 +156,18 @@ impl Telemetry {
 
 fn set_current_user(user: Option<sentry::User>) {
     sentry::Hub::main().configure_scope(|scope| scope.set_user(user));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starting_session_for_unsupported_env_disables_current_one() {
+        let mut telemetry = Telemetry::default();
+        telemetry.start("wss://api.firez.one", "1.0.0", TESTING);
+        telemetry.start("wss://example.com", "1.0.0", TESTING);
+
+        assert!(telemetry.inner.is_none());
+    }
 }


### PR DESCRIPTION
We have a bug in our Rust telemetry code where starting a new telemetry session for an **unsupported** environment doesn't stop the previous one if one already exists.

This results in very confusing Sentry issues that cannot be correlated to our infrastructure.