### PR TITLE
feat(connlib): record the number of IO errors as a metric

### DIFF
--- a/rust/connlib/tunnel/src/otel.rs
+++ b/rust/connlib/tunnel/src/otel.rs
@@ -1,3 +1,5 @@
+use std::{io, net::SocketAddr};
+
 use ip_packet::IpPacket;
 use opentelemetry::KeyValue;
 
@@ -9,6 +11,13 @@ pub fn network_type_for_packet(p: &IpPacket) -> KeyValue {
     match p {
         IpPacket::Ipv4(_) => network_type_ipv4(),
         IpPacket::Ipv6(_) => network_type_ipv6(),
+    }
+}
+
+pub fn network_type_for_addr(addr: SocketAddr) -> KeyValue {
+    match addr {
+        SocketAddr::V4(_) => network_type_ipv4(),
+        SocketAddr::V6(_) => network_type_ipv6(),
     }
 }
 
@@ -42,4 +51,27 @@ pub fn network_io_direction_receive() -> KeyValue {
 
 pub fn network_io_direction_transmit() -> KeyValue {
     KeyValue::new("network.io.direction", "transmit")
+}
+
+pub fn io_error_code(e: &io::Error) -> KeyValue {
+    KeyValue::new("error.code", e.raw_os_error().unwrap_or_default() as i64)
+}
+
+pub fn io_error_type(e: &io::Error) -> KeyValue {
+    KeyValue::new("error.type", format!("io::ErrorKind::{:?}", e.kind()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn io_error_type_serialisation() {
+        let error = io::Error::from(io::ErrorKind::NetworkUnreachable);
+
+        assert_eq!(
+            io_error_type(&error),
+            KeyValue::new("error.type", "io::ErrorKind::NetworkUnreachable")
+        );
+    }
 }

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -185,6 +185,12 @@ impl ThreadedUdpSocket {
                             }
                         };
 
+                        let io_error_counter = opentelemetry::global::meter("connlib")
+                            .u64_counter("system.network.errors")
+                            .with_description("Number of IO errors encountered")
+                            .with_unit("{error}")
+                            .init();
+
                         match socket.set_buffer_sizes(socket_factory::SEND_BUFFER_SIZE, socket_factory::RECV_BUFFER_SIZE) {
                             Ok(()) => {},
                             Err(e) => {
@@ -196,6 +202,15 @@ impl ThreadedUdpSocket {
                         let send = pin!(async {
                             while let Ok(datagram) = outbound_rx.recv_async().await {
                                 if let Err(e) = socket.send(datagram).await {
+                                    if let Some(io) = e.downcast_ref::<io::Error>() {
+                                        io_error_counter.add(1, &[
+                                            crate::otel::network_io_direction_transmit(),
+                                            crate::otel::network_type_for_addr(addr),
+                                            crate::otel::io_error_type(io),
+                                            crate::otel::io_error_code(io)
+                                        ]);
+                                    }
+
                                     // We use the inbound_tx channel to send the error back to the main thread.
                                     if inbound_tx.send_async(Err(e)).await.is_err() {
                                         tracing::debug!("Channel for inbound datagrams closed; exiting UDP thread");
@@ -211,6 +226,15 @@ impl ThreadedUdpSocket {
                         let receive = pin!(async {
                             loop {
                                 let result = socket.recv_from().await;
+
+                                if let Some(io) = result.as_ref().err().and_then(|e| e.downcast_ref::<io::Error>()) {
+                                    io_error_counter.add(1, &[
+                                        crate::otel::network_io_direction_receive(),
+                                        crate::otel::network_type_for_addr(addr),
+                                        crate::otel::io_error_type(io),
+                                        crate::otel::io_error_code(io)
+                                    ]);
+                                }
 
                                 if inbound_tx.send_async(result).await.is_err() {
                                     tracing::debug!("Channel for inbound datagrams closed; exiting UDP thread");


### PR DESCRIPTION
It will be interesting to learn for example, how many installations have no IPv6 connectivity as those will encounter `NetworkUnreachable` errors. We categorise the errors by IO direction and IP stack which will allow us to deduce this information.