### PR TITLE
fix(ci): Keep indentation of TSLINK_BUILD output

### DIFF
--- a/rust/gui-client/src-frontend/generated/AdvancedSettingsViewModel.ts
+++ b/rust/gui-client/src-frontend/generated/AdvancedSettingsViewModel.ts
@@ -1,8 +1,8 @@
 export interface AdvancedSettingsViewModel {
-  auth_url: string;
-  auth_url_is_managed: boolean;
-  api_url: string;
-  api_url_is_managed: boolean;
-  log_filter: string;
-  log_filter_is_managed: boolean;
+    auth_url: string;
+    auth_url_is_managed: boolean;
+    api_url: string;
+    api_url_is_managed: boolean;
+    log_filter: string;
+    log_filter_is_managed: boolean;
 }

--- a/rust/gui-client/src-frontend/generated/FileCount.ts
+++ b/rust/gui-client/src-frontend/generated/FileCount.ts
@@ -1,4 +1,4 @@
 export interface FileCount {
-  bytes: number;
-  files: number;
+    bytes: number;
+    files: number;
 }

--- a/rust/gui-client/src-frontend/generated/GeneralSettingsViewModel.ts
+++ b/rust/gui-client/src-frontend/generated/GeneralSettingsViewModel.ts
@@ -1,8 +1,8 @@
 export interface GeneralSettingsViewModel {
-  start_minimized: boolean;
-  start_on_login: boolean;
-  connect_on_start: boolean;
-  connect_on_start_is_managed: boolean;
-  account_slug: string;
-  account_slug_is_managed: boolean;
+    start_minimized: boolean;
+    start_on_login: boolean;
+    connect_on_start: boolean;
+    connect_on_start_is_managed: boolean;
+    account_slug: string;
+    account_slug_is_managed: boolean;
 }

--- a/rust/gui-client/src-frontend/generated/Session.ts
+++ b/rust/gui-client/src-frontend/generated/Session.ts
@@ -1,4 +1,4 @@
 export interface Session {
-  account_slug: string;
-  actor_name: string;
+    account_slug: string;
+    actor_name: string;
 }


### PR DESCRIPTION
When building the gui client with `TSLINK_BUILD=true`, the library outputs using 4 spaces for indent. These are however currently checked into git with 2 spaces per indent, which causes the Tauri workflow to fail because it checks for a pristine git directory after the build.

Unfortunately #9383 doesn't fix this issue because it has nothing to do with prettier in CI.

Fixes https://github.com/firezone/firezone/actions/runs/15457631114/job/43512703266