### PR TITLE
feat(gui-client): re-design welcome screen

### DIFF
--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -71,9 +71,9 @@
         "title": "Welcome",
         "url": "src/welcome.html",
         "fullscreen": false,
-        "resizable": true,
-        "width": 640,
-        "height": 480,
+        "resizable": false,
+        "width": 800,
+        "height": 450,
         "visible": false
       }
     ]

--- a/rust/gui-client/src/welcome.html
+++ b/rust/gui-client/src/welcome.html
@@ -9,46 +9,51 @@
     <script type="module" src="welcome.ts" defer></script>
   </head>
 
-  <body class="bg-neutral-100 text-neutral-900">
-    <div class="container mx-auto">
-      <div class="flex justify-center mt-8">
-        <h1 class="text-3xl font-bold">Welcome to Firezone.</h1>
+  <body
+    class="bg-neutral-100 min-h-screen flex items-center flex-col justify-center gap-4"
+  >
+    <img src="logo.png" alt="Firezone Logo" class="w-40 h-40" />
+
+    <h1 class="text-6xl font-bold">Firezone</h1>
+
+    <div id="signed-out">
+      <div class="flex flex-col items-center gap-4">
+        <p class="text-center">
+          You can sign in by clicking the Firezone icon the task bar or by clicking 'Sign-in' below.
+        </p>
+        <button
+          class="text-white bg-accent-450 hover:bg-accent-700 font-medium rounded-md text-md px-5 py-1.5"
+          id="sign-in"
+        >
+          Sign in
+        </button>
+        <p class="text-xs text-center">
+          Firezone will continue running after this window is closed.</br>
+          It is always available from the task bar.
+        </p>
       </div>
+    </div>
 
-      <img
-        src="logo.png"
-        alt="Firezone Logo"
-        class="mt-8 rounded-full w-48 h-48 mx-auto bg-white shadow-sm border-2 border-black"
-      />
-
-      <div id="signed-out">
-        <p class="mt-8 flex justify-center">Sign in below to get started.</p>
-        <div class="flex justify-center mt-8">
-          <button
-            class="text-white bg-accent-450 hover:bg-accent-700 font-medium rounded-sm text-lg w-full sm:w-auto px-5 py-2.5 text-center"
-            id="sign-in"
-          >
-            Sign in
-          </button>
-        </div>
-      </div>
-
-      <div id="signed-in">
-        <p class="mt-8 flex justify-center">
-          You are currently signed into&nbsp;<span
+    <div id="signed-in">
+      <div class="flex flex-col items-center gap-4">
+        <p class="text-center">
+            You are currently signed into&nbsp;<span
             class="font-bold"
             id="account-slug"
-          ></span
-          >&nbsp;as&nbsp;<span class="font-bold" id="actor-name"></span>.
+            ></span
+            >&nbsp;as&nbsp;<span class="font-bold" id="actor-name"></span>.</br>
+            Click the Firezone icon in the task bar to see the list of Resources.
         </p>
-        <div class="flex justify-center mt-8">
-          <button
-            class="text-white bg-accent-450 hover:bg-accent-700 font-medium rounded-sm text-lg w-full sm:w-auto px-5 py-2.5 text-center"
-            id="sign-out"
+        <button
+            class="text-white bg-accent-450 hover:bg-accent-700 font-medium rounded-md text-md px-5 py-1.5"
+          id="sign-out"
           >
-            Sign out
-          </button>
-        </div>
+          Sign out
+        </button>
+        <p class="text-xs text-center">
+          Firezone will continue running after this window is closed.</br>
+          It is always available from the task bar.
+        </p>
       </div>
     </div>
   </body>


### PR DESCRIPTION
Inspired by the MacOS client welcome screen, we re-design the GUI client's welcome screen.

## Signed out state

|Before|After|
|---|---|
|![before](https://github.com/user-attachments/assets/f3b8c933-09b8-4971-8598-b407d23f794b)|![after](https://github.com/user-attachments/assets/ae37cb3c-897d-4019-8977-d4d467c4f31b)|

## Signed in state

|Before|After|
|---|---|
|![before](https://github.com/user-attachments/assets/9cebb95c-9974-4f51-baa4-952e937d9a2f)|![after](https://github.com/user-attachments/assets/180ad75e-260d-4a32-b207-90e1223dc148)|

In addition to the re-design, we set the window to be not resizable.