### PR TITLE
feat(eBPF): embed BTF information in eBPF kernel

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -233,3 +233,6 @@ split-debuginfo = "packed"
 [profile.release.package.firezone-gui-client]
 debug = "full"
 split-debuginfo = "packed"
+
+[profile.release.package.ebpf-turn-router]
+debug = 2

--- a/rust/relay/ebpf-turn-router/build.rs
+++ b/rust/relay/ebpf-turn-router/build.rs
@@ -14,4 +14,5 @@ use which::which;
 fn main() {
     let bpf_linker = which("bpf-linker").expect("bpf-linker not found in $PATH");
     println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
+    println!("cargo:rustc-link-arg=--btf");
 }

--- a/rust/relay/ebpf-turn-router/build.rs
+++ b/rust/relay/ebpf-turn-router/build.rs
@@ -14,5 +14,11 @@ use which::which;
 fn main() {
     let bpf_linker = which("bpf-linker").expect("bpf-linker not found in $PATH");
     println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
-    println!("cargo:rustc-link-arg=--btf");
+
+    if std::env::var("CARGO_BUILD_TARGET")
+        .ok()
+        .is_some_and(|t| t == "bpfel-unknown-none" || t == "bpfeb-unknown-unknown")
+    {
+        println!("cargo:rustc-link-arg=--btf");
+    }
 }


### PR DESCRIPTION
It turns out that the Rust compiler doesn't always say that it is adding debug information to a binary even when it does! The build output only displays `[optimized]` when in fact it does actually emit debug information. Adding an additional linker flag configures `bpf-linker` to include the necessary BTF information in our kernel.

This makes debugging verifier errors much easier as the program output contains source code annotiations. It also should make it easier to debug issues using `xdpdump` which relies on BTF information.

Resolves: #8503