### PR TITLE
chore(docker-compose): add `init` shim for Gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -356,6 +356,7 @@ services:
       FIREZONE_ENABLE_MASQUERADE: 1 # FIXME: NOOP in latest version. Remove after next release.
       FIREZONE_API_URL: ws://api:8081
       FIREZONE_ID: 4694E56C-7643-4A15-9DF3-638E5B05F570
+    init: true
     build:
       target: dev
       context: rust


### PR DESCRIPTION
In order for the Gateway container to correctly react to signals for restarting / rebuilding, it needs to have the `init` shim activated.