### PR TITLE
docs: Reorder gcloud auth step for cloudsql

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -469,6 +469,12 @@ Install
 [`cloud-sql-proxy`](https://cloud.google.com/sql/docs/postgres/connect-instance-auth-proxy)
 (eg. `brew install cloud-sql-proxy`) and run:
 
+First, obtain a fresh token:
+
+```bash
+gcloud auth application-default login
+```
+
 ```bash
 cloud-sql-proxy --auto-iam-authn "firezone-prod:us-east1:firezone-prod?address=0.0.0.0&port=9000"
 ```
@@ -479,13 +485,6 @@ Then you can connect to the PostgreSQL using `psql`:
 # Use your work email as username to connect
 PG_USER=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" | head -n 1)
 psql "host=localhost port=9000 sslmode=disable dbname=firezone user=${PG_USER}"
-```
-
-If you have issues with credentials try refreshing the application default
-token:
-
-```bash
-gcloud auth application-default login
 ```
 
 ### Connecting to Cloud SQL instance as the `firezone` user


### PR DESCRIPTION
This is almost always required.