### PR TITLE
fix(rust): relax assertion on cloudflare tcp response

### DIFF
--- a/rust/bin-shared/tests/no_packet_loops_tcp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_tcp.rs
@@ -37,8 +37,6 @@ async fn no_packet_loops_tcp() {
     let mut bytes = vec![];
     stream.read_to_end(&mut bytes).await.unwrap();
     let s = String::from_utf8(bytes).unwrap();
-    assert_eq!(
-        s,
-        "Cloudflare encountered an error processing this request: Bad Request"
-    );
+
+    assert!(s.contains("Bad Request"));
 }


### PR DESCRIPTION
In #9498, the Cloudflare response was updated to match what appears to be a transient change on their end. It looks like this has changed again, so to prevent this from breaking CI in the future we relax the assertion.