### PR TITLE
fix(gateway/docker): Handle missing `gateway_id`

### DIFF
--- a/scripts/gateway-docker-upgrade.sh
+++ b/scripts/gateway-docker-upgrade.sh
@@ -28,7 +28,7 @@ for RUNNING_CONTAINER in $CURRENTLY_RUNNING; do
         # Due to issues like https://github.com/firezone/firezone/issues/8471 we prefer to use the FIREZONE_ID
         # env var instead of volume-mapped id files on all deployment methods. This attempts to migrate the
         # FIREZONE_ID from the running container and set it as an env var in the new container.
-        FILE_FIREZONE_ID=$(docker exec "$RUNNING_CONTAINER" cat /var/lib/firezone/gateway_id)
+        FILE_FIREZONE_ID=$(docker exec "$RUNNING_CONTAINER" /bin/sh -c "cat /var/lib/firezone/gateway_id 2>/dev/null | tr -d '\n' || true")
         if [ -n "$FILE_FIREZONE_ID" ]; then
             # Replace FIREZONE_ID in variables.env if variables.env contains FIREZONE_ID
             if grep -q "^FIREZONE_ID=" variables.env; then


### PR DESCRIPTION
If the volume was not mapped correctly, or the install command was modified, it's possible this file could be missing, which would fail the upgrade script.

This gracefully handles that edge case.

See https://firezonehq.slack.com/archives/C069H865MHP/p1743128008276809