### PR TITLE
ci: ensure all jobs are successful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,6 @@ jobs:
             echo "Completed: $completed_jobs/$total_jobs"
 
             if [ $completed_jobs -eq $total_jobs ]; then
-              echo "All jobs have completed successfully!"
               break
             fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,16 +135,16 @@ jobs:
             jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name != "required-check"))')
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
-            failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | map(.name) | .[]')
+            failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')
             completed_jobs=$(echo "$jobs_json" | jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length')
 
-            if [ -n "$failed_jobs" ]; then
-              echo "Some jobs have failed:"
-              echo "$failed_jobs" | sed 's/^/  - /'
+            if [ $failed_jobs -gt 0 ]; then
+              echo "At least one job has failed."
               exit 1
             fi
 
-            # If all jobs are complete and successful, we're done
+            echo "Completed: $completed_jobs/$total_jobs"
+
             if [ $completed_jobs -eq $total_jobs ]; then
               echo "All jobs have completed successfully!"
               break

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           while true; do
-            echo "------------------------"
-            echo "Checking all jobs in 10s"
-
-            sleep 10
             jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name != "required-check"))')
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
@@ -149,6 +145,11 @@ jobs:
               echo "All jobs have completed successfully!"
               break
             fi
+
+            echo "Checking all jobs in 10s"
+            echo "------------------------"
+
+            sleep 10
           done
 
   update-release-draft:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,22 +103,19 @@ jobs:
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
             failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')
-            completed_jobs=$(echo "$jobs_json" | jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length')
+            successful_jobs=$(echo "$jobs_json" | jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length')
 
             if [ $failed_jobs -gt 0 ]; then
               echo "At least one job has failed."
               exit 1
             fi
 
-            echo "Completed: $completed_jobs/$total_jobs"
+            echo "Succeeded: $successful_jobs/$total_jobs"
 
-            if [ $completed_jobs -eq $total_jobs ]; then
+            if [ $successful_jobs -eq $total_jobs ]; then
               echo "All jobs have completed successfully!"
               break
             fi
-
-            echo "Checking all jobs in 10s"
-            echo "------------------------"
 
             sleep 10
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Wait for scheduled jobs to succeed
+      - name: Wait for all jobs to succeed
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,49 +123,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Wait for required jobs to succeed
+      - name: Wait for scheduled jobs to succeed
         env:
-          JOBS_TO_RUN: ${{ needs.planner.outputs.jobs_to_run }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          jobs=$(echo "$JOBS_TO_RUN" | tr ',' '\n' | grep -v '^$')
-
           while true; do
             echo "------------------------"
             echo "Checking all jobs in 10s"
 
             sleep 10
-            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs')
+            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name != "required-check"))')
 
-            for job in $jobs; do
-              echo "Checking jobs with prefix '$job'..."
+            total_jobs=$(echo "$jobs_json" | jq 'length')
+            failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | map(.name) | .[]')
+            completed_jobs=$(echo "$jobs_json" | jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length')
 
-              # Check if any matching jobs exist
-              matching_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase))] | length')
+            if [ -n "$failed_jobs" ]; then
+              echo "Some jobs have failed:"
+              echo "$failed_jobs" | sed 's/^/  - /'
+              exit 1
+            fi
 
-              if [ "$matching_count" -eq 0 ]; then
-                echo "No jobs matching prefix '$job' found yet, waiting"
-                continue 2
-              fi
-
-              # List all matching jobs
-              echo "$jobs_json" | jq -r --arg job "$job" '.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | "  - \(.name): \(.status) (\(.conclusion // "in progress"))"'
-
-              failed_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | select(.conclusion == "failure")] | length')
-              running_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | select(.status == "in_progress")] | length')
-
-              if [ "$failed_count" -gt 0 ]; then
-                echo "Found $failed_count failed jobs for prefix '$job'"
-                exit 1
-              fi
-
-              if [ "$running_count" -gt 0 ]; then
-                echo "Found $running_count running jobs for prefix '$job', waiting..."
-                continue 2
-              fi
-
-              echo "All jobs with prefix '$job' succeeded!"
-            done
+            # If all jobs are complete and successful, we're done
+            if [ $completed_jobs -eq $total_jobs ]; then
+              echo "All jobs have completed successfully!"
+              break
+            fi
           done
 
   update-release-draft:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Wait for all jobs to succeed
+      - name: Wait for all jobs to complete
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
             failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')
-            successful_jobs=$(echo "$jobs_json" | jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length')
+            successful_jobs=$(echo "$jobs_json" | jq '[.[] | select(.status == "completed" and (.conclusion == "success" or .conclusion == "skipped")] | length')
 
             if [ $failed_jobs -gt 0 ]; then
               echo "At least one job has failed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,8 @@ jobs:
               # List all matching jobs
               echo "$jobs_json" | jq -r --arg job "$job" '.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | "  - \(.name): \(.status) (\(.conclusion // "in progress"))"'
 
-              failed_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | select(.conclusion != "success")] | length')
-              running_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | select(.status != "completed")] | length')
+              failed_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | select(.conclusion == "failure")] | length')
+              running_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | select(.status == "in_progress")] | length')
 
               if [ "$failed_count" -gt 0 ]; then
                 echo "Found $failed_count failed jobs for prefix '$job'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,34 +131,41 @@ jobs:
           jobs=$(echo "$JOBS_TO_RUN" | tr ',' '\n' | grep -v '^$')
 
           while true; do
+            echo "------------------------"
             echo "Checking all jobs in 10s"
 
             sleep 10
             jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs')
 
             for job in $jobs; do
-              read status conclusion <<<$(echo "$jobs_json" | jq -r --arg job "$job" '.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | "\(.status) \(.conclusion)"' | head -n1)
+              echo "Checking jobs with prefix '$job'..."
 
-              if [ -z "$status" ]; then
-                echo "Job $job not found yet, waiting"
+              # Check if any matching jobs exist
+              matching_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase))] | length')
+
+              if [ "$matching_count" -eq 0 ]; then
+                echo "No jobs matching prefix '$job' found yet, waiting"
                 continue 2
               fi
 
-              if [ "$status" != "completed" ]; then
-                echo "Job $job is still running"
-                continue 2
-              fi
+              # List all matching jobs
+              echo "$jobs_json" | jq -r --arg job "$job" '.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | "  - \(.name): \(.status) (\(.conclusion // "in progress"))"'
 
-              if [ "$conclusion" != "success" ]; then
-                echo "Job $job did not succeed! Status: $conclusion"
+              failed_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | select(.conclusion != "success")] | length')
+              running_count=$(echo "$jobs_json" | jq --arg job "$job" '[.[] | select(.name|ascii_downcase | startswith($job|ascii_downcase)) | select(.status != "completed")] | length')
+
+              if [ "$failed_count" -gt 0 ]; then
+                echo "Found $failed_count failed jobs for prefix '$job'"
                 exit 1
               fi
 
-              echo "Job $job succeeded!"
-            done
+              if [ "$running_count" -gt 0 ]; then
+                echo "Found $running_count running jobs for prefix '$job', waiting..."
+                continue 2
+              fi
 
-            echo "All required jobs succeeded!"
-            break
+              echo "All jobs with prefix '$job' succeeded!"
+            done
           done
 
   update-release-draft:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,16 @@ jobs:
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
             failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')
-            successful_jobs=$(echo "$jobs_json" | jq '[.[] | select(.status == "completed" and (.conclusion == "success" or .conclusion == "skipped")] | length')
+            completed_jobs=$(echo "$jobs_json" | jq '[.[] | select(.status == "completed")] | length')
 
             if [ $failed_jobs -gt 0 ]; then
               echo "At least one job has failed."
               exit 1
             fi
 
-            echo "Succeeded: $successful_jobs/$total_jobs"
+            echo "Completed: $completed_jobs/$total_jobs"
 
-            if [ $successful_jobs -eq $total_jobs ]; then
+            if [ $completed_jobs -eq $total_jobs ]; then
               echo "All jobs have completed successfully!"
               break
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,35 +88,6 @@ jobs:
 
           echo "jobs_to_run=$jobs" >> $GITHUB_OUTPUT
 
-  kotlin:
-    needs: planner
-    if: contains(needs.planner.outputs.jobs_to_run, 'kotlin')
-    uses: ./.github/workflows/_kotlin.yml
-    secrets: inherit
-  swift:
-    needs: planner
-    if: contains(needs.planner.outputs.jobs_to_run, 'swift')
-    uses: ./.github/workflows/_swift.yml
-    secrets: inherit
-  elixir:
-    needs: planner
-    if: contains(needs.planner.outputs.jobs_to_run, 'elixir')
-    uses: ./.github/workflows/_elixir.yml
-  rust:
-    needs: planner
-    if: contains(needs.planner.outputs.jobs_to_run, 'rust')
-    uses: ./.github/workflows/_rust.yml
-    secrets: inherit
-  static-analysis:
-    needs: planner
-    if: contains(needs.planner.outputs.jobs_to_run, 'static-analysis')
-    uses: ./.github/workflows/_static-analysis.yml
-  codeql:
-    needs: planner
-    if: contains(needs.planner.outputs.jobs_to_run, 'codeql')
-    uses: ./.github/workflows/_codeql.yml
-    secrets: inherit
-
   required-check:
     name: required-check
     needs: planner
@@ -151,6 +122,35 @@ jobs:
 
             sleep 10
           done
+
+  kotlin:
+    needs: planner
+    if: contains(needs.planner.outputs.jobs_to_run, 'kotlin')
+    uses: ./.github/workflows/_kotlin.yml
+    secrets: inherit
+  swift:
+    needs: planner
+    if: contains(needs.planner.outputs.jobs_to_run, 'swift')
+    uses: ./.github/workflows/_swift.yml
+    secrets: inherit
+  elixir:
+    needs: planner
+    if: contains(needs.planner.outputs.jobs_to_run, 'elixir')
+    uses: ./.github/workflows/_elixir.yml
+  rust:
+    needs: planner
+    if: contains(needs.planner.outputs.jobs_to_run, 'rust')
+    uses: ./.github/workflows/_rust.yml
+    secrets: inherit
+  static-analysis:
+    needs: planner
+    if: contains(needs.planner.outputs.jobs_to_run, 'static-analysis')
+    uses: ./.github/workflows/_static-analysis.yml
+  codeql:
+    needs: planner
+    if: contains(needs.planner.outputs.jobs_to_run, 'codeql')
+    uses: ./.github/workflows/_codeql.yml
+    secrets: inherit
 
   update-release-draft:
     name: update-release-draft-${{ matrix.config_name }}


### PR DESCRIPTION
When evaluating the status of all required checks, we currently only look at the very first one. This is error prone and may result in `required-check` to be marked as successful too early. Instead of iterating through the list of jobs we have scheduled, we now instead look at all jobs that are running as part of the CI run. The idea here is:

- Any job that got started need to complete (one way or another)
- If _any_ job fails, we fail the required check
- If all jobs complete without a single failure, we pass the check

This plays well with "skipped" jobs which we sometimes have as part of CI.