### PR TITLE
chore(connlib): bump `quinn-udp`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5398,8 +5398,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
-source = "git+https://github.com/quinn-rs/quinn?branch=main#19a625de606ea8e83bbf8e5c9265f21ebef193da"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -122,7 +122,7 @@ phoenix-channel = { path = "phoenix-channel" }
 png = "0.17.16"
 proptest = "1.6.0"
 proptest-state-machine = "0.3.1"
-quinn-udp = { version = "0.5.8", features = ["fast-apple-datapath"] }
+quinn-udp = { version = "0.5.12", features = ["fast-apple-datapath"] }
 rand = "0.8.5"
 rand_core = "0.6.4"
 rangemap = "1.5.1"
@@ -215,7 +215,6 @@ ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "mas
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.26" } # Waiting for release.
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.
-quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -323,8 +323,9 @@ impl UdpSocket {
         match transmit.segment_size {
             Some(segment_size) => {
                 let chunk_size = self.calculate_chunk_size(segment_size);
+                let num_batches = transmit.contents.len() / chunk_size;
 
-                for mut transmit in transmit
+                for (idx, chunk) in transmit
                     .contents
                     .chunks(chunk_size)
                     .map(|contents| Transmit {
@@ -334,18 +335,20 @@ impl UdpSocket {
                         segment_size: Some(segment_size),
                         src_ip: transmit.src_ip,
                     })
+                    .enumerate()
                 {
-                    let num_bytes = transmit.contents.len();
+                    let num_bytes = chunk.contents.len();
                     let num_packets = num_bytes / segment_size;
+                    let batch_num = idx + 1;
 
-                    tracing::trace!(target: "wire::net::send", src = ?datagram.src, %dst, ecn = ?transmit.ecn, %num_packets, %segment_size);
+                    tracing::trace!(target: "wire::net::send", src = ?datagram.src, %dst, ecn = ?chunk.ecn, %num_packets, %segment_size);
 
                     self.inner
                         .async_io(Interest::WRITABLE, || {
-                            self.state.try_send((&self.inner).into(), &transmit)
+                            self.state.try_send((&self.inner).into(), &chunk)
                         })
                         .await
-                        .with_context(|| format!("Failed to send datagram-batch with segment_size {segment_size} and total length {num_bytes} to {dst}"))?;
+                        .with_context(|| format!("Failed to send datagram-batch {batch_num}/{num_batches} with segment_size {segment_size} and total length {num_bytes} to {dst}"))?;
                 }
             }
             None => {

--- a/rust/socket-factory/src/lib.rs
+++ b/rust/socket-factory/src/lib.rs
@@ -340,10 +340,6 @@ impl UdpSocket {
 
                     tracing::trace!(target: "wire::net::send", src = ?datagram.src, %dst, ecn = ?transmit.ecn, %num_packets, %segment_size);
 
-                    if transmit.segment_size.is_some_and(|s| s > num_bytes) {
-                        transmit.segment_size = None;
-                    }
-
                     self.inner
                         .async_io(Interest::WRITABLE, || {
                             self.state.try_send((&self.inner).into(), &transmit)


### PR DESCRIPTION
The latest release includes our upstreamed fix for handling `segment_size` > `contents.len()` and therefore our local workaround is no longer necessary.