### PR TITLE
feat(apple): Allow MDM override of internet resource enabled

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -627,7 +627,7 @@ public final class MenuBar: NSObject, ObservableObject {
     enableToggle.title = internetResourceToggleTitle()
     enableToggle.target = self
 
-    if true {// store.configuration?.isOverridden(Configuration.Keys.internetResourceEnabled) ?? false {
+    if store.configuration?.isOverridden(Configuration.Keys.internetResourceEnabled) ?? false {
       enableToggle.toolTip = "This setting is overridden by your organization"
       enableToggle.isEnabled = false
       enableToggle.action = nil

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -529,7 +529,7 @@ public final class MenuBar: NSObject, ObservableObject {
     let isEnabled = store.configuration?.internetResourceEnabled == true
 
     if store.configuration?.isOverridden(Configuration.Keys.internetResourceEnabled) ?? false {
-      return isEnabled ? "Overridden: Enabled" : "Overridden: Disabled"
+      return isEnabled ? "Managed: Enabled" : "Managed: Disabled"
     }
 
     return isEnabled ? "Disable this resource" : "Enable this resource"
@@ -628,7 +628,7 @@ public final class MenuBar: NSObject, ObservableObject {
     enableToggle.target = self
 
     if store.configuration?.isOverridden(Configuration.Keys.internetResourceEnabled) ?? false {
-      enableToggle.toolTip = "This setting is overridden by your organization"
+      enableToggle.toolTip = "This setting is managed by your organization"
       enableToggle.isEnabled = false
       enableToggle.action = nil
     } else {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -526,7 +526,13 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   func internetResourceToggleTitle() -> String {
-    store.configuration?.internetResourceEnabled == true ? "Disable this resource" : "Enable this resource"
+    let isEnabled = store.configuration?.internetResourceEnabled == true
+
+    if store.configuration?.isOverridden(Configuration.Keys.internetResourceEnabled) ?? false {
+      return isEnabled ? "Overridden: Enabled" : "Overridden: Disabled"
+    }
+
+    return isEnabled ? "Disable this resource" : "Enable this resource"
   }
 
   // TODO: Refactor this when refactoring for macOS 13
@@ -618,11 +624,19 @@ public final class MenuBar: NSObject, ObservableObject {
     // Resource enable / disable toggle
     subMenu.addItem(NSMenuItem.separator())
     let enableToggle = NSMenuItem()
-    enableToggle.action = #selector(internetResourceToggle(_:))
     enableToggle.title = internetResourceToggleTitle()
-    enableToggle.toolTip = "Enable or disable resource"
-    enableToggle.isEnabled = true
     enableToggle.target = self
+
+    if true {// store.configuration?.isOverridden(Configuration.Keys.internetResourceEnabled) ?? false {
+      enableToggle.toolTip = "This setting is overridden by your organization"
+      enableToggle.isEnabled = false
+      enableToggle.action = nil
+    } else {
+      enableToggle.toolTip = "Enable or disable resource"
+      enableToggle.isEnabled = true
+      enableToggle.action = #selector(internetResourceToggle(_:))
+    }
+
     subMenu.addItem(enableToggle)
 
     return subMenu

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -235,11 +235,13 @@ struct ToggleInternetResourceButton: View {
   @EnvironmentObject var store: Store
 
   private func toggleResourceEnabledText() -> String {
-    if store.configuration?.internetResourceEnabled == true {
-      "Disable this resource"
-    } else {
-      "Enable this resource"
+    let isEnabled = store.configuration?.internetResourceEnabled ?? false
+
+    if store.configuration?.isOverridden(Configuration.Keys.internetResourceEnabled) ?? false {
+      return isEnabled ? "Overridden: Enabled" : "Overridden: Disabled"
     }
+
+    return isEnabled ? "Disable this resource" : "Enable this resource"
   }
 
   var body: some View {
@@ -260,6 +262,7 @@ struct ToggleInternetResourceButton: View {
         }
       }
     )
+    .disabled(store.configuration?.isOverridden(Configuration.Keys.internetResourceEnabled) ?? false)
   }
 }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/ResourceView.swift
@@ -238,7 +238,7 @@ struct ToggleInternetResourceButton: View {
     let isEnabled = store.configuration?.internetResourceEnabled ?? false
 
     if store.configuration?.isOverridden(Configuration.Keys.internetResourceEnabled) ?? false {
-      return isEnabled ? "Overridden: Enabled" : "Overridden: Disabled"
+      return isEnabled ? "Managed: Enabled" : "Managed: Disabled"
     }
 
     return isEnabled ? "Disable this resource" : "Enable this resource"


### PR DESCRIPTION
All the MDM configuration to shadow the `internetResourceEnabled` state.

Related: #4505 