### PR TITLE
fix(connlib): don't clear `DnsResourceNatState::Pending`

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -446,7 +446,11 @@ impl ClientState {
         let mut any_deleted = false;
 
         self.dns_resource_nat_by_gateway
-            .retain(|(_, candidate), _| {
+            .retain(|(_, candidate), state| {
+                let DnsResourceNatState::Confirmed = state else {
+                    return true;
+                };
+
                 if candidate == &message.domain() {
                     any_deleted = true;
                     return false;


### PR DESCRIPTION
When we receive a DNS query for a resource, we refresh the DNS resource NAT on the Gateway by clearing the local state. This ensures that if any of the DNS records have changed, those will be reflected in the new NAT table on the Gateway.

I cannot fully confirm my theory but I have a hunch that under certain circumstances, this would lead to loss of buffered packets which lead to connections getting reset. I couldn't confirm that in my testing though. The issues I experienced with github.com suddenly stopped :upside_down_face: 