### PR TITLE
chore(connlib): optimise RAM usage

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2535,12 +2535,12 @@ dependencies = [
 
 [[package]]
 name = "futures-bounded"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+checksum = "b604752cefc5aa3ab98992a107a8bd99465d2825c1584e0b60cb6957b21e19d7"
 dependencies = [
- "futures-timer",
  "futures-util",
+ "tokio",
 ]
 
 [[package]]
@@ -2611,12 +2611,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -5283,7 +5277,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -189,7 +189,7 @@ windows = "0.61.0"
 windows-core = "0.61.0"
 windows-implement = "0.60.0"
 winreg = "0.52.0"
-zbus = "5.5.0"
+zbus = { version = "5.5.0", default-features = false, features = ["tokio"] }
 zip = { version = "2", default-features = false }
 
 [workspace.lints.clippy]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -79,7 +79,7 @@ firezone-telemetry = { path = "telemetry" }
 firezone-tunnel = { path = "connlib/tunnel" }
 flume = { version = "0.11.1", features = ["async"] }
 futures = { version = "0.3.31" }
-futures-bounded = "0.2.1"
+futures-bounded = { version = "0.3.0", features = ["tokio"] }
 gat-lending-iterator = "0.1.6"
 glob = "0.3.2"
 hex = "0.4.3"

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -315,6 +315,7 @@ impl Tun {
 
             std::thread::Builder::new()
                 .name(format!("TUN send {n}/{num_threads}"))
+                .stack_size(100 * 1024)
                 .spawn({
                     let fd = fd.clone();
 
@@ -328,6 +329,7 @@ impl Tun {
                 .map_err(io::Error::other)?;
             std::thread::Builder::new()
                 .name(format!("TUN recv {n}/{num_threads}"))
+                .stack_size(100 * 1024)
                 .spawn({
                     let fd = fd.clone();
 

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -362,6 +362,7 @@ fn start_send_thread(
 
     std::thread::Builder::new()
         .name("TUN send".into())
+        .stack_size(100 * 1024)
         .spawn(move || loop {
             let Some(packet) = packet_rx.blocking_recv() else {
                 tracing::debug!(
@@ -416,6 +417,7 @@ fn start_recv_thread(
 ) -> io::Result<std::thread::JoinHandle<()>> {
     std::thread::Builder::new()
         .name("TUN recv".into())
+        .stack_size(100 * 1024)
         .spawn(move || {
             loop {
                 let Some(receive_result) = session.upgrade().map(|s| s.receive_blocking()) else {

--- a/rust/connlib/clients/android/src/tun.rs
+++ b/rust/connlib/clients/android/src/tun.rs
@@ -60,6 +60,7 @@ impl Tun {
 
         std::thread::Builder::new()
             .name("TUN send".to_owned())
+            .stack_size(100 * 1024)
             .spawn(move || {
                 firezone_logging::unwrap_or_warn!(
                     tun::unix::tun_send(fd, outbound_rx.into_stream(), write),
@@ -69,6 +70,7 @@ impl Tun {
             .map_err(io::Error::other)?;
         std::thread::Builder::new()
             .name("TUN recv".to_owned())
+            .stack_size(100 * 1024)
             .spawn(move || {
                 firezone_logging::unwrap_or_warn!(
                     tun::unix::tun_recv(fd, inbound_tx, read),

--- a/rust/connlib/clients/apple/src/tun.rs
+++ b/rust/connlib/clients/apple/src/tun.rs
@@ -26,6 +26,7 @@ impl Tun {
 
         std::thread::Builder::new()
             .name("TUN send".to_owned())
+            .stack_size(100 * 1024)
             .spawn(move || {
                 firezone_logging::unwrap_or_warn!(
                     tun::unix::tun_send(fd, outbound_rx.into_stream(), write),
@@ -35,6 +36,7 @@ impl Tun {
             .map_err(io::Error::other)?;
         std::thread::Builder::new()
             .name("TUN recv".to_owned())
+            .stack_size(100 * 1024)
             .spawn(move || {
                 firezone_logging::unwrap_or_warn!(
                     tun::unix::tun_recv(fd, inbound_tx, read),

--- a/rust/connlib/clients/shared/src/callbacks.rs
+++ b/rust/connlib/clients/shared/src/callbacks.rs
@@ -69,6 +69,7 @@ impl<C> BackgroundCallbacks<C> {
             threadpool: Arc::new(
                 rayon::ThreadPoolBuilder::new()
                     .num_threads(1)
+                    .stack_size(100 * 1024)
                     .thread_name(|_| "connlib callbacks".to_owned())
                     .build()
                     .expect("Unable to create thread-pool"),

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -119,7 +119,10 @@ impl Io {
             nameservers,
             tcp_socket_factory,
             udp_socket_factory,
-            dns_queries: FuturesTupleSet::new(DNS_QUERY_TIMEOUT, 1000),
+            dns_queries: FuturesTupleSet::new(
+                || futures_bounded::Delay::tokio(DNS_QUERY_TIMEOUT),
+                1000,
+            ),
             gso_queue: GsoQueue::new(),
             tun: Device::new(),
             udp_dns_server: Default::default(),
@@ -323,7 +326,8 @@ impl Io {
     pub fn reset(&mut self) {
         self.sockets.rebind(self.udp_socket_factory.clone());
         self.gso_queue.clear();
-        self.dns_queries = FuturesTupleSet::new(DNS_QUERY_TIMEOUT, 1000);
+        self.dns_queries =
+            FuturesTupleSet::new(|| futures_bounded::Delay::tokio(DNS_QUERY_TIMEOUT), 1000);
         self.nameservers.evaluate();
     }
 

--- a/rust/connlib/tunnel/src/io/nameserver_set.rs
+++ b/rust/connlib/tunnel/src/io/nameserver_set.rs
@@ -42,7 +42,10 @@ impl NameserverSet {
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
     ) -> Self {
         Self {
-            queries: FuturesTupleSet::new(DNS_TIMEOUT, MAX_DNS_SERVERS),
+            queries: FuturesTupleSet::new(
+                || futures_bounded::Delay::tokio(DNS_TIMEOUT),
+                MAX_DNS_SERVERS,
+            ),
             inner,
             tcp_socket_factory,
             udp_socket_factory,

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -165,7 +165,7 @@ impl ThreadedUdpSocket {
                 SocketAddr::V4(_) => "UDP IPv4".to_owned(),
                 SocketAddr::V6(_) => "UDP IPv6".to_owned(),
             })
-            .stack_size(400 * 1024)
+            .stack_size(500 * 1024)
             .spawn(move || {
                 tokio::runtime::Builder::new_current_thread()
                     .enable_all()

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -165,6 +165,7 @@ impl ThreadedUdpSocket {
                 SocketAddr::V4(_) => "UDP IPv4".to_owned(),
                 SocketAddr::V6(_) => "UDP IPv6".to_owned(),
             })
+            .stack_size(400 * 1024)
             .spawn(move || {
                 tokio::runtime::Builder::new_current_thread()
                     .enable_all()

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -72,8 +72,14 @@ impl Eventloop {
             tunnel,
             portal,
             tun_device_manager: Arc::new(Mutex::new(tun_device_manager)),
-            resolve_tasks: futures_bounded::FuturesTupleSet::new(DNS_RESOLUTION_TIMEOUT, 1000),
-            set_interface_tasks: futures_bounded::FuturesSet::new(Duration::from_secs(5), 10),
+            resolve_tasks: futures_bounded::FuturesTupleSet::new(
+                || futures_bounded::Delay::tokio(DNS_RESOLUTION_TIMEOUT),
+                1000,
+            ),
+            set_interface_tasks: futures_bounded::FuturesSet::new(
+                || futures_bounded::Delay::tokio(Duration::from_secs(5)),
+                10,
+            ),
             logged_permission_denied: false,
             dns_cache: moka::future::Cache::builder()
                 .name("DNS queries")

--- a/rust/telemetry/src/feature_flags.rs
+++ b/rust/telemetry/src/feature_flags.rs
@@ -51,6 +51,7 @@ pub(crate) fn reevaluate(user_id: String, env: &str) {
 fn init_runtime() -> Runtime {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1) // We only need 1 worker thread.
+        .thread_stack_size(200 * 1024)
         .thread_name("feature-flag-worker")
         .enable_io()
         .enable_time()


### PR DESCRIPTION
Currently, `connlib` spawns several threads with their default stack-size (2MB in Rust) but also depends on several crates that spawn threads themselves.

We optimise the amount of RAM we use by first decreasing the stack-size of our own threads. In addition, we mess around with some library features and dependencies to reduce the number of threads we spawn overall.