### PR TITLE
fix(gui-client): remove timeout from opening deep-link

### DIFF
--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-use std::{process::ExitCode, time::Duration};
+use std::process::ExitCode;
 
 use anyhow::{Context as _, Result, bail};
 use clap::{Args, Parser};
@@ -109,12 +109,10 @@ fn try_main(
             return Ok(());
         }
         Some(Cmd::OpenDeepLink(deep_link)) => {
-            rt.block_on(tokio::time::timeout(
-                Duration::from_secs(10),
-                deep_link::open(deep_link.url),
-            ))
-            .context("Timed out while opening deep-link")?
-            .context("Failed to open deep-link")?;
+            tracing::info!("Opening deep-link");
+
+            rt.block_on(deep_link::open(deep_link.url))
+                .context("Failed to open deep-link")?;
 
             return Ok(());
         }

--- a/rust/gui-client/src-tauri/src/deep_link.rs
+++ b/rust/gui-client/src-tauri/src/deep_link.rs
@@ -44,6 +44,8 @@ pub async fn open(url: url::Url) -> Result<()> {
         .await
         .context("Failed to send deep-link")?;
 
+    tracing::debug!("Sent deep-link, waiting for response");
+
     let response = read
         .next()
         .await
@@ -51,6 +53,8 @@ pub async fn open(url: url::Url) -> Result<()> {
         .context("Failed to receive response")?;
 
     anyhow::ensure!(response == ServerMsg::Ack);
+
+    tracing::info!("Primary instance acknowledged deep-link, goodbye!");
 
     Ok(())
 }


### PR DESCRIPTION
This timeout seems to be problematic as deep-links don't open with it at all. This is a regression from #9445.