### PR TITLE
fix(portal): Connect internet resource to internet site

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20250217005824_connect_internet_resource_to_internet_site.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250217005824_connect_internet_resource_to_internet_site.exs
@@ -1,0 +1,28 @@
+defmodule Domain.Repo.Migrations.ConnectInternetResourceToInternetSite do
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    INSERT INTO resource_connections (account_id, resource_id, gateway_group_id, created_by)
+    SELECT
+      a.id AS account_id,
+      r.id AS resource_id,
+      gg.id AS gateway_group_id,
+      'system' AS created_by
+    FROM accounts a
+    JOIN resources r ON r.account_id = a.id
+    JOIN gateway_groups gg ON gg.account_id = a.id
+    WHERE
+      a.deleted_at IS NULL
+      AND r.type = 'internet'
+      AND gg.managed_by = 'system'
+      AND gg.name = 'Internet'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM resource_connections rc
+        WHERE rc.account_id = a.id
+          AND rc.resource_id = r.id
+      )
+    """)
+  end
+end


### PR DESCRIPTION
With the internet site changes now in, editing the Internet Resource is impossible.

As such, the old instructions for using the Internet Resource no longer apply, and we need to make sure the Internet Site and Internet Resource are linked.

This migration ensures that's the case. However, if the internet resource is currently connected to another site already, we don't move it. This is only for internet resources that aren't connected to any sites yet.