### PR TITLE
fix(portal): log error when connected_nodes crossed

### DIFF
--- a/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
+++ b/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
@@ -28,6 +28,8 @@ defmodule Domain.Cluster.GoogleComputeLabelsStrategy do
     unless Domain.GoogleCloudPlatform.enabled?(),
       do: "Google Cloud Platform clustering strategy requires GoogleCloudPlatform to be enabled"
 
+    state = Map.put(state, :below_threshold?, false)
+
     {:ok, state, {:continue, :start}}
   end
 
@@ -68,14 +70,30 @@ defmodule Domain.Cluster.GoogleComputeLabelsStrategy do
             problem_nodes: inspect(problem_nodes)
           )
 
-          # Only log error if the number of connected nodes falls below the expected threshold
-          unless enough_nodes_connected?(state) do
-            Logger.error("Connected nodes count is below threshold",
-              connected_nodes: inspect(state.connected_nodes),
-              problem_nodes: inspect(problem_nodes),
-              config: inspect(state.config)
-            )
-          end
+          # Only log error if the number of connected nodes falls below the expected threshold.
+          # We only log crossing the boundary to avoid flooding the logs with messages
+          state =
+            if enough_nodes_connected?(state) do
+              if state.below_threshold? do
+                Logger.info("Connected nodes count is back above threshold",
+                  connected_nodes: inspect(state.connected_nodes),
+                  problem_nodes: inspect(problem_nodes),
+                  config: inspect(state.config)
+                )
+              end
+
+              Map.put(state, :below_threshold?, false)
+            else
+              unless state.below_threshold? do
+                Logger.error("Connected nodes count is below threshold",
+                  connected_nodes: inspect(state.connected_nodes),
+                  problem_nodes: inspect(problem_nodes),
+                  config: inspect(state.config)
+                )
+              end
+
+              Map.put(state, :below_threshold?, true)
+            end
 
           state
       end


### PR DESCRIPTION
To avoid log spam, we only log an error when the threshold boundary is crossed.