### PR TITLE
chore(infra): bump COS version for relays to `cos-117-lts`

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -54,7 +54,7 @@ locals {
 
 # Fetch most recent COS image
 data "google_compute_image" "coreos" {
-  family  = "cos-113-lts"
+  family  = "cos-117-lts"
   project = "cos-cloud"
 }
 


### PR DESCRIPTION
The 117 version uses Linux 6.6 whereas 113 only uses Linux 6.1. By using a newer kernel, we can hopefully get eBPF to work on Google Cloud.

https://cloud.google.com/container-optimized-os/docs/release-notes/m113
https://cloud.google.com/container-optimized-os/docs/release-notes/m117