### PR TITLE
feat(ci): allow winget publish to be run manually

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -1,5 +1,10 @@
 name: Publish to WinGet
 on:
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: "Release name to publish"
+        required: true
   release:
     types:
       - published
@@ -8,6 +13,9 @@ jobs:
   publish_clients:
     name: Publish ${{ matrix.identifier }} to winget
     runs-on: windows-latest
+    permissions:
+      contents: write
+      packages: write
     strategy:
       matrix:
         include:
@@ -18,12 +26,12 @@ jobs:
     steps:
       - id: get-version
         run: |
-          version=${{ github.event.release.name }}
+          version=${{ inputs.release_name || github.event.release.name }}
           version=${version#${{ matrix.tag_prefix }}-}
           echo "version=$version" >> $GITHUB_OUTPUT
         shell: bash
       - uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f # main
-        if: ${{ startsWith(github.event.release.name, matrix.tag_prefix) }}
+        if: ${{ startsWith((inputs.release_name || github.event.release.name), matrix.tag_prefix) }}
         with:
           identifier: ${{ matrix.identifier }}
           version: ${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
- Updates winget publish workflow to be run manually to re-run it after fixes
- Adds write permissions to the workflow