### PR TITLE
build(nix): manage Rust installation via `rustup`

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,5 @@
 [toolchain]
 # Keep synced with `Dockerfile`
 channel = "1.84.0"
+components = ["rust-src", "rust-analyzer", "clippy"]
+targets = ["x86_64-unknown-linux-musl"]

--- a/scripts/nix/flake.lock
+++ b/scripts/nix/flake.lock
@@ -33,45 +33,10 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1736476219,
-        "narHash": "sha256-+qyv3QqdZCdZ3cSO/cbpEY6tntyYjfe1bB12mdpNFaY=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "de30cc5963da22e9742bbbbb9a3344570ed237b9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -2,28 +2,20 @@
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
-    rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
-  outputs = { nixpkgs, flake-utils, rust-overlay, ... }:
+  outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem
       (
         system:
         let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ (import rust-overlay) ];
           };
-          rust-nightly = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
-
-          # Wrap `cargo-udeps` to ensure it uses a nightly Rust version.
-          cargo-udeps = pkgs.writeShellScriptBin "cargo-udeps" ''
-            export RUSTC="${rust-nightly}/bin/rustc";
-            export CARGO="${rust-nightly}/bin/cargo";
-            exec "${pkgs.cargo-udeps}/bin/cargo-udeps" "$@"
-          '';
 
           packages = with pkgs; [
+            rustup # We use `rustup` to manage the Rust installation in order to get `+nightly` etc features.
+
             curl
             wget
             pkg-config
@@ -54,24 +46,15 @@
             webkitgtk_4_1
             webkitgtk_4_1.dev
           ];
-
-          mkShellWithRustVersion = rustVersion: pkgs.mkShell {
-            packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.pnpm cargo-udeps pkgs.cargo-sort pkgs.cargo-deny pkgs.cargo-autoinherit ];
-            buildInputs = packages ++ [
-              (rustVersion.override {
-                extensions = [ "rust-src" "rust-analyzer" ];
-                targets = [ "x86_64-unknown-linux-musl" ];
-              })
-            ];
-            name = "rust-env";
-            src = ../../rust;
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.pnpm pkgs.cargo-sort pkgs.cargo-deny pkgs.cargo-autoinherit ];
+            buildInputs = packages;
+            src = ../..;
 
             PKG_CONFIG_PATH = with pkgs; "${glib.dev}/lib/pkgconfig:${libsoup_3.dev}/lib/pkgconfig:${webkitgtk_4_1.dev}/lib/pkgconfig:${at-spi2-atk.dev}/lib/pkgconfig:${gtk3.dev}/lib/pkgconfig:${gdk-pixbuf.dev}/lib/pkgconfig:${cairo.dev}/lib/pkgconfig:${pango.dev}/lib/pkgconfig:${harfbuzz.dev}/lib/pkgconfig";
           };
-        in
-        {
-          devShells.default = mkShellWithRustVersion (pkgs.rust-bin.fromRustupToolchainFile ../../rust/rust-toolchain.toml);
-          devShells.nightly = mkShellWithRustVersion rust-nightly;
         }
       );
 }


### PR DESCRIPTION
Using `rustup` - even on NixOS  - is easier to manage the Rust toolchain as some tools rely on being able to use the `rustup` shims such as `+nightly` to run a nightly toolchain.