### PR TITLE
fix(phoenix-channel): report connection hiccups to upper layer

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4683,6 +4683,7 @@ dependencies = [
 name = "phoenix-channel"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "backoff",
  "base64 0.22.1",
  "firezone-logging",

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -193,6 +193,11 @@ where
             phoenix_channel::Event::Closed => {
                 unimplemented!("Client never actively closes the portal connection")
             }
+            phoenix_channel::Event::Hiccup {
+                backoff,
+                max_elapsed_time,
+                error,
+            } => tracing::debug!(?backoff, ?max_elapsed_time, "{error:#}"),
         }
     }
 

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -376,6 +376,11 @@ impl Eventloop {
             phoenix_channel::Event::SuccessResponse { res: (), .. }
             | phoenix_channel::Event::HeartbeatSent
             | phoenix_channel::Event::JoinedRoom { .. } => {}
+            phoenix_channel::Event::Hiccup {
+                backoff,
+                max_elapsed_time,
+                error,
+            } => tracing::debug!(?backoff, ?max_elapsed_time, "{error:#}"),
         }
     }
 

--- a/rust/phoenix-channel/Cargo.toml
+++ b/rust/phoenix-channel/Cargo.toml
@@ -6,6 +6,7 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = { workspace = true }
 backoff = { workspace = true }
 base64 = { workspace = true }
 firezone-logging = { workspace = true }

--- a/rust/phoenix-channel/src/lib.rs
+++ b/rust/phoenix-channel/src/lib.rs
@@ -125,10 +125,6 @@ async fn connect(
         }
     }
 
-    if errors.is_empty() {
-        return Err(InternalError::InvalidUrl);
-    }
-
     Err(InternalError::SocketConnection(errors))
 }
 

--- a/rust/relay/src/main.rs
+++ b/rust/relay/src/main.rs
@@ -618,6 +618,11 @@ where
             Event::Closed => {
                 self.channel = None;
             }
+            Event::Hiccup {
+                backoff,
+                max_elapsed_time,
+                error,
+            } => tracing::warn!(?backoff, ?max_elapsed_time, "{error:#}"),
         }
     }
 }


### PR DESCRIPTION
The WebSocket connection to the portal from within the Clients, Gateways and Relays may be temporarily interrupted by IO errors. In such cases we simply reconnect to it. This isn't as much of a problem for Clients and Gateways. For Relays however, a disconnect can be disruptive for customers because the portal will send `relays_presence` events to all Clients and Gateways. Any relayed connection will therefore be interrupted. See #8177.

Relays run on our own infrastructure and we want to be notified if their connection flaps.

In order to differentiate between these scenarios, we remove the logging from within `phoenix-channel` and report these connection hiccups one layer up. This allows Clients and Gateways to log them on DEBUG whereas the Relay can log them on WARN.

Related: #8177 
Related: #7004