### PR TITLE
chore(portal): Log metrics that failed to flush

### DIFF
--- a/elixir/apps/domain/lib/domain/telemetry/reporter/google_cloud_metrics.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/reporter/google_cloud_metrics.ex
@@ -279,6 +279,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetrics do
           {:error, reason} ->
             Logger.warning("Failed to send metrics to Google Cloud Monitoring API",
               reason: inspect(reason),
+              time_series: inspect(time_series),
               count: buffer_size
             )
         end


### PR DESCRIPTION
When flushing metrics to GCP, we sometimes get the following error:

```
{400, "{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"One or more TimeSeries could not be written: timeSeries[0-51]: write for resource=gce_instance{zone:us-east1-d,instance_id:6130184649770384727} failed with: One or more points were written more frequently than the maximum sampling period configured for the metric.\",\n    \"status\": \"INVALID_ARGUMENT\",\n    \"details\": [\n      {\n        \"@type\": \"type.googleapis.com/google.monitoring.v3.CreateTimeSeriesSummary\",\n        \"totalPointCount\": 52,\n        \"successPointCount\": 48,\n        \"errors\": [\n          {\n            \"status\": {\n              \"code\": 9\n            },\n            \"pointCount\": 4\n          }\n        ]\n      }\n    ]\n  }\n}\n"}
```

It would be helpful to know exactly which metrics are failing to flush so we can further troubleshoot any issues.