### PR TITLE
fix(gateway): reply with cookie when rate limit is hit

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -23,6 +23,7 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::hash::Hash;
 use std::mem;
+use std::net::IpAddr;
 use std::ops::ControlFlow;
 use std::time::{Duration, Instant};
 use std::{collections::VecDeque, net::SocketAddr, sync::Arc};
@@ -907,6 +908,7 @@ where
             let handshake_complete_before_decapsulate = conn.wg_handshake_complete(now);
 
             let control_flow = conn.decapsulate(
+                from.ip(),
                 packet,
                 &mut self.allocations,
                 &mut self.buffered_transmits,
@@ -2103,6 +2105,7 @@ where
 
     fn decapsulate(
         &mut self,
+        src: IpAddr,
         packet: &[u8],
         allocations: &mut BTreeMap<RId, Allocation>,
         transmits: &mut VecDeque<Transmit>,
@@ -2113,7 +2116,7 @@ where
 
         let control_flow = match self
             .tunnel
-            .decapsulate_at(None, packet, ip_packet.buf(), now)
+            .decapsulate_at(Some(src), packet, ip_packet.buf(), now)
         {
             TunnResult::Done => ControlFlow::Break(Ok(())),
             TunnResult::Err(e) => ControlFlow::Break(Err(Error::Decapsulate(e))),

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9657">
+          Fixes an issue where connections would fail to establish if the
+          Gateway was under high load.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.11" date={new Date("2025-06-19")}>
         <ChangeItem pull="9564">
           Fixes an issue where connections would fail to establish if both


### PR DESCRIPTION
WireGuard implements a rate-limit mechanism when the number of handshake initiations increases a certain limit. This is important because handshakes involve asymmetric cryptography and are cryptographically expensive. To prevent DoS attacks where other peers repeatedly ask for new handshakes, the rate limiter implements a cookie mechanism where - when under load - the remote peer needs to include a given cookie in new handshakes. This cookie is tied to the peer's IP address to prevent it from being reused by other peers.

Up until now, we have not been passing the sender's IP address to `boringtun` and therefore, the only option when the rate limit was hit was to error with `UnderLoad`.

By passing the source IP of the packet, `boringtun` can engage in the cookie-reply mechanism and therefore avoid the `UnderLoad` error.

Resolves: #9643 