### PR TITLE
chore(rust): remove resolved duplicated dependency exclusion

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -71,7 +71,7 @@ jobs:
       - run: cargo clippy --all-targets --all-features ${{ steps.setup-rust.outputs.packages }}
         name: "cargo clippy"
         shell: bash
-      - run: cargo deny check --hide-inclusion-graph
+      - run: cargo deny check --hide-inclusion-graph --deny unnecessary-skip
         shell: bash
 
   test:

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -263,7 +263,6 @@ skip = [
   "regex-syntax",
   "syn",
   "sync_wrapper",
-  "tauri-winrt-notification",
   "thiserror",
   "thiserror-impl",
   "toml_edit",


### PR DESCRIPTION
We no longer have multiple versions of `tauri-winrt-notification` in our dependency tree and can therefore remove this exclusion rule.

To ensure that we don't forget to update these in the future, we now deny the `unnecessary-skip` lint that warns us when we have one of those entries.