### PR TITLE
fix(ci): exclude generated typescript from prettier fixing

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: prettier
         name: Prettier
         entry: prettier --check --ignore-unknown .
+        exclude: (^rust/gui-client/src-frontend/generated/)
         language: system
         pass_filenames: false
 


### PR DESCRIPTION
This is causing the Tauri workflows to error: https://github.com/firezone/firezone/actions/runs/15407717057