### PR TITLE
fix(portal): Add node name key to metrics labels

### DIFF
--- a/elixir/apps/domain/lib/domain/telemetry/reporter/google_cloud_metrics.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/reporter/google_cloud_metrics.ex
@@ -266,7 +266,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetrics do
     time_series =
       buffer
       |> Enum.flat_map(fn {{schema, name, tags, unit}, measurements} ->
-        labels = Map.merge(labels, tags) |> truncate_labels()
+        labels = Map.merge(labels, tags) |> truncate_labels() |> Map.merge(%{node: node()})
         format_time_series(schema, name, labels, resource, measurements, unit)
       end)
 

--- a/elixir/apps/domain/test/domain/telemetry/reporter/google_cloud_metrics_test.exs
+++ b/elixir/apps/domain/test/domain/telemetry/reporter/google_cloud_metrics_test.exs
@@ -151,7 +151,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetricsTest do
                  %{
                    "metric" => %{
                      "type" => "custom.googleapis.com/elixir/foo/count",
-                     "labels" => %{"foo" => "bar", "app" => "myapp"}
+                     "labels" => %{"foo" => "bar", "app" => "myapp", "node" => "nonode@nohost"}
                    },
                    "resource" => %{"type" => "test"},
                    "unit" => "request",
@@ -244,7 +244,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetricsTest do
                  %{
                    "metric" => %{
                      "type" => "custom.googleapis.com/elixir/foo/distribution",
-                     "labels" => %{"foo" => "bar", "app" => "myapp"}
+                     "labels" => %{"foo" => "bar", "app" => "myapp", "node" => "nonode@nohost"}
                    },
                    "resource" => %{"type" => "test"},
                    "unit" => "request",
@@ -332,7 +332,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetricsTest do
                  %{
                    "metric" => %{
                      "type" => "custom.googleapis.com/elixir/foo/sum",
-                     "labels" => %{"foo" => "bar", "app" => "myapp"}
+                     "labels" => %{"foo" => "bar", "app" => "myapp", "node" => "nonode@nohost"}
                    },
                    "resource" => %{"type" => "test"},
                    "unit" => "request",
@@ -407,7 +407,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetricsTest do
                  %{
                    "metric" => %{
                      "type" => "custom.googleapis.com/elixir/foo/summary",
-                     "labels" => %{"foo" => "bar", "app" => "myapp"}
+                     "labels" => %{"foo" => "bar", "app" => "myapp", "node" => "nonode@nohost"}
                    },
                    "resource" => %{"type" => "test"},
                    "unit" => "request",
@@ -439,7 +439,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetricsTest do
                  },
                  %{
                    "metric" => %{
-                     "labels" => %{"app" => "myapp", "foo" => "bar"},
+                     "labels" => %{"app" => "myapp", "foo" => "bar", "node" => "nonode@nohost"},
                      "type" => "custom.googleapis.com/elixir/foo/min_val"
                    },
                    "metricKind" => "GAUGE",
@@ -457,7 +457,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetricsTest do
                  },
                  %{
                    "metric" => %{
-                     "labels" => %{"app" => "myapp", "foo" => "bar"},
+                     "labels" => %{"app" => "myapp", "foo" => "bar", "node" => "nonode@nohost"},
                      "type" => "custom.googleapis.com/elixir/foo/max_val"
                    },
                    "metricKind" => "GAUGE",
@@ -531,7 +531,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetricsTest do
                  %{
                    "metric" => %{
                      "type" => "custom.googleapis.com/elixir/foo/last_value",
-                     "labels" => %{"foo" => "bar", "app" => "myapp"}
+                     "labels" => %{"foo" => "bar", "app" => "myapp", "node" => "nonode@nohost"}
                    },
                    "resource" => %{"type" => "test"},
                    "unit" => "request",


### PR DESCRIPTION
Ok, the reason why we're still getting the error `One or more points were written more frequently than the maximum sampling period configured for the metric.` is because the metric points are identified by the labels in the metric, and so are "aggregated" more frequently than our API calls.

By adding the node name to the labels, we scope the metric by that node and prevent inserting the points more often than our API calls.