### PR TITLE
fix(portal): Fix submit button spacing in settings/dns

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -56,7 +56,7 @@ defmodule Web.Settings.DNS do
                 while connected to Firezone.
               </p>
 
-              <div class="mb-12">
+              <div class="mb-8">
                 <.input field={config[:search_domain]} placeholder="E.g. example.com" />
                 <p class="mt-2 text-sm text-neutral-500">
                   Enter a valid FQDN to append to single-label DNS queries. The
@@ -151,9 +151,11 @@ defmodule Web.Settings.DNS do
                 or IPv6 connectivity may not be able to resolve DNS queries.
               </p>
             </.inputs_for>
-            <.submit_button>
-              Save
-            </.submit_button>
+            <div class="mt-16">
+              <.submit_button>
+                Save DNS Settings
+              </.submit_button>
+            </div>
           </.form>
         </div>
       </:content>


### PR DESCRIPTION
The submit button on the settings -> dns page has a couple UX issues with the new search domain section:

- It's ambiguous what the `Save` is actually saving
- The spacing makes it look like it's only saving upstream resolvers

This PR introduces a simple fix that address the two issues by:

- Updating the button text to `Save DNS Settings`
- Increasing spacing between submit button and form elements
- Slightly decreasing spacing between the `search domain` and `upstream resolvers` inputs


<img width="968" alt="Screenshot 2025-03-14 at 12 06 02 AM" src="https://github.com/user-attachments/assets/651f54c8-3b5f-4747-ad3a-e2ae32eccbf0" />


Related #5248 