### PR TITLE
feat(gateway): forward queries to local nameserver

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2027,6 +2027,7 @@ dependencies = [
  "moka",
  "nix 0.29.0",
  "phoenix-channel",
+ "resolv-conf",
  "rustls",
  "secrecy",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -93,6 +93,7 @@ rand_core = "0.6.4"
 rangemap = "1.5.1"
 rayon = "1.10.0"
 reqwest = { version = "0.12.9", default-features = false }
+resolv-conf = "0.7.0"
 rtnetlink = { version = "0.14.1", default-features = false, features = ["tokio_socket"] }
 rustls = { version = "0.23.21", default-features = false, features = ["ring"] }
 sadness-generator = "0.6.0"

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -84,6 +84,14 @@ impl RecursiveQuery {
             transport: Transport::Tcp { local, remote },
         }
     }
+
+    pub(crate) fn domain(&self) -> DomainName {
+        self.message
+            .sole_question()
+            .expect("all queries should be for a single name")
+            .qname()
+            .to_vec()
+    }
 }
 
 #[derive(Debug)]

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -84,17 +84,9 @@ impl RecursiveQuery {
             transport: Transport::Tcp { local, remote },
         }
     }
-
-    pub(crate) fn domain(&self) -> DomainName {
-        self.message
-            .sole_question()
-            .expect("all queries should be for a single name")
-            .qname()
-            .to_vec()
-    }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum Transport {
     Udp {
         /// The original source we received the DNS query on.

--- a/rust/connlib/tunnel/src/io/nameserver_set.rs
+++ b/rust/connlib/tunnel/src/io/nameserver_set.rs
@@ -1,0 +1,167 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io,
+    net::{IpAddr, SocketAddr},
+    sync::{Arc, LazyLock},
+    task::{ready, Context, Poll},
+    time::{Duration, Instant},
+};
+
+use connlib_model::DomainName;
+use domain::base::{iana::Rcode, Message, MessageBuilder, Question, Rtype};
+use futures_bounded::FuturesTupleSet;
+use socket_factory::{SocketFactory, UdpSocket};
+
+use crate::io::udp_dns;
+
+const MAX_DNS_SERVERS: usize = 10; // We don't bother selecting from more than 10 servers.
+const DNS_TIMEOUT: Duration = Duration::from_secs(2); // Every sensible DNS servers should respond within 2s.
+
+static FIREZONE_DEV: LazyLock<DomainName> = LazyLock::new(|| {
+    DomainName::vec_from_str("firezone.dev").expect("static domain should always parse")
+});
+
+pub struct NameserverSet {
+    inner: BTreeSet<IpAddr>,
+    nameserver_by_rtt: BTreeMap<Duration, IpAddr>,
+
+    socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
+    queries: FuturesTupleSet<io::Result<Message<Vec<u8>>>, QueryMetaData>,
+}
+
+struct QueryMetaData {
+    nameserver: IpAddr,
+    start: Instant,
+}
+
+impl NameserverSet {
+    pub fn new(
+        inner: BTreeSet<IpAddr>,
+        udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
+    ) -> Self {
+        Self {
+            queries: FuturesTupleSet::new(DNS_TIMEOUT, MAX_DNS_SERVERS),
+            inner,
+            socket_factory: udp_socket_factory,
+            nameserver_by_rtt: Default::default(),
+        }
+    }
+
+    pub fn evaluate(&mut self) {
+        self.nameserver_by_rtt.clear();
+        let start = Instant::now();
+
+        for nameserver in self.inner.iter().copied() {
+            if self
+                .queries
+                .try_push(
+                    udp_dns::send(
+                        self.socket_factory.clone(),
+                        SocketAddr::new(nameserver, crate::dns::DNS_PORT),
+                        query_firezone_dev(),
+                    ),
+                    QueryMetaData { nameserver, start },
+                )
+                .is_err()
+            {
+                tracing::debug!(%nameserver, "Failed to queue another DNS query");
+            }
+        }
+    }
+
+    pub fn fastest(&self) -> Option<IpAddr> {
+        let (_, ns) = self.nameserver_by_rtt.first_key_value()?;
+
+        Some(*ns)
+    }
+
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        if self.queries.is_empty() {
+            return Poll::Ready(());
+        }
+
+        loop {
+            match ready!(self.queries.poll_unpin(cx)) {
+                (Ok(Ok(response)), meta) if response.header().rcode() == Rcode::NOERROR => {
+                    let rtt = meta.start.elapsed();
+
+                    tracing::debug!(nameserver = %meta.nameserver, ?rtt, ?response, "DNS query completed");
+
+                    self.nameserver_by_rtt.insert(rtt, meta.nameserver);
+                }
+                (Ok(Ok(response)), meta) => {
+                    tracing::debug!(nameserver = %meta.nameserver, ?response, "DNS query failed");
+                }
+                (Ok(Err(e)), meta) => {
+                    tracing::debug!(nameserver = %meta.nameserver, "DNS query failed: {e}");
+                }
+                (Err(_), meta) => {
+                    tracing::debug!(nameserver = %meta.nameserver, "DNS query timed out after {DNS_TIMEOUT:?}");
+                }
+            }
+
+            let Some(fastest) = self.fastest() else {
+                continue;
+            };
+
+            if self.queries.is_empty() {
+                tracing::info!(%fastest, "Evaluated fastest nameserver");
+
+                return Poll::Ready(());
+            }
+        }
+    }
+}
+
+fn query_firezone_dev() -> Message<Vec<u8>> {
+    let mut builder = MessageBuilder::new_vec().question();
+    builder.header_mut().set_random_id();
+    builder.header_mut().set_rd(true);
+    builder.header_mut().set_qr(false);
+
+    builder
+        .push(Question::new_in(FIREZONE_DEV.clone(), Rtype::A))
+        .expect("static question should always be valid");
+
+    builder.into_message()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "Needs Internet"]
+    async fn can_evaluate_fastest_nameserver() {
+        let _guard = firezone_logging::test("debug");
+
+        let mut set = NameserverSet::new(
+            BTreeSet::from([
+                Ipv4Addr::new(1, 1, 1, 1).into(),
+                Ipv4Addr::new(8, 8, 8, 8).into(),
+                Ipv4Addr::new(8, 8, 4, 4).into(),
+                Ipv4Addr::new(9, 9, 9, 9).into(),
+                Ipv4Addr::new(100, 100, 100, 100).into(), // Also include an unreachable server.
+            ]),
+            Arc::new(socket_factory::udp),
+        );
+        set.evaluate();
+
+        std::future::poll_fn(|cx| set.poll(cx)).await;
+
+        assert!(set.fastest().is_some());
+    }
+
+    #[tokio::test]
+    async fn can_handle_no_servers() {
+        let _guard = firezone_logging::test("debug");
+
+        let mut set = NameserverSet::new(BTreeSet::default(), Arc::new(socket_factory::udp));
+
+        std::future::poll_fn(|cx| set.poll(cx)).await;
+
+        assert!(set.fastest().is_none());
+    }
+}

--- a/rust/connlib/tunnel/src/io/tcp_dns.rs
+++ b/rust/connlib/tunnel/src/io/tcp_dns.rs
@@ -1,0 +1,41 @@
+use std::{io, net::SocketAddr, sync::Arc};
+
+use domain::base::{Message, ToName as _};
+use socket_factory::{SocketFactory, TcpSocket};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+pub async fn send(
+    factory: Arc<dyn SocketFactory<TcpSocket>>,
+    server: SocketAddr,
+    query: Message<Vec<u8>>,
+) -> io::Result<Message<Vec<u8>>> {
+    let domain = query
+        .sole_question()
+        .expect("all queries should be for a single name")
+        .qname()
+        .to_vec();
+
+    tracing::trace!(target: "wire::dns::recursive::tcp", %server, %domain);
+
+    let tcp_socket = factory(&server)?; // TODO: Optimise this to reuse a TCP socket to the same resolver.
+    let mut tcp_stream = tcp_socket.connect(server).await?;
+
+    let query = query.into_octets();
+    let dns_message_length = (query.len() as u16).to_be_bytes();
+
+    tcp_stream.write_all(&dns_message_length).await?;
+    tcp_stream.write_all(&query).await?;
+
+    let mut response_length = [0u8; 2];
+    tcp_stream.read_exact(&mut response_length).await?;
+    let response_length = u16::from_be_bytes(response_length) as usize;
+
+    // A u16 is at most 65k, meaning we are okay to allocate here based on what the remote is sending.
+    let mut response = vec![0u8; response_length];
+    tcp_stream.read_exact(&mut response).await?;
+
+    let message = Message::from_octets(response)
+        .map_err(|_| io::Error::other("Failed to parse DNS message"))?;
+
+    Ok(message)
+}

--- a/rust/connlib/tunnel/src/io/udp_dns.rs
+++ b/rust/connlib/tunnel/src/io/udp_dns.rs
@@ -1,0 +1,40 @@
+use std::{
+    io,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
+};
+
+use domain::base::{Message, ToName as _};
+use socket_factory::{SocketFactory, UdpSocket};
+
+pub async fn send(
+    factory: Arc<dyn SocketFactory<UdpSocket>>,
+    server: SocketAddr,
+    query: Message<Vec<u8>>,
+) -> io::Result<Message<Vec<u8>>> {
+    let domain = query
+        .sole_question()
+        .expect("all queries should be for a single name")
+        .qname()
+        .to_vec();
+    let bind_addr = match server {
+        SocketAddr::V4(_) => SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0),
+        SocketAddr::V6(_) => SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0),
+    };
+
+    tracing::trace!(target: "wire::dns::recursive::udp", %server, %domain);
+
+    // To avoid fragmentation, IP and thus also UDP packets can only reliably sent with an MTU of <= 1500 on the public Internet.
+    const BUF_SIZE: usize = 1500;
+
+    let udp_socket = factory(&bind_addr)?;
+
+    let response = udp_socket
+        .handshake::<BUF_SIZE>(server, query.as_slice())
+        .await?;
+
+    let message = Message::from_octets(response)
+        .map_err(|_| io::Error::other("Failed to parse DNS message"))?;
+
+    Ok(message)
+}

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -29,6 +29,7 @@ libc = { workspace = true, features = ["std", "const-extern-fn", "extra_traits"]
 moka = { workspace = true, features = ["future"] }
 nix = { workspace = true }
 phoenix-channel = { workspace = true }
+resolv-conf = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -123,6 +123,12 @@ impl Eventloop {
                         continue;
                     }
 
+                    if e.root_cause()
+                        .is::<firezone_tunnel::NoNameserverAvailable>()
+                    {
+                        return Poll::Ready(Err(Error::NoNameserversAvailable(e)));
+                    }
+
                     telemetry_event!("Tunnel error: {e:#}");
                     continue;
                 }
@@ -544,6 +550,8 @@ pub enum Error {
     UpdateTun(#[source] anyhow::Error),
     #[error("{0:#}")]
     BindDnsSockets(#[source] anyhow::Error),
+    #[error("{0:#}")]
+    NoNameserversAvailable(#[source] anyhow::Error),
 }
 
 async fn resolve(domain: DomainName) -> Result<Vec<IpAddr>> {


### PR DESCRIPTION
The DNS server added in #8285 was only a dummy DNS server that added infrastructure to actually receive DNS queries on the IP of the TUN device at port 53535 and it returns SERVFAIL for all queries. For this DNS server to be useful, we need to take those queries and replay them towards a DNS server that is configured locally on the Gateway.

To achieve this, we parse `/etc/resolv.conf` during startup of the Gateway and pass the contained nameservers into the tunnel. From there, the Gateway's event-loop can receive the queries, feed them into the already existing machinery for performing recursive DNS queries that we use on the Client and resolve the records.

In its current implementation, we only use the first nameserver defined in `/etc/resolv.conf`. If the lookup fails, we send back a SERVFAIL error and log a message.

Resolves: #8221