### PR TITLE
chore(connlib): record GRO batch-size as histogram metric

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6487,6 +6487,7 @@ dependencies = [
  "gat-lending-iterator",
  "ip-packet",
  "lockfree-object-pool",
+ "opentelemetry",
  "parking_lot",
  "quinn-udp",
  "socket2",

--- a/rust/socket-factory/Cargo.toml
+++ b/rust/socket-factory/Cargo.toml
@@ -12,6 +12,7 @@ firezone-logging = { workspace = true }
 gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
 lockfree-object-pool = { workspace = true }
+opentelemetry = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true }


### PR DESCRIPTION
This will allow us to test, how many batches we typically read from the UDP socket in a single syscall. Knowing that should help in profiling #8874.