### PR TITLE
refactor(connlib): remove `SocketHandle` from TCP DNS server API

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -133,8 +133,8 @@ pub struct ClientState {
 
     tcp_dns_client: dns_over_tcp::Client,
     tcp_dns_server: dns_over_tcp::Server,
-    /// Tracks the socket on which we received a TCP DNS query by the ID of the recursive DNS query we issued.
-    tcp_dns_sockets_by_upstream_and_query_id: HashMap<(SocketAddr, u16), SocketAddr>,
+    /// Tracks the TCP stream (i.e. socket-pair) on which we received a TCP DNS query by the ID of the recursive DNS query we issued.
+    tcp_dns_streams_by_upstream_and_query_id: HashMap<(SocketAddr, u16), (SocketAddr, SocketAddr)>,
 
     /// Stores the gateways we recently connected to.
     ///
@@ -239,7 +239,7 @@ impl ClientState {
             buffered_dns_queries: Default::default(),
             tcp_dns_client: dns_over_tcp::Client::new(now, seed),
             tcp_dns_server: dns_over_tcp::Server::new(now),
-            tcp_dns_sockets_by_upstream_and_query_id: Default::default(),
+            tcp_dns_streams_by_upstream_and_query_id: Default::default(),
             pending_flows: Default::default(),
             dns_resource_nat_by_gateway: BTreeMap::new(),
         }
@@ -582,7 +582,7 @@ impl ClientState {
                     "Failed to queue UDP DNS response: {}"
                 );
             }
-            (dns::Transport::Tcp { source }, result) => {
+            (dns::Transport::Tcp { local, remote }, result) => {
                 let message = result
                     .inspect(|_| {
                         tracing::trace!("Received recursive TCP DNS response");
@@ -594,7 +594,7 @@ impl ClientState {
                     });
 
                 unwrap_or_warn!(
-                    self.tcp_dns_server.send_message(source, message),
+                    self.tcp_dns_server.send_message(local, remote, message),
                     "Failed to send TCP DNS response: {}"
                 );
             }
@@ -1133,9 +1133,9 @@ impl ClientState {
             if let Some(query_result) = self.tcp_dns_client.poll_query_result() {
                 let server = query_result.server;
                 let qid = query_result.query.header().id();
-                let known_sockets = &mut self.tcp_dns_sockets_by_upstream_and_query_id;
+                let known_sockets = &mut self.tcp_dns_streams_by_upstream_and_query_id;
 
-                let Some(source) = known_sockets.remove(&(server, qid)) else {
+                let Some((local, remote)) = known_sockets.remove(&(server, qid)) else {
                     tracing::warn!(?known_sockets, %server, %qid, "Failed to find TCP socket handle for query result");
 
                     continue;
@@ -1147,7 +1147,7 @@ impl ClientState {
                     message: query_result
                         .result
                         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{e:#}"))),
-                    transport: dns::Transport::Tcp { source },
+                    transport: dns::Transport::Tcp { local, remote },
                 });
                 continue;
             }
@@ -1279,7 +1279,8 @@ impl ClientState {
                 self.update_dns_resource_nat(now, iter::empty());
 
                 unwrap_or_debug!(
-                    self.tcp_dns_server.send_message(query.source, response),
+                    self.tcp_dns_server
+                        .send_message(query.local, query.remote, response),
                     "Failed to send TCP DNS response: {}"
                 );
             }
@@ -1294,7 +1295,8 @@ impl ClientState {
 
                 self.buffered_dns_queries
                     .push_back(dns::RecursiveQuery::via_tcp(
-                        query.source,
+                        query.local,
+                        query.remote,
                         server,
                         query.message,
                     ));
@@ -1336,8 +1338,11 @@ impl ClientState {
                 );
 
                 unwrap_or_debug!(
-                    self.tcp_dns_server
-                        .send_message(query.source, dns::servfail(query.message.for_slice_ref())),
+                    self.tcp_dns_server.send_message(
+                        query.local,
+                        query.remote,
+                        dns::servfail(query.message.for_slice_ref())
+                    ),
                     "Failed to send TCP DNS response: {}"
                 );
                 return;
@@ -1345,8 +1350,8 @@ impl ClientState {
         };
 
         let existing = self
-            .tcp_dns_sockets_by_upstream_and_query_id
-            .insert((server, query_id), query.source);
+            .tcp_dns_streams_by_upstream_and_query_id
+            .insert((server, query_id), (query.local, query.remote));
 
         debug_assert!(existing.is_none(), "Query IDs should be unique");
     }

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -1,7 +1,6 @@
 use crate::client::IpProvider;
 use anyhow::{Context, Result};
 use connlib_model::{DomainName, ResourceId};
-use dns_over_tcp::SocketHandle;
 use domain::rdata::AllRecordData;
 use domain::{
     base::{
@@ -74,7 +73,7 @@ impl RecursiveQuery {
     }
 
     pub(crate) fn via_tcp(
-        source: SocketHandle,
+        source: SocketAddr,
         server: SocketAddr,
         message: Message<Vec<u8>>,
     ) -> Self {
@@ -93,7 +92,7 @@ pub(crate) enum Transport {
         source: SocketAddr,
     },
     Tcp {
-        source: SocketHandle,
+        source: SocketAddr,
     },
 }
 

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -73,14 +73,15 @@ impl RecursiveQuery {
     }
 
     pub(crate) fn via_tcp(
-        source: SocketAddr,
+        local: SocketAddr,
+        remote: SocketAddr,
         server: SocketAddr,
         message: Message<Vec<u8>>,
     ) -> Self {
         Self {
             server,
             message,
-            transport: Transport::Tcp { source },
+            transport: Transport::Tcp { local, remote },
         }
     }
 }
@@ -92,7 +93,8 @@ pub(crate) enum Transport {
         source: SocketAddr,
     },
     Tcp {
-        source: SocketAddr,
+        local: SocketAddr,
+        remote: SocketAddr,
     },
 }
 

--- a/rust/connlib/tunnel/src/tests/dns_server_resource.rs
+++ b/rust/connlib/tunnel/src/tests/dns_server_resource.rs
@@ -39,7 +39,7 @@ impl TcpDnsServerResource {
         while let Some(query) = self.server.poll_queries() {
             let response = handle_dns_query(query.message.for_slice(), global_dns_records);
 
-            self.server.send_message(query.socket, response).unwrap();
+            self.server.send_message(query.source, response).unwrap();
         }
     }
 

--- a/rust/connlib/tunnel/src/tests/dns_server_resource.rs
+++ b/rust/connlib/tunnel/src/tests/dns_server_resource.rs
@@ -39,7 +39,9 @@ impl TcpDnsServerResource {
         while let Some(query) = self.server.poll_queries() {
             let response = handle_dns_query(query.message.for_slice(), global_dns_records);
 
-            self.server.send_message(query.source, response).unwrap();
+            self.server
+                .send_message(query.local, query.remote, response)
+                .unwrap();
         }
     }
 

--- a/rust/dns-over-tcp/src/client.rs
+++ b/rust/dns-over-tcp/src/client.rs
@@ -195,6 +195,8 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
         }
 
         for (remote, handle) in self.sockets_by_remote.iter_mut() {
+            let _guard = tracing::trace_span!("socket", %handle).entered();
+
             let socket = self.sockets.get_mut::<tcp::Socket>(*handle);
             let server = *remote;
 
@@ -399,7 +401,7 @@ fn into_failed_results(
 
 fn try_recv_response<'b>(socket: &'b mut tcp::Socket) -> Result<Option<Message<&'b [u8]>>> {
     if !socket.can_recv() {
-        tracing::trace!("Not yet ready to receive next message");
+        tracing::trace!(state = %socket.state(), "Not yet ready to receive next message");
 
         return Ok(None);
     }

--- a/rust/dns-over-tcp/src/lib.rs
+++ b/rust/dns-over-tcp/src/lib.rs
@@ -6,7 +6,7 @@ mod stub_device;
 mod time;
 
 pub use client::{Client, QueryResult};
-pub use server::{Query, Server, SocketHandle};
+pub use server::{Query, Server};
 
 fn create_tcp_socket() -> smoltcp::socket::tcp::Socket<'static> {
     /// The 2-byte length prefix of DNS over TCP messages limits their size to effectively u16::MAX.

--- a/rust/dns-over-tcp/tests/client_and_server.rs
+++ b/rust/dns-over-tcp/tests/client_and_server.rs
@@ -72,7 +72,9 @@ fn progress(
                 .unwrap()
                 .into_message();
 
-            dns_server.send_message(query.source, response).unwrap();
+            dns_server
+                .send_message(query.local, query.remote, response)
+                .unwrap();
             continue;
         }
 

--- a/rust/dns-over-tcp/tests/client_and_server.rs
+++ b/rust/dns-over-tcp/tests/client_and_server.rs
@@ -72,7 +72,7 @@ fn progress(
                 .unwrap()
                 .into_message();
 
-            dns_server.send_message(query.socket, response).unwrap();
+            dns_server.send_message(query.source, response).unwrap();
             continue;
         }
 

--- a/rust/dns-over-tcp/tests/smoke_server.rs
+++ b/rust/dns-over-tcp/tests/smoke_server.rs
@@ -113,7 +113,7 @@ impl Eventloop {
                     .into_message();
 
                 self.dns_server
-                    .send_message(query.source, response)
+                    .send_message(query.local, query.remote, response)
                     .unwrap();
                 continue;
             }

--- a/rust/dns-over-tcp/tests/smoke_server.rs
+++ b/rust/dns-over-tcp/tests/smoke_server.rs
@@ -113,7 +113,7 @@ impl Eventloop {
                     .into_message();
 
                 self.dns_server
-                    .send_message(query.socket, response)
+                    .send_message(query.source, response)
                     .unwrap();
                 continue;
             }


### PR DESCRIPTION
At present, the TCP DNS server we use in `connlib` exposes an opaque `SocketHandle` with each received query. This handle refers to the socket that the query was received on. The response needs to be sent back on the same socket because it effectively refers to the TCP stream that was established.

We need to track this `SocketHandle` all the way through to our user-space DNS client in `connlib` which actually resolves queries with a DNS server. In order to be able to reuse this DNS client on the Gateway where we receive DNS queries using a user-space socket (and thus don't have such a `SocketHandle`), we need to remove this abstraction from the public API of the TCP DNS server.

A TCP stream is effectively identified by the source and destination socket address: A given 4-tuple (source IP, source port, destination IP, destination port) can only ever hold a single TCP connection. As such, returning the local and remote `SocketAddr` with the query is sufficient to uniquely identify the socket.