### PR TITLE
fix(relay): set a Firezone ID to enable feature-flags

### DIFF
--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -115,6 +115,7 @@ fn main() {
             VERSION.unwrap_or("unknown"),
             RELAY_DSN,
         );
+        Telemetry::set_firezone_id(uuid::Uuid::new_v4().to_string());
     }
 
     let runtime = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
Our feature-flags are currently coupled to our Firezone ID. Without a Firezone ID, we cannot evaluate feature flags. In order to be able to use the feature flags to enable / disable the eBPF TURN router, we see a random UUID as the Firezone ID upon startup of the relay.

Not setting this causes the eBPF router to currently be instantly disabled as soon as we start up because the default of the feature flag is false and we don't reevaluate it later due to the missing ID.