### PR TITLE
fix(ci): ensure docker compose up runs one by one

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -130,7 +130,9 @@ jobs:
           fi
 
           # Start one-by-one to avoid variability in service startup order
-          docker compose up -d dns.httpbin.search.test httpbin download.httpbin --no-build
+          docker compose up -d dns.httpbin.search.test --no-build
+          docker compose up -d httpbin --no-build
+          docker compose up -d download.httpbin --no-build
           docker compose up -d api web domain --no-build
           docker compose up -d otel --no-build
           docker compose up -d relay-1 --no-build


### PR DESCRIPTION
Similar to the fix in #9205, the version of docker compose on GitHub runners has a race condition when upping more than one service backed by the same image.

To reduce flakiness, we ensure that `httpbin` is upped one-by-one.

Related: https://github.com/firezone/firezone/actions/runs/15408440858/job/43355659174