### PR TITLE
chore(rust): fix windows static analysis errors

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -339,7 +339,7 @@ impl tun::Tun for Tun {
         ready!(
             self.state
                 .as_mut()
-                .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Internal state gone"))?
+                .ok_or_else(|| io::Error::other("Internal state gone"))?
                 .outbound_tx
                 .poll_reserve(cx)
                 .map_err(io::Error::other)?
@@ -352,7 +352,7 @@ impl tun::Tun for Tun {
     fn send(&mut self, packet: IpPacket) -> io::Result<()> {
         self.state
             .as_mut()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Internal state gone"))?
+            .ok_or_else(|| io::Error::other("Internal state gone"))?
             .outbound_tx
             .send_item(packet)
             .map_err(io::Error::other)?;


### PR DESCRIPTION
The `static-analysis` job for Windows was not yet part of the rule set and therefore some clippy errors slipped through when we merged #9159.