### PR TITLE
chore(rust): remove double logger setup

### DIFF
--- a/rust/gui-client/src-tauri/src/deep_link/linux.rs
+++ b/rust/gui-client/src-tauri/src/deep_link/linux.rs
@@ -85,7 +85,6 @@ impl Server {
 }
 
 pub async fn open(url: &url::Url) -> Result<()> {
-    crate::logging::setup_stdout()?;
     let path = sock_path()?;
     let mut stream = UnixStream::connect(&path).await?;
 


### PR DESCRIPTION
I thought I had fixed this in #9111 but while rebasing, I must have deleted the wrong line so the logger now gets initialised twice.