### PR TITLE
feat(portal): conditional migrations on prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       RELEASE_HOSTNAME: "web.cluster.local"
       RELEASE_NAME: "web"
       # Database
+      RUN_CONDITIONAL_MIGRATIONS: "true"
       DATABASE_HOST: postgres
       DATABASE_PORT: 5432
       DATABASE_NAME: firezone_dev
@@ -147,6 +148,7 @@ services:
       RELEASE_HOSTNAME: "api.cluster.local"
       RELEASE_NAME: "api"
       # Database
+      RUN_CONDITIONAL_MIGRATIONS: "true"
       DATABASE_HOST: postgres
       DATABASE_PORT: 5432
       DATABASE_NAME: firezone_dev
@@ -211,6 +213,7 @@ services:
       RELEASE_HOSTNAME: "domain.cluster.local"
       RELEASE_NAME: "domain"
       # Database
+      RUN_CONDITIONAL_MIGRATIONS: "true"
       DATABASE_HOST: postgres
       DATABASE_PORT: 5432
       DATABASE_NAME: firezone_dev
@@ -279,6 +282,7 @@ services:
       RELEASE_HOSTNAME: "mix.cluster.local"
       RELEASE_NAME: "mix"
       # Database
+      RUN_CONDITIONAL_MIGRATIONS: "true"
       DATABASE_HOST: postgres
       DATABASE_PORT: 5432
       DATABASE_NAME: firezone_dev

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -263,6 +263,12 @@ defmodule Domain.Config.Definitions do
   ##############################################
 
   @doc """
+  Whether to run migrations in the priv/repo/conditional_migrations directory.
+  If set to false, these migrations must be manually run from an IEx shell.
+  """
+  defconfig(:run_conditional_migrations, :boolean, default: false)
+
+  @doc """
   PostgreSQL host.
   """
   defconfig(:database_host, :string, default: "postgres")

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -17,6 +17,9 @@ config :domain, generators: [binary_id: true, context_app: :domain]
 
 config :domain, sql_sandbox: false
 
+# Don't run conditional migrations by default
+config :domain, run_conditional_migrations: false
+
 config :domain, Domain.Repo,
   hostname: "localhost",
   username: "postgres",

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -13,6 +13,8 @@ config :domain, Domain.Repo,
 
 config :domain, outbound_email_adapter_configured?: true
 
+config :domain, run_conditional_migrations: false
+
 config :domain, Domain.Billing,
   enabled: System.get_env("BILLING_ENABLED", "false") == "true",
   secret_key: System.get_env("STRIPE_SECRET_KEY", "sk_dev_1111"),

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -13,7 +13,7 @@ config :domain, Domain.Repo,
 
 config :domain, outbound_email_adapter_configured?: true
 
-config :domain, run_conditional_migrations: false
+config :domain, run_conditional_migrations: true
 
 config :domain, Domain.Billing,
   enabled: System.get_env("BILLING_ENABLED", "false") == "true",

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -42,6 +42,8 @@ if config_env() == :prod do
       database: compile_config!(:database_name)
     ]
 
+  config :domain, run_conditional_migrations: compile_config!(:run_conditional_migrations)
+
   config :domain, Domain.Tokens,
     key_base: compile_config!(:tokens_key_base),
     salt: compile_config!(:tokens_salt)

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -13,6 +13,8 @@ partition_suffix =
 
 config :domain, sql_sandbox: true
 
+config :domain, run_conditional_migrations: true
+
 config :domain, Domain.Repo,
   database: "firezone_test#{partition_suffix}",
   pool: Ecto.Adapters.SQL.Sandbox,

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -55,8 +55,17 @@ defmodule Firezone.MixProject do
   end
 
   defp aliases do
+    migration_args =
+      "--migrations-path apps/domain/priv/repo/migrations --migrations-path apps/domain/priv/repo/conditional_migrations"
+
     [
-      "ecto.seed": ["ecto.create", "ecto.migrate", "run apps/domain/priv/repo/seeds.exs"],
+      "ecto.migrate": ["ecto.migrate #{migration_args}"],
+      "ecto.rollback": ["ecto.rollback #{migration_args}"],
+      "ecto.seed": [
+        "ecto.create",
+        "ecto.migrate #{migration_args}",
+        "run apps/domain/priv/repo/seeds.exs"
+      ],
       "ecto.setup": ["ecto.create", "ecto.migrate"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       sobelow: ["cmd mix sobelow"],


### PR DESCRIPTION
Some migrations take a long time to run because they require locks or modify large amounts of data. To prevent this from causing issues during deploy, we leverage Ecto's native support for loading migrations from multiple directories to introduce a `conditional_migrations/` directory that houses any conditional migrations we want to run.

To run these migrations, you'll need to do one of the following:

- `dev, test`: The `mix ecto.migrate` will run them by default because we have aliased this to load conditional_migrations for dev
- `prod`: Set the `RUN_CONDITIONAL_MIGRATIONS` env var to `true` before starting a prod server using the `bin/migrate` script.
- `dev, test, prod`: Run `Domain.Release.migrate(conditional: true)` from an IEx shell.

If conditional migrations were found that weren't executed during `Domain.Release.migrate`, a warning is logged to remind us to run them.