### PR TITLE
fix(connlib): use TCP as well to pick fastest nameserver

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -110,7 +110,11 @@ impl Io {
         let mut sockets = Sockets::default();
         sockets.rebind(udp_socket_factory.as_ref()); // Bind sockets on startup. Must happen within a tokio runtime context.
 
-        let mut nameservers = NameserverSet::new(nameservers, udp_socket_factory.clone());
+        let mut nameservers = NameserverSet::new(
+            nameservers,
+            tcp_socket_factory.clone(),
+            udp_socket_factory.clone(),
+        );
         nameservers.evaluate();
 
         Self {

--- a/rust/connlib/tunnel/src/io/nameserver_set.rs
+++ b/rust/connlib/tunnel/src/io/nameserver_set.rs
@@ -84,7 +84,7 @@ impl NameserverSet {
                 )
                 .is_err()
             {
-                tracing::debug!(%nameserver, "Failed to queue another UDP DNS query");
+                tracing::debug!(%nameserver, "Failed to queue another TCP DNS query");
             }
         }
     }


### PR DESCRIPTION
UDP is an unreliable transport and thus it can happen that a UDP DNS query gets lost in transit. Our current algorithm for picking a nameserver of all provided ones only uses UDP DNS and thus, we may run into a scenario where we falsely claim to not have nameservers simply because the UDP request or response got lost in transit.

To mitigate this, we also perform a TCP DNS query to every nameserver. TCP is reliable and will perform retransmissions in case of packet loss.