### PR TITLE
fix(relay): reduce memory usage of eBPF program to < 100MB

### DIFF
--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -305,7 +305,7 @@ mod tests {
 
     /// Memory overhead of an eBPF map.
     ///
-    /// Determined emperically.
+    /// Determined empirically.
     const HASH_MAP_OVERHEAD: f32 = 1.5;
 
     #[test]


### PR DESCRIPTION
At present, the eBPF program would try to pre-allocate around 800MB of memory for all entries in the maps. This would allow for 1 million channel mappings. We don't need that many to begin with. Reducing the max number of channels down to 65536 reduces our memory usage to less than 100MB.

Related: #7518