### PR TITLE
fix(portal): Increase directory sync timeout to 8 hours

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapter/openid_connect/directory_sync.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapter/openid_connect/directory_sync.ex
@@ -8,11 +8,11 @@ defmodule Domain.Auth.Adapter.OpenIDConnect.DirectorySync do
   # The Finch will timeout requests after 30 seconds,
   # but there are a lot of requests that need to be made
   # so we don't want to limit the timeout here
-  @async_data_fetch_timeout :timer.minutes(30)
+  @async_data_fetch_timeout :timer.hours(4)
 
   # This timeout is used to limit the time spent on a single provider
   # inserting the records into the database
-  @database_operations_timeout :timer.minutes(30)
+  @database_operations_timeout :timer.hours(4)
 
   @provider_sync_timeout @async_data_fetch_timeout + @database_operations_timeout
 


### PR DESCRIPTION
Large Okta directories can take a very long time (> 1 hour) to sync. This currently times out, preventing any entities from making it into the database.

There are many things to address in our sync operation, but this should hopefully resolve the immediate issue with the customer.

https://firezone-inc.sentry.io/issues/6537862651/?project=4508756715569152&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20Enum.to_list&referrer=issue-stream&stream_index=0