### PR TITLE
ci: properly ignore generated TS directory

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       - id: prettier
         name: Prettier
         entry: prettier --check --ignore-unknown .
-        exclude: (^rust/gui-client/src-frontend/generated/)
         language: system
         pass_filenames: false
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,5 @@ website/.next
 **/pnpm-lock.yaml
 swift/apple/**/Contents.json
 rust/gui-client/src-frontend/generated
+rust/gui-client/dist
+rust/gui-client/node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ website/.next
 **/*.wxs
 **/pnpm-lock.yaml
 swift/apple/**/Contents.json
+rust/gui-client/src-frontend/generated


### PR DESCRIPTION
Only ignoring these in the pre-commit check is not enough as that only affects CI. Instead, by adding these directories to the `.prettierignore` file, they are also ignored when prettier is invoked to format files.