### PR TITLE
fix(portal): Fix sign out acceptance test

### DIFF
--- a/elixir/apps/web/test/web/acceptance/auth_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth_test.exs
@@ -91,7 +91,7 @@ defmodule Web.Acceptance.AuthTest do
     {:ok, tokens} = Domain.Tokens.delete_tokens_for(identity)
 
     for token <- tokens do
-      assert token.deleted_at
+      assert %DateTime{} = token.deleted_at
       Domain.Events.Hooks.Tokens.on_delete(%{"id" => token.id})
     end
 

--- a/elixir/apps/web/test/web/acceptance/auth_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth_test.exs
@@ -88,7 +88,12 @@ defmodule Web.Acceptance.AuthTest do
     |> Auth.authenticate(identity)
     |> visit(~p"/#{account}/actors")
 
-    {:ok, _tokens} = Domain.Tokens.delete_tokens_for(identity)
+    {:ok, tokens} = Domain.Tokens.delete_tokens_for(identity)
+
+    for token <- tokens do
+      assert token.deleted_at
+      Domain.Events.Hooks.Tokens.on_delete(%{"id" => token.id})
+    end
 
     wait_for(
       fn ->


### PR DESCRIPTION
In #9294, we moved the token deletion side effect to the WAL consumer, which is not executed for standard tests. As such, we need to call this callback manually in the sign out acceptance test.

Fixes https://github.com/firezone/firezone/actions/runs/15337858094/job/43158416750?pr=9295