### PR TITLE
refactor(rust): tell Tauri to use our existing runtime

### DIFF
--- a/rust/gui-client/src-tauri/src/client/gui.rs
+++ b/rust/gui-client/src-tauri/src/client/gui.rs
@@ -124,6 +124,8 @@ pub(crate) fn run(
 ) -> Result<()> {
     // Needed for the deep link server
     let rt = tokio::runtime::Runtime::new().context("Couldn't start Tokio runtime")?;
+    tauri::async_runtime::set(rt.handle().clone());
+
     let _guard = rt.enter();
 
     // Make sure we're single-instance


### PR DESCRIPTION
Tauri needs a tokio runtime in order to spawn tasks. If we don't supply one, it will start its own runtime. Given that we already start a runtime, this is unnecessary.