### PR TITLE
feat(gateway): allow tunneling packets to and from TUN device

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -169,8 +169,8 @@ where
                 let dns_servers = config.dns_by_sentinel.left_values().copied().collect();
 
                 self.callbacks.on_set_interface_config(
-                    config.ip4,
-                    config.ip6,
+                    config.ip.v4,
+                    config.ip.v6,
                     dns_servers,
                     Vec::from_iter(config.ipv4_routes),
                     Vec::from_iter(config.ipv6_routes),

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -9,7 +9,7 @@ use crate::messages::{DnsServer, Interface as InterfaceConfig, IpDnsServer};
 use crate::messages::{IceCredentials, SecretKey};
 use crate::peer_store::PeerStore;
 use crate::unique_packet_buffer::UniquePacketBuffer;
-use crate::{dns, p2p_control, TunConfig};
+use crate::{dns, p2p_control, IpConfig, TunConfig};
 use anyhow::Context;
 use bimap::BiMap;
 use connlib_model::{
@@ -234,20 +234,15 @@ impl ClientState {
     }
 
     #[cfg(all(test, feature = "proptest"))]
-    pub(crate) fn tunnel_ip4(&self) -> Option<Ipv4Addr> {
-        Some(self.tun_config.as_ref()?.ip4)
-    }
-
-    #[cfg(all(test, feature = "proptest"))]
-    pub(crate) fn tunnel_ip6(&self) -> Option<Ipv6Addr> {
-        Some(self.tun_config.as_ref()?.ip6)
+    pub(crate) fn tunnel_ip_config(&self) -> Option<crate::IpConfig> {
+        Some(self.tun_config.as_ref()?.ip)
     }
 
     #[cfg(all(test, feature = "proptest"))]
     pub(crate) fn tunnel_ip_for(&self, dst: IpAddr) -> Option<IpAddr> {
         Some(match dst {
-            IpAddr::V4(_) => self.tunnel_ip4()?.into(),
-            IpAddr::V6(_) => self.tunnel_ip6()?.into(),
+            IpAddr::V4(_) => self.tunnel_ip_config()?.v4.into(),
+            IpAddr::V6(_) => self.tunnel_ip_config()?.v6.into(),
         })
     }
 
@@ -865,7 +860,7 @@ impl ClientState {
         };
 
         self.tcp_dns_client
-            .set_source_interface(tun_config.ip4, tun_config.ip6);
+            .set_source_interface(tun_config.ip.v4, tun_config.ip.v6);
 
         let upstream_resolvers = self
             .dns_mapping
@@ -991,8 +986,8 @@ impl ClientState {
         match self.tun_config.as_mut() {
             Some(existing) => {
                 // We don't really expect these to change but let's update them anyway.
-                existing.ip4 = config.ipv4;
-                existing.ip6 = config.ipv6;
+                existing.ip.v4 = config.ipv4;
+                existing.ip.v6 = config.ipv6;
             }
             None => {
                 let (ipv4_routes, ipv6_routes) = self.routes().partition_map(|route| match route {
@@ -1000,8 +995,10 @@ impl ClientState {
                     IpNetwork::V6(v6) => itertools::Either::Right(v6),
                 });
                 let new_tun_config = TunConfig {
-                    ip4: config.ipv4,
-                    ip6: config.ipv6,
+                    ip: IpConfig {
+                        v4: config.ipv4,
+                        v6: config.ipv6,
+                    },
                     dns_by_sentinel: Default::default(),
                     ipv4_routes,
                     ipv6_routes,
@@ -1596,8 +1593,7 @@ impl ClientState {
         });
 
         let new_tun_config = TunConfig {
-            ip4: config.ip4,
-            ip6: config.ip6,
+            ip: config.ip,
             dns_by_sentinel: dns_mapping
                 .iter()
                 .map(|(sentinel_dns, effective_dns)| (*sentinel_dns, effective_dns.address()))

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -304,8 +304,7 @@ pub enum ClientEvent {
 
 #[derive(Clone, derive_more::Debug, PartialEq, Eq)]
 pub struct TunConfig {
-    pub ip4: Ipv4Addr,
-    pub ip6: Ipv6Addr,
+    pub ip: IpConfig,
     /// The map of DNS servers that connlib will use.
     ///
     /// - The "left" values are the connlib-assigned, proxy (or "sentinel") IPs.
@@ -318,6 +317,12 @@ pub struct TunConfig {
     pub ipv4_routes: BTreeSet<Ipv4Network>,
     #[debug("{}", DisplaySet(ipv6_routes))]
     pub ipv6_routes: BTreeSet<Ipv6Network>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IpConfig {
+    pub v4: Ipv4Addr,
+    pub v6: Ipv6Addr,
 }
 
 #[derive(Debug)]

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -704,6 +704,38 @@ mod tests {
     }
 
     #[test]
+    fn allows_packets_for_and_from_gateway_tun_ip() {
+        let mut peer = ClientOnGateway::new(client_id(), client_tun(), gateway_tun());
+
+        let request = ip_packet::make::tcp_packet(
+            client_tun_ipv4(),
+            gateway_tun_ipv4(),
+            5401,
+            80,
+            vec![0; 100],
+        )
+        .unwrap();
+
+        let response = ip_packet::make::tcp_packet(
+            gateway_tun_ipv4(),
+            client_tun_ipv4(),
+            80,
+            5401,
+            vec![0; 100],
+        )
+        .unwrap();
+
+        assert!(peer
+            .translate_outbound(request, Instant::now())
+            .unwrap()
+            .is_some());
+        assert!(peer
+            .translate_inbound(response, Instant::now())
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
     fn dns_and_cidr_filters_dot_mix() {
         let mut peer = ClientOnGateway::new(client_id(), client_tun(), gateway_tun());
         peer.add_resource(foo_dns_resource(), None);

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -233,8 +233,8 @@ impl TunnelTest {
             Transition::UpdateUpstreamDnsServers(servers) => {
                 state.client.exec_mut(|c| {
                     c.sut.update_interface_config(Interface {
-                        ipv4: c.sut.tunnel_ip4().unwrap(),
-                        ipv6: c.sut.tunnel_ip6().unwrap(),
+                        ipv4: c.sut.tunnel_ip_config().unwrap().v4,
+                        ipv6: c.sut.tunnel_ip_config().unwrap().v6,
                         upstream_dns: servers,
                     })
                 });
@@ -256,8 +256,8 @@ impl TunnelTest {
                 });
             }
             Transition::ReconnectPortal => {
-                let ipv4 = state.client.inner().sut.tunnel_ip4().unwrap();
-                let ipv6 = state.client.inner().sut.tunnel_ip6().unwrap();
+                let ipv4 = state.client.inner().sut.tunnel_ip_config().unwrap().v4;
+                let ipv6 = state.client.inner().sut.tunnel_ip_config().unwrap().v6;
                 let upstream_dns = ref_state.client.inner().upstream_dns_resolvers();
                 let all_resources = ref_state.client.inner().all_resources();
 
@@ -715,8 +715,7 @@ impl TunnelTest {
                             preshared_key.clone(),
                             client_ice.clone(),
                             gateway_ice.clone(),
-                            self.client.inner().sut.tunnel_ip4().unwrap(),
-                            self.client.inner().sut.tunnel_ip6().unwrap(),
+                            self.client.inner().sut.tunnel_ip_config().unwrap(),
                             None,
                             resource,
                             now,


### PR DESCRIPTION
At present, Clients are only allowed to send packets to resources accessible via the Gateway but not to the Gateway itself. Thus, any application (including Firezone itself) that opens a listening socket on the TUN device will never receive any traffic.

This has opens up interesting features like hosting additional services on the machine that the Gateway is running on. Concretely, in order to implement #8221, we will run a DNS server on port 53 of the TUN device as part of the Gateway.

The diff for this ended up being a bit larger because we are introducing an `IpConfig` abstraction so we don't have to track 4 IP addresses as separate fields within `ClientOnGateway`; the connection-specific state on a Gateway. This is where we allow / deny traffic from a Client. To allow traffic for this particular Gateway, we need to know our own TUN IP configuration within the component.