### PR TITLE
feat(infra): set health check via Domain.Cluster.healthy?/0

### DIFF
--- a/elixir/apps/api/lib/api/controllers/health_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/health_controller.ex
@@ -4,7 +4,15 @@ defmodule API.HealthController do
   def healthz(conn, _params) do
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(200, Jason.encode!(%{status: "ok"}))
+    |> respond_based_on_cluster_state()
     |> halt()
+  end
+
+  defp respond_based_on_cluster_state(conn) do
+    if Domain.Cluster.healthy?() do
+      send_resp(conn, 200, Jason.encode!(%{status: :ok}))
+    else
+      send_resp(conn, 503, Jason.encode!(%{status: :unavailable}))
+    end
   end
 end

--- a/elixir/apps/domain/lib/domain/cluster.ex
+++ b/elixir/apps/domain/lib/domain/cluster.ex
@@ -29,4 +29,16 @@ defmodule Domain.Cluster do
 
     Supervisor.init(children, strategy: :rest_for_one)
   end
+
+  def healthy? do
+    config = Domain.Config.fetch_env!(:domain, __MODULE__)
+    adapter = Keyword.fetch!(config, :adapter)
+    adapter_config = Keyword.fetch!(config, :adapter_config)
+
+    if adapter && adapter_config[:health_check_supported] do
+      GenServer.call(adapter, :healthy?)
+    else
+      true
+    end
+  end
 end

--- a/elixir/apps/domain/lib/domain/telemetry/healthz_plug.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/healthz_plug.ex
@@ -13,7 +13,15 @@ defmodule Domain.Telemetry.HealthzPlug do
   def call(conn, _opts) do
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(200, Jason.encode!(%{status: :ok}))
+    |> respond_based_on_cluster_state()
     |> halt()
+  end
+
+  defp respond_based_on_cluster_state(conn) do
+    if Domain.Cluster.healthy?() do
+      send_resp(conn, 200, Jason.encode!(%{status: :ok}))
+    else
+      send_resp(conn, 503, Jason.encode!(%{status: :unavailable}))
+    end
   end
 end

--- a/elixir/apps/domain/test/domain/cluster/google_compute_labels_strategy_test.exs
+++ b/elixir/apps/domain/test/domain/cluster/google_compute_labels_strategy_test.exs
@@ -10,18 +10,98 @@ defmodule Domain.Cluster.GoogleComputeLabelsStrategyTest do
       GoogleCloudPlatform.mock_instances_list_endpoint(bypass)
 
       state = %{
+        topology: :test,
+        connect: :test,
+        list_nodes: :test,
         config: [
           project_id: "firezone-staging",
           cluster_name: "firezone",
-          cluster_version: "1"
+          cluster_version: "1",
+          api_node_count: 1,
+          domain_node_count: 1,
+          web_node_count: 1,
+          health_check_supported: true
         ]
       }
 
       assert {:ok, nodes, _state} = fetch_nodes(state)
 
       assert nodes == [
-               :"api@api-q3j6.us-east1-d.c.firezone-staging.internal"
+               :"api@api-q3j6.us-east1-d.c.firezone-staging.internal",
+               :"domain@domain-q3j6.us-east1-d.c.firezone-staging.internal",
+               :"web@web-q3j6.us-east1-d.c.firezone-staging.internal"
              ]
+    end
+  end
+
+  describe "load/1" do
+    setup do
+      bypass = Bypass.open()
+      GoogleCloudPlatform.mock_instance_metadata_token_endpoint(bypass)
+      GoogleCloudPlatform.mock_instances_list_endpoint(bypass)
+
+      Application.put_env(:domain, :cluster_strategy_reply, :ok)
+
+      :ok
+    end
+
+    test "healthy?/0 is true when all nodes connected" do
+      state = %{
+        topology: :test,
+        connect: :test,
+        list_nodes: :test,
+        config: [
+          project_id: "firezone-staging",
+          cluster_name: "firezone",
+          cluster_version: "1",
+          api_node_count: 1,
+          domain_node_count: 1,
+          web_node_count: 1,
+          health_check_supported: true
+        ]
+      }
+
+      assert %{healthy?: true} = load(state)
+    end
+
+    test "healthy?/0 is false when not all expected nodes are connected" do
+      state = %{
+        topology: :test,
+        connect: :test,
+        list_nodes: :test,
+        config: [
+          project_id: "firezone-staging",
+          cluster_name: "firezone",
+          cluster_version: "1",
+          api_node_count: 2,
+          domain_node_count: 1,
+          web_node_count: 1,
+          health_check_supported: true
+        ]
+      }
+
+      assert %{healthy?: false} = load(state)
+    end
+
+    test "healthy?/0 is false if error connecting nodes" do
+      Application.put_env(:domain, :cluster_strategy_reply, {:error, "test"})
+
+      state = %{
+        topology: :test,
+        connect: :test,
+        list_nodes: :test,
+        config: [
+          project_id: "firezone-staging",
+          cluster_name: "firezone",
+          cluster_version: "1",
+          api_node_count: 1,
+          domain_node_count: 1,
+          web_node_count: 1,
+          health_check_supported: true
+        ]
+      }
+
+      assert %{healthy?: false} = load(state)
     end
   end
 end

--- a/elixir/apps/domain/test/domain/google_cloud_platform_test.exs
+++ b/elixir/apps/domain/test/domain/google_cloud_platform_test.exs
@@ -57,7 +57,7 @@ defmodule Domain.GoogleCloudPlatformTest do
                  }
                )
 
-      assert length(nodes) == 1
+      assert length(nodes) == 3
 
       assert [
                %{
@@ -66,6 +66,30 @@ defmodule Domain.GoogleCloudPlatformTest do
                    "https://www.googleapis.com/compute/v1/projects/firezone-staging/zones/us-east1-d",
                  "labels" => %{
                    "application" => "api",
+                   "cluster_name" => "firezone",
+                   "container-vm" => "cos-105-17412-101-13",
+                   "managed_by" => "terraform",
+                   "version" => "0-0-1"
+                 }
+               },
+               %{
+                 "name" => "domain-q3j6",
+                 "zone" =>
+                   "https://www.googleapis.com/compute/v1/projects/firezone-staging/zones/us-east1-d",
+                 "labels" => %{
+                   "application" => "domain",
+                   "cluster_name" => "firezone",
+                   "container-vm" => "cos-105-17412-101-13",
+                   "managed_by" => "terraform",
+                   "version" => "0-0-1"
+                 }
+               },
+               %{
+                 "name" => "web-q3j6",
+                 "zone" =>
+                   "https://www.googleapis.com/compute/v1/projects/firezone-staging/zones/us-east1-d",
+                 "labels" => %{
+                   "application" => "web",
                    "cluster_name" => "firezone",
                    "container-vm" => "cos-105-17412-101-13",
                    "managed_by" => "terraform",

--- a/elixir/apps/domain/test/support/mocks/cluster/strategy.ex
+++ b/elixir/apps/domain/test/support/mocks/cluster/strategy.ex
@@ -1,0 +1,9 @@
+defmodule Domain.Mocks.Cluster.Strategy do
+  @moduledoc """
+  Mocks for the Cluster.Strategy module.
+  """
+
+  def connect_nodes(_topology, _connect, _list_nodes, _nodes) do
+    Application.fetch_env!(:domain, :cluster_strategy_reply)
+  end
+end

--- a/elixir/apps/domain/test/support/mocks/google_cloud_platform.ex
+++ b/elixir/apps/domain/test/support/mocks/google_cloud_platform.ex
@@ -183,6 +183,156 @@ defmodule Domain.Mocks.GoogleCloudPlatform do
                   },
                   "fingerprint" => "fK6yUz9ED6s=",
                   "lastStartTimestamp" => "2023-06-02T13:38:06.900-07:00"
+                },
+                %{
+                  "kind" => "compute#instance",
+                  "id" => "101389045528522181",
+                  "creationTimestamp" => "2023-06-02T13:38:02.907-07:00",
+                  "name" => "domain-q3j6",
+                  "tags" => %{
+                    "items" => [
+                      "app-domain"
+                    ],
+                    "fingerprint" => "utkJlpAke8c="
+                  },
+                  "machineType" =>
+                    "#{project_endpoint}/zones/us-east1-d/machineTypes/n1-standard-1",
+                  "status" => "RUNNING",
+                  "zone" => "#{project_endpoint}/zones/us-east1-d",
+                  "networkInterfaces" => [
+                    %{
+                      "kind" => "compute#networkInterface",
+                      "network" => "#{project_endpoint}/global/networks/firezone-staging",
+                      "subnetwork" => "#{project_endpoint}/regions/us-east1/subnetworks/app",
+                      "networkIP" => "10.128.0.43",
+                      "name" => "nic0",
+                      "fingerprint" => "_4XbqLiVdkI=",
+                      "stackType" => "IPV4_ONLY"
+                    }
+                  ],
+                  "disks" => [],
+                  "metadata" => %{
+                    "kind" => "compute#metadata",
+                    "fingerprint" => "3mI-QpsQdDk=",
+                    "items" => []
+                  },
+                  "serviceAccounts" => [
+                    %{
+                      "email" => "app-domain@firezone-staging.iam.gserviceaccount.com",
+                      "scopes" => [
+                        "https://www.googleapis.com/auth/compute.readonly",
+                        "https://www.googleapis.com/auth/logging.write",
+                        "https://www.googleapis.com/auth/monitoring",
+                        "https://www.googleapis.com/auth/servicecontrol",
+                        "https://www.googleapis.com/auth/service.management.readonly",
+                        "https://www.googleapis.com/auth/devstorage.read_only",
+                        "https://www.googleapis.com/auth/trace.append"
+                      ]
+                    }
+                  ],
+                  "selfLink" => "#{project_endpoint}/zones/us-east1-d/instances/domain-q3j6",
+                  "scheduling" => %{
+                    "onHostMaintenance" => "MIGRATE",
+                    "automaticRestart" => true,
+                    "preemptible" => false,
+                    "provisioningModel" => "STANDARD"
+                  },
+                  "cpuPlatform" => "Intel Haswell",
+                  "labels" => %{
+                    "application" => "domain",
+                    "cluster_name" => "firezone",
+                    "container-vm" => "cos-105-17412-101-13",
+                    "managed_by" => "terraform",
+                    "version" => "0-0-1"
+                  },
+                  "labelFingerprint" => "ISmB9O6lTvg=",
+                  "startRestricted" => false,
+                  "deletionProtection" => false,
+                  "shieldedInstanceConfig" => %{
+                    "enableSecureBoot" => false,
+                    "enableVtpm" => true,
+                    "enableIntegrityMonitoring" => true
+                  },
+                  "shieldedInstanceIntegrityPolicy" => %{
+                    "updateAutoLearnPolicy" => true
+                  },
+                  "fingerprint" => "fK6yUz9ED6s=",
+                  "lastStartTimestamp" => "2023-06-02T13:38:06.900-07:00"
+                },
+                %{
+                  "kind" => "compute#instance",
+                  "id" => "101389045528522181",
+                  "creationTimestamp" => "2023-06-02T13:38:02.907-07:00",
+                  "name" => "web-q3j6",
+                  "tags" => %{
+                    "items" => [
+                      "app-web"
+                    ],
+                    "fingerprint" => "utkJlpAke8c="
+                  },
+                  "machineType" =>
+                    "#{project_endpoint}/zones/us-east1-d/machineTypes/n1-standard-1",
+                  "status" => "RUNNING",
+                  "zone" => "#{project_endpoint}/zones/us-east1-d",
+                  "networkInterfaces" => [
+                    %{
+                      "kind" => "compute#networkInterface",
+                      "network" => "#{project_endpoint}/global/networks/firezone-staging",
+                      "subnetwork" => "#{project_endpoint}/regions/us-east1/subnetworks/app",
+                      "networkIP" => "10.128.0.43",
+                      "name" => "nic0",
+                      "fingerprint" => "_4XbqLiVdkI=",
+                      "stackType" => "IPV4_ONLY"
+                    }
+                  ],
+                  "disks" => [],
+                  "metadata" => %{
+                    "kind" => "compute#metadata",
+                    "fingerprint" => "3mI-QpsQdDk=",
+                    "items" => []
+                  },
+                  "serviceAccounts" => [
+                    %{
+                      "email" => "app-web@firezone-staging.iam.gserviceaccount.com",
+                      "scopes" => [
+                        "https://www.googleapis.com/auth/compute.readonly",
+                        "https://www.googleapis.com/auth/logging.write",
+                        "https://www.googleapis.com/auth/monitoring",
+                        "https://www.googleapis.com/auth/servicecontrol",
+                        "https://www.googleapis.com/auth/service.management.readonly",
+                        "https://www.googleapis.com/auth/devstorage.read_only",
+                        "https://www.googleapis.com/auth/trace.append"
+                      ]
+                    }
+                  ],
+                  "selfLink" => "#{project_endpoint}/zones/us-east1-d/instances/web-q3j6",
+                  "scheduling" => %{
+                    "onHostMaintenance" => "MIGRATE",
+                    "automaticRestart" => true,
+                    "preemptible" => false,
+                    "provisioningModel" => "STANDARD"
+                  },
+                  "cpuPlatform" => "Intel Haswell",
+                  "labels" => %{
+                    "application" => "web",
+                    "cluster_name" => "firezone",
+                    "container-vm" => "cos-105-17412-101-13",
+                    "managed_by" => "terraform",
+                    "version" => "0-0-1"
+                  },
+                  "labelFingerprint" => "ISmB9O6lTvg=",
+                  "startRestricted" => false,
+                  "deletionProtection" => false,
+                  "shieldedInstanceConfig" => %{
+                    "enableSecureBoot" => false,
+                    "enableVtpm" => true,
+                    "enableIntegrityMonitoring" => true
+                  },
+                  "shieldedInstanceIntegrityPolicy" => %{
+                    "updateAutoLearnPolicy" => true
+                  },
+                  "fingerprint" => "fK6yUz9ED6s=",
+                  "lastStartTimestamp" => "2023-06-02T13:38:06.900-07:00"
                 }
               ]
             },

--- a/elixir/apps/web/lib/web/controllers/health_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/health_controller.ex
@@ -4,6 +4,15 @@ defmodule Web.HealthController do
   def healthz(conn, _params) do
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(200, Jason.encode!(%{status: "ok"}))
+    |> respond_based_on_cluster_state()
+    |> halt()
+  end
+
+  defp respond_based_on_cluster_state(conn) do
+    if Domain.Cluster.healthy?() do
+      send_resp(conn, 200, Jason.encode!(%{status: :ok}))
+    else
+      send_resp(conn, 503, Jason.encode!(%{status: :unavailable}))
+    end
   end
 end

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -126,6 +126,9 @@ config :domain, Domain.Cluster,
   adapter: nil,
   adapter_config: []
 
+config :domain, Domain.Cluster.GoogleComputeLabelsStrategy,
+  libcluster_strategy_module: Cluster.Strategy
+
 config :domain, Domain.Instrumentation,
   client_logs_enabled: true,
   client_logs_bucket: "logs"

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -34,6 +34,9 @@ config :domain, platform_adapter: Domain.GoogleCloudPlatform
 
 config :domain, Domain.GoogleCloudPlatform, service_account_email: "foo@iam.example.com"
 
+config :domain, Domain.Cluster.GoogleComputeLabelsStrategy,
+  libcluster_strategy_module: Domain.Mocks.Cluster.Strategy
+
 config :domain, Domain.ComponentVersions,
   fetch_from_url: false,
   versions: [


### PR DESCRIPTION
During deploys, we successfully spin up all new nodes before bringing down old ones. However, we have no guarantee that _each_ of the api, domain, and web node types are fully spun up before we start sending requests to them.

This PR updates the `/healthz` endpoint so that it only returns `200` after the cluster is fully-formed. We determine the cluster is fully-formed if:

- We successfully fetch the list of instances from the Google API
- We successfully call `Cluster.Strategy.connect_nodes/4`
- The number and type of nodes we successfully connected to match the expect node count passed in from Terraform configuration

Related: https://github.com/firezone/environments/pull/32