### PR TITLE
fix(portal): update publications when config changes

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -46,8 +46,8 @@ config :domain, Domain.ChangeLogs.ReplicationConnection,
     password: "postgres"
   ],
   # When changing these, make sure to also:
-  #   1. Make appropriate changes to `Domain.Events.Event`
-  #   2. Add an appropriate `Domain.Events.Hooks` module
+  #   1. Make appropriate changes to `Domain.ChangeLogs.ReplicationConnection`
+  #   2. Add tests and test WAL locally
   table_subscriptions: ~w[
     accounts
     actor_group_memberships
@@ -79,8 +79,9 @@ config :domain, Domain.Events.ReplicationConnection,
     password: "postgres"
   ],
   # When changing these, make sure to also:
-  #   1. Make appropriate changes to `Domain.Events.Event`
+  #   1. Make appropriate changes to `Domain.Events.ReplicationConnection`
   #   2. Add an appropriate `Domain.Events.Hooks` module
+  #   3. Add tests and test WAL locally
   table_subscriptions: ~w[
     accounts
     actor_group_memberships


### PR DESCRIPTION
Creating a table publication(s) (and associated replication slot) is sticky. These will outlive the lifetime of the process that created them.

We don't want to remove them on shutdown, because this will pause WAL writing to disk.

However, when starting the _new_ application, it's possible `table_subscriptions` has changed (such as if we decide we no longer want events for a certain table). We weren't updating the created publication(s) with these added/removed tables, so this PR updates the replication connection setup state machine to pass through a few conditionals to get these properly updated with the diff of old vs new.