### PR TITLE
ci(rust): cross-compile without `cross`

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -195,8 +195,8 @@ jobs:
         # Syntax is weird because https://github.com/actions/runner/issues/1512
         exclude:
           # Exclude debug builds for non-amd64 targets since they won't be used.
-          - { stage: debug, arch: { platform: linux/arm/v7 } }
-          - { stage: debug, arch: { platform: linux/arm64 } }
+          # - { stage: debug, arch: { platform: linux/arm/v7 } }
+          # - { stage: debug, arch: { platform: linux/arm64 } }
           # Exclude http-test-server from perf image builds
           - { image_prefix: perf, name: { package: http-test-server } }
 
@@ -204,12 +204,28 @@ jobs:
           - target: x86_64-unknown-linux-musl
             shortname: x86_64
             platform: linux/amd64
+            install_dependencies: |
+              sudo apt-get install musl-tools
           - target: aarch64-unknown-linux-musl # E.g. AWS Graviton
             shortname: aarch64
             platform: linux/arm64
+            install_dependencies: |
+              wget -q -O- https://musl.cc/aarch64-linux-musl-cross.tgz | tar -xz -C /tmp
+
+              CC=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+
+              echo "CC_aarch64_unknown_linux_musl=$CC" >> $GITHUB_ENV
+              echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=$CC" >> $GITHUB_ENV
           - target: armv7-unknown-linux-musleabihf # E.g. Raspberry Pi
             platform: linux/arm/v7
             shortname: armv7
+            install_dependencies: |
+              wget -q -O- https://musl.cc/arm-linux-musleabihf-cross.tgz | tar -xz -C /tmp
+
+              CC=/tmp/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
+
+              echo "CC_armv7_unknown_linux_musleabihf=$CC" >> $GITHUB_ENV
+              echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER=$CC" >> $GITHUB_ENV
         name:
           - package: firezone-headless-client
             artifact: firezone-client-headless-linux
@@ -246,15 +262,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.arch.target }}
-          # Cross doesn't support scccache without a lot of work
-          cache_backend: github
-          # Cache needs to be scoped per OS version and target since cross seems to clobber the cache
-          key: ubuntu-22.04-${{ matrix.arch.target }}
-      - uses: taiki-e/install-action@0b63bc859f7224657cf7e39426848cabaa36f456 # v2.49.9
-        with:
-          tool: cross
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: ${{ matrix.arch.install_dependencies }}
       - name: Build binaries
         run: |
           set -xe
@@ -265,7 +274,7 @@ jobs:
             PROFILE=""
           fi
 
-          cross build $PROFILE -p ${{ matrix.name.package }} --target ${{ matrix.arch.target }}
+          cargo build $PROFILE -p ${{ matrix.name.package }} --target ${{ matrix.arch.target }}
 
           # Used for Docker images
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -195,8 +195,8 @@ jobs:
         # Syntax is weird because https://github.com/actions/runner/issues/1512
         exclude:
           # Exclude debug builds for non-amd64 targets since they won't be used.
-          # - { stage: debug, arch: { platform: linux/arm/v7 } }
-          # - { stage: debug, arch: { platform: linux/arm64 } }
+          - { stage: debug, arch: { platform: linux/arm/v7 } }
+          - { stage: debug, arch: { platform: linux/arm64 } }
           # Exclude http-test-server from perf image builds
           - { image_prefix: perf, name: { package: http-test-server } }
 


### PR DESCRIPTION
For #7518, we need an additional toolchain (nightly) to compile the relay and installing that within `cross` is quite complicated. Our cross-compiling needs are actually quite simple to satisfy. All we need is to download the corresponding musl toolchain and set some environment variables. The rest is handled by cargo.