### PR TITLE
ci: don't run Tauri workflows on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  tauri:
-    uses: ./.github/workflows/_tauri.yml
-    secrets: inherit
-
   build-artifacts:
     needs: update-release-draft
     uses: ./.github/workflows/_build_artifacts.yml


### PR DESCRIPTION
These take a long time and there is not really any benefit. We already run smoke-tests on both Windows and Linux runners which ensures that the GUI and IPC service compile and start. In addition, we run clippy across the entire Rust codebase.

The only thing that doesn't get tested in CI if we remove this is the bundling of the applications. This however rarely changes and one can always trigger the Tauri workflow manually for a PR to see if certain changes are working.

Related: #8948 