### PR TITLE
chore(connlib): buffer most recent TCP SYN

### DIFF
--- a/rust/connlib/tunnel/src/unique_packet_buffer.rs
+++ b/rust/connlib/tunnel/src/unique_packet_buffer.rs
@@ -27,14 +27,13 @@ impl UniquePacketBuffer {
             return;
         }
 
-        if self
-            .buffer
-            .iter()
-            .any(|buffered| is_tcp_syn_retransmit(buffered, &new))
-        {
-            tracing::trace!(packet = ?new, "Not buffering TCP SYN retransmission");
+        for buffered in self.buffer.iter_mut() {
+            if is_tcp_syn_retransmit(buffered, &new) {
+                tracing::trace!(packet = ?new, "Detected TCP SYN retransmission; replacing old one");
+                *buffered = new;
 
-            return;
+                return;
+            }
         }
 
         tracing::debug!(tag = %self.tag, is_full = %self.buffer.is_full(), packet = ?new, "Buffering packet");


### PR DESCRIPTION
When establishing connections that take longer than the TCP RTO, we may see duplicate TCP SYNs. Those have different timestamps from each other but are otherwise equal. To provide more accurate timing information to the TCP stack, we now keep the latest TCP SYN around instead of the very first one.