### PR TITLE
fix(apple): Check for 'Authentication token expired'

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -431,7 +431,7 @@ extension Adapter: CallbackHandlerDelegate {
 
       // HACK: Define more connlib error types across the FFI so we can switch on them
       // directly and not parse error strings here.
-      if error.contains("401 Unauthorized") {
+      if error.contains("401 Unauthorized") || error.contains("Authentication token expired") {
         reason = .authenticationCanceled
       }
 

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9290">
+          Fixes a minor bug that prevented alerting the user when the app signs
+          itself out due to an expired authentication token.
+        </ChangeItem>
         <ChangeItem pull="9242">
           Fixes a rare bug that could prevent certain IPv6 DNS upstream
           resolvers from being used if they contained an interface scope


### PR DESCRIPTION
Adds a lookout for the string `Authentication token expired` since error types are not translated across the FFI on Apple, and this message is used to determine whether to alert the user.

Fixes: #9289 