### PR TITLE
chore(infra): add reservation_size var to elixir app

### DIFF
--- a/terraform/modules/google-cloud/apps/elixir/main.tf
+++ b/terraform/modules/google-cloud/apps/elixir/main.tf
@@ -95,8 +95,7 @@ resource "google_compute_reservation" "reservation" {
   specific_reservation_required = true
 
   specific_reservation {
-    count = var.scaling_horizontal_replicas
-    # count = ceil(var.scaling_horizontal_replicas / length(var.compute_instance_availability_zones))
+    count = var.reservation_size
 
     instance_properties {
       machine_type = var.compute_instance_type

--- a/terraform/modules/google-cloud/apps/elixir/variables.tf
+++ b/terraform/modules/google-cloud/apps/elixir/variables.tf
@@ -122,6 +122,19 @@ variable "scaling_horizontal_replicas" {
   description = "Number of replicas in an instance group."
 }
 
+variable "reservation_size" {
+  type     = number
+  nullable = false
+  default  = 1
+
+  validation {
+    condition     = var.reservation_size >= var.scaling_horizontal_replicas
+    error_message = "Reservation size should be greater or equal to the number of scaling_horizontal_replicas."
+  }
+
+  description = "Number of reservations to create."
+}
+
 variable "scaling_max_horizontal_replicas" {
   type     = number
   nullable = true


### PR DESCRIPTION
We need to decouple the target VM size from the reservation size so that we have wiggle room to spin up new VMs if things go south during a deploy.