### PR TITLE
ci: don't build Windows headless client for perf tests

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -112,6 +112,7 @@ jobs:
 
   data-plane-windows:
     name: client-windows-${{ matrix.target }}
+    if: ${{ inputs.image_prefix != 'perf' }} # Perf testing happens only on Linux
     runs-on: windows-2019
     defaults:
       run:


### PR DESCRIPTION
Checking this based on the image prefix is a bit hacky but should speed up the pipeline a bit.

Related: #8948 