### PR TITLE
fix(portal): add if not exists to concurrent index

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20250620200756_index_actors_on_type.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250620200756_index_actors_on_type.exs
@@ -4,7 +4,7 @@ defmodule Domain.Repo.Migrations.IndexActorsOnType do
   @disable_ddl_transaction true
 
   def up do
-    create(
+    create_if_not_exists(
       index(:actors, [:account_id, :type],
         name: :index_actors_on_account_id_and_type,
         where: "deleted_at IS NULL",
@@ -14,7 +14,7 @@ defmodule Domain.Repo.Migrations.IndexActorsOnType do
   end
 
   def down do
-    drop(
+    drop_if_exists(
       index(:actors, [:account_id, :type],
         name: :index_actors_on_account_id_and_type,
         concurrently: true


### PR DESCRIPTION
With `@disable_ddl_transaction` this needs to be added.

See https://firezonehq.slack.com/archives/C04HRQTFY0Z/p1750516438992329?thread_ts=1750510766.640919&cid=C04HRQTFY0Z
