### PR TITLE
fix(apple): Force enable VPN configuration on autoStart

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -99,6 +99,7 @@ public final class Store: ObservableObject {
 
     if autoStart {
       // Try to connect on start
+      try await vpnConfigurationManager?.enableConfiguration()
       try ipcClient().start()
     }
 

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,6 +24,12 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased></Unreleased>
+      <Entry version="1.4.11" date={new Date("2025-04-18")}>
+        <ChangeItem pull="8814">
+          Fixes an issue where the app would hang on launch if another VPN app
+          was connected.
+        </ChangeItem>
+      </Entry>
       <Entry version="1.4.10" date={new Date("2025-04-17")}>
         <ChangeItem pull="8795">
           Publishes an installer package for macOS in addition to the DMG file.


### PR DESCRIPTION
If another VPN has been activated on the system while Firezone is active, Apple OSes will deactivate our configuration, and never reactivate it.

We knew this already, and always activated the configuration when starting during the sign in flow, but failed to also do this when autoStarting on launch.

This PR updates ensures that during autoStart, we re-enable the configuration as well.

Fixes #8813 