### PR TITLE
ci(rust): run the default number of proptest cases

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -116,7 +116,6 @@ jobs:
           # Needed to create tunnel interfaces in unit tests
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
-          PROPTEST_CASES: ${{ runner.os == 'Windows' && 1000 || 2000 }} # Default is only 256. Windows is very slow in GitHub Actions, so only run a 1000 cases there.
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
           TESTCASES_DIR: "connlib/tunnel/testcases"
 


### PR DESCRIPTION
By default, proptest runs all regression cases + 256 new ones. Given that we run the tests on 3 different operating systems in various versions each and that on each PR, we are likely hitting enough different cases to detect any bugs.

Related: #8948 