### PR TITLE
feat(gateway): deprecate the NAT64 module

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -170,7 +170,7 @@ impl GatewayState {
 
                 self.buffered_transmits.push_back(transmit);
 
-                return Ok(None);
+                Ok(None)
             }
             TranslateOutboundResult::Filtered => Ok(None),
         }

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -1,5 +1,6 @@
 use crate::messages::gateway::ResourceDescription;
 use crate::messages::{Answer, IceCredentials, ResolveRequest, SecretKey};
+use crate::peer::TranslateOutboundResult;
 use crate::utils::earliest;
 use crate::{GatewayEvent, IpConfig, p2p_control};
 use crate::{peer::ClientOnGateway, peer_store::PeerStore};
@@ -157,11 +158,14 @@ impl GatewayState {
             return Ok(None);
         }
 
-        let packet = peer
+        match peer
             .translate_outbound(packet, now)
-            .context("Failed to translate outbound packet")?;
+            .context("Failed to translate outbound packet")?
+        {
+            TranslateOutboundResult::Send(ip_packet) => Ok(Some(ip_packet)),
 
-        Ok(packet)
+            TranslateOutboundResult::Filtered => Ok(None),
+        }
     }
 
     pub fn cleanup_connection(&mut self, id: &ClientId) {

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -163,7 +163,15 @@ impl GatewayState {
             .context("Failed to translate outbound packet")?
         {
             TranslateOutboundResult::Send(ip_packet) => Ok(Some(ip_packet)),
+            TranslateOutboundResult::DestinationUnreachable(reply) => {
+                let Some(transmit) = encrypt_packet(reply, cid, &mut self.node, now)? else {
+                    return Ok(None);
+                };
 
+                self.buffered_transmits.push_back(transmit);
+
+                return Ok(None);
+            }
             TranslateOutboundResult::Filtered => Ok(None),
         }
     }

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -289,8 +289,11 @@ impl ClientOnGateway {
             return self.dst_unreachable(&packet);
         };
 
-        if state.resolved_ip.is_ipv4() != dst.is_ipv4() {
-            return self.dst_unreachable(&packet);
+        #[expect(clippy::collapsible_if, reason = "We want the feature flag separate.")]
+        if firezone_telemetry::feature_flags::icmp_unreachable_instead_of_nat64() {
+            if state.resolved_ip.is_ipv4() != dst.is_ipv4() {
+                return self.dst_unreachable(&packet);
+            }
         }
 
         let (source_protocol, real_ip) =

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -12,7 +12,7 @@ use dns_types::DomainName;
 use filter_engine::FilterEngine;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_network_table::IpNetworkTable;
-use ip_packet::{icmpv4, icmpv6, IpPacket, PacketBuilder, Protocol, UnsupportedProtocol};
+use ip_packet::{IpPacket, PacketBuilder, Protocol, UnsupportedProtocol, icmpv4, icmpv6};
 
 use crate::utils::network_contains_network;
 use crate::{GatewayEvent, IpConfig};

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -449,16 +449,11 @@ impl ClientOnGateway {
     }
 
     fn dst_unreachable(&self, packet: &IpPacket) -> Result<TranslateOutboundResult> {
-        let dst = packet.destination();
+        let src = packet.source();
 
-        // TODO: Should we use the source IP of the packet?
-        let icmp_error = match dst {
-            IpAddr::V4(inside_dst) => {
-                icmpv4_network_unreachable(inside_dst, self.client_tun.v4, packet)?
-            }
-            IpAddr::V6(inside_dst) => {
-                icmpv6_address_unreachable(inside_dst, self.client_tun.v6, packet)?
-            }
+        let icmp_error = match src {
+            IpAddr::V4(src) => icmpv4_network_unreachable(self.gateway_tun.v4, src, packet)?,
+            IpAddr::V6(src) => icmpv6_address_unreachable(self.gateway_tun.v6, src, packet)?,
         };
 
         Ok(TranslateOutboundResult::DestinationUnreachable(icmp_error))

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -838,10 +838,11 @@ mod tests {
             peer.translate_outbound(request, Instant::now()).unwrap(),
             crate::peer::TranslateOutboundResult::Send(_)
         ));
-        assert!(matches!(
-            peer.translate_outbound(response, Instant::now()).unwrap(),
-            crate::peer::TranslateOutboundResult::Send(_)
-        ));
+        assert!(
+            peer.translate_inbound(response, Instant::now())
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[test]

--- a/rust/ip-packet/src/make.rs
+++ b/rust/ip-packet/src/make.rs
@@ -20,7 +20,7 @@ macro_rules! build {
 
         let packet = IpPacket::new(ip, size).context("Failed to create IP packet")?;
 
-        Ok(packet)
+        ::anyhow::Ok(packet)
     }};
 }
 

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,11 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8383">
+          Deprecates the NAT64 functionality in favor of sending ICMP errors.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-03-10")}>
         <ChangeItem pull="8124">
           Fixes a bug in the routing of DNS resources that would lead to "Source


### PR DESCRIPTION
At present, the Gateway implements a NAT64 conversion that can convert IPv4 packets to IPv6 and vice versa. Doing this efficiently creates a fair amount of complexity within our `ip-packet` crate. In addition, routing ICMP errors back through our NAT is also complicated by this because we may have to translate the packet embedded in the ICMP error as well.

The NAT64 module was originally conceived as a result of the new stub resolver-based DNS architecture. When the Client resolves IPs for a domain, it doesn't know whether the domain will actually resolve to IPv4 AND IPv6 addresses so it simply assigns 4 of each to every domain. Thus, when receiving an IPv6 packet for such a DNS resource, the Gateway may only have IPv4 addresses available and can therefore not route the packet (unless it translates it).

This problem is not novel. In fact, an IP being unroutable or a particular route disappearing happens all the time on the Internet. ICMP was conceived to handle this problem and it is doing a pretty good job at it. We can make use of that and simply return an ICMP unreachable error back to the client whenever it picks an IP that we cannot map to one that we resolved.

In this PR, we leave all of the NAT64 code intact and only add a feature-flag that - when active - sends aforementioned ICMP error. While offline (and thus also for our tests), the feature-flag evaluates to false. It is however set to `true` in the backend, meaning on staging and later in production, we will send these ICMP errors.

Once this is rolled out and indeed proving to be working as intended, we can simplify our codebase and rip out the NAT64 module. At that point, we will also have to adapt the test-suite.