### PR TITLE
feat(connlib): supply multiple buffers to UDP socket

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -80,8 +80,8 @@ impl Default for Buffers {
 
         Self {
             ip: Vec::with_capacity(MAX_INBOUND_PACKET_BATCH),
-            udp4: Vec::from([0; ONE_MB]),
-            udp6: Vec::from([0; ONE_MB]),
+            udp4: vec![0; ONE_MB],
+            udp6: vec![0; ONE_MB],
         }
     }
 }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -39,8 +39,6 @@ const MAX_INBOUND_PACKET_BATCH: usize = {
     }
 };
 
-const MAX_UDP_SIZE: usize = (1 << 16) - 1;
-
 /// Bundles together all side-effects that connlib needs to have access to.
 pub struct Io {
     /// The UDP sockets used to send & receive packets from the network.
@@ -78,10 +76,12 @@ pub(crate) struct Buffers {
 
 impl Default for Buffers {
     fn default() -> Self {
+        const ONE_MB: usize = 1024 * 1024;
+
         Self {
             ip: Vec::with_capacity(MAX_INBOUND_PACKET_BATCH),
-            udp4: Vec::from([0; MAX_UDP_SIZE]),
-            udp6: Vec::from([0; MAX_UDP_SIZE]),
+            udp4: Vec::from([0; ONE_MB]),
+            udp6: Vec::from([0; ONE_MB]),
         }
     }
 }


### PR DESCRIPTION
At present, `connlib` uses `quinn-udp`'s GRO functionality to read multiple UDP packets within a single syscall. We are however only passing a single buffer and a single `RecvMeta` to the `recv` function. As a result, the function is limited to giving us only packets that originate from one particular IP.

By supplying multiple buffers (and their according `RecvMeta`s), we can now read packets from up to 10 different IPs at once within a single syscall. To obtain multiple buffers, we need to split the provided buffer into equal chunks. To ensure that each buffer can still hold several packets, we increase the buffer size to 1MB.

It is expected that is increases throughput especially on Gateways which receive UDP packets from many different IPs.