### PR TITLE
docs: Default of false for all macOS plist keys

### DIFF
--- a/website/public/policy-templates/macos/profile-manifests/dev.firezone.firezone.plist
+++ b/website/public/policy-templates/macos/profile-manifests/dev.firezone.firezone.plist
@@ -197,7 +197,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Try to connect to Firezone using the saved token and configuration when the client application starts. If the authentication token is expired, the client will start in a disconnected state.</string>
 			<key>pfm_name</key>


### PR DESCRIPTION
I was mistaken on the defaults of booleans returned by `UserDefaults` - they're false by default.

https://developer.apple.com/documentation/foundation/userdefaults/bool(forkey:)