### PR TITLE
fix(portal): fix sentry before_send when message is nil

### DIFF
--- a/elixir/apps/domain/lib/domain/telemetry/sentry.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/sentry.ex
@@ -3,9 +3,9 @@ defmodule Domain.Telemetry.Sentry do
     nil
   end
 
-  def before_send(event) do
+  def before_send(%{message: message} = event) when is_binary(message) do
     if String.contains?(
-         event.message,
+         message,
          "Node ~p not responding **~n** Removing (timedout) connection"
        ) do
       # This happens when libcluster loses connection to a node, which is normal during deploys.
@@ -15,4 +15,6 @@ defmodule Domain.Telemetry.Sentry do
       event
     end
   end
+
+  def before_send(event), do: event
 end


### PR DESCRIPTION
A regression was introduced in #9242 where it appears that some Sentry events don't contain messages, so the filtering module is updated only to act on events with messages.