### PR TITLE
fix(connlib): don't set `segment_size` if it is > than payload

### DIFF
--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -339,7 +339,7 @@ impl UdpSocket {
 
                     tracing::trace!(target: "wire::net::send", src = ?datagram.src, %dst, ecn = ?transmit.ecn, %num_packets, %segment_size);
 
-                    if transmit.segment_size.is_some_and(|s| s >= num_bytes) {
+                    if transmit.segment_size.is_some_and(|s| s > num_bytes) {
                         transmit.segment_size = None;
                     }
 


### PR DESCRIPTION
When a platform's network driver does not support GSO, `quinn-udp` detects that and disables segmentation offloading:

> 04-30 11:32:49.161 19612 19836 I connlib : quinn_udp::imp: `libc::sendmsg` failed with I/O error (os error 5); halting segmentation offload

What this means is that it sets an internal field that sets the GSO batch-size to 1 (instead of the default 32). We then use this batch-size to compute, how we are meant to chunk up the already batched datagrams. As a consequence of #8920, we are now also using a "feature" of GSO where the last datagram in a GSO batch is allowed to be less than the segment size.

The combination of these two features now makes it possible that we are passing a datagram to the kernel where the `segment_size` is greater than the actual length. Android's Linux kernel doesn't seem to like that an barfs when being passed such a datagram with an IO error 5.

The long-term fix is to sanitise this within `quinn-udp` but in the short-term, we can do this ourselves as part of the loop where we segment the datagrams.