### PR TITLE
build(nix): add dependencies for launching GUI client

### DIFF
--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -59,7 +59,7 @@
           src = ../..;
 
           PKG_CONFIG_PATH = with pkgs; "${glib.dev}/lib/pkgconfig:${libsoup_3.dev}/lib/pkgconfig:${webkitgtk_4_1.dev}/lib/pkgconfig:${at-spi2-atk.dev}/lib/pkgconfig:${gtk3.dev}/lib/pkgconfig:${gdk-pixbuf.dev}/lib/pkgconfig:${cairo.dev}/lib/pkgconfig:${pango.dev}/lib/pkgconfig:${harfbuzz.dev}/lib/pkgconfig";
-          LD_LIBRARY_PATH = "${pkgs.libayatana-appindicator}/lib:${pkgs.gtk3}/lib:${pkgs.glib}/lib";
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.libayatana-appindicator pkgs.gtk3 pkgs.glib ];
         };
       };
     };

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -48,6 +48,7 @@
         pango
         webkitgtk_4_1
         webkitgtk_4_1.dev
+        libayatana-appindicator
       ];
     in
     {
@@ -58,6 +59,7 @@
           src = ../..;
 
           PKG_CONFIG_PATH = with pkgs; "${glib.dev}/lib/pkgconfig:${libsoup_3.dev}/lib/pkgconfig:${webkitgtk_4_1.dev}/lib/pkgconfig:${at-spi2-atk.dev}/lib/pkgconfig:${gtk3.dev}/lib/pkgconfig:${gdk-pixbuf.dev}/lib/pkgconfig:${cairo.dev}/lib/pkgconfig:${pango.dev}/lib/pkgconfig:${harfbuzz.dev}/lib/pkgconfig";
+          LD_LIBRARY_PATH = "${pkgs.libayatana-appindicator}/lib:${pkgs.gtk3}/lib:${pkgs.glib}/lib";
         };
       };
     };


### PR DESCRIPTION
In order to launch a debug build of the GUI client on NixOS, we need to add the appindicator dependency and set the library lookup path correctly.