### PR TITLE
fix(rust): bump version of GUI client in rpm spec

### DIFF
--- a/rust/gui-client/src-tauri/rpm_files/firezone-gui-client.spec
+++ b/rust/gui-client/src-tauri/rpm_files/firezone-gui-client.spec
@@ -1,6 +1,6 @@
 Name: firezone-client-gui
 # mark:next-gui-version
-Version: 1.3.11
+Version: 1.4.14
 Release: 1%{?dist}
 Summary: The GUI Client for Firezone
 

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -139,6 +139,7 @@ function gui() {
     find .github -type f -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_version}"'/g;}' {} \;
     find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_version}"'/;}' {} \;
     find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_version}"'/;}' {} \;
+    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "*.spec" -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_version}"'/;}' {} \;
     cargo_update_workspace
 }
 


### PR DESCRIPTION
Our bump-versions script did not consider that we also have the version stored in the `.spec` file for rpm builds and hence this did not get bumped in a while (or ever?).