### PR TITLE
fix(apple): Actually enable/disable internet resource

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -184,6 +184,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       case .setInternetResourceEnabled(let enabled):
         configuration.internetResourceEnabled = enabled
         ConfigurationManager.shared.setInternetResourceEnabled(enabled)
+        adapter?.setInternetResourceEnabled(enabled)
         completionHandler?(nil)
 
       case .signOut:


### PR DESCRIPTION
This fixes a bug recently introduced where the actual call to connlib to enable/disable the internet resource was removed.