### PR TITLE
ci: Always select the latest Xcode version

### DIFF
--- a/scripts/build/lib.sh
+++ b/scripts/build/lib.sh
@@ -8,6 +8,10 @@ function setup_runner() {
     local app_profile_file="$2"
     local ne_profile="$3"
     local ne_profile_file="$4"
+
+    # Use the latest version of Xcode - matches what we typically use for development
+    sudo xcode-select --switch "$(ls -d /Applications/Xcode*.app | sort -V | tail -n 1)"
+
     profiles_path="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
     keychain_pass=$(openssl rand -base64 32)
     keychain_path="$(mktemp -d)/app-signing.keychain-db"


### PR DESCRIPTION
When building in CI, it's good to use the same version of Xcode that we develop with. This prevents cases where a mismatch causes builds to succeed on one and fail on the other, which can happen if system APIs are updated.