### PR TITLE
test(rust): adapt response from Cloudflare proxy

### DIFF
--- a/rust/bin-shared/tests/no_packet_loops_tcp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_tcp.rs
@@ -39,6 +39,6 @@ async fn no_packet_loops_tcp() {
     let s = String::from_utf8(bytes).unwrap();
     assert_eq!(
         s,
-        "<html>\r\n<head><title>400 Bad Request</title></head>\r\n<body>\r\n<center><h1>400 Bad Request</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>\r\n"
+        "Cloudflare encountered an error processing this request: Bad Request"
     );
 }


### PR DESCRIPTION
It appears that Cloudflare changed the response that it is sending for the 1.1.1.1 IP so we need to adapt our integration test for packet loops in order to make CI pass.