### PR TITLE
fix(deps): update github-actions in .github/actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,12 @@ updates:
     schedule:
       interval: monthly
   - package-ecosystem: github-actions
-    directory: /.github
+    directory: /
+    schedule:
+      interval: monthly
+  # Dependabot won't look in here by default
+  - package-ecosystem: github-actions
+    directory: /.github/actions
     schedule:
       interval: monthly
   - package-ecosystem: cargo


### PR DESCRIPTION
Dependabot only updates dependencies in .github/workflows. This is an attempt to tell it to also update in .github/actions too.