### PR TITLE
fix(portal): Don't set `checked` for unchecked HTML els

### DIFF
--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -108,7 +108,7 @@ defmodule Web.FormComponents do
           id={@id}
           name={@name}
           value={@value}
-          checked={@checked}
+          {if @checked, do: [checked: true], else: []}
           class={[
             "w-4 h-4 border-neutral-300",
             @class
@@ -130,7 +130,7 @@ defmodule Web.FormComponents do
       id={@id}
       name={@name}
       value={@value}
-      checked={@checked}
+      {if @checked, do: [checked: true], else: []}
       class={[
         "hidden peer",
         @class
@@ -158,7 +158,7 @@ defmodule Web.FormComponents do
           id={@id}
           name={@name}
           value={@value}
-          checked={@checked}
+          {if @checked, do: [checked: true], else: []}
           class={[
             "bg-neutral-50",
             "border border-neutral-300 text-neutral-900 rounded",


### PR DESCRIPTION
The [HTML spec says](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/checkbox#checked) that if `checked` is present _with any value_, the element should be checked. We currently treat this as a boolean, and for the unsuspecting Firezone developer, adding a `<.input type="checkbox">` can sometimes result in confusing behavior as the `checked` attribute will be set regardless of the boolean value.

This was tripping me up on #8919 so I thought I'd introduce a fix in a separate PR.

All checkboxes/radios manually tested to work fine.