### PR TITLE
fix(connlib): disable `apple-fast-datapath` on `quinn-udp`

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -118,7 +118,7 @@ phoenix-channel = { path = "phoenix-channel" }
 png = "0.17.16"
 proptest = "1.6.0"
 proptest-state-machine = "0.3.1"
-quinn-udp = { version = "0.5.8", features = ["fast-apple-datapath"] }
+quinn-udp = { version = "0.5.8" }
 rand = "0.8.5"
 gat-lending-iterator = "0.1.6"
 rand_core = "0.6.4"


### PR DESCRIPTION
There appears to be a regression on the most recent MacOS release (15.4) where we can no longer set `src_ip` on outgoing datagrams for IPv6 sockets. In order to unblock the upcoming release, disable the `fast-apple-datapath` feature until we know how to fix it.

Related: https://github.com/quinn-rs/quinn/issues/2206
Resolves: #8779 