### PR TITLE
build(deps): bump `quinn-udp` to `main`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5397,8 +5397,7 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+source = "git+https://github.com/quinn-rs/quinn?branch=main#06995454f44171d4164753b95e0bce900089a9a7"
 dependencies = [
  "cfg_aliases",
  "libc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -223,6 +223,7 @@ tracing-stackdriver = { git = "https://github.com/thomaseizinger/tracing-stackdr
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting for release.
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 moka = { git = "https://github.com/moka-rs/moka", branch = "main" } # Waiting for release.
+quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']


### PR DESCRIPTION
The most recent mainline `quinn-udp` contains a patch that preemptively disables GSO on Linux kernel versions < 4.18 where GSO is not yet supported at all. This especially affects Android devices as there are quite a few of those out there with pretty old Linux kernels.