### PR TITLE
refactor(portal): Move token events to WAL broadcaster

### DIFF
--- a/elixir/apps/domain/lib/domain/events/hooks/tokens.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/tokens.ex
@@ -3,11 +3,28 @@ defmodule Domain.Events.Hooks.Tokens do
     :ok
   end
 
-  def on_update(_old_data, _data) do
+  # updates for email tokens have no side effects
+  def on_update(%{"type" => "email"}, _data), do: :ok
+  def on_update(_old_data, %{"type" => "email"}), do: :ok
+
+  # Soft-delete
+  def on_update(%{"deleted_at" => nil} = old_data, %{"deleted_at" => deleted_at})
+      when not is_nil(deleted_at) do
+    on_delete(old_data)
+  end
+
+  # Regular update - not expected to happen in normal operation
+  def on_update(_old_data, _new_data) do
     :ok
   end
 
-  def on_delete(_old_data) do
-    :ok
+  def on_delete(%{"id" => token_id}) do
+    broadcast_disconnect(token_id)
+  end
+
+  defp broadcast_disconnect(token_id) do
+    topic = Domain.Tokens.socket_id(token_id)
+    payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
+    Phoenix.PubSub.broadcast(Domain.PubSub, topic, payload)
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/tokens.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/tokens.ex
@@ -13,7 +13,7 @@ defmodule Domain.Events.Hooks.Tokens do
     on_delete(old_data)
   end
 
-  # Regular update - not expected to happen in normal operation
+  # Regular update
   def on_update(_old_data, _new_data) do
     :ok
   end

--- a/elixir/apps/domain/lib/domain/tokens.ex
+++ b/elixir/apps/domain/lib/domain/tokens.ex
@@ -290,21 +290,7 @@ defmodule Domain.Tokens do
       |> Token.Query.delete()
       |> Repo.update_all([])
 
-    # TODO: WAL
-    :ok = Enum.each(tokens, &broadcast_disconnect_message/1)
-
     {:ok, tokens}
-  end
-
-  # TODO: WAL
-  defp broadcast_disconnect_message(%{type: :email}) do
-    :ok
-  end
-
-  defp broadcast_disconnect_message(token) do
-    topic = socket_id(token)
-    payload = %Phoenix.Socket.Broadcast{topic: topic, event: "disconnect"}
-    Phoenix.PubSub.broadcast(Domain.PubSub, topic, payload)
   end
 
   defp fetch_config! do

--- a/elixir/apps/domain/test/domain/actors_test.exs
+++ b/elixir/apps/domain/test/domain/actors_test.exs
@@ -3010,20 +3010,17 @@ defmodule Domain.ActorsTest do
       assert is_nil(other_actor.disabled_at)
     end
 
-    test "deletes token and broadcasts message to disconnect the actor sessions" do
+    test "deletes token" do
       account = Fixtures.Accounts.create_account()
       actor = Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
       Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
       identity = Fixtures.Auth.create_identity(account: account, actor: actor)
       subject = Fixtures.Auth.create_subject(identity: identity)
 
-      Phoenix.PubSub.subscribe(Domain.PubSub, "sessions:#{subject.token_id}")
-
       assert {:ok, _actor} = disable_actor(actor, subject)
 
       assert token = Repo.get(Domain.Tokens.Token, subject.token_id)
       assert token.deleted_at
-      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}
     end
 
     test "expires actor flows" do
@@ -3217,20 +3214,17 @@ defmodule Domain.ActorsTest do
       assert group.memberships == []
     end
 
-    test "deletes token and broadcasts message to disconnect the actor sessions", %{
+    test "deletes token", %{
       account: account,
       actor: actor,
       subject: subject
     } do
       Fixtures.Actors.create_actor(type: :account_admin_user, account: account)
 
-      Phoenix.PubSub.subscribe(Domain.PubSub, "sessions:#{subject.token_id}")
-
       assert {:ok, _actor} = delete_actor(actor, subject)
 
       assert token = Repo.get(Domain.Tokens.Token, subject.token_id)
       assert token.deleted_at
-      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}
     end
 
     test "deletes actor identities", %{

--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
@@ -635,7 +635,6 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       :ok = Domain.Policies.subscribe_to_events_for_actor(actor)
       :ok = Domain.Policies.subscribe_to_events_for_actor(other_actor)
       :ok = Domain.Policies.subscribe_to_events_for_actor_group(deleted_group)
-      :ok = Phoenix.PubSub.subscribe(Domain.PubSub, "sessions:#{deleted_identity_token.id}")
 
       GoogleWorkspaceDirectory.override_endpoint_url("http://localhost:#{bypass.port}/")
 
@@ -723,8 +722,8 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       assert_receive {:delete_membership, ^actor_id, ^group_id}
 
       # Signs out users which identity has been deleted
-      topic = "sessions:#{deleted_identity_token.id}"
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect", payload: nil}
+      deleted_identity_token = Repo.reload(deleted_identity_token)
+      assert deleted_identity_token.deleted_at
 
       # Deleted group deletes all policies and broadcasts reject access events for them
       policy_id = deleted_policy.id

--- a/elixir/apps/domain/test/domain/auth/adapters/jumpcloud/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/jumpcloud/jobs/sync_directory_test.exs
@@ -422,7 +422,6 @@ defmodule Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectoryTest do
       :ok = Domain.Policies.subscribe_to_events_for_actor(actor)
       :ok = Domain.Policies.subscribe_to_events_for_actor(other_actor)
       :ok = Domain.Policies.subscribe_to_events_for_actor_group(deleted_group)
-      :ok = Phoenix.PubSub.subscribe(Domain.PubSub, "sessions:#{deleted_identity_token.id}")
 
       WorkOSDirectory.override_base_url("http://localhost:#{bypass.port}")
       WorkOSDirectory.mock_list_directories_endpoint(bypass)
@@ -482,8 +481,8 @@ defmodule Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectoryTest do
       assert_receive {:delete_membership, ^actor_id, ^group_id}
 
       # Signs out users which identity has been deleted
-      topic = "sessions:#{deleted_identity_token.id}"
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect", payload: nil}
+      deleted_identity_token = Repo.reload(deleted_identity_token)
+      assert deleted_identity_token.deleted_at
 
       # Deleted group deletes all policies and broadcasts reject access events for them
       policy_id = deleted_policy.id

--- a/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/jobs/sync_directory_test.exs
@@ -472,7 +472,6 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
       :ok = Domain.Policies.subscribe_to_events_for_actor(actor)
       :ok = Domain.Policies.subscribe_to_events_for_actor(other_actor)
       :ok = Domain.Policies.subscribe_to_events_for_actor_group(deleted_group)
-      :ok = Phoenix.PubSub.subscribe(Domain.PubSub, "sessions:#{deleted_identity_token.id}")
 
       MicrosoftEntraDirectory.mock_groups_list_endpoint(
         bypass,
@@ -555,8 +554,8 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
       assert_receive {:delete_membership, ^actor_id, ^group_id}
 
       # Signs out users which identity has been deleted
-      topic = "sessions:#{deleted_identity_token.id}"
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect", payload: nil}
+      deleted_identity_token = Repo.reload(deleted_identity_token)
+      assert deleted_identity_token.deleted_at
 
       # Deleted group deletes all policies and broadcasts reject access events for them
       policy_id = deleted_policy.id

--- a/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/sync_directory_test.exs
@@ -714,7 +714,6 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
       :ok = Domain.Policies.subscribe_to_events_for_actor(actor)
       :ok = Domain.Policies.subscribe_to_events_for_actor(other_actor)
       :ok = Domain.Policies.subscribe_to_events_for_actor_group(deleted_group)
-      :ok = Phoenix.PubSub.subscribe(Domain.PubSub, "sessions:#{deleted_identity_token.id}")
 
       OktaDirectory.mock_groups_list_endpoint(bypass, 200, Jason.encode!(groups))
       OktaDirectory.mock_users_list_endpoint(bypass, 200, Jason.encode!(users))
@@ -788,8 +787,8 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
       assert_receive {:delete_membership, ^actor_id, ^group_id}
 
       # Signs out users which identity has been deleted
-      topic = "sessions:#{deleted_identity_token.id}"
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "disconnect", payload: nil}
+      deleted_identity_token = Repo.reload(deleted_identity_token)
+      assert deleted_identity_token.deleted_at
 
       # Deleted group deletes all policies and broadcasts reject access events for them
       policy_id = deleted_policy.id

--- a/elixir/apps/domain/test/domain/events/hooks/tokens_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/tokens_test.exs
@@ -13,14 +13,50 @@ defmodule Domain.Events.Hooks.TokensTest do
   end
 
   describe "update/2" do
-    test "returns :ok", %{old_data: old_data, data: data} do
-      assert :ok == on_update(old_data, data)
+    test "does not broadcast for email token updates" do
+      token_id = "token-id-123"
+      topic = "sessions:#{token_id}"
+      old_data = %{"id" => token_id, "type" => "email"}
+
+      :ok = Domain.PubSub.subscribe("sessions:#{token_id}")
+
+      assert :ok = on_update(old_data, %{})
+
+      refute_receive %Phoenix.Socket.Broadcast{
+        topic: ^topic,
+        event: "disconnect"
+      }
+    end
+
+    test "broadcasts disconnect for soft-deletions" do
+      token_id = "token-id-123"
+      topic = "sessions:#{token_id}"
+      old_data = %{"id" => token_id, "deleted_at" => nil}
+      data = %{"id" => token_id, "deleted_at" => DateTime.utc_now()}
+      :ok = Domain.PubSub.subscribe("sessions:#{token_id}")
+
+      assert :ok = on_update(old_data, data)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        topic: ^topic,
+        event: "disconnect"
+      }
     end
   end
 
   describe "delete/1" do
-    test "returns :ok", %{data: data} do
-      assert :ok == on_delete(data)
+    test "broadcasts disconnect for deletions" do
+      token_id = "token-id-123"
+      topic = "sessions:#{token_id}"
+      old_data = %{"id" => token_id}
+      :ok = Domain.PubSub.subscribe("sessions:#{token_id}")
+
+      assert :ok = on_delete(old_data)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        topic: ^topic,
+        event: "disconnect"
+      }
     end
   end
 end

--- a/elixir/apps/domain/test/domain/relays_test.exs
+++ b/elixir/apps/domain/test/domain/relays_test.exs
@@ -361,39 +361,25 @@ defmodule Domain.RelaysTest do
       assert Enum.all?(relays, & &1.deleted_at)
     end
 
-    test "broadcasts disconnect message to all connected relay sockets", %{
+    test "deletes associated tokens", %{
       account: account,
       subject: subject
     } do
       group = Fixtures.Relays.create_group(account: account)
 
       token1 = Fixtures.Relays.create_token(account: account, group: group)
-      Domain.PubSub.subscribe(Tokens.socket_id(token1))
 
       token2 = Fixtures.Relays.create_token(account: account, group: group)
-      Domain.PubSub.subscribe(Tokens.socket_id(token2))
 
       Fixtures.Relays.create_relay(account: account, group: group)
 
       assert {:ok, _group} = delete_group(group, subject)
 
-      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}
-      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}
-    end
+      token1 = Repo.reload(token1)
+      token2 = Repo.reload(token2)
 
-    test "broadcasts disconnect message to all connected relays", %{
-      account: account,
-      subject: subject
-    } do
-      group = Fixtures.Relays.create_group(account: account)
-      Fixtures.Relays.create_relay(account: account, group: group)
-      token = Fixtures.Relays.create_token(account: account, group: group)
-
-      Phoenix.PubSub.subscribe(Domain.PubSub, "sessions:#{token.id}")
-
-      assert {:ok, _group} = delete_group(group, subject)
-
-      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}
+      assert token1.deleted_at
+      assert token2.deleted_at
     end
 
     test "returns error when subject has no permission to delete groups", %{

--- a/elixir/apps/web/test/web/auth_test.exs
+++ b/elixir/apps/web/test/web/auth_test.exs
@@ -528,13 +528,12 @@ defmodule Web.AuthTest do
       assert get_session(conn, :preferred_locale) == "uk_UA"
     end
 
-    test "broadcasts to the given live_socket_id", %{
+    test "deletes token", %{
       account: account,
       admin_subject: subject,
       conn: conn
     } do
-      live_socket_id = "sessions:#{subject.token_id}"
-      Web.Endpoint.subscribe(live_socket_id)
+      live_socket_id = Domain.Tokens.socket_id(subject.token_id)
 
       conn
       |> assign(:account, account)
@@ -543,7 +542,8 @@ defmodule Web.AuthTest do
       |> put_session(:live_socket_id, live_socket_id)
       |> sign_out(%{})
 
-      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect", topic: ^live_socket_id}
+      token = Repo.get!(Domain.Tokens.Token, subject.token_id)
+      assert token.deleted_at
     end
   end
 

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -1262,7 +1262,7 @@ defmodule Web.AuthControllerTest do
       assert redirect_url =~ "post_logout_redirect_uri=#{post_redirect_url}"
     end
 
-    test "broadcasts to the given live_socket_id", %{conn: conn} do
+    test "deletes the token", %{conn: conn} do
       Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
 
       account = Fixtures.Accounts.create_account()
@@ -1279,7 +1279,8 @@ defmodule Web.AuthControllerTest do
 
       assert redirected_to(conn) =~ ~p"/#{account}"
 
-      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect", topic: ^live_socket_id}
+      token = Repo.get!(Domain.Tokens.Token, conn.assigns.subject.token_id)
+      assert token.deleted_at
     end
 
     test "works even if user is already logged out", %{conn: conn} do


### PR DESCRIPTION
Moves the broadcasting of `disconnect` messages caused by token soft-deletions to the WAL broadcaster.

Notably, many tests had to be cleaned up because they were specifically testing this side effect. Instead, these tests now test (1) the token is deleted, and then the token deletion handler is tested to ensure the message is broadcasted.

Related: https://github.com/firezone/firezone/issues/6294
Related: https://github.com/firezone/firezone/issues/8187
