### PR TITLE
ci: add new link checker workflow for website

### DIFF
--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -1,0 +1,34 @@
+name: Website Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 18 * * *"
+
+defaults:
+  run:
+    working-directory: website # Specify working directory to ensure the `.lycheeignore` file is picked up.
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check links on website
+        id: lychee
+        uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # v2.3.0
+        with:
+          fail: false
+          args: --verbose --no-progress --exclude-all-private .
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -23,7 +23,7 @@ jobs:
         uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # v2.3.0
         with:
           fail: false
-          args: --verbose --no-progress --exclude-all-private .
+          args: --verbose --no-progress --exclude-all-private --base https://firezone.dev .
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0

--- a/website/.lycheeignore
+++ b/website/.lycheeignore
@@ -5,3 +5,4 @@ https://portal.azure.com
 https://x.com/firezonehq
 https://admin.google.com/ac/owl
 https://www.flexjobs.com/blog/post/exploring-the-impact-of-remote-work-on-mental-health-and-the-workplace/
+.prettierrc.json

--- a/website/.lycheeignore
+++ b/website/.lycheeignore
@@ -1,0 +1,7 @@
+# Links included in our website known to not be broken but lychee can't check them :(
+
+https://www.gartner.com/en/information-technology/glossary/zero-trust-network-access-ztna-/
+https://portal.azure.com
+https://x.com/firezonehq
+https://admin.google.com/ac/owl
+https://www.flexjobs.com/blog/post/exploring-the-impact-of-remote-work-on-mental-health-and-the-workplace/


### PR DESCRIPTION
Turns out we have several broken links on our website currently. Broken links don't make a good impression so we should catch them as early as possible.

Due to how our website is laid out, that isn't always possible to catch these dead links in CI. The next best thing we can do is run a cron-job in our CI that checks our sourcecode and makes sure all links (including relative ones) are reachable.