### PR TITLE
ci: remove unsupported `type` attribute

### DIFF
--- a/.github/actions/setup-elixir/action.yml
+++ b/.github/actions/setup-elixir/action.yml
@@ -3,7 +3,6 @@ description: "Sets up the correct Elixir version and installs deps"
 inputs:
   mix_env:
     description: "Limit deps to mix env"
-    type: string
     required: true
 outputs:
   otp-version:


### PR DESCRIPTION
Action inputs don't support specifying a type. See https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputs.