### PR TITLE
fix(portal): trim whitespace in all remaining forms

### DIFF
--- a/elixir/apps/domain/lib/domain/actors/actor/changeset.ex
+++ b/elixir/apps/domain/lib/domain/actors/actor/changeset.ex
@@ -4,7 +4,9 @@ defmodule Domain.Actors.Actor.Changeset do
   alias Domain.Actors
   alias Domain.Actors.Actor
 
-  def allowed_updates, do: %{fields: ~w[type name]a}
+  @fields ~w[name type]a
+
+  def allowed_updates, do: %{fields: @fields}
   def allowed_updates(%Actor{last_synced_at: nil}), do: allowed_updates()
   def allowed_updates(%Actor{}), do: %{fields: ~w[type]a}
 
@@ -64,6 +66,7 @@ defmodule Domain.Actors.Actor.Changeset do
     # Actor name can be very long in case IdP syncs something crazy long to us,
     # we still don't wait to fail for that silently
     |> validate_length(:name, max: 512)
+    |> trim_change(@fields)
   end
 
   def disable_actor(%Actor{} = actor) do

--- a/elixir/apps/domain/lib/domain/actors/group/changeset.ex
+++ b/elixir/apps/domain/lib/domain/actors/group/changeset.ex
@@ -3,6 +3,8 @@ defmodule Domain.Actors.Group.Changeset do
   alias Domain.{Auth, Accounts}
   alias Domain.Actors
 
+  @fields ~w[name type]a
+
   def upsert_conflict_target do
     {:unsafe_fragment,
      "(account_id, provider_id, provider_identifier) " <>
@@ -13,8 +15,8 @@ defmodule Domain.Actors.Group.Changeset do
 
   def create(%Accounts.Account{} = account, attrs, %Auth.Subject{} = subject) do
     %Actors.Group{memberships: []}
-    |> cast(attrs, ~w[name type]a)
-    |> validate_required(~w[name type]a)
+    |> cast(attrs, @fields)
+    |> validate_required(@fields)
     |> validate_inclusion(:type, ~w[static]a)
     |> changeset()
     |> put_change(:account_id, account.id)
@@ -57,7 +59,7 @@ defmodule Domain.Actors.Group.Changeset do
 
   defp changeset(changeset) do
     changeset
-    |> trim_change(:name)
+    |> trim_change(@fields)
     |> validate_length(:name, min: 1, max: 255)
     |> unique_constraint(:name, name: :actor_groups_account_id_name_index)
   end

--- a/elixir/apps/domain/lib/domain/auth/identity/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/identity/changeset.ex
@@ -72,6 +72,7 @@ defmodule Domain.Auth.Identity.Changeset do
     |> unique_constraint(:email,
       name: :auth_identities_acct_id_provider_id_email_prov_ident_unique_idx
     )
+    |> trim_change(~w[email provider_identifier]a)
   end
 
   def update_identity_provider_state(identity_or_changeset, %{} = state, virtual_state \\ %{}) do

--- a/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/provider/changeset.ex
@@ -81,6 +81,7 @@ defmodule Domain.Auth.Provider.Changeset do
 
   defp changeset(changeset) do
     changeset
+    |> trim_change(@required_fields)
     |> validate_length(:name, min: 1, max: 255)
     |> validate_required(:adapter)
     |> unique_constraint(:base,

--- a/elixir/apps/domain/lib/domain/clients/client/changeset.ex
+++ b/elixir/apps/domain/lib/domain/clients/client/changeset.ex
@@ -171,7 +171,7 @@ defmodule Domain.Clients.Client.Changeset do
 
   defp changeset(changeset) do
     changeset
-    |> trim_change(:name)
+    |> Domain.Repo.Changeset.trim_change(~w[name external_id]a)
     |> validate_length(:name, min: 1, max: 255)
     |> assoc_constraint(:actor)
     |> unique_constraint([:actor_id, :public_key])

--- a/elixir/apps/domain/lib/domain/gateways/group/changeset.ex
+++ b/elixir/apps/domain/lib/domain/gateways/group/changeset.ex
@@ -33,7 +33,7 @@ defmodule Domain.Gateways.Group.Changeset do
   defp changeset(%Gateways.Group{} = group, attrs) do
     group
     |> cast(attrs, @fields)
-    |> trim_change(:name)
+    |> trim_change(@fields)
     |> put_default_value(:name, &Domain.NameGenerator.generate/0)
     |> validate_required(@fields)
     |> validate_length(:name, min: 1, max: 64)

--- a/elixir/apps/domain/lib/domain/policies/condition/changeset.ex
+++ b/elixir/apps/domain/lib/domain/policies/condition/changeset.ex
@@ -9,6 +9,7 @@ defmodule Domain.Policies.Condition.Changeset do
     |> put_default_value(:operator, :is_in)
     |> validate_required([:property, :operator])
     |> validate_operator()
+    |> Domain.Repo.Changeset.trim_change([:values])
   end
 
   def valid_operators_for_property(:remote_ip_location_region), do: [:is_in, :is_not_in]

--- a/elixir/apps/domain/lib/domain/relays/group/changeset.ex
+++ b/elixir/apps/domain/lib/domain/relays/group/changeset.ex
@@ -29,7 +29,7 @@ defmodule Domain.Relays.Group.Changeset do
   defp changeset(group, attrs) do
     group
     |> cast(attrs, @fields)
-    |> trim_change(:name)
+    |> trim_change(@fields)
     |> put_default_value(:name, &Domain.NameGenerator.generate/0)
     |> validate_required(@fields)
     |> validate_length(:name, min: 1, max: 64)

--- a/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
+++ b/elixir/apps/domain/lib/domain/resources/resource/changeset.ex
@@ -33,7 +33,6 @@ defmodule Domain.Resources.Resource.Changeset do
     |> validate_required(@required_fields)
     |> put_change(:persistent_id, Ecto.UUID.generate())
     |> put_change(:account_id, account.id)
-    |> update_change(:address, &String.trim/1)
     |> validate_address(account)
     |> cast_assoc(:connections,
       with: &Connection.Changeset.changeset(account.id, &1, &2, subject),
@@ -47,7 +46,6 @@ defmodule Domain.Resources.Resource.Changeset do
     |> cast(attrs, @fields)
     |> changeset()
     |> validate_required(@required_fields)
-    |> update_change(:address, &String.trim/1)
     |> validate_address(account)
     |> put_change(:persistent_id, Ecto.UUID.generate())
     |> put_change(:account_id, account.id)
@@ -266,6 +264,7 @@ defmodule Domain.Resources.Resource.Changeset do
 
   defp changeset(changeset) do
     changeset
+    |> trim_change(@fields)
     |> validate_length(:name, min: 1, max: 255)
     |> validate_length(:address_description, min: 1, max: 512)
     |> maybe_put_default_ip_stack()

--- a/elixir/apps/domain/test/domain/auth_test.exs
+++ b/elixir/apps/domain/test/domain/auth_test.exs
@@ -785,6 +785,18 @@ defmodule Domain.AuthTest do
       assert is_nil(provider.deleted_at)
     end
 
+    test "trims whitespace when creating a provider", %{
+      account: account
+    } do
+      provider_name = "newprovider"
+      attrs = Fixtures.Auth.provider_attrs(name: "   " <> provider_name <> "   ")
+
+      Domain.Config.put_env_override(:outbound_email_adapter_configured?, true)
+
+      assert {:ok, provider} = create_provider(account, attrs)
+      assert provider.name == provider_name
+    end
+
     test "returns error when email provider is disabled", %{
       account: account
     } do
@@ -2134,6 +2146,25 @@ defmodule Domain.AuthTest do
       assert is_nil(identity.deleted_at)
     end
 
+    test "trims whitespace when creating an identity", %{
+      provider: provider,
+      actor: actor
+    } do
+      provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
+      email = "foo@example.com"
+
+      attrs = %{
+        provider_identifier: "   " <> provider_identifier <> "   ",
+        provider_identifier_confirmation: "   " <> provider_identifier <> "   ",
+        email: "   " <> email <> "   "
+      }
+
+      assert {:ok, identity} = upsert_identity(actor, provider, attrs)
+
+      assert identity.provider_identifier == provider_identifier
+      assert identity.email == email
+    end
+
     test "updates existing identity", %{
       account: account,
       provider: provider,
@@ -2297,6 +2328,26 @@ defmodule Domain.AuthTest do
              }
 
       assert is_nil(identity.deleted_at)
+    end
+
+    test "trims whitespace when creating an identity", %{
+      provider: provider,
+      actor: actor,
+      subject: subject
+    } do
+      provider_identifier = Fixtures.Auth.random_provider_identifier(provider)
+      email = "foo@example.com"
+
+      attrs = %{
+        provider_identifier: "   " <> provider_identifier <> "   ",
+        provider_identifier_confirmation: "   " <> provider_identifier <> "   ",
+        email: "   " <> email <> "   "
+      }
+
+      assert {:ok, identity} = create_identity(actor, provider, attrs, subject)
+
+      assert identity.provider_identifier == provider_identifier
+      assert identity.email == email
     end
 
     test "returns error when identity already exists", %{

--- a/elixir/apps/domain/test/domain/clients_test.exs
+++ b/elixir/apps/domain/test/domain/clients_test.exs
@@ -468,6 +468,14 @@ defmodule Domain.ClientsTest do
       assert is_nil(client.verified_at)
     end
 
+    test "trims whitespace when creating client", %{admin_subject: subject} do
+      client_name = "newclient"
+      attrs = Fixtures.Clients.client_attrs(name: "   " <> client_name <> "   ")
+
+      assert {:ok, client} = upsert_client(attrs, subject)
+      assert client.name == client_name
+    end
+
     test "updates client when it already exists", %{
       account: account,
       admin_actor: actor,

--- a/elixir/apps/domain/test/domain/gateways_test.exs
+++ b/elixir/apps/domain/test/domain/gateways_test.exs
@@ -221,6 +221,17 @@ defmodule Domain.GatewaysTest do
              }
     end
 
+    test "trims whitespace when creating a group", %{subject: subject} do
+      group_name = "foo"
+
+      attrs = %{
+        name: "   " <> group_name <> "   "
+      }
+
+      assert {:ok, group} = create_group(attrs, subject)
+      assert group.name == group_name
+    end
+
     test "returns error when subject has no permission to manage groups", %{
       subject: subject
     } do
@@ -297,6 +308,18 @@ defmodule Domain.GatewaysTest do
 
       assert {:ok, group} = update_group(group, attrs, subject)
       assert group.name == "foo"
+    end
+
+    test "trims whitespace when updating a group", %{account: account, subject: subject} do
+      group = Fixtures.Gateways.create_group(account: account)
+      updated_group_name = "foo"
+
+      attrs = %{
+        name: "   " <> updated_group_name <> "   "
+      }
+
+      assert {:ok, group} = update_group(group, attrs, subject)
+      assert group.name == updated_group_name
     end
 
     test "returns error when subject has no permission to manage groups", %{

--- a/elixir/apps/domain/test/domain/relays_test.exs
+++ b/elixir/apps/domain/test/domain/relays_test.exs
@@ -180,6 +180,14 @@ defmodule Domain.RelaysTest do
              }
     end
 
+    test "trims whitespace when creating a group", %{subject: subject} do
+      group_name = "foo"
+      attrs = %{name: "   " <> group_name <> "   "}
+
+      assert {:ok, group} = create_group(attrs, subject)
+      assert group.name == group_name
+    end
+
     test "returns error when subject has no permission to manage groups", %{
       subject: subject
     } do
@@ -225,6 +233,14 @@ defmodule Domain.RelaysTest do
 
       assert group.created_by == :system
       assert group.created_by_subject == %{"name" => "System", "email" => nil}
+    end
+
+    test "trims whitespace when creating a group" do
+      group_name = "foo"
+      attrs = %{name: "   " <> group_name <> "   "}
+
+      assert {:ok, group} = create_global_group(attrs)
+      assert group.name == group_name
     end
   end
 
@@ -278,6 +294,18 @@ defmodule Domain.RelaysTest do
 
       attrs = %{
         name: "foo"
+      }
+
+      assert {:ok, group} = update_group(group, attrs, subject)
+      assert group.name == "foo"
+    end
+
+    test "trims whitespace when updating a group", %{account: account, subject: subject} do
+      group = Fixtures.Relays.create_group(account: account)
+      updated_group_name = "foo"
+
+      attrs = %{
+        name: "   " <> updated_group_name <> "   "
       }
 
       assert {:ok, group} = update_group(group, attrs, subject)

--- a/elixir/apps/domain/test/domain/resources/resource/changeset_test.exs
+++ b/elixir/apps/domain/test/domain/resources/resource/changeset_test.exs
@@ -311,6 +311,27 @@ defmodule Domain.Resources.Resource.ChangesetTest do
         refute changeset.valid?, "Expected '#{invalid_address}' to be invalid"
       end
     end
+
+    test "trims whitespace on changes" do
+      for {name, type, address, description} <- [
+            {"foo", :ip, "192.168.1.1", "local server"},
+            {"bar", :cidr, "192.168.1.0/24", "local network"},
+            {"baz", :dns, "example.com", "local server"}
+          ] do
+        changeset =
+          create(%{
+            name: "   " <> name <> "   ",
+            type: type,
+            address: "   " <> address <> "   ",
+            address_description: "   " <> description <> "   "
+          })
+
+        assert changeset.changes[:name] == name
+        assert changeset.changes[:address] == address
+        assert changeset.changes[:address_description] == description
+        assert changeset.valid?
+      end
+    end
   end
 
   def create(attrs) do


### PR DESCRIPTION
Why:

* After updating the Auth Provider changesets to trim all whitespace from user editable string fields we realized we needed to do the same for all forms/entities within Firezone.  This commit updates all entities to trim whitespace on string fields.

Fixes: #9579