### PR TITLE
docs(kb): update path to Gateway to new location

### DIFF
--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -152,7 +152,7 @@ if [ ! -e "\$BINARY_PATH" ]; then
   else
     echo "\$BINARY_PATH.download is not an executable!"
     echo "Ensure '${FIREZONE_ARTIFACT_URL}/${FIREZONE_VERSION}/\$arch' is accessible from this machine,"
-    echo "or download binary manually and install to /usr/local/bin/firezone-gateway."
+    echo "or download binary manually and install to \$BINARY_PATH"
     exit 1
   fi
 else

--- a/website/src/app/kb/administer/upgrading/readme.mdx
+++ b/website/src/app/kb/administer/upgrading/readme.mdx
@@ -56,7 +56,7 @@ and restart the service to trigger the upgrade:
 sudo systemctl stop firezone-gateway
 
 # Move the old binary to a backup location
-sudo mv /usr/local/bin/firezone-gateway /usr/local/bin/firezone-gateway.bak
+sudo mv /opt/firezone/bin/firezone-gateway /opt/firezone/bin/firezone-gateway.bak
 
 # Start the Gateway service to trigger the upgrade
 sudo systemctl start firezone-gateway


### PR DESCRIPTION
In #8480, we changed the location that `firezone-gateway` gets downloaded to but forgot to update the knowledgebase with the new path.