### PR TITLE
fix(android): fix view state lifecycle around tunnel/auth

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/auth/ui/AuthViewModel.kt
@@ -29,15 +29,11 @@ internal class AuthViewModel
                 repo.saveNonceSync(nonce)
                 repo.saveStateSync(state)
                 val config = repo.getConfigSync()
-                val token = repo.getTokenSync()
 
                 actionMutableLiveData.postValue(
-                    if (authFlowLaunched || token != null) {
-                        ViewAction.NavigateToSignIn
-                    } else {
-                        authFlowLaunched = true
-                        ViewAction.LaunchAuthFlow("${config.authUrl}/${config.accountSlug}?state=$state&nonce=$nonce&as=client")
-                    },
+                    ViewAction.LaunchAuthFlow(
+                        "${config.authUrl}/${config.accountSlug}?state=$state&nonce=$nonce&as=client",
+                    ),
                 )
             }
 

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
@@ -16,6 +16,7 @@ import dev.firezone.android.features.session.ui.SessionActivity
 internal class SplashFragment : Fragment(R.layout.fragment_splash) {
     private lateinit var binding: FragmentSplashBinding
     private val viewModel: SplashViewModel by viewModels()
+    private var isInitialLaunch: Boolean = true
 
     override fun onViewCreated(
         view: View,
@@ -25,16 +26,13 @@ internal class SplashFragment : Fragment(R.layout.fragment_splash) {
         binding = FragmentSplashBinding.bind(view)
 
         setupActionObservers()
-
-        if (savedInstanceState == null) {
-            // Trigger the initial check for tunnel state
-            viewModel.checkTunnelState(requireContext(), isInitialLaunch = true)
-        }
     }
 
     override fun onResume() {
         super.onResume()
-        viewModel.checkTunnelState(requireContext(), isInitialLaunch = false)
+        viewModel.checkTunnelState(requireContext(), isInitialLaunch)
+
+        isInitialLaunch = false
     }
 
     private fun setupActionObservers() {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
@@ -26,6 +26,17 @@ internal class SplashFragment : Fragment(R.layout.fragment_splash) {
         binding = FragmentSplashBinding.bind(view)
 
         setupActionObservers()
+
+        savedInstanceState?.let {
+            isInitialLaunch = it.getBoolean("isInitialLaunch", true)
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        
+        // Save the initial launch state to handle edge cases where the fragment is recreated
+        outState.putBoolean("isInitialLaunch", isInitialLaunch)
     }
 
     override fun onResume() {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashFragment.kt
@@ -34,7 +34,7 @@ internal class SplashFragment : Fragment(R.layout.fragment_splash) {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        
+
         // Save the initial launch state to handle edge cases where the fragment is recreated
         outState.putBoolean("isInitialLaunch", isInitialLaunch)
     }

--- a/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/features/splash/ui/SplashViewModel.kt
@@ -60,7 +60,7 @@ internal class SplashViewModel
 
                 val connectOnStart = repo.getConfigSync().connectOnStart
 
-                // If this is the initial launch connectOnStart is true, try to connect
+                // If this is the initial launch and connectOnStart is true, try to connect
                 if (isInitialLaunch && connectOnStart) {
                     TunnelService.start(context)
                     actionMutableLiveData.postValue(ViewAction.NavigateToSession)

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -320,6 +320,7 @@ class TunnelService : VpnService() {
 
                         stopNetworkMonitoring()
                         stopDisconnectMonitoring()
+                        stopSelf()
                     }
             }
         }

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,10 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9621">
+          Fixes an issue where the VPN permission screen wouldn't dismiss after
+          granting the VPN permission.
+        </ChangeItem>
         <ChangeItem pull="9564">
           Fixes an issue where connections would fail to establish if both
           Client and Gateway were behind symmetric NAT.


### PR DESCRIPTION
`onViewCreated()` is called when the view initializes, and then `onResume()` is called right after, in addition to anytime the view is shown again.

To prevent showing the VPN permission activity twice, we remove the `checkTunnelState()` from onViewCreated, allowing only `onResume()` to call it.

A boolean flag is added to track whether this is the "first" launch of the app in order to determine whether to `connectOnStart`.

Fixes #9584