### PR TITLE
refactor(relay): fail if eBPF offloading is requested but fails

### DIFF
--- a/terraform/modules/google-cloud/apps/relay/main.tf
+++ b/terraform/modules/google-cloud/apps/relay/main.tf
@@ -48,6 +48,10 @@ locals {
     {
       name  = "FIREZONE_API_URL"
       value = var.api_url
+    },
+    {
+      name  = "EBPF_OFFLOADING"
+      value = "eth0"
     }
   ], var.application_environment_variables)
 }


### PR DESCRIPTION
It happens a bunch of times to me during testing that I'd forget to set the right interface onto which the eBPF kernel should be loaded and was wondering why it didn't work. Defaulting to `eth0` wasn't a very smart decision because it means users cannot disable the eBPF kernel at all (other than via the feature-flag).

It makes more sense to default to not loading the program at all AND hard-fail if we are requested to load it but cannot. This allows us to catch configuration errors early.