### PR TITLE
fix(gui-client): allow sign-in without saving token to keyring

### DIFF
--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,6 +14,9 @@ export default function GUI({ os }: { os: OS }) {
             Fixes an upload speed performance regression.
           </ChangeItem>
         )}
+        <ChangeItem pull="8129">
+          Allows signing-in without access to the local keyring.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-02-12")}>
         <ChangeItem pull="8105">


### PR DESCRIPTION
Alternative to #8128. If the user dismissed the unlock prompt or has their keyring otherwise misconfigured, it is still useful to allow them to sign-in. They just won't stay signed-in across reboots of the device.