### PR TITLE
feat(portal): Directory Sync v2 UI

### DIFF
--- a/elixir/apps/web/lib/web/components/layouts/app.html.heex
+++ b/elixir/apps/web/lib/web/components/layouts/app.html.heex
@@ -71,6 +71,9 @@
     <:item navigate={~p"/#{@account}/settings/identity_providers"}>
       Identity Providers
     </:item>
+    <:item navigate={~p"/#{@account}/settings/directory_providers"}>
+      Directory Providers
+    </:item>
     <:item navigate={~p"/#{@account}/settings/dns"}>DNS</:item>
     <:item navigate={~p"/#{@account}/settings/api_clients"}>
       API Clients

--- a/elixir/apps/web/lib/web/live/settings/directory_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/directory_providers/index.ex
@@ -1,0 +1,74 @@
+defmodule Web.Settings.DirectoryProviders.Index do
+  use Web, :live_view
+  alias Domain.Directories
+
+  def mount(_params, _session, socket) do
+    with {:ok, directory_providers, _metadata} <-
+           Directories.list_providers_for_account(socket.assigns.account) do
+      {:ok,
+       assign(socket,
+         page_title: "Directory Providers",
+         directory_providers: directory_providers
+       )}
+    else
+      _ -> raise Web.LiveErrors.NotFoundError
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs account={@account}>
+      <.breadcrumb path={~p"/#{@account}/settings/directory_providers"}>
+        Directory Provider Settings
+      </.breadcrumb>
+    </.breadcrumbs>
+    <.section>
+      <:title>
+        Directory Providers
+      </:title>
+      <:action>
+        <.docs_action path="/authenticate/directory_sync" />
+      </:action>
+      <:help>
+        Directory providers sync your users and groups with an external source.
+      </:help>
+      <:content>
+        <.flash_group flash={@flash} />
+
+        <ul class="grid w-full gap-6 md:grid-cols-3">
+          <li>
+            <div class="block">
+              <div class="w-full font-semibold mb-3">
+                <.provider_icon adapter={:okta} class="w-5 h-5 mr-1" /> Okta
+              </div>
+              <div class="w-full text-sm">
+                Sync users, groups, and memberships from your Okta directory.
+              </div>
+              <div :if={provider_created?(@directory_providers, :okta)}>
+                <.link
+                  class={link_style()}
+                  navigate={~p"/#{@account}/settings/directory_providers/okta/edit"}
+                >
+                  Edit
+                </.link>
+              </div>
+              <div :if={not provider_created?(@directory_providers, :okta)}>
+                <.link
+                  class={link_style()}
+                  navigate={~p"/#{@account}/settings/directory_providers/okta/new"}
+                >
+                  Create
+                </.link>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </:content>
+    </.section>
+    """
+  end
+
+  defp provider_created?(directory_providers, type) do
+    Enum.any?(directory_providers, &(&1.type == type))
+  end
+end

--- a/elixir/apps/web/lib/web/live/settings/directory_providers/okta/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/directory_providers/okta/edit.ex
@@ -1,0 +1,122 @@
+defmodule Web.Settings.DirectoryProviders.Okta.Edit do
+  use Web, :live_view
+  alias Domain.Crypto
+  alias Domain.Directories
+  alias Domain.Directories.Okta.Config
+
+  def mount(_params, _session, socket) do
+    with {:ok, directory_provider} <- Directories.fetch_provider_by_account_and_type(socket.assigns.account, :okta) do
+      private_key = directory_provider.config["private_key"]
+      public_key = Crypto.JWK.public_key(private_key)
+      changeset = Config.Changeset.changeset(directory_provider.config)
+
+      {:ok, assign(socket,
+        form: to_form(changeset),
+        directory_provider: directory_provider,
+        page_title: "Edit Directory Provider: Okta",
+        public_key: public_key
+      )}
+    else
+      _ ->
+        raise Web.LiveErrors.NotFoundError
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs account={@account}>
+      <.breadcrumb path={~p"/#{@account}/settings/directory_providers"}>
+        Directory Provider Settings
+      </.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/settings/directory_providers/okta/edit"}>
+        Edit Okta Provider
+      </.breadcrumb>
+    </.breadcrumbs>
+    <.section>
+      <:title>{@page_title}</:title>
+      <:help>
+        Connect your Okta directory to sync users, groups, and memberships into Firezone.
+      </:help>
+      <:content>
+        <div class="max-w-2xl px-4 py-8 mx-auto lg:py-12">
+          <.form for={@form} phx-submit={:submit}>
+            <div class="mb-4">
+              <.input
+                label="Client ID"
+                autocomplete="off"
+                field={@form[:client_id]}
+                placeholder="Client ID for the Okta application"
+                required
+              />
+              <p class="mt-2 text-xs text-neutral-500">
+                The Client ID for the Okta application you created.
+              </p>
+            </div>
+            <div class="mb-4">
+              <p class="text-sm text-neutral-900 mb-2">
+                Copy and paste the below public key into the Okta application:
+              </p>
+              <.code_block
+                id="public-key"
+                class="w-full text-xs whitespace-pre-line rounded"
+                phx-no-format
+              >{Jason.Formatter.pretty_print(@public_key)}</.code_block>
+            </div>
+            <div class="mb-4">
+              <.input
+                label="Okta Domain"
+                autocomplete="off"
+                field={@form[:okta_domain]}
+                placeholder="company.okta.com"
+                required
+              />
+              <p class="mt-2 text-xs text-neutral-500">
+                Your organization's unique Okta domain. See
+                <.link
+                  class={link_style()}
+                  target="_blank"
+                  href="https://developer.okta.com/docs/guides/find-your-domain/main/"
+                >
+                  the Okta documentation
+                </.link>
+                for how to find this.
+              </p>
+            </div>
+            <div>
+              <.submit_button>
+                Save
+              </.submit_button>
+            </div>
+          </.form>
+        </div>
+      </:content>
+    </.section>
+    """
+  end
+
+  def handle_event("submit", attrs, socket) do
+    provider_attrs = %{
+      "config" => attrs["config"]
+    }
+
+    case Directories.update_provider_config(socket.assigns.directory_provider, provider_attrs) do
+      {:ok, _provider} ->
+        socket =
+          socket
+          |> put_flash(:info, "Okta directory provider updated successfully.")
+          |> push_navigate(to: ~p"/#{socket.assigns.account}/settings/directory_providers")
+
+        {:noreply, socket}
+
+      {:error, provider_changeset} ->
+        config_changeset = provider_changeset.changes.config
+
+        socket =
+          socket
+          |> assign(form: to_form(config_changeset))
+          |> put_flash(:error, "Failed to update Okta directory provider.")
+
+        {:noreply, socket}
+    end
+  end
+end

--- a/elixir/apps/web/lib/web/live/settings/directory_providers/okta/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/directory_providers/okta/new.ex
@@ -1,0 +1,132 @@
+defmodule Web.Settings.DirectoryProviders.Okta.New do
+  use Web, :live_view
+  alias Domain.Crypto
+  alias Domain.Directories
+  alias Domain.Directories.Okta.Config
+
+  def mount(_params, _session, socket) do
+    changeset = Config.Changeset.new()
+
+    keys =
+      if connected?(socket) do
+        private_key = Crypto.JWK.generate_private_key()
+        public_key = Crypto.JWK.public_key(private_key)
+
+        %{public_key: public_key, private_key: private_key}
+      else
+        %{public_key: "Loading...", private_key: nil}
+      end
+
+    {:ok,
+     assign(socket,
+       form: to_form(changeset),
+       page_title: "New Directory Provider: Okta",
+       public_key: keys.public_key,
+       private_key: keys.private_key
+     )}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs account={@account}>
+      <.breadcrumb path={~p"/#{@account}/settings/directory_providers"}>
+        Directory Provider Settings
+      </.breadcrumb>
+      <.breadcrumb path={~p"/#{@account}/settings/directory_providers/okta/new"}>
+        New Okta Provider
+      </.breadcrumb>
+    </.breadcrumbs>
+    <.section>
+      <:title>{@page_title}</:title>
+      <:help>
+        Connect your Okta directory to sync users, groups, and memberships into Firezone.
+      </:help>
+      <:content>
+        <div class="max-w-2xl px-4 py-8 mx-auto lg:py-12">
+          <.form for={@form} phx-submit={:submit}>
+            <div class="mb-4">
+              <.input
+                label="Client ID"
+                autocomplete="off"
+                field={@form[:client_id]}
+                placeholder="Client ID for the Okta application"
+                required
+              />
+              <p class="mt-2 text-xs text-neutral-500">
+                The Client ID for the Okta application you created.
+              </p>
+            </div>
+            <div class="mb-4">
+              <p class="text-sm text-neutral-900 mb-2">
+                Copy and paste the below public key into the Okta application:
+              </p>
+              <.code_block
+                id="public-key"
+                class="w-full text-xs whitespace-pre-line rounded"
+                phx-no-format
+              >{Jason.Formatter.pretty_print(@public_key)}</.code_block>
+            </div>
+            <div class="mb-4">
+              <.input
+                label="Okta Domain"
+                autocomplete="off"
+                field={@form[:okta_domain]}
+                placeholder="company.okta.com"
+                required
+              />
+              <p class="mt-2 text-xs text-neutral-500">
+                Your organization's unique Okta domain. See
+                <.link
+                  class={link_style()}
+                  target="_blank"
+                  href="https://developer.okta.com/docs/guides/find-your-domain/main/"
+                >
+                  the Okta documentation
+                </.link>
+                for how to find this.
+              </p>
+            </div>
+            <div>
+              <.submit_button>
+                Save
+              </.submit_button>
+            </div>
+          </.form>
+        </div>
+      </:content>
+    </.section>
+    """
+  end
+
+  def handle_event("submit", attrs, socket) do
+    config =
+      Map.merge(attrs["config"], %{
+        "private_key" => socket.assigns.private_key
+      })
+
+    provider_attrs = %{
+      "config" => config,
+      "type" => :okta
+    }
+
+    case Directories.create_provider(socket.assigns.account, provider_attrs) do
+      {:ok, _provider} ->
+        socket =
+          socket
+          |> put_flash(:info, "Okta directory provider created successfully.")
+          |> push_navigate(to: ~p"/#{socket.assigns.account}/settings/directory_providers")
+
+        {:noreply, socket}
+
+      {:error, provider_changeset} ->
+        config_changeset = provider_changeset.changes.config
+
+        socket =
+          socket
+          |> assign(form: to_form(config_changeset))
+          |> put_flash(:error, "Failed to create Okta directory provider.")
+
+        {:noreply, socket}
+    end
+  end
+end

--- a/elixir/apps/web/lib/web/router.ex
+++ b/elixir/apps/web/lib/web/router.ex
@@ -291,6 +291,15 @@ defmodule Web.Router do
           end
         end
 
+        scope "/directory_providers", DirectoryProviders do
+          live "/", Index
+
+          scope "/okta", Okta do
+            live "/new", New
+            live "/edit", Edit
+          end
+        end
+
         live "/dns", DNS
       end
     end


### PR DESCRIPTION
- [ ] Add email-based invitation flow to Google service account setup
- [ ] Use service account creds for Okta
- [ ] Use service account creds for Google
- [ ] Implement Group filters
- [ ] Multi-step wizard for new directory providers
- [ ] Remove temporary association between auth_providers and directory_providers
- [ ] Add migrate button for existing accounts