### PR TITLE
refactor(portal): Move client updates to WAL broadcaster

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -124,7 +124,7 @@ defmodule API.Client.Channel do
     OpenTelemetry.Tracer.set_current_span(opentelemetry_span_ctx)
 
     OpenTelemetry.Tracer.with_span "client.after_join" do
-      :ok = Clients.connect_client(socket.assigns.client)
+      :ok = Events.Hooks.Clients.connect(socket.assigns.client)
 
       # Subscribe for account config updates
       :ok = Events.Hooks.Accounts.subscribe(socket.assigns.client.account_id)

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -599,7 +599,7 @@ defmodule API.Gateway.Channel do
 
       :ok =
         Enum.each(client_ids, fn client_id ->
-          Clients.broadcast_to_client(
+          Events.Hooks.Clients.broadcast(
             client_id,
             {:ice_candidates, socket.assigns.gateway.id, candidates,
              {opentelemetry_ctx, opentelemetry_span_ctx}}
@@ -624,7 +624,7 @@ defmodule API.Gateway.Channel do
 
       :ok =
         Enum.each(client_ids, fn client_id ->
-          Clients.broadcast_to_client(
+          Events.Hooks.Clients.broadcast(
             client_id,
             {:invalidate_ice_candidates, socket.assigns.gateway.id, candidates,
              {opentelemetry_ctx, opentelemetry_span_ctx}}

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -1,5 +1,6 @@
 defmodule API.Client.ChannelTest do
   use API.ChannelCase, async: true
+  alias Domain.Events
 
   setup do
     account =
@@ -167,7 +168,7 @@ defmodule API.Client.ChannelTest do
   describe "join/3" do
     test "tracks presence after join", %{account: account, client: client} do
       presence =
-        Domain.Clients.Presence.list(Domain.Clients.account_clients_presence_topic(account))
+        Domain.Clients.Presence.list(Events.Hooks.Accounts.clients_presence_topic(account.id))
 
       assert %{metas: [%{online_at: online_at, phx_ref: _ref}]} = Map.fetch!(presence, client.id)
       assert is_number(online_at)
@@ -499,7 +500,7 @@ defmodule API.Client.ChannelTest do
     } do
       assert_push "init", %{}
       Process.flag(:trap_exit, true)
-      Domain.Clients.broadcast_to_client(client, :token_expired)
+      Events.Hooks.Clients.broadcast(client.id, :token_expired)
       assert_push "disconnect", %{reason: :token_expired}, 250
     end
 

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -1,5 +1,6 @@
 defmodule API.Gateway.ChannelTest do
   use API.ChannelCase, async: true
+  alias Domain.Events
 
   setup do
     account = Fixtures.Accounts.create_account()
@@ -1094,7 +1095,7 @@ defmodule API.Gateway.ChannelTest do
         "client_ids" => [client.id]
       }
 
-      :ok = Domain.Clients.connect_client(client)
+      :ok = Events.Hooks.Clients.connect(client)
       Domain.PubSub.subscribe(Domain.Tokens.socket_id(subject.token_id))
 
       push(socket, "broadcast_ice_candidates", attrs)
@@ -1132,7 +1133,7 @@ defmodule API.Gateway.ChannelTest do
         "client_ids" => [client.id]
       }
 
-      :ok = Domain.Clients.connect_client(client)
+      :ok = Events.Hooks.Clients.connect(client)
       Domain.PubSub.subscribe(Domain.Tokens.socket_id(subject.token_id))
 
       push(socket, "broadcast_invalidated_ice_candidates", attrs)

--- a/elixir/apps/domain/lib/domain/accounts.ex
+++ b/elixir/apps/domain/lib/domain/accounts.ex
@@ -93,18 +93,6 @@ defmodule Domain.Accounts do
       with: &Account.Changeset.update(&1, attrs),
       after_commit: &on_account_update/2
     )
-    |> case do
-      {:ok, %{disabled_at: nil} = account} ->
-        {:ok, account}
-
-      {:ok, account} ->
-        # TODO: WAL
-        :ok = Domain.Clients.disconnect_account_clients(account)
-        {:ok, account}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
   end
 
   defp on_account_update(account, changeset) do

--- a/elixir/apps/domain/lib/domain/events/hooks/accounts.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/accounts.ex
@@ -6,6 +6,15 @@ defmodule Domain.Events.Hooks.Accounts do
     :ok
   end
 
+  # Account disabled - disconnect clients
+  def on_update(
+        %{"disabled_at" => nil} = _old_data,
+        %{"disabled_at" => disabled_at, "id" => account_id} = _data
+      )
+      when not is_nil(disabled_at) do
+    disconnect_clients(account_id)
+  end
+
   def on_update(%{"config" => old_config}, %{"config" => config, "id" => account_id}) do
     if old_config != config do
       broadcast(account_id, :config_changed)
@@ -22,9 +31,41 @@ defmodule Domain.Events.Hooks.Accounts do
     PubSub.subscribe("accounts:#{account_id}")
   end
 
+  def subscribe_to_clients(account_id) do
+    account_id
+    |> clients_topic()
+    |> PubSub.subscribe()
+  end
+
+  def subscribe_to_clients_presence(account_id) do
+    account_id
+    |> clients_presence_topic()
+    |> PubSub.subscribe()
+  end
+
   # No unsubscribe needed - account deletions destroy any subscribed entities
 
+  def clients_presence_topic(account_or_id) do
+    "presences:#{clients_topic(account_or_id)}"
+  end
+
+  def clients_topic(account_id) do
+    "account_clients:#{account_id}"
+  end
+
+  defp topic(account_id) do
+    "accounts:#{account_id}"
+  end
+
   defp broadcast(account_id, event) do
-    PubSub.broadcast("accounts:#{account_id}", event)
+    account_id
+    |> topic()
+    |> PubSub.broadcast(event)
+  end
+
+  defp disconnect_clients(account_id) do
+    account_id
+    |> clients_topic()
+    |> PubSub.broadcast("disconnect")
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/actors.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/actors.ex
@@ -1,4 +1,6 @@
 defmodule Domain.Events.Hooks.Actors do
+  alias Domain.PubSub
+
   def on_insert(_data) do
     :ok
   end
@@ -9,5 +11,19 @@ defmodule Domain.Events.Hooks.Actors do
 
   def on_delete(_old_data) do
     :ok
+  end
+
+  def subscribe_to_clients_presence(actor_id) do
+    actor_id
+    |> clients_presence_topic()
+    |> PubSub.subscribe()
+  end
+
+  def clients_presence_topic(actor_id) do
+    "presences:#{clients_topic(actor_id)}"
+  end
+
+  defp clients_topic(actor_id) do
+    "actor_clients:#{actor_id}"
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/clients.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/clients.ex
@@ -1,13 +1,61 @@
 defmodule Domain.Events.Hooks.Clients do
+  alias Domain.PubSub
+  alias Domain.Clients.{Client, Presence}
+  alias Domain.Events
+
   def on_insert(_data) do
     :ok
   end
 
-  def on_update(_old_data, _data) do
-    :ok
+  # Soft-delete
+  def on_update(%{"deleted_at" => nil} = old_data, %{"deleted_at" => deleted_at} = _data)
+      when not is_nil(deleted_at) do
+    on_delete(old_data)
   end
 
-  def on_delete(_old_data) do
-    :ok
+  # Regular update
+  def on_update(_old_data, %{"id" => client_id} = _data) do
+    broadcast(client_id, :updated)
+  end
+
+  def on_delete(%{"id" => client_id} = _old_data) do
+    disconnect_client(client_id)
+  end
+
+  def connect(%Client{} = client) do
+    with {:ok, _} <-
+           Presence.track(
+             self(),
+             Events.Hooks.Accounts.clients_presence_topic(client.account_id),
+             client.id,
+             %{
+               online_at: System.system_time(:second)
+             }
+           ),
+         {:ok, _} <-
+           Presence.track(
+             self(),
+             Events.Hooks.Actors.clients_presence_topic(client.actor_id),
+             client.id,
+             %{}
+           ) do
+      :ok = PubSub.subscribe(topic(client.id))
+      :ok = Events.Hooks.Accounts.subscribe_to_clients(client.account_id)
+      :ok
+    end
+  end
+
+  ### PubSub
+
+  def broadcast(client_id, payload) do
+    client_id
+    |> topic()
+    |> PubSub.broadcast(payload)
+  end
+
+  defp topic(client_id), do: "clients:#{client_id}"
+
+  defp disconnect_client(client_id) do
+    broadcast(client_id, "disconnect")
   end
 end

--- a/elixir/apps/domain/test/domain/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/accounts_test.exs
@@ -746,18 +746,14 @@ defmodule Domain.AccountsTest do
              ]
     end
 
-    test "broadcasts disconnect message for the clients when account is disabled", %{
+    test "allows disabling an account", %{
       account: account
     } do
       attrs = %{
         disabled_at: DateTime.utc_now()
       }
 
-      :ok = Domain.PubSub.subscribe("account_clients:#{account.id}")
-
       assert {:ok, _account} = update_account_by_id(account.id, attrs)
-
-      assert_receive "disconnect"
     end
   end
 

--- a/elixir/apps/domain/test/domain/actors_test.exs
+++ b/elixir/apps/domain/test/domain/actors_test.exs
@@ -4,6 +4,7 @@ defmodule Domain.ActorsTest do
   alias Domain.Auth
   alias Domain.Clients
   alias Domain.Actors
+  alias Domain.Events
 
   describe "fetch_groups_count_grouped_by_provider_id/1" do
     test "returns empty map when there are no groups" do
@@ -631,7 +632,7 @@ defmodule Domain.ActorsTest do
     } do
       actor = Fixtures.Actors.create_actor(account: account)
       client = Fixtures.Clients.create_client(account: account, actor: actor)
-      Domain.Clients.connect_client(client)
+      Events.Hooks.Clients.connect(client)
 
       assert {:ok, peek} = peek_actor_clients([actor], 3, subject)
       assert [%Clients.Client{} = client] = peek[actor.id].items

--- a/elixir/apps/domain/test/domain/events/hooks/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/accounts_test.exs
@@ -53,47 +53,6 @@ defmodule Domain.Events.Hooks.AccountsTest do
       assert :ok == on_update(old_data, data)
       refute_receive :config_changed
     end
-
-    test "sends :config_changed if config changes" do
-      account = Fixtures.Accounts.create_account()
-
-      :ok = subscribe(account.id)
-
-      old_data = %{
-        "id" => account.id,
-        "config" => %{"search_domain" => "old_value", "clients_upstream_dns" => []}
-      }
-
-      data = %{
-        "id" => account.id,
-        "config" => %{
-          "search_domain" => "new_value",
-          "clients_upstream_dns" => [%{"protocol" => "ip_port", "address" => "8.8.8.8"}]
-        }
-      }
-
-      assert :ok == on_update(old_data, data)
-      assert_receive :config_changed
-    end
-
-    test "does not send :config_changed if config does not change" do
-      account = Fixtures.Accounts.create_account()
-
-      :ok = subscribe(account.id)
-
-      old_data = %{
-        "id" => account.id,
-        "config" => %{"search_domain" => "old_value", "clients_upstream_dns" => []}
-      }
-
-      data = %{
-        "id" => account.id,
-        "config" => %{"search_domain" => "old_value", "clients_upstream_dns" => []}
-      }
-
-      assert :ok == on_update(old_data, data)
-      refute_receive :config_changed
-    end
   end
 
   describe "delete/1" do

--- a/elixir/apps/domain/test/domain/events/hooks/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/accounts_test.exs
@@ -53,6 +53,47 @@ defmodule Domain.Events.Hooks.AccountsTest do
       assert :ok == on_update(old_data, data)
       refute_receive :config_changed
     end
+
+    test "sends :config_changed if config changes" do
+      account = Fixtures.Accounts.create_account()
+
+      :ok = subscribe(account.id)
+
+      old_data = %{
+        "id" => account.id,
+        "config" => %{"search_domain" => "old_value", "clients_upstream_dns" => []}
+      }
+
+      data = %{
+        "id" => account.id,
+        "config" => %{
+          "search_domain" => "new_value",
+          "clients_upstream_dns" => [%{"protocol" => "ip_port", "address" => "8.8.8.8"}]
+        }
+      }
+
+      assert :ok == on_update(old_data, data)
+      assert_receive :config_changed
+    end
+
+    test "does not send :config_changed if config does not change" do
+      account = Fixtures.Accounts.create_account()
+
+      :ok = subscribe(account.id)
+
+      old_data = %{
+        "id" => account.id,
+        "config" => %{"search_domain" => "old_value", "clients_upstream_dns" => []}
+      }
+
+      data = %{
+        "id" => account.id,
+        "config" => %{"search_domain" => "old_value", "clients_upstream_dns" => []}
+      }
+
+      assert :ok == on_update(old_data, data)
+      refute_receive :config_changed
+    end
   end
 
   describe "delete/1" do

--- a/elixir/apps/domain/test/domain/events/hooks/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/accounts_test.exs
@@ -53,6 +53,19 @@ defmodule Domain.Events.Hooks.AccountsTest do
       assert :ok == on_update(old_data, data)
       refute_receive :config_changed
     end
+
+    test "sends disconnect to clients if account is disabled" do
+      account_id = Fixtures.Accounts.create_account().id
+
+      old_data = %{"id" => account_id, "disabled_at" => nil}
+      data = %{"id" => account_id, "disabled_at" => DateTime.utc_now()}
+
+      :ok = subscribe_to_clients(account_id)
+
+      assert :ok == on_update(old_data, data)
+
+      assert_receive "disconnect"
+    end
   end
 
   describe "delete/1" do

--- a/elixir/apps/domain/test/domain/events/hooks/flows_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/flows_test.exs
@@ -70,6 +70,64 @@ defmodule Domain.Events.Hooks.FlowsTest do
       assert :ok == on_update(old_data, data)
       refute_receive {:expire_flow, ^flow_id, ^client_id, ^resource_id}
     end
+
+    test "broadcasts expire_flow if flow is expired" do
+      flow_id = "flow_123"
+      client_id = "client_123"
+      resource_id = "resource_123"
+
+      old_data = %{}
+
+      data = %{
+        "expires_at" => DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.to_iso8601(),
+        "id" => flow_id,
+        "client_id" => client_id,
+        "resource_id" => resource_id
+      }
+
+      :ok = subscribe(flow_id)
+
+      assert :ok == on_update(old_data, data)
+      assert_receive {:expire_flow, ^flow_id, ^client_id, ^resource_id}
+    end
+
+    test "does not broadcast expire_flow if flow is not expired" do
+      flow_id = "flow_123"
+      client_id = "client_123"
+      resource_id = "resource_123"
+
+      old_data = %{}
+
+      data = %{
+        "expires_at" => DateTime.utc_now() |> DateTime.add(1, :second) |> DateTime.to_iso8601(),
+        "id" => flow_id,
+        "client_id" => client_id,
+        "resource_id" => resource_id
+      }
+
+      :ok = subscribe(flow_id)
+
+      assert :ok == on_update(old_data, data)
+      refute_receive {:expire_flow, ^flow_id, ^client_id, ^resource_id}
+    end
+
+    test "does not receive broadcast when not subscribed" do
+      flow_id = "flow_123"
+      client_id = "client_123"
+      resource_id = "resource_123"
+
+      old_data = %{}
+
+      data = %{
+        "expires_at" => DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.to_iso8601(),
+        "id" => flow_id,
+        "client_id" => client_id,
+        "resource_id" => resource_id
+      }
+
+      assert :ok == on_update(old_data, data)
+      refute_receive {:expire_flow, ^flow_id, ^client_id, ^resource_id}
+    end
   end
 
   describe "delete/1" do

--- a/elixir/apps/domain/test/domain/events/hooks/flows_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/flows_test.exs
@@ -70,64 +70,6 @@ defmodule Domain.Events.Hooks.FlowsTest do
       assert :ok == on_update(old_data, data)
       refute_receive {:expire_flow, ^flow_id, ^client_id, ^resource_id}
     end
-
-    test "broadcasts expire_flow if flow is expired" do
-      flow_id = "flow_123"
-      client_id = "client_123"
-      resource_id = "resource_123"
-
-      old_data = %{}
-
-      data = %{
-        "expires_at" => DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.to_iso8601(),
-        "id" => flow_id,
-        "client_id" => client_id,
-        "resource_id" => resource_id
-      }
-
-      :ok = subscribe(flow_id)
-
-      assert :ok == on_update(old_data, data)
-      assert_receive {:expire_flow, ^flow_id, ^client_id, ^resource_id}
-    end
-
-    test "does not broadcast expire_flow if flow is not expired" do
-      flow_id = "flow_123"
-      client_id = "client_123"
-      resource_id = "resource_123"
-
-      old_data = %{}
-
-      data = %{
-        "expires_at" => DateTime.utc_now() |> DateTime.add(1, :second) |> DateTime.to_iso8601(),
-        "id" => flow_id,
-        "client_id" => client_id,
-        "resource_id" => resource_id
-      }
-
-      :ok = subscribe(flow_id)
-
-      assert :ok == on_update(old_data, data)
-      refute_receive {:expire_flow, ^flow_id, ^client_id, ^resource_id}
-    end
-
-    test "does not receive broadcast when not subscribed" do
-      flow_id = "flow_123"
-      client_id = "client_123"
-      resource_id = "resource_123"
-
-      old_data = %{}
-
-      data = %{
-        "expires_at" => DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.to_iso8601(),
-        "id" => flow_id,
-        "client_id" => client_id,
-        "resource_id" => resource_id
-      }
-
-      assert :ok == on_update(old_data, data)
-      refute_receive {:expire_flow, ^flow_id, ^client_id, ^resource_id}
-    end
   end
 
   describe "delete/1" do

--- a/elixir/apps/web/lib/web/live/actors/show.ex
+++ b/elixir/apps/web/lib/web/live/actors/show.ex
@@ -2,7 +2,7 @@ defmodule Web.Actors.Show do
   use Web, :live_view
   import Web.Actors.Components
   import Web.Clients.Components
-  alias Domain.{Accounts, Auth, Tokens, Flows, Clients}
+  alias Domain.{Accounts, Auth, Events, Tokens, Flows, Clients}
   alias Domain.Actors
 
   def mount(%{"id" => id}, _session, socket) do
@@ -10,7 +10,9 @@ defmodule Web.Actors.Show do
            Actors.fetch_actor_by_id(id, socket.assigns.subject,
              preload: [:identities, :last_seen_at, groups: [:provider]]
            ) do
-      :ok = Clients.subscribe_to_clients_presence_for_actor(actor)
+      if connected?(socket) do
+        :ok = Events.Hooks.Actors.subscribe_to_clients_presence(actor.id)
+      end
 
       available_providers =
         Auth.all_active_providers_for_account!(socket.assigns.account)

--- a/elixir/apps/web/lib/web/live/clients/index.ex
+++ b/elixir/apps/web/lib/web/live/clients/index.ex
@@ -3,10 +3,11 @@ defmodule Web.Clients.Index do
   import Web.Actors.Components
   import Web.Clients.Components
   alias Domain.Clients
+  alias Domain.Events
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      :ok = Clients.subscribe_to_clients_presence_in_account(socket.assigns.subject.account)
+      :ok = Events.Hooks.Accounts.subscribe_to_clients_presence(socket.assigns.subject.account.id)
     end
 
     socket =

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -2,7 +2,7 @@ defmodule Web.Clients.Show do
   use Web, :live_view
   import Web.Policies.Components
   import Web.Clients.Components
-  alias Domain.{Accounts, Clients, Flows}
+  alias Domain.{Accounts, Clients, Events, Flows}
 
   def mount(%{"id" => id}, _session, socket) do
     with {:ok, client} <-
@@ -16,7 +16,7 @@ defmodule Web.Clients.Show do
              ]
            ) do
       if connected?(socket) do
-        :ok = Clients.subscribe_to_clients_presence_for_actor(client.actor)
+        :ok = Events.Hooks.Actors.subscribe_to_clients_presence(client.actor_id)
       end
 
       socket =

--- a/elixir/apps/web/test/web/live/actors/index_test.exs
+++ b/elixir/apps/web/test/web/live/actors/index_test.exs
@@ -60,7 +60,7 @@ defmodule Web.Live.Actors.IndexTest do
     admin_actor = Fixtures.Actors.create_actor(account: account, type: :account_admin_user)
     Fixtures.Actors.create_membership(account: account, actor: admin_actor)
     client = Fixtures.Clients.create_client(account: account, actor: admin_actor)
-    Domain.Clients.connect_client(client)
+    Domain.Events.Hooks.Clients.connect(client)
     admin_actor = Repo.preload(admin_actor, identities: [:provider], groups: [])
 
     user_actor = Fixtures.Actors.create_actor(account: account, type: :account_user)

--- a/elixir/apps/web/test/web/live/actors/show_test.exs
+++ b/elixir/apps/web/test/web/live/actors/show_test.exs
@@ -1,5 +1,6 @@
 defmodule Web.Live.Actors.ShowTest do
   use Web.ConnCase, async: true
+  alias Domain.Events
 
   test "redirects to sign in page for unauthorized user", %{conn: conn} do
     account = Fixtures.Accounts.create_account()
@@ -91,8 +92,8 @@ defmodule Web.Live.Actors.ShowTest do
       |> live(~p"/#{account}/actors/#{actor}")
 
     Domain.Config.put_env_override(:test_pid, self())
-    Domain.Clients.subscribe_to_clients_presence_for_actor(actor)
-    assert Domain.Clients.connect_client(client) == :ok
+    :ok = Events.Hooks.Actors.subscribe_to_clients_presence(actor.id)
+    assert Events.Hooks.Clients.connect(client) == :ok
     assert_receive %Phoenix.Socket.Broadcast{topic: "presences:actor_clients:" <> _}
     assert_receive {:live_table_reloaded, "clients"}, 500
 

--- a/elixir/apps/web/test/web/live/clients/index_test.exs
+++ b/elixir/apps/web/test/web/live/clients/index_test.exs
@@ -1,5 +1,6 @@
 defmodule Web.Live.Clients.IndexTest do
   use Web.ConnCase, async: true
+  alias Domain.Events
 
   setup do
     account = Fixtures.Accounts.create_account()
@@ -59,7 +60,7 @@ defmodule Web.Live.Clients.IndexTest do
     online_client = Fixtures.Clients.create_client(account: account)
     offline_client = Fixtures.Clients.create_client(account: account)
 
-    :ok = Domain.Clients.connect_client(online_client)
+    :ok = Events.Hooks.Clients.connect(online_client)
 
     {:ok, lv, _html} =
       conn
@@ -102,8 +103,8 @@ defmodule Web.Live.Clients.IndexTest do
       |> live(~p"/#{account}/clients")
 
     Domain.Config.put_env_override(:test_pid, self())
-    Domain.Clients.subscribe_to_clients_presence_for_actor(actor)
-    assert Domain.Clients.connect_client(client) == :ok
+    :ok = Events.Hooks.Actors.subscribe_to_clients_presence(client.actor_id)
+    assert Events.Hooks.Clients.connect(client) == :ok
     assert_receive %Phoenix.Socket.Broadcast{topic: "presences:actor_clients:" <> _}
     assert_receive {:live_table_reloaded, "clients"}, 250
 

--- a/elixir/apps/web/test/web/live/clients/show_test.exs
+++ b/elixir/apps/web/test/web/live/clients/show_test.exs
@@ -1,5 +1,6 @@
 defmodule Web.Live.Clients.ShowTest do
   use Web.ConnCase, async: true
+  alias Domain.Events
 
   setup do
     account = Fixtures.Accounts.create_account()
@@ -116,7 +117,7 @@ defmodule Web.Live.Clients.ShowTest do
     identity: identity,
     conn: conn
   } do
-    :ok = Domain.Clients.connect_client(client)
+    :ok = Events.Hooks.Clients.connect(client)
 
     {:ok, lv, _html} =
       conn
@@ -144,8 +145,8 @@ defmodule Web.Live.Clients.ShowTest do
       |> authorize_conn(identity)
       |> live(~p"/#{account}/clients/#{client}")
 
-    Domain.Clients.subscribe_to_clients_presence_for_actor(actor)
-    assert Domain.Clients.connect_client(client) == :ok
+    Events.Hooks.Actors.subscribe_to_clients_presence(actor.id)
+    assert Events.Hooks.Clients.connect(client) == :ok
     assert_receive %Phoenix.Socket.Broadcast{topic: "presences:actor_clients:" <> _}
 
     wait_for(fn ->


### PR DESCRIPTION
Client updates are next on the path to moving more side effects to the WAL broadcaster. This one has the following notable changes:

- ~~The `actor_clients` pubsub topic were only used to broadcast removal of clients belonging to an actor; these are no longer needed since we handle this in the individual removal event~~ EDIT: only the presence is kept
- The `account_clients:{account_id}` pubsub and presence topic definition has been moved to `Events.Hooks.Accounts` because these are broadcasted using the account_id field based on account changes, and have nothing to do with the client lifecycle


Related: #6294 
Related: #8187
