### PR TITLE
refactor(portal): add retry logic to Stripe API client

### DIFF
--- a/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
+++ b/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
@@ -1,5 +1,6 @@
 defmodule Domain.Billing.Stripe.APIClient do
   use Supervisor
+  require Logger
 
   @pool_name __MODULE__.Finch
 
@@ -37,7 +38,7 @@ defmodule Domain.Billing.Stripe.APIClient do
       |> put_if_not_nil("email", email)
       |> URI.encode_query(:www_form)
 
-    request(api_token, :post, "customers", body)
+    request_with_retry(api_token, :post, "customers", body)
   end
 
   def update_customer(api_token, customer_id, name, metadata) do
@@ -51,11 +52,11 @@ defmodule Domain.Billing.Stripe.APIClient do
       |> Map.put("name", name)
       |> URI.encode_query(:www_form)
 
-    request(api_token, :post, "customers/#{customer_id}", body)
+    request_with_retry(api_token, :post, "customers/#{customer_id}", body)
   end
 
   def fetch_customer(api_token, customer_id) do
-    request(api_token, :get, "customers/#{customer_id}", "")
+    request_with_retry(api_token, :get, "customers/#{customer_id}", "")
   end
 
   def list_all_subscriptions(api_token, page_after \\ nil, acc \\ []) do
@@ -66,7 +67,7 @@ defmodule Domain.Billing.Stripe.APIClient do
         ""
       end
 
-    case request(api_token, :get, "subscriptions#{query_params}", "") do
+    case request_with_retry(api_token, :get, "subscriptions#{query_params}", "") do
       {:ok, %{"has_more" => true, "data" => data}} ->
         page_after = List.last(data)["id"]
         list_all_subscriptions(api_token, page_after, acc ++ data)
@@ -80,12 +81,12 @@ defmodule Domain.Billing.Stripe.APIClient do
   end
 
   def fetch_product(api_token, product_id) do
-    request(api_token, :get, "products/#{product_id}", "")
+    request_with_retry(api_token, :get, "products/#{product_id}", "")
   end
 
   def create_billing_portal_session(api_token, customer_id, return_url) do
     body = URI.encode_query(%{"customer" => customer_id, "return_url" => return_url}, :www_form)
-    request(api_token, :post, "billing_portal/sessions", body)
+    request_with_retry(api_token, :post, "billing_portal/sessions", body)
   end
 
   def create_subscription(api_token, customer_id, price_id) do
@@ -98,7 +99,69 @@ defmodule Domain.Billing.Stripe.APIClient do
         :www_form
       )
 
-    request(api_token, :post, "subscriptions", body)
+    request_with_retry(api_token, :post, "subscriptions", body)
+  end
+
+  def request_with_retry(api_token, method, path, body) do
+    max_retries = fetch_retry_config(:max_retries, 3)
+    base_delay = fetch_retry_config(:base_delay_ms, 1000)
+    max_delay = fetch_retry_config(:max_delay_ms, 10_000)
+
+    do_request_with_retry(api_token, method, path, body, 0, max_retries, base_delay, max_delay)
+  end
+
+  defp do_request_with_retry(
+         api_token,
+         method,
+         path,
+         body,
+         attempt,
+         max_retries,
+         base_delay,
+         max_delay
+       ) do
+    case request(api_token, method, path, body) do
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, {429, response}} when attempt < max_retries ->
+        delay = calculate_delay(attempt, base_delay, max_delay)
+
+        Logger.warning(
+          "Rate limited by Stripe API (429), retrying request.",
+          %{
+            request_delay: "#{delay}ms",
+            attempt_num: "#{attempt + 1} of #{max_retries}",
+            response: inspect(response)
+          }
+        )
+
+        Process.sleep(delay)
+
+        do_request_with_retry(
+          api_token,
+          method,
+          path,
+          body,
+          attempt + 1,
+          max_retries,
+          base_delay,
+          max_delay
+        )
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp calculate_delay(attempt, base_delay, max_delay) do
+    # Exponential backoff with jitter
+    exponential_delay = base_delay * :math.pow(2, attempt)
+    jitter = :rand.uniform() * 0.1 * exponential_delay
+
+    (exponential_delay + jitter)
+    |> round()
+    |> min(max_delay)
   end
 
   def request(api_token, method, path, body) do
@@ -140,5 +203,14 @@ defmodule Domain.Billing.Stripe.APIClient do
   defp fetch_config!(key) do
     Domain.Config.fetch_env!(:domain, __MODULE__)
     |> Keyword.fetch!(key)
+  end
+
+  defp fetch_retry_config(key, default) do
+    config = Domain.Config.fetch_env!(:domain, __MODULE__)
+
+    case Keyword.get(config, :retry_config) do
+      nil -> default
+      retry_config -> Keyword.get(retry_config, key, default)
+    end
   end
 end

--- a/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
+++ b/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
@@ -129,11 +129,9 @@ defmodule Domain.Billing.Stripe.APIClient do
 
         Logger.warning(
           "Rate limited by Stripe API (429), retrying request.",
-          %{
-            request_delay: "#{delay}ms",
-            attempt_num: "#{attempt + 1} of #{max_retries}",
-            response: inspect(response)
-          }
+          request_delay: "#{delay}ms",
+          attempt_num: "#{attempt + 1} of #{max_retries}",
+          response: inspect(response)
         )
 
         Process.sleep(delay)

--- a/elixir/apps/domain/test/domain/billing/stripe/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/billing/stripe/api_client_test.exs
@@ -1,0 +1,43 @@
+defmodule Domain.Billing.Stripe.APIClientTest do
+  use Domain.DataCase, async: true
+  alias Domain.Mocks.Stripe
+  import Domain.Billing.Stripe.APIClient
+
+  describe "client retry logic" do
+    test "retries on 429 rate limit responses" do
+      bypass = Bypass.open()
+      account = Fixtures.Accounts.create_account()
+
+      # Configure to return 429 on first 2 requests, then succeed
+      Stripe.enable_rate_limiting(2)
+      Stripe.mock_create_customer_endpoint(bypass, account)
+
+      # This should succeed after 2 retries
+      {:ok, _customer} =
+        create_customer("secret_token_123", account.name, "test@example.com", %{})
+
+      # Verify 3 total requests were made (2 failures + 1 success)
+      assert Stripe.get_request_count() == 3
+
+      Domain.Mocks.Stripe.disable_rate_limiting()
+    end
+
+    test "gives up after max retries exceeded" do
+      bypass = Bypass.open()
+      account = Fixtures.Accounts.create_account()
+
+      # Configure to always return 429
+      Stripe.configure_rate_limiting(fn _count -> true end)
+      Stripe.mock_create_customer_endpoint(bypass, account)
+
+      # This should fail after exhausting retries
+      {:error, {429, _}} =
+        create_customer("secret_token_123", account.name, "test@example.com", %{})
+
+      # Should have made max_retries + 1 attempts
+      assert Stripe.get_request_count() == 4
+
+      Domain.Mocks.Stripe.disable_rate_limiting()
+    end
+  end
+end

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -92,7 +92,12 @@ config :domain, Domain.Auth.Adapters.Okta.APIClient, finch_transport_opts: []
 
 config :domain, Domain.Billing.Stripe.APIClient,
   endpoint: "https://api.stripe.com",
-  finch_transport_opts: []
+  finch_transport_opts: [],
+  retry_config: [
+    max_retries: 3,
+    base_delay_ms: 1000,
+    max_delay_ms: 10_000
+  ]
 
 config :domain, Domain.Billing,
   enabled: true,

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -26,6 +26,15 @@ config :domain, Domain.Events.ReplicationConnection,
     database: "firezone_test#{partition_suffix}"
   ]
 
+config :domain, Domain.Billing.Stripe.APIClient,
+  endpoint: "https://api.stripe.com",
+  finch_transport_opts: [],
+  retry_config: [
+    max_retries: 3,
+    base_delay_ms: 100,
+    max_delay_ms: 1000
+  ]
+
 config :domain, Domain.Telemetry, enabled: false
 
 config :domain, Domain.ConnectivityChecks, enabled: false


### PR DESCRIPTION
Why:

* We've seen some Stripe API requests come back with 429 responses, which likely could be retried and succeed.  This commit adds some basic retry logic to our Stripe API client.

Related: #9396 