### PR TITLE
chore(billing): Enable automatic tax calculation by default

### DIFF
--- a/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
+++ b/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
@@ -93,7 +93,7 @@ defmodule Domain.Billing.Stripe.APIClient do
       URI.encode_query(
         %{
           "customer" => customer_id,
-          "automatic_tax" => %{"enabled" => true},
+          "automatic_tax[enabled]" => true,
           "items[0][price]" => price_id
         },
         :www_form

--- a/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
+++ b/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
@@ -93,6 +93,7 @@ defmodule Domain.Billing.Stripe.APIClient do
       URI.encode_query(
         %{
           "customer" => customer_id,
+          "automatic_tax" => %{"enabled" => true},
           "items[0][price]" => price_id
         },
         :www_form

--- a/elixir/apps/domain/test/domain/billing_test.exs
+++ b/elixir/apps/domain/test/domain/billing_test.exs
@@ -560,7 +560,8 @@ defmodule Domain.BillingTest do
 
       assert params == %{
                "customer" => customer_id,
-               "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}}
+               "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}},
+               "automatic_tax" => %{"enabled" => true}
              }
     end
 

--- a/elixir/apps/domain/test/domain/billing_test.exs
+++ b/elixir/apps/domain/test/domain/billing_test.exs
@@ -561,7 +561,7 @@ defmodule Domain.BillingTest do
       assert params == %{
                "customer" => customer_id,
                "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}},
-               "automatic_tax" => %{"enabled" => true}
+               "automatic_tax" => %{"enabled" => "true"}
              }
     end
 
@@ -697,7 +697,7 @@ defmodule Domain.BillingTest do
       assert params == %{
                "customer" => customer_id,
                "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}},
-               "automatic_tax" => %{"enabled" => true}
+               "automatic_tax" => %{"enabled" => "true"}
              }
     end
 

--- a/elixir/apps/domain/test/domain/billing_test.exs
+++ b/elixir/apps/domain/test/domain/billing_test.exs
@@ -695,7 +695,8 @@ defmodule Domain.BillingTest do
 
       assert params == %{
                "customer" => customer_id,
-               "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}}
+               "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}},
+               "automatic_tax" => %{"enabled" => true}
              }
     end
 


### PR DESCRIPTION
When a customer signs up for Starter or Team, we don't enable tax calculation by default. This means customers can upgrade to Team, start paying invoices, and we won't collect taxes.

This creates a management issue and possible tax liability since I need to manually reconcile these.

Instead, since we have Stripe Tax configured on our account, we can enable automatic tax calculation when the subscription is created. Any products (Starter/Team/Enterprise) therefore in the subscription will automatically collect tax appropriately.

In most cases in the US, the tax rate is 0. In EU transactions, for B2B sales, the tax rate for us is also 0 (reverse charge basis). If we sell a Team subscription to an individual, however, we need to collect VAT.

There doesn't seem to be a way to block consumer EU transactions in Stripe, so we'll likely need to register for VAT in the EU if we cross the reporting threshold.