### PR TITLE
ci(swift): split uploads of packages into two

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -108,14 +108,18 @@ jobs:
           API_KEY_ID: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY_ID }}"
           API_KEY: "${{ secrets.APPLE_APP_STORE_CONNECT_API_KEY }}"
           TEMP_DIR: "${{ runner.temp }}"
-      - name: Upload package artifacts
+      - name: Upload .dmg artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: "${{ github.event_name == 'workflow_dispatch' && matrix.job_name == 'build-macos-standalone' }}"
         with:
-          name: macos-client-standalone
-          path: |
-            "${{ runner.temp }}/${{ matrix.artifact-file }}"
-            "${{ runner.temp }}/${{ matrix.pkg-artifact-file }}"
+          name: macos-client-standalone-dmg
+          path: "${{ runner.temp }}/${{ matrix.artifact-file }}"
+      - name: Upload .pkg artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: "${{ github.event_name == 'workflow_dispatch' && matrix.job_name == 'build-macos-standalone' }}"
+        with:
+          name: macos-client-standalone-pkg
+          path: "${{ runner.temp }}/${{ matrix.pkg-artifact-file }}"
       - run: ${{ matrix.upload-script }}
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
         env:


### PR DESCRIPTION
In #8795 we added an additional path to the artifact upload which appeared to have broken it. The action cannot seem to handle multiple direct paths that lead to files. It tries to but fails:

```
Multiple search paths detected. Calculating the least common ancestor of all paths
The least common ancestor is /Users/runner/work/firezone/firezone/"/Users/runner/work/_temp. This will be the root directory of the artifact
Warning: No files were found with the provided path: "/Users/runner/work/_temp/firezone-macos-client-1.4.12.dmg"
"/Users/runner/work/_temp/firezone-macos-client-1.4.12.pkg". No artifacts will be uploaded.
```

Source: https://github.com/firezone/firezone/actions/runs/14571295945/job/40868936348#step:7:31

Splitting this step into two and creating one artifact each fixes this as can be seen in the following job (which I triggered for this PR): https://github.com/firezone/firezone/actions/runs/14572176039/job/40871304453