### PR TITLE
refactor(gui-client): tidy up app startup

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -10,8 +10,9 @@ use anyhow::{Context as _, Result, bail};
 use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, elevation, gui, logging, settings};
-use firezone_telemetry::Telemetry;
+use firezone_telemetry::{Telemetry, analytics};
 use settings::AdvancedSettingsLegacy;
+use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
 
 fn main() -> ExitCode {
@@ -21,18 +22,10 @@ fn main() -> ExitCode {
         std::env::set_var("GDK_BACKEND", "x11");
     }
 
-    let cli = Cli::parse();
-
-    // TODO: Remove, this is only needed for Portal connections and the GUI process doesn't connect to the Portal. Unless it's also needed for update checks.
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .expect("Calling `install_default` only once per process should always succeed");
-
     let mut telemetry = Telemetry::default();
-    let settings = settings::load_advanced_settings::<AdvancedSettingsLegacy>().unwrap_or_default();
-    let rt = tokio::runtime::Runtime::new().expect("Couldn't start Tokio runtime");
+    let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
 
-    match try_main(cli, &rt, &mut telemetry, settings) {
+    match rt.block_on(try_main(&mut telemetry)) {
         Ok(()) => {
             rt.block_on(telemetry.stop());
 
@@ -48,12 +41,9 @@ fn main() -> ExitCode {
     }
 }
 
-fn try_main(
-    cli: Cli,
-    rt: &tokio::runtime::Runtime,
-    telemetry: &mut Telemetry,
-    mut settings: AdvancedSettingsLegacy,
-) -> Result<()> {
+fn try_main(rt: &Runtime, telemetry: &mut Telemetry) -> Result<()> {
+    let cli = Cli::parse();
+
     let config = gui::RunConfig {
         inject_faults: cli.inject_faults,
         debug_update_check: cli.debug_update_check,
@@ -66,17 +56,47 @@ fn try_main(
         fail_with: cli.fail_on_purpose(),
     };
 
+    let mut advanced_settings =
+        settings::load_advanced_settings::<AdvancedSettingsLegacy>().unwrap_or_default();
+
+    let mdm_settings = settings::load_mdm_settings()
+        .inspect_err(|e| tracing::debug!("Failed to load MDM settings {e:#}"))
+        .unwrap_or_default();
+
+    let api_url = mdm_settings
+        .api_url
+        .as_ref()
+        .unwrap_or(&advanced_settings.api_url)
+        .to_string();
+
+    telemetry.start(
+        &api_url,
+        firezone_gui_client::RELEASE,
+        firezone_telemetry::GUI_DSN,
+    );
+
     // Don't fix the log filter for smoke tests because we can't show a dialog there.
     if !config.smoke_test {
-        fix_log_filter(&mut settings)?;
+        fix_log_filter(&mut advanced_settings)?;
     }
 
-    let log_filter = std::env::var("RUST_LOG").unwrap_or_else(|_| settings.log_filter.clone());
+    let log_filter = std::env::var("RUST_LOG")
+        .ok()
+        .or(mdm_settings.log_filter.clone())
+        .unwrap_or_else(|| advanced_settings.log_filter.clone());
 
     let logging::Handles {
         logger: _logger,
         reloader,
     } = firezone_gui_client::logging::setup_gui(&log_filter)?;
+
+    // Get the device ID before starting Tokio, so that all the worker threads will inherit the correct scope.
+    // Technically this means we can fail to get the device ID on a newly-installed system, since the Tunnel service may not have fully started up when the GUI process reaches this point, but in practice it's unlikely.
+    if let Ok(id) = firezone_bin_shared::device_id::get() {
+        Telemetry::set_firezone_id(id.id.clone());
+
+        analytics::identify(id.id, api_url, firezone_gui_client::RELEASE.to_owned());
+    }
 
     match cli.command {
         None if cli.check_elevation() => match elevation::gui_check() {
@@ -120,7 +140,7 @@ fn try_main(
         }
         Some(Cmd::SmokeTest) => {
             // Can't check elevation here because the Windows CI is always elevated
-            gui::run(rt, telemetry, config, settings, reloader)?;
+            gui::run(rt, config, mdm_settings, advanced_settings, reloader)?;
 
             return Ok(());
         }
@@ -128,7 +148,7 @@ fn try_main(
 
     // Happy-path: Run the GUI.
 
-    match gui::run(rt, telemetry, config, settings, reloader) {
+    match gui::run(rt, config, mdm_settings, advanced_settings, reloader) {
         Ok(()) => {}
         Err(anyhow) => {
             if anyhow

--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -160,6 +160,7 @@ pub fn setup_stdout() -> Result<FilterReloadHandle> {
 
     Ok(reloader)
 }
+
 /// Reads the log filter for the Tunnel service or for debug commands
 ///
 /// e.g. `info`

--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -160,7 +160,6 @@ pub fn setup_stdout() -> Result<FilterReloadHandle> {
 
     Ok(reloader)
 }
-
 /// Reads the log filter for the Tunnel service or for debug commands
 ///
 /// e.g. `info`

--- a/rust/gui-client/src-tauri/src/view.rs
+++ b/rust/gui-client/src-tauri/src/view.rs
@@ -39,7 +39,7 @@ async fn clear_logs(managed: tauri::State<'_, Managed>) -> Result<()> {
     let (tx, rx) = tokio::sync::oneshot::channel();
 
     managed
-        .ctlr_tx
+        .req_tx
         .send(ControllerRequest::ClearLogs(tx))
         .await
         .context("Failed to send `ClearLogs` command")?;
@@ -53,7 +53,7 @@ async fn clear_logs(managed: tauri::State<'_, Managed>) -> Result<()> {
 
 #[tauri::command]
 async fn export_logs(app: tauri::AppHandle, managed: tauri::State<'_, Managed>) -> Result<()> {
-    show_export_dialog(&app, managed.ctlr_tx.clone())?;
+    show_export_dialog(&app, managed.req_tx.clone())?;
 
     Ok(())
 }
@@ -68,7 +68,7 @@ async fn apply_general_settings(
     }
 
     managed
-        .ctlr_tx
+        .req_tx
         .send(ControllerRequest::ApplyGeneralSettings(Box::new(settings)))
         .await
         .context("Failed to send `ApplyGeneralSettings` command")?;
@@ -86,7 +86,7 @@ async fn apply_advanced_settings(
     }
 
     managed
-        .ctlr_tx
+        .req_tx
         .send(ControllerRequest::ApplyAdvancedSettings(Box::new(settings)))
         .await
         .context("Failed to send `ApplySettings` command")?;
@@ -104,7 +104,7 @@ async fn reset_advanced_settings(managed: tauri::State<'_, Managed>) -> Result<(
 #[tauri::command]
 async fn reset_general_settings(managed: tauri::State<'_, Managed>) -> Result<()> {
     managed
-        .ctlr_tx
+        .req_tx
         .send(ControllerRequest::ResetGeneralSettings)
         .await
         .context("Failed to send `ResetGeneralSettings` command")?;
@@ -149,7 +149,7 @@ fn show_export_dialog(app: &tauri::AppHandle, ctlr_tx: CtlrTx) -> Result<()> {
 #[tauri::command]
 async fn sign_in(managed: tauri::State<'_, Managed>) -> Result<()> {
     managed
-        .ctlr_tx
+        .req_tx
         .send(ControllerRequest::SignIn)
         .await
         .context("Failed to send `SignIn` command")?;
@@ -160,7 +160,7 @@ async fn sign_in(managed: tauri::State<'_, Managed>) -> Result<()> {
 #[tauri::command]
 async fn sign_out(managed: tauri::State<'_, Managed>) -> Result<()> {
     managed
-        .ctlr_tx
+        .req_tx
         .send(ControllerRequest::SignOut)
         .await
         .context("Failed to send `SignOut` command")?;
@@ -171,7 +171,7 @@ async fn sign_out(managed: tauri::State<'_, Managed>) -> Result<()> {
 #[tauri::command]
 async fn update_state(managed: tauri::State<'_, Managed>) -> Result<()> {
     managed
-        .ctlr_tx
+        .req_tx
         .send(ControllerRequest::UpdateState)
         .await
         .context("Failed to send `UpdateState` command")?;

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -56,6 +56,19 @@ where
     Ok(reload_handle1.merge(reload_handle2))
 }
 
+/// Sets up a bootstrap logger.
+pub fn setup_bootstrap() -> Result<DefaultGuard> {
+    let directives = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+
+    let (filter, _) = try_filter(&directives).context("failed to parse directives")?;
+    let layer = tracing_subscriber::fmt::layer()
+        .event_format(Format::new())
+        .with_filter(filter);
+    let subscriber = Registry::default().with(layer);
+
+    Ok(subscriber.set_default())
+}
+
 #[expect(
     clippy::disallowed_methods,
     reason = "This is the alternative function."

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -66,7 +66,7 @@ pub fn setup_bootstrap() -> Result<DefaultGuard> {
         .with_filter(filter);
     let subscriber = Registry::default().with(layer);
 
-    Ok(subscriber.set_default())
+    Ok(tracing::dispatcher::set_default(&subscriber.into()))
 }
 
 #[expect(


### PR DESCRIPTION
As part of investigating #9400, I refactored the startup code of the GUI client to play around with the initialization order of the runtime and other parts. After finding the root cause (fixed in #9469), I figured it would still be nice to land these improvements.

This refactors the app startup:

- Only initialize what is absolutely necessary outside of `try_main`: The runtime and the telemetry instance.
- Settings are loaded earlier
- Telemetry is initializer earlier
- Add a bootstrap logger that logs to stdout whilst we are booting
- Re-order some code inside `gui::run` to bundle the initialization of Tauri into a single command chain