### PR TITLE
fix(connlib): fail event-loops if UDP threads stop

### DIFF
--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -96,6 +96,12 @@ where
                         continue;
                     }
 
+                    if e.root_cause()
+                        .is::<firezone_tunnel::UdpSocketThreadStopped>()
+                    {
+                        return Poll::Ready(Err(e));
+                    }
+
                     tracing::warn!("Tunnel error: {e:#}");
                     continue;
                 }

--- a/rust/connlib/clients/shared/src/eventloop.rs
+++ b/rust/connlib/clients/shared/src/eventloop.rs
@@ -1,5 +1,5 @@
 use crate::{PHOENIX_TOPIC, callbacks::Callbacks};
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use connlib_model::{PublicKey, ResourceId};
 use firezone_tunnel::messages::RelaysPresence;
 use firezone_tunnel::messages::client::{
@@ -55,7 +55,7 @@ impl<C> Eventloop<C>
 where
     C: Callbacks + 'static,
 {
-    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), phoenix_channel::Error>> {
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
         loop {
             match self.rx.poll_recv(cx) {
                 Poll::Ready(None) => return Poll::Ready(Ok(())),
@@ -102,8 +102,9 @@ where
                 Poll::Pending => {}
             }
 
-            match self.portal.poll(cx)? {
-                Poll::Ready(event) => {
+            match self.portal.poll(cx) {
+                Poll::Ready(result) => {
+                    let event = result.context("connection to the portal failed")?;
                     self.handle_portal_event(event);
                     continue;
                 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -71,6 +71,7 @@ pub type ClientTunnel = Tunnel<ClientState>;
 pub use client::ClientState;
 pub use gateway::{DnsResourceNatEntry, GatewayState, ResolveDnsRequest};
 pub use io::NoNameserverAvailable;
+pub use sockets::UdpSocketThreadStopped;
 pub use utils::turn;
 
 /// [`Tunnel`] glues together connlib's [`Io`] component and the respective (pure) state of a client or gateway.

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -58,7 +58,7 @@ impl Sockets {
         Poll::Ready(())
     }
 
-    pub fn poll_send_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    pub fn poll_send_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
         if let Some(socket) = self.socket_v4.as_mut() {
             ready!(socket.poll_send_ready(cx))?;
         }
@@ -227,26 +227,29 @@ impl ThreadedUdpSocket {
         })
     }
 
-    fn poll_send_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.outbound_tx
-            .poll_ready_unpin(cx)
-            .map_err(io::Error::other)
+    fn poll_send_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        ready!(self.outbound_tx.poll_ready_unpin(cx)).map_err(|_| UdpSocketThreadStopped)?;
+
+        Poll::Ready(Ok(()))
     }
 
-    fn send(&mut self, datagram: DatagramOut) -> io::Result<()> {
+    fn send(&mut self, datagram: DatagramOut) -> Result<()> {
         self.outbound_tx
             .start_send_unpin(datagram)
-            .map_err(io::Error::other)
+            .map_err(|_| UdpSocketThreadStopped)?;
+
+        Ok(())
     }
 
-    fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<DatagramSegmentIter>> {
+    fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<Result<DatagramSegmentIter>> {
         let Some(iter) = ready!(self.inbound_rx.poll_next_unpin(cx)) else {
-            return Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::NotConnected,
-                "UDP recv thread stopped",
-            )));
+            return Poll::Ready(Err(anyhow::Error::new(UdpSocketThreadStopped)));
         };
 
         Poll::Ready(Ok(iter))
     }
 }
+
+#[derive(thiserror::Error, Debug)]
+#[error("UDP socket thread stopped")]
+pub struct UdpSocketThreadStopped;

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -242,9 +242,7 @@ impl ThreadedUdpSocket {
     }
 
     fn poll_recv_from(&mut self, cx: &mut Context<'_>) -> Poll<Result<DatagramSegmentIter>> {
-        let Some(iter) = ready!(self.inbound_rx.poll_next_unpin(cx)) else {
-            return Poll::Ready(Err(anyhow::Error::new(UdpSocketThreadStopped)));
-        };
+        let iter = ready!(self.inbound_rx.poll_next_unpin(cx)).ok_or(UdpSocketThreadStopped)?;
 
         Poll::Ready(Ok(iter))
     }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -128,6 +128,12 @@ impl Eventloop {
                         return Poll::Ready(Err(e));
                     }
 
+                    if e.root_cause()
+                        .is::<firezone_tunnel::UdpSocketThreadStopped>()
+                    {
+                        return Poll::Ready(Err(e));
+                    }
+
                     tracing::warn!("Tunnel error: {e:#}");
                     continue;
                 }


### PR DESCRIPTION
The UDP socket threads added in #7590 are designed to never exit. UDP sockets are stateless and therefore any error condition on them should be isolated to sending / receiving a particular datagram. It is however possible that code panics which will shut down the threads irrecoverably. In this unlikely event, `connlib`'s event-loop would keep spinning and spam the log with "UDP socket stopped". There is no good way on how we can recover from such a situation automatically, so we just quit `connlib` in that case and shut everything down.

To model this new error path, we refactor the `DisconnectError` to be internally backed by `anyhow`.