### PR TITLE
ci(rust): install nightly toolchain

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -29,6 +29,9 @@ outputs:
       (runner.os == 'Linux' && '--workspace') ||
       (runner.os == 'macOS' && '-p connlib-client-apple -p connlib-client-shared -p firezone-tunnel -p snownet') ||
       (runner.os == 'Windows' && '-p connlib-client-shared -p connlib-model -p firezone-bin-shared -p firezone-gui-client -p firezone-gui-client-common -p firezone-headless-client -p firezone-logging -p firezone-telemetry -p firezone-tunnel -p gui-smoke-test -p http-test-server -p ip-packet -p phoenix-channel -p snownet -p socket-factory -p tun') }}
+  nightly_version:
+    description: The nightly version of Rust
+    value: ${{ steps.nightly.outputs.nightly }}
 
 runs:
   using: "composite"
@@ -81,6 +84,16 @@ runs:
         components: rustfmt,clippy
     - if: inputs.targets != ''
       run: rustup target add ${{ inputs.targets }}
+      shell: bash
+
+    - name: Install nightly Rust
+      id: nightly
+      run: |
+        NIGHTLY="nightly-2024-12-13"
+
+        rustup toolchain install $NIGHTLY
+
+        echo "nightly=$NIGHTLY" >> $GITHUB_OUTPUT
       shell: bash
 
     # Start sccache

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -56,8 +56,7 @@ jobs:
         with:
           tool: cargo-udeps,cargo-deny
       - run: |
-          rustup install --no-self-update nightly-2024-12-13 --profile minimal # The exact nightly version doesn't matter, just pin a random one.
-          cargo +nightly-2024-12-13 udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
+          cargo +${{ steps.setup-rust.outputs.nightly_version }} udeps --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
         name: Check for unused dependencies
       - run: cargo fmt -- --check
       - run: cargo doc --all-features --no-deps --document-private-items ${{ steps.setup-rust.outputs.packages }}


### PR DESCRIPTION
For #8501, we need to install a nightly toolchain in our CI system in order to compile to eBPF kernel. We already use a nightly toolchain for one of the static analysis tools.

In this PR, we extend our `setup-rust` action to install the nightly toolchain for us which allows us to reuse that later.