### PR TITLE
refactor(apple): Don't create variables we don't use

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -507,7 +507,8 @@ public struct SettingsView: View {
                 action: {
                   self.isExportingLogs = true
                   Task.detached(priority: .background) { [weak model] in // self can't be weakly captured in views
-                    guard let model else { return }
+                    guard model != nil else { return }
+
                     let archiveURL = LogExporter.tempFile()
                     try await LogExporter.export(to: archiveURL)
                     await MainActor.run {


### PR DESCRIPTION
Both warnings-as-errors and the linter don't error on this particular warning unfortunately.

👎 