### PR TITLE
fix(portal): Properly check background jobs

### DIFF
--- a/elixir/apps/domain/lib/domain/application.ex
+++ b/elixir/apps/domain/lib/domain/application.ex
@@ -83,13 +83,11 @@ defmodule Domain.Application do
   end
 
   defp replication do
-    {enabled, config} =
-      Application.get_env(:domain, Domain.Events.ReplicationConnection)
-      |> Keyword.pop(:enabled)
+    config = Application.fetch_env!(:domain, Domain.Events.ReplicationConnection)
 
-    if enabled do
+    if config[:enabled] do
       [
-        replication_child_spec(config)
+        replication_child_spec()
       ]
     else
       []
@@ -97,7 +95,9 @@ defmodule Domain.Application do
   end
 
   defp replication_child_spec(config) do
-    {connection_opts, config} = Keyword.pop(config, :connection_opts)
+    {connection_opts, config} =
+      Application.fetch_env!(:domain, Domain.Events.ReplicationConnection)
+      |> Keyword.pop(:connection_opts)
 
     init_state = %{
       connection_opts: connection_opts,

--- a/elixir/apps/domain/lib/domain/application.ex
+++ b/elixir/apps/domain/lib/domain/application.ex
@@ -94,7 +94,7 @@ defmodule Domain.Application do
     end
   end
 
-  defp replication_child_spec(config) do
+  defp replication_child_spec do
     {connection_opts, config} =
       Application.fetch_env!(:domain, Domain.Events.ReplicationConnection)
       |> Keyword.pop(:connection_opts)

--- a/elixir/apps/domain/lib/domain/application.ex
+++ b/elixir/apps/domain/lib/domain/application.ex
@@ -79,7 +79,7 @@ defmodule Domain.Application do
 
   # TODO: Configure Oban workers to only run on domain nodes
   defp oban do
-    {Oban, Application.fetch_env!(:domain, Oban)}
+    [{Oban, Application.fetch_env!(:domain, Oban)}]
   end
 
   defp replication do

--- a/elixir/apps/domain/test/domain/events/replication_connection_test.exs
+++ b/elixir/apps/domain/test/domain/events/replication_connection_test.exs
@@ -18,9 +18,11 @@ defmodule Domain.Events.ReplicationConnectionTest do
 
   # Used to test live connection
   setup_all do
-    {connection_opts, config} =
+    {_enabled, config} =
       Application.fetch_env!(:domain, Domain.Events.ReplicationConnection)
-      |> Keyword.pop(:connection_opts)
+      |> Keyword.pop(:enabled)
+
+    {connection_opts, config} = Keyword.pop(config, :connection_opts)
 
     init_state = %{
       connection_opts: connection_opts,

--- a/elixir/apps/domain/test/domain/events/replication_connection_test.exs
+++ b/elixir/apps/domain/test/domain/events/replication_connection_test.exs
@@ -18,11 +18,9 @@ defmodule Domain.Events.ReplicationConnectionTest do
 
   # Used to test live connection
   setup_all do
-    {_enabled, config} =
+    {connection_opts, config} =
       Application.fetch_env!(:domain, Domain.Events.ReplicationConnection)
-      |> Keyword.pop(:enabled)
-
-    {connection_opts, config} = Keyword.pop(config, :connection_opts)
+      |> Keyword.pop(:connection_opts)
 
     init_state = %{
       connection_opts: connection_opts,

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -31,6 +31,7 @@ config :domain, Domain.Repo,
   start_apps_before_migration: [:ssl, :logger_json]
 
 config :domain, Domain.Events.ReplicationConnection,
+  enabled: true,
   connection_opts: [
     hostname: "localhost",
     port: 5432,

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -28,6 +28,7 @@ if config_env() == :prod do
            )
 
   config :domain, Domain.Events.ReplicationConnection,
+    enabled: compile_config!(:background_jobs_enabled),
     connection_opts: [
       hostname: compile_config!(:database_host),
       port: compile_config!(:database_port),


### PR DESCRIPTION
The `background_jobs_enabled` config in an ENV var that needs to be set for a specific configuration key. It's not set on the top-level `:domain` config by default.

Instead, it's used to enable / disable specific modules to start by the application's Supervisor.

The `Domain.Events.ReplicationConnection` module is updated in this PR to follow this convention.