### PR TITLE
refactor(connlib): forward error from source IP resolver

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6369,7 +6369,6 @@ dependencies = [
  "bufferpool",
  "bytes",
  "derive_more 1.0.0",
- "firezone-logging",
  "gat-lending-iterator",
  "ip-packet",
  "opentelemetry",

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -105,7 +105,7 @@ pub fn tcp_socket_factory(addr: &SocketAddr) -> io::Result<TcpSocket> {
 }
 
 pub fn udp_socket_factory(src_addr: &SocketAddr) -> io::Result<UdpSocket> {
-    let source_ip_resolver = |dst| Ok(Some(get_best_non_tunnel_route(dst)?.addr));
+    let source_ip_resolver = |dst| Ok(get_best_non_tunnel_route(dst)?.addr);
 
     let socket =
         socket_factory::udp(src_addr)?.with_source_ip_resolver(Box::new(source_ip_resolver));

--- a/rust/connlib/socket-factory/Cargo.toml
+++ b/rust/connlib/socket-factory/Cargo.toml
@@ -9,7 +9,6 @@ anyhow = { workspace = true }
 bufferpool = { workspace = true }
 bytes = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
-firezone-logging = { workspace = true }
 gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }


### PR DESCRIPTION
In order to avoid routing loops on Windows, our UDP and TCP sockets in `connlib` embed a "source IP resolver" that finds the "next best" interface after our TUN device according to Windows' routing metrics. This ensures that packets don't get routed back into our TUN device.

Currently, errors during this process are only logged on TRACE and therefore not visible in Sentry. We fix this by moving around some of the function interfaces and forward the error from the source IP resolver together with some context of the destination IP.