### PR TITLE
fix(connlib): ensure we don't mistake SYN-ACK for SYN

### DIFF
--- a/rust/connlib/tunnel/src/unique_packet_buffer.rs
+++ b/rust/connlib/tunnel/src/unique_packet_buffer.rs
@@ -74,7 +74,9 @@ fn is_tcp_syn_retransmit(buffered: &IpPacket, new: &IpPacket) -> bool {
     };
 
     buffered.syn()
+        && !buffered.ack()
         && new.syn()
+        && !new.ack()
         && buffered.source_port() == new.source_port()
         && buffered.destination_port() == new.destination_port()
         && buffered.sequence_number() == new.sequence_number()


### PR DESCRIPTION
This shouldn't matter because we are only using the `UniquePacketBuffer` on the client and not on the Gateway where SYN-ACK packets would be sent from. To be fully correct though, we need to also compare the ACK flag of the two packets.