### PR TITLE
ci: explicitly bundle the tunnel service

### DIFF
--- a/rust/gui-client/build.sh
+++ b/rust/gui-client/build.sh
@@ -51,6 +51,28 @@ INTERMEDIATE_DIR=$(ls -d "$BUNDLES_DIR"/*/)
 # Delete the archives, we will re-create them.
 rm "$INTERMEDIATE_DIR"/*.tar.gz
 
+# The directory layout of `$BUNDLES_DIR` now looks like this:
+#  └── firezone-client-gui_1.x.y_$arch
+#     ├── control
+#     │   ├── control
+#     │   └── md5sums
+#     ├── data
+#     │   └── usr
+#     │       ├── bin
+#     │       │   └── firezone-client-gui
+#     │       ├── lib
+#     │       │   ├── systemd
+#     │       │   │   └── system
+#     │       │   │       └── firezone-client-ipc.service
+#     │       │   └── sysusers.d
+#     │       │       └── firezone-client-ipc.conf
+#     │       └── share
+#     │           ├── applications
+#     │           │   └── firezone-client-gui.desktop
+#     │           └── icons
+#     │               └── ...
+#     └── debian-binary
+
 # Add the scripts
 cp src-tauri/deb_files/postinst src-tauri/deb_files/prerm "$INTERMEDIATE_DIR/control/"
 

--- a/rust/gui-client/build.sh
+++ b/rust/gui-client/build.sh
@@ -48,6 +48,9 @@ rm "$BUNDLES_DIR"/*.deb
 # files inside that dir
 INTERMEDIATE_DIR=$(ls -d "$BUNDLES_DIR"/*/)
 
+# Delete the archives, we will re-create them.
+rm "$INTERMEDIATE_DIR"/*.tar.gz
+
 # Add the scripts
 cp src-tauri/deb_files/postinst src-tauri/deb_files/prerm "$INTERMEDIATE_DIR/control/"
 

--- a/rust/gui-client/build.sh
+++ b/rust/gui-client/build.sh
@@ -51,10 +51,16 @@ INTERMEDIATE_DIR=$(ls -d "$BUNDLES_DIR"/*/)
 # Add the scripts
 cp src-tauri/deb_files/postinst src-tauri/deb_files/prerm "$INTERMEDIATE_DIR/control/"
 
+# Add the IPC service
+cp ../target/release/firezone-client-ipc "$INTERMEDIATE_DIR/data/usr/bin/"
+
 pushd "$INTERMEDIATE_DIR"
 
 # Rebuild the control tarball
 tar -C "control" -czf "control.tar.gz" control md5sums postinst prerm
+
+# Rebuild the data tarball
+tar -C "data" -czf "data.tar.gz" usr
 
 # Rebuild the deb package, and give it a predictable name that
 # `tauri-rename-linux.sh` can fix


### PR DESCRIPTION
Currently, the Tauri build is broken on `main` because #9045 accidentally merged a bit too soon. In that PR, the two binaries that the `gui-client` crate is composed of are now both defined in `src/bin`.

For some reason, this breaks Tauri's bundler and now on aarch64, it stops including the `firezone-client-ipc` binary in the bundle. I don't fully understand why and how that even works for x64 in the first place. Nowhere in our repository can I find a configuration for the bundler as to why it should even include that binary in the first place.

To fix this, we now explicitly copy this binary into the correct path and also rebuild the `data` archive in addition to the `control` archive.