### PR TITLE
fix(apple): ensure log file exists before writing to it

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -5,8 +5,8 @@
 //
 
 import FirezoneKit
-import SwiftUI
 import Sentry
+import SwiftUI
 
 @main
 struct FirezoneApp: App {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -143,10 +143,10 @@ public class Configuration: ObservableObject {
     // so this feature only enabled for macOS 13 and higher given the tiny Firezone installbase for macOS 12.
     func updateAppService() async throws {
       if #available(macOS 13.0, *) {
-          // Getting the status initially appears to be blocking sometimes
-          SentrySDK.pauseAppHangTracking()
-          defer { SentrySDK.resumeAppHangTracking() }
-          let status = SMAppService.mainApp.status
+        // Getting the status initially appears to be blocking sometimes
+        SentrySDK.pauseAppHangTracking()
+        defer { SentrySDK.resumeAppHangTracking() }
+        let status = SMAppService.mainApp.status
 
         if !startOnLogin, status == .enabled {
           try await SMAppService.mainApp.unregister()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -5,8 +5,8 @@
 //
 
 import Foundation
-import UserNotifications
 import Sentry
+import UserNotifications
 
 #if os(macOS)
   import AppKit

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/GrantVPNView.swift
@@ -6,8 +6,8 @@
 //
 
 import Combine
-import SwiftUI
 import Sentry
+import SwiftUI
 
 #if os(macOS)
   import SystemExtensions

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/MenuBar.swift
@@ -11,8 +11,8 @@ import Combine
 import Foundation
 import NetworkExtension
 import OSLog
-import SwiftUI
 import Sentry
+import SwiftUI
 
 #if os(macOS)
   @MainActor

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9597">
+          Fixes an issue where certain log files would not be recreated after
+          logs were cleared.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.3" date={new Date("2025-06-19")}>
         <ChangeItem pull="9564">
           Fixes an issue where connections would fail to establish if both


### PR DESCRIPTION
Similar to the issue for the gui clients, the log file handle needs to be able to be rolled over after logs are cleared.

related: #6850 