### PR TITLE
refactor(portal): Rename resource_cidrs -> device_cidrs

### DIFF
--- a/elixir/apps/domain/lib/domain/network.ex
+++ b/elixir/apps/domain/lib/domain/network.ex
@@ -8,13 +8,11 @@ defmodule Domain.Network do
     ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 48}
   }
 
-  # For generating new IPs for CIDR/IP Resources
-  @resource_cidrs %{
+  # For generating new IPs for clients and gateways
+  @device_cidrs %{
     ipv4: %Postgrex.INET{address: {100, 64, 0, 0}, netmask: 11},
     ipv6: %Postgrex.INET{address: {64_768, 8_225, 4_369, 0, 0, 0, 0, 0}, netmask: 107}
   }
-
-  def resource_cidrs, do: @resource_cidrs
 
   def reserved_cidrs, do: @reserved_cidrs
 
@@ -23,7 +21,7 @@ defmodule Domain.Network do
       raise "fetch_next_available_address/1 must be called inside a transaction"
     end
 
-    cidrs = Keyword.get(opts, :cidrs, @resource_cidrs)
+    cidrs = Keyword.get(opts, :cidrs, @device_cidrs)
     cidr = Map.fetch!(cidrs, type)
     hosts = Domain.Types.CIDR.count_hosts(cidr)
     offset = Enum.random(2..max(2, hosts - 2))


### PR DESCRIPTION
I was debugging some of this just now and realized our naming / comments are incorrect here, so thought I'd open a PR to tidy things up for the next person reading this.

Resource CIDRs actually occupy the `100.96.0.0/11` range (and IPv6 equivalent), but the portal doesn't generate these.