### PR TITLE
ci: move GUI smoke tests to tauri workflow

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -120,42 +120,6 @@ jobs:
           CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise the tests take forever.
           TESTCASES_DIR: "connlib/tunnel/testcases"
 
-  # Runs the Tauri client smoke test, built in debug mode. We can't run it in release
-  # mode because of a known issue: <https://github.com/firezone/firezone/blob/456e044f882c2bb314e19cc44c0d19c5ad817b7c/rust/windows-client/src-tauri/src/client.rs#L162-L164>
-  gui-smoke-test:
-    name: gui-smoke-test-${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
-    runs-on: ${{ matrix.runs-on }}
-    defaults:
-      run:
-        # Must be in this dir for `pnpm` to work
-        working-directory: ./rust/gui-client
-      # The Windows client ignores RUST_LOG because it uses a settings file instead
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/setup-node
-      - uses: ./.github/actions/setup-rust
-      - uses: ./.github/actions/setup-tauri-v2
-        timeout-minutes: 10
-        with:
-          runtime: true
-      - run: pnpm install
-      - run: pnpm vite build
-      - name: Build client
-        run: cargo build -p firezone-gui-client --all-targets
-      - uses: taiki-e/install-action@1cefd1553b1693f47889dc747f7d230904296a3b # v2.52.6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tool: dump_syms
-      - name: Run smoke test
-        working-directory: ./rust
-        run: cargo run -p gui-smoke-test
-        timeout-minutes: 2
-
   headless-client:
     name: headless-client-${{ matrix.test }}-${{ matrix.runs-on }}
     strategy:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -41,6 +41,42 @@ jobs:
       - run: pnpm install
       - run: pnpm eslint .
 
+  # Runs the Tauri client smoke test, built in debug mode. We can't run it in release
+  # mode because of a known issue: <https://github.com/firezone/firezone/blob/456e044f882c2bb314e19cc44c0d19c5ad817b7c/rust/windows-client/src-tauri/src/client.rs#L162-L164>
+  smoke-test:
+    name: gui-smoke-test-${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        # Must be in this dir for `pnpm` to work
+        working-directory: ./rust/gui-client
+      # The Windows client ignores RUST_LOG because it uses a settings file instead
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/setup-tauri-v2
+        timeout-minutes: 10
+        with:
+          runtime: true
+      - run: pnpm install
+      - run: pnpm vite build
+      - name: Build client
+        run: cargo build -p firezone-gui-client --all-targets
+      - uses: taiki-e/install-action@1cefd1553b1693f47889dc747f7d230904296a3b # v2.52.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tool: dump_syms
+      - name: Run smoke test
+        working-directory: ./rust
+        run: cargo run -p gui-smoke-test
+        timeout-minutes: 2
+
   build-gui:
     name: build-gui-${{ matrix.runs-on }}
     needs: update-release-draft


### PR DESCRIPTION
Now that we have conditional workflows, it makes more sense to move the GUI smoke test job to the Tauri workflow file. These smoke tests only need to run if we actually change something in the GUI client itself.

At the moment, these also fail on the Windows runners so moving them allows us to merge Rust code whilst we wait for GitHub to provide a fix.