### PR TITLE
fix(portal): index auth_providers on adapter

### DIFF
--- a/elixir/apps/domain/priv/repo/manual_migrations/20250622165802_index_auth_providers_on_adapter.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250622165802_index_auth_providers_on_adapter.exs
@@ -1,0 +1,22 @@
+defmodule Domain.Repo.Migrations.IndexAuthProvidersOnAdapter do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def up do
+    # Used for refresh access token job which uses a cross-account query,
+    # so account_id is intentionally not included in the index.
+    create_if_not_exists(
+      index(
+        :auth_providers,
+        [:adapter],
+        where: "disabled_at IS NULL AND deleted_at IS NULL",
+        name: :index_auth_providers_on_adapter
+      )
+    )
+  end
+
+  def down do
+    drop_if_exists(index(:auth_providers, [:adapter], name: :index_auth_providers_on_adapter))
+  end
+end


### PR DESCRIPTION
The `refresh_tokens` job for each auth provider uses a cross-account query that unfortunately hits no indexes. This can cause slow queries each time the job runs for the adapter.

We add a simple sparse index to speed this query up.

Related: https://firezone-inc.sentry.io/issues/6346235615/?project=4508756715569152&query=is%3Aunresolved&referrer=issue-stream&stream_index=1