### PR TITLE
chore(ci): Remove version override from buildx

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -77,11 +77,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-          # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-          # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.15.1
+            image=moby/buildkit:v0.20.0
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
@@ -330,11 +327,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-          # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-          # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.15.1
+            image=moby/buildkit:v0.20.0
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
@@ -445,11 +439,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-          # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-          # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.15.1
+            image=moby/buildkit:v0.20.0
       - name: Build Version Tags
         run: |
           set -xe

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -76,9 +76,6 @@ jobs:
           ref: ${{ inputs.sha }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.20.0
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
@@ -326,9 +323,6 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.20.0
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:
@@ -438,9 +432,6 @@ jobs:
         run: ls -R /tmp/digests
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.20.0
       - name: Build Version Tags
         run: |
           set -xe

--- a/.github/workflows/_deploy_production.yml
+++ b/.github/workflows/_deploy_production.yml
@@ -51,9 +51,6 @@ jobs:
           project: firezone-prod
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.20.0
       - name: Pull and push images
         run: |
           set -xe
@@ -180,9 +177,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.20.0
       - name: Pull and push
         run: |
           set -xe

--- a/.github/workflows/_deploy_production.yml
+++ b/.github/workflows/_deploy_production.yml
@@ -52,11 +52,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-          # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-          # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.15.1
+            image=moby/buildkit:v0.20.0
       - name: Pull and push images
         run: |
           set -xe
@@ -184,11 +181,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-          # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-          # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.15.1
+            image=moby/buildkit:v0.20.0
       - name: Pull and push
         run: |
           set -xe

--- a/.github/workflows/build-postgres.yml
+++ b/.github/workflows/build-postgres.yml
@@ -17,9 +17,6 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.20.0
       - uses: ./.github/actions/gcp-docker-login
         id: login
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,11 +58,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
-          # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
-          # We should for any updates on buildx and on the setup-buildx-action itself.
           driver-opts: |
-            image=moby/buildkit:v0.15.1
+            image=moby/buildkit:v0.20.0
       - name: Pull and push
         run: |
           set -xe

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,9 +57,6 @@ jobs:
           echo "major_minor_version=$MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.20.0
       - name: Pull and push
         run: |
           set -xe


### PR DESCRIPTION
The override we needed from before is no longer needed.