### PR TITLE
fix(windows): silence `0x800706D9` when DNS deactivation fails

### DIFF
--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -76,6 +76,17 @@ pub mod error {
     /// assert_eq!(firezone_bin_shared::windows::error::NOT_SUPPORTED.0 as u32, 0x80070032)
     /// ```
     pub const NOT_SUPPORTED: HRESULT = HRESULT::from_win32(0x0032);
+
+    /// Win32 error code when failing to communicate with the endpoint mapper.
+    ///
+    /// The docs say:
+    ///
+    /// > There are no more endpoints available from the endpoint mapper.
+    ///
+    /// ```
+    /// assert_eq!(firezone_bin_shared::windows::error::EPT_S_NOT_REGISTERED.0 as u32, 0x800706D9)
+    /// ```
+    pub const EPT_S_NOT_REGISTERED: HRESULT = HRESULT::from_win32(0x06D9);
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -31,10 +31,10 @@ impl DnsController {
         let hklm = winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE);
 
         if let Err(error) = delete_subkey(&hklm, local_nrpt_path().join(NRPT_REG_KEY)) {
-            tracing::error!("Failed to delete local NRPT: {error:#}");
+            tracing::warn!("Failed to delete local NRPT: {error:#}");
         }
         if let Err(error) = delete_subkey(&hklm, group_nrpt_path().join(NRPT_REG_KEY)) {
-            tracing::error!("Failed to delete group NRPT: {error:#}");
+            tracing::warn!("Failed to delete group NRPT: {error:#}");
         }
 
         if let Err(e) = refresh_group_policy() {

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -37,7 +37,10 @@ impl DnsController {
             tracing::error!("Failed to delete group NRPT: {error:#}");
         }
 
-        refresh_group_policy()?;
+        if let Err(e) = refresh_group_policy() {
+            tracing::debug!("{e:#}");
+        }
+
         tracing::info!("Deactivated DNS control");
 
         Ok(())

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -200,7 +200,8 @@ fn group_nrpt_path() -> &'static Path {
 
 fn refresh_group_policy() -> Result<()> {
     // SAFETY: No pointers involved, and the docs say nothing about threads.
-    unsafe { RefreshPolicyEx(true, RP_FORCE) }?;
+    unsafe { RefreshPolicyEx(true, RP_FORCE) }.context("Failed to refresh group policy")?;
+
     Ok(())
 }
 

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -28,6 +28,7 @@ impl DnsController {
     /// Deactivate any control Firezone has over the computer's DNS
     ///
     /// Must be `sync` so we can call it from `Drop`
+    #[expect(clippy::unnecessary_wraps, reason = "Linux version is fallible")]
     pub fn deactivate(&mut self) -> Result<()> {
         let hklm = winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE);
 

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -40,7 +40,7 @@ impl DnsController {
 
         match refresh_group_policy() {
             Ok(()) => {}
-            Err(e) if e.code() == EPT_S_NOT_REGISTERED => {
+            Err(e) if e.root_cause().downcast_ref::<windows::core::Error>().is_some_and(|e| e.code() == EPT_S_NOT_REGISTERED) => {
                 // This may happen if we make this syscall multiple times in a row (which we do as we shut down).
                 // It isn't very concerning and deactivation of DNS control is on a best-effort basis anyway.
             }

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -40,7 +40,11 @@ impl DnsController {
 
         match refresh_group_policy() {
             Ok(()) => {}
-            Err(e) if e.root_cause().downcast_ref::<windows::core::Error>().is_some_and(|e| e.code() == EPT_S_NOT_REGISTERED) => {
+            Err(e)
+                if e.root_cause()
+                    .downcast_ref::<windows::core::Error>()
+                    .is_some_and(|e| e.code() == EPT_S_NOT_REGISTERED) =>
+            {
                 // This may happen if we make this syscall multiple times in a row (which we do as we shut down).
                 // It isn't very concerning and deactivation of DNS control is on a best-effort basis anyway.
             }


### PR DESCRIPTION
The error code we see here means "There are no more endpoints available from the endpoint mapper." This has something to do with Windows' internal RPC communication between components. DNS deactivation is on a best-effort basis and it appears that everything else is working just fine, despite this error.

It appears to happen when we shut down our own service, so perhaps it is just a race condition.