### PR TITLE
chore(telemetry): flush before ending session

### DIFF
--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -141,8 +141,8 @@ impl Telemetry {
         let Some(inner) = self.inner.take() else {
             return;
         };
+
         tracing::info!("Stopping telemetry");
-        sentry::end_session_with_status(status);
 
         // Sentry uses blocking IO for flushing ..
         let _ = tokio::task::spawn_blocking(move || {
@@ -154,6 +154,8 @@ impl Telemetry {
             tracing::debug!("Flushed telemetry");
         })
         .await;
+
+        sentry::end_session_with_status(status);
     }
 
     pub fn set_account_slug(slug: String) {

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -141,7 +141,6 @@ impl Telemetry {
         let Some(inner) = self.inner.take() else {
             return;
         };
-
         tracing::info!("Stopping telemetry");
 
         // Sentry uses blocking IO for flushing ..


### PR DESCRIPTION
I am not sure if this is currently breaking anything but it seems more correct to flush all events first and then end the session.