### PR TITLE
fix(ci): lock xcode major

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -27,6 +27,8 @@ jobs:
     name: ${{ matrix.job_name }}
     needs: update-release-draft
     runs-on: macos-15
+    env:
+      XCODE_MAJOR: 16
     permissions:
       contents: write # for attaching the build artifacts to the release
       id-token: write

--- a/scripts/build/lib.sh
+++ b/scripts/build/lib.sh
@@ -10,7 +10,7 @@ function setup_runner() {
     local ne_profile_file="$4"
 
     # Use the latest version of Xcode - matches what we typically use for development
-    sudo xcode-select --switch "$(ls -d /Applications/Xcode*.app | sort -V | tail -n 1)"
+    sudo xcode-select --switch "$(ls -d /Applications/Xcode*${XCODE_MAJOR}*.app | sort -V | tail -n 1)"
 
     # The GitHub runners stopped including the iOS SDK
     xcodebuild -downloadPlatform iOS


### PR DESCRIPTION
Apple won't allow apps built with Xcode betas to be reviewed.

<img width="1146" alt="Screenshot 2025-06-19 at 9 04 17 AM" src="https://github.com/user-attachments/assets/11470f04-603b-4c5c-aad2-fba0e4eb391a" />
