### PR TITLE
feat(ci): Add custom postgres Dockerfile for wal2json

### DIFF
--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     services:
       postgres:
-        image: postgres:15.5
+        image: us-east1-docker.pkg.dev/firezone-staging/firezone/postgres:15
         ports:
           - 5432:5432
         env:
@@ -131,7 +131,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     services:
       postgres:
-        image: postgres:15.5
+        image: us-east1-docker.pkg.dev/firezone-staging/firezone/postgres:15
         ports:
           - 5432:5432
         env:
@@ -185,7 +185,7 @@ jobs:
         MIX_TEST_PARTITION: [1]
     services:
       postgres:
-        image: postgres:15.5
+        image: us-east1-docker.pkg.dev/firezone-staging/firezone/postgres:15
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/build-postgres.yml
+++ b/.github/workflows/build-postgres.yml
@@ -18,11 +18,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-          # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-          # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.15.1
+            image=moby/buildkit:v0.20.0
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:

--- a/.github/workflows/build-postgres.yml
+++ b/.github/workflows/build-postgres.yml
@@ -1,0 +1,42 @@
+name: Build Postgres
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
+          # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
+          # We should for any updates on buildx and on the setup-buildx-action itself.
+          driver-opts: |
+            image=moby/buildkit:v0.15.1
+      - uses: ./.github/actions/gcp-docker-login
+        id: login
+        with:
+          project: firezone-staging
+      - name: Build and push
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: elixir
+          file: elixir/Dockerfile.postgres-dev
+          platforms: |
+            linux/amd64
+            linux/arm64
+          push: true
+          tags: |
+            ${{ steps.login.outputs.registry }}/firezone/postgres:latest
+            ${{ steps.login.outputs.registry }}/firezone/postgres:${{ github.sha }}
+            ${{ steps.login.outputs.registry }}/firezone/postgres:15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ services:
   # Dependencies
   postgres:
     # TODO: Enable pgaudit on dev instance. See https://github.com/pgaudit/pgaudit/issues/44#issuecomment-455090262
-    image: postgres:15
+    # Includes wal2json
+    image: us-east1-docker.pkg.dev/firezone-staging/firezone/postgres:15
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:

--- a/elixir/Dockerfile.postgres-dev
+++ b/elixir/Dockerfile.postgres-dev
@@ -1,0 +1,17 @@
+# Builds a Postgres image with needed extensions and modules for local development
+
+# Install wal2json
+ARG POSTGRES_VERSION=15
+FROM postgres:${POSTGRES_VERSION}-alpine AS builder
+RUN apk add --no-cache \
+  build-base \
+  git \
+  llvm \
+  clang
+RUN git clone https://github.com/eulerto/wal2json.git
+WORKDIR /wal2json
+RUN USE_PGXS=1 make && make install
+
+# Prepare final image
+FROM postgres:${POSTGRES_VERSION}-alpine
+COPY --from=builder /wal2json/wal2json.so /usr/local/lib/postgresql/

--- a/elixir/Dockerfile.postgres-dev
+++ b/elixir/Dockerfile.postgres-dev
@@ -7,11 +7,13 @@ RUN apk add --no-cache \
   build-base \
   git \
   llvm \
-  clang
-RUN git clone https://github.com/eulerto/wal2json.git
-WORKDIR /wal2json
+  clang \
+  curl
+ARG WAL2JSON_VERSION=2_6
+RUN curl -fssL https://github.com/eulerto/wal2json/archive/refs/tags/wal2json_${WAL2JSON_VERSION}.tar.gz | tar -xzf - -C /tmp --strip-components=1
+WORKDIR /tmp
 RUN USE_PGXS=1 make && make install
 
 # Prepare final image
 FROM postgres:${POSTGRES_VERSION}-alpine
-COPY --from=builder /wal2json/wal2json.so /usr/local/lib/postgresql/
+COPY --from=builder /tmp/wal2json.so /usr/local/lib/postgresql/


### PR DESCRIPTION
In order to develop and test WAL replication, we need the wal2json module installed in our dev postgres image. The module itself builds very quickly, but I thought it would be better to have this automatically built and pushed as part of a nightly job so that CI and developers can make use of it.