### PR TITLE
fix(swift): Allow too many parameters in onSetInterfaceConfig

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -360,6 +360,7 @@ extension Adapter {
 // MARK: Implementing CallbackHandlerDelegate
 
 extension Adapter: CallbackHandlerDelegate {
+  // swiftlint:disable:next function_parameter_count
   public func onSetInterfaceConfig(
     tunnelAddressIPv4: String,
     tunnelAddressIPv6: String,

--- a/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
+++ b/swift/apple/FirezoneNetworkExtension/CallbackHandler.swift
@@ -17,6 +17,7 @@ extension RustString: @unchecked Sendable {}
 extension RustString: Error {}
 
 public protocol CallbackHandlerDelegate: AnyObject {
+  // swiftlint:disable:next function_parameter_count
   func onSetInterfaceConfig(
     tunnelAddressIPv4: String,
     tunnelAddressIPv6: String,
@@ -31,7 +32,7 @@ public protocol CallbackHandlerDelegate: AnyObject {
 
 public class CallbackHandler {
   public weak var delegate: CallbackHandlerDelegate?
-
+  // swiftlint:disable:next function_parameter_count
   func onSetInterfaceConfig(
     tunnelAddressIPv4: RustString,
     tunnelAddressIPv6: RustString,

--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -36,7 +36,7 @@ class NetworkSettings {
     guard let domain = domain else {
         self.matchDomains = [""]
         self.searchDomains = [""]
-        return;
+        return
     }
 
     self.matchDomains = ["", domain]


### PR DESCRIPTION
We don't necessarily care if we slightly go over the function parameter count lint in `onSetInterfaceConfig`.