### PR TITLE
test(connlib): increase grace period for unit test

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -413,13 +413,7 @@ mod tests {
             panic!("Unexpected result");
         };
 
-        let grace_period = if cfg!(windows) {
-            Duration::from_millis(100)
-        } else {
-            Duration::from_millis(1)
-        };
-
-        assert!(timeout.duration_since(now) < grace_period);
+        assert!(timeout.duration_since(now) < Duration::from_millis(100));
     }
 
     static mut DUMMY_BUF: Buffers = Buffers {


### PR DESCRIPTION
This test appears to be sometimes flaky in CI, likely due to noisy neighbours.