### PR TITLE
fix(portal): Disable mock sync job in prod

### DIFF
--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -111,6 +111,9 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :domain, Domain.Mailer, adapter: Swoosh.Adapters.Local
 
+# Enable the mock adapter for development
+config :domain, Domain.Auth.Adapters.Mock.Jobs.SyncDirectory, enabled: true
+
 config :workos, WorkOS.Client,
   api_key: System.get_env("WORKOS_API_KEY"),
   client_id: System.get_env("WORKOS_CLIENT_ID"),

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -112,8 +112,8 @@ if config_env() == :prod do
   config :domain, Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectory,
     enabled: compile_config!(:background_jobs_enabled)
 
-  config :domain, Domain.Auth.Adapters.Mock.Jobs.SyncDirectory,
-    enabled: compile_config!(:background_jobs_enabled)
+  # Don't enable the mock sync directory job in production
+  config :domain, Domain.Auth.Adapters.Mock.Jobs.SyncDirectory, enabled: false
 
   if web_external_url = compile_config!(:web_external_url) do
     %{


### PR DESCRIPTION
The adapter itself isn't enabled in the UI on prod, but the background job to sync mock data was. This prevents the job from being started and emitting log noise into production logs.