### PR TITLE
ci: fix winget releaser workflow

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -15,7 +15,6 @@ jobs:
             tag_prefix: gui-client
           - identifier: Firezone.Client.Headless
             tag_prefix: headless-client
-    if: ${{ startsWith(github.event.release.name, matrix.tag_prefix) }}
     steps:
       - id: get-version
         run: |
@@ -24,6 +23,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
         shell: bash
       - uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f # main
+        if: ${{ startsWith(github.event.release.name, matrix.tag_prefix) }}
         with:
           identifier: ${{ matrix.identifier }}
           version: ${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
`if` attributes on the job level cannot contain `matrix` variables.