### PR TITLE
fix(ci): maintain whitespace in sources list

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -466,7 +466,7 @@ jobs:
         working-directory: /tmp/digests/${{ matrix.image.name }}
         run: |
           tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image.name }}@sha256:%s' *)
+          sources=$(printf '${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image.name }}@sha256:%s ' *)
 
           echo "Tags: $tags"
           echo "Sources: $sources"


### PR DESCRIPTION
Another issue was introduced in #9590 - we need to maintain the whitespace in the sources list when generating them.

Fixes https://github.com/firezone/firezone/actions/runs/15859521283/job/44713395755

