### PR TITLE
fix(connlib): don't buffer when recreating DNS resource NAT

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -201,7 +201,10 @@ impl PendingFlow {
     fn new(now: Instant, trigger: ConnectionTrigger) -> Self {
         let mut this = Self {
             last_intent_sent_at: now,
-            resource_packets: UniquePacketBuffer::with_capacity_power_of_2(Self::CAPACITY_POW_2),
+            resource_packets: UniquePacketBuffer::with_capacity_power_of_2(
+                Self::CAPACITY_POW_2,
+                "pending-flow-resources",
+            ),
             udp_dns_queries: AllocRingBuffer::with_capacity_power_of_2(Self::CAPACITY_POW_2),
             tcp_dns_queries: AllocRingBuffer::with_capacity_power_of_2(Self::CAPACITY_POW_2),
         };
@@ -389,7 +392,8 @@ impl ClientState {
                 Entry::Vacant(v) => {
                     self.peers
                         .add_ips_with_resource(gid, proxy_ips.iter().copied(), rid);
-                    let mut buffered_packets = UniquePacketBuffer::with_capacity_power_of_2(5); // 2^5 = 32
+                    let mut buffered_packets =
+                        UniquePacketBuffer::with_capacity_power_of_2(5, "dns-resource-nat-initial"); // 2^5 = 32
                     buffered_packets.extend(packets_for_domain);
 
                     v.insert(DnsResourceNatState::Pending {
@@ -405,8 +409,10 @@ impl ClientState {
                     match state {
                         DnsResourceNatState::Confirmed => continue,
                         DnsResourceNatState::Recreating => {
-                            let mut buffered_packets =
-                                UniquePacketBuffer::with_capacity_power_of_2(5); // 2^5 = 32
+                            let mut buffered_packets = UniquePacketBuffer::with_capacity_power_of_2(
+                                5, // 2^5 = 32
+                                "dns-resource-nat-recreating",
+                            );
                             buffered_packets.extend(packets_for_domain);
 
                             *state = DnsResourceNatState::Pending {

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -27,6 +27,10 @@ export default function Android() {
         <ChangeItem pull="8926">
           Rolls over to a new log-file as soon as logs are cleared.
         </ChangeItem>
+        <ChangeItem pull="8935">
+          Improves reliability for upload-intensive connections with many concurrent
+          DNS queries.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.7" date={new Date("2025-04-21")}>
         <ChangeItem pull="8798">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -37,6 +37,10 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull="8926">
           Rolls over to a new log-file as soon as logs are cleared.
         </ChangeItem>
+        <ChangeItem pull="8935">
+          Improves reliability for upload-intensive connections with many concurrent
+          DNS queries.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.11" date={new Date("2025-04-21")}>
         <ChangeItem pull="8798">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -44,6 +44,10 @@ export default function Headless({ os }: { os: OS }) {
             Improves connection reliability by maintaining the order of IP packets.
           </ChangeItem>
         )}
+        <ChangeItem pull="8935">
+          Improves reliability for upload-intensive connections with many concurrent
+          DNS queries.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.6" date={new Date("2025-04-15")}>
         {os == OS.Linux && (


### PR DESCRIPTION
In order to detect changes to DNS records of DNS resources, `connlib` will recreate the DNS resource NAT whenever it receives a query for a DNS resource. The way we implemented this was by clearing the local state of the DNS resource NAT, which triggered us to perform the handshake with the Gateway again upon the next packet for this resource. The Gateway would then perform the DNS query and respond back when this was finished.

In order to not drop any packets, `connlib` has a buffer where it keeps the packets that are arriving in the meantime. This works reasonably well when the connection is first set up because we are only buffering a TCP SYN or equivalent handshake packet. Yet, when the connection is full use, and the application just so happens to make another DNS query, we halt the entire flow of packets until this is confirmed again. To prevent high memory use, the buffer for this packets is constrained to 32 packets which is nowhere near enough when a connection is actively transferring data (like a file upload).

In most cases, the DNS query on the Gateway will yield the exact same results as because the records haven't changed. Thus, there is no reason for us to actually halt the flow of these packets when we are _recreating_ the DNS resource NAT. That way, this handshake happens in parallel to the actual packet flow and does not interrupt anything in the happy path case.