### PR TITLE
fix(eBPF): implement "is port in allocation range" ourselves

### DIFF
--- a/rust/relay/ebpf-turn-router/src/config.rs
+++ b/rust/relay/ebpf-turn-router/src/config.rs
@@ -1,5 +1,3 @@
-use core::ops::RangeInclusive;
-
 use aya_ebpf::{macros::map, maps::Array};
 use ebpf_shared::Config;
 
@@ -11,10 +9,12 @@ pub fn udp_checksum_enabled() -> bool {
     config().udp_checksum_enabled()
 }
 
-pub fn allocation_range() -> RangeInclusive<u16> {
-    let config = config();
+pub fn lowest_allocation_port() -> u16 {
+    config().lowest_allocation_port()
+}
 
-    config.lowest_allocation_port()..=(config.highest_allocation_port())
+pub fn highest_allocation_port() -> u16 {
+    config().highest_allocation_port()
 }
 
 fn config() -> Config {

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -68,6 +68,18 @@ static UDP_TO_CHAN_64: HashMap<PortAndPeerV6, ClientAndChannelV4> =
 
 #[xdp]
 pub fn handle_turn(ctx: XdpContext) -> u32 {
+    trace!(
+        &ctx,
+        "udp-checksumming = {}, lowest-allocation-port = {}, highest-allocation-port = {}",
+        if config::udp_checksum_enabled() {
+            "true"
+        } else {
+            "false"
+        },
+        config::lowest_allocation_port(),
+        config::highest_allocation_port(),
+    );
+
     try_handle_turn(&ctx).unwrap_or_else(|e| match e {
         Error::NotIp | Error::NotUdp => xdp_action::XDP_PASS,
 

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -133,7 +133,7 @@ fn try_handle_turn_ipv4(ctx: &XdpContext, eth: Eth) -> Result<(), Error> {
         udp_payload_len
     );
 
-    if config::allocation_range().contains(&udp.dst()) {
+    if is_port_in_allocation_range(udp.dst()) {
         try_handle_ipv4_udp_to_channel_data(ctx, eth, ipv4, udp)?;
         stats::emit_data_relayed(ctx, udp_payload_len);
 
@@ -268,7 +268,7 @@ fn try_handle_turn_ipv6(ctx: &XdpContext, eth: Eth) -> Result<(), Error> {
         udp_payload_len
     );
 
-    if config::allocation_range().contains(&udp.dst()) {
+    if is_port_in_allocation_range(udp.dst()) {
         try_handle_ipv6_udp_to_channel_data(ctx, eth, ipv6, udp)?;
         stats::emit_data_relayed(ctx, udp_payload_len);
 
@@ -375,6 +375,10 @@ fn try_handle_ipv6_channel_data_to_udp(
     remove_channel_data_header_ipv6(ctx)?;
 
     Ok(())
+}
+
+fn is_port_in_allocation_range(port: u16) -> bool {
+    port >= config::lowest_allocation_port() && port <= config::highest_allocation_port()
 }
 
 /// Defines our panic handler.


### PR DESCRIPTION
I am suspecting that something is wrong with the check that a port is indeed within that range. Thus, we now implemented this ourselves with two simple conditions.