### PR TITLE
fix(ci): Don't `compose up` the same image simultaneously

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,8 @@ jobs:
           # Start services in the same order each time for the tests
           docker compose up -d iperf3
           docker compose up -d api web domain --no-build
-          docker compose up -d relay-1 relay-2 --no-build
+          docker compose up -d relay-1 --no-build
+          docker compose up -d relay-2 --no-build
           docker compose up -d gateway --no-build
           docker compose up -d client --no-build
       - name: Add 10ms simulated latency


### PR DESCRIPTION
Recently GitHub actions seems to have installed a buggy version of compose that [fails with `fatalError`](https://github.com/firezone/firezone/actions/runs/15181224905/job/42691214402?pr=9203) on this line `docker compose up -d relay-1 relay-2 --no-build`.

Since those point to the same underlying image, I speculate that separating these out will temporary alleviate this issue for us. 