### PR TITLE
feat(linux-client): reduce number of TUN threads to 1

### DIFF
--- a/rust/headless-client/src/ipc_service.rs
+++ b/rust/headless-client/src/ipc_service.rs
@@ -338,7 +338,7 @@ impl<'a> Handler<'a> {
             .next_client_split()
             .await
             .context("Failed to wait for incoming IPC connection from a GUI")?;
-        let tun_device = TunDeviceManager::new(ip_packet::MAX_IP_SIZE, crate::NUM_TUN_THREADS)?;
+        let tun_device = TunDeviceManager::new(ip_packet::MAX_IP_SIZE, 1)?;
 
         Ok(Self {
             dns_controller,

--- a/rust/headless-client/src/lib.rs
+++ b/rust/headless-client/src/lib.rs
@@ -46,9 +46,6 @@ use ip_network::{Ipv4Network, Ipv6Network};
 /// Only used on Linux
 pub const FIREZONE_GROUP: &str = "firezone-client";
 
-/// Empirically tested to have the best performance.
-pub const NUM_TUN_THREADS: usize = 2;
-
 /// CLI args common to both the IPC service and the headless Client
 #[derive(clap::Parser)]
 pub struct CliCommon {

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -244,10 +244,7 @@ fn main() -> Result<()> {
         let mut terminate = signals::Terminate::new()?;
         let mut hangup = signals::Hangup::new()?;
 
-        let mut tun_device = TunDeviceManager::new(
-            ip_packet::MAX_IP_SIZE,
-            firezone_headless_client::NUM_TUN_THREADS,
-        )?;
+        let mut tun_device = TunDeviceManager::new(ip_packet::MAX_IP_SIZE, 1)?;
         let mut cb_rx = ReceiverStream::new(cb_rx).fuse();
 
         let tokio_handle = tokio::runtime::Handle::current();

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -27,6 +27,12 @@ export default function Headless({ os }: { os: OS }) {
             of 10MB.
           </ChangeItem>
           )}
+        {os === OS.Linux && (
+          <ChangeItem pull="8914">
+            Reduces the number of TUN threads to 1 to match other platforms and mitigate
+            packet reordering issues.
+          </ChangeItem>
+          )}
       </Unreleased>
       <Entry version="1.4.6" date={new Date("2025-04-15")}>
         {os == OS.Linux && (


### PR DESCRIPTION
Having multiple threads for reading and writing the TUN device can cause packet re-orderings on the client. All other clients only use a single TUN thread, so aligning this value means a more consistent behaviour of Firezone across all platforms.