### PR TITLE
fix(android): drop session in a new thread

### DIFF
--- a/rust/android-client-ffi/src/lib.rs
+++ b/rust/android-client-ffi/src/lib.rs
@@ -493,6 +493,12 @@ pub unsafe extern "system" fn Java_dev_firezone_android_tunnel_ConnlibSession_di
     catch_and_throw(&mut env, |_| {
         session.runtime.block_on(session.telemetry.stop());
     });
+
+    // Drop session in new thread to ensure we are not dropping a runtime in a runtime.
+    // The Android app may call this from a callback which is executed within the runtime.
+    std::thread::spawn(move || {
+        drop(session);
+    });
 }
 
 /// # Safety

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -20,7 +20,12 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9394">
+          Fixes a minor issue that would cause background service panic when
+          signing out.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.0" date={new Date("2025-06-02")}>
         <ChangeItem pull="9300">
           Uses the new IP stack setting for DNS resources, which allows DNS


### PR DESCRIPTION
When the Android app calls `disconnect`, it is still within the context of a `connlib` callback. That callback is executed within the runtime that we are trying to drop. That is not allowed and leads to a panic.

Resolves: #9390