### PR TITLE
feat(gateway): send `$identify` event with account-slug

### DIFF
--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -346,6 +346,10 @@ where
         }
     }
 
+    pub fn url(&self) -> String {
+        self.url_prototype.expose_secret().base_url()
+    }
+
     /// Initiate a graceful close of the connection.
     pub fn close(&mut self) -> Result<(), Connecting> {
         tracing::info!("Closing connection to portal");

--- a/rust/connlib/phoenix-channel/src/login_url.rs
+++ b/rust/connlib/phoenix-channel/src/login_url.rs
@@ -203,6 +203,15 @@ impl<TFinish> LoginUrl<TFinish> {
     pub fn host_and_port(&self) -> (&str, u16) {
         (&self.host, self.port)
     }
+
+    pub fn base_url(&self) -> String {
+        let mut url = self.url.clone();
+
+        url.set_path("");
+        url.set_query(None);
+
+        url.to_string()
+    }
 }
 
 /// Parse the host from a URL, including port if present. e.g. `example.com:8080`.
@@ -314,4 +323,25 @@ fn set_ws_scheme<E>(url: &mut Url) -> Result<(), LoginUrlError<E>> {
         .expect("Developer error: the match before this should make sure we can set this");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_url_removes_params_and_path() {
+        let login_url = LoginUrl::client(
+            "wss://api.firez.one",
+            &SecretString::new("foobar".to_owned()),
+            "some-id".to_owned(),
+            None,
+            DeviceInfo::default(),
+        )
+        .unwrap();
+
+        let base_url = login_url.base_url();
+
+        assert_eq!(base_url, "wss://api.firez.one")
+    }
 }

--- a/rust/connlib/phoenix-channel/src/login_url.rs
+++ b/rust/connlib/phoenix-channel/src/login_url.rs
@@ -342,6 +342,6 @@ mod tests {
 
         let base_url = login_url.base_url();
 
-        assert_eq!(base_url, "wss://api.firez.one")
+        assert_eq!(base_url, "wss://api.firez.one/")
     }
 }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -5,7 +5,7 @@ use dns_lookup::{AddrInfoHints, AddrInfoIter, LookupError};
 use dns_types::DomainName;
 use firezone_bin_shared::TunDeviceManager;
 use firezone_logging::telemetry_span;
-use firezone_telemetry::Telemetry;
+use firezone_telemetry::{Telemetry, analytics};
 use firezone_tunnel::messages::gateway::{
     AllowAccess, ClientIceCandidates, ClientsIceCandidates, ConnectionReady, EgressMessages,
     IngressMessages, RejectAccess, RequestConnection,
@@ -25,6 +25,8 @@ use std::time::{Duration, Instant};
 use std::{io, mem};
 use tokio::sync::Mutex;
 use tracing::Instrument;
+
+use crate::RELEASE;
 
 pub const PHOENIX_TOPIC: &str = "gateway";
 
@@ -51,6 +53,7 @@ pub struct Eventloop {
     tunnel: GatewayTunnel,
     portal: PhoenixChannel<(), IngressMessages, (), PublicKeyParam>,
     tun_device_manager: Arc<Mutex<TunDeviceManager>>,
+    firezone_id: String,
 
     resolve_tasks:
         futures_bounded::FuturesTupleSet<Result<Vec<IpAddr>, Arc<anyhow::Error>>, ResolveTrigger>,
@@ -66,12 +69,14 @@ impl Eventloop {
         tunnel: GatewayTunnel,
         mut portal: PhoenixChannel<(), IngressMessages, (), PublicKeyParam>,
         tun_device_manager: TunDeviceManager,
+        firezone_id: String,
     ) -> Self {
         portal.connect(PublicKeyParam(tunnel.public_key().to_bytes()));
 
         Self {
             tunnel,
             portal,
+            firezone_id,
             tun_device_manager: Arc::new(Mutex::new(tun_device_manager)),
             resolve_tasks: futures_bounded::FuturesTupleSet::new(DNS_RESOLUTION_TIMEOUT, 1000),
             set_interface_tasks: futures_bounded::FuturesSet::new(Duration::from_secs(5), 10),
@@ -379,7 +384,14 @@ impl Eventloop {
                 ..
             } => {
                 if let Some(account_slug) = init.account_slug {
-                    Telemetry::set_account_slug(account_slug);
+                    Telemetry::set_account_slug(account_slug.clone());
+
+                    analytics::identify(
+                        self.firezone_id.clone(),
+                        self.portal.url(),
+                        RELEASE.to_owned(),
+                        Some(account_slug),
+                    )
                 }
 
                 self.tunnel.state_mut().update_relays(

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -33,6 +33,7 @@ use url::Url;
 mod eventloop;
 
 const ID_PATH: &str = "/var/lib/firezone/gateway_id";
+const RELEASE: &str = concat!("gateway@", env!("CARGO_PKG_VERSION"));
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
@@ -54,7 +55,7 @@ fn main() -> ExitCode {
     if cli.is_telemetry_allowed() {
         telemetry.start(
             cli.api_url.as_str(),
-            concat!("gateway@", env!("CARGO_PKG_VERSION")),
+            RELEASE,
             firezone_telemetry::GATEWAY_DSN,
         );
     }
@@ -171,7 +172,7 @@ async fn try_main(cli: Cli) -> Result<ExitCode> {
     }
 
     let task = tokio::spawn(future::poll_fn({
-        let mut eventloop = Eventloop::new(tunnel, portal, tun_device_manager);
+        let mut eventloop = Eventloop::new(tunnel, portal, tun_device_manager, firezone_id);
 
         move |cx| eventloop.poll(cx)
     }))

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -127,8 +127,13 @@ async fn try_main(cli: Cli) -> Result<ExitCode> {
         opentelemetry::global::set_meter_provider(provider);
     }
 
-    let login = LoginUrl::gateway(cli.api_url, &cli.token, firezone_id, cli.firezone_name)
-        .context("Failed to construct URL for logging into portal")?;
+    let login = LoginUrl::gateway(
+        cli.api_url,
+        &cli.token,
+        firezone_id.clone(),
+        cli.firezone_name,
+    )
+    .context("Failed to construct URL for logging into portal")?;
 
     let resolv_conf = resolv_conf::Config::parse(
         std::fs::read_to_string("/etc/resolv.conf").context("Failed to read /etc/resolv.conf")?,


### PR DESCRIPTION
When we receive the `account_slug` from the portal, the Gateway now sends a `$identify` event to PostHog. This will allow us to target Gateways with feature-flags based on the account they are connected to.