### PR TITLE
feat(portal): populate otel resource attributes

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -227,7 +227,17 @@ if config_env() == :prod do
   ###############################
 
   if System.get_env("OTLP_ENDPOINT") do
-    config :opentelemetry, resource_detectors: [:otel_resource_env_var, :otel_resource_app_env]
+    config :opentelemetry,
+      resource_detectors: [:otel_resource_env_var, :otel_resource_app_env],
+      resource: %{
+        service: %{
+          # These are populated on our GCP VMs
+          name: System.get_env("APPLICATION_NAME"),
+          namespace: System.get_env("GCP_PROJECT_ID"),
+          version: System.get_env("RELEASE_VSN"),
+          instance: %{id: System.get_env("GCP_INSTANCE_NAME")}
+        }
+      }
 
     config :opentelemetry,
       span_processor: :batch,


### PR DESCRIPTION
If the otel collector runs on a different node from the elixir apps, these won't be set anymore.

Luckily, all of the info we need is already in the application's env, so we can simply copy them over to the needed attributes.

Related: https://github.com/firezone/infra/pull/47
Related: https://github.com/firezone/infra/pull/47#discussion_r2149291472
Related: https://opentelemetry.io/docs/languages/erlang/resources/#adding-resources-with-os-and-otp-application-environment-variables
Related: https://opentelemetry.io/docs/specs/semconv/resource/#service