### PR TITLE
feat(windows): optimise network change detection

### DIFF
--- a/rust/bin-shared/src/network_changes/windows.rs
+++ b/rust/bin-shared/src/network_changes/windows.rs
@@ -356,13 +356,7 @@ fn get_network_id_of_firezone_adapter() -> Result<GUID> {
         .context("Failed to open registry key")?;
 
     for key in profiles.enum_keys() {
-        let guid = match key {
-            Ok(guid) => guid,
-            Err(e) => {
-                tracing::debug!("Failed to open key: {e}");
-                continue;
-            }
-        };
+        let guid = key?;
 
         let profile_name = profiles
             .open_subkey(&guid)?

--- a/rust/bin-shared/src/network_changes/windows.rs
+++ b/rust/bin-shared/src/network_changes/windows.rs
@@ -356,11 +356,13 @@ fn get_network_id_of_firezone_adapter() -> Result<GUID> {
         .context("Failed to open registry key")?;
 
     for key in profiles.enum_keys() {
-        let guid = key?;
+        let guid = key.context("Failed to enumerate key")?;
 
         let profile_name = profiles
-            .open_subkey(&guid)?
-            .get_value::<String, _>("ProfileName")?;
+            .open_subkey(&guid)
+            .with_context(|| format!("Failed to open key `{guid}`"))?
+            .get_value::<String, _>("ProfileName")
+            .context("Failed to get profile name")?;
 
         if profile_name == "Firezone" {
             let uuid = guid.trim_start_matches("{").trim_end_matches("}");

--- a/rust/bin-shared/src/network_changes/windows.rs
+++ b/rust/bin-shared/src/network_changes/windows.rs
@@ -408,7 +408,7 @@ impl INetworkEvents_Impl for Callback_Impl {
             .unwrap_or_else(|e| e.into_inner());
 
         if network_states
-            .get(&networkid)
+            .get(networkid)
             .is_some_and(|state| *state == newconnectivity)
         {
             tracing::debug!(?networkid, "Ignoring duplicate network change");

--- a/rust/bin-shared/src/network_changes/windows.rs
+++ b/rust/bin-shared/src/network_changes/windows.rs
@@ -352,9 +352,11 @@ impl INetworkEvents_Impl for Callback_Impl {
 
     fn NetworkConnectivityChanged(
         &self,
-        _networkid: &GUID,
-        _newconnectivity: NLM_CONNECTIVITY,
+        networkid: &GUID,
+        newconnectivity: NLM_CONNECTIVITY,
     ) -> WinResult<()> {
+        tracing::debug!(?networkid, ?newconnectivity, "Network connectivity changed");
+
         // No reasonable way to translate this error into a Windows error
         self.tx.notify().ok();
         Ok(())

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -8,7 +8,13 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os === OS.Windows && (
+          <ChangeItem pull="9021">
+            Optimizes network change detection.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.4.12" date={new Date("2025-04-30")}>
         {os === OS.Linux && (
           <ChangeItem pull="8731">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -9,7 +9,13 @@ export default function Headless({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os === OS.Windows && (
+          <ChangeItem pull="9021">
+            Optimizes network change detection.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.4.7" date={new Date("2025-04-30")}>
         <ChangeItem pull="8798">
           Improves performance of relayed connections on IPv4-only systems.


### PR DESCRIPTION
Presently, the network change detection on Windows is very naive and simply emits a change event everytime _anything_ changes. We can optimise this and therefore improve the start-up time of Firezone by:

- Filtering out duplicate events
- Filtering out network change events for our own network adapter

This reduces the number of network change events to 1 during startup. As far as I can tell from the code comments in this area, we explicitly send this one to ensure we don't run into a race condition whilst we are starting up.

Resolves: #8905