### PR TITLE
refactor(portal): broadcast client struct when updated

### DIFF
--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -762,15 +762,27 @@ defmodule API.Client.ChannelTest do
     end
   end
 
-  describe "handle_info/2 :updated" do
-    test "sends init message", %{
-      socket: socket
+  describe "handle_info/2 {:updated, client}" do
+    test "sends init message when breaking fields change", %{
+      socket: socket,
+      client: client
     } do
       assert_push "init", %{}
 
-      send(socket.channel_pid, :updated)
-
+      updated_client = %{client | verified_at: DateTime.utc_now()}
+      send(socket.channel_pid, {:updated, updated_client})
       assert_push "init", %{}
+    end
+
+    test "does not send init message when name changes", %{
+      socket: socket,
+      client: client
+    } do
+      assert_push "init", %{}
+
+      send(socket.channel_pid, {:updated, %{client | name: "New Name"}})
+
+      refute_push "init", %{}
     end
   end
 

--- a/elixir/apps/domain/lib/domain.ex
+++ b/elixir/apps/domain/lib/domain.ex
@@ -34,6 +34,10 @@ defmodule Domain do
     end
   end
 
+  @doc """
+    Converts a map of string params to a schema struct with values casted.
+    This is useful for sending valid structs from the WAL consumers.
+  """
   def struct_from_params(schema_module, params) do
     schema_module.__schema__(:fields)
     |> Enum.reduce(struct(schema_module), fn field, acc ->

--- a/elixir/apps/domain/lib/domain.ex
+++ b/elixir/apps/domain/lib/domain.ex
@@ -34,6 +34,24 @@ defmodule Domain do
     end
   end
 
+  def struct_from_params(schema_module, params) do
+    schema_module.__schema__(:fields)
+    |> Enum.reduce(struct(schema_module), fn field, acc ->
+      case Map.get(params, to_string(field)) do
+        nil ->
+          acc
+
+        value ->
+          field_type = schema_module.__schema__(:type, field)
+
+          case Ecto.Type.cast(field_type, value) do
+            {:ok, casted_value} -> Map.put(acc, field, casted_value)
+            :error -> acc
+          end
+      end
+    end)
+  end
+
   @doc """
   When used, dispatch to the appropriate schema/context/changeset/query/etc.
   """

--- a/elixir/apps/domain/lib/domain/events/hooks/clients.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/clients.ex
@@ -1,6 +1,7 @@
 defmodule Domain.Events.Hooks.Clients do
   @behaviour Domain.Events.Hooks
   alias Domain.PubSub
+  alias Domain.Clients
 
   @impl true
   def on_insert(_data), do: :ok
@@ -13,8 +14,9 @@ defmodule Domain.Events.Hooks.Clients do
   end
 
   # Regular update
-  def on_update(_old_data, %{"id" => client_id} = _data) do
-    PubSub.Client.broadcast(client_id, :updated)
+  def on_update(_old_data, data) do
+    client = Domain.struct_from_params(Clients.Client, data)
+    PubSub.Client.broadcast(client.id, {:updated, client})
   end
 
   @impl true

--- a/elixir/apps/domain/test/domain/events/hooks/clients_test.exs
+++ b/elixir/apps/domain/test/domain/events/hooks/clients_test.exs
@@ -36,7 +36,8 @@ defmodule Domain.Events.Hooks.ClientsTest do
 
       assert :ok == on_update(old_data, data)
 
-      assert_receive :updated
+      assert_receive {:updated, %Clients.Client{} = updated_client}
+      assert updated_client.id == client.id
       refute_receive "disconnect"
     end
   end


### PR DESCRIPTION
When a client is updated, we may need to re-initialize it if "breaking" fields are updated. If non-breaking fields are changed, such as name, we don't need to re-initialize the client.

This PR also adds a helper `struct_from_params/2` which will create a schema struct from WAL data in order to type cast any needed data for convenience. This avoid having to do a DB hit - we _already have the data from the DB_ - we just need to format and send it.

Related: #9501 