### PR TITLE
fix(infra): Remove unused ingress Relay UDP ports

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -404,37 +404,6 @@ resource "google_compute_firewall" "http-health-checks" {
   }
 }
 
-# Allow inbound traffic
-resource "google_compute_firewall" "ingress-ipv4" {
-  project = var.project_id
-
-  name      = "${local.application_name}-ingress-ipv4"
-  network   = var.network
-  direction = "INGRESS"
-
-  target_tags   = ["app-${local.application_name}"]
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "udp"
-  }
-}
-
-resource "google_compute_firewall" "ingress-ipv6" {
-  project = var.project_id
-
-  name      = "${local.application_name}-ingress-ipv6"
-  network   = var.network
-  direction = "INGRESS"
-
-  target_tags   = ["app-${local.application_name}"]
-  source_ranges = ["::/0"]
-
-  allow {
-    protocol = "udp"
-  }
-}
-
 # Allow outbound traffic
 resource "google_compute_firewall" "egress-ipv4" {
   project = var.project_id


### PR DESCRIPTION
These are redundant since we explicitly allow STUN/TURN traffic a few lines up.