### PR TITLE
refactor(apple): Add Settings model

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -56,13 +56,17 @@ class IPCClient {
   let encoder = PropertyListEncoder()
   let decoder = PropertyListDecoder()
 
-  func start(token: String? = nil) throws {
-    var options: [String: NSObject] = [:]
+  // Auto-connect
+  func start() throws {
+    try session().startTunnel(options: nil)
+  }
 
-    // Pass token if provided
-    if let token = token {
-      options.merge(["token": token as NSObject]) { _, new in new }
-    }
+  // Sign in
+  func start(token: String, accountSlug: String) throws {
+    let options: [String: NSObject] = [
+      "token": token as NSObject,
+      "accountSlug": accountSlug as NSObject
+    ]
 
     try session().startTunnel(options: options)
   }
@@ -105,32 +109,8 @@ class IPCClient {
     }
   }
 
-  func setAuthURL(_ authURL: String) async throws {
-    try await sendMessageWithoutResponse(ProviderMessage.setAuthURL(authURL))
-  }
-
-  func setApiURL(_ apiURL: String) async throws {
-    try await sendMessageWithoutResponse(ProviderMessage.setApiURL(apiURL))
-  }
-
-  func setLogFilter(_ logFilter: String) async throws {
-    try await sendMessageWithoutResponse(ProviderMessage.setLogFilter(logFilter))
-  }
-
-  func setActorName(_ actorName: String) async throws {
-    try await sendMessageWithoutResponse(ProviderMessage.setActorName(actorName))
-  }
-
-  func setAccountSlug(_ accountSlug: String) async throws {
-    try await sendMessageWithoutResponse(ProviderMessage.setAccountSlug(accountSlug))
-  }
-
-  func setInternetResourceEnabled(_ enabled: Bool) async throws {
-    try await sendMessageWithoutResponse(ProviderMessage.setInternetResourceEnabled(enabled))
-  }
-
-  func setConnectOnStart(_ connectOnStart: Bool) async throws {
-    try await sendMessageWithoutResponse(ProviderMessage.setConnectOnStart(connectOnStart))
+  func setConfiguration(_ configuration: Configuration) async throws {
+    try await sendMessageWithoutResponse(ProviderMessage.setConfiguration(configuration))
   }
 
   func fetchResources() async throws -> ResourceList {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -11,11 +11,13 @@ public class Configuration: Codable {
   public static let defaultLogFilter = "info"
 #endif
 
+  public static let defaultAccountSlug = ""
+  public static let defaultConnectOnStart = true
+
   public struct Keys {
     public static let authURL = "authURL"
     public static let apiURL = "apiURL"
     public static let logFilter = "logFilter"
-    public static let actorName = "actorName"
     public static let accountSlug = "accountSlug"
     public static let internetResourceEnabled = "internetResourceEnabled"
     public static let firezoneId = "firezoneId"
@@ -24,7 +26,6 @@ public class Configuration: Codable {
   }
 
   public var authURL: String?
-  public var actorName: String?
   public var firezoneId: String?
   public var apiURL: String?
   public var logFilter: String?
@@ -36,7 +37,6 @@ public class Configuration: Codable {
   private var overriddenKeys: Set<String> = []
 
   public init(userDict: [String: Any?], managedDict: [String: Any?]) {
-    self.actorName = userDict[Keys.actorName] as? String
     self.firezoneId = userDict[Keys.firezoneId] as? String
 
     setValue(forKey: Keys.authURL, from: managedDict, and: userDict) { [weak self] in self?.authURL = $0 }
@@ -56,6 +56,14 @@ public class Configuration: Codable {
 
   func isOverridden(_ key: String) -> Bool {
     return overriddenKeys.contains(key)
+  }
+
+  func applySettings(_ settings: Settings) {
+    self.authURL = settings.authURL
+    self.apiURL = settings.apiURL
+    self.logFilter = settings.logFilter
+    self.accountSlug = settings.accountSlug
+    self.connectOnStart = settings.connectOnStart
   }
 
   private func setValue<T>(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/ProviderMessage.swift
@@ -7,20 +7,11 @@
 
 import Foundation
 
-// TODO: Can we simplify this / abstract it?
-// swiftlint:disable cyclomatic_complexity
-
 public enum ProviderMessage: Codable {
   case getResourceList(Data)
   case getConfiguration(Data)
+  case setConfiguration(Configuration)
   case signOut
-  case setAuthURL(String)
-  case setApiURL(String)
-  case setLogFilter(String)
-  case setActorName(String)
-  case setAccountSlug(String)
-  case setInternetResourceEnabled(Bool)
-  case setConnectOnStart(Bool)
   case clearLogs
   case getLogFolderSize
   case exportLogs
@@ -34,14 +25,8 @@ public enum ProviderMessage: Codable {
   enum MessageType: String, Codable {
     case getResourceList
     case getConfiguration
+    case setConfiguration
     case signOut
-    case setAuthURL
-    case setApiURL
-    case setLogFilter
-    case setActorName
-    case setAccountSlug
-    case setInternetResourceEnabled
-    case setConnectOnStart
     case clearLogs
     case getLogFolderSize
     case exportLogs
@@ -52,33 +37,15 @@ public enum ProviderMessage: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let type = try container.decode(MessageType.self, forKey: .type)
     switch type {
-    case .setAuthURL:
-      let value = try container.decode(String.self, forKey: .value)
-      self = .setAuthURL(value)
-    case .setApiURL:
-      let value = try container.decode(String.self, forKey: .value)
-      self = .setApiURL(value)
-    case .setLogFilter:
-      let value = try container.decode(String.self, forKey: .value)
-      self = .setLogFilter(value)
-    case .setActorName:
-      let value = try container.decode(String.self, forKey: .value)
-      self = .setActorName(value)
-    case .setAccountSlug:
-      let value = try container.decode(String.self, forKey: .value)
-      self = .setAccountSlug(value)
-    case .setInternetResourceEnabled:
-      let value = try container.decode(Bool.self, forKey: .value)
-      self = .setInternetResourceEnabled(value)
-    case .setConnectOnStart:
-      let value = try container.decode(Bool.self, forKey: .value)
-      self = .setConnectOnStart(value)
     case .getResourceList:
       let value = try container.decode(Data.self, forKey: .value)
       self = .getResourceList(value)
     case .getConfiguration:
       let value = try container.decode(Data.self, forKey: .value)
       self = .getConfiguration(value)
+    case .setConfiguration:
+      let value = try container.decode(Configuration.self, forKey: .value)
+      self = .setConfiguration(value)
     case .signOut:
       self = .signOut
     case .clearLogs:
@@ -95,32 +62,14 @@ public enum ProviderMessage: Codable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     switch self {
-    case .setAuthURL(let value):
-      try container.encode(MessageType.setAuthURL, forKey: .type)
-      try container.encode(value, forKey: .value)
-    case .setApiURL(let value):
-      try container.encode(MessageType.setApiURL, forKey: .type)
-      try container.encode(value, forKey: .value)
-    case .setLogFilter(let value):
-      try container.encode(MessageType.setLogFilter, forKey: .type)
-      try container.encode(value, forKey: .value)
-    case .setActorName(let value):
-      try container.encode(MessageType.setActorName, forKey: .type)
-      try container.encode(value, forKey: .value)
-    case .setAccountSlug(let value):
-      try container.encode(MessageType.setAccountSlug, forKey: .type)
-      try container.encode(value, forKey: .value)
-    case .setInternetResourceEnabled(let value):
-      try container.encode(MessageType.setInternetResourceEnabled, forKey: .type)
-      try container.encode(value, forKey: .value)
-    case .setConnectOnStart(let value):
-      try container.encode(MessageType.setConnectOnStart, forKey: .type)
-      try container.encode(value, forKey: .value)
     case .getResourceList(let value):
       try container.encode(MessageType.getResourceList, forKey: .type)
       try container.encode(value, forKey: .value)
     case .getConfiguration(let value):
       try container.encode(MessageType.getConfiguration, forKey: .type)
+      try container.encode(value, forKey: .value)
+    case .setConfiguration(let value):
+      try container.encode(MessageType.setConfiguration, forKey: .type)
       try container.encode(value, forKey: .value)
     case .signOut:
       try container.encode(MessageType.signOut, forKey: .type)
@@ -135,5 +84,3 @@ public enum ProviderMessage: Codable {
     }
   }
 }
-
-// swiftlint:enable cyclomatic_complexity

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -1,0 +1,97 @@
+//
+//  Settings.swift
+//  © 2025 Firezone, Inc.
+//  LICENSE: Apache-2.0
+//
+//  Settings represents the binding between our source-of-truth, Configuration, and user-configurable settings
+//  available in the SettingsView.
+
+import Foundation
+
+class Settings {
+  @Published var authURL: String
+  @Published var apiURL: String
+  @Published var logFilter: String
+  @Published var accountSlug: String
+  @Published var connectOnStart: Bool
+  var isAuthURLOverridden = false
+  var isApiURLOverridden = false
+  var isLogFilterOverridden = false
+  var isAccountSlugOverridden = false
+  var isConnectOnStartOverridden = false
+
+  private var configuration: Configuration
+
+  init(from configuration: Configuration) {
+    self.configuration = configuration
+    self.authURL = configuration.authURL ?? Configuration.defaultAuthURL
+    self.apiURL = configuration.apiURL ?? Configuration.defaultApiURL
+    self.logFilter = configuration.logFilter ?? Configuration.defaultLogFilter
+    self.accountSlug = configuration.accountSlug ?? Configuration.defaultAccountSlug
+    self.connectOnStart = configuration.connectOnStart ?? Configuration.defaultConnectOnStart
+
+    self.isAuthURLOverridden = configuration.isOverridden(Configuration.Keys.authURL)
+    self.isApiURLOverridden = configuration.isOverridden(Configuration.Keys.apiURL)
+    self.isLogFilterOverridden = configuration.isOverridden(Configuration.Keys.logFilter)
+    self.isAccountSlugOverridden = configuration.isOverridden(Configuration.Keys.accountSlug)
+    self.isConnectOnStartOverridden = configuration.isOverridden(Configuration.Keys.connectOnStart)
+  }
+
+  func areAllFieldsOverridden() -> Bool {
+    return (isAuthURLOverridden &&
+            isApiURLOverridden &&
+            isLogFilterOverridden &&
+            isAccountSlugOverridden &&
+            isConnectOnStartOverridden)
+  }
+
+  func isValid() -> Bool {
+    guard let apiURL = URL(string: apiURL),
+          apiURL.host != nil,
+          ["wss", "ws"].contains(apiURL.scheme),
+          apiURL.pathComponents.isEmpty
+    else {
+      return false
+    }
+
+    guard let authURL = URL(string: authURL),
+          authURL.host != nil,
+          ["http", "https"].contains(authURL.scheme),
+          authURL.pathComponents.isEmpty
+    else {
+      return false
+    }
+
+    guard !logFilter.isEmpty
+    else {
+      return false
+    }
+
+    return true
+  }
+
+  func isDefault() -> Bool {
+    return (authURL == Configuration.defaultAuthURL &&
+            apiURL == Configuration.defaultApiURL &&
+            logFilter == Configuration.defaultLogFilter &&
+            accountSlug == Configuration.defaultAccountSlug &&
+            connectOnStart == Configuration.defaultConnectOnStart)
+  }
+
+  func isSaved() -> Bool {
+    return (
+      authURL == configuration.authURL &&
+      apiURL == configuration.apiURL &&
+      logFilter == configuration.logFilter &&
+      accountSlug == configuration.accountSlug &&
+      connectOnStart == configuration.connectOnStart)
+  }
+
+  func reset() {
+    self.authURL = Configuration.defaultAuthURL
+    self.apiURL = Configuration.defaultApiURL
+    self.logFilter = Configuration.defaultLogFilter
+    self.accountSlug = Configuration.defaultAccountSlug
+    self.connectOnStart = Configuration.defaultConnectOnStart
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -210,6 +210,13 @@ public final class MenuBar: NSObject, ObservableObject {
         self.handleStatusChanged()
       }).store(in: &cancellables)
 
+    store.$configuration
+      .receive(on: DispatchQueue.main)
+      .sink(receiveValue: { [weak self] _ in
+        self?.updateSignInMenuItems()
+      })
+      .store(in: &cancellables)
+
     updateChecker.$updateAvailable
       .receive(on: DispatchQueue.main)
       .sink(receiveValue: { [weak self] _ in
@@ -350,13 +357,18 @@ public final class MenuBar: NSObject, ObservableObject {
       signOutMenuItem.isHidden = true
       settingsMenuItem.target = self
     case .connected, .reasserting, .connecting:
-      let title = "Signed in as \(store.configuration?.actorName ?? "Unknown User")"
+      let title = "Signed in as \(store.actorName)"
       signInMenuItem.title = title
       signInMenuItem.target = nil
       signOutMenuItem.isHidden = false
       settingsMenuItem.target = self
     @unknown default:
       break
+    }
+
+    // Configuration must be initialized to manage settings
+    if store.configuration == nil {
+      settingsMenuItem.target = nil
     }
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/iOSNavigationView.swift
@@ -60,7 +60,7 @@ struct iOSNavigationView<Content: View>: View { // swiftlint:disable:this type_n
   private var authMenu: some View {
     Menu {
       if store.status == .connected {
-        Text("Signed in as \(store.configuration?.actorName ?? "Unknown user")")
+        Text("Signed in as \(store.actorName)")
         Button(
           action: {
             signOutButtonTapped()

--- a/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
+++ b/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
@@ -19,9 +19,9 @@ class ConfigurationManager {
 
   // We maintain a cache of the user dictionary to buffer against unnecessary reads from UserDefaults which
   // can cause deadlocks in rare cases.
-  var userDict: [String: Any?]
+  private var userDict: [String: Any?]
 
-  var managedDict: [String: Any?] {
+  private var managedDict: [String: Any?] {
     userDefaults.dictionary(forKey: managedDictKey) ?? [:]
   }
 
@@ -33,39 +33,19 @@ class ConfigurationManager {
     Telemetry.firezoneId = userDict[Configuration.Keys.firezoneId] as? String
   }
 
-  func setAuthURL(_ authURL: String) {
-    userDict[Configuration.Keys.authURL] = authURL
+  // Save user-settable configuration
+  func setConfiguration(_ configuration: Configuration) {
+    userDict[Configuration.Keys.authURL] = configuration.authURL
+    userDict[Configuration.Keys.apiURL] = configuration.apiURL
+    userDict[Configuration.Keys.logFilter] = configuration.logFilter
+    userDict[Configuration.Keys.accountSlug] = configuration.accountSlug
+    userDict[Configuration.Keys.connectOnStart] = configuration.connectOnStart
+
     saveUserDict()
   }
 
-  func setApiURL(_ apiURL: String) {
-    userDict[Configuration.Keys.apiURL] = apiURL
-    saveUserDict()
-  }
-
-  func setLogFilter(_ logFilter: String) {
-    userDict[Configuration.Keys.logFilter] = logFilter
-    saveUserDict()
-  }
-
-  func setActorName(_ actorName: String) {
-    userDict[Configuration.Keys.actorName] = actorName
-    saveUserDict()
-  }
-
-  func setAccountSlug(_ accountSlug: String) {
-    userDict[Configuration.Keys.accountSlug] = accountSlug
-    saveUserDict()
-  }
-
-  func setInternetResourceEnabled(_ internetResourceEnabled: Bool) {
-    userDict[Configuration.Keys.internetResourceEnabled] = internetResourceEnabled
-    saveUserDict()
-  }
-
-  func setConnectOnStart(_ connectOnStart: Bool) {
-    userDict[Configuration.Keys.connectOnStart] = connectOnStart
-    saveUserDict()
+  func toConfiguration() -> Configuration {
+    return Configuration(userDict: userDict, managedDict: managedDict)
   }
 
   // Firezone ID migration. Can be removed once most clients migrate past 1.4.15.


### PR DESCRIPTION
The settings fields are getting tedious to manage individually, so a helper class `Settings` is added which abstracts all of the view-related logic applicable to user-defined settings.

When settings are saved, they are first applied to the `store`'s existing Configuration, and then that configuration is saved via a new consolidated IPC call `setConfiguration`.

`actorName` has been moved to a GUI-only cached store since it does not need to live on `Configuration` any longer.

This greatly simplifies both the view logic and the IPC interface.

Notably, this does not handle the edge case where the configuration is updated while the Settings window is open. That is saved for a later time.