### PR TITLE
fix(infra): Fix SSH firewall rules; enforce Relays IAP

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -13,6 +13,10 @@ locals {
     "35.235.240.0/20"
   ]
 
+  iap_ipv6_ranges = [
+    "2600:2d00:1:7::/64"
+  ]
+
   gateway_image_tag = var.gateway_image_tag != null ? var.gateway_image_tag : var.image_tag
   relay_image_tag   = var.relay_image_tag != null ? var.relay_image_tag : var.image_tag
   portal_image_tag  = var.portal_image_tag != null ? var.portal_image_tag : var.image_tag
@@ -232,16 +236,6 @@ resource "google_compute_firewall" "ssh-ipv4" {
     ports    = [22]
   }
 
-  allow {
-    protocol = "udp"
-    ports    = [22]
-  }
-
-  allow {
-    protocol = "sctp"
-    ports    = [22]
-  }
-
   log_config {
     metadata = "INCLUDE_ALL_METADATA"
   }
@@ -251,7 +245,32 @@ resource "google_compute_firewall" "ssh-ipv4" {
   target_tags = concat(
     module.web.target_tags,
     module.api.target_tags,
-    module.domain.target_tags
+    module.domain.target_tags,
+    module.relays[0].target_tags
+  )
+}
+
+resource "google_compute_firewall" "ssh-ipv6" {
+  project = module.google-cloud-project.project.project_id
+
+  name    = "iap-ssh-ipv6"
+  network = module.google-cloud-vpc.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = [22]
+  }
+
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+
+  source_ranges = local.iap_ipv6_ranges
+  target_tags = concat(
+    module.web.target_tags,
+    module.api.target_tags,
+    module.domain.target_tags,
+    module.relays[0].target_tags
   )
 }
 

--- a/terraform/environments/production/relays.tf
+++ b/terraform/environments/production/relays.tf
@@ -384,34 +384,6 @@ module "relays" {
   token   = var.relay_token
 }
 
-# Allow SSH access using IAP for relays
-resource "google_compute_firewall" "relays-ssh-ipv4" {
-  count   = length(module.relays) > 0 ? 1 : 0
-  project = module.google-cloud-project.project.project_id
-  name    = "relays-ssh-ipv4"
-  network = google_compute_network.network.self_link
-  allow {
-    protocol = "tcp"
-    ports    = [22]
-  }
-  allow {
-    protocol = "udp"
-    ports    = [22]
-  }
-  allow {
-    protocol = "sctp"
-    ports    = [22]
-  }
-
-  log_config {
-    metadata = "INCLUDE_ALL_METADATA"
-  }
-
-  # Only allows connections using IAP
-  source_ranges = local.iap_ipv4_ranges
-  target_tags   = module.relays[0].target_tags
-}
-
 # Trigger an alert when there is at least one region without a healthy relay
 resource "google_monitoring_alert_policy" "connected_relays_count" {
   project = module.google-cloud-project.project.project_id

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -23,6 +23,10 @@ locals {
     "35.235.240.0/20"
   ]
 
+  iap_ipv6_ranges = [
+    "2600:2d00:1:7::/64"
+  ]
+
   gateway_image_tag = var.gateway_image_tag != null ? var.gateway_image_tag : var.image_tag
   relay_image_tag   = var.relay_image_tag != null ? var.relay_image_tag : var.image_tag
   portal_image_tag  = var.portal_image_tag != null ? var.portal_image_tag : var.image_tag
@@ -152,7 +156,7 @@ module "google-cloud-sql" {
 resource "google_compute_firewall" "ssh-ipv4" {
   project = module.google-cloud-project.project.project_id
 
-  name    = "ssh-ipv4"
+  name    = "iap-ssh-ipv4"
   network = module.google-cloud-vpc.self_link
 
   allow {
@@ -160,29 +164,23 @@ resource "google_compute_firewall" "ssh-ipv4" {
     ports    = [22]
   }
 
-  allow {
-    protocol = "udp"
-    ports    = [22]
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
   }
 
-  allow {
-    protocol = "sctp"
-    ports    = [22]
-  }
-
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = local.iap_ipv4_ranges
   target_tags = concat(
     module.web.target_tags,
     module.api.target_tags,
     module.domain.target_tags,
-    length(module.relays) > 0 ? module.relays[0].target_tags : []
+    module.relays[0].target_tags
   )
 }
 
 resource "google_compute_firewall" "ssh-ipv6" {
   project = module.google-cloud-project.project.project_id
 
-  name    = "ssh-ipv6"
+  name    = "iap-ssh-ipv6"
   network = module.google-cloud-vpc.self_link
 
   allow {
@@ -190,21 +188,16 @@ resource "google_compute_firewall" "ssh-ipv6" {
     ports    = [22]
   }
 
-  allow {
-    protocol = "udp"
-    ports    = [22]
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
   }
 
-  allow {
-    protocol = "sctp"
-    ports    = [22]
-  }
-
-  source_ranges = ["::/0"]
+  source_ranges = local.iap_ipv6_ranges
   target_tags = concat(
     module.web.target_tags,
     module.api.target_tags,
-    module.domain.target_tags
+    module.domain.target_tags,
+    module.relays[0].target_tags
   )
 }
 

--- a/terraform/environments/staging/relays.tf
+++ b/terraform/environments/staging/relays.tf
@@ -384,34 +384,6 @@ module "relays" {
   token   = var.relay_token
 }
 
-# Allow SSH access using IAP for relays
-resource "google_compute_firewall" "relays-ssh-ipv4" {
-  count   = length(module.relays) > 0 ? 1 : 0
-  project = module.google-cloud-project.project.project_id
-  name    = "relays-ssh-ipv4"
-  network = module.google-cloud-vpc.id
-  allow {
-    protocol = "tcp"
-    ports    = [22]
-  }
-  allow {
-    protocol = "udp"
-    ports    = [22]
-  }
-  allow {
-    protocol = "sctp"
-    ports    = [22]
-  }
-
-  log_config {
-    metadata = "INCLUDE_ALL_METADATA"
-  }
-
-  # Only allows connections using IAP
-  source_ranges = local.iap_ipv4_ranges
-  target_tags   = module.relays[0].target_tags
-}
-
 # Trigger an alert when there is at least one region without a healthy relay
 resource "google_monitoring_alert_policy" "connected_relays_count" {
   project = module.google-cloud-project.project.project_id


### PR DESCRIPTION
This PR resolves more drift between staging and prod in the area of SSH firewall rules:

- Adds IPv6 SSH IAP access to prod firewall
- Removes SCTP and UDP port 22 access (this is not required by SSH)
- Enforces IAP for SSH access on staging
- Enable firewall logging for SSH on staging