### PR TITLE
fix(infra/portal): Allow full instance surge during deploys

### DIFF
--- a/terraform/modules/google-cloud/apps/elixir/main.tf
+++ b/terraform/modules/google-cloud/apps/elixir/main.tf
@@ -89,7 +89,7 @@ resource "google_compute_reservation" "reservation" {
   specific_reservation_required = true
 
   specific_reservation {
-    count = var.reservation_size
+    count = var.scaling_horizontal_replicas * 2
 
     instance_properties {
       machine_type = var.compute_instance_type

--- a/terraform/modules/google-cloud/apps/elixir/main.tf
+++ b/terraform/modules/google-cloud/apps/elixir/main.tf
@@ -329,11 +329,13 @@ resource "google_compute_region_instance_group_manager" "application" {
     type           = "PROACTIVE"
     minimal_action = "REPLACE"
 
-    # With reservations we need to take one instance down before provisioning a new one,
-    # otherwise we will get an error that there are no available instances for the targeted
-    # reservation.
-    max_unavailable_fixed = 1
-    max_surge_fixed       = max(max(1, var.scaling_horizontal_replicas - 1), length(var.compute_instance_availability_zones))
+    # The number of instances that can be unavailable (from the target size) during the update. We set
+    # this to 0 because we want all new instances to come online before we start taking down the old ones.
+    max_unavailable_fixed = 0
+
+    # The number of additional instances that can be created during the update. Since we are reserving 2 * the
+    # number of instances in the group, we set this to the target number of instances.
+    max_surge_fixed = var.scaling_horizontal_replicas
   }
 
   timeouts {

--- a/terraform/modules/google-cloud/apps/elixir/variables.tf
+++ b/terraform/modules/google-cloud/apps/elixir/variables.tf
@@ -122,19 +122,6 @@ variable "scaling_horizontal_replicas" {
   description = "Number of replicas in an instance group."
 }
 
-variable "reservation_size" {
-  type     = number
-  nullable = false
-  default  = 1
-
-  validation {
-    condition     = var.reservation_size >= var.scaling_horizontal_replicas
-    error_message = "Reservation size should be greater or equal to the number of scaling_horizontal_replicas."
-  }
-
-  description = "Number of reservations to create."
-}
-
 variable "scaling_max_horizontal_replicas" {
   type     = number
   nullable = true


### PR DESCRIPTION
During a deploy, we had `max_surge_fixed` set to the target instance count - 1, which caused only 3 nodes to be spun up at a time instead of the full 4.

We also had max_unavailable_fixed = 1 which allowed the instance group manager to bring an old, healthy node down before the last remaining node was spun up.

Since[ we are now always setting](https://github.com/firezone/environments/pull/29) the reservation_size to 2*replicas, we can fix these values to make sure all new VMs spin up before old ones deleted.