### PR TITLE
build(rust): bump `aya` to include BTF information feature

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "aya"
 version = "0.13.1"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "assert_matches",
  "aya-obj",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "aya-build"
 version = "0.1.2"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "aya-ebpf"
 version = "0.1.1"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "aya-ebpf-bindings",
  "aya-ebpf-cty",
@@ -571,7 +571,7 @@ dependencies = [
 [[package]]
 name = "aya-ebpf-bindings"
 version = "0.1.1"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "aya-ebpf-cty",
 ]
@@ -579,12 +579,12 @@ dependencies = [
 [[package]]
 name = "aya-ebpf-cty"
 version = "0.2.2"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 
 [[package]]
 name = "aya-ebpf-macros"
 version = "0.1.1"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -595,7 +595,7 @@ dependencies = [
 [[package]]
 name = "aya-log"
 version = "0.2.1"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "aya",
  "aya-log-common",
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "aya-log-common"
 version = "0.1.15"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "num_enum",
 ]
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "aya-log-ebpf"
 version = "0.1.1"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "aya-ebpf",
  "aya-log-common",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "aya-log-ebpf-macros"
 version = "0.1.0"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "aya-log-common",
  "aya-log-parser",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "aya-log-parser"
 version = "0.1.13"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "aya-log-common",
 ]
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "aya-obj"
 version = "0.2.1"
-source = "git+https://github.com/aya-rs/aya#0237e36dbeb882dccc4887fadc3e0dd0324e2eb7"
+source = "git+https://github.com/aya-rs/aya#c65a200e9a6b0349178c0ee2bba280e498b48108"
 dependencies = [
  "bytes",
  "hashbrown 0.15.2",
@@ -3860,7 +3860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4430,7 +4430,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.87",

--- a/rust/relay/ebpf-turn-router/build.rs
+++ b/rust/relay/ebpf-turn-router/build.rs
@@ -14,11 +14,4 @@ use which::which;
 fn main() {
     let bpf_linker = which("bpf-linker").expect("bpf-linker not found in $PATH");
     println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
-
-    if std::env::var("CARGO_BUILD_TARGET")
-        .ok()
-        .is_some_and(|t| t == "bpfel-unknown-none" || t == "bpfeb-unknown-unknown")
-    {
-        println!("cargo:rustc-link-arg=--btf");
-    }
 }


### PR DESCRIPTION
The latest version of `aya-build` automatically builds our eBPF program with BTF information enabled.

Related: https://github.com/aya-rs/aya/pull/1250