### PR TITLE
fix(eBPF): drop messed up packets

### DIFF
--- a/rust/relay/ebpf-turn-router/src/error.rs
+++ b/rust/relay/ebpf-turn-router/src/error.rs
@@ -34,6 +34,7 @@ pub enum UnsupportedChannel {
 }
 
 impl aya_log_ebpf::WriteToBuf for Error {
+    #[inline(always)]
     fn write(self, buf: &mut [u8]) -> Option<NonZeroUsize> {
         let msg = match self {
             Error::PacketTooShort => "Packet is too short",

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -75,10 +75,7 @@ pub fn handle_turn(ctx: XdpContext) -> u32 {
         | Error::NotAChannelDataMessage
         | Error::Ipv4PacketWithOptions => xdp_action::XDP_PASS,
 
-        Error::XdpStoreBytesFailed
-        | Error::XdpAdjustHeadFailed
-        | Error::XdpLoadBytesFailed
-        | Error::PacketTooShort
+        Error::PacketTooShort
         | Error::NoMacAddress
         | Error::UnsupportedChannel(_)
         | Error::NoEntry(_) => {
@@ -87,7 +84,10 @@ pub fn handle_turn(ctx: XdpContext) -> u32 {
             xdp_action::XDP_PASS
         }
 
-        Error::BadChannelDataLength => {
+        Error::BadChannelDataLength
+        | Error::XdpStoreBytesFailed
+        | Error::XdpAdjustHeadFailed
+        | Error::XdpLoadBytesFailed => {
             debug!(&ctx, "Dropping packet: {}", e);
 
             xdp_action::XDP_DROP


### PR DESCRIPTION
In case any of the xdp store/adjust/load functions fail, we need to drop the packet. By the time we get to these functions, we have already overwrote the Ethernet, IP and UDP headers and would only need to copy them either forwards or backwards to get rid of or add the channel data header. Forwarding these packets to userspace is pointless.