### PR TITLE
feat(connlib): add FFI for changing log-level on MacOS

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Connlib/Generated/connlib-client-apple/connlib-client-apple.h
+++ b/swift/apple/FirezoneNetworkExtension/Connlib/Generated/connlib-client-apple/connlib-client-apple.h
@@ -15,5 +15,6 @@ struct __private__ResultPtrAndPtr __swift_bridge__$WrappedSession$connect(void* 
 void __swift_bridge__$WrappedSession$reset(void* self);
 void* __swift_bridge__$WrappedSession$set_dns(void* self, void* dns_servers);
 void* __swift_bridge__$WrappedSession$set_disabled_resources(void* self, void* disabled_resources);
+void* __swift_bridge__$WrappedSession$set_log_directives(void* self, void* directives);
 
 

--- a/swift/apple/FirezoneNetworkExtension/Connlib/Generated/connlib-client-apple/connlib-client-apple.swift
+++ b/swift/apple/FirezoneNetworkExtension/Connlib/Generated/connlib-client-apple/connlib-client-apple.swift
@@ -49,6 +49,10 @@ extension WrappedSessionRefMut {
     public func setDisabledResources<GenericIntoRustString: IntoRustString>(_ disabled_resources: GenericIntoRustString) throws -> () {
         try { let val = __swift_bridge__$WrappedSession$set_disabled_resources(ptr, { let rustString = disabled_resources.intoRustString(); rustString.isOwned = false; return rustString.ptr }()); if val != nil { throw RustString(ptr: val!) } else { return } }()
     }
+
+    public func setLogDirectives<GenericIntoRustString: IntoRustString>(_ directives: GenericIntoRustString) throws -> () {
+        try { let val = __swift_bridge__$WrappedSession$set_log_directives(ptr, { let rustString = directives.intoRustString(); rustString.isOwned = false; return rustString.ptr }()); if val != nil { throw RustString(ptr: val!) } else { return } }()
+    }
 }
 public class WrappedSessionRef {
     var ptr: UnsafeMutableRawPointer


### PR DESCRIPTION
This isn't plugged into anything yet on the Swift side but lays the foundation for changing the log-level at runtime without having to sign the user out.