### PR TITLE
fix(connlib): send IO errors from UDP threads to event-loop

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -176,7 +176,7 @@ impl Io {
         if let Poll::Ready(network) = self.sockets.poll_recv_from(cx) {
             return Poll::Ready(Ok(Input::Network(
                 network
-                    .context("Failed to receive from UDP sockets")?
+                    .context("UDP socket failed")?
                     .filter(is_max_wg_packet_size),
             )));
         }


### PR DESCRIPTION
With #7590, we've moved all UDP IO operations to a separate thread. As a result, some of the error handling of IO errors within the Client's and Gateway's event-loop no longer applied as those are now captured within the respective thread. To fix this, we extend the type-signature of the receive-channel to also allow for errors and use that to send back errors from sending AND receiving UDP datagrams.