### PR TITLE
fix(portal): Add ReplicationConnectionManager

### DIFF
--- a/elixir/apps/domain/lib/domain/application.ex
+++ b/elixir/apps/domain/lib/domain/application.ex
@@ -41,9 +41,7 @@ defmodule Domain.Application do
 
       # Observability
       Domain.Telemetry
-    ] ++
-      oban() ++
-      replication()
+    ] ++ oban() ++ replication()
   end
 
   defp configure_logger do
@@ -86,31 +84,9 @@ defmodule Domain.Application do
     config = Application.fetch_env!(:domain, Domain.Events.ReplicationConnection)
 
     if config[:enabled] do
-      [
-        replication_child_spec()
-      ]
+      [Domain.Events.ReplicationConnectionManager]
     else
       []
     end
-  end
-
-  defp replication_child_spec do
-    {connection_opts, config} =
-      Application.fetch_env!(:domain, Domain.Events.ReplicationConnection)
-      |> Keyword.pop(:connection_opts)
-
-    init_state = %{
-      connection_opts: connection_opts,
-      instance: struct(Domain.Events.ReplicationConnection, config)
-    }
-
-    %{
-      id: Domain.Events.ReplicationConnection,
-      start: {Domain.Events.ReplicationConnection, :start_link, [init_state]},
-      restart: :transient,
-      # Allow up to 240 restarts in 20 minutes - covers duration of a deploy
-      max_restarts: 240,
-      max_seconds: 1200
-    }
   end
 end

--- a/elixir/apps/domain/lib/domain/events/replication_connection_manager.ex
+++ b/elixir/apps/domain/lib/domain/events/replication_connection_manager.ex
@@ -1,0 +1,70 @@
+defmodule Domain.Events.ReplicationConnectionManager do
+  @moduledoc """
+    Manages the Postgrex.ReplicationConnection to ensure that we always have one running to prevent
+    unbounded growth of the WAL log and ensure we are processing events.
+  """
+  use GenServer
+  require Logger
+
+  @retry_interval :timer.seconds(30)
+
+  # Should be enough to gracefully handle transient network issues and DB restarts,
+  # but not too long to avoid broadcasting needed events.
+  @max_retries 10
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    send(self(), :connect)
+
+    {:ok, %{retries: 0}}
+  end
+
+  @impl true
+  def handle_info(:connect, %{retries: retries} = state) do
+    Process.send_after(self(), :connect, @retry_interval)
+
+    case Domain.Events.ReplicationConnection.start_link(replication_child_spec()) do
+      {:ok, _pid} ->
+        # Our process won
+        {:noreply, %{state | retries: 0}}
+
+      {:error, {:already_started, _pid}} ->
+        # Another process already started the connection
+        {:noreply, %{state | retries: 0}}
+
+      {:error, reason} ->
+        if retries < @max_retries do
+          Logger.info("Failed to start replication connection",
+            retries: retries,
+            max_retries: @max_retries,
+            reason: inspect(reason)
+          )
+
+          {:noreply, %{state | retries: retries + 1}}
+        else
+          Logger.error(
+            "Failed to start replication connection after #{@max_retries} attempts, giving up!",
+            reason: inspect(reason)
+          )
+
+          # Let the supervisor restart us
+          {:stop, :normal, state}
+        end
+    end
+  end
+
+  defp replication_child_spec do
+    {connection_opts, config} =
+      Application.fetch_env!(:domain, Domain.Events.ReplicationConnection)
+      |> Keyword.pop(:connection_opts)
+
+    %{
+      connection_opts: connection_opts,
+      instance: struct(Domain.Events.ReplicationConnection, config)
+    }
+  end
+end


### PR DESCRIPTION
When deploying, new Elixir nodes are spun up before the old ones are brought down. This ensures that the state in the cluster is merge into the new nodes between the old ones go away.

This also means, however, that the existing WAL consumer is still up when our new one tries to come online.

Normally, this isn't an issue, because we find the old pid and return it with `{:ok, existing_pid}`. When that VM goes away, the Supervisor(s) of the new application notice and restart it,

However, if the cluster state diverges or is inconsistent during this period, we may fail to find the existing pid, and try to start a new ReplicationConnection. If the old pid is still active, this will fail because there's a mutex on the connection. The original implementation was designed to handle this case using the Supervisor with a `:transient` restart policy.

What the author failed to understand is that the restart policy applies only to _restarts_ and not initial starts, so if all of the new application servers fail to find the old pid which is still connected, and they all fail to come up, we won't consume the WAL.

This is fixed with a `ReplicationConnectionManager` that always comes up fine, and then simply tries to start a `ReplicationConnection` every 30s, giving up after 5 minutes if it can't start one or find an existing one. This will crash, causing the Supervisor to restart us, and then notify us.