### PR TITLE
feat(portal): add OIDC claims logger

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/openid_connect.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/openid_connect.ex
@@ -351,17 +351,9 @@ defmodule Domain.Auth.Adapters.OpenIDConnect do
   defp parse_jwt(token) do
     {:ok, JOSE.JWT.peek(token)}
   rescue
-    ae in ArgumentError ->
-      Logger.info("Arg Error", reason: inspect(ae))
-      {:error, "Could not parse token"}
-
-    de in Jason.DecodeError ->
-      Logger.info("Decode Error", reason: inspect(de))
-      {:error, "Could not decode token json"}
-
-    other ->
-      Logger.info("Unknown error while parsing jwt", reason: inspect(other))
-      {:error, "Unknown error while parsing jwt"}
+    ArgumentError -> {:error, "Could not parse token"}
+    Jason.DecodeError -> {:error, "Could not decode token json"}
+    other -> {:error, "Unknown error while parsing jwt"}
   end
 
   defp fetch_userinfo(config, tokens) do

--- a/elixir/apps/domain/lib/domain/auth/adapters/openid_connect.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/openid_connect.ex
@@ -333,25 +333,15 @@ defmodule Domain.Auth.Adapters.OpenIDConnect do
         access_token: inspect(access_token.fields)
       )
 
-      Logger.info(inspect(access_token.fields))
-
       Logger.info("ID Token Claims",
         provider_id: provider.id,
         id_token: inspect(id_token.fields)
       )
-
-      Logger.info(inspect(id_token.fields))
     else
       {:error, reason} ->
         Logger.info("Error parsing JWT",
           provider_id: provider.id,
           reason: inspect(reason)
-        )
-
-      other ->
-        Logger.info("Error parsing JWT",
-          provider_id: provider.id,
-          reason: inspect(other)
         )
     end
 
@@ -361,9 +351,17 @@ defmodule Domain.Auth.Adapters.OpenIDConnect do
   defp parse_jwt(token) do
     {:ok, JOSE.JWT.peek(token)}
   rescue
-    ArgumentError -> {:error, "Could not parse token"}
-    Jason.DecodeError -> {:error, "Could not decode token json"}
-    _ -> {:error, "Unknown error while parsing jwt"}
+    ae in ArgumentError ->
+      Logger.info("Arg Error", reason: inspect(ae))
+      {:error, "Could not parse token"}
+
+    de in Jason.DecodeError ->
+      Logger.info("Decode Error", reason: inspect(de))
+      {:error, "Could not decode token json"}
+
+    other ->
+      Logger.info("Unknown error while parsing jwt", reason: inspect(other))
+      {:error, "Unknown error while parsing jwt"}
   end
 
   defp fetch_userinfo(config, tokens) do


### PR DESCRIPTION
Why:

* To help better debug OIDC provider connection issues a claims logger has been added during the Auth Provider connect step.  This will allow us to see if there are any unexpected claims being sent back from the IdP during the setup of the Auth Provider.