### PR TITLE
fix(ci): download musl build deps from google cloud

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -207,7 +207,9 @@ jobs:
             install_dependencies: |
               # TODO: musl.cc has blocked GitHub actions: https://github.com/orgs/community/discussions/27906
               # Find some other way to keep these updated.
-              wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/aarch64-linux-musl-cross.tgz | tar -xz -C /tmp
+              if ! -e /tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc; then
+                wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/aarch64-linux-musl-cross.tgz | tar -xz -C /tmp
+              fi
 
               CC=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
 
@@ -219,7 +221,9 @@ jobs:
             install_dependencies: |
               # TODO: musl.cc has blocked GitHub actions: https://github.com/orgs/community/discussions/27906
               # Find some other way to keep these updated.
-              wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/arm-linux-musleabihf-cross.tgz | tar -xz -C /tmp
+              if ! -e /tmp/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc; then
+                wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/arm-linux-musleabihf-cross.tgz | tar -xz -C /tmp
+              fi
 
               CC=/tmp/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
 
@@ -266,6 +270,11 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.arch.target }}
+      - name: Cache toolchain
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        with:
+          path: /tmp/*-linux-musl-cross
+          key: ${{ runner.os }}-musl-cross
       - name: Install dependencies
         run: ${{ matrix.arch.install_dependencies }}
       - uses: taiki-e/install-action@84c20235bedc3797c7e1ddf685c574a4a6c666da # v2.52.2

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -205,7 +205,9 @@ jobs:
             shortname: aarch64
             platform: linux/arm64
             install_dependencies: |
-              wget -q -O- https://musl.cc/aarch64-linux-musl-cross.tgz | tar -xz -C /tmp
+              # TODO: musl.cc has blocked GitHub actions: https://github.com/orgs/community/discussions/27906
+              # Find some other way to keep these updated.
+              wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/aarch64-linux-musl-cross.tgz | tar -xz -C /tmp
 
               CC=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
 
@@ -215,7 +217,9 @@ jobs:
             platform: linux/arm/v7
             shortname: armv7
             install_dependencies: |
-              wget -q -O- https://musl.cc/arm-linux-musleabihf-cross.tgz | tar -xz -C /tmp
+              # TODO: musl.cc has blocked GitHub actions: https://github.com/orgs/community/discussions/27906
+              # Find some other way to keep these updated.
+              wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/arm-linux-musleabihf-cross.tgz | tar -xz -C /tmp
 
               CC=/tmp/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
 
@@ -254,6 +258,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.sha }}
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+        with:
+          workload_identity_provider: "projects/85623168602/locations/global/workloadIdentityPools/github/providers/firezone-provider"
+          service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.arch.target }}

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -262,7 +262,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.sha }}
-      - name: Authenticate to Google Cloud
+      - name: Authenticate to Google Cloud Staging
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
         with:
           workload_identity_provider: "projects/85623168602/locations/global/workloadIdentityPools/github/providers/firezone-provider"
@@ -273,8 +273,10 @@ jobs:
       - name: Cache toolchain
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
-          path: /tmp/*-linux-musl-cross
-          key: ${{ runner.os }}-musl-cross
+          path: |
+            /tmp/aarch64-linux-musl-cross
+            /tmp/arm-linux-musleabihf-cross
+          key: ${{ runner.os }}-${{ matrix.arch.shortname }}-musl-cross
       - name: Install dependencies
         run: ${{ matrix.arch.install_dependencies }}
       - uses: taiki-e/install-action@84c20235bedc3797c7e1ddf685c574a4a6c666da # v2.52.2

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -208,10 +208,10 @@ jobs:
               # TODO: musl.cc has blocked GitHub actions: https://github.com/orgs/community/discussions/27906
               # Find some other way to keep these updated.
               if ! -e /tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc; then
-                wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/aarch64-linux-musl-cross.tgz | tar -xz -C /tmp
+                wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/aarch64-linux-musl-cross.tgz | tar -xz -C /tmp/toolchain
               fi
 
-              CC=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+              CC=/tmp/toolchain/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
 
               echo "CC_aarch64_unknown_linux_musl=$CC" >> $GITHUB_ENV
               echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=$CC" >> $GITHUB_ENV
@@ -222,10 +222,10 @@ jobs:
               # TODO: musl.cc has blocked GitHub actions: https://github.com/orgs/community/discussions/27906
               # Find some other way to keep these updated.
               if ! -e /tmp/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc; then
-                wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/arm-linux-musleabihf-cross.tgz | tar -xz -C /tmp
+                wget -q -O- https://storage.cloud.google.com/firezone-ci-dependencies/arm-linux-musleabihf-cross.tgz | tar -xz -C /tmp/toolchain
               fi
 
-              CC=/tmp/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
+              CC=/tmp/toolchain/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
 
               echo "CC_armv7_unknown_linux_musleabihf=$CC" >> $GITHUB_ENV
               echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER=$CC" >> $GITHUB_ENV
@@ -273,9 +273,7 @@ jobs:
       - name: Cache toolchain
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
-          path: |
-            /tmp/aarch64-linux-musl-cross
-            /tmp/arm-linux-musleabihf-cross
+          path: /tmp/toolchain
           key: ${{ runner.os }}-${{ matrix.arch.shortname }}-musl-cross
       - name: Install dependencies
         run: ${{ matrix.arch.install_dependencies }}


### PR DESCRIPTION
musl.cc wholesale blocked GitHub Actions due to "abuse" so we need a stop-gap measure to obtain these tools in CI runs.

Unfortunately there are no publicly-listed mirror for these build tools, and any cron job we attempt to run to update these is going to be blocked as well, so I simply uploaded them manually to a GCP bucket for now.