### PR TITLE
fix(android): ensure connectOnStart applies only to start

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
@@ -25,11 +25,16 @@ internal class SplashFragment : Fragment(R.layout.fragment_splash) {
         binding = FragmentSplashBinding.bind(view)
 
         setupActionObservers()
+
+        if (savedInstanceState == null) {
+            // Trigger the initial check for tunnel state
+            viewModel.checkTunnelState(requireContext(), isInitialLaunch = true)
+        }
     }
 
     override fun onResume() {
         super.onResume()
-        viewModel.checkTunnelState(requireContext())
+        viewModel.checkTunnelState(requireContext(), isInitialLaunch = false)
     }
 
     private fun setupActionObservers() {


### PR DESCRIPTION
A bug was introduced in #9227 where the `connectOnStart` was being read for both resumed launches and initial launches. This PR updates that logic so that we only check `connectOnStart` when the app is actually launched.

On mobile platforms, this flag is not as clearcut as on desktop platforms, but it's maintained here because ChromeOS is also used on desktop systems.