### PR TITLE
chore(telemetry): rate limit identical events to 1 per 5min

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2520,6 +2520,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ip-packet",
+ "moka",
  "opentelemetry",
  "opentelemetry_sdk",
  "parking_lot",

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 ip-packet = { workspace = true }
+moka = { workspace = true, features = ["sync"] }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 parking_lot = { workspace = true }


### PR DESCRIPTION
It is in the nature of our application that errors may occur in rapid succession if anything in the packet processing path fails. Most of the time, these repeated errors don't add any additional information so reporting one of them to Sentry is more than enough.

To achieve this, we add a `before_send` callback that utilizes a concurrent cache with an upper bound of 10000 items and a TTL of 5 minutes. In other words, if we have submitted an event to Sentry that had the exact same message in the last 5 minutes, we will not send it.

Internally, `moka` uses a concurrent hash map and therefore, the key is hashed and not actually stored. Hash codes are u64, meaning the memory footprint of this cache is only ~ 64kb (not accounting for constant overhead of the cache internals).