### PR TITLE
feat(apple): re-enable `quinn-udp`s fast data path feature

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5355,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.5.11"
-source = "git+https://github.com/quinn-rs/quinn?branch=main#8f1a529837c7c99741d4097446a85e4482bf65b3"
+source = "git+https://github.com/quinn-rs/quinn?branch=main#19a625de606ea8e83bbf8e5c9265f21ebef193da"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -118,7 +118,7 @@ phoenix-channel = { path = "phoenix-channel" }
 png = "0.17.16"
 proptest = "1.6.0"
 proptest-state-machine = "0.3.1"
-quinn-udp = { version = "0.5.8" }
+quinn-udp = { version = "0.5.8", features = ["fast-apple-datapath"] }
 rand = "0.8.5"
 gat-lending-iterator = "0.1.6"
 rand_core = "0.6.4"


### PR DESCRIPTION
Now that https://github.com/quinn-rs/quinn/pull/2208 is merged, we can re-enable the `apple-fast-datapath` feature again on Apple platforms. Even if we cannot yet measure a speed-increase yet, this should at least make UDP operations more efficient and thus reduce CPU and battery usage.