### PR TITLE
fix(portal): diff = now - past

### DIFF
--- a/elixir/apps/domain/lib/domain/replication/connection.ex
+++ b/elixir/apps/domain/lib/domain/replication/connection.ex
@@ -476,7 +476,7 @@ defmodule Domain.Replication.Connection do
            ) do
         # Since we receive a commit for each operation and we process each operation
         # one-by-one, we can use the commit timestamp to check if we are lagging behind.
-        lag_ms = DateTime.diff(commit_timestamp, DateTime.utc_now(), :millisecond)
+        lag_ms = DateTime.diff(DateTime.utc_now(), commit_timestamp, :millisecond)
         send(self(), {:check_warning_threshold, lag_ms})
         send(self(), {:check_error_threshold, lag_ms})
 

--- a/elixir/apps/domain/test/domain/replication/connection_test.exs
+++ b/elixir/apps/domain/test/domain/replication/connection_test.exs
@@ -337,7 +337,7 @@ defmodule Domain.Replication.ConnectionTest do
 
       # Simulate a commit timestamp that exceeds the threshold
       timestamp =
-        DateTime.diff(DateTime.utc_now(), ~U[2000-01-01 00:00:00Z], :microsecond) + 10_000_000
+        DateTime.diff(DateTime.utc_now(), ~U[2000-01-01 00:00:00Z], :microsecond) - 10_000_000
 
       commit_data = <<?C, flags::binary, lsn::binary, end_lsn::binary, timestamp::64>>
 
@@ -365,7 +365,7 @@ defmodule Domain.Replication.ConnectionTest do
       end_lsn = <<0::32, 200::32>>
       # Simulate a commit timestamp that is within the threshold
       timestamp =
-        DateTime.diff(DateTime.utc_now(), ~U[2000-01-01 00:00:00Z], :microsecond) + 1_000_000
+        DateTime.diff(DateTime.utc_now(), ~U[2000-01-01 00:00:00Z], :microsecond) - 1_000_000
 
       commit_data = <<?C, flags::binary, lsn::binary, end_lsn::binary, timestamp::64>>
 
@@ -497,7 +497,7 @@ defmodule Domain.Replication.ConnectionTest do
 
       # Simulate a commit timestamp that exceeds both thresholds (70 seconds lag)
       timestamp =
-        DateTime.diff(DateTime.utc_now(), ~U[2000-01-01 00:00:00Z], :microsecond) + 70_000_000
+        DateTime.diff(DateTime.utc_now(), ~U[2000-01-01 00:00:00Z], :microsecond) - 70_000_000
 
       commit_data = <<?C, flags::binary, lsn::binary, end_lsn::binary, timestamp::64>>
 
@@ -534,7 +534,7 @@ defmodule Domain.Replication.ConnectionTest do
 
       # Simulate a commit timestamp with moderate lag (10 seconds)
       timestamp =
-        DateTime.diff(DateTime.utc_now(), ~U[2000-01-01 00:00:00Z], :microsecond) + 10_000_000
+        DateTime.diff(DateTime.utc_now(), ~U[2000-01-01 00:00:00Z], :microsecond) - 10_000_000
 
       commit_data = <<?C, flags::binary, lsn::binary, end_lsn::binary, timestamp::64>>
 


### PR DESCRIPTION
We were performing the diff backwards, so the bypass never kicked in.