### PR TITLE
feat(portal): add replication config (#9395)

### DIFF
--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -69,7 +69,9 @@ defmodule Domain.Config.Definitions do
          :database_pool_size,
          :database_ssl_enabled,
          :database_ssl_opts,
-         :database_parameters
+         :database_parameters,
+         :database_replication_slot_name,
+         :database_publication_name
        ]},
       {"Cloud Platform",
        [
@@ -291,16 +293,6 @@ defmodule Domain.Config.Definitions do
   defconfig(:database_password, :string, default: nil, sensitive: true)
 
   @doc """
-  Replication user that will be used to connect to replication slots.
-  """
-  defconfig(:database_replication_user, :string, default: nil, sensitive: true)
-
-  @doc """
-  Replication password for the replication user.
-  """
-  defconfig(:database_replication_password, :string, default: nil, sensitive: true)
-
-  @doc """
   Size of the connection pool to the PostgreSQL database.
   """
   defconfig(:database_pool_size, :integer,
@@ -314,6 +306,16 @@ defmodule Domain.Config.Definitions do
   with at least `cacertfile` option present.
   """
   defconfig(:database_ssl_enabled, :boolean, default: false)
+
+  @doc """
+  Name of the replication slot used by Firezone.
+  """
+  defconfig(:database_replication_slot_name, :string, default: "events_slot")
+
+  @doc """
+  Name of the publication used by Firezone.
+  """
+  defconfig(:database_publication_name, :string, default: "events")
 
   @doc """
   SSL options for connecting to the PostgreSQL database.

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -29,6 +29,8 @@ if config_env() == :prod do
 
   config :domain, Domain.Events.ReplicationConnection,
     enabled: compile_config!(:background_jobs_enabled),
+    replication_slot_name: compile_config!(:database_replication_slot_name),
+    publication_name: compile_config!(:database_publication_name),
     connection_opts: [
       hostname: compile_config!(:database_host),
       port: compile_config!(:database_port),


### PR DESCRIPTION
> This PR adds two configuration keys for the replication connection.

> Exemple usecase:
> If you run two firezone control planes on the same db cluster (like me 😂 ), you'll need to have two different replication slot names

Related: #9395 