### PR TITLE
refactor(eBPF): imply `XDP_TX` from `Ok(())`

### DIFF
--- a/rust/relay/ebpf-turn-router/src/error.rs
+++ b/rust/relay/ebpf-turn-router/src/error.rs
@@ -1,7 +1,5 @@
 use core::num::NonZeroUsize;
 
-use aya_ebpf::bindings::xdp_action;
-
 #[derive(Debug, Clone, Copy)]
 pub enum Error {
     PacketTooShort,
@@ -15,24 +13,6 @@ pub enum Error {
     XdpLoadBytesFailed,
     XdpAdjustHeadFailed,
     XdpStoreBytesFailed,
-}
-
-impl Error {
-    pub fn xdp_action(&self) -> xdp_action::Type {
-        match self {
-            Error::PacketTooShort => xdp_action::XDP_PASS,
-            Error::NotUdp => xdp_action::XDP_PASS,
-            Error::NotTurn => xdp_action::XDP_PASS,
-            Error::NotIp => xdp_action::XDP_PASS,
-            Error::Ipv4PacketWithOptions => xdp_action::XDP_PASS,
-            Error::BadChannelDataLength => xdp_action::XDP_DROP,
-            Error::NotAChannelDataMessage => xdp_action::XDP_PASS,
-            Error::NoChannelBinding => xdp_action::XDP_PASS,
-            Error::XdpLoadBytesFailed => xdp_action::XDP_PASS,
-            Error::XdpAdjustHeadFailed => xdp_action::XDP_PASS,
-            Error::XdpStoreBytesFailed => xdp_action::XDP_PASS,
-        }
-    }
 }
 
 impl aya_log_ebpf::WriteToBuf for Error {

--- a/rust/relay/ebpf-turn-router/src/error.rs
+++ b/rust/relay/ebpf-turn-router/src/error.rs
@@ -5,6 +5,9 @@ use aya_ebpf::bindings::xdp_action;
 #[derive(Debug, Clone, Copy)]
 pub enum Error {
     PacketTooShort,
+    NotUdp,
+    NotTurn,
+    NotIp,
     Ipv4PacketWithOptions,
     NotAChannelDataMessage,
     BadChannelDataLength,
@@ -18,6 +21,9 @@ impl Error {
     pub fn xdp_action(&self) -> xdp_action::Type {
         match self {
             Error::PacketTooShort => xdp_action::XDP_PASS,
+            Error::NotUdp => xdp_action::XDP_PASS,
+            Error::NotTurn => xdp_action::XDP_PASS,
+            Error::NotIp => xdp_action::XDP_PASS,
             Error::Ipv4PacketWithOptions => xdp_action::XDP_PASS,
             Error::BadChannelDataLength => xdp_action::XDP_DROP,
             Error::NotAChannelDataMessage => xdp_action::XDP_PASS,
@@ -33,6 +39,9 @@ impl aya_log_ebpf::WriteToBuf for Error {
     fn write(self, buf: &mut [u8]) -> Option<NonZeroUsize> {
         let msg = match self {
             Error::PacketTooShort => "Packet is too short",
+            Error::NotUdp => "Not a UDP packet",
+            Error::NotTurn => "Not TURN traffic",
+            Error::NotIp => "Not an IP packet",
             Error::Ipv4PacketWithOptions => "IPv4 packet has options",
             Error::NotAChannelDataMessage => "Not a channel data message",
             Error::BadChannelDataLength => "Channel data length does not match packet length",

--- a/rust/relay/ebpf-turn-router/src/error.rs
+++ b/rust/relay/ebpf-turn-router/src/error.rs
@@ -9,6 +9,9 @@ pub enum Error {
     NotAChannelDataMessage,
     BadChannelDataLength,
     NoChannelBinding,
+    XdpLoadBytesFailed,
+    XdpAdjustHeadFailed,
+    XdpStoreBytesFailed,
 }
 
 impl Error {
@@ -19,6 +22,9 @@ impl Error {
             Error::BadChannelDataLength => xdp_action::XDP_DROP,
             Error::NotAChannelDataMessage => xdp_action::XDP_PASS,
             Error::NoChannelBinding => xdp_action::XDP_PASS,
+            Error::XdpLoadBytesFailed => xdp_action::XDP_PASS,
+            Error::XdpAdjustHeadFailed => xdp_action::XDP_PASS,
+            Error::XdpStoreBytesFailed => xdp_action::XDP_PASS,
         }
     }
 }
@@ -31,6 +37,9 @@ impl aya_log_ebpf::WriteToBuf for Error {
             Error::NotAChannelDataMessage => "Not a channel data message",
             Error::BadChannelDataLength => "Channel data length does not match packet length",
             Error::NoChannelBinding => "No channel binding",
+            Error::XdpLoadBytesFailed => "Failed to load bytes",
+            Error::XdpAdjustHeadFailed => "Failed to adjust head",
+            Error::XdpStoreBytesFailed => "Failed to store bytes",
         };
 
         msg.write(buf)

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -69,7 +69,7 @@ pub fn handle_turn(ctx: XdpContext) -> u32 {
 fn try_handle_turn(ctx: &XdpContext) -> Result<u32, Error> {
     let eth = Eth::parse(ctx)?;
 
-    let action = match eth.ether_type() {
+    match eth.ether_type() {
         EtherType::Ipv4 => try_handle_turn_ipv4(ctx)?,
         EtherType::Ipv6 => try_handle_turn_ipv6(ctx)?,
         _ => return Err(Error::NotIp),
@@ -77,15 +77,13 @@ fn try_handle_turn(ctx: &XdpContext) -> Result<u32, Error> {
 
     // If we send the packet back out, swap the source and destination MAC addresses.
     // We will have adjusted the packet pointers so we need to reparse the packet.
-    if action == xdp_action::XDP_TX {
-        Eth::parse(ctx)?.swap_src_and_dst();
-    }
+    Eth::parse(ctx)?.swap_src_and_dst();
 
-    Ok(action)
+    Ok(xdp_action::XDP_TX)
 }
 
 #[inline(always)]
-fn try_handle_turn_ipv4(ctx: &XdpContext) -> Result<u32, Error> {
+fn try_handle_turn_ipv4(ctx: &XdpContext) -> Result<(), Error> {
     let ipv4 = Ip4::parse(ctx)?;
 
     if ipv4.protocol() != IpProto::Udp {
@@ -106,28 +104,24 @@ fn try_handle_turn_ipv4(ctx: &XdpContext) -> Result<u32, Error> {
     );
 
     if config::allocation_range().contains(&udp.dst()) {
-        let action = try_handle_ipv4_udp_to_channel_data(ctx, ipv4, udp)?;
+        try_handle_ipv4_udp_to_channel_data(ctx, ipv4, udp)?;
         stats::emit_data_relayed(ctx, udp_payload_len);
 
-        return Ok(action);
+        return Ok(());
     }
 
     if udp.dst() == 3478 {
-        let action = try_handle_ipv4_channel_data_to_udp(ctx, ipv4, udp)?;
+        try_handle_ipv4_channel_data_to_udp(ctx, ipv4, udp)?;
         stats::emit_data_relayed(ctx, udp_payload_len - CdHdr::LEN as u16);
 
-        return Ok(action);
+        return Ok(());
     }
 
     Err(Error::NotTurn)
 }
 
 #[inline(always)]
-fn try_handle_ipv4_channel_data_to_udp(
-    ctx: &XdpContext,
-    ipv4: Ip4,
-    udp: Udp,
-) -> Result<u32, Error> {
+fn try_handle_ipv4_channel_data_to_udp(ctx: &XdpContext, ipv4: Ip4, udp: Udp) -> Result<(), Error> {
     let cd = ChannelData::parse(ctx, Ipv4Hdr::LEN)?;
 
     // SAFETY: ???
@@ -149,15 +143,11 @@ fn try_handle_ipv4_channel_data_to_udp(
 
     remove_channel_data_header_ipv4(ctx)?;
 
-    Ok(xdp_action::XDP_TX)
+    Ok(())
 }
 
 #[inline(always)]
-fn try_handle_ipv4_udp_to_channel_data(
-    ctx: &XdpContext,
-    ipv4: Ip4,
-    udp: Udp,
-) -> Result<u32, Error> {
+fn try_handle_ipv4_udp_to_channel_data(ctx: &XdpContext, ipv4: Ip4, udp: Udp) -> Result<(), Error> {
     let client_and_channel =
         unsafe { UDP_TO_CHAN_44.get(&PortAndPeerV4::new(ipv4.src(), udp.dst(), udp.src())) }
             .ok_or(Error::NoChannelBinding)?;
@@ -182,11 +172,11 @@ fn try_handle_ipv4_udp_to_channel_data(
 
     add_channel_data_header_ipv4(ctx, channel_data_header)?;
 
-    Ok(xdp_action::XDP_TX)
+    Ok(())
 }
 
 #[inline(always)]
-fn try_handle_turn_ipv6(ctx: &XdpContext) -> Result<u32, Error> {
+fn try_handle_turn_ipv6(ctx: &XdpContext) -> Result<(), Error> {
     let ipv6 = Ip6::parse(ctx)?;
 
     if ipv6.protocol() != IpProto::Udp {
@@ -207,27 +197,23 @@ fn try_handle_turn_ipv6(ctx: &XdpContext) -> Result<u32, Error> {
     );
 
     if config::allocation_range().contains(&udp.dst()) {
-        let action = try_handle_ipv6_udp_to_channel_data(ctx, ipv6, udp)?;
+        try_handle_ipv6_udp_to_channel_data(ctx, ipv6, udp)?;
         stats::emit_data_relayed(ctx, udp_payload_len);
 
-        return Ok(action);
+        return Ok(());
     }
 
     if udp.dst() == 3478 {
-        let action = try_handle_ipv6_channel_data_to_udp(ctx, ipv6, udp)?;
+        try_handle_ipv6_channel_data_to_udp(ctx, ipv6, udp)?;
         stats::emit_data_relayed(ctx, udp_payload_len - CdHdr::LEN as u16);
 
-        return Ok(action);
+        return Ok(());
     }
 
     Err(Error::NotTurn)
 }
 
-fn try_handle_ipv6_udp_to_channel_data(
-    ctx: &XdpContext,
-    ipv6: Ip6,
-    udp: Udp,
-) -> Result<u32, Error> {
+fn try_handle_ipv6_udp_to_channel_data(ctx: &XdpContext, ipv6: Ip6, udp: Udp) -> Result<(), Error> {
     let client_and_channel =
         unsafe { UDP_TO_CHAN_66.get(&PortAndPeerV6::new(ipv6.src(), udp.dst(), udp.src())) }
             .ok_or(Error::NoChannelBinding)?;
@@ -252,14 +238,10 @@ fn try_handle_ipv6_udp_to_channel_data(
 
     add_channel_data_header_ipv6(ctx, channel_data_header)?;
 
-    Ok(xdp_action::XDP_TX)
+    Ok(())
 }
 
-fn try_handle_ipv6_channel_data_to_udp(
-    ctx: &XdpContext,
-    ipv6: Ip6,
-    udp: Udp,
-) -> Result<u32, Error> {
+fn try_handle_ipv6_channel_data_to_udp(ctx: &XdpContext, ipv6: Ip6, udp: Udp) -> Result<(), Error> {
     let cd = ChannelData::parse(ctx, Ipv6Hdr::LEN)?;
 
     // SAFETY: ???
@@ -281,7 +263,7 @@ fn try_handle_ipv6_channel_data_to_udp(
 
     remove_channel_data_header_ipv6(ctx)?;
 
-    Ok(xdp_action::XDP_TX)
+    Ok(())
 }
 
 /// Defines our panic handler.

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -147,7 +147,7 @@ fn try_handle_ipv4_channel_data_to_udp(
         new_udp_len,
     );
 
-    remove_channel_data_header_ipv4(ctx);
+    remove_channel_data_header_ipv4(ctx)?;
 
     Ok(xdp_action::XDP_TX)
 }
@@ -180,7 +180,7 @@ fn try_handle_ipv4_udp_to_channel_data(
 
     let channel_data_header = [cd_num[0], cd_num[1], cd_len[0], cd_len[1]];
 
-    add_channel_data_header_ipv4(ctx, channel_data_header);
+    add_channel_data_header_ipv4(ctx, channel_data_header)?;
 
     Ok(xdp_action::XDP_TX)
 }
@@ -250,7 +250,7 @@ fn try_handle_ipv6_udp_to_channel_data(
 
     let channel_data_header = [cd_num[0], cd_num[1], cd_len[0], cd_len[1]];
 
-    add_channel_data_header_ipv6(ctx, channel_data_header);
+    add_channel_data_header_ipv6(ctx, channel_data_header)?;
 
     Ok(xdp_action::XDP_TX)
 }
@@ -279,7 +279,7 @@ fn try_handle_ipv6_channel_data_to_udp(
         new_udp_len,
     );
 
-    remove_channel_data_header_ipv6(ctx);
+    remove_channel_data_header_ipv6(ctx)?;
 
     Ok(xdp_action::XDP_TX)
 }


### PR DESCRIPTION
Currently, the eBPF code isn't consistent in how it handles XDP actions. For some cases, we return errors and then map them to `XDP_PASS` or `XDP_DROP`. For others, we return `Ok(XDP_PASS)`. This is unnecessarily hard to understand.

We refactor the eBPF kernel to ALWAYS use `Error`s for all code-paths that don't end in `XDP_TX`, i.e. when we successfully modified the packet and want to send it back out.

In addition, we also change the way we log these errors. Not all errors are equal and most `XDP_PASS` actions don't need to be logged. Those packets are simply passing through.

Finally, we also introduce new checks in case any calls to the eBPF helper functions fail.

Related: #7518