### PR TITLE
refactor(portal): Allow user to migrate internet resource

### DIFF
--- a/elixir/apps/domain/lib/domain/billing/event_handler.ex
+++ b/elixir/apps/domain/lib/domain/billing/event_handler.ex
@@ -300,7 +300,8 @@ defmodule Domain.Billing.EventHandler do
 
           {:ok, internet_gateway_group} = Domain.Gateways.create_internet_group(account)
 
-          {:ok, _resource} = Domain.Resources.create_internet_resource(account, internet_gateway_group)
+          {:ok, _resource} =
+            Domain.Resources.create_internet_resource(account, internet_gateway_group)
 
           :ok
         else

--- a/elixir/apps/domain/lib/domain/billing/event_handler.ex
+++ b/elixir/apps/domain/lib/domain/billing/event_handler.ex
@@ -296,11 +296,11 @@ defmodule Domain.Billing.EventHandler do
               provider_identifier_confirmation: metadata["account_admin_email"] || account_email
             })
 
-          {:ok, _resource} = Domain.Resources.create_internet_resource(account)
-
           {:ok, _gateway_group} = Domain.Gateways.create_group(account, %{name: "Default Site"})
 
-          {:ok, _internet_gateway_group} = Domain.Gateways.create_internet_group(account)
+          {:ok, internet_gateway_group} = Domain.Gateways.create_internet_group(account)
+
+          {:ok, _resource} = Domain.Resources.create_internet_resource(account, internet_gateway_group)
 
           :ok
         else

--- a/elixir/apps/domain/lib/domain/gateways.ex
+++ b/elixir/apps/domain/lib/domain/gateways.ex
@@ -36,6 +36,14 @@ defmodule Domain.Gateways do
     end
   end
 
+  def fetch_internet_group(%Accounts.Account{} = account) do
+    Group.Query.not_deleted()
+    |> Group.Query.by_managed_by(:system)
+    |> Group.Query.by_account_id(account.id)
+    |> Group.Query.by_name("Internet")
+    |> Repo.fetch(Group.Query, [])
+  end
+
   def list_groups(%Auth.Subject{} = subject, opts \\ []) do
     with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_gateways_permission()) do
       Group.Query.not_deleted()
@@ -46,12 +54,14 @@ defmodule Domain.Gateways do
 
   def all_groups!(%Auth.Subject{} = subject) do
     Group.Query.not_deleted()
+    |> Group.Query.by_managed_by(:account)
     |> Authorizer.for_subject(subject)
     |> Repo.all()
   end
 
   def all_groups_for_account!(%Accounts.Account{} = account) do
     Group.Query.not_deleted()
+    |> Group.Query.by_managed_by(:account)
     |> Group.Query.by_account_id(account.id)
     |> Repo.all()
   end

--- a/elixir/apps/domain/lib/domain/gateways/group/query.ex
+++ b/elixir/apps/domain/lib/domain/gateways/group/query.ex
@@ -18,6 +18,14 @@ defmodule Domain.Gateways.Group.Query do
     where(queryable, [groups: groups], groups.account_id == ^account_id)
   end
 
+  def by_managed_by(queryable, managed_by) do
+    where(queryable, [groups: groups], groups.managed_by == ^managed_by)
+  end
+
+  def by_name(queryable, name) do
+    where(queryable, [groups: groups], groups.name == ^name)
+  end
+
   # Pagination
 
   @impl Domain.Repo.Query

--- a/elixir/apps/domain/lib/domain/resources.ex
+++ b/elixir/apps/domain/lib/domain/resources.ex
@@ -231,8 +231,18 @@ defmodule Domain.Resources do
     end
   end
 
-  def create_internet_resource(%Accounts.Account{} = account) do
-    attrs = %{type: :internet, name: "Internet"}
+  def create_internet_resource(%Accounts.Account{} = account, %Gateways.Group{} = group) do
+    attrs = %{
+      type: :internet,
+      name: "Internet",
+      connections: %{
+        group.id => %{
+          gateway_group_id: group.id,
+          enabled: true
+        }
+      }
+    }
+
     changeset = Resource.Changeset.create(account, attrs)
 
     with {:ok, resource} <- Repo.insert(changeset) do
@@ -323,6 +333,11 @@ defmodule Domain.Resources do
 
   def delete_connections_for(%Gateways.Group{} = gateway_group, %Auth.Subject{} = subject) do
     Connection.Query.by_gateway_group_id(gateway_group.id)
+    |> delete_connections(subject)
+  end
+
+  def delete_connections_for(%Resource{} = resource, %Auth.Subject{} = subject) do
+    Connection.Query.by_resource_id(resource.id)
     |> delete_connections(subject)
   end
 

--- a/elixir/apps/domain/lib/domain/resources/connection/changeset.ex
+++ b/elixir/apps/domain/lib/domain/resources/connection/changeset.ex
@@ -18,5 +18,6 @@ defmodule Domain.Resources.Connection.Changeset do
     |> assoc_constraint(:gateway_group)
     |> assoc_constraint(:account)
     |> put_change(:account_id, account_id)
+    |> put_subject_trail(:created_by, :system)
   end
 end

--- a/elixir/apps/domain/lib/domain/resources/connection/changeset.ex
+++ b/elixir/apps/domain/lib/domain/resources/connection/changeset.ex
@@ -6,11 +6,16 @@ defmodule Domain.Resources.Connection.Changeset do
   @required_fields @fields
 
   def changeset(account_id, connection, attrs, %Auth.Subject{} = subject) do
-    changeset(account_id, connection, attrs)
+    base_changeset(account_id, connection, attrs)
     |> put_subject_trail(:created_by, subject)
   end
 
   def changeset(account_id, connection, attrs) do
+    base_changeset(account_id, connection, attrs)
+    |> put_change(:created_by, :system)
+  end
+
+  defp base_changeset(account_id, connection, attrs) do
     connection
     |> cast(attrs, @fields)
     |> validate_required(@required_fields)
@@ -18,6 +23,5 @@ defmodule Domain.Resources.Connection.Changeset do
     |> assoc_constraint(:gateway_group)
     |> assoc_constraint(:account)
     |> put_change(:account_id, account_id)
-    |> put_subject_trail(:created_by, :system)
   end
 end

--- a/elixir/apps/domain/priv/repo/migrations/20240808165513_add_internet_resources.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20240808165513_add_internet_resources.exs
@@ -19,12 +19,5 @@ defmodule Domain.Repo.Migrations.AddInternetResources do
         name: "unique_internet_resource_per_account"
       )
     )
-
-    # Manual migration that needs to be run after deployment
-    # (Domain.Accounts.Account.Query.not_deleted()
-    # |> Domain.Repo.all()
-    # |> Enum.each(fn account ->
-    #   Domain.Resources.create_internet_resource(account)
-    # end))
   end
 end

--- a/elixir/apps/domain/priv/repo/migrations/20250214183755_create_uuid_extension.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250214183755_create_uuid_extension.exs
@@ -1,0 +1,11 @@
+defmodule Domain.Repo.Migrations.CreateUuidExtension do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"")
+  end
+
+  def down do
+    execute("DROP EXTENSION IF EXISTS \"uuid-ossp\"")
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20250214183914_create_internet_site.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250214183914_create_internet_site.exs
@@ -1,0 +1,37 @@
+defmodule Domain.Repo.Migrations.CreateInternetSite do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    INSERT INTO gateway_groups (
+      id,
+      account_id,
+      name,
+      created_by,
+      managed_by,
+      inserted_at,
+      updated_at
+    )
+    SELECT
+      uuid_generate_v4(),
+      id,
+      'Internet',
+      'system',
+      'system',
+      NOW(),
+      NOW()
+    FROM accounts
+    WHERE deleted_at IS NULL
+    """)
+  end
+
+  def down do
+    execute("""
+    DELETE FROM gateway_groups
+    WHERE name = 'Internet'
+      AND created_by = 'system'
+      AND managed_by = 'system'
+      AND account_id IN (SELECT id FROM accounts WHERE deleted_at IS NULL);
+    """)
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20250214183914_create_internet_site.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250214183914_create_internet_site.exs
@@ -22,6 +22,13 @@ defmodule Domain.Repo.Migrations.CreateInternetSite do
       NOW()
     FROM accounts
     WHERE deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM gateway_groups g
+      WHERE g.account_id = a.id
+        AND g.name = 'Internet'
+        AND g.created_by = 'system'
+        AND g.managed_by = 'system')
     """)
   end
 

--- a/elixir/apps/domain/priv/repo/migrations/20250214183914_create_internet_site.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250214183914_create_internet_site.exs
@@ -24,11 +24,11 @@ defmodule Domain.Repo.Migrations.CreateInternetSite do
     WHERE deleted_at IS NULL
     AND NOT EXISTS (
       SELECT 1
-      FROM gateway_groups g
-      WHERE g.account_id = a.id
-        AND g.name = 'Internet'
-        AND g.created_by = 'system'
-        AND g.managed_by = 'system')
+      FROM gateway_groups
+      WHERE gateway_groups.account_id = accounts.id
+        AND gateway_groups.name = 'Internet'
+        AND gateway_groups.created_by = 'system'
+        AND gateway_groups.managed_by = 'system')
     """)
   end
 

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -73,9 +73,16 @@ end
 
 IO.puts("")
 
-for account <- [account, other_account] do
-  Domain.Resources.create_internet_resource(account)
-end
+{:ok, internet_gateway_group} =
+  Gateways.create_internet_group(account)
+
+{:ok, other_internet_gateway_group} =
+  Gateways.create_internet_group(other_account)
+
+Domain.Resources.create_internet_resource(account, internet_gateway_group)
+Domain.Resources.create_internet_resource(other_account, other_internet_gateway_group)
+
+IO.puts("")
 
 {:ok, everyone_group} =
   Domain.Actors.create_managed_group(account, %{
@@ -666,12 +673,6 @@ IO.puts("Created relays:")
 IO.puts("  Group #{relay_group.name}:")
 IO.puts("    IPv4: #{relay.ipv4} IPv6: #{relay.ipv6}")
 IO.puts("")
-
-{:ok, _internet_gateway_group} =
-  Gateways.create_internet_group(account)
-
-{:ok, _internet_gateway_group} =
-  Gateways.create_internet_group(other_account)
 
 gateway_group =
   account

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -8,7 +8,8 @@ defmodule Web.Resources.Edit do
            Resources.fetch_resource_by_id(id, socket.assigns.subject,
              preload: :gateway_groups,
              filter: [
-               deleted?: false
+               deleted?: false,
+               type: [:dns, :ip, :cidr]
              ]
            ) do
       gateway_groups = Gateways.all_groups!(socket.assigns.subject)

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -9,7 +9,7 @@ defmodule Web.Resources.Edit do
              preload: :gateway_groups,
              filter: [
                deleted?: false,
-               type: [:dns, :ip, :cidr]
+               type: ["cidr", "dns", "ip"]
              ]
            ) do
       gateway_groups = Gateways.all_groups!(socket.assigns.subject)

--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -7,19 +7,22 @@ defmodule Web.Resources.Index do
       :ok = Resources.subscribe_to_events_for_account(socket.assigns.account)
     end
 
+    {:ok, internet_site} = Domain.Gateways.fetch_internet_group(socket.assigns.account)
+
     socket =
       socket
       |> assign(page_title: "Resources")
+      |> assign(internet_site: internet_site)
       |> assign_live_table("resources",
         query_module: Resources.Resource.Query,
         sortable_fields: [
           {:resources, :name},
           {:resources, :address}
         ],
-        # TODO: uncomment when internet sites migration is executed
-        # enforce_filters: [
-        #   {:type, {:not_in, ["internet"]}}
-        # ],
+        enforce_filters: [
+          # The Internet Resource is shown in another section
+          {:type, {:not_in, ["internet"]}}
+        ],
         callback: &handle_resources_update!/2
       )
 
@@ -58,8 +61,16 @@ defmodule Web.Resources.Index do
         Resources
       </:title>
       <:help>
-        Resources define the subnets, hosts, and applications for which you want to manage access. You can manage Resources per Site
-        in the <.link navigate={~p"/#{@account}/sites"} class={link_style()}>Sites</.link> section.
+        <p class="mb-2">
+          Resources define the subnets, hosts, and applications for which you want to manage access. You can manage Resources per Site
+          in the <.link navigate={~p"/#{@account}/sites"} class={link_style()}>Sites</.link> section.
+        </p>
+        <p :if={Domain.Accounts.internet_resource_enabled?(@account)}>
+          The Internet Resource can now be managed in the
+          <.link navigate={~p"/#{@account}/sites/#{@internet_site}"} class={link_style()}>
+            Internet Site.
+          </.link>
+        </p>
       </:help>
       <:action>
         <.docs_action path="/deploy/resources" />

--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -7,7 +7,10 @@ defmodule Web.Resources.Index do
       :ok = Resources.subscribe_to_events_for_account(socket.assigns.account)
     end
 
-    {:ok, internet_site} = Domain.Gateways.fetch_internet_group(socket.assigns.account)
+    internet_site = case Domain.Gateways.fetch_internet_group(socket.assigns.account) do
+      {:ok, internet_site} -> internet_site
+      _ -> nil
+    end
 
     socket =
       socket
@@ -65,7 +68,7 @@ defmodule Web.Resources.Index do
           Resources define the subnets, hosts, and applications for which you want to manage access. You can manage Resources per Site
           in the <.link navigate={~p"/#{@account}/sites"} class={link_style()}>Sites</.link> section.
         </p>
-        <p :if={Domain.Accounts.internet_resource_enabled?(@account)}>
+        <p :if={Domain.Accounts.internet_resource_enabled?(@account) && @internet_site}>
           The Internet Resource can now be managed in the
           <.link navigate={~p"/#{@account}/sites/#{@internet_site}"} class={link_style()}>
             Internet Site.

--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -7,10 +7,11 @@ defmodule Web.Resources.Index do
       :ok = Resources.subscribe_to_events_for_account(socket.assigns.account)
     end
 
-    internet_site = case Domain.Gateways.fetch_internet_group(socket.assigns.account) do
-      {:ok, internet_site} -> internet_site
-      _ -> nil
-    end
+    internet_site =
+      case Domain.Gateways.fetch_internet_group(socket.assigns.account) do
+        {:ok, internet_site} -> internet_site
+        _ -> nil
+      end
 
     socket =
       socket

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -114,7 +114,7 @@ defmodule Web.Resources.Show do
           (replaced)
         </span>
       </:title>
-      <:action :if={is_nil(@resource.deleted_at)}>
+      <:action :if={@resource.type != :internet && is_nil(@resource.deleted_at)}>
         <.edit_button navigate={~p"/#{@account}/resources/#{@resource.id}/edit?#{@params}"}>
           Edit Resource
         </.edit_button>

--- a/elixir/apps/web/lib/web/live/sign_up.ex
+++ b/elixir/apps/web/lib/web/live/sign_up.ex
@@ -424,12 +424,6 @@ defmodule Web.SignUp do
       end
     )
     |> Ecto.Multi.run(
-      :internet_resource,
-      fn _repo, %{account: account} ->
-        Domain.Resources.create_internet_resource(account)
-      end
-    )
-    |> Ecto.Multi.run(
       :default_site,
       fn _repo, %{account: account} ->
         Domain.Gateways.create_group(account, %{name: "Default Site"})
@@ -439,6 +433,12 @@ defmodule Web.SignUp do
       :internet_site,
       fn _repo, %{account: account} ->
         Domain.Gateways.create_internet_group(account)
+      end
+    )
+    |> Ecto.Multi.run(
+      :internet_resource,
+      fn _repo, %{account: account, internet_site: internet_site} ->
+        Domain.Resources.create_internet_resource(account, internet_site)
       end
     )
     |> Ecto.Multi.run(

--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -249,8 +249,12 @@ defmodule Web.Sites.Index do
       }>
         <div class="px-1 text-neutral-500">
           <p class="mb-2">
-            WARNING: You need to migrate your existing Internet Resource to this Site before <strong>March 15, 2025</strong>. After this date, it will be permanently migrated
-            for you. Click the button below to migrate now.
+            ACTION REQUIRED: Please migrate your existing Internet Resource to this Site before <strong>March 15, 2025</strong>.
+          </p>
+          <p class="mb-8 text-sm">
+            <.website_link path="/blog/internet-resource-migration">
+              Read more about why this is necessary.
+            </.website_link>
           </p>
           <.button_with_confirmation
             id="migrate_internet_resource"

--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -289,11 +289,6 @@ defmodule Web.Sites.Index do
             </:dialog_cancel_button>
             Migrate Internet Resource
           </.button_with_confirmation>
-          <p class="mt-2 text-sm">
-            <.website_link path="/blog/internet-resource-migration">
-              Read more about why this is necessary.
-            </.website_link>
-          </p>
         </div>
       </:content>
     </.section>

--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -276,9 +276,11 @@ defmodule Web.Sites.Index do
                 Site to the <strong>Internet</strong>
                 Site. This cannot be reversed.
               </p>
+              <p class="mb-2">
+                Any Clients connected to this Resource will be immediately disconnected.
+              </p>
               <p>
-                Any Clients connected to this Resource will be immediately disconnected. You will need to deploy new Gateways in the Internet Site
-                to reconnect them.
+                To minimize downtime, it is recommended to deploy new Gateways in the Internet Site before completing the migration of the Internet Resource.
               </p>
             </:dialog_content>
             <:dialog_confirm_button>

--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -270,9 +270,7 @@ defmodule Web.Sites.Index do
                 Migrating the Internet Resource will permanently
                 move it from the <strong>{@existing_internet_resource_group_name}</strong>
                 Site to the <strong>Internet</strong>
-                Site. This
-                cannot
-                be reversed.
+                Site. This cannot be reversed.
               </p>
               <p>
                 Any Clients connected to this Resource will be immediately disconnected. You will need to deploy new Gateways in the Internet Site

--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -1,38 +1,59 @@
 defmodule Web.Sites.Index do
   use Web, :live_view
   alias Domain.Gateways
+  require Logger
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
       :ok = Gateways.subscribe_to_gateways_presence_in_account(socket.assigns.account)
     end
 
-    with {:ok, managed_groups, _metadata} <-
-           Gateways.list_groups(socket.assigns.subject,
-             preload: [
-               gateways: [:online?]
-             ],
-             filter: [managed_by: "system"]
-           ) do
-      socket =
-        socket
-        |> assign(page_title: "Sites")
-        |> assign(managed_groups: managed_groups)
-        |> assign_live_table("groups",
-          query_module: Gateways.Group.Query,
-          sortable_fields: [
-            {:groups, :name}
-          ],
-          enforce_filters: [
-            {:managed_by, "account"}
-          ],
-          callback: &handle_groups_update!/2
-        )
+    {:ok, managed_groups, _metadata} =
+      Gateways.list_groups(socket.assigns.subject,
+        preload: [
+          gateways: [:online?]
+        ],
+        filter: [
+          managed_by: "system"
+        ]
+      )
 
-      {:ok, socket}
-    else
-      _other -> raise Web.LiveErrors.NotFoundError
-    end
+    {:ok, internet_resource} =
+      Domain.Resources.fetch_internet_resource(socket.assigns.subject,
+        preload: [connections: :gateway_group]
+      )
+
+    existing_connection =
+      Enum.find(internet_resource.connections, fn connection ->
+        connection.gateway_group.name != "Internet"
+      end)
+
+    existing_internet_resource_group_name =
+      case existing_connection do
+        nil -> nil
+        connection -> connection.gateway_group.name
+      end
+
+    internet_gateway_group = Enum.find(managed_groups, fn group -> group.name == "Internet" end)
+
+    socket =
+      socket
+      |> assign(page_title: "Sites")
+      |> assign(internet_resource: internet_resource)
+      |> assign(existing_internet_resource_group_name: existing_internet_resource_group_name)
+      |> assign(internet_gateway_group: internet_gateway_group)
+      |> assign_live_table("groups",
+        query_module: Gateways.Group.Query,
+        sortable_fields: [
+          {:groups, :name}
+        ],
+        enforce_filters: [
+          {:managed_by, "account"}
+        ],
+        callback: &handle_groups_update!/2
+      )
+
+    {:ok, socket}
   end
 
   def handle_params(params, uri, socket) do
@@ -185,14 +206,12 @@ defmodule Web.Sites.Index do
       </:content>
     </.section>
 
-    <% internet_gateway_group =
-      Enum.find(assigns.managed_groups, fn group -> group.name == "Internet" end) %>
-    <.section :if={internet_gateway_group} id="internet-site-banner">
+    <.section id="internet-site-banner">
       <:title>
         <div class="flex items-center space-x-2.5">
           <span>Internet</span>
 
-          <% online? = Enum.any?(internet_gateway_group.gateways, & &1.online?) %>
+          <% online? = Enum.any?(@internet_gateway_group.gateways, & &1.online?) %>
 
           <.ping_icon
             :if={Domain.Accounts.internet_resource_enabled?(@account)}
@@ -212,18 +231,67 @@ defmodule Web.Sites.Index do
         </div>
       </:title>
 
+      <:action>
+        <.docs_action path="/deploy/resources" fragment="the-internet-resource" />
+      </:action>
+
       <:action :if={Domain.Accounts.internet_resource_enabled?(@account)}>
-        <.edit_button navigate={~p"/#{@account}/sites/#{internet_gateway_group}"}>
-          Manage Full-route Tunneling
+        <.edit_button navigate={~p"/#{@account}/sites/#{@internet_gateway_group}"}>
+          Manage Internet Site
         </.edit_button>
       </:action>
 
       <:help>
-        This is a dedicated Site for Internet traffic that does not match any specific Resource.
-        Deploy Gateways here to secure access to the public Internet for your workforce.
+        Use the Internet Site to manage secure, private access to the public internet for your workforce.
       </:help>
 
-      <:content></:content>
+      <:content :if={
+        Domain.Accounts.internet_resource_enabled?(@account) &&
+          needs_internet_resource_migration?(@internet_resource, @internet_gateway_group)
+      }>
+        <div class="px-1 text-neutral-500">
+          <p class="mb-2">
+            WARNING: You need to migrate your existing Internet Resource to this Site before <strong>March 15, 2025</strong>. After this date, it will be permanently migrated
+            for you. Click the button below to migrate now.
+          </p>
+          <.button_with_confirmation
+            id="migrate_internet_resource"
+            style="warning"
+            confirm_style="warning"
+            icon="hero-exclamation-triangle-solid"
+            on_confirm="migrate_internet_resource"
+          >
+            <:dialog_title>Confirm Internet Resource Migration from {@existing_internet_resource_group_name}</:dialog_title>
+            <:dialog_content>
+              <p class="text-center my-8">
+                <.icon name="hero-exclamation-triangle-solid" class="w-16 h-16 text-primary-500" />
+              </p>
+              <p class="mb-2">
+              Migrating the Internet Resource will permanentely
+              move it from the <strong>{@existing_internet_resource_group_name}</strong> Site to the <strong>Internet</strong> Site. This
+              cannot
+              be reversed.
+            </p>
+            <p>
+              Any clients connected to this Resource will be immediately disconnected. You will need to deploy new Gateways in the Internet Site
+              to reconnect them.
+            </p>
+            </:dialog_content>
+            <:dialog_confirm_button>
+              Migrate Internet Resource
+            </:dialog_confirm_button>
+            <:dialog_cancel_button>
+              Cancel
+            </:dialog_cancel_button>
+            Migrate Internet Resource
+          </.button_with_confirmation>
+          <p class="mt-2 text-sm">
+            <.website_link path="/blog/internet-resource-migration">
+              Read more about why this is necessary.
+            </.website_link>
+          </p>
+        </div>
+      </:content>
     </.section>
     """
   end
@@ -237,12 +305,21 @@ defmodule Web.Sites.Index do
         preload: [
           gateways: [:online?]
         ],
-        filter: [managed_by: "system"]
+        filter: [
+          name: "Internet",
+          managed_by: "system"
+        ]
       )
+
+    {:ok, internet_resource} =
+      Domain.Resources.fetch_internet_resource(socket.assigns.subject, preload: :connections)
+
+    internet_gateway_group = Enum.find(managed_groups, fn group -> group.name == "Internet" end)
 
     socket =
       socket
-      |> assign(managed_groups: managed_groups)
+      |> assign(internet_resource: internet_resource)
+      |> assign(internet_gateway_group: internet_gateway_group)
       |> reload_live_table!("groups")
 
     {:noreply, socket}
@@ -250,4 +327,64 @@ defmodule Web.Sites.Index do
 
   def handle_event(event, params, socket) when event in ["paginate", "order_by", "filter"],
     do: handle_live_table_event(event, params, socket)
+
+  def handle_event("migrate_internet_resource", _, socket) do
+    internet_resource = socket.assigns.internet_resource
+    internet_gateway_group = socket.assigns.internet_gateway_group
+
+    case migrate_internet_resource(
+           internet_resource,
+           internet_gateway_group,
+           socket.assigns.subject
+         ) do
+      {:ok, internet_resource} ->
+        dbg(internet_resource)
+
+        socket =
+          socket
+          |> assign(internet_resource: internet_resource)
+          |> put_flash(:info, "Internet Resource migrated successfully.")
+
+        {:noreply, socket}
+
+      _ ->
+        {:noreply, socket |> put_flash(:error, "Failed to migrate Internet Resource.")}
+    end
+  end
+
+  defp needs_internet_resource_migration?(internet_resource, internet_gateway_group) do
+    # can only be in the internet site now
+    length(internet_resource.connections) > 1 ||
+      Enum.all?(internet_resource.connections, fn connection ->
+        connection.gateway_group_id != internet_gateway_group.id
+      end)
+  end
+
+  defp migrate_internet_resource(internet_resource, internet_gateway_group, subject) do
+    attrs = %{
+      connections: %{
+        internet_gateway_group.id => %{
+          gateway_group_id: internet_gateway_group.id,
+          resource_id: internet_resource.id,
+          enabled: true
+        }
+      }
+    }
+
+    Domain.Repo.transaction(fn ->
+      with {:ok, _count} <- Domain.Resources.delete_connections_for(internet_resource, subject),
+           {:updated, resource} <-
+             Domain.Resources.update_or_replace_resource(internet_resource, attrs, subject) do
+        resource
+      else
+        {:error, changeset} ->
+          Logger.error("Failed to migrate Internet Resource",
+            reason: inspect(changeset),
+            account: internet_resource.account_id
+          )
+
+          Domain.Repo.rollback(changeset)
+      end
+    end)
+  end
 end

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -1,7 +1,6 @@
 defmodule Web.Sites.Show do
   use Web, :live_view
-  import Web.Policies.Components
-  alias Domain.{Accounts, Gateways, Resources, Policies, Flows, Tokens}
+  alias Domain.{Gateways, Resources, Policies, Flows, Tokens}
 
   def mount(%{"id" => id}, _session, socket) do
     with {:ok, group} <-
@@ -195,11 +194,10 @@ defmodule Web.Sites.Show do
       </:action>
 
       <:help :if={@group.managed_by == :system and @group.name == "Internet"}>
-        The Internet Site is a dedicated Site for Internet traffic that does not match any specific Resource.
-        Deploy Gateways here to secure access to the public Internet for your workforce.
+        Use this Site to manage secure, private access to the public internet for your workforce.
       </:help>
 
-      <:content>
+      <:content :if={@group.managed_by != :system and @group.name != "Internet"}>
         <.vertical_table id="group">
           <.vertical_table_row>
             <:label>Name</:label>
@@ -452,61 +450,9 @@ defmodule Web.Sites.Show do
                 >
                   Add a policy
                 </.link>
-                to allow usage of the Internet Site.
+                to configure access to the internet.
               </div>
             </div>
-          </:empty>
-        </.live_table>
-      </:content>
-    </.section>
-
-    <.section :if={@group.managed_by == :system and @group.name == "Internet"}>
-      <:title>Recent Connections</:title>
-      <:help>
-        Recent connections opened by Actors to the Internet.
-      </:help>
-      <:content>
-        <.live_table
-          id="flows"
-          rows={@flows}
-          row_id={&"flows-#{&1.id}"}
-          filters={@filters_by_table_id["flows"]}
-          filter={@filter_form_by_table_id["flows"]}
-          ordered_by={@order_by_table_id["flows"]}
-          metadata={@flows_metadata}
-        >
-          <:col :let={flow} label="authorized">
-            <.relative_datetime datetime={flow.inserted_at} />
-          </:col>
-          <:col :let={flow} label="policy">
-            <.link navigate={~p"/#{@account}/policies/#{flow.policy_id}"} class={[link_style()]}>
-              <.policy_name policy={flow.policy} />
-            </.link>
-          </:col>
-          <:col :let={flow} label="client, actor" class="w-3/12">
-            <.link navigate={~p"/#{@account}/clients/#{flow.client_id}"} class={[link_style()]}>
-              {flow.client.name}
-            </.link>
-            owned by
-            <.link navigate={~p"/#{@account}/actors/#{flow.client.actor_id}"} class={[link_style()]}>
-              {flow.client.actor.name}
-            </.link>
-            {flow.client_remote_ip}
-          </:col>
-          <:col :let={flow} label="gateway" class="w-3/12">
-            <.link navigate={~p"/#{@account}/gateways/#{flow.gateway_id}"} class={[link_style()]}>
-              {flow.gateway.group.name}-{flow.gateway.name}
-            </.link>
-            <br />
-            <code class="text-xs">{flow.gateway_remote_ip}</code>
-          </:col>
-          <:col :let={flow} :if={Accounts.flow_activities_enabled?(@account)} label="activity">
-            <.link navigate={~p"/#{@account}/flows/#{flow.id}"} class={[link_style()]}>
-              Show
-            </.link>
-          </:col>
-          <:empty>
-            <div class="text-center text-neutral-500 p-4">No activity to display.</div>
           </:empty>
         </.live_table>
       </:content>

--- a/elixir/apps/web/test/web/live/sites/show_test.exs
+++ b/elixir/apps/web/test/web/live/sites/show_test.exs
@@ -570,7 +570,7 @@ defmodule Web.Live.Sites.ShowTest do
       gateway = Fixtures.Gateways.create_gateway(account: account, group: group)
       gateway = Repo.preload(gateway, :group)
 
-      {:ok, resource} = Domain.Resources.create_internet_resource(account)
+      {:ok, resource} = Domain.Resources.create_internet_resource(account, group)
 
       %{
         group: group,

--- a/elixir/apps/web/test/web/live/sites/show_test.exs
+++ b/elixir/apps/web/test/web/live/sites/show_test.exs
@@ -579,7 +579,7 @@ defmodule Web.Live.Sites.ShowTest do
       }
     end
 
-    test "does not allow to editing", %{
+    test "does not allow editing", %{
       account: account,
       group: group,
       identity: identity,
@@ -591,27 +591,6 @@ defmodule Web.Live.Sites.ShowTest do
         |> live(~p"/#{account}/sites/#{group}")
 
       refute has_element?(lv, "a", "Edit Site")
-    end
-
-    test "renders group details", %{
-      account: account,
-      identity: identity,
-      group: group,
-      conn: conn
-    } do
-      {:ok, lv, _html} =
-        conn
-        |> authorize_conn(identity)
-        |> live(~p"/#{account}/sites/#{group}")
-
-      table =
-        lv
-        |> element("#group")
-        |> render()
-        |> vertical_table_to_map()
-
-      assert table["name"] =~ "Internet"
-      assert table["created"] =~ "system"
     end
 
     test "renders online gateways table", %{
@@ -742,45 +721,6 @@ defmodule Web.Live.Sites.ShowTest do
                assert row["id"]
                assert row["status"] == "Active"
              end)
-    end
-
-    test "renders logs table", %{
-      account: account,
-      identity: identity,
-      group: group,
-      resource: resource,
-      conn: conn
-    } do
-      flow =
-        Fixtures.Flows.create_flow(
-          account: account,
-          resource: resource
-        )
-
-      flow =
-        Repo.preload(flow, client: [:actor], gateway: [:group], policy: [:actor_group, :resource])
-
-      {:ok, lv, _html} =
-        conn
-        |> authorize_conn(identity)
-        |> live(~p"/#{account}/sites/#{group}")
-
-      [row] =
-        lv
-        |> element("#flows")
-        |> render()
-        |> table_to_map()
-
-      assert row["authorized"]
-      assert row["policy"] =~ flow.policy.actor_group.name
-      assert row["policy"] =~ flow.policy.resource.name
-
-      assert row["gateway"] ==
-               "#{flow.gateway.group.name}-#{flow.gateway.name} #{flow.gateway.last_seen_remote_ip}"
-
-      assert row["client, actor"] =~ flow.client.name
-      assert row["client, actor"] =~ "owned by #{flow.client.actor.name}"
-      assert row["client, actor"] =~ to_string(flow.client_remote_ip)
     end
 
     test "does not allow deleting the group", %{


### PR DESCRIPTION
Building on top of #6905, we add a `Migrate Internet Resource` button that allows the admin to preemptively migrate their Internet Resource to the new Internet Site.

<img width="1233" alt="Screenshot 2025-02-13 at 11 10 19 PM" src="https://github.com/user-attachments/assets/25036e9e-af9a-4515-952e-344b25a53d63" />

<img width="728" alt="Screenshot 2025-02-13 at 11 09 50 PM" src="https://github.com/user-attachments/assets/13ea42af-5fb1-4e9d-b96c-9f28c6a91f9d" />
