### PR TITLE
fix(infra): Use 2 for default relay queue_count

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/variables.tf
+++ b/terraform/modules/google-cloud/apps/relay/variables.tf
@@ -35,9 +35,10 @@ variable "naming_suffix" {
 # less than or equal to half the maximum number of queues.
 # The active queue count will need to be set at boot in order to be half this, because
 # gve driver defaults to setting the active queue count to the maximum.
+# NOTE 2: The maximum number here should max the number of vCPUs.
 variable "queue_count" {
   type        = number
-  default     = 4
+  default     = 2
   description = "Number of max RX / TX queues to assign to the NIC."
 
   validation {


### PR DESCRIPTION
It seems that this cannot be higher than the number of vCPUs in the instance.

```
Instance 'relay-7h8s' creation failed: Invalid value for field 'resource.networkInterfaces[0].queueCount': '4'. Networking queue number is invalid: '4'. (when acting as '85623168602@cloudservices.gserviceaccount.com')
```