### PR TITLE
fix(ci): don't require required-check to finish from itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           set -e
 
           while true; do
-            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name != "required-check"))')
+            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name | contains("required-check") | not))')
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
             failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')


### PR DESCRIPTION
When this workflow is called from `cd.yml`, its name is `ci / required-check`, causing this match to fail and forever wait.