### PR TITLE
fix(connlib): re-add resource if ip_stack changes

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1553,7 +1553,10 @@ impl ClientState {
         };
 
         if let Some(resource) = self.resources_by_id.get(&new_resource.id()) {
-            if resource.has_different_address(&new_resource) {
+            let resource_addressability_changed = resource.has_different_address(&new_resource)
+                || resource.has_different_ip_stack(&new_resource);
+
+            if resource_addressability_changed {
                 self.remove_resource(resource.id());
             }
         }

--- a/rust/connlib/tunnel/src/client/resource.rs
+++ b/rust/connlib/tunnel/src/client/resource.rs
@@ -169,6 +169,13 @@ impl Resource {
         }
     }
 
+    pub fn has_different_ip_stack(&self, other: &Resource) -> bool {
+        match (self, other) {
+            (Resource::Dns(dns_a), Resource::Dns(dns_b)) => dns_a.ip_stack != dns_b.ip_stack,
+            _ => false,
+        }
+    }
+
     pub fn addresses(&self) -> Vec<IpNetwork> {
         match self {
             Resource::Dns(_) => vec![],


### PR DESCRIPTION
In #9300, we added logic to control whether we emit A and/or AAAA records for a DNS resource based on the `ip_stack` property of the `Resource` struct.

Unfortunately this didn't take updates into account when the client was signed in, so updating a DNS resource's ip_stack failed to update the client's local Resource copy.

To fix this, we determine if `resource_addressability_changed` which is true if the resource's address, or ip_stack, has changed meaningfully. If so, we remove the resource prior to evaluating the remaining logic of the `resource_created_or_updated` handler, which in turn causes the resource to be re-added, effectively updating its ip_stack.

Related: https://github.com/firezone/firezone/pull/9300#issuecomment-2932365798