### PR TITLE
fix(portal): bypass delayed events past threshold

### DIFF
--- a/elixir/apps/domain/lib/domain/change_logs/replication_connection.ex
+++ b/elixir/apps/domain/lib/domain/change_logs/replication_connection.ex
@@ -4,8 +4,10 @@ defmodule Domain.ChangeLogs.ReplicationConnection do
   use Domain.Replication.Connection,
     # Allow up to 30 seconds of processing lag before alerting - this should be less
     # than or equal to the wal_sender_timeout setting, which is typically 60s.
-    alert_threshold_ms: 30_000,
-    publication_name: "change_logs"
+    warning_threshold_ms: 30 * 1_000,
+
+    # 1 month in ms - we never want to bypass changelog inserts
+    error_threshold_ms: 30 * 24 * 60 * 60 * 1_000
 
   # Bump this to signify a change in the audit log schema. Use with care.
   @vsn 0

--- a/elixir/apps/domain/lib/domain/events/replication_connection.ex
+++ b/elixir/apps/domain/lib/domain/events/replication_connection.ex
@@ -3,8 +3,10 @@ defmodule Domain.Events.ReplicationConnection do
 
   use Domain.Replication.Connection,
     # Allow up to 5 seconds of lag before alerting
-    alert_threshold_ms: 5_000,
-    publication_name: "events"
+    warning_threshold_ms: 5_000,
+
+    # Allow up to 5 minutes of lag before bypassing hooks
+    error_threshold_ms: 300_000
 
   require Logger
 


### PR DESCRIPTION
When attempting to process a WAL that's _very_ far behind, it's helpful to have a time past which we simply `noop` the handlers.