### PR TITLE
fix(gateway): respond with SERVFAIL for missing nameserver

### DIFF
--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -149,13 +149,8 @@ impl Io {
         self.sockets.poll_has_sockets(cx)
     }
 
-    pub fn fastest_nameserver(&self) -> io::Result<IpAddr> {
-        let ns = self
-            .nameservers
-            .fastest()
-            .ok_or(io::Error::other(NoNameserverAvailable))?;
-
-        Ok(ns)
+    pub fn fastest_nameserver(&self) -> Option<IpAddr> {
+        self.nameservers.fastest()
     }
 
     pub fn poll<'b>(
@@ -411,10 +406,6 @@ impl Io {
         self.tcp_dns_server.send_response(to, message)
     }
 }
-
-#[derive(Debug, thiserror::Error)]
-#[error("No nameserver available to handle DNS query")]
-pub struct NoNameserverAvailable;
 
 fn is_max_wg_packet_size(d: &DatagramIn) -> bool {
     let len = d.packet.len();

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -372,7 +372,7 @@ impl GatewayTunnel {
                     let Some(nameserver) = self.io.fastest_nameserver() else {
                         tracing::warn!(query = ?query.message, "No nameserver available to handle TCP DNS query");
 
-                        self.io.send_udp_dns_response(
+                        self.io.send_tcp_dns_response(
                             query.remote,
                             dns_types::Response::servfail(&query.message),
                         )?;

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -123,12 +123,6 @@ impl Eventloop {
                     }
 
                     if e.root_cause()
-                        .is::<firezone_tunnel::NoNameserverAvailable>()
-                    {
-                        return Poll::Ready(Err(e));
-                    }
-
-                    if e.root_cause()
                         .is::<firezone_tunnel::UdpSocketThreadStopped>()
                     {
                         return Poll::Ready(Err(e));


### PR DESCRIPTION
When we implemented #8350, we chose an error handling strategy that would shutdown the Gateway in case we didn't have a nameserver selected for handling those SRV and TXT queries. At the time, this was deemed to be sufficiently rare to be an adequate strategy. We have since learned that this can indeed happen when the Gateway starts without network connectivity which is quite common when using tools such as terraform to provision infrastructure.

In #9060, we fix this by re-evaluating the fastest nameserver on a timer. This however doesn't change the error handling strategy when we don't have a working nameserver at all. It is practically impossible to have a working Gateway yet us being unable to select a nameserver. We read them from `/etc/resolv.conf` which is what `libc` uses to also resolve the domain we connect to for the WebSocket. A working WebSocket connection is required for us to establish connections to Clients, which in turn is a precursor to us receiving DNS queries from a Client.

It causes unnecessary complexity to have a code path that can potentially terminate the Gateway, yet is practically unreachable. To fix this situation, we remove this code path and instead reply with a DNS SERVFAIL error.