### PR TITLE
feat(ci): allow publish workflow to be run manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,11 @@
 name: Publish
 run-name: Triggered by ${{ github.actor }}
 on:
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: "Existing release name to publish"
+        required: true
   release:
     types:
       - published
@@ -11,7 +16,7 @@ concurrency:
 
 jobs:
   publish-docker-images:
-    if: ${{ startsWith(github.event.release.name, 'gateway') || startsWith(github.event.release.name, 'headless-client') }}
+    if: ${{ startsWith(inputs.release_name || github.event.release.name, 'gateway') || startsWith(inputs.release_name || github.event.release.name, 'headless-client') }}
     runs-on: ubuntu-22.04
     permissions:
       # Needed to upload artifacts to a release
@@ -35,11 +40,11 @@ jobs:
         run: |
           set -xe
 
-          if [[ "${{ github.event.release.name }}" =~ gateway* ]]; then
+          if [[ "${{ inputs.release_name || github.event.release.name }}" =~ gateway* ]]; then
             ARTIFACT=gateway
             # mark:next-gateway-version
             VERSION="1.4.12"
-          elif [[ "${{ github.event.release.name }}" =~ headless* ]]; then
+          elif [[ "${{ inputs.release_name || github.event.release.name }}" =~ headless* ]]; then
             ARTIFACT=client
             # mark:next-headless-version
             VERSION="1.5.1"
@@ -125,10 +130,10 @@ jobs:
           token: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
 
       - id: Create PR
-        if: ${{ startsWith(github.event.release.name, matrix.component) }}
+        if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.component) }}
         run: |
           # Extract version from release name
-          version=${{ github.event.release.name }}
+          version=${{ inputs.release_name || github.event.release.name }}
           version=${version#${{ matrix.component }}-}
 
           # Configure gpg


### PR DESCRIPTION
This allows us to retroactively run publish workflows that may have failed due to workflow bugs.

Needed to publish the 1.4.11 gateway image.