### PR TITLE
fix(apple): drop `Session` in a new task

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -418,7 +418,11 @@ extension Adapter: CallbackHandlerDelegate {
   func onDisconnect(error: DisconnectError) {
     // Immediately invalidate our session pointer to prevent workQueue items from trying to use it.
     // Assigning to `nil` will invoke `Drop` on the Rust side.
-    session = nil
+    // We need to do it in a new task to all Rust to break cycling dependencies as callbacks are executed
+    // on the same runtime as the session is running.
+    Task {
+        session = nil
+    }
 
     // Since connlib has already shutdown by this point, we queue this callback
     // to ensure that we can clean up even if connlib exits before we are done.

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -418,7 +418,7 @@ extension Adapter: CallbackHandlerDelegate {
   func onDisconnect(error: DisconnectError) {
     // Immediately invalidate our session pointer to prevent workQueue items from trying to use it.
     // Assigning to `nil` will invoke `Drop` on the Rust side.
-    // We need to do it in a new task to all Rust to break cycling dependencies as callbacks are executed
+    // We need to do it in a new task to allow Rust to break cyclic dependencies as callbacks are executed
     // on the same runtime as the session is running.
     Task {
         session = nil


### PR DESCRIPTION
Until we implement #3959 for the Apple client, we need to be careful around how we de-initialise the Rust session. Callback-based designs are difficult to get right across boundaries because they enable re-entrances which then lead to runtime errors.

Specifically, freeing the session needs to cleanup the tokio runtime but that is impossible if the callback is still executed from that exact runtime. To workaround this, we need to free the session pointer from a new task.

Moving to #3959 will solve this in a much more intuitive way because we can ditch the callbacks and instead move to a stream of events that the host app can consume.