### PR TITLE
refactor(portal): move resource events to WAL

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -79,8 +79,8 @@ defmodule API.Client.Channel do
       # where resource might be renamed which should be propagated to the UI.
       :ok =
         Enum.each(resources, fn resource ->
-          :ok = Resources.unsubscribe_from_events_for_resource(resource)
-          :ok = Resources.subscribe_to_events_for_resource(resource)
+          :ok = Events.Hooks.Resources.unsubscribe(resource.id)
+          :ok = Events.Hooks.Resources.subscribe(resource.id)
         end)
 
       # Subscribe for known gateway group names so that if they are updated - we can render change in the UI
@@ -316,8 +316,8 @@ defmodule API.Client.Channel do
         actor_group_id: actor_group_id,
         resource_id: resource_id
       } do
-      :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
-      :ok = Resources.subscribe_to_events_for_resource(resource_id)
+      :ok = Events.Hooks.Resources.unsubscribe(resource_id)
+      :ok = Events.Hooks.Resources.subscribe(resource_id)
 
       case Resources.fetch_and_authorize_resource_by_id(resource_id, socket.assigns.subject,
              preload: [:gateway_groups]
@@ -358,7 +358,7 @@ defmodule API.Client.Channel do
         actor_group_id: actor_group_id,
         resource_id: resource_id
       } do
-      :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
+      :ok = Events.Hooks.Resources.unsubscribe(resource_id)
 
       # We potentially can re-create the flow but this will require keep tracking of client connections to gateways,
       # which is not worth it as this case should be pretty rare. Instead we just tell client to remove it

--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -79,6 +79,8 @@ defmodule API.Client.Channel do
       # where resource might be renamed which should be propagated to the UI.
       :ok =
         Enum.each(resources, fn resource ->
+          # TODO: WAL
+          # Why are we unsubscribing and subscribing again?
           :ok = Events.Hooks.Resources.unsubscribe(resource.id)
           :ok = Events.Hooks.Resources.subscribe(resource.id)
         end)
@@ -89,6 +91,8 @@ defmodule API.Client.Channel do
         |> Enum.flat_map(& &1.gateway_groups)
         |> Enum.uniq()
         |> Enum.each(fn gateway_group ->
+          # TODO: WAL
+          # Why are we unsubscribing and subscribing again?
           :ok = Events.Hooks.GatewayGroups.unsubscribe(gateway_group.id)
           :ok = Events.Hooks.GatewayGroups.subscribe(gateway_group.id)
         end)
@@ -316,6 +320,8 @@ defmodule API.Client.Channel do
         actor_group_id: actor_group_id,
         resource_id: resource_id
       } do
+      # TODO: WAL
+      # Why are we unsubscribing and subscribing again?
       :ok = Events.Hooks.Resources.unsubscribe(resource_id)
       :ok = Events.Hooks.Resources.subscribe(resource_id)
 
@@ -415,6 +421,8 @@ defmodule API.Client.Channel do
 
         :ok =
           Enum.each(relays, fn relay ->
+            # TODO: WAL
+            # Why are we unsubscribing and subscribing again?
             :ok = Relays.unsubscribe_from_relay_presence(relay)
             :ok = Relays.subscribe_to_relay_presence(relay)
           end)
@@ -451,6 +459,8 @@ defmodule API.Client.Channel do
 
           :ok =
             Enum.each(relays, fn relay ->
+              # TODO: WAL
+              # Why are we unsubscribing and subscribing again?
               :ok = Relays.unsubscribe_from_relay_presence(relay)
               :ok = Relays.subscribe_to_relay_presence(relay)
             end)

--- a/elixir/apps/api/lib/api/controllers/resource_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/resource_controller.ex
@@ -94,7 +94,7 @@ defmodule API.ResourceController do
 
     with {:ok, resource} <- Resources.fetch_active_resource_by_id_or_persistent_id(id, subject) do
       case Resources.update_resource(resource, attrs, subject) do
-        {:updated, updated_resource} ->
+        {:ok, updated_resource} ->
           render(conn, :show, resource: updated_resource)
 
         {:error, reason} ->

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -117,7 +117,7 @@ defmodule API.Gateway.Channel do
   # This event is ignored because we will receive a reject_access message from
   # the Flows which will trigger a reject_access event
   def handle_info({:delete_resource, resource_id}, socket) do
-    :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
+    :ok = Events.Hooks.Resources.unsubscribe(resource_id)
     {:noreply, socket}
   end
 
@@ -318,8 +318,8 @@ defmodule API.Gateway.Channel do
       client = Clients.fetch_client_by_id!(client_id, preload: [:actor])
       resource = Resources.fetch_resource_by_id!(resource_id)
 
-      :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
-      :ok = Resources.subscribe_to_events_for_resource(resource_id)
+      :ok = Events.Hooks.Resources.unsubscribe(resource_id)
+      :ok = Events.Hooks.Resources.subscribe(resource_id)
 
       opentelemetry_headers = :otel_propagator_text_map.inject([])
 
@@ -388,8 +388,8 @@ defmodule API.Gateway.Channel do
              socket.assigns.gateway.last_seen_version
            ) do
         {:cont, resource} ->
-          :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
-          :ok = Resources.subscribe_to_events_for_resource(resource_id)
+          :ok = Events.Hooks.Resources.unsubscribe(resource_id)
+          :ok = Events.Hooks.Resources.subscribe(resource_id)
 
           opentelemetry_headers = :otel_propagator_text_map.inject([])
           ref = encode_ref(socket, {channel_pid, socket_ref, resource_id, opentelemetry_headers})
@@ -458,8 +458,8 @@ defmodule API.Gateway.Channel do
              socket.assigns.gateway.last_seen_version
            ) do
         {:cont, resource} ->
-          :ok = Resources.unsubscribe_from_events_for_resource(resource_id)
-          :ok = Resources.subscribe_to_events_for_resource(resource_id)
+          :ok = Events.Hooks.Resources.unsubscribe(resource_id)
+          :ok = Events.Hooks.Resources.subscribe(resource_id)
 
           opentelemetry_headers = :otel_propagator_text_map.inject([])
           ref = encode_ref(socket, {channel_pid, socket_ref, resource_id, opentelemetry_headers})

--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -171,6 +171,8 @@ defmodule API.Gateway.Channel do
 
         :ok =
           Enum.each(relays, fn relay ->
+            # TODO: WAL
+            # Why are we unsubscribing and subscribing again?
             :ok = Domain.Relays.unsubscribe_from_relay_presence(relay)
             :ok = Domain.Relays.subscribe_to_relay_presence(relay)
           end)
@@ -212,6 +214,8 @@ defmodule API.Gateway.Channel do
 
           :ok =
             Enum.each(relays, fn relay ->
+              # TODO: WAL
+              # Why are we unsubscribing and subscribing again?
               :ok = Relays.unsubscribe_from_relay_presence(relay)
               :ok = Relays.subscribe_to_relay_presence(relay)
             end)
@@ -318,6 +322,8 @@ defmodule API.Gateway.Channel do
       client = Clients.fetch_client_by_id!(client_id, preload: [:actor])
       resource = Resources.fetch_resource_by_id!(resource_id)
 
+      # TODO: WAL
+      # Why are we unsubscribing and subscribing again?
       :ok = Events.Hooks.Resources.unsubscribe(resource_id)
       :ok = Events.Hooks.Resources.subscribe(resource_id)
 
@@ -388,6 +394,8 @@ defmodule API.Gateway.Channel do
              socket.assigns.gateway.last_seen_version
            ) do
         {:cont, resource} ->
+          # TODO: WAL
+          # Why are we unsubscribing and subscribing again?
           :ok = Events.Hooks.Resources.unsubscribe(resource_id)
           :ok = Events.Hooks.Resources.subscribe(resource_id)
 
@@ -458,6 +466,8 @@ defmodule API.Gateway.Channel do
              socket.assigns.gateway.last_seen_version
            ) do
         {:cont, resource} ->
+          # TODO: WAL
+          # Why are we unsubscribing and subscribing again?
           :ok = Events.Hooks.Resources.unsubscribe(resource_id)
           :ok = Events.Hooks.Resources.subscribe(resource_id)
 

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -512,8 +512,20 @@ defmodule API.Client.ChannelTest do
     } do
       assert_push "init", %{}
 
-      {:updated, _resource} =
-        Domain.Resources.update_resource(resource, %{name: "foobar"}, subject)
+      {:ok, _resource} = Domain.Resources.update_resource(resource, %{name: "foobar"}, subject)
+
+      old_data = %{
+        "id" => resource.id,
+        "account_id" => resource.account_id,
+        "address" => resource.address,
+        "name" => resource.name,
+        "type" => "dns",
+        "filters" => [],
+        "ip_stack" => "dual"
+      }
+
+      data = Map.put(old_data, "name", "new name")
+      Events.Hooks.Resources.on_update(old_data, data)
 
       assert_push "resource_created_or_updated", %{}
     end

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -275,12 +275,25 @@ defmodule API.Gateway.ChannelTest do
 
       assert_push "allow_access", %{}
 
-      {:updated, resource} =
+      {:ok, resource} =
         Domain.Resources.update_resource(
           resource,
           %{"name" => Ecto.UUID.generate()},
           subject
         )
+
+      old_data = %{
+        "id" => resource.id,
+        "account_id" => resource.account_id,
+        "address" => resource.address,
+        "name" => resource.name,
+        "type" => "dns",
+        "filters" => [],
+        "ip_stack" => "dual"
+      }
+
+      data = Map.put(old_data, "name", "new name")
+      Events.Hooks.Resources.on_update(old_data, data)
 
       assert_push "resource_updated", payload
 
@@ -687,12 +700,25 @@ defmodule API.Gateway.ChannelTest do
 
       assert_push "request_connection", %{}, 200
 
-      {:updated, resource} =
+      {:ok, resource} =
         Domain.Resources.update_resource(
           resource,
           %{"name" => Ecto.UUID.generate()},
           subject
         )
+
+      old_data = %{
+        "id" => resource.id,
+        "account_id" => resource.account_id,
+        "address" => resource.address,
+        "name" => resource.name,
+        "type" => "dns",
+        "filters" => [],
+        "ip_stack" => "dual"
+      }
+
+      data = Map.put(old_data, "name", "new name")
+      Events.Hooks.Resources.on_update(old_data, data)
 
       assert_push "resource_updated", payload, 200
 
@@ -909,12 +935,25 @@ defmodule API.Gateway.ChannelTest do
 
       assert_push "authorize_flow", %{}
 
-      {:updated, resource} =
+      {:ok, resource} =
         Domain.Resources.update_resource(
           resource,
           %{"name" => Ecto.UUID.generate()},
           subject
         )
+
+      old_data = %{
+        "id" => resource.id,
+        "account_id" => resource.account_id,
+        "address" => resource.address,
+        "name" => resource.name,
+        "type" => "dns",
+        "filters" => [],
+        "ip_stack" => "dual"
+      }
+
+      data = Map.put(old_data, "name", "new name")
+      Events.Hooks.Resources.on_update(old_data, data)
 
       assert_push "resource_updated", payload
 

--- a/elixir/apps/domain/lib/domain/events/hooks/accounts.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/accounts.ex
@@ -37,6 +37,12 @@ defmodule Domain.Events.Hooks.Accounts do
     |> PubSub.subscribe()
   end
 
+  def subscribe_to_resources(account_id) do
+    account_id
+    |> resources_topic()
+    |> PubSub.subscribe()
+  end
+
   def subscribe_to_clients_presence(account_id) do
     account_id
     |> clients_presence_topic()
@@ -49,8 +55,6 @@ defmodule Domain.Events.Hooks.Accounts do
     |> PubSub.subscribe()
   end
 
-  # No unsubscribe needed - account deletions destroy any subscribed entities
-
   def clients_presence_topic(account_id) do
     "presences:#{clients_topic(account_id)}"
   end
@@ -61,6 +65,16 @@ defmodule Domain.Events.Hooks.Accounts do
 
   def gateways_presence_topic(account_id) do
     "presences:account_gateways:#{account_id}"
+  end
+
+  def broadcast_to_resources(account_id, payload) do
+    account_id
+    |> resources_topic()
+    |> PubSub.broadcast(payload)
+  end
+
+  defp resources_topic(account_id) do
+    "account_resources:#{account_id}"
   end
 
   defp topic(account_id) do

--- a/elixir/apps/domain/lib/domain/events/hooks/resource_connections.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resource_connections.ex
@@ -9,7 +9,7 @@ defmodule Domain.Events.Hooks.ResourceConnections do
     # The flow expires_at field is not used for any persistence-related reason.
     # Remove it and broadcast directly to subscribed pids to remove the flow
     # from their local state. This is hook is called when resources change sites.
-    Task.async(fn ->
+    Task.start(fn ->
       {:ok, _flows} = Flows.expire_flows_for_resource_id(resource_id)
     end)
 

--- a/elixir/apps/domain/lib/domain/events/hooks/resource_connections.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resource_connections.ex
@@ -8,7 +8,7 @@ defmodule Domain.Events.Hooks.ResourceConnections do
     # TODO: WAL
     # The flow expires_at field is not used for any persistence-related reason.
     # Remove it and broadcast directly to subscribed pids to remove the flow
-    # from their local state. This is hook is called when resources change sites.
+    # from their local state. This hook is called when resources change sites.
     Task.start(fn ->
       {:ok, _flows} = Flows.expire_flows_for_resource_id(resource_id)
     end)

--- a/elixir/apps/domain/lib/domain/events/hooks/resources.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resources.ex
@@ -1,6 +1,6 @@
 defmodule Domain.Events.Hooks.Resources do
   alias Domain.Events.Hooks.Accounts
-  alias Domain.PubSub
+  alias Domain.{Flows, PubSub}
 
   def on_insert(%{"id" => resource_id, "account_id" => account_id} = _data) do
     payload = {:create_resource, resource_id}
@@ -14,8 +14,49 @@ defmodule Domain.Events.Hooks.Resources do
     on_delete(old_data)
   end
 
-  def on_update(_old_data, _data) do
+  # Breaking update - expire flows so that new flows are created
+  def on_update(
+        %{
+          "type" => old_type,
+          "address" => old_address,
+          "filters" => old_filters,
+          "ip_stack" => old_ip_stack
+        } = _old_data,
+        %{
+          "type" => type,
+          "address" => address,
+          "filters" => filters,
+          "ip_stack" => ip_stack,
+          "id" => resource_id,
+          "account_id" => account_id
+        } = _data
+      )
+      when old_type != type or
+             old_address != address or
+             old_filters != filters or
+             old_ip_stack != ip_stack do
+    # TODO: WAL
+    # Directly broadcast to subscribed pids to remove the flow
+    Task.async(fn ->
+      {:ok, _flows} = Flows.expire_flows_for_resource_id(resource_id)
+
+      payload = {:delete_resource, resource_id}
+      broadcast(resource_id, payload)
+      Accounts.broadcast_to_resources(account_id, payload)
+
+      payload = {:create_resource, resource_id}
+      broadcast(resource_id, payload)
+      Accounts.broadcast_to_resources(account_id, payload)
+    end)
+
     :ok
+  end
+
+  # Non-breaking update - for non-addressability changes - e.g. name, description, etc.
+  def on_update(_old_data, %{"id" => resource_id, "account_id" => account_id} = _data) do
+    payload = {:update_resource, resource_id}
+    broadcast(resource_id, payload)
+    Accounts.broadcast_to_resources(account_id, payload)
   end
 
   def on_delete(%{"id" => resource_id, "account_id" => account_id} = _old_data) do

--- a/elixir/apps/domain/lib/domain/events/hooks/resources.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resources.ex
@@ -8,12 +8,20 @@ defmodule Domain.Events.Hooks.Resources do
     Accounts.broadcast_to_resources(account_id, payload)
   end
 
+  # Soft-delete
+  def on_update(%{"deleted_at" => nil} = old_data, %{"deleted_at" => deleted_at} = _data)
+      when not is_nil(deleted_at) do
+    on_delete(old_data)
+  end
+
   def on_update(_old_data, _data) do
     :ok
   end
 
-  def on_delete(_old_data) do
-    :ok
+  def on_delete(%{"id" => resource_id, "account_id" => account_id} = _old_data) do
+    payload = {:delete_resource, resource_id}
+    broadcast(resource_id, payload)
+    Accounts.broadcast_to_resources(account_id, payload)
   end
 
   def subscribe(resource_id) do

--- a/elixir/apps/domain/lib/domain/events/hooks/resources.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resources.ex
@@ -1,8 +1,11 @@
 defmodule Domain.Events.Hooks.Resources do
+  alias Domain.Events.Hooks.Accounts
   alias Domain.PubSub
 
-  def on_insert(_data) do
-    :ok
+  def on_insert(%{"id" => resource_id, "account_id" => account_id} = _data) do
+    payload = {:create_resource, resource_id}
+    broadcast(resource_id, payload)
+    Accounts.broadcast_to_resources(account_id, payload)
   end
 
   def on_update(_old_data, _data) do

--- a/elixir/apps/domain/lib/domain/events/hooks/resources.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resources.ex
@@ -1,4 +1,6 @@
 defmodule Domain.Events.Hooks.Resources do
+  alias Domain.PubSub
+
   def on_insert(_data) do
     :ok
   end
@@ -9,5 +11,27 @@ defmodule Domain.Events.Hooks.Resources do
 
   def on_delete(_old_data) do
     :ok
+  end
+
+  def subscribe(resource_id) do
+    resource_id
+    |> topic()
+    |> PubSub.subscribe()
+  end
+
+  def unsubscribe(resource_id) do
+    resource_id
+    |> topic()
+    |> PubSub.unsubscribe()
+  end
+
+  def broadcast(resource_id, payload) do
+    resource_id
+    |> topic()
+    |> PubSub.broadcast(payload)
+  end
+
+  defp topic(resource_id) do
+    "resource:#{resource_id}"
   end
 end

--- a/elixir/apps/domain/lib/domain/events/hooks/resources.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resources.ex
@@ -37,7 +37,7 @@ defmodule Domain.Events.Hooks.Resources do
              old_ip_stack != ip_stack do
     # TODO: WAL
     # Directly broadcast to subscribed pids to remove the flow
-    Task.async(fn ->
+    Task.start(fn ->
       {:ok, _flows} = Flows.expire_flows_for_resource_id(resource_id)
 
       payload = {:delete_resource, resource_id}

--- a/elixir/apps/domain/lib/domain/flows.ex
+++ b/elixir/apps/domain/lib/domain/flows.ex
@@ -228,6 +228,12 @@ defmodule Domain.Flows do
     |> expire_flows()
   end
 
+  def expire_flows_for_resource_id(resource_id) do
+    Flow.Query.all()
+    |> Flow.Query.by_resource_id(resource_id)
+    |> expire_flows()
+  end
+
   defp expire_flows(queryable, subject) do
     with :ok <- Auth.ensure_has_permissions(subject, Authorizer.create_flows_permission()) do
       queryable

--- a/elixir/apps/domain/lib/domain/resources.ex
+++ b/elixir/apps/domain/lib/domain/resources.ex
@@ -229,13 +229,8 @@ defmodule Domain.Resources do
 
   def create_resource(attrs, %Auth.Subject{} = subject) do
     with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_resources_permission()) do
-      changeset = Resource.Changeset.create(subject.account, attrs, subject)
-
-      with {:ok, resource} <- Repo.insert(changeset) do
-        # TODO: WAL
-        :ok = broadcast_resource_events(:create, resource)
-        {:ok, resource}
-      end
+      Resource.Changeset.create(subject.account, attrs, subject)
+      |> Repo.insert()
     end
   end
 
@@ -251,13 +246,8 @@ defmodule Domain.Resources do
       }
     }
 
-    changeset = Resource.Changeset.create(account, attrs)
-
-    with {:ok, resource} <- Repo.insert(changeset) do
-      # TODO: WAL
-      :ok = broadcast_resource_events(:create, resource)
-      {:ok, resource}
-    end
+    Resource.Changeset.create(account, attrs)
+    |> Repo.insert()
   end
 
   def change_resource(%Resource{} = resource, attrs \\ %{}, %Auth.Subject{} = subject) do

--- a/elixir/apps/domain/lib/domain/resources.ex
+++ b/elixir/apps/domain/lib/domain/resources.ex
@@ -277,11 +277,7 @@ defmodule Domain.Resources do
           |> Repo.preload(:connections)
           |> Resource.Changeset.update(attrs, subject)
         end,
-        after_update_commit: fn resource, changeset ->
-          if Map.has_key?(changeset.changes, :connections) do
-            {:ok, _flows} = Flows.expire_flows_for(resource, subject)
-          end
-
+        after_update_commit: fn resource, _changeset ->
           # TODO: WAL
           broadcast_resource_events(:update, resource)
         end,

--- a/elixir/apps/domain/lib/domain/resources.ex
+++ b/elixir/apps/domain/lib/domain/resources.ex
@@ -365,7 +365,7 @@ defmodule Domain.Resources do
   defp resource_topic(resource_id), do: "resource:#{resource_id}"
 
   defp account_topic(%Accounts.Account{} = account), do: account_topic(account.id)
-  defp account_topic(account_id), do: "account_policies:#{account_id}"
+  defp account_topic(account_id), do: "account_resources:#{account_id}"
 
   def subscribe_to_events_for_resource(resource_or_id) do
     resource_or_id |> resource_topic() |> PubSub.subscribe()

--- a/elixir/apps/domain/lib/domain/resources.ex
+++ b/elixir/apps/domain/lib/domain/resources.ex
@@ -304,8 +304,6 @@ defmodule Domain.Resources do
       )
       |> case do
         {:ok, resource} ->
-          # TODO: WAL
-          :ok = broadcast_resource_events(:delete, resource)
           {:ok, _policies} = Policies.delete_policies_for(resource, subject)
           {:ok, resource}
 

--- a/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
@@ -5,7 +5,6 @@ defmodule Domain.Resources.Resource.Changeset do
 
   @fields ~w[address address_description name type ip_stack]a
   @update_fields ~w[address address_description name type ip_stack]a
-  @replace_fields ~w[type address filters ip_stack]a
   @required_fields ~w[name type]a
 
   # Reference list of common TLDs from IANA
@@ -68,7 +67,6 @@ defmodule Domain.Resources.Resource.Changeset do
       with: &Connection.Changeset.changeset(resource.account_id, &1, &2, subject),
       required: true
     )
-    |> maybe_breaking_change()
   end
 
   def delete(%Resource{} = resource) do
@@ -263,16 +261,6 @@ defmodule Domain.Resources.Resource.Changeset do
         |> Enum.reduce(changeset, fn {_type, cidr}, changeset ->
           validate_not_in_cidr(changeset, :address, cidr)
         end)
-    end
-  end
-
-  defp maybe_breaking_change(%{valid?: false} = changeset), do: {changeset, false}
-
-  defp maybe_breaking_change(changeset) do
-    if any_field_changed?(changeset, @replace_fields) do
-      {changeset, true}
-    else
-      {changeset, false}
     end
   end
 

--- a/elixir/apps/domain/test/domain/events/hooks/resource_connections_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/resource_connections_test.exs
@@ -1,5 +1,5 @@
 defmodule Domain.Events.Hooks.ResourceConnectionsTest do
-  use ExUnit.Case, async: true
+  use Domain.DataCase, async: true
   import Domain.Events.Hooks.ResourceConnections
 
   setup do
@@ -19,8 +19,20 @@ defmodule Domain.Events.Hooks.ResourceConnectionsTest do
   end
 
   describe "delete/1" do
-    test "returns :ok", %{data: data} do
-      assert :ok == on_delete(data)
+    test "returns :ok" do
+      flow = Fixtures.Flows.create_flow()
+
+      assert DateTime.compare(DateTime.utc_now(), flow.expires_at) == :lt
+
+      assert :ok == on_delete(%{"resource_id" => flow.resource_id})
+
+      # TODO: WAL
+      # Remove this when flow removal is directly broadcasted
+      Process.sleep(100)
+
+      flow = Repo.reload(flow)
+
+      assert DateTime.compare(DateTime.utc_now(), flow.expires_at) == :gt
     end
   end
 end

--- a/elixir/apps/domain/test/domain/events/hooks/resources_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/resources_test.exs
@@ -1,10 +1,6 @@
 defmodule Domain.Events.Hooks.ResourcesTest do
-  use ExUnit.Case, async: true
+  use Domain.DataCase, async: true
   import Domain.Events.Hooks.Resources
-
-  setup do
-    %{old_data: %{}, data: %{}}
-  end
 
   describe "insert/1" do
     test "broadcasts :create_resource to subscribed" do
@@ -30,6 +26,21 @@ defmodule Domain.Events.Hooks.ResourcesTest do
   end
 
   describe "update/2" do
+    setup do
+      flow = Fixtures.Flows.create_flow()
+
+      old_data = %{
+        "type" => "dns",
+        "address" => "1.2.3.4",
+        "filters" => [],
+        "ip_stack" => "dual",
+        "id" => flow.resource_id,
+        "account_id" => flow.account_id
+      }
+
+      %{flow: flow, old_data: old_data}
+    end
+
     test "broadcasts :delete_resource to subscribed for soft-deletions" do
       resource_id = "test_resource"
       account_id = "test_account"
@@ -55,8 +66,106 @@ defmodule Domain.Events.Hooks.ResourcesTest do
       refute_receive {:delete_resource, ^resource_id}
     end
 
-    test "returns :ok", %{old_data: old_data, data: data} do
+    test "expires flows when resource type changes", %{flow: flow, old_data: old_data} do
+      :ok = subscribe(flow.resource_id)
+      :ok = Domain.Events.Hooks.Accounts.subscribe_to_resources(flow.account_id)
+
+      data = Map.put(old_data, "type", "cidr")
+
       assert :ok == on_update(old_data, data)
+
+      Process.sleep(100)
+      flow = Repo.reload(flow)
+
+      assert DateTime.compare(DateTime.utc_now(), flow.expires_at) == :gt
+
+      resource_id = flow.resource_id
+
+      assert_receive {:delete_resource, ^resource_id}
+      assert_receive {:delete_resource, ^resource_id}
+      assert_receive {:create_resource, ^resource_id}
+      assert_receive {:create_resource, ^resource_id}
+    end
+
+    test "expires flows when resource address changes", %{flow: flow, old_data: old_data} do
+      :ok = subscribe(flow.resource_id)
+      :ok = Domain.Events.Hooks.Accounts.subscribe_to_resources(flow.account_id)
+
+      data = Map.put(old_data, "address", "4.3.2.1")
+
+      assert :ok == on_update(old_data, data)
+
+      Process.sleep(100)
+      flow = Repo.reload(flow)
+
+      assert DateTime.compare(DateTime.utc_now(), flow.expires_at) == :gt
+
+      resource_id = flow.resource_id
+
+      assert_receive {:delete_resource, ^resource_id}
+      assert_receive {:delete_resource, ^resource_id}
+      assert_receive {:create_resource, ^resource_id}
+      assert_receive {:create_resource, ^resource_id}
+    end
+
+    test "expires flows when resource filters change", %{flow: flow, old_data: old_data} do
+      :ok = subscribe(flow.resource_id)
+      :ok = Domain.Events.Hooks.Accounts.subscribe_to_resources(flow.account_id)
+
+      data = Map.put(old_data, "filters", ["new_filter"])
+
+      assert :ok == on_update(old_data, data)
+
+      Process.sleep(100)
+      flow = Repo.reload(flow)
+
+      assert DateTime.compare(DateTime.utc_now(), flow.expires_at) == :gt
+
+      resource_id = flow.resource_id
+
+      assert_receive {:delete_resource, ^resource_id}
+      assert_receive {:delete_resource, ^resource_id}
+      assert_receive {:create_resource, ^resource_id}
+      assert_receive {:create_resource, ^resource_id}
+    end
+
+    test "expires flows when resource ip_stack changes", %{flow: flow, old_data: old_data} do
+      :ok = subscribe(flow.resource_id)
+      :ok = Domain.Events.Hooks.Accounts.subscribe_to_resources(flow.account_id)
+
+      data = Map.put(old_data, "ip_stack", "ipv4_only")
+
+      assert :ok == on_update(old_data, data)
+
+      Process.sleep(100)
+      flow = Repo.reload(flow)
+
+      assert DateTime.compare(DateTime.utc_now(), flow.expires_at) == :gt
+
+      resource_id = flow.resource_id
+
+      assert_receive {:delete_resource, ^resource_id}
+      assert_receive {:delete_resource, ^resource_id}
+      assert_receive {:create_resource, ^resource_id}
+      assert_receive {:create_resource, ^resource_id}
+    end
+
+    test "broadcasts update for non-addressability change", %{flow: flow, old_data: old_data} do
+      :ok = subscribe(flow.resource_id)
+      :ok = Domain.Events.Hooks.Accounts.subscribe_to_resources(flow.account_id)
+
+      data = Map.put(old_data, "name", "New Name")
+
+      assert :ok == on_update(old_data, data)
+
+      assert DateTime.compare(DateTime.utc_now(), flow.expires_at) == :lt
+
+      resource_id = flow.resource_id
+
+      assert_receive {:update_resource, ^resource_id}
+      assert_receive {:update_resource, ^resource_id}
+      refute_receive {:delete_resource, ^resource_id}
+      refute_receive {:create_resource, ^resource_id}
     end
   end
 

--- a/elixir/apps/domain/test/domain/resources/resource/changeset_test.exs
+++ b/elixir/apps/domain/test/domain/resources/resource/changeset_test.exs
@@ -208,7 +208,7 @@ defmodule Domain.Resources.Resource.ChangesetTest do
             {"192.168.1.255/32", "192.168.1.255/32"},
             {"2607:f8b0:4012:0::200e/128", "2607:f8b0:4012::200e/128"}
           ] do
-        {changeset, _} =
+        changeset =
           update(
             resource,
             %{
@@ -241,7 +241,7 @@ defmodule Domain.Resources.Resource.ChangesetTest do
         "2607:f8b0:4012:0::200e/128:80"
       ]
       |> Enum.each(fn invalid_cidr ->
-        {changeset, _} = update(resource, %{type: :cidr, address: invalid_cidr}, subject)
+        changeset = update(resource, %{type: :cidr, address: invalid_cidr}, subject)
         refute changeset.valid?, "Expected '#{invalid_cidr}' to be invalid"
       end)
     end
@@ -253,7 +253,7 @@ defmodule Domain.Resources.Resource.ChangesetTest do
             {"192.168.1.255", "192.168.1.255"},
             {"2607:f8b0:4012:0::200e", "2607:f8b0:4012::200e"}
           ] do
-        {changeset, _} =
+        changeset =
           update(
             resource,
             %{
@@ -283,14 +283,14 @@ defmodule Domain.Resources.Resource.ChangesetTest do
         "[2607:f8b0:4012:0::200e]:80"
       ]
       |> Enum.each(fn invalid_ip ->
-        {changeset, _} = update(resource, %{type: :ip, address: invalid_ip}, subject)
+        changeset = update(resource, %{type: :ip, address: invalid_ip}, subject)
         refute changeset.valid?, "Expected '#{invalid_ip}' to be invalid"
       end)
     end
 
     test "accepts valid DNS addresses", %{resource: resource, subject: subject} do
       for valid_address <- @valid_dns_addresses do
-        {changeset, _} =
+        changeset =
           update(
             resource,
             %{
@@ -307,7 +307,7 @@ defmodule Domain.Resources.Resource.ChangesetTest do
       end
 
       for invalid_address <- @invalid_dns_addresses do
-        {changeset, _} = update(resource, %{type: :dns, address: invalid_address}, subject)
+        changeset = update(resource, %{type: :dns, address: invalid_address}, subject)
         refute changeset.valid?, "Expected '#{invalid_address}' to be invalid"
       end
     end

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -1467,27 +1467,6 @@ defmodule Domain.ResourcesTest do
       assert Repo.aggregate(Domain.Network.Address, :count) == address_count
     end
 
-    test "broadcasts an account message when resource is created", %{
-      account: account,
-      subject: subject
-    } do
-      gateway = Fixtures.Gateways.create_gateway(account: account)
-
-      attrs =
-        Fixtures.Resources.resource_attrs(
-          connections: [
-            %{gateway_group_id: gateway.group_id}
-          ]
-        )
-
-      :ok = Events.Hooks.Accounts.subscribe_to_resources(account.id)
-
-      assert {:ok, resource} = create_resource(attrs, subject)
-
-      assert_receive {:create_resource, resource_id}
-      assert resource_id == resource.id
-    end
-
     test "returns error when subject has no permission to create resources", %{
       subject: subject
     } do

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -3,6 +3,7 @@ defmodule Domain.ResourcesTest do
   import Domain.Resources
   alias Domain.Resources
   alias Domain.Actors
+  alias Domain.Events
 
   setup do
     account = Fixtures.Accounts.create_account()
@@ -1615,6 +1616,10 @@ defmodule Domain.ResourcesTest do
       gateway_group_ids = Enum.map(resource.connections, & &1.gateway_group_id)
       assert gateway_group_ids == [gateway2.group_id]
 
+      # TODO: WAL
+      # Remove this when directly broadcasting flow removals
+      Events.Hooks.ResourceConnections.on_delete(%{"resource_id" => resource.id})
+      Process.sleep(100)
       flow = Repo.reload(flow)
       assert DateTime.compare(flow.expires_at, DateTime.utc_now()) == :lt
     end

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -1480,7 +1480,7 @@ defmodule Domain.ResourcesTest do
           ]
         )
 
-      :ok = subscribe_to_events_for_account(account)
+      :ok = Events.Hooks.Accounts.subscribe_to_resources(account.id)
 
       assert {:ok, resource} = create_resource(attrs, subject)
 
@@ -1539,7 +1539,7 @@ defmodule Domain.ResourcesTest do
       resource: resource,
       subject: subject
     } do
-      :ok = subscribe_to_events_for_account(account)
+      :ok = Events.Hooks.Accounts.subscribe_to_resources(account.id)
 
       attrs = %{"name" => "foo"}
       assert {:updated, resource} = update_resource(resource, attrs, subject)
@@ -1552,7 +1552,7 @@ defmodule Domain.ResourcesTest do
       resource: resource,
       subject: subject
     } do
-      :ok = subscribe_to_events_for_resource(resource)
+      :ok = Events.Hooks.Resources.subscribe(resource.id)
 
       attrs = %{"name" => "foo"}
       assert {:updated, resource} = update_resource(resource, attrs, subject)
@@ -1649,7 +1649,7 @@ defmodule Domain.ResourcesTest do
       subject: subject
     } do
       flow = Fixtures.Flows.create_flow(account: account, resource: resource, subject: subject)
-      :ok = subscribe_to_events_for_account(account)
+      :ok = Events.Hooks.Accounts.subscribe_to_resources(account.id)
 
       attrs = %{"address" => "foo"}
 
@@ -1764,7 +1764,7 @@ defmodule Domain.ResourcesTest do
       resource: resource,
       subject: subject
     } do
-      :ok = subscribe_to_events_for_account(account)
+      :ok = Events.Hooks.Accounts.subscribe_to_resources(account.id)
 
       assert {:ok, resource} = delete_resource(resource, subject)
 
@@ -1776,7 +1776,7 @@ defmodule Domain.ResourcesTest do
       resource: resource,
       subject: subject
     } do
-      :ok = subscribe_to_events_for_resource(resource)
+      :ok = Events.Hooks.Resources.subscribe(resource.id)
 
       assert {:ok, resource} = delete_resource(resource, subject)
 

--- a/elixir/apps/domain/test/domain/resources_test.exs
+++ b/elixir/apps/domain/test/domain/resources_test.exs
@@ -1738,31 +1738,6 @@ defmodule Domain.ResourcesTest do
       assert Repo.aggregate(Resources.Connection.Query.by_gateway_group_id(group.id), :count) == 0
     end
 
-    test "broadcasts an account message when resource is deleted", %{
-      account: account,
-      resource: resource,
-      subject: subject
-    } do
-      :ok = Events.Hooks.Accounts.subscribe_to_resources(account.id)
-
-      assert {:ok, resource} = delete_resource(resource, subject)
-
-      assert_receive {:delete_resource, resource_id}
-      assert resource_id == resource.id
-    end
-
-    test "broadcasts a resource message when resource is deleted", %{
-      resource: resource,
-      subject: subject
-    } do
-      :ok = Events.Hooks.Resources.subscribe(resource.id)
-
-      assert {:ok, resource} = delete_resource(resource, subject)
-
-      assert_receive {:delete_resource, resource_id}
-      assert resource_id == resource.id
-    end
-
     test "returns error when subject has no permission to delete resources", %{
       resource: resource,
       subject: subject

--- a/elixir/apps/web/lib/web/live/resources/edit.ex
+++ b/elixir/apps/web/lib/web/live/resources/edit.ex
@@ -257,7 +257,7 @@ defmodule Web.Resources.Edit do
            attrs,
            socket.assigns.subject
          ) do
-      {:updated, resource} ->
+      {:ok, resource} ->
         socket = put_flash(socket, :info, "Resource #{resource.name} updated successfully.")
 
         if site_id = socket.assigns.params["site_id"] do

--- a/elixir/apps/web/lib/web/live/resources/index.ex
+++ b/elixir/apps/web/lib/web/live/resources/index.ex
@@ -1,10 +1,11 @@
 defmodule Web.Resources.Index do
   use Web, :live_view
+  alias Domain.Events
   alias Domain.Resources
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      :ok = Resources.subscribe_to_events_for_account(socket.assigns.account)
+      :ok = Events.Hooks.Accounts.subscribe_to_resources(socket.assigns.account.id)
     end
 
     socket =

--- a/elixir/apps/web/lib/web/live/resources/show.ex
+++ b/elixir/apps/web/lib/web/live/resources/show.ex
@@ -2,14 +2,14 @@ defmodule Web.Resources.Show do
   use Web, :live_view
   import Web.Policies.Components
   import Web.Resources.Components
-  alias Domain.{Accounts, Resources, Policies, Flows}
+  alias Domain.{Accounts, Events, Resources, Policies, Flows}
 
   def mount(%{"id" => id} = params, _session, socket) do
     with {:ok, resource} <- fetch_resource(id, socket.assigns.subject),
          {:ok, actor_groups_peek} <-
            Resources.peek_resource_actor_groups([resource], 3, socket.assigns.subject) do
       if connected?(socket) do
-        :ok = Resources.subscribe_to_events_for_resource(resource)
+        :ok = Events.Hooks.Resources.subscribe(resource.id)
       end
 
       socket =

--- a/elixir/apps/web/test/web/live/resources/edit_test.exs
+++ b/elixir/apps/web/test/web/live/resources/edit_test.exs
@@ -235,6 +235,18 @@ defmodule Web.Live.Resources.EditTest do
       conn
       |> live(~p"/#{account}/resources/#{resource}/edit")
 
+    old_data = %{
+      "id" => resource.id,
+      "account_id" => resource.account_id,
+      "type" => resource.type,
+      "address" => resource.address,
+      "filters" => resource.filters,
+      "ip_stack" => resource.ip_stack
+    }
+
+    data = Map.put(old_data, "filters", attrs.filters)
+    :ok = Events.Hooks.Resources.on_update(old_data, data)
+
     {:ok, _lv, html} =
       lv
       |> form("form", resource: attrs)

--- a/elixir/apps/web/test/web/live/resources/edit_test.exs
+++ b/elixir/apps/web/test/web/live/resources/edit_test.exs
@@ -1,5 +1,6 @@
 defmodule Web.Live.Resources.EditTest do
   use Web.ConnCase, async: true
+  alias Domain.Events
 
   setup do
     account = Fixtures.Accounts.create_account()
@@ -228,7 +229,7 @@ defmodule Web.Live.Resources.EditTest do
       }
     }
 
-    :ok = Domain.Resources.subscribe_to_events_for_account(account)
+    :ok = Events.Hooks.Accounts.subscribe_to_resources(account.id)
 
     {:ok, lv, _html} =
       conn

--- a/elixir/apps/web/test/web/live/resources/index_test.exs
+++ b/elixir/apps/web/test/web/live/resources/index_test.exs
@@ -1,5 +1,6 @@
 defmodule Web.Live.Resources.IndexTest do
   use Web.ConnCase, async: true
+  alias Domain.Events
 
   setup do
     account = Fixtures.Accounts.create_account()
@@ -267,7 +268,13 @@ defmodule Web.Live.Resources.IndexTest do
       refute html =~ "The table data has changed."
       refute html =~ "reload-btn"
 
-      Fixtures.Resources.create_resource(account: account)
+      resource = Fixtures.Resources.create_resource(account: account)
+
+      # Simulate WAL broadcast
+      Events.Hooks.Resources.on_insert(%{
+        "id" => resource.id,
+        "account_id" => account.id
+      })
 
       reload_btn =
         lv

--- a/elixir/apps/web/test/web/live/resources/index_test.exs
+++ b/elixir/apps/web/test/web/live/resources/index_test.exs
@@ -302,6 +302,19 @@ defmodule Web.Live.Resources.IndexTest do
 
       Domain.Resources.delete_resource(resource, subject)
 
+      Events.Hooks.Resources.on_update(
+        %{
+          "id" => resource.id,
+          "account_id" => account.id,
+          "deleted_at" => nil
+        },
+        %{
+          "id" => resource.id,
+          "account_id" => account.id,
+          "deleted_at" => DateTime.utc_now()
+        }
+      )
+
       reload_btn =
         lv
         |> element("#resources-reload-btn")


### PR DESCRIPTION
We move the resource events to the WAL system. Notably, we no longer need `fetch_and_update_breakable` for resource updates, so a bit of refactoring is included to update the call sites for those.

Additionally, we need to add a `Flow.expire_flows_for_resource_id/1` function to expire flows from the WAL system. This is now being called in the WAL event handler. To prevent this from blocking the WAL consumer/broadcaster, we wrap it with a Task.async. These will be cleaned up when the lookup table for access is implemented next.

Another thing to note is that we lose the `subject` when moving from `Flows.expire_flows_for(%Resource{}, subject)` to `Flows.expire_flows_for_resource_id(resource_id)` when a resource is deleted or updated by an actor since we respond to this event in the WAL where that data isn't available. However, we don't actually _use_ the subject when expiring flows (other than authorize the initial resource update), so this isn't an issue.

Related: #9501 