### PR TITLE
feat(portal): Search domain UI and JSON view

### DIFF
--- a/elixir/apps/api/lib/api/client/views/interface.ex
+++ b/elixir/apps/api/lib/api/client/views/interface.ex
@@ -11,6 +11,7 @@ defmodule API.Client.Views.Interface do
       end)
 
     %{
+      search_domain: client.account.config.search_domain,
       upstream_dns: upstream_dns,
       ipv4: client.ipv4,
       ipv6: client.ipv6

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -8,7 +8,8 @@ defmodule API.Client.ChannelTest do
           clients_upstream_dns: [
             %{protocol: "ip_port", address: "1.1.1.1"},
             %{protocol: "ip_port", address: "8.8.8.8:53"}
-          ]
+          ],
+          search_domain: "example.com"
         },
         features: %{
           internet_resource: true
@@ -352,7 +353,8 @@ defmodule API.Client.ChannelTest do
                upstream_dns: [
                  %{protocol: :ip_port, address: "1.1.1.1:53"},
                  %{protocol: :ip_port, address: "8.8.8.8:53"}
-               ]
+               ],
+               search_domain: "example.com"
              }
     end
 
@@ -710,7 +712,8 @@ defmodule API.Client.ChannelTest do
           clients_upstream_dns: [
             %{protocol: "ip_port", address: "1.2.3.1"},
             %{protocol: "ip_port", address: "1.8.8.1:53"}
-          ]
+          ],
+          search_domain: "example.com"
         }
       )
 
@@ -724,7 +727,8 @@ defmodule API.Client.ChannelTest do
                upstream_dns: [
                  %{protocol: :ip_port, address: "1.2.3.1:53"},
                  %{protocol: :ip_port, address: "1.8.8.1:53"}
-               ]
+               ],
+               search_domain: "example.com"
              }
     end
   end

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -167,6 +167,12 @@ defmodule Web.Resources.Edit do
                   <code class="ml-2 px-0.5 font-semibold">us-east?.c.com</code>
                   matches a single character (e.g. <code class="px-0.5 font-semibold">us-east1.c.com</code>).
                 </div>
+                <div class="mt-2 text-xs text-neutral-500">
+                  The search domain can be <.link
+                    href={~p"/#{@account}/settings/dns"}
+                    class={link_style()}
+                  >configured in settings</.link>.
+                </div>
               </div>
               <div :if={to_string(@form[:type].value) == "ip"} class="mt-2 text-xs text-neutral-500">
                 IPv4 and IPv6 addresses are supported.

--- a/elixir/apps/web/lib/web/live/resources/new.ex
+++ b/elixir/apps/web/lib/web/live/resources/new.ex
@@ -152,6 +152,12 @@ defmodule Web.Resources.New do
                   <code class="ml-2 px-0.5 font-semibold">us-east?.c.com</code>
                   matches a single character (e.g. <code class="px-0.5 font-semibold">us-east1.c.com</code>).
                 </div>
+                <div class="mt-2 text-xs text-neutral-500">
+                  The search domain can be <.link
+                    href={~p"/#{@account}/settings/dns"}
+                    class={link_style()}
+                  >configured in settings</.link>.
+                </div>
               </div>
               <div :if={@form[:type].value == :ip} class="mt-2 text-xs text-neutral-500">
                 IPv4 and IPv6 addresses are supported.

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -38,35 +38,46 @@ defmodule Web.Settings.DNS do
       </:action>
 
       <:help>
-        Configure the upstream resolver used by connected Clients.
-        Queries for Resources will <strong>always</strong> use Firezone's internal DNS.
-        All other queries will use the resolvers configured here or the Client's
-        system resolvers if none are configured.
+        <p>
+          Configure the default DNS suffix and upstream resolvers used by devices when the Firezone Client is connected.
+        </p>
+        <p>
+          Queries for Resources will <strong>always</strong> use Firezone's internal DNS.
+          All other queries will use the resolvers configured here or the device's
+          system resolvers if none are configured.
+        </p>
       </:help>
 
       <:content>
         <div class="max-w-2xl px-4 py-8 mx-auto">
-          <h2 class="mb-4 text-xl text-neutral-900">Client DNS</h2>
-
-          <.flash kind={:success} flash={@flash} phx-click="lv:clear-flash" />
-
-          <% empty? =
-            Domain.Repo.Changeset.empty?(@form.source) and
-              Enum.empty?(@account.config.clients_upstream_dns) %>
-
-          <p :if={not empty?} class="mb-4 text-neutral-500">
-            Upstream resolvers will be used by Clients in the order they are listed below.
-          </p>
-
-          <p :if={empty?} class="text-neutral-500">
-            No upstream resolvers have been configured. Click <strong>New Resolver</strong>
-            to add one.
-          </p>
-
           <.form for={@form} phx-submit={:submit} phx-change={:change}>
-            <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
-              <div>
-                <.inputs_for :let={config} field={@form[:config]}>
+            <.flash kind={:success} flash={@flash} phx-click="lv:clear-flash" />
+
+            <.inputs_for :let={config} field={@form[:config]}>
+              <h2 class="mb-4 text-xl text-neutral-900">Default DNS Suffix</h2>
+
+              <p class="mb-4 text-neutral-500">
+                The default DNS suffix will be appended to all single-label DNS queries made by Client devices
+                while connected to Firezone.
+              </p>
+
+              <div class="mb-12">
+                <.input field={config[:search_domain]} placeholder="E.g. example.com" />
+              </div>
+
+              <h2 class="mb-4 text-xl text-neutral-900">Upstream Resolvers</h2>
+
+              <p :if={not upstream_dns_empty?(@account, @form)} class="mb-4 text-neutral-500">
+                Upstream resolvers will be used by Clients in the order they are listed below.
+              </p>
+
+              <p :if={upstream_dns_empty?(@account, @form)} class="text-neutral-500">
+                No upstream resolvers have been configured. Click <strong>New Resolver</strong>
+                to add one.
+              </p>
+
+              <div class="grid gap-4 mb-4 sm:grid-cols-1 sm:gap-6 sm:mb-6">
+                <div>
                   <.inputs_for :let={dns} field={config[:clients_upstream_dns]}>
                     <input
                       type="hidden"
@@ -85,10 +96,10 @@ defmodule Web.Settings.DNS do
                           value={dns[:protocol].value}
                         />
                       </div>
-                      <div class="w-3/4">
+                      <div class="flex-grow">
                         <.input label="Address" field={dns[:address]} placeholder="E.g. 1.1.1.1" />
                       </div>
-                      <div class="w-1/12 flex">
+                      <div class="justify-self-end">
                         <div class="pt-7">
                           <button
                             type="button"
@@ -105,6 +116,7 @@ defmodule Web.Settings.DNS do
                       </div>
                     </div>
                   </.inputs_for>
+
                   <input type="hidden" name={"#{config.name}[clients_upstream_dns_drop][]"} />
                   <.button
                     class="mt-6 w-full"
@@ -122,18 +134,19 @@ defmodule Web.Settings.DNS do
                   >
                     {error}
                   </.error>
-                </.inputs_for>
+                </div>
               </div>
+
               <p class="text-sm text-neutral-500">
                 <strong>Note:</strong>
                 It is highly recommended to specify <strong>both</strong>
                 IPv4 and IPv6 addresses when adding upstream resolvers. Otherwise, Clients without IPv4
                 or IPv6 connectivity may not be able to resolve DNS queries.
               </p>
-              <.submit_button>
-                Save
-              </.submit_button>
-            </div>
+            </.inputs_for>
+            <.submit_button>
+              Save
+            </.submit_button>
           </.form>
         </div>
       </:content>
@@ -169,6 +182,15 @@ defmodule Web.Settings.DNS do
 
         {:noreply, assign(socket, form: form)}
     end
+  end
+
+  defp upstream_dns_empty?(account, form) do
+    upstream_dns_changes =
+      Map.get(form.source.changes, :config, %{})
+      |> Map.get(:changes, %{})
+      |> Map.get(:clients_upstream_dns, %{})
+
+    Enum.empty?(account.config.clients_upstream_dns) and Enum.empty?(upstream_dns_changes)
   end
 
   defp dns_options do

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -39,12 +39,7 @@ defmodule Web.Settings.DNS do
 
       <:help>
         <p>
-          Configure the default DNS suffix and upstream resolvers used by devices when the Firezone Client is connected.
-        </p>
-        <p>
-          Queries for Resources will <strong>always</strong> use Firezone's internal DNS.
-          All other queries will use the resolvers configured here or the device's
-          system resolvers if none are configured.
+          Configure the search domain and upstream resolvers used by devices when the Firezone Client is connected.
         </p>
       </:help>
 
@@ -54,21 +49,33 @@ defmodule Web.Settings.DNS do
             <.flash kind={:success} flash={@flash} phx-click="lv:clear-flash" />
 
             <.inputs_for :let={config} field={@form[:config]}>
-              <h2 class="mb-4 text-xl text-neutral-900">Default DNS Suffix</h2>
+              <h2 class="mb-4 text-xl text-neutral-900">Search Domain</h2>
 
               <p class="mb-4 text-neutral-500">
-                The default DNS suffix will be appended to all single-label DNS queries made by Client devices
+                The search domain, or default DNS suffix, will be appended to all single-label DNS queries made by Client devices
                 while connected to Firezone.
               </p>
 
               <div class="mb-12">
                 <.input field={config[:search_domain]} placeholder="E.g. example.com" />
+                <p class="mt-2 text-sm text-neutral-500">
+                  Enter a valid FQDN to append to single-label DNS queries. The
+                  resulting FQDN will be used to match against DNS Resources in
+                  your account, or forwarded to the upstream resolvers if no
+                  match is found.
+                </p>
               </div>
 
               <h2 class="mb-4 text-xl text-neutral-900">Upstream Resolvers</h2>
 
+              <p class="mb-4 text-neutral-500">
+                Queries for Resources will <strong>always</strong> use Firezone's internal DNS.
+                All other queries will use the resolvers configured here or the device's
+                system resolvers if none are configured.
+              </p>
+
               <p :if={not upstream_dns_empty?(@account, @form)} class="mb-4 text-neutral-500">
-                Upstream resolvers will be used by Clients in the order they are listed below.
+                Upstream resolvers will be used by Client devices in the order they are listed below.
               </p>
 
               <p :if={upstream_dns_empty?(@account, @form)} class="text-neutral-500">

--- a/elixir/apps/web/test/web/live/settings/dns_test.exs
+++ b/elixir/apps/web/test/web/live/settings/dns_test.exs
@@ -56,7 +56,8 @@ defmodule Web.Live.Settings.DNSTest do
 
     assert find_inputs(form) == [
              "account[config][_persistent_id]",
-             "account[config][clients_upstream_dns_drop][]"
+             "account[config][clients_upstream_dns_drop][]",
+             "account[config][search_domain]"
            ]
   end
 
@@ -94,8 +95,71 @@ defmodule Web.Live.Settings.DNSTest do
              "account[config][clients_upstream_dns][0][address]",
              "account[config][clients_upstream_dns][0][protocol]",
              "account[config][clients_upstream_dns_drop][]",
-             "account[config][clients_upstream_dns_sort][]"
+             "account[config][clients_upstream_dns_sort][]",
+             "account[config][search_domain]"
            ]
+  end
+
+  test "saves search domain", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    account = Fixtures.Accounts.update_account(account, %{config: %{clients_upstream_dns: []}})
+
+    attrs = %{
+      account: %{
+        config: %{
+          search_domain: "example.com"
+        }
+      }
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/dns")
+
+    lv
+    |> form("form", attrs)
+    |> render_submit()
+
+    assert lv
+           |> form("form")
+           |> find_inputs() == [
+             "account[config][_persistent_id]",
+             "account[config][clients_upstream_dns_drop][]",
+             "account[config][search_domain]"
+           ]
+
+    account = Domain.Accounts.fetch_account_by_id!(account.id)
+
+    assert account.config.search_domain == "example.com"
+  end
+
+  test "renders error for invalid search domain", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    account = Fixtures.Accounts.update_account(account, %{config: %{clients_upstream_dns: []}})
+
+    attrs = %{
+      account: %{
+        config: %{
+          search_domain: "example"
+        }
+      }
+    }
+
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/dns")
+
+    assert lv
+           |> form("form", attrs)
+           |> render_change() =~ "must be a valid fully-qualified domain name"
   end
 
   test "saves custom DNS server address", %{
@@ -141,7 +205,8 @@ defmodule Web.Live.Settings.DNSTest do
              "account[config][clients_upstream_dns][0][address]",
              "account[config][clients_upstream_dns][0][protocol]",
              "account[config][clients_upstream_dns_drop][]",
-             "account[config][clients_upstream_dns_sort][]"
+             "account[config][clients_upstream_dns_sort][]",
+             "account[config][search_domain]"
            ]
   end
 
@@ -183,7 +248,8 @@ defmodule Web.Live.Settings.DNSTest do
              "account[config][clients_upstream_dns][2][address]",
              "account[config][clients_upstream_dns][2][protocol]",
              "account[config][clients_upstream_dns_drop][]",
-             "account[config][clients_upstream_dns_sort][]"
+             "account[config][clients_upstream_dns_sort][]",
+             "account[config][search_domain]"
            ]
   end
 


### PR DESCRIPTION
- Adds a simple text input to configure search domains ("default DNS suffix") in the Settings -> DNS page.
- Sends the `search_domain` field as part of the client's `init` message
- Fixes a minor UI alignment inconsistency for the upstream resolvers field so that the total form width and `New resolver` button width are the same.


<img width="1137" alt="Screenshot 2025-03-09 at 10 56 56 PM" src="https://github.com/user-attachments/assets/a1d5a570-8eae-4aa9-8a1c-6aaeb9f4c33a" />



Fixes #8365 