### PR TITLE
fix(portal): treat missing organizationUnits as empty list

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
@@ -196,6 +196,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClient do
   # stop.
   #
   # For members, this happens quite often and we want to return an empty list.
+  # For organization units, this is expected if the Google account has no org units.
   defp list(uri, api_token, key) do
     request = Finch.build(:get, uri, [{"Authorization", "Bearer #{api_token}"}])
     response = Finch.request(request, @pool_name)
@@ -249,6 +250,10 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClient do
 
       # This is expected if the group has no members or we're on the last page
       :error when key == "members" ->
+        {:ok, [], nil}
+
+      # organizationUnits will be missing if the Google account has no org units
+      :error when key == "organizationUnits" ->
         {:ok, [], nil}
 
       :error ->

--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
@@ -182,7 +182,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       assert list_organization_units(api_token) == {:error, :retry_later}
     end
 
-    test "returns invalid_response when api responds without expected JSON keys" do
+    test "returns empty list when api responds without expected JSON keys" do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
 
@@ -192,7 +192,8 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         Jason.encode!(%{})
       )
 
-      assert list_organization_units(api_token) == {:error, :invalid_response}
+      assert {:ok, organization_units} = list_organization_units(api_token)
+      assert organization_units == []
     end
 
     test "returns invalid_response when api responds with unexpected data format" do
@@ -202,7 +203,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"organization_units" => "invalid data"})
+        Jason.encode!(%{"organizationUnits" => "invalid data"})
       )
 
       assert list_organization_units(api_token) == {:error, :invalid_response}


### PR DESCRIPTION
When a Google account has no organization units defined in its directory, the Google API can return a `200` response without the `organizationUnits` key. In such cases, we should treat this as an empty list such that the remainder of the sync will continue.