### PR TITLE
fix(android): Bump Android NDK and build target

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -18,7 +18,7 @@ runs:
     - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
     - name: Install NDK
-      run: sdkmanager "ndk;27.2.12479018" # Must match `kotlin/android/app/build.gradle.kts`
+      run: sdkmanager "ndk;28.1.13356709" # Must match `kotlin/android/app/build.gradle.kts`
       shell: bash
 
     - name: Validate Gradle wrapper

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -43,14 +43,14 @@ android {
     }
 
     namespace = "dev.firezone.android"
-    compileSdk = 35
-    ndkVersion = "27.2.12479018" // Must match `.github/actions/setup-android/action.yml`
+    compileSdk = 36
+    ndkVersion = "28.1.13356709" // Must match `.github/actions/setup-android/action.yml`
 
     defaultConfig {
         applicationId = "dev.firezone.android"
         // Android 8
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = (System.currentTimeMillis() / 1000 / 10).toInt()
         // mark:next-android-version
         versionName = "1.4.9"


### PR DESCRIPTION
Android recently bumped their default page size to 16 KB, which requires an updated NDK to successfully build connlib.

See https://developer.android.com/guide/practices/page-sizes