### PR TITLE
ci(rust): add timeout to GUI smoke tests

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -161,6 +161,7 @@ jobs:
       - name: Run smoke test
         working-directory: ./rust
         run: cargo run -p gui-smoke-test
+        timeout-minutes: 2
 
   headless-client:
     name: headless-client-${{ matrix.test }}-${{ matrix.runs-on }}


### PR DESCRIPTION
These don't have an inherent timeout so the CI job gets stuck forever. They typically finish in about a minute.