### PR TITLE
revert: "Enable automatic tax calculation by default"

### DIFF
--- a/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
+++ b/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
@@ -93,7 +93,6 @@ defmodule Domain.Billing.Stripe.APIClient do
       URI.encode_query(
         %{
           "customer" => customer_id,
-          "automatic_tax[enabled]" => true,
           "items[0][price]" => price_id
         },
         :www_form

--- a/elixir/apps/domain/test/domain/billing_test.exs
+++ b/elixir/apps/domain/test/domain/billing_test.exs
@@ -560,8 +560,7 @@ defmodule Domain.BillingTest do
 
       assert params == %{
                "customer" => customer_id,
-               "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}},
-               "automatic_tax" => %{"enabled" => "true"}
+               "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}}
              }
     end
 
@@ -696,8 +695,7 @@ defmodule Domain.BillingTest do
 
       assert params == %{
                "customer" => customer_id,
-               "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}},
-               "automatic_tax" => %{"enabled" => "true"}
+               "items" => %{"0" => %{"price" => "price_1OkUIcADeNU9NGxvTNA4PPq6"}}
              }
     end
 


### PR DESCRIPTION
This needs #8670 in order to function.

Reverts firezone/firezone#8552