### PR TITLE
fix(apple): Pass menuBar to AppView

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -40,12 +40,13 @@ struct FirezoneApp: App {
       "Welcome to Firezone",
       id: AppView.WindowDefinition.main.identifier
     ) {
-      if appDelegate.menuBar == nil {
-        ProgressView("Loading...")
-      } else {
+      if let menuBar = appDelegate.menuBar {
         // menuBar will be initialized by this point
         AppView()
           .environmentObject(store)
+          .environmentObject(menuBar)
+      } else {
+        ProgressView("Loading...")
       }
     }
     .handlesExternalEvents(

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -19,7 +19,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8249">
+          Fixes a regression that caused a crash if "Open menu" was clicked in
+          the Welcome screen.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.4" date={new Date("2025-02-24")}>
         <ChangeItem pull="8202">
           Fixes a crash that occurred if the system reports invalid DNS servers.


### PR DESCRIPTION
A regression was introduced in #8218 that removed the `menuBar` as an environment object for `AppView`.

Unfortunately this compiles just fine, as EnvironmentObjects are loaded at runtime, causing the "Open Menu" button to crash since it's looking for a non-existent EnvironmentObject.
