### PR TITLE
chore(ci): Bump next clients version to 1.5.0

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -126,9 +126,9 @@ jobs:
         target: [x86_64-pc-windows-msvc]
         package: [firezone-headless-client]
         # mark:next-headless-version
-        release_name: [headless-client-1.4.9]
+        release_name: [headless-client-1.5.0]
         # mark:next-headless-version
-        version: [1.4.9]
+        version: [1.5.0]
     env:
       ARTIFACT_PATH: ${{ matrix.artifact }}_${{ matrix.version }}_${{ matrix.arch }}.exe
       RELEASE_NAME: ${{ matrix.release_name }}
@@ -226,9 +226,9 @@ jobs:
             artifact: firezone-client-headless-linux
             image_name: client
             # mark:next-headless-version
-            release_name: headless-client-1.4.9
+            release_name: headless-client-1.5.0
             # mark:next-headless-version
-            version: 1.4.9
+            version: 1.5.0
           - package: firezone-relay
             artifact: firezone-relay
             image_name: relay

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write # for updating the release draft
     env:
       # mark:next-android-version
-      RELEASE_NAME: android-client-1.4.9
+      RELEASE_NAME: android-client-1.5.0
     steps:
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
@@ -100,7 +100,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # mark:next-android-version
-          RELEASE_NAME: android-client-1.4.9
+          RELEASE_NAME: android-client-1.5.0
         run: |
           export ARTIFACT_PATH="$RUNNER_TEMP/firezone-${RELEASE_NAME}.${{ matrix.package-type }}"
           cp "${{ matrix.output-path }}" "$ARTIFACT_PATH"

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # mark:next-apple-version
-      RELEASE_NAME: macos-client-1.4.16
+      RELEASE_NAME: macos-client-1.5.0
     steps:
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
@@ -53,11 +53,11 @@ jobs:
             build-script: scripts/build/macos-standalone.sh
             upload-script: scripts/upload/github-release.sh
             # mark:next-apple-version
-            artifact-file: "firezone-macos-client-1.4.16.dmg"
+            artifact-file: "firezone-macos-client-1.5.0.dmg"
             # mark:next-apple-version
-            pkg-artifact-file: "firezone-macos-client-1.4.16.pkg"
+            pkg-artifact-file: "firezone-macos-client-1.5.0.pkg"
             # mark:next-apple-version
-            release-name: macos-client-1.4.16
+            release-name: macos-client-1.5.0
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # mark:next-gui-version
-      RELEASE_NAME: gui-client-1.4.15
+      RELEASE_NAME: gui-client-1.5.0
     steps:
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: "${{ github.event_name == 'workflow_dispatch' && github.ref_name == 'main' }}"
@@ -57,19 +57,19 @@ jobs:
             pkg-extension: msi
     env:
       # mark:next-gui-version
-      ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.4.15_${{ matrix.arch }}
+      ARTIFACT_SRC: ./rust/gui-client/firezone-client-gui-${{ matrix.os }}_1.5.0_${{ matrix.arch }}
       # mark:next-gui-version
-      ARTIFACT_DST: firezone-client-gui-${{ matrix.os }}_1.4.15_${{ matrix.arch }}
+      ARTIFACT_DST: firezone-client-gui-${{ matrix.os }}_1.5.0_${{ matrix.arch }}
       AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
       # mark:next-gui-version
-      BINARY_DEST_PATH: firezone-client-gui-${{ matrix.os }}_1.4.15_${{ matrix.arch }}
+      BINARY_DEST_PATH: firezone-client-gui-${{ matrix.os }}_1.5.0_${{ matrix.arch }}
       # Seems like there's no way to de-dupe env vars that depend on each other
       # mark:next-gui-version
-      FIREZONE_GUI_VERSION: 1.4.15
+      FIREZONE_GUI_VERSION: 1.5.0
       RENAME_SCRIPT: ../../scripts/build/tauri-rename-${{ matrix.os }}.sh
       TEST_INSTALL_SCRIPT: ../../scripts/tests/gui-client-install-${{ matrix.os }}-${{ matrix.pkg-extension }}.sh
       TARGET_DIR: ../target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           - release_name: gateway-1.4.10
             config_name: release-drafter-gateway.yml
           # mark:next-headless-version
-          - release_name: headless-client-1.4.9
+          - release_name: headless-client-1.5.0
             config_name: release-drafter-headless-client.yml
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
             ARTIFACT=client
             # mark:next-headless-version
-            VERSION="1.4.9"
+            VERSION="1.5.0"
           else
             echo "Shouldn't have gotten here. Exiting."
             exit 1

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         targetSdk = 36
         versionCode = (System.currentTimeMillis() / 1000 / 10).toInt()
         // mark:next-android-version
-        versionName = "1.4.9"
+        versionName = "1.5.0"
         multiDexEnabled = true
         testInstrumentationRunner = "dev.firezone.android.core.HiltTestRunner"
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -80,7 +80,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-client-ffi"
-version = "1.4.9"
+version = "1.5.0"
 dependencies = [
  "android_log-sys",
  "anyhow",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-gui-client"
-version = "1.4.15"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "firezone-headless-client"
-version = "1.4.9"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "backoff",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "apple-client-ffi"
-version = "1.4.16"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "backoff",

--- a/rust/android-client-ffi/Cargo.toml
+++ b/rust/android-client-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "android-client-ffi"
 # mark:next-android-version
-version = "1.4.9"
+version = "1.5.0"
 edition = { workspace = true }
 license = { workspace = true }
 

--- a/rust/apple-client-ffi/Cargo.toml
+++ b/rust/apple-client-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "apple-client-ffi"
 # mark:next-apple-version
-version = "1.4.16"
+version = "1.5.0"
 edition = { workspace = true }
 license = { workspace = true }
 

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-gui-client"
 # mark:next-gui-version
-version = "1.4.15"
+version = "1.5.0"
 description = "Firezone"
 edition = { workspace = true }
 default-run = "firezone-gui-client"

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "firezone-headless-client"
 # mark:next-headless-version
-version = "1.4.9"
+version = "1.5.0"
 edition = { workspace = true }
 authors = ["Firezone, Inc."]
 license = { workspace = true }

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -106,7 +106,7 @@ function apple() {
 # 7. Commit the changes and open a PR.
 function android() {
     current_android_version="1.4.8"
-    next_android_version="1.4.9"
+    next_android_version="1.5.0"
 
     update_changelog "website/src/components/Changelog/Android.tsx" "$current_android_version"
     find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_android_version}"'/g;}' {} \;
@@ -131,7 +131,7 @@ function android() {
 # 5. Commit the changes and open a PR.
 function gui() {
     current_gui_version="1.4.14"
-    next_gui_version="1.4.15"
+    next_gui_version="1.5.0"
 
     update_changelog "website/src/components/Changelog/GUI.tsx" "$current_gui_version"
     find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_gui_version}"'/g;}' {} \;
@@ -154,7 +154,7 @@ function gui() {
 # 4. Commit the changes and open a PR.
 function headless() {
     current_headless_version="1.4.8"
-    next_headless_version="1.4.9"
+    next_headless_version="1.5.0"
 
     update_changelog "website/src/components/Changelog/Headless.tsx" "$current_headless_version"
     find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_headless_version}"'/g;}' {} \;

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -70,7 +70,7 @@ function update_changelog() {
 # 7. Commit the changes and open a PR.
 function apple() {
     current_apple_version="1.4.15"
-    next_apple_version="1.4.16"
+    next_apple_version="1.5.0"
 
     update_changelog "website/src/components/Changelog/Apple.tsx" "$current_apple_version"
     find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_apple_version}"'/g;}' {} \;

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -565,7 +565,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/debug";
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.4.16;
+				MARKETING_VERSION = 1.5.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
@@ -607,7 +607,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/release";
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.4.16;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
@@ -648,7 +648,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/debug";
-				MARKETING_VERSION = 1.4.16;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
@@ -686,7 +686,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/release";
-				MARKETING_VERSION = 1.4.16;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = "-lconnlib";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
 				PRODUCT_NAME = "$(PRODUCT_BUNDLE_IDENTIFIER)";
@@ -860,7 +860,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.4.16;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -910,7 +910,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.4.16;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
We've decided we'll be bumping the minor with shipping managed configurations support.