### PR TITLE
fix(portal): Update gateway channel to process resource_update

### DIFF
--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -72,6 +72,12 @@ defmodule API.Gateway.Channel do
   ##### Reacting to domain events ####
   ####################################
 
+  # Resource create message is a no-op for the Gateway as the Resource
+  # details will be sent to the Gateway on an :authorize_flow message
+  def handle_info({:create_resource, _resource_id}, socket) do
+    {:norely, socket}
+  end
+
   # Resource is updated, eg. traffic filters are changed
   def handle_info({:update_resource, resource_id}, socket) do
     OpenTelemetry.Ctx.attach(socket.assigns.opentelemetry_ctx)

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -446,6 +446,15 @@ defmodule API.Gateway.ChannelTest do
     end
   end
 
+  describe "handle_info/2 :create_resource" do
+    test "does nothing", %{
+      resource: resource,
+      socket: socket
+    } do
+      send(socket.channel_pid, {:create_resource, resource.id})
+    end
+  end
+
   describe "handle_info/2 :delete_resource" do
     test "does nothing", %{
       resource: resource,


### PR DESCRIPTION
Why:

* After merging #8267 it was discovered that there was a race condition that allowed a `resource_create` message to end up at the Gateway Channel process.  Previously, this message would not have ever arrived, because we were replacing Resource IDs when a breaking change was made, but since that is no longer the case, it is possible that a connection could be established between the time the `delete_resource` and `create_resource` messages are sent and the `create_resource` would end up at the Gateway Channel process.  This commit adds a no-op handler to make sure the message gets processed without throwing an error.