### PR TITLE
refactor(portal): compile_config macro to env_var_to_config

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters.ex
@@ -29,7 +29,7 @@ defmodule Domain.Auth.Adapters do
   end
 
   def list_user_provisioned_adapters! do
-    enabled_adapters = Domain.Config.compile_config!(:auth_provider_adapters)
+    enabled_adapters = Domain.Config.env_var_to_config!(:auth_provider_adapters)
     enabled_idp_adapters = enabled_adapters -- ~w[email userpass]a
     Map.take(@adapters, enabled_idp_adapters)
   end

--- a/elixir/apps/domain/lib/domain/config.ex
+++ b/elixir/apps/domain/lib/domain/config.ex
@@ -10,11 +10,10 @@ defmodule Domain.Config do
   end
 
   def fetch_resolved_configs_with_sources!(_account_id, keys, _opts \\ []) do
-    db_config = %{}
-    env_config = System.get_env()
+    env_var_to_config = System.get_env()
 
     for key <- keys, into: %{} do
-      case Fetcher.fetch_source_and_config(Definitions, key, db_config, env_config) do
+      case Fetcher.fetch_source_and_config(Definitions, key, env_var_to_config) do
         {:ok, source, config} ->
           {key, {source, config}}
 
@@ -25,15 +24,15 @@ defmodule Domain.Config do
   end
 
   @doc """
-  Similar to `compile_config/2` but raises an error if the configuration is invalid.
+  Similar to `env_var_to_config/2` but raises an error if the configuration is invalid.
 
   This function does not resolve values from the database because it's intended use is during
   compilation and before application boot (in `config/runtime.exs`).
 
   If you need to resolve values from the database, use `fetch_config/1` or `fetch_config!/1`.
   """
-  def compile_config!(module \\ Definitions, key, env_config \\ System.get_env()) do
-    case Fetcher.fetch_source_and_config(module, key, %{}, env_config) do
+  def env_var_to_config!(module \\ Definitions, key, env_var_to_config \\ System.get_env()) do
+    case Fetcher.fetch_source_and_config(module, key, env_var_to_config) do
       {:ok, _source, value} ->
         value
 
@@ -43,15 +42,15 @@ defmodule Domain.Config do
   end
 
   @doc """
-  Similar to `compile_config!/3` but returns nil if the configuration is invalid.
+  Similar to `env_var_to_config!/3` but returns nil if the configuration is invalid.
 
   This function does not resolve values from the database because it's intended use is during
   compilation and before application boot (in `config/runtime.exs`).
 
   If you need to resolve values from the database, use `fetch_config/1` or `fetch_config!/1`.
   """
-  def compile_config(module \\ Definitions, key, env_config \\ System.get_env()) do
-    case Fetcher.fetch_source_and_config(module, key, %{}, env_config) do
+  def env_var_to_config(module \\ Definitions, key, env_var_to_config \\ System.get_env()) do
+    case Fetcher.fetch_source_and_config(module, key, env_var_to_config) do
       {:ok, _source, value} ->
         value
 

--- a/elixir/apps/domain/lib/domain/config/definition.ex
+++ b/elixir/apps/domain/lib/domain/config/definition.ex
@@ -47,14 +47,13 @@ defmodule Domain.Config.Definition do
           default: term,
           sensitive: boolean(),
           dump: dump_callback(),
-          legacy_keys: [legacy_key()],
           changeset: changeset_callback()
         ]
 
   defmacro __using__(_opts) do
     quote do
       import Domain.Config.Definition
-      import Domain.Config, only: [compile_config!: 1]
+      import Domain.Config, only: [env_var_to_config!: 1]
 
       # Accumulator keeps the list of defined config keys
       Module.register_attribute(__MODULE__, :configs, accumulate: true)
@@ -103,7 +102,7 @@ defmodule Domain.Config.Definition do
 
   def fetch_spec_and_opts!(module, key) do
     {type, opts} = apply(module, key, [])
-    {resolve_opts, opts} = Keyword.split(opts, [:legacy_keys, :default])
+    {resolve_opts, opts} = Keyword.split(opts, [:default])
     {validate_opts, opts} = Keyword.split(opts, [:changeset])
     {debug_opts, opts} = Keyword.split(opts, [:sensitive])
     {dump_opts, opts} = Keyword.split(opts, [:dump])

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -403,10 +403,10 @@ defmodule Domain.Config.Definitions do
       keyword = Dumper.keyword(map)
 
       cond do
-        compile_config!(:erlang_cluster_adapter) == Elixir.Cluster.Strategy.Epmd ->
+        env_var_to_config!(:erlang_cluster_adapter) == Elixir.Cluster.Strategy.Epmd ->
           Keyword.update!(keyword, :hosts, fn hosts -> Enum.map(hosts, &String.to_atom/1) end)
 
-        compile_config!(:erlang_cluster_adapter) == Elixir.Cluster.Strategy.Kubernetes ->
+        env_var_to_config!(:erlang_cluster_adapter) == Elixir.Cluster.Strategy.Kubernetes ->
           Keyword.new(keyword, fn
             {k, v} when k in [:mode, :kubernetes_ip_lookup_mode] -> {k, String.to_atom(v)}
             {k, v} -> {k, v}
@@ -581,7 +581,7 @@ defmodule Domain.Config.Definitions do
   """
   defconfig(:outbound_email_from, :string,
     default: fn ->
-      external_uri = URI.parse(compile_config!(:web_external_url))
+      external_uri = URI.parse(env_var_to_config!(:web_external_url))
       "firezone@#{external_uri.host}"
     end,
     sensitive: true,

--- a/elixir/apps/domain/lib/domain/config/errors.ex
+++ b/elixir/apps/domain/lib/domain/config/errors.ex
@@ -2,8 +2,6 @@ defmodule Domain.Config.Errors do
   alias Domain.Config.Definition
   require Logger
 
-  @env_doc_url "https://www.firezone.dev/docs/reference/env-vars/#environment-variable-listing"
-
   def raise_error!(errors) do
     errors
     |> format_error()
@@ -18,7 +16,6 @@ defmodule Domain.Config.Errors do
       "Missing required configuration value for '#{key}'.",
       "## How to fix?",
       env_example(key),
-      db_example(key),
       format_doc(module, key)
     ]
     |> Enum.reject(&is_nil/1)
@@ -49,7 +46,6 @@ defmodule Domain.Config.Errors do
 
   defp source({:app_env, key}), do: "application environment #{key}"
   defp source({:env, key}), do: "environment variable #{Domain.Config.Resolver.env_key(key)}"
-  defp source({:db, key}), do: "database configuration #{key}"
   defp source(:default), do: "default value"
 
   defp format_errors(module, key, values_and_errors) do
@@ -84,8 +80,6 @@ defmodule Domain.Config.Errors do
         ## Documentation
 
         #{doc}
-
-        You can find more information on configuration here: #{@env_doc_url}
         """
     end
   end
@@ -105,27 +99,9 @@ defmodule Domain.Config.Errors do
     """
     ### Using environment variables
 
-    You can set this configuration via environment variable by adding it to `.env` file:
+    You can set this configuration with an environment variable:
 
         #{Domain.Config.Resolver.env_key(key)}=YOUR_VALUE
     """
-  end
-
-  defp db_example(key) do
-    if key in Domain.Accounts.Config.__schema__(:fields) do
-      """
-      ### Using database
-
-      Or you can set this configuration in the database by either setting it via the admin panel,
-      or by running an SQL query:
-
-          cd $HOME/.firezone
-          docker compose exec postgres psql \\
-            -U postgres \\
-            -h 127.0.0.1 \\
-            -d firezone \\
-            -c "UPDATE configurations SET #{key} = 'YOUR_VALUE'"
-      """
-    end
   end
 end

--- a/elixir/apps/domain/lib/domain/config/fetcher.ex
+++ b/elixir/apps/domain/lib/domain/config/fetcher.ex
@@ -4,17 +4,16 @@ defmodule Domain.Config.Fetcher do
   @spec fetch_source_and_config(
           module(),
           key :: atom(),
-          db_configurations :: map(),
-          env_configurations :: map()
+          env_var_to_configurations :: map()
         ) ::
           {:ok, Resolver.source(), term()} | {:error, {[String.t()], metadata: term()}}
-  def fetch_source_and_config(module, key, %{} = db_configurations, %{} = env_configurations)
+  def fetch_source_and_config(module, key, %{} = env_var_to_configurations)
       when is_atom(module) and is_atom(key) do
     {type, {resolve_opts, validate_opts, dump_opts, _debug_opts}} =
       Definition.fetch_spec_and_opts!(module, key)
 
     with {:ok, {source, value}} <-
-           resolve_value(module, key, env_configurations, db_configurations, resolve_opts),
+           resolve_value(module, key, env_var_to_configurations, resolve_opts),
          {:ok, value} <- cast_value(module, key, source, value, type),
          {:ok, value} <- validate_value(module, key, source, value, type, validate_opts) do
       if dump_cb = Keyword.get(dump_opts, :dump) do
@@ -25,8 +24,8 @@ defmodule Domain.Config.Fetcher do
     end
   end
 
-  defp resolve_value(module, key, env_configurations, db_configurations, opts) do
-    with :error <- Resolver.resolve(key, env_configurations, db_configurations, opts) do
+  defp resolve_value(module, key, env_var_to_configurations, opts) do
+    with :error <- Resolver.resolve(key, env_var_to_configurations, opts) do
       {:error, {{nil, ["is required"]}, module: module, key: key, source: :not_found}}
     end
   end

--- a/elixir/apps/domain/test/domain/config/definition_test.exs
+++ b/elixir/apps/domain/test/domain/config/definition_test.exs
@@ -15,8 +15,6 @@ defmodule Domain.Config.DefinitionTest do
 
     defconfig(:optional, Types.IP, default: "0.0.0.0")
 
-    defconfig(:with_legacy_key, :string, legacy_keys: [{:env, "FOO", "100.0"}])
-
     defconfig(:with_validation, :integer,
       changeset: fn changeset, key ->
         Ecto.Changeset.validate_number(changeset, key,
@@ -41,7 +39,6 @@ defmodule Domain.Config.DefinitionTest do
                {Definitions, :with_dump},
                {Definitions, :sensitive},
                {Definitions, :with_validation},
-               {Definitions, :with_legacy_key},
                {Definitions, :optional},
                {Definitions, :required}
              ]
@@ -50,7 +47,6 @@ defmodule Domain.Config.DefinitionTest do
     test "inserts a function which returns spec of a given config definition" do
       assert Definitions.required() == {Types.IP, []}
       assert Definitions.optional() == {Types.IP, default: "0.0.0.0"}
-      assert Definitions.with_legacy_key() == {:string, legacy_keys: [{:env, "FOO", "100.0"}]}
       assert {:integer, changeset: _cb} = Definitions.with_validation()
 
       assert InvalidDefinitions.required() == {Types.IP, [foo: :bar]}
@@ -69,9 +65,6 @@ defmodule Domain.Config.DefinitionTest do
 
       assert fetch_spec_and_opts!(Definitions, :optional) ==
                {Types.IP, {[default: "0.0.0.0"], [], [], []}}
-
-      assert fetch_spec_and_opts!(Definitions, :with_legacy_key) ==
-               {:string, {[legacy_keys: [{:env, "FOO", "100.0"}]], [], [], []}}
 
       assert {:integer, {[], [{:changeset, _cb}], [], []}} =
                fetch_spec_and_opts!(Definitions, :with_validation)

--- a/elixir/apps/domain/test/domain/config/fetcher_test.exs
+++ b/elixir/apps/domain/test/domain/config/fetcher_test.exs
@@ -10,10 +10,7 @@ defmodule Domain.Config.FetcherTest do
 
     defconfig(:optional, Types.IP, default: "0.0.0.0")
 
-    defconfig(:optional_generated, Types.IP,
-      legacy_keys: [{:env, "OGID", "1.0"}],
-      default: fn -> "1.1.1.1" end
-    )
+    defconfig(:optional_generated, Types.IP, default: fn -> "1.1.1.1" end)
 
     defconfig(:one_of, {:one_of, [:string, :integer]},
       changeset: fn
@@ -65,31 +62,31 @@ defmodule Domain.Config.FetcherTest do
 
   describe "fetch_source_and_config/4" do
     test "returns error when required config is not set" do
-      assert fetch_source_and_config(Test, :required, %{}, %{}) ==
+      assert fetch_source_and_config(Test, :required, %{}) ==
                {:error,
                 {{nil, ["is required"]}, [module: Test, key: :required, source: :not_found]}}
     end
 
     test "does not allow to explicitly set required config to nil" do
-      assert fetch_source_and_config(Test, :required, %{required: nil}, %{}) ==
+      assert fetch_source_and_config(Test, :required, %{}) ==
                {:error,
                 {{nil, ["is required"]}, [module: Test, key: :required, source: :not_found]}}
 
-      assert fetch_source_and_config(Test, :required, %{}, %{"REQUIRED" => nil}) ==
+      assert fetch_source_and_config(Test, :required, %{"REQUIRED" => nil}) ==
                {:error,
                 {{nil, ["is required"]}, [module: Test, key: :required, source: :not_found]}}
     end
 
     test "returns default value when config is not set" do
-      assert fetch_source_and_config(Test, :optional, %{}, %{}) ==
+      assert fetch_source_and_config(Test, :optional, %{}) ==
                {:ok, :default, %Postgrex.INET{address: {0, 0, 0, 0}, netmask: nil}}
 
-      assert fetch_source_and_config(Test, :optional_generated, %{}, %{}) ==
+      assert fetch_source_and_config(Test, :optional_generated, %{}) ==
                {:ok, :default, %Postgrex.INET{address: {1, 1, 1, 1}, netmask: nil}}
     end
 
     test "returns error when resolved value is invalid" do
-      assert fetch_source_and_config(Test, :invalid_with_validation, %{}, %{}) ==
+      assert fetch_source_and_config(Test, :invalid_with_validation, %{}) ==
                {:error,
                 {{-1, ["must be greater than or equal to 0"]},
                  [
@@ -98,67 +95,49 @@ defmodule Domain.Config.FetcherTest do
                    source: :default
                  ]}}
 
-      assert fetch_source_and_config(Test, :required, %{required: "a.b.c.d"}, %{}) ==
-               {:error,
-                {{"a.b.c.d", ["is invalid"]},
-                 [
-                   module: __MODULE__.Test,
-                   key: :required,
-                   source: {:db, :required}
-                 ]}}
-
-      assert fetch_source_and_config(Test, :one_of, %{one_of: :atom}, %{}) ==
-               {:error,
-                {{:atom, ["must be one of: string, integer"]},
-                 [
-                   module: __MODULE__.Test,
-                   key: :one_of,
-                   source: {:db, :one_of}
-                 ]}}
-
-      assert fetch_source_and_config(Test, :array, %{}, %{}) ==
+      assert fetch_source_and_config(Test, :array, %{}) ==
                {:error,
                 {[{3, ["must be less than or equal to 2"]}],
                  [module: __MODULE__.Test, key: :array, source: :default]}}
     end
 
     test "casts binary to appropriate data type" do
-      assert fetch_source_and_config(Test, :array, %{}, %{"ARRAY" => "0,1,2"}) ==
+      assert fetch_source_and_config(Test, :array, %{"ARRAY" => "0,1,2"}) ==
                {:ok, {:env, "ARRAY"}, [0, 1, 2]}
 
       json = Jason.encode!(%{foo: :bar})
 
-      assert fetch_source_and_config(Test, :json, %{}, %{"JSON" => json}) ==
+      assert fetch_source_and_config(Test, :json, %{"JSON" => json}) ==
                {:ok, {:env, "JSON"}, foo: "bar"}
 
       json = Jason.encode!([%{foo: :bar}])
 
-      assert fetch_source_and_config(Test, :json_array, %{}, %{"JSON_ARRAY" => json}) ==
+      assert fetch_source_and_config(Test, :json_array, %{"JSON_ARRAY" => json}) ==
                {:ok, {:env, "JSON_ARRAY"}, [%{"foo" => "bar"}]}
 
-      assert fetch_source_and_config(Test, :optional, %{}, %{"OPTIONAL" => "127.0.0.1"}) ==
+      assert fetch_source_and_config(Test, :optional, %{"OPTIONAL" => "127.0.0.1"}) ==
                {:ok, {:env, "OPTIONAL"}, %Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}}
 
-      assert fetch_source_and_config(Test, :boolean, %{}, %{"BOOLEAN" => "true"}) ==
+      assert fetch_source_and_config(Test, :boolean, %{"BOOLEAN" => "true"}) ==
                {:ok, {:env, "BOOLEAN"}, true}
     end
 
     test "applies dump function" do
       json = Jason.encode!(%{foo: :bar})
 
-      assert fetch_source_and_config(Test, :json, %{}, %{"JSON" => json}) ==
+      assert fetch_source_and_config(Test, :json, %{"JSON" => json}) ==
                {:ok, {:env, "JSON"}, foo: "bar"}
     end
 
     test "does not apply dump function on invalid values" do
-      assert fetch_source_and_config(Test, :json, %{}, %{"JSON" => "foo"}) ==
+      assert fetch_source_and_config(Test, :json, %{"JSON" => "foo"}) ==
                {:error,
                 {{"foo", ["unexpected byte at position 0: 0x66 (\"f\")"]},
                  [module: __MODULE__.Test, key: :json, source: {:env, "JSON"}]}}
     end
 
     test "returns error when type can't be casted" do
-      assert fetch_source_and_config(Test, :integer, %{}, %{"INTEGER" => "X"}) ==
+      assert fetch_source_and_config(Test, :integer, %{"INTEGER" => "X"}) ==
                {:error,
                 {{"X", ["cannot be cast to an integer"]},
                  [
@@ -167,7 +146,7 @@ defmodule Domain.Config.FetcherTest do
                    source: {:env, "INTEGER"}
                  ]}}
 
-      assert fetch_source_and_config(Test, :integer, %{}, %{"INTEGER" => "123a"}) ==
+      assert fetch_source_and_config(Test, :integer, %{"INTEGER" => "123a"}) ==
                {:error,
                 {{"123a",
                   ["cannot be cast to an integer, got a reminder a after an integer value 123"]},
@@ -179,12 +158,12 @@ defmodule Domain.Config.FetcherTest do
 
       json = Jason.encode!(%{foo: :bar})
 
-      assert fetch_source_and_config(Test, :json, %{}, %{"JSON" => json}) ==
+      assert fetch_source_and_config(Test, :json, %{"JSON" => json}) ==
                {:ok, {:env, "JSON"}, foo: "bar"}
 
       json = Jason.encode!([%{foo: :bar}])
 
-      assert fetch_source_and_config(Test, :json_array, %{}, %{"JSON_ARRAY" => json}) ==
+      assert fetch_source_and_config(Test, :json_array, %{"JSON_ARRAY" => json}) ==
                {:ok, {:env, "JSON_ARRAY"}, [%{"foo" => "bar"}]}
     end
 
@@ -192,26 +171,14 @@ defmodule Domain.Config.FetcherTest do
       key = :optional_generated
 
       # Generated default value
-      assert fetch_source_and_config(Test, key, %{}, %{}) ==
+      assert fetch_source_and_config(Test, key, %{}) ==
                {:ok, :default, %Postgrex.INET{address: {1, 1, 1, 1}}}
 
-      # DB value overrides default
-      db = %{optional_generated: "2.2.2.2"}
+      # env overrides default
+      env = %{"OPTIONAL_GENERATED" => "3.3.3.3"}
 
-      assert fetch_source_and_config(Test, key, db, %{}) ==
-               {:ok, {:db, key}, %Postgrex.INET{address: {2, 2, 2, 2}}}
-
-      # Legacy env overrides DB
-      env = %{"OGID" => "3.3.3.3"}
-
-      assert fetch_source_and_config(Test, key, db, env) ==
-               {:ok, {:env, "OGID"}, %Postgrex.INET{address: {3, 3, 3, 3}}}
-
-      # Env overrides legacy env
-      env = Map.merge(env, %{"OPTIONAL_GENERATED" => "4.4.4.4"})
-
-      assert fetch_source_and_config(Test, key, db, env) ==
-               {:ok, {:env, "OPTIONAL_GENERATED"}, %Postgrex.INET{address: {4, 4, 4, 4}}}
+      assert fetch_source_and_config(Test, key, env) ==
+               {:ok, {:env, "OPTIONAL_GENERATED"}, %Postgrex.INET{address: {3, 3, 3, 3}}}
     end
   end
 end

--- a/elixir/apps/domain/test/domain/config_test.exs
+++ b/elixir/apps/domain/test/domain/config_test.exs
@@ -8,10 +8,7 @@ defmodule Domain.ConfigTest do
 
     defconfig(:required, Types.IP)
 
-    defconfig(:optional_generated, Types.IP,
-      legacy_keys: [{:env, "OGID", "1.0"}],
-      default: fn -> "1.1.1.1" end
-    )
+    defconfig(:optional_generated, Types.IP, default: fn -> "1.1.1.1" end)
 
     defconfig(:one_of, {:one_of, [:string, :integer]},
       changeset: fn
@@ -103,7 +100,7 @@ defmodule Domain.ConfigTest do
 
       ### Using environment variables
 
-      You can set this configuration via environment variable by adding it to `.env` file:
+      You can set this configuration with an environment variable:
 
           SECRET_KEY_BASE=YOUR_VALUE
 
@@ -112,8 +109,6 @@ defmodule Domain.ConfigTest do
 
       Primary secret key base for the Phoenix application.
 
-
-      You can find more information on configuration here: https://www.firezone.dev/docs/reference/env-vars/#environment-variable-listing
       """
 
       assert_raise RuntimeError, message, fn ->
@@ -152,7 +147,7 @@ defmodule Domain.ConfigTest do
 
       ### Using environment variables
 
-      You can set this configuration via environment variable by adding it to `.env` file:
+      You can set this configuration with an environment variable:
 
           SECRET_KEY_BASE=YOUR_VALUE
 
@@ -161,8 +156,6 @@ defmodule Domain.ConfigTest do
 
       Primary secret key base for the Phoenix application.
 
-
-      You can find more information on configuration here: https://www.firezone.dev/docs/reference/env-vars/#environment-variable-listing
       """
 
       assert_raise RuntimeError, message, fn ->
@@ -186,8 +179,6 @@ defmodule Domain.ConfigTest do
 
       If this field is not set or set to `nil`, the server for `api` and `web` apps will not start.
 
-
-      You can find more information on configuration here: https://www.firezone.dev/docs/reference/env-vars/#environment-variable-listing
       """
 
       assert_raise RuntimeError, message, fn ->
@@ -196,9 +187,9 @@ defmodule Domain.ConfigTest do
     end
   end
 
-  describe "compile_config!/1" do
+  describe "env_var_to_config!/1" do
     test "returns config value" do
-      assert compile_config!(Test, :optional_generated) ==
+      assert env_var_to_config!(Test, :optional_generated) ==
                %Postgrex.INET{address: {1, 1, 1, 1}, netmask: nil}
     end
 
@@ -210,13 +201,13 @@ defmodule Domain.ConfigTest do
 
       ### Using environment variables
 
-      You can set this configuration via environment variable by adding it to `.env` file:
+      You can set this configuration with an environment variable:
 
           REQUIRED=YOUR_VALUE
       """
 
       assert_raise RuntimeError, message, fn ->
-        compile_config!(Test, :required)
+        env_var_to_config!(Test, :required)
       end
     end
 
@@ -230,7 +221,7 @@ defmodule Domain.ConfigTest do
       """
 
       assert_raise RuntimeError, message, fn ->
-        compile_config!(Test, :integer, %{"INTEGER" => "123a"})
+        env_var_to_config!(Test, :integer, %{"INTEGER" => "123a"})
       end
     end
 
@@ -244,7 +235,7 @@ defmodule Domain.ConfigTest do
       """
 
       assert_raise RuntimeError, message, fn ->
-        compile_config!(Test, :required, %{"REQUIRED" => "a.b.c.d"})
+        env_var_to_config!(Test, :required, %{"REQUIRED" => "a.b.c.d"})
       end
 
       message = """
@@ -256,7 +247,7 @@ defmodule Domain.ConfigTest do
       """
 
       assert_raise RuntimeError, message, fn ->
-        compile_config!(Test, :one_of, %{"ONE_OF" => "X"})
+        env_var_to_config!(Test, :one_of, %{"ONE_OF" => "X"})
       end
 
       message = """
@@ -270,7 +261,7 @@ defmodule Domain.ConfigTest do
       """
 
       assert_raise RuntimeError, message, fn ->
-        compile_config!(Test, :array, %{"ARRAY" => "1,-1,0,2,-100,-2"})
+        env_var_to_config!(Test, :array, %{"ARRAY" => "1,-1,0,2,-100,-2"})
       end
 
       message = """
@@ -282,7 +273,7 @@ defmodule Domain.ConfigTest do
       """
 
       assert_raise RuntimeError, message, fn ->
-        compile_config!(Test, :url, %{"URL" => "foo.bar/baz"})
+        env_var_to_config!(Test, :url, %{"URL" => "foo.bar/baz"})
       end
     end
 
@@ -296,7 +287,7 @@ defmodule Domain.ConfigTest do
       """
 
       assert_raise RuntimeError, message, fn ->
-        compile_config!(Test, :sensitive, %{"SENSITIVE" => "foo"})
+        env_var_to_config!(Test, :sensitive, %{"SENSITIVE" => "foo"})
       end
     end
 
@@ -310,15 +301,15 @@ defmodule Domain.ConfigTest do
       """
 
       assert_raise RuntimeError, message, fn ->
-        compile_config!(Test, :enum, %{"ENUM" => "foo"})
+        env_var_to_config!(Test, :enum, %{"ENUM" => "foo"})
       end
     end
 
     test "casts module name enums" do
-      assert compile_config!(Test, :enum, %{"ENUM" => "value1"}) == :foo
-      assert compile_config!(Test, :enum, %{"ENUM" => "value2"}) == Domain.ConfigTest.Test
+      assert env_var_to_config!(Test, :enum, %{"ENUM" => "value1"}) == :foo
+      assert env_var_to_config!(Test, :enum, %{"ENUM" => "value2"}) == Domain.ConfigTest.Test
 
-      assert compile_config!(Test, :enum, %{"ENUM" => "Elixir.Domain.ConfigTest.Test"}) ==
+      assert env_var_to_config!(Test, :enum, %{"ENUM" => "Elixir.Domain.ConfigTest.Test"}) ==
                Domain.ConfigTest.Test
     end
   end

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -1,7 +1,7 @@
 import Config
 
 if config_env() == :prod do
-  import Domain.Config, only: [compile_config!: 1, compile_config: 1]
+  import Domain.Config, only: [env_var_to_config!: 1, env_var_to_config: 1]
 
   ###############################
   ##### Domain ##################
@@ -10,129 +10,130 @@ if config_env() == :prod do
   config :domain,
          Domain.Repo,
          [
-           {:database, compile_config!(:database_name)},
-           {:username, compile_config!(:database_user)},
-           {:port, compile_config!(:database_port)},
-           {:pool_size, compile_config!(:database_pool_size)},
-           {:ssl, compile_config!(:database_ssl_enabled)},
-           {:ssl_opts, compile_config!(:database_ssl_opts)},
-           {:parameters, compile_config!(:database_parameters)}
+           {:database, env_var_to_config!(:database_name)},
+           {:username, env_var_to_config!(:database_user)},
+           {:port, env_var_to_config!(:database_port)},
+           {:pool_size, env_var_to_config!(:database_pool_size)},
+           {:ssl, env_var_to_config!(:database_ssl_enabled)},
+           {:ssl_opts, env_var_to_config!(:database_ssl_opts)},
+           {:parameters, env_var_to_config!(:database_parameters)}
          ] ++
-           if(compile_config(:database_password),
-             do: [{:password, compile_config!(:database_password)}],
+           if(env_var_to_config(:database_password),
+             do: [{:password, env_var_to_config!(:database_password)}],
              else: []
            ) ++
-           if(compile_config(:database_socket_dir),
-             do: [{:socket_dir, compile_config!(:database_socket_dir)}],
-             else: [{:hostname, compile_config!(:database_host)}]
+           if(env_var_to_config(:database_socket_dir),
+             do: [{:socket_dir, env_var_to_config!(:database_socket_dir)}],
+             else: [{:hostname, env_var_to_config!(:database_host)}]
            )
 
   config :domain, Domain.Events.ReplicationConnection,
-    enabled: compile_config!(:background_jobs_enabled),
-    replication_slot_name: compile_config!(:database_replication_slot_name),
-    publication_name: compile_config!(:database_publication_name),
+    enabled: env_var_to_config!(:background_jobs_enabled),
+    replication_slot_name: env_var_to_config!(:database_replication_slot_name),
+    publication_name: env_var_to_config!(:database_publication_name),
     connection_opts: [
-      hostname: compile_config!(:database_host),
-      port: compile_config!(:database_port),
-      ssl: compile_config!(:database_ssl_enabled),
-      ssl_opts: compile_config!(:database_ssl_opts),
-      parameters: compile_config!(:database_parameters),
-      username: compile_config!(:database_user),
-      password: compile_config!(:database_password),
-      database: compile_config!(:database_name)
+      hostname: env_var_to_config!(:database_host),
+      port: env_var_to_config!(:database_port),
+      ssl: env_var_to_config!(:database_ssl_enabled),
+      ssl_opts: env_var_to_config!(:database_ssl_opts),
+      parameters: env_var_to_config!(:database_parameters),
+      username: env_var_to_config!(:database_user),
+      password: env_var_to_config!(:database_password),
+      database: env_var_to_config!(:database_name)
     ]
 
-  config :domain, run_conditional_migrations: compile_config!(:run_conditional_migrations)
+  config :domain, run_conditional_migrations: env_var_to_config!(:run_conditional_migrations)
 
   config :domain, Domain.Tokens,
-    key_base: compile_config!(:tokens_key_base),
-    salt: compile_config!(:tokens_salt)
+    key_base: env_var_to_config!(:tokens_key_base),
+    salt: env_var_to_config!(:tokens_salt)
 
   config :domain, Domain.Gateways,
-    gateway_ipv4_masquerade: compile_config!(:gateway_ipv4_masquerade),
-    gateway_ipv6_masquerade: compile_config!(:gateway_ipv6_masquerade)
+    gateway_ipv4_masquerade: env_var_to_config!(:gateway_ipv4_masquerade),
+    gateway_ipv6_masquerade: env_var_to_config!(:gateway_ipv6_masquerade)
 
   config :domain, Domain.Auth.Adapters.GoogleWorkspace.APIClient,
-    finch_transport_opts: compile_config!(:http_client_ssl_opts)
+    finch_transport_opts: env_var_to_config!(:http_client_ssl_opts)
 
   config :domain, Domain.Billing.Stripe.APIClient,
     endpoint: "https://api.stripe.com",
     finch_transport_opts: []
 
   config :domain, Domain.Billing,
-    enabled: compile_config!(:billing_enabled),
-    secret_key: compile_config!(:stripe_secret_key),
-    webhook_signing_secret: compile_config!(:stripe_webhook_signing_secret),
-    default_price_id: compile_config!(:stripe_default_price_id)
+    enabled: env_var_to_config!(:billing_enabled),
+    secret_key: env_var_to_config!(:stripe_secret_key),
+    webhook_signing_secret: env_var_to_config!(:stripe_webhook_signing_secret),
+    default_price_id: env_var_to_config!(:stripe_default_price_id)
 
-  config :domain, platform_adapter: compile_config!(:platform_adapter)
+  config :domain, platform_adapter: env_var_to_config!(:platform_adapter)
 
-  if platform_adapter = compile_config!(:platform_adapter) do
-    config :domain, platform_adapter, compile_config!(:platform_adapter_config)
+  if platform_adapter = env_var_to_config!(:platform_adapter) do
+    config :domain, platform_adapter, env_var_to_config!(:platform_adapter_config)
   end
 
   config :domain, Domain.Cluster,
-    adapter: compile_config!(:erlang_cluster_adapter),
-    adapter_config: compile_config!(:erlang_cluster_adapter_config)
+    adapter: env_var_to_config!(:erlang_cluster_adapter),
+    adapter_config: env_var_to_config!(:erlang_cluster_adapter_config)
 
   config :domain, Domain.Instrumentation,
-    client_logs_enabled: compile_config!(:instrumentation_client_logs_enabled),
-    client_logs_bucket: compile_config!(:instrumentation_client_logs_bucket)
+    client_logs_enabled: env_var_to_config!(:instrumentation_client_logs_enabled),
+    client_logs_bucket: env_var_to_config!(:instrumentation_client_logs_bucket)
 
   config :domain, Domain.Analytics,
-    mixpanel_token: compile_config!(:mixpanel_token),
-    hubspot_workspace_id: compile_config!(:hubspot_workspace_id)
+    mixpanel_token: env_var_to_config!(:mixpanel_token),
+    hubspot_workspace_id: env_var_to_config!(:hubspot_workspace_id)
 
   config :domain, :enabled_features,
-    idp_sync: compile_config!(:feature_idp_sync_enabled),
-    sign_up: compile_config!(:feature_sign_up_enabled),
-    flow_activities: compile_config!(:feature_flow_activities_enabled),
-    self_hosted_relays: compile_config!(:feature_self_hosted_relays_enabled),
-    policy_conditions: compile_config!(:feature_policy_conditions_enabled),
-    multi_site_resources: compile_config!(:feature_multi_site_resources_enabled),
-    rest_api: compile_config!(:feature_rest_api_enabled),
-    internet_resource: compile_config!(:feature_internet_resource_enabled)
+    idp_sync: env_var_to_config!(:feature_idp_sync_enabled),
+    sign_up: env_var_to_config!(:feature_sign_up_enabled),
+    flow_activities: env_var_to_config!(:feature_flow_activities_enabled),
+    self_hosted_relays: env_var_to_config!(:feature_self_hosted_relays_enabled),
+    policy_conditions: env_var_to_config!(:feature_policy_conditions_enabled),
+    multi_site_resources: env_var_to_config!(:feature_multi_site_resources_enabled),
+    rest_api: env_var_to_config!(:feature_rest_api_enabled),
+    internet_resource: env_var_to_config!(:feature_internet_resource_enabled)
 
-  config :domain, sign_up_whitelisted_domains: compile_config!(:sign_up_whitelisted_domains)
+  config :domain, sign_up_whitelisted_domains: env_var_to_config!(:sign_up_whitelisted_domains)
 
-  config :domain, docker_registry: compile_config!(:docker_registry)
+  config :domain, docker_registry: env_var_to_config!(:docker_registry)
 
-  config :domain, outbound_email_adapter_configured?: !!compile_config!(:outbound_email_adapter)
+  config :domain,
+    outbound_email_adapter_configured?: !!env_var_to_config!(:outbound_email_adapter)
 
-  config :domain, web_external_url: compile_config!(:web_external_url)
+  config :domain, web_external_url: env_var_to_config!(:web_external_url)
 
   # Enable background jobs only on dedicated nodes
   config :domain, Domain.Tokens.Jobs.DeleteExpiredTokens,
-    enabled: compile_config!(:background_jobs_enabled)
+    enabled: env_var_to_config!(:background_jobs_enabled)
 
   config :domain, Domain.Billing.Jobs.CheckAccountLimits,
-    enabled: compile_config!(:background_jobs_enabled)
+    enabled: env_var_to_config!(:background_jobs_enabled)
 
   config :domain, Domain.Auth.Adapters.GoogleWorkspace.Jobs.RefreshAccessTokens,
-    enabled: compile_config!(:background_jobs_enabled)
+    enabled: env_var_to_config!(:background_jobs_enabled)
 
   config :domain, Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectory,
-    enabled: compile_config!(:background_jobs_enabled)
+    enabled: env_var_to_config!(:background_jobs_enabled)
 
   config :domain, Domain.Auth.Adapters.MicrosoftEntra.Jobs.RefreshAccessTokens,
-    enabled: compile_config!(:background_jobs_enabled)
+    enabled: env_var_to_config!(:background_jobs_enabled)
 
   config :domain, Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectory,
-    enabled: compile_config!(:background_jobs_enabled)
+    enabled: env_var_to_config!(:background_jobs_enabled)
 
   config :domain, Domain.Auth.Adapters.Okta.Jobs.RefreshAccessTokens,
-    enabled: compile_config!(:background_jobs_enabled)
+    enabled: env_var_to_config!(:background_jobs_enabled)
 
   config :domain, Domain.Auth.Adapters.Okta.Jobs.SyncDirectory,
-    enabled: compile_config!(:background_jobs_enabled)
+    enabled: env_var_to_config!(:background_jobs_enabled)
 
   config :domain, Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectory,
-    enabled: compile_config!(:background_jobs_enabled)
+    enabled: env_var_to_config!(:background_jobs_enabled)
 
   # Don't enable the mock sync directory job in production
   config :domain, Domain.Auth.Adapters.Mock.Jobs.SyncDirectory, enabled: false
 
-  if web_external_url = compile_config!(:web_external_url) do
+  if web_external_url = env_var_to_config!(:web_external_url) do
     %{
       scheme: web_external_url_scheme,
       host: web_external_url_host,
@@ -146,9 +147,9 @@ if config_env() == :prod do
 
     config :web, Web.Endpoint,
       http: [
-        ip: compile_config!(:phoenix_listen_address).address,
-        port: compile_config!(:phoenix_http_web_port),
-        protocol_options: compile_config!(:phoenix_http_protocol_options)
+        ip: env_var_to_config!(:phoenix_listen_address).address,
+        port: env_var_to_config!(:phoenix_http_web_port),
+        protocol_options: env_var_to_config!(:phoenix_http_protocol_options)
       ],
       url: [
         scheme: web_external_url_scheme,
@@ -156,7 +157,7 @@ if config_env() == :prod do
         port: web_external_url_port,
         path: web_external_url_path
       ],
-      secret_key_base: compile_config!(:secret_key_base),
+      secret_key_base: env_var_to_config!(:secret_key_base),
       check_origin: [
         "#{web_external_url_scheme}://#{web_external_url_host}:#{web_external_url_port}",
         "#{web_external_url_scheme}://*.#{web_external_url_host}:#{web_external_url_port}",
@@ -164,22 +165,22 @@ if config_env() == :prod do
         "#{web_external_url_scheme}://*.#{web_external_url_host}"
       ],
       live_view: [
-        signing_salt: compile_config!(:live_view_signing_salt)
+        signing_salt: env_var_to_config!(:live_view_signing_salt)
       ]
 
     config :web,
-      external_trusted_proxies: compile_config!(:phoenix_external_trusted_proxies),
-      private_clients: compile_config!(:phoenix_private_clients)
+      external_trusted_proxies: env_var_to_config!(:phoenix_external_trusted_proxies),
+      private_clients: env_var_to_config!(:phoenix_private_clients)
 
     config :web,
-      cookie_secure: compile_config!(:phoenix_secure_cookies),
-      cookie_signing_salt: compile_config!(:cookie_signing_salt),
-      cookie_encryption_salt: compile_config!(:cookie_encryption_salt)
+      cookie_secure: env_var_to_config!(:phoenix_secure_cookies),
+      cookie_signing_salt: env_var_to_config!(:cookie_signing_salt),
+      cookie_encryption_salt: env_var_to_config!(:cookie_encryption_salt)
 
-    config :web, api_url_override: compile_config!(:api_url_override)
+    config :web, api_url_override: env_var_to_config!(:api_url_override)
   end
 
-  if api_external_url = compile_config!(:api_external_url) do
+  if api_external_url = env_var_to_config!(:api_external_url) do
     %{
       scheme: api_external_url_scheme,
       host: api_external_url_host,
@@ -193,9 +194,9 @@ if config_env() == :prod do
 
     config :api, API.Endpoint,
       http: [
-        ip: compile_config!(:phoenix_listen_address).address,
-        port: compile_config!(:phoenix_http_api_port),
-        protocol_options: compile_config!(:phoenix_http_protocol_options)
+        ip: env_var_to_config!(:phoenix_listen_address).address,
+        port: env_var_to_config!(:phoenix_http_api_port),
+        protocol_options: env_var_to_config!(:phoenix_http_protocol_options)
       ],
       url: [
         scheme: api_external_url_scheme,
@@ -203,20 +204,20 @@ if config_env() == :prod do
         port: api_external_url_port,
         path: api_external_url_path
       ],
-      secret_key_base: compile_config!(:secret_key_base)
+      secret_key_base: env_var_to_config!(:secret_key_base)
 
     config :api,
-      cookie_secure: compile_config!(:phoenix_secure_cookies),
-      cookie_signing_salt: compile_config!(:cookie_signing_salt),
-      cookie_encryption_salt: compile_config!(:cookie_encryption_salt)
+      cookie_secure: env_var_to_config!(:phoenix_secure_cookies),
+      cookie_signing_salt: env_var_to_config!(:cookie_signing_salt),
+      cookie_encryption_salt: env_var_to_config!(:cookie_encryption_salt)
 
     config :api,
-      external_trusted_proxies: compile_config!(:phoenix_external_trusted_proxies),
-      private_clients: compile_config!(:phoenix_private_clients)
+      external_trusted_proxies: env_var_to_config!(:phoenix_external_trusted_proxies),
+      private_clients: env_var_to_config!(:phoenix_private_clients)
 
     config :api, API.RateLimit,
-      refill_rate: compile_config!(:api_refill_rate),
-      capacity: compile_config!(:api_capacity)
+      refill_rate: env_var_to_config!(:api_refill_rate),
+      capacity: env_var_to_config!(:api_capacity)
 
     config :web,
       api_external_url: api_external_url
@@ -250,33 +251,35 @@ if config_env() == :prod do
   end
 
   config :domain, Domain.Telemetry,
-    healthz_port: compile_config!(:healthz_port),
-    metrics_reporter: compile_config!(:telemetry_metrics_reporter)
+    healthz_port: env_var_to_config!(:healthz_port),
+    metrics_reporter: env_var_to_config!(:telemetry_metrics_reporter)
 
-  if telemetry_metrics_reporter = compile_config!(:telemetry_metrics_reporter) do
-    config :domain, telemetry_metrics_reporter, compile_config!(:telemetry_metrics_reporter_opts)
+  if telemetry_metrics_reporter = env_var_to_config!(:telemetry_metrics_reporter) do
+    config :domain,
+           telemetry_metrics_reporter,
+           env_var_to_config!(:telemetry_metrics_reporter_opts)
   end
 
   config :domain,
-    http_client_ssl_opts: compile_config!(:http_client_ssl_opts)
+    http_client_ssl_opts: env_var_to_config!(:http_client_ssl_opts)
 
   config :openid_connect,
-    finch_transport_opts: compile_config!(:http_client_ssl_opts)
+    finch_transport_opts: env_var_to_config!(:http_client_ssl_opts)
 
   config :domain,
          Domain.Mailer,
          [
-           adapter: compile_config!(:outbound_email_adapter),
-           from_email: compile_config!(:outbound_email_from)
-         ] ++ compile_config!(:outbound_email_adapter_opts)
+           adapter: env_var_to_config!(:outbound_email_adapter),
+           from_email: env_var_to_config!(:outbound_email_from)
+         ] ++ env_var_to_config!(:outbound_email_adapter_opts)
 
   config :workos, WorkOS.Client,
-    api_key: compile_config!(:workos_api_key),
-    client_id: compile_config!(:workos_client_id)
+    api_key: env_var_to_config!(:workos_api_key),
+    client_id: env_var_to_config!(:workos_client_id)
 
   # Sentry
 
-  with api_external_url <- compile_config!(:api_external_url),
+  with api_external_url <- env_var_to_config!(:api_external_url),
        api_external_url_host <- URI.parse(api_external_url).host,
        environment_name when environment_name in [:staging, :production] <-
          (case api_external_url_host do


### PR DESCRIPTION
The `compile_config` macro only works on environment and DB variables. This caused recent confusion when determining where `database_pool_size` was coming from.

To fix this issue, we rename `compile_config` to be more clear.

We also remove the technical debt around supporting "legacy keys" and DB-based configuration.

The configuration compiler now works exclusively on environment variables only, where it is still useful for:

- Casting environment variables to their expected type
- Alerting us when one is missing that should be set