### PR TITLE
fix(linux): check for correct sign of netlink error code

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -287,7 +287,7 @@ async fn remove_route(route: &IpNetwork, idx: u32, handle: &Handle) {
 
     // "No such process" is another version of "route does not exist".
     // See <https://askubuntu.com/questions/1330333/what-causes-rtnetlink-answers-no-such-process-when-using-ifdown-command>.
-    if matches!(&err, NetlinkError(err) if err.raw_code() == ESRCH) {
+    if matches!(&err, NetlinkError(err) if err.raw_code() == -ESRCH) {
         return;
     }
 


### PR DESCRIPTION
We've previously tried to handle the "No such process" error from netlink when it tries to remove a route that no longer exists. What we failed to do is use the correct sign for the error code as netlink errors are always negative, yet when printed, the are positive numbers.