### PR TITLE
fix(portal): Allow .local for search_domains

### DIFF
--- a/elixir/apps/domain/lib/domain/accounts/config/changeset.ex
+++ b/elixir/apps/domain/lib/domain/accounts/config/changeset.ex
@@ -31,9 +31,6 @@ defmodule Domain.Accounts.Config.Changeset do
         String.starts_with?(domain, ".") ->
           [search_domain: "must not start with a dot"]
 
-        String.ends_with?(domain, ".local") || String.ends_with?(domain, ".local.") ->
-          [search_domain: "must not end with .local"]
-
         String.contains?(domain, "..") ->
           [search_domain: "must not contain consecutive dots"]
 

--- a/elixir/apps/domain/test/domain/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/accounts_test.exs
@@ -631,20 +631,16 @@ defmodule Domain.AccountsTest do
              }
     end
 
-    test "returns error when search_domain ends with .local", %{account: account} do
+    # Explicitly used by customers
+    test "allows search_domains that end with .local", %{account: account} do
       attrs = %{
         config: %{
           search_domain: "test.local"
         }
       }
 
-      assert {:error, changeset} = update_account_by_id(account.id, attrs)
-
-      assert errors_on(changeset) == %{
-               config: %{
-                 search_domain: ["must not end with .local"]
-               }
-             }
+      assert {:ok, account} = update_account_by_id(account.id, attrs)
+      assert account.config.search_domain == "test.local"
     end
 
     test "returns error when search_domain contains consecutive dots", %{account: account} do


### PR DESCRIPTION
This apparently is explicitly used by customers. See https://firezonehq.slack.com/archives/C08FPHECLUF/p1742221580587719?thread_ts=1741639183.188459&cid=C08FPHECLUF