### PR TITLE
chore(rust): fix features in `bin-shared`

### DIFF
--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -23,10 +23,10 @@ serde_json = { workspace = true }
 smbios-lib = { workspace = true }
 socket-factory = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "net", "rt", "sync", "process"] }
+tokio = { workspace = true, features = ["io-util", "net", "rt", "sync", "process", "signal"] }
 tracing = { workspace = true }
 tun = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 bufferpool = { workspace = true }


### PR DESCRIPTION
When this crate is compiled by itself, these features are required. This doesn't show up in CI because there we compile the entire workspace and some crate somewhere already activates these features then.