### PR TITLE
fix(apple): Persist last notified version

### DIFF
--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -19,7 +19,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8122">
+          Fixes a rare crash that could occur when dismissing the update
+          available notification.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.2" date={new Date("2025-02-13")}>
         <ChangeItem pull="8104">
           Fixes a minor memory leak that could occur after being unexpectedly


### PR DESCRIPTION
Notifications on Apple platforms are delivered with best-effort reliability and are not guaranteed.

They can also be queued up by the system so that, for example, it's possible to issue a notification, quit the app, and then upon the next launch of the app, receive the notification. 

In this second case, if the user dismissed the notification, we will crash. This is because we only track the `lastNotifiedVersion` in the `NotificationAdapter` instance object and don't persist it to disk, then we assert the value not to be nil when saving the user's `dismiss` action.

To fix this, we persist the `lastNotifiedVersion` to the `UserDefaults` store and attempt to read this when the user is dismissing the notification. If we can't read it for some reason, we still dismiss the notification but won't prevent showing it again on the next update check.

A minor bug is also fixed where the original author didn't correctly call the function's `completionHandler`. Also, unused instance vars `lastDismissedVersion` left over from the original author are removed as well.