### PR TITLE
fix(portal): update non-root layout to use main.css

### DIFF
--- a/elixir/apps/web/lib/web/controllers/error_html/404.html.heex
+++ b/elixir/apps/web/lib/web/controllers/error_html/404.html.heex
@@ -17,6 +17,12 @@
       nonce={@conn.private.csp_nonce}
       href={~p"/assets/app.css"}
     />
+    <link
+      phx-track-static
+      rel="stylesheet"
+      nonce={@conn.private.csp_nonce}
+      href={~p"/assets/main.css"}
+    />
     <script
       defer
       phx-track-static

--- a/elixir/apps/web/lib/web/controllers/error_html/500.html.heex
+++ b/elixir/apps/web/lib/web/controllers/error_html/500.html.heex
@@ -17,6 +17,12 @@
       nonce={@conn.private.csp_nonce}
       href={~p"/assets/app.css"}
     />
+    <link
+      phx-track-static
+      rel="stylesheet"
+      nonce={@conn.private.csp_nonce}
+      href={~p"/assets/main.css"}
+    />
     <script
       defer
       phx-track-static

--- a/elixir/apps/web/lib/web/controllers/sign_in_html.ex
+++ b/elixir/apps/web/lib/web/controllers/sign_in_html.ex
@@ -25,6 +25,12 @@ defmodule Web.SignInHTML do
           nonce={@conn.private.csp_nonce}
           href={~p"/assets/app.css"}
         />
+        <link
+          phx-track-static
+          rel="stylesheet"
+          nonce={@conn.private.csp_nonce}
+          href={~p"/assets/main.css"}
+        />
       </head>
       <body class="bg-neutral-50">
         <main class="h-auto pt-16">


### PR DESCRIPTION
After updating the CSS config to use `main.css` in the portal the root layout was updated, but there were a small number of one-off templates that do not use the root layout and those pages were not updated with the new `main.css` file.  This commit updates those non-root templates.

Fixes #9532 