### PR TITLE
fix(portal): only show `never synced` correctly

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
@@ -63,6 +63,7 @@ defmodule Domain.Auth.Provider.Changeset do
 
     provider
     |> change()
+    |> put_change(:last_synced_at, nil)
     |> put_change(:last_sync_error, error)
     |> put_change(:last_syncs_failed, last_syncs_failed + 1)
   end

--- a/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
@@ -63,7 +63,6 @@ defmodule Domain.Auth.Provider.Changeset do
 
     provider
     |> change()
-    |> put_change(:last_synced_at, nil)
     |> put_change(:last_sync_error, error)
     |> put_change(:last_syncs_failed, last_syncs_failed + 1)
   end

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
@@ -327,7 +327,11 @@ defmodule Web.Settings.IdentityProviders.Components do
         <.relative_datetime datetime={@provider.last_synced_at} />
       </span>
     </div>
-    <div :if={is_nil(@provider.last_synced_at)} class="flex items-center">
+    {# TODO: IDP sync - clean this up}
+    <div
+      :if={is_nil(@provider.last_synced_at) && @provider.last_syncs_failed == 0}
+      class="flex items-center"
+    >
       <.ping_icon color="danger" />
       <span class="ml-2.5">
         Never synced


### PR DESCRIPTION
It's confusing that we clear this field upon sync failure. Instead, we let it track the time of the last sync.

Will be cleaned up in #6294 so just applying a minimal fix now.

Fixes #7715