### PR TITLE
fix(gateway): don't route packets from expired NAT sessions

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -95,9 +95,12 @@ impl GatewayState {
         };
         let cid = peer.id();
 
-        let packet = peer
+        let Some(packet) = peer
             .translate_inbound(packet, now)
-            .context("Failed to translate inbound packet")?;
+            .context("Failed to translate inbound packet")?
+        else {
+            return Ok(None);
+        };
 
         let Some(encrypted_packet) = self
             .node

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -252,7 +252,10 @@ mod tests {
 
         // Assert
         if response_delay >= Duration::from_secs(60) {
-            assert_eq!(translate_incoming, TranslateIncomingResult::NoNatSession);
+            assert_eq!(
+                translate_incoming,
+                TranslateIncomingResult::ExpiredNatSession
+            );
         } else {
             assert_eq!(
                 translate_incoming,

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -31,6 +31,7 @@ impl NatTable {
         let mut removed = Vec::new();
 
         for (outside, e) in self.last_seen.iter() {
+            // After TTL, we move the entry to the `expired` table.
             if now.duration_since(*e) >= TTL {
                 if let Some((inside, _)) = self.table.remove_by_right(outside) {
                     tracing::debug!(?inside, ?outside, "NAT session expired");
@@ -38,6 +39,7 @@ impl NatTable {
                 }
             }
 
+            // After 5 * TTL, we GC the entry to clean up memory.
             if now.duration_since(*e) >= 5 * TTL {
                 if let Some((inside, _)) = self.expired.remove_by_right(outside) {
                     removed.push(inside);

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -22,7 +22,7 @@ pub(crate) struct NatTable {
     pub(crate) last_seen: BTreeMap<(Protocol, IpAddr), Instant>,
 }
 
-const TTL: Duration = Duration::from_secs(60);
+pub(crate) const TTL: Duration = Duration::from_secs(60);
 
 impl NatTable {
     pub(crate) fn handle_timeout(&mut self, now: Instant) {

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8124">
+          Fixes a bug in the routing of DNS resources that would lead to "Source
+          not allowed" errors in the Client logs.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.4" date={new Date("2025-02-11")}>
         <ChangeItem pull="7944">
           Fixes an edge case where a busy Gateway could experience a deadlock


### PR DESCRIPTION
When we receive an inbound packet from the TUN device on the Gateway, we make a lookup in the NAT table to see if it needs to be translated back to a DNS proxy IP.

At present, non-existence of such a NAT entry results in the packet being sent entirely unmodified because that is what needs to happen for CIDR resources. Whilst that is important, the same code path is currently being executed for DNS resources whose NAT session expired! Those packets should be dropped instead which is what we do with this PR.

To differentiate between not having a NAT session at all or whether a previous one existed but is expired now, we keep around all previous "outside" tuples of NAT sessions around. Those are only very small in their memory-footprint. The entire NAT table is scoped to a connection to the given peer and will thus eventually freed once the peer disconnects. This allows us to reliably and cheaply detect, whether a packet is using an expired NAT session. This check must be cheap because all traffic of CIDR resources and the Internet resource needs to perform this check such that we know that they don't have to be translated.

This might be the source of some of the "Source not allowed" errors we have been seeing in client logs.