### PR TITLE
chore(connlib): log malformed IP packets

### DIFF
--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -561,7 +561,9 @@ impl IpPacket {
             return None;
         }
 
-        UdpSlice::from_slice(self.payload()).ok()
+        UdpSlice::from_slice(self.payload())
+            .inspect_err(|e| tracing::debug!("Invalid UDP packet: {e}"))
+            .ok()
     }
 
     pub fn as_udp_mut(&mut self) -> Option<UdpHeaderSliceMut> {
@@ -569,7 +571,9 @@ impl IpPacket {
             return None;
         }
 
-        UdpHeaderSliceMut::from_slice(self.payload_mut()).ok()
+        UdpHeaderSliceMut::from_slice(self.payload_mut())
+            .inspect_err(|e| tracing::debug!("Invalid UDP packet: {e}"))
+            .ok()
     }
 
     pub fn as_tcp(&self) -> Option<TcpSlice> {
@@ -577,7 +581,9 @@ impl IpPacket {
             return None;
         }
 
-        TcpSlice::from_slice(self.payload()).ok()
+        TcpSlice::from_slice(self.payload())
+            .inspect_err(|e| tracing::debug!("Invalid TCP packet: {e}"))
+            .ok()
     }
 
     pub fn as_tcp_mut(&mut self) -> Option<TcpHeaderSliceMut> {
@@ -585,7 +591,9 @@ impl IpPacket {
             return None;
         }
 
-        TcpHeaderSliceMut::from_slice(self.payload_mut()).ok()
+        TcpHeaderSliceMut::from_slice(self.payload_mut())
+            .inspect_err(|e| tracing::debug!("Invalid TCP packet: {e}"))
+            .ok()
     }
 
     fn set_icmpv6_checksum(&mut self) {
@@ -632,7 +640,9 @@ impl IpPacket {
             return None;
         }
 
-        Icmpv4Slice::from_slice(self.payload()).ok()
+        Icmpv4Slice::from_slice(self.payload())
+            .inspect_err(|e| tracing::debug!("Invalid ICMPv4 packet: {e}"))
+            .ok()
     }
 
     pub fn as_icmpv4_mut(&mut self) -> Option<Icmpv4HeaderSliceMut> {
@@ -640,7 +650,9 @@ impl IpPacket {
             return None;
         }
 
-        Icmpv4HeaderSliceMut::from_slice(self.payload_mut()).ok()
+        Icmpv4HeaderSliceMut::from_slice(self.payload_mut())
+            .inspect_err(|e| tracing::debug!("Invalid ICMPv4 packet: {e}"))
+            .ok()
     }
 
     /// In case the packet is an ICMP unreachable error, parses the unroutable packet from the ICMP payload.
@@ -736,7 +748,9 @@ impl IpPacket {
             return None;
         }
 
-        Icmpv6Slice::from_slice(self.payload()).ok()
+        Icmpv6Slice::from_slice(self.payload())
+            .inspect_err(|e| tracing::debug!("Invalid ICMPv6 packet: {e}"))
+            .ok()
     }
 
     pub fn as_icmpv6_mut(&mut self) -> Option<Icmpv6EchoHeaderSliceMut> {
@@ -744,7 +758,9 @@ impl IpPacket {
             return None;
         }
 
-        Icmpv6EchoHeaderSliceMut::from_slice(self.payload_mut()).ok()
+        Icmpv6EchoHeaderSliceMut::from_slice(self.payload_mut())
+            .inspect_err(|e| tracing::debug!("Invalid ICMPv6 packet: {e}"))
+            .ok()
     }
 
     pub fn as_fz_p2p_control(&self) -> Option<FzP2pControlSlice> {


### PR DESCRIPTION
When determining, how to NAT a certain packet, we need to identify whether it is a UDP, TCP or ICMP packet and extract the relevant port or identifier from it. When parsing these packets, we may run into a situation where the IP number says that the packet is TCP but it is actually malformed and we cannot parse the port from it.

In such situations, we end up constructing a `UnsupportedProtocol` error that then confusingly states the we don't support the TCP protocol (or UDP / ICMP if those are malformed).

The parsing error here is currently silently discarded as part of the `.ok()` combinator when constructing the relevant slice. To make these logs easier to understand, we now add an `inspect_err` call prior to this the prints, why the packet could not be parsed.

Long-term, I am planning to refactor our IP packet model to eagerly parse the layer 3 + 4 headers. This will also be necessary to implement segmentation offloading on the TUN device. Doing so will improve situations like because we will either pass through the malformed packet (if at least the header is intact) or drop it much earlier already. In either case, accessing things like port numbers will be infallible as part of the processing code.