### PR TITLE
fix(rust): Temporarily ignore unmaintained crates

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -87,6 +87,9 @@ ignore = [
   "RUSTSEC-2024-0420",
   "RUSTSEC-2024-0421",
 
+  "RUSTSEC-2025-0012", # backoff, See #8386
+  "RUSTSEC-2024-0436", # paste, See #8387
+
   "RUSTSEC-2024-0429", # `glib`, need to wait for tauri to upgrade
 
   #"RUSTSEC-0000-0000",


### PR DESCRIPTION
Related: #8386 
Related: #8387 