### PR TITLE
fix(windows): don't double shutdown session

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -203,9 +203,6 @@ impl Drop for Tun {
             "Shutting down packet channel..."
         );
         self.inbound_rx.close(); // This avoids a deadlock when we join the worker thread, see PR 5571
-        if let Err(error) = self.session.shutdown() {
-            tracing::error!("wintun::Session::shutdown: {error:#}");
-        }
         if let Err(error) = self
             .recv_thread
             .take()

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -17,6 +17,12 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull="8129">
           Allows signing-in without access to the local keyring.
         </ChangeItem>
+        {os === OS.Windows && (
+          <ChangeItem pull="8156">
+            Fixes a race condition that attempted to remove the WinTUN adapter
+            twice upon shutdown.
+          </ChangeItem>
+        )}
       </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-02-12")}>
         <ChangeItem pull="8105">


### PR DESCRIPTION
The `wintun` crate will already shutdown the session for us when the last instance of `Session` gets dropped. Shutting down the session prior to that already results in an attempt to close an adapter that is no longer present, causing WinTUN to log (unactionable) errors.