### PR TITLE
feat(gui-client): configure IPC service to log to stdout

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -16,7 +16,6 @@ use firezone_gui_client_common::{
     settings::AdvancedSettings,
     updates,
 };
-use firezone_headless_client::LogFilterReloader;
 use firezone_logging::err_with_src;
 use firezone_telemetry as telemetry;
 use futures::FutureExt;
@@ -120,7 +119,7 @@ impl GuiIntegration for TauriIntegration {
 pub(crate) fn run(
     cli: client::Cli,
     advanced_settings: AdvancedSettings,
-    reloader: LogFilterReloader,
+    reloader: firezone_logging::FilterReloadHandle,
     mut telemetry: telemetry::Telemetry,
 ) -> Result<()> {
     // Needed for the deep link server

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -663,7 +663,7 @@ fn setup_logging(
 
     let stdout_layer = tracing_subscriber::fmt::layer()
         .with_ansi(firezone_logging::stdout_supports_ansi())
-        .event_format(firezone_logging::Format::new());
+        .event_format(firezone_logging::Format::new().without_timestamp());
 
     let subscriber = Registry::default()
         .with(file_layer.with_filter(file_filter))

--- a/rust/headless-client/src/ipc_service/windows.rs
+++ b/rust/headless-client/src/ipc_service/windows.rs
@@ -1,6 +1,7 @@
 use crate::CliCommon;
 use anyhow::{bail, Context as _, Result};
 use firezone_bin_shared::platform::DnsControlMethod;
+use firezone_logging::FilterReloadHandle;
 use firezone_telemetry::Telemetry;
 use futures::channel::mpsc;
 use std::{
@@ -214,7 +215,7 @@ fn service_run(arguments: Vec<OsString>) {
 fn fallible_service_run(
     arguments: Vec<OsString>,
     logging_handle: firezone_logging::file::Handle,
-    log_filter_reloader: crate::LogFilterReloader,
+    log_filter_reloader: FilterReloadHandle,
 ) -> Result<()> {
     tracing::info!(?arguments, "fallible_windows_service_run");
     if !elevation_check()? {
@@ -329,7 +330,7 @@ fn fallible_service_run(
 ///
 /// Logging must already be set up before calling this.
 async fn service_run_async(
-    log_filter_reloader: &crate::LogFilterReloader,
+    log_filter_reloader: &FilterReloadHandle,
     telemetry: &mut Telemetry,
     shutdown_rx: mpsc::Receiver<()>,
 ) -> Result<()> {

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -7,12 +7,14 @@ mod unwrap_or;
 mod ansi;
 mod err_with_sources;
 
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 use sentry_tracing::EventFilter;
 use tracing::{subscriber::DefaultGuard, Subscriber};
 use tracing_log::LogTracer;
 use tracing_subscriber::{
-    filter::ParseError, fmt, layer::SubscriberExt as _, registry::LookupSpan,
+    filter::ParseError, fmt, layer::SubscriberExt as _, registry::LookupSpan, reload,
     util::SubscriberInitExt, EnvFilter, Layer, Registry,
 };
 
@@ -21,7 +23,7 @@ pub use err_with_sources::{err_with_src, ErrorWithSources};
 pub use format::Format;
 
 /// Registers a global subscriber with stdout logging and `additional_layer`
-pub fn setup_global_subscriber<L>(additional_layer: L) -> Result<()>
+pub fn setup_global_subscriber<L>(additional_layer: L) -> Result<FilterReloadHandle>
 where
     L: Layer<Registry> + Send + Sync,
 {
@@ -30,21 +32,24 @@ where
     }
 
     let directives = std::env::var("RUST_LOG").unwrap_or_default();
+
+    let (filter1, reload_handle1) =
+        try_filter(&directives).context("Failed to parse directives")?;
+    let (filter2, reload_handle2) =
+        try_filter(&directives).context("Failed to parse directives")?;
+
     let subscriber = Registry::default()
-        .with(
-            additional_layer
-                .with_filter(try_filter(&directives).context("Failed to parse directives")?),
-        )
+        .with(additional_layer.with_filter(filter1))
         .with(sentry_layer())
         .with(
             fmt::layer()
                 .with_ansi(stdout_supports_ansi())
                 .event_format(Format::new())
-                .with_filter(try_filter(&directives).context("Failed to parse directives")?),
+                .with_filter(filter2),
         );
     init(subscriber)?;
 
-    Ok(())
+    Ok(reload_handle1.merge(reload_handle2))
 }
 
 #[expect(
@@ -59,7 +64,23 @@ pub fn init(subscriber: impl Subscriber + Send + Sync + 'static) -> Result<()> {
 }
 
 /// Constructs an opinionated [`EnvFilter`] with some crates already silenced.
-pub fn try_filter(directives: &str) -> Result<EnvFilter, ParseError> {
+pub fn try_filter<S>(
+    directives: &str,
+) -> Result<(reload::Layer<EnvFilter, S>, FilterReloadHandle), ParseError>
+where
+    S: 'static,
+{
+    let env_filter = parse_filter(directives)?;
+
+    let (layer, reload_handle) = reload::Layer::new(env_filter);
+    let handle = FilterReloadHandle {
+        inner: Arc::new(reload_handle),
+    };
+
+    Ok((layer, handle))
+}
+
+fn parse_filter(directives: &str) -> Result<EnvFilter, ParseError> {
     /// A filter directive that silences noisy crates.
     ///
     /// For debugging, it is useful to set a catch-all log like `debug`.
@@ -70,11 +91,65 @@ pub fn try_filter(directives: &str) -> Result<EnvFilter, ParseError> {
     /// If necessary, you can still activate logs from these crates by restating them in your directive with a lower filter, i.e. `netlink_proto=debug`.
     const IRRELEVANT_CRATES: &str = "netlink_proto=warn,os_info=warn,rustls=warn";
 
-    if directives.is_empty() {
-        return EnvFilter::try_new(IRRELEVANT_CRATES);
+    let env_filter = if directives.is_empty() {
+        EnvFilter::try_new(IRRELEVANT_CRATES)?
+    } else {
+        EnvFilter::try_new(format!("{IRRELEVANT_CRATES},{directives}"))?
+    };
+
+    Ok(env_filter)
+}
+
+pub struct FilterReloadHandle {
+    inner: Arc<dyn Reload + Send + Sync>,
+}
+
+impl std::fmt::Debug for FilterReloadHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FilterReloadHandle").finish_non_exhaustive()
+    }
+}
+
+impl FilterReloadHandle {
+    pub fn reload(&self, new_filter: &str) -> Result<()> {
+        self.inner.reload(new_filter)?;
+
+        Ok(())
     }
 
-    EnvFilter::try_new(format!("{IRRELEVANT_CRATES},{directives}"))
+    pub fn merge(self, other: FilterReloadHandle) -> Self {
+        Self {
+            inner: Arc::new((self, other)),
+        }
+    }
+}
+
+trait Reload {
+    fn reload(&self, new_filter: &str) -> Result<()>;
+}
+
+impl<S> Reload for tracing_subscriber::reload::Handle<EnvFilter, S>
+where
+    S: 'static,
+{
+    fn reload(&self, new_filter: &str) -> Result<()> {
+        let filter = parse_filter(new_filter).context("Failed to parse new filter")?;
+
+        self.reload(filter).context("Failed to reload filter")?;
+
+        Ok(())
+    }
+}
+
+impl Reload for (FilterReloadHandle, FilterReloadHandle) {
+    fn reload(&self, new_filter: &str) -> Result<()> {
+        let (a, b) = self;
+
+        a.reload(new_filter)?;
+        b.reload(new_filter)?;
+
+        Ok(())
+    }
 }
 
 /// Initialises a logger to be used in tests.
@@ -136,7 +211,8 @@ where
             )
         })
         .enable_span_attributes()
-        .with_filter(try_filter("trace").expect("static filter always parses")) // Filter out noisy crates but pass all events otherwise.
+        .with_filter(parse_filter("trace").expect("static filter always parses"))
+    // Filter out noisy crates but pass all events otherwise.
 }
 
 #[doc(hidden)]

--- a/website/src/app/kb/client-apps/linux-gui-client/readme.mdx
+++ b/website/src/app/kb/client-apps/linux-gui-client/readme.mdx
@@ -153,6 +153,14 @@ To export or clear your logs:
 1. Click `Diagnostic Logs`.
 1. Click `Export Logs` or `Clear Log Directory`.
 
+The IPC service (`firezone-client-ipc.service`) also logs to stdout which is
+captured by systemd and sent to journald. To view the logs of the IPC service,
+use:
+
+```bash
+journalctl -efu firezone-client-ipc.service
+```
+
 ## Uninstalling
 
 1. Remove the auto-start link: `firezone-client-gui debug set-autostart false`

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -8,7 +8,13 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os === OS.Linux && (
+          <ChangeItem pull="8219">
+            Configures the IPC service to log to journald.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.4.6" date={new Date("2025-02-20")}>
         {os === OS.Linux && (
           <ChangeItem pull="8117">


### PR DESCRIPTION
On Linux, logs sent to stdout from a systemd-service are automatically captured by `journald`. This is where most admins expect logs to be and frankly, doing any kind of debugging of Firezone is much easier if you can do `journalctl -efu firezone-client-ipc.service` in a terminal and check what the IPC service is doing.

On Windows, stdout from a service is (unfortunately) ignored.

To achieve this and also allow dynamically changing the log-filter, I had to introduce a (long-overdue) abstraction over tracing's "reload" layer that allows us to combine multiple reload-handles into one. Unfortunately, neither the `reload::Layer` nor the `reload::Handle` implement `Clone`, which makes this unnecessarily difficult.

Related: #8173