### PR TITLE
refactor(gui-client): scope telemetry sessions to GUI client

### DIFF
--- a/rust/bin-shared/src/device_id.rs
+++ b/rust/bin-shared/src/device_id.rs
@@ -8,6 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[derive(Debug, Clone)]
 pub struct DeviceId {
     pub id: String,
 }

--- a/rust/gui-client/src-tauri/src/service/linux.rs
+++ b/rust/gui-client/src-tauri/src/service/linux.rs
@@ -3,8 +3,6 @@ use std::path::PathBuf;
 use anyhow::{Result, bail};
 use firezone_bin_shared::{DnsControlMethod, signals};
 
-use firezone_telemetry::Telemetry;
-
 /// Cross-platform entry point for systemd / Windows services
 ///
 /// Linux uses the CLI args from here, Windows does not
@@ -18,20 +16,12 @@ pub fn run(log_dir: Option<PathBuf>, dns_control: DnsControlMethod) -> Result<()
         .build()?;
     let _guard = rt.enter();
     let mut signals = signals::Terminate::new()?;
-    let mut telemetry = Telemetry::default();
 
     rt.block_on(super::ipc_listen(
         dns_control,
         &log_filter_reloader,
         &mut signals,
-        &mut telemetry,
     ))
-    .inspect(|_| rt.block_on(telemetry.stop()))
-    .inspect_err(|e| {
-        tracing::error!("Tunnel service failed: {e:#}");
-
-        rt.block_on(telemetry.stop_on_crash())
-    })
 }
 
 /// Returns true if the Tunnel service can run properly

--- a/rust/gui-client/src-tauri/src/service/linux.rs
+++ b/rust/gui-client/src-tauri/src/service/linux.rs
@@ -22,6 +22,7 @@ pub fn run(log_dir: Option<PathBuf>, dns_control: DnsControlMethod) -> Result<()
         &log_filter_reloader,
         &mut signals,
     ))
+    .inspect_err(|e| tracing::error!("IPC service failed: {e:#}"))
 }
 
 /// Returns true if the Tunnel service can run properly

--- a/rust/gui-client/src-tauri/src/service/windows.rs
+++ b/rust/gui-client/src-tauri/src/service/windows.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context as _, Result};
 use firezone_bin_shared::DnsControlMethod;
-use firezone_logging::FilterReloadHandle;
 use futures::channel::mpsc;
 use std::path::PathBuf;
 use std::{
@@ -283,7 +282,7 @@ fn run_service(arguments: Vec<OsString>) {
     let result = rt
         .block_on(super::ipc_listen(
             DnsControlMethod::Nrpt,
-            log_filter_reloader,
+            &log_filter_reloader,
             &mut signals,
         ))
         .inspect_err(|e| tracing::error!("Tunnel service failed: {e:#}"));


### PR DESCRIPTION
For our telemetry sessions with Sentry, we need to know which environment we are running in, i.e. staging, production or on-prem. The GUI client's tunnel service doesn't have a concept of an environment until a GUI connects and sends the `StartTelemetry` message. Therefore, we should scope a telemetry session to a GUI being connected over IPC.

Any errors around setting up / tearing down the background service are a catch-22. Until a GUI connects, we can't initialise the telemetry connection but if we fail to set up the background service, no GUI can ever connect. Hence, the current setup and tear down of the `Telemetry` module around the `ipc_listen` calls can safely be removed as they are effectively no-ops anyway.