### PR TITLE
fix(portal): Interpret missing `members` as empty list

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/api_client.ex
@@ -144,14 +144,14 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClient do
           response: inspect(response)
         )
 
-        {:error, :retry_later}
+        {:error, :invalid_response}
 
       {:ok, %Finch.Response{status: status}} when status in 300..399 ->
         Logger.warning("API request succeeded with unexpected 3xx status #{status}",
           response: inspect(response)
         )
 
-        {:error, :retry_later}
+        {:error, :invalid_response}
 
       {:ok, %Finch.Response{body: raw_body, status: status}} when status in 400..499 ->
         Logger.error("API request failed with 4xx status #{status}",
@@ -179,7 +179,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClient do
           uri: inspect(uri)
         )
 
-        {:error, :retry_later}
+        {:error, :invalid_response}
 
       :error ->
         Logger.error("API response did not contain expected 'value' key",
@@ -187,10 +187,10 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClient do
           uri: inspect(uri)
         )
 
-        {:error, :retry_later}
+        {:error, :invalid_response}
 
       other ->
-        Logger.error("Unexpected response from API",
+        Logger.error("Invalid response from API",
           response: inspect(response),
           other: inspect(other)
         )

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
@@ -126,14 +126,14 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
           response: inspect(response)
         )
 
-        {:error, :retry_later}
+        {:error, :invalid_response}
 
       {:ok, %Finch.Response{status: status}} when status in 300..399 ->
         Logger.warning("API request succeeded with unexpected 3xx status #{status}",
           response: inspect(response)
         )
 
-        {:error, :retry_later}
+        {:error, :invalid_response}
 
       {:ok, %Finch.Response{body: raw_body, status: status}} when status in 400..499 ->
         Logger.error("API request failed with 4xx status #{status}",
@@ -161,10 +161,10 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
           uri: inspect(uri)
         )
 
-        {:error, :retry_later}
+        {:error, :invalid_response}
 
       other ->
-        Logger.error("Unexpected response from API",
+        Logger.error("Invalid response from API",
           response: inspect(response),
           other: inspect(other)
         )

--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
@@ -48,18 +48,18 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       assert list_users(api_token) == {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_users_list_endpoint(bypass, 201)
-      assert list_users(api_token) == {:error, :retry_later}
+      assert list_users(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_users_list_endpoint(bypass, 301)
-      assert list_users(api_token) == {:error, :retry_later}
+      assert list_users(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -83,7 +83,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       assert list_users(api_token) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds without expected JSON keys" do
+    test "returns invalid_response when api responds without expected JSON keys" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -93,10 +93,10 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         Jason.encode!(%{})
       )
 
-      assert list_users(api_token) == {:error, :retry_later}
+      assert list_users(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -106,7 +106,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         Jason.encode!(%{"users" => "invalid data"})
       )
 
-      assert list_users(api_token) == {:error, :retry_later}
+      assert list_users(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do
@@ -147,18 +147,18 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
                {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(bypass, 201)
-      assert list_organization_units(api_token) == {:error, :retry_later}
+      assert list_organization_units(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(bypass, 301)
-      assert list_organization_units(api_token) == {:error, :retry_later}
+      assert list_organization_units(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -182,7 +182,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       assert list_organization_units(api_token) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds without expected JSON keys" do
+    test "returns invalid_response when api responds without expected JSON keys" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -192,10 +192,10 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         Jason.encode!(%{})
       )
 
-      assert list_organization_units(api_token) == {:error, :retry_later}
+      assert list_organization_units(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -205,7 +205,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         Jason.encode!(%{"organization_units" => "invalid data"})
       )
 
-      assert list_organization_units(api_token) == {:error, :retry_later}
+      assert list_organization_units(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do
@@ -250,18 +250,18 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       assert list_groups(api_token) == {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(bypass, 201)
-      assert list_groups(api_token) == {:error, :retry_later}
+      assert list_groups(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(bypass, 301)
-      assert list_groups(api_token) == {:error, :retry_later}
+      assert list_groups(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -285,7 +285,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       assert list_groups(api_token) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds without expected JSON keys" do
+    test "returns invalid_response when api responds without expected JSON keys" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -295,10 +295,10 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         Jason.encode!(%{})
       )
 
-      assert list_groups(api_token) == {:error, :retry_later}
+      assert list_groups(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -308,7 +308,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         Jason.encode!(%{"groups" => "invalid data"})
       )
 
-      assert list_groups(api_token) == {:error, :retry_later}
+      assert list_groups(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do
@@ -352,20 +352,20 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
                {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_group_members_list_endpoint(bypass, group_id, 201)
-      assert list_group_members(api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_token, group_id) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_group_members_list_endpoint(bypass, group_id, 301)
-      assert list_group_members(api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_token, group_id) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -392,7 +392,8 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       assert list_group_members(api_token, group_id) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds without expected JSON keys" do
+    # Google often omits the "members" key if there are no members in the group
+    test "returns empty list when api responds without expected JSON keys" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
@@ -404,10 +405,10 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         Jason.encode!(%{})
       )
 
-      assert list_group_members(api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_token, group_id) == {:ok, []}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
@@ -416,10 +417,10 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         bypass,
         group_id,
         200,
-        Jason.encode!(%{"group_members" => "invalid data"})
+        Jason.encode!(%{"members" => "invalid data"})
       )
 
-      assert list_group_members(api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_token, group_id) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do

--- a/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/api_client_test.exs
@@ -55,18 +55,18 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       assert list_users(api_token) == {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       MicrosoftEntraDirectory.mock_users_list_endpoint(bypass, 201)
-      assert list_users(api_token) == {:error, :retry_later}
+      assert list_users(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       MicrosoftEntraDirectory.mock_users_list_endpoint(bypass, 301)
-      assert list_users(api_token) == {:error, :retry_later}
+      assert list_users(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -90,7 +90,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       assert list_users(api_token) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds without expected JSON keys" do
+    test "returns invalid_response when api responds without expected JSON keys" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -100,10 +100,10 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         Jason.encode!(%{})
       )
 
-      assert list_users(api_token) == {:error, :retry_later}
+      assert list_users(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -113,7 +113,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         Jason.encode!(%{"users" => "invalid data"})
       )
 
-      assert list_users(api_token) == {:error, :retry_later}
+      assert list_users(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do
@@ -156,18 +156,18 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       assert list_groups(api_token) == {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       MicrosoftEntraDirectory.mock_groups_list_endpoint(bypass, 201)
-      assert list_groups(api_token) == {:error, :retry_later}
+      assert list_groups(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       MicrosoftEntraDirectory.mock_groups_list_endpoint(bypass, 301)
-      assert list_groups(api_token) == {:error, :retry_later}
+      assert list_groups(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -191,7 +191,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       assert list_groups(api_token) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds without expected JSON keys" do
+    test "returns invalid_response when api responds without expected JSON keys" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -201,10 +201,10 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         Jason.encode!(%{})
       )
 
-      assert list_groups(api_token) == {:error, :retry_later}
+      assert list_groups(api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -214,7 +214,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         Jason.encode!(%{"groups" => "invalid data"})
       )
 
-      assert list_groups(api_token) == {:error, :retry_later}
+      assert list_groups(api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do
@@ -260,20 +260,20 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
                {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
       MicrosoftEntraDirectory.mock_group_members_list_endpoint(bypass, group_id, 201)
-      assert list_group_members(api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_token, group_id) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
       MicrosoftEntraDirectory.mock_group_members_list_endpoint(bypass, group_id, 301)
-      assert list_group_members(api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_token, group_id) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -300,7 +300,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       assert list_group_members(api_token, group_id) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds without expected JSON keys" do
+    test "returns invalid_response when api responds without expected JSON keys" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
@@ -312,10 +312,10 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         Jason.encode!(%{})
       )
 
-      assert list_group_members(api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_token, group_id) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
@@ -327,7 +327,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         Jason.encode!(%{"group_members" => "invalid data"})
       )
 
-      assert list_group_members(api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_token, group_id) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do

--- a/elixir/apps/domain/test/domain/auth/adapters/okta/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/okta/api_client_test.exs
@@ -42,20 +42,20 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
                {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       api_base_url = "http://localhost:#{bypass.port}/"
       OktaDirectory.mock_users_list_endpoint(bypass, 201)
-      assert list_users(api_base_url, api_token) == {:error, :retry_later}
+      assert list_users(api_base_url, api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       api_base_url = "http://localhost:#{bypass.port}/"
       OktaDirectory.mock_users_list_endpoint(bypass, 301)
-      assert list_users(api_base_url, api_token) == {:error, :retry_later}
+      assert list_users(api_base_url, api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -81,7 +81,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
       assert list_users(api_base_url, api_token) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       api_base_url = "http://localhost:#{bypass.port}/"
@@ -92,7 +92,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
         Jason.encode!(%{"invalid" => "format"})
       )
 
-      assert list_users(api_base_url, api_token) == {:error, :retry_later}
+      assert list_users(api_base_url, api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do
@@ -144,20 +144,20 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
                {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       api_base_url = "http://localhost:#{bypass.port}/"
       OktaDirectory.mock_groups_list_endpoint(bypass, 201)
-      assert list_groups(api_base_url, api_token) == {:error, :retry_later}
+      assert list_groups(api_base_url, api_token) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       api_base_url = "http://localhost:#{bypass.port}/"
       OktaDirectory.mock_groups_list_endpoint(bypass, 301)
-      assert list_groups(api_base_url, api_token) == {:error, :retry_later}
+      assert list_groups(api_base_url, api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -183,7 +183,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
       assert list_groups(api_base_url, api_token) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       api_base_url = "http://localhost:#{bypass.port}/"
@@ -194,7 +194,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
         Jason.encode!(%{"invalid" => "format"})
       )
 
-      assert list_groups(api_base_url, api_token) == {:error, :retry_later}
+      assert list_groups(api_base_url, api_token) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do
@@ -244,22 +244,22 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
                {:error, %Mint.TransportError{reason: :econnrefused}}
     end
 
-    test "returns retry_later when api responds with unexpected 2xx status" do
+    test "returns invalid_response when api responds with unexpected 2xx status" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
       api_base_url = "http://localhost:#{bypass.port}/"
       OktaDirectory.mock_group_members_list_endpoint(bypass, group_id, 201)
-      assert list_group_members(api_base_url, api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_base_url, api_token, group_id) == {:error, :invalid_response}
     end
 
-    test "returns retry_later when api responds with unexpected 3xx status" do
+    test "returns invalid_response when api responds with unexpected 3xx status" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
       api_base_url = "http://localhost:#{bypass.port}/"
       OktaDirectory.mock_group_members_list_endpoint(bypass, group_id, 301)
-      assert list_group_members(api_base_url, api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_base_url, api_token, group_id) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with 4xx status" do
@@ -288,7 +288,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
       assert list_group_members(api_base_url, api_token, group_id) == {:error, :retry_later}
     end
 
-    test "returns retry_later when api responds with unexpected data format" do
+    test "returns invalid_response when api responds with unexpected data format" do
       api_token = Ecto.UUID.generate()
       group_id = Ecto.UUID.generate()
       bypass = Bypass.open()
@@ -301,7 +301,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
         Jason.encode!(%{"invalid" => "data"})
       )
 
-      assert list_group_members(api_base_url, api_token, group_id) == {:error, :retry_later}
+      assert list_group_members(api_base_url, api_token, group_id) == {:error, :invalid_response}
     end
 
     test "returns error when api responds with invalid JSON" do


### PR DESCRIPTION
The Google API will often return a missing `members` key alongside a `200` response from their members API. The documentation here isn't clear whether this key is expected or not, but since the sync has been working fine up until #8608, we can only surmise that the missing key in fact means the group has no members.

This PR updates the Google API client so that a `default_if_missing` can be passed in which is returned if the API response is missing the JSON key to fetch.

For the users, groups, and organization units fetches, we consider a missing key to be an error and we return `{:error, :invalid_response}` since this most likely indicates an API problem.

For the members endpoint, we consider the missing key to be the empty set.

Additionally, a bug is fixed that was introduced in #8608 whereupon we returned `{:error, :retry_later}` for newly-accounted-for API responses, which would have caused a "sync failed" email to be sent to the admins on the instance.

Instead, we want to return `{:error, :invalid_response}` which will stop the sync from progressing, and log it internally.