### PR TITLE
feat(apple): Allow user to configure connect on start

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -129,6 +129,10 @@ class IPCClient {
     try await sendMessageWithoutResponse(ProviderMessage.setInternetResourceEnabled(enabled))
   }
 
+  func setConnectOnStart(_ connectOnStart: Bool) async throws {
+    try await sendMessageWithoutResponse(ProviderMessage.setConnectOnStart(connectOnStart))
+  }
+
   func fetchResources() async throws -> ResourceList {
     return try await withCheckedThrowingContinuation { continuation in
       do {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -20,6 +20,7 @@ public class Configuration: Codable {
     public static let internetResourceEnabled = "internetResourceEnabled"
     public static let firezoneId = "firezoneId"
     public static let hideAdminPortalMenuItem = "hideAdminPortalMenuItem"
+    public static let connectOnStart = "connectOnStart"
   }
 
   public var authURL: String?
@@ -30,6 +31,7 @@ public class Configuration: Codable {
   public var accountSlug: String?
   public var internetResourceEnabled: Bool?
   public var hideAdminPortalMenuItem: Bool?
+  public var connectOnStart: Bool?
 
   private var overriddenKeys: Set<String> = []
 
@@ -47,6 +49,9 @@ public class Configuration: Codable {
     setValue(forKey: Keys.hideAdminPortalMenuItem, from: managedDict, and: userDict) { [weak self] in
       self?.hideAdminPortalMenuItem = $0
     }
+    setValue(forKey: Keys.connectOnStart, from: managedDict, and: userDict) { [weak self] in
+      self?.connectOnStart = $0
+    }
   }
 
   func isOverridden(_ key: String) -> Bool {
@@ -59,11 +64,15 @@ public class Configuration: Codable {
     and userDict: [String: Any?],
     setter: (T) -> Void
   ) {
-    if let value = managedDict[key] as? T {
+    if let value = managedDict[key],
+       let typedValue = value as? T {
       overriddenKeys.insert(key)
-      setter(value)
-    } else if let value = userDict[key] as? T {
-      setter(value)
+      return setter(typedValue)
+    }
+
+    if let value = userDict[key],
+       let typedValue = value as? T {
+      setter(typedValue)
     }
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
@@ -20,6 +20,7 @@ public enum ProviderMessage: Codable {
   case setActorName(String)
   case setAccountSlug(String)
   case setInternetResourceEnabled(Bool)
+  case setConnectOnStart(Bool)
   case clearLogs
   case getLogFolderSize
   case exportLogs
@@ -40,6 +41,7 @@ public enum ProviderMessage: Codable {
     case setActorName
     case setAccountSlug
     case setInternetResourceEnabled
+    case setConnectOnStart
     case clearLogs
     case getLogFolderSize
     case exportLogs
@@ -68,6 +70,9 @@ public enum ProviderMessage: Codable {
     case .setInternetResourceEnabled:
       let value = try container.decode(Bool.self, forKey: .value)
       self = .setInternetResourceEnabled(value)
+    case .setConnectOnStart:
+      let value = try container.decode(Bool.self, forKey: .value)
+      self = .setConnectOnStart(value)
     case .getResourceList:
       let value = try container.decode(Data.self, forKey: .value)
       self = .getResourceList(value)
@@ -107,6 +112,9 @@ public enum ProviderMessage: Codable {
       try container.encode(value, forKey: .value)
     case .setInternetResourceEnabled(let value):
       try container.encode(MessageType.setInternetResourceEnabled, forKey: .type)
+      try container.encode(value, forKey: .value)
+    case .setConnectOnStart(let value):
+      try container.encode(MessageType.setConnectOnStart, forKey: .type)
       try container.encode(value, forKey: .value)
     case .getResourceList(let value):
       try container.encode(MessageType.getResourceList, forKey: .type)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -85,9 +85,12 @@ public final class Store: ObservableObject {
           self.vpnConfigurationManager = manager
           try await setupTunnelObservers()
           try await manager.enableConfiguration()
-          try ipcClient().start()
           self.configuration = try await ipcClient().getConfiguration()
           Telemetry.firezoneId = configuration?.firezoneId
+
+          if configuration?.connectOnStart ?? true {
+            try ipcClient().start()
+          }
         } else {
           status = .invalid
         }
@@ -280,6 +283,11 @@ public final class Store: ObservableObject {
   func setInternetResourceEnabled(_ internetResourceEnabled: Bool) async throws {
     try await ipcClient().setInternetResourceEnabled(internetResourceEnabled)
     configuration?.internetResourceEnabled = internetResourceEnabled
+  }
+
+  func setConnectOnStart(_ connectOnStart: Bool) async throws {
+    try await ipcClient().setConnectOnStart(connectOnStart)
+    configuration?.connectOnStart = connectOnStart
   }
 
   // MARK: Private functions

--- a/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
+++ b/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
@@ -63,6 +63,11 @@ class ConfigurationManager {
     saveUserDict()
   }
 
+  func setConnectOnStart(_ connectOnStart: Bool) {
+    userDict[Configuration.Keys.connectOnStart] = connectOnStart
+    saveUserDict()
+  }
+
   // Firezone ID migration. Can be removed once most clients migrate past 1.4.15.
   private func migrateFirezoneId() {
 

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -187,6 +187,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         adapter?.setInternetResourceEnabled(enabled)
         completionHandler?(nil)
 
+      case .setConnectOnStart(let connectOnStart):
+        configuration.connectOnStart = connectOnStart
+        ConfigurationManager.shared.setConnectOnStart(connectOnStart)
+        completionHandler?(nil)
+
       case .signOut:
         do {
           try Token.delete()


### PR DESCRIPTION
Exposes a configuration toggle to connect on start, allowing it to be overridden by MDM. Currently we assume this to be true.

Will need to refactor the settings soon to a dedicated `ObservableObject` in the ViewModel to make these validations and field checks less verbose.

related: #4505 