### PR TITLE
fix(connlib): don't hard-fail if buffer increase is rejected

### DIFF
--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -191,15 +191,11 @@ impl ThreadedUdpSocket {
                         .with_unit("{error}")
                         .build();
 
-                    match socket.set_buffer_sizes(
+                    if let Err(e) = socket.set_buffer_sizes(
                         socket_factory::SEND_BUFFER_SIZE,
                         socket_factory::RECV_BUFFER_SIZE,
                     ) {
-                        Ok(()) => {}
-                        Err(e) => {
-                            let _ = error_tx.send(Err(e));
-                            return;
-                        }
+                        tracing::warn!("Failed to set socket buffer sizes: {e}");
                     }
 
                     let send = pin!(async {

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -48,6 +48,10 @@ export default function Android() {
           Fixes an issue where connections failed to establish on machines with
           multiple valid egress IPs.
         </ChangeItem>
+        <ChangeItem pull="9366">
+          Fixes an issue where Firezone could not start if the operating system
+          refused our request to increase the UDP socket buffer sizes.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.8" date={new Date("2025-04-30")}>
         <ChangeItem pull="8920">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9366">
+          Fixes an issue where Firezone could not start if the operating system
+          refused our request to increase the UDP socket buffer sizes.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.1" date={new Date("2025-06-01")}>
         <ChangeItem pull="9308">
           Fixes an issue where the network extension could crash when viewing

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -28,6 +28,10 @@ export default function GUI({ os }: { os: OS }) {
             .
           </ChangeItem>
         )}
+        <ChangeItem pull="9366">
+          Fixes an issue where Firezone could not start if the operating system
+          refused our request to increase the UDP socket buffer sizes.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.14" date={new Date("2025-05-21")}>
         <ChangeItem pull="9147">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -27,6 +27,10 @@ export default function Gateway() {
           Fixes an issue where connections failed to establish on machines with
           multiple valid egress IPs.
         </ChangeItem>
+        <ChangeItem pull="9366">
+          Fixes an issue where Firezone could not start if the operating system
+          refused our request to increase the UDP socket buffer sizes.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.9" date={new Date("2025-05-14")}>
         <ChangeItem pull="9059">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -14,6 +14,10 @@ export default function Headless({ os }: { os: OS }) {
           Fixes an issue where connections failed to establish on machines with
           multiple valid egress IPs.
         </ChangeItem>
+        <ChangeItem pull="9366">
+          Fixes an issue where Firezone could not start if the operating system
+          refused our request to increase the UDP socket buffer sizes.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.8" date={new Date("2025-05-14")}>
         <ChangeItem pull="9014">


### PR DESCRIPTION
When `connlib` creates new UDP sockets for the p2p traffic, it tries to increase the send and receive buffers for improved performance. Failure to do so currently results in `connlib` failing to start entirely. This is unnecessarily harsh, we can simply log a warning instead and move on.