### PR TITLE
fix(portal): add account_id,type index on actors

### DIFF
--- a/elixir/apps/domain/lib/domain/billing/jobs/check_account_limits.ex
+++ b/elixir/apps/domain/lib/domain/billing/jobs/check_account_limits.ex
@@ -10,6 +10,10 @@ defmodule Domain.Billing.Jobs.CheckAccountLimits do
   def execute(_config) do
     Accounts.all_active_accounts!()
     |> Enum.each(fn account ->
+      # TODO: Slow DB queries
+      # These can be slow if an index-only scan is not possible.
+      # Consider using a trigger function and counter fields to maintain an accurate
+      # count of account limits.
       if Billing.enabled?() and Billing.account_provisioned?(account) do
         []
         |> check_users_limit(account)

--- a/elixir/apps/domain/priv/repo/migrations/20250620200756_index_actors_on_type.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250620200756_index_actors_on_type.exs
@@ -1,0 +1,19 @@
+defmodule Domain.Repo.Migrations.IndexActorsOnType do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def up do
+    create(
+      index(:actors, [:account_id, :type],
+        name: :index_actors_on_account_id_and_type,
+        where: "deleted_at IS NULL",
+        concurrently: true
+      )
+    )
+  end
+
+  def down do
+    drop(index(:actors, [:account_id, :type], name: :index_actors_on_account_id_and_type))
+  end
+end


### PR DESCRIPTION
`Repo.aggregate(:count)` which performs a `COUNT(*)` query should be relatively fast if it's able to do an index-only scan. For that to happen we need to ensure all of the fields in the WHERE clause are indexed. Currently, we're missing an index on `actors.type` so a full row scan is executed per account each time we calculate Billing limits, every 5 minutes, for all accounts.

If we need to check these limits more often and/or our data grows in size, it could be worth moving these to a limits counter field on `accounts` which is maintained via INSERT/DELETE triggers.

Related: https://firezone-inc.sentry.io/issues/6346235615/events/588a61860e0b4875a5dbe8531dbb806a/?project=4508756715569152&referrer=next-event