### PR TITLE
refactor(apple): Use string for URL configuration

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -105,11 +105,11 @@ class IPCClient {
     }
   }
 
-  func setAuthURL(_ authURL: URL) async throws {
+  func setAuthURL(_ authURL: String) async throws {
     try await sendMessageWithoutResponse(ProviderMessage.setAuthURL(authURL))
   }
 
-  func setApiURL(_ apiURL: URL) async throws {
+  func setApiURL(_ apiURL: String) async throws {
     try await sendMessageWithoutResponse(ProviderMessage.setApiURL(apiURL))
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -41,13 +41,12 @@ public enum Telemetry {
     }
   }
 
-  public static func setEnvironmentOrClose(_ apiURL: URL) {
+  public static func setEnvironmentOrClose(_ apiURL: String) {
     var environment: String?
-    let str = apiURL.absoluteString
 
-    if str.starts(with: "wss://api.firezone.dev") {
+    if apiURL.starts(with: "wss://api.firezone.dev") {
       environment = "production"
-    } else if str.starts(with: "wss://api.firez.one") {
+    } else if apiURL.starts(with: "wss://api.firez.one") {
       environment = "staging"
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -85,18 +85,12 @@ public class VPNConfigurationManager {
 
     var migrated = false
 
-    if let apiURLString = providerConfiguration["apiURL"],
-       let apiURL = URL(string: apiURLString),
-       apiURL.host != nil,
-       ["wss", "ws"].contains(apiURL.scheme) {
+    if let apiURL = providerConfiguration["apiURL"] {
       try await ipcClient.setApiURL(apiURL)
       migrated = true
     }
 
-    if let authURLString = providerConfiguration["authBaseURL"],
-       let authURL = URL(string: authURLString),
-       authURL.host != nil,
-       ["https", "http"].contains(authURL.scheme) {
+    if let authURL = providerConfiguration["authBaseURL"] {
       try await ipcClient.setAuthURL(authURL)
       migrated = true
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -1,13 +1,6 @@
-//
-//  Configuration.swift
-//  (c) 2025 Firezone, Inc.
-//  LICENSE: Apache-2.0
-//
-
 import Foundation
 
 public class Configuration: Codable {
-
 #if DEBUG
   public static let defaultAuthURL = "https://app.firez.one"
   public static let defaultApiURL = "wss://api.firez.one"
@@ -18,7 +11,8 @@ public class Configuration: Codable {
   public static let defaultLogFilter = "info"
 #endif
 
-  public enum Keys {
+  // Replace Keys enum with string constants
+  public struct Keys {
     public static let authURL = "authURL"
     public static let apiURL = "apiURL"
     public static let logFilter = "logFilter"
@@ -42,43 +36,30 @@ public class Configuration: Codable {
     self.actorName = userDict[Keys.actorName] as? String
     self.firezoneId = userDict[Keys.firezoneId] as? String
 
-    if let authURL = managedDict[Keys.authURL] as? String {
-      self.overriddenKeys.insert(Keys.authURL)
-      self.authURL = authURL
-    } else if let authURL = userDict[Keys.authURL] as? String {
-      self.authURL = authURL
-    }
-
-    if let apiURL = managedDict[Keys.apiURL] as? String {
-      self.overriddenKeys.insert(Keys.apiURL)
-      self.apiURL = apiURL
-    } else if let apiURL = userDict[Keys.apiURL] as? String {
-      self.apiURL = apiURL
-    }
-
-    if let logFilter = managedDict[Keys.logFilter] as? String {
-      self.overriddenKeys.insert(Keys.logFilter)
-      self.logFilter = logFilter
-    } else {
-      self.logFilter = userDict[Keys.logFilter] as? String
-    }
-
-    if let accountSlug = managedDict[Keys.accountSlug] as? String {
-      self.overriddenKeys.insert(Keys.accountSlug)
-      self.accountSlug = accountSlug
-    } else {
-      self.accountSlug = userDict[Keys.accountSlug] as? String
-    }
-
-    if let internetResourceEnabled = managedDict[Keys.internetResourceEnabled] as? Bool {
-      self.overriddenKeys.insert(Keys.internetResourceEnabled)
-      self.internetResourceEnabled = internetResourceEnabled
-    } else {
-      self.internetResourceEnabled = userDict[Keys.internetResourceEnabled] as? Bool
+    setValue(forKey: Keys.authURL, from: managedDict, and: userDict) { [weak self] in self?.authURL = $0 }
+    setValue(forKey: Keys.apiURL, from: managedDict, and: userDict) { [weak self] in self?.apiURL = $0 }
+    setValue(forKey: Keys.logFilter, from: managedDict, and: userDict) { [weak self] in self?.logFilter = $0 }
+    setValue(forKey: Keys.accountSlug, from: managedDict, and: userDict) { [weak self] in self?.accountSlug = $0 }
+    setValue(forKey: Keys.internetResourceEnabled, from: managedDict, and: userDict) { [weak self] in
+      self?.internetResourceEnabled = $0
     }
   }
 
   func isOverridden(_ key: String) -> Bool {
     return overriddenKeys.contains(key)
+  }
+
+  private func setValue<T>(
+    forKey key: String, // Changed from Keys to String
+    from managedDict: [String: Any?],
+    and userDict: [String: Any?],
+    setter: (T) -> Void
+  ) {
+    if let value = managedDict[key] as? T {
+      overriddenKeys.insert(key)
+      setter(value)
+    } else if let value = userDict[key] as? T {
+      setter(value)
+    }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -9,12 +9,12 @@ import Foundation
 public class Configuration: Codable {
 
 #if DEBUG
-  public static let defaultAuthURL = URL(string: "https://app.firez.one")!
-  public static let defaultApiURL = URL(string: "wss://api.firez.one")!
+  public static let defaultAuthURL = "https://app.firez.one"
+  public static let defaultApiURL = "wss://api.firez.one"
   public static let defaultLogFilter = "debug"
 #else
-  public static let defaultAuthURL = URL(string: "https://app.firezone.dev")!
-  public static let defaultApiURL = URL(string: "wss://api.firezone.dev")!
+  public static let defaultAuthURL = "https://app.firezone.dev"
+  public static let defaultApiURL = "wss://api.firezone.dev"
   public static let defaultLogFilter = "info"
 #endif
 
@@ -28,10 +28,10 @@ public class Configuration: Codable {
     public static let firezoneId = "firezoneId"
   }
 
-  public var authURL: URL?
+  public var authURL: String?
   public var actorName: String?
   public var firezoneId: String?
-  public var apiURL: URL?
+  public var apiURL: String?
   public var logFilter: String?
   public var accountSlug: String?
   public var internetResourceEnabled: Bool?
@@ -42,20 +42,18 @@ public class Configuration: Codable {
     self.actorName = userDict[Keys.actorName] as? String
     self.firezoneId = userDict[Keys.firezoneId] as? String
 
-    if let authURLString = managedDict[Keys.authURL] as? String,
-       let authURL = URL(string: authURLString) {
+    if let authURL = managedDict[Keys.authURL] as? String {
       self.overriddenKeys.insert(Keys.authURL)
       self.authURL = authURL
-    } else if let authURLString = userDict[Keys.authURL] as? String {
-      self.authURL = URL(string: authURLString)
+    } else if let authURL = userDict[Keys.authURL] as? String {
+      self.authURL = authURL
     }
 
-    if let apiURLString = managedDict[Keys.apiURL] as? String,
-       let apiURL = URL(string: apiURLString) {
+    if let apiURL = managedDict[Keys.apiURL] as? String {
       self.overriddenKeys.insert(Keys.apiURL)
       self.apiURL = apiURL
-    } else if let apiURLString = userDict[Keys.apiURL] as? String {
-      self.apiURL = URL(string: apiURLString)
+    } else if let apiURL = userDict[Keys.apiURL] as? String {
+      self.apiURL = apiURL
     }
 
     if let logFilter = managedDict[Keys.logFilter] as? String {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -11,7 +11,6 @@ public class Configuration: Codable {
   public static let defaultLogFilter = "info"
 #endif
 
-  // Replace Keys enum with string constants
   public struct Keys {
     public static let authURL = "authURL"
     public static let apiURL = "apiURL"
@@ -50,7 +49,7 @@ public class Configuration: Codable {
   }
 
   private func setValue<T>(
-    forKey key: String, // Changed from Keys to String
+    forKey key: String,
     from managedDict: [String: Any?],
     and userDict: [String: Any?],
     setter: (T) -> Void

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
@@ -14,8 +14,8 @@ public enum ProviderMessage: Codable {
   case getResourceList(Data)
   case getConfiguration(Data)
   case signOut
-  case setAuthURL(URL)
-  case setApiURL(URL)
+  case setAuthURL(String)
+  case setApiURL(String)
   case setLogFilter(String)
   case setActorName(String)
   case setAccountSlug(String)
@@ -51,10 +51,10 @@ public enum ProviderMessage: Codable {
     let type = try container.decode(MessageType.self, forKey: .type)
     switch type {
     case .setAuthURL:
-      let value = try container.decode(URL.self, forKey: .value)
+      let value = try container.decode(String.self, forKey: .value)
       self = .setAuthURL(value)
     case .setApiURL:
-      let value = try container.decode(URL.self, forKey: .value)
+      let value = try container.decode(String.self, forKey: .value)
       self = .setApiURL(value)
     case .setLogFilter:
       let value = try container.decode(String.self, forKey: .value)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/WebAuthSession.swift
@@ -16,9 +16,8 @@ struct WebAuthSession {
   static let anchor = PresentationAnchor()
 
   static func signIn(store: Store) async throws {
-    let authURL = store.configuration?.authURL ?? Configuration.defaultAuthURL
-
-    guard let authClient = try? AuthClient(authURL: authURL),
+    guard let authURL = URL(string: store.configuration?.authURL ?? Configuration.defaultAuthURL),
+          let authClient = try? AuthClient(authURL: authURL),
           let url = try? authClient.build()
     else {
       // Should never get here because we perform URL validation on input, but handle this just in case

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -256,12 +256,12 @@ public final class Store: ObservableObject {
     Telemetry.accountSlug = accountSlug
   }
 
-  func setAuthURL(_ authURL: URL) async throws {
+  func setAuthURL(_ authURL: String) async throws {
     try await ipcClient().setAuthURL(authURL)
     configuration?.authURL = authURL
   }
 
-  func setApiURL(_ apiURL: URL) async throws {
+  func setApiURL(_ apiURL: String) async throws {
     try await ipcClient().setApiURL(apiURL)
     configuration?.apiURL = apiURL
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -723,7 +723,11 @@ public final class MenuBar: NSObject, ObservableObject {
   }
 
   @objc func adminPortalButtonTapped() {
-    let authURL = store.configuration?.authURL ?? Configuration.defaultAuthURL
+    guard let authURL = URL(string: store.configuration?.authURL ?? Configuration.defaultAuthURL)
+    else {
+      Log.warning("admin portal URL invalid: \(String(describing: store.configuration?.authURL))")
+      return
+    }
 
     Task { await NSWorkspace.shared.openAsync(authURL) }
   }

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -173,14 +173,14 @@ class Adapter {
   private var resourceListJSON: String?
 
   /// Starting parameters
-  private let apiURL: URL
+  private let apiURL: String
   private let token: Token
   private let id: String
   private let logFilter: String
   private let connlibLogFolderPath: String
 
   init(
-    apiURL: URL,
+    apiURL: String,
     token: Token,
     id: String,
     logFilter: String,
@@ -223,7 +223,7 @@ class Adapter {
 
       // Grab a session pointer
       session = try WrappedSession.connect(
-        "\(apiURL)",
+        apiURL,
         "\(token)",
         "\(id)",
         "\(Telemetry.accountSlug!)",

--- a/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
+++ b/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
@@ -33,13 +33,13 @@ class ConfigurationManager {
     Telemetry.firezoneId = userDict[Configuration.Keys.firezoneId] as? String
   }
 
-  func setAuthURL(_ authURL: URL) {
-    userDict[Configuration.Keys.authURL] = authURL.absoluteString
+  func setAuthURL(_ authURL: String) {
+    userDict[Configuration.Keys.authURL] = authURL
     saveUserDict()
   }
 
-  func setApiURL(_ apiURL: URL) {
-    userDict[Configuration.Keys.apiURL] = apiURL.absoluteString
+  func setApiURL(_ apiURL: String) {
+    userDict[Configuration.Keys.apiURL] = apiURL
     saveUserDict()
   }
 


### PR DESCRIPTION
In the UI, we need to use Strings to bind to the text inputs.
In the configuration dictionaries, we need to use Strings to save the URLs.

It makes no sense to convert these to URLs in between. Instead, we can validate upon save and then use them as Strings throughout.