### PR TITLE
chore(gateway): record metrics about dropped packets

### DIFF
--- a/rust/connlib/tunnel/src/otel.rs
+++ b/rust/connlib/tunnel/src/otel.rs
@@ -1,7 +1,7 @@
 use std::{io, net::SocketAddr};
 
 use ip_packet::IpPacket;
-use opentelemetry::KeyValue;
+use opentelemetry::{KeyValue, Value};
 
 pub fn network_transport_udp() -> KeyValue {
     KeyValue::new("network.transport", "udp")
@@ -58,7 +58,23 @@ pub fn io_error_code(e: &io::Error) -> KeyValue {
 }
 
 pub fn io_error_type(e: &io::Error) -> KeyValue {
-    KeyValue::new("error.type", format!("io::ErrorKind::{:?}", e.kind()))
+    error_type(format!("io::ErrorKind::{:?}", e.kind()))
+}
+
+pub fn error_type(ty: impl Into<Value>) -> KeyValue {
+    KeyValue::new("error.type", ty)
+}
+
+pub mod metrics {
+    use opentelemetry::metrics::Counter;
+
+    pub fn network_packet_dropped() -> Counter<u64> {
+        opentelemetry::global::meter("connlib")
+            .u64_counter("network.packet.dropped")
+            .with_description("Count of packets that are dropped or discarded")
+            .with_unit("{packet}")
+            .init()
+    }
 }
 
 #[cfg(test)]

--- a/rust/connlib/tunnel/src/unique_packet_buffer.rs
+++ b/rust/connlib/tunnel/src/unique_packet_buffer.rs
@@ -16,9 +16,7 @@ impl UniquePacketBuffer {
             tag,
             num_dropped_packets: opentelemetry::global::meter("connlib")
                 .u64_counter("network.packet.dropped")
-                .with_description(
-                    "The number of packets which have been dropped due to buffer overflows.",
-                )
+                .with_description("Count of packets that are dropped or discarded")
                 .with_unit("{packet}")
                 .init(),
         }

--- a/rust/connlib/tunnel/src/unique_packet_buffer.rs
+++ b/rust/connlib/tunnel/src/unique_packet_buffer.rs
@@ -14,11 +14,7 @@ impl UniquePacketBuffer {
         Self {
             buffer: AllocRingBuffer::with_capacity_power_of_2(capacity),
             tag,
-            num_dropped_packets: opentelemetry::global::meter("connlib")
-                .u64_counter("network.packet.dropped")
-                .with_description("Count of packets that are dropped or discarded")
-                .with_unit("{packet}")
-                .init(),
+            num_dropped_packets: crate::otel::metrics::network_packet_dropped(),
         }
     }
 
@@ -48,7 +44,7 @@ impl UniquePacketBuffer {
                     crate::otel::network_type_for_packet(&new),
                     crate::otel::network_io_direction_transmit(),
                     KeyValue::new("system.buffer.pool.name", self.tag),
-                    KeyValue::new("error.type", "buffer-full"),
+                    KeyValue::new("error.type", "BufferFull"),
                 ],
             );
         }

--- a/rust/connlib/tunnel/src/unique_packet_buffer.rs
+++ b/rust/connlib/tunnel/src/unique_packet_buffer.rs
@@ -15,7 +15,7 @@ impl UniquePacketBuffer {
             buffer: AllocRingBuffer::with_capacity_power_of_2(capacity),
             tag,
             num_dropped_packets: opentelemetry::global::meter("connlib")
-                .u64_counter("system.network.packet.dropped")
+                .u64_counter("network.packet.dropped")
                 .with_description(
                     "The number of packets which have been dropped due to buffer overflows.",
                 )

--- a/rust/connlib/tunnel/src/unique_packet_buffer.rs
+++ b/rust/connlib/tunnel/src/unique_packet_buffer.rs
@@ -48,6 +48,7 @@ impl UniquePacketBuffer {
                     crate::otel::network_type_for_packet(&new),
                     crate::otel::network_io_direction_transmit(),
                     KeyValue::new("system.buffer.pool.name", self.tag),
+                    KeyValue::new("error.type", "buffer-full"),
                 ],
             );
         }

--- a/rust/connlib/tunnel/src/unique_packet_buffer.rs
+++ b/rust/connlib/tunnel/src/unique_packet_buffer.rs
@@ -44,7 +44,7 @@ impl UniquePacketBuffer {
                     crate::otel::network_type_for_packet(&new),
                     crate::otel::network_io_direction_transmit(),
                     KeyValue::new("system.buffer.pool.name", self.tag),
-                    KeyValue::new("error.type", "BufferFull"),
+                    crate::otel::error_type("BufferFull"),
                 ],
             );
         }


### PR DESCRIPTION
When a NAT session expires or other unallowed traffic is routed to the Gateway, we drop these packets. It will be useful to learn, how often that actually happens and what the reason is for why they got dropped. To do so, we add a counter metric for these packets.