### PR TITLE
feat(portal): Send gateway ipv4 and ipv6 to client

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -534,7 +534,8 @@ defmodule API.Client.Channel do
 
   def handle_info(
         {:connect, _socket_ref, resource_id, gateway_group_id, gateway_id, gateway_public_key,
-         preshared_key, ice_credentials, {opentelemetry_ctx, opentelemetry_span_ctx}},
+         gateway_ipv4, gateway_ipv6, preshared_key, ice_credentials,
+         {opentelemetry_ctx, opentelemetry_span_ctx}},
         socket
       ) do
     OpenTelemetry.Ctx.attach(opentelemetry_ctx)
@@ -548,6 +549,8 @@ defmodule API.Client.Channel do
         gateway_group_id: gateway_group_id,
         gateway_id: gateway_id,
         gateway_public_key: gateway_public_key,
+        gateway_ipv4: gateway_ipv4,
+        gateway_ipv6: gateway_ipv6,
         gateway_ice_credentials: ice_credentials.gateway
       }
 

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -495,6 +495,8 @@ defmodule API.Gateway.Channel do
               socket.assigns.gateway.group_id,
               socket.assigns.gateway.id,
               socket.assigns.gateway.public_key,
+              socket.assigns.gateway.ipv4,
+              socket.assigns.gateway.ipv6,
               preshared_key,
               ice_credentials,
               {opentelemetry_ctx, opentelemetry_span_ctx}

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -1377,15 +1377,19 @@ defmodule API.Client.ChannelTest do
       send(
         channel_pid,
         {:connect, socket_ref, resource_id, gateway.group_id, gateway.id, gateway.public_key,
-         preshared_key, ice_credentials, otel_ctx}
+         gateway.ipv4, gateway.ipv6, preshared_key, ice_credentials, otel_ctx}
       )
 
       gateway_group_id = gateway.group_id
       gateway_id = gateway.id
       gateway_public_key = gateway.public_key
+      gateway_ipv4 = gateway.ipv4
+      gateway_ipv6 = gateway.ipv6
 
       assert_push "flow_created", %{
         gateway_public_key: ^gateway_public_key,
+        gateway_ipv4: ^gateway_ipv4,
+        gateway_ipv6: ^gateway_ipv6,
         resource_id: ^resource_id,
         client_ice_credentials: %{username: client_ice_username, password: client_ice_password},
         gateway_group_id: ^gateway_group_id,

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -931,6 +931,8 @@ defmodule API.Gateway.ChannelTest do
       gateway_group_id = gateway.group_id
       gateway_id = gateway.id
       gateway_public_key = gateway.public_key
+      gateway_ipv4 = gateway.ipv4
+      gateway_ipv6 = gateway.ipv6
       resource_id = resource.id
 
       ice_credentials = %{
@@ -965,6 +967,8 @@ defmodule API.Gateway.ChannelTest do
         ^gateway_group_id,
         ^gateway_id,
         ^gateway_public_key,
+        ^gateway_ipv4,
+        ^gateway_ipv6,
         ^preshared_key,
         ^ice_credentials,
         {_opentelemetry_ctx, opentelemetry_span_ctx}


### PR DESCRIPTION
In order to properly handle SRV and TXT records on the clients, we need to be able to pick a Gateway using the initial query itself. After that, we need to know the Gateway Tunnel IPs we're connecting to so we can have the query perform the lookup.

Fixes #8281 