### PR TITLE
fix(portal): Prevent additional email identities per actor

### DIFF
--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -19,9 +19,9 @@ defmodule Web.Actors.Users.NewIdentity do
           |> Keyword.fetch!(:provisioners)
           |> Enum.member?(:manual)
         end)
-          |> Enum.reject(fn provider ->
-            provider.adapter == :email
-          end)
+        |> Enum.reject(fn provider ->
+          provider.adapter == :email
+        end)
 
       provider = List.first(providers)
       changeset = Auth.new_identity(actor, provider)

--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -6,7 +6,7 @@ defmodule Web.Actors.Users.NewIdentity do
   def mount(%{"id" => id} = params, _session, socket) do
     with {:ok, actor} <-
            Actors.fetch_actor_by_id(id, socket.assigns.subject,
-             preload: [:memberships],
+             preload: [:memberships, :identities],
              filter: [
                deleted?: false,
                types: ["account_user", "account_admin_user"]
@@ -20,7 +20,10 @@ defmodule Web.Actors.Users.NewIdentity do
           |> Enum.member?(:manual)
         end)
         |> Enum.reject(fn provider ->
-          provider.adapter == :email
+          provider.adapter == :email and
+            Enum.any?(actor.identities, fn identity ->
+              identity.provider_id == provider.id
+            end)
         end)
 
       provider = List.first(providers)

--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -15,15 +15,14 @@ defmodule Web.Actors.Users.NewIdentity do
       providers =
         Auth.all_active_providers_for_account!(socket.assigns.account)
         |> Enum.filter(fn provider ->
-          Auth.fetch_provider_capabilities!(provider)
-          |> Keyword.fetch!(:provisioners)
-          |> Enum.member?(:manual)
-        end)
-        |> Enum.reject(fn provider ->
-          provider.adapter == :email and
-            Enum.any?(actor.identities, fn identity ->
-              identity.provider_id == provider.id
-            end)
+          # TODO: This will be refactored to enforce with a DB constraint, but for now
+          # we don't allow creating multiple identities per actor for the same provider.
+          Enum.all?(actor.identities, fn identity ->
+            identity.provider_id != provider.id
+          end) and
+            Auth.fetch_provider_capabilities!(provider)
+            |> Keyword.fetch!(:provisioners)
+            |> Enum.member?(:manual)
         end)
 
       provider = List.first(providers)

--- a/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
+++ b/elixir/apps/web/lib/web/live/actors/users/new_identity.ex
@@ -19,6 +19,9 @@ defmodule Web.Actors.Users.NewIdentity do
           |> Keyword.fetch!(:provisioners)
           |> Enum.member?(:manual)
         end)
+          |> Enum.reject(fn provider ->
+            provider.adapter == :email
+          end)
 
       provider = List.first(providers)
       changeset = Auth.new_identity(actor, provider)

--- a/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
+++ b/elixir/apps/web/test/web/live/actors/users/new_identity_test.exs
@@ -5,16 +5,22 @@ defmodule Web.Live.Actors.User.NewIdentityTest do
     Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
     account = Fixtures.Accounts.create_account()
-    provider = Fixtures.Auth.create_email_provider(account: account)
+    _provider = Fixtures.Auth.create_email_provider(account: account)
+
+    # TODO: Users won't be able to naturally arrive at some of the routes tested on this page without another
+    # manual provisioning provider like OIDC, so we add it here. Clean this up when identities are refactored.
+    {oidc_provider, _bypass} =
+      Fixtures.Auth.start_and_create_openid_connect_provider(account: account)
 
     actor =
       Fixtures.Actors.create_actor(
         type: :account_admin_user,
         account: account,
-        provider: provider
+        provider: oidc_provider
       )
 
-    identity = Fixtures.Auth.create_identity(account: account, provider: provider, actor: actor)
+    identity =
+      Fixtures.Auth.create_identity(account: account, provider: oidc_provider, actor: actor)
 
     %{
       account: account,


### PR DESCRIPTION
This is a UI-only change for now to serve as a stop-gap while we work to overhaul the identity domain model.

Related: #6294 