### PR TITLE
ci(windows): try to repair VS installation

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -53,12 +53,6 @@ runs:
       run: Set-MpPreference -DisableRealtimeMonitoring $true
       shell: powershell
 
-    - name: Repair VS installation
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        vs_buildtools.exe --add Microsoft.VisualStudio.Workload.VCTools --quiet --wait --norestart
-      shell: powershell
-
     - name: Extract Rust version
       run: |
         RUST_TOOLCHAIN=$(grep 'channel' rust-toolchain.toml | awk -F '"' '{print $2}')
@@ -87,3 +81,9 @@ runs:
     - name: Start sccache
       run: $SCCACHE_PATH --start-server
       shell: bash
+
+    - name: Repair VS installation
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        vs_buildtools.exe --add Microsoft.VisualStudio.Workload.VCTools --quiet --wait --norestart
+      shell: powershell

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -53,6 +53,12 @@ runs:
       run: Set-MpPreference -DisableRealtimeMonitoring $true
       shell: powershell
 
+    - name: Repair VS installation
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        vs_buildtools.exe --add Microsoft.VisualStudio.Workload.VCTools --quiet --wait --norestart
+      shell: powershell
+
     - name: Extract Rust version
       run: |
         RUST_TOOLCHAIN=$(grep 'channel' rust-toolchain.toml | awk -F '"' '{print $2}')

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -82,6 +82,7 @@ runs:
       run: $SCCACHE_PATH --start-server
       shell: bash
 
-    - name: Repair VS installation
+    - uses: TheMrMilchmann/setup-msvc-dev@v3
       if: ${{ runner.os == 'Windows' }}
-      uses: microsoft/setup-msbuild@v2
+      with:
+        arch: x64

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -84,6 +84,4 @@ runs:
 
     - name: Repair VS installation
       if: ${{ runner.os == 'Windows' }}
-      run: |
-        vs_buildtools.exe --add Microsoft.VisualStudio.Workload.VCTools --quiet --wait --norestart
-      shell: powershell
+      uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
It appears that the latest pre-release image of the Windows runners breaks the Rust installation of the build tools.