### PR TITLE
fix(apple): Try to connect on launch

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -97,7 +97,7 @@ public final class Store: ObservableObject {
 
     try ipcClient().subscribeToVPNStatusUpdates(handler: statusChangeHandler)
 
-    if autoStart && status == .disconnected {
+    if autoStart {
       // Try to connect on start
       try ipcClient().start()
     }

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -19,7 +19,11 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8477">
+          Fixes an issue where the app would not auto-connect on launch.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.7" date={new Date("2025-03-14")}>
         <ChangeItem pull="8421">
           Applies the search domain configured in the admin portal, if any.


### PR DESCRIPTION
This is a regression introduced in c9f085c102. The `status` at this point is still `nil` because we have not yet fully subscribed to VPN status change updates from the system.

That actually shouldn't prevent us from trying to start the tunnel anyway. If the `token` is missing from the Keychain, the tunnel process will no-op. So we simply try to start a session on launch always.

Fixes #8456 