### PR TITLE
refactor(eBPF): rename `slice_mut_at` module

### DIFF
--- a/rust/relay/ebpf-turn-router/src/channel_data.rs
+++ b/rust/relay/ebpf-turn-router/src/channel_data.rs
@@ -1,4 +1,4 @@
-use crate::{Error, slice_mut_at::slice_mut_at, udp::UdpHdr};
+use crate::{Error, ref_mut_at::ref_mut_at, udp::UdpHdr};
 use aya_ebpf::programs::XdpContext;
 use network_types::eth::EthHdr;
 
@@ -12,7 +12,7 @@ pub struct ChannelData<'a> {
 impl<'a> ChannelData<'a> {
     #[inline(always)]
     pub fn parse(ctx: &'a XdpContext, ip_header_length: usize) -> Result<Self, Error> {
-        let hdr = slice_mut_at::<CdHdr>(ctx, EthHdr::LEN + ip_header_length + UdpHdr::LEN)?;
+        let hdr = ref_mut_at::<CdHdr>(ctx, EthHdr::LEN + ip_header_length + UdpHdr::LEN)?;
 
         if !(0x4000..0x4FFF).contains(&u16::from_be_bytes(hdr.number)) {
             return Err(Error::NotAChannelDataMessage);

--- a/rust/relay/ebpf-turn-router/src/eth.rs
+++ b/rust/relay/ebpf-turn-router/src/eth.rs
@@ -5,7 +5,7 @@ use network_types::eth::{EthHdr, EtherType};
 
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use crate::{error::Error, slice_mut_at::slice_mut_at};
+use crate::{error::Error, ref_mut_at::ref_mut_at};
 
 const MAX_ETHERNET_MAPPINGS: u32 = 0x100000;
 
@@ -18,7 +18,7 @@ impl<'a> Eth<'a> {
     #[inline(always)]
     pub fn parse(ctx: &'a XdpContext) -> Result<Self, Error> {
         Ok(Self {
-            inner: slice_mut_at::<EthHdr>(ctx, 0)?,
+            inner: ref_mut_at::<EthHdr>(ctx, 0)?,
             ctx,
         })
     }

--- a/rust/relay/ebpf-turn-router/src/ip4.rs
+++ b/rust/relay/ebpf-turn-router/src/ip4.rs
@@ -1,6 +1,6 @@
 use core::net::Ipv4Addr;
 
-use crate::{Error, checksum::ChecksumUpdate, slice_mut_at::slice_mut_at};
+use crate::{Error, checksum::ChecksumUpdate, ref_mut_at::ref_mut_at};
 use aya_ebpf::programs::XdpContext;
 use aya_log_ebpf::debug;
 use network_types::{eth::EthHdr, ip::IpProto};
@@ -14,7 +14,7 @@ pub struct Ip4<'a> {
 impl<'a> Ip4<'a> {
     #[inline(always)]
     pub fn parse(ctx: &'a XdpContext) -> Result<Self, Error> {
-        let ip4_hdr = slice_mut_at::<Ipv4Hdr>(ctx, EthHdr::LEN)?;
+        let ip4_hdr = ref_mut_at::<Ipv4Hdr>(ctx, EthHdr::LEN)?;
 
         // IPv4 packets with options are handled in user-space.
         if usize::from(ip4_hdr.ihl()) * 4 != Ipv4Hdr::LEN {

--- a/rust/relay/ebpf-turn-router/src/ip6.rs
+++ b/rust/relay/ebpf-turn-router/src/ip6.rs
@@ -1,6 +1,6 @@
 use core::net::Ipv6Addr;
 
-use crate::{Error, checksum::ChecksumUpdate, slice_mut_at::slice_mut_at};
+use crate::{Error, checksum::ChecksumUpdate, ref_mut_at::ref_mut_at};
 use aya_ebpf::programs::XdpContext;
 use aya_log_ebpf::debug;
 use network_types::{eth::EthHdr, ip::IpProto};
@@ -16,7 +16,7 @@ impl<'a> Ip6<'a> {
     pub fn parse(ctx: &'a XdpContext) -> Result<Self, Error> {
         Ok(Self {
             ctx,
-            inner: slice_mut_at::<Ipv6Hdr>(ctx, EthHdr::LEN)?,
+            inner: ref_mut_at::<Ipv6Hdr>(ctx, EthHdr::LEN)?,
         })
     }
 

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -33,7 +33,7 @@ mod eth;
 mod ip4;
 mod ip6;
 mod move_headers;
-mod slice_mut_at;
+mod ref_mut_at;
 mod stats;
 mod udp;
 

--- a/rust/relay/ebpf-turn-router/src/ref_mut_at.rs
+++ b/rust/relay/ebpf-turn-router/src/ref_mut_at.rs
@@ -3,7 +3,7 @@ use aya_ebpf::programs::XdpContext;
 use crate::error::Error;
 
 #[inline(always)]
-pub(crate) fn slice_mut_at<T>(ctx: &XdpContext, offset: usize) -> Result<&mut T, Error> {
+pub(crate) fn ref_mut_at<T>(ctx: &XdpContext, offset: usize) -> Result<&mut T, Error> {
     let start = ctx.data();
     let end = ctx.data_end();
     let len = core::mem::size_of::<T>();

--- a/rust/relay/ebpf-turn-router/src/ref_mut_at.rs
+++ b/rust/relay/ebpf-turn-router/src/ref_mut_at.rs
@@ -2,6 +2,10 @@ use aya_ebpf::programs::XdpContext;
 
 use crate::error::Error;
 
+/// Returns a mutable reference to a type `T` at the specified offset in the packet data.
+///
+/// The length is based on the size of `T` and the bytes at the specified offset will simply be cast into `T`.
+/// `T` should therefore most definitely be `repr(C)`.
 #[inline(always)]
 pub(crate) fn ref_mut_at<T>(ctx: &XdpContext, offset: usize) -> Result<&mut T, Error> {
     let start = ctx.data();

--- a/rust/relay/ebpf-turn-router/src/udp.rs
+++ b/rust/relay/ebpf-turn-router/src/udp.rs
@@ -1,4 +1,4 @@
-use crate::{Error, checksum::ChecksumUpdate, slice_mut_at::slice_mut_at};
+use crate::{Error, checksum::ChecksumUpdate, ref_mut_at::ref_mut_at};
 use aya_ebpf::programs::XdpContext;
 use aya_log_ebpf::debug;
 use network_types::eth::EthHdr;
@@ -14,7 +14,7 @@ impl<'a> Udp<'a> {
     pub fn parse(ctx: &'a XdpContext, ip_header_length: usize) -> Result<Self, Error> {
         Ok(Self {
             ctx,
-            inner: slice_mut_at::<UdpHdr>(ctx, EthHdr::LEN + ip_header_length)?,
+            inner: ref_mut_at::<UdpHdr>(ctx, EthHdr::LEN + ip_header_length)?,
         })
     }
 


### PR DESCRIPTION
The name `slice_mut_at` came from a time where this function actually returned a slice of bytes. It has since been refactored to return a mutable reference to a type T that gets set by the caller. Thus, `ref_mut_at` is a much more fitting name.