### PR TITLE
fix(connlib): don't recreate DNS resource NAT for failed domains

### DIFF
--- a/rust/connlib/model/src/lib.rs
+++ b/rust/connlib/model/src/lib.rs
@@ -28,7 +28,7 @@ pub struct ResourceId(Uuid);
 pub struct RelayId(Uuid);
 
 impl RelayId {
-    pub fn from_u128(v: u128) -> Self {
+    pub const fn from_u128(v: u128) -> Self {
         Self(Uuid::from_u128(v))
     }
 }
@@ -46,13 +46,13 @@ impl ResourceId {
         ResourceId(Uuid::new_v4())
     }
 
-    pub fn from_u128(v: u128) -> Self {
+    pub const fn from_u128(v: u128) -> Self {
         Self(Uuid::from_u128(v))
     }
 }
 
 impl GatewayId {
-    pub fn from_u128(v: u128) -> Self {
+    pub const fn from_u128(v: u128) -> Self {
         Self(Uuid::from_u128(v))
     }
 }
@@ -69,7 +69,7 @@ impl FromStr for ClientId {
 }
 
 impl ClientId {
-    pub fn from_u128(v: u128) -> Self {
+    pub const fn from_u128(v: u128) -> Self {
         Self(Uuid::from_u128(v))
     }
 }
@@ -168,7 +168,7 @@ impl FromStr for SiteId {
 }
 
 impl SiteId {
-    pub fn from_u128(v: u128) -> Self {
+    pub const fn from_u128(v: u128) -> Self {
         Self(Uuid::from_u128(v))
     }
 }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -503,7 +503,7 @@ impl ClientState {
         }
     }
 
-    fn encapsulate(&mut self, packet: IpPacket, now: Instant) -> Option<snownet::Transmit> {
+    fn encapsulate(&mut self, mut packet: IpPacket, now: Instant) -> Option<snownet::Transmit> {
         let dst = packet.destination();
 
         if is_definitely_not_a_resource(dst) {
@@ -537,9 +537,9 @@ impl ClientState {
         // Re-send if older than X.
 
         if let Some((domain, _)) = self.stub_resolver.resolve_resource_by_ip(&dst) {
-            if !self.dns_resource_nat.is_active(peer.id(), domain, &packet) {
-                return None;
-            }
+            packet = self
+                .dns_resource_nat
+                .handle_outgoing(peer.id(), domain, packet)?;
         }
 
         let gid = peer.id();

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -28,7 +28,6 @@ use crate::peer::GatewayOnClient;
 use lru::LruCache;
 use secrecy::{ExposeSecret as _, Secret};
 use snownet::{ClientNode, NoTurnServers, RelaySocket, Transmit};
-use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::num::NonZeroUsize;
@@ -911,6 +910,7 @@ impl ClientState {
         trigger: impl Into<ConnectionTrigger>,
         now: Instant,
     ) {
+        use std::collections::hash_map::Entry;
         let trigger = trigger.into();
 
         debug_assert!(self.resources_by_id.contains_key(&resource));

--- a/rust/connlib/tunnel/src/client/dns_resource_nat.rs
+++ b/rust/connlib/tunnel/src/client/dns_resource_nat.rs
@@ -346,6 +346,30 @@ mod tests {
         assert!(maybe_packet.is_some());
     }
 
+    #[test]
+    fn resend_intent_after_2_seconds() {
+        let mut dns_resource_nat = DnsResourceNat::default();
+        let mut now = Instant::now();
+
+        let mut update_fn = |now| {
+            dns_resource_nat.update(
+                EXAMPLE_COM.to_vec(),
+                GID,
+                RID,
+                PROXY_IPS,
+                VecDeque::default(),
+                now,
+            )
+        };
+
+        assert!(update_fn(now).is_some());
+        assert!(update_fn(now).is_none());
+
+        now += Duration::from_secs(2);
+
+        assert!(update_fn(now).is_some());
+    }
+
     const EXAMPLE_COM: DomainNameRef =
         unsafe { DomainNameRef::from_octets_unchecked(b"\x08example\x03com\x00") };
     const GID: GatewayId = GatewayId::from_u128(1);

--- a/rust/connlib/tunnel/src/client/dns_resource_nat.rs
+++ b/rust/connlib/tunnel/src/client/dns_resource_nat.rs
@@ -273,6 +273,40 @@ mod tests {
     }
 
     #[test]
+    fn recreate_failed_nat() {
+        let mut dns_resource_nat = DnsResourceNat::default();
+
+        dns_resource_nat.update(
+            EXAMPLE_COM.to_vec(),
+            GID,
+            RID,
+            PROXY_IPS,
+            VecDeque::default(),
+            Instant::now(),
+        );
+        dns_resource_nat.on_domain_status(
+            GID,
+            p2p_control::dns_resource_nat::DomainStatus {
+                status: p2p_control::dns_resource_nat::NatStatus::Inactive,
+                resource: RID,
+                domain: EXAMPLE_COM.to_vec(),
+            },
+        );
+
+        dns_resource_nat.recreate(EXAMPLE_COM.to_vec());
+
+        let intent = dns_resource_nat.update(
+            EXAMPLE_COM.to_vec(),
+            GID,
+            RID,
+            PROXY_IPS,
+            VecDeque::default(),
+            Instant::now(),
+        );
+        assert!(intent.is_some());
+    }
+
+    #[test]
     fn buffer_packets_until_nat_is_active() {
         let mut dns_resource_nat = DnsResourceNat::default();
 

--- a/rust/connlib/tunnel/src/client/dns_resource_nat.rs
+++ b/rust/connlib/tunnel/src/client/dns_resource_nat.rs
@@ -1,0 +1,222 @@
+use std::{
+    collections::{BTreeMap, VecDeque, btree_map::Entry},
+    net::IpAddr,
+    time::{Duration, Instant},
+};
+
+use connlib_model::{GatewayId, ResourceId};
+use dns_types::DomainName;
+use ip_packet::IpPacket;
+
+use crate::{p2p_control, unique_packet_buffer::UniquePacketBuffer};
+
+/// Tracks the domains for which we have set up a NAT per gateway.
+///
+/// The IPs for DNS resources get assigned on the client.
+/// In order to route them to the actual resource, the gateway needs to set up a NAT table.
+/// Until the NAT is set up, packets sent to these resources are effectively black-holed.
+#[derive(Default)]
+pub struct DnsResourceNat {
+    inner: BTreeMap<(GatewayId, DomainName), State>,
+}
+
+impl DnsResourceNat {
+    pub fn update(
+        &mut self,
+        domain: DomainName,
+        gid: GatewayId,
+        rid: ResourceId,
+        proxy_ips: &[IpAddr],
+        packets_for_domain: VecDeque<IpPacket>,
+        now: Instant,
+    ) -> Option<IpPacket> {
+        match self.inner.entry((gid, domain.clone())) {
+            Entry::Vacant(v) => {
+                let mut buffered_packets =
+                    UniquePacketBuffer::with_capacity_power_of_2(5, "dns-resource-nat-initial"); // 2^5 = 32
+                buffered_packets.extend(packets_for_domain);
+
+                v.insert(State::Pending {
+                    sent_at: now,
+                    buffered_packets,
+
+                    is_recreating: false,
+                });
+            }
+            Entry::Occupied(mut o) => {
+                let state = o.get_mut();
+
+                match state {
+                    State::Confirmed => return None,
+                    State::Failed => return None,
+                    State::Recreating => {
+                        let mut buffered_packets = UniquePacketBuffer::with_capacity_power_of_2(
+                            5, // 2^5 = 32
+                            "dns-resource-nat-recreating",
+                        );
+                        buffered_packets.extend(packets_for_domain);
+
+                        *state = State::Pending {
+                            sent_at: now,
+                            buffered_packets,
+                            is_recreating: true,
+                        };
+                    }
+                    State::Pending {
+                        sent_at,
+                        buffered_packets,
+                        ..
+                    } => {
+                        let time_since_last_attempt = now.duration_since(*sent_at);
+                        buffered_packets.extend(packets_for_domain);
+
+                        if time_since_last_attempt < Duration::from_secs(2) {
+                            return None;
+                        }
+
+                        *sent_at = now;
+                    }
+                }
+            }
+        }
+
+        let packet =
+            match p2p_control::dns_resource_nat::assigned_ips(rid, domain, proxy_ips.to_vec()) {
+                Ok(packet) => packet,
+                Err(e) => {
+                    tracing::warn!("Failed to create IP packet for `AssignedIp`s event: {e:#}");
+                    return None;
+                }
+            };
+
+        Some(packet)
+    }
+
+    /// Recreate the DNS resource NAT state for a given domain.
+    ///
+    /// This will trigger the client to submit another `AssignedIp`s event to the Gateway.
+    /// On the Gateway, such an event causes a new DNS resolution.
+    ///
+    /// We call this function every time a client issues a DNS query for a certain domain.
+    /// Coupling this behaviour together allows a client to refresh the DNS resolution of a DNS resource on the Gateway
+    /// through local DNS resolutions.
+    ///
+    /// We model the [`State::Recreating`] state differently from just removing the entry to allow packets
+    /// to continue flowing to the Gateway while the DNS resource NAT is being recreated.
+    /// In most cases, the DNS records will not change and as such, performing this will not interrupt the flow of packets.
+    pub fn recreate(&mut self, domain: DomainName) {
+        for state in self
+            .inner
+            .iter_mut()
+            .filter_map(|((_, candidate), b)| (candidate == &domain).then_some(b))
+        {
+            match state {
+                State::Pending { .. } => continue,
+                State::Recreating => continue,
+                State::Confirmed | State::Failed => {
+                    tracing::debug!(%domain, "Re-creating DNS resource NAT");
+                    *state = State::Recreating;
+                }
+            }
+        }
+    }
+
+    // TODO: Improve name.
+    pub fn is_active(&mut self, gid: GatewayId, domain: &DomainName, packet: &IpPacket) -> bool {
+        if let Some(State::Pending {
+            buffered_packets,
+            is_recreating: false, // Important: Only buffer if this is the first time we are setting up the DNS resource NAT (i.e. if we are not recreating it).
+            ..
+        }) = self.inner.get_mut(&(gid, domain.clone()))
+        {
+            buffered_packets.push(packet.clone());
+            return false;
+        }
+
+        true
+    }
+
+    pub fn clear_by_gateway(&mut self, gid: &GatewayId) {
+        self.inner.retain(|(gateway, _), _| gateway != gid);
+    }
+
+    pub fn clear_by_domain(&mut self, domain: &DomainName) {
+        self.inner.retain(|(_, candidate), _| candidate != domain);
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    pub(crate) fn on_domain_status(
+        &mut self,
+        gid: GatewayId,
+        res: p2p_control::dns_resource_nat::DomainStatus,
+    ) -> impl IntoIterator<Item = IpPacket> {
+        let Entry::Occupied(mut nat_entry) = self.inner.entry((gid, res.domain.clone())) else {
+            tracing::debug!(%gid, domain = %res.domain, "No DNS resource NAT state, ignoring response");
+            return into_iter(None);
+        };
+
+        let nat_state = nat_entry.get_mut();
+
+        if res.status != p2p_control::dns_resource_nat::NatStatus::Active {
+            tracing::debug!(%gid, domain = %res.domain, "DNS resource NAT is not active");
+            nat_state.failed();
+            return into_iter(None);
+        }
+
+        tracing::debug!(%gid, domain = %res.domain, num_buffered_packets = %nat_state.num_buffered_packets(), "DNS resource NAT is active");
+
+        into_iter(Some(nat_state.confirm()))
+    }
+}
+
+fn into_iter<T>(option: Option<T>) -> impl IntoIterator<Item = IpPacket>
+where
+    T: IntoIterator<Item = IpPacket>,
+{
+    option.into_iter().flatten()
+}
+
+enum State {
+    Pending {
+        sent_at: Instant,
+        buffered_packets: UniquePacketBuffer,
+
+        is_recreating: bool,
+    },
+    Recreating,
+    Confirmed,
+    Failed,
+}
+
+impl State {
+    fn num_buffered_packets(&self) -> usize {
+        match self {
+            State::Pending {
+                buffered_packets, ..
+            } => buffered_packets.len(),
+            State::Confirmed => 0,
+            State::Recreating => 0,
+            State::Failed => 0,
+        }
+    }
+
+    fn confirm(&mut self) -> impl Iterator<Item = IpPacket> + use<> {
+        let buffered_packets = match std::mem::replace(self, State::Confirmed) {
+            State::Pending {
+                buffered_packets, ..
+            } => Some(buffered_packets.into_iter()),
+            State::Recreating => None,
+            State::Confirmed => None,
+            State::Failed => None,
+        };
+
+        buffered_packets.into_iter().flatten()
+    }
+
+    fn failed(&mut self) {
+        *self = State::Failed;
+    }
+}


### PR DESCRIPTION
Before a Client can send packets to a DNS resource, the Gateway must first setup a NAT table between the IPs assigned by the Client and the IPs the domain actually resolves to. This is what we call the DNS resource NAT.

The communication for this process happens over IP through the tunnel which is an unreliable transport. To ensure that this works reliably even in the presence of packet loss on the wire, the Client uses an idempotent algorithm where it tracks the state of the NAT for each domain that is has ever assigned IPs for (i.e. received an A or AAAA query from an application). This algorithm ensures that if we don't hear anything back from the Gateway within 2s, another packet for setting up the NAT is sent as soon as we receive _any_ DNS query.

This design balances efficiency (we don't try forever) with reliability (we always check all of them).

In case a domain does not resolve at all or there are resolution errors, the Gateway replies with `NatStatus::Inactive`. At present, the Client doesn't handle this in any particular way other than logging that it was not able to successfully setup the NAT.

The combination of the above results in an undesirable behaviour: If an application queries a domain without A and AAAA records once, we will keep retrying forever to resolve it upon every other DNS query issued to the system. To fix this, we introduce `dns_resource_nat::State::Failed`. Entries in this state are ignored as part of the above algorithm and only recreated when explicitly told to do so which we only do when we receive another DNS query for this domain.

To handle the increased complexity around this system, we extract it into its own component and add a fleet of unit tests for its behaviour.