### PR TITLE
feat(infra): Use gVNIC for relay network interface driver

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -197,6 +197,8 @@ resource "google_compute_instance_template" "application" {
   network_interface {
     subnetwork = var.instances[each.key].subnet
 
+    nic_type = "GVNIC"
+
     stack_type = "IPV4_IPV6"
 
     ipv6_access_config {


### PR DESCRIPTION
This is supposed to offer much better performance and networking features in GCP. I would bet it supports XDP as well, unlike the default VIRTIO_NET driver.

See: https://cloud.google.com/compute/docs/networking/using-gvnic

Related: https://github.com/firezone/firezone/issues/7518#issuecomment-2762357354