### PR TITLE
fix(apple): Handle tunnel starting before GUI after upgrade

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -47,6 +47,9 @@ class Adapter {
 
   private var session: WrappedSession?
 
+  // Our local copy of the accountSlug
+  private var accountSlug: String
+
   /// Network settings
   private var networkSettings: NetworkSettings?
 
@@ -184,6 +187,7 @@ class Adapter {
     token: Token,
     id: String,
     logFilter: String,
+    accountSlug: String,
     internetResourceEnabled: Bool,
     packetTunnelProvider: PacketTunnelProvider
   ) {
@@ -193,6 +197,7 @@ class Adapter {
     self.packetTunnelProvider = packetTunnelProvider
     self.callbackHandler = CallbackHandler()
     self.logFilter = logFilter
+    self.accountSlug = accountSlug
     self.connlibLogFolderPath = SharedAccess.connlibLogFolderURL?.path ?? ""
     self.networkSettings = nil
     self.internetResourceEnabled = internetResourceEnabled
@@ -226,7 +231,7 @@ class Adapter {
         apiURL,
         "\(token)",
         "\(id)",
-        "\(Telemetry.accountSlug!)",
+        accountSlug,
         DeviceMetadata.getDeviceName(),
         DeviceMetadata.getOSVersion(),
         connlibLogFolderPath,


### PR DESCRIPTION
If the user tries to start the tunnel from system settings without launching the GUI after upgrading to >= 1.4.15, the new configuration will be empty, and we'll fail to set the accountSlug, preventing the tunnel from starting.

To fix this, we add a simple convenience function that returns the legacy configuration, and we use this configuration to start the tunnel in case the GUI hasn't started.

Once the GUI starts, the legacy configuration is migrated and deleted, so this is more of an edge case. Still, given the hundreds/thousands of Apple device installations we have, someone is bound to hit it, and it would be better to spend a few minutes saving potentially man-hours of troubleshooting later.