### PR TITLE
chore(gateway): set account-slug in telemetry context

### DIFF
--- a/rust/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/connlib/tunnel/src/messages/gateway.rs
@@ -120,6 +120,8 @@ pub struct InitGateway {
     pub config: Config,
     #[serde(default)]
     pub relays: Vec<Relay>,
+    #[serde(default)]
+    pub account_slug: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -5,6 +5,7 @@ use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
 use dns_types::DomainName;
 use firezone_bin_shared::TunDeviceManager;
 use firezone_logging::telemetry_span;
+use firezone_telemetry::Telemetry;
 use firezone_tunnel::messages::gateway::{
     AllowAccess, ClientIceCandidates, ClientsIceCandidates, ConnectionReady, EgressMessages,
     IngressMessages, RejectAccess, RequestConnection,
@@ -377,6 +378,10 @@ impl Eventloop {
                 msg: IngressMessages::Init(init),
                 ..
             } => {
+                if let Some(account_slug) = init.account_slug {
+                    Telemetry::set_account_slug(account_slug);
+                }
+
                 self.tunnel.state_mut().update_relays(
                     BTreeSet::default(),
                     firezone_tunnel::turn(&init.relays),


### PR DESCRIPTION
This PR adds an optional field `account_slug` to the Gateway's init message. If populated, we will use this field to set the account-slug in the telemetry context. This will allow us to know, which customers a particular Sentry issue is related to.