### PR TITLE
fix(portal): Add `managed_by` to gateway groups index

### DIFF
--- a/elixir/apps/domain/lib/domain/gateways/group/changeset.ex
+++ b/elixir/apps/domain/lib/domain/gateways/group/changeset.ex
@@ -37,7 +37,7 @@ defmodule Domain.Gateways.Group.Changeset do
     |> put_default_value(:name, &Domain.NameGenerator.generate/0)
     |> validate_required(@fields)
     |> validate_length(:name, min: 1, max: 64)
-    |> unique_constraint(:name, name: :gateway_groups_account_id_name_index)
+    |> unique_constraint(:name, name: :gateway_groups_account_id_name_managed_by_index)
   end
 
   def delete(%Gateways.Group{} = group) do

--- a/elixir/apps/domain/priv/repo/migrations/20250219233330_scope_gateway_groups_name_index_by_managed_by.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250219233330_scope_gateway_groups_name_index_by_managed_by.exs
@@ -1,0 +1,18 @@
+defmodule Domain.Repo.Migrations.ScopeGatewayGroupsNameIndexByManagedBy do
+  use Ecto.Migration
+
+  # With the introduction of Internet Sites, some customers may have already named
+  # one of their Sites "Internet". This migration will scope the name constraint to
+  # include the managed_by column.
+  def change do
+    execute("DROP INDEX gateway_groups_account_id_name_index")
+
+    create(
+      index(:gateway_groups, [:account_id, :name, :managed_by],
+        name: :gateway_groups_account_id_name_managed_by_index,
+        unique: true,
+        where: "deleted_at IS NULL"
+      )
+    )
+  end
+end


### PR DESCRIPTION
Some customers have already picked the `Internet` name, which is making our migrations fail.

This scopes the unique name index by `managed_by` so that our attempts to create them succeed.