### PR TITLE
refactor(apple): Collapse ViewModels to app-wide Store

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Favorites.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public class Favorites: ObservableObject {
+public final class Favorites: ObservableObject {
   private static let key = "favoriteResourceIDs"
-  @Published private(set) var ids: Set<String>
+  private var ids: Set<String>
 
   public init() {
     ids = Favorites.load()
@@ -28,6 +28,10 @@ public class Favorites: ObservableObject {
     objectWillChange.send()
     ids.remove(id)
     save()
+  }
+
+  func isEmpty() -> Bool {
+    return ids.isEmpty
   }
 
   private func save() {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/FirstTimeView.swift
@@ -31,13 +31,13 @@ struct FirstTimeView: View {
         Spacer()
         HStack {
           Button("Close this window") {
-            AppViewModel.WindowDefinition.main.window()?.close()
+            AppView.WindowDefinition.main.window()?.close()
           }
           .buttonStyle(.borderedProminent)
           .controlSize(.large)
           Button("Open menu") {
             menuBar.showMenu()
-            AppViewModel.WindowDefinition.main.window()?.close()
+            AppView.WindowDefinition.main.window()?.close()
           }
           .buttonStyle(.borderedProminent)
           .controlSize(.large)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -14,16 +14,16 @@ private func copyToClipboard(_ value: String) {
 }
 
 struct ResourceView: View {
-  @ObservedObject var model: SessionViewModel
+  @EnvironmentObject var store: Store
   var resource: Resource
   @Environment(\.openURL) var openURL
 
   var body: some View {
     List {
       if resource.isInternetResource() {
-        InternetResourceHeader(model: model, resource: resource)
+        InternetResourceHeader(resource: resource)
       } else {
-        NonInternetResourceHeader(model: model, resource: resource)
+        NonInternetResourceHeader(resource: resource)
       }
 
       if let site = resource.sites.first {
@@ -98,7 +98,7 @@ struct ResourceView: View {
 }
 
 struct NonInternetResourceHeader: View {
-  @ObservedObject var model: SessionViewModel
+  @EnvironmentObject var store: Store
   var resource: Resource
   @Environment(\.openURL) var openURL
 
@@ -170,10 +170,10 @@ struct NonInternetResourceHeader: View {
         }
       }
 
-      if model.favorites.ids.contains(resource.id) {
+      if store.favorites.contains(resource.id) {
         Button(
           action: {
-            model.favorites.remove(resource.id)
+            store.favorites.remove(resource.id)
           },
           label: {
             HStack {
@@ -186,7 +186,7 @@ struct NonInternetResourceHeader: View {
       } else {
         Button(
           action: {
-            model.favorites.add(resource.id)
+            store.favorites.add(resource.id)
           }, label: {
             HStack {
               Image(systemName: "star.fill")
@@ -201,7 +201,7 @@ struct NonInternetResourceHeader: View {
 }
 
 struct InternetResourceHeader: View {
-  @ObservedObject var model: SessionViewModel
+  @EnvironmentObject var store: Store
   var resource: Resource
 
   var body: some View {
@@ -225,17 +225,17 @@ struct InternetResourceHeader: View {
         Text("All network traffic")
       }
 
-      ToggleInternetResourceButton(resource: resource, model: model)
+      ToggleInternetResourceButton(resource: resource)
     }
   }
 }
 
 struct ToggleInternetResourceButton: View {
   var resource: Resource
-  @ObservedObject var model: SessionViewModel
+  @EnvironmentObject var store: Store
 
   private func toggleResourceEnabledText() -> String {
-    if model.isInternetResourceEnabled() {
+    if store.internetResourceEnabled() {
       "Disable this resource"
     } else {
       "Enable this resource"
@@ -247,7 +247,7 @@ struct ToggleInternetResourceButton: View {
       action: {
         Task {
           do {
-            try await model.store.toggleInternetResource(enabled: !model.isInternetResourceEnabled())
+            try await store.toggleInternetResource(enabled: !store.internetResourceEnabled())
           } catch {
             Log.error(error)
           }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/WelcomeView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/WelcomeView.swift
@@ -8,18 +8,9 @@ import AuthenticationServices
 import Combine
 import SwiftUI
 
-@MainActor
-final class WelcomeViewModel: ObservableObject {
-  let store: Store
-
-  init(store: Store) {
-    self.store = store
-  }
-}
-
 struct WelcomeView: View {
   @EnvironmentObject var errorHandler: GlobalErrorHandler
-  @ObservedObject var model: WelcomeViewModel
+  @EnvironmentObject var store: Store
 
   var body: some View {
     VStack(
@@ -40,7 +31,7 @@ struct WelcomeView: View {
         Button("Sign in") {
           Task {
             do {
-              try await WebAuthSession.signIn(store: model.store)
+              try await WebAuthSession.signIn(store: store)
             } catch {
               Log.error(error)
 


### PR DESCRIPTION
Our application state is incredibly simple, only consisting of a handful of properties.

Throughout our codebase, we use a singular global state store called `Store`. We then inject this as the singular piece of state into each view's model.

This is unnecessary boilerplate and leads to lots of duplicated logic. Instead we refactor away (nearly) all of the application's view models and instead use an `@EnvironmentObject` to inject the store into each view.

This convention drastically simplifies state tracking logic and boilerplate in the views.