### PR TITLE
fix(connlib): Always emit_resources_changed

### DIFF
--- a/rust/connlib/tunnel/src/client/resource.rs
+++ b/rust/connlib/tunnel/src/client/resource.rs
@@ -167,12 +167,6 @@ impl Resource {
         }
     }
 
-    pub fn display_fields_changed(&self, other: &Resource) -> bool {
-        self.name() != other.name()
-            || self.address_description() != other.address_description()
-            || self.sites() != other.sites()
-    }
-
     pub fn addresses(&self) -> Vec<IpNetwork> {
         match self {
             Resource::Dns(_) => vec![],


### PR DESCRIPTION
When adding a new Resource that has the same address as a previous Resource, we would fail to call `emit_resources_changed`, and the Resource would fail to show up in the client's resource list.

This happened because we essentially didn't consider "activating" the resource if the resource address didn't change.

With this PR, we always do the following:

- DNS Resource: Add address to the stub resolver -> no-op if address exists
- CIDR Resource: `maybe_update_cidr_resources` -> no-op if duplicate CIDR is added
- Internet Resource: No-op if resource ID doesn't change (it shouldn't ever)

Since we remove the early-exit logic, the `maybe_update_tun_routes` and `emit_resources_changed` is always called.

`maybe_update_tun_routes` is a no-op if the address hasn't changed, so the early-exit logic to avoid calling that seems to be redundant.

## Tested:

- [x] Adding / removing a resource
- [x] Updating a resource's fields individually, observing the client resource updates properly
- [x] Adding two CIDR resources with the same address, observing that the routing table _was not updated_ (thus no disruption to packet flows).


Fixes #8100 