### PR TITLE
fix(ci): Use `Developer ID Installer` cert to sign pkg

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -99,6 +99,8 @@ jobs:
           INSTALLER_CERT_PASS: "${{ secrets.APPLE_MAC_INSTALLER_CERTIFICATE_P12_PASSWORD }}"
           STANDALONE_BUILD_CERT: "${{ secrets.APPLE_STANDALONE_BUILD_CERTIFICATE_BASE64 }}"
           STANDALONE_BUILD_CERT_PASS: "${{ secrets.APPLE_STANDALONE_BUILD_CERTIFICATE_P12_PASSWORD }}"
+          STANDALONE_INSTALLER_CERT: "${{ secrets.APPLE_STANDALONE_MAC_INSTALLER_CERTIFICATE_BASE64 }}"
+          STANDALONE_INSTALLER_CERT_PASS: "${{ secrets.APPLE_STANDALONE_MAC_INSTALLER_CERTIFICATE_P12_PASSWORD }}"
           ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.artifact-file }}"
           PKG_ARTIFACT_PATH: "${{ runner.temp }}/${{ matrix.pkg-artifact-file }}"
           NOTARIZE: "${{ github.event_name == 'workflow_dispatch' }}"

--- a/scripts/build/lib.sh
+++ b/scripts/build/lib.sh
@@ -45,6 +45,11 @@ function setup_runner() {
         "$STANDALONE_BUILD_CERT_PASS" \
         "$keychain_pass" \
         "$keychain_path"
+    install_cert \
+        "$STANDALONE_INSTALLER_CERT" \
+        "$STANDALONE_INSTALLER_CERT_PASS" \
+        "$keychain_pass" \
+        "$keychain_path"
 }
 
 function base64_decode() {

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -17,8 +17,8 @@ staging_dmg_path="$temp_dir/staging.dmg"
 staging_pkg_path="$temp_dir/staging.pkg"
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}
 project_file=swift/apple/Firezone.xcodeproj
-codesign_identity="Developer ID Application: Firezone, Inc. (47R2M6779T)"
-installer_code_sign_identity="3rd Party Mac Developer Installer: Firezone, Inc. (47R2M6779T)"
+code_sign_identity="Developer ID Application: Firezone, Inc. (47R2M6779T)"
+installer_code_sign_identity="Developer ID Installer: Firezone, Inc. (47R2M6779T)"
 
 if [ "${CI:-}" = "true" ]; then
     # Configure the environment for building, signing, and packaging in CI
@@ -35,7 +35,7 @@ seconds_since_epoch=$(date +%s)
 xcodebuild build \
     GIT_SHA="$git_sha" \
     CODE_SIGN_STYLE=Manual \
-    CODE_SIGN_IDENTITY="$codesign_identity" \
+    CODE_SIGN_IDENTITY="$code_sign_identity" \
     PACKET_TUNNEL_PROVIDER_SUFFIX=-systemextension \
     OTHER_CODE_SIGN_FLAGS="--timestamp" \
     CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
@@ -103,7 +103,7 @@ hdiutil detach "$mount_dir"
 hdiutil convert "$staging_dmg_path" -format UDZO -o "$dmg_path"
 
 # Sign disk image
-codesign --force --sign "$codesign_identity" "$dmg_path"
+code_sign --force --sign "$code_sign_identity" "$dmg_path"
 
 echo "Disk image created at $dmg_path"
 

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -103,7 +103,7 @@ hdiutil detach "$mount_dir"
 hdiutil convert "$staging_dmg_path" -format UDZO -o "$dmg_path"
 
 # Sign disk image
-code_sign --force --sign "$code_sign_identity" "$dmg_path"
+codesign --force --sign "$code_sign_identity" "$dmg_path"
 
 echo "Disk image created at $dmg_path"
 

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -288,6 +288,11 @@ Application certificates are **precious** and we only have a limited number of
 them. They also cannot be revoked. So do not generate them. Instead, obtain it
 from 1Password.
 
+Also, the signing certificate for the package installer artifact specifically needs
+to be a `Developer ID Installer` certificate, not a `Developer ID Application` or
+`Apple Distribution` certificate. This is needed to sign the PKG files we distribute
+that are consumed by MDMs.
+
 Once you've done that, you can create the provisioning profiles and update the
 GitHub secrets using the same steps as above, only using the following secrets
 names:
@@ -295,6 +300,8 @@ names:
 ```
 APPLE_STANDALONE_BUILD_CERTIFICATE_BASE64
 APPLE_STANDALONE_BUILD_CERTIFICATE_P12_PASSWORD
+APPLE_STANDALONE_MAC_INSTALLER_CERTIFICATE_BASE64
+APPLE_STANDALONE_MAC_INSTALLER_CERTIFICATE_P12_PASSWORD
 APPLE_STANDALONE_MACOS_APP_PROVISIONING_PROFILE
 APPLE_STANDALONE_MACOS_NE_PROVISIONING_PROFILE
 ```


### PR DESCRIPTION
Apple requires standalone-distributed `PKG` installers to be signed with a Developer ID Installer certificate.

Fixes https://github.com/firezone/firezone/actions/runs/14497960810/job/40670440720#step:6:3500