### PR TITLE
fix(connlib): move `wire::dev::recv` log to right location

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -41,6 +41,8 @@ impl Device {
         let n = std::task::ready!(tun.poll_recv_many(cx, buf, max));
 
         for packet in &buf[..n] {
+            tracing::trace!(target: "wire::dev::recv", ?packet);
+
             if tracing::event_enabled!(target: "wire::dns::qry", Level::TRACE) {
                 if let Some(query) = parse_dns_query(packet) {
                     tracing::trace!(target: "wire::dns::qry", ?query);
@@ -50,8 +52,6 @@ impl Device {
             if packet.is_fz_p2p_control() {
                 tracing::warn!("Packet matches heuristics of FZ-internal p2p control protocol");
             }
-
-            tracing::trace!(target: "wire::dev::recv", ?packet);
         }
 
         Poll::Ready(n)


### PR DESCRIPTION
I don't understand why but in the current location, this log simply doesn't show up for anything other than UDP packets. If we move it up, it will actually log all packets.