### PR TITLE
fix(portal): Don't use liveview navigate for mailtos

### DIFF
--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -116,6 +116,7 @@
       Please
       <.link
         class={link_style()}
+        target="_blank"
         href={mailto_support(@account, @subject, "Enable account: #{@account.name}")}
       >
         contact support

--- a/elixir/apps/web/lib/web/live/settings/account.ex
+++ b/elixir/apps/web/lib/web/live/settings/account.ex
@@ -80,6 +80,7 @@ defmodule Web.Settings.Account do
           <span :if={Accounts.account_active?(@account)}>disable your account and</span>
           schedule it for deletion, please <.link
             class={link_style()}
+            target="_blank"
             href={mailto_support(@account, @subject, "Account termination request: #{@account.name}")}
           >contact support</.link>.
         </p>

--- a/elixir/apps/web/lib/web/live/settings/billing.ex
+++ b/elixir/apps/web/lib/web/live/settings/billing.ex
@@ -42,15 +42,6 @@ defmodule Web.Settings.Billing do
         <.button icon="hero-pencil" phx-click="redirect_to_billing_portal">
           Manage
         </.button>
-        <.button navigate={
-          mailto_support(
-            @account,
-            @subject,
-            "Billing question: #{@account.name}"
-          )
-        }>
-          Contact Sales Team
-        </.button>
       </:action>
       <:content>
         <.flash :if={@error} kind={:error}>
@@ -75,6 +66,21 @@ defmodule Web.Settings.Billing do
             <:label>Current Plan</:label>
             <:value>
               {@account.metadata.stripe.product_name}
+              <span class="ml-1">
+                <.link
+                  class={link_style()}
+                  target="_blank"
+                  href={
+                    mailto_support(
+                      @account,
+                      @subject,
+                      "Billing question: #{@account.name}"
+                    )
+                  }
+                >
+                  Contact sales
+                </.link>
+              </span>
             </:value>
           </.vertical_table_row>
 
@@ -248,6 +254,7 @@ defmodule Web.Settings.Billing do
           <span :if={Accounts.account_active?(@account)}>disable your account and</span>
           schedule it for deletion, please <.link
             class={link_style()}
+            target="_blank"
             href={mailto_support(@account, @subject, "Account termination request: #{@account.name}")}
           >contact support</.link>.
         </p>

--- a/elixir/apps/web/test/web/live/settings/billing_test.exs
+++ b/elixir/apps/web/test/web/live/settings/billing_test.exs
@@ -92,6 +92,20 @@ defmodule Web.Live.Settings.BillingTest do
     assert html =~ "Billing portal is temporarily unavailable, please try again later."
   end
 
+  test "renders Contact sales link", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/billing")
+
+    assert has_element?(lv, "a[href*='mailto:support']")
+    assert html =~ "Contact sales"
+  end
+
   test "renders billing portal button", %{
     account: account,
     identity: identity,


### PR DESCRIPTION
These cause full page reloads along with a warning. These should be `link href` instead.