### PR TITLE
feat(portal): Show Internet Resource in resources/index

### DIFF
--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -7,17 +7,10 @@ defmodule Web.Resources.Index do
       :ok = Resources.subscribe_to_events_for_account(socket.assigns.account)
     end
 
-    internet_site =
-      case Domain.Gateways.fetch_internet_group(socket.assigns.account) do
-        {:ok, internet_site} -> internet_site
-        _ -> nil
-      end
-
     socket =
       socket
       |> assign(stale: false)
       |> assign(page_title: "Resources")
-      |> assign(internet_site: internet_site)
       |> assign_live_table("resources",
         query_module: Resources.Resource.Query,
         sortable_fields: [
@@ -69,12 +62,6 @@ defmodule Web.Resources.Index do
         <p class="mb-2">
           Resources define the subnets, hosts, and applications for which you want to manage access. You can manage Resources per Site
           in the <.link navigate={~p"/#{@account}/sites"} class={link_style()}>Sites</.link> section.
-        </p>
-        <p :if={Domain.Accounts.internet_resource_enabled?(@account) && @internet_site}>
-          The Internet Resource can now be managed in the
-          <.link navigate={~p"/#{@account}/sites/#{@internet_site}"} class={link_style()}>
-            Internet Site.
-          </.link>
         </p>
       </:help>
       <:action>
@@ -159,6 +146,21 @@ defmodule Web.Resources.Index do
           </:empty>
         </.live_table>
       </:content>
+    </.section>
+
+    <.section :if={Domain.Accounts.internet_resource_enabled?(@account)}>
+      <:title>
+        Internet
+      </:title>
+      <:help>
+        The Internet Resource is a special resource that matches all traffic not matched by any other resource.
+      </:help>
+      <:action>
+        <.button id="view-internet-resource" navigate={~p"/#{@account}/resources/internet"}>
+          View Internet Resource
+        </.button>
+      </:action>
+      <:content></:content>
     </.section>
     """
   end

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -5,16 +5,7 @@ defmodule Web.Resources.Show do
   alias Domain.{Accounts, Resources, Policies, Flows}
 
   def mount(%{"id" => id} = params, _session, socket) do
-    with {:ok, resource} <-
-           Resources.fetch_resource_by_id_or_persistent_id(id, socket.assigns.subject,
-             preload: [
-               :gateway_groups,
-               :created_by_actor,
-               created_by_identity: [:actor],
-               replaced_by_resource: [],
-               replaces_resource: []
-             ]
-           ),
+    with {:ok, resource} <- fetch_resource(id, socket.assigns.subject),
          {:ok, actor_groups_peek} <-
            Resources.peek_resource_actor_groups([resource], 3, socket.assigns.subject) do
       if connected?(socket) do
@@ -442,5 +433,29 @@ defmodule Web.Resources.Show do
     else
       false
     end
+  end
+
+  defp fetch_resource("internet", subject) do
+    Resources.fetch_internet_resource(subject,
+      preload: [
+        :gateway_groups,
+        :created_by_actor,
+        created_by_identity: [:actor],
+        replaced_by_resource: [],
+        replaces_resource: []
+      ]
+    )
+  end
+
+  defp fetch_resource(id, subject) do
+    Resources.fetch_resource_by_id_or_persistent_id(id, subject,
+      preload: [
+        :gateway_groups,
+        :created_by_actor,
+        created_by_identity: [:actor],
+        replaced_by_resource: [],
+        replaces_resource: []
+      ]
+    )
   end
 end

--- a/elixir/apps/web/test/web/live/resources/show_test.exs
+++ b/elixir/apps/web/test/web/live/resources/show_test.exs
@@ -45,6 +45,27 @@ defmodule Web.Live.Resources.ShowTest do
                }}}
   end
 
+  test "renders internet resource without action buttons", %{
+    account: account,
+    identity: identity,
+    conn: conn
+  } do
+    group = Fixtures.Gateways.create_internet_group(account: account)
+
+    resource =
+      Fixtures.Resources.create_internet_resource(
+        account: account,
+        connections: [%{gateway_group_id: group.id}]
+      )
+
+    {:ok, _lv, html} =
+      conn
+      |> authorize_conn(identity)
+      |> live(~p"/#{account}/resources/#{resource}")
+
+    assert active_buttons(html) == []
+  end
+
   test "renders deleted resource without action buttons", %{
     account: account,
     resource: resource,

--- a/elixir/apps/web/test/web/live/sites/index_test.exs
+++ b/elixir/apps/web/test/web/live/sites/index_test.exs
@@ -118,7 +118,7 @@ defmodule Web.Live.Sites.IndexTest do
     identity: identity,
     conn: conn
   } do
-    {:ok, group} = Domain.Gateways.create_internet_group(account)
+    group = Fixtures.Gateways.create_internet_group(account: account)
 
     {:ok, lv, _html} =
       conn
@@ -139,7 +139,7 @@ defmodule Web.Live.Sites.IndexTest do
   } do
     account = Fixtures.Accounts.update_account(account, features: %{internet_resource: true})
 
-    {:ok, group} = Domain.Gateways.create_internet_group(account)
+    group = Fixtures.Gateways.create_internet_group(account: account)
     gateway = Fixtures.Gateways.create_gateway(account: account, group: group)
     Domain.Config.put_env_override(:test_pid, self())
     :ok = Domain.Gateways.subscribe_to_gateways_presence_in_account(account)


### PR DESCRIPTION
After removing some of the functionality for viewing the Internet Resource, customer was confused where to find it again.

This places an `Internet` section in the Resources index page (similar to Sites page) with a short help text and an action button to view the Internet Resource.

This also adds a convenient helper that allows us to route to `/#{account}/resources/internet` for a nicer-looking URL that users can bookmark if needed.

<img width="1423" alt="Screenshot 2025-03-19 at 11 52 31 PM" src="https://github.com/user-attachments/assets/f2da1c31-92b2-429e-832f-73ddd0524155" />


Fixes #8479 