### PR TITLE
chore(ci): bump windows-2019 runners to windows-2022

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -113,7 +113,7 @@ jobs:
   data-plane-windows:
     name: client-windows-${{ matrix.target }}
     if: ${{ inputs.image_prefix != 'perf' }} # Perf testing happens only on Linux
-    runs-on: windows-2019
+    runs-on: windows-2022
     defaults:
       run:
         working-directory: rust
@@ -154,8 +154,7 @@ jobs:
           mv target/${{ matrix.target }}/${{ inputs.profile }}/${{ matrix.package }}.exe $ARTIFACT_PATH
       - name: Install AzureSignTool
         shell: bash
-        # AzureSignTool >= 5 needs .NET 8. windows-2019 runner only has .NET 7.
-        run: dotnet tool install --global AzureSignTool --version 4.0.1
+        run: dotnet tool install --global AzureSignTool
       - name: Sign the binary
         shell: bash
         env:

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -68,8 +68,8 @@ jobs:
             macos-13,
             macos-14,
             macos-15,
-            windows-2019,
             windows-2022,
+            windows-2025
           ]
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2019, windows-2022]
+        runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
@@ -162,8 +162,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { runs-on: windows-2019, test: token-path-windows.ps1 }
           - { runs-on: windows-2022, test: token-path-windows.ps1 }
+          - { runs-on: windows-2025, test: token-path-windows.ps1 }
           - { runs-on: ubuntu-22.04, test: linux-group.sh }
           - { runs-on: ubuntu-24.04, test: linux-group.sh }
           - { runs-on: ubuntu-22.04, test: token-path-linux.sh }

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -69,7 +69,7 @@ jobs:
             macos-14,
             macos-15,
             windows-2022,
-            windows-2025
+            windows-2025,
           ]
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -52,7 +52,7 @@ jobs:
             arch: aarch64
             os: linux
             pkg-extension: deb
-          - runs-on: windows-2019
+          - runs-on: windows-2022
             arch: x86_64
             os: windows
             pkg-extension: msi
@@ -93,8 +93,7 @@ jobs:
       - name: Install AzureSignTool
         if: ${{ runner.os == 'Windows' }}
         shell: bash
-        # AzureSignTool >= 5 needs .NET 8. windows-2019 runner only has .NET 7.
-        run: dotnet tool install --global AzureSignTool --version 4.0.1
+        run: dotnet tool install --global AzureSignTool
       - name: Build release exe and MSI / deb
         env:
           CARGO_PROFILE_RELEASE_LTO: thin # Fat LTO is getting too slow / RAM-hungry on Tauri builds


### PR DESCRIPTION
Windows server 2019 is end of life apparently.

https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#windows-server-2019-is-closing-down