### PR TITLE
chore(portal): Drop unused table configurations

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20250421182422_drop_configurations.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250421182422_drop_configurations.exs
@@ -1,0 +1,7 @@
+defmodule Domain.Repo.Migrations.DropConfigurations do
+  use Ecto.Migration
+
+  def change do
+    drop(table(:configurations))
+  end
+end


### PR DESCRIPTION
This was left behind in a large refactor as part of #3642 and was never cleaned up.

I verified on prod this table in fact has no meaningful data in it and has not changed since that PR was merged.