### PR TITLE
chore(portal): don't log found nodes

### DIFF
--- a/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
+++ b/elixir/apps/domain/lib/domain/cluster/google_compute_labels_strategy.ex
@@ -181,8 +181,6 @@ defmodule Domain.Cluster.GoogleComputeLabelsStrategy do
         discovered_nodes_count: count
       })
 
-      Logger.debug("Found #{count} nodes", module: __MODULE__, nodes: Enum.join(nodes, ", "))
-
       {:ok, nodes}
     end
   end


### PR DESCRIPTION
These are better logged elsewhere and this is just noise.