### PR TITLE
feat(telemetry): send `account_slug` to PostHog

### DIFF
--- a/rust/apple-client-ffi/src/lib.rs
+++ b/rust/apple-client-ffi/src/lib.rs
@@ -257,9 +257,14 @@ impl WrappedSession {
         let mut telemetry = Telemetry::default();
         telemetry.start(&api_url, RELEASE, APPLE_DSN);
         Telemetry::set_firezone_id(device_id.clone());
-        Telemetry::set_account_slug(account_slug);
+        Telemetry::set_account_slug(account_slug.clone());
 
-        analytics::identify(device_id.clone(), api_url.to_string(), RELEASE.to_owned());
+        analytics::identify(
+            device_id.clone(),
+            api_url.to_string(),
+            RELEASE.to_owned(),
+            Some(account_slug),
+        );
 
         init_logging(log_dir.into(), log_filter)?;
         install_rustls_crypto_provider();

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -231,7 +231,12 @@ fn connect(
     Telemetry::set_firezone_id(device_id.clone());
     Telemetry::set_account_slug(account_slug);
 
-    analytics::identify(device_id.clone(), api_url.to_string(), RELEASE.to_owned());
+    analytics::identify(
+        device_id.clone(),
+        api_url.to_string(),
+        RELEASE.to_owned(),
+        Some(account_slug),
+    );
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
     install_rustls_crypto_provider();

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -229,7 +229,7 @@ fn connect(
     let mut telemetry = Telemetry::default();
     telemetry.start(&api_url, RELEASE, platform::DSN);
     Telemetry::set_firezone_id(device_id.clone());
-    Telemetry::set_account_slug(account_slug);
+    Telemetry::set_account_slug(account_slug.clone());
 
     analytics::identify(
         device_id.clone(),

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -10,7 +10,7 @@ use anyhow::{Context as _, Result, bail};
 use clap::{Args, Parser};
 use controller::Failure;
 use firezone_gui_client::{controller, deep_link, elevation, gui, logging, settings};
-use firezone_telemetry::{Telemetry, analytics};
+use firezone_telemetry::Telemetry;
 use settings::AdvancedSettingsLegacy;
 use tokio::runtime::Runtime;
 use tracing::subscriber::DefaultGuard;
@@ -103,7 +103,7 @@ fn try_main(
     // Get the device ID before starting Tokio, so that all the worker threads will inherit the correct scope.
     // Technically this means we can fail to get the device ID on a newly-installed system, since the Tunnel service may not have fully started up when the GUI process reaches this point, but in practice it's unlikely.
     if let Ok(id) = firezone_bin_shared::device_id::get() {
-        Telemetry::set_firezone_id(id.id.clone());
+        Telemetry::set_firezone_id(id.id);
     }
 
     match cli.command {

--- a/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
+++ b/rust/gui-client/src-tauri/src/bin/firezone-gui-client.rs
@@ -104,8 +104,6 @@ fn try_main(
     // Technically this means we can fail to get the device ID on a newly-installed system, since the Tunnel service may not have fully started up when the GUI process reaches this point, but in practice it's unlikely.
     if let Ok(id) = firezone_bin_shared::device_id::get() {
         Telemetry::set_firezone_id(id.id.clone());
-
-        analytics::identify(id.id, api_url, firezone_gui_client::RELEASE.to_owned());
     }
 
     match cli.command {

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -552,13 +552,13 @@ impl<'a> Handler<'a> {
                 Telemetry::set_firezone_id(self.device_id.id.clone());
 
                 if let Some(account_slug) = account_slug {
-                    Telemetry::set_account_slug(account_slug);
+                    Telemetry::set_account_slug(account_slug.clone());
 
                     analytics::identify(
                         self.device_id.id.clone(),
                         environment,
                         release,
-                        account_slug,
+                        Some(account_slug),
                     );
                 }
             }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -553,6 +553,13 @@ impl<'a> Handler<'a> {
 
                 if let Some(account_slug) = account_slug {
                     Telemetry::set_account_slug(account_slug);
+
+                    analytics::identify(
+                        self.device_id.id.clone(),
+                        environment,
+                        release,
+                        account_slug,
+                    );
                 }
             }
         }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -205,6 +205,7 @@ fn main() -> Result<()> {
         firezone_id.clone(),
         cli.api_url.to_string(),
         RELEASE.to_owned(),
+        None,
     );
 
     let url = LoginUrl::client(

--- a/rust/telemetry/src/analytics.rs
+++ b/rust/telemetry/src/analytics.rs
@@ -22,7 +22,12 @@ pub fn new_session(distinct_id: String, api_url: String) {
 }
 
 /// Associate several properties with a particular "distinct_id" in PostHog.
-pub fn identify(distinct_id: String, api_url: String, release: String) {
+pub fn identify(
+    distinct_id: String,
+    api_url: String,
+    release: String,
+    account_slug: Option<String>,
+) {
     RUNTIME.spawn({
         let distinct_id = distinct_id.clone();
         let api_url = api_url.clone();
@@ -35,6 +40,7 @@ pub fn identify(distinct_id: String, api_url: String, release: String) {
                 IdentifyProperties {
                     set: PersonProperties {
                         release,
+                        account_slug,
                         os: std::env::consts::OS.to_owned(),
                     },
                 },
@@ -131,6 +137,8 @@ struct IdentifyProperties {
 #[derive(serde::Serialize)]
 struct PersonProperties {
     release: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account_slug: Option<String>,
     #[serde(rename = "$os")]
     os: String,
 }


### PR DESCRIPTION
In order to more easily target customers with certain feature flags, we include the `account_slug` in the `$identify` event to PostHog. This will allow us to create Cohorts in PostHog and enable / disable feature flags for all installations of Firezone for a particular customer.