### PR TITLE
fix(portal): Use account param for autoredirect

### DIFF
--- a/elixir/apps/web/lib/web/plugs/auto_redirect_default_provider.ex
+++ b/elixir/apps/web/lib/web/plugs/auto_redirect_default_provider.ex
@@ -2,13 +2,16 @@ defmodule Web.Plugs.AutoRedirectDefaultProvider do
   use Phoenix.VerifiedRoutes, endpoint: Web.Endpoint, router: Web.Router
   import Plug.Conn
   import Phoenix.Controller, only: [redirect: 2]
-  alias Domain.Auth
+  alias Domain.{Auth, Accounts}
 
   def init(opts), do: opts
 
   # client sign in
-  def call(%{params: %{"as" => "client"}} = conn, _opts) do
-    with account <- conn.assigns.account,
+  def call(
+        %{params: %{"as" => "client", "account_id_or_slug" => account_id_or_slug}} = conn,
+        _opts
+      ) do
+    with {:ok, account} <- Accounts.fetch_account_by_id_or_slug(account_id_or_slug),
          {:ok, provider} <- Auth.fetch_default_provider_for_account(account) do
       redirect_path = ~p"/#{account}/sign_in/providers/#{provider}/redirect"
 


### PR DESCRIPTION
When the client is connecting for the first time without any cookies loaded the `conn.assigns.account` is non-existent, causing a `KeyError`.

Instead, we should be loading this param from the URL and fetching the account from it.