### PR TITLE
refactor(portal): don't send `ip_stack` for non-DNS resources

### DIFF
--- a/elixir/apps/api/lib/api/client/views/resource.ex
+++ b/elixir/apps/api/lib/api/client/views/resource.ex
@@ -11,8 +11,7 @@ defmodule API.Client.Views.Resource do
       id: resource.id,
       type: :internet,
       gateway_groups: Views.GatewayGroup.render_many(resource.gateway_groups),
-      can_be_disabled: true,
-      ip_stack: resource.ip_stack
+      can_be_disabled: true
     }
   end
 
@@ -28,8 +27,7 @@ defmodule API.Client.Views.Resource do
       address_description: resource.address_description,
       name: resource.name,
       gateway_groups: Views.GatewayGroup.render_many(resource.gateway_groups),
-      filters: Enum.flat_map(resource.filters, &render_filter/1),
-      ip_stack: resource.ip_stack
+      filters: Enum.flat_map(resource.filters, &render_filter/1)
     }
   end
 
@@ -41,9 +39,9 @@ defmodule API.Client.Views.Resource do
       address_description: resource.address_description,
       name: resource.name,
       gateway_groups: Views.GatewayGroup.render_many(resource.gateway_groups),
-      filters: Enum.flat_map(resource.filters, &render_filter/1),
-      ip_stack: resource.ip_stack
+      filters: Enum.flat_map(resource.filters, &render_filter/1)
     }
+    |> maybe_put_ip_stack(resource)
   end
 
   def render_filter(%Resources.Resource.Filter{ports: ports} = filter) when length(ports) > 0 do
@@ -81,5 +79,13 @@ defmodule API.Client.Views.Resource do
 
   defp port_to_number(port) do
     port |> String.trim() |> String.to_integer()
+  end
+
+  defp maybe_put_ip_stack(attrs, %{ip_stack: nil}) do
+    attrs
+  end
+
+  defp maybe_put_ip_stack(attrs, resource) do
+    Map.put(attrs, :ip_stack, resource.ip_stack)
   end
 end

--- a/elixir/apps/api/lib/api/controllers/resource_json.ex
+++ b/elixir/apps/api/lib/api/controllers/resource_json.ex
@@ -25,8 +25,16 @@ defmodule API.ResourceJSON do
       name: resource.name,
       address: resource.address,
       address_description: resource.address_description,
-      type: resource.type,
-      ip_stack: resource.ip_stack
+      type: resource.type
     }
+    |> maybe_put_ip_stack(resource)
+  end
+
+  defp maybe_put_ip_stack(attrs, %{ip_stack: nil}) do
+    attrs
+  end
+
+  defp maybe_put_ip_stack(attrs, resource) do
+    Map.put(attrs, :ip_stack, resource.ip_stack)
   end
 end

--- a/elixir/apps/api/lib/api/schemas/resource_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/resource_schema.ex
@@ -27,8 +27,7 @@ defmodule API.Schemas.Resource do
         "name" => "Prod DB",
         "address" => "10.0.0.10",
         "address_description" => "Production Database",
-        "type" => "ip",
-        "ip_stack" => nil
+        "type" => "ip"
       }
     })
   end
@@ -96,8 +95,7 @@ defmodule API.Schemas.Resource do
           "name" => "Prod DB",
           "address" => "10.0.0.10",
           "address_description" => "Production Database",
-          "type" => "ip",
-          "ip_stack" => nil
+          "type" => "ip"
         }
       }
     })
@@ -123,16 +121,14 @@ defmodule API.Schemas.Resource do
             "name" => "Prod DB",
             "address" => "10.0.0.10",
             "address_description" => "Production Database",
-            "type" => "ip",
-            "ip_stack" => nil
+            "type" => "ip"
           },
           %{
             "id" => "3b9451c9-5616-48f8-827f-009ace22d015",
             "name" => "Admin Dashboard",
             "address" => "10.0.0.20",
             "address_description" => "Production Admin Dashboard",
-            "type" => "ip",
-            "ip_stack" => nil
+            "type" => "ip"
           }
         ],
         "metadata" => %{

--- a/elixir/apps/api/lib/api/schemas/resource_schema.ex
+++ b/elixir/apps/api/lib/api/schemas/resource_schema.ex
@@ -28,7 +28,7 @@ defmodule API.Schemas.Resource do
         "address" => "10.0.0.10",
         "address_description" => "Production Database",
         "type" => "ip",
-        "ip_stack" => "ipv4_only"
+        "ip_stack" => nil
       }
     })
   end
@@ -97,7 +97,7 @@ defmodule API.Schemas.Resource do
           "address" => "10.0.0.10",
           "address_description" => "Production Database",
           "type" => "ip",
-          "ip_stack" => "ipv4_only"
+          "ip_stack" => nil
         }
       }
     })
@@ -123,14 +123,16 @@ defmodule API.Schemas.Resource do
             "name" => "Prod DB",
             "address" => "10.0.0.10",
             "address_description" => "Production Database",
-            "type" => "ip"
+            "type" => "ip",
+            "ip_stack" => nil
           },
           %{
             "id" => "3b9451c9-5616-48f8-827f-009ace22d015",
             "name" => "Admin Dashboard",
             "address" => "10.0.0.20",
             "address_description" => "Production Admin Dashboard",
-            "type" => "ip"
+            "type" => "ip",
+            "ip_stack" => nil
           }
         ],
         "metadata" => %{

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -309,7 +309,6 @@ defmodule API.Client.ChannelTest do
       assert %{
                id: cidr_resource.id,
                type: :cidr,
-               ip_stack: nil,
                name: cidr_resource.name,
                address: cidr_resource.address,
                address_description: cidr_resource.address_description,
@@ -330,7 +329,6 @@ defmodule API.Client.ChannelTest do
       assert %{
                id: ip_resource.id,
                type: :cidr,
-               ip_stack: nil,
                name: ip_resource.name,
                address: "#{ip_resource.address}/32",
                address_description: ip_resource.address_description,
@@ -351,7 +349,6 @@ defmodule API.Client.ChannelTest do
       assert %{
                id: internet_resource.id,
                type: :internet,
-               ip_stack: nil,
                gateway_groups: [
                  %{
                    id: internet_gateway_group.id,


### PR DESCRIPTION
We always return the `ip_stack` field when rendering resource for both WebSocket and REST APIs. If the resource's type is not `:dns` then this will be `nil`.

Related: https://github.com/firezone/firezone/pull/9303#discussion_r2119681062