### PR TITLE
fix(ci): fetch depth 20 for merge group CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
 
           # Fetch base ref for merge_group
           if [ "${{ github.event_name }}" = "merge_group" ]; then
-            git fetch origin ${{ github.event.merge_group.base_ref }} --depth=1
+            # Base ref could be a few commits away, so fetch a few commits in case the queue is long
+            git fetch origin ${{ github.event.merge_group.base_ref }} --depth=20
             git diff --name-only ${{ github.event.merge_group.base_sha }} ${{ github.sha }} > changed_files.txt
 
             echo "Changed files:"


### PR DESCRIPTION
When a CI job is running as part of a merge group, it's possible the base ref is a few commits away if the merge queue has items in it. So we update the fetch depth to 20.