### PR TITLE
fix(portal): fix problem_nodes removal

### DIFF
--- a/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
+++ b/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
@@ -58,6 +58,8 @@ defmodule Domain.Cluster.GoogleComputeLabelsStrategy do
           Map.put(state, :connected_nodes, nodes)
 
         {:error, problem_nodes} ->
+          problem_nodes = Enum.map(problem_nodes, &elem(&1, 0))
+
           state = Map.put(state, :connected_nodes, nodes -- problem_nodes)
 
           # Expected during deploy as the list of nodes received does not factor in the health check


### PR DESCRIPTION
The shape of this from libcluster is `[:"NODE_NAME": connected_bool?]` so we need to extract the first element of each item before using this var.

This is just for logging and doesn't affect how we actually connect to nodes.