### PR TITLE
ci: build GUI smoke tests with opt-level 1

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -71,6 +71,8 @@ jobs:
       - run: pnpm vite build
       - name: Build client
         run: cargo build -p firezone-gui-client --all-targets
+        env:
+          CARGO_PROFILE_TEST_OPT_LEVEL: 1 # Otherwise Windows fails to link the binaries.
       - uses: taiki-e/install-action@1cefd1553b1693f47889dc747f7d230904296a3b # v2.52.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub appears to have broken compilation of our Rust smoke-tests with a recent update to the runners. It is only the smoke-tests that fail to build, regular Rust tests and also the release binaries build fine.

With this patch, we also set an opt-level of 1 for the smoke tests to see if we can use that as a workaround to have a green CI.