### PR TITLE
fix(gui-client): don't busy-loop when update checker is disabled

### DIFF
--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -389,12 +389,12 @@ impl<I: GuiIntegration> Controller<I> {
                 return Poll::Ready(EventloopTick::ControllerRequest(maybe_req));
             }
 
-            if let Poll::Ready(Some(notification)) = self.updates_rx.poll_next_unpin(cx) {
-                return Poll::Ready(EventloopTick::UpdateNotification(notification));
-            }
-
             if let Poll::Ready(new_instance) = self.gui_ipc_clients.poll_next_unpin(cx) {
                 return Poll::Ready(EventloopTick::NewInstanceLaunched(new_instance));
+            }
+
+            if let Poll::Ready(Some(notification)) = self.updates_rx.poll_next_unpin(cx) {
+                return Poll::Ready(EventloopTick::UpdateNotification(notification));
             }
 
             Poll::Pending


### PR DESCRIPTION
The GUI client's update checker is a task that runs concurrently to the main event-loop of the client. When a new update is found, it sends a notification through a channel. When the update checker is disabled via MDM, this channel is instantly closed, resulting in `None` being read as part of the event-loop in the client.

Previously, we would then return `Poll::Ready(EventloopTick::UpdateNotification(None))` and then simply ignore this event. This however is wrong. Returning `Poll::Ready` means that the future needs to be polled again, resulting in an effective busy-loop where we constantly emit the above event and then ignore it. Due to the priority order that was previously defined, this led to us never checking another channel: The one where we receive deep-links from 2nd GUI instances.

As a result, signing into the client when the update checker was disabled does not work and instead, the newly launched instance hangs because it can never send over the deep-link.

Resolves: #9420