### PR TITLE
refactor(apple): Only apply MDM config when changed

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
+++ b/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
@@ -80,7 +80,17 @@ class ConfigurationManager {
   }
 
   @objc private func handleUserDefaultsChanged(_ notification: Notification) {
-    self.managedDict = userDefaults.dictionary(forKey: managedDictKey) ?? [:]
+    let newManagedDict = (userDefaults.dictionary(forKey: managedDictKey) ?? [:]) as [String: Any?]
+
+    // NSDictionary conforms to Equatable
+    if (managedDict as NSDictionary) != (newManagedDict as NSDictionary) {
+      Log.log("""
+        Applying MDM configuration:
+          Old: \(managedDict)
+          New: \(newManagedDict)
+      """)
+      self.managedDict = newManagedDict
+    }
   }
 
   private func saveUserDict() {

--- a/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
+++ b/swift/apple/FirezoneNetworkExtension/ConfigurationManager.swift
@@ -83,14 +83,12 @@ class ConfigurationManager {
     let newManagedDict = (userDefaults.dictionary(forKey: managedDictKey) ?? [:]) as [String: Any?]
 
     // NSDictionary conforms to Equatable
-    if (managedDict as NSDictionary) != (newManagedDict as NSDictionary) {
-      Log.log("""
-        Applying MDM configuration:
-          Old: \(managedDict)
-          New: \(newManagedDict)
-      """)
-      self.managedDict = newManagedDict
+    if (managedDict as NSDictionary) == (newManagedDict as NSDictionary) {
+      return
     }
+
+    Log.log("Applying MDM configuration. Old: \(managedDict) New: \(newManagedDict)")
+    self.managedDict = newManagedDict
   }
 
   private func saveUserDict() {


### PR DESCRIPTION
In #9169 we applied MDM configuration from MDM upon _any_ change to UserDefaults. This is unnecessary.

Instead, we can compare new vs old and only apply the new dict if there's changes.

In this PR we also log the old and new dicts for debugging reasons.