### PR TITLE
feat(headless-client): require Firezone ID on CLI

### DIFF
--- a/website/src/app/kb/client-apps/linux-headless-client/readme.mdx
+++ b/website/src/app/kb/client-apps/linux-headless-client/readme.mdx
@@ -57,8 +57,8 @@ Set some environment variables to configure it:
 
 ```bash
 export FIREZONE_NAME="Development API test client"
-export FIREZONE_ID=$(head -c 32 /dev/urandom | sha256)
-export FIREZONE_TOKEN=<TOKEN>
+export FIREZONE_ID="<UNIQUE_STRING>" # Generate with `head -c 32 /dev/urandom | sha256`
+export FIREZONE_TOKEN="<TOKEN>"
 export LOG_DIR="./"
 sudo -E ./firezone-client-headless-linux_1.0.0_x86_64
 ```

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,6 +10,11 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9638">
+          **BREAKING**: The `FIREZONE_ID` env variable is now required. The
+          Headless Client will no longer read the Firezone ID from disk. We
+          recommend setting it to a unique, static string.
+        </ChangeItem>
         <ChangeItem pull="9564">
           Fixes an issue where connections would fail to establish if both
           Client and Gateway were behind symmetric NAT.


### PR DESCRIPTION
Currently, the Headless Client automatically generates a Firezone ID when it is started. This makes it difficult for us to track a single Client in ephemeral environments like CI. In order to avoid spamming our analytics infrastructure in PostHog with once-off installations, we make the `FIREZONE_ID` env variable required when launching the Client.