### PR TITLE
fix(gui-client): remove bad hook dependencies

### DIFF
--- a/rust/gui-client/src-frontend/components/App.tsx
+++ b/rust/gui-client/src-frontend/components/App.tsx
@@ -92,7 +92,7 @@ export default function App() {
       advancedSettingsChangedUnlisten.then((unlistenFn) => unlistenFn());
       logsRecountedUnlisten.then((unlistenFn) => unlistenFn());
     };
-  }, [location, handleClick]);
+  }, []);
 
   const isDev = import.meta.env.DEV;
 

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,11 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9537">
+          Fixes an issue that caused increased CPU and memory consumption.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.2" date={new Date("2025-06-12")}>
         <ChangeItem pull="8160">
           Moves network change listening to the tunnel service for improved


### PR DESCRIPTION
The removed hook dependencies are invalid because the side-effect specified in `useEffect` does in fact not depend on them. However, as a result of these dependencies, the `useEffect` closure appears to run in an end-less loop, constantly sending the `update_state` command to the backend which in turn re-sends all state to the frontend, causing a massive CPU and memory spike.

Resolves: #9519