### PR TITLE
chore(phoenix-channel): downgrade log about dropped messages

### DIFF
--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -306,7 +306,7 @@ where
         if self.pending_messages.len() > MAX_BUFFERED_MESSAGES {
             self.pending_messages.clear();
 
-            tracing::warn!(
+            tracing::debug!(
                 "Dropping pending messages to portal because we exceeded the maximum of {MAX_BUFFERED_MESSAGES}"
             );
         }


### PR DESCRIPTION
This can easily happen if we are briefly disconnected from the portal. It is not the end of the world and not worth creating Sentry alerts for.

Originally, this was intended to be a way of detecting "bad connectivity" but that didn't really work.