### PR TITLE
feat(portal): Enable 1G of swap on portal instances

### DIFF
--- a/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
+++ b/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
@@ -98,3 +98,8 @@ runcmd:
   - sudo ip6tables-restore < /etc/iptables/rules.v6
   - systemctl daemon-reload
   - systemctl start otel-collector.service
+  # Enable swapspace to minimize OOM kills
+  - fallocate -l 1G /var/swapfile
+  - chmod 600 /var/swapfile
+  - mkswap /var/swapfile
+  - swapon /var/swapfile


### PR DESCRIPTION
The `e2-micro` instances we'll be rolling out have 1G of memory (which should be plenty), but it would be helpful to be able to handle small spikes without getting OOM-killed.

Related #8344 