### PR TITLE
chore(gui-client): specify correct path to frontend

### DIFF
--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -66,7 +66,7 @@
       {
         "label": "main",
         "title": "Firezone",
-        "url": "src-frontend/index.html",
+        "url": "index.html",
         "fullscreen": false,
         "resizable": false,
         "width": 900,


### PR DESCRIPTION
When debugging logging is enabled, we see that Tauri currently iterates through several possible paths of the frontend page before it finds the one that it actually renders. We can fix this by specifying the URL without the directory path.

```
2025-06-06T08:23:06.538Z DEBUG tauri::manager: Asset `src-frontend/index.html` not found; fallback to src-frontend/index.html.html
2025-06-06T08:23:06.538Z DEBUG tauri::manager: Asset `src-frontend/index.html` not found; fallback to src-frontend/index.html/index.html
2025-06-06T08:23:06.539Z DEBUG tauri::manager: Asset `src-frontend/index.html` not found; fallback to index.html
2025-06-06T08:23:06.566Z DEBUG firezone_gui_client::controller: Starting new instance of `Controller`
```