### PR TITLE
ci: Give client time to reconnect to portal in api-restart test

### DIFF
--- a/scripts/tests/direct-curl-api-restart.sh
+++ b/scripts/tests/direct-curl-api-restart.sh
@@ -4,8 +4,14 @@ source "./scripts/tests/lib.sh"
 
 docker compose restart api # Restart portal
 
+# Give the client time to reconnect
+sleep 3
+
 client_curl_resource "172.20.0.100/get"
 
 docker compose restart api # Restart again
+
+# Give the client time to reconnect
+sleep 3
 
 client_curl_resource "172.20.0.100/get"


### PR DESCRIPTION
Our `direct-curl-api-restart` test is flaky. Poking through the logs, we see that the API restarts and the client immediately begins backoff-reconnecting.

The problem is we don't sleep before running the first `curl`, so there's a possibility the client is not connected to the API when the `curl` starts.

This _should_ be fine, and [we see packets being buffered properly](https://github.com/firezone/firezone/actions/runs/13490584992/job/37688267194?pr=8238#step:8:134), but I'm not certain they're flushed. Or if they are, it's still allowing the curl to succeed, and the test fails.

This may be catching something, so I wanted to open this PR for awareness.