### PR TITLE
chore(website): update wording for pricing plan

### DIFF
--- a/website/src/app/pricing/_page.tsx
+++ b/website/src/app/pricing/_page.tsx
@@ -416,15 +416,9 @@ export default function _Page() {
                   billing cycle.
                 </p>
                 <p className="mt-2">
-                  For the <strong>Enterprise</strong> plan, we will periodically
-                  check your active seat count and will contact you to true up
-                  your account once a quarter if there is a substantial change.
-                  Enterprise plans{" "}
-                  <strong>
-                    will never become automatically locked or disabled due to an
-                    increase in usage
-                  </strong>
-                  .
+                  For the <strong>Enterprise</strong> plan, contact your account
+                  manager to request a seat increase. You'll then be billed for
+                  the prorated amount for the remainder of the billing cycle.
                 </p>
               </Accordion.Content>
             </Accordion.Panel>


### PR DESCRIPTION
This isn't strictly true - in most cases we actually do set this limit and enforce it, which is what I think is the correct thing to do.

Related: #8668 