### PR TITLE
chore(snownet): add more logging for connections

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -343,6 +343,8 @@ where
             return;
         };
 
+        tracing::info!(?candidate, "Received candidate from remote");
+
         agent.add_remote_candidate(candidate.clone());
 
         generate_optimistic_candidates(agent);
@@ -1221,6 +1223,8 @@ fn generate_optimistic_candidates(agent: &mut IceAgent) {
         .collect::<Vec<_>>();
 
     for c in optimistic_candidates {
+        tracing::info!(candidate = ?c, "Adding optimistic candidate for remote");
+
         agent.add_remote_candidate(c);
     }
 }


### PR DESCRIPTION
In a recent release, `str0m` downgraded all INFO logs to DEBUG. Whilst generally appreciated, it means we don't have a lot of visibility anymore into which candidates are being exchanged and what the ICE credentials of the connections are.

We re-add this information to our existing logs when creating and updating connections.