### PR TITLE
ci: fix bad GitHub workflow job id

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
 
-      - id: Create PR
+      - name: Create PR
         if: ${{ startsWith(github.event.release.name, matrix.component) }}
         run: |
           # Extract version from release name


### PR DESCRIPTION
Spaces in `id`s are not allowed. This was intended to be a `name` anyway.