### PR TITLE
ci: ignore HN link in link checker

### DIFF
--- a/website/.lycheeignore
+++ b/website/.lycheeignore
@@ -6,3 +6,4 @@ https://x.com/firezonehq
 https://admin.google.com/ac/owl
 https://www.flexjobs.com/blog/post/exploring-the-impact-of-remote-work-on-mental-health-and-the-workplace/
 .prettierrc.json
+https://news.ycombinator.com/item?id=28683231


### PR DESCRIPTION
This link repeatedly returns a 403 in our CI link checker, despite being available.

Fixes: #9140
Fixes: #9120