### PR TITLE
feat(telemetry): include environment in decide request

### DIFF
--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -169,7 +169,11 @@ impl Telemetry {
             |user| user.id = Some(id)
         });
 
-        feature_flags::reevaluate(id);
+        let Some(client) = sentry::Hub::main().client() else {
+            return;
+        };
+
+        feature_flags::reevaluate(id, client.options().environment.to_owned());
     }
 }
 


### PR DESCRIPTION
This allows us to toggle feature-flags based on environments.