### PR TITLE
feat(connlib): increase the number of GRO batches

### DIFF
--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -470,7 +470,7 @@ impl UdpSocket {
 /// Thus, our main job within this iterator is to loop over the `buffers` and `meta` pair-wise, inspect the `meta` and segment the data within the buffer accordingly.
 #[derive(derive_more::Debug)]
 pub struct DatagramSegmentIter<
-    const N: usize = 32,
+    const N: usize = { quinn_udp::BATCH_SIZE },
     B = lockfree_object_pool::MutexOwnedReusable<Vec<u8>>,
 > {
     #[debug(skip)]

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -470,7 +470,7 @@ impl UdpSocket {
 /// Thus, our main job within this iterator is to loop over the `buffers` and `meta` pair-wise, inspect the `meta` and segment the data within the buffer accordingly.
 #[derive(derive_more::Debug)]
 pub struct DatagramSegmentIter<
-    const N: usize = 10,
+    const N: usize = 32,
     B = lockfree_object_pool::MutexOwnedReusable<Vec<u8>>,
 > {
     #[debug(skip)]


### PR DESCRIPTION
When reading from our UDP socket, we utilise GRO to read multiple packets originating from the same IP + port and with the same length in a single syscall. Currently, we can read up to 10 different combinations here in a single syscall. `quinn_udp` actually exposes a constant for how many batches it can handle at a time. Instead of hard-coding the value 10, we now follow this constant.

On Linux and MacOS (with `apple-fast-datapath`), this constant has the value 32. On Windows, it is 1.

Even on my not-so-fast Internet connection of 100Mbit, I can see an increase in batch-count of up to 29 so increasing this value seems to be definitely worth it.