### PR TITLE
fix(gateway): bump timeoutstart to 15s

### DIFF
--- a/scripts/gateway-systemd-install.sh
+++ b/scripts/gateway-systemd-install.sh
@@ -67,7 +67,7 @@ ExecStartPre=/usr/local/bin/firezone-gateway-init
 ExecStart=/opt/firezone/bin/firezone-gateway
 
 # Restart on failure
-TimeoutStartSec=3s
+TimeoutStartSec=15s
 TimeoutStopSec=15s
 Restart=always
 RestartSec=7


### PR DESCRIPTION
3s on a fresh install may be too low for the binary to download.

Related: https://firezonehq.slack.com/archives/C08FPHECLUF/p1750946191078759?thread_ts=1750940488.328739&cid=C08FPHECLUF