### PR TITLE
fix(website): make changelog more typesafe

### DIFF
--- a/website/src/components/Changelog/Entry.tsx
+++ b/website/src/components/Changelog/Entry.tsx
@@ -18,7 +18,9 @@ export default function Entry({
     day: "numeric",
   };
   const utcDateString = date.toLocaleDateString("en-US", options);
-  const numChildren = React.Children.count(children);
+  const numChangeItems = React.Children.toArray(children).filter(
+    (child) => React.isValidElement(child) && child.type === ChangeItem
+  ).length;
 
   return (
     <tr className="border-t">
@@ -30,7 +32,7 @@ export default function Entry({
       </td>
       <td className="px-2 py-1 sm:px-3 sm:py-1.5 md:px-4 md:py-2 lg:px-6 lg:py-4">
         <ul className="list-disc space-y-2 pl-4 mb-4">
-          {numChildren == 0 ? (
+          {numChangeItems == 0 ? (
             <ChangeItem>
               This is a maintenance release with no user-facing changes.
             </ChangeItem>

--- a/website/src/components/Changelog/Entry.tsx
+++ b/website/src/components/Changelog/Entry.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import ChangeItem from "./ChangeItem";
+import React from "react";
 
 export default function Entry({
   version,

--- a/website/src/components/Changelog/Entry.tsx
+++ b/website/src/components/Changelog/Entry.tsx
@@ -16,6 +16,8 @@ export default function Entry({
     day: "numeric",
   };
   const utcDateString = date.toLocaleDateString("en-US", options);
+  const numChildren = React.Children.count(children);
+
   return (
     <tr className="border-t">
       <td className="px-2 py-1 sm:px-3 sm:py-1.5 md:px-4 md:py-2 lg:px-6 lg:py-4">
@@ -25,7 +27,15 @@ export default function Entry({
         <time dateTime={date.toDateString()}>{utcDateString}</time>
       </td>
       <td className="px-2 py-1 sm:px-3 sm:py-1.5 md:px-4 md:py-2 lg:px-6 lg:py-4">
-        <ul className="list-disc space-y-2 pl-4 mb-4">{children}</ul>
+        <ul className="list-disc space-y-2 pl-4 mb-4">
+          {numChildren == 0 ? (
+            <ChangeItem>
+              This is a maintenance release with no user-facing changes.
+            </ChangeItem>
+          ) : (
+            children
+          )}
+        </ul>
       </td>
     </tr>
   );

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -1,31 +1,13 @@
 import Link from "next/link";
 import Entry from "./Entry";
-import Entries from "./Entries";
+import Entries, { DownloadLink } from "./Entries";
 import ChangeItem from "./ChangeItem";
 import Unreleased from "./Unreleased";
+import { OS } from ".";
 
-export default function GUI({ title }: { title: string }) {
-  const downloadLinks =
-    title === "Windows GUI"
-      ? [
-          {
-            title: "Download for x86_64",
-            href: "/dl/firezone-client-gui-windows/:version/x86_64",
-          },
-        ]
-      : [
-          {
-            title: "Download for x86_64",
-            href: "/dl/firezone-client-gui-linux/:version/x86_64",
-          },
-          {
-            title: "Download for aarch64",
-            href: "/dl/firezone-client-gui-linux/:version/aarch64",
-          },
-        ];
-
+export default function GUI({ os }: { os: OS }) {
   return (
-    <Entries downloadLinks={downloadLinks} title={title}>
+    <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="8035">
@@ -40,29 +22,29 @@ export default function GUI({ title }: { title: string }) {
         )}
       </Unreleased>
       <Entry version="1.4.3" date={new Date("2025-02-05")}>
-        {title == "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem>
             This is a maintenance release with no user-facing changes.
           </ChangeItem>
         )}
-        {title == "Windows" && (
+        {os === OS.Windows && (
           <ChangeItem pull="8003">
             Removes dependency on `netsh`, making sign-in faster.
           </ChangeItem>
         )}
-        {title == "Windows" && (
+        {os === OS.Windows && (
           <ChangeItem pull="7972">
             Makes DNS configuration more resilient.
           </ChangeItem>
         )}
       </Entry>
       <Entry version="1.4.2" date={new Date("2025-01-30")}>
-        {title == "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem>
             This is a maintenance with no user-facing changes.
           </ChangeItem>
         )}
-        {title == "Windows" && (
+        {os === OS.Windows && (
           <ChangeItem pull="7912">
             Fixes an issue where the tunnel device could not be created,
             resulting in an immediate sign-out after signing-in.
@@ -73,12 +55,12 @@ export default function GUI({ title }: { title: string }) {
         <ChangeItem pull="7551">
           Fixes an issue where large DNS responses were incorrectly discarded.
         </ChangeItem>
-        {title == "Windows" && (
+        {os === OS.Windows && (
           <ChangeItem pull="7556">
             Disables URO/GRO due to hardware / driver bugs.
           </ChangeItem>
         )}
-        {title == "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem pull="7822">
             Makes the runtime dependency on `update-desktop-database` optional,
             thus improving compatibility on non-Ubuntu systems.
@@ -94,7 +76,7 @@ export default function GUI({ title }: { title: string }) {
           Makes use of the new control protocol, delivering faster and more
           robust connection establishment.
         </ChangeItem>
-        {title == "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem pull="7449">
             Uses multiple threads to read & write to the TUN device, greatly
             improving performance.
@@ -126,7 +108,7 @@ export default function GUI({ title }: { title: string }) {
       </Entry>
       <Entry version="1.3.10" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="7009">
             The IPC service `firezone-client-ipc.exe` is now signed.
           </ChangeItem>
@@ -134,7 +116,7 @@ export default function GUI({ title }: { title: string }) {
         <ChangeItem pull="7123">
           Reports the version to the Portal correctly.
         </ChangeItem>
-        {title === "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem pull="6996">
             Supports Ubuntu 24.04, no longer supports Ubuntu 20.04.
           </ChangeItem>
@@ -145,13 +127,13 @@ export default function GUI({ title }: { title: string }) {
         </ChangeItem>
       </Entry>
       <Entry version="1.3.9" date={new Date("2024-10-09")}>
-        {title === "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem pull="6987">
             Fixes a crash on startup caused by incorrect permissions on the ID
             file.
           </ChangeItem>
         )}
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem>
             This is a maintenance release with no user-facing changes.
           </ChangeItem>
@@ -159,7 +141,7 @@ export default function GUI({ title }: { title: string }) {
       </Entry>
       <Entry version="1.3.8" date={new Date("2024-10-08")}>
         <ChangeItem pull="6874">Fixes the GUI shutting down slowly.</ChangeItem>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="6931">
             Mitigates an issue where `ipconfig` and WSL weren't aware of
             Firezone DNS resolvers. Users may need to restart WSL after signing
@@ -179,7 +161,7 @@ export default function GUI({ title }: { title: string }) {
         <ChangeItem pull="6782">
           Adds always-on error reporting using sentry.io.
         </ChangeItem>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="6874">
             Fixes a delay when closing the GUI.
           </ChangeItem>
@@ -199,7 +181,7 @@ export default function GUI({ title }: { title: string }) {
           Fixes an issue where some browsers may fail to route DNS Resources
           correctly.
         </ChangeItem>
-        {title === "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem pull="6780">
             Fixes a bug where the Linux Clients didn't work on ZFS filesystems.
           </ChangeItem>
@@ -208,7 +190,7 @@ export default function GUI({ title }: { title: string }) {
           Fixes a bug where auto-sign-in with an expired token would cause a
           "Couldn't send Disconnect" error message.
         </ChangeItem>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="6810">
             Fixes a bug where roaming from Ethernet to WiFi would cause Firezone
             to fail to connect to the portal.
@@ -234,7 +216,7 @@ export default function GUI({ title }: { title: string }) {
             This is a maintenance release with no user-facing changes.
           </ChangeItem>
         )}
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="6681">
             Fixes a bug where sign-in fails if IPv6 is disabled.
           </ChangeItem>
@@ -265,7 +247,7 @@ export default function GUI({ title }: { title: string }) {
           download.
         </ChangeItem>
         <ChangeItem pull="6449">Checks for updates once a day</ChangeItem>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="6472">
             Fixes an issue where Split DNS didn't work for domain-joined Windows
             machines
@@ -290,13 +272,13 @@ export default function GUI({ title }: { title: string }) {
         <ChangeItem pull="5901">
           Implements glob-like matching of domains for DNS resources.
         </ChangeItem>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="6280">
             Fixes a bug where the "Clear Logs" button did not clear the IPC
             service logs.
           </ChangeItem>
         )}
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="6308">
             Fixes a bug where the GUI could not run if the user is Administrator
           </ChangeItem>
@@ -332,7 +314,7 @@ export default function GUI({ title }: { title: string }) {
         <ChangeItem pull="5923">
           Adds the ability to mark Resources as favorites.
         </ChangeItem>
-        {title === "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem pull="6163">
             Supports using `etc-resolv-conf` DNS control method, or disabling
             DNS control
@@ -341,7 +323,7 @@ export default function GUI({ title }: { title: string }) {
         <ChangeItem pull="6181">
           Improves reliability of DNS resolution of non-resources.
         </ChangeItem>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="6163">Supports disabling DNS control</ChangeItem>
         )}
         <ChangeItem pull="6184">
@@ -355,10 +337,10 @@ export default function GUI({ title }: { title: string }) {
         </ChangeItem>
       </Entry>
       <Entry version="1.1.8" date={new Date("2024-08-01")}>
-        {title === "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem pull="5978">Adds network roaming support.</ChangeItem>
         )}
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="6051">
             Fixes "Element not found" error when setting routes.
           </ChangeItem>
@@ -371,13 +353,13 @@ export default function GUI({ title }: { title: string }) {
         </ChangeItem>
       </Entry>
       <Entry version="1.1.7" date={new Date("2024-07-17")}>
-        {title === "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem pull="5848">
             Stops the GUI and prompts you to re-launch it if you update Firezone
             while the GUI is running.
           </ChangeItem>
         )}
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="5375">
             Improves sign-in speed and fixes a DNS leak
           </ChangeItem>
@@ -388,7 +370,7 @@ export default function GUI({ title }: { title: string }) {
           Unexpected IPC service stops are now reported as "IPC connection
           closed".
         </ChangeItem>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem pull="5827">
             Fixes a bug where DNS could stop working when you sign out.
           </ChangeItem>
@@ -398,12 +380,12 @@ export default function GUI({ title }: { title: string }) {
         </ChangeItem>
       </Entry>
       <Entry version="1.1.5" date={new Date("2024-07-08")}>
-        {title === "Linux GUI" && (
+        {os === OS.Linux && (
           <ChangeItem pull="5793">
             The Linux GUI Client is now built for both x86-64 and ARM64.
           </ChangeItem>
         )}
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <ChangeItem>
             This is a maintenance release with no user-facing changes.
           </ChangeItem>
@@ -431,14 +413,14 @@ export default function GUI({ title }: { title: string }) {
         <li className="pl-2">
           Reduces noise in logs for the default log level.
         </li>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <li className="pl-2">
             Substantially reduces memory usage for the IPC service.
           </li>
         )}
       </Entry>
       <Entry version="1.1.1" date={new Date("2024-06-27")}>
-        {title === "Windows" ? (
+        {title === OS.Windows ? (
           <p>This release fixes a performance issue.</p>
         ) : (
           <p>This is a maintenance release with no user-facing changes.</p>
@@ -462,7 +444,7 @@ export default function GUI({ title }: { title: string }) {
           Updates log file endings to JSONL and adds syslog-style logs for
           easier readability.
         </li>
-        {title === "Windows" && (
+        {title === OS.Windows && (
           <li className="pl-2">
             Fixes a hang that could occur when the Client is quit, preventing it
             from opening again.
@@ -512,4 +494,36 @@ export default function GUI({ title }: { title: string }) {
       </Entry>
     </Entries>
   );
+}
+
+function downloadLinks(os: OS): DownloadLink[] {
+  switch (os) {
+    case OS.Windows:
+      return [
+        {
+          title: "Download for x86_64",
+          href: "/dl/firezone-client-gui-windows/:version/x86_64",
+        },
+      ];
+    case OS.Linux:
+      return [
+        {
+          title: "Download for x86_64",
+          href: "/dl/firezone-client-gui-linux/:version/x86_64",
+        },
+        {
+          title: "Download for aarch64",
+          href: "/dl/firezone-client-gui-linux/:version/aarch64",
+        },
+      ];
+  }
+}
+
+function title(os: OS): string {
+  switch (os) {
+    case OS.Windows:
+      return "Windows GUI";
+    case OS.Linux:
+      return "Linux GUI";
+  }
 }

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -22,11 +22,6 @@ export default function GUI({ os }: { os: OS }) {
         )}
       </Unreleased>
       <Entry version="1.4.3" date={new Date("2025-02-05")}>
-        {os === OS.Linux && (
-          <ChangeItem>
-            This is a maintenance release with no user-facing changes.
-          </ChangeItem>
-        )}
         {os === OS.Windows && (
           <ChangeItem pull="8003">
             Removes dependency on `netsh`, making sign-in faster.
@@ -39,11 +34,6 @@ export default function GUI({ os }: { os: OS }) {
         )}
       </Entry>
       <Entry version="1.4.2" date={new Date("2025-01-30")}>
-        {os === OS.Linux && (
-          <ChangeItem>
-            This is a maintenance with no user-facing changes.
-          </ChangeItem>
-        )}
         {os === OS.Windows && (
           <ChangeItem pull="7912">
             Fixes an issue where the tunnel device could not be created,
@@ -133,11 +123,6 @@ export default function GUI({ os }: { os: OS }) {
             file.
           </ChangeItem>
         )}
-        {title === OS.Windows && (
-          <ChangeItem>
-            This is a maintenance release with no user-facing changes.
-          </ChangeItem>
-        )}
       </Entry>
       <Entry version="1.3.8" date={new Date("2024-10-08")}>
         <ChangeItem pull="6874">Fixes the GUI shutting down slowly.</ChangeItem>
@@ -211,11 +196,6 @@ export default function GUI({ os }: { os: OS }) {
         </ChangeItem>
       </Entry>
       <Entry version="1.3.3" date={new Date("2024-09-13")}>
-        {title === "Linux GUI" && (
-          <ChangeItem>
-            This is a maintenance release with no user-facing changes.
-          </ChangeItem>
-        )}
         {title === OS.Windows && (
           <ChangeItem pull="6681">
             Fixes a bug where sign-in fails if IPv6 is disabled.
@@ -383,11 +363,6 @@ export default function GUI({ os }: { os: OS }) {
         {os === OS.Linux && (
           <ChangeItem pull="5793">
             The Linux GUI Client is now built for both x86-64 and ARM64.
-          </ChangeItem>
-        )}
-        {title === OS.Windows && (
-          <ChangeItem>
-            This is a maintenance release with no user-facing changes.
           </ChangeItem>
         )}
       </Entry>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -13,7 +13,7 @@ export default function GUI({ os }: { os: OS }) {
           Shows a non-disruptive toast notification and quits the GUI client in
           case the IPC service gets shutdown through the service manager.
         </ChangeItem>
-        {title == "Windows GUI" && (
+        {os === OS.Windows && (
           <ChangeItem pull="8083">
             Fixes a regression introduced in 1.4.3 where Firezone would not work
             on systems with a disabled IPv6 stack.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import Entry from "./Entry";
 import Entries, { DownloadLink } from "./Entries";
 import ChangeItem from "./ChangeItem";
@@ -98,7 +97,7 @@ export default function GUI({ os }: { os: OS }) {
       </Entry>
       <Entry version="1.3.10" date={new Date("2024-10-31")}>
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="7009">
             The IPC service `firezone-client-ipc.exe` is now signed.
           </ChangeItem>
@@ -126,7 +125,7 @@ export default function GUI({ os }: { os: OS }) {
       </Entry>
       <Entry version="1.3.8" date={new Date("2024-10-08")}>
         <ChangeItem pull="6874">Fixes the GUI shutting down slowly.</ChangeItem>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="6931">
             Mitigates an issue where `ipconfig` and WSL weren't aware of
             Firezone DNS resolvers. Users may need to restart WSL after signing
@@ -146,7 +145,7 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull="6782">
           Adds always-on error reporting using sentry.io.
         </ChangeItem>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="6874">
             Fixes a delay when closing the GUI.
           </ChangeItem>
@@ -175,7 +174,7 @@ export default function GUI({ os }: { os: OS }) {
           Fixes a bug where auto-sign-in with an expired token would cause a
           "Couldn't send Disconnect" error message.
         </ChangeItem>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="6810">
             Fixes a bug where roaming from Ethernet to WiFi would cause Firezone
             to fail to connect to the portal.
@@ -196,7 +195,7 @@ export default function GUI({ os }: { os: OS }) {
         </ChangeItem>
       </Entry>
       <Entry version="1.3.3" date={new Date("2024-09-13")}>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="6681">
             Fixes a bug where sign-in fails if IPv6 is disabled.
           </ChangeItem>
@@ -227,7 +226,7 @@ export default function GUI({ os }: { os: OS }) {
           download.
         </ChangeItem>
         <ChangeItem pull="6449">Checks for updates once a day</ChangeItem>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="6472">
             Fixes an issue where Split DNS didn't work for domain-joined Windows
             machines
@@ -252,13 +251,13 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull="5901">
           Implements glob-like matching of domains for DNS resources.
         </ChangeItem>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="6280">
             Fixes a bug where the "Clear Logs" button did not clear the IPC
             service logs.
           </ChangeItem>
         )}
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="6308">
             Fixes a bug where the GUI could not run if the user is Administrator
           </ChangeItem>
@@ -303,7 +302,7 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull="6181">
           Improves reliability of DNS resolution of non-resources.
         </ChangeItem>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="6163">Supports disabling DNS control</ChangeItem>
         )}
         <ChangeItem pull="6184">
@@ -320,7 +319,7 @@ export default function GUI({ os }: { os: OS }) {
         {os === OS.Linux && (
           <ChangeItem pull="5978">Adds network roaming support.</ChangeItem>
         )}
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="6051">
             Fixes "Element not found" error when setting routes.
           </ChangeItem>
@@ -339,7 +338,7 @@ export default function GUI({ os }: { os: OS }) {
             while the GUI is running.
           </ChangeItem>
         )}
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="5375">
             Improves sign-in speed and fixes a DNS leak
           </ChangeItem>
@@ -350,7 +349,7 @@ export default function GUI({ os }: { os: OS }) {
           Unexpected IPC service stops are now reported as "IPC connection
           closed".
         </ChangeItem>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <ChangeItem pull="5827">
             Fixes a bug where DNS could stop working when you sign out.
           </ChangeItem>
@@ -388,14 +387,14 @@ export default function GUI({ os }: { os: OS }) {
         <li className="pl-2">
           Reduces noise in logs for the default log level.
         </li>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <li className="pl-2">
             Substantially reduces memory usage for the IPC service.
           </li>
         )}
       </Entry>
       <Entry version="1.1.1" date={new Date("2024-06-27")}>
-        {title === OS.Windows ? (
+        {os === OS.Windows ? (
           <p>This release fixes a performance issue.</p>
         ) : (
           <p>This is a maintenance release with no user-facing changes.</p>
@@ -419,7 +418,7 @@ export default function GUI({ os }: { os: OS }) {
           Updates log file endings to JSONL and adds syslog-style logs for
           easier readability.
         </li>
-        {title === OS.Windows && (
+        {os === OS.Windows && (
           <li className="pl-2">
             Fixes a hang that could occur when the Client is quit, preventing it
             from opening again.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -280,26 +280,26 @@ function downloadLinks(os: OS): DownloadLink[] {
   switch (os) {
     case OS.Windows:
       return [
-          {
-            href: "/dl/firezone-client-headless-windows/:version/x86_64",
-            title: "Download for x86_64",
-          },
-        ];
+        {
+          href: "/dl/firezone-client-headless-windows/:version/x86_64",
+          title: "Download for x86_64",
+        },
+      ];
     case OS.Linux:
       return [
-          {
-            href: "/dl/firezone-client-headless-linux/:version/x86_64",
-            title: "Download for x86_64",
-          },
-          {
-            href: "/dl/firezone-client-headless-linux/:version/aarch64",
-            title: "Download for aarch64",
-          },
-          {
-            href: "/dl/firezone-client-headless-linux/:version/armv7",
-            title: "Download for armv7",
-          },
-        ];
+        {
+          href: "/dl/firezone-client-headless-linux/:version/x86_64",
+          title: "Download for x86_64",
+        },
+        {
+          href: "/dl/firezone-client-headless-linux/:version/aarch64",
+          title: "Download for aarch64",
+        },
+        {
+          href: "/dl/firezone-client-headless-linux/:version/armv7",
+          title: "Download for armv7",
+        },
+      ];
   }
 }
 

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -1,35 +1,13 @@
 import ChangeItem from "./ChangeItem";
 import Entry from "./Entry";
-import Entries from "./Entries";
+import Entries, { DownloadLink } from "./Entries";
 import Link from "next/link";
 import Unreleased from "./Unreleased";
+import { OS } from ".";
 
-export default function Headless({ title }: { title: string }) {
-  const downloadLinks =
-    title === "Windows Headless"
-      ? [
-          {
-            href: "/dl/firezone-client-headless-windows/:version/x86_64",
-            title: "Download for x86_64",
-          },
-        ]
-      : [
-          {
-            href: "/dl/firezone-client-headless-linux/:version/x86_64",
-            title: "Download for x86_64",
-          },
-          {
-            href: "/dl/firezone-client-headless-linux/:version/aarch64",
-            title: "Download for aarch64",
-          },
-          {
-            href: "/dl/firezone-client-headless-linux/:version/armv7",
-            title: "Download for armv7",
-          },
-        ];
-
+export default function Headless({ os }: { os: OS }) {
   return (
-    <Entries downloadLinks={downloadLinks} title={title}>
+    <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="8055">
@@ -54,7 +32,7 @@ export default function Headless({ title }: { title: string }) {
       </Entry>
 
       {/* The Windows headless client didn't exist before 1.4.2 */}
-      {title === "Linux Headless" && (
+      {os === OS.Linux && (
         <>
           <Entry version="1.4.1" date={new Date("2025-01-28")}>
             <ChangeItem pull="7551">
@@ -296,4 +274,40 @@ export default function Headless({ title }: { title: string }) {
       )}
     </Entries>
   );
+}
+
+function downloadLinks(os: OS): DownloadLink[] {
+  switch (os) {
+    case OS.Windows:
+      return [
+          {
+            href: "/dl/firezone-client-headless-windows/:version/x86_64",
+            title: "Download for x86_64",
+          },
+        ];
+    case OS.Linux:
+      return [
+          {
+            href: "/dl/firezone-client-headless-linux/:version/x86_64",
+            title: "Download for x86_64",
+          },
+          {
+            href: "/dl/firezone-client-headless-linux/:version/aarch64",
+            title: "Download for aarch64",
+          },
+          {
+            href: "/dl/firezone-client-headless-linux/:version/armv7",
+            title: "Download for armv7",
+          },
+        ];
+  }
+}
+
+function title(os: OS): string {
+  switch (os) {
+    case OS.Windows:
+      return "Windows Headless";
+    case OS.Linux:
+      return "Linux Headless";
+  }
 }

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -14,7 +14,7 @@ export default function Headless({ os }: { os: OS }) {
           Hides the <code>--check</code> and <code>--exit</code> CLI options
           from the help output. These are only used internally.
         </ChangeItem>
-        {title == "Windows Headless" && (
+        {os === OS.Windows && (
           <ChangeItem pull="8083">
             Fixes a regression introduced in 1.4.2 where Firezone would not work
             on systems with a disabled IPv6 stack.

--- a/website/src/components/Changelog/index.tsx
+++ b/website/src/components/Changelog/index.tsx
@@ -33,19 +33,19 @@ export default function Changelog() {
           <Apple />
         </TabsItem>
         <TabsItem title="Windows GUI" icon={FaWindows}>
-          <GUI title="Windows" />
+          <GUI os={OS.Windows} />
         </TabsItem>
         <TabsItem title="Windows Headless" icon={FaWindows}>
-          <Headless title="Windows Headless" />
+          <Headless os={OS.Windows} />
         </TabsItem>
         <TabsItem title="Android" icon={FaAndroid}>
           <Android />
         </TabsItem>
         <TabsItem title="Linux GUI" icon={FaLinux}>
-          <GUI title="Linux GUI" />
+          <GUI os={OS.Linux} />
         </TabsItem>
         <TabsItem title="Linux Headless" icon={FaLinux}>
-          <Headless title="Linux Headless" />
+          <Headless os={OS.Linux} />
         </TabsItem>
       </TabsGroup>
       {sha && (
@@ -62,4 +62,9 @@ export default function Changelog() {
       )}
     </section>
   );
+}
+
+export enum OS {
+  Windows,
+  Linux,
 }


### PR DESCRIPTION
We currently have a bug in our changelog where the wrong download links are being rendered for the Windows GUI client because we are incorrectly matching on the title.

To fix this, we stop matching on the title and instead pass an `OS` enum in the respective changelog components that need to differentiate between OS-specific entries.