### PR TITLE
feat(relay): add `SOFTWARE` attribute

### DIFF
--- a/rust/relay/src/lib.rs
+++ b/rust/relay/src/lib.rs
@@ -16,17 +16,23 @@ pub use server::{
     CreatePermission, Refresh, Server,
 };
 pub use sleep::Sleep;
+use stun_codec::rfc5389::attributes::Software;
 pub use stun_codec::rfc8656::attributes::AddressFamily;
 
 use std::{
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::LazyLock,
 };
 
-pub const VERSION: &str = match option_env!("GITHUB_SHA") {
-    Some(sha) => sha,
-    None => "unknown",
-};
+pub const VERSION: Option<&str> = option_env!("GITHUB_SHA");
+pub static SOFTWARE: LazyLock<Software> = LazyLock::new(|| {
+    Software::new(format!(
+        "firezone-relay; rev={}",
+        VERSION.map(|rev| &rev[..8]).unwrap_or("xxxx")
+    ))
+    .expect("less than 128 chars")
+});
 
 /// Describes the IP stack of a relay server.
 #[derive(Debug, Copy, Clone)]

--- a/rust/relay/src/lib.rs
+++ b/rust/relay/src/lib.rs
@@ -23,6 +23,11 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
 };
 
+pub const VERSION: &str = match option_env!("GITHUB_SHA") {
+    Some(sha) => sha,
+    None => "unknown",
+};
+
 /// Describes the IP stack of a relay server.
 #[derive(Debug, Copy, Clone)]
 pub enum IpStack {

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -8,7 +8,7 @@ use firezone_logging::{err_with_src, sentry_layer};
 use firezone_relay::sockets::Sockets;
 use firezone_relay::{
     sockets, AddressFamily, AllocationPort, ChannelData, ClientSocket, Command, IpStack,
-    PeerSocket, Server, Sleep,
+    PeerSocket, Server, Sleep, VERSION,
 };
 use firezone_telemetry::{Telemetry, RELAY_DSN};
 use futures::{future, FutureExt};
@@ -104,11 +104,7 @@ fn main() {
 
     let mut telemetry = Telemetry::default();
     if args.telemetry {
-        telemetry.start(
-            args.api_url.as_str(),
-            option_env!("GITHUB_SHA").unwrap_or("unknown"),
-            RELAY_DSN,
-        );
+        telemetry.start(args.api_url.as_str(), VERSION, RELAY_DSN);
     }
 
     let runtime = tokio::runtime::Builder::new_current_thread()

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -104,7 +104,11 @@ fn main() {
 
     let mut telemetry = Telemetry::default();
     if args.telemetry {
-        telemetry.start(args.api_url.as_str(), VERSION, RELAY_DSN);
+        telemetry.start(
+            args.api_url.as_str(),
+            VERSION.unwrap_or("unknown"),
+            RELAY_DSN,
+        );
     }
 
     let runtime = tokio::runtime::Builder::new_current_thread()

--- a/rust/relay/src/server/client_message.rs
+++ b/rust/relay/src/server/client_message.rs
@@ -1,6 +1,6 @@
 use crate::auth::{generate_password, split_username, systemtime_from_unix, FIREZONE};
 use crate::server::channel_data::ChannelData;
-use crate::server::UDP_TRANSPORT;
+use crate::server::{error_response, UDP_TRANSPORT};
 use crate::Attribute;
 use anyhow::{Context, Result};
 use bytecodec::DecodeExt;
@@ -17,7 +17,7 @@ use stun_codec::rfc5766::methods::{ALLOCATE, CHANNEL_BIND, CREATE_PERMISSION, RE
 use stun_codec::rfc8656::attributes::{
     AdditionalAddressFamily, AddressFamily, RequestedAddressFamily,
 };
-use stun_codec::{Message, MessageClass, Method, TransactionId};
+use stun_codec::{Message, MessageClass, TransactionId};
 use uuid::Uuid;
 
 /// The maximum lifetime of an allocation.
@@ -613,17 +613,6 @@ fn bad_request(message: &Message<Attribute>) -> Message<Attribute> {
         message.transaction_id(),
         ErrorCode::from(BadRequest),
     )
-}
-
-fn error_response(
-    method: Method,
-    transaction_id: TransactionId,
-    error_code: ErrorCode,
-) -> Message<Attribute> {
-    let mut message = Message::new(MessageClass::ErrorResponse, method, transaction_id);
-    message.add_attribute(error_code);
-
-    message
 }
 
 #[derive(Debug)]

--- a/rust/relay/tests/regression.rs
+++ b/rust/relay/tests/regression.rs
@@ -3,7 +3,7 @@
 use bytecodec::{DecodeExt, EncodeExt};
 use firezone_relay::{
     AddressFamily, Allocate, AllocationPort, Attribute, Binding, ChannelBind, ChannelData,
-    ClientMessage, ClientSocket, Command, IpStack, PeerSocket, Refresh, Server,
+    ClientMessage, ClientSocket, Command, IpStack, PeerSocket, Refresh, Server, SOFTWARE,
 };
 use rand::rngs::mock::StepRng;
 use secrecy::SecretString;
@@ -835,6 +835,7 @@ fn binding_response(
 ) -> Message<Attribute> {
     let mut message =
         Message::<Attribute>::new(MessageClass::SuccessResponse, BINDING, transaction_id);
+    message.add_attribute(SOFTWARE.clone());
     message.add_attribute(XorMappedAddress::new(address.into()));
 
     message
@@ -849,6 +850,7 @@ fn allocate_response(
 ) -> Message<Attribute> {
     let mut message =
         Message::<Attribute>::new(MessageClass::SuccessResponse, ALLOCATE, transaction_id);
+    message.add_attribute(SOFTWARE.clone());
     message.add_attribute(XorRelayAddress::new(SocketAddr::new(
         public_relay_addr.into(),
         port,
@@ -865,6 +867,7 @@ fn unauthorized_allocate_response(
 ) -> Message<Attribute> {
     let mut message =
         Message::<Attribute>::new(MessageClass::ErrorResponse, ALLOCATE, transaction_id);
+    message.add_attribute(SOFTWARE.clone());
     message.add_attribute(ErrorCode::from(Unauthorized));
     message.add_attribute(Realm::new("firezone".to_owned()).unwrap());
     message.add_attribute(Nonce::new(nonce.as_hyphenated().to_string()).unwrap());
@@ -875,13 +878,18 @@ fn unauthorized_allocate_response(
 fn refresh_response(transaction_id: TransactionId, lifetime: Lifetime) -> Message<Attribute> {
     let mut message =
         Message::<Attribute>::new(MessageClass::SuccessResponse, REFRESH, transaction_id);
+    message.add_attribute(SOFTWARE.clone());
     message.add_attribute(lifetime);
 
     message
 }
 
 fn channel_bind_response(transaction_id: TransactionId) -> Message<Attribute> {
-    Message::<Attribute>::new(MessageClass::SuccessResponse, CHANNEL_BIND, transaction_id)
+    let mut message =
+        Message::<Attribute>::new(MessageClass::SuccessResponse, CHANNEL_BIND, transaction_id);
+    message.add_attribute(SOFTWARE.clone());
+
+    message
 }
 
 fn parse_message(message: &[u8]) -> Message<Attribute> {


### PR DESCRIPTION
Adding a `SOFTWARE` attribute is recommended by the spec and will allow us to identify from client logs, which version of the relay we are talking to.