### PR TITLE
fix(portal): Fetch latest Okta access_token before API call

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapter/openid_connect/directory_sync.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapter/openid_connect/directory_sync.ex
@@ -140,12 +140,12 @@ defmodule Domain.Auth.Adapter.OpenIDConnect.DirectorySync do
     )
 
     finish_time = System.monotonic_time(:millisecond)
-    Logger.info("Finished syncing in #{time_taken(start_time, finish_time)}")
+    Logger.info("Finished syncing #{adapter} providers in #{time_taken(start_time, finish_time)}")
   end
 
   defp sync_provider(module, provider) do
     start_time = System.monotonic_time(:millisecond)
-    Logger.debug("Syncing provider")
+    Logger.info("Syncing provider: #{provider.id}")
 
     if Domain.Accounts.idp_sync_enabled?(provider.account) do
       {:ok, pid} = Task.Supervisor.start_link()

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
@@ -1,6 +1,7 @@
 defmodule Domain.Auth.Adapters.Okta.APIClient do
   use Supervisor
   require Logger
+  alias Domain.Auth.Provider
 
   @pool_name __MODULE__.Finch
 
@@ -29,7 +30,9 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     [conn_opts: [transport_opts: transport_opts]]
   end
 
-  def list_users(endpoint, api_token) do
+  def list_users(%Provider{} = provider) do
+    endpoint = provider.adapter_config["api_base_url"]
+
     uri =
       URI.parse("#{endpoint}/api/v1/users")
       |> URI.append_query(
@@ -42,7 +45,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
       {"Content-Type", "application/json; okta-response=omitCredentials,omitCredentialsLinks"}
     ]
 
-    with {:ok, users} <- list_all(uri, headers, api_token) do
+    with {:ok, users} <- list_all(uri, headers, provider) do
       active_users =
         Enum.filter(users, fn user ->
           user["status"] == "ACTIVE"
@@ -52,7 +55,9 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     end
   end
 
-  def list_groups(endpoint, api_token) do
+  def list_groups(%Provider{} = provider) do
+    endpoint = provider.adapter_config["api_base_url"]
+
     uri =
       URI.parse("#{endpoint}/api/v1/groups")
       |> URI.append_query(
@@ -63,10 +68,12 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
 
     headers = []
 
-    list_all(uri, headers, api_token)
+    list_all(uri, headers, provider)
   end
 
-  def list_group_members(endpoint, api_token, group_id) do
+  def list_group_members(%Provider{} = provider, group_id) do
+    endpoint = provider.adapter_config["api_base_url"]
+
     uri =
       URI.parse("#{endpoint}/api/v1/groups/#{group_id}/users")
       |> URI.append_query(
@@ -77,7 +84,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
 
     headers = []
 
-    with {:ok, members} <- list_all(uri, headers, api_token) do
+    with {:ok, members} <- list_all(uri, headers, provider) do
       enabled_members =
         Enum.filter(members, fn member ->
           member["status"] == "ACTIVE"
@@ -87,14 +94,14 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     end
   end
 
-  defp list_all(uri, headers, api_token, acc \\ []) do
-    case list(uri, headers, api_token) do
+  defp list_all(uri, headers, provider, acc \\ []) do
+    case list(uri, headers, provider) do
       {:ok, list, nil} ->
         {:ok, List.flatten(Enum.reverse([list | acc]))}
 
       {:ok, list, next_page_uri} ->
         URI.parse(next_page_uri)
-        |> list_all(headers, api_token, [list | acc])
+        |> list_all(headers, provider, [list | acc])
 
       {:error, reason} ->
         {:error, reason}
@@ -108,7 +115,8 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
   end
 
   # TODO: Need to catch 401/403 specifically when error message is in header
-  defp list(uri, headers, api_token) do
+  defp list(uri, headers, %Provider{} = provider) do
+    api_token = fetch_latest_access_token(provider)
     headers = headers ++ [{"Authorization", "Bearer #{api_token}"}]
     request = Finch.build(:get, uri, headers)
 
@@ -135,17 +143,21 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
 
         {:error, :invalid_response}
 
-      {:ok, %Finch.Response{body: raw_body, status: status}} when status in 400..499 ->
+      {:ok, %Finch.Response{body: raw_body, status: status, headers: headers}}
+      when status in 400..499 ->
         Logger.error("API request failed with 4xx status #{status}",
           response: inspect(response)
         )
 
         case Jason.decode(raw_body) do
           {:ok, json_response} ->
+            # Errors are in JSON body
             {:error, {status, json_response}}
 
           _error ->
-            {:error, {status, response}}
+            # Errors should be in www-authenticate header
+            error_map = parse_headers_for_errors(headers)
+            {:error, {status, error_map}}
         end
 
       {:ok, %Finch.Response{status: status}} when status in 500..599 ->
@@ -190,4 +202,59 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
   end
 
   defp parse_link_header(nil), do: nil
+
+  defp parse_headers_for_errors(headers) do
+    headers
+    |> Enum.find({}, fn {key, _val} -> key == "www-authenticate" end)
+    |> parse_error_header()
+  end
+
+  defp parse_error_header({"www-authenticate", errors}) do
+    String.split(errors, ",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.filter(&String.starts_with?(&1, "error"))
+    |> Enum.map(&String.replace(&1, "\"", ""))
+    |> Enum.map(&String.split(&1, "="))
+    |> Enum.into(%{}, fn [k, v] -> {k, v} end)
+  end
+
+  defp parse_error_header(_) do
+    Logger.info("No www-authenticate header present")
+    %{"error" => "unknown", "error_message" => "no www-authenticate header present"}
+  end
+
+  defp fetch_latest_access_token(provider) do
+    access_token = provider.adapter_state["access_token"]
+
+    if is_access_token_active?(access_token) do
+      access_token
+    else
+      # Fetch provider from DB and return latest access token
+      {:ok, provider} = Domain.Auth.fetch_active_provider_by_id(provider.id)
+      provider.adapter_state["access_token"]
+    end
+  end
+
+  defp is_access_token_active?(nil) do
+    Logger.info("JWT is nil")
+    false
+  end
+
+  defp is_access_token_active?("") do
+    Logger.info("JWT is empty")
+    false
+  end
+
+  defp is_access_token_active?(token) when is_binary(token) do
+    current_time = DateTime.utc_now()
+
+    with jwt <- JOSE.JWT.peek(token),
+         {:ok, timestamp_time} <- DateTime.from_unix(jwt.fields["exp"]),
+         :lt <- DateTime.compare(current_time, timestamp_time),
+         time_diff <- DateTime.diff(timestamp_time, current_time) do
+      time_diff >= 2 * 60
+    else
+      _ -> false
+    end
+  end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
@@ -274,12 +274,10 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
   end
 
   defp parse_jwt(token) do
-    try do
-      {:ok, JOSE.JWT.peek(token)}
-    rescue
-      ArgumentError -> {:error, "Could not parse token"}
-      Jason.DecodeError -> {:error, "Could not decode token json"}
-      _ -> {:error, "Unknown error while parsing jwt"}
-    end
+    {:ok, JOSE.JWT.peek(token)}
+  rescue
+    ArgumentError -> {:error, "Could not parse token"}
+    Jason.DecodeError -> {:error, "Could not decode token json"}
+    _ -> {:error, "Unknown error while parsing jwt"}
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
@@ -235,15 +235,8 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     end
   end
 
-  defp access_token_active?(nil) do
-    Logger.info("JWT is nil")
-    false
-  end
-
-  defp access_token_active?("") do
-    Logger.info("JWT is empty")
-    false
-  end
+  defp access_token_active?(nil), do: false
+  defp access_token_active?(""), do: false
 
   defp access_token_active?(token) when is_binary(token) do
     current_time = DateTime.utc_now()

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
@@ -226,7 +226,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
   defp fetch_latest_access_token(provider) do
     access_token = provider.adapter_state["access_token"]
 
-    if is_access_token_active?(access_token) do
+    if access_token_active?(access_token) do
       access_token
     else
       # Fetch provider from DB and return latest access token
@@ -235,17 +235,17 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     end
   end
 
-  defp is_access_token_active?(nil) do
+  defp access_token_active?(nil) do
     Logger.info("JWT is nil")
     false
   end
 
-  defp is_access_token_active?("") do
+  defp access_token_active?("") do
     Logger.info("JWT is empty")
     false
   end
 
-  defp is_access_token_active?(token) when is_binary(token) do
+  defp access_token_active?(token) when is_binary(token) do
     current_time = DateTime.utc_now()
 
     with jwt <- JOSE.JWT.peek(token),

--- a/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/sync_directory_test.exs
@@ -6,10 +6,30 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
 
   describe "execute/1" do
     setup do
+      jwk = %{
+        "kty" => "oct",
+        "k" => :jose_base64url.encode("super_secret_key")
+      }
+
+      jws = %{
+        "alg" => "HS256"
+      }
+
+      claims = %{
+        "sub" => "1234567890",
+        "name" => "FooBar",
+        "iat" => DateTime.utc_now() |> DateTime.to_unix(),
+        "exp" => DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.to_unix()
+      }
+
+      {_, jwt} =
+        JOSE.JWT.sign(jwk, jws, claims)
+        |> JOSE.JWS.compact()
+
       account = Fixtures.Accounts.create_account()
 
       {provider, bypass} =
-        Fixtures.Auth.start_and_create_okta_provider(account: account)
+        Fixtures.Auth.start_and_create_okta_provider(account: account, access_token: jwt)
 
       %{
         bypass: bypass,

--- a/elixir/apps/domain/test/support/fixtures/auth.ex
+++ b/elixir/apps/domain/test/support/fixtures/auth.ex
@@ -302,12 +302,17 @@ defmodule Domain.Fixtures.Auth do
         Fixtures.Accounts.create_account(assoc_attrs)
       end)
 
+    {access_token, attrs} =
+      pop_assoc_fixture(attrs, :access_token, & &1)
+
     {:ok, provider} = Auth.create_provider(account, attrs)
+
+    access_token = access_token || "OIDC_ACCESS_TOKEN"
 
     update!(provider,
       disabled_at: nil,
       adapter_state: %{
-        "access_token" => "OIDC_ACCESS_TOKEN",
+        "access_token" => access_token,
         "refresh_token" => "OIDC_REFRESH_TOKEN",
         "expires_at" => DateTime.utc_now() |> DateTime.add(1, :day),
         "claims" => "openid email profile offline_access"


### PR DESCRIPTION
Why:

* The Okta IdP sync job needs to make sure it is always using the latest access token available.  If not, there is the possibility for the job to take too long to complete and the access token that the job started with might time out.  This commit updates the Okta API client to always check and make sure it is using the latest access token for each request to the Okta API.