### PR TITLE
fix(relay): update `aya-build` dependency to latest version

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "aya-build"
 version = "0.1.2"
-source = "git+https://github.com/thomaseizinger/aya?branch=fix%2Faya-build-pin-nightly#c766051000cc41e3409477a8fec8547acc4d72fd"
+source = "git+https://github.com/thomaseizinger/aya?branch=fix%2Faya-build-pin-nightly#55ad60e4660a270a50a513f0ff6deb0d6c8d9a62"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/rust/relay/server/build.rs
+++ b/rust/relay/server/build.rs
@@ -14,7 +14,7 @@ fn main() -> anyhow::Result<()> {
 
     aya_build::build_ebpf(
         [package],
-        aya_build::Toolchain::Custom("+nightly-2024-12-13"),
+        aya_build::Toolchain::Custom("nightly-2024-12-13"),
     )?;
 
     Ok(())


### PR DESCRIPTION
As part of working on https://github.com/aya-rs/aya/pull/1228, which I am depending on in here I had to force-push which will break CI. Opening this to fix it.