### PR TITLE
chore: trigger staging deploy on checks passed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,3 +34,19 @@ jobs:
     with:
       profile: "release"
       stage: "release"
+
+  notify:
+    needs: ci
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Send 'checks-passed' event
+        env:
+          GH_TOKEN: ${{ secrets.INFRA_REPOSITORY_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/firezone/firezone/dispatches \
+            --raw-field "event_type=checks-passed" \
+            --field "client_payload[sha]=${{ github.sha }}"


### PR DESCRIPTION
Now that our infra-as-code is moved into another repo, we need a mechanism to trigger the staging deploy. We can use `repository_dispatch` for that, which allows us to trigger the staging workflow by sending an HTTP API request that matches the configuration of the `repository_dispatch` workflow trigger on that repo.

Related: https://github.com/firezone/infra/pull/36