### PR TITLE
fix(portal): ignore expected replication connection failures

### DIFF
--- a/elixir/apps/domain/lib/domain/events/replication_connection.ex
+++ b/elixir/apps/domain/lib/domain/events/replication_connection.ex
@@ -64,9 +64,8 @@ defmodule Domain.Events.ReplicationConnection do
         {:ok, pid}
 
       error ->
-        Logger.error("Failed to start replication connection!",
-          error: inspect(error)
-        )
+        # This is expected in clustered environments.
+        Logger.info("Failed to start replication connection", error: inspect(error))
 
         error
     end


### PR DESCRIPTION
These are expected during deploys, so don't log them as errors. If the Supervisor fails to start us after exhausting all attempts, it will log an error.