### PR TITLE
fix(gui-client): update telemetry context on new session

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -328,7 +328,7 @@ fn connect(
 
     let mut telemetry = Telemetry::default();
     telemetry.start(&api_url, RELEASE, ANDROID_DSN);
-    telemetry.set_firezone_id(device_id.clone());
+    Telemetry::set_firezone_id(device_id.clone());
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
     install_rustls_crypto_provider();

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -239,8 +239,8 @@ impl WrappedSession {
     ) -> Result<Self> {
         let mut telemetry = Telemetry::default();
         telemetry.start(&api_url, RELEASE, APPLE_DSN);
-        telemetry.set_firezone_id(device_id.clone());
-        telemetry.set_account_slug(account_slug);
+        Telemetry::set_firezone_id(device_id.clone());
+        Telemetry::set_account_slug(account_slug);
 
         init_logging(log_dir.into(), log_filter)?;
         install_rustls_crypto_provider();

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> ExitCode {
         .expect("Failed to create tokio runtime");
 
     match runtime
-        .block_on(try_main(cli, &mut telemetry))
+        .block_on(try_main(cli))
         .context("Failed to start Gateway")
     {
         Ok(ExitCode::SUCCESS) => {
@@ -97,13 +97,13 @@ fn has_necessary_permissions() -> bool {
     is_root || has_net_admin
 }
 
-async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<ExitCode> {
+async fn try_main(cli: Cli) -> Result<ExitCode> {
     firezone_logging::setup_global_subscriber(layer::Identity::default())
         .context("Failed to set up logging")?;
 
     let firezone_id = get_firezone_id(cli.firezone_id).await
         .context("Couldn't read FIREZONE_ID or write it to disk: Please provide it through the env variable or provide rw access to /var/lib/firezone/")?;
-    telemetry.set_firezone_id(firezone_id.clone());
+    Telemetry::set_firezone_id(firezone_id.clone());
 
     let login = LoginUrl::gateway(
         cli.api_url,

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -3,7 +3,7 @@ use clap::{Args, Parser};
 use firezone_gui_client_common::{
     self as common, controller::Failure, deep_link, settings::AdvancedSettings,
 };
-use firezone_telemetry as telemetry;
+use firezone_telemetry::{self as telemetry, Telemetry};
 use tracing::instrument;
 use tracing_subscriber::EnvFilter;
 
@@ -101,7 +101,7 @@ fn run_gui(cli: Cli) -> Result<()> {
     // Get the device ID before starting Tokio, so that all the worker threads will inherit the correct scope.
     // Technically this means we can fail to get the device ID on a newly-installed system, since the IPC service may not have fully started up when the GUI process reaches this point, but in practice it's unlikely.
     if let Ok(id) = firezone_headless_client::device_id::get() {
-        telemetry.set_firezone_id(id.id);
+        Telemetry::set_firezone_id(id.id);
     }
     fix_log_filter(&mut settings)?;
     let common::logging::Handles {

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -3,7 +3,7 @@ use clap::{Args, Parser};
 use firezone_gui_client_common::{
     self as common, controller::Failure, deep_link, settings::AdvancedSettings,
 };
-use firezone_telemetry::{self as telemetry, Telemetry};
+use firezone_telemetry::Telemetry;
 use tracing::instrument;
 use tracing_subscriber::EnvFilter;
 
@@ -60,11 +60,11 @@ pub(crate) fn run() -> Result<()> {
         Some(Cmd::SmokeTest) => {
             // Can't check elevation here because the Windows CI is always elevated
             let settings = common::settings::load_advanced_settings().unwrap_or_default();
-            let mut telemetry = telemetry::Telemetry::default();
+            let mut telemetry = Telemetry::default();
             telemetry.start(
                 settings.api_url.as_ref(),
                 firezone_gui_client_common::RELEASE,
-                telemetry::GUI_DSN,
+                firezone_telemetry::GUI_DSN,
             );
             // Don't fix the log filter for smoke tests
             let common::logging::Handles {
@@ -91,12 +91,12 @@ pub(crate) fn run() -> Result<()> {
 // Can't `instrument` this because logging isn't running when we enter it.
 fn run_gui(cli: Cli) -> Result<()> {
     let mut settings = common::settings::load_advanced_settings().unwrap_or_default();
-    let mut telemetry = telemetry::Telemetry::default();
+    let mut telemetry = Telemetry::default();
     // In the future telemetry will be opt-in per organization, that's why this isn't just at the top of `main`
     telemetry.start(
         settings.api_url.as_ref(),
         firezone_gui_client_common::RELEASE,
-        telemetry::GUI_DSN,
+        firezone_telemetry::GUI_DSN,
     );
     // Get the device ID before starting Tokio, so that all the worker threads will inherit the correct scope.
     // Technically this means we can fail to get the device ID on a newly-installed system, since the IPC service may not have fully started up when the GUI process reaches this point, but in practice it's unlikely.

--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -242,7 +242,6 @@ pub(crate) fn run(
                     ctlr_rx,
                     advanced_settings,
                     reloader,
-                    &mut telemetry,
                     updates_rx,
                 )).catch_unwind().await;
 

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -257,7 +257,7 @@ async fn ipc_listen(
         .context("Failed to read / create device ID")?
         .id;
 
-    telemetry.set_firezone_id(firezone_id);
+    Telemetry::set_firezone_id(firezone_id);
 
     let mut server = IpcServer::new(ServiceId::Prod).await?;
     let mut dns_controller = DnsController { dns_control_method };
@@ -564,7 +564,7 @@ impl<'a> Handler<'a> {
                     .start(&environment, &release, firezone_telemetry::GUI_DSN);
 
                 if let Some(account_slug) = account_slug {
-                    self.telemetry.set_account_slug(account_slug);
+                    Telemetry::set_account_slug(account_slug);
                 }
             }
         }
@@ -581,7 +581,7 @@ impl<'a> Handler<'a> {
 
         assert!(self.session.is_none());
         let device_id = device_id::get_or_create().context("Failed to get-or-create device ID")?;
-        self.telemetry.set_firezone_id(device_id.id.clone());
+        Telemetry::set_firezone_id(device_id.id.clone());
 
         let url = LoginUrl::client(
             Url::parse(api_url).context("Failed to parse URL")?,

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -179,7 +179,7 @@ fn main() -> Result<()> {
         Some(id) => id,
         None => device_id::get_or_create().context("Could not get `firezone_id` from CLI, could not read it from disk, could not generate it and save it to disk")?.id,
     };
-    telemetry.set_firezone_id(firezone_id.clone());
+    Telemetry::set_firezone_id(firezone_id.clone());
 
     let url = LoginUrl::client(
         cli.api_url,

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -143,26 +143,26 @@ impl Telemetry {
         .await;
     }
 
-    pub fn set_account_slug(&mut self, slug: String) {
-        self.update_user(|user| {
+    pub fn set_account_slug(slug: String) {
+        update_user(|user| {
             user.other.insert("account_slug".to_owned(), slug.into());
         });
     }
 
-    pub fn set_firezone_id(&mut self, id: String) {
-        self.update_user(|user| {
+    pub fn set_firezone_id(id: String) {
+        update_user(|user| {
             user.id = Some(id);
         });
     }
+}
 
-    fn update_user(&mut self, update: impl FnOnce(&mut sentry::User)) {
-        sentry::Hub::main().configure_scope(|scope| {
-            let mut user = scope.user().cloned().unwrap_or_default();
-            update(&mut user);
+fn update_user(update: impl FnOnce(&mut sentry::User)) {
+    sentry::Hub::main().configure_scope(|scope| {
+        let mut user = scope.user().cloned().unwrap_or_default();
+        update(&mut user);
 
-            scope.set_user(Some(user));
-        });
-    }
+        scope.set_user(Some(user));
+    });
 }
 
 fn set_current_user(user: Option<sentry::User>) {


### PR DESCRIPTION
Every time we start a new session, our telemetry context potentially changes, i.e. the user may sign into a new account. This should ensure that both the IPC service and the GUI always use the most up-to-date `account_slug` as part of Sentry events. In addition, this will also set the `account_slug` for clients that just signed in. Previously, the `account_slug` would only get populated on the next start of the client.