### PR TITLE
fix(apple/iOS): Use pointer directly for libresolv API calls

### DIFF
--- a/scripts/build/lib.sh
+++ b/scripts/build/lib.sh
@@ -8,6 +8,10 @@ function setup_runner() {
     local app_profile_file="$2"
     local ne_profile="$3"
     local ne_profile_file="$4"
+
+    # Use the latest version of Xcode - matches what we typically use for development
+    sudo xcode-select --switch "$(ls -d /Applications/Xcode*.app | sort -V | tail -n 1)"
+
     profiles_path="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
     keychain_pass=$(openssl rand -base64 32)
     keychain_path="$(mktemp -d)/app-signing.keychain-db"

--- a/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
@@ -10,17 +10,17 @@ public class BindResolvers {
   var state = __res_9_state()
 
   public init() {
-    res_9_ninit(&state)
+    res_9_ninit(state)
   }
 
   deinit {
-    res_9_ndestroy(&state)
+    res_9_ndestroy(state)
   }
 
   public final func getservers() -> [res_9_sockaddr_union] {
     let maxServers = 10
     var servers = [res_9_sockaddr_union](repeating: res_9_sockaddr_union(), count: maxServers)
-    let found = Int(res_9_getservers(&state, &servers, Int32(maxServers)))
+    let found = Int(res_9_getservers(state, &servers, Int32(maxServers)))
 
     // filter is to remove the erroneous empty entry when there's no real servers
     return Array(servers[0..<found]).filter { $0.sin.sin_len > 0 }


### PR DESCRIPTION
Somewhere between Xcode 16.0 and Xcode 16.3, the API for the libresolv functions we call changed slightly, and we can now pass the return value of `__res_9_state()` directly to the `res_9_ninit`, `res_9_ndestroy` and `res_9_getservers` functions.