### PR TITLE
feat(relay): Bump RX/TX queue count to 2

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -199,6 +199,12 @@ resource "google_compute_instance_template" "application" {
 
     nic_type = "GVNIC"
 
+    # Maximum NIC Rx/Tx queue count. The default is 1. Adjust this based on number of vCPUs.
+    # NOTE: Minimum of 2 is required for XDP programs to load onto the NIC.
+    # This is because the `gve` driver expects the number of active queues to be
+    # less than or equal to half the maximum number of queues.
+    queue_count = 2
+
     stack_type = "IPV4_IPV6"
 
     ipv6_access_config {


### PR DESCRIPTION
By default, GCP VMs have a max RX/TX queue count of `1`. While this is a fine default, it causes XDP programs to fail to load onto the virtual NIC with the following error:

```
gve 0000:00:04.0 eth0: XDP load failed: The number of configured RX queues 1 should be equal to the number of configured TX queues 1 and the number of configured RX/TX queues should be less than or equal to half the maximum number of RX/TX queues 1
```

To fix this, we can bump the maximum queue count to `2` (the max support by gVNIC is 16), allowing the current queue count of `1` to satisfy the condition.