### PR TITLE
fix(gateway): Prefer setting FIREZONE_ID over /var/lib/firezone

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -246,6 +246,7 @@ defmodule Web.Sites.NewToken do
       end
 
     [
+      {"FIREZONE_ID", Ecto.UUID.generate()},
       {"FIREZONE_TOKEN", encoded_token},
       api_url_override
     ]
@@ -266,7 +267,6 @@ defmodule Web.Sites.NewToken do
       "--health-cmd=\"ip link | grep tun-firezone\"",
       "--name=firezone-gateway",
       "--cap-add=NET_ADMIN",
-      "--volume /var/lib/firezone",
       "--sysctl net.ipv4.ip_forward=1",
       "--sysctl net.ipv4.conf.all.src_valid_mark=1",
       "--sysctl net.ipv6.conf.all.disable_ipv6=0",

--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -23,6 +23,11 @@ if [ -z "$FIREZONE_TOKEN" ]; then
     exit 1
 fi
 
+if [ -z "$FIREZONE_ID" ]; then
+    echo "FIREZONE_ID is required"
+    exit 1
+fi
+
 # Setup user and group
 sudo groupadd -f firezone
 id -u firezone >/dev/null 2>&1 || sudo useradd -r -g firezone -s /sbin/nologin firezone
@@ -43,8 +48,6 @@ User=firezone
 Group=firezone
 PermissionsStartOnly=true
 SyslogIdentifier=firezone-gateway
-StateDirectory=firezone
-StateDirectoryMode=0755
 
 # Environment variables
 Environment="FIREZONE_NAME=$FIREZONE_NAME"
@@ -101,9 +104,6 @@ RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK
 # while restricting it to only that capability.
 AmbientCapabilities=CAP_NET_ADMIN
 CapabilityBoundingSet=CAP_NET_ADMIN
-
-# Allow write access only to specific directories needed at runtime.
-ReadWriteDirectories=/var/lib/firezone
 
 # Make some sensitive paths inaccessible.
 InaccessiblePaths=/root /home


### PR DESCRIPTION
When deploying a Gateway from the admin portal UI, we show various environment variables required for setup. Until now, we've relied on the `/var/lib/firezone` persistence method for identifying the Gateway.

However, this can cause issues on some systems that don't have writeable access to /var/lib/firezone, or old versions of systemd that don't support sandboxed access to this directory.

This PR updates each deployment method to use `FIREZONE_ID` instead everywhere. Additionally, since the Docker upgrade script needs to reinvoke the new container using the same arguments (more or less) as the install, we need to extract the old `/var/lib/firezone/gateway_id` file out of the existing container if it exists, and try to insert it into the upgraded container.

Tested both scripts, including upgrades for the Docker script.

Fixes: #8471 