### PR TITLE
fix(website): Use `dummy` when mixpanel token is blank

### DIFF
--- a/website/src/components/Analytics/Mixpanel.tsx
+++ b/website/src/components/Analytics/Mixpanel.tsx
@@ -8,7 +8,7 @@ import { HubSpotSubmittedFormData } from "./types";
 function _Mixpanel() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const mpToken = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN || "";
+  const mpToken = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN || "dummy";
   const host = "https://t.firez.one";
 
   useEffect(() => {


### PR DESCRIPTION
This fixes an issue on dev if the `NEXT_PUBLIC_MIXPANEL_TOKEN` env var is not available.