### PR TITLE
chore(portal): Log error for unknown channel messages

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -935,6 +935,13 @@ defmodule API.Client.Channel do
     end
   end
 
+  # Catch-all for unknown messages
+  def handle_in(message, payload, socket) do
+    Logger.error("Unknown client message", message: message, payload: payload)
+
+    {:reply, {:error, %{reason: :unknown_message}}, socket}
+  end
+
   defp select_relays(socket, except_ids \\ []) do
     {:ok, relays} =
       Relays.all_connected_relays_for_account(socket.assigns.subject.account, except_ids)

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -657,6 +657,13 @@ defmodule API.Gateway.Channel do
     end
   end
 
+  # Catch-all for unknown messages
+  def handle_in(message, payload, socket) do
+    Logger.error("Unknown gateway message", message: message, payload: payload)
+
+    {:reply, {:error, %{reason: :unknown_message}}, socket}
+  end
+
   defp encode_ref(socket, tuple) do
     ref =
       tuple

--- a/elixir/apps/api/lib/api/relay/channel.ex
+++ b/elixir/apps/api/lib/api/relay/channel.ex
@@ -2,6 +2,7 @@ defmodule API.Relay.Channel do
   use API, :channel
   alias Domain.Relays
   require OpenTelemetry.Tracer
+  require Logger
 
   @impl true
   def join("relay", %{"stamp_secret" => stamp_secret}, socket) do
@@ -44,5 +45,13 @@ defmodule API.Relay.Channel do
       :ok = Relays.connect_relay(socket.assigns.relay, stamp_secret)
       {:noreply, socket}
     end
+  end
+
+  # Catch-all for unknown messages
+  @impl true
+  def handle_in(message, payload, socket) do
+    Logger.error("Unknown relay message", message: message, payload: payload)
+
+    {:reply, {:error, %{reason: :unknown_message}}, socket}
   end
 end

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -2446,4 +2446,11 @@ defmodule API.Client.ChannelTest do
       assert client.id == client_id
     end
   end
+
+  describe "handle_in/3 for unknown messages" do
+    test "it doesn't crash", %{socket: socket} do
+      ref = push(socket, "unknown_message", %{})
+      assert_reply ref, :error, %{reason: :unknown_message}
+    end
+  end
 end

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -1181,4 +1181,11 @@ defmodule API.Gateway.ChannelTest do
       assert upserted_activity.account_id == account.id
     end
   end
+
+  describe "handle_in/3 for unknown messages" do
+    test "it doesn't crash", %{socket: socket} do
+      ref = push(socket, "unknown_message", %{})
+      assert_reply ref, :error, %{reason: :unknown_message}
+    end
+  end
 end

--- a/elixir/apps/api/test/api/relay/channel_test.exs
+++ b/elixir/apps/api/test/api/relay/channel_test.exs
@@ -52,4 +52,11 @@ defmodule API.Relay.ChannelTest do
       assert_push "init", %{}
     end
   end
+
+  describe "handle_in/3 for unknown messages" do
+    test "it doesn't crash", %{socket: socket} do
+      ref = push(socket, "unknown_message", %{})
+      assert_reply ref, :error, %{reason: :unknown_message}
+    end
+  end
 end


### PR DESCRIPTION
Instead of crashing, it would make sense to log these and let the connected entity maintain its WebSocket connection.

This should never happen in practice if we maintain our version compatibility matrix properly, but it will help reduce the blast radius of a channel message bug that happens to slip out into the wild.

Fixes #4679