### PR TITLE
chore(ci): Upload signed artifacts to run on workflow_dispatch

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -76,13 +76,13 @@ jobs:
           ${{ matrix.build-command }}
           rm "$KEYSTORE_PATH"
       - name: Setup sentry CLI
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           organization: firezone-inc
       - name: Upload debug symbols to Sentry
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         run: |
           sentry-cli debug-files upload --log-level info --project android-client --include-sources ../../rust/target
       - name: Run Unit Test
@@ -95,7 +95,7 @@ jobs:
           path: |
             ./kotlin/android/${{ matrix.output-path }}
       - name: Upload package to release
-        if: ${{ matrix.package-type == 'apk' && github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.ref_name == 'main' && matrix.package-type == 'apk' && github.event_name == 'workflow_dispatch' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # mark:next-android-version

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -76,13 +76,13 @@ jobs:
           ${{ matrix.build-command }}
           rm "$KEYSTORE_PATH"
       - name: Setup sentry CLI
-        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           organization: firezone-inc
       - name: Upload debug symbols to Sentry
-        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         run: |
           sentry-cli debug-files upload --log-level info --project android-client --include-sources ../../rust/target
       - name: Run Unit Test

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -120,13 +120,13 @@ jobs:
           RELEASE_NAME: "${{ matrix.release-name }}"
           PLATFORM: "${{ matrix.platform }}"
       - name: Setup sentry CLI
-        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           organization: firezone-inc
       - name: Upload debug symbols to Sentry
-        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         run: |
           # Remove the /Applications symlink in the DMG staging directory so Sentry doesn't
           # attempt to walk it.

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -105,12 +105,12 @@ jobs:
           TEMP_DIR: "${{ runner.temp }}"
       - name: Upload package artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: "${{ matrix.job_name == 'build-macos-standalone' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' && matrix.job_name == 'build-macos-standalone' }}"
         with:
           name: ${{ matrix.artifact-file }}
           path: "${{ runner.temp }}/${{ matrix.artifact-file }}"
       - run: ${{ matrix.upload-script }}
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         env:
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"
@@ -120,13 +120,13 @@ jobs:
           RELEASE_NAME: "${{ matrix.release-name }}"
           PLATFORM: "${{ matrix.platform }}"
       - name: Setup sentry CLI
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           organization: firezone-inc
       - name: Upload debug symbols to Sentry
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         run: |
           # Remove the /Applications symlink in the DMG staging directory so Sentry doesn't
           # attempt to walk it.


### PR DESCRIPTION
When testing certain PRs, it's helpful to have signed release builds for various platforms.

These can be built by manually triggering their respective workflow from the GitHub UI. In these cases, we want to upload the artifacts to the workflow run, but _not_ upload the artifacts to the release.

We only want to upload artifacts to the release if the `github.ref_name` is `main`.