### PR TITLE
chore(ci): Simulate latency for performance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,13 +185,9 @@ jobs:
           docker compose up -d client --no-build
       - name: Add 10ms simulated latency
         run: |
-          # Add 10ms latency to the client
           docker compose exec -d client tc qdisc add dev eth0 root netem delay 10ms
-          # Add 10ms latency to the gateway
           docker compose exec -d gateway tc qdisc add dev eth0 root netem delay 10ms
-          # Add 10ms latency to the relay-1
           docker compose exec -d relay-1 tc qdisc add dev eth0 root netem delay 10ms
-          # Add 10ms latency to the relay-2
           docker compose exec -d relay-2 tc qdisc add dev eth0 root netem delay 10ms
       - name: "Performance test: ${{ matrix.test_name }}"
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,10 @@ jobs:
           docker compose up -d relay-1 relay-2 --no-build
           docker compose up -d gateway --no-build
           docker compose up -d client --no-build
-      - name: Add 10ms simulated latency to gateway and relays
+      - name: Add 10ms simulated latency
         run: |
+          # Add 10ms latency to the client
+          docker compose exec -d client tc qdisc add dev eth0 root netem delay 10ms
           # Add 10ms latency to the gateway
           docker compose exec -d gateway tc qdisc add dev eth0 root netem delay 10ms
           # Add 10ms latency to the relay-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,14 @@ jobs:
           docker compose up -d relay-1 relay-2 --no-build
           docker compose up -d gateway --no-build
           docker compose up -d client --no-build
+      - name: Add 10ms simulated latency to gateway and relays
+        run: |
+          # Add 10ms latency to the gateway
+          docker compose exec -d gateway tc qdisc add dev eth0 root netem delay 10ms
+          # Add 10ms latency to the relay-1
+          docker compose exec -d relay-1 tc qdisc add dev eth0 root netem delay 10ms
+          # Add 10ms latency to the relay-2
+          docker compose exec -d relay-2 tc qdisc add dev eth0 root netem delay 10ms
       - name: "Performance test: ${{ matrix.test_name }}"
         timeout-minutes: 5
         env:


### PR DESCRIPTION
Based on recent findings concerning throughput dropoff with increased latency, it would be a good idea to add a small amount of latency to our performance test suite to make sure we catch any latency-sensitive regressions.

Related: https://github.com/firezone/firezone/issues/8699