### PR TITLE
chore(portal): Optionally drop `NotFoundError` to sentry

### DIFF
--- a/elixir/apps/domain/lib/domain/telemetry/sentry.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/sentry.ex
@@ -1,0 +1,13 @@
+defmodule Domain.Telemetry.Sentry do
+  def before_send(%{original_exception: %{report_to_sentry: report_to_sentry}} = event) do
+    if report_to_sentry do
+      event
+    else
+      nil
+    end
+  end
+
+  def before_send(event) do
+    event
+  end
+end

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -25,7 +25,7 @@ defmodule Web.SignIn do
       {:ok, socket}
     else
       _other ->
-        raise Web.LiveErrors.NotFoundError
+        raise Web.LiveErrors.NotFoundError, report_to_sentry: false
     end
   end
 

--- a/elixir/apps/web/lib/web/live_errors.ex
+++ b/elixir/apps/web/lib/web/live_errors.ex
@@ -1,6 +1,6 @@
 defmodule Web.LiveErrors do
   defmodule NotFoundError do
-    defexception message: "Not Found"
+    defexception message: "Not Found", report_to_sentry: true
 
     defimpl Plug.Exception do
       def status(_exception), do: 404

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -278,6 +278,19 @@ config :workos, WorkOS.Client,
   client_id: "client_123456789",
   baseurl: "https://api.workos.com"
 
+# Base Sentry config
+config :sentry,
+  before_send: {Domain.Telemetry.Sentry, :before_send},
+  # disable Sentry by default, enable in runtime.exs
+  dsn: nil,
+  environment_name: :unknown,
+  enable_source_code_context: true,
+  root_source_code_paths: [
+    Path.join(File.cwd!(), "apps/domain"),
+    Path.join(File.cwd!(), "apps/web"),
+    Path.join(File.cwd!(), "apps/api")
+  ]
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -115,3 +115,6 @@ config :workos, WorkOS.Client,
   api_key: System.get_env("WORKOS_API_KEY"),
   client_id: System.get_env("WORKOS_CLIENT_ID"),
   baseurl: System.get_env("WORKOS_BASE_URL", "https://api.workos.com")
+
+config :sentry,
+  environment_name: :dev

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -247,17 +247,10 @@ if config_env() == :prod do
 
   # Sentry
 
-  # Base Sentry config
+  # Enable Sentry by default in runtime prod env
   config :sentry,
     dsn:
-      "https://29f4ab7c6c473c17bc01f8aeffb0ac16@o4507971108339712.ingest.us.sentry.io/4508756715569152",
-    environment_name: :unknown,
-    enable_source_code_context: true,
-    root_source_code_paths: [
-      Path.join(File.cwd!(), "apps/domain"),
-      Path.join(File.cwd!(), "apps/web"),
-      Path.join(File.cwd!(), "apps/api")
-    ]
+      "https://29f4ab7c6c473c17bc01f8aeffb0ac16@o4507971108339712.ingest.us.sentry.io/4508756715569152"
 
   # Environment-specific Sentry overrides
   if api_external_url = compile_config!(:api_external_url) do

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -106,3 +106,6 @@ config :phoenix, :plug_init_mode, :runtime
 config :workos, WorkOS.Client,
   api_key: "sk_example_123456789",
   client_id: "client_123456789"
+
+config :sentry,
+  environment_name: :test


### PR DESCRIPTION
By specifying the `before_send` hook, we can easily drop events based on their data, such as `original_exception` which contains the original exception instance raised.

Leveraging this, we can add a `report_to_sentry` parameter to `Web.LiveErrors.NotFound` to optionally ignore certain not found errors from going to Sentry.