### PR TITLE
fix(ci): dont require upload-bencher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,7 @@ jobs:
           set -e
 
           while true; do
-            optional_jobs=("required-check" "upload-bencher")
-            optional_jobs_json=$(printf '%s\n' "${optional_jobs[@]}" | jq -R . | jq -s .)
-            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name | IN($optional_jobs_json) | not))' --argjson optional_jobs_json "$optional_jobs_json")
+            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name != "required-check" and .name != "upload-bencher"))')
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
             failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,8 @@ jobs:
           set -e
 
           while true; do
-            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name | contains("required-check") | not))')
+            optional_jobs=("required-check" "upload-bencher")
+            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name | IN("'"${optional_jobs[@]}"'") | not))')
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
             failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,8 @@ jobs:
 
           while true; do
             optional_jobs=("required-check" "upload-bencher")
-            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name | IN("'"${optional_jobs[@]}"'") | not))')
+            optional_jobs_json=$(printf '%s\n' "${optional_jobs[@]}" | jq -R . | jq -s .)
+            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name | IN($optional_jobs_json) | not))' --argjson optional_jobs_json "$optional_jobs_json")
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
             failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')


### PR DESCRIPTION
Bencher is not the most reliable service, so this PR prevent us from failing CI runs on the `uploader-bencher` job.