### PR TITLE
feat(connlib): add TTL to DNS resource NAT

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -315,7 +315,10 @@ impl GatewayState {
                 dns_resource_nat::NatStatus::Inactive
             });
 
-        let packet = dns_resource_nat::domain_status(req.resource, req.domain, nat_status)?;
+        let default_ttl = 30; // TODO: Extend this to use the actual TTL from the DNS response.
+
+        let packet =
+            dns_resource_nat::domain_status(req.resource, req.domain, nat_status, default_ttl)?;
 
         let Some(transmit) = encrypt_packet(packet, req.client, &mut self.node, now)? else {
             return Ok(());
@@ -455,6 +458,7 @@ fn handle_p2p_control_packet(
                     req.resource,
                     req.domain,
                     dns_resource_nat::NatStatus::Inactive,
+                    0,
                 )
                 .inspect_err(|e| tracing::warn!("Failed to create `DomainStatus` packet: {e:#}"))
                 .ok()?;


### PR DESCRIPTION
A little experiment. Could be useful once we have a DNS TTL available on the Gateway and therefore hint at the client, when it would make sense to requery DNS.