### PR TITLE
feat(apple): Allow user-configurable account slug

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
@@ -16,7 +16,8 @@ struct WebAuthSession {
   static let anchor = PresentationAnchor()
 
   static func signIn(store: Store) async throws {
-    let authURL = store.configuration?.authURL ?? Configuration.defaultAuthURL
+    let baseURL = store.configuration?.authURL ?? Configuration.defaultAuthURL
+    let authURL = baseURL.appendingPathComponent(store.configuration?.accountSlug ?? "")
 
     guard let authClient = try? AuthClient(authURL: authURL),
           let url = try? authClient.build()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -220,6 +220,9 @@ public final class Store: ObservableObject {
   func signIn(authResponse: AuthResponse) async throws {
     // Save actorName
     try await setActorName(authResponse.actorName)
+
+    // This will save the account slug even if overridden from MDM. This is what we want - if the admin removes the
+    // override, this will take effect again.
     try await setAccountSlug(authResponse.accountSlug)
 
     try await manager().enableConfiguration()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -160,8 +160,8 @@ class SettingsViewModel: ObservableObject {
 
     self.areSettingsValid = isAuthURLValid() && isApiURLValid() && isLogFilterValid() && isAccountSlugValid()
 
-    self.areSettingsDefault = (self.authURL == Configuration.defaultAuthURL.absoluteString &&
-                               self.apiURL == Configuration.defaultApiURL.absoluteString &&
+    self.areSettingsDefault = (self.authURL == Configuration.defaultAuthURL &&
+                               self.apiURL == Configuration.defaultApiURL &&
                                self.logFilter == Configuration.defaultLogFilter &&
                                self.accountSlug == "")
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -446,7 +446,7 @@ public struct SettingsView: View {
               .autocorrectionDisabled()
               .textInputAutocapitalization(.never)
               .submitLabel(.done)
-              .disabled(viewModel.isAuthURLOverridden)
+              .disabled(viewModel.isAccountSlugOverridden)
             }
           },
           header: { Text("General Settings") },

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -268,26 +268,33 @@ public struct SettingsView: View {
   }
 
   public var body: some View {
-    #if os(iOS)
-      NavigationView {
-        TabView {
-          generalTab
-            .tabItem {
-              Image(systemName: "slider.horizontal.2")
-              Text("General")
-            }
-          advancedTab
-            .tabItem {
-              Image(systemName: "slider.horizontal.3")
-              Text("Advanced")
-            }
-            .badge(viewModel.areSettingsValid ? nil : "!")
-          logsTab
-            .tabItem {
-              Image(systemName: "doc.text")
-              Text("Diagnostic Logs")
-            }
+#if os(iOS)
+    NavigationView {
+      ZStack {
+        Color(UIColor.systemGroupedBackground)
+          .ignoresSafeArea()
+
+        VStack {
+          TabView {
+            generalTab
+              .tabItem {
+                Image(systemName: "slider.horizontal.3")
+                Text("General")
+              }
+            advancedTab
+              .tabItem {
+                Image(systemName: "gearshape.2")
+                Text("Advanced")
+              }
+              .badge(viewModel.areSettingsValid ? nil : "!")
+            logsTab
+              .tabItem {
+                Image(systemName: "doc.text")
+                Text("Diagnostic Logs")
+              }
+          }
         }
+        .padding(.bottom, 10)
         .toolbar {
           ToolbarItem(placement: .navigationBarTrailing) {
             Button("Save") {
@@ -309,24 +316,24 @@ public struct SettingsView: View {
         }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
+        .alert(
+          "Saving settings will sign you out",
+          isPresented: $isShowingConfirmationAlert,
+          presenting: confirmationAlertContinueAction,
+          actions: { confirmationAlertContinueAction in
+            Button("Cancel", role: .cancel) {
+              // Nothing to do
+            }
+            Button("Continue") {
+              withErrorHandler { try await confirmationAlertContinueAction.performAction(on: self) }
+            }
+          },
+          message: { _ in
+            Text("Changing settings will sign you out and disconnect you from resources")
+          }
+        )
       }
-      .alert(
-        "Saving settings will sign you out",
-        isPresented: $isShowingConfirmationAlert,
-        presenting: confirmationAlertContinueAction,
-        actions: { confirmationAlertContinueAction in
-          Button("Cancel", role: .cancel) {
-            // Nothing to do
-          }
-          Button("Continue") {
-            withErrorHandler { try await confirmationAlertContinueAction.performAction(on: self) }
-          }
-        },
-        message: { _ in
-          Text("Changing settings will sign you out and disconnect you from resources")
-        }
-      )
-
+    }
     #elseif os(macOS)
       VStack {
         TabView {
@@ -441,55 +448,10 @@ public struct SettingsView: View {
               .submitLabel(.done)
               .disabled(viewModel.isAuthURLOverridden)
             }
-            VStack(alignment: .leading, spacing: 2) {
-              Text("API URL")
-                .foregroundStyle(.secondary)
-                .font(.caption)
-              TextField(
-                PlaceholderText.apiURL,
-                text: $viewModel.apiURLString
-              )
-              .autocorrectionDisabled()
-              .textInputAutocapitalization(.never)
-              .submitLabel(.done)
-              .disabled(viewModel.isApiURLOverridden)
-            }
-            VStack(alignment: .leading, spacing: 2) {
-              Text("Log Filter")
-                .foregroundStyle(.secondary)
-                .font(.caption)
-              TextField(
-                PlaceholderText.logFilter,
-                text: $viewModel.logFilterString
-              )
-              .autocorrectionDisabled()
-              .textInputAutocapitalization(.never)
-              .submitLabel(.done)
-              .disabled(viewModel.isLogFilterOverridden)
-            }
-            HStack {
-              Spacer()
-              Button(
-                "Reset to Defaults",
-                action: {
-                  viewModel.revertToDefaultSettings()
-                }
-              )
-              .disabled(viewModel.shouldDisableResetButton)
-              Spacer()
-            }
           },
-          header: { Text("Advanced Settings") },
-          footer: { Text(FootnoteText.forAdvanced ?? "") }
+          header: { Text("General Settings") },
         )
       }
-      Spacer()
-      HStack {
-        Text("Build: \(BundleHelper.gitSha)")
-          .textSelection(.enabled)
-          .foregroundColor(.gray)
-        Spacer()
-      }.padding([.leading, .bottom], 20)
     }
 #endif
   }
@@ -625,8 +587,11 @@ public struct SettingsView: View {
             .textSelection(.enabled)
             .foregroundColor(.gray)
           Spacer()
-        }.padding([.leading, .bottom], 20)
+        }
+        .padding([.leading, .bottom], 20)
+        .background(Color(uiColor: .secondarySystemBackground))
       }
+      .background(Color(uiColor: .secondarySystemBackground))
     #endif
   }
 

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,6 +24,11 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9119">
+          Automatically saves the account slug after the first sign in, and adds
+          a new
+          <code>General</code> tab in Settings to allow updating it.
+        </ChangeItem>
         <ChangeItem pull="9014">
           Fixes an issue where idle connections would be slow (~60s) in
           detecting changes to network connectivity.
@@ -39,8 +44,9 @@ export default function Apple() {
       </Unreleased>
       <Entry version="1.4.14" date={new Date("2025-05-02")}>
         <ChangeItem pull="9005">
-          Fixes an issue where the IP checksum was not updated when ECN bits were set.
-          This caused packet loss on recent MacOS versions which default to using ECN.
+          Fixes an issue where the IP checksum was not updated when ECN bits
+          were set. This caused packet loss on recent MacOS versions which
+          default to using ECN.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.13" date={new Date("2025-04-30")}>
@@ -58,8 +64,8 @@ export default function Apple() {
           Rolls over to a new log-file as soon as logs are cleared.
         </ChangeItem>
         <ChangeItem pull="8935">
-          Improves reliability for upload-intensive connections with many concurrent
-          DNS queries.
+          Improves reliability for upload-intensive connections with many
+          concurrent DNS queries.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.12" date={new Date("2025-04-21")}>


### PR DESCRIPTION
Now that configuration is persisted in a more reasonable fashion, we can expose a new `General` section to the Settings, allowing the user to configure an account slug.

This field will automatically be populated upon the first sign in, so that subsequent sign-ins will take the user directly to the account sign in page.


Fixes #5119 
Related #8919