### PR TITLE
fix(portal): broadcast before possible query errors out

### DIFF
--- a/elixir/apps/domain/lib/domain/events/hooks/actor_group_memberships.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/actor_group_memberships.ex
@@ -18,9 +18,9 @@ defmodule Domain.Events.Hooks.ActorGroupMemberships do
   @impl true
   def on_delete(%{"actor_id" => actor_id, "group_id" => group_id} = _old_data) do
     Task.start(fn ->
-      {:ok, _flows} = Flows.expire_flows_for(actor_id, group_id)
       :ok = PubSub.Actor.Memberships.broadcast(actor_id, {:delete_membership, actor_id, group_id})
       broadcast_access(:reject, actor_id, group_id)
+      {:ok, _flows} = Flows.expire_flows_for(actor_id, group_id)
     end)
 
     :ok

--- a/elixir/apps/domain/lib/domain/events/hooks/policies.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/policies.ex
@@ -60,8 +60,6 @@ defmodule Domain.Events.Hooks.Policies do
       )
       when not is_nil(disabled_at) do
     Task.start(fn ->
-      Flows.expire_flows_for_policy_id(policy_id)
-
       # TODO: WAL
       # Disabling a policy should broadcast directly to the subscribed clients/gateways
       payload = {:disable_policy, policy_id}
@@ -70,6 +68,8 @@ defmodule Domain.Events.Hooks.Policies do
 
       payload = {:reject_access, policy_id, actor_group_id, resource_id}
       :ok = PubSub.ActorGroup.Policies.broadcast(actor_group_id, payload)
+
+      Flows.expire_flows_for_policy_id(policy_id)
     end)
 
     :ok
@@ -108,8 +108,6 @@ defmodule Domain.Events.Hooks.Policies do
     # Only act upon this if the policy is not deleted or disabled
     if is_nil(data["deleted_at"]) and is_nil(data["disabled_at"]) do
       Task.start(fn ->
-        Flows.expire_flows_for_policy_id(policy_id)
-
         # TODO: WAL
         # Deleting a policy should broadcast directly to the subscribed clients/gateways
         payload = {:delete_policy, old_policy_id}
@@ -125,6 +123,8 @@ defmodule Domain.Events.Hooks.Policies do
 
         payload = {:allow_access, policy_id, actor_group_id, resource_id}
         :ok = PubSub.ActorGroup.Policies.broadcast(actor_group_id, payload)
+
+        Flows.expire_flows_for_policy_id(policy_id)
       end)
     else
       Logger.warning("Breaking update ignored for policy as it is deleted or disabled",
@@ -152,8 +152,6 @@ defmodule Domain.Events.Hooks.Policies do
         } = _old_data
       ) do
     Task.start(fn ->
-      Flows.expire_flows_for_policy_id(policy_id)
-
       # TODO: WAL
       # Deleting a policy should broadcast directly to the subscribed clients/gateways
       payload = {:delete_policy, policy_id}
@@ -162,6 +160,8 @@ defmodule Domain.Events.Hooks.Policies do
 
       payload = {:reject_access, policy_id, actor_group_id, resource_id}
       :ok = PubSub.ActorGroup.Policies.broadcast(actor_group_id, payload)
+
+      Flows.expire_flows_for_policy_id(policy_id)
     end)
 
     :ok

--- a/elixir/apps/domain/lib/domain/events/hooks/resources.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/resources.ex
@@ -41,8 +41,6 @@ defmodule Domain.Events.Hooks.Resources do
     # TODO: WAL
     # Directly broadcast to subscribed pids to remove the flow
     Task.start(fn ->
-      {:ok, _flows} = Flows.expire_flows_for_resource_id(resource_id)
-
       payload = {:delete_resource, resource_id}
       PubSub.Resource.broadcast(resource_id, payload)
       PubSub.Account.Resources.broadcast(account_id, payload)
@@ -50,6 +48,8 @@ defmodule Domain.Events.Hooks.Resources do
       payload = {:create_resource, resource_id}
       PubSub.Resource.broadcast(resource_id, payload)
       PubSub.Account.Resources.broadcast(account_id, payload)
+
+      {:ok, _flows} = Flows.expire_flows_for_resource_id(resource_id)
     end)
 
     :ok

--- a/elixir/apps/domain/lib/domain/flows.ex
+++ b/elixir/apps/domain/lib/domain/flows.ex
@@ -161,6 +161,10 @@ defmodule Domain.Flows do
     end
   end
 
+  # TODO: WAL
+  # Remove all of the indexes used for these after flow expiration is moved to state
+  # broadcasts
+
   def expire_flows_for(%Auth.Identity{} = identity) do
     Flow.Query.all()
     |> Flow.Query.by_identity_id(identity.id)


### PR DESCRIPTION
When handling some side effects, if the query fails for whatever reason, we don't want these preventing handling side effects.

Related: https://firezone-inc.sentry.io/issues/6346235615/events/d30d222f8a3e436d8058a54c0b2a508c/?project=4508756715569152&query=is%3Aunresolved&referrer=previous-event&stream_index=3