### PR TITLE
fix(relay): remove `Config` caching

### DIFF
--- a/rust/relay/server/src/ebpf/linux.rs
+++ b/rust/relay/server/src/ebpf/linux.rs
@@ -25,11 +25,6 @@ const PAGE_COUNT: usize = 0x1000;
 pub struct Program {
     ebpf: aya::Ebpf,
 
-    /// A cached version of our current config.
-    ///
-    /// Allows for faster access without issuing sys-calls to read it from the map.
-    config: Config,
-
     #[expect(dead_code, reason = "We are just keeping it alive.")]
     stats: AsyncPerfEventArray<MapData>,
 }
@@ -113,11 +108,7 @@ impl Program {
 
         tracing::info!("eBPF TURN router loaded and attached to interface {interface}");
 
-        Ok(Self {
-            ebpf,
-            stats,
-            config: Config::default(),
-        })
+        Ok(Self { ebpf, stats })
     }
 
     pub fn add_channel_binding(
@@ -225,20 +216,9 @@ impl Program {
     }
 
     pub fn set_config(&mut self, config: Config) -> Result<()> {
-        if config == self.config {
-            tracing::debug!(config = ?self.config, "No change to config, skipping update");
-
-            return Ok(());
-        }
-
-        self.config = config;
         self.config_array_mut()?.set(0, config, 0)?;
 
         Ok(())
-    }
-
-    pub fn config(&self) -> Config {
-        self.config
     }
 
     fn chan_to_udp_44_map_mut(


### PR DESCRIPTION
In #8650, we originally added a feature-flag for toggling the eBPF TURN router on and off at runtime. This later got removed again in #8681. What remained was a "caching system" of the config that the eBPF kernel and user space share with each other.
This config was initialised to the default configuration. If the to-be-set config was the same as the current config, the config would not actually apply to the array that was shared with the eBPF kernel.

At the time, we assumed that, if the config was not set in the kernel, the lookup in the array would yield `None` and we would fall back to the `Default` implementation of `Config`. This assumption was wrong. It appears that look-ups in the array always yield an element: all zeros. Initialising our config with all zeros yields the following:

![image](https://github.com/user-attachments/assets/6556f32d-8cff-4fba-aa29-f9ac7349ace6)

Of course, if this range is not initialised correctly, we can never actually route packets arriving on allocation ports and with UDP checksumming turned off, all packets routed the other way will have an invalid checksum and therefore be dropped by the receiving host.

Our integration test did not catch this because in there, we purposely disable UDP checksumming. That meant that the "caching" check in the `ebpf::Program` did not trigger and we actually did set a `Config` in the array, therefore initialising the allocation port range correctly and allowing the packet to be routed.

To fix this, we remove this caching check again which means every `Config` we set on the eBPF program actually gets copied to the shared array. Originally, this caching check was introduced to avoid a syscall on every event-loop iteration as part of checking the feature-flag. Now that the feature-flag has been removed, we don't need to have this cache anymore.

Resolves: #8803 