### PR TITLE
fix(ci): set github token for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,7 @@ jobs:
         id: set-variables
         env:
           release_name: ${{ inputs.release_name || github.event.release.name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -xe
 


### PR DESCRIPTION
This env var needs to be explicitly set.

Related: #9618 