### PR TITLE
chore(gui-client): only read `is_finished` once

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -212,6 +212,8 @@ struct TunState {
 
 impl Drop for Tun {
     fn drop(&mut self) {
+        const SHUTDOWN_WAIT: Duration = Duration::from_secs(10);
+
         let recv_thread = self
             .recv_thread
             .take()
@@ -234,8 +236,8 @@ impl Drop for Tun {
                 break;
             }
 
-            if start.elapsed() > Duration::from_secs(5) {
-                tracing::warn!(%recv_thread_finished, %send_thread_finished, "TUN worker threads did not exit gracefully in 5s");
+            if start.elapsed() > SHUTDOWN_WAIT {
+                tracing::warn!(%recv_thread_finished, %send_thread_finished, "TUN worker threads did not exit gracefully in {SHUTDOWN_WAIT:?}");
                 return;
             }
 


### PR DESCRIPTION
For at least 1 user, the threads shut down correctly, but we didn't seem to have exited the loop. In https://firezone-inc.sentry.io/issues/6335839279/events/c11596de18924ee3a1b64ced89b1fba2/?project=4508008945549312, we can see that both flags are marked as `true` yet we still emitted the message.

The only way how I can explain this is that the thread shut down in between the two times we've called the `is_finished` function. To ensure this doesn't happen, we now only read it once.

This however also shows that 5s may not be enough time for WinTUN to shutdown. Therefore, we increase the grace period to 10s.