### PR TITLE
fix(apple): don't send connlib DNS server IPs that aren't IPs

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -448,7 +448,22 @@ extension Adapter: CallbackHandlerDelegate {
     let resolvers = resetToSystemDNSGettingBindResolvers()
 #endif
 
-    return resolvers
+    var parsedResolvers: [String] = []
+
+    // Normalize addresses to remove any possible scope suffixes
+    resolvers.forEach { stringAddress in
+      if let ipv4Address = IPv4Address(stringAddress) {
+        return parsedResolvers.append("\(ipv4Address)")
+      }
+
+      if let ipv6Address = IPv6Address(stringAddress) {
+        return parsedResolvers.append("\(ipv6Address)")
+      }
+
+      Log.warning("IP address \(stringAddress) did not parse as either IPv4 or IPv6")
+    }
+
+    return parsedResolvers
   }
 }
 

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,13 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9242">
+          Fixes a rare bug that could prevent certain IPv6 DNS upstream
+          resolvers from being used if they contained an interface scope
+          specifier.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.0" date={new Date("2025-05-26")}>
         <ChangeItem pull="9230">
           Finalizes the managed configuration support for the macOS client. For


### PR DESCRIPTION
When pulling IPs from system resolvers, it's possible the IPv6 addresses may contain scopes which will cause connlib to barf when parsing.

To fix these, we first convert to the Swift-native type `IPv4Address` or `IPv6Address` and then use the string representation of those types, which normalizes them to plain addresses.

Fixes #9055 