### PR TITLE
fix(gateway): Apply more specific firewall rules on start

### DIFF
--- a/rust/docker-init-gateway.sh
+++ b/rust/docker-init-gateway.sh
@@ -7,13 +7,13 @@ fi
 
 IFACE="tun-firezone"
 # Enable masquerading for Firezone tunnel traffic
-iptables -C FORWARD -i $IFACE -j ACCEPT > /dev/null 2>&1 || iptables -I FORWARD 1 -i $IFACE -j ACCEPT
-iptables -C FORWARD -o $IFACE -j ACCEPT > /dev/null 2>&1 || iptables -I FORWARD 1 -o $IFACE -j ACCEPT
-iptables -t nat -C POSTROUTING -s 100.64.0.0/11 -o e+ -j MASQUERADE > /dev/null 2>&1 || iptables -t nat -A POSTROUTING -s 100.64.0.0/11 -o e+ -j MASQUERADE
-iptables -t nat -C POSTROUTING -s 100.64.0.0/11 -o w+ -j MASQUERADE > /dev/null 2>&1 || iptables -t nat -A POSTROUTING -s 100.64.0.0/11 -o w+ -j MASQUERADE
-ip6tables -C FORWARD -i $IFACE -j ACCEPT > /dev/null 2>&1 || ip6tables -I FORWARD 1 -i $IFACE -j ACCEPT
-ip6tables -C FORWARD -o $IFACE -j ACCEPT > /dev/null 2>&1 || ip6tables -I FORWARD 1 -o $IFACE -j ACCEPT
-ip6tables -t nat -C POSTROUTING -s fd00:2021:1111::/107 -o e+ -j MASQUERADE > /dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -s fd00:2021:1111::/107 -o e+ -j MASQUERADE
-ip6tables -t nat -C POSTROUTING -s fd00:2021:1111::/107 -o w+ -j MASQUERADE > /dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -s fd00:2021:1111::/107 -o w+ -j MASQUERADE
+iptables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -I FORWARD 1 -i $IFACE -j ACCEPT
+iptables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -I FORWARD 1 -o $IFACE -j ACCEPT
+iptables -t nat -C POSTROUTING -s 100.64.0.0/11 -o e+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -s 100.64.0.0/11 -o e+ -j MASQUERADE
+iptables -t nat -C POSTROUTING -s 100.64.0.0/11 -o w+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -s 100.64.0.0/11 -o w+ -j MASQUERADE
+ip6tables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -I FORWARD 1 -i $IFACE -j ACCEPT
+ip6tables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -I FORWARD 1 -o $IFACE -j ACCEPT
+ip6tables -t nat -C POSTROUTING -s fd00:2021:1111::/107 -o e+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -s fd00:2021:1111::/107 -o e+ -j MASQUERADE
+ip6tables -t nat -C POSTROUTING -s fd00:2021:1111::/107 -o w+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -s fd00:2021:1111::/107 -o w+ -j MASQUERADE
 
 exec "$@"

--- a/rust/docker-init-gateway.sh
+++ b/rust/docker-init-gateway.sh
@@ -6,14 +6,14 @@ if [ -f "${FIREZONE_TOKEN}" ]; then
 fi
 
 IFACE="tun-firezone"
-# Enable masquerading for our TUN interface
-iptables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -i $IFACE -j ACCEPT
-iptables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || iptables -A FORWARD -o $IFACE -j ACCEPT
-iptables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o e+ -j MASQUERADE
-iptables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || iptables -t nat -A POSTROUTING -o w+ -j MASQUERADE
-ip6tables -C FORWARD -i $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -i $IFACE -j ACCEPT
-ip6tables -C FORWARD -o $IFACE -j ACCEPT >/dev/null 2>&1 || ip6tables -A FORWARD -o $IFACE -j ACCEPT
-ip6tables -t nat -C POSTROUTING -o e+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o e+ -j MASQUERADE
-ip6tables -t nat -C POSTROUTING -o w+ -j MASQUERADE >/dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o w+ -j MASQUERADE
+# Enable masquerading for Firezone tunnel traffic
+iptables -C FORWARD -i $IFACE -j ACCEPT > /dev/null 2>&1 || iptables -I FORWARD 1 -i $IFACE -j ACCEPT
+iptables -C FORWARD -o $IFACE -j ACCEPT > /dev/null 2>&1 || iptables -I FORWARD 1 -o $IFACE -j ACCEPT
+iptables -t nat -C POSTROUTING -s 100.64.0.0/11 -o e+ -j MASQUERADE > /dev/null 2>&1 || iptables -t nat -A POSTROUTING -s 100.64.0.0/11 -o e+ -j MASQUERADE
+iptables -t nat -C POSTROUTING -s 100.64.0.0/11 -o w+ -j MASQUERADE > /dev/null 2>&1 || iptables -t nat -A POSTROUTING -s 100.64.0.0/11 -o w+ -j MASQUERADE
+ip6tables -C FORWARD -i $IFACE -j ACCEPT > /dev/null 2>&1 || ip6tables -I FORWARD 1 -i $IFACE -j ACCEPT
+ip6tables -C FORWARD -o $IFACE -j ACCEPT > /dev/null 2>&1 || ip6tables -I FORWARD 1 -o $IFACE -j ACCEPT
+ip6tables -t nat -C POSTROUTING -s fd00:2021:1111::/107 -o e+ -j MASQUERADE > /dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -s fd00:2021:1111::/107 -o e+ -j MASQUERADE
+ip6tables -t nat -C POSTROUTING -s fd00:2021:1111::/107 -o w+ -j MASQUERADE > /dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -s fd00:2021:1111::/107 -o w+ -j MASQUERADE
 
 exec "$@"

--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -163,15 +163,15 @@ fi
 chmod 0755 "\$BINARY_PATH"
 chown firezone:firezone "\$BINARY_PATH"
 
-# Enable masquerading for ethernet and wireless interfaces
-iptables -C FORWARD -i tun-firezone -j ACCEPT > /dev/null 2>&1 || iptables -A FORWARD -i tun-firezone -j ACCEPT
-iptables -C FORWARD -o tun-firezone -j ACCEPT > /dev/null 2>&1 || iptables -A FORWARD -o tun-firezone -j ACCEPT
-iptables -t nat -C POSTROUTING -o e+ -j MASQUERADE > /dev/null 2>&1 || iptables -t nat -A POSTROUTING -o e+ -j MASQUERADE
-iptables -t nat -C POSTROUTING -o w+ -j MASQUERADE > /dev/null 2>&1 || iptables -t nat -A POSTROUTING -o w+ -j MASQUERADE
-ip6tables -C FORWARD -i tun-firezone -j ACCEPT > /dev/null 2>&1 || ip6tables -A FORWARD -i tun-firezone -j ACCEPT
-ip6tables -C FORWARD -o tun-firezone -j ACCEPT > /dev/null 2>&1 || ip6tables -A FORWARD -o tun-firezone -j ACCEPT
-ip6tables -t nat -C POSTROUTING -o e+ -j MASQUERADE > /dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o e+ -j MASQUERADE
-ip6tables -t nat -C POSTROUTING -o w+ -j MASQUERADE > /dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -o w+ -j MASQUERADE
+# Enable masquerading for Firezone tunnel traffic
+iptables -C FORWARD -i tun-firezone -j ACCEPT > /dev/null 2>&1 || iptables -I FORWARD 1 -i tun-firezone -j ACCEPT
+iptables -C FORWARD -o tun-firezone -j ACCEPT > /dev/null 2>&1 || iptables -I FORWARD 1 -o tun-firezone -j ACCEPT
+iptables -t nat -C POSTROUTING -s 100.64.0.0/11 -o e+ -j MASQUERADE > /dev/null 2>&1 || iptables -t nat -A POSTROUTING -s 100.64.0.0/11 -o e+ -j MASQUERADE
+iptables -t nat -C POSTROUTING -s 100.64.0.0/11 -o w+ -j MASQUERADE > /dev/null 2>&1 || iptables -t nat -A POSTROUTING -s 100.64.0.0/11 -o w+ -j MASQUERADE
+ip6tables -C FORWARD -i tun-firezone -j ACCEPT > /dev/null 2>&1 || ip6tables -I FORWARD 1 -i tun-firezone -j ACCEPT
+ip6tables -C FORWARD -o tun-firezone -j ACCEPT > /dev/null 2>&1 || ip6tables -I FORWARD 1 -o tun-firezone -j ACCEPT
+ip6tables -t nat -C POSTROUTING -s fd00:2021:1111::/107 -o e+ -j MASQUERADE > /dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -s fd00:2021:1111::/107 -o e+ -j MASQUERADE
+ip6tables -t nat -C POSTROUTING -s fd00:2021:1111::/107 -o w+ -j MASQUERADE > /dev/null 2>&1 || ip6tables -t nat -A POSTROUTING -s fd00:2021:1111::/107 -o w+ -j MASQUERADE
 
 # Enable packet forwarding for IPv4 and IPv6
 sysctl -w net.ipv4.ip_forward=1


### PR DESCRIPTION
On some Linux distributions (Amazon Linux 2023), the default `iptables` install includes a blanket deny rule in the `FORWARD` chain that prevents packets from the tunnel interface from ever leaving the host. To fix this, we ensure our `FORWARD` chain rules are inserted with priority 1 which takes precedence over the blanket-deny rule.

We also update our MASQUERADE in the NAT table to apply only to the CIDR range possible for Gateway tunnel IPs, as opposed to the default `0.0.0.0/0`.

Fixes #8481 