### PR TITLE
refactor(portal): Add more logging around sign in errors

### DIFF
--- a/elixir/apps/web/lib/web/controllers/auth_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/auth_controller.ex
@@ -394,16 +394,16 @@ defmodule Web.AuthController do
       {:ok, redirect_params, persisted_verifier, delete_auth_state(conn, provider_id)}
     else
       {:error, :auth_state_missing} ->
-        Logger.info("Auth state missing")
+        Logger.info("Auth state missing", provider_id: provider_id)
         {:error, :invalid_state, delete_auth_state(conn, provider_id)}
 
       {:error, :invalid_state} ->
-        Logger.info("Auth state is invalid")
+        Logger.info("Auth state is invalid", provider_id: provider_id)
         {:error, :invalid_state, delete_auth_state(conn, provider_id)}
 
       _ ->
         # Not logging the actual error as it may contain sensitive info
-        Logger.warning("Unknown error while verifying state")
+        Logger.warning("Unknown error while verifying state", provider_id: provider_id)
         {:error, :invalid_state, delete_auth_state(conn, provider_id)}
     end
   end

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -547,7 +547,7 @@ defmodule Web.AuthControllerTest do
         })
 
       assert redirected_to(conn) == ~p"/#{account}"
-      assert flash(conn, :error) == "The sign in token is expired."
+      assert flash(conn, :error) == "The sign in token is missing or expired. Please try again."
     end
 
     test "uses redirect params from the request query when auth state does not exist", %{


### PR DESCRIPTION
Why:

* To allow for more accurate and efficient troubleshooting in production.