### PR TITLE
feat(gateway): multi-threaded UDP socket

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -100,9 +100,9 @@ impl Io {
     pub fn new(
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
+        mut sockets: Sockets,
         nameservers: BTreeSet<IpAddr>,
     ) -> Self {
-        let mut sockets = Sockets::default();
         sockets.rebind(udp_socket_factory.clone()); // Bind sockets on startup.
 
         let mut nameservers = NameserverSet::new(
@@ -480,6 +480,7 @@ mod tests {
             let mut io = Io::new(
                 Arc::new(|_| Err(io::Error::other("not implemented"))),
                 Arc::new(|_| Err(io::Error::other("not implemented"))),
+                Sockets::default(),
                 BTreeSet::new(),
             );
             io.set_tun(Box::new(DummyTun));

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -15,6 +15,7 @@ use io::{Buffers, Io};
 use ip_network::{Ipv4Network, Ipv6Network};
 use ip_packet::Ecn;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
+use sockets::Sockets;
 use std::{
     collections::BTreeSet,
     fmt,
@@ -118,6 +119,7 @@ impl ClientTunnel {
             io: Io::new(
                 tcp_socket_factory,
                 udp_socket_factory.clone(),
+                Sockets::default(),
                 BTreeSet::default(),
             ),
             role_state: ClientState::new(rand::random(), Instant::now()),
@@ -247,7 +249,12 @@ impl GatewayTunnel {
         nameservers: BTreeSet<IpAddr>,
     ) -> Self {
         Self {
-            io: Io::new(tcp_socket_factory, udp_socket_factory.clone(), nameservers),
+            io: Io::new(
+                tcp_socket_factory,
+                udp_socket_factory.clone(),
+                Sockets::default(),
+                nameservers,
+            ),
             role_state: GatewayState::new(rand::random(), Instant::now()),
             buffers: Buffers::default(),
             packet_counter: opentelemetry::global::meter("connlib")

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -20,6 +20,7 @@ use std::{
     collections::BTreeSet,
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    num::NonZeroUsize,
     sync::Arc,
     task::{Context, Poll, ready},
     time::Instant,
@@ -247,12 +248,13 @@ impl GatewayTunnel {
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
         nameservers: BTreeSet<IpAddr>,
+        num_udp_threads: NonZeroUsize,
     ) -> Self {
         Self {
             io: Io::new(
                 tcp_socket_factory,
                 udp_socket_factory.clone(),
-                Sockets::default(),
+                Sockets::new(num_udp_threads),
                 nameservers,
             ),
             role_state: GatewayState::new(rand::random(), Instant::now()),

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -79,7 +79,7 @@ pub use utils::turn;
 /// [`Tunnel`] glues together connlib's [`Io`] component and the respective (pure) state of a client or gateway.
 ///
 /// Most of connlib's functionality is implemented as a pure state machine in [`ClientState`] and [`GatewayState`].
-/// The only job of [`Tunnel`] is to take input from the TUN [`Device`](crate::device_channel::Device), [`Sockets`](crate::sockets::Sockets) or time and pass it to the respective state.
+/// The only job of [`Tunnel`] is to take input from the TUN [`Device`](crate::device_channel::Device), [`Sockets`] or time and pass it to the respective state.
 pub struct Tunnel<TRoleState> {
     /// (pure) state that differs per role, either [`ClientState`] or [`GatewayState`].
     role_state: TRoleState,

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -30,7 +30,7 @@ impl Default for Sockets {
     fn default() -> Self {
         Self {
             waker: Default::default(),
-            num_threads: NonZeroUsize::new(1).unwrap(),
+            num_threads: NonZeroUsize::new(1).expect("1 > 0"),
             socket_v4: Default::default(),
             socket_v6: Default::default(),
         }

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -181,7 +181,6 @@ struct ThreadedUdpSocket {
 }
 
 impl ThreadedUdpSocket {
-    #[expect(clippy::unwrap_in_result, reason = "We unwrap in the new thread.")]
     fn new(
         sf: Arc<dyn SocketFactory<UdpSocket>>,
         mut addr: SocketAddr,

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -22,10 +22,7 @@ use phoenix_channel::PhoenixChannel;
 use secrecy::{Secret, SecretString};
 use std::{collections::BTreeSet, path::Path};
 use std::{fmt, pin::pin};
-use std::{
-    num::{NonZero, NonZeroUsize},
-    sync::Arc,
-};
+use std::{num::NonZeroUsize, sync::Arc};
 use std::{process::ExitCode, str::FromStr};
 use tokio::io::AsyncWriteExt;
 use tokio::signal::ctrl_c;

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -47,6 +47,8 @@ pub fn udp(std_addr: &SocketAddr) -> io::Result<UdpSocket> {
         socket.set_only_v6(true)?;
     }
 
+    #[cfg(unix)]
+    socket.set_reuse_port(true)?; // Allow spawning multiple threads for the same port.
     socket.set_nonblocking(true)?;
     socket.bind(&addr)?;
 

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -175,6 +175,10 @@ impl UdpSocket {
         })
     }
 
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
     /// Configures a new source IP resolver for this UDP socket.
     ///
     /// In case [`DatagramOut::src`] is [`None`], this function will be used to set a source IP given the destination IP of the datagram.


### PR DESCRIPTION
By utilising the `SO_REUSEPORT` socket option, we can bind additional sockets to the same IP + port combination. This allows us to spawn additional threads that can send and receive from the same address. The Linux kernel load balances between these sockets, i.e. packets with the same source IP + port will always be sent to the same socket. As such, this setting is primarily useful for the Gateway as it sends packets to many different Clients.

So far, the number threads is hard-coded to be at most 2 if we are on a system with 6 or more cores. It is configurable on the CLI so we can easily experiment and benchmark, how effective it is to increase this number.