### PR TITLE
refactor(gui-client): streamline command handling

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -99,7 +99,7 @@ fn try_main(cli: Cli, rt: &tokio::runtime::Runtime, mut settings: AdvancedSettin
             // Fall-through to running the GUI if elevation check should be bypassed.
         }
 
-        // All commands below _don't_ end up running the GUI.
+        // All commands below _don't_ end up running the GUI because they return early.
         Some(Cmd::Debug {
             command: DebugCommand::Replicate6791,
         }) => {
@@ -127,6 +127,8 @@ fn try_main(cli: Cli, rt: &tokio::runtime::Runtime, mut settings: AdvancedSettin
             return Ok(());
         }
     };
+
+    // Happy-path: Run the GUI.
 
     match gui::run(rt, config, settings, reloader) {
         Ok(()) => {}

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -116,13 +116,11 @@ fn try_main(cli: Cli, rt: &tokio::runtime::Runtime, mut settings: AdvancedSettin
         // If we already tried to elevate ourselves, don't try again
         Some(Cmd::Elevated) => run_gui(rt, config, settings, reloader)?,
         Some(Cmd::OpenDeepLink(deep_link)) => {
-            if let Err(error) = rt.block_on(deep_link::open(deep_link.url)) {
-                tracing::error!("Error in `OpenDeepLink`: {error:#}");
-            }
+            rt.block_on(deep_link::open(deep_link.url))
+                .context("Failed to open deep-link")?;
         }
         Some(Cmd::SmokeTest) => {
             // Can't check elevation here because the Windows CI is always elevated
-
             gui::run(rt, config, settings, reloader)?;
         }
     };

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -10,9 +10,7 @@ use anyhow::{Context as _, Result, bail};
 use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, elevation, gui, logging, settings};
-use firezone_logging::FilterReloadHandle;
 use firezone_telemetry::Telemetry;
-use gui::RunConfig;
 use settings::AdvancedSettings;
 use tracing_subscriber::EnvFilter;
 
@@ -130,22 +128,8 @@ fn try_main(cli: Cli, rt: &tokio::runtime::Runtime, mut settings: AdvancedSettin
         }
     };
 
-    run_gui(rt, config, settings, reloader)?;
-
-    Ok(())
-}
-
-/// `gui::run` but wrapped in `anyhow::Result`
-///
-/// Automatically logs or shows error dialogs for important user-actionable errors
-fn run_gui(
-    rt: &tokio::runtime::Runtime,
-    config: RunConfig,
-    settings: AdvancedSettings,
-    reloader: FilterReloadHandle,
-) -> Result<()> {
     match gui::run(rt, config, settings, reloader) {
-        Ok(()) => Ok(()),
+        Ok(()) => {}
         Err(anyhow) => {
             if anyhow
                 .chain()
@@ -177,9 +161,11 @@ fn run_gui(
                 "An unexpected error occurred. Please try restarting Firezone. If the issue persists, contact your administrator.",
             )?;
 
-            Err(anyhow)
+            return Err(anyhow);
         }
-    }
+    };
+
+    Ok(())
 }
 
 /// Parse the log filter from settings, showing an error and fixing it if needed

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -130,7 +130,6 @@ fn try_main(cli: Cli, rt: &tokio::runtime::Runtime, settings: AdvancedSettings) 
 /// `gui::run` but wrapped in `anyhow::Result`
 ///
 /// Automatically logs or shows error dialogs for important user-actionable errors
-// Can't `instrument` this because logging isn't running when we enter it.
 fn run_gui(
     rt: &tokio::runtime::Runtime,
     config: RunConfig,

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 use anyhow::{Context, Result, bail};
 use firezone_logging::err_with_src;
-use firezone_telemetry as telemetry;
 use futures::SinkExt as _;
 use std::time::Duration;
 use tauri::Manager;

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -146,13 +146,13 @@ pub struct AlreadyRunning;
 /// Runs the Tauri GUI and returns on exit or unrecoverable error
 #[instrument(skip_all)]
 pub fn run(
+    rt: tokio::runtime::Runtime,
     config: RunConfig,
     advanced_settings: AdvancedSettings,
     reloader: firezone_logging::FilterReloadHandle,
     mut telemetry: telemetry::Telemetry,
 ) -> Result<()> {
     // Needed for the deep link server
-    let rt = tokio::runtime::Runtime::new().context("Couldn't start Tokio runtime")?;
     tauri::async_runtime::set(rt.handle().clone());
 
     let _guard = rt.enter();

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -146,11 +146,10 @@ pub struct AlreadyRunning;
 /// Runs the Tauri GUI and returns on exit or unrecoverable error
 #[instrument(skip_all)]
 pub fn run(
-    rt: tokio::runtime::Runtime,
+    rt: &tokio::runtime::Runtime,
     config: RunConfig,
     advanced_settings: AdvancedSettings,
     reloader: firezone_logging::FilterReloadHandle,
-    mut telemetry: telemetry::Telemetry,
 ) -> Result<()> {
     // Needed for the deep link server
     tauri::async_runtime::set(rt.handle().clone());
@@ -337,8 +336,7 @@ pub fn run(
             .context("Controller failed")?;
 
         anyhow::Ok(())
-    })
-    .inspect_err(|_| rt.block_on(telemetry.stop_on_crash()))?;
+    })?;
 
     tracing::info!("Controller exited gracefully");
 

--- a/rust/tests/gui-smoke-test/src/main.rs
+++ b/rust/tests/gui-smoke-test/src/main.rs
@@ -118,6 +118,7 @@ impl App {
                 .to_str()
                 .context("Should be able to convert Path to &str")?, // For some reason `xvfb-run` doesn't just use our current working dir
             "--no-deep-links",
+            "--no-elevation-check",
         ]
         .into_iter()
         .chain(args.iter().copied())
@@ -149,7 +150,10 @@ impl App {
 
     // Strange signature needed to match Linux
     fn gui_command(&self, args: &[&str]) -> Result<Exec> {
-        Ok(Exec::cmd(gui_path()).arg("--no-deep-links").args(args))
+        Ok(Exec::cmd(gui_path())
+            .arg("--no-deep-links")
+            .arg("--no-elevation-check")
+            .args(args))
     }
 }
 


### PR DESCRIPTION
The way the GUI client currently handles the commands and flags provided via the CLI is somewhat confusing. There are various helper functions that get called from the same place. We duplicate setup like the `tokio` runtime in multiple places and the also loggers get initialised all over the place.

To streamline this, we move global setup like `tokio` and telemetry to the top-layer. From there, we delegate to a `try_main` function which handles the various CLI commands. The default path from here is to run the gui by delegating to the `gui` module. If not, we bail out early.

This structure is significantly easier to understand and provides error and telemetry handling in a single place.