### PR TITLE
feat(gui-client): introduce "General" settings page

### DIFF
--- a/rust/gui-client/src-frontend/components/AdvancedSettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/AdvancedSettingsPage.tsx
@@ -1,26 +1,21 @@
 import React, { useEffect, useState } from "react";
-import {
-  Button,
-  TextInput,
-  Label,
-  TextInputProps,
-  Tooltip,
-} from "flowbite-react";
-import { AdvancedSettingsViewModel as Settings } from "../generated/AdvancedSettingsViewModel";
+import { Button, Label } from "flowbite-react";
+import { AdvancedSettingsViewModel } from "../generated/AdvancedSettingsViewModel";
+import { ManagedTextInput } from "./ManagedInput";
 
-interface SettingsPageProps {
-  settings: Settings | null;
-  saveSettings: (settings: Settings) => void;
+interface Props {
+  settings: AdvancedSettingsViewModel | null;
+  saveSettings: (settings: AdvancedSettingsViewModel) => void;
   resetSettings: () => void;
 }
 
-export default function SettingsPage({
+export default function AdvancedSettingsPage({
   settings,
   saveSettings,
   resetSettings,
-}: SettingsPageProps) {
+}: Props) {
   // Local settings can be edited without affecting the global state.
-  const [localSettings, setLocalSettings] = useState<Settings>(
+  const [localSettings, setLocalSettings] = useState<AdvancedSettingsViewModel>(
     settings ?? {
       api_url: "",
       api_url_is_managed: false,
@@ -45,9 +40,9 @@ export default function SettingsPage({
   }, [settings]);
 
   return (
-    <div className="container mx-auto p-4">
+    <div className="container p-4">
       <div className="pb-2">
-        <h2 className="text-xl font-semibold mb-4">Advanced Settings</h2>
+        <h2 className="text-xl font-semibold">Advanced Settings</h2>
       </div>
 
       <p className="text-neutral-900 mb-6">
@@ -61,7 +56,7 @@ export default function SettingsPage({
           e.preventDefault();
           saveSettings(localSettings);
         }}
-        className="max-w mx-auto flex flex-col gap-2"
+        className="max-w flex flex-col gap-2"
       >
         <div>
           <Label className="text-neutral-600" htmlFor="auth-base-url-input">
@@ -129,21 +124,4 @@ export default function SettingsPage({
       </form>
     </div>
   );
-}
-
-function ManagedTextInput(props: TextInputProps & { managed: boolean }) {
-  let { managed, ...inputProps } = props;
-
-  if (managed) {
-    return (
-      <Tooltip
-        content="This setting is managed by your organisation."
-        clearTheme={{ target: true }}
-      >
-        <TextInput {...inputProps} disabled={true} />
-      </Tooltip>
-    );
-  } else {
-    return <TextInput {...inputProps} />;
-  }
 }

--- a/rust/gui-client/src-frontend/components/App.tsx
+++ b/rust/gui-client/src-frontend/components/App.tsx
@@ -32,8 +32,10 @@ import { GeneralSettingsViewModel } from "../generated/GeneralSettingsViewModel"
 export default function App() {
   let [session, setSession] = useState<Session | null>(null);
   let [logCount, setLogCount] = useState<FileCount | null>(null);
-  let [generalSettings, setGeneralSettings] = useState<GeneralSettingsViewModel | null>(null);
-  let [advancedSettings, setAdvancedSettings] = useState<AdvancedSettingsViewModel | null>(null);
+  let [generalSettings, setGeneralSettings] =
+    useState<GeneralSettingsViewModel | null>(null);
+  let [advancedSettings, setAdvancedSettings] =
+    useState<AdvancedSettingsViewModel | null>(null);
 
   useEffect(() => {
     const signedInUnlisten = listen<Session>("signed_in", (e) => {
@@ -60,7 +62,9 @@ export default function App() {
       (e) => {
         let advancedSettings = e.payload;
 
-        console.log("advanced_settings_changed", { settings: advancedSettings });
+        console.log("advanced_settings_changed", {
+          settings: advancedSettings,
+        });
         setAdvancedSettings(advancedSettings);
       }
     );
@@ -175,6 +179,7 @@ export default function App() {
                 saveSettings={(settings) =>
                   invoke("apply_general_settings", { settings })
                 }
+                resetSettings={() => invoke("reset_general_settings")}
               />
             }
           />

--- a/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from "react";
+import { Button, Label, ToggleSwitch } from "flowbite-react";
+import { GeneralSettingsViewModel } from "../generated/GeneralSettingsViewModel";
+import { ManagedToggleSwitch, ManagedTextInput } from "./ManagedInput";
+
+interface Props {
+  settings: GeneralSettingsViewModel | null;
+  saveSettings: (settings: GeneralSettingsViewModel) => void;
+}
+
+export default function GeneralSettingsPage({
+  settings,
+  saveSettings,
+}: Props) {
+  // Local settings can be edited without affecting the global state.
+  const [localSettings, setLocalSettings] = useState<GeneralSettingsViewModel>(
+    settings ?? {
+      start_minimized: true,
+      account_slug: "",
+      connect_on_start: false,
+      start_on_login: false,
+      account_slug_is_managed: false,
+      connect_on_start_is_managed: false,
+    }
+  );
+
+  useEffect(() => {
+    setLocalSettings(
+      settings ?? {
+        start_minimized: true,
+        account_slug: "",
+        connect_on_start: false,
+        start_on_login: false,
+        account_slug_is_managed: false,
+        connect_on_start_is_managed: false,
+      }
+    );
+  }, [settings]);
+
+  return (
+    <div className="container p-4">
+      <div className="pb-2">
+        <h2 className="text-xl font-semibold">General settings</h2>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          saveSettings(localSettings);
+        }}
+        className="max-w flex flex-col gap-2"
+      >
+        <div className="flex flex-row gap-2 items-center">
+          <ToggleSwitch
+            name="start_minimized"
+            id="start-minimized-input"
+            checked={localSettings.start_minimized}
+            onChange={(e) =>
+              setLocalSettings({
+                ...localSettings,
+                start_minimized: e,
+              })
+            }
+          />
+          <Label className="text-neutral-600" htmlFor="start-minimized-input">
+            Start minimized
+          </Label>
+        </div>
+
+        <div className="flex flex-row gap-2 items-center">
+          <ToggleSwitch
+            name="start_on_login"
+            id="start-on-login-input"
+            checked={localSettings.start_on_login}
+            onChange={(e) =>
+              setLocalSettings({
+                ...localSettings,
+                start_on_login: e,
+              })
+            }
+          />
+          <Label className="text-neutral-600" htmlFor="start-on-login-input">
+            Start on Login
+          </Label>
+        </div>
+
+        <div className="flex flex-row gap-2 items-center">
+          <ManagedToggleSwitch
+            name="connect-on-start"
+            id="connect-on-start-input"
+            managed={localSettings.connect_on_start_is_managed}
+            checked={localSettings.connect_on_start}
+            onChange={(e) =>
+              setLocalSettings({
+                ...localSettings,
+                connect_on_start: e,
+              })
+            }
+          />
+          <Label className="text-neutral-600" htmlFor="connect-on-start-input">
+            Connect on start
+          </Label>
+        </div>
+
+        <div>
+          <Label className="text-neutral-600" htmlFor="account-slug-input">
+            Account slug
+          </Label>
+          <ManagedTextInput
+            name="account_slug"
+            id="account-slug-input"
+            managed={localSettings.account_slug_is_managed}
+            value={localSettings.account_slug}
+            onChange={(e) =>
+              setLocalSettings({
+                ...localSettings,
+                account_slug: e.target.value,
+              })
+            }
+          />
+        </div>
+
+        <div className="flex justify-end gap-4 mt-4">
+          <Button type="submit">Apply</Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
@@ -70,56 +70,61 @@ export default function GeneralSettingsPage({
           />
         </div>
 
-        <div className="flex flex-row gap-2 items-center">
-          <ToggleSwitch
-            name="start_minimized"
-            id="start-minimized-input"
-            checked={localSettings.start_minimized}
-            onChange={(e) =>
-              setLocalSettings({
-                ...localSettings,
-                start_minimized: e,
-              })
-            }
-          />
-          <Label className="text-neutral-600" htmlFor="start-minimized-input">
-            Start minimized
-          </Label>
-        </div>
+        <div className="max-w-1/2">
+          <div className="mt-4 flex justify-between items-center">
+            <Label className="text-neutral-600" htmlFor="start-minimized-input">
+              Start minimized
+            </Label>
+            <ToggleSwitch
+              name="start_minimized"
+              id="start-minimized-input"
+              checked={localSettings.start_minimized}
+              onChange={(e) =>
+                setLocalSettings({
+                  ...localSettings,
+                  start_minimized: e,
+                })
+              }
+            />
+          </div>
 
-        <div className="flex flex-row gap-2 items-center">
-          <ToggleSwitch
-            name="start_on_login"
-            id="start-on-login-input"
-            checked={localSettings.start_on_login}
-            onChange={(e) =>
-              setLocalSettings({
-                ...localSettings,
-                start_on_login: e,
-              })
-            }
-          />
-          <Label className="text-neutral-600" htmlFor="start-on-login-input">
-            Start on Login
-          </Label>
-        </div>
+          <div className="mt-4 flex justify-between items-center">
+            <Label className="text-neutral-600" htmlFor="start-on-login-input">
+              Start on Login
+            </Label>
+            <ToggleSwitch
+              name="start_on_login"
+              id="start-on-login-input"
+              checked={localSettings.start_on_login}
+              onChange={(e) =>
+                setLocalSettings({
+                  ...localSettings,
+                  start_on_login: e,
+                })
+              }
+            />
+          </div>
 
-        <div className="flex flex-row gap-2 items-center">
-          <ManagedToggleSwitch
-            name="connect-on-start"
-            id="connect-on-start-input"
-            managed={localSettings.connect_on_start_is_managed}
-            checked={localSettings.connect_on_start}
-            onChange={(e) =>
-              setLocalSettings({
-                ...localSettings,
-                connect_on_start: e,
-              })
-            }
-          />
-          <Label className="text-neutral-600" htmlFor="connect-on-start-input">
-            Connect on start
-          </Label>
+          <div className="mt-4 flex justify-between items-center">
+            <Label
+              className="text-neutral-600"
+              htmlFor="connect-on-start-input"
+            >
+              Connect on start
+            </Label>
+            <ManagedToggleSwitch
+              name="connect-on-start"
+              id="connect-on-start-input"
+              managed={localSettings.connect_on_start_is_managed}
+              checked={localSettings.connect_on_start}
+              onChange={(e) =>
+                setLocalSettings({
+                  ...localSettings,
+                  connect_on_start: e,
+                })
+              }
+            />
+          </div>
         </div>
 
         <div className="flex justify-end gap-4 mt-4">

--- a/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
@@ -52,6 +52,24 @@ export default function GeneralSettingsPage({
         }}
         className="max-w flex flex-col gap-2"
       >
+        <div>
+          <Label className="text-neutral-600" htmlFor="account-slug-input">
+            Account slug
+          </Label>
+          <ManagedTextInput
+            name="account_slug"
+            id="account-slug-input"
+            managed={localSettings.account_slug_is_managed}
+            value={localSettings.account_slug}
+            onChange={(e) =>
+              setLocalSettings({
+                ...localSettings,
+                account_slug: e.target.value,
+              })
+            }
+          />
+        </div>
+
         <div className="flex flex-row gap-2 items-center">
           <ToggleSwitch
             name="start_minimized"
@@ -102,24 +120,6 @@ export default function GeneralSettingsPage({
           <Label className="text-neutral-600" htmlFor="connect-on-start-input">
             Connect on start
           </Label>
-        </div>
-
-        <div>
-          <Label className="text-neutral-600" htmlFor="account-slug-input">
-            Account slug
-          </Label>
-          <ManagedTextInput
-            name="account_slug"
-            id="account-slug-input"
-            managed={localSettings.account_slug_is_managed}
-            value={localSettings.account_slug}
-            onChange={(e) =>
-              setLocalSettings({
-                ...localSettings,
-                account_slug: e.target.value,
-              })
-            }
-          />
         </div>
 
         <div className="flex justify-end gap-4 mt-4">

--- a/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
@@ -90,7 +90,7 @@ export default function GeneralSettingsPage({
 
           <div className="mt-4 flex justify-between items-center">
             <Label className="text-neutral-600" htmlFor="start-on-login-input">
-              Start on Login
+              Start on login
             </Label>
             <ToggleSwitch
               name="start_on_login"

--- a/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
@@ -6,11 +6,13 @@ import { ManagedToggleSwitch, ManagedTextInput } from "./ManagedInput";
 interface Props {
   settings: GeneralSettingsViewModel | null;
   saveSettings: (settings: GeneralSettingsViewModel) => void;
+  resetSettings: () => void;
 }
 
 export default function GeneralSettingsPage({
   settings,
   saveSettings,
+  resetSettings,
 }: Props) {
   // Local settings can be edited without affecting the global state.
   const [localSettings, setLocalSettings] = useState<GeneralSettingsViewModel>(
@@ -121,6 +123,9 @@ export default function GeneralSettingsPage({
         </div>
 
         <div className="flex justify-end gap-4 mt-4">
+          <Button type="reset" onClick={resetSettings} color="alternative">
+            Reset to Defaults
+          </Button>
           <Button type="submit">Apply</Button>
         </div>
       </form>

--- a/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
+++ b/rust/gui-client/src-frontend/components/GeneralSettingsPage.tsx
@@ -70,8 +70,8 @@ export default function GeneralSettingsPage({
           />
         </div>
 
-        <div className="max-w-1/2">
-          <div className="mt-4 flex justify-between items-center">
+        <div className="flex flex-col max-w-1/2 gap-4 mt-4">
+          <div className="flex justify-between items-center">
             <Label className="text-neutral-600" htmlFor="start-minimized-input">
               Start minimized
             </Label>
@@ -88,7 +88,7 @@ export default function GeneralSettingsPage({
             />
           </div>
 
-          <div className="mt-4 flex justify-between items-center">
+          <div className="flex justify-between items-center">
             <Label className="text-neutral-600" htmlFor="start-on-login-input">
               Start on login
             </Label>
@@ -105,7 +105,7 @@ export default function GeneralSettingsPage({
             />
           </div>
 
-          <div className="mt-4 flex justify-between items-center">
+          <div className="flex justify-between items-center">
             <Label
               className="text-neutral-600"
               htmlFor="connect-on-start-input"

--- a/rust/gui-client/src-frontend/components/ManagedInput.tsx
+++ b/rust/gui-client/src-frontend/components/ManagedInput.tsx
@@ -1,0 +1,49 @@
+import {
+  TextInputProps,
+  Tooltip,
+  TextInput,
+  ToggleSwitch,
+  ToggleSwitchProps,
+} from "flowbite-react";
+import React, { PropsWithChildren } from "react";
+
+export function ManagedTextInput(props: TextInputProps & { managed: boolean }) {
+  let { managed, ...inputProps } = props;
+
+  if (managed) {
+    return (
+      <ManagedTooltip>
+        <TextInput {...inputProps} disabled={true} />
+      </ManagedTooltip>
+    );
+  } else {
+    return <TextInput {...inputProps} />;
+  }
+}
+
+export function ManagedToggleSwitch(props: ToggleSwitchProps & { managed: boolean }) {
+  let { managed, ...toggleSwitchProps } = props;
+
+  if (managed) {
+    return (
+      <ManagedTooltip>
+        <ToggleSwitch {...toggleSwitchProps} disabled={true} />
+      </ManagedTooltip>
+    );
+  } else {
+    return <ToggleSwitch {...toggleSwitchProps} />;
+  }
+}
+
+function ManagedTooltip(props: PropsWithChildren) {
+  let { children } = props;
+
+  return (
+    <Tooltip
+      content="This setting is managed by your organisation."
+      clearTheme={{ target: true }}
+    >
+      {children}
+    </Tooltip>
+  );
+}

--- a/rust/gui-client/src-frontend/components/ManagedInput.tsx
+++ b/rust/gui-client/src-frontend/components/ManagedInput.tsx
@@ -21,7 +21,9 @@ export function ManagedTextInput(props: TextInputProps & { managed: boolean }) {
   }
 }
 
-export function ManagedToggleSwitch(props: ToggleSwitchProps & { managed: boolean }) {
+export function ManagedToggleSwitch(
+  props: ToggleSwitchProps & { managed: boolean }
+) {
   let { managed, ...toggleSwitchProps } = props;
 
   if (managed) {

--- a/rust/gui-client/src-frontend/generated/GeneralSettingsViewModel.ts
+++ b/rust/gui-client/src-frontend/generated/GeneralSettingsViewModel.ts
@@ -1,8 +1,8 @@
 export interface GeneralSettingsViewModel {
-    start_minimized: boolean;
-    start_on_login: boolean;
-    connect_on_start: boolean;
-    connect_on_start_is_managed: boolean;
-    account_slug: string;
-    account_slug_is_managed: boolean;
+  start_minimized: boolean;
+  start_on_login: boolean;
+  connect_on_start: boolean;
+  connect_on_start_is_managed: boolean;
+  account_slug: string;
+  account_slug_is_managed: boolean;
 }

--- a/rust/gui-client/src-frontend/generated/GeneralSettingsViewModel.ts
+++ b/rust/gui-client/src-frontend/generated/GeneralSettingsViewModel.ts
@@ -1,0 +1,8 @@
+export interface GeneralSettingsViewModel {
+    start_minimized: boolean;
+    start_on_login: boolean;
+    connect_on_start: boolean;
+    connect_on_start_is_managed: boolean;
+    account_slug: string;
+    account_slug_is_managed: boolean;
+}

--- a/rust/gui-client/src-frontend/main.tsx
+++ b/rust/gui-client/src-frontend/main.tsx
@@ -25,6 +25,15 @@ const customTheme = createTheme({
       },
     },
   },
+  toggleSwitch: {
+    toggle: {
+      checked: {
+        color: {
+          default: "bg-accent-500"
+        }
+      }
+    }
+  },
 });
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement, {

--- a/rust/gui-client/src-frontend/main.tsx
+++ b/rust/gui-client/src-frontend/main.tsx
@@ -29,10 +29,10 @@ const customTheme = createTheme({
     toggle: {
       checked: {
         color: {
-          default: "bg-accent-500"
-        }
-      }
-    }
+          default: "bg-accent-500",
+        },
+      },
+    },
   },
 });
 

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -10,7 +10,8 @@ use crate::{
     ipc::{self, ClientRead, ClientWrite, SocketId},
     logging::FileCount,
     settings::{
-        self, AdvancedSettings, AdvancedSettingsLegacy, AdvancedSettingsViewModel, MdmSettings,
+        self, AdvancedSettings, AdvancedSettingsLegacy, AdvancedSettingsViewModel, GeneralSettings,
+        GeneralSettingsViewModel, MdmSettings,
     },
     updates,
 };
@@ -101,14 +102,21 @@ impl GuiIntegration for TauriIntegration {
     fn notify_settings_changed(
         &self,
         mdm_settings: MdmSettings,
+        general_settings: GeneralSettings,
         advanced_settings: AdvancedSettings,
     ) -> Result<()> {
         self.app
             .emit(
-                "settings_changed",
+                "general_settings_changed",
+                GeneralSettingsViewModel::new(mdm_settings.clone(), general_settings),
+            )
+            .context("Failed to send `general_settings_changed` event")?;
+        self.app
+            .emit(
+                "advanced_settings_changed",
                 AdvancedSettingsViewModel::new(mdm_settings, advanced_settings),
             )
-            .context("Failed to send `settings_changed` event")?;
+            .context("Failed to send `advanced_settings_changed` event")?;
 
         Ok(())
     }
@@ -174,10 +182,11 @@ impl GuiIntegration for TauriIntegration {
     fn show_settings_page(
         &self,
         mdm_settings: MdmSettings,
+        general_settings: GeneralSettings,
         advanced_settings: AdvancedSettings,
     ) -> Result<()> {
-        self.notify_settings_changed(mdm_settings, advanced_settings)?; // Ensure settings are up to date in GUI.
-        self.navigate("settings")?;
+        self.notify_settings_changed(mdm_settings, general_settings, advanced_settings)?; // Ensure settings are up to date in GUI.
+        self.navigate("general-settings")?;
         self.set_window_visible(true)?;
 
         Ok(())

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -64,7 +64,7 @@ pub struct GeneralSettings {
     pub favorite_resources: HashSet<ResourceId>,
     #[serde(default)]
     pub internet_resource_enabled: Option<bool>,
-    #[serde(default = "start_minimzed_default")]
+    #[serde(default = "start_minimized_default")]
     pub start_minimized: bool,
     #[serde(default)]
     pub start_on_login: Option<bool>,
@@ -74,7 +74,7 @@ pub struct GeneralSettings {
     pub account_slug: Option<String>,
 }
 
-fn start_minimzed_default() -> bool {
+fn start_minimized_default() -> bool {
     true
 }
 

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -64,6 +64,18 @@ pub struct GeneralSettings {
     pub favorite_resources: HashSet<ResourceId>,
     #[serde(default)]
     pub internet_resource_enabled: Option<bool>,
+    #[serde(default = "start_minimzed_default")]
+    pub start_minimized: bool,
+    #[serde(default)]
+    pub start_on_login: Option<bool>,
+    #[serde(default)]
+    pub connect_on_start: Option<bool>,
+    #[serde(default)]
+    pub account_slug: Option<String>,
+}
+
+fn start_minimzed_default() -> bool {
+    true
 }
 
 #[tslink::tslink(target = "./gui-client/src-frontend/generated/AdvancedSettingsViewModel.ts")]
@@ -171,6 +183,10 @@ pub async fn migrate_legacy_settings(
     let general = GeneralSettings {
         favorite_resources: legacy.favorite_resources,
         internet_resource_enabled: legacy.internet_resource_enabled,
+        start_minimized: true,
+        start_on_login: None,
+        connect_on_start: None,
+        account_slug: None,
     };
 
     if let Err(e) = save_general(&general).await {

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -78,6 +78,36 @@ fn start_minimzed_default() -> bool {
     true
 }
 
+#[tslink::tslink(target = "./gui-client/src-frontend/generated/GeneralSettingsViewModel.ts")]
+#[derive(Clone, Serialize)]
+pub struct GeneralSettingsViewModel {
+    pub start_minimized: bool,
+    pub start_on_login: bool,
+    pub connect_on_start: bool,
+    pub connect_on_start_is_managed: bool,
+    pub account_slug: String,
+    pub account_slug_is_managed: bool,
+}
+
+impl GeneralSettingsViewModel {
+    pub fn new(mdm_settings: MdmSettings, general_settings: GeneralSettings) -> Self {
+        Self {
+            connect_on_start_is_managed: mdm_settings.connect_on_start.is_some(),
+            account_slug_is_managed: mdm_settings.account_slug.is_some(),
+            start_minimized: general_settings.start_minimized,
+            start_on_login: general_settings.start_on_login.is_some_and(|v| v),
+            connect_on_start: mdm_settings
+                .connect_on_start
+                .or(general_settings.connect_on_start)
+                .is_some_and(|v| v),
+            account_slug: mdm_settings
+                .account_slug
+                .or(general_settings.account_slug)
+                .unwrap_or_default(),
+        }
+    }
+}
+
 #[tslink::tslink(target = "./gui-client/src-frontend/generated/AdvancedSettingsViewModel.ts")]
 #[derive(Clone, Serialize)]
 pub struct AdvancedSettingsViewModel {

--- a/rust/gui-client/src-tauri/src/view.rs
+++ b/rust/gui-client/src-tauri/src/view.rs
@@ -62,7 +62,7 @@ async fn export_logs(app: tauri::AppHandle, managed: tauri::State<'_, Managed>) 
 async fn apply_general_settings(
     managed: tauri::State<'_, Managed>,
     settings: GeneralSettingsForm,
-) -> Result<(), String> {
+) -> Result<()> {
     if managed.inner().inject_faults {
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
@@ -71,7 +71,7 @@ async fn apply_general_settings(
         .ctlr_tx
         .send(ControllerRequest::ApplyGeneralSettings(Box::new(settings)))
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| anyhow::Error::msg(e.to_string()))?;
 
     Ok(())
 }
@@ -102,12 +102,12 @@ async fn reset_advanced_settings(managed: tauri::State<'_, Managed>) -> Result<(
 }
 
 #[tauri::command]
-async fn reset_general_settings(managed: tauri::State<'_, Managed>) -> Result<(), String> {
+async fn reset_general_settings(managed: tauri::State<'_, Managed>) -> Result<()> {
     managed
         .ctlr_tx
         .send(ControllerRequest::ResetGeneralSettings)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| anyhow::Error::msg(e.to_string()))?;
 
     Ok(())
 }
@@ -196,5 +196,11 @@ impl Serialize for Error {
 impl From<anyhow::Error> for Error {
     fn from(value: anyhow::Error) -> Self {
         Self(value)
+    }
+}
+
+impl From<String> for Error {
+    fn from(value: String) -> Self {
+        Self(anyhow::Error::msg(value))
     }
 }

--- a/rust/gui-client/src-tauri/src/view.rs
+++ b/rust/gui-client/src-tauri/src/view.rs
@@ -71,7 +71,7 @@ async fn apply_general_settings(
         .ctlr_tx
         .send(ControllerRequest::ApplyGeneralSettings(Box::new(settings)))
         .await
-        .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+        .context("Failed to send `ApplyGeneralSettings` command")?;
 
     Ok(())
 }
@@ -107,7 +107,7 @@ async fn reset_general_settings(managed: tauri::State<'_, Managed>) -> Result<()
         .ctlr_tx
         .send(ControllerRequest::ResetGeneralSettings)
         .await
-        .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+        .context("Failed to send `ResetGeneralSettings` command")?;
 
     Ok(())
 }
@@ -196,11 +196,5 @@ impl Serialize for Error {
 impl From<anyhow::Error> for Error {
     fn from(value: anyhow::Error) -> Self {
         Self(value)
-    }
-}
-
-impl From<String> for Error {
-    fn from(value: String) -> Self {
-        Self(anyhow::Error::msg(value))
     }
 }

--- a/rust/gui-client/src-tauri/src/view.rs
+++ b/rust/gui-client/src-tauri/src/view.rs
@@ -27,6 +27,7 @@ pub fn generate_handler() -> impl Fn(Invoke<Wry>) -> bool + Send + Sync + 'stati
         apply_advanced_settings,
         reset_advanced_settings,
         apply_general_settings,
+        reset_general_settings,
         sign_in,
         sign_out,
         update_state,
@@ -96,6 +97,17 @@ async fn apply_advanced_settings(
 #[tauri::command]
 async fn reset_advanced_settings(managed: tauri::State<'_, Managed>) -> Result<()> {
     apply_advanced_settings(managed, AdvancedSettings::default()).await?;
+
+    Ok(())
+}
+
+#[tauri::command]
+async fn reset_general_settings(managed: tauri::State<'_, Managed>) -> Result<(), String> {
+    managed
+        .ctlr_tx
+        .send(ControllerRequest::ResetGeneralSettings)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -37,6 +37,10 @@ export default function GUI({ os }: { os: OS }) {
           Fixes an issue where Firezone could not start if the operating system
           refused our request to increase the UDP socket buffer sizes.
         </ChangeItem>
+        <ChangeItem pull="9381">
+          Introduces "General" settings, allowing the user to manage autostart
+          behaviour as well as the to-be-used account slug.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.14" date={new Date("2025-05-21")}>
         <ChangeItem pull="9147">


### PR DESCRIPTION
This PR introduces "General" settings for the GUI client. The "Settings" menu item in the GUI is split into two sub-sections. The menu item is collapsible but open by default.

|General|Advanced|
|---|---|
|![](https://github.com/user-attachments/assets/190cd23a-7ff6-4097-9eb5-a4ccf4a9c4a0)|![](https://github.com/user-attachments/assets/d538b749-9fe0-4995-84fc-b5c88132ede6)|

"Connect on start" and "Account slug" can both be MDM managed. The autostart functionality is implemented via the Windows Registry.