### PR TITLE
feat(gui-client): compile-time link event names and routes

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8074,9 +8074,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tslink"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cbdb11a5a2f2c51118b6a0e4ffde3b547402970d16a80cf7b3ca29d1c7fea4"
+checksum = "18e32680d9db89f48d580c57d1b5be17c3ba2a1a2f72e7d03eb21061d0208c0d"
 dependencies = [
  "convert_case 0.6.0",
  "lazy_static",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -188,7 +188,7 @@ tracing-opentelemetry = "0.30.0"
 tracing-stackdriver = "0.11.0"
 tracing-subscriber = { version = "0.3.19", features = ["parking_lot"] }
 trackable = "1.3.0"
-tslink = "0.3.0"
+tslink = "0.4.0"
 tun = { path = "connlib/tun" }
 url = "2.5.2"
 uuid = "1.17.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -188,6 +188,7 @@ tracing-opentelemetry = "0.30.0"
 tracing-stackdriver = "0.11.0"
 tracing-subscriber = { version = "0.3.19", features = ["parking_lot"] }
 trackable = "1.3.0"
+tslink = "0.3.0"
 tun = { path = "connlib/tun" }
 url = "2.5.2"
 uuid = "1.17.0"

--- a/rust/gui-client/src-frontend/components/App.tsx
+++ b/rust/gui-client/src-frontend/components/App.tsx
@@ -19,7 +19,7 @@ import {
 import React, { useEffect, useState } from "react";
 import { NavLink, Route, Routes } from "react-router";
 import { AdvancedSettingsViewModel } from "../generated/AdvancedSettingsViewModel";
-import { FileCount } from "../generated/FileCount";
+import { FileCount, LOGS_RECOUNTED } from "../generated/FileCount";
 import { Session } from "../generated/Session";
 import About from "./AboutPage";
 import AdvancedSettingsPage from "./AdvancedSettingsPage";
@@ -27,7 +27,12 @@ import ColorPalette from "./ColorPalettePage";
 import Diagnostics from "./DiagnosticsPage";
 import GeneralSettingsPage from "./GeneralSettingsPage";
 import Overview from "./OverviewPage";
-import { GeneralSettingsViewModel } from "../generated/GeneralSettingsViewModel";
+import {
+  ADVANCED_SETTINGS_CHANGED,
+  GENERAL_SETTINGS_CHANGED,
+  GeneralSettingsViewModel,
+} from "../generated/GeneralSettingsViewModel";
+import { ABOUT, GENERAL_SETTINGS, OVERVIEW } from "../generated/Routes";
 
 export default function App() {
   let [session, setSession] = useState<Session | null>(null);
@@ -49,29 +54,31 @@ export default function App() {
       setSession(null);
     });
     const generalSettingsChangedUnlisten = listen<GeneralSettingsViewModel>(
-      "general_settings_changed",
+      GENERAL_SETTINGS_CHANGED,
       (e) => {
         let generalSettings = e.payload;
 
-        console.log("general_settings_changed", { settings: generalSettings });
+        console.log(`${GENERAL_SETTINGS_CHANGED}`, {
+          settings: generalSettings,
+        });
         setGeneralSettings(generalSettings);
       }
     );
     const advancedSettingsChangedUnlisten = listen<AdvancedSettingsViewModel>(
-      "advanced_settings_changed",
+      ADVANCED_SETTINGS_CHANGED,
       (e) => {
         let advancedSettings = e.payload;
 
-        console.log("advanced_settings_changed", {
+        console.log(`${ADVANCED_SETTINGS_CHANGED}`, {
           settings: advancedSettings,
         });
         setAdvancedSettings(advancedSettings);
       }
     );
-    const logsRecountedUnlisten = listen<FileCount>("logs_recounted", (e) => {
+    const logsRecountedUnlisten = listen<FileCount>(LOGS_RECOUNTED, (e) => {
       let file_count = e.payload;
 
-      console.log("logs_recounted", { file_count });
+      console.log(`${LOGS_RECOUNTED}`, { file_count });
       setLogCount(file_count);
     });
 
@@ -96,7 +103,7 @@ export default function App() {
       >
         <SidebarItems>
           <SidebarItemGroup>
-            <NavLink to="/overview">
+            <NavLink to={`/${OVERVIEW}`}>
               {({ isActive }) => (
                 <SidebarItem active={isActive} icon={HomeIcon} as="div">
                   Overview
@@ -104,7 +111,7 @@ export default function App() {
               )}
             </NavLink>
             <SidebarCollapse label="Settings" open={true} icon={Bars3Icon}>
-              <NavLink to="/general-settings">
+              <NavLink to={`/${GENERAL_SETTINGS}`}>
                 {({ isActive }) => (
                   <SidebarItem active={isActive} icon={CogIcon} as="div">
                     General
@@ -134,7 +141,7 @@ export default function App() {
                 </SidebarItem>
               )}
             </NavLink>
-            <NavLink to="/about">
+            <NavLink to={`/${ABOUT}`}>
               {({ isActive }) => (
                 <SidebarItem
                   active={isActive}

--- a/rust/gui-client/src-frontend/generated/FileCount.ts
+++ b/rust/gui-client/src-frontend/generated/FileCount.ts
@@ -2,3 +2,4 @@ export interface FileCount {
     bytes: number;
     files: number;
 }
+export const LOGS_RECOUNTED = "logs_recounted";

--- a/rust/gui-client/src-frontend/generated/GeneralSettingsViewModel.ts
+++ b/rust/gui-client/src-frontend/generated/GeneralSettingsViewModel.ts
@@ -6,3 +6,5 @@ export interface GeneralSettingsViewModel {
     account_slug: string;
     account_slug_is_managed: boolean;
 }
+export const GENERAL_SETTINGS_CHANGED = "general_settings_changed";
+export const ADVANCED_SETTINGS_CHANGED = "advanced_settings_changed";

--- a/rust/gui-client/src-frontend/generated/Routes.ts
+++ b/rust/gui-client/src-frontend/generated/Routes.ts
@@ -1,0 +1,3 @@
+export const ABOUT = "about";
+export const GENERAL_SETTINGS = "general-settings";
+export const OVERVIEW = "overview";

--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -62,7 +62,7 @@ tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tslink = "0.3.0"
+tslink = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 zip = { workspace = true, features = ["deflate", "time"] }

--- a/rust/gui-client/src-tauri/src/gui.rs
+++ b/rust/gui-client/src-tauri/src/gui.rs
@@ -13,7 +13,7 @@ use crate::{
         self, AdvancedSettings, AdvancedSettingsLegacy, AdvancedSettingsViewModel, GeneralSettings,
         GeneralSettingsViewModel, MdmSettings,
     },
-    updates,
+    updates, view,
 };
 use anyhow::{Context, Result, bail};
 use firezone_logging::err_with_src;
@@ -106,13 +106,13 @@ impl GuiIntegration for TauriIntegration {
     ) -> Result<()> {
         self.app
             .emit(
-                "general_settings_changed",
+                GeneralSettingsViewModel::GENERAL_SETTINGS_CHANGED,
                 GeneralSettingsViewModel::new(mdm_settings.clone(), general_settings),
             )
             .context("Failed to send `general_settings_changed` event")?;
         self.app
             .emit(
-                "advanced_settings_changed",
+                AdvancedSettingsViewModel::ADVANCED_SETTINGS_CHANGED,
                 AdvancedSettingsViewModel::new(mdm_settings, advanced_settings),
             )
             .context("Failed to send `advanced_settings_changed` event")?;
@@ -122,7 +122,7 @@ impl GuiIntegration for TauriIntegration {
 
     fn notify_logs_recounted(&self, file_count: &FileCount) -> Result<()> {
         self.app
-            .emit("logs_recounted", file_count)
+            .emit(FileCount::LOGS_RECOUNTED, file_count)
             .context("Failed to send `logs_recounted` event")?;
 
         Ok(())
@@ -172,7 +172,7 @@ impl GuiIntegration for TauriIntegration {
             Some(session) => self.notify_signed_in(session)?,
             None => self.notify_signed_out()?,
         };
-        self.navigate("overview")?;
+        self.navigate(view::routes::OVERVIEW)?;
         self.set_window_visible(true)?;
 
         Ok(())
@@ -185,14 +185,14 @@ impl GuiIntegration for TauriIntegration {
         advanced_settings: AdvancedSettings,
     ) -> Result<()> {
         self.notify_settings_changed(mdm_settings, general_settings, advanced_settings)?; // Ensure settings are up to date in GUI.
-        self.navigate("general-settings")?;
+        self.navigate(view::routes::GENERAL_SETTINGS)?;
         self.set_window_visible(true)?;
 
         Ok(())
     }
 
     fn show_about_page(&self) -> Result<()> {
-        self.navigate("about")?;
+        self.navigate(view::routes::ABOUT)?;
         self.set_window_visible(true)?;
 
         Ok(())

--- a/rust/gui-client/src-tauri/src/logging.rs
+++ b/rust/gui-client/src-tauri/src/logging.rs
@@ -211,6 +211,11 @@ pub struct FileCount {
     files: u64,
 }
 
+impl FileCount {
+    #[tslink::tslink(target = "./gui-client/src-frontend/generated/FileCount.ts")]
+    pub const LOGS_RECOUNTED: &str = "logs_recounted";
+}
+
 pub async fn clear_gui_logs() -> Result<()> {
     clear_logs(&known_dirs::logs().context("Can't compute GUI log dir")?).await
 }

--- a/rust/gui-client/src-tauri/src/settings.rs
+++ b/rust/gui-client/src-tauri/src/settings.rs
@@ -91,6 +91,9 @@ pub struct GeneralSettingsViewModel {
 }
 
 impl GeneralSettingsViewModel {
+    #[tslink::tslink(target = "./gui-client/src-frontend/generated/GeneralSettingsViewModel.ts")]
+    pub const GENERAL_SETTINGS_CHANGED: &str = "general_settings_changed";
+
     pub fn new(mdm_settings: MdmSettings, general_settings: GeneralSettings) -> Self {
         Self {
             connect_on_start_is_managed: mdm_settings.connect_on_start.is_some(),
@@ -121,6 +124,9 @@ pub struct AdvancedSettingsViewModel {
 }
 
 impl AdvancedSettingsViewModel {
+    #[tslink::tslink(target = "./gui-client/src-frontend/generated/GeneralSettingsViewModel.ts")]
+    pub const ADVANCED_SETTINGS_CHANGED: &str = "advanced_settings_changed";
+
     pub fn new(mdm_settings: MdmSettings, advanced_settings: AdvancedSettings) -> Self {
         Self {
             auth_url_is_managed: mdm_settings.auth_url.is_some(),

--- a/rust/gui-client/src-tauri/src/view.rs
+++ b/rust/gui-client/src-tauri/src/view.rs
@@ -12,6 +12,15 @@ use crate::{
     settings::AdvancedSettings,
 };
 
+pub mod routes {
+    #[tslink::tslink(target = "./gui-client/src-frontend/generated/Routes.ts")]
+    pub const OVERVIEW: &str = "overview";
+    #[tslink::tslink(target = "./gui-client/src-frontend/generated/Routes.ts")]
+    pub const GENERAL_SETTINGS: &str = "general-settings";
+    #[tslink::tslink(target = "./gui-client/src-frontend/generated/Routes.ts")]
+    pub const ABOUT: &str = "about";
+}
+
 #[derive(Clone, serde::Deserialize)]
 pub struct GeneralSettingsForm {
     pub start_minimized: bool,


### PR DESCRIPTION
The API between frontend and backend in the GUI client relies on both sides using the same strings for event and routes:

Events will only be delivered to the correct listener if the frontend listens on the topic that the backend broadcasts on. Similarly, the backend can only navigate to the correct view if the frontend has a route for a given page.

To provide additional safety when making changes to the GUI client, we upgrade `tslink` to the latest version which provides support for exporting constants. These constants are then used to host these event names and routes.