### PR TITLE
fix(portal): preserve device name (#9393)

### DIFF
--- a/elixir/apps/domain/lib/domain/clients/client/changeset.ex
+++ b/elixir/apps/domain/lib/domain/clients/client/changeset.ex
@@ -19,7 +19,6 @@ defmodule Domain.Clients.Client.Changeset do
     Clients.Client.Query.all()
     |> update([clients: clients],
       set: [
-        name: fragment("EXCLUDED.name"),
         public_key: fragment("EXCLUDED.public_key"),
         last_used_token_id: fragment("EXCLUDED.last_used_token_id"),
         last_seen_user_agent: fragment("EXCLUDED.last_seen_user_agent"),

--- a/elixir/apps/domain/test/domain/clients_test.exs
+++ b/elixir/apps/domain/test/domain/clients_test.exs
@@ -497,7 +497,7 @@ defmodule Domain.ClientsTest do
 
       assert Repo.aggregate(Clients.Client, :count, :id) == 1
 
-      assert updated_client.name != client.name
+      assert updated_client.name == client.name
       assert updated_client.last_seen_remote_ip.address == subject.context.remote_ip
       assert updated_client.last_seen_remote_ip != client.last_seen_remote_ip
       assert updated_client.last_seen_user_agent == subject.context.user_agent


### PR DESCRIPTION
When upserting a client, the device name would overwrite any name changes performed by the admin. To prevent this, we don't allow changing a device's name on upsert conflicts, only on initial insert and updates.

Fixes #8536