### PR TITLE
feat(relay): allow controlling log-level at runtime

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2403,6 +2403,7 @@ name = "firezone-relay"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "aya",
  "aya-build",
  "aya-log",

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -9,6 +9,7 @@ development = ["difference", "env_logger"]
 
 [dependencies]
 anyhow = { workspace = true }
+axum = { workspace = true, features = ["http1", "tokio", "query"] }
 backoff = { workspace = true }
 base64 = { workspace = true }
 bytecodec = { workspace = true }

--- a/rust/relay/server/src/control_endpoint.rs
+++ b/rust/relay/server/src/control_endpoint.rs
@@ -1,0 +1,53 @@
+use axum::Router;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::routing::post;
+use firezone_logging::FilterReloadHandle;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+/// Runs an HTTP server that responds to `POST /log_filter?directives=` and sets the given directives as the new log-filter.
+pub async fn serve(
+    addr: impl Into<SocketAddr>,
+    filter_reload_handle: FilterReloadHandle,
+) -> std::io::Result<()> {
+    let addr = addr.into();
+
+    let service = Router::new()
+        .route("/log_filter", post(set_log_filter))
+        .with_state(AppState {
+            handle: Arc::new(filter_reload_handle),
+        })
+        .into_make_service();
+
+    axum::serve(tokio::net::TcpListener::bind(addr).await?, service).await?;
+
+    Ok(())
+}
+
+async fn set_log_filter(Query(params): Query<QueryParams>, state: State<AppState>) -> StatusCode {
+    let directives = params.directives;
+
+    match state.handle.reload(&directives) {
+        Ok(()) => {
+            tracing::info!(%directives, "Applied new logging directives");
+
+            StatusCode::OK
+        }
+        Err(e) => {
+            tracing::info!(%directives, "Failed to set log filter to new directives: {e}");
+
+            StatusCode::BAD_REQUEST
+        }
+    }
+}
+
+#[derive(Clone)]
+struct AppState {
+    handle: Arc<FilterReloadHandle>,
+}
+
+#[derive(serde::Deserialize)]
+struct QueryParams {
+    directives: String,
+}

--- a/rust/relay/server/src/lib.rs
+++ b/rust/relay/server/src/lib.rs
@@ -5,6 +5,7 @@ mod server;
 mod sleep;
 
 pub mod auth;
+pub mod control_endpoint;
 pub mod ebpf;
 #[cfg(feature = "proptest")]
 #[allow(clippy::unwrap_used)]

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -92,7 +92,7 @@ struct Args {
     health_check: http_health_check::HealthCheckArgs,
 
     /// The address of the local interface where we should serve our control endpoint.
-    #[arg(long, env, hide = true, default_value = "0.0.0.0:9999")]
+    #[arg(long, env, hide = true, default_value = "127.0.0.1:9999")]
     control_endpoint: SocketAddr,
 
     /// Enable sentry.io crash-reporting agent.


### PR DESCRIPTION
When debugging issues with the relays on GCP, it is useful to be able to change the log-level at runtime without having to redeploy them. We can achieve this by running an additional HTTP server as part of the relay that response to HTTP POST requests that contain new logging directives.