### PR TITLE
feat(rust): stream logs to Sentry when enabled in PostHog

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6360,9 +6360,9 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a505499b38861edd82b5a688fa06ba4ba5875bb832adeeeba22b7b23fc4bc39a"
+checksum = "507ac2be9bf2da56c831da57faf1dadd81f434bd282935cdb06193d0c94e8811"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -6372,18 +6372,18 @@ dependencies = [
  "sentry-contexts",
  "sentry-core",
  "sentry-debug-images",
+ "sentry-log",
  "sentry-panic",
  "sentry-tracing",
  "tokio",
  "ureq",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "sentry-actix"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ad8bfdcfbc6e0d0dacaa5728555085ef459fa9226cfc2fe64eefa4b8038b7f"
+checksum = "8402c142005ee560ae361c73ebece13a299ec3e9cce5b8654479ea9aac8dc8df"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -6394,9 +6394,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dace796060e4ad10e3d1405b122ae184a8b2e71dce05ae450e4f81b7686b0d9"
+checksum = "eb4416302fa5325181a120e0fe7d4afd83cd95e52a9b86afa34a8161383fe0dc"
 dependencies = [
  "backtrace",
  "regex",
@@ -6405,9 +6405,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bd9e6b51ffe2bc7188ebe36cb67557cb95749c08a3f81f33e8c9b135e0d1bc"
+checksum = "936752f42b6f651dcb257da0bfa235ecc79e82011c49ed3383c212cc582263ff"
 dependencies = [
  "hostname",
  "libc",
@@ -6419,9 +6419,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7426d4beec270cfdbb50f85f0bb2ce176ea57eed0b11741182a163055a558187"
+checksum = "00e9bd2cadaeda3af41e9fa5d14645127d6f6a4aec73da3ae38e477ecafd3682"
 dependencies = [
  "rand 0.9.1",
  "sentry-types",
@@ -6431,19 +6431,29 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df15c066c04f34c4dfd496a8e76590106b93283f72ef1a47d8fb24d88493424"
+checksum = "e1e074fe9a0970c91999b23ed3195e6e30990d589fba3a68f20a1686af0f5cda"
 dependencies = [
  "findshlibs",
  "sentry-core",
 ]
 
 [[package]]
-name = "sentry-panic"
-version = "0.38.1"
+name = "sentry-log"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92beed69b776a162b6d269bef1eaa3e614090b6df45a88d9b239c4fdbffdfba"
+checksum = "a693f27e3f63ae085cf7c176b5c44038af27c8a0170d01db30ccf776c2d40ce3"
+dependencies = [
+ "log",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4651d34f3ba649d9e6dc1268443cae6728b8f741c2f0264004f8ecf5b247330d"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -6451,10 +6461,11 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c323492795de90824f3198562e33dd74ae3bc852fbb13c0cabec54a1cf73cd"
+checksum = "c25c47d36bc80c74d26d568ffe970c37b337c061b7234ad6f2d159439c16f000"
 dependencies = [
+ "bitflags 2.9.1",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -6463,9 +6474,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b6c9287202294685cb1f749b944dbbce8160b81a1061ecddc073025fed129f"
+checksum = "a08e7154abe2cd557f26fd70038452810748aefdf39bc973f674421224b147c1"
 dependencies = [
  "debugid",
  "hex",
@@ -8485,17 +8496,31 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
 dependencies = [
  "base64 0.22.1",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
- "url",
+ "ureq-proto",
+ "utf-8",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -139,8 +139,8 @@ sadness-generator = "0.6.0"
 sd-notify = "0.4.5" # This is a pure Rust re-implementation, so it isn't vulnerable to CVE-2024-3094
 secrecy = "0.8"
 semver = "1.0.26"
-sentry = { version = "0.38.1", default-features = false }
-sentry-tracing = "0.38.1"
+sentry = { version = "0.41.0", default-features = false }
+sentry-tracing = "0.41.0"
 serde = "1.0.219"
 serde_json = "1.0.140"
 serde_variant = "0.1.3"

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -217,7 +217,7 @@ impl<'a> Eventloop<'a> {
             }
 
             match self.telemetry_refresh.poll_tick(cx) {
-                Poll::Ready(()) => {
+                Poll::Ready(_) => {
                     self.telemetry.refresh_config();
                     continue;
                 }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -92,7 +92,7 @@ impl<'a> Eventloop<'a> {
                     tracing::debug!(%domain, ?ips, ?cause, "DNS cache entry evicted");
                 })
                 .build(),
-            telemetry_refresh: tokio::time::interval(Duration::from_secs(60 * 5)),
+            telemetry_refresh: tokio::time::interval(Duration::from_secs(60)),
             telemetry,
         }
     }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -180,7 +180,8 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<ExitCode> {
     }
 
     let task = tokio::spawn(future::poll_fn({
-        let mut eventloop = Eventloop::new(tunnel, portal, tun_device_manager, firezone_id);
+        let mut eventloop =
+            Eventloop::new(tunnel, portal, tun_device_manager, firezone_id, telemetry);
 
         move |cx| eventloop.poll(cx)
     }))

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -105,13 +105,15 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<ExitCode> {
         .context("Couldn't read FIREZONE_ID or write it to disk: Please provide it through the env variable or provide rw access to /var/lib/firezone/")?;
 
     if cli.is_telemetry_allowed() {
-        telemetry.start(
-            cli.api_url.as_str(),
-            concat!("gateway@", env!("CARGO_PKG_VERSION")),
-            firezone_telemetry::GATEWAY_DSN,
-        );
+        telemetry
+            .start(
+                cli.api_url.as_str(),
+                concat!("gateway@", env!("CARGO_PKG_VERSION")),
+                firezone_telemetry::GATEWAY_DSN,
+                firezone_id.clone(),
+            )
+            .await;
     }
-    Telemetry::set_firezone_id(firezone_id.clone());
 
     if cli.metrics {
         let exporter = opentelemetry_stdout::MetricExporter::default();

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -71,22 +71,27 @@ fn try_main(
         .inspect_err(|e| tracing::debug!("Failed to load MDM settings {e:#}"))
         .unwrap_or_default();
 
-    // Get the device ID before starting Tokio, so that all the worker threads will inherit the correct scope.
-    // Technically this means we can fail to get the device ID on a newly-installed system, since the Tunnel service may not have fully started up when the GUI process reaches this point, but in practice it's unlikely.
-    let id = firezone_bin_shared::device_id::get().context("Failed to get device ID")?;
-    Telemetry::set_firezone_id(id.id.clone());
-
     let api_url = mdm_settings
         .api_url
         .as_ref()
         .unwrap_or(&advanced_settings.api_url)
         .to_string();
 
-    telemetry.start(
+    // Get the device ID before starting Tokio, so that all the worker threads will inherit the correct scope.
+    // Technically this means we can fail to get the device ID on a newly-installed system, since the Tunnel service may not have fully started up when the GUI process reaches this point, but in practice it's unlikely.
+    let id = firezone_bin_shared::device_id::get().context("Failed to get device ID")?;
+    analytics::identify(
+        id.id.clone(),
+        api_url.clone(),
+        firezone_gui_client::RELEASE.to_owned(),
+    );
+
+    rt.block_on(telemetry.start(
         &api_url,
         firezone_gui_client::RELEASE,
         firezone_telemetry::GUI_DSN,
-    );
+        id.id,
+    ));
 
     // Don't fix the log filter for smoke tests because we can't show a dialog there.
     if !config.smoke_test {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -11,6 +11,7 @@ use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, elevation, gui, logging, settings};
 use firezone_telemetry::Telemetry;
+use firezone_telemetry::analytics;
 use settings::AdvancedSettingsLegacy;
 use tokio::runtime::Runtime;
 use tracing::subscriber::DefaultGuard;

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -85,6 +85,7 @@ fn try_main(
         id.id.clone(),
         api_url.clone(),
         firezone_gui_client::RELEASE.to_owned(),
+        None,
     );
 
     rt.block_on(telemetry.start(

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -548,8 +548,13 @@ impl<'a> Handler<'a> {
                 account_slug,
             } => {
                 self.telemetry
-                    .start(&environment, &release, firezone_telemetry::GUI_DSN);
-                Telemetry::set_firezone_id(self.device_id.id.clone());
+                    .start(
+                        &environment,
+                        &release,
+                        firezone_telemetry::GUI_DSN,
+                        self.device_id.id.clone(),
+                    )
+                    .await;
 
                 if let Some(account_slug) = account_slug {
                     Telemetry::set_account_slug(account_slug.clone());
@@ -576,7 +581,6 @@ impl<'a> Handler<'a> {
 
         assert!(self.session.is_none());
         let device_id = device_id::get_or_create().context("Failed to get-or-create device ID")?;
-        Telemetry::set_firezone_id(device_id.id.clone());
 
         let url = LoginUrl::client(
             Url::parse(api_url).context("Failed to parse URL")?,

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -323,7 +323,7 @@ fn main() -> Result<()> {
                     session.reset();
                     continue;
                 },
-                () = telemetry_refresh.tick() => {
+                _ = telemetry_refresh.tick() => {
                     telemetry.refresh_config();
                     continue;
                 }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -286,7 +286,7 @@ fn main() -> Result<()> {
             new_network_notifier(tokio_handle.clone(), dns_control_method).await?;
         drop(tokio_handle);
 
-        let mut telemetry_refresh = tokio::time::interval(Duration::from_secs(5 * 60));
+        let mut telemetry_refresh = tokio::time::interval(Duration::from_secs(60));
 
         let tun = {
             let _guard = telemetry_span!("create_tun_device").entered();

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -221,8 +221,8 @@ where
 
     sentry_tracing::layer()
         .event_filter(move |md| match *md.level() {
-            Level::ERROR | Level::WARN => EventFilter::Event,
-            Level::INFO | Level::DEBUG => EventFilter::Breadcrumb,
+            Level::ERROR | Level::WARN => EventFilter::Event | EventFilter::Breadcrumb | EventFilter::Log,
+            Level::INFO | Level::DEBUG => EventFilter::Breadcrumb | EventFilter::Log,
             Level::TRACE if md.target() == TELEMETRY_TARGET => EventFilter::Event,
             _ => EventFilter::Ignore,
         })

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -111,8 +111,7 @@ fn parse_filter(directives: &str) -> Result<EnvFilter, ParseError> {
     ///
     /// By prepending this directive to the active log filter, a simple directive like `debug` actually produces useful logs.
     /// If necessary, you can still activate logs from these crates by restating them in your directive with a lower filter, i.e. `netlink_proto=debug`.
-    const IRRELEVANT_CRATES: &str =
-        "netlink_proto=warn,os_info=warn,rustls=warn,opentelemetry_sdk=info,opentelemetry=info";
+    const IRRELEVANT_CRATES: &str = "netlink_proto=warn,os_info=warn,rustls=warn,opentelemetry_sdk=info,opentelemetry=info,hyper_util=info";
 
     let env_filter = if directives.is_empty() {
         EnvFilter::try_new(IRRELEVANT_CRATES)?

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -118,19 +118,20 @@ fn main() {
 
     let args = Args::parse();
 
-    let mut telemetry = Telemetry::default();
-    if args.telemetry {
-        telemetry.start(
-            args.api_url.as_str(),
-            VERSION.unwrap_or("unknown"),
-            RELAY_DSN,
-        );
-    }
-
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("Failed to build tokio runtime");
+
+    let mut telemetry = Telemetry::default();
+    if args.telemetry {
+        runtime.block_on(telemetry.start(
+            args.api_url.as_str(),
+            VERSION.unwrap_or("unknown"),
+            RELAY_DSN,
+            String::new(), // Relays don't have a Firezone ID.
+        ));
+    }
 
     match runtime.block_on(try_main(args)) {
         Ok(()) => runtime.block_on(telemetry.stop()),

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -13,7 +13,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 parking_lot = { workspace = true }
 reqwest = { workspace = true }
-sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing", "release-health"] }
+sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing", "release-health", "logs"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -159,6 +159,7 @@ impl Telemetry {
                 })),
                 max_breadcrumbs: 500,
                 before_send: Some(event_rate_limiter(Duration::from_secs(60 * 5))),
+                enable_logs: true,
                 ..Default::default()
             },
         ));


### PR DESCRIPTION
Sentry has a new "Logs" feature where we can stream logs directly to Sentry. Doing this for all Clients and Gateways would be way too much data to collect though.

In order to aid debugging from customer installations, we add a PostHog-managed feature flag that - if set to `true` - enables the streaming of logs to Sentry. This feature flag is evaluated every time the telemetry context is initialised:

- For all FFI usages of connlib, this happens every time a new session is created.
- For the Windows/Linux Tunnel service, this also happens every time we create a new session.
- For the Headless Client and Gateway, it happens on startup and afterwards, every minute. The feature-flag context itself is only checked every 5 minutes though so it might take up to 5 minutes before this takes effect.

The default value - like all feature flags - is `false`. Therefore, if there is any issue with the PostHog service, we will fallback to the previous behaviour where logs are simply stored locally.

Resolves: #9600