### PR TITLE
chore(swift): Remove typo semicolon in NetworkSettings.swift

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -36,7 +36,7 @@ class NetworkSettings {
     guard let domain = domain else {
         self.matchDomains = [""]
         self.searchDomains = [""]
-        return;
+        return
     }
 
     self.matchDomains = ["", domain]


### PR DESCRIPTION
This snuck in and I didn't catch it.