### PR TITLE
chore(apple): Disable Sentry debug mode on dev

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -38,11 +38,6 @@ public enum Telemetry {
       options.environment = "entrypoint" // will be reconfigured in VPNConfigurationManager
       options.releaseName = releaseName()
       options.dist = distributionType()
-
-#if DEBUG
-      // https://docs.sentry.io/platforms/apple/guides/ios/configuration/options/#debug
-      options.debug = true
-#endif
     }
   }
 


### PR DESCRIPTION
This just adds a bunch of log noise and is only helpful if we're trying to debug the Sentry integration itself.