### PR TITLE
fix(portal): sort before asserting on list equality

### DIFF
--- a/elixir/apps/domain/test/domain/actors_test.exs
+++ b/elixir/apps/domain/test/domain/actors_test.exs
@@ -1029,7 +1029,10 @@ defmodule Domain.ActorsTest do
       provider_identifiers = Enum.map(attrs_list, & &1["provider_identifier"])
 
       assert {:ok, sync_data} = sync_provider_groups(provider, attrs_list)
-      assert Enum.map(sync_data.groups, & &1.name) == [deleted_group.name, group2.name]
+
+      assert Enum.sort(Enum.map(sync_data.groups, & &1.name)) ==
+               Enum.sort([deleted_group.name, group2.name])
+
       assert sync_data.deleted == []
       assert sync_data.plan == {provider_identifiers, []}
     end

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -1905,11 +1905,13 @@ defmodule Domain.AuthTest do
       assert {:ok,
               %{
                 identities: [_id1, _id2, _id3, _id4, _id5],
-                plan: {[], ["USER_ID5", "USER_ID4", "USER_ID3"], delete},
+                plan: {[], upsert, delete},
                 deleted: [deleted_identity1, deleted_identity2],
                 inserted: [],
                 actor_ids_by_provider_identifier: actor_ids_by_provider_identifier
               }} = sync_provider_identities(provider, attrs_list)
+
+      assert Enum.sort(upsert) == ["USER_ID3", "USER_ID4", "USER_ID5"]
 
       assert Enum.take(provider_identifiers, 2)
              |> Enum.all?(&(&1 in delete))


### PR DESCRIPTION
Fixes minor flakiness introduced in #9373 