### PR TITLE
fix(portal): trim whitespace in auth provider forms

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/settings/changeset.ex
@@ -19,6 +19,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Settings.Changeset do
       settings
       |> cast(attrs, @fields)
       |> validate_required(@fields)
+      |> trim_fields()
       |> OpenIDConnect.Settings.Changeset.validate_discovery_document_uri()
       |> validate_inclusion(:response_type, ~w[code])
       |> cast_embed(:service_account_json_key,
@@ -35,5 +36,13 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Settings.Changeset do
     key
     |> cast(attrs, @key_fields)
     |> validate_required(@key_fields)
+  end
+
+  defp trim_fields(changeset) do
+    changeset
+    |> Domain.Repo.Changeset.trim_change(:response_type)
+    |> Domain.Repo.Changeset.trim_change(:client_id)
+    |> Domain.Repo.Changeset.trim_change(:client_secret)
+    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/settings/changeset.ex
@@ -19,7 +19,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Settings.Changeset do
       settings
       |> cast(attrs, @fields)
       |> validate_required(@fields)
-      |> trim_fields()
+      |> Domain.Repo.Changeset.trim_change(@fields)
       |> OpenIDConnect.Settings.Changeset.validate_discovery_document_uri()
       |> validate_inclusion(:response_type, ~w[code])
       |> cast_embed(:service_account_json_key,
@@ -36,13 +36,5 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Settings.Changeset do
     key
     |> cast(attrs, @key_fields)
     |> validate_required(@key_fields)
-  end
-
-  defp trim_fields(changeset) do
-    changeset
-    |> Domain.Repo.Changeset.trim_change(:response_type)
-    |> Domain.Repo.Changeset.trim_change(:client_id)
-    |> Domain.Repo.Changeset.trim_change(:client_secret)
-    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/jumpcloud/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/jumpcloud/settings/changeset.ex
@@ -14,20 +14,12 @@ defmodule Domain.Auth.Adapters.JumpCloud.Settings.Changeset do
       settings
       |> cast(attrs, @fields)
       |> validate_required(@fields)
-      |> trim_fields()
+      |> Domain.Repo.Changeset.trim_change(@fields)
       |> OpenIDConnect.Settings.Changeset.validate_discovery_document_uri()
       |> validate_inclusion(:response_type, ~w[code])
 
     Enum.reduce(Settings.scope(), changeset, fn scope, changeset ->
       validate_format(changeset, :scope, ~r/#{scope}/, message: "must include #{scope} scope")
     end)
-  end
-
-  defp trim_fields(changeset) do
-    changeset
-    |> Domain.Repo.Changeset.trim_change(:response_type)
-    |> Domain.Repo.Changeset.trim_change(:client_id)
-    |> Domain.Repo.Changeset.trim_change(:client_secret)
-    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/jumpcloud/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/jumpcloud/settings/changeset.ex
@@ -14,11 +14,20 @@ defmodule Domain.Auth.Adapters.JumpCloud.Settings.Changeset do
       settings
       |> cast(attrs, @fields)
       |> validate_required(@fields)
+      |> trim_fields()
       |> OpenIDConnect.Settings.Changeset.validate_discovery_document_uri()
       |> validate_inclusion(:response_type, ~w[code])
 
     Enum.reduce(Settings.scope(), changeset, fn scope, changeset ->
       validate_format(changeset, :scope, ~r/#{scope}/, message: "must include #{scope} scope")
     end)
+  end
+
+  defp trim_fields(changeset) do
+    changeset
+    |> Domain.Repo.Changeset.trim_change(:response_type)
+    |> Domain.Repo.Changeset.trim_change(:client_id)
+    |> Domain.Repo.Changeset.trim_change(:client_secret)
+    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/settings/changeset.ex
@@ -13,20 +13,12 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Settings.Changeset do
       settings
       |> cast(attrs, @fields)
       |> validate_required(@fields)
-      |> trim_fields()
+      |> Domain.Repo.Changeset.trim_change(@fields)
       |> OpenIDConnect.Settings.Changeset.validate_discovery_document_uri()
       |> validate_inclusion(:response_type, ~w[code])
 
     Enum.reduce(Settings.scope(), changeset, fn scope, changeset ->
       validate_format(changeset, :scope, ~r/#{scope}/, message: "must include #{scope} scope")
     end)
-  end
-
-  defp trim_fields(changeset) do
-    changeset
-    |> Domain.Repo.Changeset.trim_change(:response_type)
-    |> Domain.Repo.Changeset.trim_change(:client_id)
-    |> Domain.Repo.Changeset.trim_change(:client_secret)
-    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/settings/changeset.ex
@@ -13,11 +13,20 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Settings.Changeset do
       settings
       |> cast(attrs, @fields)
       |> validate_required(@fields)
+      |> trim_fields()
       |> OpenIDConnect.Settings.Changeset.validate_discovery_document_uri()
       |> validate_inclusion(:response_type, ~w[code])
 
     Enum.reduce(Settings.scope(), changeset, fn scope, changeset ->
       validate_format(changeset, :scope, ~r/#{scope}/, message: "must include #{scope} scope")
     end)
+  end
+
+  defp trim_fields(changeset) do
+    changeset
+    |> Domain.Repo.Changeset.trim_change(:response_type)
+    |> Domain.Repo.Changeset.trim_change(:client_id)
+    |> Domain.Repo.Changeset.trim_change(:client_secret)
+    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/settings/changeset.ex
@@ -15,22 +15,12 @@ defmodule Domain.Auth.Adapters.Okta.Settings.Changeset do
       settings
       |> cast(attrs, @fields)
       |> validate_required(@fields)
-      |> trim_fields()
+      |> Domain.Repo.Changeset.trim_change(@fields)
       |> OpenIDConnect.Settings.Changeset.validate_discovery_document_uri()
       |> validate_inclusion(:response_type, ~w[code])
 
     Enum.reduce(Settings.scope(), changeset, fn scope, changeset ->
       validate_format(changeset, :scope, ~r/#{scope}/, message: "must include #{scope} scope")
     end)
-  end
-
-  defp trim_fields(changeset) do
-    changeset
-    |> Domain.Repo.Changeset.trim_change(:response_type)
-    |> Domain.Repo.Changeset.trim_change(:client_id)
-    |> Domain.Repo.Changeset.trim_change(:client_secret)
-    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
-    |> Domain.Repo.Changeset.trim_change(:okta_account_domain)
-    |> Domain.Repo.Changeset.trim_change(:api_base_url)
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/settings/changeset.ex
@@ -15,11 +15,22 @@ defmodule Domain.Auth.Adapters.Okta.Settings.Changeset do
       settings
       |> cast(attrs, @fields)
       |> validate_required(@fields)
+      |> trim_fields()
       |> OpenIDConnect.Settings.Changeset.validate_discovery_document_uri()
       |> validate_inclusion(:response_type, ~w[code])
 
     Enum.reduce(Settings.scope(), changeset, fn scope, changeset ->
       validate_format(changeset, :scope, ~r/#{scope}/, message: "must include #{scope} scope")
     end)
+  end
+
+  defp trim_fields(changeset) do
+    changeset
+    |> Domain.Repo.Changeset.trim_change(:response_type)
+    |> Domain.Repo.Changeset.trim_change(:client_id)
+    |> Domain.Repo.Changeset.trim_change(:client_secret)
+    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
+    |> Domain.Repo.Changeset.trim_change(:okta_account_domain)
+    |> Domain.Repo.Changeset.trim_change(:api_base_url)
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
@@ -10,7 +10,7 @@ defmodule Domain.Auth.Adapters.OpenIDConnect.Settings.Changeset do
     struct
     |> cast(attrs, @fields)
     |> validate_required(@fields)
-    |> trim_fields()
+    |> Domain.Repo.Changeset.trim_change(@fields)
     |> validate_discovery_document_uri()
     |> validate_inclusion(:response_type, ~w[code])
     |> validate_format(:scope, ~r/openid/, message: "must include openid scope")
@@ -43,13 +43,5 @@ defmodule Domain.Auth.Adapters.OpenIDConnect.Settings.Changeset do
           [{:discovery_document_uri, "invalid URL"}]
       end
     end)
-  end
-
-  defp trim_fields(changeset) do
-    changeset
-    |> Domain.Repo.Changeset.trim_change(:response_type)
-    |> Domain.Repo.Changeset.trim_change(:client_id)
-    |> Domain.Repo.Changeset.trim_change(:client_secret)
-    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
@@ -10,6 +10,7 @@ defmodule Domain.Auth.Adapters.OpenIDConnect.Settings.Changeset do
     struct
     |> cast(attrs, @fields)
     |> validate_required(@fields)
+    |> trim_fields()
     |> validate_discovery_document_uri()
     |> validate_inclusion(:response_type, ~w[code])
     |> validate_format(:scope, ~r/openid/, message: "must include openid scope")
@@ -42,5 +43,13 @@ defmodule Domain.Auth.Adapters.OpenIDConnect.Settings.Changeset do
           [{:discovery_document_uri, "invalid URL"}]
       end
     end)
+  end
+
+  defp trim_fields(changeset) do
+    changeset
+    |> Domain.Repo.Changeset.trim_change(:response_type)
+    |> Domain.Repo.Changeset.trim_change(:client_id)
+    |> Domain.Repo.Changeset.trim_change(:client_secret)
+    |> Domain.Repo.Changeset.trim_change(:discovery_document_uri)
   end
 end

--- a/elixir/apps/domain/test/domain/auth/adapters/openid_connect_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/openid_connect_test.exs
@@ -112,6 +112,39 @@ defmodule Domain.Auth.Adapters.OpenIDConnectTest do
                "discovery_document_uri" => discovery_document_url
              }
     end
+
+    test "trims whitespace in adapter config" do
+      account = Fixtures.Accounts.create_account()
+      bypass = Domain.Mocks.OpenIDConnect.discovery_document_server()
+      discovery_document_url = "http://localhost:#{bypass.port}/.well-known/openid-configuration"
+
+      attrs =
+        Fixtures.Auth.provider_attrs(
+          adapter: :openid_connect,
+          adapter_config: %{
+            response_type: "   code   ",
+            client_id: "   client_id   ",
+            client_secret: "   client_secret   ",
+            discovery_document_uri: "   " <> discovery_document_url <> "   "
+          }
+        )
+
+      changeset = Ecto.Changeset.change(%Auth.Provider{account_id: account.id}, attrs)
+
+      assert %Ecto.Changeset{} = changeset = provider_changeset(changeset)
+      assert {:ok, provider} = Repo.insert(changeset)
+
+      assert provider.name == attrs.name
+      assert provider.adapter == attrs.adapter
+
+      assert provider.adapter_config == %{
+               "scope" => "openid email profile",
+               "response_type" => "code",
+               "client_id" => "client_id",
+               "client_secret" => "client_secret",
+               "discovery_document_uri" => discovery_document_url
+             }
+    end
   end
 
   describe "ensure_provisioned/1" do


### PR DESCRIPTION
Why:

* We recently had an issue where a space was entered into a provider form field and caused our system to not be able to authenticate the admin when setting up the auth provider and directory sync.  To mitigate this moving forward we are making sure all white space is trimmed in the form fields.  This commit focuses on the form fields for the auth providers.

related: #9579