### PR TITLE
feat(portal): Zero-click client authentication

### DIFF
--- a/elixir/apps/domain/lib/domain/auth.ex
+++ b/elixir/apps/domain/lib/domain/auth.ex
@@ -152,20 +152,20 @@ defmodule Domain.Auth do
     end
   end
 
-  def list_providers(%Subject{} = subject, opts \\ []) do
-    with :ok <- ensure_has_permissions(subject, Authorizer.manage_providers_permission()) do
-      Provider.Query.not_deleted()
-      |> Authorizer.for_subject(Provider, subject)
-      |> Repo.list(Provider.Query, opts)
-    end
-  end
-
   # Used during client auth
   def fetch_default_provider_for_account(%Accounts.Account{} = account, opts \\ []) do
     Provider.Query.not_disabled()
     |> Provider.Query.by_account_id(account.id)
     |> Provider.Query.assigned_default()
     |> Repo.fetch(Provider.Query, opts)
+  end
+
+  def list_providers(%Subject{} = subject, opts \\ []) do
+    with :ok <- ensure_has_permissions(subject, Authorizer.manage_providers_permission()) do
+      Provider.Query.not_deleted()
+      |> Authorizer.for_subject(Provider, subject)
+      |> Repo.list(Provider.Query, opts)
+    end
   end
 
   # used to build list of auth options for the UI

--- a/elixir/apps/domain/lib/domain/auth.ex
+++ b/elixir/apps/domain/lib/domain/auth.ex
@@ -263,23 +263,24 @@ defmodule Domain.Auth do
   # Update default provider for client auth
   def assign_default_provider(%Provider{} = provider, %Subject{} = subject) do
     with :ok <- ensure_has_permissions(subject, Authorizer.manage_providers_permission()) do
-      {:ok, result} =
-        Repo.transaction(fn ->
-          # 1. Clear default for all other providers
+      Repo.transaction(fn ->
+        # 1. Clear default for all other providers
+        {_count, nil} =
           Provider.Query.not_disabled()
           |> Authorizer.for_subject(Provider, subject)
           |> Repo.update_all(set: [assigned_default_at: nil])
 
-          # 2. Set default for the given provider
+        # 2. Set default for the given provider
+        {:ok, provider} =
           Provider.Query.not_disabled()
           |> Provider.Query.by_id(provider.id)
           |> Authorizer.for_subject(Provider, subject)
           |> Repo.fetch_and_update(Provider.Query,
             with: &Provider.Changeset.assign_default_provider/1
           )
-        end)
 
-      result
+        provider
+      end)
     end
   end
 

--- a/elixir/apps/domain/lib/domain/auth/provider.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider.ex
@@ -28,6 +28,7 @@ defmodule Domain.Auth.Provider do
 
     field :disabled_at, :utc_datetime_usec
     field :deleted_at, :utc_datetime_usec
+    field :assigned_default_at, :utc_datetime_usec
     timestamps()
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
@@ -6,7 +6,7 @@ defmodule Domain.Auth.Provider.Changeset do
   @create_fields ~w[id name adapter provisioner adapter_config adapter_state disabled_at assigned_default_at]a
   @update_fields ~w[name adapter_config
                     last_syncs_failed last_sync_error sync_disabled_at sync_error_emailed_at
-                    adapter_state provisioner disabled_at deleted_at assigned_default_at]a
+                    adapter_state provisioner disabled_at deleted_at]a
   @required_fields ~w[name adapter adapter_config provisioner]a
 
   def create(account, attrs, %Subject{} = subject) do

--- a/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
@@ -3,10 +3,10 @@ defmodule Domain.Auth.Provider.Changeset do
   alias Domain.Accounts
   alias Domain.Auth.{Subject, Provider, Adapters}
 
-  @create_fields ~w[id name adapter provisioner adapter_config adapter_state disabled_at]a
+  @create_fields ~w[id name adapter provisioner adapter_config adapter_state disabled_at assigned_default_at]a
   @update_fields ~w[name adapter_config
                     last_syncs_failed last_sync_error sync_disabled_at sync_error_emailed_at
-                    adapter_state provisioner disabled_at deleted_at]a
+                    adapter_state provisioner disabled_at deleted_at assigned_default_at]a
   @required_fields ~w[name adapter adapter_config provisioner]a
 
   def create(account, attrs, %Subject{} = subject) do
@@ -41,6 +41,12 @@ defmodule Domain.Auth.Provider.Changeset do
     provider
     |> cast(attrs, @update_fields)
     |> changeset()
+  end
+
+  def assign_default_provider(%Provider{} = provider) do
+    provider
+    |> change()
+    |> put_change(:assigned_default_at, DateTime.utc_now())
   end
 
   def sync_finished(%Provider{} = provider) do
@@ -88,6 +94,10 @@ defmodule Domain.Auth.Provider.Changeset do
     |> unique_constraint(:base,
       name: :unique_account_adapter_index,
       message: "only one of this adapter type may be enabled per account"
+    )
+    |> unique_constraint(:base,
+      name: :auth_providers_account_id_assigned_default_at_index,
+      message: "only one provider may be assigned default for client authentication"
     )
     |> validate_provisioner()
     |> validate_required(@required_fields)

--- a/elixir/apps/domain/lib/domain/auth/provider/query.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/query.ex
@@ -14,6 +14,10 @@ defmodule Domain.Auth.Provider.Query do
     where(queryable, [providers: providers], is_nil(providers.disabled_at))
   end
 
+  def assigned_default(queryable) do
+    where(queryable, [providers: providers], not is_nil(providers.assigned_default_at))
+  end
+
   def by_id(queryable, id)
 
   def by_id(queryable, {:not, id}) do

--- a/elixir/apps/domain/priv/repo/migrations/20250513211142_add_default_to_auth_providers.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250513211142_add_default_to_auth_providers.exs
@@ -1,0 +1,31 @@
+defmodule Domain.Repo.Migrations.AddDefaultToAuthProviders do
+  use Ecto.Migration
+
+  def up do
+    alter table(:auth_providers) do
+      add(:assigned_default_at, :utc_datetime_usec)
+    end
+
+    create(
+      index(:auth_providers, :account_id,
+        name: :auth_providers_account_id_assigned_default_at_index,
+        unique: true,
+        where: "deleted_at IS NULL AND disabled_at IS NULL AND assigned_default_at IS NOT NULL"
+      )
+    )
+  end
+
+  def down do
+    drop(
+      index(:auth_providers, :account_id,
+        name: :auth_providers_account_id_assigned_default_at_index,
+        unique: true,
+        where: "deleted_at IS NULL AND disabled_at IS NULL AND assigned_default_at IS NOT NULL"
+      )
+    )
+
+    alter table(:auth_providers) do
+      remove(:assigned_default_at)
+    end
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20250513211142_add_default_to_auth_providers.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250513211142_add_default_to_auth_providers.exs
@@ -1,6 +1,8 @@
 defmodule Domain.Repo.Migrations.AddDefaultToAuthProviders do
   use Ecto.Migration
 
+  @disable_ddl_transaction true
+
   def up do
     alter table(:auth_providers) do
       add(:assigned_default_at, :utc_datetime_usec)
@@ -10,7 +12,8 @@ defmodule Domain.Repo.Migrations.AddDefaultToAuthProviders do
       index(:auth_providers, :account_id,
         name: :auth_providers_account_id_assigned_default_at_index,
         unique: true,
-        where: "deleted_at IS NULL AND disabled_at IS NULL AND assigned_default_at IS NOT NULL"
+        where: "deleted_at IS NULL AND disabled_at IS NULL AND assigned_default_at IS NOT NULL",
+        concurrently: true
       )
     )
   end
@@ -20,7 +23,8 @@ defmodule Domain.Repo.Migrations.AddDefaultToAuthProviders do
       index(:auth_providers, :account_id,
         name: :auth_providers_account_id_assigned_default_at_index,
         unique: true,
-        where: "deleted_at IS NULL AND disabled_at IS NULL AND assigned_default_at IS NOT NULL"
+        where: "deleted_at IS NULL AND disabled_at IS NULL AND assigned_default_at IS NOT NULL",
+        concurrently: true
       )
     )
 

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -218,9 +218,9 @@ defmodule Domain.AuthTest do
   end
 
   describe "fetch_default_provider_for_account/2" do
-    test "returns empty list if there are no default providers" do
+    test "returns not found if no default providers exist" do
       account = Fixtures.Accounts.create_account()
-      assert fetch_default_provider_for_account(account) == []
+      assert fetch_default_provider_for_account(account) == {:error, :not_found}
     end
 
     test "returns default provider for account" do
@@ -238,9 +238,75 @@ defmodule Domain.AuthTest do
   end
 
   describe "assign_default_provider/2" do
+    setup do
+      account = Fixtures.Accounts.create_account()
+      actor = Fixtures.Actors.create_actor(account: account, type: :account_admin_user)
+      identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+      subject = Fixtures.Auth.create_subject(identity: identity)
+
+      %{
+        account: account,
+        actor: actor,
+        identity: identity,
+        subject: subject
+      }
+    end
+
+    test "assigns default provider for account", %{account: account, subject: subject} do
+      {provider, _bypass} =
+        Fixtures.Auth.start_and_create_openid_connect_provider(account: account)
+
+      assert {:ok, provider} = assign_default_provider(provider, subject)
+      assert provider.assigned_default_at
+    end
+
+    test "removes default from all other providers", %{account: account, subject: subject} do
+      {provider1, _bypass} =
+        Fixtures.Auth.start_and_create_openid_connect_provider(
+          account: account,
+          assigned_default_at: DateTime.utc_now()
+        )
+
+      {provider2, _bypass} =
+        Fixtures.Auth.start_and_create_openid_connect_provider(account: account)
+
+      assert {:ok, provider} = assign_default_provider(provider2, subject)
+      assert provider.assigned_default_at
+
+      assert provider1 = Repo.reload(provider1)
+      assert is_nil(provider1.assigned_default_at)
+    end
   end
 
   describe "clear_default_provider/1" do
+    setup do
+      account = Fixtures.Accounts.create_account()
+      actor = Fixtures.Actors.create_actor(account: account, type: :account_admin_user)
+      identity = Fixtures.Auth.create_identity(account: account, actor: actor)
+      subject = Fixtures.Auth.create_subject(identity: identity)
+
+      %{
+        account: account,
+        actor: actor,
+        identity: identity,
+        subject: subject
+      }
+    end
+
+    test "clears default provider from account", %{account: account, subject: subject} do
+      {provider, _bypass} =
+        Fixtures.Auth.start_and_create_openid_connect_provider(
+          account: account,
+          assigned_default_at: DateTime.utc_now()
+        )
+
+      assert {:ok, default_provider} = fetch_default_provider_for_account(account)
+      assert provider.id == default_provider.id
+
+      assert {_count, nil} = clear_default_provider(subject)
+      provider = Repo.reload(provider)
+      assert is_nil(provider.assigned_default_at)
+    end
   end
 
   describe "list_providers/2" do

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -217,6 +217,32 @@ defmodule Domain.AuthTest do
     end
   end
 
+  describe "fetch_default_provider_for_account/2" do
+    test "returns empty list if there are no default providers" do
+      account = Fixtures.Accounts.create_account()
+      assert fetch_default_provider_for_account(account) == []
+    end
+
+    test "returns default provider for account" do
+      account = Fixtures.Accounts.create_account()
+
+      {provider, _bypass} =
+        Fixtures.Auth.start_and_create_openid_connect_provider(
+          account: account,
+          assigned_default_at: DateTime.utc_now()
+        )
+
+      assert {:ok, fetched_provider} = fetch_default_provider_for_account(account)
+      assert fetched_provider.id == provider.id
+    end
+  end
+
+  describe "assign_default_provider/2" do
+  end
+
+  describe "clear_default_provider/1" do
+  end
+
   describe "list_providers/2" do
     test "returns all not soft-deleted providers for a given account" do
       account = Fixtures.Accounts.create_account()

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -291,7 +291,9 @@ defmodule Domain.AuthTest do
           assigned_default_at: DateTime.utc_now()
         )
 
-      assert {:error, :not_found} = assign_default_provider(other_provider, subject)
+      assert_raise MatchError, fn ->
+        assign_default_provider(other_provider, subject)
+      end
     end
   end
 

--- a/elixir/apps/web/lib/web/components/form_components.ex
+++ b/elixir/apps/web/lib/web/components/form_components.ex
@@ -234,7 +234,7 @@ defmodule Web.FormComponents do
         class={[
           "text-sm bg-neutral-50",
           "border border-neutral-300 text-neutral-900 rounded",
-          "block p-2.5",
+          "block",
           !@inline_errors && "w-full",
           @errors != [] && "border-rose-400 focus:border-rose-400"
         ]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
@@ -368,4 +368,18 @@ defmodule Web.Settings.IdentityProviders.Components do
     </div>
     """
   end
+
+  attr :provider, Domain.Auth.Provider, required: true
+
+  def assigned_default_badge(assigns) do
+    ~H"""
+    <.badge
+      :if={!is_nil(@provider.assigned_default_at)}
+      title="This provider is the default for client authentication"
+      class="ml-2"
+    >
+      default
+    </.badge>
+    """
+  end
 end

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -154,7 +154,10 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
           <.vertical_table id="provider">
             <.vertical_table_row>
               <:label>Name</:label>
-              <:value>{@provider.name}</:value>
+              <:value>
+                {@provider.name}
+                <.assigned_default_badge provider={@provider} />
+              </:value>
             </.vertical_table_row>
             <.vertical_table_row>
               <:label>Status</:label>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
@@ -156,10 +156,21 @@ defmodule Web.Settings.IdentityProviders.Index do
     assigns = assign(assigns, options: options, value: value)
 
     ~H"""
-    <.form phx-submit="default_provider_save" phx-change="default_provider_change" for={nil}>
+    <.form
+      id="default-provider-form"
+      phx-submit="default_provider_save"
+      phx-change="default_provider_change"
+      for={nil}
+    >
       <div class="flex gap-2 items-center">
         <div class="w-32">
-          <.input name="provider_id" type="select" options={@options} value={@value} />
+          <.input
+            id="default-provider-select"
+            name="provider_id"
+            type="select"
+            options={@options}
+            value={@value}
+          />
         </div>
         <.submit_button
           phx-disable-with="Saving..."

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
@@ -219,7 +219,8 @@ defmodule Web.Settings.IdentityProviders.Index do
       socket.assigns.providers
       |> Enum.find(fn provider -> provider.id == provider_id end)
 
-    with {:ok, _provider} <- Auth.assign_default_provider(provider, socket.assigns.subject),
+    with true <- provider.adapter not in [:email, :userpass],
+         {:ok, _provider} <- Auth.assign_default_provider(provider, socket.assigns.subject),
          {:ok, providers, _metadata} <- Auth.list_providers(socket.assigns.subject) do
       socket =
         socket

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
@@ -154,7 +154,10 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
           <.vertical_table id="provider">
             <.vertical_table_row>
               <:label>Name</:label>
-              <:value>{@provider.name}</:value>
+              <:value>
+                {@provider.name}
+                <.assigned_default_badge provider={@provider} />
+              </:value>
             </.vertical_table_row>
             <.vertical_table_row>
               <:label>Status</:label>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -152,7 +152,10 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
           <.vertical_table id="provider">
             <.vertical_table_row>
               <:label>Name</:label>
-              <:value>{@provider.name}</:value>
+              <:value>
+                {@provider.name}
+                <.assigned_default_badge provider={@provider} />
+              </:value>
             </.vertical_table_row>
             <.vertical_table_row>
               <:label>Status</:label>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/mock/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/mock/show.ex
@@ -141,7 +141,10 @@ defmodule Web.Settings.IdentityProviders.Mock.Show do
           <.vertical_table id="provider">
             <.vertical_table_row>
               <:label>Name</:label>
-              <:value>{@provider.name}</:value>
+              <:value>
+                {@provider.name}
+                <.assigned_default_badge provider={@provider} />
+              </:value>
             </.vertical_table_row>
             <.vertical_table_row>
               <:label>Description</:label>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -152,7 +152,10 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
           <.vertical_table id="provider">
             <.vertical_table_row>
               <:label>Name</:label>
-              <:value>{@provider.name}</:value>
+              <:value>
+                {@provider.name}
+                <.assigned_default_badge provider={@provider} />
+              </:value>
             </.vertical_table_row>
             <.vertical_table_row>
               <:label>Status</:label>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -132,7 +132,10 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
           <.vertical_table id="provider">
             <.vertical_table_row>
               <:label>Name</:label>
-              <:value>{@provider.name}</:value>
+              <:value>
+                {@provider.name}
+                <.assigned_default_badge provider={@provider} />
+              </:value>
             </.vertical_table_row>
             <.vertical_table_row>
               <:label>Status</:label>

--- a/elixir/apps/web/lib/web/plugs/auto_redirect_default_provider.ex
+++ b/elixir/apps/web/lib/web/plugs/auto_redirect_default_provider.ex
@@ -1,0 +1,35 @@
+defmodule Web.Plugs.AutoRedirectDefaultProvider do
+  use Phoenix.VerifiedRoutes, endpoint: Web.Endpoint, router: Web.Router
+  import Plug.Conn
+  import Phoenix.Controller, only: [redirect: 2]
+  alias Domain.Auth
+
+  def init(opts), do: opts
+
+  # client sign in
+  def call(%{params: %{"as" => "client"}} = conn, _opts) do
+    with account <- conn.assigns.account,
+         {:ok, provider} <- Auth.fetch_default_provider_for_account(account) do
+      redirect_path = ~p"/#{account}/sign_in/providers/#{provider}/redirect"
+
+      # Append original query params
+      full_redirect_path =
+        if conn.query_string != "" do
+          redirect_path <> "?" <> conn.query_string
+        else
+          redirect_path
+        end
+
+      conn
+      |> redirect(to: full_redirect_path)
+      |> halt()
+    else
+      _ -> conn
+    end
+  end
+
+  # Non-client sign in
+  def call(conn, _opts) do
+    conn
+  end
+end

--- a/elixir/apps/web/lib/web/router.ex
+++ b/elixir/apps/web/lib/web/router.ex
@@ -74,7 +74,12 @@ defmodule Web.Router do
   end
 
   scope "/:account_id_or_slug", Web do
-    pipe_through [:public, :account, :redirect_if_user_is_authenticated]
+    pipe_through [
+      :public,
+      :account,
+      :redirect_if_user_is_authenticated,
+      Web.Plugs.AutoRedirectDefaultProvider
+    ]
 
     live_session :redirect_if_user_is_authenticated,
       on_mount: [


### PR DESCRIPTION
Adds a new field to `settings/identity_providers` that allows an Admin to designate any non-email/otp provider as the `default` for client authentication. Clients will then navigate directly to the provider's `/redirect` endpoint when authenticating, which in many cases will automatically sign them in.

No existing providers are updated in this PR.


https://github.com/user-attachments/assets/7b962a25-76fd-491f-a194-60ed993821fc

