### PR TITLE
chore(connlib): improve `wire::dev` logging

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -55,7 +55,7 @@ impl Device {
                 tracing::warn!("Packet matches heuristics of FZ-internal p2p control protocol");
             }
 
-            tracing::trace!(target: "wire::dev::recv", dst = %packet.destination(), src = %packet.source(), bytes = %packet.packet().len());
+            tracing::trace!(target: "wire::dev::recv", ?packet);
         }
 
         Poll::Ready(n)
@@ -77,7 +77,7 @@ impl Device {
             }
         }
 
-        tracing::trace!(target: "wire::dev::send", dst = %packet.destination(), src = %packet.source(), bytes = %packet.packet().len());
+        tracing::trace!(target: "wire::dev::send", ?packet);
 
         debug_assert!(
             !packet.is_fz_p2p_control(),

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -168,6 +168,14 @@ impl std::fmt::Debug for IpPacket {
             if tcp.syn() {
                 dbg.field("syn", &true);
             }
+
+            if tcp.rst() {
+                dbg.field("rst", &true);
+            }
+
+            if tcp.fin() {
+                dbg.field("fin", &true);
+            }
         }
 
         if let Some(udp) = self.as_udp() {


### PR DESCRIPTION
This will log more details about the packet, such as SYN, RST and FIN flags for TCP.