### PR TITLE
refactor(portal): Use appropriate access token for Google IdP

### DIFF
--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
@@ -48,7 +48,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
                       %{req_headers: [{"authorization", "Bearer GOOGLE_0AUTH_ACCESS_TOKEN"} | _]}}
     end
 
-    test "uses admin user token as a fallback when service account is not configured" do
+    test "does not use admin user token when service account is set" do
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.override_token_endpoint("http://localhost:#{bypass.port}/")
 
@@ -65,14 +65,12 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       end)
 
       GoogleWorkspaceDirectory.override_endpoint_url("http://localhost:#{bypass.port}/")
-      GoogleWorkspaceDirectory.mock_groups_list_endpoint(bypass, [])
-      GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(bypass, [])
-      GoogleWorkspaceDirectory.mock_users_list_endpoint(bypass, [])
 
       {:ok, pid} = Task.Supervisor.start_link()
+
       assert execute(%{task_supervisor: pid}) == :ok
 
-      assert_receive {:bypass_request,
+      refute_receive {:bypass_request,
                       %{req_headers: [{"authorization", "Bearer OIDC_ACCESS_TOKEN"} | _]}}
     end
 

--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace_test.exs
@@ -139,7 +139,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspaceTest do
     end
   end
 
-  describe "fetch_service_account_token/1" do
+  describe "fetch_service_account_access_token/1" do
     test "generates a valid JWT" do
       Bypass.open()
       |> Mocks.GoogleWorkspaceDirectory.mock_token_endpoint()
@@ -147,7 +147,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspaceTest do
       {provider, _bypass} = Fixtures.Auth.start_and_create_google_workspace_provider()
       provider = Repo.get!(Auth.Provider, provider.id)
 
-      assert fetch_service_account_token(provider) == {:ok, "GOOGLE_0AUTH_ACCESS_TOKEN"}
+      assert fetch_service_account_access_token(provider) == {:ok, "GOOGLE_0AUTH_ACCESS_TOKEN"}
     end
 
     test "returns error when API is not available" do
@@ -158,7 +158,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspaceTest do
       {provider, _bypass} = Fixtures.Auth.start_and_create_google_workspace_provider()
       provider = Repo.get!(Auth.Provider, provider.id)
 
-      assert fetch_service_account_token(provider) ==
+      assert fetch_service_account_access_token(provider) ==
                {:error, %Mint.TransportError{reason: :econnrefused}}
     end
   end


### PR DESCRIPTION
Why:

* Previously, when running a directory sync with the Google Workspace IdP adapter, if a service account had been configured but there was a problem getting an access token for the service account, the sync job would fall back to using a personal access token.  We no longer want to rely on any personal access token once a service account has been configured.  This commit will make sure that if a service account is configured there is no way to fall back to any personal access token.


Fixes #8409 