### PR TITLE
fix(portal): Add more validation to `search_domain`

### DIFF
--- a/elixir/apps/domain/lib/domain/accounts/config/changeset.ex
+++ b/elixir/apps/domain/lib/domain/accounts/config/changeset.ex
@@ -28,8 +28,11 @@ defmodule Domain.Accounts.Config.Changeset do
         String.length(domain) > 255 ->
           [search_domain: "must not exceed 255 characters"]
 
-        String.starts_with?(domain, ".") || String.ends_with?(domain, ".") ->
-          [search_domain: "must not start or end with a dot"]
+        String.starts_with?(domain, ".") ->
+          [search_domain: "must not start with a dot"]
+
+        String.ends_with?(domain, ".local") || String.ends_with?(domain, ".local.") ->
+          [search_domain: "must not end with .local"]
 
         String.contains?(domain, "..") ->
           [search_domain: "must not contain consecutive dots"]

--- a/elixir/apps/domain/test/domain/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/accounts_test.exs
@@ -626,15 +626,15 @@ defmodule Domain.AccountsTest do
 
       assert errors_on(changeset) == %{
                config: %{
-                 search_domain: ["must not start or end with a dot"]
+                 search_domain: ["must not start with a dot"]
                }
              }
     end
 
-    test "returns error when search_domain ends with a dot", %{account: account} do
+    test "returns error when search_domain ends with .local", %{account: account} do
       attrs = %{
         config: %{
-          search_domain: "example.com."
+          search_domain: "test.local"
         }
       }
 
@@ -642,7 +642,7 @@ defmodule Domain.AccountsTest do
 
       assert errors_on(changeset) == %{
                config: %{
-                 search_domain: ["must not start or end with a dot"]
+                 search_domain: ["must not end with .local"]
                }
              }
     end


### PR DESCRIPTION
- Prevents `.local`
- Allows ending with `.`

https://github.com/firezone/firezone/pull/8391/files#r1985958387