### PR TITLE
feat(portal): Create pgaudit extension

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   # Dependencies
   postgres:
+    # TODO: Enable pgaudit on dev instance. See https://github.com/pgaudit/pgaudit/issues/44#issuecomment-455090262
     image: postgres:15
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/elixir/apps/domain/priv/repo/migrations/20250313193005_create_pgaudit_extension.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250313193005_create_pgaudit_extension.exs
@@ -1,0 +1,22 @@
+defmodule Domain.Repo.Migrations.CreatePgauditExtension do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+      DO $$
+      BEGIN
+          CREATE EXTENSION IF NOT EXISTS pgaudit;
+      EXCEPTION
+          WHEN OTHERS THEN
+              RAISE NOTICE 'Extension "pgaudit" is not available, skipping...';
+      END;
+      $$;
+    """)
+  end
+
+  def down do
+    execute("""
+      DROP EXTENSION IF EXISTS pgaudit;
+    """)
+  end
+end


### PR DESCRIPTION
[Step 2](https://cloud.google.com/sql/docs/postgres/pg-audit#set-pgaudit-flag-values) of the pgaudit setup guide for Google Cloud SQL. It would be good to have detailed pg audit logs on the master application instance in case things go wrong.

Notably, this prevents erroring out when the `pgaudit` is not available, which by default, it is. Enabling the `pgaudit` extension for our dev instance is left as a future endeavor.

Supersedes #5442