### PR TITLE
ci: increase max number of Rust dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,7 @@ updates:
       interval: monthly
   - package-ecosystem: cargo
     directory: rust/
+    open-pull-requests-limit: 20
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
We have a lot of Rust dependencies and the default limit of 5 just spoon-feeds us the updates.