### PR TITLE
feat(connlib): mirror ECN bits on TUN device

### DIFF
--- a/.github/codespellrc
+++ b/.github/codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = ./elixir/apps/domain/lib/domain/name_generator.ex,./**/*.svg,./elixir/deps,./**/*.min.js,./kotlin/android/app/build,./kotlin/android/build,./e2e/pnpm-lock.yaml,./website/.next,./website/pnpm-lock.yaml,./rust/connlib/tunnel/testcases,./rust/gui-client/dist,./rust/target,Cargo.lock,./website/docs/reference/api/*.mdx,./**/erl_crash.dump,./cover,./vendor,*.json,seeds.exs,./**/node_modules,./deps,./priv/static,./priv/plts,./**/priv/static,./.git,./_build,*.cast,./**/proptest-regressions
-ignore-words-list = optin,crate,keypair,keypairs,iif,statics,wee,anull,commitish,inout,fo,superceded,ECT
+ignore-words-list = optin,crate,keypair,keypairs,iif,statics,wee,anull,commitish,inout,fo,superceded,ect

--- a/.github/codespellrc
+++ b/.github/codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = ./elixir/apps/domain/lib/domain/name_generator.ex,./**/*.svg,./elixir/deps,./**/*.min.js,./kotlin/android/app/build,./kotlin/android/build,./e2e/pnpm-lock.yaml,./website/.next,./website/pnpm-lock.yaml,./rust/connlib/tunnel/testcases,./rust/gui-client/dist,./rust/target,Cargo.lock,./website/docs/reference/api/*.mdx,./**/erl_crash.dump,./cover,./vendor,*.json,seeds.exs,./**/node_modules,./deps,./priv/static,./priv/plts,./**/priv/static,./.git,./_build,*.cast,./**/proptest-regressions
-ignore-words-list = optin,crate,keypair,keypairs,iif,statics,wee,anull,commitish,inout,fo,superceded
+ignore-words-list = optin,crate,keypair,keypairs,iif,statics,wee,anull,commitish,inout,fo,superceded,ECT

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6122,6 +6122,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "firezone-logging",
+ "ip-packet",
  "quinn-udp",
  "socket2",
  "tokio",

--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -2,6 +2,7 @@
 
 use firezone_bin_shared::{TunDeviceManager, platform::udp_socket_factory};
 use ip_network::Ipv4Network;
+use ip_packet::Ecn;
 use socket_factory::DatagramOut;
 use std::{
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},
@@ -45,6 +46,7 @@ async fn no_packet_loops_udp() {
             dst: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(141, 101, 90, 0), 3478)), // stun.cloudflare.com,
             packet: &hex_literal::hex!("000100002112A4420123456789abcdef01234567").as_ref(),
             segment_size: None,
+            ecn: Ecn::NonEct,
         })
         .unwrap();
 

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -9,7 +9,7 @@ use firezone_logging::{telemetry_event, telemetry_span};
 use futures::FutureExt as _;
 use futures_bounded::FuturesTupleSet;
 use gso_queue::GsoQueue;
-use ip_packet::{IpPacket, MAX_FZ_PAYLOAD};
+use ip_packet::{Ecn, IpPacket, MAX_FZ_PAYLOAD};
 use nameserver_set::NameserverSet;
 use socket_factory::{DatagramIn, SocketFactory, TcpSocket, UdpSocket};
 use std::{
@@ -296,8 +296,15 @@ impl Io {
         }
     }
 
-    pub fn send_network(&mut self, src: Option<SocketAddr>, dst: SocketAddr, payload: &[u8]) {
-        self.gso_queue.enqueue(src, dst, payload, Instant::now())
+    pub fn send_network(
+        &mut self,
+        src: Option<SocketAddr>,
+        dst: SocketAddr,
+        payload: &[u8],
+        ecn: Ecn,
+    ) {
+        self.gso_queue
+            .enqueue(src, dst, payload, ecn, Instant::now())
     }
 
     pub fn send_dns_query(&mut self, query: dns::RecursiveQuery) {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -144,7 +144,7 @@ impl ClientTunnel {
 
             if let Some(trans) = self.role_state.poll_transmit() {
                 self.io
-                    .send_network(trans.src, trans.dst, &trans.payload, Ecn::Ect0);
+                    .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
                 continue;
             }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -249,7 +249,7 @@ impl GatewayTunnel {
 
             if let Some(trans) = self.role_state.poll_transmit() {
                 self.io
-                    .send_network(trans.src, trans.dst, &trans.payload, Ecn::Ect0);
+                    .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
                 continue;
             }
 

--- a/rust/etherparse-ext/src/ipv4_header_slice_mut.rs
+++ b/rust/etherparse-ext/src/ipv4_header_slice_mut.rs
@@ -43,4 +43,12 @@ impl<'a> Ipv4HeaderSliceMut<'a> {
         // Safety: Slice it at least of length 20 as checked in the ctor.
         unsafe { write_to_offset_unchecked(self.slice, 2, len) };
     }
+
+    pub fn set_ecn(&mut self, ecn: u8) {
+        let current = self.slice[1];
+        let new = current & 0b1111_1100 | ecn;
+
+        // Safety: Slice it at least of length 20 as checked in the ctor.
+        unsafe { write_to_offset_unchecked(self.slice, 1, [new]) };
+    }
 }

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -179,6 +179,19 @@ impl std::fmt::Debug for IpPacket {
                 .field("dst_port", &udp.destination_port());
         }
 
+        match self.ecn() {
+            Ecn::NonEct => {}
+            Ecn::Ect1 => {
+                dbg.field("ecn", &"ECT(1)");
+            }
+            Ecn::Ect0 => {
+                dbg.field("ecn", &"ECT(0)");
+            }
+            Ecn::Ce => {
+                dbg.field("ecn", &"CE");
+            }
+        };
+
         dbg.finish()
     }
 }

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 [dependencies]
 bytes = { workspace = true }
 firezone-logging = { workspace = true }
+ip-packet = { workspace = true }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true }
 tokio = { workspace = true, features = ["net"] }

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -260,7 +260,7 @@ impl UdpSocket {
                 let num_packets = meta.len / segment_size;
                 let trailing_bytes = meta.len % segment_size;
 
-                tracing::trace!(target: "wire::net::recv", src = %meta.addr, dst = %local, %num_packets, %segment_size, %trailing_bytes);
+                tracing::trace!(target: "wire::net::recv", src = %meta.addr, dst = %local, ecn = ?meta.ecn, %num_packets, %segment_size, %trailing_bytes);
 
                 let iter = buffer[..meta.len]
                     .chunks(meta.stride)
@@ -315,7 +315,7 @@ impl UdpSocket {
                 {
                     let num_packets = transmit.contents.len() / segment_size;
 
-                    tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, %num_packets, %segment_size);
+                    tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, ecn = ?transmit.ecn, %num_packets, %segment_size);
 
                     self.inner.try_io(Interest::WRITABLE, || {
                         self.state.try_send((&self.inner).into(), &transmit)
@@ -325,7 +325,7 @@ impl UdpSocket {
             None => {
                 let num_bytes = transmit.contents.len();
 
-                tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, %num_bytes);
+                tracing::trace!(target: "wire::net::send", src = ?datagram.src, dst = %datagram.dst, ecn = ?transmit.ecn, %num_bytes);
 
                 self.inner.try_io(Interest::WRITABLE, || {
                     self.state.try_send((&self.inner).into(), &transmit)

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -1,5 +1,6 @@
 use bytes::Buf as _;
 use firezone_logging::err_with_src;
+use ip_packet::Ecn;
 use quinn_udp::Transmit;
 use std::collections::HashMap;
 use std::fmt;
@@ -198,6 +199,7 @@ pub struct DatagramIn<'a> {
     pub local: SocketAddr,
     pub from: SocketAddr,
     pub packet: &'a [u8],
+    pub ecn: Ecn,
 }
 
 /// An outbound UDP datagram.
@@ -206,6 +208,7 @@ pub struct DatagramOut<B> {
     pub dst: SocketAddr,
     pub packet: B,
     pub segment_size: Option<usize>,
+    pub ecn: Ecn,
 }
 
 impl UdpSocket {
@@ -265,6 +268,12 @@ impl UdpSocket {
                         local,
                         from: meta.addr,
                         packet,
+                        ecn: match meta.ecn {
+                            Some(quinn_udp::EcnCodepoint::Ce) => Ecn::Ce,
+                            Some(quinn_udp::EcnCodepoint::Ect0) => Ecn::Ect0,
+                            Some(quinn_udp::EcnCodepoint::Ect1) => Ecn::Ect1,
+                            None => Ecn::NonEct,
+                        },
                     });
 
                 return Poll::Ready(Ok(iter));
@@ -285,6 +294,7 @@ impl UdpSocket {
             datagram.src.map(|s| s.ip()),
             datagram.packet.deref().chunk(),
             datagram.segment_size,
+            datagram.ecn,
         )?
         else {
             return Ok(());
@@ -343,7 +353,7 @@ impl UdpSocket {
         payload: &[u8],
     ) -> io::Result<Vec<u8>> {
         let transmit = self
-            .prepare_transmit(dst, None, payload, None)?
+            .prepare_transmit(dst, None, payload, None, Ecn::NonEct)?
             .ok_or_else(|| io::Error::other("Failed to prepare `Transmit`"))?;
 
         self.inner
@@ -373,6 +383,7 @@ impl UdpSocket {
         src_ip: Option<IpAddr>,
         packet: &'a [u8],
         segment_size: Option<usize>,
+        ecn: Ecn,
     ) -> io::Result<Option<quinn_udp::Transmit<'a>>> {
         let src_ip = match src_ip {
             Some(src_ip) => Some(src_ip),
@@ -390,7 +401,12 @@ impl UdpSocket {
 
         let transmit = quinn_udp::Transmit {
             destination: dst,
-            ecn: None,
+            ecn: match ecn {
+                Ecn::NonEct => None,
+                Ecn::Ect1 => Some(quinn_udp::EcnCodepoint::Ect1),
+                Ecn::Ect0 => Some(quinn_udp::EcnCodepoint::Ect0),
+                Ecn::Ce => Some(quinn_udp::EcnCodepoint::Ce),
+            },
             contents: packet,
             segment_size,
             src_ip,


### PR DESCRIPTION
From the perspective of any application, Firezone is a layer-3 network and will thus use the host's networking stack to form IP packets for whichever application protocol is in use (UDP, TCP, etc). These packets then get encapsulated into UDP packets by Firezone and sent to a Gateway.

As a result of this design, the IP header seen by the networking stacks of the Client and the receiving service are not visible to any intermediary along the network path of the Client and Gateway.

In case this network path is congested and middleboxes such as routers need to drop packets, they will look at the ECN bits in the IP header (of the UDP packet generated by a Client or Gateway) and flip a bit in case the previous value indicated support for ECN (`0x01` or `0x10`). When received by a network stack that supports ECN, seeing `0x11` means that the network path is congested and that it must reduce its send/receive windows (or otherwise throttle the connection).

At present, this doesn't work with Firezone because of the aforementioned encapsulation of IP packets. To support ECN, we need to therefore:

- Copy ECN bits from a received IP packet to the datagram that encapsulates it: This ensures that if the Client's network stack support ECN, we mirror that support on the wire.
- Copy ECN bits from a received datagram to the IP packet the is sent to the TUN device: This ensures that if the "Congestion Experienced" bit get set along the network path between Client and Gateway, we reflect that accordingly on the IP packet emitted by the TUN device.

Resolves: #3758