### PR TITLE
ci: reduce link checker concurrency

### DIFF
--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -13,13 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Restore lychee cache
-        uses: actions/cache@v4
-        with:
-          path: website/.lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
-
       - name: Check links on website
         id: lychee
         uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # v2.4.0

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -13,12 +13,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: website/.lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
       - name: Check links on website
         id: lychee
         uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # v2.4.0
         with:
           fail: false
-          args: --verbose --no-progress --exclude-all-private --base https://firezone.dev .
+          args: --verbose --no-progress --exclude-all-private --cache --max-cache-age 2d --base https://firezone.dev .
           workingDirectory: website
 
       - name: Create Issue From File

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -25,7 +25,7 @@ jobs:
         uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # v2.4.0
         with:
           fail: false
-          args: --verbose --no-progress --exclude-all-private --cache --max-cache-age 2d --base https://firezone.dev .
+          args: --verbose --no-progress --exclude-all-private --cache --max-cache-age 2d --cache-exclude-status 400..599 --max-concurrency 2 --retry-wait-time 60 --base https://firezone.dev .
           workingDirectory: website
 
       - name: Create Issue From File

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -25,7 +25,7 @@ jobs:
         uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # v2.4.0
         with:
           fail: false
-          args: --verbose --no-progress --exclude-all-private --cache --max-cache-age 2d --cache-exclude-status 400..599 --max-concurrency 1 --retry-wait-time 60 --base https://firezone.dev .
+          args: --verbose --no-progress --exclude-all-private --cache --cache-exclude-status 400..599 --max-concurrency 1 --retry-wait-time 60 --base https://firezone.dev .
           workingDirectory: website
 
       - name: Create Issue From File

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -25,7 +25,7 @@ jobs:
         uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c # v2.4.0
         with:
           fail: false
-          args: --verbose --no-progress --exclude-all-private --cache --max-cache-age 2d --cache-exclude-status 400..599 --max-concurrency 2 --retry-wait-time 60 --base https://firezone.dev .
+          args: --verbose --no-progress --exclude-all-private --cache --max-cache-age 2d --cache-exclude-status 400..599 --max-concurrency 1 --retry-wait-time 60 --base https://firezone.dev .
           workingDirectory: website
 
       - name: Create Issue From File


### PR DESCRIPTION
Our link checker `lychee` doesn't appear to de-duplicate requests to the same URL which causes 429 errors with GitHub. To workaround this, we reduce the concurrency to 1 and activate `lychee`'s cache. This cache is just a file on disk. We don't need to actually save this in GitHub actions' cache because all we want is for lychee to not make a request to same URL again in the same session.

Related: https://github.com/lycheeverse/lychee-action/issues/289