### PR TITLE
fix(tests): wait for visible els before click

### DIFF
--- a/elixir/apps/web/test/support/acceptance_case.ex
+++ b/elixir/apps/web/test/support/acceptance_case.ex
@@ -89,8 +89,7 @@ defmodule Web.AcceptanceCase do
   def assert_el(session, query, started_at \\ nil)
 
   def assert_el(session, %Query{} = query, started_at) do
-    now = :erlang.monotonic_time(:milli_seconds)
-    started_at = started_at || now
+    started_at = started_at || :erlang.monotonic_time(:milli_seconds)
 
     try do
       case execute_query(session, query) do
@@ -115,7 +114,7 @@ defmodule Web.AcceptanceCase do
         Wallaby.StaleReferenceError,
         Wallaby.QueryError
       ] ->
-        time_spent = now - started_at
+        time_spent = :erlang.monotonic_time(:milli_seconds) - started_at
         max_wait_seconds = fetch_default_wait_seconds!()
 
         if time_spent > :timer.seconds(max_wait_seconds) do

--- a/elixir/apps/web/test/web/acceptance/auth_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth_test.exs
@@ -40,7 +40,7 @@ defmodule Web.Acceptance.AuthTest do
       |> visit(~p"/#{account}/actors")
       |> assert_el(Query.css("#user-menu-button"))
       |> click(Query.css("#user-menu-button"))
-      |> assert_el(Query.link("Sign out"))
+      |> assert_el(Query.link("Sign out", visible: true))
       |> click(Query.link("Sign out"))
       |> assert_el(Query.text("Sign in with username and password"))
       |> Auth.assert_unauthenticated()


### PR DESCRIPTION
We had an old bug in one of our acceptance tests that is just now being hit again due to the faster runners.

- We need to wait for the dropdown to become visible before clicking
- We fix a minor timer issue that was calculating elapsed time incorrectly when determining when time out finding an el.