### PR TITLE
chore(apple): Remove useless IPC error log

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -13,15 +13,12 @@ import NetworkExtension
 
 class IPCClient {
   enum Error: Swift.Error {
-    case invalidNotification
     case decodeIPCDataFailed
     case noIPCData
     case invalidStatus(NEVPNStatus)
 
     var localizedDescription: String {
       switch self {
-      case .invalidNotification:
-        return "NEVPNStatusDidChange notification doesn't seem to be valid."
       case .decodeIPCDataFailed:
         return "Decoding IPC data failed."
       case .noIPCData:
@@ -263,7 +260,6 @@ class IPCClient {
       for await notification in NotificationCenter.default.notifications(named: .NEVPNStatusDidChange) {
         guard let session = notification.object as? NETunnelProviderSession
         else {
-          Log.error(Error.invalidNotification)
           return
         }
 


### PR DESCRIPTION
This error case happens during normal operation, particularly when exiting the application and can be dropped.