### PR TITLE
fix(gui-client): don't bother user with error details

### DIFF
--- a/rust/gui-client/src-common/src/errors.rs
+++ b/rust/gui-client/src-common/src/errors.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use firezone_headless_client::ipc;
 
+pub const GENERIC_MSG: &str = "An unexpected error occurred. Please try restarting Firezone. If the issue persists, contact your administrator.";
+
 // TODO: Replace with `anyhow` gradually per <https://github.com/firezone/firezone/pull/3546#discussion_r1477114789>
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -34,7 +36,7 @@ impl Error {
             }
             Error::IpcClosed => "IPC connection closed".to_string(),
             Error::IpcRead(_) => "IPC read failure".to_string(),
-            Error::Other(error) => error.to_string(),
+            Error::Other(_) => GENERIC_MSG.to_string(),
         }
     }
 }

--- a/rust/gui-client/src-tauri/src/client.rs
+++ b/rust/gui-client/src-tauri/src/client.rs
@@ -129,7 +129,7 @@ fn run_gui(cli: Cli) -> Result<()> {
                 return Err(anyhow);
             }
 
-            common::errors::show_error_dialog(anyhow.to_string())?;
+            common::errors::show_error_dialog(common::errors::GENERIC_MSG.to_owned())?;
             tracing::error!("GUI failed: {anyhow:#}");
 
             Err(anyhow)


### PR DESCRIPTION
There is no reason to show the chain of errors to the user, we are logging it on ERROR level and will thus be notified via Sentry.