### PR TITLE
chore(apple): add `.swift-format` file

### DIFF
--- a/swift/apple/.swift-format
+++ b/swift/apple/.swift-format
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "indentation": {
+        "spaces": 2
+    }
+}


### PR DESCRIPTION
When using alternative editors other than Xcode, Intellisense is usually provided by `sourcekit-lsp`. The LSP server also uses `swift-format` under the hood to format the code but appears to default to using 4 spaces for indentation. In order to standardise on how much indentation is used, we add a `.swift-format` file that specifies is.