### PR TITLE
feat(snownet): decrease idle connection ICE timeout

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2246,8 +2246,8 @@ fn apply_default_stun_timings(agent: &mut IceAgent) {
 
 fn apply_idle_stun_timings(agent: &mut IceAgent) {
     agent.set_max_stun_retransmits(4);
-    agent.set_max_stun_rto(Duration::from_secs(60));
-    agent.set_initial_stun_rto(Duration::from_secs(60));
+    agent.set_max_stun_rto(Duration::from_secs(25));
+    agent.set_initial_stun_rto(Duration::from_secs(25));
 }
 
 /// A session ID is constant for as long as a [`Node`] is operational.
@@ -2291,6 +2291,6 @@ mod tests {
 
         apply_idle_stun_timings(&mut agent);
 
-        assert_eq!(agent.ice_timeout(), Duration::from_secs(240))
+        assert_eq!(agent.ice_timeout(), Duration::from_secs(100))
     }
 }


### PR DESCRIPTION
Any well-behaved NAT should keep the port mappings of an established UDP connection open for 120s, even without seeing any traffic. Not all NATs in the wild are well-behaved though and a discarded port mapping causes connectivity loss for customers.

To combat these situations, we decrease the timer for STUN probes on idle connections from 60s to 25s.

Related: #9526