### PR TITLE
ci: create Sentry releases for Android clients

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -24,6 +24,8 @@ jobs:
             projects: headless-client
           - component: macos-client
             projects: apple-client
+          - component: android-client
+            projects: android-client
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
This marks the release in Sentry as "released" and also attaches the commits to it that we made since the last release.