### PR TITLE
chore(infra): Use simplified config for swap space

### DIFF
--- a/.github/workflows/_terraform.yml
+++ b/.github/workflows/_terraform.yml
@@ -29,7 +29,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cloud-init
           sudo cloud-init schema --config-file terraform/modules/google-cloud/apps/relay/templates/cloud-init.yaml
-          sudo cloud-init schema --config-file terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
+          # This doesn't work if the file contains interpolated variables
+          # sudo cloud-init schema --config-file terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
           sudo cloud-init schema --config-file terraform/modules/google-cloud/apps/gateway-region-instance-group/templates/cloud-init.yaml
       - name: Check Formatting
         working-directory: terraform

--- a/terraform/modules/google-cloud/apps/elixir/main.tf
+++ b/terraform/modules/google-cloud/apps/elixir/main.tf
@@ -198,7 +198,9 @@ resource "google_compute_instance_template" "application" {
       }
     })
 
-    user-data = templatefile("${path.module}/templates/cloud-init.yaml", {})
+    user-data = templatefile("${path.module}/templates/cloud-init.yaml", {
+      swap_size_gb = var.compute_swap_size_gb
+    })
 
     google-logging-enabled       = "true"
     google-logging-use-fluentbit = "true"

--- a/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
+++ b/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
@@ -101,5 +101,5 @@ runcmd:
 
 swap:
   filename: /swapfile
-  size: "${swap_size_gb}G"
-  maxsize: "${swap_size_gb}G"
+  size: ${swap_size_gb}G
+  maxsize: ${swap_size_gb}G

--- a/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
+++ b/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
@@ -98,8 +98,8 @@ runcmd:
   - sudo ip6tables-restore < /etc/iptables/rules.v6
   - systemctl daemon-reload
   - systemctl start otel-collector.service
-  # Enable swapspace to minimize OOM kills
-  - fallocate -l 1G /var/swapfile
-  - chmod 600 /var/swapfile
-  - mkswap /var/swapfile
-  - swapon /var/swapfile
+
+swap:
+  filename: /swapfile
+  size: ${swap_size_gb}G
+  maxsize: ${swap_size_gb}G

--- a/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
+++ b/terraform/modules/google-cloud/apps/elixir/templates/cloud-init.yaml
@@ -101,5 +101,5 @@ runcmd:
 
 swap:
   filename: /swapfile
-  size: ${swap_size_gb}G
-  maxsize: ${swap_size_gb}G
+  size: "${swap_size_gb}G"
+  maxsize: "${swap_size_gb}G"

--- a/terraform/modules/google-cloud/apps/elixir/variables.tf
+++ b/terraform/modules/google-cloud/apps/elixir/variables.tf
@@ -29,6 +29,12 @@ variable "compute_boot_disk_type" {
   description = "Type of the boot disk."
 }
 
+variable "compute_swap_size_gb" {
+  type        = number
+  default     = 0
+  description = "Size of the swap disk in GB."
+}
+
 ################################################################################
 ## VPC
 ################################################################################


### PR DESCRIPTION
Turns out cloud-init has native support for configuring swapfiles, so we use that here and make it configurable.

The `environments` submodule will be updated to inject the current value into here.