### PR TITLE
fix(portal): Use explicit UTC timezone for NOW()

### DIFF
--- a/elixir/apps/domain/lib/domain/accounts/account/query.ex
+++ b/elixir/apps/domain/lib/domain/accounts/account/query.ex
@@ -74,7 +74,7 @@ defmodule Domain.Accounts.Account.Query do
       queryable,
       [accounts: accounts],
       fragment(
-        "(?->'notifications'->?->>'last_notified')::timestamp < NOW() - ?::interval",
+        "(?->'notifications'->?->>'last_notified')::timestamp < timezone('UTC', NOW()) - ?::interval",
         accounts.config,
         ^notification,
         ^interval

--- a/elixir/apps/domain/lib/domain/actors/group/query.ex
+++ b/elixir/apps/domain/lib/domain/actors/group/query.ex
@@ -68,7 +68,7 @@ defmodule Domain.Actors.Group.Query do
     |> Ecto.Query.select([groups: groups], groups)
     |> Ecto.Query.update([groups: groups],
       set: [
-        deleted_at: fragment("COALESCE(?, NOW())", groups.deleted_at)
+        deleted_at: fragment("COALESCE(?, timezone('UTC', NOW()))", groups.deleted_at)
       ]
     )
   end

--- a/elixir/apps/domain/lib/domain/auth/identity/query.ex
+++ b/elixir/apps/domain/lib/domain/auth/identity/query.ex
@@ -203,7 +203,7 @@ defmodule Domain.Auth.Identity.Query do
     |> Ecto.Query.select([identities: identities], identities)
     |> Ecto.Query.update([identities: identities],
       set: [
-        deleted_at: fragment("COALESCE(?, NOW())", identities.deleted_at),
+        deleted_at: fragment("COALESCE(?, timezone('UTC', NOW()))", identities.deleted_at),
         provider_state: ^%{}
       ]
     )

--- a/elixir/apps/domain/lib/domain/auth/provider/query.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/query.ex
@@ -48,7 +48,7 @@ defmodule Domain.Auth.Provider.Query do
       [providers: providers],
       is_nil(providers.last_synced_at) or
         fragment(
-          "? + LEAST((interval '10 minute' * (COALESCE(?, 0) ^ 2 + 1)), interval '4 hours') < NOW()",
+          "? + LEAST((interval '10 minute' * (COALESCE(?, 0) ^ 2 + 1)), interval '4 hours') < timezone('UTC', NOW())",
           providers.last_synced_at,
           providers.last_syncs_failed
         )

--- a/elixir/apps/domain/lib/domain/clients/client/changeset.ex
+++ b/elixir/apps/domain/lib/domain/clients/client/changeset.ex
@@ -36,7 +36,7 @@ defmodule Domain.Clients.Client.Changeset do
         device_uuid: fragment("EXCLUDED.device_uuid"),
         identifier_for_vendor: fragment("EXCLUDED.identifier_for_vendor"),
         firebase_installation_id: fragment("EXCLUDED.firebase_installation_id"),
-        updated_at: fragment("NOW()"),
+        updated_at: fragment("timezone('UTC', NOW())"),
         verified_at:
           fragment(
             """

--- a/elixir/apps/domain/lib/domain/clients/client/query.ex
+++ b/elixir/apps/domain/lib/domain/clients/client/query.ex
@@ -66,7 +66,7 @@ defmodule Domain.Clients.Client.Query do
     |> Ecto.Query.select([clients: clients], clients)
     |> Ecto.Query.update([clients: clients],
       set: [
-        deleted_at: fragment("COALESCE(?, NOW())", clients.deleted_at)
+        deleted_at: fragment("COALESCE(?, timezone('UTC', NOW()))", clients.deleted_at)
       ]
     )
   end

--- a/elixir/apps/domain/lib/domain/flows/flow/query.ex
+++ b/elixir/apps/domain/lib/domain/flows/flow/query.ex
@@ -6,7 +6,7 @@ defmodule Domain.Flows.Flow.Query do
   end
 
   def not_expired(queryable \\ all()) do
-    where(queryable, [flows: flows], flows.expires_at > fragment("NOW()"))
+    where(queryable, [flows: flows], flows.expires_at > fragment("timezone('UTC', NOW())"))
   end
 
   def by_id(queryable, id) do
@@ -67,7 +67,7 @@ defmodule Domain.Flows.Flow.Query do
     |> Ecto.Query.select([flows: flows], flows)
     |> Ecto.Query.update([flows: flows],
       set: [
-        expires_at: fragment("LEAST(?, NOW())", flows.expires_at)
+        expires_at: fragment("LEAST(?, timezone('UTC', NOW()))", flows.expires_at)
       ]
     )
   end
@@ -117,10 +117,10 @@ defmodule Domain.Flows.Flow.Query do
     ]
 
   def filter_by_expired(queryable, "expired") do
-    {queryable, dynamic([flows: flows], flows.expires_at < fragment("NOW()"))}
+    {queryable, dynamic([flows: flows], flows.expires_at < fragment("timezone('UTC', NOW())"))}
   end
 
   def filter_by_expired(queryable, "not_expired") do
-    {queryable, dynamic([flows: flows], flows.expires_at >= fragment("NOW()"))}
+    {queryable, dynamic([flows: flows], flows.expires_at >= fragment("timezone('UTC', NOW())"))}
   end
 end

--- a/elixir/apps/domain/lib/domain/policies/policy/query.ex
+++ b/elixir/apps/domain/lib/domain/policies/policy/query.ex
@@ -73,7 +73,7 @@ defmodule Domain.Policies.Policy.Query do
     |> Ecto.Query.select([policies: policies], policies)
     |> Ecto.Query.update([policies: policies],
       set: [
-        deleted_at: fragment("COALESCE(?, NOW())", policies.deleted_at)
+        deleted_at: fragment("COALESCE(?, timezone('UTC', NOW()))", policies.deleted_at)
       ]
     )
   end

--- a/elixir/apps/domain/lib/domain/tokens.ex
+++ b/elixir/apps/domain/lib/domain/tokens.ex
@@ -143,7 +143,7 @@ defmodule Domain.Tokens do
           ),
         expires_at:
           fragment(
-            "CASE WHEN ? - 1 = 0 THEN COALESCE(?, NOW()) ELSE ? END",
+            "CASE WHEN ? - 1 = 0 THEN COALESCE(?, timezone('UTC', NOW())) ELSE ? END",
             tokens.remaining_attempts,
             tokens.expires_at,
             tokens.expires_at

--- a/elixir/apps/domain/lib/domain/tokens/token/query.ex
+++ b/elixir/apps/domain/lib/domain/tokens/token/query.ex
@@ -30,7 +30,7 @@ defmodule Domain.Tokens.Token.Query do
       [tokens: tokens],
       not is_nil(tokens.expires_at) and
         fragment(
-          "NOW() + '5 seconds'::interval < ? AND ? < NOW() + ?::interval",
+          "timezone('UTC', NOW()) + '5 seconds'::interval < ? AND ? < timezone('UTC', NOW()) + ?::interval",
           tokens.expires_at,
           tokens.expires_at,
           ^duration
@@ -83,7 +83,7 @@ defmodule Domain.Tokens.Token.Query do
     |> Ecto.Query.select([tokens: tokens], tokens)
     |> Ecto.Query.update([tokens: tokens],
       set: [
-        deleted_at: fragment("COALESCE(?, NOW())", tokens.deleted_at)
+        deleted_at: fragment("COALESCE(?, timezone('UTC', NOW()))", tokens.deleted_at)
       ]
     )
   end


### PR DESCRIPTION
Fixes #8373 