### PR TITLE
chore(client,gateway): log portal connection hiccups on INFO

### DIFF
--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -255,7 +255,11 @@ impl Eventloop {
                 backoff,
                 max_elapsed_time,
                 error,
-            } => tracing::debug!(?backoff, ?max_elapsed_time, "{error:#}"),
+            } => tracing::info!(
+                ?backoff,
+                ?max_elapsed_time,
+                "Hiccup in portal connection: {error:#}"
+            ),
         }
     }
 

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -433,7 +433,11 @@ impl Eventloop {
                 backoff,
                 max_elapsed_time,
                 error,
-            } => tracing::debug!(?backoff, ?max_elapsed_time, "{error:#}"),
+            } => tracing::info!(
+                ?backoff,
+                ?max_elapsed_time,
+                "Hiccup in portal connection: {error:#}"
+            ),
         }
     }
 


### PR DESCRIPTION
These don't happen very often so are safe to log on INFO. That is the default log level and it is useful to see, why we are re-connecting to the portal.