### PR TITLE
fix(portal): Prevent dupe sync adapters

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
@@ -87,7 +87,7 @@ defmodule Domain.Auth.Provider.Changeset do
     )
     |> unique_constraint(:base,
       name: :unique_account_adapter_index,
-      message: "only of this adapter type may be enabled per account"
+      message: "only one of this adapter type may be enabled per account"
     )
     |> validate_provisioner()
     |> validate_required(@required_fields)

--- a/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
@@ -85,6 +85,10 @@ defmodule Domain.Auth.Provider.Changeset do
       name: :auth_providers_account_id_oidc_adapter_index,
       message: "this provider is already connected"
     )
+    |> unique_constraint(:base,
+      name: :unique_account_adapter_index,
+      message: "only of this adapter type may be enabled per account"
+    )
     |> validate_provisioner()
     |> validate_required(@required_fields)
   end

--- a/elixir/apps/domain/priv/repo/migrations/20250422031005_create_unique_index_auth_provider_account_adapter.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250422031005_create_unique_index_auth_provider_account_adapter.exs
@@ -7,7 +7,7 @@ defmodule Domain.Repo.Migrations.CreateUniqueIndexAuthProviderAccountAdapter do
         unique: true,
         name: :unique_account_adapter_index,
         where:
-          "deleted_at IS NULL AND adapter IN ('google_workspace', 'okta', 'jumpcloud', 'microsoft_entra')"
+          "deleted_at IS NULL AND adapter IN ('mock', 'google_workspace', 'okta', 'jumpcloud', 'microsoft_entra')"
       )
     )
   end

--- a/elixir/apps/domain/priv/repo/migrations/20250422031005_create_unique_index_auth_provider_account_adapter.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250422031005_create_unique_index_auth_provider_account_adapter.exs
@@ -1,0 +1,14 @@
+defmodule Domain.Repo.Migrations.CreateUniqueIndexAuthProviderAccountAdapter do
+  use Ecto.Migration
+
+  def change do
+    create(
+      index(:auth_providers, [:account_id, :adapter],
+        unique: true,
+        name: :unique_account_adapter_index,
+        where:
+          "deleted_at IS NULL AND adapter IN ('google_workspace', 'okta', 'jumpcloud', 'microsoft_entra')"
+      )
+    )
+  end
+end


### PR DESCRIPTION
Prevents more than one sync-enabled adapter per account in order to prepare for eventually adding a unique constraint on `provider_identifier` for identities and groups per account.

Related: #6294 