### PR TITLE
chore(phoenix-channel): log all errors when connection fails

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4661,6 +4661,7 @@ dependencies = [
  "futures",
  "hex",
  "hostname",
+ "itertools 0.13.0",
  "libc",
  "os_info",
  "rand_core 0.6.4",

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -15,6 +15,7 @@ libc = { workspace = true }
 os_info = { workspace = true }
 rand_core = { workspace = true }
 secrecy = { workspace = true }
+itertools = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -11,11 +11,11 @@ base64 = { workspace = true }
 firezone-logging = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+itertools = { workspace = true }
 libc = { workspace = true }
 os_info = { workspace = true }
 rand_core = { workspace = true }
 secrecy = { workspace = true }
-itertools = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }


### PR DESCRIPTION
Currently, we are only logging the last error when we fail to connect to any of the addresses from the portal. This is often not useful because the last one is likely to be an IPv6 address which may not be supported on the system so all we learn is "The requested address is not valid in its context.".