### PR TITLE
chore(eBPF): use `RangeInclusive::contains` again

### DIFF
--- a/rust/relay/ebpf-turn-router/src/config.rs
+++ b/rust/relay/ebpf-turn-router/src/config.rs
@@ -1,3 +1,5 @@
+use core::ops::RangeInclusive;
+
 use aya_ebpf::{macros::map, maps::Array};
 use ebpf_shared::Config;
 
@@ -9,12 +11,11 @@ pub fn udp_checksum_enabled() -> bool {
     config().udp_checksum_enabled()
 }
 
-pub fn lowest_allocation_port() -> u16 {
-    config().lowest_allocation_port()
-}
+pub fn allocation_range() -> RangeInclusive<u16> {
+    let low = config().lowest_allocation_port();
+    let high = config().highest_allocation_port();
 
-pub fn highest_allocation_port() -> u16 {
-    config().highest_allocation_port()
+    low..=high
 }
 
 fn config() -> Config {


### PR DESCRIPTION
Now that we have figured out what the problem was with the eBPF kernel not routing certain packets, we can undo the manual implementation of the allocation range checking again and use the more concise `RangeInclusive::contains`.

Related: #8809
Related: #8807