### PR TITLE
chore(relay): ignore eBPF integration test

### DIFF
--- a/rust/relay/server/tests/ebpf_ipv4.rs
+++ b/rust/relay/server/tests/ebpf_ipv4.rs
@@ -8,6 +8,7 @@ use ebpf_shared::Config;
 use stun_codec::rfc5766::attributes::ChannelNumber;
 
 #[tokio::test]
+#[ignore = "Needs root"]
 async fn ping_pong() {
     let _guard = firezone_logging::test("trace,mio=off");
 


### PR DESCRIPTION
This needs elevated privileges to run. Our current pattern for these is to set them as ignored. In CI, we run all tests, including the ignored ones.