### PR TITLE
chore(rust): sort `workspace.dependencies` table

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,32 +44,49 @@ bimap = "0.6"
 boringtun = { version = "0.6", default-features = false }
 bytecodec = "0.4.15"
 bytes = { version = "1.9.0", default-features = false }
+caps = "0.5.5"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
 clap = "4.5.28"
+connlib-client-android = { path = "connlib/clients/android" }
+connlib-client-apple = { path = "connlib/clients/apple" }
+connlib-client-shared = { path = "connlib/clients/shared" }
+connlib-model = { path = "connlib/model" }
 derive_more = "1.0.0"
 difference = "2.0.0"
 dirs = "5.0.1"
 divan = "0.1.17"
 dns-lookup = "2.0"
+dns-over-tcp = { path = "dns-over-tcp" }
+dns-types = { path = "dns-types" }
 either = "1"
 env_logger = "0.11.6"
 etherparse = "0.16"
+firezone-bin-shared = { path = "bin-shared" }
+firezone-gui-client-common = { path = "gui-client/src-common" }
+firezone-headless-client = { path = "headless-client" }
+firezone-logging = { path = "logging" }
+firezone-relay = { path = "relay" }
+firezone-telemetry = { path = "telemetry" }
+firezone-tunnel = { path = "connlib/tunnel" }
+flume = { version = "0.11.1", features = ["async"] }
 futures = { version = "0.3.31" }
 futures-bounded = "0.2.1"
 glob = "0.3.2"
 hex = "0.4.3"
 hex-display = "0.3.0"
 hex-literal = "0.4.1"
-caps = "0.5.5"
 humantime = "2.1"
+ip-packet = { path = "ip-packet" }
 ip_network = { version = "0.4", default-features = false }
 ip_network_table = { version = "0.2", default-features = false }
 itertools = "0.13"
 jni = "0.21.1"
-supports-color = "3.0.2"
 keyring = "3.6.1"
 known-folders = "1.2.0"
+l4-tcp-dns-server = { path = "connlib/l4-tcp-dns-server" }
+l4-udp-dns-server = { path = "connlib/l4-udp-dns-server" }
 libc = "0.2.150"
+lockfree-object-pool = "0.1.6"
 log = "0.4"
 lru = "0.12.5"
 mio = "1.0.3"
@@ -78,15 +95,15 @@ native-dialog = "0.7.0"
 nix = "0.29.0"
 nu-ansi-term = "0.50"
 once_cell = "1.17.1"
-ringbuffer = "0.15.0"
 opentelemetry = "0.26.0"
 opentelemetry-otlp = "0.26.0"
 opentelemetry_sdk = "0.26.0"
 os_info = { version = "3", default-features = false }
 output_vt100 = "0.1"
+parking_lot = "0.12.3"
+phoenix-channel = { path = "phoenix-channel" }
 png = "0.17.16"
 proptest = "1.6.0"
-parking_lot = "0.12.3"
 proptest-state-machine = "0.3.1"
 quinn-udp = { version = "0.5.8", features = ["fast-apple-datapath"] }
 rand = "0.8.5"
@@ -95,6 +112,7 @@ rangemap = "1.5.1"
 rayon = "1.10.0"
 reqwest = { version = "0.12.9", default-features = false }
 resolv-conf = "0.7.0"
+ringbuffer = "0.15.0"
 rtnetlink = { version = "0.14.1", default-features = false, features = ["tokio_socket"] }
 rustls = { version = "0.23.21", default-features = false, features = ["ring"] }
 sadness-generator = "0.6.0"
@@ -109,21 +127,24 @@ sha2 = "0.10.8"
 smallvec = "1.13.2"
 smbios-lib = "0.9.2"
 smoltcp = { version = "0.12", default-features = false }
+snownet = { path = "connlib/snownet" }
+socket-factory = { path = "socket-factory" }
+socket2 = { version = "0.5" }
 static_assertions = "1.1.0"
 str0m = { version = "0.7.0", default-features = false, features = ["sha1"] }
 strum = { version = "0.27.1", features = ["derive"] }
 stun_codec = "0.3.4"
 subprocess = "0.2.9"
 subtle = "2.5.0"
+supports-color = "3.0.2"
 swift-bridge = "0.1.57"
 swift-bridge-build = "0.1.57"
-lockfree-object-pool = "0.1.6"
 tauri = "2.2.5"
 tauri-build = "2.0.1"
 tauri-plugin-dialog = "2.2.0"
 tauri-plugin-notification = "2.2.0"
-tauri-plugin-shell = "2.2.0"
 tauri-plugin-opener = "2.2.0"
+tauri-plugin-shell = "2.2.0"
 tauri-runtime = "2.3.0"
 tauri-utils = "2.1.1"
 tempfile = "3.13.0"
@@ -133,46 +154,24 @@ thiserror = "1.0.68"
 time = "0.3.37"
 tokio = "1.43"
 tokio-stream = "0.1.17"
-flume = { version = "0.11.1", features = ["async"] }
 tokio-tungstenite = "0.23.1"
 tokio-util = "0.7.13"
 tracing = { version = "0.1.40" }
 tracing-appender = "0.2.3"
 tracing-core = "0.1.31"
+tracing-journald = "0.3.1"
 tracing-log = "0.2.0"
 tracing-macros = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" } # Contains `dbg!` but for `tracing`.
 tracing-opentelemetry = "0.27.0"
 tracing-stackdriver = "0.11.0"
-tracing-journald = "0.3.1"
 tracing-subscriber = { version = "0.3.19", features = ["parking_lot"] }
 trackable = "1.3.0"
+tun = { path = "tun" }
 url = "2.5.2"
 uuid = "1.14.0"
 windows = "0.58.0"
 winreg = "0.52.0"
 zip = { version = "2", default-features = false }
-
-connlib-client-android = { path = "connlib/clients/android" }
-connlib-client-apple = { path = "connlib/clients/apple" }
-connlib-client-shared = { path = "connlib/clients/shared" }
-firezone-bin-shared = { path = "bin-shared" }
-firezone-logging = { path = "logging" }
-firezone-telemetry = { path = "telemetry" }
-firezone-headless-client = { path = "headless-client" }
-firezone-gui-client-common = { path = "gui-client/src-common" }
-snownet = { path = "connlib/snownet" }
-l4-udp-dns-server = { path = "connlib/l4-udp-dns-server" }
-l4-tcp-dns-server = { path = "connlib/l4-tcp-dns-server" }
-dns-over-tcp = { path = "dns-over-tcp" }
-dns-types = { path = "dns-types" }
-firezone-relay = { path = "relay" }
-connlib-model = { path = "connlib/model" }
-firezone-tunnel = { path = "connlib/tunnel" }
-phoenix-channel = { path = "phoenix-channel" }
-ip-packet = { path = "ip-packet" }
-socket-factory = { path = "socket-factory" }
-tun = { path = "tun" }
-socket2 = { version = "0.5" }
 
 [workspace.lints.clippy]
 dbg_macro = "warn"


### PR DESCRIPTION
Unfortunately, `cargo sort` doesn't yet handle this.

Related: https://github.com/DevinR528/cargo-sort/pull/55