### PR TITLE
fix(android): make task dependencies explicit

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -250,3 +250,7 @@ tasks.matching { it.name.matches(Regex("merge.*JniLibFolders")) }.configureEach 
     inputs.dir(layout.buildDirectory.file("rustJniLibs/android"))
     dependsOn("cargoBuild")
 }
+
+tasks.matching { it.name == "appDistributionUploadRelease" }.configureEach {
+    dependsOn("processReleaseGoogleServices")
+}


### PR DESCRIPTION
Fixes a new issue gradle seems to complain about:

https://github.com/firezone/firezone/actions/runs/13339271704