### PR TITLE
fix(portal): bump width of default auth provider selection

### DIFF
--- a/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
@@ -93,11 +93,13 @@ defmodule Web.Settings.IdentityProviders.Index do
           ordered_by={@order_by_table_id["providers"]}
           metadata={@providers_metadata}
         >
-          <:col :let={provider} field={{:providers, :name}} label="Name" class="w-2/12">
-            <.link navigate={view_provider(@account, provider)} class={[link_style()]}>
-              {provider.name}
-            </.link>
-            <.assigned_default_badge provider={provider} />
+          <:col :let={provider} field={{:providers, :name}} label="Name" class="w-3/12">
+            <div class="flex flex-wrap">
+              <.link navigate={view_provider(@account, provider)} class={[link_style()]}>
+                {provider.name}
+              </.link>
+              <.assigned_default_badge provider={provider} />
+            </div>
           </:col>
           <:col :let={provider} label="Type" class="w-2/12">
             {adapter_name(provider.adapter)}
@@ -163,15 +165,13 @@ defmodule Web.Settings.IdentityProviders.Index do
       for={nil}
     >
       <div class="flex gap-2 items-center">
-        <div class="flex-1 min-w-[12rem]">
-          <.input
-            id="default-provider-select"
-            name="provider_id"
-            type="select"
-            options={@options}
-            value={@value}
-          />
-        </div>
+        <.input
+          id="default-provider-select"
+          name="provider_id"
+          type="select"
+          options={@options}
+          value={@value}
+        />
         <.submit_button
           phx-disable-with="Saving..."
           {if @default_provider_changed, do: [], else: [disabled: true, style: "disabled"]}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
@@ -163,7 +163,7 @@ defmodule Web.Settings.IdentityProviders.Index do
       for={nil}
     >
       <div class="flex gap-2 items-center">
-        <div class="w-48">
+        <div class="flex-1 min-w-[12rem]">
           <.input
             id="default-provider-select"
             name="provider_id"

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/index.ex
@@ -163,7 +163,7 @@ defmodule Web.Settings.IdentityProviders.Index do
       for={nil}
     >
       <div class="flex gap-2 items-center">
-        <div class="w-32">
+        <div class="w-48">
           <.input
             id="default-provider-select"
             name="provider_id"


### PR DESCRIPTION
This is just a bit short at the moment:

<img width="467" alt="Screenshot 2025-05-16 at 3 55 55 PM" src="https://github.com/user-attachments/assets/6d4b6d6d-d3a2-453e-a860-cb638127f684" />
