### PR TITLE
feat(connlib): listen on 52625 by default

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -12,6 +12,7 @@ use core::fmt;
 use firezone_logging::err_with_src;
 use hex_display::HexDisplayExt;
 use ip_packet::{ConvertibleIpv4Packet, ConvertibleIpv6Packet, IpPacket, IpPacketBuf};
+use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand::seq::IteratorRandom;
 use rand::{Rng, RngCore, SeedableRng, random};
@@ -357,6 +358,8 @@ where
         };
 
         agent.add_remote_candidate(candidate.clone());
+
+        generate_optimistic_candidates(agent);
 
         match candidate.kind() {
             CandidateKind::Host => {
@@ -1168,6 +1171,64 @@ where
         for candidate in allocation.current_relay_candidates() {
             add_local_candidate(connection, agent, candidate, &mut self.pending_events);
         }
+    }
+}
+
+/// Generate optimistic candidates based on the ones we have already received.
+///
+/// In order to aid the creation of peer-to-peer connections,
+/// we create an additional server-reflexive candidate
+/// for each combination of public IP and host listening port.
+///
+/// IF the listening port of the remote peer happened to be forwarded, this will
+/// allow us to create a direct connection despite the presence of a symmetric NAT.
+///
+/// Consider the following scenario:
+///
+/// - Agent 1 listens on `10.0.0.1:52625` and has a public IP of `1.1.1.1`
+/// - Agent 2 listens on `192.168.0.1:52625` and has a public IP of `2.2.2.2`
+///
+/// Both agents are behind symmetric NAT.
+/// Therefore, the observed port through STUN will not be 52625 but something else entirely.
+/// For this example, let's assume 40000.
+///
+/// Now let's assume that the network administrator forwards port 52625 on one symmetric NAT.
+/// With the below strategy, agent 2 will create an additional server-reflexive candidate
+/// of `1.1.1.1:52625` based on the observed public IP and the port of the host candidate.
+/// This is the port forwarded by the network administrator which will allow the traffic to
+/// flow through to the agent.
+///
+/// In a double symmetric NAT case, this will create a peer-reflexive candidate.
+/// If only one peer is behind symmetric NAT, this creates a predictable path through the NAT.
+///
+/// In both cases, a direct connection will be established and we don't need to fall back to a relay.
+fn generate_optimistic_candidates(agent: &mut IceAgent) {
+    let remote_candidates = agent.remote_candidates();
+
+    let public_ips = remote_candidates
+        .iter()
+        .filter_map(|c| (c.kind() == CandidateKind::ServerReflexive).then_some(c.addr().ip()));
+
+    let host_candidates = remote_candidates
+        .iter()
+        .filter_map(|c| (c.kind() == CandidateKind::Host).then_some(c.addr()));
+
+    let optimistic_candidates = public_ips
+        .cartesian_product(host_candidates)
+        .filter_map(|(ip, base)| {
+            let addr = SocketAddr::new(ip, base.port());
+
+            Candidate::server_reflexive(addr, base, Protocol::Udp)
+                .inspect_err(
+                    |e| tracing::debug!(%addr, %base, "Failed to create optimistic candidate: {e}"),
+                )
+                .ok()
+        })
+        .filter(|c| !remote_candidates.contains(c))
+        .collect::<Vec<_>>();
+
+    for c in optimistic_candidates {
+        agent.add_remote_candidate(c);
     }
 }
 
@@ -2274,6 +2335,8 @@ impl fmt::Display for SessionId {
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+
     use super::*;
 
     #[test]
@@ -2292,5 +2355,26 @@ mod tests {
         apply_idle_stun_timings(&mut agent);
 
         assert_eq!(agent.ice_timeout(), Duration::from_secs(100))
+    }
+
+    #[test]
+    fn generates_correct_optimistic_candidates() {
+        let base = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 52625));
+        let addr = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
+
+        let host = Candidate::host(base, "udp").unwrap();
+        let srvflx =
+            Candidate::server_reflexive(SocketAddr::new(addr, 40000), base, "udp").unwrap();
+
+        let mut agent = IceAgent::new();
+        agent.add_remote_candidate(host);
+        agent.add_remote_candidate(srvflx);
+
+        generate_optimistic_candidates(&mut agent);
+
+        let expected_candidate =
+            Candidate::server_reflexive(SocketAddr::new(addr, 52625), base, "udp").unwrap();
+
+        assert!(agent.remote_candidates().contains(&expected_candidate))
     }
 }

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -640,14 +640,13 @@ impl ReferenceState {
                     && has_dns_server
                     && gateway_is_present_in_case_dns_server_is_cidr_resource
             }),
-            Transition::RoamClient { ip4, ip6, port } => {
+            Transition::RoamClient { ip4, ip6 } => {
                 // In production, we always rebind to a new port so we never roam to our old existing IP / port combination.
 
                 let is_assigned_ip4 = ip4.is_some_and(|ip| state.network.contains(ip));
                 let is_assigned_ip6 = ip6.is_some_and(|ip| state.network.contains(ip));
-                let is_previous_port = state.client.old_ports.contains(port);
 
-                !is_assigned_ip4 && !is_assigned_ip6 && !is_previous_port
+                !is_assigned_ip4 && !is_assigned_ip6
             }
             Transition::ReconnectPortal => true,
             Transition::DeactivateResource(r) => {

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -2,7 +2,7 @@ use super::{
     QueryId,
     dns_records::DnsRecords,
     reference::{PrivateKey, private_key},
-    sim_net::{Host, any_ip_stack, any_port, host},
+    sim_net::{Host, any_ip_stack, host},
     sim_relay::{SimRelay, map_explode},
     strategies::latency,
     transition::{DPort, Destination, DnsQuery, DnsTransport, Identifier, SPort, Seq},
@@ -1107,7 +1107,7 @@ pub(crate) fn ref_client_host(
 ) -> impl Strategy<Value = Host<RefClient>> {
     host(
         any_ip_stack(),
-        any_port(),
+        Just(52625),
         ref_client(
             tunnel_ip4s,
             tunnel_ip6s,

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -2,7 +2,7 @@ use super::{
     dns_records::DnsRecords,
     dns_server_resource::{TcpDnsServerResource, UdpDnsServerResource},
     reference::{PrivateKey, private_key},
-    sim_net::{Host, any_port, dual_ip_stack, host},
+    sim_net::{Host, dual_ip_stack, host},
     sim_relay::{SimRelay, map_explode},
     strategies::latency,
     unreachable_hosts::{IcmpError, UnreachableHosts},
@@ -309,7 +309,7 @@ pub(crate) fn ref_gateway_host(
 ) -> impl Strategy<Value = Host<RefGateway>> {
     host(
         dual_ip_stack(),
-        any_port(),
+        Just(52625),
         ref_gateway(tunnel_ip4s, tunnel_ip6s, site_specific_dns_records),
         latency(200), // We assume gateways have a somewhat decent Internet connection.
     )

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -248,9 +248,9 @@ impl TunnelTest {
                     })
                 });
             }
-            Transition::RoamClient { ip4, ip6, port } => {
+            Transition::RoamClient { ip4, ip6 } => {
                 state.network.remove_host(&state.client);
-                state.client.update_interface(ip4, ip6, port);
+                state.client.update_interface(ip4, ip6);
                 debug_assert!(
                     state
                         .network

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -5,7 +5,7 @@ use crate::{
 use connlib_model::{RelayId, ResourceId};
 use dns_types::{DomainName, RecordType};
 
-use super::sim_net::{Host, any_ip_stack, any_port};
+use super::sim_net::{Host, any_ip_stack};
 use crate::messages::DnsServer;
 use prop::collection;
 use proptest::{prelude::*, sample};
@@ -62,7 +62,6 @@ pub(crate) enum Transition {
     RoamClient {
         ip4: Option<Ipv4Addr>,
         ip6: Option<Ipv6Addr>,
-        port: u16,
     },
 
     /// Reconnect to the portal.
@@ -374,9 +373,8 @@ pub(crate) fn maybe_available_response_rtypes(
 }
 
 pub(crate) fn roam_client() -> impl Strategy<Value = Transition> {
-    (any_ip_stack(), any_port()).prop_map(move |(ip_stack, port)| Transition::RoamClient {
+    (any_ip_stack()).prop_map(move |ip_stack| Transition::RoamClient {
         ip4: ip_stack.as_v4().copied(),
         ip6: ip_stack.as_v6().copied(),
-        port,
     })
 }


### PR DESCRIPTION
Presently, `connlib` always just lets the OS pick a random port for our UDP socket. This works well in many cases but has the downside that IF network admins would like to aid in the process of establishing direct connections, they cannot open a specific port because it is always random.

It doesn't cost us anything to try and bind to a particular port (here 52625) and fallback to a random one if something is listening there.

The port 52625 was chosen because:

- It is within the ephemeral port range and will therefore never be registered to anything else.
- It is an palindrome and therefore easy to remember.
- When typing FIRE on a phone keypad, it you get the numbers 3473. 52625 is the port at the offset 3473 from the ephemeral port range.

In order for this port to be useful in establishing direct connections, we generate optimistic candidates based on existing remote candidates by combining the IP of all server-reflexive candidates with the port of all host candidates.

This patch deliberately does not publicly announce this feature in the docs or the changelog so we can first gather experience with it in our own test environment.

Resolves: #9559