### PR TITLE
fix(connlib): only disable not-yet-disabled resources

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -961,8 +961,9 @@ impl ClientState {
             self.add_resource(resource.clone());
         }
 
-        for disabled_resource in &new_disabled_resources {
-            self.disable_resource(*disabled_resource);
+        for new_disabled_resource in new_disabled_resources.difference(&current_disabled_resources)
+        {
+            self.disable_resource(*new_disabled_resource);
         }
 
         self.maybe_update_cidr_resources();


### PR DESCRIPTION
Didn't test this but I think the logic checks out (and our proptests should catch any bugs here).

Fixes: #8523