### PR TITLE
chore(nix): bump to 24.11 and remove `flake-utils`

### DIFF
--- a/scripts/nix/flake.lock
+++ b/scripts/nix/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1744309437,
@@ -35,23 +17,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/scripts/nix/flake.lock
+++ b/scripts/nix/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "lastModified": 1744309437,
+        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "type": "indirect"
       }
     },

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-24.05";
+    nixpkgs.url = "nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -29,7 +29,7 @@
             libsoup
             webkitgtk
             librsvg
-            gnome.zenity
+            zenity
             desktop-file-utils
             android-tools
             terraform

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -1,66 +1,64 @@
 {
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-24.11";
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem
-      (
-        system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            config = {
-              allowUnfree = true;
-            };
-          };
+  outputs = { nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+        config = {
+          allowUnfree = true;
+        };
+      };
 
-          packages = with pkgs; [
-            rustup # We use `rustup` to manage the Rust installation in order to get `+nightly` etc features.
+      packages = with pkgs; [
+        rustup # We use `rustup` to manage the Rust installation in order to get `+nightly` etc features.
 
-            curl
-            wget
-            pkg-config
-            dbus
-            openssl_3
-            glib
-            gtk3
-            libsoup
-            webkitgtk
-            librsvg
-            zenity
-            desktop-file-utils
-            android-tools
-            terraform
-            llvmPackages.bintools-unwrapped
-            bpftools
+        curl
+        wget
+        pkg-config
+        dbus
+        openssl_3
+        glib
+        gtk3
+        libsoup
+        webkitgtk
+        librsvg
+        zenity
+        desktop-file-utils
+        android-tools
+        terraform
+        llvmPackages.bintools-unwrapped
+        bpftools
 
-            # For Tauri
-            at-spi2-atk
-            atkmm
-            cairo
-            gdk-pixbuf
-            glib
-            gobject-introspection
-            gobject-introspection.dev
-            gtk3
-            harfbuzz
-            librsvg
-            libsoup_3
-            pango
-            webkitgtk_4_1
-            webkitgtk_4_1.dev
-          ];
-        in
-        {
-          devShells.default = pkgs.mkShell {
-            packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.pnpm pkgs.cargo-sort pkgs.cargo-deny pkgs.cargo-autoinherit ];
-            buildInputs = packages;
-            src = ../..;
+        # For Tauri
+        at-spi2-atk
+        atkmm
+        cairo
+        gdk-pixbuf
+        glib
+        gobject-introspection
+        gobject-introspection.dev
+        gtk3
+        harfbuzz
+        librsvg
+        libsoup_3
+        pango
+        webkitgtk_4_1
+        webkitgtk_4_1.dev
+      ];
+    in
+    {
+      devShells = {
+        x86_64-linux.default = pkgs.mkShell {
+          packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.pnpm pkgs.cargo-sort pkgs.cargo-deny pkgs.cargo-autoinherit ];
+          buildInputs = packages;
+          src = ../..;
 
-            PKG_CONFIG_PATH = with pkgs; "${glib.dev}/lib/pkgconfig:${libsoup_3.dev}/lib/pkgconfig:${webkitgtk_4_1.dev}/lib/pkgconfig:${at-spi2-atk.dev}/lib/pkgconfig:${gtk3.dev}/lib/pkgconfig:${gdk-pixbuf.dev}/lib/pkgconfig:${cairo.dev}/lib/pkgconfig:${pango.dev}/lib/pkgconfig:${harfbuzz.dev}/lib/pkgconfig";
-          };
-        }
-      );
+          PKG_CONFIG_PATH = with pkgs; "${glib.dev}/lib/pkgconfig:${libsoup_3.dev}/lib/pkgconfig:${webkitgtk_4_1.dev}/lib/pkgconfig:${at-spi2-atk.dev}/lib/pkgconfig:${gtk3.dev}/lib/pkgconfig:${gdk-pixbuf.dev}/lib/pkgconfig:${cairo.dev}/lib/pkgconfig:${pango.dev}/lib/pkgconfig:${harfbuzz.dev}/lib/pkgconfig";
+        };
+      };
+    };
 }


### PR DESCRIPTION
In order to get more recent tools like `cargo deny` that support Rust 2024, we need to bump the nixpkgs release we depend on to 24.11. As part of doing so, we simplify the flake to not depend on `flake-utils` as we only build for a single system anyway.