### PR TITLE
fix(portal): use existing database user for replication

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -36,8 +36,8 @@ if config_env() == :prod do
       ssl: compile_config!(:database_ssl_enabled),
       ssl_opts: compile_config!(:database_ssl_opts),
       parameters: compile_config!(:database_parameters),
-      username: compile_config!(:database_replication_user),
-      password: compile_config!(:database_replication_password),
+      username: compile_config!(:database_user),
+      password: compile_config!(:database_password),
       database: compile_config!(:database_name)
     ]
 


### PR DESCRIPTION
Turns out we are making replication overly complex by creating a dedicated user for it. The `web` user is already privileged and we can reuse it since the replication system operates in the same security context as the remaining app.