### PR TITLE
fix(portal): norely -> noreply in gateway/channel.ex

### DIFF
--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -75,7 +75,7 @@ defmodule API.Gateway.Channel do
   # Resource create message is a no-op for the Gateway as the Resource
   # details will be sent to the Gateway on an :authorize_flow message
   def handle_info({:create_resource, _resource_id}, socket) do
-    {:norely, socket}
+    {:noreply, socket}
   end
 
   # Resource is updated, eg. traffic filters are changed

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -451,7 +451,7 @@ defmodule API.Gateway.ChannelTest do
       resource: resource,
       socket: socket
     } do
-      assert {:noreply, socket} = send(socket.channel_pid, {:create_resource, resource.id})
+      send(socket.channel_pid, {:create_resource, resource.id})
     end
   end
 

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -451,7 +451,7 @@ defmodule API.Gateway.ChannelTest do
       resource: resource,
       socket: socket
     } do
-      send(socket.channel_pid, {:create_resource, resource.id})
+      assert {:noreply, socket} = send(socket.channel_pid, {:create_resource, resource.id})
     end
   end
 


### PR DESCRIPTION
Fixes a typo that snuck in in #8267 