### PR TITLE
fix(portal): Don't peek groups for api_client actors

### DIFF
--- a/elixir/apps/web/lib/web/live/actors/index.ex
+++ b/elixir/apps/web/lib/web/live/actors/index.ex
@@ -96,7 +96,8 @@ defmodule Web.Actors.Index do
           </:col>
 
           <:col :let={actor} label="groups" class="w-1/12">
-            <.popover placement="right">
+            <span :if={actor.type == :api_client}>None</span>
+            <.popover :if={actor.type != :api_client} placement="right">
               <:target>
                 <.link
                   navigate={~p"/#{@account}/actors/#{actor}?#groups"}


### PR DESCRIPTION
API clients don't belong to any actor_groups and attempting to deep link into the `groups` section when viewing an actor raises a 500 error.

This PR fixes that by removing the deep link into `actor_groups` from the actors index view.

