### PR TITLE
feat(gateway): add optional otlp metrics exporter

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "nix 0.29.0",
  "num_cpus",
  "opentelemetry",
+ "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "phoenix-channel",

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -27,6 +27,7 @@ libc = { workspace = true, features = ["std", "const-extern-fn", "extra_traits"]
 moka = { workspace = true, features = ["future"] }
 num_cpus = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
+opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }
 opentelemetry-stdout = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 phoenix-channel = { workspace = true }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -14,7 +14,8 @@ use firezone_bin_shared::{
 use firezone_telemetry::{Telemetry, otel};
 use firezone_tunnel::GatewayTunnel;
 use ip_packet::IpPacket;
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use phoenix_channel::LoginUrl;
 use phoenix_channel::get_user_agent;
 
@@ -114,16 +115,36 @@ async fn try_main(cli: Cli) -> Result<ExitCode> {
     Telemetry::set_firezone_id(firezone_id.clone());
 
     if cli.metrics {
-        let exporter = opentelemetry_stdout::MetricExporter::default();
-        let reader = PeriodicReader::builder(exporter).build();
-        let provider = SdkMeterProvider::builder()
-            .with_reader(reader)
-            .with_resource(otel::default_resource_with([
-                otel::attr::service_name!(),
-                otel::attr::service_version!(),
-                otel::attr::service_instance_id(firezone_id.clone()),
-            ]))
-            .build();
+        let resource = otel::default_resource_with([
+            otel::attr::service_name!(),
+            otel::attr::service_version!(),
+            otel::attr::service_instance_id(firezone_id.clone()),
+        ]);
+
+        let provider = match cli.otlp_grpc_endpoint.clone() {
+            None => {
+                let exporter = opentelemetry_stdout::MetricExporter::default();
+
+                SdkMeterProvider::builder()
+                    .with_periodic_exporter(exporter)
+                    .with_resource(resource)
+                    .build()
+            }
+            Some(endpoint) => {
+                let grpc_endpoint = format!("http://{endpoint}");
+
+                let exporter = opentelemetry_otlp::MetricExporter::builder()
+                    .with_tonic()
+                    .with_endpoint(grpc_endpoint)
+                    .build()
+                    .context("Failed to build OTLP metric exporter")?;
+
+                SdkMeterProvider::builder()
+                    .with_periodic_exporter(exporter)
+                    .with_resource(resource)
+                    .build()
+            }
+        };
 
         opentelemetry::global::set_meter_provider(provider);
     }
@@ -260,9 +281,17 @@ struct Cli {
     #[arg(long, env = "FIREZONE_NUM_TUN_THREADS", default_value_t)]
     tun_threads: NumThreads,
 
-    /// Dump internal metrics to stdout every 60s.
+    /// Enable internal metrics.
+    ///
+    /// By default, they will be dumped to stdout every 60s.
     #[arg(long, hide = true, env = "FIREZONE_METRICS", default_value_t = false)]
     metrics: bool,
+
+    /// Which OTLP collector we should connect to.
+    ///
+    /// If set, we will report metrics to this collector via gRPC.
+    #[arg(long, env, hide = true)]
+    otlp_grpc_endpoint: Option<String>,
 
     /// Validates the checksums of all packets leaving the TUN device.
     #[arg(

--- a/rust/telemetry/src/otel.rs
+++ b/rust/telemetry/src/otel.rs
@@ -1,7 +1,7 @@
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::{
     Resource,
-    resource::{ResourceDetector, TelemetryResourceDetector},
+    resource::{EnvResourceDetector, ResourceDetector, TelemetryResourceDetector},
 };
 
 pub mod attr {
@@ -110,6 +110,7 @@ pub fn default_resource_with<const N: usize>(attributes: [KeyValue; N]) -> Resou
     Resource::builder_empty()
         .with_detector(Box::new(TelemetryResourceDetector))
         .with_detector(Box::new(OsResourceDetector))
+        .with_detector(Box::new(EnvResourceDetector::new()))
         .with_attributes(attributes)
         .build()
 }


### PR DESCRIPTION
Hi,

Currently in the gateway, some metrics can be printed every 60s. I propose adding an optional otlp metrics exporter.

I'm aware of https://github.com/firezone/firezone/issues/8353 and similar issues about sending metrics to the portal. But it's not yet implemented and as with the relay it could be useful for some users to be able to collect these more advanced internal metrics.

Maybe in the future, I'll add metrics about the number of peers/resources.

Related: https://github.com/firezone/firezone/issues/1550