### PR TITLE
ci: only run 1000 proptest cases on Windows

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -135,7 +135,7 @@ jobs:
           # Needed to create tunnel interfaces in unit tests
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
-          PROPTEST_CASES: 2000 # Default is only 256.
+          PROPTEST_CASES: ${{ runner.os == 'Windows' && 1000 || 2000 }} # Default is only 256. Windows is very slow in GitHub Actions, so only run a 1000 cases there.
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
           TESTCASES_DIR: "connlib/tunnel/testcases"
 


### PR DESCRIPTION
Windows runners are very slow on GitHub actions. The Rust tests on Windows are regularly the last CI job to finish. In order to speed up overall CI runtime, reduce the number of cases we run on Windows to 1000. It doesn't really matter which OS we run these on as the proptests are entirely platform-agnostic. We just need to get a good amount of testcases in on each CI run.