### PR TITLE
chore(rust): remove stale error context

### DIFF
--- a/rust/connlib/clients/shared/src/lib.rs
+++ b/rust/connlib/clients/shared/src/lib.rs
@@ -129,9 +129,7 @@ where
     let tunnel = ClientTunnel::new(tcp_socket_factory, udp_socket_factory);
     let mut eventloop = Eventloop::new(tunnel, callbacks, portal, rx);
 
-    std::future::poll_fn(|cx| eventloop.poll(cx))
-        .await
-        .context("connection to the portal failed")?;
+    std::future::poll_fn(|cx| eventloop.poll(cx)).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Minor oversight from #8783. We accidentally retained this `.context` even though there are now multiple error paths from the `Eventloop`, not just portal connection errors.