### PR TITLE
fix(website): use `<code>` over backticks

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -179,7 +179,8 @@ export default function Android() {
       <Entry version="1.3.4" date={new Date("2024-09-26")}>
         <ChangeItem pull="6809">
           Fixes a bug where non-wildcard DNS resources were not prioritised over
-          wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+          wildcard ones (e.g. <code>app.example.com</code> vs{" "}
+          <code>*.example.com</code>).
         </ChangeItem>
       </Entry>
       <Entry version="1.3.3" date={new Date("2024-09-24")}>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -321,7 +321,8 @@ export default function Apple() {
       <Entry version="1.3.5" date={new Date("2024-09-26")}>
         <ChangeItem pull="6809">
           Fixes a bug where non-wildcard DNS resources were not prioritised over
-          wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+          wildcard ones (e.g. <code>app.example.com</code> vs{" "}
+          <code>*.example.com</code>).
         </ChangeItem>
       </Entry>
       <Entry version="1.3.4" date={new Date("2024-09-25")}>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -31,8 +31,8 @@ export default function GUI({ os }: { os: OS }) {
       </Unreleased>
       <Entry version="1.4.14" date={new Date("2025-05-21")}>
         <ChangeItem pull="9147">
-          Fixes an issue where connections failed to establish on machines
-          with multiple valid egress IPs.
+          Fixes an issue where connections failed to establish on machines with
+          multiple valid egress IPs.
         </ChangeItem>
         <ChangeItem pull="9136">
           Launching Firezone while it is already running while now re-activate
@@ -40,14 +40,16 @@ export default function GUI({ os }: { os: OS }) {
         </ChangeItem>
         {os === OS.Windows && (
           <ChangeItem pull="9154">
-            Renames the background service from `FirezoneClientIpcService`
-            to `FirezoneClientTunnelService`.
+            Renames the background service from{" "}
+            <code>FirezoneClientIpcService</code>
+            to <code>FirezoneClientTunnelService</code>.
           </ChangeItem>
         )}
         {os === OS.Linux && (
           <ChangeItem pull="9154">
-            Renames the systemd service from `firezone-client-ipc.service`
-            to `firezone-client-tunnel.service`.
+            Renames the systemd service from{" "}
+            <code>firezone-client-ipc.service</code> to
+            <code>firezone-client-tunnel.service</code>.
           </ChangeItem>
         )}
         {os === OS.Linux && (
@@ -58,7 +60,7 @@ export default function GUI({ os }: { os: OS }) {
         {os === OS.Windows && (
           <ChangeItem pull="9213">
             Adds the Client to the winget repository. You can install it via
-            `winget install Firezone.Client.GUI`.
+            <code>winget install Firezone.Client.GUI</code>.
           </ChangeItem>
         )}
       </Entry>
@@ -207,7 +209,7 @@ export default function GUI({ os }: { os: OS }) {
       <Entry version="1.4.3" date={new Date("2025-02-05")}>
         {os === OS.Windows && (
           <ChangeItem pull="8003">
-            Removes dependency on `netsh`, making sign-in faster.
+            Removes dependency on <code>netsh</code>, making sign-in faster.
           </ChangeItem>
         )}
         {os === OS.Windows && (
@@ -235,8 +237,8 @@ export default function GUI({ os }: { os: OS }) {
         )}
         {os === OS.Linux && (
           <ChangeItem pull="7822">
-            Makes the runtime dependency on `update-desktop-database` optional,
-            thus improving compatibility on non-Ubuntu systems.
+            Makes the runtime dependency on <code>update-desktop-database</code>{" "}
+            optional, thus improving compatibility on non-Ubuntu systems.
           </ChangeItem>
         )}
       </Entry>
@@ -283,7 +285,7 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem>Handles DNS queries over TCP correctly.</ChangeItem>
         {os === OS.Windows && (
           <ChangeItem pull="7009">
-            The IPC service `firezone-client-ipc.exe` is now signed.
+            The IPC service <code>firezone-client-ipc.exe</code> is now signed.
           </ChangeItem>
         )}
         <ChangeItem pull="7123">
@@ -311,9 +313,9 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull="6874">Fixes the GUI shutting down slowly.</ChangeItem>
         {os === OS.Windows && (
           <ChangeItem pull="6931">
-            Mitigates an issue where `ipconfig` and WSL weren't aware of
-            Firezone DNS resolvers. Users may need to restart WSL after signing
-            in to Firezone.
+            Mitigates an issue where <code>ipconfig</code> and WSL weren't aware
+            of Firezone DNS resolvers. Users may need to restart WSL after
+            signing in to Firezone.
           </ChangeItem>
         )}
       </Entry>
@@ -341,7 +343,8 @@ export default function GUI({ os }: { os: OS }) {
       <Entry version="1.3.6" date={new Date("2024-09-25")}>
         <ChangeItem pull="6809">
           Fixes a bug where non-wildcard DNS resources were not prioritised over
-          wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+          wildcard ones (e.g. <code>app.example.com</code> vs{" "}
+          <code>*.example.com</code>).
         </ChangeItem>
       </Entry>
       <Entry version="1.3.5" date={new Date("2024-09-25")}>
@@ -479,8 +482,8 @@ export default function GUI({ os }: { os: OS }) {
         </ChangeItem>
         {os === OS.Linux && (
           <ChangeItem pull="6163">
-            Supports using `etc-resolv-conf` DNS control method, or disabling
-            DNS control
+            Supports using <code>etc-resolv-conf</code> DNS control method, or
+            disabling DNS control
           </ChangeItem>
         )}
         <ChangeItem pull="6181">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -106,11 +106,11 @@ export default function Gateway() {
       </Entry>
       <Entry version="1.4.3" date={new Date("2025-01-28")}>
         <ChangeItem pull="7567">
-          Fixes an issue where ICMPv6's `PacketTooBig' errors were not correctly
+          Fixes an issue where ICMPv6's 'PacketTooBig' errors were not correctly
           translated by the NAT64 module.
         </ChangeItem>
         <ChangeItem pull="7565">
-          Fails early in case the binary is not started as `root` or with the
+          Fails early in case the binary is not started as <code>root</code> or with the
           `CAP_NET_ADMIN` capability. The check can be skipped with
           `--no-check`.
         </ChangeItem>

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -24,8 +24,8 @@ export default function Gateway() {
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
         <ChangeItem pull="9147">
-          Fixes an issue where connections failed to establish on machines
-          with multiple valid egress IPs.
+          Fixes an issue where connections failed to establish on machines with
+          multiple valid egress IPs.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.4.9" date={new Date("2025-05-14")}>
@@ -34,8 +34,8 @@ export default function Gateway() {
           not be sent.
         </ChangeItem>
         <ChangeItem pull="9060">
-          Fixes an issue where service discovery for DNS resources would fail
-          in case the Gateway's started up with no network connectivity.
+          Fixes an issue where service discovery for DNS resources would fail in
+          case the Gateway's started up with no network connectivity.
         </ChangeItem>
         <ChangeItem pull="9088">
           Fixes an issue where large batches of packets to the same Client got
@@ -64,8 +64,9 @@ export default function Gateway() {
           across GSO batches.
         </ChangeItem>
         <ChangeItem pull="8937">
-          Fixes an issue where connections to DNS resources which utilise round-robin
-          DNS may be interrupted whenever the Client re-queried the DNS name.
+          Fixes an issue where connections to DNS resources which utilise
+          round-robin DNS may be interrupted whenever the Client re-queried the
+          DNS name.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.6" date={new Date("2025-04-15")}>
@@ -110,9 +111,10 @@ export default function Gateway() {
           translated by the NAT64 module.
         </ChangeItem>
         <ChangeItem pull="7565">
-          Fails early in case the binary is not started as <code>root</code> or with the
-          `CAP_NET_ADMIN` capability. The check can be skipped with
-          `--no-check`.
+          Fails early in case the binary is not started as <code>root</code> or
+          with the
+          <code>CAP_NET_ADMIN</code> capability. The check can be skipped with
+          <code>--no-check</code>.
         </ChangeItem>
       </Entry>
       <Entry version="1.4.2" date={new Date("2024-12-13")}>
@@ -127,7 +129,7 @@ export default function Gateway() {
         <ChangeItem pull="7449">
           Uses multiple threads to read & write to the TUN device, greatly
           improving performance. The number of threads can be controlled with
-          `FIREZONE_NUM_TUN_THREADS` and defaults to 2.
+          <code>FIREZONE_NUM_TUN_THREADS</code> and defaults to 2.
         </ChangeItem>
         <ChangeItem pull="7479">
           Fixes an issue where SSH connections involving NAT64 failed to
@@ -163,7 +165,7 @@ export default function Gateway() {
         </ChangeItem>
         <ChangeItem pull="7103">
           Adds on-by-default error reporting using sentry.io. Disable by setting
-          `FIREZONE_NO_TELEMETRY=true`.
+          <code>FIREZONE_NO_TELEMETRY=true</code>.
         </ChangeItem>
         <ChangeItem pull="7164">
           Fixes an issue where the Gateway would fail to accept connections and
@@ -206,7 +208,7 @@ export default function Gateway() {
       </Entry>
       <Entry version="1.1.4" date={new Date("2024-08-08")}>
         <li className="pl-2">
-          Removes `FIREZONE_ENABLE_MASQUERADE` env variable. Masquerading is now
+          Removes <code>FIREZONE_ENABLE_MASQUERADE</code> env variable. Masquerading is now
           always enabled unconditionally.
         </li>
       </Entry>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -11,8 +11,8 @@ export default function Headless({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="9147">
-          Fixes an issue where connections failed to establish on machines
-          with multiple valid egress IPs.
+          Fixes an issue where connections failed to establish on machines with
+          multiple valid egress IPs.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.4.8" date={new Date("2025-05-14")}>
@@ -32,7 +32,7 @@ export default function Headless({ os }: { os: OS }) {
         {os === OS.Windows && (
           <ChangeItem pull="9213">
             Adds the Client to the winget repository. You can install it via
-            `winget install Firezone.Client.Headless`.
+            <code>winget install Firezone.Client.Headless</code>.
           </ChangeItem>
         )}
       </Entry>
@@ -139,13 +139,14 @@ export default function Headless({ os }: { os: OS }) {
             </ChangeItem>
             <ChangeItem pull="7770">
               BREAKING: Removes the positional token argument on the CLI. Use
-              `FIREZONE_TOKEN` or `FIREZONE_TOKEN_PATH` env variables instead.
+              <code>FIREZONE_TOKEN</code> or <code>FIREZONE_TOKEN_PATH</code>{" "}
+              env variables instead.
             </ChangeItem>
           </Entry>
           <Entry version="1.4.0" date={new Date("2024-12-13")}>
             <ChangeItem pull="7350">
               Allows disabling telemetry by setting
-              `FIREZONE_NO_TELEMETRY=true`.
+              <code>FIREZONE_NO_TELEMETRY=true</code>.
             </ChangeItem>
             <ChangeItem pull="7210">
               Adds support for GSO (Generic Segmentation Offload), delivering
@@ -213,7 +214,8 @@ export default function Headless({ os }: { os: OS }) {
           <Entry version="1.3.3" date={new Date("2024-09-25")}>
             <ChangeItem pull="6809">
               Fixes a bug where non-wildcard DNS resources were not prioritised
-              over wildcard ones (e.g. `app.example.com` vs `*.example.com`).
+              over wildcard ones (e.g. <code>app.example.com</code> vs{" "}
+              <code>*.example.com</code>).
             </ChangeItem>
           </Entry>
           <Entry version="1.3.2" date={new Date("2024-09-25")}>
@@ -271,7 +273,7 @@ export default function Headless({ os }: { os: OS }) {
           </Entry>
           <Entry version="1.1.5" date={new Date("2024-08-08")}>
             <ChangeItem pull="6163">
-              Uses `systemd-resolved` DNS control by default on Linux
+              Uses <code>systemd-resolved</code> DNS control by default on Linux
             </ChangeItem>
             <ChangeItem pull="6184">
               Mitigates a bug where the Client can panic if an internal channel


### PR DESCRIPTION
The changelog entries are written in TSX which is HTML, so backticks render as backticks on the website. Updating these to use `<code>` blocks correctly triggers the proper CSS to apply.