### PR TITLE
fix(windows): don't warn on disabled IP stack

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -135,7 +135,12 @@ fn add_route(route: IpNetwork, iface_idx: u32) {
         return;
     }
 
-    tracing::warn!( %route, "Failed to add route: {}", err_with_src(&e));
+    if e.code() == NOT_FOUND {
+        tracing::debug!(%route, "Failed to add route: IP stack disabled?");
+        return;
+    }
+
+    tracing::warn!(%route, "Failed to add route: {}", err_with_src(&e));
 }
 
 // It's okay if this blocks until the route is removed in the OS.


### PR DESCRIPTION
When an IP stack is programmatically disabled, such as with:

> reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters" /v DisabledComponents /t REG_DWORD /d 255 /f

Attempting to interact with this IP stack will yield "NOT_FOUND" errors. These aren't worth reporting to Sentry because there isn't much we can do about it.