### PR TITLE
feat(snownet): increase ICE timeout

### DIFF
--- a/rust/connlib/snownet/src/backoff.rs
+++ b/rust/connlib/snownet/src/backoff.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 const MULTIPLIER: f32 = 1.5;
-const MAX_ELAPSED_TIME: Duration = Duration::from_secs(8);
+const MAX_ELAPSED_TIME: Duration = Duration::from_secs(15);
 
 #[derive(Debug)]
 pub struct ExponentialBackoff {
@@ -53,7 +53,7 @@ pub fn new(now: Instant, interval: Duration) -> ExponentialBackoff {
 ///
 /// The current strategy is multiplying the previous interval by 1.5 and adding them up.
 #[cfg(test)]
-pub fn steps(start: Instant) -> [Instant; 4] {
+pub fn steps(start: Instant) -> [Instant; 6] {
     fn secs(secs: f64) -> Duration {
         Duration::from_nanos((secs * 1_000_000_000.0) as u64)
     }
@@ -63,6 +63,8 @@ pub fn steps(start: Instant) -> [Instant; 4] {
         start + secs(1.0 + 1.5),
         start + secs(1.0 + 1.5 + 2.25),
         start + secs(1.0 + 1.5 + 2.25 + 3.375),
+        start + secs(1.0 + 1.5 + 2.25 + 3.375 + 5.0625),
+        start + secs(1.0 + 1.5 + 2.25 + 3.375 + 5.0625 + 7.59375),
     ]
 }
 

--- a/rust/connlib/snownet/src/backoff.rs
+++ b/rust/connlib/snownet/src/backoff.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 const MULTIPLIER: f32 = 1.5;
-const MAX_ELAPSED_TIME: Duration = Duration::from_secs(15);
+const MAX_ELAPSED_TIME: Duration = Duration::from_secs(8);
 
 #[derive(Debug)]
 pub struct ExponentialBackoff {
@@ -53,7 +53,7 @@ pub fn new(now: Instant, interval: Duration) -> ExponentialBackoff {
 ///
 /// The current strategy is multiplying the previous interval by 1.5 and adding them up.
 #[cfg(test)]
-pub fn steps(start: Instant) -> [Instant; 6] {
+pub fn steps(start: Instant) -> [Instant; 4] {
     fn secs(secs: f64) -> Duration {
         Duration::from_nanos((secs * 1_000_000_000.0) as u64)
     }
@@ -63,8 +63,6 @@ pub fn steps(start: Instant) -> [Instant; 6] {
         start + secs(1.0 + 1.5),
         start + secs(1.0 + 1.5 + 2.25),
         start + secs(1.0 + 1.5 + 2.25 + 3.375),
-        start + secs(1.0 + 1.5 + 2.25 + 3.375 + 5.0625),
-        start + secs(1.0 + 1.5 + 2.25 + 3.375 + 5.0625 + 7.59375),
     ]
 }
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2239,7 +2239,7 @@ fn new_agent() -> IceAgent {
 }
 
 fn apply_default_stun_timings(agent: &mut IceAgent) {
-    agent.set_max_stun_retransmits(8);
+    agent.set_max_stun_retransmits(12);
     agent.set_max_stun_rto(Duration::from_millis(1500));
     agent.set_initial_stun_rto(Duration::from_millis(250))
 }
@@ -2282,7 +2282,7 @@ mod tests {
 
         apply_default_stun_timings(&mut agent);
 
-        assert_eq!(agent.ice_timeout(), Duration::from_millis(9250))
+        assert_eq!(agent.ice_timeout(), Duration::from_millis(15250))
     }
 
     #[test]

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -382,9 +382,9 @@ impl TunnelTest {
     ///
     /// Consequently, this function needs to loop until no host can make progress at which point we consider the [`Transition`] complete.
     ///
-    /// At most, we will spend 10s of "simulation time" advancing the state.
+    /// At most, we will spend 20s of "simulation time" advancing the state.
     fn advance(&mut self, ref_state: &ReferenceState, buffered_transmits: &mut BufferedTransmits) {
-        let cut_off = self.flux_capacitor.now::<Instant>() + Duration::from_secs(10);
+        let cut_off = self.flux_capacitor.now::<Instant>() + Duration::from_secs(20);
 
         'outer: while self.flux_capacitor.now::<Instant>() < cut_off {
             let now = self.flux_capacitor.now();


### PR DESCRIPTION
Some of our users are facing issues on what looks to be very unreliable network connections. At present, we consider a connection dead if we don't receive a response within 9.25 seconds. Cutting a connection and re-establishing it _should_ not be a problem in general and TCP connections happening through Firezone should resume gracefully. Further work on whether that is actually the case is due in #9531. Until then, we increase the ICE timeout to ~15s.

Related: #9526