### PR TITLE
ci(rust): make `compile-packages` opt-out from workspace

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -19,7 +19,7 @@ outputs:
     value: ${{
       (runner.os == 'Linux' && '--workspace') ||
       (runner.os == 'macOS' && '--workspace --exclude ebpf-turn-router --exclude gui-smoke-test') ||
-      (runner.os == 'Windows' && '-p connlib-client-shared -p connlib-model -p firezone-bin-shared -p firezone-gui-client -p firezone-gui-client-common -p firezone-headless-client -p firezone-logging -p firezone-telemetry -p firezone-tunnel -p gui-smoke-test -p http-test-server -p ip-packet -p phoenix-channel -p snownet -p socket-factory -p tun') }}
+      (runner.os == 'Windows' && '--workspace --exclude ebpf-turn-router') }}
   test-packages:
     description: Testable packages for the current OS
     value: ${{

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -19,7 +19,7 @@ outputs:
     value: ${{
       (runner.os == 'Linux' && '--workspace') ||
       (runner.os == 'macOS' && '--workspace --exclude ebpf-turn-router --exclude gui-smoke-test') ||
-      (runner.os == 'Windows' && '--workspace --exclude ebpf-turn-router --exclude connlib-client-apple') }}
+      (runner.os == 'Windows' && '--workspace --exclude ebpf-turn-router --exclude connlib-client-apple --exclude connlib-client-android') }}
   test-packages:
     description: Testable packages for the current OS
     value: ${{

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -19,7 +19,7 @@ outputs:
     value: ${{
       (runner.os == 'Linux' && '--workspace') ||
       (runner.os == 'macOS' && '--workspace --exclude ebpf-turn-router --exclude gui-smoke-test') ||
-      (runner.os == 'Windows' && '--workspace --exclude ebpf-turn-router') }}
+      (runner.os == 'Windows' && '--workspace --exclude ebpf-turn-router --exclude connlib-client-apple') }}
   test-packages:
     description: Testable packages for the current OS
     value: ${{

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -51,6 +51,9 @@ jemallocator = { workspace = true }
 nix = { workspace = true }
 dns-lookup = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+dns-lookup = { workspace = true }
+
 [dev-dependencies]
 serde_json = { workspace = true, features = ["std"] }
 

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -14,7 +14,6 @@ boringtun = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 connlib-model = { workspace = true }
-dns-lookup = { workspace = true }
 dns-types = { workspace = true }
 either = { workspace = true }
 firezone-bin-shared = { workspace = true }
@@ -50,6 +49,7 @@ uuid = { workspace = true, features = ["v4"] }
 caps = { workspace = true }
 jemallocator = { workspace = true }
 nix = { workspace = true }
+dns-lookup = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true, features = ["std"] }


### PR DESCRIPTION
Instead of explicitly listing every package we want to compile, attempt to compile the entire workspace and exclude the ones we know won't work on Windows.