### PR TITLE
feat(apple): Apply MDM changes to Configuration

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -176,8 +176,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         completionHandler?(configurationPayload)
 
       case .setConfiguration(let configuration):
-        self.configuration = configuration
         ConfigurationManager.shared.setConfiguration(configuration)
+        self.configuration = ConfigurationManager.shared.toConfiguration()
         completionHandler?(nil)
 
       case .signOut:


### PR DESCRIPTION
When the MDM installs a configuration payload to `dev.firezone.firezone.network-extension`, the tunnel service will now be notified of a change to its `managedDict`, applying the configuration and updating `packetTunnelProvider`'s local copy so that it'll be returned on the next configuration fetch from the UI.

Related: #4505 