### PR TITLE
test(connlib): correctly assert in `Io` unit-test

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -469,7 +469,7 @@ mod tests {
             panic!("Unexpected result");
         };
 
-        assert!(timeout.duration_since(now) < Duration::from_millis(100));
+        assert!(timeout >= now, "timeout = {timeout:?}, now = {now:?}");
     }
 
     static mut DUMMY_BUF: Buffers = Buffers { ip: Vec::new() };


### PR DESCRIPTION
Not sure what I was smoking when I wrote this test but the current assertion makes no sense for what we actually want to test.

As the test name says, we want to assert that if we are given an `Instant` in the past, we do in fact return a more recent one and therefore what is returned in `Input::Timeout` is at least as recent as `now`.