### PR TITLE
build(rust): depend on `quinn-udp`'s `main` branch

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5327,9 +5327,8 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+version = "0.5.11"
+source = "git+https://github.com/quinn-rs/quinn?branch=main#8f1a529837c7c99741d4097446a85e4482bf65b3"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -208,6 +208,7 @@ ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "mas
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.26" } # Waiting for release.
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.
+quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']


### PR DESCRIPTION
The latest `main` of `quinn-udp` includes important patches that will surface errors around dropped packets.