### PR TITLE
chore(gui-client): improve context when `resolvectl` fails

### DIFF
--- a/rust/headless-client/src/dns_control/linux.rs
+++ b/rust/headless-client/src/dns_control/linux.rs
@@ -48,7 +48,10 @@ impl DnsController {
         // Flushing is only implemented for systemd-resolved
         if matches!(self.dns_control_method, DnsControlMethod::SystemdResolved) {
             tracing::debug!("Flushing systemd-resolved DNS cache...");
-            Command::new("resolvectl").arg("flush-caches").status()?;
+            Command::new("resolvectl")
+                .arg("flush-caches")
+                .status()
+                .context("Failed to run `resolvectl flush-caches`")?;
             tracing::debug!("Flushed DNS.");
         }
         Ok(())


### PR DESCRIPTION
Took me a while to figure out what the "File not found" error was pointing to. Adding some context should help.