### PR TITLE
ci: Prevent having to manually update provisioning profile UUIDs

### DIFF
--- a/scripts/build/ios-appstore.sh
+++ b/scripts/build/ios-appstore.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 source "./scripts/build/lib.sh"
 
 # Define needed variables
-app_profile_id=8da59aa3-e8da-4a8c-9902-2d540324d92c
-ne_profile_id=0fccb78a-97c0-41b9-8c54-9c995280ea8e
+app_profile_id=$(extract_uuid "$IOS_APP_PROVISIONING_PROFILE")
+ne_profile_id=$(extract_uuid "$IOS_NE_PROVISIONING_PROFILE")
 temp_dir="${TEMP_DIR:-$(mktemp -d)}"
 archive_path="$temp_dir/Firezone.xcarchive"
 export_options_plist_path="$temp_dir/ExportOptions.plist"

--- a/scripts/build/lib.sh
+++ b/scripts/build/lib.sh
@@ -56,6 +56,12 @@ function setup_runner() {
         "$keychain_path"
 }
 
+function extract_uuid() {
+    local b64_profile="$1"
+
+    echo "$b64_profile" | base64 --decode | security cms -D | plutil -extract UUID raw -o - -
+}
+
 function base64_decode() {
     local input_stdin="$1"
     local output_path="$2"

--- a/scripts/build/macos-appstore.sh
+++ b/scripts/build/macos-appstore.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 source "./scripts/build/lib.sh"
 
 # Define needed variables
-app_profile_id=2bf20e38-81ea-40d0-91e5-330cf58f52d9
-ne_profile_id=2c683d1a-4479-451c-9ee6-ae7d4aca5c93
+app_profile_id=$(extract_uuid "$MACOS_APP_PROVISIONING_PROFILE")
+ne_profile_id=$(extract_uuid "$MACOS_NE_PROVISIONING_PROFILE")
 temp_dir="${TEMP_DIR:-$(mktemp -d)}"
 package_path="$temp_dir/Firezone.pkg"
 git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 source "./scripts/build/lib.sh"
 
 # Define needed variables
-app_profile_id=c5d97f71-de80-4dfc-80f8-d0a4393ff082
-ne_profile_id=153db941-2136-4d6c-96ef-52f748521e78
+app_profile_id=$(extract_uuid "$STANDALONE_MACOS_APP_PROVISIONING_PROFILE")
+ne_profile_id=$(extract_uuid "$STANDALONE_MACOS_NE_PROVISIONING_PROFILE")
 notarize=${NOTARIZE:-"false"}
 temp_dir="${TEMP_DIR:-$(mktemp -d)}"
 dmg_dir="$temp_dir/dmg"

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -12,6 +12,23 @@ clients.
 1. Request your Firezone email added to our Apple Developer Account
 1. Open Xcode, go to Settings -> Account and log in.
 
+If you're working on the macOS client, you'll need to disable SIP and enable
+system extension development mode:
+
+1. Follow
+   [these instructions](https://developer.apple.com/documentation/security/disabling-and-enabling-system-integrity-protection)
+   to disable SIP.
+1. After that's complete, turn on system extension development mode:
+
+```bash
+systemextensionsctl developer on
+```
+
+This will prevent macOS from blocking the Network Extension from loading due to
+notarization or filepath restrictions.
+
+**Be sure to re-enable SIP to test the app in a production-like environment.**
+
 You may consider using a macOS VM (such as Parallels Desktop) to test the
 standalone macOS client, as it can be easier to test different macOS versions
 and configurations without risking your main machine.

--- a/swift/apple/README.md
+++ b/swift/apple/README.md
@@ -12,23 +12,6 @@ clients.
 1. Request your Firezone email added to our Apple Developer Account
 1. Open Xcode, go to Settings -> Account and log in.
 
-If you're working on the macOS client, you'll need to disable SIP and enable
-system extension development mode:
-
-1. Follow
-   [these instructions](https://developer.apple.com/documentation/security/disabling-and-enabling-system-integrity-protection)
-   to disable SIP.
-1. After that's complete, turn on system extension development mode:
-
-```bash
-systemextensionsctl developer on
-```
-
-This will prevent macOS from blocking the Network Extension from loading due to
-notarization or filepath restrictions.
-
-**Be sure to re-enable SIP to test the app in a production-like environment.**
-
 You may consider using a macOS VM (such as Parallels Desktop) to test the
 standalone macOS client, as it can be easier to test different macOS versions
 and configurations without risking your main machine.
@@ -271,12 +254,6 @@ APPLE_MACOS_NE_PROVISIONING_PROFILE
 ```bash
 base64 < profile.mobileprovision
 ```
-
-1. Now, you need to update the build scripts to use these. Edit
-   `scripts/build/*-appstore.sh` and update the provisioning profile UUIDs. The
-   UUID can be found by grepping for them in the provisioning profile files
-   themselves, or just opening them in a text editor and looking halfway down
-   the file. They should be the only UUIDs in the file.
 
 ## Generating new signing certificates and provisioning profiles for standalone distribution
 


### PR DESCRIPTION
When updating the provisioning profiles (i.e. when changing anything the Apple Developer Portal), we needed to manually update these build scripts to point to the new UUIDs.

This can be made simpler to automatically pull it out of the profiles in CI.