### PR TITLE
chore(eBPF): warn when dropping packets

### DIFF
--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -88,7 +88,7 @@ pub fn handle_turn(ctx: XdpContext) -> u32 {
         | Error::XdpStoreBytesFailed(_)
         | Error::XdpAdjustHeadFailed(_)
         | Error::XdpLoadBytesFailed(_) => {
-            debug!(&ctx, "Dropping packet: {}", e);
+            warn!(&ctx, "Dropping packet: {}", e);
 
             xdp_action::XDP_DROP
         }


### PR DESCRIPTION
When we decide to drop a packet, it means something is seriously off and we should look into it. These warnings will propagate to userspace and trigger a warning that gets reported to Sentry (if telemetry is enabled).