### PR TITLE
fix(gui-client): apply log directives from MDM config

### DIFF
--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -235,6 +235,12 @@ pub fn run(
         .inspect_err(|e| tracing::debug!("Failed to load MDM settings {e:#}"))
         .unwrap_or_default();
 
+    if let Some(directives) = mdm_settings.log_filter.as_ref() {
+        if let Err(e) = reloader.reload(directives) {
+            tracing::info!(%directives, "Failed to apply MDM logging directives: {e:#}");
+        }
+    }
+
     let api_url = mdm_settings
         .api_url
         .as_ref()

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,12 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9443">
+          Fixes an issue where log directives applied via MDM would not be
+          applied on startup.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.1" date={new Date("2025-06-05")}>
         <ChangeItem pull="9418">
           Fixes an issue where advanced settings were not saved and loaded


### PR DESCRIPTION
When introducing the MDM config, we took into account the log directives from the config when applying it via the GUI but failed to apply the new directives on startup.