### PR TITLE
fix(rust): Downgrade fastest nameserver to DEBUG

### DIFF
--- a/rust/connlib/tunnel/src/io/nameserver_set.rs
+++ b/rust/connlib/tunnel/src/io/nameserver_set.rs
@@ -55,7 +55,7 @@ impl NameserverSet {
             return;
         }
 
-        tracing::info!(ips = ?self.inner, "Evaluating fastest nameserver");
+        tracing::debug!(ips = ?self.inner, "Evaluating fastest nameserver");
 
         let start = Instant::now();
 
@@ -128,7 +128,7 @@ impl NameserverSet {
             };
 
             if self.queries.is_empty() {
-                tracing::info!(%fastest, "Evaluated fastest nameserver");
+                tracing::debug!(%fastest, "Evaluated fastest nameserver");
 
                 return Poll::Ready(());
             }


### PR DESCRIPTION
These run every minute and add a lot of noise to the logs.

```
May 11 18:21:14 gateway-z1w4 firezone-gateway[2007]: 2025-05-11T18:21:14.154Z  INFO firezone_tunnel::io::nameserver_set: Evaluating fastest nameserver ips={127.0.0.53}
May 11 18:21:14 gateway-z1w4 firezone-gateway[2007]: 2025-05-11T18:21:14.155Z  INFO firezone_tunnel::io::nameserver_set: Evaluated fastest nameserver fastest=127.0.0.53
May 11 18:22:14 gateway-z1w4 firezone-gateway[2007]: 2025-05-11T18:22:14.154Z  INFO firezone_tunnel::io::nameserver_set: Evaluating fastest nameserver ips={127.0.0.53}
May 11 18:22:14 gateway-z1w4 firezone-gateway[2007]: 2025-05-11T18:22:14.155Z  INFO firezone_tunnel::io::nameserver_set: Evaluated fastest nameserver fastest=127.0.0.53
May 11 18:23:14 gateway-z1w4 firezone-gateway[2007]: 2025-05-11T18:23:14.153Z  INFO firezone_tunnel::io::nameserver_set: Evaluating fastest nameserver ips={127.0.0.53}
May 11 18:23:14 gateway-z1w4 firezone-gateway[2007]: 2025-05-11T18:23:14.155Z  INFO firezone_tunnel::io::nameserver_set: Evaluated fastest nameserver fastest=127.0.0.53
May 11 18:24:14 gateway-z1w4 firezone-gateway[2007]: 2025-05-11T18:24:14.154Z  INFO firezone_tunnel::io::nameserver_set: Evaluating fastest nameserver ips={127.0.0.53}
May 11 18:24:14 gateway-z1w4 firezone-gateway[2007]: 2025-05-11T18:24:14.155Z  INFO firezone_tunnel::io::nameserver_set: Evaluated fastest nameserver fastest=127.0.0.53
May 11 18:25:14 gateway-z1w4 firezone-gateway[2007]: 2025-05-11T18:25:14.153Z  INFO firezone_tunnel::io::nameserver_set: Evaluating fastest nameserver ips={127.0.0.53}
```