### PR TITLE
fix(gui-client): don't panic during `setup` hook

### DIFF
--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,6 +14,12 @@ export default function GUI({ os }: { os: OS }) {
             Optimizes network change detection.
           </ChangeItem>
         )}
+        {os === OS.Windows && (
+          <ChangeItem pull="9112">
+            Fixes a rare crash that could occur if the tray menu cannot be
+            initialised.
+          </ChangeItem>
+        )}
       </Unreleased>
       <Entry version="1.4.12" date={new Date("2025-04-30")}>
         {os === OS.Linux && (


### PR DESCRIPTION
As part of launching the Tauri GUI client, we need to observe a specific initialisation order. In particular, we need to wait until Tauri sends us a `RunEvent::Ready` before we can initialise things like the tray menu.

To make this more convenient, Tauri offers a so-called "setup hook" that can be set on the app builder. Unfortunately, Tauri internally panics if this provided setup-hook returns an `Err`. Removing this is tracked upstream: https://github.com/tauri-apps/tauri/issues/12815.

Until this is fixed, we stop using this "setup hook" and instead spawn our own task that performs this work. This task needs to wait until Tauri is ready. To achieve that, we introduce an additional mpsc channel that sends a notification every time we receive a `RunEvent::Ready`. That should only happen once. We only read from the receiver once, which is why we ignore the error on the sending side in case the receiver has already been dropped.

Resolves: #9101