### PR TITLE
fix(apple): web auth session mem leak

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
@@ -13,6 +13,7 @@ import AuthenticationServices
 @MainActor
 struct WebAuthSession {
   private static let scheme = "firezone-fd0020211111"
+  static let anchor = PresentationAnchor()
 
   static func signIn(store: Store) async throws {
     guard let authURL = store.authURL(),
@@ -22,8 +23,6 @@ struct WebAuthSession {
       // Should never get here because we perform URL validation on input, but handle this just in case
       throw AuthClientError.invalidAuthURL
     }
-
-    let anchor = PresentationAnchor()
 
     let authResponse: AuthResponse? = try await withCheckedThrowingContinuation { continuation in
       let session = ASWebAuthenticationSession(url: url, callbackURLScheme: scheme) { returnedURL, error in
@@ -62,7 +61,7 @@ struct WebAuthSession {
 }
 
 // Required shim to use as "presentationAnchor" for the Webview. Why Apple?
-private final class PresentationAnchor: NSObject, ASWebAuthenticationPresentationContextProviding {
+final class PresentationAnchor: NSObject, ASWebAuthenticationPresentationContextProviding {
   @MainActor
   func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
     ASPresentationAnchor()

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -23,6 +23,9 @@ export default function Apple() {
         <ChangeItem pull="8202">
           Fixes a crash that occurred if the system reports invalid DNS servers.
         </ChangeItem>
+        <ChangeItem pull="8237">
+          Fixes a minor memory leak that would occur each time you sign in.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.3" date={new Date("2025-02-16")}>
         <ChangeItem pull="8122">


### PR DESCRIPTION
We had a very small memory leak due to a circular reference in the `WebAuthSession` class.

<img width="1552" alt="Screenshot 2025-02-23 at 7 00 50 PM" src="https://github.com/user-attachments/assets/d91a6fb9-8d96-4648-a451-0d1361870b28" />
