### PR TITLE
fix(portal): ensure sentry reports conditional migrations

### DIFF
--- a/elixir/apps/domain/lib/domain/release.ex
+++ b/elixir/apps/domain/lib/domain/release.ex
@@ -5,11 +5,17 @@ defmodule Domain.Release do
   @repos Application.compile_env!(@otp_app, :ecto_repos)
 
   def migrate(opts \\ []) do
+    Application.ensure_all_started(:sentry)
+
     conditional =
       Keyword.get(
         opts,
         :conditional,
-        Application.get_env(:domain, :run_conditional_migrations, false)
+        Application.get_env(
+          :domain,
+          :run_conditional_migrations,
+          System.get_env("RUN_CONDITIONAL_MIGRATIONS") == "true"
+        )
       )
 
     for repo <- @repos do
@@ -63,7 +69,7 @@ defmodule Domain.Release do
     Ecto.Migrator.with_repo(repo, fn repo ->
       Ecto.Migrator.run(repo, paths, :up, all: true)
 
-      if conditional do
+      unless conditional do
         check_pending_conditional_migrations(@otp_app, repo)
       end
     end)
@@ -80,17 +86,30 @@ defmodule Domain.Release do
 
         migrations ->
           # Count pending migrations (status = :down)
-          pending = Enum.count(migrations, fn {status, _, _} -> status == :down end)
-
-          if pending > 0 do
-            Logger.warning("""
-              #{pending} pending conditional migration(s) were not run because run_conditional_migrations is false.
-              Run the following command from an IEx shell when you're ready to execute them:
-
-              Domain.Release.migrate(conditional: true)
-            """)
-          end
+          Enum.count(migrations, fn {status, _, _} -> status == :down end)
+          |> maybe_log_error()
       end
     end
+  end
+
+  defp maybe_log_error(0), do: nil
+
+  defp maybe_log_error(pending) do
+    error = """
+      #{pending} pending conditional migration(s) were not run because run_conditional_migrations is false.
+      Run the following command from an IEx shell when you're ready to execute them:
+
+      Domain.Release.migrate(conditional: true)
+    """
+
+    Logger.error(error)
+
+    # Sentry logger handler may not be fully initialized, so manually send
+    # a message and wait for it to flush.
+    Task.start(fn ->
+      Sentry.capture_message(error)
+    end)
+
+    Process.sleep(1_000)
   end
 end

--- a/elixir/apps/domain/lib/domain/release.ex
+++ b/elixir/apps/domain/lib/domain/release.ex
@@ -5,7 +5,8 @@ defmodule Domain.Release do
   @repos Application.compile_env!(@otp_app, :ecto_repos)
 
   def migrate(opts \\ []) do
-    Application.ensure_all_started(:sentry)
+    IO.puts("Starting sentry app..")
+    {:ok, _} = Application.ensure_all_started(:sentry)
 
     conditional =
       Keyword.get(
@@ -105,7 +106,7 @@ defmodule Domain.Release do
     Logger.error(error)
 
     # Sentry logger handler may not be fully initialized, so manually send
-    # a message and wait for it to flush.
+    # a message and wait for it to send.
     Task.start(fn ->
       Sentry.capture_message(error)
     end)


### PR DESCRIPTION
Sentry isn't started when this runs, so start it and manually capture a message to ensure we're reminded about pending conditional migrations.

Verified that this works with the Release script.