### PR TITLE
fix(portal): Increase memberships txn timeout to 60s

### DIFF
--- a/elixir/apps/domain/lib/domain/actors.ex
+++ b/elixir/apps/domain/lib/domain/actors.ex
@@ -256,7 +256,7 @@ defmodule Domain.Actors do
 
         group
       end)
-    end)
+    end, timeout: 60_000)
   end
 
   def delete_group(%Group{provider_id: nil} = group, %Auth.Subject{} = subject) do


### PR DESCRIPTION
When we upsert identities or delete providers, we call this transaction, which does a `Group.Query.lock |> Repo.all` and has a high likelihood of timing out with a nontrivial number of synced groups. This also happens when deleting an account (see 526f9ca269 ).

This doesn't fix the problem entirely but at least reduces the blast radius until we can introduce a proper fix in #8187 (see 526f9ca269)

Fixes #8358 

