### PR TITLE
ci: Don't specify Xcode version

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -30,8 +30,6 @@ jobs:
     permissions:
       contents: write # for attaching the build artifacts to the release
       id-token: write
-    env:
-      XCODE_VERSION: "16.2"
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/build/lib.sh
+++ b/scripts/build/lib.sh
@@ -12,9 +12,6 @@ function setup_runner() {
     keychain_pass=$(openssl rand -base64 32)
     keychain_path="$(mktemp -d)/app-signing.keychain-db"
 
-    # Select Xcode specified by the workflow
-    sudo xcode-select -s "/Applications/Xcode_$XCODE_VERSION.app"
-
     # Install provisioning profiles
     mkdir -p "$profiles_path"
     base64_decode "$app_profile" "$profiles_path/$app_profile_file"


### PR DESCRIPTION
A particular version of Xcode locks in particular versions of SDKs to build against. If we hardcode this, the benefit is that we have a predictable and repeatable build environment.

The downside is whenever GitHub updates its macOS runner images, we could fail to build due to a version mismatch.

In general, drift between Xcode versions isn't a problem, and tracking the latest will more closely track developer's machines.