### PR TITLE
feat(rust): use jemalloc for Gateway and Relay

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2216,6 +2216,7 @@ dependencies = [
  "futures-bounded",
  "ip-packet",
  "ip_network",
+ "jemallocator",
  "libc",
  "moka",
  "nix 0.29.0",
@@ -2422,6 +2423,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-display",
+ "jemallocator",
  "mio",
  "once_cell",
  "opentelemetry",
@@ -3641,6 +3643,26 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -81,6 +81,7 @@ firezone-tunnel = { path = "connlib/tunnel" }
 flume = { version = "0.11.1", features = ["async"] }
 futures = { version = "0.3.31" }
 futures-bounded = "0.2.1"
+gat-lending-iterator = "0.1.6"
 glob = "0.3.2"
 hex = "0.4.3"
 hex-display = "0.3.0"
@@ -90,6 +91,7 @@ ip-packet = { path = "ip-packet" }
 ip_network = { version = "0.4", default-features = false }
 ip_network_table = { version = "0.2", default-features = false }
 itertools = "0.13"
+jemallocator = "0.5.4"
 jni = "0.21.1"
 keyring = "3.6.1"
 known-folders = "1.2.0"
@@ -120,7 +122,6 @@ proptest = "1.6.0"
 proptest-state-machine = "0.3.1"
 quinn-udp = { version = "0.5.8" }
 rand = "0.8.5"
-gat-lending-iterator = "0.1.6"
 rand_core = "0.6.4"
 rangemap = "1.5.1"
 rayon = "1.10.0"
@@ -183,9 +184,9 @@ trackable = "1.3.0"
 tun = { path = "tun" }
 url = "2.5.2"
 uuid = "1.16.0"
+which = "4.4.2"
 windows = "0.58.0"
 winreg = "0.52.0"
-which = "4.4.2"
 zbus = "5.5.0"
 zip = { version = "2", default-features = false }
 

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -25,7 +25,6 @@ futures = { workspace = true }
 futures-bounded = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
-jemallocator = { workspace = true }
 libc = { workspace = true, features = ["std", "const-extern-fn", "extra_traits"] }
 moka = { workspace = true, features = ["future"] }
 nix = { workspace = true }
@@ -50,6 +49,7 @@ uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = { workspace = true }
+jemallocator = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true, features = ["std"] }

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -25,6 +25,7 @@ futures = { workspace = true }
 futures-bounded = { workspace = true }
 ip-packet = { workspace = true }
 ip_network = { workspace = true }
+jemallocator = { workspace = true }
 libc = { workspace = true, features = ["std", "const-extern-fn", "extra_traits"] }
 moka = { workspace = true, features = ["future"] }
 nix = { workspace = true }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 use crate::eventloop::{Eventloop, PHOENIX_TOPIC};
 use anyhow::{Context, Result};
 use backoff::ExponentialBackoffBuilder;

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -1,4 +1,5 @@
-#[global_allocator]
+#[cfg(unix)]
+#[cfg_attr(unix, global_allocator)]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use crate::eventloop::{Eventloop, PHOENIX_TOPIC};

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -23,7 +23,6 @@ firezone-telemetry = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 hex-display = { workspace = true }
-jemallocator = { workspace = true }
 mio = { workspace = true, features = ["net"] }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
@@ -54,6 +53,7 @@ uuid = { workspace = true, features = ["v4"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 aya = { workspace = true, features = ["tokio"] }
 aya-log = { workspace = true }
+jemallocator = { workspace = true }
 
 [dev-dependencies]
 difference = { workspace = true }

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -23,6 +23,7 @@ firezone-telemetry = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 hex-display = { workspace = true }
+jemallocator = { workspace = true }
 mio = { workspace = true, features = ["net"] }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-#[global_allocator]
+#[cfg(unix)]
+#[cfg_attr(unix, global_allocator)]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use anyhow::{Context, Result, bail};

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 use anyhow::{Context, Result, bail};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;


### PR DESCRIPTION
`jemalloc` is a modern allocator that is designed for multi-threaded systems and can better handle smaller allocations that may otherwise fragment the heap. Firezone's components, especially Relays and Gateways are intended to operate with a long uptime and therefore need to handle memory efficiently.