### PR TITLE
fix(apple): Correctly handle stopTunnel and completionHandlers

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -65,6 +65,7 @@ class IPCClient {
 
   func signOut() async throws {
     try await sendMessageWithoutResponse(ProviderMessage.signOut)
+    try stop()
   }
 
   func stop() throws {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/SharedAccess.swift
@@ -7,17 +7,6 @@
 import Foundation
 
 public struct SharedAccess {
-  public enum Error: Swift.Error {
-    case unableToWriteToFile(URL, Swift.Error)
-
-    var localizedDescription: String {
-      switch self {
-      case .unableToWriteToFile(let url, let error):
-        return "Unable to write to \(url): \(error)"
-      }
-    }
-  }
-
   public static var baseFolderURL: URL {
     guard
       let url = FileManager.default.containerURL(

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -245,7 +245,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       let size = await Log.size(of: logFolderURL)
       let data = withUnsafeBytes(of: size) { Data($0) }
 
-      // Ensure completionHandler is called on the same queue as handleAppMessage
+      // Ensure completionHandler is called on the same actor as handleAppMessage
       await MainActor.run { completionHandler?(data) }
     }
   }

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9308">
+          Fixes a minor crash in the network extension that could occur when
+          viewing the Diagnostic Logs tab in app settings.
+        </ChangeItem>
         <ChangeItem pull="9242">
           Fixes a rare bug that could prevent certain IPv6 DNS upstream
           resolvers from being used if they contained an interface scope


### PR DESCRIPTION
This PR fixes two crashes related to lifetimes on Apple:

- `completionHandler` was being called from within a Task executor context, which could be different from the one the IPC call was received on
- The `getLogFolderSize` task could return and attempt to call `completionHandler` after the PacketTunnelProvider deinit'd
- We were calling the completionHandler from `stopTunnel` manually. Apple explicitly says not to do this. Instead, we must call `cancelTunnelWithError(nil)` when we want to stop the tunnel from e.g. the `onDisconnect`. Apple with then call our `stopTunnel` override. The downside is that we have no control over the `NEProviderStopReason` received in this callback, but we don't use it anyway. Instead, we write the reason to a temporary file and read it from the GUI process when we detect a status change to `disconnected`. When that occurs, we're able to show a UI notification (macOS only - iOS can show this notification from the PacketTunnelProvider itself).