### PR TITLE
fix(gui-client): use "Firezone" as the application name on Linux

### DIFF
--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
   "mainBinaryName": "firezone-client-gui",
   "identifier": "dev.firezone.client",
   "plugins": {},
-  "productName": "firezone-client-gui",
+  "productName": "Firezone",
   "app": {
     "withGlobalTauri": true,
     "security": {

--- a/rust/gui-client/src-tauri/tauri.windows.conf.json
+++ b/rust/gui-client/src-tauri/tauri.windows.conf.json
@@ -2,6 +2,5 @@
   "build": {
     "beforeBundleCommand": "bash -c '../../scripts/build/sign.sh ../target/release/Firezone.exe ../target/release/firezone-client-ipc.exe'"
   },
-  "mainBinaryName": "Firezone",
-  "productName": "Firezone"
+  "mainBinaryName": "Firezone"
 }


### PR DESCRIPTION
The current `.desktop` file uses the `firezone-client-gui` name from the Tauri config. This looks ugly and unprofessional. Instead, we should just call this "Firezone".

![image](https://github.com/user-attachments/assets/3c4705fb-3611-4da9-9254-eaee06a8d749)

Resolves: #8205