### PR TITLE
feat(infra): Use GVNIC and set queue_count=2 for elixir app

### DIFF
--- a/terraform/modules/google-cloud/apps/elixir/main.tf
+++ b/terraform/modules/google-cloud/apps/elixir/main.tf
@@ -153,8 +153,10 @@ resource "google_compute_instance_template" "application" {
   }
 
   network_interface {
-    subnetwork = var.vpc_subnetwork
-    stack_type = "IPV4_IPV6"
+    subnetwork  = var.vpc_subnetwork
+    nic_type    = "GVNIC"
+    queue_count = var.queue_count
+    stack_type  = "IPV4_IPV6"
 
     ipv6_access_config {
       network_tier = "PREMIUM"

--- a/terraform/modules/google-cloud/apps/elixir/variables.tf
+++ b/terraform/modules/google-cloud/apps/elixir/variables.tf
@@ -35,6 +35,27 @@ variable "compute_swap_size_gb" {
   description = "Size of the swap disk in GB."
 }
 
+variable "queue_count" {
+  type        = number
+  default     = 2
+  description = "Number of max RX / TX queues to assign to the NIC."
+
+  validation {
+    condition     = var.queue_count >= 2
+    error_message = "queue_count must be greater than or equal to 2."
+  }
+
+  validation {
+    condition     = var.queue_count % 2 == 0
+    error_message = "queue_count must be an even number."
+  }
+
+  validation {
+    condition     = var.queue_count <= 16
+    error_message = "queue_count must be less than or equal to 16."
+  }
+}
+
 ################################################################################
 ## VPC
 ################################################################################


### PR DESCRIPTION
This aligns with the relay app and is safe for all machine types.

See https://cloud.google.com/compute/docs/networking/using-gvnic