### PR TITLE
chore(connlib): filter noisy log from `opentelemetry_sdk`

### DIFF
--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -93,7 +93,8 @@ fn parse_filter(directives: &str) -> Result<EnvFilter, ParseError> {
     ///
     /// By prepending this directive to the active log filter, a simple directive like `debug` actually produces useful logs.
     /// If necessary, you can still activate logs from these crates by restating them in your directive with a lower filter, i.e. `netlink_proto=debug`.
-    const IRRELEVANT_CRATES: &str = "netlink_proto=warn,os_info=warn,rustls=warn";
+    const IRRELEVANT_CRATES: &str =
+        "netlink_proto=warn,os_info=warn,rustls=warn,opentelemetry_sdk=info";
 
     let env_filter = if directives.is_empty() {
         EnvFilter::try_new(IRRELEVANT_CRATES)?


### PR DESCRIPTION
Opentelemetry logs a DEBUG log every time it creates a new meter. That happens fairly often now in our codebase which spams the logs on the DEBUG level.

```
2025-05-09T02:31:51.147Z DEBUG opentelemetry_sdk:  name="MeterProvider.ExistingMeterReturned" meter_name="connlib"
```

We fix that be setting `opentelemetry_sdk` to default to `INFO` if it is not specified explicitly.