### PR TITLE
fix(gui-client): initialise logger one layer up

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -70,6 +70,8 @@ fn main() -> anyhow::Result<()> {
         // If we already tried to elevate ourselves, don't try again
         Some(Cmd::Elevated) => run_gui(config),
         Some(Cmd::OpenDeepLink(deep_link)) => {
+            firezone_gui_client::logging::setup_stdout()?;
+
             let rt = tokio::runtime::Runtime::new()?;
             if let Err(error) = rt.block_on(deep_link::open(&deep_link.url)) {
                 tracing::error!("Error in `OpenDeepLink`: {error:#}");

--- a/rust/gui-client/src-tauri/src/deep_link/linux.rs
+++ b/rust/gui-client/src-tauri/src/deep_link/linux.rs
@@ -86,7 +86,6 @@ impl Server {
 
 pub async fn open(url: &url::Url) -> Result<()> {
     crate::logging::setup_stdout()?;
-
     let path = sock_path()?;
     let mut stream = UnixStream::connect(&path).await?;
 


### PR DESCRIPTION
Initialising the logger as part of the `open` function causes a flaky test in case there is already another logger initialised.

Fixes: #9096