### PR TITLE
feat(portal): Add account delete button

### DIFF
--- a/elixir/apps/domain/lib/domain/mailer/account_delete_email.ex
+++ b/elixir/apps/domain/lib/domain/mailer/account_delete_email.ex
@@ -1,0 +1,25 @@
+defmodule Domain.Mailer.AccountDelete do
+  import Swoosh.Email
+  import Domain.Mailer
+  import Phoenix.Template, only: [embed_templates: 2]
+
+  embed_templates "account_delete_email/*.text", suffix: "_text"
+
+  def account_delete_email(
+        %Domain.Accounts.Account{} = account,
+        %Domain.Auth.Subject{} = subject
+      ) do
+    default_email()
+    |> subject("ACCOUNT DELETE REQUEST - #{account.slug}")
+    |> to("support@firezone.dev")
+    |> reply_to(identity_to_reply_to(subject.identity))
+    |> render_text_body(__MODULE__, :account_delete_request,
+      account: account,
+      subject: subject
+    )
+  end
+
+  defp identity_to_reply_to(nil), do: "notifications@firezone.dev"
+
+  defp identity_to_reply_to(%Domain.Auth.Identity{} = identity), do: identity.provider_identifier
+end

--- a/elixir/apps/domain/lib/domain/mailer/account_delete_email/account_delete_request.text.eex
+++ b/elixir/apps/domain/lib/domain/mailer/account_delete_email/account_delete_request.text.eex
@@ -1,5 +1,15 @@
 REQUEST TO DELETE ACCOUNT!
 
+
+To perform the deletion:
+------------------------
+1. Go to the Stripe dashboard
+2. Lookup the customer by account id from below (<%= @account.id %>)
+3. Cancel the subscription (choose "immediately")
+4. Open an IEx shell to prod
+5. Run `Domain.Ops.delete_disabled_account("<%= @account.id %>")`
+
+
 Request details:
 ----------------
 Account ID:   <%= @account.id %>

--- a/elixir/apps/domain/lib/domain/mailer/account_delete_email/account_delete_request.text.eex
+++ b/elixir/apps/domain/lib/domain/mailer/account_delete_email/account_delete_request.text.eex
@@ -1,0 +1,10 @@
+REQUEST TO DELETE ACCOUNT!
+
+Request details:
+----------------
+Account ID:   <%= @account.id %>
+Account Slug: <%= @account.slug %>
+Account Name: <%= @account.name %>
+Actor ID:     <%= @subject.actor.id %>
+Actor Name:   <%= @subject.actor.name %>
+Identifier:   <%= @subject.identity.provider_identifier %>

--- a/elixir/apps/domain/test/domain/mailer/account_delete_email_test.exs
+++ b/elixir/apps/domain/test/domain/mailer/account_delete_email_test.exs
@@ -1,0 +1,27 @@
+defmodule Domain.Mailer.AccountDeleteEmailTest do
+  use Domain.DataCase, async: true
+  import Domain.Mailer.AccountDelete
+
+  setup do
+    account = Fixtures.Accounts.create_account()
+    actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
+    identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+    subject = Fixtures.Auth.create_subject(identity: identity)
+
+    %{
+      account: account,
+      subject: subject
+    }
+  end
+
+  describe "account_delete_email/2" do
+    test "should contain account info", %{account: account, subject: subject} do
+      email_body = account_delete_email(account, subject)
+
+      assert email_body.text_body =~ "REQUEST TO DELETE ACCOUNT!"
+      assert email_body.text_body =~ ~r/Account ID:\s*#{account.id}/
+      assert email_body.text_body =~ ~r/Actor ID:\s*#{subject.actor.id}/
+      assert email_body.text_body =~ ~r/Identifier:\s*#{subject.identity.provider_identifier}/
+    end
+  end
+end

--- a/elixir/apps/web/lib/web/live/settings/account.ex
+++ b/elixir/apps/web/lib/web/live/settings/account.ex
@@ -6,6 +6,7 @@ defmodule Web.Settings.Account do
     socket =
       assign(socket,
         page_title: "Account",
+        delete_requested: false,
         account_type: Accounts.type(socket.assigns.account)
       )
 
@@ -71,22 +72,59 @@ defmodule Web.Settings.Account do
       <:title>
         Danger zone
       </:title>
+      <:action>
+        <.button_with_confirmation
+          id="delete_account"
+          style="danger"
+          icon="hero-trash-solid"
+          on_confirm="delete_account"
+          disabled={@delete_requested}
+        >
+          <:dialog_title>Confirm Account Deletion</:dialog_title>
+          <:dialog_content>
+            This Account will be scheduled for complete deletion.<br /><br />
+            Are you sure you want to delete your Account?
+          </:dialog_content>
+          <:dialog_confirm_button>
+            Delete Account
+          </:dialog_confirm_button>
+          <:dialog_cancel_button>
+            Cancel
+          </:dialog_cancel_button>
+          <span :if={@delete_requested}>Delete Requested</span>
+          <span :if={!@delete_requested}>Delete Account</span>
+        </.button_with_confirmation>
+      </:action>
       <:content>
         <h3 class="ml-4 mb-4 font-medium text-neutral-900">
           Terminate account
         </h3>
         <p class="ml-4 mb-4 text-neutral-600">
-          <.icon name="hero-exclamation-circle" class="inline-block w-5 h-5 mr-1 text-red-500" /> To
-          <span :if={Accounts.account_active?(@account)}>disable your account and</span>
-          schedule it for deletion, please <.link
-            class={link_style()}
-            target="_blank"
-            href={mailto_support(@account, @subject, "Account termination request: #{@account.name}")}
-          >contact support</.link>.
+          <.icon name="hero-exclamation-circle" class="inline-block w-5 h-5 mr-1 text-red-500" />
+          <span :if={@delete_requested}>
+            A request has been sent to delete your Account.
+          </span>
+          <span :if={!@delete_requested}>
+            Schedule your account for deletion.
+          </span>
         </p>
       </:content>
     </.section>
     """
+  end
+
+  def handle_event("delete_account", _params, socket) do
+    Domain.Mailer.AccountDelete.account_delete_email(
+      socket.assigns.account,
+      socket.assigns.subject
+    )
+    |> Domain.Mailer.deliver()
+
+    socket =
+      socket
+      |> assign(:delete_requested, true)
+
+    {:noreply, socket}
   end
 
   defp notifications_table(assigns) do

--- a/elixir/apps/web/lib/web/live/settings/account.ex
+++ b/elixir/apps/web/lib/web/live/settings/account.ex
@@ -82,8 +82,9 @@ defmodule Web.Settings.Account do
         >
           <:dialog_title>Confirm Account Deletion</:dialog_title>
           <:dialog_content>
-            This Account will be scheduled for complete deletion.<br /><br />
-            Are you sure you want to delete your Account?
+            This account <strong>{@account.slug}</strong>
+            will be scheduled for complete deletion.<br /><br />
+            Are you sure you want to delete your account?
           </:dialog_content>
           <:dialog_confirm_button>
             Delete Account
@@ -102,7 +103,7 @@ defmodule Web.Settings.Account do
         <p class="ml-4 mb-4 text-neutral-600">
           <.icon name="hero-exclamation-circle" class="inline-block w-5 h-5 mr-1 text-red-500" />
           <span :if={@delete_requested}>
-            A request has been sent to delete your Account.
+            A request has been sent to delete your account.
           </span>
           <span :if={!@delete_requested}>
             Schedule your account for deletion.

--- a/elixir/apps/web/test/web/live/settings/account_test.exs
+++ b/elixir/apps/web/test/web/live/settings/account_test.exs
@@ -135,4 +135,28 @@ defmodule Web.Live.Settings.AccountTest do
     html = lv |> render()
     assert html =~ "Gateway Upgrade Available"
   end
+
+  test "sends account deletion email", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    {:ok, lv, _html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/settings/account")
+
+    assert lv
+           |> element("button[type=submit]", "Delete Account")
+           |> render_click()
+           |> element_to_text() =~ "A request has been sent to delete your Account"
+
+    assert_email_sent(fn email ->
+      assert email.subject == "ACCOUNT DELETE REQUEST - #{account.slug}"
+      assert email.text_body =~ "REQUEST TO DELETE ACCOUNT!"
+      assert email.text_body =~ "#{account.id}"
+      assert email.text_body =~ "#{account.slug}"
+      assert email.text_body =~ "#{identity.actor_id}"
+    end)
+  end
 end

--- a/elixir/apps/web/test/web/live/settings/account_test.exs
+++ b/elixir/apps/web/test/web/live/settings/account_test.exs
@@ -149,7 +149,7 @@ defmodule Web.Live.Settings.AccountTest do
     assert lv
            |> element("button[type=submit]", "Delete Account")
            |> render_click()
-           |> element_to_text() =~ "A request has been sent to delete your Account"
+           |> element_to_text() =~ "A request has been sent to delete your account"
 
     assert_email_sent(fn email ->
       assert email.subject == "ACCOUNT DELETE REQUEST - #{account.slug}"


### PR DESCRIPTION
Why:

* This commit will allow account admins to send a request through the Firezone portal to schedule a deletion of their account, rather than having the account admins email their request manually.  Doing this through the portal allows us to verify that the request actually came from an admin of the account.