### PR TITLE
chore(gateway): remove log around "No NAT session"

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -307,7 +307,11 @@ impl ClientOnGateway {
 
                 return Ok(None);
             }
-            TranslateIncomingResult::NoNatSession => return Ok(Some(packet)),
+            TranslateIncomingResult::NoNatSession => {
+                // No NAT session means packet is likely for Internet Resource or a CIDR resource.
+
+                return Ok(Some(packet));
+            }
         };
 
         let mut packet = packet

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -102,8 +102,6 @@ impl NatTable {
                 return Ok(TranslateIncomingResult::ExpiredNatSession);
             }
 
-            tracing::trace!(?outside, "No active NAT session; skipping translation");
-
             return Ok(TranslateIncomingResult::NoNatSession);
         }
 
@@ -116,8 +114,6 @@ impl NatTable {
         if self.expired.contains(&outside) {
             return Ok(TranslateIncomingResult::ExpiredNatSession);
         }
-
-        tracing::trace!(?outside, "No active NAT session; skipping translation");
 
         Ok(TranslateIncomingResult::NoNatSession)
     }


### PR DESCRIPTION
This is pretty confusing when reading logs. For inbound packets, we assume that if we don't have a NAT session, they belong to the Internet Resource or a CIDR resource, meaning this log shows up for all packets for those resources and even for packets that don't belong to any resource at all.