### PR TITLE
chore(apple): downgrade warning about installed crypto provider

### DIFF
--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -337,8 +337,6 @@ fn install_rustls_crypto_provider() {
     let existing = rustls::crypto::ring::default_provider().install_default();
 
     if existing.is_err() {
-        // On Apple platforms, network extensions get terminated on disconnect and thus all memory is free'd.
-        // Therefore, this should not never happen unless the above is somehow no longer true.
-        tracing::warn!("Skipping install of crypto provider because we already have one.");
+        tracing::debug!("Skipping install of crypto provider because we already have one.");
     }
 }


### PR DESCRIPTION
With the introduction of system extensions, the memory is no longer free'd after the tunnel disconnects meaning this can easily happen.