### PR TITLE
fix(connlib): correctly compute the GSO batch size

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -19,7 +19,12 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="8754">
+          Fixes a performance regression that could lead to packet drops under
+          high load.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-03-15")}>
         <ChangeItem pull="8445">
           Fixes a bug where search domains changes weren't applied if already signed in.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -8,7 +8,14 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os === OS.Linux && (
+          <ChangeItem pull="8754">
+            Fixes a performance regression that could lead to packet drops under
+            high load.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.4.9" date={new Date("2025-03-14")}>
         {os === OS.Windows && (
           <ChangeItem pull="8422">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -26,6 +26,10 @@ export default function Gateway() {
         <ChangeItem pull="8383">
           Deprecates the NAT64 functionality in favor of sending ICMP errors.
         </ChangeItem>
+        <ChangeItem pull="8754">
+          Fixes a performance regression that could lead to packet drops under
+          high load.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-03-10")}>
         <ChangeItem pull="8124">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -9,7 +9,14 @@ export default function Headless({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os == OS.Linux && (
+          <ChangeItem pull="8754">
+            Fixes a performance regression that could lead to packet drops under
+            high load.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.4.5" date={new Date("2025-03-14")}>
         {os === OS.Windows && (
           <ChangeItem pull="8422">


### PR DESCRIPTION
We are currently naively chunking our buffer into `segment_size * max_gso_segments()`. `max_gso_segments` is by default 64. Assuming we processed several IP packets, this would quickly balloon to a size that the kernel cannot handle. For example, during an `iperf3` run, we receive _a lot_ of packets at maximum MTU size (1280). With the overhead that we are adding to the packet, this results in a UDP payload size of 1320.

```
1320 x 64 = 84480
```

That is way too large for the kernel to handle and it will fail the `sendmsg` call with `EMSGSIZE`. Unfortunately, this error wasn't surfaced because `quinn_udp` handles it internally because it can also happen as a result of MTU probes.

We've already patched `quinn_udp` in the past to move the handling of more quinn-specific errors to the infallible `send` function. The same is being done for this error in https://github.com/quinn-rs/quinn/pull/2199.

Resolves: #8699