### PR TITLE
fix(portal): Handle missing params in idp callback

### DIFF
--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -350,6 +350,14 @@ defmodule Web.AuthController do
     end
   end
 
+  def handle_idp_callback(conn, %{
+        "account_id_or_slug" => account_id
+      }) do
+    conn
+    |> put_flash(:error, "Invalid request.")
+    |> redirect(to: ~p"/#{account_id}")
+  end
+
   def verify_idp_state_and_fetch_verifier(conn, provider_id, state) do
     with {:ok, {redirect_params, persisted_state, persisted_verifier}, conn} <-
            fetch_auth_state(conn, provider_id),

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -905,6 +905,18 @@ defmodule Web.AuthControllerTest do
       }
     end
 
+    test "redirects with an error when params aren't provided", %{
+      account: account,
+      provider: provider,
+      conn: conn
+    } do
+      conn =
+        get(conn, ~p"/#{account.id}/sign_in/providers/#{provider.id}/handle_callback")
+
+      assert redirected_to(conn) == ~p"/#{account.id}"
+      assert flash(conn, :error) == "Invalid request."
+    end
+
     test "redirects with an error when state cookie does not exist", %{
       account: account,
       provider: provider,


### PR DESCRIPTION
It's possible for a client or admin to try and load the redirect URL directly, or a misconfigured IdP may redirect back to us with missing params. We should redirect with an error flash instead of 500'ing.