### PR TITLE
fix(portal): Remove redundant index on actor_group_memberships

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20250509035642_remove_redundant_index_on_actor_group_memberships.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250509035642_remove_redundant_index_on_actor_group_memberships.exs
@@ -1,0 +1,12 @@
+defmodule Domain.Repo.Migrations.RemoveRedundantIndexOnActorGroupMemberships do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+
+  def up do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS actor_group_memberships_actor_id_index")
+  end
+
+  def down do
+    create(index("actor_group_memberships", [:actor_id], concurrently: true))
+  end
+end


### PR DESCRIPTION
Why:

* It was pointed out that the way Postgresql does compound indexes there is no need to have an individual index on the first column of the compound index.  This commit removes the redundant index on the `actor_id` for the `actor_group_membership` table.