### PR TITLE
fix(infra): Add naming suffix to relay compute reservations

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -127,7 +127,7 @@ resource "google_compute_reservation" "relay_reservation" {
 
   project = var.project_id
 
-  name = "relays-${element(each.value.zones, length(each.value.zones) - 1)}-${each.value.type}"
+  name = "relays-${element(each.value.zones, length(each.value.zones) - 1)}-${each.value.type}-${var.naming_suffix}"
   zone = element(each.value.zones, length(each.value.zones) - 1)
 
   specific_reservation_required = true


### PR DESCRIPTION
Unfortunately relay reservations need the naming suffix as well because they require unique names in the project and `create_before_destroy` is taking effect.

https://app.terraform.io/app/firezone/workspaces/staging/runs/run-kfD9JtvTZEsXnfzA