### PR TITLE
ci: Publish headless client 1.4.2

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -131,9 +131,9 @@ jobs:
         target: [x86_64-pc-windows-msvc]
         package: [firezone-headless-client]
         # mark:next-headless-version
-        release_name: [headless-client-1.4.2]
+        release_name: [headless-client-1.4.3]
         # mark:next-headless-version
-        version: [1.4.2]
+        version: [1.4.3]
     env:
       ARTIFACT_PATH: ${{ matrix.artifact }}_${{ matrix.version }}_${{ matrix.arch }}.exe
       RELEASE_NAME: ${{ matrix.release_name }}
@@ -215,9 +215,9 @@ jobs:
             artifact: firezone-client-headless-linux
             image_name: client
             # mark:next-headless-version
-            release_name: headless-client-1.4.2
+            release_name: headless-client-1.4.3
             # mark:next-headless-version
-            version: 1.4.2
+            version: 1.4.3
           - package: firezone-relay
             artifact: firezone-relay
             image_name: relay

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           - release_name: gateway-1.4.4
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
-          - release_name: headless-client-1.4.2
+          - release_name: headless-client-1.4.3
             config_name: release-drafter-headless-client.yml
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
             ARTIFACT=client
             # mark:next-headless-version
-            VERSION="1.4.2"
+            VERSION="1.4.3"
           else
             echo "Shouldn't have gotten here. Exiting."
             exit 1

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-headless-client"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "atomicwrites",

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-headless-client"
 # mark:next-headless-version
-version = "1.4.2"
+version = "1.4.3"
 edition = { workspace = true }
 authors = ["Firezone, Inc."]
 license = { workspace = true }

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -118,10 +118,10 @@ function gui() {
     cargo_update_workspace
 }
 
-# Linux Headless
+# Windows / Linux Headless
 #
-# Unlike the Apple, Android, and GUI clients, headless binaries for Linux are
-# built on each `main` workflow.
+# Unlike the Apple, Android, and GUI clients, headless binaries for Windows and
+# Linux are built on each `main` workflow.
 #
 # Instructions:
 # 1. Perform any final QA testing on the new release assets, then publish the
@@ -131,8 +131,8 @@ function gui() {
 # 4. Commit the changes and open a PR. Ensure the Changelog is correctly
 #    updated with the changes.
 function headless() {
-    current_headless_version="1.4.1"
-    next_headless_version="1.4.2"
+    current_headless_version="1.4.2"
+    next_headless_version="1.4.3"
 
     find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_headless_version}"'/g;}' {} \;
     find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_headless_version}"'/g;}' {} \;

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -46,7 +46,7 @@ module.exports = [
     source: "/dl/firezone-client-headless-windows/latest/x86_64",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.1/firezone-client-headless-windows_1.4.1_x86_64.exe",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.2/firezone-client-headless-windows_1.4.2_x86_64.exe",
     permanent: false,
   },
   /*
@@ -72,21 +72,21 @@ module.exports = [
     source: "/dl/firezone-client-headless-linux/latest/x86_64",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.1/firezone-client-headless-linux_1.4.1_x86_64",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.2/firezone-client-headless-linux_1.4.2_x86_64",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-headless-linux/latest/aarch64",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.1/firezone-client-headless-linux_1.4.1_aarch64",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.2/firezone-client-headless-linux_1.4.2_aarch64",
     permanent: false,
   },
   {
     source: "/dl/firezone-client-headless-linux/latest/armv7",
     destination:
       // mark:current-headless-version
-      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.1/firezone-client-headless-linux_1.4.1_armv7",
+      "https://www.github.com/firezone/firezone/releases/download/headless-client-1.4.2/firezone-client-headless-linux_1.4.2_armv7",
     permanent: false,
   },
   /*

--- a/website/src/app/api/releases/route.ts
+++ b/website/src/app/api/releases/route.ts
@@ -11,7 +11,7 @@ export async function GET(_req: NextRequest) {
     // mark:current-gui-version
     gui: "1.4.3",
     // mark:current-headless-version
-    headless: "1.4.1",
+    headless: "1.4.2",
     // mark:current-gateway-version
     gateway: "1.4.3",
   };

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -31,7 +31,8 @@ export default function Headless({ title }: { title: string }) {
   return (
     <Entries downloadLinks={downloadLinks} title={title}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased>
+      <Unreleased></Unreleased>
+      <Entry version="1.4.2" date={new Date("2025-02-10")}>
         <ChangeItem pull="8041">
           Publishes the headless client for Windows.
         </ChangeItem>
@@ -39,233 +40,249 @@ export default function Headless({ title }: { title: string }) {
           Only write logs using ANSI-escape codes if the underlying output
           stream supports it.
         </ChangeItem>
-      </Unreleased>
-      <Entry version="1.4.1" date={new Date("2025-01-28")}>
-        <ChangeItem pull="7551">
-          Fixes an issue where large DNS responses were incorrectly discarded.
-        </ChangeItem>
-        <ChangeItem pull="7770">
-          BREAKING: Removes the positional token argument on the CLI. Use
-          `FIREZONE_TOKEN` or `FIREZONE_TOKEN_PATH` env variables instead.
-        </ChangeItem>
       </Entry>
-      <Entry version="1.4.0" date={new Date("2024-12-13")}>
-        <ChangeItem pull="7350">
-          Allows disabling telemetry by setting `FIREZONE_NO_TELEMETRY=true`.
-        </ChangeItem>
-        <ChangeItem pull="7210">
-          Adds support for GSO (Generic Segmentation Offload), delivering
-          throughput improvements of up to 60%.
-        </ChangeItem>
-        <ChangeItem>
-          Makes use of the new control protocol, delivering faster and more
-          robust connection establishment.
-        </ChangeItem>
-        <ChangeItem pull="7449">
-          Uses multiple threads to read & write to the TUN device, greatly
-          improving performance.
-        </ChangeItem>
-        <ChangeItem pull="7477">
-          Improves connection setup latency by buffering initial packets.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.3.7" date={new Date("2024-11-15")}>
-        <ChangeItem pull="7334">
-          Fixes an issue where symmetric NATs would generate unnecessary
-          candidate for hole-punching.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.3.6" date={new Date("2024-11-08")}>
-        <ChangeItem pull="7263">
-          Mitigates a crash in case the maximum packet size is not respected.
-        </ChangeItem>
-        <ChangeItem pull="7265">
-          Prevents re-connections to the portal from hanging for longer than 5s.
-        </ChangeItem>
-        <ChangeItem pull="7288">
-          Fixes an issue where network roaming would cause Firezone to become
-          unresponsive.
-        </ChangeItem>
-        <ChangeItem pull="7287">
-          Fixes an issue where subsequent SIGHUP signals after the first one
-          were ignored.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.3.5" date={new Date("2024-10-31")}>
-        <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
-        <ChangeItem pull="7164">
-          Fixes an issue where Firezone would fail to establish connections to
-          Gateways and the client had to be restarted.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.3.4" date={new Date("2024-10-02")}>
-        <ChangeItem pull="6831">
-          Ensures Firefox doesn't attempt to use DNS over HTTPS when Firezone is
-          active.
-        </ChangeItem>
-        <ChangeItem pull="6845">
-          Fixes connectivity issues on idle connections by entering an
-          always-on, low-power mode instead of closing them.
-        </ChangeItem>
-        <ChangeItem pull="6782">
-          Adds always-on error reporting using sentry.io.
-        </ChangeItem>
-        <ChangeItem pull="6857">
-          Sends the motherboard's hardware ID for device verification.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.3.3" date={new Date("2024-09-25")}>
-        <ChangeItem pull="6809">
-          Fixes a bug where non-wildcard DNS resources were not prioritised over
-          wildcard ones (e.g. `app.example.com` vs `*.example.com`).
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.3.2" date={new Date("2024-09-25")}>
-        <ChangeItem pull="6765">
-          Fixes a bug where DNS PTR queries by the system did not get answered.
-        </ChangeItem>
-        <ChangeItem pull="6722">
-          Fixes a routing bug when one of several overlapping CIDR resources
-          gets disabled / removed.
-        </ChangeItem>
-        <ChangeItem pull="6780">
-          Fixes a bug where the Linux Clients didn't work on ZFS filesystems.
-        </ChangeItem>
-        <ChangeItem pull="6788">
-          Fixes an issue where some browsers may fail to route DNS Resources
-          correctly.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.3.1" date={new Date("2024-09-05")}>
-        <ChangeItem pull="6563">
-          Removes unnecessary packet buffers for a minor performance increase.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.3.0" date={new Date("2024-08-30")}>
-        <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>
-      </Entry>
-      <Entry version="1.2.0" date={new Date("2024-08-21")}>
-        <ChangeItem pull="5901">
-          Implements glob-like matching of domains for DNS resources.
-        </ChangeItem>
-        <ChangeItem pull="6361">
-          Connections to Gateways are now sticky for the duration of the
-          Client's session to fix issues with long-lived TCP connections.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.1.7" date={new Date("2024-08-13")}>
-        <ChangeItem pull="6276">
-          Fixes a bug where relayed connections failed to establish after an
-          idle period.
-        </ChangeItem>
-        <ChangeItem pull="6277">
-          Fixes a bug where restrictive NATs caused connectivity problems.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.1.6" date={new Date("2024-08-09")}>
-        <ChangeItem pull="6233">
-          Fixes an issue where the IPC service can panic during DNS resolution.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.1.5" date={new Date("2024-08-08")}>
-        <ChangeItem pull="6163">
-          Uses `systemd-resolved` DNS control by default on Linux
-        </ChangeItem>
-        <ChangeItem pull="6184">
-          Mitigates a bug where the Client can panic if an internal channel
-          fills up
-        </ChangeItem>
-        <ChangeItem pull="6181">
-          Improves reliability of DNS resolution of non-resources.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.1.4" date={new Date("2024-08-02")}>
-        <ChangeItem pull="6143">
-          Fixes an issue where DNS queries could time out on some networks.
-        </ChangeItem>
-      </Entry>
-      <Entry version="1.1.3" date={new Date("2024-07-05")}>
-        <li className="pl-2">
-          Fixes an{" "}
-          <Link
-            href="https://github.com/firezone/firezone/pull/5700"
-            className="text-accent-500 underline hover:no-underline"
-          >
-            issue
-          </Link>{" "}
-          where a stale DNS cache could prevent traffic from routing to DNS
-          Resources if they were updated while the Client was signed in.
-        </li>
-      </Entry>
-      <Entry version="1.1.2" date={new Date("2024-07-03")}>
-        <li className="pl-2">
-          Prevents Firezone's stub resolver from intercepting DNS record types
-          besides A, AAAA, and PTR. These are now forwarded to your upstream DNS
-          resolver.
-        </li>
-      </Entry>
-      <Entry version="1.1.1" date={new Date("2024-06-29")}>
-        <li className="pl-2">
-          Fixes an issue that could cause Resources to be unreachable a few
-          hours after roaming networks.
-        </li>
-        <li className="pl-2">
-          Reduces noise in logs for the default log level.
-        </li>
-      </Entry>
-      <Entry version="1.1.0" date={new Date("2024-06-27")}>
-        <li className="pl-2">
-          Introduces the new DNS routing system supported by 1.1.0 Gateways
-          which results in much more stable connections for DNS Resources,
-          especially when wildcards are used.
-        </li>
-        <li className="pl-2">
-          Improves reliability when roaming between networks.
-        </li>
-        <li className="pl-2">
-          Closes idle connections to Gateways that have not seen traffic for
-          more than 5 minutes which reduces power consumption when not accessing
-          Resources.
-        </li>
-        <li className="pl-2">
-          Updates log file endings to JSONL and adds syslog-style logs for
-          easier readability.
-        </li>
-        <p>
-          <strong>Note:</strong> Client versions 1.1.x are incompatible with
-          Gateways running 1.0.x.
-        </p>
-      </Entry>
-      <Entry version="1.0.8" date={new Date("2024-06-17")}>
-        This is a maintenance release with no major user-facing changes.
-      </Entry>
-      <Entry version="1.0.7" date={new Date("2024-06-12")}>
-        This release fixes a bug where the incorrect Client version was reported
-        to the admin portal.
-      </Entry>
-      <Entry version="1.0.6" date={new Date("2024-06-11")}>
-        This release contains connectivity fixes and performance improvements
-        and is recommended for all users.
-      </Entry>
-      <Entry version="1.0.5" date={new Date("2024-05-22")}>
-        This is a maintenance release with no major user-facing changes.
-      </Entry>
-      <Entry version="1.0.4" date={new Date("2024-05-14")}>
-        This is a maintenance release with no major user-facing changes.
-      </Entry>
-      <Entry version="1.0.3" date={new Date("2024-05-08")}>
-        Maintenance release.
-      </Entry>
-      <Entry version="1.0.2" date={new Date("2024-04-30")}>
-        This release reverts a change that could cause connectivity issues seen
-        by some users.
-      </Entry>
-      <Entry version="1.0.1" date={new Date("2024-04-29")}>
-        Update the upgrade URLs used to check for new versions.
-      </Entry>
-      <Entry version="1.0.0" date={new Date("2024-04-24")}>
-        Initial release.
-      </Entry>
+
+      {/* The Windows headless client didn't exist before 1.4.2 */}
+      {title === "Linux Headless" && (
+        <>
+          <Entry version="1.4.1" date={new Date("2025-01-28")}>
+            <ChangeItem pull="7551">
+              Fixes an issue where large DNS responses were incorrectly
+              discarded.
+            </ChangeItem>
+            <ChangeItem pull="7770">
+              BREAKING: Removes the positional token argument on the CLI. Use
+              `FIREZONE_TOKEN` or `FIREZONE_TOKEN_PATH` env variables instead.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.4.0" date={new Date("2024-12-13")}>
+            <ChangeItem pull="7350">
+              Allows disabling telemetry by setting
+              `FIREZONE_NO_TELEMETRY=true`.
+            </ChangeItem>
+            <ChangeItem pull="7210">
+              Adds support for GSO (Generic Segmentation Offload), delivering
+              throughput improvements of up to 60%.
+            </ChangeItem>
+            <ChangeItem>
+              Makes use of the new control protocol, delivering faster and more
+              robust connection establishment.
+            </ChangeItem>
+            <ChangeItem pull="7449">
+              Uses multiple threads to read & write to the TUN device, greatly
+              improving performance.
+            </ChangeItem>
+            <ChangeItem pull="7477">
+              Improves connection setup latency by buffering initial packets.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.3.7" date={new Date("2024-11-15")}>
+            <ChangeItem pull="7334">
+              Fixes an issue where symmetric NATs would generate unnecessary
+              candidate for hole-punching.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.3.6" date={new Date("2024-11-08")}>
+            <ChangeItem pull="7263">
+              Mitigates a crash in case the maximum packet size is not
+              respected.
+            </ChangeItem>
+            <ChangeItem pull="7265">
+              Prevents re-connections to the portal from hanging for longer than
+              5s.
+            </ChangeItem>
+            <ChangeItem pull="7288">
+              Fixes an issue where network roaming would cause Firezone to
+              become unresponsive.
+            </ChangeItem>
+            <ChangeItem pull="7287">
+              Fixes an issue where subsequent SIGHUP signals after the first one
+              were ignored.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.3.5" date={new Date("2024-10-31")}>
+            <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
+            <ChangeItem pull="7164">
+              Fixes an issue where Firezone would fail to establish connections
+              to Gateways and the client had to be restarted.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.3.4" date={new Date("2024-10-02")}>
+            <ChangeItem pull="6831">
+              Ensures Firefox doesn't attempt to use DNS over HTTPS when
+              Firezone is active.
+            </ChangeItem>
+            <ChangeItem pull="6845">
+              Fixes connectivity issues on idle connections by entering an
+              always-on, low-power mode instead of closing them.
+            </ChangeItem>
+            <ChangeItem pull="6782">
+              Adds always-on error reporting using sentry.io.
+            </ChangeItem>
+            <ChangeItem pull="6857">
+              Sends the motherboard's hardware ID for device verification.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.3.3" date={new Date("2024-09-25")}>
+            <ChangeItem pull="6809">
+              Fixes a bug where non-wildcard DNS resources were not prioritised
+              over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.3.2" date={new Date("2024-09-25")}>
+            <ChangeItem pull="6765">
+              Fixes a bug where DNS PTR queries by the system did not get
+              answered.
+            </ChangeItem>
+            <ChangeItem pull="6722">
+              Fixes a routing bug when one of several overlapping CIDR resources
+              gets disabled / removed.
+            </ChangeItem>
+            <ChangeItem pull="6780">
+              Fixes a bug where the Linux Clients didn't work on ZFS
+              filesystems.
+            </ChangeItem>
+            <ChangeItem pull="6788">
+              Fixes an issue where some browsers may fail to route DNS Resources
+              correctly.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.3.1" date={new Date("2024-09-05")}>
+            <ChangeItem pull="6563">
+              Removes unnecessary packet buffers for a minor performance
+              increase.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.3.0" date={new Date("2024-08-30")}>
+            <ChangeItem pull="6434">
+              Adds the Internet Resource feature.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.2.0" date={new Date("2024-08-21")}>
+            <ChangeItem pull="5901">
+              Implements glob-like matching of domains for DNS resources.
+            </ChangeItem>
+            <ChangeItem pull="6361">
+              Connections to Gateways are now sticky for the duration of the
+              Client's session to fix issues with long-lived TCP connections.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.1.7" date={new Date("2024-08-13")}>
+            <ChangeItem pull="6276">
+              Fixes a bug where relayed connections failed to establish after an
+              idle period.
+            </ChangeItem>
+            <ChangeItem pull="6277">
+              Fixes a bug where restrictive NATs caused connectivity problems.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.1.6" date={new Date("2024-08-09")}>
+            <ChangeItem pull="6233">
+              Fixes an issue where the IPC service can panic during DNS
+              resolution.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.1.5" date={new Date("2024-08-08")}>
+            <ChangeItem pull="6163">
+              Uses `systemd-resolved` DNS control by default on Linux
+            </ChangeItem>
+            <ChangeItem pull="6184">
+              Mitigates a bug where the Client can panic if an internal channel
+              fills up
+            </ChangeItem>
+            <ChangeItem pull="6181">
+              Improves reliability of DNS resolution of non-resources.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.1.4" date={new Date("2024-08-02")}>
+            <ChangeItem pull="6143">
+              Fixes an issue where DNS queries could time out on some networks.
+            </ChangeItem>
+          </Entry>
+          <Entry version="1.1.3" date={new Date("2024-07-05")}>
+            <li className="pl-2">
+              Fixes an{" "}
+              <Link
+                href="https://github.com/firezone/firezone/pull/5700"
+                className="text-accent-500 underline hover:no-underline"
+              >
+                issue
+              </Link>{" "}
+              where a stale DNS cache could prevent traffic from routing to DNS
+              Resources if they were updated while the Client was signed in.
+            </li>
+          </Entry>
+          <Entry version="1.1.2" date={new Date("2024-07-03")}>
+            <li className="pl-2">
+              Prevents Firezone's stub resolver from intercepting DNS record
+              types besides A, AAAA, and PTR. These are now forwarded to your
+              upstream DNS resolver.
+            </li>
+          </Entry>
+          <Entry version="1.1.1" date={new Date("2024-06-29")}>
+            <li className="pl-2">
+              Fixes an issue that could cause Resources to be unreachable a few
+              hours after roaming networks.
+            </li>
+            <li className="pl-2">
+              Reduces noise in logs for the default log level.
+            </li>
+          </Entry>
+          <Entry version="1.1.0" date={new Date("2024-06-27")}>
+            <li className="pl-2">
+              Introduces the new DNS routing system supported by 1.1.0 Gateways
+              which results in much more stable connections for DNS Resources,
+              especially when wildcards are used.
+            </li>
+            <li className="pl-2">
+              Improves reliability when roaming between networks.
+            </li>
+            <li className="pl-2">
+              Closes idle connections to Gateways that have not seen traffic for
+              more than 5 minutes which reduces power consumption when not
+              accessing Resources.
+            </li>
+            <li className="pl-2">
+              Updates log file endings to JSONL and adds syslog-style logs for
+              easier readability.
+            </li>
+            <p>
+              <strong>Note:</strong> Client versions 1.1.x are incompatible with
+              Gateways running 1.0.x.
+            </p>
+          </Entry>
+          <Entry version="1.0.8" date={new Date("2024-06-17")}>
+            This is a maintenance release with no major user-facing changes.
+          </Entry>
+          <Entry version="1.0.7" date={new Date("2024-06-12")}>
+            This release fixes a bug where the incorrect Client version was
+            reported to the admin portal.
+          </Entry>
+          <Entry version="1.0.6" date={new Date("2024-06-11")}>
+            This release contains connectivity fixes and performance
+            improvements and is recommended for all users.
+          </Entry>
+          <Entry version="1.0.5" date={new Date("2024-05-22")}>
+            This is a maintenance release with no major user-facing changes.
+          </Entry>
+          <Entry version="1.0.4" date={new Date("2024-05-14")}>
+            This is a maintenance release with no major user-facing changes.
+          </Entry>
+          <Entry version="1.0.3" date={new Date("2024-05-08")}>
+            Maintenance release.
+          </Entry>
+          <Entry version="1.0.2" date={new Date("2024-04-30")}>
+            This release reverts a change that could cause connectivity issues
+            seen by some users.
+          </Entry>
+          <Entry version="1.0.1" date={new Date("2024-04-29")}>
+            Update the upgrade URLs used to check for new versions.
+          </Entry>
+          <Entry version="1.0.0" date={new Date("2024-04-24")}>
+            Initial release.
+          </Entry>
+        </>
+      )}
     </Entries>
   );
 }


### PR DESCRIPTION
Publishes the headless client 1.4.2, now with Windows support.

Resolves: #3782 