### PR TITLE
feat(gateway): add CLI flag to validate checksums of all packets

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2251,6 +2251,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tun",
  "url",
  "uuid",
 ]

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "fs", "signal", "rt"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+tun = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 


### PR DESCRIPTION
Validating checksums can be expensive so this is off-by-default. The intent is to turn it on in our staging environment so we can detects bugs in our packet handling code during testing.