### PR TITLE
chore(rust-ffi): log non-authentication errors on error

### DIFF
--- a/rust/connlib/clients/android/src/lib.rs
+++ b/rust/connlib/clients/android/src/lib.rs
@@ -258,6 +258,10 @@ impl Callbacks for CallbackHandler {
     }
 
     fn on_disconnect(&self, error: DisconnectError) {
+        if !error.is_authentication_error() {
+            tracing::error!("{error}")
+        }
+
         self.env(|mut env| {
             let error = env
                 .new_string(serde_json::to_string(&error.to_string())?)

--- a/rust/connlib/clients/apple/src/lib.rs
+++ b/rust/connlib/clients/apple/src/lib.rs
@@ -166,6 +166,10 @@ impl Callbacks for CallbackHandler {
     }
 
     fn on_disconnect(&self, error: DisconnectError) {
+        if !error.is_authentication_error() {
+            tracing::error!("{error}")
+        }
+
         self.inner.on_disconnect(error.to_string());
     }
 }


### PR DESCRIPTION
In the FFI layer, it is tricky to decide what we should do with errors. On the one hand, logging and returning errors is an anti-pattern because it may lead to duplicate logs. In this particular case however, it is useful to log the error on the Rust side because it allows our Sentry integration to capture and include the DEBUG logs prior to this one which may add crucial context.