### PR TITLE
fix(portal): Fix layout of live_table filters controls

### DIFF
--- a/elixir/apps/web/lib/web/live_table.ex
+++ b/elixir/apps/web/lib/web/live_table.ex
@@ -168,12 +168,14 @@ defmodule Web.LiveTable do
           </.button>
         </div>
 
-        <.filter
-          :for={filter <- @filters}
-          live_table_id={@live_table_id}
-          form={@form}
-          filter={filter}
-        />
+        <div class="space-y-2 md:space-y-0 md:gap-1 md:flex">
+          <.filter
+            :for={filter <- @filters}
+            live_table_id={@live_table_id}
+            form={@form}
+            filter={filter}
+          />
+        </div>
       </div>
     </.form>
     """


### PR DESCRIPTION
Fixes layout of filters controls. A more permanent fix will be introduced as part of #8255 