### PR TITLE
fix(portal): optionally enable optimistic lock

### DIFF
--- a/elixir/apps/domain/lib/domain/telemetry/reporter/google_cloud_metrics.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/reporter/google_cloud_metrics.ex
@@ -350,7 +350,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetrics do
   defp update_last_flushed_at(log, true) do
     log
     |> Log.Changeset.changeset()
-    |> Log.Changeset.update_last_flushed_at(DateTime.utc_now())
+    |> Log.Changeset.update_last_flushed_at_with_lock(DateTime.utc_now())
     # No fields are updated, but we need to force the update for optimistic locking to work
     |> Repo.update(force: true)
   end

--- a/elixir/apps/domain/lib/domain/telemetry/reporter/google_cloud_metrics.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/reporter/google_cloud_metrics.ex
@@ -114,7 +114,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetrics do
         log = get_log()
 
         # Flush immediately if the buffer is full
-        flush(project_id, resource, labels, {buffer_size, buffer}, log)
+        flush(project_id, resource, labels, {buffer_size, buffer}, log, false)
       else
         {buffer_size, buffer}
       end
@@ -127,7 +127,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetrics do
 
     {buffer_size, buffer} =
       if all_intervals_greater_than_5s?(buffer) && havent_flushed_in_over_5s?(log) do
-        flush(project_id, resource, labels, {buffer_size, buffer}, log)
+        flush(project_id, resource, labels, {buffer_size, buffer}, log, true)
       else
         {buffer_size, buffer}
       end
@@ -299,7 +299,8 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetrics do
          resource,
          labels,
          {buffer_size, buffer},
-         log
+         log,
+         lock
        ) do
     time_series =
       buffer
@@ -308,7 +309,7 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetrics do
         format_time_series(schema, name, labels, resource, measurements, unit)
       end)
 
-    case update_last_flushed_at(log) do
+    case update_last_flushed_at(log, lock) do
       {:ok, _} ->
         case GoogleCloudPlatform.send_metrics(project_id, time_series) do
           :ok ->
@@ -334,16 +335,22 @@ defmodule Domain.Telemetry.Reporter.GoogleCloudMetrics do
     end
   end
 
-  defp update_last_flushed_at(nil) do
+  defp update_last_flushed_at(nil, _) do
     %Log{last_flushed_at: DateTime.utc_now(), reporter_module: "#{__MODULE__}"}
     |> Log.Changeset.changeset()
     |> Repo.insert()
   end
 
-  defp update_last_flushed_at(log) do
+  defp update_last_flushed_at(log, false) do
     log
     |> Log.Changeset.changeset()
-    |> Log.Changeset.update_last_flushed_at_with_lock(DateTime.utc_now())
+    |> Repo.update(force: true)
+  end
+
+  defp update_last_flushed_at(log, true) do
+    log
+    |> Log.Changeset.changeset()
+    |> Log.Changeset.update_last_flushed_at(DateTime.utc_now())
     # No fields are updated, but we need to force the update for optimistic locking to work
     |> Repo.update(force: true)
   end


### PR DESCRIPTION
When the buffer is full, we want to update immediately, without locking.