### PR TITLE
fix(portal): Attach Sentry in each umbrella app

### DIFF
--- a/elixir/apps/api/lib/api/application.ex
+++ b/elixir/apps/api/lib/api/application.ex
@@ -6,6 +6,15 @@ defmodule API.Application do
     _ = :opentelemetry_cowboy.setup()
     _ = OpentelemetryPhoenix.setup(adapter: :cowboy2)
 
+    # Configure Sentry to capture Logger messages
+    :logger.add_handler(:sentry, Sentry.LoggerHandler, %{
+      config: %{
+        level: :warning,
+        metadata: :all,
+        capture_log_messages: true
+      }
+    })
+
     children = [
       API.Endpoint,
       API.RateLimit

--- a/elixir/apps/domain/lib/domain/telemetry/sentry.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/sentry.ex
@@ -1,9 +1,9 @@
 defmodule Domain.Telemetry.Sentry do
-  def before_send(%{original_exception: %{report_to_sentry: report_to_sentry}} = event) do
-    if report_to_sentry do
-      event
-    else
+  def before_send(%{original_exception: %{skip_sentry: skip_sentry}} = event) do
+    if skip_sentry do
       nil
+    else
+      event
     end
   end
 

--- a/elixir/apps/web/lib/web/application.ex
+++ b/elixir/apps/web/lib/web/application.ex
@@ -7,6 +7,15 @@ defmodule Web.Application do
     _ = :opentelemetry_cowboy.setup()
     _ = OpentelemetryPhoenix.setup(adapter: :cowboy2)
 
+    # Configure Sentry to capture Logger messages
+    :logger.add_handler(:sentry, Sentry.LoggerHandler, %{
+      config: %{
+        level: :warning,
+        metadata: :all,
+        capture_log_messages: true
+      }
+    })
+
     children = [
       Web.Endpoint
     ]

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -25,7 +25,7 @@ defmodule Web.SignIn do
       {:ok, socket}
     else
       _other ->
-        raise Web.LiveErrors.NotFoundError, report_to_sentry: false
+        raise Web.LiveErrors.NotFoundError, skip_sentry: true
     end
   end
 

--- a/elixir/apps/web/lib/web/live_errors.ex
+++ b/elixir/apps/web/lib/web/live_errors.ex
@@ -1,6 +1,6 @@
 defmodule Web.LiveErrors do
   defmodule NotFoundError do
-    defexception message: "Not Found", report_to_sentry: true
+    defexception message: "Not Found", skip_sentry: false
 
     defimpl Plug.Exception do
       def status(_exception), do: 404

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -168,17 +168,6 @@ config :web, api_url_override: "ws://localhost:13001/"
 ##### API #####################
 ###############################
 
-config :api, :logger, [
-  {:handler, :api, Sentry.LoggerHandler,
-   %{
-     config: %{
-       level: :warning,
-       metadata: :all,
-       capture_log_messages: true
-     }
-   }}
-]
-
 config :api, ecto_repos: [Domain.Repo]
 config :api, generators: [binary_id: true, context_app: :domain]
 


### PR DESCRIPTION
- Attaches the Sentry Logging hook in each of [api, web, domain]
- Removes errant Sentry logging configuration in config/config.exs
- Fixes the exception logger to default to logging exceptions, use `skip_sentry: true` to skip

Tested successfully in dev. Hopefully the cluster behaves the same way.

Fixes #8639 