### PR TITLE
ci: automatically upload published clients to winget

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -5,7 +5,7 @@ on:
       - published
 
 jobs:
-  publish:
+  gui_client:
     name: Publish GUI Client to winget
     runs-on: windows-latest
     if: ${{ startsWith(github.event.release.name, gui-client) }}
@@ -19,6 +19,24 @@ jobs:
       - uses: vedantmgoyal9/winget-releaser@3e78d7ff0f525445bca5d6a989d31cdca383372e # main
         with:
           identifier: Firezone.Client.GUI
+          version: ${{ steps.get-version.outputs.version }}
+          token: ${{ secrets.WINGET_TOKEN }}
+          release-notes-url: https://firezone.dev/changelog
+
+  headless_client:
+    name: Publish Headless Client to winget
+    runs-on: windows-latest
+    if: ${{ startsWith(github.event.release.name, headless-client) }}
+    steps:
+      - id: get-version
+        run: |
+          version=${{ github.event.release.name }}
+          version=${version#headless-client-}
+          echo "version=$version" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: vedantmgoyal9/winget-releaser@3e78d7ff0f525445bca5d6a989d31cdca383372e # main
+        with:
+          identifier: Firezone.Client.Headless
           version: ${{ steps.get-version.outputs.version }}
           token: ${{ secrets.WINGET_TOKEN }}
           release-notes-url: https://firezone.dev/changelog

--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -5,38 +5,27 @@ on:
       - published
 
 jobs:
-  gui_client:
-    name: Publish GUI Client to winget
+  publish_clients:
+    name: Publish ${{ matrix.identifier }} to winget
     runs-on: windows-latest
-    if: ${{ startsWith(github.event.release.name, gui-client) }}
+    strategy:
+      matrix:
+        include:
+          - identifier: Firezone.Client.GUI
+            tag_prefix: gui-client
+          - identifier: Firezone.Client.Headless
+            tag_prefix: headless-client
+    if: ${{ startsWith(github.event.release.name, matrix.tag_prefix) }}
     steps:
       - id: get-version
         run: |
           version=${{ github.event.release.name }}
-          version=${version#gui-client-}
+          version=${version#${{ matrix.tag_prefix }}-}
           echo "version=$version" >> $GITHUB_OUTPUT
         shell: bash
       - uses: vedantmgoyal9/winget-releaser@3e78d7ff0f525445bca5d6a989d31cdca383372e # main
         with:
-          identifier: Firezone.Client.GUI
-          version: ${{ steps.get-version.outputs.version }}
-          token: ${{ secrets.WINGET_TOKEN }}
-          release-notes-url: https://firezone.dev/changelog
-
-  headless_client:
-    name: Publish Headless Client to winget
-    runs-on: windows-latest
-    if: ${{ startsWith(github.event.release.name, headless-client) }}
-    steps:
-      - id: get-version
-        run: |
-          version=${{ github.event.release.name }}
-          version=${version#headless-client-}
-          echo "version=$version" >> $GITHUB_OUTPUT
-        shell: bash
-      - uses: vedantmgoyal9/winget-releaser@3e78d7ff0f525445bca5d6a989d31cdca383372e # main
-        with:
-          identifier: Firezone.Client.Headless
+          identifier: ${{ matrix.identifier }}
           version: ${{ steps.get-version.outputs.version }}
           token: ${{ secrets.WINGET_TOKEN }}
           release-notes-url: https://firezone.dev/changelog

--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -1,0 +1,24 @@
+name: Publish to WinGet
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    name: Publish GUI Client to winget
+    runs-on: windows-latest
+    if: ${{ startsWith(github.event.release.name, gui-client) }}
+    steps:
+      - id: get-version
+        run: |
+          version=${{ github.event.release.name }}
+          version=${version#gui-client-}
+          echo "version=$version" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: vedantmgoyal9/winget-releaser@3e78d7ff0f525445bca5d6a989d31cdca383372e # main
+        with:
+          identifier: Firezone.Client.GUI
+          version: ${{ steps.get-version.outputs.version }}
+          token: ${{ secrets.WINGET_TOKEN }}
+          release-notes-url: https://firezone.dev/changelog

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -13,12 +13,6 @@ export default function GUI({ os }: { os: OS }) {
           Fixes an issue where changing the Advanced settings would reset
           the favourited resources.
         </ChangeItem>
-        {os === OS.Windows && (
-          <ChangeItem pull="9213">
-            Adds the Client to the winget repository. You can install it via
-            `winget install Firezone.Client.GUI`.
-          </ChangeItem>
-        )}
       </Unreleased>
       <Entry version="1.4.14" date={new Date("2025-05-21")}>
         <ChangeItem pull="9147">
@@ -44,6 +38,12 @@ export default function GUI({ os }: { os: OS }) {
         {os === OS.Linux && (
           <ChangeItem pull="9181">
             Increases minimum supported CentOS version to 10.
+          </ChangeItem>
+        )}
+        {os === OS.Windows && (
+          <ChangeItem pull="9213">
+            Adds the Client to the winget repository. You can install it via
+            `winget install Firezone.Client.GUI`.
           </ChangeItem>
         )}
       </Entry>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -13,6 +13,12 @@ export default function GUI({ os }: { os: OS }) {
           Fixes an issue where changing the Advanced settings would reset
           the favourited resources.
         </ChangeItem>
+        {os === OS.Windows && (
+          <ChangeItem pull="9213">
+            Adds the Client to the winget repository. You can install it via
+            `winget install Firezone.Client.GUI`.
+          </ChangeItem>
+        )}
       </Unreleased>
       <Entry version="1.4.14" date={new Date("2025-05-21")}>
         <ChangeItem pull="9147">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -14,12 +14,6 @@ export default function Headless({ os }: { os: OS }) {
           Fixes an issue where connections failed to establish on machines
           with multiple valid egress IPs.
         </ChangeItem>
-        {os === OS.Windows && (
-          <ChangeItem pull="9213">
-            Adds the Client to the winget repository. You can install it via
-            `winget install Firezone.Client.Headless`.
-          </ChangeItem>
-        )}
       </Unreleased>
       <Entry version="1.4.8" date={new Date("2025-05-14")}>
         <ChangeItem pull="9014">
@@ -33,6 +27,12 @@ export default function Headless({ os }: { os: OS }) {
         {os === OS.Windows && (
           <ChangeItem pull="9021">
             Optimizes network change detection.
+          </ChangeItem>
+        )}
+        {os === OS.Windows && (
+          <ChangeItem pull="9213">
+            Adds the Client to the winget repository. You can install it via
+            `winget install Firezone.Client.Headless`.
           </ChangeItem>
         )}
       </Entry>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -14,6 +14,12 @@ export default function Headless({ os }: { os: OS }) {
           Fixes an issue where connections failed to establish on machines
           with multiple valid egress IPs.
         </ChangeItem>
+        {os === OS.Windows && (
+          <ChangeItem pull="9213">
+            Adds the Client to the winget repository. You can install it via
+            `winget install Firezone.Client.Headless`.
+          </ChangeItem>
+        )}
       </Unreleased>
       <Entry version="1.4.8" date={new Date("2025-05-14")}>
         <ChangeItem pull="9014">


### PR DESCRIPTION
This utilizes the https://github.com/vedantmgoyal9/winget-releaser action to automatically submit a PR to the winget repository every time we publish a new version of the GUI / Headless Client.

The bot uses the initial manifest added in https://github.com/microsoft/winget-pkgs/pull/259366 and updates the installer link and hash.

Resolves: #4729