### PR TITLE
feat(connlib): expand single-label queries using search-domain

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -117,6 +117,7 @@ jobs:
           rg --count --no-ignore "Too big DNS response, truncating" $TESTCASES_DIR
           rg --count --no-ignore "Destination is unreachable" $TESTCASES_DIR
           rg --count --no-ignore "Forwarding query for DNS resource to corresponding site" $TESTCASES_DIR
+          rg --count --no-ignore "Expanded single-label query into FQDN using search-domain" $TESTCASES_DIR
 
         env:
           # <https://github.com/rust-lang/cargo/issues/5999>

--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -9,7 +9,7 @@ use crate::tun::Tun;
 use anyhow::{Context as _, Result};
 use backoff::ExponentialBackoffBuilder;
 use connlib_client_shared::{Callbacks, DisconnectError, Session, V4RouteList, V6RouteList};
-use connlib_model::ResourceView;
+use connlib_model::{DomainName, ResourceView};
 use firezone_logging::{err_with_src, sentry_layer};
 use firezone_telemetry::{Telemetry, ANDROID_DSN};
 use ip_network::{Ipv4Network, Ipv6Network};
@@ -170,6 +170,7 @@ impl Callbacks for CallbackHandler {
         tunnel_address_v4: Ipv4Addr,
         tunnel_address_v6: Ipv6Addr,
         dns_addresses: Vec<IpAddr>,
+        _search_domain: Option<DomainName>,
         route_list_4: Vec<Ipv4Network>,
         route_list_6: Vec<Ipv6Network>,
     ) {

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use anyhow::Result;
 use backoff::ExponentialBackoffBuilder;
 use connlib_client_shared::{Callbacks, DisconnectError, Session, V4RouteList, V6RouteList};
+use connlib_model::DomainName;
 use connlib_model::ResourceView;
 use firezone_logging::err_with_src;
 use firezone_logging::sentry_layer;
@@ -127,6 +128,7 @@ impl Callbacks for CallbackHandler {
         tunnel_address_v4: Ipv4Addr,
         tunnel_address_v6: Ipv6Addr,
         dns_addresses: Vec<IpAddr>,
+        _search_domain: Option<DomainName>,
         route_list_v4: Vec<Ipv4Network>,
         route_list_v6: Vec<Ipv6Network>,
     ) {

--- a/rust/connlib/clients/shared/src/callbacks.rs
+++ b/rust/connlib/clients/shared/src/callbacks.rs
@@ -1,4 +1,4 @@
-use connlib_model::ResourceView;
+use connlib_model::{DomainName, ResourceView};
 use ip_network::{Ipv4Network, Ipv6Network};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
@@ -17,6 +17,7 @@ pub trait Callbacks: Clone + Send + Sync {
         _: Ipv4Addr,
         _: Ipv6Addr,
         _: Vec<IpAddr>,
+        _: Option<DomainName>,
         _: Vec<Ipv4Network>,
         _: Vec<Ipv6Network>,
     ) {
@@ -83,6 +84,7 @@ where
         ipv4_addr: Ipv4Addr,
         ipv6_addr: Ipv6Addr,
         dns_addresses: Vec<IpAddr>,
+        search_domain: Option<DomainName>,
         route_list_4: Vec<Ipv4Network>,
         route_list_6: Vec<Ipv6Network>,
     ) {
@@ -93,6 +95,7 @@ where
                 ipv4_addr,
                 ipv6_addr,
                 dns_addresses,
+                search_domain,
                 route_list_4,
                 route_list_6,
             );

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -172,6 +172,7 @@ where
                     config.ip.v4,
                     config.ip.v6,
                     dns_servers,
+                    config.search_domain,
                     Vec::from_iter(config.ipv4_routes),
                     Vec::from_iter(config.ipv6_routes),
                 );

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1064,6 +1064,7 @@ impl ClientState {
                         v6: config.ipv6,
                     },
                     dns_by_sentinel: Default::default(),
+                    search_domain: config.search_domain.clone(),
                     ipv4_routes,
                     ipv6_routes,
                 };
@@ -1742,6 +1743,7 @@ impl ClientState {
                 .iter()
                 .map(|(sentinel_dns, effective_dns)| (*sentinel_dns, effective_dns.address()))
                 .collect::<BiMap<_, _>>(),
+            search_domain: config.search_domain,
             ipv4_routes,
             ipv6_routes,
         };

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1045,7 +1045,7 @@ impl ClientState {
     }
 
     pub fn update_interface_config(&mut self, config: InterfaceConfig) {
-        tracing::trace!(upstream_dns = ?config.upstream_dns, ipv4 = %config.ipv4, ipv6 = %config.ipv6, "Received interface configuration from portal");
+        tracing::trace!(upstream_dns = ?config.upstream_dns, search_domain = ?config.search_domain, ipv4 = %config.ipv4, ipv6 = %config.ipv6, "Received interface configuration from portal");
 
         match self.tun_config.as_mut() {
             Some(existing) => {
@@ -1072,6 +1072,7 @@ impl ClientState {
             }
         }
 
+        self.stub_resolver.set_search_domain(config.search_domain);
         self.upstream_dns = config.upstream_dns;
 
         self.update_dns_mapping()

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -261,12 +261,7 @@ impl StubResolver {
         tracing::trace!("Parsed packet as DNS query: '{qtype} {domain}'");
 
         if domain == *DOH_CANARY_DOMAIN {
-            let payload = MessageBuilder::new_vec()
-                .start_answer(&message, Rcode::NXDOMAIN)
-                .context("Failed to create answer from DNS query")?
-                .into_message();
-
-            return Ok(ResolveStrategy::LocalResponse(payload));
+            return Ok(ResolveStrategy::LocalResponse(nxdomain(message)));
         }
 
         // `match_resource` is `O(N)` which we deem fine for DNS queries.
@@ -310,6 +305,13 @@ pub fn servfail(message: Message<&[u8]>) -> Message<Vec<u8>> {
     MessageBuilder::new_vec()
         .start_answer(&message, Rcode::SERVFAIL)
         .expect("should always be able to create a heap-allocated SERVFAIL message")
+        .into_message()
+}
+
+fn nxdomain(message: Message<&[u8]>) -> Message<Vec<u8>> {
+    MessageBuilder::new_vec()
+        .start_answer(&message, Rcode::NXDOMAIN)
+        .expect("should always be able to create a heap-allocated NXDOMAIN message")
         .into_message()
 }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -379,6 +379,7 @@ pub struct TunConfig {
     ///   If upstream DNS servers are configured (in the portal), we will use those.
     ///   Otherwise, we will use the DNS servers configured on the system.
     pub dns_by_sentinel: BiMap<IpAddr, SocketAddr>,
+    pub search_domain: Option<DomainName>,
 
     #[debug("{}", DisplaySet(ipv4_routes))]
     pub ipv4_routes: BTreeSet<Ipv4Network>,

--- a/rust/connlib/tunnel/src/messages.rs
+++ b/rust/connlib/tunnel/src/messages.rs
@@ -170,6 +170,8 @@ pub struct Interface {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
     pub upstream_dns: Vec<DnsServer>,
+    #[serde(default)]
+    pub search_domain: Option<DomainName>,
 }
 
 /// A single relay

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -206,10 +206,18 @@ fn assert_packets_properties<T, U>(
                     assert_destination_is_cdir_resource(gateway_received_request, resource_dst)
                 }
                 Destination::DomainName { name, .. } => {
+                    let domain = match ref_client.fully_qualify_using_search_domain(name.clone()) {
+                        Ok(domain) => domain,
+                        Err(e) => {
+                            tracing::error!(target: "assertions", "Failed to fully-qualify domain: {e:#}");
+                            return;
+                        }
+                    };
+
                     assert_destination_is_dns_resource(
                         gateway_received_request,
                         global_dns_records,
-                        name,
+                        &domain,
                     );
 
                     assert_proxy_ip_mapping_is_stable(
@@ -377,9 +385,9 @@ fn assert_destination_is_dns_resource(
         .collect::<Vec<_>>();
 
     if !possible_resource_ips.contains(&actual) {
-        tracing::error!(target: "assertions", %actual, ?possible_resource_ips, "❌ Unknown resource IP");
+        tracing::error!(target: "assertions", %domain, %actual, ?possible_resource_ips, "❌ Unknown resource IP");
     } else {
-        tracing::info!(target: "assertions", ip = %actual, "✅ Resource IP is valid");
+        tracing::info!(target: "assertions", %domain, ip = %actual, "✅ Resource IP is valid");
     }
 }
 

--- a/rust/headless-client/src/dns_control/windows.rs
+++ b/rust/headless-client/src/dns_control/windows.rs
@@ -15,6 +15,7 @@
 
 use super::DnsController;
 use anyhow::{Context as _, Result};
+use connlib_model::DomainName;
 use firezone_bin_shared::platform::{DnsControlMethod, CREATE_NO_WINDOW, TUNNEL_UUID};
 use firezone_bin_shared::windows::error::EPT_S_NOT_REGISTERED;
 use std::{io, net::IpAddr, os::windows::process::CommandExt, path::Path, process::Command};
@@ -66,7 +67,11 @@ impl DnsController {
     ///
     /// Must be async and an owned `Vec` to match the Linux signature
     #[expect(clippy::unused_async)]
-    pub async fn set_dns(&mut self, dns_config: Vec<IpAddr>) -> Result<()> {
+    pub async fn set_dns(
+        &mut self,
+        dns_config: Vec<IpAddr>,
+        _search_domain: Option<DomainName>,
+    ) -> Result<()> {
         match self.dns_control_method {
             DnsControlMethod::Disabled => {}
             DnsControlMethod::Nrpt => {
@@ -277,7 +282,7 @@ mod tests {
         ];
         rt.block_on(async {
             dns_controller
-                .set_dns(fz_dns_servers.clone())
+                .set_dns(fz_dns_servers.clone(), None)
                 .await
                 .unwrap();
         });

--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -449,11 +449,12 @@ impl<'a> Handler<'a> {
                 ipv4,
                 ipv6,
                 dns,
+                search_domain,
                 ipv4_routes,
                 ipv6_routes,
             } => {
                 self.tun_device.set_ips(ipv4, ipv6).await?;
-                self.dns_controller.set_dns(dns).await?;
+                self.dns_controller.set_dns(dns, search_domain).await?;
                 if let Some(instant) = self.last_connlib_start_instant.take() {
                     tracing::info!(elapsed = ?instant.elapsed(), "Tunnel ready");
                 }

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -12,7 +12,7 @@
 
 use anyhow::{Context as _, Result};
 use connlib_client_shared::Callbacks;
-use connlib_model::ResourceView;
+use connlib_model::{DomainName, ResourceView};
 use firezone_bin_shared::platform::DnsControlMethod;
 use firezone_logging::FilterReloadHandle;
 use std::{
@@ -84,6 +84,7 @@ pub enum ConnlibMsg {
         ipv4: Ipv4Addr,
         ipv6: Ipv6Addr,
         dns: Vec<IpAddr>,
+        search_domain: Option<DomainName>,
         ipv4_routes: Vec<Ipv4Network>,
         ipv6_routes: Vec<Ipv6Network>,
     },
@@ -110,6 +111,7 @@ impl Callbacks for CallbackHandler {
         ipv4: Ipv4Addr,
         ipv6: Ipv6Addr,
         dns: Vec<IpAddr>,
+        search_domain: Option<DomainName>,
         ipv4_routes: Vec<Ipv4Network>,
         ipv6_routes: Vec<Ipv6Network>,
     ) {
@@ -118,6 +120,7 @@ impl Callbacks for CallbackHandler {
                 ipv4,
                 ipv6,
                 dns,
+                search_domain,
                 ipv4_routes,
                 ipv6_routes,
             })
@@ -151,6 +154,6 @@ mod tests {
     // Make sure it's okay to store a bunch of these to mitigate #5880
     #[test]
     fn callback_msg_size() {
-        assert_eq!(std::mem::size_of::<ConnlibMsg>(), 96)
+        assert_eq!(std::mem::size_of::<ConnlibMsg>(), 120)
     }
 }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -297,13 +297,14 @@ fn main() -> Result<()> {
                     ipv4,
                     ipv6,
                     dns,
+                    search_domain,
                     ipv4_routes,
                     ipv6_routes,
                 } => {
                     tun_device.set_ips(ipv4, ipv6).await?;
                     tun_device.set_routes(ipv4_routes, ipv6_routes).await?;
 
-                    dns_controller.set_dns(dns).await?;
+                    dns_controller.set_dns(dns, search_domain).await?;
 
                     // `on_set_interface_config` is guaranteed to be called when the tunnel is completely ready
                     // <https://github.com/firezone/firezone/pull/6026#discussion_r1692297438>


### PR DESCRIPTION
Search domains are a way of performing a DNS lookup without typing the full-qualified domain name. For example, with a search domain of `example.com`, performing a DNS query for `app` will automatically expand the query to `app.example.com`. At present, this doesn't work with Firezone because there is no way to configure an account-wide search-domain.

With this PR, we extend the `Interface` message sent by the portal to also include an optional `search_domain` field that must be a valid domain name. If set, `connlib`'s DNS stub resolver will now append this domain to all single-label queries and match the resulting domain against all active DNS resource.

On Linux - with `systemd-resolved` as the DNS backend - we need to set the search domain on the TUN interface as well and enable LLMNR in order to be able to intercept these queries. `resolved` expands the query for us, however, meaning with this configuration, we don't actually receive a single-label query in `connlib`. Instead, we directly see `app.example.com` when we type `host app` or `dig +search app` and have `example.com` as our search domain.

MacOS has a similar system but with a different fallack. There, the operating system will first try all configured search domains on the system (typically just the ones set prior to Firezone starting), and send queries for FQDN to all resolvers. If none of the resolvers (including Firezone's stub resolver) return results, it sends the single-label query directly to the primary resolver. To handle this case, Firezone needs to know about the search-domain and expand it itself when it receives the single-label query. In the future, we may want to look into how we can configure MacOS such that it performs this expansion for us.

On Windows and Android, queries for a single-label domain will be directly sent to Firezone's stub resolver where we then hit the same codepath as explained above.

Specifically, the way this codepath works is that if we receive a single-label query AND we have a search-domain set, we expand it and match that particular query against our list of resources. In every other case, we continue on with the single-label domain.

Related: #8365
Fixes: #8377