### PR TITLE
chore(gateway): require 4 cores to spawn more TUN threads

### DIFF
--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -261,7 +261,7 @@ struct NumThreads(pub usize);
 
 impl Default for NumThreads {
     fn default() -> Self {
-        if num_cpus::get() < 2 {
+        if num_cpus::get() < 4 {
             return Self(1);
         }
 


### PR DESCRIPTION
By default, we spawn 1 TUN send and 1 TUN receive thread on the Gateway. In addition to that, we also have the main processing thread that encrypts and decrypts packets. With #7590, we will be separating out the UDP send and receive operations into yet another thread. As a result, we will have at a minimum 4 threads running that perform IO or important work.

Thus, in order to benefit from TUN multi-queue, we need more than 4 cores to be able to efficiently parallelise work.

Related: #8769