### PR TITLE
fix(ci): Revert removal of `CURRENT_PROJECT_VERSION`

### DIFF
--- a/scripts/build/ios-appstore.sh
+++ b/scripts/build/ios-appstore.sh
@@ -27,12 +27,14 @@ fi
 
 # Build and sign app
 echo "Building and signing app..."
+seconds_since_epoch=$(date +%s)
 xcodebuild archive \
     GIT_SHA="$git_sha" \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGN_IDENTITY="$code_sign_identity" \
     APP_PROFILE_ID="$app_profile_id" \
     NE_PROFILE_ID="$ne_profile_id" \
+    CURRENT_PROJECT_VERSION="$seconds_since_epoch" \
     -project "$project_file" \
     -skipMacroValidation \
     -archivePath "$archive_path" \

--- a/scripts/build/macos-appstore.sh
+++ b/scripts/build/macos-appstore.sh
@@ -27,6 +27,7 @@ fi
 
 # Build and sign
 echo "Building and signing app..."
+seconds_since_epoch=$(date +%s)
 xcodebuild build \
     GIT_SHA="$git_sha" \
     CODE_SIGN_STYLE=Manual \
@@ -34,6 +35,7 @@ xcodebuild build \
     CONFIGURATION_BUILD_DIR="$temp_dir" \
     APP_PROFILE_ID="$app_profile_id" \
     NE_PROFILE_ID="$ne_profile_id" \
+    CURRENT_PROJECT_VERSION="$seconds_since_epoch" \
     ONLY_ACTIVE_ARCH=NO \
     -project "$project_file" \
     -skipMacroValidation \

--- a/scripts/build/macos-standalone.sh
+++ b/scripts/build/macos-standalone.sh
@@ -31,6 +31,7 @@ fi
 
 # Build and sign
 echo "Building and signing app..."
+seconds_since_epoch=$(date +%s)
 xcodebuild build \
     GIT_SHA="$git_sha" \
     CODE_SIGN_STYLE=Manual \
@@ -42,6 +43,7 @@ xcodebuild build \
     APP_PROFILE_ID="$app_profile_id" \
     NE_PROFILE_ID="$ne_profile_id" \
     ONLY_ACTIVE_ARCH=NO \
+    CURRENT_PROJECT_VERSION="$seconds_since_epoch" \
     -project "$project_file" \
     -skipMacroValidation \
     -configuration Release \


### PR DESCRIPTION
In #9072 this variable was removed in favor of populating it via an Xcode build script. It appears however that the script does not take effect properly when run from CLI and we need to populate this variable again.