### PR TITLE
fix(portal): alter db user role with replication

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20250430195212_alter_role_with_replication.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250430195212_alter_role_with_replication.exs
@@ -1,0 +1,11 @@
+defmodule Domain.Repo.Migrations.AlterRoleWithReplication do
+  use Ecto.Migration
+
+  def up do
+    execute("ALTER ROLE CURRENT_USER WITH REPLICATION")
+  end
+
+  def down do
+    execute("ALTER ROLE CURRENT_USER WITH NOREPLICATION")
+  end
+end


### PR DESCRIPTION
We need the `replication` attribute set on the db user. This is trivially done in a migration, and with the `CURRENT_USER` specifier, we don't need to fetch the Application configuration.