### PR TITLE
ci: update to new `cargo sort` release

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
           - -i
           - "4"
   - repo: https://github.com/DevinR528/cargo-sort
-    rev: v2.1.0
+    rev: v2.0.1
     hooks:
       - id: cargo-sort
         args: ["--check", "--workspace", "rust/"]

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
           - -i
           - "4"
   - repo: https://github.com/DevinR528/cargo-sort
-    rev: v1.0.9
+    rev: v2.1.0
     hooks:
       - id: cargo-sort
         args: ["--check", "--workspace", "rust/"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,33 +1,33 @@
 [workspace]
 members = [
-  "android-client-ffi",
-  "apple-client-ffi",
-  "bin-shared",
-  "client-shared",
-  "connlib/bufferpool",
-  "connlib/dns-over-tcp",
-  "connlib/dns-types",
-  "connlib/etherparse-ext",
-  "connlib/ip-packet",
-  "connlib/l4-tcp-dns-server",
-  "connlib/l4-udp-dns-server",
-  "connlib/model",
-  "connlib/phoenix-channel",
-  "connlib/snownet",
-  "connlib/socket-factory",
-  "connlib/tun",
-  "connlib/tunnel",
-  "gateway",
-  "gui-client/src-admx-macro",
-  "gui-client/src-tauri",
-  "headless-client",
-  "logging",
-  "relay/ebpf-shared",
-  "relay/ebpf-turn-router",
-  "relay/server",
-  "telemetry",
-  "tests/gui-smoke-test",
-  "tests/http-test-server",
+    "android-client-ffi",
+    "apple-client-ffi",
+    "bin-shared",
+    "client-shared",
+    "connlib/bufferpool",
+    "connlib/dns-over-tcp",
+    "connlib/dns-types",
+    "connlib/etherparse-ext",
+    "connlib/ip-packet",
+    "connlib/l4-tcp-dns-server",
+    "connlib/l4-udp-dns-server",
+    "connlib/model",
+    "connlib/phoenix-channel",
+    "connlib/snownet",
+    "connlib/socket-factory",
+    "connlib/tun",
+    "connlib/tunnel",
+    "gateway",
+    "gui-client/src-admx-macro",
+    "gui-client/src-tauri",
+    "headless-client",
+    "logging",
+    "relay/ebpf-shared",
+    "relay/ebpf-turn-router",
+    "relay/server",
+    "telemetry",
+    "tests/gui-smoke-test",
+    "tests/http-test-server",
 ]
 
 resolver = "2"
@@ -237,15 +237,15 @@ lto = "fat"
 # at the expense of compilation time
 codegen-units = 1
 
-# Override build settings just for the GUI client, so we get a pdb/dwp
-# Cargo ignores profile settings if they're not in the workspace's Cargo.toml
-[profile.dev.package.firezone-gui-client]
-debug = "full"
-split-debuginfo = "packed"
-
 [profile.release.package.firezone-gui-client]
 debug = "full"
 split-debuginfo = "packed"
 
 [profile.release.package.ebpf-turn-router]
 debug = 2
+
+# Override build settings just for the GUI client, so we get a pdb/dwp
+# Cargo ignores profile settings if they're not in the workspace's Cargo.toml
+[profile.dev.package.firezone-gui-client]
+debug = "full"
+split-debuginfo = "packed"

--- a/rust/apple-client-ffi/Cargo.toml
+++ b/rust/apple-client-ffi/Cargo.toml
@@ -5,8 +5,10 @@ version = "1.5.2"
 edition = { workspace = true }
 license = { workspace = true }
 
-[build-dependencies]
-swift-bridge-build = { workspace = true }
+[lib]
+name = "connlib"
+crate-type = ["staticlib"]
+doc = false
 
 [dependencies]
 anyhow = { workspace = true }
@@ -37,10 +39,8 @@ url = { workspace = true }
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 oslog = { version = "0.2.0", default-features = false }
 
-[lib]
-name = "connlib"
-crate-type = ["staticlib"]
-doc = false
+[build-dependencies]
+swift-bridge-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -28,14 +28,9 @@ tracing = { workspace = true }
 tun = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
-[dev-dependencies]
-bufferpool = { workspace = true }
-bytes = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-
 [target.'cfg(target_os = "linux")'.dependencies]
-dirs = { workspace = true }
 atomicwrites = { workspace = true }
+dirs = { workspace = true }
 flume = { workspace = true }
 libc = { workspace = true }
 netlink-packet-core = { workspace = true }
@@ -46,43 +41,49 @@ rtnetlink = { workspace = true }
 zbus = { workspace = true } # Can't use `zbus`'s `tokio` feature here, or it will break toast popups all the way over in `gui-client`.
 
 [target.'cfg(windows)'.dependencies]
+ipconfig = "0.3.2"
+itertools = { workspace = true }
 known-folders = { workspace = true }
 ring = "0.17"
+tokio-util = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 windows-core = { workspace = true }
 windows-implement = { workspace = true }
-wintun = "0.5.1"
 winreg = { workspace = true }
-tokio-util = { workspace = true }
-ipconfig = "0.3.2"
-itertools = { workspace = true }
+wintun = "0.5.1"
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true
 features = [
-  # For implementing COM interfaces
-  "Win32_Foundation",
-  # For listening for network change events
-  "Win32_Networking_NetworkListManager",
-  "Win32_NetworkManagement_IpHelper",
-  "Win32_NetworkManagement_Ndis",
-  "Win32_Networking_WinSock",
-  "Win32_Security",
-  "Win32_System_Com",
-  # Needed to listen for system DNS changes
-  "Win32_System_Registry",
-  "Win32_System_Threading",
-  "Win32_System_SystemInformation", # For uptime
-  "Win32_System_GroupPolicy", # For NRPT when GPO is used
+    # For implementing COM interfaces
+    "Win32_Foundation",
+    # For listening for network change events
+    "Win32_Networking_NetworkListManager",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Networking_WinSock",
+    "Win32_Security",
+    "Win32_System_Com",
+    # Needed to listen for system DNS changes
+    "Win32_System_Registry",
+    "Win32_System_Threading",
+    "Win32_System_SystemInformation",
+    # For uptime
+    "Win32_System_GroupPolicy", # For NRPT when GPO is used
 ]
 
-[target.'cfg(windows)'.dev-dependencies]
-ip-packet = { workspace = true }
-tokio = { workspace = true, features = ["net", "time"] }
+[dev-dependencies]
+bufferpool = { workspace = true }
+bytes = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 mutants = "0.0.3" # Needed to mark functions as exempt from `cargo-mutants` testing
 tempfile = { workspace = true }
+
+[target.'cfg(windows)'.dev-dependencies]
+ip-packet = { workspace = true }
+tokio = { workspace = true, features = ["net", "time"] }
 
 [lints]
 workspace = true

--- a/rust/connlib/phoenix-channel/Cargo.toml
+++ b/rust/connlib/phoenix-channel/Cargo.toml
@@ -27,11 +27,11 @@ tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["std", "v4"] }
 
-[target.'cfg(system_certs)'.dependencies]
-tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
-
 [target.'cfg(not(system_certs))'.dependencies]
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
+
+[target.'cfg(system_certs)'.dependencies]
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 hostname = "0.4.0"

--- a/rust/connlib/tun/Cargo.toml
+++ b/rust/connlib/tun/Cargo.toml
@@ -10,10 +10,10 @@ anyhow = { workspace = true }
 ip-packet = { workspace = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
+flume = { workspace = true }
+futures = { workspace = true }
 libc = { workspace = true }
 tokio = { workspace = true }
-futures = { workspace = true }
-flume = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 
+[features]
+proptest = ["dep:proptest"]
+divan = ["dep:divan"]
+
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true, features = ["std"] }
@@ -64,10 +68,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 name = "divan"
 harness = false
 required-features = ["divan"]
-
-[features]
-proptest = ["dep:proptest"]
-divan = ["dep:divan"]
 
 [lints]
 workspace = true

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -47,9 +47,9 @@ uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = { workspace = true }
+dns-lookup = { workspace = true }
 jemallocator = { workspace = true }
 nix = { workspace = true, features = ["user"] }
-dns-lookup = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 dns-lookup = { workspace = true }

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -8,9 +8,12 @@ default-run = "firezone-gui-client"
 authors = ["Firezone, Inc."]
 license = { workspace = true }
 
-[build-dependencies]
-anyhow = { workspace = true }
-tauri-build = { workspace = true, features = [] }
+[features]
+# this feature is used for production builds or when `devPath` points to the filesystem
+# DO NOT REMOVE!!
+# TODO: We can probably remove this, per <https://github.com/tauri-apps/tauri/releases/tag/tauri-v2.0.0-beta.8>
+# I don't know how to verify this change, so I won't do it right now.
+custom-protocol = ["tauri/custom-protocol"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -66,34 +69,31 @@ zip = { workspace = true, features = ["deflate", "time"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 dirs = { workspace = true }
 nix = { workspace = true, features = ["user"] }
-tracing-journald = { workspace = true }
 sd-notify = { workspace = true }
+tracing-journald = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-tauri-winrt-notification = "0.7.2"
-winreg = { workspace = true }
-windows-service = { workspace = true }
 admx-macro = { workspace = true }
+tauri-winrt-notification = "0.7.2"
+windows-service = { workspace = true }
+winreg = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 workspace = true
 features = [
-  "Win32_Foundation",
-  "Win32_System_Threading",
-  "Win32_System_Pipes", # For IPC system
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_Pipes", # For IPC system
 ]
+
+[build-dependencies]
+anyhow = { workspace = true }
+tauri-build = { workspace = true, features = [] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-
-[features]
-# this feature is used for production builds or when `devPath` points to the filesystem
-# DO NOT REMOVE!!
-# TODO: We can probably remove this, per <https://github.com/tauri-apps/tauri/releases/tag/tauri-v2.0.0-beta.8>
-# I don't know how to verify this change, so I won't do it right now.
-custom-protocol = ["tauri/custom-protocol"]
 
 [lints]
 workspace = true

--- a/rust/relay/ebpf-turn-router/Cargo.toml
+++ b/rust/relay/ebpf-turn-router/Cargo.toml
@@ -4,19 +4,19 @@ version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 
+[[bin]]
+name = "ebpf-turn-router-main" # This needs to be different from the package name otherwise the build-script fails to differentiate between the directory it is built in and the actual binary.
+path = "src/main.rs"
+
 [dependencies]
 aya-ebpf = { workspace = true }
 aya-log-ebpf = { workspace = true }
 ebpf-shared = { workspace = true }
 network-types = { workspace = true }
 
-[dev-dependencies]
-hex-literal = { workspace = true }
-ip-packet = { workspace = true }
-
 [build-dependencies]
 which = { workspace = true }
 
-[[bin]]
-name = "ebpf-turn-router-main" # This needs to be different from the package name otherwise the build-script fails to differentiate between the directory it is built in and the actual binary.
-path = "src/main.rs"
+[dev-dependencies]
+hex-literal = { workspace = true }
+ip-packet = { workspace = true }

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -55,15 +55,15 @@ aya = { workspace = true, features = ["tokio"] }
 aya-log = { workspace = true }
 jemallocator = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.build-dependencies]
+anyhow = "1"
+aya-build = { workspace = true }
+
 [dev-dependencies]
 difference = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing", "metrics"] }
 test-strategy = { workspace = true }
 tokio = { workspace = true, features = ["process", "macros", "net"] }
-
-[target.'cfg(target_os = "linux")'.build-dependencies]
-anyhow = "1"
-aya-build = { workspace = true }
 
 [[test]]
 name = "regression"

--- a/scripts/nix/flake.lock
+++ b/scripts/nix/flake.lock
@@ -15,9 +15,26 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1748693115,
+        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/scripts/nix/flake.nix
+++ b/scripts/nix/flake.nix
@@ -1,16 +1,22 @@
 {
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-24.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
-  outputs = { nixpkgs, ... }:
+  outputs = { nixpkgs, nixpkgs-unstable, ... }:
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs {
         inherit system;
-        config = {
-          allowUnfree = true;
-        };
+        config.allowUnfree = true;
+        overlays = [
+          (final: _prev: {
+            unstable = import nixpkgs-unstable {
+              inherit (final) system config;
+            };
+          })
+        ];
       };
 
       packages = with pkgs; [
@@ -54,7 +60,7 @@
     {
       devShells = {
         x86_64-linux.default = pkgs.mkShell {
-          packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.pnpm pkgs.cargo-sort pkgs.cargo-deny pkgs.cargo-autoinherit pkgs.dump_syms pkgs.xvfb-run ];
+          packages = [ pkgs.cargo-tauri pkgs.iptables pkgs.pnpm pkgs.unstable.cargo-sort pkgs.cargo-deny pkgs.cargo-autoinherit pkgs.dump_syms pkgs.xvfb-run ];
           buildInputs = packages;
           src = ../..;
 


### PR DESCRIPTION
The latest release now also sorts workspace dependencies, as well as different dependency sections. Keeping these things sorted reduces the chances of merge conflicts when multiple PRs edit these files.