### PR TITLE
fix(gui-client): allow legacy settings to parse new format

### DIFF
--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -42,6 +42,7 @@ pub struct MdmSettings {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct AdvancedSettingsLegacy {
+    #[serde(alias = "auth_url")]
     pub auth_base_url: Url,
     pub api_url: Url,
     #[serde(default)]
@@ -303,5 +304,14 @@ mod tests {
         assert_eq!(actual.auth_base_url.to_string(), "https://example.com/");
         assert_eq!(actual.api_url.to_string(), "wss://example.com/");
         assert_eq!(actual.log_filter, "info");
+    }
+
+    #[test]
+    fn legacy_settings_can_parse_new_config() {
+        let advanced_settings = AdvancedSettings::default();
+
+        let new_format = serde_json::to_string(&advanced_settings).unwrap();
+
+        serde_json::from_str::<AdvancedSettingsLegacy>(&new_format).unwrap();
     }
 }

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,12 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9418">
+          Fixes an issue where advanced settings were not saved and loaded
+          properly across restarts of the Client.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.0" date={new Date("2025-06-05")}>
         <ChangeItem pull="9300">
           Uses the new IP stack setting for DNS resources, which allows DNS


### PR DESCRIPTION
As part of the introduction of General settings, we split up "Advanced settings" and also renamed one of the fields. Upon first start, the settings are migrated to the new format. What we failed to notice is that one the next subsequent start, the legacy settings struct will fail to parse the now migrated configuration and fall back to the default. This then appears as if the settings are not getting saved.

Resolves: #9417