### PR TITLE
build(rust): bump `stun_codec`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -776,12 +776,12 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecodec"
-version = "0.4.15"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf4c9d0bbf32eea58d7c0f812058138ee8edaf0f2802b6d03561b504729a325"
+checksum = "f1016c00ae68a934cd21f6e3837555ffdc977c0bd8e7df3093ca35c3d726789e"
 dependencies = [
  "byteorder",
- "trackable 0.2.24",
+ "trackable",
 ]
 
 [[package]]
@@ -2362,7 +2362,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-stackdriver",
  "tracing-subscriber",
- "trackable 1.3.0",
+ "trackable",
  "url",
  "uuid",
 ]
@@ -6564,9 +6564,9 @@ dependencies = [
 
 [[package]]
 name = "stun_codec"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feed9dafe0bda84f2b6ca3ce726b0a1f1ac2e8b63c6ecfb89b08b32313247b5b"
+checksum = "2663da41e3e056af18e2ec9ca537d53a4667798fdf92684f9848bd248263223a"
 dependencies = [
  "bytecodec",
  "byteorder",
@@ -6574,7 +6574,7 @@ dependencies = [
  "hmac",
  "md5",
  "sha1",
- "trackable 1.3.0",
+ "trackable",
 ]
 
 [[package]]
@@ -7636,16 +7636,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "trackable"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98abb9e7300b9ac902cc04920945a874c1973e08c310627cc4458c04b70dd32"
-dependencies = [
- "trackable 1.3.0",
- "trackable_derive",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,7 +50,7 @@ backoff = { version = "0.4", features = ["tokio"] }
 base64 = { version = "0.22.1", default-features = false }
 bimap = "0.6"
 boringtun = { version = "0.6", default-features = false }
-bytecodec = "0.4.15"
+bytecodec = "0.5.0"
 bytes = { version = "1.9.0", default-features = false }
 caps = "0.5.5"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
@@ -148,7 +148,7 @@ socket2 = { version = "0.5" }
 static_assertions = "1.1.0"
 str0m = { version = "0.8.0", default-features = false, features = ["sha1"] }
 strum = { version = "0.27.1", features = ["derive"] }
-stun_codec = "0.3.4"
+stun_codec = "0.4.0"
 subprocess = "0.2.9"
 subtle = "2.5.0"
 supports-color = "3.0.2"

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -268,7 +268,6 @@ skip = [
   "thiserror-impl",
   "toml_edit",
   "tower",
-  "trackable",
   "wasi",
   "windows",
   "windows-collections",


### PR DESCRIPTION
This brings in new versions of `stun_codec` and `bytecodec` which end up removing a duplicate dependency from our dependency tree.

Related: https://github.com/sile/bytecodec/pull/8
Related: https://github.com/sile/stun_codec