### PR TITLE
fix(rust): use `rust-lld` linker for MSVC

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -3,3 +3,8 @@ rustflags="-C force-frame-pointers=yes"
 
 [target.x86_64-unknown-linux-gnu]
 rustflags="-C force-frame-pointers=yes"
+
+# https://github.com/rust-lang/rust/issues/141626
+# (can be removed once link.exe is fixed)
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"


### PR DESCRIPTION
The latest VisualStudio version shipped a bug in the MSVC linker that cannot handle symbols above a certain size. Switching to the Rust linker fixes this issue.

Related: https://github.com/rust-lang/rust/issues/141626