### PR TITLE
feat(portal): introduce `actor_resources`

### DIFF
--- a/elixir/apps/domain/lib/domain/accounts/account.ex
+++ b/elixir/apps/domain/lib/domain/accounts/account.ex
@@ -28,6 +28,7 @@ defmodule Domain.Accounts.Account do
     has_many :actors, Domain.Actors.Actor, where: [deleted_at: nil]
     has_many :actor_group_memberships, Domain.Actors.Membership, where: [deleted_at: nil]
     has_many :actor_groups, Domain.Actors.Group, where: [deleted_at: nil]
+    has_many :actor_resources, Domain.Actors.Resource
 
     has_many :auth_providers, Domain.Auth.Provider, where: [deleted_at: nil]
     has_many :auth_identities, Domain.Auth.Identity, where: [deleted_at: nil]

--- a/elixir/apps/domain/lib/domain/actors/actor.ex
+++ b/elixir/apps/domain/lib/domain/actors/actor.ex
@@ -19,6 +19,7 @@ defmodule Domain.Actors.Actor do
     # TODO: where doesn't work on join tables so soft-deleted records will be preloaded,
     # ref https://github.com/firezone/firezone/issues/2162
     has_many :groups, through: [:memberships, :group]
+    has_many :actor_resources, Domain.Actors.Resource, on_replace: :delete
 
     belongs_to :account, Domain.Accounts.Account
 

--- a/elixir/apps/domain/lib/domain/actors/resource.ex
+++ b/elixir/apps/domain/lib/domain/actors/resource.ex
@@ -1,0 +1,20 @@
+defmodule Domain.Actors.Resource do
+  @moduledoc """
+    Provides a join table to function as a consistent view of which actors potentially
+    have access to which resources. This table should be updated whenever:
+
+    - A membership is created or deleted
+    - A policy is updated, created, enabled, deleted, or disabled
+
+    Cascading deletes is enabled for the references so that deletetion of any actor, resource, or
+    associated account will clean up the join table.
+  """
+  use Domain, :schema
+
+  @primary_key false
+  schema "actor_resources" do
+    belongs_to :account, Domain.Accounts.Account, primary_key: true
+    belongs_to :actor, Domain.Actors.Actor, primary_key: true
+    belongs_to :resource, Domain.Resources.Resource, primary_key: true
+  end
+end

--- a/elixir/apps/domain/lib/domain/actors/resource.ex
+++ b/elixir/apps/domain/lib/domain/actors/resource.ex
@@ -16,5 +16,7 @@ defmodule Domain.Actors.Resource do
     belongs_to :account, Domain.Accounts.Account, primary_key: true
     belongs_to :actor, Domain.Actors.Actor, primary_key: true
     belongs_to :resource, Domain.Resources.Resource, primary_key: true
+
+    timestamps(type: :utc_datetime_usec, updated_at: false)
   end
 end

--- a/elixir/apps/domain/lib/domain/actors/resource/query.ex
+++ b/elixir/apps/domain/lib/domain/actors/resource/query.ex
@@ -1,34 +1,121 @@
 defmodule Domain.Actors.Resource.Query do
   use Domain, :query
-  alias Domain.Actors.{Actor, Membership, Resource}
+  alias Domain.Actors.{Actor, Membership}
+  alias Domain.Policies.Policy
 
-  # Used for disable and soft-delete
-  def by_policies(queryable) do
-    from actor_resource in Resource,
-      join: actor in Actor,
-      on: actor_resource.actor_id == actor.id,
+  def insert_for_policy_ids(policy_ids) do
+    from policy in Policy,
       join: membership in Membership,
-      on: actor.id == membership.actor_id,
-      join: policy in subquery(queryable),
       on:
-        actor_resource.resource_id == policy.resource_id and
-          membership.group_id == policy.actor_group_id and
-          actor_resource.account_id == policy.account_id,
-      select: actor_resource
+        membership.group_id == policy.actor_group_id and
+          membership.account_id == policy.account_id,
+      where: policy.id in ^policy_ids,
+      where: is_nil(policy.deleted_at) and is_nil(policy.disabled_at),
+      select: %{
+        account_id: policy.account_id,
+        actor_id: membership.actor_id,
+        resource_id: policy.resource_id,
+        inserted_at: fragment("TIMEZONE('UTC', NOW())")
+      }
   end
 
-  # Used for enable and insert
-  def insert_for_policies(queryable) do
-    from policy in queryable,
+  def delete_for_policy_ids(policy_ids) do
+    from policy in Policy,
       join: membership in Membership,
+      on:
+        membership.group_id == policy.actor_group_id and
+          membership.account_id == policy.account_id,
+      where: policy.id in ^policy_ids
+  end
+
+  def insert_for_actor_ids(actor_ids) do
+    from actor in Actor,
+      join: membership in Membership,
+      on:
+        membership.actor_id == actor.id and
+          membership.account_id == actor.account_id,
+      join: policy in Policy,
       on: policy.actor_group_id == membership.group_id,
-      join: actor in Actor,
-      on: membership.actor_id == actor.id,
+      where: policy.account_id == actor.account_id,
+      where: is_nil(policy.deleted_at) and is_nil(policy.disabled_at),
+      where: actor.id in ^actor_ids,
       select: %{
+        account_id: actor.account_id,
         actor_id: actor.id,
         resource_id: policy.resource_id,
-        account_id: policy.account_id,
-        inserted_at: fragment("timezone(UTC, NOW())")
+        inserted_at: fragment("TIMEZONE('UTC', NOW())")
       }
+  end
+
+  def delete_for_actor_ids(actor_ids) do
+    from actor in Actor,
+      join: membership in Membership,
+      on:
+        membership.actor_id == actor.id and
+          membership.account_id == actor.account_id,
+      join: policy in Policy,
+      on: policy.actor_group_id == membership.group_id,
+      where: policy.account_id == actor.account_id,
+      where: actor.id in ^actor_ids
+  end
+
+  def insert_for_actor_group_ids(actor_group_ids) do
+    from membership in Membership,
+      join: policy in Policy,
+      on: policy.actor_group_id == membership.group_id,
+      where: policy.account_id == membership.account_id,
+      where: is_nil(policy.deleted_at) and is_nil(policy.disabled_at),
+      where: membership.group_id in ^actor_group_ids,
+      select: %{
+        account_id: membership.account_id,
+        actor_id: membership.actor_id,
+        resource_id: policy.resource_id,
+        inserted_at: fragment("TIMEZONE('UTC', NOW())")
+      }
+  end
+
+  def delete_for_actor_group_ids(actor_group_ids) do
+    from membership in Membership,
+      join: policy in Policy,
+      on: policy.actor_group_id == membership.group_id,
+      where: policy.account_id == membership.account_id,
+      where: membership.group_id in ^actor_group_ids
+  end
+
+  def insert_for_memberships(account_id, tuples) do
+    dynamic_query =
+      Enum.reduce(tuples, dynamic(true), fn {group_id, actor_id}, acc ->
+        dynamic([m], (m.group_id == ^group_id and m.actor_id == ^actor_id) or ^acc)
+      end)
+
+    from membership in Membership,
+      where: ^dynamic_query,
+      where: membership.account_id == ^account_id,
+      join: policy in Policy,
+      on:
+        policy.actor_group_id == membership.group_id and
+          policy.account_id == membership.account_id,
+      where: is_nil(policy.deleted_at) and is_nil(policy.disabled_at),
+      select: %{
+        account_id: membership.account_id,
+        actor_id: membership.actor_id,
+        resource_id: policy.resource_id,
+        inserted_at: fragment("TIMEZONE('UTC', NOW())")
+      }
+  end
+
+  def delete_for_memberships(account_id, tuples) do
+    dynamic_query =
+      Enum.reduce(tuples, dynamic(true), fn {group_id, actor_id}, acc ->
+        dynamic([m], (m.group_id == ^group_id and m.actor_id == ^actor_id) or ^acc)
+      end)
+
+    from membership in Membership,
+      where: ^dynamic_query,
+      where: membership.account_id == ^account_id,
+      join: policy in Policy,
+      on:
+        policy.actor_group_id == membership.group_id and
+          policy.account_id == membership.account_id
   end
 end

--- a/elixir/apps/domain/lib/domain/actors/resource/query.ex
+++ b/elixir/apps/domain/lib/domain/actors/resource/query.ex
@@ -1,0 +1,34 @@
+defmodule Domain.Actors.Resource.Query do
+  use Domain, :query
+  alias Domain.Actors.{Actor, Membership, Resource}
+
+  # Used for disable and soft-delete
+  def by_policies(queryable) do
+    from actor_resource in Resource,
+      join: actor in Actor,
+      on: actor_resource.actor_id == actor.id,
+      join: membership in Membership,
+      on: actor.id == membership.actor_id,
+      join: policy in subquery(queryable),
+      on:
+        actor_resource.resource_id == policy.resource_id and
+          membership.group_id == policy.actor_group_id and
+          actor_resource.account_id == policy.account_id,
+      select: actor_resource
+  end
+
+  # Used for enable and insert
+  def insert_for_policies(queryable) do
+    from policy in queryable,
+      join: membership in Membership,
+      on: policy.actor_group_id == membership.group_id,
+      join: actor in Actor,
+      on: membership.actor_id == actor.id,
+      select: %{
+        actor_id: actor.id,
+        resource_id: policy.resource_id,
+        account_id: policy.account_id,
+        inserted_at: fragment("timezone(UTC, NOW())")
+      }
+  end
+end

--- a/elixir/apps/domain/lib/domain/events/event.ex
+++ b/elixir/apps/domain/lib/domain/events/event.ex
@@ -27,15 +27,15 @@ defmodule Domain.Events.Event do
   ############
 
   defp process(:insert, "accounts", _old_data, data) do
-    Hooks.Accounts.insert(data)
+    Hooks.Accounts.on_insert(data)
   end
 
   defp process(:update, "accounts", old_data, data) do
-    Hooks.Accounts.update(old_data, data)
+    Hooks.Accounts.on_update(old_data, data)
   end
 
   defp process(:delete, "accounts", old_data, _data) do
-    Hooks.Accounts.delete(old_data)
+    Hooks.Accounts.on_delete(old_data)
   end
 
   ###########################
@@ -43,15 +43,15 @@ defmodule Domain.Events.Event do
   ###########################
 
   defp process(:insert, "actor_group_memberships", _old_data, data) do
-    Hooks.ActorGroupMemberships.insert(data)
+    Hooks.ActorGroupMemberships.on_insert(data)
   end
 
   defp process(:update, "actor_group_memberships", old_data, data) do
-    Hooks.ActorGroupMemberships.update(old_data, data)
+    Hooks.ActorGroupMemberships.on_update(old_data, data)
   end
 
   defp process(:delete, "actor_group_memberships", old_data, _data) do
-    Hooks.ActorGroupMemberships.delete(old_data)
+    Hooks.ActorGroupMemberships.on_delete(old_data)
   end
 
   ################
@@ -59,15 +59,15 @@ defmodule Domain.Events.Event do
   ################
 
   defp process(:insert, "actor_groups", _old_data, data) do
-    Hooks.ActorGroups.insert(data)
+    Hooks.ActorGroups.on_insert(data)
   end
 
   defp process(:update, "actor_groups", old_data, data) do
-    Hooks.ActorGroups.update(old_data, data)
+    Hooks.ActorGroups.on_update(old_data, data)
   end
 
   defp process(:delete, "actor_groups", old_data, _data) do
-    Hooks.ActorGroups.delete(old_data)
+    Hooks.ActorGroups.on_delete(old_data)
   end
 
   ##########
@@ -75,15 +75,15 @@ defmodule Domain.Events.Event do
   ##########
 
   defp process(:insert, "actors", _old_data, data) do
-    Hooks.Actors.insert(data)
+    Hooks.Actors.on_insert(data)
   end
 
   defp process(:update, "actors", old_data, data) do
-    Hooks.Actors.update(old_data, data)
+    Hooks.Actors.on_update(old_data, data)
   end
 
   defp process(:delete, "actors", old_data, _data) do
-    Hooks.Actors.delete(old_data)
+    Hooks.Actors.on_delete(old_data)
   end
 
   ###################
@@ -91,15 +91,15 @@ defmodule Domain.Events.Event do
   ###################
 
   defp process(:insert, "auth_identities", _old_data, data) do
-    Hooks.AuthIdentities.insert(data)
+    Hooks.AuthIdentities.on_insert(data)
   end
 
   defp process(:update, "auth_identities", old_data, data) do
-    Hooks.AuthIdentities.update(old_data, data)
+    Hooks.AuthIdentities.on_update(old_data, data)
   end
 
   defp process(:delete, "auth_identities", old_data, _data) do
-    Hooks.AuthIdentities.delete(old_data)
+    Hooks.AuthIdentities.on_delete(old_data)
   end
 
   ##################
@@ -107,15 +107,15 @@ defmodule Domain.Events.Event do
   ##################
 
   defp process(:insert, "auth_providers", _old_data, data) do
-    Hooks.AuthProviders.insert(data)
+    Hooks.AuthProviders.on_insert(data)
   end
 
   defp process(:update, "auth_providers", old_data, data) do
-    Hooks.AuthProviders.update(old_data, data)
+    Hooks.AuthProviders.on_update(old_data, data)
   end
 
   defp process(:delete, "auth_providers", old_data, _data) do
-    Hooks.AuthProviders.delete(old_data)
+    Hooks.AuthProviders.on_delete(old_data)
   end
 
   ###########
@@ -123,15 +123,15 @@ defmodule Domain.Events.Event do
   ###########
 
   defp process(:insert, "clients", _old_data, data) do
-    Hooks.Clients.insert(data)
+    Hooks.Clients.on_insert(data)
   end
 
   defp process(:update, "clients", old_data, data) do
-    Hooks.Clients.update(old_data, data)
+    Hooks.Clients.on_update(old_data, data)
   end
 
   defp process(:delete, "clients", old_data, _data) do
-    Hooks.Clients.delete(old_data)
+    Hooks.Clients.on_delete(old_data)
   end
 
   ###################
@@ -139,15 +139,15 @@ defmodule Domain.Events.Event do
   ###################
 
   defp process(:insert, "flow_activities", _old_data, data) do
-    Hooks.FlowActivities.insert(data)
+    Hooks.FlowActivities.on_insert(data)
   end
 
   defp process(:update, "flow_activities", old_data, data) do
-    Hooks.FlowActivities.update(old_data, data)
+    Hooks.FlowActivities.on_update(old_data, data)
   end
 
   defp process(:delete, "flow_activities", old_data, _data) do
-    Hooks.FlowActivities.delete(old_data)
+    Hooks.FlowActivities.on_delete(old_data)
   end
 
   #########
@@ -155,15 +155,15 @@ defmodule Domain.Events.Event do
   #########
 
   defp process(:insert, "flows", _old_data, data) do
-    Hooks.Flows.insert(data)
+    Hooks.Flows.on_insert(data)
   end
 
   defp process(:update, "flows", old_data, data) do
-    Hooks.Flows.update(old_data, data)
+    Hooks.Flows.on_update(old_data, data)
   end
 
   defp process(:delete, "flows", old_data, _data) do
-    Hooks.Flows.delete(old_data)
+    Hooks.Flows.on_delete(old_data)
   end
 
   ##################
@@ -171,15 +171,15 @@ defmodule Domain.Events.Event do
   ##################
 
   defp process(:insert, "gateway_groups", _old_data, data) do
-    Hooks.GatewayGroups.insert(data)
+    Hooks.GatewayGroups.on_insert(data)
   end
 
   defp process(:update, "gateway_groups", old_data, data) do
-    Hooks.GatewayGroups.update(old_data, data)
+    Hooks.GatewayGroups.on_update(old_data, data)
   end
 
   defp process(:delete, "gateway_groups", old_data, _data) do
-    Hooks.GatewayGroups.delete(old_data)
+    Hooks.GatewayGroups.on_delete(old_data)
   end
 
   ############
@@ -187,15 +187,15 @@ defmodule Domain.Events.Event do
   ############
 
   defp process(:insert, "gateways", _old_data, data) do
-    Hooks.Gateways.insert(data)
+    Hooks.Gateways.on_insert(data)
   end
 
   defp process(:update, "gateways", old_data, data) do
-    Hooks.Gateways.update(old_data, data)
+    Hooks.Gateways.on_update(old_data, data)
   end
 
   defp process(:delete, "gateways", old_data, _data) do
-    Hooks.Gateways.delete(old_data)
+    Hooks.Gateways.on_delete(old_data)
   end
 
   ############
@@ -203,15 +203,15 @@ defmodule Domain.Events.Event do
   ############
 
   defp process(:insert, "policies", _old_data, data) do
-    Hooks.Policies.insert(data)
+    Hooks.Policies.on_insert(data)
   end
 
   defp process(:update, "policies", old_data, data) do
-    Hooks.Policies.update(old_data, data)
+    Hooks.Policies.on_update(old_data, data)
   end
 
   defp process(:delete, "policies", old_data, _data) do
-    Hooks.Policies.delete(old_data)
+    Hooks.Policies.on_delete(old_data)
   end
 
   ################
@@ -219,15 +219,15 @@ defmodule Domain.Events.Event do
   ################
 
   defp process(:insert, "relay_groups", _old_data, data) do
-    Hooks.RelayGroups.insert(data)
+    Hooks.RelayGroups.on_insert(data)
   end
 
   defp process(:update, "relay_groups", old_data, data) do
-    Hooks.RelayGroups.update(old_data, data)
+    Hooks.RelayGroups.on_update(old_data, data)
   end
 
   defp process(:delete, "relay_groups", old_data, _data) do
-    Hooks.RelayGroups.delete(old_data)
+    Hooks.RelayGroups.on_delete(old_data)
   end
 
   ##########
@@ -235,15 +235,15 @@ defmodule Domain.Events.Event do
   ##########
 
   defp process(:insert, "relays", _old_data, data) do
-    Hooks.Relays.insert(data)
+    Hooks.Relays.on_insert(data)
   end
 
   defp process(:update, "relays", old_data, data) do
-    Hooks.Relays.update(old_data, data)
+    Hooks.Relays.on_update(old_data, data)
   end
 
   defp process(:delete, "relays", old_data, _data) do
-    Hooks.Relays.delete(old_data)
+    Hooks.Relays.on_delete(old_data)
   end
 
   ########################
@@ -251,15 +251,15 @@ defmodule Domain.Events.Event do
   ########################
 
   defp process(:insert, "resource_connections", _old_data, data) do
-    Hooks.ResourceConnections.insert(data)
+    Hooks.ResourceConnections.on_insert(data)
   end
 
   defp process(:update, "resource_connections", old_data, data) do
-    Hooks.ResourceConnections.update(old_data, data)
+    Hooks.ResourceConnections.on_update(old_data, data)
   end
 
   defp process(:delete, "resource_connections", old_data, _data) do
-    Hooks.ResourceConnections.delete(old_data)
+    Hooks.ResourceConnections.on_delete(old_data)
   end
 
   #############
@@ -267,15 +267,15 @@ defmodule Domain.Events.Event do
   #############
 
   defp process(:insert, "resources", _old_data, data) do
-    Hooks.Resources.insert(data)
+    Hooks.Resources.on_insert(data)
   end
 
   defp process(:update, "resources", old_data, data) do
-    Hooks.Resources.update(old_data, data)
+    Hooks.Resources.on_update(old_data, data)
   end
 
   defp process(:delete, "resources", old_data, _data) do
-    Hooks.Resources.delete(old_data)
+    Hooks.Resources.on_delete(old_data)
   end
 
   ##########
@@ -283,15 +283,15 @@ defmodule Domain.Events.Event do
   ##########
 
   defp process(:insert, "tokens", _old_data, data) do
-    Hooks.Tokens.insert(data)
+    Hooks.Tokens.on_insert(data)
   end
 
   defp process(:update, "tokens", old_data, data) do
-    Hooks.Tokens.update(old_data, data)
+    Hooks.Tokens.on_update(old_data, data)
   end
 
   defp process(:delete, "tokens", old_data, _data) do
-    Hooks.Tokens.delete(old_data)
+    Hooks.Tokens.on_delete(old_data)
   end
 
   #############

--- a/elixir/apps/domain/lib/domain/events/event.ex
+++ b/elixir/apps/domain/lib/domain/events/event.ex
@@ -70,6 +70,22 @@ defmodule Domain.Events.Event do
     Hooks.ActorGroups.on_delete(old_data)
   end
 
+  ###################
+  # actor_resources #
+  ###################
+
+  defp process(:insert, "actor_resources", _old_data, data) do
+    Hooks.ActorResources.on_insert(data)
+  end
+
+  defp process(:update, "actor_resources", old_data, data) do
+    Hooks.ActorResources.on_update(old_data, data)
+  end
+
+  defp process(:delete, "actor_resources", old_data, _data) do
+    Hooks.ActorResources.on_delete(old_data)
+  end
+
   ##########
   # actors #
   ##########

--- a/elixir/apps/domain/lib/domain/events/hooks/accounts.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/accounts.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.Accounts do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/actor_group_memberships.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/actor_group_memberships.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.ActorGroupMemberships do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/actor_groups.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/actor_groups.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.ActorGroups do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/actor_resources.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/actor_resources.ex
@@ -1,0 +1,13 @@
+defmodule Domain.Events.Hooks.ActorResources do
+  def on_insert(_data) do
+    :ok
+  end
+
+  def on_update(_old_data, _data) do
+    :ok
+  end
+
+  def on_delete(_old_data) do
+    :ok
+  end
+end

--- a/elixir/apps/domain/lib/domain/events/hooks/actors.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/actors.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.Actors do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/auth_identities.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/auth_identities.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.AuthIdentities do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/auth_providers.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/auth_providers.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.AuthProviders do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/clients.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/clients.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.Clients do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/flow_activities.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/flow_activities.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.FlowActivities do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/flows.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/flows.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.Flows do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/gateway_groups.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/gateway_groups.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.GatewayGroups do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/gateways.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/gateways.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.Gateways do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/policies.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/policies.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.Policies do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/relay_groups.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/relay_groups.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.RelayGroups do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/relays.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/relays.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.Relays do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/resource_connections.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resource_connections.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.ResourceConnections do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/resources.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resources.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.Resources do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/tokens.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/tokens.ex
@@ -1,13 +1,13 @@
 defmodule Domain.Events.Hooks.Tokens do
-  def insert(_data) do
+  def on_insert(_data) do
     :ok
   end
 
-  def update(_old_data, _data) do
+  def on_update(_old_data, _data) do
     :ok
   end
 
-  def delete(_old_data) do
+  def on_delete(_old_data) do
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/resources/resource.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource.ex
@@ -23,6 +23,7 @@ defmodule Domain.Resources.Resource do
 
     has_many :policies, Domain.Policies.Policy, where: [deleted_at: nil]
     has_many :actor_groups, through: [:policies, :actor_group]
+    has_many :actor_resources, Domain.Actors.Resource, on_replace: :delete
 
     # Warning: do not do Repo.preload/2 for this field, it will not work intentionally,
     # because the actual preload query should also use joins and process policy conditions

--- a/elixir/apps/domain/priv/repo/migrations/20250501061920_add_actor_resources.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250501061920_add_actor_resources.exs
@@ -1,0 +1,28 @@
+defmodule Domain.Repo.Migrations.AddActorResources do
+  use Ecto.Migration
+
+  def up do
+    create table(:actor_resources, primary_key: false) do
+      add(:account_id, references(:accounts, type: :binary_id, on_delete: :delete_all),
+        primary_key: true,
+        null: false
+      )
+
+      add(:actor_id, references(:actors, type: :binary_id, on_delete: :delete_all),
+        primary_key: true,
+        null: false
+      )
+
+      add(:resource_id, references(:resources, type: :binary_id, on_delete: :delete_all),
+        primary_key: true,
+        null: false
+      )
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+  end
+
+  def down do
+    drop(table(:actor_resources))
+  end
+end

--- a/elixir/apps/domain/test/domain/events/hooks/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/accounts_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.AccountsTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/actor_group_memberships_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/actor_group_memberships_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.ActorGroupMembershipsTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/actor_groups_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/actor_groups_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.ActorGroupsTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/actors_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/actors_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.ActorsTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/auth_identities_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/auth_identities_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.AuthIdentitiesTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/auth_providers_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/auth_providers_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.AuthProvidersTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/clients_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/clients_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.ClientsTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/flow_activities_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/flow_activities_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.FlowActivitiesTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/flows_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/flows_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.FlowsTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/gateway_groups_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/gateway_groups_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.GatewayGroupsTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/gateways_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/gateways_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.GatewaysTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/policies_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/policies_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.PoliciesTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/relay_groups_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/relay_groups_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.RelayGroupsTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/relays_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/relays_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.RelaysTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/resource_connections_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/resource_connections_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.ResourceConnectionsTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/resources_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/resources_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.ResourcesTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/tokens_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/tokens_test.exs
@@ -8,19 +8,19 @@ defmodule Domain.Events.Hooks.TokensTest do
 
   describe "insert/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == insert(data)
+      assert :ok == on_insert(data)
     end
   end
 
   describe "update/2" do
     test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == update(old_data, data)
+      assert :ok == on_update(old_data, data)
     end
   end
 
   describe "delete/1" do
     test "returns :ok", %{data: data} do
-      assert :ok == delete(data)
+      assert :ok == on_delete(data)
     end
   end
 end

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -49,6 +49,7 @@ config :domain, Domain.Events.ReplicationConnection,
     accounts
     actor_group_memberships
     actor_groups
+    actor_resources
     actors
     auth_identities
     auth_providers


### PR DESCRIPTION
Whenever a membership is added or removed or a policy is created/updated/deleted, we need to broadcast to all relevant clients and gateways certain allow and reject access events.

Our new system for doing this, the WAL, doesn't handle this case very well. This is because there is no single event we can reference in the WAL to determine when an actor loses access to a resource based on the state of the DB.

What we do today is re-query the DB for all the of side effects of membership or policy changes, and then broadcast based on these. This introduces two issues:

- There's a minor consistency issue because two queries issued around the same time could potentially return different results if the associated memberships or policies were changed in between, and there isn't a consistent ordering for them
- We don't guarantee that a broadcast will occur when the associated memberships or policies change, since the node could have rebooted, process crashed, etc

To fix this, we introduce the `actor_resources` join table which maintains a persistent, up-to-date snapshot to answer the question "which actors have access to which resources", which is essentially the same thing as "which resources should be populated in actors clients' resource menus". This table is maintained for each membership or policy update.

We can then listen for WAL events on this table alone to determine when to broadcast `allow_access` and `reject_access` to the appropriate subscribers.

This also greatly simplifies the number of PubSub topics the client needs to subscribe to. Now, clients can simply subscribe to `actor:#{actor.id}` and receive all resource-related events for its actor.

Note that the `flows` table conveniently handles the `expire_flows` message for us already.