### PR TITLE
fix(gui-client): reference `CARGO_PKG_VERSION` in service

### DIFF
--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -474,10 +474,7 @@ impl<'a> Handler<'a> {
         // Synchronous DNS resolution here
         let portal = PhoenixChannel::disconnected(
             Secret::new(url),
-            // The IPC service must use the GUI's version number, not the Headless Client's.
-            // But refactoring to separate the IPC service from the Headless Client will take a while.
-            // mark:next-gui-version
-            get_user_agent(None, "1.4.14"),
+            get_user_agent(None, env!("CARGO_PKG_VERSION")),
             "client",
             (),
             || {


### PR DESCRIPTION
Now that we have moved all files of the Tunnel service into the `gui-client` crate, we can directly reference the `CARGO_PKG_VERSION` env variable instead of having to hard-code the number in the source-code.