### PR TITLE
feat(ci): Publish installer PKG for macOS standalone

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -55,6 +55,8 @@ jobs:
             # mark:next-apple-version
             artifact-file: "firezone-macos-client-1.4.10.dmg"
             # mark:next-apple-version
+            pkg-artifact-file: "firezone-macos-client-1.4.10.pkg"
+            # mark:next-apple-version
             release-name: macos-client-1.4.10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -98,6 +100,7 @@ jobs:
           STANDALONE_BUILD_CERT: "${{ secrets.APPLE_STANDALONE_BUILD_CERTIFICATE_BASE64 }}"
           STANDALONE_BUILD_CERT_PASS: "${{ secrets.APPLE_STANDALONE_BUILD_CERTIFICATE_P12_PASSWORD }}"
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
+          PKG_ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.pkg-artifact-file }}"
           NOTARIZE: "${{ github.event_name == 'workflow_dispatch' }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
@@ -107,12 +110,25 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: "${{ github.event_name == 'workflow_dispatch' && matrix.job_name == 'build-macos-standalone' }}"
         with:
-          name: ${{ matrix.artifact-file }}
-          path: "${{ runner.temp }}/${{ matrix.artifact-file }}"
+          name: macos-client-standalone
+          path: |
+            "${{ runner.temp }}/${{ matrix.artifact-file }}"
+            "${{ runner.temp }}/${{ matrix.pkg-artifact-file }}"
       - run: ${{ matrix.upload-script }}
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         env:
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
+          ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"
+          API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
+          API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          RELEASE_NAME: "${{ matrix.release-name }}"
+          PLATFORM: "${{ matrix.platform }}"
+      # We also publish a pkg file for MDMs that don't like our DMG (Intune error 0x87D30139)
+      - run: ${{ matrix.upload-script }}
+        if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && matrix.job_name == 'build-macos-standalone' }}"
+        env:
+          ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.pkg-artifact-file }}"
           ISSUER_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}"
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -125,6 +125,8 @@ if [ "$notarize" = "true" ]; then
     # Verify notarization
     xcrun stapler validate "$dmg_path"
 
+    echo "Disk image notarized!"
+
     # Submit PKG to be notarized. Can take a few minutes. Notarizes embedded app bundle as well.
     xcrun notarytool submit "$staging_pkg_path" \
         --key "$private_key_path" \

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -13,10 +13,12 @@ notarize=${NOTARIZE:-"false"}
 temp_dir="${TEMP_DIR:-$(mktemp -d)}"
 dmg_dir="$temp_dir/dmg"
 dmg_path="$temp_dir/Firezone.dmg"
-package_path="$temp_dir/package.dmg"
+staging_dmg_path="$temp_dir/staging.dmg"
+staging_pkg_path="$temp_dir/staging.pkg"
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}
 project_file=swift/apple/Firezone.xcodeproj
 codesign_identity="Developer ID Application: Firezone, Inc. (47R2M6779T)"
+installer_code_sign_identity="3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
 
 if [ "${CI:-}" = "true" ]; then
     # Configure the environment for building, signing, and packaging in CI
@@ -49,6 +51,13 @@ xcodebuild build \
     -sdk macosx \
     -destination 'platform=macOS'
 
+# We also publish a pkg file for MDMs that don't like our DMG (Intune error 0x87D30139)
+productbuild \
+    --sign "$installer_code_sign_identity" \
+    --component "$temp_dir/Firezone.app" \
+    /Applications \
+    "$staging_pkg_path"
+
 # Create disk image
 mkdir -p "$dmg_dir/.background"
 mv "$temp_dir/Firezone.app" "$dmg_dir/Firezone.app"
@@ -59,10 +68,10 @@ hdiutil create \
     -srcfolder "$dmg_dir" \
     -ov \
     -format UDRW \
-    "$package_path"
+    "$staging_dmg_path"
 
 # Mount disk image for customization
-mount_dir=$(hdiutil attach "$package_path" -readwrite -noverify -noautoopen | grep -o "/Volumes/.*")
+mount_dir=$(hdiutil attach "$staging_dmg_path" -readwrite -noverify -noautoopen | grep -o "/Volumes/.*")
 
 # Embed background image to instruct user to drag app to /Applications
 osascript <<EOF
@@ -91,28 +100,24 @@ EOF
 hdiutil detach "$mount_dir"
 
 # Convert to read-only
-hdiutil convert "$package_path" -format UDZO -o "$dmg_path"
+hdiutil convert "$staging_dmg_path" -format UDZO -o "$dmg_path"
 
 # Sign disk image
 codesign --force --sign "$codesign_identity" "$dmg_path"
 
 echo "Disk image created at $dmg_path"
 
-# Notarize disk image; notarizes embedded app bundle as well
+# Notarize disk image and package installer; notarizes embedded app bundle as well
 if [ "$notarize" = "true" ]; then
     private_key_path="$temp_dir/firezone-api-key.p8"
     base64_decode "$API_KEY" "$private_key_path"
 
-    # Submit app bundle to be notarized. Can take a few minutes.
-    # Notarizes embedded app bundle as well.
+    # Submit DMG to be notarized. Can take a few minutes. Notarizes embedded app bundle as well.
     xcrun notarytool submit "$dmg_path" \
         --key "$private_key_path" \
         --key-id "$API_KEY_ID" \
         --issuer "$ISSUER_ID" \
         --wait
-
-    # Clean up private key
-    rm "$private_key_path"
 
     # Staple notarization ticket to app bundle
     xcrun stapler staple "$dmg_path"
@@ -120,12 +125,33 @@ if [ "$notarize" = "true" ]; then
     # Verify notarization
     xcrun stapler validate "$dmg_path"
 
-    echo "Disk image notarized!"
+    # Submit PKG to be notarized. Can take a few minutes. Notarizes embedded app bundle as well.
+    xcrun notarytool submit "$staging_pkg_path" \
+        --key "$private_key_path" \
+        --key-id "$API_KEY_ID" \
+        --issuer "$ISSUER_ID" \
+        --wait
+
+    # Staple notarization ticket to app bundle
+    xcrun stapler staple "$staging_pkg_path"
+
+    # Verify notarization
+    xcrun stapler validate "$staging_pkg_path"
+
+    echo "Installer PKG notarized!"
+
+    # Clean up private key
+    rm "$private_key_path"
 fi
 
 # Move to final location the uploader expects
 if [[ -n "${ARTIFACT_PATH:-}" ]]; then
     mv "$dmg_path" "$ARTIFACT_PATH"
 
-    echo "Moved disk image to $ARTIFACT_PATH"
+    echo "Moved DMG to $ARTIFACT_PATH"
+fi
+if [[ -n "${PKG_ARTIFACT_PATH:-}" ]]; then
+    mv "$staging_pkg_path" "$PKG_ARTIFACT_PATH"
+
+    echo "Moved PKG to $PKG_ARTIFACT_PATH"
 fi

--- a/scripts/upload/app-store-connect.sh
+++ b/scripts/upload/app-store-connect.sh
@@ -20,7 +20,7 @@ cd "$temp_dir"
 # Submit app to App Store Connect
 xcrun altool \
     --upload-app \
-    -f "$PRIMARY_ARTIFACT_PATH" \
+    -f "$ARTIFACT_PATH" \
     -t "$PLATFORM" \
     --apiKey "$API_KEY_ID" \
     --apiIssuer "$ISSUER_ID"

--- a/scripts/upload/app-store-connect.sh
+++ b/scripts/upload/app-store-connect.sh
@@ -20,7 +20,7 @@ cd "$temp_dir"
 # Submit app to App Store Connect
 xcrun altool \
     --upload-app \
-    -f "$ARTIFACT_PATH" \
+    -f "$PRIMARY_ARTIFACT_PATH" \
     -t "$PLATFORM" \
     --apiKey "$API_KEY_ID" \
     --apiIssuer "$ISSUER_ID"

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -13,6 +13,13 @@ module.exports = [
       "https://www.github.com/firezone/firezone/releases/download/macos-client-1.4.9/firezone-macos-client-1.4.9.dmg",
     permanent: false,
   },
+  {
+    source: "/dl/firezone-client-macos/pkg/latest",
+    destination:
+      // mark:current-apple-version
+      "https://www.github.com/firezone/firezone/releases/download/macos-client-1.4.9/firezone-macos-client-1.4.9.pkg",
+    permanent: false,
+  },
   /*
    *
    * Android Client

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -12,7 +12,11 @@ export default function Apple() {
     },
     {
       href: "/dl/firezone-client-macos/:version",
-      title: "Download standalone package for macOS",
+      title: "Download standalone DMG file for macOS",
+    },
+    {
+      href: "/dl/firezone-client-macos/pkg/:version",
+      title: "Download standalone installer PKG file for macOS",
     },
   ];
 

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -9,6 +9,11 @@ const versionedRedirects = [
       "https://www.github.com/firezone/firezone/releases/download/macos-client-:version/firezone-macos-client-:version.dmg",
   },
   {
+    source: /^\/dl\/firezone-client-macos\/pkg\/(\d+\.\d+\.\d+)$/,
+    destination:
+      "https://www.github.com/firezone/firezone/releases/download/macos-client-:version/firezone-macos-client-:version.pkg",
+  },
+  {
     source: /^\/dl\/firezone-client-android\/(\d+\.\d+\.\d+)$/,
     destination:
       "https://www.github.com/firezone/firezone/releases/download/android-client-:version/firezone-android-client-:version.apk",
@@ -68,6 +73,7 @@ const versionedRedirects = [
 export const config = {
   matcher: [
     "/dl/firezone-client-macos/(\\d+).(\\d+).(\\d+)",
+    "/dl/firezone-client-macos/pkg/(\\d+).(\\d+).(\\d+)",
     "/dl/firezone-client-android/(\\d+).(\\d+).(\\d+)",
     "/dl/firezone-client-gui-windows/(\\d+).(\\d+).(\\d+)/x86_64",
     "/dl/firezone-client-headless-windows/(\\d+).(\\d+).(\\d+)/x86_64",


### PR DESCRIPTION
Microsoft Intune's DMG provisioner currently fails unexpectedly when trying to provision our published DMG file with the error:

> The DMG file couldn't be mounted for installation. Check the DMG file if the error persists. (0x87D30139)

I ran the following verification commands locally, which all passed:

```
hdiutil verify -verbose <dmg>
hdiutil imageinfo -verbose <dmg>
hdiutil hfsanalyze -verbose <dmg>
hdiutil checksum -type SHA256 -verbose <dmg>
hdiutil info -verbose
hdiutil pmap -verbose <dmg>
```

So the issue appears to be most likely that Intune doens't like the `/Applications` shortcut in the DMG. This is a UX feature to make it easy to drag the application the /Applications folder upon opening the DMG.

So we're publishing an PKG in addition to the DMG, which should be a more reliable artifact for MDMs to use.