### PR TITLE
chore(deps): Bump next-hubspot to 2.0.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
     "md5": "^2.3.0",
     "mixpanel-browser": "^2.64.0",
     "next": "^14.2.26",
-    "next-hubspot": "^1.3.0",
+    "next-hubspot": "^2.0.0",
     "next-sitemap": "^4.2.3",
     "postcss": "8.5.3",
     "react": "18.3.1",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^14.2.26
         version: 14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-hubspot:
-        specifier: ^1.3.0
-        version: 1.3.0(next@14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^2.0.0
+        version: 2.0.0(next@14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       next-sitemap:
         specifier: ^4.2.3
         version: 4.2.3(next@14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1407,16 +1407,12 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next-hubspot@1.3.0:
-    resolution: {integrity: sha512-W19Mtemz+q6f7ZSOUh8rf2p/Su8H36cZs3WAzmY/t6/zar9m9Uk4C0s6iSVom6UFI0WjW2tZYWabsWB5z1pmIA==}
+  next-hubspot@2.0.0:
+    resolution: {integrity: sha512-ZfvU4JIVtTDYUSuvJeSK+ea/6GBkKIRl/qfUIhkbukrO/bammQPrOy5AH7ZxoCio66JHDEKjI73bO+yo7IMarQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      next: ^13.0.0 || ^14.0.0
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
+      next: ^13 || ^14 || ^15
+      react: ^18 || ^19
 
   next-sitemap@4.2.3:
     resolution: {integrity: sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==}
@@ -3658,12 +3654,10 @@ snapshots:
   neo-async@2.6.2:
     optional: true
 
-  next-hubspot@1.3.0(next@14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-hubspot@2.0.0(next@14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       next: 14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
 
   next-sitemap@4.2.3(next@14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:

--- a/website/src/components/HubspotForm/index.tsx
+++ b/website/src/components/HubspotForm/index.tsx
@@ -10,7 +10,7 @@ export default function HubspotForm({
   formId: string;
   title?: string;
 }) {
-  const { loaded, error, formCreated } = useHubspotForm({
+  const { isScriptLoaded, isScriptError, scriptError, isFormCreated } = useHubspotForm({
     portalId: portalId,
     formId: formId,
     target: "#hubspot-form",


### PR DESCRIPTION
This dependency had some breaking changes for 2.0.0 which required updated some variable names from imports.

Supersedes #8991 