### PR TITLE
feat(ci): use larger runners for all jobs

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   control-plane:
     name: ${{ matrix.image_name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     strategy:
       fail-fast: false
       matrix:
@@ -113,7 +113,7 @@ jobs:
   data-plane-windows:
     name: client-windows-${{ matrix.target }}
     if: ${{ inputs.image_prefix != 'perf' }} # Perf testing happens only on Linux
-    runs-on: windows-2022
+    runs-on: windows-2022-xlarge
     defaults:
       run:
         working-directory: rust
@@ -173,7 +173,7 @@ jobs:
 
   data-plane-linux:
     name: ${{ matrix.name.image_name }}-${{ matrix.arch.shortname }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     defaults:
       run:
         working-directory: rust
@@ -401,7 +401,7 @@ jobs:
     name: merge-${{ matrix.image.name }}
     needs: data-plane-linux
     if: ${{ always() }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   analyze:
     name: analyze-${{ matrix.working-directory }}
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-14') || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-14-xlarge') || 'ubuntu-22.04-xlarge' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     defaults:
       run:
         working-directory: ./elixir
@@ -44,7 +44,7 @@ jobs:
           reporter: java-junit
 
   type-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     defaults:
       run:
         working-directory: ./elixir
@@ -82,7 +82,7 @@ jobs:
         run: mix dialyzer --format dialyxir
 
   static-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     defaults:
       run:
         working-directory: ./elixir
@@ -111,7 +111,7 @@ jobs:
         run: mix deps.unlock --check-unused
 
   migrations-and-seed-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     defaults:
       run:
         working-directory: ./elixir
@@ -150,7 +150,7 @@ jobs:
     name: acceptance-test-${{ matrix.MIX_TEST_PARTITION }}
     permissions:
       checks: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     defaults:
       run:
         working-directory: ./elixir

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -74,7 +74,7 @@ env:
 jobs:
   integration-tests:
     name: ${{ matrix.test.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   static-analysis:
     # Android SDK tools hardware accel is available only on Linux runners
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-android
@@ -23,7 +23,7 @@ jobs:
 
   update-release-draft:
     name: update-release-draft
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     permissions:
       contents: write # for updating the release draft
     env:
@@ -50,7 +50,7 @@ jobs:
     needs: update-release-draft
     if: "${{ github.event_name == 'workflow_dispatch' }}"
     # Android SDK tools hardware accel is available only on Linux runners
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +117,7 @@ jobs:
 
   build_debug:
     # Android SDK tools hardware accel is available only on Linux runners
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     name: build-debug
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
-        runs-on: [ubuntu-22.04, macos-14, windows-2022]
+        runs-on: [ubuntu-22.04-xlarge, macos-14-xlarge, windows-2022-xlarge]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -63,13 +63,13 @@ jobs:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         runs-on:
           [
-            ubuntu-22.04,
-            ubuntu-24.04,
-            macos-13,
-            macos-14,
-            macos-15,
-            windows-2022,
-            windows-2025,
+            ubuntu-22.04-xlarge,
+            ubuntu-24.04-xlarge,
+            macos-13-xlarge,
+            macos-14-xlarge,
+            macos-15-xlarge,
+            windows-2022-xlarge,
+            windows-2025-xlarge,
           ]
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -126,12 +126,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { runs-on: windows-2022, test: token-path-windows.ps1 }
-          - { runs-on: windows-2025, test: token-path-windows.ps1 }
-          - { runs-on: ubuntu-22.04, test: linux-group.sh }
-          - { runs-on: ubuntu-24.04, test: linux-group.sh }
-          - { runs-on: ubuntu-22.04, test: token-path-linux.sh }
-          - { runs-on: ubuntu-24.04, test: token-path-linux.sh }
+          - { runs-on: windows-2022-xlarge, test: token-path-windows.ps1 }
+          - { runs-on: windows-2025-xlarge, test: token-path-windows.ps1 }
+          - { runs-on: ubuntu-22.04-xlarge, test: linux-group.sh }
+          - { runs-on: ubuntu-24.04-xlarge, test: linux-group.sh }
+          - { runs-on: ubuntu-22.04-xlarge, test: token-path-linux.sh }
+          - { runs-on: ubuntu-24.04-xlarge, test: token-path-linux.sh }
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-lint:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
@@ -32,7 +32,7 @@ jobs:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 #v5.5.3
 
   version-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check version is up to date
@@ -49,7 +49,7 @@ jobs:
           fi
 
   link-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
@@ -58,7 +58,7 @@ jobs:
           args: --offline --verbose --no-progress **/*.md
 
   global-linter:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   update-release-draft:
     name: update-release-draft
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     env:
       # mark:next-apple-version
       RELEASE_NAME: macos-client-1.5.4
@@ -26,7 +26,7 @@ jobs:
   build:
     name: ${{ matrix.job_name }}
     needs: update-release-draft
-    runs-on: macos-15
+    runs-on: macos-15-xlarge
     env:
       XCODE_MAJOR: 16
     permissions:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   update-release-draft:
     name: update-release-draft
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     env:
       # mark:next-gui-version
       RELEASE_NAME: gui-client-1.5.5
@@ -38,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   static-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-node
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
+        runs-on: [ubuntu-22.04-xlarge, ubuntu-24.04-xlarge, windows-2022-xlarge, windows-2025-xlarge]
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
@@ -92,15 +92,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-22.04
+          - runs-on: ubuntu-22.04-xlarge
             arch: x86_64
             os: linux
             pkg-extension: deb
-          - runs-on: ubuntu-22.04-arm
+          - runs-on: ubuntu-22.04-arm-xlarge
             arch: aarch64
             os: linux
             pkg-extension: deb
-          - runs-on: windows-2022
+          - runs-on: windows-2022-xlarge
             arch: x86_64
             os: windows
             pkg-extension: msi

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -52,7 +52,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-22.04-xlarge, ubuntu-24.04-xlarge, windows-2022-xlarge, windows-2025-xlarge]
+        runs-on:
+          [
+            ubuntu-22.04-xlarge,
+            ubuntu-24.04-xlarge,
+            windows-2022-xlarge,
+            windows-2025-xlarge,
+          ]
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
 
   notify:
     needs: ci
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     steps:
       - name: Send 'checks-passed' event
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   planner:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xlarge
     outputs:
       jobs_to_run: ${{ steps.plan.outputs.jobs_to_run }}
     steps:
@@ -104,7 +104,7 @@ jobs:
   required-check:
     name: required-check
     needs: planner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xlarge
     steps:
       - uses: actions/checkout@v4
       - name: Wait for all jobs to complete
@@ -174,7 +174,7 @@ jobs:
 
   update-release-draft:
     name: update-release-draft-${{ matrix.config_name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     strategy:
       fail-fast: false
       matrix:
@@ -263,7 +263,7 @@ jobs:
   perf-tests:
     name: perf-tests
     needs: build-perf-artifacts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     permissions:
       contents: read
       id-token: write
@@ -362,7 +362,7 @@ jobs:
   upload-bencher:
     continue-on-error: true
     needs: perf-tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   publish_clients:
     name: Publish ${{ matrix.identifier }} to winget
-    runs-on: windows-latest
+    runs-on: windows-latest-xlarge
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         startsWith(inputs.release_name || github.event.release.name, 'gateway') ||
         startsWith(inputs.release_name || github.event.release.name, 'headless-client')
       }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     permissions:
       # Needed to upload artifacts to a release
       packages: write
@@ -123,7 +123,7 @@ jobs:
           done
 
   create-publish-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xlarge
     strategy:
       matrix:
         component:

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   create_sentry_release:
     name: create_${{ matrix.component }}_sentry_release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     strategy:
       matrix:
         include:

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linkChecker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xlarge
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:


### PR DESCRIPTION
Append `-xlarge` to the previous runner labels to match new larger runners.