### PR TITLE
build(rust): bump `str0m` to v0.7.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6232,8 +6232,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.6.3"
-source = "git+https://github.com/algesten/str0m?branch=main#c46970284af32b3497c780aceaad41304447a57b"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b85058b6dca67818698a745d12e16884b17d5c31cc20377a4413bf492ca0142"
 dependencies = [
  "combine",
  "crc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -107,7 +107,7 @@ smallvec = "1.13.2"
 smbios-lib = "0.9.2"
 smoltcp = { version = "0.12", default-features = false }
 static_assertions = "1.1.0"
-str0m = { version = "0.6.3", default-features = false, features = ["sha1"] }
+str0m = { version = "0.7.0", default-features = false, features = ["sha1"] }
 strum = { version = "0.27.1", features = ["derive"] }
 stun_codec = "0.3.4"
 subprocess = "0.2.9"
@@ -185,7 +185,6 @@ private-intra-doc-links = "allow" # We don't publish any of our docs but want to
 
 [patch.crates-io]
 boringtun = { git = "https://github.com/firezone/boringtun", branch = "master" }
-str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "master" } # Waiting for release.
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.26" } # Waiting for release.


### PR DESCRIPTION
Good to get rid of patch dependencies where possible.