### PR TITLE
chore(infra): Bump elixir VM image to COS 117

### DIFF
--- a/terraform/modules/google-cloud/apps/elixir/main.tf
+++ b/terraform/modules/google-cloud/apps/elixir/main.tf
@@ -75,7 +75,7 @@ locals {
 
 # Fetch most recent COS image
 data "google_compute_image" "coreos" {
-  family  = "cos-113-lts"
+  family  = "cos-117-lts"
   project = "cos-cloud"
 }
 


### PR DESCRIPTION
The relay was bumped here for the updated kernel. Would be good to stay standardized.