### PR TITLE
feat(portal): Add changelog link to outdated gateway email

### DIFF
--- a/elixir/apps/domain/lib/domain/mailer/notifications/outdated_gateway.html.eex
+++ b/elixir/apps/domain/lib/domain/mailer/notifications/outdated_gateway.html.eex
@@ -71,6 +71,9 @@
                   <p style="margin: 0; line-height: 24px">
                     The latest Firezone Gateway release is: <%= @latest_version %>
                   </p>
+                  <p style="margin: 0; line-height: 24px">
+                    <a href="https://www.firezone.dev/changelog?utm_source=email" target="_blank">See what's changed in this release</a>.
+                  </p>
                   <div role="separator" style="line-height: 16px">&zwj;</div>
                   <p style="margin: 0; line-height: 24px;">
                     The following list of Gateways in your Firezone Account can be updated.
@@ -91,7 +94,7 @@
                   <div role="separator" style="background-color: #d1d1d1; height: 1px; line-height: 1px; margin: 32px 0;">&zwj;</div>
                   <p style="margin: 0; line-height: 24px;">
                     We recommend updating the Gateways at your earliest convenience. Help on how to update Gateways can be found
-                    in our <a href="https://www.firezone.dev/kb/administer/upgrading">Firezone Gateway Upgrade Guide</a>
+                    in our <a href="https://www.firezone.dev/kb/administer/upgrading">Firezone Gateway Upgrade Guide</a>.
                     <br>
                     <br>
                     Thanks, <br>The Firezone Team

--- a/elixir/apps/domain/lib/domain/mailer/notifications/outdated_gateway.html.eex
+++ b/elixir/apps/domain/lib/domain/mailer/notifications/outdated_gateway.html.eex
@@ -72,7 +72,7 @@
                     The latest Firezone Gateway release is: <%= @latest_version %>
                   </p>
                   <p style="margin: 0; line-height: 24px">
-                    <a href="https://www.firezone.dev/changelog?utm_source=email" target="_blank">See what's changed in this release</a>.
+                    <a href="https://www.firezone.dev/changelog?tab=gateway" target="_blank">See what's changed in this release</a>.
                   </p>
                   <div role="separator" style="line-height: 16px">&zwj;</div>
                   <p style="margin: 0; line-height: 24px;">

--- a/elixir/apps/domain/lib/domain/mailer/notifications/outdated_gateway.text.eex
+++ b/elixir/apps/domain/lib/domain/mailer/notifications/outdated_gateway.text.eex
@@ -2,6 +2,8 @@ Gateway Update Available!
 
 The latest Firezone Gateway release is: <%= @latest_version %>
 
+See what's changed: https://www.firezone.dev/changelog?utm_source=email
+
 The following list of Gateways in your Firezone Account can be updated:
 <%= for gateway <- @gateways do %>
 <%= "- #{gateway.name} -> #{gateway.last_seen_version}" %>

--- a/elixir/apps/domain/lib/domain/mailer/notifications/outdated_gateway.text.eex
+++ b/elixir/apps/domain/lib/domain/mailer/notifications/outdated_gateway.text.eex
@@ -2,7 +2,7 @@ Gateway Update Available!
 
 The latest Firezone Gateway release is: <%= @latest_version %>
 
-See what's changed: https://www.firezone.dev/changelog?utm_source=email
+See what's changed: https://www.firezone.dev/changelog?tab=gateway
 
 The following list of Gateways in your Firezone Account can be updated:
 <%= for gateway <- @gateways do %>


### PR DESCRIPTION
It would be useful to have a link to the changelog in our outdated gateway email.

See https://firezonehq.slack.com/archives/C069H865MHP/p1742088424077639

<img width="638" alt="Screenshot 2025-03-16 at 9 39 22 PM" src="https://github.com/user-attachments/assets/f67b9b3e-9796-45a9-ae90-26eeabc40740" />
