### PR TITLE
build(rust): move our own `windows` dependency to `0.61.0`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2185,9 +2185,9 @@ dependencies = [
  "tracing",
  "tun",
  "uuid",
- "windows 0.58.0",
- "windows-core 0.58.0",
- "windows-implement 0.58.0",
+ "windows 0.61.1",
+ "windows-core 0.61.0",
+ "windows-implement 0.60.0",
  "winreg 0.52.0",
  "wintun",
  "zbus 5.5.0",
@@ -2283,7 +2283,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "windows 0.58.0",
+ "windows 0.61.1",
 ]
 
 [[package]]
@@ -2376,7 +2376,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "windows 0.58.0",
+ "windows 0.61.1",
  "windows-service",
  "winreg 0.52.0",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -186,6 +186,8 @@ url = "2.5.2"
 uuid = "1.16.0"
 which = "4.4.2"
 windows = "0.58.0"
+windows-core = "0.58.0"
+windows-implement = "0.58.0"
 winreg = "0.52.0"
 zbus = "5.5.0"
 zip = { version = "2", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -185,9 +185,9 @@ tun = { path = "tun" }
 url = "2.5.2"
 uuid = "1.16.0"
 which = "4.4.2"
-windows = "0.58.0"
-windows-core = "0.58.0"
-windows-implement = "0.58.0"
+windows = "0.61.0"
+windows-core = "0.61.0"
+windows-implement = "0.60.0"
 winreg = "0.52.0"
 zbus = "5.5.0"
 zip = { version = "2", default-features = false }

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -48,7 +48,6 @@ tokio-util = { workspace = true }
 workspace = true
 features = [
   # For implementing COM interfaces
-  "implement",
   "Win32_Foundation",
   # For listening for network change events
   "Win32_Networking_NetworkListManager",

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -38,8 +38,8 @@ zbus = { workspace = true } # Can't use `zbus`'s `tokio` feature here, or it wil
 known-folders = { workspace = true }
 ring = "0.17"
 uuid = { workspace = true, features = ["v4"] }
-windows-core = "0.58.0"
-windows-implement = "0.58.0"
+windows-core = { workspace = true }
+windows-implement = { workspace = true }
 wintun = "0.5.1"
 winreg = { workspace = true }
 tokio-util = { workspace = true }

--- a/rust/bin-shared/src/network_changes/windows.rs
+++ b/rust/bin-shared/src/network_changes/windows.rs
@@ -384,7 +384,7 @@ mod async_dns {
         task::LocalSet,
     };
     use windows::Win32::{
-        Foundation::{BOOLEAN, CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
+        Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
         System::Registry,
         System::Threading::{
             CreateEventA, INFINITE, RegisterWaitForSingleObject, UnregisterWaitEx,
@@ -627,7 +627,7 @@ mod async_dns {
     // This function runs on a worker thread in a Windows-managed thread pool where
     // many API calls are illegal, so try not to do anything in here. Right now
     // all we do is wake up our Tokio task.
-    unsafe extern "system" fn callback(ctx: *mut c_void, _: BOOLEAN) {
+    unsafe extern "system" fn callback(ctx: *mut c_void, _: bool) {
         let tx = unsafe { &*(ctx as *const mpsc::Sender<()>) };
         // It's not a problem if sending fails. It either means the `Listener`
         // is closing down, or it's already been notified.

--- a/rust/bin-shared/src/network_changes/windows.rs
+++ b/rust/bin-shared/src/network_changes/windows.rs
@@ -588,7 +588,13 @@ mod async_dns {
             // Ask Windows to signal our event once when anything inside this key changes.
             // We can't ask for repeated signals.
             unsafe {
-                Registry::RegNotifyChangeKeyValue(key_handle, true, notify_flags, inner.event, true)
+                Registry::RegNotifyChangeKeyValue(
+                    key_handle,
+                    true,
+                    notify_flags,
+                    Some(inner.event),
+                    true,
+                )
             }
             .ok()
             .context("`RegNotifyChangeKeyValue` failed")?;
@@ -606,7 +612,7 @@ mod async_dns {
         /// - `drop` which does not consume `self` and does not bubble errors, but which runs even if we forget to call `close`
         fn close_dont_drop(&mut self) -> Result<()> {
             if let Some(inner) = self.inner.take() {
-                unsafe { UnregisterWaitEx(inner.wait_handle, INVALID_HANDLE_VALUE) }
+                unsafe { UnregisterWaitEx(inner.wait_handle, Some(INVALID_HANDLE_VALUE)) }
                     .context("Should be able to `UnregisterWaitEx` in the DNS change listener")?;
                 unsafe { CloseHandle(inner.event) }
                     .context("Should be able to `CloseHandle` in the DNS change listener")?;
@@ -653,7 +659,7 @@ mod async_dns {
                 | Registry::REG_NOTIFY_THREAD_AGNOSTIC;
             let key_handle = Registry::HKEY(key.raw_handle() as *mut c_void);
             unsafe {
-                Registry::RegNotifyChangeKeyValue(key_handle, true, notify_flags, event, true)
+                Registry::RegNotifyChangeKeyValue(key_handle, true, notify_flags, Some(event), true)
             }
             .ok()
             .expect("`RegNotifyChangeKeyValue` failed");

--- a/rust/headless-client/src/ipc_service/windows.rs
+++ b/rust/headless-client/src/ipc_service/windows.rs
@@ -122,9 +122,9 @@ impl ProcessToken {
             LookupAccountSidW(
                 None,
                 sid,
-                PWSTR::from_raw(name.as_mut_ptr()),
+                Some(PWSTR::from_raw(name.as_mut_ptr())),
                 &mut name_size,
-                PWSTR::from_raw(domain.as_mut_ptr()),
+                Some(PWSTR::from_raw(domain.as_mut_ptr())),
                 &mut domain_size,
                 &mut sid_type,
             )


### PR DESCRIPTION
Version `0.61.0` is what most of our dependencies bring in, so depending on that allows us to unify the dependency tree here.