### PR TITLE
feat(connlib): request larger buffers for UDP sockets

### DIFF
--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -185,6 +185,15 @@ impl ThreadedUdpSocket {
                             }
                         };
 
+                        let send_buf_size = socket.send_buffer_size();
+                        let recv_buf_size = socket.recv_buffer_size();
+                        let port = socket.port();
+                        let ip_version = match addr {
+                            SocketAddr::V4(_) => "IPv4",
+                            SocketAddr::V6(_) => "IPv6",
+                        };
+
+                        tracing::info!(%send_buf_size, %recv_buf_size, %port, "Bound new {ip_version} UDP p2p socket");
 
                         let send = pin!(async {
                             while let Ok(datagram) = outbound_rx.recv_async().await {

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -193,16 +193,6 @@ impl ThreadedUdpSocket {
                             },
                         }
 
-                        let send_buf_size = socket.send_buffer_size();
-                        let recv_buf_size = socket.recv_buffer_size();
-                        let port = socket.port();
-                        let ip_version = match addr {
-                            SocketAddr::V4(_) => "IPv4",
-                            SocketAddr::V6(_) => "IPv6",
-                        };
-
-                        tracing::info!(%send_buf_size, %recv_buf_size, %port, "Bound new {ip_version} UDP p2p socket");
-
                         let send = pin!(async {
                             while let Ok(datagram) = outbound_rx.recv_async().await {
                                 if let Err(e) = socket.send(datagram).await {

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -173,7 +173,7 @@ impl ThreadedUdpSocket {
                     .build()
                     .expect("Failed to spawn tokio runtime on UDP thread")
                     .block_on(async move {
-                        let socket = match sf(&addr) {
+                        let mut socket = match sf(&addr) {
                             Ok(s) => {
                                 let _ = error_tx.send(Ok(()));
 
@@ -184,6 +184,14 @@ impl ThreadedUdpSocket {
                                 return;
                             }
                         };
+
+                        match socket.set_buffer_sizes(socket_factory::SEND_BUFFER_SIZE, socket_factory::RECV_BUFFER_SIZE) {
+                            Ok(()) => {},
+                            Err(e) => {
+                                let _ = error_tx.send(Err(e));
+                                return;
+                            },
+                        }
 
                         let send_buf_size = socket.send_buffer_size();
                         let recv_buf_size = socket.recv_buffer_size();

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -23,6 +23,8 @@ use tokio::io::Interest;
 
 pub trait SocketFactory<S>: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}
 
+pub const RECV_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+
 impl<F, S> SocketFactory<S> for F where F: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}
 
 pub fn tcp(addr: &SocketAddr) -> io::Result<TcpSocket> {
@@ -50,6 +52,8 @@ pub fn udp(std_addr: &SocketAddr) -> io::Result<UdpSocket> {
 
     socket.set_nonblocking(true)?;
     socket.bind(&addr)?;
+
+    socket.set_recv_buffer_size(RECV_BUFFER_SIZE)?;
 
     let send_buf_size = socket.send_buffer_size()?;
     let recv_buf_size = socket.recv_buffer_size()?;

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -23,6 +23,7 @@ use tokio::io::Interest;
 
 pub trait SocketFactory<S>: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}
 
+pub const SEND_BUFFER_SIZE: usize = 1 * 1024 * 1024;
 pub const RECV_BUFFER_SIZE: usize = 10 * 1024 * 1024;
 
 impl<F, S> SocketFactory<S> for F where F: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}
@@ -53,6 +54,7 @@ pub fn udp(std_addr: &SocketAddr) -> io::Result<UdpSocket> {
     socket.set_nonblocking(true)?;
     socket.bind(&addr)?;
 
+    socket.set_send_buffer_size(SEND_BUFFER_SIZE)?;
     socket.set_recv_buffer_size(RECV_BUFFER_SIZE)?;
 
     let send_buf_size = socket.send_buffer_size()?;

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -23,8 +23,9 @@ use tokio::io::Interest;
 
 pub trait SocketFactory<S>: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}
 
-pub const SEND_BUFFER_SIZE: usize = 1 * 1024 * 1024;
-pub const RECV_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+pub const SEND_BUFFER_SIZE: usize = ONE_MB;
+pub const RECV_BUFFER_SIZE: usize = 10 * ONE_MB;
+const ONE_MB: usize = 1024 * 1024;
 
 impl<F, S> SocketFactory<S> for F where F: Fn(&SocketAddr) -> io::Result<S> + Send + Sync + 'static {}
 

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -62,7 +62,7 @@ pub fn udp(std_addr: &SocketAddr) -> io::Result<UdpSocket> {
 
     let socket = std::net::UdpSocket::from(socket);
     let socket = tokio::net::UdpSocket::try_from(socket)?;
-    let socket = UdpSocket::new(socket, send_buf_size, recv_buf_size)?;
+    let socket = UdpSocket::new(socket)?;
 
     Ok(socket)
 }
@@ -160,16 +160,10 @@ pub struct UdpSocket {
 
     gro_batch_histogram: opentelemetry::metrics::Histogram<u64>,
     port: u16,
-    send_buffer_size: usize,
-    recv_buffer_size: usize,
 }
 
 impl UdpSocket {
-    fn new(
-        inner: tokio::net::UdpSocket,
-        send_buffer_size: usize,
-        recv_buffer_size: usize,
-    ) -> io::Result<Self> {
+    fn new(inner: tokio::net::UdpSocket) -> io::Result<Self> {
         let port = inner.local_addr()?.port();
 
         Ok(UdpSocket {
@@ -190,33 +184,25 @@ impl UdpSocket {
                 .with_unit("{batches}")
                 .with_boundaries((1..32_u64).map(|i| i as f64).collect())
                 .init(),
-            send_buffer_size,
-            recv_buffer_size,
         })
     }
 
     pub fn set_buffer_sizes(
         &mut self,
-        send_buffer_size: usize,
-        recv_buffer_size: usize,
+        requested_send_buffer_size: usize,
+        requested_recv_buffer_size: usize,
     ) -> io::Result<()> {
         let socket = socket2::SockRef::from(&self.inner);
 
-        socket.set_send_buffer_size(send_buffer_size)?;
-        socket.set_recv_buffer_size(recv_buffer_size)?;
+        socket.set_send_buffer_size(requested_send_buffer_size)?;
+        socket.set_recv_buffer_size(requested_recv_buffer_size)?;
 
-        self.send_buffer_size = send_buffer_size;
-        self.recv_buffer_size = recv_buffer_size;
+        let send_buffer_size = socket.send_buffer_size()?;
+        let recv_buffer_size = socket.recv_buffer_size()?;
+
+        tracing::info!(%requested_send_buffer_size, %send_buffer_size, %requested_recv_buffer_size, %recv_buffer_size, port = %self.port, "Set UDP socket buffer sizes");
 
         Ok(())
-    }
-
-    pub fn send_buffer_size(&self) -> usize {
-        self.send_buffer_size
-    }
-
-    pub fn recv_buffer_size(&self) -> usize {
-        self.recv_buffer_size
     }
 
     pub fn port(&self) -> u16 {

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -55,9 +55,6 @@ pub fn udp(std_addr: &SocketAddr) -> io::Result<UdpSocket> {
     socket.set_nonblocking(true)?;
     socket.bind(&addr)?;
 
-    socket.set_send_buffer_size(SEND_BUFFER_SIZE)?;
-    socket.set_recv_buffer_size(RECV_BUFFER_SIZE)?;
-
     let send_buf_size = socket.send_buffer_size()?;
     let recv_buf_size = socket.recv_buffer_size()?;
 
@@ -196,6 +193,22 @@ impl UdpSocket {
             send_buffer_size,
             recv_buffer_size,
         })
+    }
+
+    pub fn set_buffer_sizes(
+        &mut self,
+        send_buffer_size: usize,
+        recv_buffer_size: usize,
+    ) -> io::Result<()> {
+        let socket = socket2::SockRef::from(&self.inner);
+
+        socket.set_send_buffer_size(send_buffer_size)?;
+        socket.set_recv_buffer_size(recv_buffer_size)?;
+
+        self.send_buffer_size = send_buffer_size;
+        self.recv_buffer_size = recv_buffer_size;
+
+        Ok(())
     }
 
     pub fn send_buffer_size(&self) -> usize {

--- a/website/src/app/kb/deploy/gateways/readme.mdx
+++ b/website/src/app/kb/deploy/gateways/readme.mdx
@@ -127,12 +127,15 @@ to distribute Client connections across them.
 
 ### Performance tuning
 
-The default receive buffer size on Linux is quite small which can limit the maximum
-throughput. On startup, Gateways attempt to increase the size of the UDP receive
-buffers to 10 MB. However, the actual size of the receive buffer is limited by the
-`net.core.rmem_max` kernel parameter. For the increased buffer size to take effect,
-you may need to increase the `net.core.rmem_max` parameter in your system.
+The default receive buffer size on Linux is quite small which can limit the
+maximum throughput that users perceive in "upload scenarios" (i.e. where the
+Gateway needs to receive large volumes of traffic).
 
+On startup, the Gateway attempts to increase the size of the UDP receive buffers
+to 10 MB. However, the actual size of the receive buffer is limited by the
+`net.core.rmem_max` kernel parameter. For the increased buffer size to take
+effect, you may need to increase the `net.core.rmem_max` parameter on the
+Gateway's host system.
 ## Deploy a single Gateway
 
 Deploying a single Gateway can be accomplished in the admin portal.

--- a/website/src/app/kb/deploy/gateways/readme.mdx
+++ b/website/src/app/kb/deploy/gateways/readme.mdx
@@ -125,6 +125,14 @@ Firezone's
 [automatic load balancing](/kb/architecture/critical-sequences#high-availability)
 to distribute Client connections across them.
 
+### Performance tuning
+
+The default receive buffer size on Linux is quite small which can limit the maximum
+throughput. On startup, Gateways attempt to increase the size of the UDP receive
+buffers to 10 MB. However, the actual size of the receive buffer is limited by the
+`net.core.rmem_max` kernel parameter. For the increased buffer size to take effect,
+you may need to increase the `net.core.rmem_max` parameter in your system.
+
 ## Deploy a single Gateway
 
 Deploying a single Gateway can be accomplished in the admin portal.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -23,7 +23,14 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8731">
+          Improves throughput performance by requesting socket receive buffers
+          of 10MB. The actual size of the buffers is capped by the operating
+          system. You may need to adjust `kern.ipc.maxsockbuf` for this to take
+          full effect.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.12" date={new Date("2025-04-21")}>
         <ChangeItem pull="8798">
           Improves performance of relayed connections on IPv4-only systems.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -27,7 +27,7 @@ export default function Apple() {
         <ChangeItem pull="8731">
           Improves throughput performance by requesting socket receive buffers
           of 10MB. The actual size of the buffers is capped by the operating
-          system. You may need to adjust `kern.ipc.maxsockbuf` for this to take
+          system. You may need to adjust <code>kern.ipc.maxsockbuf</code> for this to take
           full effect.
         </ChangeItem>
       </Unreleased>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -13,7 +13,7 @@ export default function GUI({ os }: { os: OS }) {
           <ChangeItem pull="8731">
             Improves throughput performance by requesting socket receive buffers
             of 10MB. The actual size of the buffers is capped by the operating
-            system. You may need to adjust `net.core.rmem_max` for this to take
+            system. You may need to adjust <code>net.core.rmem_max</code> for this to take
             full effect.
           </ChangeItem>
           )}

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -8,7 +8,22 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os === OS.Linux && (
+          <ChangeItem pull="8731">
+            Improves throughput performance by requesting socket receive buffers
+            of 10MB. The actual size of the buffers is capped by the operating
+            system. You may need to adjust `net.core.rmem_max` for this to take
+            full effect.
+          </ChangeItem>
+          )}
+        {os === OS.Windows && (
+          <ChangeItem pull="8731">
+            Improves throughput performance by requesting socket receive buffers
+            of 10MB.
+          </ChangeItem>
+          )}
+      </Unreleased>
       <Entry version="1.4.11" date={new Date("2025-04-21")}>
         <ChangeItem pull="8798">
           Improves performance of relayed connections on IPv4-only systems.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -29,7 +29,7 @@ export default function Gateway() {
         <ChangeItem pull="8731">
           Improves throughput performance by requesting socket receive buffers
           of 10MB. The actual size of the buffers is capped by the operating
-          system. You may need to adjust `net.core.rmem_max` for this to take
+          system. You may need to adjust <code>net.core.rmem_max</code> for this to take
           full effect.
         </ChangeItem>
       </Unreleased>

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -26,6 +26,12 @@ export default function Gateway() {
         <ChangeItem pull="8798">
           Improves performance of relayed connections on IPv4-only systems.
         </ChangeItem>
+        <ChangeItem pull="8731">
+          Improves throughput performance by requesting socket receive buffers
+          of 10MB. The actual size of the buffers is capped by the operating
+          system. You may need to adjust `net.core.rmem_max` for this to take
+          full effect.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.6" date={new Date("2025-04-15")}>
         <ChangeItem pull="8383">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -13,6 +13,20 @@ export default function Headless({ os }: { os: OS }) {
         <ChangeItem pull="8798">
           Improves performance of relayed connections on IPv4-only systems.
         </ChangeItem>
+        {os === OS.Linux && (
+          <ChangeItem pull="8731">
+            Improves throughput performance by requesting socket receive buffers
+            of 10MB. The actual size of the buffers is capped by the operating
+            system. You may need to adjust `net.core.rmem_max` for this to take
+            full effect.
+          </ChangeItem>
+          )}
+        {os === OS.Windows && (
+          <ChangeItem pull="8731">
+            Improves throughput performance by requesting socket receive buffers
+            of 10MB.
+          </ChangeItem>
+          )}
       </Unreleased>
       <Entry version="1.4.6" date={new Date("2025-04-15")}>
         {os == OS.Linux && (

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -17,7 +17,7 @@ export default function Headless({ os }: { os: OS }) {
           <ChangeItem pull="8731">
             Improves throughput performance by requesting socket receive buffers
             of 10MB. The actual size of the buffers is capped by the operating
-            system. You may need to adjust `net.core.rmem_max` for this to take
+            system. You may need to adjust <code>net.core.rmem_max</code> for this to take
             full effect.
           </ChangeItem>
           )}


### PR DESCRIPTION
Sufficiently large receive buffers are important to sustain high-throughput as latency increases. If the receive buffer in the kernel is too small, packets need to be dropped on arrival.

Firefox uses 1MB in its QUIC stack [0]. `quic-go` recommends to set send and receive buffers to 7.5 MB [1]. Power users of Firezone are likely receiving a lot more traffic than the average Firefox user (especially with Internet Resource activated) so setting it to 10 MB seems reasonable. Sending packets is likely not as critical because we have back-pressure through our system such that we will stop reading IP packets when we cannot write to our UDP socket. The UDP socket is sitting in a separate thread and those threads are connected with dedicated queues which act as another buffer. However, as the data below shows, some systems have really small send buffers which are currently likely a speed bottleneck because we need to suspend writing so frequently.

Assuming a 50ms latency, the bandwidth-delay product tells us that we can (in theory) saturate a 1.6 Gbps link with a 10MB receive buffer (assuming the OS also has large enough buffer sizes in its TCP or QUIC stack):

```
80 Mb / 0.05s = 1600Mbps
```

Experiments and research [2] show the following:

|OS|Receive buffer (default)|Receive buffer (this PR)|Send buffer (default)|Send buffer (this PR)|
|---|---|---|---|---|
|Windows|65KB|10MB|65KB|1MB|
|MacOS|786KB|8MB|9KB|1MB|
|Linux|212KB|212KB|212KB|212KB|

With the exception of Linux, the OSes appear to be quite generous with how big they allow receive buffers to be. On Linux, these limit can be changed by setting the `core.net.rmem_max` and `core.net.wmem_max` parameters using `sysctl`.

Most of our users are on Windows and MacOS, meaning they immediately benefit from this without having to change any system settings. Larger client-side UDP receive buffers are critical for any "download" scenario which is likely the majority of usecases that Firezone is used for.

On Windows, increasing this receive buffer almost doubles the throughput in an iperf3 download test.

[0]: https://github.com/mozilla/neqo/pull/2470
[1]: https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
[2]: https://unix.stackexchange.com/a/424381