### PR TITLE
fix(connlib): ensure ICE timing config applies immediately

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6597,8 +6597,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3e9d7aa295a1f2af6c92e0ad254fe807487a25c7b0360b4d697bb445db9164"
+source = "git+https://github.com/firezone/str0m?branch=main#8401a07556ee930866768d3993514fedb455b0b3"
 dependencies = [
  "combine",
  "crc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -215,6 +215,7 @@ ip_network = { git = "https://github.com/JakubOnderka/ip_network", branch = "mas
 ip_network_table = { git = "https://github.com/edmonds/ip_network_table", branch = "some-useful-traits" } # For `Debug` and `Clone`
 tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdriver", branch = "bump-otel-0.26" } # Waiting for release.
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.
+str0m = { git = "https://github.com/firezone/str0m", branch = "main" }
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']


### PR DESCRIPTION
When there is no traffic going through the tunnel, Firezone switches into a low-power mode where it only sends STUN bindings every 60s. As soon as we see traffic, we move out of this low-power mode to detect connectivity problems early.

Applying this new timing config however does not clear some internal caches in `str0m` and therefore, it can take up to the previously set timeout value until str0m actually picks up on the new timers.

This is being fixed in https://github.com/algesten/str0m/pull/649. Until that is merged, we depend on our fork that has these changes merged already.

Resolves: #8999 