### PR TITLE
fix(connlib): Emit resources updated when display fields change

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1432,6 +1432,8 @@ impl ClientState {
     }
 
     pub fn add_resource(&mut self, new_resource: impl TryInto<Resource, Error: std::error::Error>) {
+        let mut display_fields_changed = false;
+
         let new_resource = match new_resource.try_into() {
             Ok(r) => r,
             Err(e) => {
@@ -1441,6 +1443,10 @@ impl ClientState {
         };
 
         if let Some(resource) = self.resources_by_id.get(&new_resource.id()) {
+            display_fields_changed = resource.name() != new_resource.name()
+                || resource.address_description() != new_resource.address_description()
+                || resource.sites() != new_resource.sites();
+
             if resource.has_different_address(&new_resource) {
                 self.remove_resource(resource.id());
             }
@@ -1470,6 +1476,10 @@ impl ClientState {
         };
 
         if !added {
+            if display_fields_changed {
+                self.emit_resources_changed();
+            }
+
             return;
         }
 

--- a/rust/connlib/tunnel/src/client/resource.rs
+++ b/rust/connlib/tunnel/src/client/resource.rs
@@ -127,6 +127,14 @@ impl Resource {
         }
     }
 
+    pub fn address_description(&self) -> Option<&str> {
+        match self {
+            Resource::Dns(r) => r.address_description.as_deref(),
+            Resource::Cidr(r) => r.address_description.as_deref(),
+            Resource::Internet(_) => None,
+        }
+    }
+
     pub fn has_different_address(&self, other: &Resource) -> bool {
         match (self, other) {
             (Resource::Dns(dns_a), Resource::Dns(dns_b)) => dns_a.address != dns_b.address,

--- a/rust/connlib/tunnel/src/client/resource.rs
+++ b/rust/connlib/tunnel/src/client/resource.rs
@@ -144,6 +144,12 @@ impl Resource {
         }
     }
 
+    pub fn display_fields_changed(&self, other: &Resource) -> bool {
+        self.name() != other.name()
+            || self.address_description() != other.address_description()
+            || self.sites() != other.sites()
+    }
+
     pub fn addresses(&self) -> Vec<IpNetwork> {
         match self {
             Resource::Dns(_) => vec![],

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,7 +21,7 @@ export default function Android() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="8286">
-          Fixes a bug that prevent certain Resource fields from being updated
+          Fixes a bug that prevented certain Resource fields from being updated
           when they were updated in the admin portal.
         </ChangeItem>
       </Unreleased>

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -19,7 +19,12 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8286">
+          Fixes a bug that prevent certain Resource fields from being updated
+          when they were updated in the admin portal.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.2" date={new Date("2025-02-16")}>
         <ChangeItem pull="8117">
           Fixes an upload speed performance regression.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -21,7 +21,7 @@ export default function Apple() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="8286">
-          Fixes a bug that prevent certain Resource fields from being updated
+          Fixes a bug that prevented certain Resource fields from being updated
           when they were updated in the admin portal.
         </ChangeItem>
       </Unreleased>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -19,7 +19,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8286">
+          Fixes a bug that prevent certain Resource fields from being updated
+          when they were updated in the admin portal.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-02-24")}>
         <ChangeItem pull="8251">
           Fixes an issue where the update checker would not properly notify the

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,7 @@ export default function GUI({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="8286">
-          Fixes a bug that prevent certain Resource fields from being updated
+          Fixes a bug that prevented certain Resource fields from being updated
           when they were updated in the admin portal.
         </ChangeItem>
       </Unreleased>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -8,7 +8,12 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8286">
+          Fixes a bug that prevent certain Resource fields from being updated
+          when they were updated in the admin portal.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.7" date={new Date("2025-02-26")}>
         {os === OS.Linux && (
           <ChangeItem pull="8219">


### PR DESCRIPTION
Whenever a Resource's name, address_description, or assigned sites change, it is not currently reflected in clients. For that to happen the address is changed.

This PR updates that behavior so that if any display fields are changed, the `on_update_resources` callback is called which properly updates the resource list views in clients.

Fixes #8284 