### PR TITLE
chore(connlib): setup feature-flag infrastructure

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2249,7 +2249,12 @@ dependencies = [
 name = "firezone-telemetry"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "parking_lot",
+ "reqwest",
  "sentry",
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -86,6 +86,7 @@ os_info = { version = "3", default-features = false }
 output_vt100 = "0.1"
 png = "0.17.16"
 proptest = "1.6.0"
+parking_lot = "0.12.3"
 proptest-state-machine = "0.3.1"
 quinn-udp = { version = "0.5.8", features = ["fast-apple-datapath"] }
 rand = "0.8.5"

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -5,7 +5,12 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
+parking_lot = { workspace = true }
+reqwest = { workspace = true, features = ["blocking"] }
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -28,7 +28,21 @@ pub const TESTING: Dsn = Dsn("https://55ef451fca9054179a11f5d132c02f45@o45079711
 
 const POSTHOG_API_KEY: &str = "phc_uXXl56plyvIBHj81WwXBLtdPElIRbm7keRTdUCmk8ll";
 
+// Process-wide storage of enabled feature flags.
+//
+// Defaults to everything off.
 static FEATURE_FLAGS: LazyLock<Mutex<FeatureFlags>> = LazyLock::new(Mutex::default);
+
+/// Exposes all feature flags as public, static functions.
+///
+/// These only ever hit an in-memory location so can even be called from hot paths.
+pub mod feature_flags {
+    use crate::*;
+
+    pub fn icmp_unreachable_instead_of_nat64() -> bool {
+        FEATURE_FLAGS.lock().icmp_unreachable_instead_of_nat64
+    }
+}
 
 mod env {
     use std::borrow::Cow;
@@ -180,14 +194,6 @@ impl Telemetry {
                 scope.set_context("flags", sentry_flag_context(flags));
             });
         });
-    }
-}
-
-pub mod feature_flags {
-    use crate::*;
-
-    pub fn icmp_unreachable_instead_of_nat64() -> bool {
-        FEATURE_FLAGS.lock().icmp_unreachable_instead_of_nat64
     }
 }
 


### PR DESCRIPTION
In order to more safely roll out certain changes, being able to runtime-toggle features is crucial. For this purpose, we build a simple integration with Posthog that allows us to evaluate feature flags based on the Firezone ID of a Client or Gateway.

The feature flags are also set in a dedicated context for Sentry events. This allows us to see, which feature flags were active when a certain error is logged to Sentry.