### PR TITLE
chore(portal): drop index concurrently

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20250620200756_index_actors_on_type.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250620200756_index_actors_on_type.exs
@@ -14,6 +14,11 @@ defmodule Domain.Repo.Migrations.IndexActorsOnType do
   end
 
   def down do
-    drop(index(:actors, [:account_id, :type], name: :index_actors_on_account_id_and_type))
+    drop(
+      index(:actors, [:account_id, :type],
+        name: :index_actors_on_account_id_and_type,
+        concurrently: true
+      )
+    )
   end
 end


### PR DESCRIPTION
Looks like postgres does support this, so adding for good measure.