### PR TITLE
fix(android): Ensure Android layouts `fitsSystemWindows`

### DIFF
--- a/kotlin/android/app/src/main/res/layout/activity_auth.xml
+++ b/kotlin/android/app/src/main/res/layout/activity_auth.xml
@@ -5,8 +5,9 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
+	tools:context=".features.auth.ui.AuthActivity"
 	android:padding="@dimen/spacing_medium"
-	tools:context=".features.auth.ui.AuthActivity">
+	android:fitsSystemWindows="true">
 
 	<androidx.constraintlayout.widget.ConstraintLayout
 		android:id="@+id/llContainer"

--- a/kotlin/android/app/src/main/res/layout/activity_custom_uri_handler.xml
+++ b/kotlin/android/app/src/main/res/layout/activity_custom_uri_handler.xml
@@ -5,7 +5,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".features.customuri.ui.CustomUriHandlerActivity">
+    tools:context=".features.customuri.ui.CustomUriHandlerActivity"
+    android:padding="@dimen/spacing_medium"
+    android:fitsSystemWindows="true">
 
   <TextView
       android:layout_width="wrap_content"

--- a/kotlin/android/app/src/main/res/layout/activity_main.xml
+++ b/kotlin/android/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"
-    tools:context=".core.presentation.MainActivity">
+    tools:context=".core.presentation.MainActivity"
+    android:padding="@dimen/spacing_medium"
+    android:fitsSystemWindows="true">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragmentContainer"

--- a/kotlin/android/app/src/main/res/layout/activity_session.xml
+++ b/kotlin/android/app/src/main/res/layout/activity_session.xml
@@ -5,7 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/spacing_4x">
+    android:padding="@dimen/spacing_medium"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/llContainer"
@@ -48,6 +49,7 @@
         android:layout_height="wrap_content"
         android:text="@string/resources"
         android:layout_marginTop="@dimen/spacing_4x"
+        android:layout_marginLeft="@dimen/spacing_medium"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/llContainer" />
 
@@ -90,6 +92,7 @@
         style="?attr/materialButtonOutlinedStyle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/spacing_medium"
         android:layout_marginEnd="8dp"
         android:text="@string/settings"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -101,6 +104,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
+        android:layout_marginEnd="@dimen/spacing_medium"
         android:text="@string/sign_out"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -111,6 +115,7 @@
         android:layout_width="200dp"
         android:layout_height="20dp"
         android:layout_marginTop="26dp"
+        android:layout_marginRight="@dimen/spacing_medium"
         android:textAlignment="textEnd"
         android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"

--- a/kotlin/android/app/src/main/res/layout/activity_settings.xml
+++ b/kotlin/android/app/src/main/res/layout/activity_settings.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/spacing_4x">
+    android:padding="@dimen/spacing_medium"
+    android:fitsSystemWindows="true">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btCancel"

--- a/kotlin/android/app/src/main/res/layout/activity_vpn_permission.xml
+++ b/kotlin/android/app/src/main/res/layout/activity_vpn_permission.xml
@@ -6,7 +6,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="@dimen/spacing_medium"
-    tools:context=".features.permission.vpn.ui.VpnPermissionActivity">
+    tools:context=".features.permission.vpn.ui.VpnPermissionActivity"
+    android:fitsSystemWindows="true">
 
   <androidx.appcompat.widget.LinearLayoutCompat
       android:id="@+id/llContainer"

--- a/kotlin/android/app/src/main/res/layout/fragment_resource_details.xml
+++ b/kotlin/android/app/src/main/res/layout/fragment_resource_details.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="16dp">
+    android:padding="@dimen/spacing_medium"
+    android:fitsSystemWindows="true">
 
     <!-- Resource Section -->
     <TextView

--- a/kotlin/android/app/src/main/res/layout/fragment_settings_advanced.xml
+++ b/kotlin/android/app/src/main/res/layout/fragment_settings_advanced.xml
@@ -5,7 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true"
-    android:padding="0dp">
+    android:padding="@dimen/spacing_medium"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/kotlin/android/app/src/main/res/layout/fragment_settings_logs.xml
+++ b/kotlin/android/app/src/main/res/layout/fragment_settings_logs.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="16dp">
+    android:padding="@dimen/spacing_medium"
+    android:fitsSystemWindows="true">
 
     <!-- Display Log Directory Size -->
     <TextView

--- a/kotlin/android/app/src/main/res/layout/fragment_sign_in.xml
+++ b/kotlin/android/app/src/main/res/layout/fragment_sign_in.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/spacing_medium">
+    android:padding="@dimen/spacing_medium"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/llContainer"

--- a/kotlin/android/app/src/main/res/layout/fragment_splash.xml
+++ b/kotlin/android/app/src/main/res/layout/fragment_splash.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/spacing_medium">
+    android:padding="@dimen/spacing_medium"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/llContainer"

--- a/kotlin/android/app/src/main/res/layout/list_item_resource.xml
+++ b/kotlin/android/app/src/main/res/layout/list_item_resource.xml
@@ -5,7 +5,8 @@
 	android:id="@+id/enabled"
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content"
-	android:paddingVertical="@dimen/spacing_small">
+	android:padding="@dimen/spacing_medium"
+	android:fitsSystemWindows="true">
 
 	<TextView
 		android:id="@+id/resourceNameText"

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -20,6 +20,10 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="8376">
+          Fixes a bug where UI controls could overlap with system controls on
+          some devices.
+        </ChangeItem>
         <ChangeItem pull="8286">
           Fixes a bug that prevented certain Resource fields from being updated
           when they were updated in the admin portal.


### PR DESCRIPTION
- Sets the `fitsSystemWindows` var to avoid overlapping any system controls
- Makes all margin padding consistent at `@dimen/spacing_medium` so that no controls are right on the edge of the view

Fixes: https://firezonehq.slack.com/archives/C08FPHECLUF/p1741266356394749
Fixes: #7094