### PR TITLE
chore(connlib): log all tunnel errors on WARN

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -1,7 +1,6 @@
 use crate::{PHOENIX_TOPIC, callbacks::Callbacks};
 use anyhow::Result;
 use connlib_model::{PublicKey, ResourceId};
-use firezone_logging::{err_with_src, telemetry_event};
 use firezone_tunnel::messages::RelaysPresence;
 use firezone_tunnel::messages::client::{
     EgressMessages, FailReason, FlowCreated, FlowCreationFailed, GatewayIceCandidates,
@@ -96,12 +95,9 @@ where
                     continue;
                 }
                 Poll::Ready(Err(e)) => {
-                    debug_assert_ne!(
-                        e.kind(),
-                        io::ErrorKind::WouldBlock,
-                        "Tunnel should never emit WouldBlock errors but suspend instead"
-                    );
-                    telemetry_event!("Tunnel error: {}", err_with_src(&e));
+                    let e = anyhow::Error::new(e);
+
+                    tracing::warn!("Tunnel error: {e:#}");
                     continue;
                 }
                 Poll::Pending => {}


### PR DESCRIPTION
Currently, errors encountered as part of operating the tunnel are non-fatal and only logged on `TRACE` in order to not flood the logs. Recent improvements around how the event loop operates made it such that we actually emit a lot less errors and ideally there should be 0. Therefore we can now employ a much more strict policy and log all errors here on `WARN` in order to get Sentry alerts.