### PR TITLE
fix(connlib): don't buffer exact & TCP SYN retransmissions

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -820,9 +820,6 @@ impl ClientState {
             Entry::Occupied(mut o) => {
                 let pending_flow = o.get_mut();
                 pending_flow.packets.push(packet);
-                let num_buffered = pending_flow.packets.len();
-
-                tracing::debug!(%num_buffered, "Buffering packet in `PendingFlow`");
 
                 let time_since_last_intent = now.duration_since(pending_flow.last_intent_sent_at);
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -3,12 +3,12 @@ mod resource;
 pub(crate) use resource::{CidrResource, Resource};
 #[cfg(all(feature = "proptest", test))]
 pub(crate) use resource::{DnsResource, InternetResource};
-use ringbuffer::{AllocRingBuffer, RingBuffer};
 
 use crate::dns::StubResolver;
 use crate::messages::{DnsServer, Interface as InterfaceConfig, IpDnsServer};
 use crate::messages::{IceCredentials, SecretKey};
 use crate::peer_store::PeerStore;
+use crate::unique_packet_buffer::UniquePacketBuffer;
 use crate::{dns, p2p_control, TunConfig};
 use anyhow::Context;
 use bimap::BiMap;
@@ -152,7 +152,7 @@ pub struct ClientState {
 enum DnsResourceNatState {
     Pending {
         sent_at: Instant,
-        buffered_packets: AllocRingBuffer<IpPacket>,
+        buffered_packets: UniquePacketBuffer,
     },
     Confirmed,
 }
@@ -181,7 +181,7 @@ impl DnsResourceNatState {
 
 struct PendingFlow {
     last_intent_sent_at: Instant,
-    packets: AllocRingBuffer<IpPacket>,
+    packets: UniquePacketBuffer,
 }
 
 impl PendingFlow {
@@ -192,7 +192,7 @@ impl PendingFlow {
     const CAPACITY_POW_2: usize = 7; // 2^7 = 128
 
     fn new(now: Instant, packet: IpPacket) -> Self {
-        let mut packets = AllocRingBuffer::with_capacity_power_of_2(Self::CAPACITY_POW_2);
+        let mut packets = UniquePacketBuffer::with_capacity_power_of_2(Self::CAPACITY_POW_2);
         packets.push(packet);
 
         Self {
@@ -375,7 +375,7 @@ impl ClientState {
                 Entry::Vacant(v) => {
                     self.peers
                         .add_ips_with_resource(gid, proxy_ips.iter().copied(), rid);
-                    let mut buffered_packets = AllocRingBuffer::with_capacity_power_of_2(5); // 2^5 = 32
+                    let mut buffered_packets = UniquePacketBuffer::with_capacity_power_of_2(5); // 2^5 = 32
                     buffered_packets.extend(packets_for_domain);
 
                     v.insert(DnsResourceNatState::Pending {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -36,6 +36,7 @@ mod sockets;
 #[cfg(all(test, feature = "proptest"))]
 #[allow(clippy::unwrap_in_result)]
 mod tests;
+mod unique_packet_buffer;
 mod utils;
 
 const REALM: &str = "firezone";

--- a/rust/connlib/tunnel/src/unique_packet_buffer.rs
+++ b/rust/connlib/tunnel/src/unique_packet_buffer.rs
@@ -13,6 +13,12 @@ impl UniquePacketBuffer {
     }
 
     pub fn push(&mut self, packet: IpPacket) {
+        if self.buffer.contains(&packet) {
+            tracing::trace!(?packet, "Skipping duplicate packet");
+
+            return;
+        }
+
         self.buffer.push(packet);
     }
 

--- a/rust/connlib/tunnel/src/unique_packet_buffer.rs
+++ b/rust/connlib/tunnel/src/unique_packet_buffer.rs
@@ -1,0 +1,37 @@
+use ip_packet::IpPacket;
+use ringbuffer::{AllocRingBuffer, RingBuffer};
+
+pub struct UniquePacketBuffer {
+    buffer: AllocRingBuffer<IpPacket>,
+}
+
+impl UniquePacketBuffer {
+    pub fn with_capacity_power_of_2(capacity: usize) -> Self {
+        Self {
+            buffer: AllocRingBuffer::with_capacity_power_of_2(capacity),
+        }
+    }
+
+    pub fn push(&mut self, packet: IpPacket) {
+        self.buffer.push(packet);
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+}
+
+impl Extend<IpPacket> for UniquePacketBuffer {
+    fn extend<T: IntoIterator<Item = IpPacket>>(&mut self, iter: T) {
+        self.buffer.extend(iter)
+    }
+}
+
+impl IntoIterator for UniquePacketBuffer {
+    type Item = IpPacket;
+    type IntoIter = <AllocRingBuffer<IpPacket> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.buffer.into_iter()
+    }
+}

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -163,7 +163,8 @@ impl std::fmt::Debug for IpPacket {
 
         if let Some(tcp) = self.as_tcp() {
             dbg.field("src_port", &tcp.source_port())
-                .field("dst_port", &tcp.destination_port());
+                .field("dst_port", &tcp.destination_port())
+                .field("seq", &tcp.sequence_number());
 
             if tcp.syn() {
                 dbg.field("syn", &true);


### PR DESCRIPTION
Whilst we are establishing a connection, the host network stack may run into timeouts and retransmit packets. Buffering these copies doesn't make any sense because we are then just flooding the remote with e.g. 4 TCP SYNs for the same connection.

This check is O(N) with the number of buffered packets. Those are at most a few dozens so there shouldn't be a need for anything more efficient.