### PR TITLE
fix(elixir): use same bypass var intra test

### DIFF
--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/refresh_access_tokens_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/refresh_access_tokens_test.exs
@@ -36,15 +36,15 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.RefreshAccessTokensTest do
     } do
       {token, claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "OTHER_REFRESH_TOKEN",
         "expires_in" => nil
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       assert execute(%{}) == :ok
 

--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace_test.exs
@@ -182,8 +182,9 @@ defmodule Domain.Auth.Adapters.GoogleWorkspaceTest do
     } do
       {token, claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -217,15 +218,15 @@ defmodule Domain.Auth.Adapters.GoogleWorkspaceTest do
     } do
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -285,15 +286,15 @@ defmodule Domain.Auth.Adapters.GoogleWorkspaceTest do
           "sub" => "foo@bar.com"
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -310,15 +311,15 @@ defmodule Domain.Auth.Adapters.GoogleWorkspaceTest do
       identity = Fixtures.Auth.create_identity(account: account)
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"

--- a/elixir/apps/domain/test/domain/auth/adapters/jumpcloud.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/jumpcloud.exs
@@ -128,9 +128,9 @@ defmodule Domain.Auth.Adapters.JumpCloudTest do
           "email" => email
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo(%{
         "email" => email,
         "sub" => identity.provider_identifier
       })
@@ -171,15 +171,15 @@ defmodule Domain.Auth.Adapters.JumpCloudTest do
           "sub" => identity.provider_identifier
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -240,15 +240,15 @@ defmodule Domain.Auth.Adapters.JumpCloudTest do
           "sub" => Ecto.UUID.generate()
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -270,15 +270,15 @@ defmodule Domain.Auth.Adapters.JumpCloudTest do
           "sub" => identity.provider_identifier
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"

--- a/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/jobs/refresh_access_tokens_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/jobs/refresh_access_tokens_test.exs
@@ -36,15 +36,15 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.RefreshAccessTokensTest do
     } do
       {token, claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "OTHER_REFRESH_TOKEN",
         "expires_in" => nil
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       assert execute(%{}) == :ok
 

--- a/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra_test.exs
@@ -141,9 +141,9 @@ defmodule Domain.Auth.Adapters.MicrosoftEntraTest do
           "sub" => sub
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo(%{
         "email" => email,
         "sub" => sub
       })
@@ -185,15 +185,15 @@ defmodule Domain.Auth.Adapters.MicrosoftEntraTest do
           "sub" => Ecto.UUID.generate()
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -255,15 +255,15 @@ defmodule Domain.Auth.Adapters.MicrosoftEntraTest do
           "sub" => Ecto.UUID.generate()
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -286,15 +286,15 @@ defmodule Domain.Auth.Adapters.MicrosoftEntraTest do
           "sub" => Ecto.UUID.generate()
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"

--- a/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/refresh_access_tokens_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/refresh_access_tokens_test.exs
@@ -36,15 +36,15 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.RefreshAccessTokensTest do
     } do
       {token, claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "OTHER_REFRESH_TOKEN",
         "expires_in" => nil
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       assert execute(%{}) == :ok
 

--- a/elixir/apps/domain/test/domain/auth/adapters/okta_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/okta_test.exs
@@ -138,8 +138,10 @@ defmodule Domain.Auth.Adapters.OktaTest do
       bypass: bypass
     } do
       {token, claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -173,15 +175,15 @@ defmodule Domain.Auth.Adapters.OktaTest do
     } do
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -241,15 +243,15 @@ defmodule Domain.Auth.Adapters.OktaTest do
           "sub" => "foo@bar.com"
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -267,15 +269,15 @@ defmodule Domain.Auth.Adapters.OktaTest do
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = PKCE.code_verifier()
       redirect_uri = "https://example.com/"

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -3210,8 +3210,9 @@ defmodule Domain.AuthTest do
           "sub" => "foo@bar.com"
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3256,8 +3257,9 @@ defmodule Domain.AuthTest do
           "exp" => DateTime.to_unix(expires_at)
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3304,8 +3306,9 @@ defmodule Domain.AuthTest do
           "exp" => DateTime.to_unix(expires_at)
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3339,8 +3342,9 @@ defmodule Domain.AuthTest do
           "exp" => DateTime.to_unix(expires_at)
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3373,8 +3377,9 @@ defmodule Domain.AuthTest do
           "exp" => DateTime.utc_now() |> DateTime.add(1_000_000, :second) |> DateTime.to_unix()
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3406,8 +3411,9 @@ defmodule Domain.AuthTest do
           "exp" => DateTime.utc_now() |> DateTime.add(1_000_000, :second) |> DateTime.to_unix()
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3439,8 +3445,9 @@ defmodule Domain.AuthTest do
           "exp" => DateTime.utc_now() |> DateTime.add(1_000_000, :second) |> DateTime.to_unix()
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3471,8 +3478,9 @@ defmodule Domain.AuthTest do
           "exp" => DateTime.utc_now() |> DateTime.add(1_000_000, :second) |> DateTime.to_unix()
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3499,8 +3507,10 @@ defmodule Domain.AuthTest do
       subject = Fixtures.Auth.create_subject(identity: identity)
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3525,8 +3535,10 @@ defmodule Domain.AuthTest do
       subject = Fixtures.Auth.create_subject(identity: identity)
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3550,8 +3562,10 @@ defmodule Domain.AuthTest do
       identity = Fixtures.Auth.create_identity(account: account, provider: provider, actor: actor)
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3575,8 +3589,10 @@ defmodule Domain.AuthTest do
       identity = Fixtures.Auth.create_identity(account: account, provider: provider, actor: actor)
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"
@@ -3601,8 +3617,10 @@ defmodule Domain.AuthTest do
       subject = Fixtures.Auth.create_subject(identity: identity)
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       code_verifier = Domain.Auth.Adapters.OpenIDConnect.PKCE.code_verifier()
       redirect_uri = "https://example.com/"

--- a/elixir/apps/domain/test/domain/tokens/jobs/refresh_browser_session_tokens_test.exs
+++ b/elixir/apps/domain/test/domain/tokens/jobs/refresh_browser_session_tokens_test.exs
@@ -35,15 +35,15 @@ defmodule Domain.Tokens.Jobs.RefreshBrowserSessionTokensTest do
 
       {id_token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{
         "token_type" => "Bearer",
         "id_token" => id_token,
         "access_token" => "MY_ACCESS_TOKEN",
         "refresh_token" => "MY_REFRESH_TOKEN",
         "expires_in" => 3600
       })
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       assert execute(%{}) == :ok
 

--- a/elixir/apps/web/test/web/controllers/auth_controller_test.exs
+++ b/elixir/apps/web/test/web/controllers/auth_controller_test.exs
@@ -1088,8 +1088,10 @@ defmodule Web.AuthControllerTest do
         )
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       conn =
         conn
@@ -1123,8 +1125,10 @@ defmodule Web.AuthControllerTest do
         )
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       conn =
         conn
@@ -1162,8 +1166,10 @@ defmodule Web.AuthControllerTest do
         )
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       conn =
         conn
@@ -1206,8 +1212,10 @@ defmodule Web.AuthControllerTest do
         )
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       conn =
         conn

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/connect_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/connect_test.exs
@@ -201,8 +201,10 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.Connect do
         )
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       cookie_key = "fz_auth_state_#{provider.id}"
       redirected_conn = fetch_cookies(redirected_conn)
@@ -257,8 +259,10 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.Connect do
         )
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       cookie_key = "fz_auth_state_#{provider.id}"
       redirected_conn = fetch_cookies(redirected_conn)

--- a/elixir/apps/web/test/web/live/settings/identity_providers/jumpcloud/connect_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/jumpcloud/connect_test.exs
@@ -202,8 +202,9 @@ defmodule Web.Live.Settings.IdentityProviders.JumpCloud.Connect do
           "sub" => sub
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass, %{"sub" => sub})
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo(%{"sub" => sub})
 
       cookie_key = "fz_auth_state_#{provider.id}"
       redirected_conn = fetch_cookies(redirected_conn)
@@ -265,9 +266,9 @@ defmodule Web.Live.Settings.IdentityProviders.JumpCloud.Connect do
           "sub" => sub
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo(%{
         "sub" => sub
       })
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/microsoft_entra/connect_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/microsoft_entra/connect_test.exs
@@ -211,8 +211,9 @@ defmodule Web.Live.Settings.IdentityProviders.MicrosoftEntra.Connect do
           "sub" => sub
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass, %{"sub" => sub})
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo(%{"sub" => sub})
 
       cookie_key = "fz_auth_state_#{provider.id}"
       redirected_conn = fetch_cookies(redirected_conn)
@@ -274,9 +275,9 @@ defmodule Web.Live.Settings.IdentityProviders.MicrosoftEntra.Connect do
           "sub" => sub
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo(%{
         "sub" => sub
       })
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/okta/connect_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/okta/connect_test.exs
@@ -203,8 +203,9 @@ defmodule Web.Live.Settings.IdentityProviders.Okta.Connect do
           "sub" => sub
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass, %{"sub" => sub})
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo(%{"sub" => sub})
 
       cookie_key = "fz_auth_state_#{provider.id}"
       redirected_conn = fetch_cookies(redirected_conn)
@@ -266,9 +267,9 @@ defmodule Web.Live.Settings.IdentityProviders.Okta.Connect do
           "sub" => sub
         })
 
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-
-      Mocks.OpenIDConnect.expect_userinfo(bypass, %{
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo(%{
         "sub" => sub
       })
 

--- a/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/connect_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/openid_connect/connect_test.exs
@@ -163,8 +163,10 @@ defmodule Web.Live.Settings.IdentityProviders.OpenIDConnect.Connect do
         )
 
       {token, _claims} = Mocks.OpenIDConnect.generate_openid_connect_token(provider, identity)
-      Mocks.OpenIDConnect.expect_refresh_token(bypass, %{"id_token" => token})
-      Mocks.OpenIDConnect.expect_userinfo(bypass)
+
+      bypass
+      |> Mocks.OpenIDConnect.expect_refresh_token(%{"id_token" => token})
+      |> Mocks.OpenIDConnect.expect_userinfo()
 
       cookie_key = "fz_auth_state_#{provider.id}"
       redirected_conn = fetch_cookies(redirected_conn)


### PR DESCRIPTION
There seems to be some kind of race condition when calling `Bypass.expect/4` in quick succession with the same `bypass` var. This causes some interceptions to fail, causing flaky tests.

To fix this, we chain the `bypass` objects together between uses.

