### PR TITLE
fix(connlib): forward search-domain-expanded queries to upstream

### DIFF
--- a/rust/ip-packet/src/udp_header_slice_mut.rs
+++ b/rust/ip-packet/src/udp_header_slice_mut.rs
@@ -40,6 +40,29 @@ impl<'a> UdpHeaderSliceMut<'a> {
         // Safety: Slice it at least of length 8 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 6, checksum.to_be_bytes()) };
     }
+
+    /// Sets the UDP payload and updates the length field.
+    ///
+    /// The `payload` must fit within the remaining slice after the 8-byte UDP header.
+    /// If the payload is too large, this method will panic.
+    pub fn set_payload(&mut self, payload: &[u8]) {
+        let udp_header_len = 8;
+        let total_len = udp_header_len + payload.len();
+
+        // Check if the payload fits within the slice
+        assert!(
+            total_len <= self.slice.len(),
+            "Payload too large for UDP packet buffer: {} bytes needed, {} bytes available",
+            total_len,
+            self.slice.len()
+        );
+
+        // Update the payload
+        self.slice[udp_header_len..udp_header_len + payload.len()].copy_from_slice(payload);
+
+        // Update the length field
+        self.set_length(total_len as u16);
+    }
 }
 
 #[cfg(test)]
@@ -69,5 +92,43 @@ mod tests {
         assert_eq!(slice.destination_port(), 40);
         assert_eq!(slice.length(), 50);
         assert_eq!(slice.checksum(), 60);
+    }
+
+    #[test]
+    fn set_payload_updates_payload_and_length() {
+        let mut buf = vec![0; 20 + 8 + 10]; // IP header (20) + UDP header (8) + payload space (10)
+
+        PacketBuilder::ipv4([0u8; 4], [0u8; 4], 0)
+            .udp(10, 20)
+            .write(&mut buf, &[1, 2, 3])
+            .unwrap();
+
+        let mut slice = UdpHeaderSliceMut::from_slice(&mut buf[20..]).unwrap();
+
+        let new_payload = vec![4, 5, 6, 7];
+        slice.set_payload(&new_payload);
+
+        let updated_slice = UdpHeaderSlice::from_slice(&buf[20..]).unwrap();
+        assert_eq!(updated_slice.length(), 8 + new_payload.len() as u16);
+
+        // Manually extract payload (after 8-byte header)
+        let payload = &buf[20 + 8..20 + 8 + new_payload.len()];
+        assert_eq!(payload, &new_payload);
+    }
+
+    #[test]
+    #[should_panic(expected = "Payload too large for UDP packet buffer")]
+    fn set_payload_panics_on_too_large_payload() {
+        let mut buf = vec![0; 20 + 8 + 5]; // IP header (20) + UDP header (8) + 5 bytes payload space
+
+        PacketBuilder::ipv4([0u8; 4], [0u8; 4], 0)
+            .udp(10, 20)
+            .write(&mut buf, &[1, 2, 3])
+            .unwrap();
+
+        let mut slice = UdpHeaderSliceMut::from_slice(&mut buf[20..]).unwrap();
+
+        let oversized_payload = vec![1, 2, 3, 4, 5, 6]; // 6 bytes > 5 bytes available
+        slice.set_payload(&oversized_payload);
     }
 }

--- a/rust/ip-packet/src/udp_header_slice_mut.rs
+++ b/rust/ip-packet/src/udp_header_slice_mut.rs
@@ -40,29 +40,6 @@ impl<'a> UdpHeaderSliceMut<'a> {
         // Safety: Slice it at least of length 8 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 6, checksum.to_be_bytes()) };
     }
-
-    /// Sets the UDP payload and updates the length field.
-    ///
-    /// The `payload` must fit within the remaining slice after the 8-byte UDP header.
-    /// If the payload is too large, this method will panic.
-    pub fn set_payload(&mut self, payload: &[u8]) {
-        let udp_header_len = 8;
-        let total_len = udp_header_len + payload.len();
-
-        // Check if the payload fits within the slice
-        assert!(
-            total_len <= self.slice.len(),
-            "Payload too large for UDP packet buffer: {} bytes needed, {} bytes available",
-            total_len,
-            self.slice.len()
-        );
-
-        // Update the payload
-        self.slice[udp_header_len..udp_header_len + payload.len()].copy_from_slice(payload);
-
-        // Update the length field
-        self.set_length(total_len as u16);
-    }
 }
 
 #[cfg(test)]
@@ -92,43 +69,5 @@ mod tests {
         assert_eq!(slice.destination_port(), 40);
         assert_eq!(slice.length(), 50);
         assert_eq!(slice.checksum(), 60);
-    }
-
-    #[test]
-    fn set_payload_updates_payload_and_length() {
-        let mut buf = vec![0; 20 + 8 + 10]; // IP header (20) + UDP header (8) + payload space (10)
-
-        PacketBuilder::ipv4([0u8; 4], [0u8; 4], 0)
-            .udp(10, 20)
-            .write(&mut buf, &[1, 2, 3])
-            .unwrap();
-
-        let mut slice = UdpHeaderSliceMut::from_slice(&mut buf[20..]).unwrap();
-
-        let new_payload = vec![4, 5, 6, 7];
-        slice.set_payload(&new_payload);
-
-        let updated_slice = UdpHeaderSlice::from_slice(&buf[20..]).unwrap();
-        assert_eq!(updated_slice.length(), 8 + new_payload.len() as u16);
-
-        // Manually extract payload (after 8-byte header)
-        let payload = &buf[20 + 8..20 + 8 + new_payload.len()];
-        assert_eq!(payload, &new_payload);
-    }
-
-    #[test]
-    #[should_panic(expected = "Payload too large for UDP packet buffer")]
-    fn set_payload_panics_on_too_large_payload() {
-        let mut buf = vec![0; 20 + 8 + 5]; // IP header (20) + UDP header (8) + 5 bytes payload space
-
-        PacketBuilder::ipv4([0u8; 4], [0u8; 4], 0)
-            .udp(10, 20)
-            .write(&mut buf, &[1, 2, 3])
-            .unwrap();
-
-        let mut slice = UdpHeaderSliceMut::from_slice(&mut buf[20..]).unwrap();
-
-        let oversized_payload = vec![1, 2, 3, 4, 5, 6]; // 6 bytes > 5 bytes available
-        slice.set_payload(&oversized_payload);
     }
 }


### PR DESCRIPTION
In #8378, functionality was implemented that expands single-label DNS queries using an admin-configured `search_domain`. However, that PR only applied this behavior to queries that matched a DNS Resource.

In many corporate environments, a search domain (say `corp.net`) is configured, and hosts on the corporate network use single-label queries to reach other internal corporate services. In some cases, the organization uses MDM to set the search domain on their fleet of devices, so that all queries automatically get expanded by the OS.

In other cases however, the admin relies on the VPN client to set this search domain (this is fairly common with e.g. OpenVPN and AnyConnect) so that when the VPN is connected, it applies to the system.

This PR updates our search domain expansion to apply to _all_ single-label queries, such that administrator achieves the same use case other VPN clients support above.