### PR TITLE
fix(ci): use relaxed naming for ignored checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           set -e
 
           while true; do
-            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select(.name != "ci / required-check" and .name != "ci / upload-bencher"))')
+            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select((.name | contains("required-check") | not) and (.name | contains("upload-bencher") | not)))')
 
             total_jobs=$(echo "$jobs_json" | jq 'length')
             failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')


### PR DESCRIPTION
These jobs have the `ci / ` prefix when run on main, but no prefix when run on PRs. To fix the ignored checks, we need to use `contains`.