### PR TITLE
ci(rust): only run proptest's regression seeds on Windows

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -116,6 +116,7 @@ jobs:
           # Needed to create tunnel interfaces in unit tests
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo --preserve-env"
           PROPTEST_VERBOSE: 0 # Otherwise the output is very long.
+          PROPTEST_CASES: ${{ runner.os == 'Windows' && '0' || '256' }} # Default is only 256. Windows is very slow in GitHub Actions, so only run the regression cases there.
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
           TESTCASES_DIR: "connlib/tunnel/testcases"
 


### PR DESCRIPTION
GitHub's Windows runners are very slow. In order to not prolong CI runs too much, we set the number of _additional_ proptest cases for Windows to 0. This means we still run all the regression seeds that we've accumulated in `proptest-regressions/tests.txt` and simply don't generate any new ones on top of it.

This is also a good benchmark to ensure that our regression seeds cover all cases that we are testing further down below using the coverage grepping.

Related: #8948 