### PR TITLE
fix(portal): Use threshold-based logging for cluster errors

### DIFF
--- a/elixir/apps/domain/lib/domain/telemetry/sentry.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/sentry.ex
@@ -1,13 +1,18 @@
 defmodule Domain.Telemetry.Sentry do
-  def before_send(%{original_exception: %{skip_sentry: skip_sentry}} = event) do
-    if skip_sentry do
+  def before_send(%{original_exception: %{skip_sentry: skip_sentry}}) when skip_sentry do
+    nil
+  end
+
+  def before_send(event) do
+    if String.contains?(
+         event.message,
+         "Node ~p not responding **~n** Removing (timedout) connection"
+       ) do
+      # This happens when libcluster loses connection to a node, which is normal during deploys.
+      # We have threshold-based error logging in Domain.Cluster.GoogleComputeLabelsStrategy to report those.
       nil
     else
       event
     end
-  end
-
-  def before_send(event) do
-    event
   end
 end


### PR DESCRIPTION
We periodically fetch a list of all `RUNNING` VMs in GCP and then try to connect to them for clustering. However, during deploys, it's expected that we won't be able to connect to new VMs until they are fully up. The fetch doesn't take health checks into account, so we need a threshold-based error logging.

To address this, we do the following:

- We only log an error when failing to connect to nodes if we are currently below the threshold for each of the `api`, `domain`, and `web` node counts
- We silence node timeout errors, as these will happen during deploys