### PR TITLE
fix(ci): split newline correctly in github workflow file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,11 @@ concurrency:
 
 jobs:
   publish-docker-images:
-    if: ${{ \
-      startsWith(inputs.release_name || github.event.release.name, 'gateway') || \
-      startsWith(inputs.release_name || github.event.release.name, 'headless-client') }}
+    if: >-
+      ${{
+        startsWith(inputs.release_name || github.event.release.name, 'gateway') ||
+        startsWith(inputs.release_name || github.event.release.name, 'headless-client')
+      }}
     runs-on: ubuntu-22.04
     permissions:
       # Needed to upload artifacts to a release


### PR DESCRIPTION
GitHub doesn't like this syntax.

Related: #9618 