### PR TITLE
ci: Use search_domain for one resource in CI test

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -126,7 +126,7 @@ jobs:
           fi
 
           # Start one-by-one to avoid variability in service startup order
-          docker compose up -d dns.httpbin httpbin download.httpbin --no-build
+          docker compose up -d dns.httpbin.test httpbin download.httpbin --no-build
           docker compose up -d api web domain --no-build
           docker compose up -d otel --no-build
           docker compose up -d relay-1 --no-build

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -126,7 +126,7 @@ jobs:
           fi
 
           # Start one-by-one to avoid variability in service startup order
-          docker compose up -d dns.httpbin.test httpbin download.httpbin --no-build
+          docker compose up -d dns.httpbin.search.test httpbin download.httpbin --no-build
           docker compose up -d api web domain --no-build
           docker compose up -d otel --no-build
           docker compose up -d relay-1 --no-build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -409,7 +409,7 @@ services:
       dns_resources:
         ipv4_address: 172.21.0.101
 
-  dns.httpbin.test:
+  dns.httpbin.search.test:
     image: kennethreitz/httpbin
     healthcheck:
       test: ["CMD-SHELL", "ps -C gunicorn"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -409,7 +409,7 @@ services:
       dns_resources:
         ipv4_address: 172.21.0.101
 
-  dns.httpbin:
+  dns.httpbin.test:
     image: kennethreitz/httpbin
     healthcheck:
       test: ["CMD-SHELL", "ps -C gunicorn"]

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -39,7 +39,7 @@ defmodule Domain.Repo.Seeds do
         name: "Firezone Account",
         slug: "firezone",
         config: %{
-          search_domain: "httpbin.test"
+          search_domain: "httpbin.search.test"
         }
       })
 
@@ -1024,8 +1024,8 @@ defmodule Domain.Repo.Seeds do
       Resources.create_resource(
         %{
           type: :dns,
-          name: "**.httpbin.test",
-          address: "**.httpbin.test",
+          name: "**.httpbin.search.test",
+          address: "**.httpbin.search.test",
           address_description: "http://httpbin/",
           connections: [%{gateway_group_id: gateway_group.id}],
           filters: [
@@ -1133,7 +1133,7 @@ defmodule Domain.Repo.Seeds do
     {:ok, _} =
       Policies.create_policy(
         %{
-          name: "All Access To dns.httpbin",
+          name: "All Access To **.httpbin",
           actor_group_id: everyone_group.id,
           resource_id: dns_httpbin_resource.id
         },
@@ -1143,7 +1143,7 @@ defmodule Domain.Repo.Seeds do
     {:ok, _} =
       Policies.create_policy(
         %{
-          name: "All Access To httpbin.test",
+          name: "All Access To **.httpbin.search.test",
           actor_group_id: everyone_group.id,
           resource_id: search_domain_resource.id
         },

--- a/elixir/apps/domain/priv/repo/seeds.exs
+++ b/elixir/apps/domain/priv/repo/seeds.exs
@@ -37,7 +37,10 @@ defmodule Domain.Repo.Seeds do
     {:ok, account} =
       Accounts.create_account(%{
         name: "Firezone Account",
-        slug: "firezone"
+        slug: "firezone",
+        config: %{
+          search_domain: "httpbin.test"
+        }
       })
 
     account =
@@ -1017,6 +1020,23 @@ defmodule Domain.Repo.Seeds do
         admin_subject
       )
 
+    {:ok, search_domain_resource} =
+      Resources.create_resource(
+        %{
+          type: :dns,
+          name: "**.httpbin.test",
+          address: "**.httpbin.test",
+          address_description: "http://httpbin/",
+          connections: [%{gateway_group_id: gateway_group.id}],
+          filters: [
+            %{ports: ["80", "433"], protocol: :tcp},
+            %{ports: ["53"], protocol: :udp},
+            %{protocol: :icmp}
+          ]
+        },
+        admin_subject
+      )
+
     IO.puts("Created resources:")
     IO.puts("  #{dns_google_resource.address} - DNS - gateways: #{gateway_name}")
     IO.puts("  #{address_description_null_resource.address} - DNS - gateways: #{gateway_name}")
@@ -1027,6 +1047,7 @@ defmodule Domain.Repo.Seeds do
     IO.puts("  #{ip_resource.address} - IP - gateways: #{gateway_name}")
     IO.puts("  #{cidr_resource.address} - CIDR - gateways: #{gateway_name}")
     IO.puts("  #{dns_httpbin_resource.address} - DNS - gateways: #{gateway_name}")
+    IO.puts("  #{search_domain_resource.address} - DNS - gateways: #{gateway_name}")
     IO.puts("")
 
     {:ok, _} =
@@ -1115,6 +1136,16 @@ defmodule Domain.Repo.Seeds do
           name: "All Access To dns.httpbin",
           actor_group_id: everyone_group.id,
           resource_id: dns_httpbin_resource.id
+        },
+        admin_subject
+      )
+
+    {:ok, _} =
+      Policies.create_policy(
+        %{
+          name: "All Access To httpbin.test",
+          actor_group_id: everyone_group.id,
+          resource_id: search_domain_resource.id
         },
         admin_subject
       )

--- a/scripts/tests/direct-dns-api-down.sh
+++ b/scripts/tests/direct-dns-api-down.sh
@@ -2,7 +2,7 @@
 
 source "./scripts/tests/lib.sh"
 
-HTTPBIN=dns.httpbin
+HTTPBIN=dns
 
 function run_test() {
     echo "# Access httpbin by DNS"

--- a/scripts/tests/direct-dns-two-resources.sh
+++ b/scripts/tests/direct-dns-two-resources.sh
@@ -5,7 +5,7 @@
 
 source "./scripts/tests/lib.sh"
 
-RESOURCE1=dns.httpbin
+RESOURCE1=dns
 RESOURCE2=download.httpbin
 
 echo "# Try to ping httpbin as DNS resource 1"

--- a/scripts/tests/direct-dns.sh
+++ b/scripts/tests/direct-dns.sh
@@ -6,6 +6,7 @@
 source "./scripts/tests/lib.sh"
 
 HTTPBIN=dns
+HTTPBIN_FQDN="$HTTPBIN.httpbin.search.test"
 
 # Re-up the gateway since a local dev setup may run this back-to-back
 docker compose up -d gateway --no-build
@@ -14,7 +15,7 @@ echo "# check original resolv.conf"
 client sh -c "cat /etc/resolv.conf.before-firezone"
 
 echo "# Make sure gateway can reach httpbin by DNS"
-gateway sh -c "curl --fail $HTTPBIN/get"
+gateway sh -c "curl --fail $HTTPBIN_FQDN/get"
 
 echo "# Try to ping httpbin as a DNS resource"
 client_ping_resource "$HTTPBIN"

--- a/scripts/tests/direct-dns.sh
+++ b/scripts/tests/direct-dns.sh
@@ -5,7 +5,7 @@
 
 source "./scripts/tests/lib.sh"
 
-HTTPBIN=dns.httpbin
+HTTPBIN=dns
 
 # Re-up the gateway since a local dev setup may run this back-to-back
 docker compose up -d gateway --no-build

--- a/scripts/tests/systemd/dns-systemd-resolved.sh
+++ b/scripts/tests/systemd/dns-systemd-resolved.sh
@@ -25,7 +25,7 @@ create_token_file
 
 sudo cp "scripts/tests/systemd/$SERVICE_NAME.service" /usr/lib/systemd/system/
 
-HTTPBIN=dns.httpbin
+HTTPBIN=dns
 
 # I'm assuming the docker iface name is relatively constant
 DOCKER_IFACE="docker0"

--- a/scripts/tests/systemd/dns-systemd-resolved.sh
+++ b/scripts/tests/systemd/dns-systemd-resolved.sh
@@ -26,13 +26,14 @@ create_token_file
 sudo cp "scripts/tests/systemd/$SERVICE_NAME.service" /usr/lib/systemd/system/
 
 HTTPBIN=dns
+HTTPBIN_FQDN="$HTTPBIN.httpbin.search.test"
 
 # I'm assuming the docker iface name is relatively constant
 DOCKER_IFACE="docker0"
 FZ_IFACE="tun-firezone"
 
 echo "# Make sure gateway can reach httpbin by DNS"
-gateway sh -c "curl --fail $HTTPBIN/get"
+gateway sh -c "curl --fail $HTTPBIN_FQDN/get"
 
 echo "# Accessing a resource should fail before the client is up"
 # Force curl to try the Firezone interface. I can't block off the Docker interface yet

--- a/scripts/tests/tcp-dns.sh
+++ b/scripts/tests/tcp-dns.sh
@@ -5,7 +5,7 @@ source "./scripts/tests/lib.sh"
 client sh -c "apk add bind-tools" # The compat tests run using the production image which doesn't have `dig`.
 
 echo "Resolving DNS resource over TCP with search domain"
-client sh -c "dig +tcp dns"
+client sh -c "dig +search +tcp dns"
 
 echo "Resolving DNS resource over TCP with FQDN"
 client sh -c "dig +tcp download.httpbin"

--- a/scripts/tests/tcp-dns.sh
+++ b/scripts/tests/tcp-dns.sh
@@ -4,8 +4,11 @@ source "./scripts/tests/lib.sh"
 
 client sh -c "apk add bind-tools" # The compat tests run using the production image which doesn't have `dig`.
 
-echo "Resolving DNS resource over TCP"
-client sh -c "dig +tcp dns.httpbin"
+echo "Resolving DNS resource over TCP with search domain"
+client sh -c "dig +tcp dns"
+
+echo "Resolving DNS resource over TCP with FQDN"
+client sh -c "dig +tcp download.httpbin"
 
 echo "Resolving non-DNS resource over TCP"
 client sh -c "dig +tcp example.com"


### PR DESCRIPTION
- Adds a `search_domain` of `httpbin.test` in seeds
- Updates one of our DNS resources under CI test to use this