### PR TITLE
fix(apple): set new project version on each build

### DIFF
--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -113,7 +113,7 @@ done
 
 target_list="${target_list% }"
 
-# Set the project (build) version to the current epoch so that's it monotonically increases
+# Set the project (build) version to the current epoch so that it monotonically increases
 seconds_since_epoch=$(date +%s)
 export CURRENT_PROJECT_VERSION=$seconds_since_epoch
 

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -113,5 +113,9 @@ done
 
 target_list="${target_list% }"
 
+# Set the project (build) version to the current epoch so that's it monotonically increases
+seconds_since_epoch=$(date +%s)
+export CURRENT_PROJECT_VERSION=$seconds_since_epoch
+
 # Build the library
 cargo build --verbose $target_list $CONFIGURATION_ARGS

--- a/rust/connlib/clients/apple/build-rust.sh
+++ b/rust/connlib/clients/apple/build-rust.sh
@@ -113,9 +113,5 @@ done
 
 target_list="${target_list% }"
 
-# Set the project (build) version to the current epoch so that it monotonically increases
-seconds_since_epoch=$(date +%s)
-export CURRENT_PROJECT_VERSION=$seconds_since_epoch
-
 # Build the library
 cargo build --verbose $target_list $CONFIGURATION_ARGS

--- a/scripts/build/ios-appstore.sh
+++ b/scripts/build/ios-appstore.sh
@@ -27,14 +27,12 @@ fi
 
 # Build and sign app
 echo "Building and signing app..."
-seconds_since_epoch=$(date +%s)
 xcodebuild archive \
     GIT_SHA="$git_sha" \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGN_IDENTITY="$code_sign_identity" \
     APP_PROFILE_ID="$app_profile_id" \
     NE_PROFILE_ID="$ne_profile_id" \
-    CURRENT_PROJECT_VERSION="$seconds_since_epoch" \
     -project "$project_file" \
     -skipMacroValidation \
     -archivePath "$archive_path" \

--- a/scripts/build/macos-appstore.sh
+++ b/scripts/build/macos-appstore.sh
@@ -27,7 +27,6 @@ fi
 
 # Build and sign
 echo "Building and signing app..."
-seconds_since_epoch=$(date +%s)
 xcodebuild build \
     GIT_SHA="$git_sha" \
     CODE_SIGN_STYLE=Manual \
@@ -36,7 +35,6 @@ xcodebuild build \
     APP_PROFILE_ID="$app_profile_id" \
     NE_PROFILE_ID="$ne_profile_id" \
     ONLY_ACTIVE_ARCH=NO \
-    CURRENT_PROJECT_VERSION="$seconds_since_epoch" \
     -project "$project_file" \
     -skipMacroValidation \
     -configuration Release \

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -31,7 +31,6 @@ fi
 
 # Build and sign
 echo "Building and signing app..."
-seconds_since_epoch=$(date +%s)
 xcodebuild build \
     GIT_SHA="$git_sha" \
     CODE_SIGN_STYLE=Manual \
@@ -43,7 +42,6 @@ xcodebuild build \
     APP_PROFILE_ID="$app_profile_id" \
     NE_PROFILE_ID="$ne_profile_id" \
     ONLY_ACTIVE_ARCH=NO \
-    CURRENT_PROJECT_VERSION="$seconds_since_epoch" \
     -project "$project_file" \
     -skipMacroValidation \
     -configuration Release \

--- a/swift/apple/.gitignore
+++ b/swift/apple/.gitignore
@@ -4,3 +4,4 @@ build/
 DerivedData/
 xcuserdata/
 **/*.xcuserstate
+Firezone/xcconfig/dynamic_build_number.xcconfig

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8DCC024328D512AE007E12D2 /* Build configuration list for PBXNativeTarget "Firezone" */;
 			buildPhases = (
+				8D40C0B72DD1335C00ACF8D7 /* Generate build number */,
 				8DCC021528D512AC007E12D2 /* Sources */,
 				8D70FAE62D4971E900216473 /* SwiftLint */,
 				8DCC021628D512AC007E12D2 /* Frameworks */,
@@ -400,6 +401,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		8D40C0B72DD1335C00ACF8D7 /* Generate build number */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Generate build number";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Set the project (build) version to the current epoch so that it monotonically increases\nseconds_since_epoch=$(date +%s)\necho \"CURRENT_PROJECT_VERSION = $seconds_since_epoch\" > Firezone/xcconfig/dynamic_build_number.xcconfig\n";
+		};
 		8D70FAE62D4971E900216473 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/swift/apple/Firezone/xcconfig/config.xcconfig
+++ b/swift/apple/Firezone/xcconfig/config.xcconfig
@@ -6,4 +6,6 @@ APP_GROUP_ID_PRE_1_4_0[sdk=macosx*] = 47R2M6779T.group.dev.firezone.firezone
 APP_GROUP_ID[sdk=iphoneos*] = group.dev.firezone.firezone
 APP_GROUP_ID_PRE_1_4_0[sdk=iphoneos*] = group.dev.firezone.firezone
 CODE_SIGN_STYLE = Automatic
-CURRENT_PROJECT_VERSION = 0
+
+// Include the dynamic build number created during the build phase
+#include? "dynamic_build_number.xcconfig"


### PR DESCRIPTION
When developing the macOS app, we always build the exact same version and build code for each build. ~~This _may_ be one reason why we constantly have to deactivate the extension before the new one will launch.~~ Edit: Just tested, and I can verify that this does fix the issue on dev builds, so no more having to uninstall the sysex between builds.

Even if that's not the reason, this is a cleaner approach than building it in our prod-only scripts.