### PR TITLE
fix(eBPF): explicitly attach in SKB mode

### DIFF
--- a/rust/relay/server/src/ebpf/linux.rs
+++ b/rust/relay/server/src/ebpf/linux.rs
@@ -35,7 +35,7 @@ impl Program {
             .try_into()?;
         program.load().context("Failed to load program")?;
         program
-            .attach(interface, XdpFlags::default())
+            .attach(interface, XdpFlags::SKB_MODE)
             .with_context(|| format!("Failed to attached to interface {interface}"))?;
 
         let mut stats = AsyncPerfEventArray::try_from(


### PR DESCRIPTION
It appears that the gVNIC driver in Google Cloud doesn't give us enough headroom to use `bpf_xdp_adjust_head` with a delta of 4 bytes. Currently, we are loading the XDP program with default flags. By loading it explicitly in SKB mode, we should be able to workaround these driver limitations at the expense of some performance (which should still be better than userspace!).

Related: https://github.com/GoogleCloudPlatform/compute-virtual-ethernet-linux/issues/70