### PR TITLE
feat(portal): Add broadcast to simulate more real-world events

### DIFF
--- a/elixir/apps/domain/lib/domain/events/event.ex
+++ b/elixir/apps/domain/lib/domain/events/event.ex
@@ -17,6 +17,9 @@ defmodule Domain.Events.Event do
     data = zip(tuple_data, relation.columns)
 
     process(op, table, old_data, data)
+
+    # TODO: This is only for load testing. Remove this.
+    Domain.PubSub.broadcast("events", {op, table, old_data, data})
   end
 
   ############


### PR DESCRIPTION
We are currently consuming the WAL on production and it has shown very little cost in terms of resource usage.

It would be better to get a more real-world test by sending actual broadcasts with data.

To do this, we simply send a `Domain.PubSub.broadcast` with all of the data received in the WAL message, which represents an absolute worst-case scenario.