### PR TITLE
fix(connlib): maintain packet order across GSO batches

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -255,10 +255,6 @@ impl Io {
 
                 self.timeout = None; // Clear the timeout.
 
-                // Piggy back onto the timeout we already have.
-                // It is not important when we call this, just needs to be called occasionally.
-                self.gso_queue.handle_timeout(now);
-
                 return Poll::Ready(Ok(Input::Timeout(now)));
             }
         }
@@ -350,8 +346,7 @@ impl Io {
         payload: &[u8],
         ecn: Ecn,
     ) {
-        self.gso_queue
-            .enqueue(src, dst, payload, ecn, Instant::now());
+        self.gso_queue.enqueue(src, dst, payload, ecn);
 
         self.packet_counter.add(
             1,

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -1046,7 +1046,7 @@ fn extract_l4_proto(payload: &[u8], protocol: IpNumber) -> Result<Layer4Protocol
 /// Models the possible ECN states.
 ///
 /// See <https://www.rfc-editor.org/rfc/rfc3168#section-23.1> for details.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Ecn {
     NonEct = 0b00,
     Ect1 = 0b01,


### PR DESCRIPTION
Despite our efforts in #8912, the current implementation still does not do enough to maintain packet ordering across GSO batches.

At present, we very aggressively batch packets of the same length together. This however is too eager when we consider packet flows such as the following:

```
9:03:49.585143 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [.], seq 1:1229, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 1228
09:03:49.585151 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [P.], seq 1229:2063, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 834
09:03:49.585157 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [P.], seq 2063:3094, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 1031
09:03:49.585187 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [.], seq 3094:4322, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 1228
09:03:49.585188 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [P.], seq 4322:5156, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 834
09:03:49.585227 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [.], seq 5156:6384, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 1228
09:03:49.585228 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [P.], seq 6384:7612, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 1228
09:03:49.585230 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [P.], seq 7612:8249, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 637
09:03:49.585846 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [.], seq 8249:9477, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 1228
09:03:49.585851 IP 10.128.15.241.3000 > 100.69.109.138.53474: Flags [P.], seq 9477:10705, ack 524, win 249, options [nop,nop,TS val 3862031964 ecr 1928356896], length 1228
```

As we can see here, the remote sends us packet batches of varying lengths:

- 1228, 834
- 1031
- 1228, 834
- 1228, 1228, 637
- 1228, 1228

1228 represents a "full" TCP packet so any packet following a full-packet SHOULD be grouped together into a GSO batch.

Currently, we are batching all the 1228 packets together and we ignore the fact that there were actually smaller sized packets inbetween those that belong together.

To mitigate this, we refactor the `GsoQueue` to remove the `segment_size` from the binning key of our map and instead only group batches by their source, destination and ECN information. Within such a connection, we then create an ordered list of batches. A new batch is started if the length differs or we have previously pushed a packet that isn't of the length of the batch, therefore signalling the end of the batch.

The result here looks very promising (this is loading `blog.firezone.dev` via the `lynx` browser from within the headless-client docker container, so going through a Gateway running this PR):

|main|this PR|
|---|---|
|![Screenshot From 2025-04-29 10-32-00](https://github.com/user-attachments/assets/ba0535e4-1df9-4601-a2d7-ba099ba2313f)|![image](https://github.com/user-attachments/assets/ab2ccec7-ce96-4305-8514-2e43d82ecc7d)|

Related: #8899 