### PR TITLE
fix(portal): Uniq nodes before counting

### DIFF
--- a/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
+++ b/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
@@ -187,7 +187,9 @@ defmodule Domain.Cluster.GoogleComputeLabelsStrategy do
   end
 
   defp connected_node_count(nodes, target_app) do
-    Enum.count(nodes, fn node_name ->
+    nodes
+    |> Enum.uniq()
+    |> Enum.count(fn node_name ->
       app =
         node_name
         |> Atom.to_string()


### PR DESCRIPTION
While we shouldn't have any duplicates in this list, it would be a good idea to unique the node names before counting just to be sure.