### PR TITLE
fix(connlib): Update search_domain for exsiting TunConfigs

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1050,6 +1050,9 @@ impl ClientState {
                 // We don't really expect these to change but let's update them anyway.
                 existing.ip.v4 = config.ipv4;
                 existing.ip.v6 = config.ipv6;
+
+                // These are safe to always update
+                existing.search_domain = config.search_domain.clone();
             }
             None => {
                 let (ipv4_routes, ipv6_routes) = self.routes().partition_map(|route| match route {


### PR DESCRIPTION
For existing `TunConfig`, we had a bug where we failed to update the search_domain if the effective dns_servers were unchanged.

@thomaseizinger I can see why you want to refactor this; it's quite a mess to follow ;-). I was going to try my hand at cleaning it up a little bit just so I can grok it but I figured since this area is going to be changing quite a bit in #8263, I'll leave those changes out for now.