### PR TITLE
fix(ci): remove unused id from step in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,9 +128,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
-
-      - id: Create PR
-        if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.component) }}
+      - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.component) }}
         run: |
           # Extract version from release name
           version=${{ inputs.release_name || github.event.release.name }}


### PR DESCRIPTION
This isn't a valid name and can be removed anyway.

Related: #9615 