### PR TITLE
refactor(connlib): decouple mangled DNS queries from DNS mapping

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -5,6 +5,7 @@ pub(crate) use resource::{CidrResource, Resource};
 pub(crate) use resource::{DnsResource, InternetResource};
 
 use crate::dns::StubResolver;
+use crate::expiring_map::ExpiringMap;
 use crate::messages::{DnsServer, Interface as InterfaceConfig, IpDnsServer};
 use crate::messages::{IceCredentials, SecretKey};
 use crate::peer_store::PeerStore;
@@ -119,10 +120,8 @@ pub struct ClientState {
 
     /// Maps from connlib-assigned IP of a DNS server back to the originally configured system DNS resolver.
     dns_mapping: BiMap<IpAddr, DnsServer>,
-    /// DNS queries that had their destination IP mangled because the servers is a CIDR resource.
-    ///
-    /// The [`Instant`] tracks when the DNS query expires.
-    mangled_dns_queries: HashMap<(SocketAddr, u16), Instant>,
+    /// UDP DNS queries that had their destination IP mangled to redirect them to another DNS resolver through the tunnel.
+    udp_dns_sockets_by_upstream_and_query_id: ExpiringMap<(SocketAddr, u16), SocketAddr>,
     /// Manages internal dns records and emits forwarding event when not internally handled
     stub_resolver: StubResolver,
 
@@ -217,7 +216,7 @@ impl ClientState {
             system_resolvers: Default::default(),
             sites_status: Default::default(),
             gateways_site: Default::default(),
-            mangled_dns_queries: Default::default(),
+            udp_dns_sockets_by_upstream_and_query_id: Default::default(),
             stub_resolver: Default::default(),
             disabled_resources: Default::default(),
             buffered_transmits: Default::default(),
@@ -528,9 +527,7 @@ impl ClientState {
 
         let packet = maybe_mangle_dns_response_from_cidr_resource(
             packet,
-            &self.dns_mapping,
-            &mut self.mangled_dns_queries,
-            now,
+            &mut self.udp_dns_sockets_by_upstream_and_query_id,
         );
 
         Some(packet)
@@ -851,7 +848,6 @@ impl ClientState {
 
     fn set_dns_mapping(&mut self, new_mapping: BiMap<IpAddr, DnsServer>) {
         self.dns_mapping = new_mapping;
-        self.mangled_dns_queries.clear();
     }
 
     fn initialise_tcp_dns_client(&mut self) {
@@ -1020,9 +1016,7 @@ impl ClientState {
     }
 
     pub fn poll_timeout(&mut self) -> Option<Instant> {
-        // The number of mangled DNS queries is expected to be fairly small because we only track them whilst connecting to a CIDR resource that is a DNS server.
-        // Thus, sorting these values on-demand even within `poll_timeout` is expected to be performant enough.
-        let next_dns_query_expiry = self.mangled_dns_queries.values().min().copied();
+        let next_dns_query_expiry = self.udp_dns_sockets_by_upstream_and_query_id.poll_timeout();
 
         earliest(
             earliest(
@@ -1037,7 +1031,8 @@ impl ClientState {
         self.node.handle_timeout(now);
         self.drain_node_events();
 
-        self.mangled_dns_queries.retain(|_, exp| now < *exp);
+        self.udp_dns_sockets_by_upstream_and_query_id
+            .handle_timeout(now);
 
         self.advance_dns_tcp_sockets(now);
     }
@@ -1134,8 +1129,11 @@ impl ClientState {
                 if self.should_forward_dns_query_to_gateway(upstream.ip()) {
                     tracing::trace!(server = %upstream, %query_id, "Forwarding UDP DNS query via tunnel");
 
-                    self.mangled_dns_queries
-                        .insert((upstream, message.header().id()), now + IDS_EXPIRE);
+                    self.udp_dns_sockets_by_upstream_and_query_id.insert(
+                        (upstream, message.header().id()),
+                        SocketAddr::new(packet.destination(), 53),
+                        now + IDS_EXPIRE,
+                    );
                     packet.set_dst(upstream.ip());
                     packet.update_checksum();
 
@@ -1781,9 +1779,7 @@ fn is_definitely_not_a_resource(ip: IpAddr) -> bool {
 
 fn maybe_mangle_dns_response_from_cidr_resource(
     mut packet: IpPacket,
-    dns_mapping: &BiMap<IpAddr, DnsServer>,
-    mangeled_dns_queries: &mut HashMap<(SocketAddr, u16), Instant>,
-    now: Instant,
+    udp_dns_sockets_by_upstream_and_query_id: &mut ExpiringMap<(SocketAddr, u16), SocketAddr>,
 ) -> IpPacket {
     let src_ip = packet.source();
 
@@ -1794,22 +1790,15 @@ fn maybe_mangle_dns_response_from_cidr_resource(
     let src_port = udp.source_port();
     let src_socket = SocketAddr::new(src_ip, src_port);
 
-    let Some(sentinel) = dns_mapping.get_by_right(&DnsServer::from(src_socket)) else {
-        return packet;
-    };
-
     let Ok(message) = domain::base::Message::from_slice(udp.payload()) else {
         return packet;
     };
 
-    let Some(query_sent_at) = mangeled_dns_queries
-        .remove(&(src_socket, message.header().id()))
-        .map(|expires_at| expires_at - IDS_EXPIRE)
+    let Some(original_dst) =
+        udp_dns_sockets_by_upstream_and_query_id.remove(&(src_socket, message.header().id()))
     else {
         return packet;
     };
-
-    let rtt = now.duration_since(query_sent_at);
 
     let domain = message
         .sole_question()
@@ -1817,9 +1806,9 @@ fn maybe_mangle_dns_response_from_cidr_resource(
         .map(|q| q.into_qname())
         .map(tracing::field::display);
 
-    tracing::trace!(server = %src_ip, query_id = %message.header().id(), ?rtt, domain, "Received UDP DNS response via tunnel");
+    tracing::trace!(server = %src_ip, query_id = %message.header().id(), domain, "Received UDP DNS response via tunnel");
 
-    packet.set_src(*sentinel);
+    packet.set_src(original_dst.ip());
     packet.update_checksum();
 
     packet

--- a/rust/connlib/tunnel/src/expiring_map.rs
+++ b/rust/connlib/tunnel/src/expiring_map.rs
@@ -2,10 +2,19 @@ use core::fmt;
 use std::{collections::BTreeMap, mem, time::Instant};
 
 /// A map that automatically removes entries after a given expiration time.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ExpiringMap<K, V> {
     inner: BTreeMap<K, V>,
     expiration: BTreeMap<Instant, Vec<K>>,
+}
+
+impl<K, V> Default for ExpiringMap<K, V> {
+    fn default() -> Self {
+        Self {
+            inner: BTreeMap::new(),
+            expiration: BTreeMap::new(),
+        }
+    }
 }
 
 impl<K, V> ExpiringMap<K, V>
@@ -20,6 +29,7 @@ where
         old_value
     }
 
+    #[cfg(test)]
     pub fn get(&self, key: &K) -> Option<&V> {
         self.inner.get(key)
     }

--- a/rust/connlib/tunnel/src/expiring_map.rs
+++ b/rust/connlib/tunnel/src/expiring_map.rs
@@ -1,0 +1,98 @@
+use core::fmt;
+use std::{collections::BTreeMap, mem, time::Instant};
+
+/// A map that automatically removes entries after a given expiration time.
+#[derive(Debug, Default)]
+pub struct ExpiringMap<K, V> {
+    inner: BTreeMap<K, V>,
+    expiration: BTreeMap<Instant, Vec<K>>,
+}
+
+impl<K, V> ExpiringMap<K, V>
+where
+    K: Ord + Clone + fmt::Debug,
+    V: fmt::Debug,
+{
+    pub fn insert(&mut self, key: K, value: V, expiration: Instant) -> Option<V> {
+        let old_value = self.inner.insert(key.clone(), value);
+        self.expiration.entry(expiration).or_default().push(key);
+
+        old_value
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.inner.get(key)
+    }
+
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        self.expiration.retain(|_, keys| {
+            keys.retain(|k| k != key);
+            !keys.is_empty()
+        });
+        self.inner.remove(key)
+    }
+
+    pub fn poll_timeout(&self) -> Option<Instant> {
+        self.expiration.keys().next().cloned()
+    }
+
+    pub fn handle_timeout(&mut self, now: Instant) {
+        let not_yet_expired = self.expiration.split_off(&now);
+
+        for key in mem::replace(&mut self.expiration, not_yet_expired)
+            .into_values()
+            .flatten()
+        {
+            let Some(value) = self.inner.remove(&key) else {
+                continue;
+            };
+
+            tracing::debug!(?key, ?value, "Entry expired");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn poll_timeout_returns_next_expiration() {
+        let mut map = ExpiringMap::default();
+        let now = Instant::now();
+
+        map.insert("key1", "value1", now + Duration::from_secs(1));
+        map.insert("key2", "value2", now + Duration::from_secs(2));
+
+        assert_eq!(map.poll_timeout(), Some(now + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn handle_timeout_removes_expired_entries() {
+        let mut map = ExpiringMap::default();
+        let now = Instant::now();
+
+        map.insert("key1", "value1", now + Duration::from_secs(1));
+        map.insert("key2", "value2", now + Duration::from_secs(2));
+
+        map.handle_timeout(now + Duration::from_millis(1001)); // Just after key1 expires
+
+        assert_eq!(map.get(&"key1"), None);
+        assert_eq!(map.get(&"key2"), Some(&"value2"));
+    }
+
+    #[test]
+    fn removing_item_updates_expiration() {
+        let mut map = ExpiringMap::default();
+        let now = Instant::now();
+
+        map.insert("key1", "value1", now + Duration::from_secs(1));
+        map.insert("key2", "value2", now + Duration::from_secs(2));
+
+        map.remove(&"key1");
+
+        assert_eq!(map.poll_timeout(), Some(now + Duration::from_secs(2)));
+    }
+}

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -24,6 +24,7 @@ use tun::Tun;
 mod client;
 mod device_channel;
 mod dns;
+mod expiring_map;
 mod gateway;
 mod io;
 pub mod messages;


### PR DESCRIPTION
When `connlib` receives a UDP packet for one of its DNS resolver IPs and determines that it needs to be forwarded to another resolver through the tunnel, it mangles the destination IP + port to point to this new resolver. In order for the response to be correctly recognised by the application, the response packet needs its _source_ IP + port mangled. This information is currently stored in a `HashMap` together with an expiry timestamp.

To be precise, the information that is captured is only the new destination socket, not the current one. The old socket is then later implied by the DNS mapping that we remember internally, i.e. which one of `connlib`'s DNS resolver IPs maps to which upstream DNS server.

For the usecase of forwarding DNS queries of type SRV and TXT to the site that hosts the DNS resource in question, we want to send those DNS queries to a Gateway within that site. For UDP DNS queries, this requires the same data structure as we do for DNS queries that are tunneled to another DNS resolver _beyond_ the Gateway. In fact, from the perspective of the Client, there is no difference between a packet that is handled by the Gateway or by a resolver behind the Gateway. The only difference is in the new destination IP + port.

In the case where the Gateway is targeted with the DNS query, we won't be able to resolve the original destination socket from the DNS mapping data structure because the Gateway's IP isn't explicitly configured as a DNS resolver.

To handle both of these cases with the same data structure, we refactor this temporary mapping to simply store the original destination socket. To make the data structure less complicated to use, we introduce an `ExpiringMap` that automatically removes entries after a certain deadline. This is important for UDP DNS queries to ensure this map doesn't in an unbounded manner if for some reason, the configured DNS resolver never replies.

Related: #8221