### PR TITLE
fix(connlib): never clear ECT from IP packets

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -211,7 +211,8 @@ impl ClientTunnel {
                             continue;
                         };
 
-                        self.io.send_tun(packet.with_ecn(received.ecn));
+                        self.io
+                            .send_tun(packet.with_ecn_from_transport(received.ecn));
                     }
 
                     continue;
@@ -344,7 +345,8 @@ impl GatewayTunnel {
                             continue;
                         };
 
-                        self.io.send_tun(packet.with_ecn(received.ecn));
+                        self.io
+                            .send_tun(packet.with_ecn_from_transport(received.ecn));
                     }
 
                     continue;

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -892,29 +892,28 @@ impl IpPacket {
     /// - if the IP packet signalled an ECN-capable transport (i.e. the originating network stack is ECN-capable)
     /// - and we have experienced congestion along the way (i.e. the provided ECN value is [`Ecn::Ce`]).
     pub fn with_ecn_from_transport(self, ecn: Ecn) -> Self {
+        use Ecn::*;
+
         let ecn = match (self.ecn(), ecn) {
-            (Ecn::NonEct, Ecn::NonEct)
-            | (Ecn::Ect1, Ecn::Ect1)
-            | (Ecn::Ect0, Ecn::Ect0)
-            | (Ecn::Ce, Ecn::Ce) => {
+            (NonEct, NonEct) | (Ect1, Ect1) | (Ect0, Ect0) | (Ce, Ce) => {
                 // No change needed
                 return self;
             }
-            (Ecn::NonEct, Ecn::Ect0 | Ecn::Ect1 | Ecn::Ce) => {
+            (NonEct, Ect0 | Ect1 | Ce) => {
                 // Packet sender is not ECN-capable, ignore any update.
                 return self;
             }
-            (Ecn::Ect1 | Ecn::Ect0 | Ecn::Ce, Ecn::NonEct) | (Ecn::Ce, Ecn::Ect0 | Ecn::Ect1) => {
+            (Ect1 | Ect0 | Ce, NonEct) | (Ce, Ect0 | Ect1) => {
                 // We already have ECN information, refuse to clear it.
                 return self;
             }
-            (Ecn::Ect1, Ecn::Ect0) | (Ecn::Ect0, Ecn::Ect1) => {
+            (Ect1, Ect0) | (Ect0, Ect1) => {
                 // Don't switch between ECT0 and ECT1, they are equivalent.
                 return self;
             }
-            (Ecn::Ect1, Ecn::Ce) | (Ecn::Ect0, Ecn::Ce) => {
+            (Ect1, Ce) | (Ect0, Ce) => {
                 // ECN-capable transport has been signalled and our update is CE, update it!
-                Ecn::Ce
+                Ce
             }
         };
 

--- a/rust/ip-packet/src/lib.rs
+++ b/rust/ip-packet/src/lib.rs
@@ -885,7 +885,46 @@ impl IpPacket {
         }
     }
 
-    pub fn with_ecn(mut self, ecn: Ecn) -> Self {
+    /// Updates the ECN flags of this packet with the ECN value from the transport layer.
+    ///
+    /// After tunneling an IP packet, we need to merge the ECN flags from the transport layer with the ones already set on the IP packet.
+    /// Essentially, the only time we need to update the ECN flags is:
+    /// - if the IP packet signalled an ECN-capable transport (i.e. the originating network stack is ECN-capable)
+    /// - and we have experienced congestion along the way (i.e. the provided ECN value is [`Ecn::Ce`]).
+    pub fn with_ecn_from_transport(self, ecn: Ecn) -> Self {
+        let ecn = match (self.ecn(), ecn) {
+            (Ecn::NonEct, Ecn::NonEct)
+            | (Ecn::Ect1, Ecn::Ect1)
+            | (Ecn::Ect0, Ecn::Ect0)
+            | (Ecn::Ce, Ecn::Ce) => {
+                // No change needed
+                return self;
+            }
+            (Ecn::NonEct, Ecn::Ect0 | Ecn::Ect1 | Ecn::Ce) => {
+                // Packet sender is not ECN-capable, ignore any update.
+                return self;
+            }
+            (Ecn::Ect1 | Ecn::Ect0 | Ecn::Ce, Ecn::NonEct) | (Ecn::Ce, Ecn::Ect0 | Ecn::Ect1) => {
+                // We already have ECN information, refuse to clear it.
+                return self;
+            }
+            (Ecn::Ect1, Ecn::Ect0) | (Ecn::Ect0, Ecn::Ect1) => {
+                // Don't switch between ECT0 and ECT1, they are equivalent.
+                return self;
+            }
+            (Ecn::Ect1, Ecn::Ce) | (Ecn::Ect0, Ecn::Ce) => {
+                // ECN-capable transport has been signalled and our update is CE, update it!
+                Ecn::Ce
+            }
+        };
+
+        self.with_ecn(ecn)
+    }
+
+    /// Applies the raw ECN value.
+    ///
+    /// This is most likely not what you want unless you know what you're doing or you are writing a test.
+    fn with_ecn(mut self, ecn: Ecn) -> Self {
         match &mut self {
             IpPacket::Ipv4(ip) => ip.header_mut().set_ecn(ecn as u8),
             IpPacket::Ipv6(ip) => ip.header_mut().set_ecn(ecn as u8),
@@ -1146,5 +1185,27 @@ mod tests {
             ip4_header.header_checksum,
             ip4_header.calc_header_checksum()
         );
+    }
+
+    #[test]
+    fn ecn_from_transport_happy_path() {
+        let p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
+            .unwrap()
+            .with_ecn(Ecn::Ect0);
+
+        let p_with_ce = p.with_ecn_from_transport(Ecn::Ce);
+
+        assert_eq!(p_with_ce.ecn(), Ecn::Ce);
+    }
+
+    #[test]
+    fn ecn_from_transport_no_clear_ect() {
+        let p = crate::make::udp_packet(Ipv4Addr::LOCALHOST, Ipv4Addr::LOCALHOST, 0, 0, vec![])
+            .unwrap()
+            .with_ecn(Ecn::Ect0);
+
+        let p_with_ce = p.with_ecn_from_transport(Ecn::NonEct);
+
+        assert_eq!(p_with_ce.ecn(), Ecn::Ect0);
     }
 }

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -24,7 +24,7 @@ export default function Gateway() {
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
         <ChangeItem pull="9009">
-          Fixes an issue where ECN bits got erronously cleared without updating
+          Fixes an issue where ECN bits got erroneously cleared without updating
           the packet checksum. This caused packet loss on recent MacOS versions
           which attempt to use ECN.
         </ChangeItem>

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,13 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9009">
+          Fixes an issue where ECN bits got erronously cleared without updating
+          the packet checksum. This caused packet loss on recent MacOS versions
+          which attempt to use ECN.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.7" date={new Date("2025-04-30")}>
         <ChangeItem pull="8798">
           Improves performance of relayed connections on IPv4-only systems.


### PR DESCRIPTION
ECN information is helpful to allow the congestion controllers to more easily fine-tune their send and receive windows. When a Firezone Client receives an IP packet where the ECN bits signal an ECN capable transport, we mirror this bit on the UDP datagram that carries the encrypted IP packet.

When receiving a datagram with ECN bits set, the Gateway will then apply these bits to the decrypted IP packet and pass it along towards its destination.

This implementation is unfortunately a bit too naive. Not all devices on the Internet support ECN and therefore, we may receive a datagram that has its ECN bits cleared when the ECN bits on the inner IP packet still signal an ECN capable transport. In this case, we should _not_ override the ECN bits and instead pass the IP packet along as is. Network devices along the path between Gateway and Resource may still use these ECN bits to signal congestion.

We fix this by making the `with_ecn` function on `IpPacket` private. It is not meant to be used outside of the module. We supersede it with a `with_ecn_from_transport` function that implements the above logic.