### PR TITLE
feat(connlib): allow and route packets to Gateway TUN IPs

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -7,7 +7,7 @@ use firezone_tunnel::messages::client::{
     GatewaysIceCandidates, IngressMessages, InitClient,
 };
 use firezone_tunnel::messages::RelaysPresence;
-use firezone_tunnel::ClientTunnel;
+use firezone_tunnel::{ClientTunnel, IpConfig};
 use phoenix_channel::{ErrorReply, OutboundRequestId, PhoenixChannel, PublicKeyParam};
 use std::time::Instant;
 use std::{
@@ -263,6 +263,8 @@ where
                 gateway_id,
                 site_id,
                 gateway_public_key,
+                gateway_ipv4,
+                gateway_ipv6,
                 preshared_key,
                 client_ice_credentials,
                 gateway_ice_credentials,
@@ -271,6 +273,10 @@ where
                     resource_id,
                     gateway_id,
                     PublicKey::from(gateway_public_key.0),
+                    IpConfig {
+                        v4: gateway_ipv4,
+                        v6: gateway_ipv6,
+                    },
                     site_id,
                     preshared_key,
                     client_ice_credentials,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -9,7 +9,7 @@ use crate::messages::{DnsServer, Interface as InterfaceConfig, IpDnsServer};
 use crate::messages::{IceCredentials, SecretKey};
 use crate::peer_store::PeerStore;
 use crate::unique_packet_buffer::UniquePacketBuffer;
-use crate::{dns, is_peer, p2p_control, IpConfig, TunConfig};
+use crate::{dns, is_peer, p2p_control, IpConfig, TunConfig, IPV4_TUNNEL, IPV6_TUNNEL};
 use anyhow::Context;
 use bimap::BiMap;
 use connlib_model::{
@@ -943,6 +943,8 @@ impl ClientState {
         self.active_cidr_resources
             .iter()
             .map(|(ip, _)| ip)
+            .chain(iter::once(IPV4_TUNNEL.into()))
+            .chain(iter::once(IPV6_TUNNEL.into()))
             .chain(iter::once(IPV4_RESOURCES.into()))
             .chain(iter::once(IPV6_RESOURCES.into()))
             .chain(iter::once(DNS_SENTINELS_V4.into()))

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -2279,6 +2279,8 @@ mod proptests {
         HashSet::from_iter(
             resource_routes
                 .into_iter()
+                .chain(iter::once(IPV4_TUNNEL.into()))
+                .chain(iter::once(IPV6_TUNNEL.into()))
                 .chain(iter::once(IPV4_RESOURCES.into()))
                 .chain(iter::once(IPV6_RESOURCES.into()))
                 .chain(iter::once(DNS_SENTINELS_V4.into()))

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -77,6 +77,11 @@ impl GatewayState {
         }
     }
 
+    #[cfg(all(test, feature = "proptest"))]
+    pub(crate) fn tunnel_ip_config(&self) -> Option<IpConfig> {
+        self.tun_ip_config
+    }
+
     pub(crate) fn public_key(&self) -> PublicKey {
         self.node.public_key()
     }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -83,7 +83,7 @@ impl GatewayState {
     ) -> Result<Option<snownet::EncryptedPacket>> {
         let dst = packet.destination();
 
-        if !crate::is_client(dst) {
+        if !crate::is_peer(dst) {
             return Ok(None);
         }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -376,7 +376,7 @@ where
     }
 }
 
-pub fn is_client(dst: IpAddr) -> bool {
+pub fn is_peer(dst: IpAddr) -> bool {
     match dst {
         IpAddr::V4(v4) => IPV4_TUNNEL.contains(v4),
         IpAddr::V6(v6) => IPV6_TUNNEL.contains(v6),
@@ -388,7 +388,7 @@ mod unittests {
     use super::*;
 
     #[test]
-    fn mldv2_routers_are_not_clients() {
-        assert!(!is_client("ff02::16".parse().unwrap()))
+    fn mldv2_routers_are_not_peers() {
+        assert!(!is_peer("ff02::16".parse().unwrap()))
     }
 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -325,6 +325,15 @@ pub struct IpConfig {
     pub v6: Ipv6Addr,
 }
 
+impl IpConfig {
+    pub fn is_ip(&self, ip: IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(v4) => v4 == self.v4,
+            IpAddr::V6(v6) => v6 == self.v6,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum GatewayEvent {
     AddedIceCandidates {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -49,11 +49,21 @@ const REALM: &str = "firezone";
 /// Thus, it is chosen as a safe, upper boundary that is not meant to be hit (and thus doesn't affect performance), yet acts as a safe guard, just in case.
 const MAX_EVENTLOOP_ITERS: u32 = 5000;
 
+pub const IPV4_TUNNEL: Ipv4Network = match Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 0), 11) {
+    Ok(n) => n,
+    Err(_) => unreachable!(),
+};
+pub const IPV6_TUNNEL: Ipv6Network =
+    match Ipv6Network::new(Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, 0), 107) {
+        Ok(n) => n,
+        Err(_) => unreachable!(),
+    };
+
 pub type GatewayTunnel = Tunnel<GatewayState>;
 pub type ClientTunnel = Tunnel<ClientState>;
 
 pub use client::ClientState;
-pub use gateway::{DnsResourceNatEntry, GatewayState, ResolveDnsRequest, IPV4_PEERS, IPV6_PEERS};
+pub use gateway::{DnsResourceNatEntry, GatewayState, ResolveDnsRequest};
 pub use utils::turn;
 
 /// [`Tunnel`] glues together connlib's [`Io`] component and the respective (pure) state of a client or gateway.
@@ -363,5 +373,22 @@ where
         }
 
         list.finish()
+    }
+}
+
+pub fn is_client(dst: IpAddr) -> bool {
+    match dst {
+        IpAddr::V4(v4) => IPV4_TUNNEL.contains(v4),
+        IpAddr::V6(v6) => IPV6_TUNNEL.contains(v6),
+    }
+}
+
+#[cfg(test)]
+mod unittests {
+    use super::*;
+
+    #[test]
+    fn mldv2_routers_are_not_clients() {
+        assert!(!is_client("ff02::16".parse().unwrap()))
     }
 }

--- a/rust/connlib/tunnel/src/messages/client.rs
+++ b/rust/connlib/tunnel/src/messages/client.rs
@@ -4,7 +4,10 @@ use crate::messages::{IceCredentials, Interface, Key, Relay, RelaysPresence, Sec
 use connlib_model::{GatewayId, ResourceId, Site, SiteId};
 use ip_network::IpNetwork;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::{
+    collections::BTreeSet,
+    net::{Ipv4Addr, Ipv6Addr},
+};
 
 /// Description of a resource that maps to a DNS record.
 #[derive(Debug, Deserialize)]
@@ -88,6 +91,8 @@ pub struct FlowCreated {
     pub resource_id: ResourceId,
     pub gateway_id: GatewayId,
     pub gateway_public_key: Key,
+    pub gateway_ipv4: Ipv4Addr,
+    pub gateway_ipv6: Ipv6Addr,
     #[serde(rename = "gateway_group_id")]
     pub site_id: SiteId,
     pub preshared_key: SecretKey,

--- a/rust/connlib/tunnel/src/messages/client.rs
+++ b/rust/connlib/tunnel/src/messages/client.rs
@@ -281,7 +281,7 @@ mod tests {
 
     #[test]
     fn can_deserialize_flow_created() {
-        let json = r#"{"event":"flow_created","ref":null,"topic":"client","payload":{"gateway_group_id":"ef42a07f-87d0-40da-baa7-e881e619ea1c","gateway_id":"d263d490-a0bb-452a-8990-01d27a1f1144","resource_id":"733e8d14-c18d-4931-af30-3639fa09c0c0","preshared_key":"anX2T9RH9mimT5Xd5+HqNGV0bfCodWDHQch1DLiFNls=","client_ice_credentials":{"username":"resc","password":"rqi3ibvfikfaxj3wgp7muh"},"gateway_ice_credentials":{"username":"jbi4","password":"a6oeevhlutevykcifd5r2a"},"gateway_public_key":"uMBCkAxTewfSgypIyxdQ18uCi84HLtKmQJy0wvQrYWY="}}"#;
+        let json = r#"{"event":"flow_created","ref":null,"topic":"client","payload":{"gateway_group_id":"ef42a07f-87d0-40da-baa7-e881e619ea1c","gateway_id":"d263d490-a0bb-452a-8990-01d27a1f1144","resource_id":"733e8d14-c18d-4931-af30-3639fa09c0c0","preshared_key":"anX2T9RH9mimT5Xd5+HqNGV0bfCodWDHQch1DLiFNls=","client_ice_credentials":{"username":"resc","password":"rqi3ibvfikfaxj3wgp7muh"},"gateway_ice_credentials":{"username":"jbi4","password":"a6oeevhlutevykcifd5r2a"},"gateway_public_key":"uMBCkAxTewfSgypIyxdQ18uCi84HLtKmQJy0wvQrYWY=","gateway_ipv4":"100.72.145.83","gateway_ipv6":"fd00:2021:1111::5:bcfd"}}"#;
 
         let message = serde_json::from_str::<IngressMessages>(json).unwrap();
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -448,7 +448,7 @@ impl GatewayOnClient {
 pub(crate) struct NotClientIp(IpAddr);
 
 #[derive(Debug, thiserror::Error)]
-#[error("Accessing this resource IP is not allowed: {0}")]
+#[error("Traffic to/from this resource IP is not allowed: {0}")]
 pub(crate) struct NotAllowedResource(IpAddr);
 
 #[derive(Debug)]

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -622,6 +622,7 @@ impl RefClient {
         }
     }
 
+    #[expect(clippy::too_many_arguments, reason = "We don't care.")]
     pub(crate) fn on_icmp_packet(
         &mut self,
         src: IpAddr,
@@ -630,6 +631,7 @@ impl RefClient {
         identifier: Identifier,
         payload: u64,
         gateway_by_resource: impl Fn(ResourceId) -> Option<GatewayId>,
+        gateway_by_ip: impl Fn(IpAddr) -> Option<GatewayId>,
     ) {
         self.on_packet(
             src,
@@ -638,9 +640,11 @@ impl RefClient {
             |ref_client| &mut ref_client.expected_icmp_handshakes,
             payload,
             gateway_by_resource,
+            gateway_by_ip,
         );
     }
 
+    #[expect(clippy::too_many_arguments, reason = "We don't care.")]
     pub(crate) fn on_udp_packet(
         &mut self,
         src: IpAddr,
@@ -649,6 +653,7 @@ impl RefClient {
         dport: DPort,
         payload: u64,
         gateway_by_resource: impl Fn(ResourceId) -> Option<GatewayId>,
+        gateway_by_ip: impl Fn(IpAddr) -> Option<GatewayId>,
     ) {
         self.on_packet(
             src,
@@ -657,9 +662,11 @@ impl RefClient {
             |ref_client| &mut ref_client.expected_udp_handshakes,
             payload,
             gateway_by_resource,
+            gateway_by_ip,
         );
     }
 
+    #[expect(clippy::too_many_arguments, reason = "We don't care.")]
     pub(crate) fn on_tcp_packet(
         &mut self,
         src: IpAddr,
@@ -668,6 +675,7 @@ impl RefClient {
         dport: DPort,
         payload: u64,
         gateway_by_resource: impl Fn(ResourceId) -> Option<GatewayId>,
+        gateway_by_ip: impl Fn(IpAddr) -> Option<GatewayId>,
     ) {
         self.on_packet(
             src,
@@ -676,9 +684,11 @@ impl RefClient {
             |ref_client| &mut ref_client.expected_tcp_exchanges,
             payload,
             gateway_by_resource,
+            gateway_by_ip,
         );
     }
 
+    #[expect(clippy::too_many_arguments, reason = "We don't care.")]
     #[tracing::instrument(level = "debug", skip_all, fields(dst, resource, gateway))]
     fn on_packet<E>(
         &mut self,
@@ -688,29 +698,42 @@ impl RefClient {
         map: impl FnOnce(&mut Self) -> &mut BTreeMap<GatewayId, BTreeMap<u64, E>>,
         payload: u64,
         gateway_by_resource: impl Fn(ResourceId) -> Option<GatewayId>,
+        gateway_by_ip: impl Fn(IpAddr) -> Option<GatewayId>,
     ) {
-        let Some(resource) = self.resource_by_dst(&dst) else {
-            tracing::warn!("Unknown resource");
-            return;
+        let gateway = if dst.ip_addr().is_some_and(crate::is_peer) {
+            let Some(gateway) = gateway_by_ip(dst.ip_addr().unwrap()) else {
+                tracing::error!("Unknown gateway");
+                return;
+            };
+            tracing::Span::current().record("gateway", tracing::field::display(gateway));
+
+            gateway
+        } else {
+            let Some(resource) = self.resource_by_dst(&dst) else {
+                tracing::warn!("Unknown resource");
+                return;
+            };
+
+            tracing::Span::current().record("resource", tracing::field::display(resource));
+
+            let Some(gateway) = gateway_by_resource(resource) else {
+                tracing::error!("No gateway for resource");
+                return;
+            };
+
+            tracing::Span::current().record("gateway", tracing::field::display(gateway));
+
+            self.connect_to_resource(resource, dst);
+            self.set_resource_online(resource);
+
+            gateway
         };
-
-        tracing::Span::current().record("resource", tracing::field::display(resource));
-
-        let Some(gateway) = gateway_by_resource(resource) else {
-            tracing::error!("No gateway for resource");
-            return;
-        };
-
-        tracing::Span::current().record("gateway", tracing::field::display(gateway));
-
-        self.connect_to_resource(resource, dst);
-        self.set_resource_online(resource);
 
         if !self.is_tunnel_ip(src) {
             return;
         }
 
-        tracing::debug!(%payload, "Sending packet to resource");
+        tracing::debug!(%payload, "Sending packet");
 
         map(self)
             .entry(gateway)
@@ -1117,6 +1140,7 @@ fn ref_client(
 
 fn default_routes_v4() -> Vec<Ipv4Network> {
     vec![
+        Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 0), 11).unwrap(),
         Ipv4Network::new(Ipv4Addr::new(100, 96, 0, 0), 11).unwrap(),
         Ipv4Network::new(Ipv4Addr::new(100, 100, 111, 0), 24).unwrap(),
     ]
@@ -1124,6 +1148,7 @@ fn default_routes_v4() -> Vec<Ipv4Network> {
 
 fn default_routes_v6() -> Vec<Ipv6Network> {
     vec![
+        Ipv6Network::new(Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, 0), 107).unwrap(),
         Ipv6Network::new(
             Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0x8000, 0, 0, 0, 0),
             107,

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -430,7 +430,7 @@ pub struct RefClient {
 
     /// The CIDR resources the client is connected to.
     #[debug(skip)]
-    pub(crate) connected_cidr_resources: HashSet<ResourceId>,
+    pub(crate) connected_cidr_resources: BTreeSet<ResourceId>,
 
     /// Actively disabled resources by the UI
     #[debug(skip)]
@@ -500,6 +500,13 @@ impl RefClient {
         self.resources.retain(|r| r.id() != *resource);
 
         self.cidr_resources = self.recalculate_cidr_routes();
+    }
+
+    pub(crate) fn connected_resources(&self) -> impl Iterator<Item = ResourceId> + '_ {
+        self.connected_cidr_resources.iter().copied().chain(
+            self.internet_resource
+                .filter(|_| self.connected_internet_resource),
+        )
     }
 
     fn recalculate_cidr_routes(&mut self) -> IpNetworkTable<ResourceId> {

--- a/rust/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/connlib/tunnel/src/tests/stub_portal.rs
@@ -9,7 +9,6 @@ use crate::messages::{gateway, DnsServer};
 use crate::{client, proptest::*};
 use connlib_model::GatewayId;
 use connlib_model::{ResourceId, SiteId};
-use ip_network::{Ipv4Network, Ipv6Network};
 use itertools::Itertools;
 use proptest::{
     sample::Selector,
@@ -276,29 +275,19 @@ impl StubPortal {
     }
 }
 
-const IPV4_TUNNEL: Ipv4Network = match Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 0), 11) {
-    Ok(n) => n,
-    Err(_) => unreachable!(),
-};
-const IPV6_TUNNEL: Ipv6Network =
-    match Ipv6Network::new(Ipv6Addr::new(0xfd00, 0x2021, 0x1111, 0, 0, 0, 0, 0), 107) {
-        Ok(n) => n,
-        Err(_) => unreachable!(),
-    };
-
 /// An [`Iterator`] over the possible IPv4 addresses of a tunnel interface.
 ///
 /// We use the CG-NAT range for IPv4.
 /// See <https://github.com/firezone/firezone/blob/81dfa90f38299595e14ce9e022d1ee919909f124/elixir/apps/domain/lib/domain/network.ex#L7>.
 fn tunnel_ip4s() -> impl Iterator<Item = Ipv4Addr> {
-    IPV4_TUNNEL.hosts()
+    crate::IPV4_TUNNEL.hosts()
 }
 
 /// An [`Iterator`] over the possible IPv6 addresses of a tunnel interface.
 ///
 /// See <https://github.com/firezone/firezone/blob/81dfa90f38299595e14ce9e022d1ee919909f124/elixir/apps/domain/lib/domain/network.ex#L8>.
 fn tunnel_ip6s() -> impl Iterator<Item = Ipv6Addr> {
-    IPV6_TUNNEL
+    crate::IPV6_TUNNEL
         .subnets_with_prefix(128)
         .map(|n| n.network_address())
 }

--- a/rust/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/connlib/tunnel/src/tests/stub_portal.rs
@@ -214,6 +214,14 @@ impl StubPortal {
         Some(gid)
     }
 
+    pub(crate) fn gateway_by_ip(&self, ip: IpAddr) -> Option<GatewayId> {
+        self.gateways_by_site
+            .values()
+            .flatten()
+            .find(|(_, ipv4_addr, ipv6_addr)| *ipv4_addr == ip || *ipv6_addr == ip)
+            .map(|(gid, _, _)| *gid)
+    }
+
     pub(crate) fn gateways(&self) -> impl Strategy<Value = BTreeMap<GatewayId, Host<RefGateway>>> {
         self.gateways_by_site
             .values()

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -727,6 +727,7 @@ impl TunnelTest {
                         resource_id,
                         gateway_id,
                         gateway_key,
+                        gateway.inner().sut.tunnel_ip_config().unwrap(),
                         site_id,
                         preshared_key,
                         client_ice,

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -125,6 +125,15 @@ pub(crate) enum Destination {
     IpAddr(IpAddr),
 }
 
+impl Destination {
+    pub(crate) fn ip_addr(&self) -> Option<IpAddr> {
+        match self {
+            Destination::DomainName { .. } => None,
+            Destination::IpAddr(addr) => Some(*addr),
+        }
+    }
+}
+
 /// Helper enum
 #[derive(Debug, Clone)]
 enum PacketDestination {

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -11,7 +11,7 @@ use firezone_tunnel::messages::gateway::{
 };
 use firezone_tunnel::messages::{ConnectionAccepted, GatewayResponse, RelaysPresence};
 use firezone_tunnel::{
-    DnsResourceNatEntry, GatewayTunnel, IpConfig, ResolveDnsRequest, IPV4_PEERS, IPV6_PEERS,
+    DnsResourceNatEntry, GatewayTunnel, IpConfig, ResolveDnsRequest, IPV4_TUNNEL, IPV6_TUNNEL,
 };
 use phoenix_channel::{PhoenixChannel, PublicKeyParam};
 use std::collections::BTreeSet;
@@ -374,7 +374,7 @@ impl Eventloop {
                                 .await
                                 .context("Failed to set TUN interface IPs")?;
                             tun_device_manager
-                                .set_routes(vec![IPV4_PEERS], vec![IPV6_PEERS])
+                                .set_routes(vec![IPV4_TUNNEL], vec![IPV6_TUNNEL])
                                 .await
                                 .context("Failed to set TUN routes")?;
 


### PR DESCRIPTION
At the moment, `connlib` doesn't allow routing packets directly to Gateways because the subnet we've chosen for the tunnel IPs isn't part of the routing table. In addition, all traffic within `connlib` is expected to be targeting a resource _beyond_ a Gateway.

In order to resolve SRV and TXT records within a certain site, we've opted to host a DNS server on the Gateway's TUN device. See #8285 for details on that. To actually reach that DNS server, we need to add a few new control flows to `connlib` where we detect whether a packet is directly for the tunnel IP of a Gateway or for a resource.

We only know a Gateway's IP once we are connected to it, meaning we cannot route those packets prior to that. We also cannot establish a connection when the user attempts to as every connection intent sent to the portal needs to reference a Resource. For the usecase of resolving SRV and TXT records, the packets will be associated with the DNS resource for which we are trying to resolve records.

This patch only established the base connectivity and necessary exceptions to the Client's filter rules in order to route packets to the Gateway's TUN device. The following commands have been issued against a staging Gateway, demonstrating connectivity to the Gateway's TUN device from a Client after establishing a connection to it:

```
❯ ping github.com -c 1
PING github.com (fd00:2021:1111:8000::) 56 data bytes
64 bytes from github.com (fd00:2021:1111:8000::): icmp_seq=1 ttl=50 time=1441 ms

--- github.com ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 1440.614/1440.614/1440.614/0.000 ms

❯ ping 100.72.145.83 -c 1
PING 100.72.145.83 (100.72.145.83) 56(84) bytes of data.
64 bytes from 100.72.145.83: icmp_seq=1 ttl=64 time=213 ms

--- 100.72.145.83 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 212.574/212.574/212.574/0.000 ms
```

Related: #8221