### PR TITLE
feat(relay): implement eBPF routing for IPv6

### DIFF
--- a/rust/relay/ebpf-turn-router/src/channel_data.rs
+++ b/rust/relay/ebpf-turn-router/src/channel_data.rs
@@ -1,4 +1,4 @@
-use crate::{Error, ip4::Ipv4Hdr, slice_mut_at::slice_mut_at, udp::UdpHdr};
+use crate::{Error, slice_mut_at::slice_mut_at, udp::UdpHdr};
 use aya_ebpf::programs::XdpContext;
 use network_types::eth::EthHdr;
 
@@ -11,8 +11,8 @@ pub struct ChannelData<'a> {
 
 impl<'a> ChannelData<'a> {
     #[inline(always)]
-    pub fn parse(ctx: &'a XdpContext) -> Result<Self, Error> {
-        let hdr = slice_mut_at::<CdHdr>(ctx, EthHdr::LEN + Ipv4Hdr::LEN + UdpHdr::LEN)?;
+    pub fn parse(ctx: &'a XdpContext, ip_header_length: usize) -> Result<Self, Error> {
+        let hdr = slice_mut_at::<CdHdr>(ctx, EthHdr::LEN + ip_header_length + UdpHdr::LEN)?;
 
         if !(0x4000..0x4FFF).contains(&u16::from_be_bytes(hdr.number)) {
             return Err(Error::NotAChannelDataMessage);
@@ -21,7 +21,10 @@ impl<'a> ChannelData<'a> {
         // The eBPF verifier doesn't allow you to use data read from the packet to index into the packet.
         // Hence, we cannot read the length of the channel-data message and use it on the packet.
         // So what we do instead is, we check how many bytes we have left in the packet and compare it to the length we read.
-        let length = remaining_bytes(ctx, EthHdr::LEN + Ipv4Hdr::LEN + UdpHdr::LEN + CdHdr::LEN)?;
+        let length = remaining_bytes(
+            ctx,
+            EthHdr::LEN + ip_header_length + UdpHdr::LEN + CdHdr::LEN,
+        )?;
 
         // We received less (or more) data than the header said we would.
         if length != usize::from(u16::from_be_bytes(hdr.length)) {

--- a/rust/relay/ebpf-turn-router/src/checksum.rs
+++ b/rust/relay/ebpf-turn-router/src/checksum.rs
@@ -30,12 +30,20 @@ impl ChecksumUpdate {
         self.remove_u16(fold_u32_into_u16(val))
     }
 
+    pub fn remove_u128(self, val: u128) -> Self {
+        self.remove_u16(fold_u128_into_u16(val))
+    }
+
     pub fn add_u16(self, val: u16) -> Self {
         self.ones_complement_add(val)
     }
 
     pub fn add_u32(self, val: u32) -> Self {
         self.add_u16(fold_u32_into_u16(val))
+    }
+
+    pub fn add_u128(self, val: u128) -> Self {
+        self.add_u16(fold_u128_into_u16(val))
     }
 
     pub fn add_update(self, update: ChecksumUpdate) -> Self {
@@ -58,6 +66,20 @@ impl ChecksumUpdate {
 
 #[inline(always)]
 fn fold_u32_into_u16(mut csum: u32) -> u16 {
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+
+    csum as u16
+}
+
+#[inline(always)]
+fn fold_u128_into_u16(mut csum: u128) -> u16 {
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
+    csum = (csum & 0xffff) + (csum >> 16);
     csum = (csum & 0xffff) + (csum >> 16);
     csum = (csum & 0xffff) + (csum >> 16);
 

--- a/rust/relay/ebpf-turn-router/src/ip6.rs
+++ b/rust/relay/ebpf-turn-router/src/ip6.rs
@@ -1,0 +1,78 @@
+use core::net::Ipv6Addr;
+
+use crate::{Error, checksum::ChecksumUpdate, slice_mut_at::slice_mut_at};
+use aya_ebpf::programs::XdpContext;
+use aya_log_ebpf::debug;
+use network_types::{eth::EthHdr, ip::IpProto};
+
+/// Represents an IPv4 header within our packet.
+pub struct Ip6<'a> {
+    ctx: &'a XdpContext,
+    inner: &'a mut Ipv6Hdr,
+}
+
+impl<'a> Ip6<'a> {
+    #[inline(always)]
+    pub fn parse(ctx: &'a XdpContext) -> Result<Self, Error> {
+        Ok(Self {
+            ctx,
+            inner: slice_mut_at::<Ipv6Hdr>(ctx, EthHdr::LEN)?,
+        })
+    }
+
+    pub fn src(&self) -> Ipv6Addr {
+        self.inner.src_addr.into()
+    }
+
+    pub fn dst(&self) -> Ipv6Addr {
+        self.inner.dst_addr.into()
+    }
+
+    pub fn protocol(&self) -> IpProto {
+        self.inner.next_hdr
+    }
+
+    pub fn payload_len(&self) -> u16 {
+        u16::from_be_bytes(self.inner.payload_len)
+    }
+
+    /// Update this packet with a new source, destination, and total length.
+    ///
+    /// Returns a [`ChecksumUpdate`] representing the checksum-difference of the "IP pseudo-header."
+    /// which is used in certain L4 protocols (e.g. UDP).
+    #[inline(always)]
+    pub fn update(self, new_src: Ipv6Addr, new_dst: Ipv6Addr, new_len: u16) -> ChecksumUpdate {
+        let src = self.src();
+        let dst = self.dst();
+
+        self.inner.src_addr = new_src.octets();
+        self.inner.dst_addr = new_dst.octets();
+        self.inner.payload_len = new_len.to_be_bytes();
+
+        let ip_pseudo_header = ChecksumUpdate::default()
+            .remove_u128(src.to_bits())
+            .add_u128(new_src.to_bits())
+            .remove_u128(dst.to_bits())
+            .add_u128(new_dst.to_bits());
+
+        debug!(
+            self.ctx,
+            "IP6 header update: src {:i} -> {:i}; dst {:i} -> {:i}", src, new_src, dst, new_dst,
+        );
+
+        ip_pseudo_header
+    }
+}
+
+// Copied from `network-types` but uses byte-arrays instead of `u32` and `u16`
+// See <https://github.com/vadorovsky/network-types/issues/32>.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Ipv6Hdr {
+    pub version_traffic_class_flow_label: [u8; 4],
+    pub payload_len: [u8; 2],
+    pub next_hdr: IpProto,
+    pub hop_limit: u8,
+    pub src_addr: [u8; 16],
+    pub dst_addr: [u8; 16],
+}

--- a/rust/relay/ebpf-turn-router/src/ip6.rs
+++ b/rust/relay/ebpf-turn-router/src/ip6.rs
@@ -5,7 +5,7 @@ use aya_ebpf::programs::XdpContext;
 use aya_log_ebpf::debug;
 use network_types::{eth::EthHdr, ip::IpProto};
 
-/// Represents an IPv4 header within our packet.
+/// Represents an IPv6 header within our packet.
 pub struct Ip6<'a> {
     ctx: &'a XdpContext,
     inner: &'a mut Ipv6Hdr,

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -12,9 +12,16 @@ use aya_log_ebpf::*;
 use channel_data::{CdHdr, ChannelData};
 use ebpf_shared::{ClientAndChannelV4, ClientAndChannelV6, PortAndPeerV4, PortAndPeerV6};
 use eth::Eth;
-use ip4::Ip4;
-use move_headers::{add_channel_data_header_ipv4, remove_channel_data_header_ipv4};
-use network_types::{eth::EtherType, ip::IpProto};
+use ip4::{Ip4, Ipv4Hdr};
+use ip6::Ip6;
+use move_headers::{
+    add_channel_data_header_ipv4, add_channel_data_header_ipv6, remove_channel_data_header_ipv4,
+    remove_channel_data_header_ipv6,
+};
+use network_types::{
+    eth::EtherType,
+    ip::{IpProto, Ipv6Hdr},
+};
 use udp::{Udp, UdpHdr};
 
 mod channel_data;
@@ -23,6 +30,7 @@ mod config;
 mod error;
 mod eth;
 mod ip4;
+mod ip6;
 mod move_headers;
 mod slice_mut_at;
 mod udp;
@@ -81,7 +89,7 @@ fn try_handle_turn_ipv4(ctx: &XdpContext) -> Result<u32, Error> {
         return Ok(xdp_action::XDP_PASS);
     }
 
-    let udp = Udp::parse(ctx)?; // TODO: Change the API so we parse the UDP header _from_ the ipv4 struct?
+    let udp = Udp::parse(ctx, Ipv4Hdr::LEN)?; // TODO: Change the API so we parse the UDP header _from_ the ipv4 struct?
 
     trace!(
         ctx,
@@ -114,7 +122,7 @@ fn try_handle_ipv4_channel_data_to_udp(
     ipv4: Ip4,
     udp: Udp,
 ) -> Result<u32, Error> {
-    let cd = ChannelData::parse(ctx)?;
+    let cd = ChannelData::parse(ctx, Ipv4Hdr::LEN)?;
 
     // SAFETY: ???
     let maybe_peer =
@@ -192,8 +200,119 @@ fn try_handle_ipv4_udp_to_channel_data(
 }
 
 #[inline(always)]
-fn try_handle_turn_ipv6(_: &XdpContext) -> Result<u32, Error> {
+fn try_handle_turn_ipv6(ctx: &XdpContext) -> Result<u32, Error> {
+    let ipv6 = Ip6::parse(ctx)?;
+
+    if ipv6.protocol() != IpProto::Udp {
+        return Ok(xdp_action::XDP_PASS);
+    }
+
+    let udp = Udp::parse(ctx, Ipv6Hdr::LEN)?; // TODO: Change the API so we parse the UDP header _from_ the ipv4 struct?
+
+    trace!(
+        ctx,
+        "New packet from {:i}:{} for {:i}:{} with UDP payload {}",
+        ipv6.src(),
+        udp.src(),
+        ipv6.dst(),
+        udp.dst(),
+        udp.len()
+    );
+
+    if config::allocation_range().contains(&udp.dst()) {
+        let action = try_handle_ipv6_udp_to_channel_data(ctx, ipv6, udp)?;
+
+        return Ok(action);
+    }
+
+    if udp.dst() == 3478 {
+        let action = try_handle_ipv6_channel_data_to_udp(ctx, ipv6, udp)?;
+
+        return Ok(action);
+    }
+
     Ok(xdp_action::XDP_PASS)
+}
+
+fn try_handle_ipv6_udp_to_channel_data(
+    ctx: &XdpContext,
+    ipv6: Ip6,
+    udp: Udp,
+) -> Result<u32, Error> {
+    let maybe_client =
+        unsafe { UDP_TO_CHAN_66.get(&PortAndPeerV6::new(ipv6.src(), udp.dst(), udp.src())) };
+    let Some(client_and_channel) = maybe_client else {
+        debug!(
+            ctx,
+            "No channel binding from {:i}:{} on allocation {}",
+            ipv6.src(),
+            udp.src(),
+            udp.dst(),
+        );
+
+        return Ok(xdp_action::XDP_PASS);
+    };
+
+    let new_src = ipv6.dst(); // The IP we received the packet on will be the new source IP.
+    let new_ipv6_total_len = ipv6.payload_len() + CdHdr::LEN as u16;
+    let pseudo_header = ipv6.update(new_src, client_and_channel.client_ip(), new_ipv6_total_len);
+
+    let udp_len = udp.len();
+    let new_udp_len = udp_len + CdHdr::LEN as u16;
+    udp.update(
+        pseudo_header,
+        3478,
+        client_and_channel.client_port(),
+        new_udp_len,
+    );
+
+    let cd_num = client_and_channel.channel().to_be_bytes();
+    let cd_len = (udp_len - UdpHdr::LEN as u16).to_be_bytes(); // The `length` field in the UDP header includes the header itself. For the channel-data field, we only want the length of the payload.
+
+    let channel_data_header = [cd_num[0], cd_num[1], cd_len[0], cd_len[1]];
+
+    add_channel_data_header_ipv6(ctx, channel_data_header);
+
+    Ok(xdp_action::XDP_TX)
+}
+
+fn try_handle_ipv6_channel_data_to_udp(
+    ctx: &XdpContext,
+    ipv6: Ip6,
+    udp: Udp,
+) -> Result<u32, Error> {
+    let cd = ChannelData::parse(ctx, Ipv6Hdr::LEN)?;
+
+    // SAFETY: ???
+    let maybe_peer =
+        unsafe { CHAN_TO_UDP_66.get(&ClientAndChannelV6::new(ipv6.src(), udp.src(), cd.number())) };
+    let Some(port_and_peer) = maybe_peer else {
+        debug!(
+            ctx,
+            "No channel binding from {:i}:{} for channel {}",
+            ipv6.src(),
+            udp.src(),
+            cd.number(),
+        );
+
+        return Ok(xdp_action::XDP_PASS);
+    };
+
+    let new_src = ipv6.dst(); // The IP we received the packet on will be the new source IP.
+    let new_ipv6_payload_len = ipv6.payload_len() - CdHdr::LEN as u16;
+    let pseudo_header = ipv6.update(new_src, port_and_peer.peer_ip(), new_ipv6_payload_len);
+
+    let new_udp_len = udp.len() - CdHdr::LEN as u16;
+    udp.update(
+        pseudo_header,
+        port_and_peer.allocation_port(),
+        port_and_peer.peer_port(),
+        new_udp_len,
+    );
+
+    remove_channel_data_header_ipv6(ctx);
+
+    Ok(xdp_action::XDP_TX)
 }
 
 /// Defines our panic handler.

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -10,7 +10,7 @@ use aya_ebpf::{
 };
 use aya_log_ebpf::*;
 use channel_data::{CdHdr, ChannelData};
-use ebpf_shared::{ClientAndChannelV4, PortAndPeerV4};
+use ebpf_shared::{ClientAndChannelV4, ClientAndChannelV6, PortAndPeerV4, PortAndPeerV6};
 use eth::Eth;
 use ip4::Ip4;
 use move_headers::{add_channel_data_header_ipv4, remove_channel_data_header_ipv4};
@@ -35,6 +35,12 @@ static CHAN_TO_UDP_44: HashMap<ClientAndChannelV4, PortAndPeerV4> =
     HashMap::with_max_entries(0x100000, 0);
 #[map]
 static UDP_TO_CHAN_44: HashMap<PortAndPeerV4, ClientAndChannelV4> =
+    HashMap::with_max_entries(0x100000, 0);
+#[map]
+static CHAN_TO_UDP_66: HashMap<ClientAndChannelV6, PortAndPeerV6> =
+    HashMap::with_max_entries(0x100000, 0);
+#[map]
+static UDP_TO_CHAN_66: HashMap<PortAndPeerV6, ClientAndChannelV6> =
     HashMap::with_max_entries(0x100000, 0);
 
 #[xdp]

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -207,8 +207,7 @@ fn try_handle_turn_ipv6(ctx: &XdpContext) -> Result<u32, Error> {
         return Ok(xdp_action::XDP_PASS);
     }
 
-    let udp = Udp::parse(ctx, Ipv6Hdr::LEN)?; // TODO: Change the API so we parse the UDP header _from_ the ipv4 struct?
-
+    let udp = Udp::parse(ctx, Ipv6Hdr::LEN)?; // TODO: Change the API so we parse the UDP header _from_ the ipv6 struct?
     trace!(
         ctx,
         "New packet from {:i}:{} for {:i}:{} with UDP payload {}",

--- a/rust/relay/ebpf-turn-router/src/move_headers.rs
+++ b/rust/relay/ebpf-turn-router/src/move_headers.rs
@@ -28,6 +28,22 @@ pub fn add_channel_data_header_ipv4(ctx: &XdpContext, mut header: [u8; 4]) {
 }
 
 #[inline(always)]
+pub fn remove_channel_data_header_ipv6(ctx: &XdpContext) {
+    move_headers::<{ CdHdr::LEN as i32 }, { Ipv6Hdr::LEN }>(ctx)
+}
+
+#[inline(always)]
+pub fn add_channel_data_header_ipv6(ctx: &XdpContext, mut header: [u8; 4]) {
+    move_headers::<{ -(CdHdr::LEN as i32) }, { Ipv6Hdr::LEN }>(ctx);
+    let offset = (EthHdr::LEN + Ipv6Hdr::LEN + UdpHdr::LEN) as u32;
+
+    let header_ptr = &mut header as *mut _ as *mut c_void;
+    let header_len = CdHdr::LEN as u32;
+
+    unsafe { bpf_xdp_store_bytes(ctx.ctx, offset, header_ptr, header_len) };
+}
+
+#[inline(always)]
 fn move_headers<const DELTA: i32, const IP_HEADER_LEN: usize>(ctx: &XdpContext) {
     // Scratch space for our headers.
     // IPv6 headers are always 40 bytes long.

--- a/rust/relay/ebpf-turn-router/src/udp.rs
+++ b/rust/relay/ebpf-turn-router/src/udp.rs
@@ -1,7 +1,7 @@
 use crate::{Error, checksum::ChecksumUpdate, slice_mut_at::slice_mut_at};
 use aya_ebpf::programs::XdpContext;
 use aya_log_ebpf::debug;
-use network_types::{eth::EthHdr, ip::Ipv4Hdr};
+use network_types::eth::EthHdr;
 
 /// Represents a UDP header within our packet.
 pub struct Udp<'a> {
@@ -11,10 +11,10 @@ pub struct Udp<'a> {
 
 impl<'a> Udp<'a> {
     #[inline(always)]
-    pub fn parse(ctx: &'a XdpContext) -> Result<Self, Error> {
+    pub fn parse(ctx: &'a XdpContext, ip_header_length: usize) -> Result<Self, Error> {
         Ok(Self {
             ctx,
-            inner: slice_mut_at::<UdpHdr>(ctx, EthHdr::LEN + Ipv4Hdr::LEN)?,
+            inner: slice_mut_at::<UdpHdr>(ctx, EthHdr::LEN + ip_header_length)?,
         })
     }
 


### PR DESCRIPTION
This fills in the boilerplate for handling IPv6 packets in the eBPF code. Unfortunately, we cannot add an integration test for this because IPv6 doesn't have a checksum and thus doesn't allow the UDP checksum to be set to 0. Because Linux (and other OSs too I'd assume) offload UDP checksumming to the NIC yet on the loopback interface, the packets never get to the NIC, our eBPF code sees only a partial checksum and can thus updates the checksum incorrectly.

Related: #7518
Related: #8502 