### PR TITLE
fix(gui-client): call `wintun::Session::shutdown` on drop

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -253,6 +253,12 @@ impl Drop for Tun {
     }
 }
 
+impl Drop for TunState {
+    fn drop(&mut self) {
+        let _ = self.session.shutdown(); // Cancels any `receive_blocking` calls.
+    }
+}
+
 impl Tun {
     fn new(mtu: u32) -> Result<Self> {
         let path = ensure_dll().context("Failed to ensure `wintun.dll` is in place")?;

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -426,7 +426,9 @@ fn start_recv_thread(
             let pkt = match receive_result {
                 Ok(pkt) => pkt,
                 Err(wintun::Error::ShuttingDown) => {
-                    tracing::debug!("Stopping recv worker thread because Wintun is shutting down");
+                    tracing::debug!(
+                        "Stopping TUN recv worker thread because Wintun is shutting down"
+                    );
                     break;
                 }
                 Err(e) => {

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -204,10 +204,6 @@ pub struct Tun {
 
 /// All state relevant to the WinTUN device.
 struct TunState {
-    #[expect(
-        dead_code,
-        reason = "The send/recv threads have `Weak` references to this which we need to keep alive"
-    )]
     session: Arc<wintun::Session>,
 
     outbound_tx: PollSender<IpPacket>,


### PR DESCRIPTION
The bugfix we attempted in #8156 turned out wrong. Reading the source-code, we have to call `Session::shutdown` in order to actually cancel the `Session::receive_blocking` call. Not doing so means we run into the timeout when discarding the `Tun` device because the recv-thread is stuck in `Session::receive_blocking`.

Fixes: #8395