### PR TITLE
ci(android): only build release bundles on request

### DIFF
--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -48,6 +48,7 @@ jobs:
       id-token: write
     name: build-release-${{ matrix.package-type }}
     needs: update-release-draft
+    if: "${{ github.event_name == 'workflow_dispatch' }}"
     # Android SDK tools hardware accel is available only on Linux runners
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
The debug build is good enough if one wants to test a particular PR on a real device. When necessary, a release build can be trigger explicitly for a particular branch.

Related: #8948 