### PR TITLE
fix(portal): Delete soft-deleted synced actor_groups

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20250402071836_remove_duplicate_groups.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250402071836_remove_duplicate_groups.exs
@@ -9,18 +9,9 @@ defmodule Domain.Repo.Migrations.RemoveDuplicateGroups do
     # Step 1: Remove all duplicate deleted groups
     execute("""
     DELETE FROM actor_groups
-    WHERE id IN (
-      SELECT a.id
-      FROM actor_groups a
-      INNER JOIN actor_groups b
-      ON a.account_id = b.account_id
-      AND a.provider_id = b.provider_id
-      AND a.provider_identifier = b.provider_identifier
-      WHERE a.deleted_at IS NOT NULL
-      AND b.deleted_at IS NULL
-      AND a.provider_id IS NOT NULL
-      AND a.provider_identifier IS NOT NULL
-    )
+    WHERE DELETED_AT IS NOT NULL
+    AND provider_identifier IS NOT NULL
+    AND provider_id IS NOT NULL
     """)
 
     # Step 2: Drop existing index


### PR DESCRIPTION
The previous migration only accounted for soft-deleted rows that have an active counterpart.

This fails the new unique index if multiple soft-deleted rows exist for the same `account_id, provider_id, provider_identifier` combination.

Instead, to appease the new index, we need to delete all soft-deleted rows where these fields exist.

Related: #8615 