### PR TITLE
fix(rust): don't use jemalloc on ARMv7

### DIFF
--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -1,5 +1,5 @@
-#[cfg(unix)]
-#[cfg_attr(unix, global_allocator)]
+#[cfg(all(unix, not(target_arch = "arm")))]
+#[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use crate::eventloop::{Eventloop, PHOENIX_TOPIC};

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-#[cfg(unix)]
-#[cfg_attr(unix, global_allocator)]
+#[cfg(all(unix, not(target_arch = "arm")))]
+#[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use anyhow::{Context, Result, bail};


### PR DESCRIPTION
Doesn't compile on ARMv7 so we just fallback to the default allocator there.