### PR TITLE
chore(rust): set `opentelemetry` to INFO

### DIFF
--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -94,7 +94,7 @@ fn parse_filter(directives: &str) -> Result<EnvFilter, ParseError> {
     /// By prepending this directive to the active log filter, a simple directive like `debug` actually produces useful logs.
     /// If necessary, you can still activate logs from these crates by restating them in your directive with a lower filter, i.e. `netlink_proto=debug`.
     const IRRELEVANT_CRATES: &str =
-        "netlink_proto=warn,os_info=warn,rustls=warn,opentelemetry_sdk=info";
+        "netlink_proto=warn,os_info=warn,rustls=warn,opentelemetry_sdk=info,opentelemetry=info";
 
     let env_filter = if directives.is_empty() {
         EnvFilter::try_new(IRRELEVANT_CRATES)?


### PR DESCRIPTION
This is currently spammy on DEBUG for all platforms where we don't collect metrics.