### PR TITLE
fix(android): Call disconnect in onDisconnect

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -143,6 +143,11 @@ class TunnelService : VpnService() {
                 repo.clearToken()
                 repo.clearActorName()
 
+                // Free the connlib session
+                connlibSessionPtr?.let {
+                    ConnlibSession.disconnect(it)
+                }
+
                 shutdown()
                 if (startedByUser) {
                     updateStatusNotification(TunnelStatusNotification.SignedOut)

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -19,7 +19,12 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8110">
+          Fixes a minor memory leak that could occur after being disconnected
+          unexpectedly.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.1" date={new Date("2025-01-28")}>
         <ChangeItem pull="7891">
           Substantially reduces memory usage when sending large amounts of data.


### PR DESCRIPTION
We need to call `disconnect()` in `onDisconnect` to free the memory associated with the connlib session.

Related: https://github.com/firezone/firezone/pull/8104