### PR TITLE
chore(gui-client): rename log file of tunnel service

### DIFF
--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -123,7 +123,7 @@ pub fn setup_tunnel(
     let (file_filter, file_reloader) = firezone_logging::try_filter(&directives)?;
     let (stdout_filter, stdout_reloader) = firezone_logging::try_filter(&directives)?;
 
-    let (file_layer, file_handle) = firezone_logging::file::layer(&log_path, "ipc-service");
+    let (file_layer, file_handle) = firezone_logging::file::layer(&log_path, "tunnel-service");
 
     let stdout_layer = tracing_subscriber::fmt::layer()
         .with_ansi(firezone_logging::stdout_supports_ansi())


### PR DESCRIPTION
This is a left-over from the rename of the background service for the GUI client from IPC to Tunnel service.