### PR TITLE
fix(portal): use distinct slot names

### DIFF
--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -316,12 +316,22 @@ defmodule Domain.Config.Definitions do
   @doc """
   Name of the replication slot used by Firezone.
   """
-  defconfig(:database_replication_slot_name, :string, default: "events_slot")
+  defconfig(:database_events_replication_slot_name, :string, default: "events_slot")
 
   @doc """
   Name of the publication used by Firezone.
   """
-  defconfig(:database_publication_name, :string, default: "events")
+  defconfig(:database_events_publication_name, :string, default: "events")
+
+  @doc """
+  Name of the replication slot used by Firezone.
+  """
+  defconfig(:database_change_logs_replication_slot_name, :string, default: "change_logs_slot")
+
+  @doc """
+  Name of the publication used by Firezone.
+  """
+  defconfig(:database_change_logs_publication_name, :string, default: "change_logs")
 
   @doc """
   SSL options for connecting to the PostgreSQL database.

--- a/elixir/apps/domain/lib/domain/replication/connection.ex
+++ b/elixir/apps/domain/lib/domain/replication/connection.ex
@@ -65,11 +65,9 @@ defmodule Domain.Replication.Connection do
     quote bind_quoted: [opts: opts] do
       # Only these two are configurable
       @alert_threshold_ms Keyword.fetch!(opts, :alert_threshold_ms)
-      @publication_name Keyword.fetch!(opts, :publication_name)
 
       # Everything else uses defaults
       @status_log_interval :timer.minutes(5)
-      @replication_slot_name "#{@publication_name}_slot"
       @schema "public"
       @output_plugin "pgoutput"
       @proto_version 1
@@ -98,8 +96,8 @@ defmodule Domain.Replication.Connection do
 
       defstruct schema: @schema,
                 step: :disconnected,
-                publication_name: @publication_name,
-                replication_slot_name: @replication_slot_name,
+                publication_name: "",
+                replication_slot_name: "",
                 output_plugin: @output_plugin,
                 proto_version: @proto_version,
                 table_subscriptions: [],
@@ -243,7 +241,7 @@ defmodule Domain.Replication.Connection do
       end
 
       def handle_result([%Postgrex.Result{}], %__MODULE__{step: :start_replication_slot} = state) do
-        Logger.info("Starting replication slot #{state.replication_slot_name}",
+        Logger.info("#{__MODULE__}: Starting replication slot #{state.replication_slot_name}",
           state: inspect(state)
         )
 

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -29,8 +29,8 @@ if config_env() == :prod do
 
   config :domain, Domain.ChangeLogs.ReplicationConnection,
     enabled: env_var_to_config!(:background_jobs_enabled),
-    replication_slot_name: env_var_to_config!(:database_replication_slot_name),
-    publication_name: env_var_to_config!(:database_publication_name),
+    replication_slot_name: env_var_to_config!(:database_change_logs_replication_slot_name),
+    publication_name: env_var_to_config!(:database_change_logs_publication_name),
     connection_opts: [
       hostname: env_var_to_config!(:database_host),
       port: env_var_to_config!(:database_port),
@@ -44,8 +44,8 @@ if config_env() == :prod do
 
   config :domain, Domain.Events.ReplicationConnection,
     enabled: env_var_to_config!(:background_jobs_enabled),
-    replication_slot_name: env_var_to_config!(:database_replication_slot_name),
-    publication_name: env_var_to_config!(:database_publication_name),
+    replication_slot_name: env_var_to_config!(:database_events_replication_slot_name),
+    publication_name: env_var_to_config!(:database_events_publication_name),
     connection_opts: [
       hostname: env_var_to_config!(:database_host),
       port: env_var_to_config!(:database_port),

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -21,12 +21,16 @@ config :domain, Domain.Repo,
   queue_target: 1000
 
 config :domain, Domain.ChangeLogs.ReplicationConnection,
+  replication_slot_name: "test_change_logs_slot",
+  publication_name: "test_change_logs_publication",
   enabled: false,
   connection_opts: [
     database: "firezone_test#{partition_suffix}"
   ]
 
 config :domain, Domain.Events.ReplicationConnection,
+  replication_slot_name: "test_events_slot",
+  publication_name: "test_events_publication",
   enabled: false,
   connection_opts: [
     database: "firezone_test#{partition_suffix}"


### PR DESCRIPTION
These were being configured using the same default `events_` value.