### PR TITLE
fix(apple/macOS): Move to .idle state after log export

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -251,7 +251,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
   func exportLogs(_ completionHandler: @escaping (Data?) -> Void) {
     func sendChunk(_ tunnelLogArchive: TunnelLogArchive) {
       do {
-        let chunk = try tunnelLogArchive.readChunk()
+        let (chunk, done) = try tunnelLogArchive.readChunk()
+
+        if done {
+          self.logExportState = .idle
+        }
+
         completionHandler(chunk)
       } catch {
         Log.error(error)

--- a/swift/apple/FirezoneNetworkExtension/TunnelLogArchive.swift
+++ b/swift/apple/FirezoneNetworkExtension/TunnelLogArchive.swift
@@ -65,7 +65,7 @@ class TunnelLogArchive {
     )
   }
 
-  func readChunk() throws -> Data {
+  func readChunk() throws -> (Data, Bool) {
     if self.fileHandle == nil {
       // Open the file for reading
       try self.fileHandle = FileHandle(forReadingFrom: archiveURL)
@@ -94,7 +94,7 @@ class TunnelLogArchive {
       cleanup()
     }
 
-    return try encoder.encode(chunk)
+    return try (encoder.encode(chunk), chunk.done)
   }
 
   func cleanup() {


### PR DESCRIPTION
This fixes a bug where we couldn't export logs twice because we never returned to the `.idle` state after export.

Fixes #8015 