### PR TITLE
fix(android): Remove fitsSystemWindows from bottom sheet layout

### DIFF
--- a/kotlin/android/app/src/main/res/layout/fragment_resource_details.xml
+++ b/kotlin/android/app/src/main/res/layout/fragment_resource_details.xml
@@ -3,8 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="@dimen/spacing_medium"
-    android:fitsSystemWindows="true">
+    android:padding="@dimen/spacing_medium">
 
     <!-- Resource Section -->
     <TextView


### PR DESCRIPTION
This overrides the padding set in the bottom sheet, and is unnecessary because the outer-most layout contains `fitsSystemWindows=true`.

Fixes #8384 