### PR TITLE
fix(apple): Don't throw when quitting with a stopped tunnel

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -68,7 +68,7 @@ class IPCClient {
   }
 
   func stop() throws {
-    try session([.connected, .connecting, .reasserting]).stopTunnel()
+    try session().stopTunnel()
   }
 
 #if os(macOS)


### PR DESCRIPTION
If the tunnel is already down when we try to quit the application, we were throwing a harmless error because we mistakenly required a connected status to send the `stopTunnel` command, which is just a no-op if we're already connected.