### PR TITLE
feat(relay): introduce feature-flag for toggling eBPF program

### DIFF
--- a/rust/relay/ebpf-shared/src/lib.rs
+++ b/rust/relay/ebpf-shared/src/lib.rs
@@ -204,6 +204,7 @@ impl PortAndPeerV6 {
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct Config {
+    pub relaying_enabled: bool,
     pub udp_checksum_enabled: bool,
     pub lowest_allocation_port: u16,
     pub highest_allocation_port: u16,
@@ -212,6 +213,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            relaying_enabled: true,
             udp_checksum_enabled: true,
             lowest_allocation_port: 49152,
             highest_allocation_port: 65535,

--- a/rust/relay/ebpf-shared/src/lib.rs
+++ b/rust/relay/ebpf-shared/src/lib.rs
@@ -201,7 +201,7 @@ impl PortAndPeerV6 {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct Config {
     pub udp_checksum_enabled: bool,

--- a/rust/relay/ebpf-turn-router/src/config.rs
+++ b/rust/relay/ebpf-turn-router/src/config.rs
@@ -11,6 +11,10 @@ pub fn udp_checksum_enabled() -> bool {
     config().udp_checksum_enabled
 }
 
+pub fn relaying_enabled() -> bool {
+    config().relaying_enabled
+}
+
 pub fn allocation_range() -> RangeInclusive<u16> {
     let config = config();
 

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -97,6 +97,10 @@ pub fn handle_turn(ctx: XdpContext) -> u32 {
 
 #[inline(always)]
 fn try_handle_turn(ctx: &XdpContext) -> Result<u32, Error> {
+    if !config::relaying_enabled() {
+        return Ok(xdp_action::XDP_PASS);
+    }
+
     let eth = Eth::parse(ctx)?;
 
     match eth.ether_type() {

--- a/rust/relay/server/src/ebpf/stub.rs
+++ b/rust/relay/server/src/ebpf/stub.rs
@@ -39,4 +39,8 @@ impl Program {
     pub fn set_config(&mut self, _: Config) -> Result<()> {
         Ok(())
     }
+
+    pub fn config(&self) -> Config {
+        Config::default()
+    }
 }

--- a/rust/telemetry/src/feature_flags.rs
+++ b/rust/telemetry/src/feature_flags.rs
@@ -24,6 +24,10 @@ pub fn drop_llmnr_nxdomain_responses() -> bool {
     FEATURE_FLAGS.read().drop_llmnr_nxdomain_responses
 }
 
+pub fn ebpf_turn_router_enabled() -> bool {
+    FEATURE_FLAGS.read().ebpf_turn_router_enabled
+}
+
 pub(crate) fn reevaluate(user_id: String, env: &str) {
     let api_key = match env {
         crate::env::PRODUCTION => POSTHOG_API_KEY_PROD,
@@ -130,6 +134,8 @@ struct FeatureFlags {
     icmp_unreachable_instead_of_nat64: bool,
     #[serde(default)]
     drop_llmnr_nxdomain_responses: bool,
+    #[serde(default)]
+    ebpf_turn_router_enabled: bool,
 }
 
 fn sentry_flag_context(flags: FeatureFlags) -> sentry::protocol::Context {
@@ -138,12 +144,14 @@ fn sentry_flag_context(flags: FeatureFlags) -> sentry::protocol::Context {
     enum SentryFlag {
         IcmpUnreachableInsteadOfNat64 { result: bool },
         DropLlmnrNxdomainResponses { result: bool },
+        EbpfTurnRouterEnabled { result: bool },
     }
 
     // Exhaustive destruction so we don't forget to update this when we add a flag.
     let FeatureFlags {
         icmp_unreachable_instead_of_nat64,
         drop_llmnr_nxdomain_responses,
+        ebpf_turn_router_enabled,
     } = flags;
 
     let value = serde_json::json!({
@@ -151,7 +159,8 @@ fn sentry_flag_context(flags: FeatureFlags) -> sentry::protocol::Context {
             SentryFlag::IcmpUnreachableInsteadOfNat64 {
                 result: icmp_unreachable_instead_of_nat64,
             },
-            SentryFlag::DropLlmnrNxdomainResponses { result: drop_llmnr_nxdomain_responses }
+            SentryFlag::DropLlmnrNxdomainResponses { result: drop_llmnr_nxdomain_responses },
+            SentryFlag::EbpfTurnRouterEnabled { result: ebpf_turn_router_enabled }
         ]
     });
 


### PR DESCRIPTION
This PR implements a feature-flag in PostHog that we can use to toggle the use of the eBPF data plane at runtime. At every tick of the event-loop, the relay will compare the (cached) configuration of the eBPF program with the (cached) value of the feature-flag. If they differ, the flag will be updated and upon the next packet, the eBPF program will act accordingly.

Feature-flags are re-evaluated every 5 minutes, meaning there is some delay until this gets applied.

The default value of our all our feature-flags is `false`, meaning if there is some problem with evaluating them, we'd turn the eBPF data plane off. Performing routing in userspace is slower but it is a safer default.

Resolves: #8548