### PR TITLE
fix(ci): Fix github actions dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,11 @@ updates:
     schedule:
       interval: monthly
   - package-ecosystem: pip
-    directory: /
+    directory: /.github
     schedule:
       interval: monthly
   - package-ecosystem: github-actions
-    directory: /
+    directory: /.github
     schedule:
       interval: monthly
   - package-ecosystem: cargo


### PR DESCRIPTION
Our GitHub actions packages are not being updated. This may be a reason why.

Edit: Looks like it's not applying to our composite actions in .github/actions. Will see if this fixes it.