### PR TITLE
fix(portal): fix false-positive cluster errors

### DIFF
--- a/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
+++ b/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
@@ -171,7 +171,7 @@ defmodule Domain.Cluster.GoogleComputeLabelsStrategy do
   end
 
   defp enough_nodes_connected?(state) do
-    connected_nodes = state.connected_nodes
+    connected_nodes = state.connected_nodes ++ [Node.self()]
     expected_api_node_count = Keyword.fetch!(state.config, :api_node_count)
     expected_domain_node_count = Keyword.fetch!(state.config, :domain_node_count)
     expected_web_node_count = Keyword.fetch!(state.config, :web_node_count)

--- a/elixir/apps/domain/lib/domain/telemetry/sentry.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/sentry.ex
@@ -3,9 +3,10 @@ defmodule Domain.Telemetry.Sentry do
     nil
   end
 
-  def before_send(%{message: message} = event) when is_binary(message) do
+  def before_send(%{message: %{formatted: formatted_message}} = event)
+      when is_binary(formatted_message) do
     if String.contains?(
-         message,
+         formatted_message,
          "Node ~p not responding **~n** Removing (timedout) connection"
        ) do
       # This happens when libcluster loses connection to a node, which is normal during deploys.


### PR DESCRIPTION
Fixes the following issues after learning they're still a problem:

- We need to include our own node when checking for connected node count
- Need to match against the `formatted` key inside message when filtering Sentry events