### PR TITLE
chore(rust): remove telemetry spans and events

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2502,7 +2502,6 @@ dependencies = [
  "nu-ansi-term 0.50.1",
  "output_vt100",
  "parking_lot",
- "rand 0.8.5",
  "sentry-tracing",
  "supports-color",
  "tempfile",

--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -13,7 +13,7 @@ use std::{io, mem};
 use backoff::ExponentialBackoff;
 use backoff::backoff::Backoff;
 use base64::Engine;
-use firezone_logging::{err_with_src, telemetry_span};
+use firezone_logging::err_with_src;
 use futures::future::BoxFuture;
 use futures::{FutureExt, SinkExt, StreamExt};
 use itertools::Itertools as _;
@@ -261,8 +261,6 @@ where
         socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     ) -> io::Result<Self> {
         let host_and_port = url.expose_secret().host_and_port();
-
-        let _span = telemetry_span!("resolve_portal_url", host = %host_and_port.0).entered();
 
         // Statically resolve the host in the URL to a set of addresses.
         // We use these when connecting the socket to avoid a dependency on DNS resolution later on.

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -19,7 +19,7 @@ use anyhow::Context;
 use bimap::BiMap;
 use connlib_model::{GatewayId, PublicKey, RelayId, ResourceId, ResourceStatus, ResourceView};
 use connlib_model::{Site, SiteId};
-use firezone_logging::{err_with_src, telemetry_event, unwrap_or_debug, unwrap_or_warn};
+use firezone_logging::{err_with_src, unwrap_or_debug, unwrap_or_warn};
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_network_table::IpNetworkTable;
 use ip_packet::{IpPacket, MAX_UDP_PAYLOAD};
@@ -474,7 +474,7 @@ impl ClientState {
                         }
                     })
                     .unwrap_or_else(|e| {
-                        telemetry_event!("Recursive UDP DNS query failed: {}", err_with_src(&e));
+                        tracing::debug!("Recursive UDP DNS query failed: {}", err_with_src(&e));
 
                         dns_types::Response::servfail(&response.query)
                     });
@@ -490,7 +490,7 @@ impl ClientState {
                         tracing::trace!("Received recursive TCP DNS response");
                     })
                     .unwrap_or_else(|e| {
-                        telemetry_event!("Recursive TCP DNS query failed: {}", err_with_src(&e));
+                        tracing::debug!("Recursive TCP DNS query failed: {}", err_with_src(&e));
 
                         dns_types::Response::servfail(&response.query)
                     });

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -5,7 +5,7 @@ use dns_types::{
     DomainName, DomainNameRef, OwnedRecordData, Query, RecordType, Response, ResponseBuilder,
     ResponseCode,
 };
-use firezone_logging::{err_with_src, telemetry_span};
+use firezone_logging::err_with_src;
 use itertools::Itertools;
 use pattern::{Candidate, Pattern};
 use std::io;
@@ -231,8 +231,6 @@ impl StubResolver {
     ///
     /// This performs a linear search and is thus O(N) and **must not** be called in the hot-path of packet routing.
     fn match_resource_linear(&self, domain: &dns_types::DomainName) -> Option<Resource> {
-        let _span = telemetry_span!("match_resource_linear").entered();
-
         let name = Candidate::from_domain(domain);
 
         for (pattern, r) in &self.dns_resources {

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -24,7 +24,6 @@ use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use std::{io, mem};
 use tokio::sync::Mutex;
-use tracing::Instrument;
 
 use crate::RELEASE;
 

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -4,7 +4,7 @@ use boringtun::x25519::PublicKey;
 use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
 use dns_types::DomainName;
 use firezone_bin_shared::TunDeviceManager;
-use firezone_telemetry::Telemetry;
+use firezone_telemetry::{Telemetry, analytics};
 
 use firezone_tunnel::messages::gateway::{
     AllowAccess, ClientIceCandidates, ClientsIceCandidates, ConnectionReady, EgressMessages,

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -4,8 +4,8 @@ use boringtun::x25519::PublicKey;
 use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
 use dns_types::DomainName;
 use firezone_bin_shared::TunDeviceManager;
-use firezone_logging::telemetry_span;
-use firezone_telemetry::{Telemetry, analytics};
+use firezone_telemetry::Telemetry;
+
 use firezone_tunnel::messages::gateway::{
     AllowAccess, ClientIceCandidates, ClientsIceCandidates, ConnectionReady, EgressMessages,
     IngressMessages, RejectAccess, RequestConnection,
@@ -585,7 +585,6 @@ async fn resolve(domain: DomainName) -> Result<Vec<IpAddr>> {
     let dname = domain.to_string();
 
     let addresses = tokio::task::spawn_blocking(move || resolve_addresses(&dname))
-        .instrument(telemetry_span!("resolve_dns_resource"))
         .await
         .context("DNS resolution task failed")?
         .context("DNS resolution failed")?;

--- a/rust/logging/Cargo.toml
+++ b/rust/logging/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = { workspace = true }
 nu-ansi-term = { workspace = true }
 output_vt100 = { workspace = true }
 parking_lot = { workspace = true }
-rand = { workspace = true }
 sentry-tracing = { workspace = true }
 supports-color = { workspace = true }
 time = { workspace = true, features = ["formatting"] }

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -156,11 +156,6 @@ impl Telemetry {
                 environment: Some(Cow::Borrowed(environment.as_str())),
                 // We can't get the release number ourselves because we don't know if we're embedded in a GUI Client or a Headless Client.
                 release: Some(release.to_owned().into()),
-                traces_sampler: Some(Arc::new(|tx| {
-                    // Only submit `telemetry` spans to Sentry.
-                    // Those get sampled at creation time (to save CPU power) so we want to submit all of them.
-                    if tx.name() == "telemetry" { 1.0 } else { 0.0 }
-                })),
                 max_breadcrumbs: 500,
                 before_send: Some(event_rate_limiter(Duration::from_secs(60 * 5))),
                 enable_logs,


### PR DESCRIPTION
Originally, we introduced these to gather some data from logs / warnings that we considered to be too spammy. We've since merged a burst-protection that will at most submit the same event once every 5 minutes.

The data from the telemetry spans themselves have not been used at all.