### PR TITLE
fix(portal): Set migration_lock to advisory lock

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -27,6 +27,7 @@ config :domain, Domain.Repo,
   queue_target: 500,
   queue_interval: 1000,
   migration_timestamps: [type: :timestamptz],
+  migration_lock: :pg_advisory_lock,
   start_apps_before_migration: [:ssl, :logger_json]
 
 config :domain, Domain.Tokens,


### PR DESCRIPTION
The migration that failed today got hung up on a global migration lock. This PR would alleviate that if we also run the index creation concurrently, which we should do in many cases.

See https://hexdocs.pm/ecto_sql/Ecto.Migration.html#index/3-adding-dropping-indexes-concurrently