### PR TITLE
fix(apple): Isolate debug and release Keychain items

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 public struct Token: CustomStringConvertible {
+  // Debug builds can't write to release build Keychain items, so keep them separate
+#if DEBUG
+  private static let label = "Firezone token (debug)"
+#else
+  private static let label = "Firezone token"
+#endif
+
   private static let query: [CFString: Any] = [
     kSecAttrLabel: "Firezone token",
     kSecAttrAccount: "1",


### PR DESCRIPTION
On macOS, the token is saved in the system keychain so that the `root` user is able to manage it. `secd`, the daemon that responds to Keychain requests, is very strict about which binaries can access Keychain items created by other binaries.

In development, the Firezone system extension runs from an unprivileged directory, and isn't release-signed, which means it is not able to manage the Keychain token for the release binary, and vice-versa.

To fix this, we isolate the Keychain items from each other with different labels for `debug` and `release`, where the latter is unchanged.

This is only an issue on debug, so a Changelog entry is not created.

Fixes #8917 
Fixes #8642 