### PR TITLE
fix(apple): Handle libresolv allocation more robustly

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
@@ -10,17 +10,17 @@ public class BindResolvers {
   var state = __res_9_state()
 
   public init() {
-    res_9_ninit(&state)
+    res_9_ninit(state)
   }
 
   deinit {
-    res_9_ndestroy(&state)
+    res_9_ndestroy(state)
   }
 
   public final func getservers() -> [res_9_sockaddr_union] {
     let maxServers = 10
     var servers = [res_9_sockaddr_union](repeating: res_9_sockaddr_union(), count: maxServers)
-    let found = Int(res_9_getservers(&state, &servers, Int32(maxServers)))
+    let found = Int(res_9_getservers(state, &servers, Int32(maxServers)))
 
     // filter is to remove the erroneous empty entry when there's no real servers
     return Array(servers[0..<found]).filter { $0.sin.sin_len > 0 }

--- a/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
@@ -8,28 +8,22 @@
 import FirezoneKit
 
 public class BindResolvers {
-  var state: UnsafeMutablePointer<__res_9_state>?
+  var state: __res_9_state
 
   public init() {
     self.state = __res_9_state()
-    res_9_ninit(state)
+
+    res_9_ninit(&state)
   }
 
   deinit {
-    res_9_ndestroy(state)
+    res_9_ndestroy(&state)
   }
 
   public final func getservers() -> [res_9_sockaddr_union] {
-    guard let state
-    else {
-      Log.warning("state is not initialized, allocation error?")
-
-      return []
-    }
-
     let maxServers = 10
     var servers = [res_9_sockaddr_union](repeating: res_9_sockaddr_union(), count: maxServers)
-    let found = Int(res_9_getservers(state, &servers, Int32(maxServers)))
+    let found = Int(res_9_getservers(&state, &servers, Int32(maxServers)))
 
     // filter is to remove the erroneous empty entry when there's no real servers
     return Array(servers[0..<found]).filter { $0.sin.sin_len > 0 }

--- a/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
@@ -8,28 +8,15 @@
 import FirezoneKit
 
 public class BindResolvers {
-  enum Error: Swift.Error {
-    case failedToAllocateMemory
-  }
-
   var state: UnsafeMutablePointer<__res_9_state>?
 
   public init() {
-    guard let state = __res_9_state()
-    else {
-      Log.error(Error.failedToAllocateMemory)
-
-      return
-    }
-
-    self.state = state
+    self.state = __res_9_state()
     res_9_ninit(state)
   }
 
   deinit {
-    if let state {
-      res_9_ndestroy(state)
-    }
+    res_9_ndestroy(state)
   }
 
   public final func getservers() -> [res_9_sockaddr_union] {


### PR DESCRIPTION
Xcode recently started complaining about these due to improved type checking in Swift. Looks like `state` is already the correct type here. We update the usage not to require a ref.

We also add better nil checking here in case the system is under extreme memory pressure, the app will still function but system resolver reading might not work under these conditions.