### PR TITLE
chore(docs): Remove defaults from macOS profile manifest

### DIFF
--- a/website/dev.firezone.firezone.plist
+++ b/website/dev.firezone.firezone.plist
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>pfm_app_url</key>
+	<string>https://www.firezone.dev/kb/client-apps/macos-client</string>
+	<key>pfm_description</key>
+	<string>Manage configuration for the Firezone macOS client.</string>
+	<key>pfm_documentation_url</key>
+	<string>https://www.firezone.dev/kb/deploy/clients#provision-with-mdm</string>
+	<key>pfm_domain</key>
+	<string>dev.firezone.firezone</string>
+	<key>pfm_format_version</key>
+	<integer>1</integer>
+	<key>pfm_last_modified</key>
+	<date>2025-05-23T07:58:48Z</date>
+	<key>pfm_platforms</key>
+	<array>
+		<string>macOS</string>
+	</array>
+	<key>pfm_subkeys</key>
+	<array>
+		<dict>
+			<key>pfm_default</key>
+			<string>Configures Firezone configuration preferences</string>
+			<key>pfm_description</key>
+			<string>Description of the payload.</string>
+			<key>pfm_description_reference</key>
+			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>Firezone</string>
+			<key>pfm_description</key>
+			<string>Name of the payload.</string>
+			<key>pfm_description_reference</key>
+			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>dev.firezone.firezone</string>
+			<key>pfm_description</key>
+			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<key>pfm_description_reference</key>
+			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>dev.firezone.firezone</string>
+			<key>pfm_description</key>
+			<string>The type of the payload, a reverse dns string.</string>
+			<key>pfm_description_reference</key>
+			<string>The payload type.</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<key>pfm_description_reference</key>
+			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_description</key>
+			<string>The version of the whole configuration profile.</string>
+			<key>pfm_description_reference</key>
+			<string>The version number of the individual payload.
+A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<key>pfm_name</key>
+			<string>PayloadOrganization</string>
+			<key>pfm_title</key>
+			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>https://app.firezone.dev</string>
+			<key>pfm_description</key>
+			<string>The base URL to open when users click "Sign in". The accountSlug will be appended to this.</string>
+			<key>pfm_name</key>
+			<string>authURL</string>
+			<key>pfm_title</key>
+			<string>Authentication URL</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>wss://api.firezone.dev</string>
+			<key>pfm_description</key>
+			<string>The WebSocket URL of the Firezone control plane to connect to.</string>
+			<key>pfm_name</key>
+			<string>apiURL</string>
+			<key>pfm_title</key>
+			<string>WebSocket API URL</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>info</string>
+			<key>pfm_description</key>
+			<string>The RUST_LOG-style filter string to apply to the connectivity library for increasing log output to use for connectivity troubleshooting.</string>
+			<key>pfm_name</key>
+			<string>logFilter</string>
+			<key>pfm_title</key>
+			<string>RUST_LOG filter string</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Your Firezone account ID or slug which will be appended to the authURL to form the complete sign in URL. Will be set automatically by the client after the first successful authentication.</string>
+			<key>pfm_name</key>
+			<string>accountSlug</string>
+			<key>pfm_title</key>
+			<string>Account ID or Slug</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Hide the Admin portal link in the Firezone menu in the macOS menu bar.</string>
+			<key>pfm_name</key>
+			<string>hideAdminPortalMenuItem</string>
+			<key>pfm_title</key>
+			<string>Hide admin portal link</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Try to connect to Firezone using the saved token and configuration when the client application starts. If the authentication token is expired, the client will start in a disconnected state.</string>
+			<key>pfm_name</key>
+			<string>connectOnStart</string>
+			<key>pfm_title</key>
+			<string>Connect on start</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Start the Firezone client when the user logs into the machine. Requires the Firezone client to be running to take effect. In many cases you probably want to configure this using a Managed Login Items payload instead to force the client to be running.</string>
+			<key>pfm_name</key>
+			<string>startOnLogin</string>
+			<key>pfm_title</key>
+			<string>Start on login</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Disables the update check and notification for the Standalone variant of the macOS client. App Store variant versions 1.4.15 and higher already have this disabled.</string>
+			<key>pfm_name</key>
+			<string>disableUpdateCheck</string>
+			<key>pfm_title</key>
+			<string>Disable update check</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>https://www.firezone.dev/support</string>
+			<key>pfm_description</key>
+			<string>The URL to which users will be taken to when clicking the Help -&gt; Support link in the menu bar.</string>
+			<key>pfm_name</key>
+			<string>supportURL</string>
+			<key>pfm_title</key>
+			<string>Support URL</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+	</array>
+	<key>pfm_targets</key>
+	<array>
+		<string>user</string>
+	</array>
+	<key>pfm_title</key>
+	<string>Firezone</string>
+	<key>pfm_unique</key>
+	<true/>
+	<key>pfm_version</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/website/public/policy-templates/macos/profile-manifests/dev.firezone.firezone.plist
+++ b/website/public/policy-templates/macos/profile-manifests/dev.firezone.firezone.plist
@@ -126,10 +126,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<string>https://app.firezone.dev</string>
 			<key>pfm_description</key>
-			<string>The base URL to open when users sign in. The accountSlug will be appended to this. In most cases you shouldn't change this. Setting this field will override the user's setting.</string>
+			<string>The base URL to open when users sign in. The accountSlug will be appended to this. In most cases you shouldn't change this. Setting this field will override the user's setting. If unset, defaults to https://app.firezone.dev.</string>
 			<key>pfm_name</key>
 			<string>authURL</string>
 			<key>pfm_title</key>
@@ -138,10 +136,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<string>wss://api.firezone.dev</string>
 			<key>pfm_description</key>
-			<string>The control plane WebSocket URL that the network extension connects to. In most cases you shouldn't change this. Setting this field will override the user's setting.</string>
+			<string>The control plane WebSocket URL that the network extension connects to. In most cases you shouldn't change this. Setting this field will override the user's setting. If unset, defaults to wss://api.firezone.dev.</string>
 			<key>pfm_name</key>
 			<string>apiURL</string>
 			<key>pfm_title</key>
@@ -150,10 +146,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<string>info</string>
 			<key>pfm_description</key>
-			<string>The RUST_LOG-style filter string to apply to the network extension for increasing log output to use for connectivity troubleshooting. In most cases you shouldn't change this. Setting this field will override the user's setting.</string>
+			<string>The RUST_LOG-style filter string to apply to the network extension for increasing log output to use for connectivity troubleshooting. In most cases you shouldn't change this. Setting this field will override the user's setting. If unset, defaults to "info".</string>
 			<key>pfm_name</key>
 			<string>logFilter</string>
 			<key>pfm_title</key>
@@ -172,22 +166,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
-			<string>If set to true and you have the Internet Resource enabled for this user in the Firezone admin portal, enforces the use of the Internet Resource for this Mac while Firezone is signed in. If set to false, prevents the Internet Resource from being used. Setting this field will prevent the user from enabling or disabling the Internet Resource.</string>
-			<key>pfm_name</key>
-			<string>internetResourceEnabled</string>
-			<key>pfm_title</key>
-			<string>Enforce full-tunnel on or off</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<false/>
-			<key>pfm_description</key>
-			<string>Hide the Admin portal link in the Firezone menu in the macOS menu bar.</string>
+			<string>Hide the Admin portal link in the Firezone menu in the macOS menu bar. If unset, defaults to false.</string>
 			<key>pfm_name</key>
 			<string>hideAdminPortalMenuItem</string>
 			<key>pfm_title</key>
@@ -196,10 +176,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
-			<string>Try to connect to Firezone using the saved token and configuration when the client application starts. If the authentication token is expired, the client will start in a disconnected state. Setting this field will override the user's setting.</string>
+			<string>Try to connect to Firezone using the saved token and configuration when the client application starts. If the authentication token is expired, the client will start in a disconnected state. Setting this field will override the user's setting. If unset, defaults to false.</string>
 			<key>pfm_name</key>
 			<string>connectOnStart</string>
 			<key>pfm_title</key>
@@ -208,10 +186,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
-			<string>Start the Firezone client when the user logs into the machine. In many cases you probably want to configure this using a Managed Login Items payload instead. Requires the Firezone client to be running to take effect. Setting this field will override the user's setting.</string>
+			<string>Start the Firezone client when the user logs into the machine. In many cases you probably want to configure this using a Managed Login Items payload instead. Requires the Firezone client to be running to take effect. Setting this field will override the user's setting. If unset, defaults to false.</string>
 			<key>pfm_name</key>
 			<string>startOnLogin</string>
 			<key>pfm_title</key>
@@ -220,10 +196,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
-			<string>Disables the update check and notification for the standalone variant of the macOS client. App Store variant versions 1.4.15 and higher already have this disabled.</string>
+			<string>Disables the update check and notification for the standalone variant of the macOS client. App Store variant versions 1.4.15 and higher already have this disabled. If unset, defaults to false.</string>
 			<key>pfm_name</key>
 			<string>disableUpdateCheck</string>
 			<key>pfm_title</key>
@@ -232,10 +206,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<string>https://www.firezone.dev/support</string>
 			<key>pfm_description</key>
-			<string>The URL to which users will be taken to when clicking the Help -&gt; Support link in the menu bar.</string>
+			<string>The URL to which users will be taken to when clicking the Help -&gt; Support link in the menu bar. If unset, defaults to https://www.firezone.dev/support.</string>
 			<key>pfm_name</key>
 			<string>supportURL</string>
 			<key>pfm_title</key>


### PR DESCRIPTION
Having defaults in here is confusing, because they are actually all unset by default which means the user settings won't be overridden.

This is the final version submitted at https://github.com/profilemanifests/profilemanifests