### PR TITLE
refactor(portal): start using created_by_subject

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/identity/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/identity/changeset.ex
@@ -11,6 +11,7 @@ defmodule Domain.Auth.Identity.Changeset do
       ) do
     actor
     |> create_identity(provider, attrs)
+    |> reset_created_by()
     |> put_subject_trail(:created_by, subject)
   end
 

--- a/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
@@ -135,12 +135,4 @@ defmodule Domain.Auth.Provider.Changeset do
     |> change()
     |> put_default_value(:deleted_at, DateTime.utc_now())
   end
-
-  defp reset_created_by(changeset) do
-    changeset
-    |> put_change(:created_by, nil)
-    |> put_change(:created_by_identity_id, nil)
-    |> put_change(:created_by_actor_id, nil)
-    |> put_change(:created_by_subject, nil)
-  end
 end

--- a/elixir/apps/domain/lib/domain/repo/changeset.ex
+++ b/elixir/apps/domain/lib/domain/repo/changeset.ex
@@ -177,6 +177,14 @@ defmodule Domain.Repo.Changeset do
     |> put_default_value(:"#{field}_identity_id", subject.identity.id)
   end
 
+  def reset_created_by(changeset) do
+    changeset
+    |> put_change(:created_by, nil)
+    |> put_change(:created_by_identity_id, nil)
+    |> put_change(:created_by_actor_id, nil)
+    |> put_change(:created_by_subject, nil)
+  end
+
   # Validations
 
   def validate_list(

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -2431,6 +2431,12 @@ defmodule Domain.AuthTest do
       assert identity.provider_state == %{}
       assert identity.provider_virtual_state == %{}
       assert identity.account_id == provider.account_id
+
+      assert identity.created_by_subject == %{
+               "name" => subject.actor.name,
+               "email" => subject.identity.email
+             }
+
       assert is_nil(identity.deleted_at)
     end
 

--- a/elixir/apps/web/lib/web/components/core_components.ex
+++ b/elixir/apps/web/lib/web/components/core_components.ex
@@ -1117,57 +1117,42 @@ defmodule Web.CoreComponents do
   @doc """
   Renders creation timestamp and entity.
   """
-  attr :account, :any, required: true
   attr :schema, :any, required: true
 
   def created_by(%{schema: %{created_by: :system}} = assigns) do
     ~H"""
-    <.relative_datetime datetime={@schema.inserted_at} /> by system
+    <.relative_datetime datetime={@schema.inserted_at} /> by System
     """
   end
 
   def created_by(%{schema: %{created_by: :actor}} = assigns) do
     ~H"""
-    <.relative_datetime datetime={@schema.inserted_at} /> by
-    <.actor_link account={@account} actor={@schema.created_by_actor} />
+    <.relative_datetime datetime={@schema.inserted_at} /> by {@schema.created_by_subject["name"]}
     """
   end
 
   def created_by(%{schema: %{created_by: :identity}} = assigns) do
     ~H"""
-    <.relative_datetime datetime={@schema.inserted_at} /> by
-    <.link
-      class="text-accent-500 hover:underline"
-      navigate={~p"/#{@schema.account_id}/actors/#{@schema.created_by_identity.actor.id}"}
-    >
-      <%= assigns.schema.created_by_identity.actor.name %>
-    </.link>
+    <.relative_datetime datetime={@schema.inserted_at} /> by {@schema.created_by_subject["name"]}
     """
   end
 
   def created_by(%{schema: %{created_by: :provider}} = assigns) do
     ~H"""
-    <.relative_datetime datetime={@schema.inserted_at} /> by
-    <.link
-      class="text-accent-500 hover:underline"
-      navigate={Web.Settings.IdentityProviders.Components.view_provider(@account, @schema.provider)}
-    >
-      <%= @schema.provider.name %>
-    </.link> sync
+    <.relative_datetime datetime={@schema.inserted_at} /> by Directory Sync
     """
   end
 
   @doc """
   Renders verification timestamp and entity.
   """
-  attr :account, :any, required: true
   attr :schema, :any, required: true
 
   def verified_by(%{schema: %{verified_by: :system}} = assigns) do
     ~H"""
     <div class="flex items-center gap-x-1">
       <.icon name="hero-shield-check" class="w-4 h-4" /> Verified
-      <.relative_datetime datetime={@schema.verified_at} /> by system
+      <.relative_datetime datetime={@schema.verified_at} /> by System
     </div>
     """
   end
@@ -1176,8 +1161,7 @@ defmodule Web.CoreComponents do
     ~H"""
     <div class="flex items-center gap-x-1">
       <.icon name="hero-shield-check" class="w-4 h-4" /> Verified
-      <.relative_datetime datetime={@schema.verified_at} /> by
-      <.actor_link account={@account} actor={@schema.verified_by_actor} />
+      <.relative_datetime datetime={@schema.verified_at} /> by {@schema.verified_by_subject["name"]}
     </div>
     """
   end
@@ -1186,13 +1170,7 @@ defmodule Web.CoreComponents do
     ~H"""
     <div class="flex items-center gap-x-1">
       <.icon name="hero-shield-check" class="w-4 h-4" /> Verified
-      <.relative_datetime datetime={@schema.verified_at} /> by
-      <.link
-        class="text-accent-500 hover:underline"
-        navigate={~p"/#{@schema.account_id}/actors/#{@schema.verified_by_identity.actor_id}"}
-      >
-        {assigns.schema.verified_by_actor.name}
-      </.link>
+      <.relative_datetime datetime={@schema.verified_at} /> by {@schema.verified_by_subject["name"]}
     </div>
     """
   end

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -269,7 +269,7 @@ defmodule Web.Actors.Show do
             <.identity_identifier account={@account} identity={identity} />
           </:col>
           <:col :let={identity} label="created">
-            <.created_by account={@account} schema={identity} />
+            <.created_by schema={identity} />
           </:col>
           <:col :let={identity} label="last signed in">
             <.relative_datetime datetime={identity.last_seen_at} />
@@ -415,7 +415,7 @@ defmodule Web.Actors.Show do
             {token.name}
           </:col>
           <:col :let={token} label="created" class="w-2/12">
-            <.created_by account={@account} schema={token} />
+            <.created_by schema={token} />
           </:col>
           <:col :let={token} label="expires" class="w-1/12">
             <%= if DateTime.compare(token.expires_at, DateTime.utc_now()) == :lt do %>

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -274,7 +274,7 @@ defmodule Web.Clients.Show do
               </.popover>
             </:label>
             <:value>
-              <.verified_by account={@account} schema={@client} />
+              <.verified_by schema={@client} />
             </:value>
           </.vertical_table_row>
 

--- a/elixir/apps/web/lib/web/live/groups/show.ex
+++ b/elixir/apps/web/lib/web/live/groups/show.ex
@@ -129,7 +129,7 @@ defmodule Web.Groups.Show do
           </.vertical_table_row>
           <.vertical_table_row>
             <:label>Created</:label>
-            <:value><.created_by account={@account} schema={@group} /></:value>
+            <:value><.created_by schema={@group} /></:value>
           </.vertical_table_row>
         </.vertical_table>
       </:content>

--- a/elixir/apps/web/lib/web/live/policies/show.ex
+++ b/elixir/apps/web/lib/web/live/policies/show.ex
@@ -230,7 +230,7 @@ defmodule Web.Policies.Show do
               Created
             </:label>
             <:value>
-              <.created_by account={@account} schema={@policy} />
+              <.created_by schema={@policy} />
             </:value>
           </.vertical_table_row>
         </.vertical_table>

--- a/elixir/apps/web/lib/web/live/relay_groups/show.ex
+++ b/elixir/apps/web/lib/web/live/relay_groups/show.ex
@@ -84,7 +84,7 @@ defmodule Web.RelayGroups.Show do
             <.vertical_table_row>
               <:label>Created</:label>
               <:value>
-                <.created_by account={@account} schema={@group} />
+                <.created_by schema={@group} />
               </:value>
             </.vertical_table_row>
           </.vertical_table>

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -238,7 +238,7 @@ defmodule Web.Resources.Show do
               Created
             </:label>
             <:value>
-              <.created_by account={@account} schema={@resource} />
+              <.created_by schema={@resource} />
             </:value>
           </.vertical_table_row>
         </.vertical_table>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/show.ex
@@ -200,7 +200,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Show do
             <.vertical_table_row>
               <:label>Created</:label>
               <:value>
-                <.created_by account={@account} schema={@provider} />
+                <.created_by schema={@provider} />
               </:value>
             </.vertical_table_row>
           </.vertical_table>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/show.ex
@@ -211,7 +211,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Show do
             <.vertical_table_row>
               <:label>Created</:label>
               <:value>
-                <.created_by account={@account} schema={@provider} />
+                <.created_by schema={@provider} />
               </:value>
             </.vertical_table_row>
           </.vertical_table>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/show.ex
@@ -198,7 +198,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Show do
             <.vertical_table_row>
               <:label>Created</:label>
               <:value>
-                <.created_by account={@account} schema={@provider} />
+                <.created_by schema={@provider} />
               </:value>
             </.vertical_table_row>
           </.vertical_table>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/mock/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/mock/show.ex
@@ -203,7 +203,7 @@ defmodule Web.Settings.IdentityProviders.Mock.Show do
             <.vertical_table_row>
               <:label>Created</:label>
               <:value>
-                <.created_by account={@account} schema={@provider} />
+                <.created_by schema={@provider} />
               </:value>
             </.vertical_table_row>
           </.vertical_table>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/show.ex
@@ -218,7 +218,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Show do
             <.vertical_table_row>
               <:label>Created</:label>
               <:value>
-                <.created_by account={@account} schema={@provider} />
+                <.created_by schema={@provider} />
               </:value>
             </.vertical_table_row>
           </.vertical_table>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/show.ex
@@ -175,7 +175,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Show do
             <.vertical_table_row>
               <:label>Created</:label>
               <:value>
-                <.created_by account={@account} schema={@provider} />
+                <.created_by schema={@provider} />
               </:value>
             </.vertical_table_row>
           </.vertical_table>

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/system/show.ex
@@ -102,7 +102,7 @@ defmodule Web.Settings.IdentityProviders.System.Show do
             <.vertical_table_row>
               <:label>Created</:label>
               <:value>
-                <.created_by account={@account} schema={@provider} />
+                <.created_by schema={@provider} />
               </:value>
             </.vertical_table_row>
           </.vertical_table>

--- a/elixir/apps/web/lib/web/live/sites/show.ex
+++ b/elixir/apps/web/lib/web/live/sites/show.ex
@@ -206,7 +206,7 @@ defmodule Web.Sites.Show do
           <.vertical_table_row>
             <:label>Created</:label>
             <:value>
-              <.created_by account={@account} schema={@group} />
+              <.created_by schema={@group} />
             </:value>
           </.vertical_table_row>
         </.vertical_table>

--- a/elixir/apps/web/test/web/live/actors/show_test.exs
+++ b/elixir/apps/web/test/web/live/actors/show_test.exs
@@ -322,7 +322,8 @@ defmodule Web.Live.Actors.ShowTest do
         Fixtures.Auth.create_identity(account: account, actor: actor)
         |> Ecto.Changeset.change(
           created_by: :identity,
-          created_by_identity_id: admin_identity.id
+          created_by_identity_id: admin_identity.id,
+          created_by_subject: %{"name" => actor.name, "email" => admin_identity.email}
         )
         |> Repo.update!()
 
@@ -367,7 +368,7 @@ defmodule Web.Live.Actors.ShowTest do
         "#{synced_identity.provider_identifier}",
         fn row ->
           refute row["actions"]
-          assert row["created"] =~ "by #{synced_identity.provider.name} sync"
+          assert row["created"] =~ "by Directory Sync"
           assert row["last signed in"] == "Never"
         end
       )

--- a/elixir/apps/web/test/web/live/groups/show_test.exs
+++ b/elixir/apps/web/test/web/live/groups/show_test.exs
@@ -166,7 +166,7 @@ defmodule Web.Live.Groups.ShowTest do
            |> element("#group")
            |> render()
            |> vertical_table_to_map()
-           |> Map.fetch!("created") =~ "by #{provider.name} sync"
+           |> Map.fetch!("created") =~ "by Directory Sync"
   end
 
   test "renders group actors", %{

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/show_test.exs
@@ -142,7 +142,8 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.ShowTest do
     provider
     |> Ecto.Changeset.change(
       created_by: :identity,
-      created_by_identity_id: identity.id
+      created_by_identity_id: identity.id,
+      created_by_subject: %{"name" => actor.name, "email" => identity.email}
     )
     |> Repo.update!()
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/jumpcloud/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/jumpcloud/show_test.exs
@@ -163,7 +163,8 @@ defmodule Web.Live.Settings.IdentityProviders.JumpCloud.ShowTest do
     provider
     |> Ecto.Changeset.change(
       created_by: :identity,
-      created_by_identity_id: identity.id
+      created_by_identity_id: identity.id,
+      created_by_subject: %{"name" => actor.name, "email" => identity.email}
     )
     |> Repo.update!()
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/microsoft_entra/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/microsoft_entra/show_test.exs
@@ -142,7 +142,8 @@ defmodule Web.Live.Settings.IdentityProviders.MicrosoftEntra.ShowTest do
     provider
     |> Ecto.Changeset.change(
       created_by: :identity,
-      created_by_identity_id: identity.id
+      created_by_identity_id: identity.id,
+      created_by_subject: %{"name" => actor.name, "email" => identity.email}
     )
     |> Repo.update!()
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/okta/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/okta/show_test.exs
@@ -142,7 +142,8 @@ defmodule Web.Live.Settings.IdentityProviders.Okta.ShowTest do
     provider
     |> Ecto.Changeset.change(
       created_by: :identity,
-      created_by_identity_id: identity.id
+      created_by_identity_id: identity.id,
+      created_by_subject: %{"name" => actor.name, "email" => identity.email}
     )
     |> Repo.update!()
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/show_test.exs
@@ -103,7 +103,8 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.ShowTest do
     provider
     |> Ecto.Changeset.change(
       created_by: :identity,
-      created_by_identity_id: identity.id
+      created_by_identity_id: identity.id,
+      created_by_subject: %{"name" => actor.name, "email" => identity.email}
     )
     |> Repo.update!()
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/system/show_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/system/show_test.exs
@@ -92,7 +92,8 @@ defmodule Web.Live.Settings.IdentityProviders.System.ShowTest do
     provider
     |> Ecto.Changeset.change(
       created_by: :identity,
-      created_by_identity_id: identity.id
+      created_by_identity_id: identity.id,
+      created_by_subject: %{"name" => actor.name, "email" => identity.email}
     )
     |> Repo.update!()
 


### PR DESCRIPTION
Now that we've added the `created_by_subject` column on all relevant tables, we can start using that data in the portal.