### PR TITLE
refactor(gui-client): update settings window via event

### DIFF
--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -469,11 +469,16 @@ impl<I: GuiIntegration> Controller<I> {
 
                 self.advanced_settings = *settings;
 
+                // Save to disk
+                settings::save(&self.advanced_settings).await?;
+
+                // Tell tunnel about new log level
                 self.send_ipc(&service::ClientMsg::ApplyLogFilter {
                     directives: self.advanced_settings.log_filter.clone(),
                 })
                 .await?;
 
+                // Notify GUI that settings have changed
                 self.integration
                     .notify_settings_changed(&self.advanced_settings)?;
 

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -79,8 +79,8 @@ pub trait GuiIntegration {
     fn show_notification(&self, title: &str, body: &str) -> Result<()>;
     fn show_update_notification(&self, ctlr_tx: CtlrTx, title: &str, url: url::Url) -> Result<()>;
 
-    /// Shows a window that the system tray knows about, e.g. not Welcome.
-    fn show_window(&self, window: system_tray::Window) -> Result<()>;
+    fn show_settings_window(&self) -> Result<()>;
+    fn show_about_window(&self) -> Result<()>;
 }
 
 pub enum ControllerRequest {
@@ -568,7 +568,11 @@ impl<I: GuiIntegration> Controller<I> {
                 self.update_disabled_resources().await?;
             }
             SystemTrayMenu(system_tray::Event::ShowWindow(window)) => {
-                self.integration.show_window(window)?;
+                match window {
+                    system_tray::Window::About => self.integration.show_about_window()?,
+                    system_tray::Window::Settings => self.integration.show_settings_window()?,
+                };
+
                 // When the About or Settings windows are hidden / shown, log the
                 // run ID and uptime. This makes it easy to check client stability on
                 // dev or test systems without parsing the whole log file.

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -119,6 +119,14 @@ impl GuiIntegration for TauriIntegration {
         Ok(())
     }
 
+    fn notify_settings_changed(&self, settings: &AdvancedSettings) -> Result<()> {
+        self.app
+            .emit("settings_changed", settings)
+            .context("Failed to send `settings_changed` event")?;
+
+        Ok(())
+    }
+
     fn open_url<P: AsRef<str>>(&self, url: P) -> Result<()> {
         tauri_plugin_opener::open_url(url, Option::<&str>::None)?;
 
@@ -141,8 +149,11 @@ impl GuiIntegration for TauriIntegration {
         os::show_update_notification(&self.app, ctlr_tx, title, url)
     }
 
-    fn show_settings_window(&self) -> Result<()> {
-        self.show_window("settings")
+    fn show_settings_window(&self, settings: &AdvancedSettings) -> Result<()> {
+        self.show_window("settings")?;
+        self.notify_settings_changed(settings)?; // Ensure settings are up to date in GUI.
+
+        Ok(())
     }
 
     fn show_about_window(&self) -> Result<()> {
@@ -224,7 +235,6 @@ pub fn run(
             logging::export_logs,
             settings::apply_advanced_settings,
             settings::reset_advanced_settings,
-            settings::get_advanced_settings,
             crate::welcome::sign_in,
             crate::welcome::sign_out,
         ])

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -51,6 +51,23 @@ struct TauriIntegration {
     tray: system_tray::Tray,
 }
 
+impl TauriIntegration {
+    fn show_window(&self, label: &str) -> Result<()> {
+        let win = self
+            .app
+            .get_webview_window(label)
+            .with_context(|| format!("Couldn't get handle to `{label}` window"))?;
+
+        // Needed to bring shown windows to the front
+        // `request_user_attention` and `set_focus` don't work, at least on Linux
+        win.hide()?;
+        // Needed to show windows that are completely hidden
+        win.show()?;
+
+        Ok(())
+    }
+}
+
 impl Drop for TauriIntegration {
     fn drop(&mut self) {
         tracing::debug!("Instructing Tauri to exit");
@@ -124,23 +141,12 @@ impl GuiIntegration for TauriIntegration {
         os::show_update_notification(&self.app, ctlr_tx, title, url)
     }
 
-    fn show_window(&self, window: system_tray::Window) -> Result<()> {
-        let id = match window {
-            system_tray::Window::About => "about",
-            system_tray::Window::Settings => "settings",
-        };
+    fn show_settings_window(&self) -> Result<()> {
+        self.show_window("settings")
+    }
 
-        let win = self
-            .app
-            .get_webview_window(id)
-            .context("Couldn't get handle to `{id}` window")?;
-
-        // Needed to bring shown windows to the front
-        // `request_user_attention` and `set_focus` don't work, at least on Linux
-        win.hide()?;
-        // Needed to show windows that are completely hidden
-        win.show()?;
-        Ok(())
+    fn show_about_window(&self) -> Result<()> {
+        self.show_window("about")
     }
 }
 

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -54,7 +54,7 @@ pub struct AdvancedSettings {
 mod defaults {
     pub(crate) const AUTH_BASE_URL: &str = "https://app.firez.one";
     pub(crate) const API_URL: &str = "wss://api.firez.one/";
-    pub(crate) const LOG_FILTER: &str = "firezone_gui_client=debug,info";
+    pub(crate) const LOG_FILTER: &str = "debug";
 }
 
 #[cfg(not(debug_assertions))]

--- a/rust/gui-client/src/settings.ts
+++ b/rust/gui-client/src/settings.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import "flowbite"
 
 // Custom types
@@ -98,26 +99,7 @@ async function resetAdvancedSettings() {
   lockAdvancedSettingsForm();
 
   try {
-    let settings = (await invoke("reset_advanced_settings")) as Settings;
-    authBaseUrlInput.value = settings.auth_base_url;
-    apiUrlInput.value = settings.api_url;
-    logFilterInput.value = settings.log_filter;
-  } catch (e) {
-    console.error(e);
-  } finally {
-    unlockAdvancedSettingsForm();
-  }
-}
-
-async function getAdvancedSettings() {
-  console.log("Getting advanced settings");
-  lockAdvancedSettingsForm();
-
-  try {
-    let settings = (await invoke("get_advanced_settings")) as Settings;
-    authBaseUrlInput.value = settings.auth_base_url;
-    apiUrlInput.value = settings.api_url;
-    logFilterInput.value = settings.log_filter;
+    await invoke("reset_advanced_settings")
   } catch (e) {
     console.error(e);
   } finally {
@@ -183,5 +165,10 @@ logsTabBtn.addEventListener("click", (_e) => {
   countLogs();
 });
 
-// Load settings
-getAdvancedSettings();
+listen<Settings>('settings_changed', (e) => {
+  let settings = e.payload;
+
+  authBaseUrlInput.value = settings.auth_base_url;
+  apiUrlInput.value = settings.api_url;
+  logFilterInput.value = settings.log_filter;
+})


### PR DESCRIPTION
Ensuring that the "Settings" window always displays the latest state is important. At the moment, we achieve this by fetching the settings from Rust every time we know that they changed and when the window is opened. Currently, the settings can only change as a result of the reset button.

Once we integrate MDM-controlled configuration into the GUI client, the settings can change at any point when administrators push a new configuration change. The window doesn't know that though.

To simplify the code and handle dynamic changes to the settings, we now use an event to send the settings to the frontend.