### PR TITLE
chore(rust): bump str0m

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6817,8 +6817,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.8.0"
-source = "git+https://github.com/algesten/str0m?branch=main#a5b57274f5d726e15a254ef2864fe929181f0f3b"
+version = "0.9.0"
+source = "git+https://github.com/algesten/str0m?branch=main#ae56ce32718c0646a67c16bb58f8dd6e3c380658"
 dependencies = [
  "combine",
  "crc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -152,7 +152,7 @@ snownet = { path = "connlib/snownet" }
 socket-factory = { path = "connlib/socket-factory" }
 socket2 = { version = "0.5" }
 static_assertions = "1.1.0"
-str0m = { version = "0.8.0", default-features = false, features = ["sha1"] }
+str0m = { version = "0.9.0", default-features = false, features = ["sha1"] }
 strum = { version = "0.27.1", features = ["derive"] }
 stun_codec = "0.4.0"
 subprocess = "0.2.9"

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1307,7 +1307,7 @@ fn relay_candidate(
             return None;
         };
 
-        let new_candidate = match Candidate::relayed(addr, local, Protocol::Udp) {
+        let new_candidate = match Candidate::relayed(addr, Protocol::Udp, local) {
             Ok(c) => c,
             Err(e) => {
                 tracing::debug!(
@@ -2117,7 +2117,7 @@ mod tests {
         assert_eq!(
             next_event,
             Some(Event::New(
-                Candidate::relayed(RELAY_ADDR_IP4, PEER1, Protocol::Udp).unwrap()
+                Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp, PEER1).unwrap()
             ))
         );
         let next_event = allocation.poll_event();
@@ -2164,13 +2164,13 @@ mod tests {
         assert_eq!(
             allocation.poll_event(),
             Some(Event::Invalid(
-                Candidate::relayed(RELAY_ADDR_IP4, PEER1, Protocol::Udp).unwrap()
+                Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp, PEER1).unwrap()
             ))
         );
         assert_eq!(
             allocation.poll_event(),
             Some(Event::Invalid(
-                Candidate::relayed(RELAY_ADDR_IP6, PEER1, Protocol::Udp).unwrap()
+                Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp, PEER1).unwrap()
             ))
         );
         assert!(allocation.poll_event().is_none());
@@ -2481,8 +2481,8 @@ mod tests {
         assert_eq!(
             iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>(),
             vec![
-                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP4, PEER1, Protocol::Udp).unwrap()),
-                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP6, PEER1, Protocol::Udp).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp, PEER1).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp, PEER1).unwrap()),
             ]
         )
     }
@@ -2501,8 +2501,8 @@ mod tests {
         assert_eq!(
             iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>(),
             vec![
-                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP4, PEER1, Protocol::Udp).unwrap()),
-                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP6, PEER1, Protocol::Udp).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp, PEER1).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp, PEER1).unwrap()),
             ]
         )
     }
@@ -2533,8 +2533,8 @@ mod tests {
         assert_eq!(
             iter::from_fn(|| allocation.poll_event()).collect::<Vec<_>>(),
             vec![
-                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP4, PEER1, Protocol::Udp).unwrap()),
-                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP6, PEER1, Protocol::Udp).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP4, Protocol::Udp, PEER1).unwrap()),
+                Event::Invalid(Candidate::relayed(RELAY_ADDR_IP6, Protocol::Udp, PEER1).unwrap()),
             ]
         );
         assert_eq!(

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -22,8 +22,8 @@ export default function Android() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="9564">
-          Fixes an issue where connections would fail to establish if
-          both Client and Gateway were behind symmetric NAT.
+          Fixes an issue where connections would fail to establish if both
+          Client and Gateway were behind symmetric NAT.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.5.1" date={new Date("2025-06-04")}>

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -20,7 +20,12 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9564">
+          Fixes an issue where connections would fail to establish if
+          both Client and Gateway were behind symmetric NAT.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.1" date={new Date("2025-06-04")}>
         <ChangeItem pull="9394">
           Fixes a minor issue that would cause background service panic when

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9564">
+          Fixes an issue where connections would fail to establish if
+          both Client and Gateway were behind symmetric NAT.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.2" date={new Date("2025-06-03")}>
         <ChangeItem pull="9300">
           Uses the new IP stack setting for DNS resources, which allows DNS

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -26,8 +26,8 @@ export default function Apple() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="9564">
-          Fixes an issue where connections would fail to establish if
-          both Client and Gateway were behind symmetric NAT.
+          Fixes an issue where connections would fail to establish if both
+          Client and Gateway were behind symmetric NAT.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.5.2" date={new Date("2025-06-03")}>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -12,8 +12,8 @@ export default function GUI({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="9564">
-          Fixes an issue where connections would fail to establish if
-          both Client and Gateway were behind symmetric NAT.
+          Fixes an issue where connections would fail to establish if both
+          Client and Gateway were behind symmetric NAT.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.5.3" date={new Date("2025-06-16")}>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,12 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9564">
+          Fixes an issue where connections would fail to establish if
+          both Client and Gateway were behind symmetric NAT.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.3" date={new Date("2025-06-16")}>
         <ChangeItem pull="9537">
           Fixes an issue that caused increased CPU and memory consumption.

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9564">
+          Fixes an issue where connections would fail to establish if
+          both Client and Gateway were behind symmetric NAT.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.10" date={new Date("2025-06-05")}>
         <ChangeItem pull="9147">
           Fixes an issue where connections failed to establish on machines with

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -24,8 +24,8 @@ export default function Gateway() {
     <Entries downloadLinks={downloadLinks} title="Gateway">
       <Unreleased>
         <ChangeItem pull="9564">
-          Fixes an issue where connections would fail to establish if
-          both Client and Gateway were behind symmetric NAT.
+          Fixes an issue where connections would fail to establish if both
+          Client and Gateway were behind symmetric NAT.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.4.10" date={new Date("2025-06-05")}>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -11,8 +11,8 @@ export default function Headless({ os }: { os: OS }) {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="9564">
-          Fixes an issue where connections would fail to establish if
-          both Client and Gateway were behind symmetric NAT.
+          Fixes an issue where connections would fail to establish if both
+          Client and Gateway were behind symmetric NAT.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.5.0" date={new Date("2025-06-05")}>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -9,7 +9,12 @@ export default function Headless({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9564">
+          Fixes an issue where connections would fail to establish if
+          both Client and Gateway were behind symmetric NAT.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.0" date={new Date("2025-06-05")}>
         <ChangeItem pull="9300">
           Uses the new IP stack setting for DNS resources, which allows DNS


### PR DESCRIPTION
The recent changes to str0m include a bug fix for network constellations where both peers are behind symmetric NAT and therefore need a relay-relay candidate pair to succeed. In the current version, such candidate pairs would erroneously be rejected as redundant with host candidates.

Fixes: #9514