### PR TITLE
fix(portal): Add indexes to actor_group_memberships

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20250508192722_add_indexes_to_actor_group_memberships.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250508192722_add_indexes_to_actor_group_memberships.exs
@@ -1,0 +1,11 @@
+defmodule Domain.Repo.Migrations.AddIndexesToActorGroupMemberships do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create(index("actor_group_memberships", [:group_id], concurrently: true))
+    create(index("actor_group_memberships", [:actor_id], concurrently: true))
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20250508192722_add_indexes_to_actor_group_memberships.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250508192722_add_indexes_to_actor_group_memberships.exs
@@ -2,7 +2,6 @@ defmodule Domain.Repo.Migrations.AddIndexesToActorGroupMemberships do
   use Ecto.Migration
 
   @disable_ddl_transaction true
-  @disable_migration_lock true
 
   def change do
     create(index("actor_group_memberships", [:group_id], concurrently: true))


### PR DESCRIPTION
Why:

* As we move towards hard deleting data one issue we've run into is with cascading deletes on the actor_group_memberships table.  In order to solve this problem indexes have been created on the `actor_id` and `group_id` columns of the actor_group_memberships.