### PR TITLE
ci: add `rand` group for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,10 @@ updates:
         patterns:
           - aya
           - aya-*
+      rand:
+        patterns:
+          - rand
+          - rand_*
   - package-ecosystem: gradle
     directory: kotlin/android/
     schedule:


### PR DESCRIPTION
The crates of the `rand` ecosystem need to be bumped together.