### PR TITLE
chore(portal): Leave notes around sync frequency

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/jobs/sync_directory.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/jobs/sync_directory.ex
@@ -1,6 +1,7 @@
 defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectory do
   use Domain.Jobs.Job,
     otp_app: :domain,
+    # Database lock prevents updating more frequently than 10 minutes
     every: :timer.minutes(2),
     executor: Domain.Jobs.Executors.Concurrent
 

--- a/elixir/apps/domain/lib/domain/auth/adapters/jumpcloud/jobs/sync_directory.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/jumpcloud/jobs/sync_directory.ex
@@ -1,6 +1,7 @@
 defmodule Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectory do
   use Domain.Jobs.Job,
     otp_app: :domain,
+    # Database lock prevents updating more frequently than 10 minutes
     every: :timer.minutes(5),
     executor: Domain.Jobs.Executors.Concurrent
 

--- a/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/jobs/sync_directory.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/jobs/sync_directory.ex
@@ -1,6 +1,7 @@
 defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectory do
   use Domain.Jobs.Job,
     otp_app: :domain,
+    # Database lock prevents updating more frequently than 10 minutes
     every: :timer.minutes(5),
     executor: Domain.Jobs.Executors.Concurrent
 

--- a/elixir/apps/domain/lib/domain/auth/adapters/mock/jobs/sync_directory.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/mock/jobs/sync_directory.ex
@@ -1,6 +1,7 @@
 defmodule Domain.Auth.Adapters.Mock.Jobs.SyncDirectory do
   use Domain.Jobs.Job,
     otp_app: :domain,
+    # Database lock prevents updating more frequently than 10 minutes
     every: :timer.minutes(1),
     executor: Domain.Jobs.Executors.Concurrent
 

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/jobs/sync_directory.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/jobs/sync_directory.ex
@@ -1,6 +1,7 @@
 defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectory do
   use Domain.Jobs.Job,
     otp_app: :domain,
+    # Database lock prevents updating more frequently than 10 minutes
     every: :timer.minutes(20),
     executor: Domain.Jobs.Executors.Concurrent
 


### PR DESCRIPTION
When reading through these modules, it's helpful to know that the actual sync data update doesn't occur more often than 10 minutes due to a database check.