### PR TITLE
feat(gui-client): gracefully handle missing `resolvectl`

### DIFF
--- a/rust/gui-client/src-common/src/controller.rs
+++ b/rust/gui-client/src-common/src/controller.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, Context, Result};
 use connlib_model::ResourceView;
 use firezone_bin_shared::platform::DnsControlMethod;
 use firezone_headless_client::{
+    InstallationProblem,
     IpcClientMsg::{self, SetDisabledResources},
     IpcServerMsg, IpcServiceError, LogFilterReloader,
 };
@@ -565,6 +566,13 @@ impl<I: GuiIntegration> Controller<'_, I> {
                         .show_alert()
                         .context("Couldn't show Disconnected alert")?;
                 }
+            }
+            IpcServerMsg::InstallationCorrupt(InstallationProblem::ResolveCtlNotFound) => {
+                self.sign_out().await?;
+                self.integration.show_notification(
+                    "Firezone disconnected",
+                    "Unable to find `resolvectl`. Is `systemd-resolved` installed and set up correctly?",
+                )?;
             }
             IpcServerMsg::OnUpdateResources(resources) => {
                 if !self.status.needs_resource_updates() {

--- a/rust/gui-client/src-tauri/src/client/gui/os_linux.rs
+++ b/rust/gui-client/src-tauri/src/client/gui/os_linux.rs
@@ -46,6 +46,8 @@ pub(crate) fn show_update_notification(
 
 /// Show a notification in the bottom right of the screen
 pub(crate) fn show_notification(app: &AppHandle, title: &str, body: &str) -> Result<()> {
+    tracing::debug!(?title, ?body, "show_notification");
+
     app.notification()
         .builder()
         .title(title)

--- a/rust/headless-client/src/dns_control.rs
+++ b/rust/headless-client/src/dns_control.rs
@@ -49,3 +49,7 @@ impl DnsController {
 pub fn system_resolvers_for_gui() -> Result<Vec<IpAddr>> {
     system_resolvers(DnsControlMethod::default())
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("The resolvectl binary could not be found")]
+pub struct ResolveCtlNotFound;

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -36,7 +36,7 @@ pub use clear_logs::clear_logs;
 pub use dns_control::DnsController;
 pub use ipc_service::{
     ipc, run_only_ipc_service, ClientMsg as IpcClientMsg, Error as IpcServiceError,
-    ServerMsg as IpcServerMsg,
+    InstallationProblem, ServerMsg as IpcServerMsg,
 };
 
 use ip_network::{Ipv4Network, Ipv6Network};

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -8,7 +8,13 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os === OS.Linux && (
+          <ChangeItem pull="8127">
+            Notifies the user in case `resolvectl` is not present.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-02-12")}>
         <ChangeItem pull="8105">
           Fixes a visual regression where the Settings and About window lost


### PR DESCRIPTION
On Linux, we rely on `resolvectl` being installed in order to control DNS. If that isn't the case, we send an IPC message back to the GUI in order to sign out and show a notification to the user.