### PR TITLE
feat(apple): Add start on login functionality

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -60,6 +60,7 @@ public class Configuration: Codable {
     }
     setValue(forKey: Keys.startOnLogin, from: managedDict, and: userDict) { [weak self] in
       self?.startOnLogin = $0
+    }
     setValue(forKey: Keys.disableUpdateCheck, from: managedDict, and: userDict) { [weak self] in
       self?.disableUpdateCheck = $0
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -13,6 +13,7 @@ public class Configuration: Codable {
 
   public static let defaultAccountSlug = ""
   public static let defaultConnectOnStart = true
+  public static let defaultStartOnLogin = false
 
   public struct Keys {
     public static let authURL = "authURL"
@@ -23,6 +24,7 @@ public class Configuration: Codable {
     public static let firezoneId = "firezoneId"
     public static let hideAdminPortalMenuItem = "hideAdminPortalMenuItem"
     public static let connectOnStart = "connectOnStart"
+    public static let startOnLogin = "startOnLogin"
   }
 
   public var authURL: String?
@@ -33,6 +35,7 @@ public class Configuration: Codable {
   public var internetResourceEnabled: Bool?
   public var hideAdminPortalMenuItem: Bool?
   public var connectOnStart: Bool?
+  public var startOnLogin: Bool?
 
   private var overriddenKeys: Set<String> = []
 
@@ -52,6 +55,9 @@ public class Configuration: Codable {
     setValue(forKey: Keys.connectOnStart, from: managedDict, and: userDict) { [weak self] in
       self?.connectOnStart = $0
     }
+    setValue(forKey: Keys.startOnLogin, from: managedDict, and: userDict) { [weak self] in
+      self?.startOnLogin = $0
+    }
   }
 
   func isOverridden(_ key: String) -> Bool {
@@ -64,6 +70,7 @@ public class Configuration: Codable {
     self.logFilter = settings.logFilter
     self.accountSlug = settings.accountSlug
     self.connectOnStart = settings.connectOnStart
+    self.startOnLogin = settings.startOnLogin
   }
 
   private func setValue<T>(

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Settings.swift
@@ -14,11 +14,13 @@ class Settings {
   @Published var logFilter: String
   @Published var accountSlug: String
   @Published var connectOnStart: Bool
+  @Published var startOnLogin: Bool
   var isAuthURLOverridden = false
   var isApiURLOverridden = false
   var isLogFilterOverridden = false
   var isAccountSlugOverridden = false
   var isConnectOnStartOverridden = false
+  var isStartOnLoginOverridden = false
 
   private var configuration: Configuration
 
@@ -29,12 +31,14 @@ class Settings {
     self.logFilter = configuration.logFilter ?? Configuration.defaultLogFilter
     self.accountSlug = configuration.accountSlug ?? Configuration.defaultAccountSlug
     self.connectOnStart = configuration.connectOnStart ?? Configuration.defaultConnectOnStart
+    self.startOnLogin = configuration.startOnLogin ?? Configuration.defaultStartOnLogin
 
     self.isAuthURLOverridden = configuration.isOverridden(Configuration.Keys.authURL)
     self.isApiURLOverridden = configuration.isOverridden(Configuration.Keys.apiURL)
     self.isLogFilterOverridden = configuration.isOverridden(Configuration.Keys.logFilter)
     self.isAccountSlugOverridden = configuration.isOverridden(Configuration.Keys.accountSlug)
     self.isConnectOnStartOverridden = configuration.isOverridden(Configuration.Keys.connectOnStart)
+    self.isStartOnLoginOverridden = configuration.isOverridden(Configuration.Keys.startOnLogin)
   }
 
   func areAllFieldsOverridden() -> Bool {
@@ -42,7 +46,8 @@ class Settings {
             isApiURLOverridden &&
             isLogFilterOverridden &&
             isAccountSlugOverridden &&
-            isConnectOnStartOverridden)
+            isConnectOnStartOverridden &&
+            isStartOnLoginOverridden)
   }
 
   func isValid() -> Bool {
@@ -75,7 +80,8 @@ class Settings {
             apiURL == Configuration.defaultApiURL &&
             logFilter == Configuration.defaultLogFilter &&
             accountSlug == Configuration.defaultAccountSlug &&
-            connectOnStart == Configuration.defaultConnectOnStart)
+            connectOnStart == Configuration.defaultConnectOnStart &&
+            startOnLogin == Configuration.defaultStartOnLogin)
   }
 
   func isSaved() -> Bool {
@@ -84,7 +90,8 @@ class Settings {
       apiURL == configuration.apiURL &&
       logFilter == configuration.logFilter &&
       accountSlug == configuration.accountSlug &&
-      connectOnStart == configuration.connectOnStart)
+      connectOnStart == configuration.connectOnStart &&
+      startOnLogin == configuration.startOnLogin)
   }
 
   func reset() {
@@ -93,5 +100,6 @@ class Settings {
     self.logFilter = Configuration.defaultLogFilter
     self.accountSlug = Configuration.defaultAccountSlug
     self.connectOnStart = Configuration.defaultConnectOnStart
+    self.startOnLogin = Configuration.defaultStartOnLogin
   }
 }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -8,6 +8,7 @@ import Combine
 import NetworkExtension
 import UserNotifications
 import OSLog
+import ServiceManagement
 
 #if os(macOS)
 import AppKit
@@ -158,15 +159,12 @@ public final class Store: ObservableObject {
   // can fetch configuration. We try a few times here to do that so that we can determine connectOnStart, before
   // giving up and polling configuration anyway.
   private func initConfiguration() async throws {
-    var configuration: Configuration?
     let end = Date().addingTimeInterval(3)
 
     while configuration == nil && Date() < end {
-      configuration = try await getConfigurationStartingSystemExtension()
+      _ = try await reloadConfigurationStartingSystemExtension()
       try await Task.sleep(nanoseconds: 100_000_000)
     }
-
-    self.configuration = configuration
 
     beginConfigurationPolling()
   }
@@ -267,7 +265,7 @@ public final class Store: ObservableObject {
           self.configurationUpdateTask = Task {
             if !Task.isCancelled {
               do {
-                self.configuration = try await self.getConfigurationStartingSystemExtension()
+                _ = try await self.reloadConfigurationStartingSystemExtension()
               } catch let error as NSError {
                 // https://developer.apple.com/documentation/networkextension/nevpnerror-swift.struct/code
                 if error.domain == "NEVPNErrorDomain" && error.code == 1 {
@@ -291,7 +289,7 @@ public final class Store: ObservableObject {
     self.configurationTimer = timer
   }
 
-  private func getConfigurationStartingSystemExtension() async throws -> Configuration? {
+  private func reloadConfigurationStartingSystemExtension() async throws -> Configuration? {
     var configuration = try await ipcClient().getConfiguration()
 
 #if os(macOS)
@@ -301,11 +299,32 @@ public final class Store: ObservableObject {
     }
 #endif
 
+    self.configuration = configuration
+
     if Telemetry.firezoneId == nil {
       Telemetry.firezoneId = configuration?.firezoneId
     }
 
+    try await updateAppService()
+
     return configuration
+  }
+
+  // Register / unregister our launch service based on configuration. This is a major pain to do on macOS 12 and below,
+  // so this feature only enabled for macOS 13 and higher given the tiny Firezone installbase for macOS 12.
+  private func updateAppService() async throws {
+    if #available(macOS 13.0, *) {
+      let startOnLogin = configuration?.startOnLogin ?? Configuration.defaultStartOnLogin
+
+      if !startOnLogin, SMAppService.mainApp.status == .enabled {
+        try await SMAppService.mainApp.unregister()
+        return
+      }
+
+      if startOnLogin, SMAppService.mainApp.status != .enabled {
+        try SMAppService.mainApp.register()
+      }
+    }
   }
 
   // Network Extensions don't have a 2-way binding up to the GUI process,

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -8,9 +8,9 @@ import Combine
 import NetworkExtension
 import UserNotifications
 import OSLog
-import ServiceManagement
 
 #if os(macOS)
+import ServiceManagement
 import AppKit
 #endif
 
@@ -313,6 +313,7 @@ public final class Store: ObservableObject {
   // Register / unregister our launch service based on configuration. This is a major pain to do on macOS 12 and below,
   // so this feature only enabled for macOS 13 and higher given the tiny Firezone installbase for macOS 12.
   private func updateAppService() async throws {
+#if os(macOS)
     if #available(macOS 13.0, *) {
       let startOnLogin = configuration?.startOnLogin ?? Configuration.defaultStartOnLogin
 
@@ -325,6 +326,7 @@ public final class Store: ObservableObject {
         try SMAppService.mainApp.register()
       }
     }
+#endif
   }
 
   // Network Extensions don't have a 2-way binding up to the GUI process,

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -376,7 +376,7 @@ public struct SettingsView: View {
             Text("Automatically connect when Firezone is launched")
           }
           .toggleStyle(.checkbox)
-          .disabled(viewModel.settings.isConnectOnStartOverridden)
+          .disabled(viewModel.settings.isStartOnLoginOverridden)
 
           Toggle(isOn: $viewModel.settings.startOnLogin) {
             Text("Start Firezone when you sign into your Mac")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -129,12 +129,15 @@ class SettingsViewModel: ObservableObject {
     })
     .store(in: &cancellables)
 
-    settings.$connectOnStart
-      .receive(on: RunLoop.main)
-      .sink(receiveValue: { [weak self] _ in
-        self?.updateDerivedState()
-      })
-      .store(in: &cancellables)
+    Publishers.MergeMany([
+      settings.$connectOnStart,
+      settings.$startOnLogin
+    ])
+    .receive(on: RunLoop.main)
+    .sink(receiveValue: { [weak self] _ in
+      self?.updateDerivedState()
+    })
+    .store(in: &cancellables)
   }
 
   private func updateDerivedState() {
@@ -368,8 +371,15 @@ public struct SettingsView: View {
             .frame(width: 250)
           }
           .padding(.bottom, 10)
+
           Toggle(isOn: $viewModel.settings.connectOnStart) {
-            Text("Connect on launch")
+            Text("Automatically connect when Firezone is launched")
+          }
+          .toggleStyle(.checkbox)
+          .disabled(viewModel.settings.isConnectOnStartOverridden)
+
+          Toggle(isOn: $viewModel.settings.startOnLogin) {
+            Text("Start Firezone when you sign into your Mac")
           }
           .toggleStyle(.checkbox)
           .disabled(viewModel.settings.isConnectOnStartOverridden)
@@ -401,7 +411,7 @@ public struct SettingsView: View {
               Spacer()
 
               Toggle(isOn: $viewModel.settings.connectOnStart) {
-                Text("Connect on launch")
+                Text("Automatically connect when Firezone is launched")
               }
               .toggleStyle(.switch)
               .disabled(viewModel.settings.isConnectOnStartOverridden)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -376,13 +376,13 @@ public struct SettingsView: View {
             Text("Automatically connect when Firezone is launched")
           }
           .toggleStyle(.checkbox)
-          .disabled(viewModel.settings.isStartOnLoginOverridden)
+          .disabled(viewModel.settings.isConnectOnStartOverridden)
 
           Toggle(isOn: $viewModel.settings.startOnLogin) {
             Text("Start Firezone when you sign into your Mac")
           }
           .toggleStyle(.checkbox)
-          .disabled(viewModel.settings.isConnectOnStartOverridden)
+          .disabled(viewModel.settings.isStartOnLoginOverridden)
         }
         .padding(10)
         Spacer()

--- a/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
+++ b/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
@@ -40,6 +40,7 @@ class ConfigurationManager {
     userDict[Configuration.Keys.logFilter] = configuration.logFilter
     userDict[Configuration.Keys.accountSlug] = configuration.accountSlug
     userDict[Configuration.Keys.connectOnStart] = configuration.connectOnStart
+    userDict[Configuration.Keys.startOnLogin] = configuration.startOnLogin
 
     saveUserDict()
   }


### PR DESCRIPTION
Adds a new settings/configuration item `startOnLogin` which simply adds a "Login Item" which starts Firezone after signing into the Mac.

This feature is macOS 13 and above only because otherwise we will need to bundle a helper application to register as a service to start the app. Given our very small footprint of macOS 12 users, and how unsupported it is, this is ok.

When it comes time to implement MDM for this feature, note that Apple provides a means to enforce login items via the [`ServiceManagementLoginItems` payload](https://developer.apple.com/documentation/devicemanagement/servicemanagementmanagedloginitems) which is outside the scope of `com.apple.configuration.managed`. This enforces the login item in System Settings so that the user is unable to disable it.

We also add functionality here, but bear in mind that even if we disable the Toggle switch in our Settings page, the user could still disable the item in system settings unless it is being set through MDM via the service management key above.

Another thing to note is that this setting is applied on the GUI side of the tunnel only, because it is inherently tied to the process it is running as. We are not able to (nor does it make sense to) enable the login item for the tunnel service. This should be fine.

Tested to ensure enabling/disabling appropriately adds and removes the login item (and re-adds it if I manually remove it from system settings).


Related: #8916 
Related: #2306 