### PR TITLE
fix(gateway): truncate payload of ICMP errors

### DIFF
--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9059">
+          Fixes an issue where ICMP unreachable errors for large packets would
+          not be sent.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.8" date={new Date("2025-05-02")}>
         <ChangeItem pull="9009">
           Fixes an issue where ECN bits got erroneously cleared without updating


### PR DESCRIPTION
When the Gateway is handed an IP packet for a DNS resource that it cannot route, it sends back an ICMP unreachable error. According to RFC 792 [0] (for ICMPv4) and RFC 4443 [1] (for ICMPv6), parts of the original packet should be included in the ICMP error payload to allow the sending party to correlate, what could not be sent.

For ICMPv4, the RFC says:

```
Internet Header + 64 bits of Data Datagram

The internet header plus the first 64 bits of the original
datagram's data.  This data is used by the host to match the
message to the appropriate process.  If a higher level protocol
uses port numbers, they are assumed to be in the first 64 data
bits of the original datagram's data.
```

For ICMPv6, the RFC says:

```
As much of invoking packet as possible without the ICMPv6 packet exceeding the minimum IPv6 MTU
```

[0]: https://datatracker.ietf.org/doc/html/rfc792
[1]: https://datatracker.ietf.org/doc/html/rfc4443#section-3.1