### PR TITLE
feat(portal): Support `search_domain` field in Account.Config

### DIFF
--- a/elixir/apps/domain/lib/domain/accounts/config.ex
+++ b/elixir/apps/domain/lib/domain/accounts/config.ex
@@ -3,6 +3,8 @@ defmodule Domain.Accounts.Config do
 
   @primary_key false
   embedded_schema do
+    field :search_domain, :string
+
     embeds_many :clients_upstream_dns, ClientsUpstreamDNS,
       primary_key: false,
       on_replace: :delete do

--- a/elixir/apps/domain/test/domain/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/accounts_test.exs
@@ -583,6 +583,118 @@ defmodule Domain.AccountsTest do
              }
     end
 
+    test "returns error when search_domain is invalid", %{account: account} do
+      attrs = %{
+        config: %{
+          search_domain: "invalid"
+        }
+      }
+
+      assert {:error, changeset} = update_account_by_id(account.id, attrs)
+
+      assert errors_on(changeset) == %{
+               config: %{
+                 search_domain: ["must be a valid fully-qualified domain name"]
+               }
+             }
+    end
+
+    test "returns error when search_domain is too long", %{account: account} do
+      attrs = %{
+        config: %{
+          search_domain: String.duplicate("a", 256)
+        }
+      }
+
+      assert {:error, changeset} = update_account_by_id(account.id, attrs)
+
+      assert errors_on(changeset) == %{
+               config: %{
+                 search_domain: ["must not exceed 255 characters"]
+               }
+             }
+    end
+
+    test "returns error when search_domain starts with a dot", %{account: account} do
+      attrs = %{
+        config: %{
+          search_domain: ".example.com"
+        }
+      }
+
+      assert {:error, changeset} = update_account_by_id(account.id, attrs)
+
+      assert errors_on(changeset) == %{
+               config: %{
+                 search_domain: ["must not start or end with a dot"]
+               }
+             }
+    end
+
+    test "returns error when search_domain ends with a dot", %{account: account} do
+      attrs = %{
+        config: %{
+          search_domain: "example.com."
+        }
+      }
+
+      assert {:error, changeset} = update_account_by_id(account.id, attrs)
+
+      assert errors_on(changeset) == %{
+               config: %{
+                 search_domain: ["must not start or end with a dot"]
+               }
+             }
+    end
+
+    test "returns error when search_domain contains consecutive dots", %{account: account} do
+      attrs = %{
+        config: %{
+          search_domain: "example..com"
+        }
+      }
+
+      assert {:error, changeset} = update_account_by_id(account.id, attrs)
+
+      assert errors_on(changeset) == %{
+               config: %{
+                 search_domain: ["must not contain consecutive dots"]
+               }
+             }
+    end
+
+    test "returns error when search_domain labels exceed 63 characters", %{account: account} do
+      attrs = %{
+        config: %{
+          search_domain: "a" <> String.duplicate("a", 63) <> ".com"
+        }
+      }
+
+      assert {:error, changeset} = update_account_by_id(account.id, attrs)
+
+      assert errors_on(changeset) == %{
+               config: %{
+                 search_domain: ["each label must not exceed 63 characters"]
+               }
+             }
+    end
+
+    test "returns error when search_domain contains invalid characters", %{account: account} do
+      attrs = %{
+        config: %{
+          search_domain: "example.com!"
+        }
+      }
+
+      assert {:error, changeset} = update_account_by_id(account.id, attrs)
+
+      assert errors_on(changeset) == %{
+               config: %{
+                 search_domain: ["must be a valid fully-qualified domain name"]
+               }
+             }
+    end
+
     test "updates account and broadcasts a message", %{account: account} do
       Bypass.open()
       |> Domain.Mocks.Stripe.mock_update_customer_endpoint(account)


### PR DESCRIPTION
Introduces a simple `search_domain` field embed into our existing `Accounts.Account.Config` embedded schema. This will be sent to clients to append to single-label DNS queries.

UI and API changes will come in subsequent PRs: this one adds field and (lots of) validations only.

Related: #8365