### PR TITLE
fix(portal): Fix typo in sites index

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/index.ex
+++ b/elixir/apps/web/lib/web/live/sites/index.ex
@@ -25,7 +25,8 @@ defmodule Web.Sites.Index do
              ),
            connection when not is_nil(connection) <-
              Enum.find(internet_resource.connections, fn connection ->
-               connection.gateway_group.name != "Internet" && connection.managed_by != "system"
+               connection.gateway_group.name != "Internet" &&
+                 connection.gateway_group.managed_by != "system"
              end) do
         {internet_resource, connection.gateway_group.name}
       else


### PR DESCRIPTION
Fixes a typo introduced in #6905 