### PR TITLE
fix(gui-client): hide the `.desktop` entry for deep-links

### DIFF
--- a/rust/gui-client/src-common/src/deep_link/linux.rs
+++ b/rust/gui-client/src-common/src/deep_link/linux.rs
@@ -120,6 +120,7 @@ Terminal=false
 Type=Application
 MimeType=x-scheme-handler/{}
 Categories=Network;
+NoDisplay=true
 ",
         exe.display(),
         super::FZ_SCHEME


### PR DESCRIPTION
On Linux desktops, we install a dedicated `.desktop` file that is responsible for handling our deep-links for sign-in. This desktop entry is not meant to be launched manually and therefore should be hidden from the application menus.