### PR TITLE
feat(windows): introduce dedicated "TUN send" thread

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1988,6 +1988,7 @@ dependencies = [
  "socket-factory",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "tracing",
  "tun",
  "uuid",

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -41,6 +41,7 @@ windows-core = "0.58.0"
 windows-implement = "0.58.0"
 wintun = "0.5.1"
 winreg = { workspace = true }
+tokio-util = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true

--- a/rust/bin-shared/benches/tunnel.rs
+++ b/rust/bin-shared/benches/tunnel.rs
@@ -80,6 +80,8 @@ mod platform {
                     panic!("Wrong request code");
                 }
 
+                poll_fn(|cx| tun.poll_send_ready(cx)).await.unwrap();
+
                 tun.send(
                     ip_packet::make::udp_packet(
                         original_pkt.destination(),

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -197,7 +197,6 @@ pub struct Tun {
     inbound_rx: mpsc::Receiver<IpPacket>,
     send_thread: Option<std::thread::JoinHandle<()>>,
     recv_thread: Option<std::thread::JoinHandle<()>>,
-    session: Arc<wintun::Session>,
     luid: wintun::NET_LUID_LH,
 }
 
@@ -269,7 +268,6 @@ impl Tun {
             recv_thread: Some(recv_thread),
             outbound_tx: PollSender::new(outbound_tx),
             inbound_rx,
-            session: Arc::clone(&session),
         })
     }
 

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -207,6 +207,7 @@ impl Drop for Tun {
             "Shutting down packet channel..."
         );
 
+        self.outbound_tx.close();
         self.inbound_rx.close(); // This avoids a deadlock when we join the worker thread, see PR 5571
 
         if let Err(error) = self

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -207,8 +207,9 @@ impl Drop for Tun {
             "Shutting down packet channel..."
         );
 
+        // Close channels to avoid deadlocks, see <https://github.com/firezone/firezone/pull/5571>.
         self.outbound_tx.close();
-        self.inbound_rx.close(); // This avoids a deadlock when we join the worker thread, see PR 5571
+        self.inbound_rx.close();
 
         if let Err(error) = self
             .recv_thread


### PR DESCRIPTION
Same as done for unix-based operation systems in #8117, we introduce a dedicated "TUN send" thread for Windows in this PR. Not only does this move the syscalls and copying of sending packets away from `connlib`'s main thread but it also establishes backpressure between those threads properly.

WinTUN does not have any ability to signal that it has space in its send buffer. If it fails to allocate a packet for sending, it will return `ERROR_BUFFER_OVERFLOW` [0]. We now handle this case gracefully by suspending the send thread for 10ms and then try again. This isn't a great way of establishing back-pressure but at least we don't have any packet loss.

To test this, I temporarily lowered the ring buffer size and ran a speed test. In that, I could confirm that `ERROR_BUFFER_OVERFLOW` is indeed emitted and handled as intended.

[0]: https://git.zx2c4.com/wintun/tree/api/session.c#n267