### PR TITLE
feat(apple): Disable the update checker for MDM and App store

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -13,6 +13,7 @@ public class Configuration: Codable {
 
   public static let defaultAccountSlug = ""
   public static let defaultConnectOnStart = true
+  public static let defaultDisableUpdateCheck = false
 
   public struct Keys {
     public static let authURL = "authURL"
@@ -23,6 +24,7 @@ public class Configuration: Codable {
     public static let firezoneId = "firezoneId"
     public static let hideAdminPortalMenuItem = "hideAdminPortalMenuItem"
     public static let connectOnStart = "connectOnStart"
+    public static let disableUpdateCheck = "disableUpdateCheck"
   }
 
   public var authURL: String?
@@ -33,6 +35,7 @@ public class Configuration: Codable {
   public var internetResourceEnabled: Bool?
   public var hideAdminPortalMenuItem: Bool?
   public var connectOnStart: Bool?
+  public var disableUpdateCheck: Bool?
 
   private var overriddenKeys: Set<String> = []
 
@@ -51,6 +54,9 @@ public class Configuration: Codable {
     }
     setValue(forKey: Keys.connectOnStart, from: managedDict, and: userDict) { [weak self] in
       self?.connectOnStart = $0
+    }
+    setValue(forKey: Keys.disableUpdateCheck, from: managedDict, and: userDict) { [weak self] in
+      self?.disableUpdateCheck = $0
     }
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -25,7 +25,7 @@ public final class MenuBar: NSObject, ObservableObject {
   var lastShownOthers: [Resource] = []
   var wasInternetResourceEnabled: Bool?
   var cancellables: Set<AnyCancellable> = []
-  var updateChecker: UpdateChecker = UpdateChecker()
+  var updateChecker: UpdateChecker
   var updateMenuDisplayed: Bool = false
   var signedOutIcon: NSImage?
   var signedInConnectedIcon: NSImage?
@@ -167,6 +167,7 @@ public final class MenuBar: NSObject, ObservableObject {
   public init(store: Store) {
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     self.store = store
+    self.updateChecker = UpdateChecker(store: store)
     self.signedOutIcon = NSImage(named: "MenuBarIconSignedOut")
     self.signedInConnectedIcon = NSImage(named: "MenuBarIconSignedInConnected")
     self.signedOutIconNotification = NSImage(named: "MenuBarIconSignedOutNotification")


### PR DESCRIPTION
For App Store installed macOS clients, it doesn't make sense to run an update checker, because the system is managing the updates, and will notify the user if there's an update available for Firezone (the user has configured the system to manage app updates).

Related: #7664 
Related: #4505 