### PR TITLE
chore(ci): remove write perms on winget workflow

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -13,9 +13,6 @@ jobs:
   publish_clients:
     name: Publish ${{ matrix.identifier }} to winget
     runs-on: windows-latest
-    permissions:
-      contents: write
-      packages: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This wasn't the issue - the issue was that @firezone-bot needed access to the firezone/winget-pkgs repo.