### PR TITLE
fix(gui-client): don't reset favourites when settings change

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -11,7 +11,7 @@ use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, elevation, gui, logging, settings};
 use firezone_telemetry::Telemetry;
-use settings::AdvancedSettings;
+use settings::AdvancedSettingsLegacy;
 use tracing_subscriber::EnvFilter;
 
 fn main() -> ExitCode {
@@ -28,7 +28,7 @@ fn main() -> ExitCode {
         .install_default()
         .expect("Calling `install_default` only once per process should always succeed");
 
-    let settings = settings::load_advanced_settings().unwrap_or_default();
+    let settings = settings::load_advanced_settings::<AdvancedSettingsLegacy>().unwrap_or_default();
 
     let mut telemetry = Telemetry::default();
     telemetry.start(
@@ -61,7 +61,11 @@ fn main() -> ExitCode {
     }
 }
 
-fn try_main(cli: Cli, rt: &tokio::runtime::Runtime, mut settings: AdvancedSettings) -> Result<()> {
+fn try_main(
+    cli: Cli,
+    rt: &tokio::runtime::Runtime,
+    mut settings: AdvancedSettingsLegacy,
+) -> Result<()> {
     let config = gui::RunConfig {
         inject_faults: cli.inject_faults,
         debug_update_check: cli.debug_update_check,
@@ -186,11 +190,11 @@ fn try_main(cli: Cli, rt: &tokio::runtime::Runtime, mut settings: AdvancedSettin
 }
 
 /// Parse the log filter from settings, showing an error and fixing it if needed
-fn fix_log_filter(settings: &mut AdvancedSettings) -> Result<()> {
+fn fix_log_filter(settings: &mut AdvancedSettingsLegacy) -> Result<()> {
     if EnvFilter::try_new(&settings.log_filter).is_ok() {
         return Ok(());
     }
-    settings.log_filter = AdvancedSettings::default().log_filter;
+    settings.log_filter = AdvancedSettingsLegacy::default().log_filter;
 
     native_dialog::MessageDialog::new()
         .set_title("Log filter error")

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -5,6 +5,7 @@ use crate::gui::Managed;
 use anyhow::{Context as _, Result};
 use connlib_model::ResourceId;
 use firezone_bin_shared::known_dirs;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use std::{collections::HashSet, path::PathBuf};
@@ -40,7 +41,7 @@ pub(crate) async fn reset_advanced_settings(
 }
 
 #[derive(Clone, Deserialize, Serialize)]
-pub struct AdvancedSettings {
+pub struct AdvancedSettingsLegacy {
     pub auth_base_url: Url,
     pub api_url: Url,
     #[serde(default)]
@@ -48,6 +49,21 @@ pub struct AdvancedSettings {
     #[serde(default)]
     pub internet_resource_enabled: Option<bool>,
     pub log_filter: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct AdvancedSettings {
+    pub auth_base_url: Url,
+    pub api_url: Url,
+    pub log_filter: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct GeneralSettings {
+    #[serde(default)]
+    pub favorite_resources: HashSet<ResourceId>,
+    #[serde(default)]
+    pub internet_resource_enabled: Option<bool>,
 }
 
 #[cfg(debug_assertions)]
@@ -64,7 +80,7 @@ mod defaults {
     pub(crate) const LOG_FILTER: &str = "info";
 }
 
-impl Default for AdvancedSettings {
+impl Default for AdvancedSettingsLegacy {
     fn default() -> Self {
         Self {
             auth_base_url: Url::parse(defaults::AUTH_BASE_URL).expect("static URL is a valid URL"),
@@ -76,9 +92,19 @@ impl Default for AdvancedSettings {
     }
 }
 
-impl AdvancedSettings {
+impl GeneralSettings {
     pub fn internet_resource_enabled(&self) -> bool {
         self.internet_resource_enabled.is_some_and(|v| v)
+    }
+}
+
+impl Default for AdvancedSettings {
+    fn default() -> Self {
+        Self {
+            auth_base_url: Url::parse(defaults::AUTH_BASE_URL).expect("static URL is a valid URL"),
+            api_url: Url::parse(defaults::API_URL).expect("static URL is a valid URL"),
+            log_filter: defaults::LOG_FILTER.to_string(),
+        }
     }
 }
 
@@ -88,9 +114,64 @@ pub fn advanced_settings_path() -> Result<PathBuf> {
         .join("advanced_settings.json"))
 }
 
-/// Saves the settings to disk
-pub async fn save(settings: &AdvancedSettings) -> Result<()> {
+pub fn general_settings_path() -> Result<PathBuf> {
+    Ok(known_dirs::settings()
+        .context("`known_dirs::settings` failed")?
+        .join("general_settings.json"))
+}
+
+pub async fn migrate_legacy_settings(
+    legacy: AdvancedSettingsLegacy,
+) -> (GeneralSettings, AdvancedSettings) {
+    let general_settings = load_general_settings();
+
+    let advanced = AdvancedSettings {
+        auth_base_url: legacy.auth_base_url,
+        api_url: legacy.api_url,
+        log_filter: legacy.log_filter,
+    };
+
+    if let Ok(general) = general_settings {
+        return (general, advanced);
+    }
+
+    let general = GeneralSettings {
+        favorite_resources: legacy.favorite_resources,
+        internet_resource_enabled: legacy.internet_resource_enabled,
+    };
+
+    if let Err(e) = save_general(&general).await {
+        tracing::error!("Failed to write new general settings: {e:#}");
+        return (general, advanced);
+    }
+    if let Err(e) = save_advanced(&advanced).await {
+        tracing::error!("Failed to write new advanced settings: {e:#}");
+        return (general, advanced);
+    }
+
+    tracing::info!("Successfully migrate settings");
+
+    (general, advanced)
+}
+
+/// Saves the advanced settings to disk
+pub async fn save_advanced(settings: &AdvancedSettings) -> Result<()> {
     let path = advanced_settings_path()?;
+    let dir = path
+        .parent()
+        .context("settings path should have a parent")?;
+
+    tokio::fs::create_dir_all(dir).await?;
+    tokio::fs::write(&path, serde_json::to_string(settings)?).await?;
+
+    tracing::debug!(?path, "Saved settings");
+
+    Ok(())
+}
+
+/// Saves the general settings to disk
+pub async fn save_general(settings: &GeneralSettings) -> Result<()> {
+    let path = general_settings_path()?;
     let dir = path
         .parent()
         .context("settings path should have a parent")?;
@@ -106,8 +187,21 @@ pub async fn save(settings: &AdvancedSettings) -> Result<()> {
 /// Return advanced settings if they're stored on disk
 ///
 /// Uses std::fs, so stick it in `spawn_blocking` for async contexts
-pub fn load_advanced_settings() -> Result<AdvancedSettings> {
+pub fn load_advanced_settings<T>() -> Result<T>
+where
+    T: DeserializeOwned,
+{
     let path = advanced_settings_path()?;
+    let text = std::fs::read_to_string(path)?;
+    let settings = serde_json::from_str(&text)?;
+    Ok(settings)
+}
+
+/// Return general settings if they're stored on disk
+///
+/// Uses std::fs, so stick it in `spawn_blocking` for async contexts
+pub fn load_general_settings() -> Result<GeneralSettings> {
+    let path = general_settings_path()?;
     let text = std::fs::read_to_string(path)?;
     let settings = serde_json::from_str(&text)?;
     Ok(settings)

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -8,7 +8,12 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9211">
+          Fixes an issue where changing the Advanced settings would reset
+          the favourited resources.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.14" date={new Date("2025-05-21")}>
         <ChangeItem pull="9147">
           Fixes an issue where connections failed to establish on machines


### PR DESCRIPTION
The GUI client currently has a bug that resets the favourites and the status of the Internet Resource every time the advanced settings are saved. This happens because those fields are annotated with `#[serde(default)]` and are thus initialised to their default value when the struct is deserialised from the frontend.

To mitigate this, we introduce a new `GeneralSettings` struct that holds the status of the Internet Resource and the list of favourites. When a client starts up, it will try to migrate the existing advanced settings into the new split of general and advanced settings.