### PR TITLE
chore(portal): ack WAL records more often

### DIFF
--- a/elixir/apps/domain/lib/domain/replication/connection.ex
+++ b/elixir/apps/domain/lib/domain/replication/connection.ex
@@ -424,7 +424,8 @@ defmodule Domain.Replication.Connection do
           columns: columns
         }
 
-        {:noreply, ack(server_wal_end), %{state | relations: Map.put(state.relations, id, relation)}}
+        {:noreply, ack(server_wal_end),
+         %{state | relations: Map.put(state.relations, id, relation)}}
       end
 
       defp handle_message(%Decoder.Messages.Insert{} = msg, server_wal_end, state) do

--- a/elixir/apps/domain/lib/domain/replication/connection.ex
+++ b/elixir/apps/domain/lib/domain/replication/connection.ex
@@ -428,9 +428,7 @@ defmodule Domain.Replication.Connection do
       end
 
       defp handle_message(%Decoder.Messages.Insert{} = msg, server_wal_end, state) do
-        if state.error_threshold_exceeded? do
-          :ok
-        else
+        unless state.error_threshold_exceeded? do
           {op, table, _old_data, data} = transform(msg, state.relations)
           :ok = on_insert(server_wal_end, table, data)
         end
@@ -439,9 +437,7 @@ defmodule Domain.Replication.Connection do
       end
 
       defp handle_message(%Decoder.Messages.Update{} = msg, server_wal_end, state) do
-        if state.error_threshold_exceeded? do
-          :ok
-        else
+        unless state.error_threshold_exceeded? do
           {op, table, old_data, data} = transform(msg, state.relations)
           :ok = on_update(server_wal_end, table, old_data, data)
         end
@@ -450,9 +446,7 @@ defmodule Domain.Replication.Connection do
       end
 
       defp handle_message(%Decoder.Messages.Delete{} = msg, server_wal_end, state) do
-        if state.error_threshold_exceeded? do
-          :ok
-        else
+        unless state.error_threshold_exceeded? do
           {op, table, old_data, _data} = transform(msg, state.relations)
           :ok = on_delete(server_wal_end, table, old_data)
         end

--- a/elixir/apps/domain/lib/domain/replication/manager.ex
+++ b/elixir/apps/domain/lib/domain/replication/manager.ex
@@ -56,8 +56,11 @@ defmodule Domain.Replication.Manager do
     end
   end
 
-  def handle_info({:EXIT, pid, _reason}, %{connection_pid: pid} = state) do
-    Logger.warning("Replication connection died, restarting immediately",
+  def handle_info(
+        {:EXIT, pid, _reason},
+        %{connection_module: connection_module, connection_pid: pid} = state
+      ) do
+    Logger.warning("#{connection_module}: Replication connection died, restarting immediately",
       died_pid: inspect(pid),
       died_node: node(pid)
     )

--- a/elixir/apps/domain/test/domain/replication/connection_test.exs
+++ b/elixir/apps/domain/test/domain/replication/connection_test.exs
@@ -312,8 +312,14 @@ defmodule Domain.Replication.ConnectionTest do
         <<?w, server_wal_start::64, server_wal_end::64, server_system_clock::64, message::binary>>
 
       new_state = %{state | counter: state.counter + 1}
+      expected_wal_end = server_wal_end + 1
 
-      assert {:noreply, [], ^new_state} = TestReplicationConnection.handle_data(write_data, state)
+      assert {:noreply, [ack_message], ^new_state} =
+               TestReplicationConnection.handle_data(write_data, state)
+
+      # Validate the acknowledgment structure without pinning the timestamp
+      assert <<?r, ^expected_wal_end::64, ^expected_wal_end::64, ^expected_wal_end::64,
+               _timestamp::64, 1::8>> = ack_message
     end
 
     test "handle_data handles unknown message" do
@@ -344,8 +350,14 @@ defmodule Domain.Replication.ConnectionTest do
         <<?w, server_wal_start::64, server_wal_end::64, server_system_clock::64,
           begin_data::binary>>
 
-      assert {:noreply, [], _state} =
+      expected_wal_end = server_wal_end + 1
+
+      assert {:noreply, [ack_message], _state} =
                TestReplicationConnection.handle_data(write_message, state)
+
+      # Validate acknowledgment structure
+      assert <<?r, ^expected_wal_end::64, ^expected_wal_end::64, ^expected_wal_end::64,
+               _timestamp::64, 1::8>> = ack_message
 
       assert_receive({:check_warning_threshold, lag_ms})
       assert lag_ms > 5_000
@@ -372,8 +384,14 @@ defmodule Domain.Replication.ConnectionTest do
         <<?w, server_wal_start::64, server_wal_end::64, server_system_clock::64,
           begin_data::binary>>
 
-      assert {:noreply, [], _state} =
+      expected_wal_end = server_wal_end + 1
+
+      assert {:noreply, [ack_message], _state} =
                TestReplicationConnection.handle_data(write_message, state)
+
+      # Validate acknowledgment structure
+      assert <<?r, ^expected_wal_end::64, ^expected_wal_end::64, ^expected_wal_end::64,
+               _timestamp::64, 1::8>> = ack_message
 
       assert_receive({:check_warning_threshold, lag_ms})
       assert lag_ms < 5_000
@@ -503,8 +521,14 @@ defmodule Domain.Replication.ConnectionTest do
         <<?w, server_wal_start::64, server_wal_end::64, server_system_clock::64,
           begin_data::binary>>
 
-      assert {:noreply, [], _state} =
+      expected_wal_end = server_wal_end + 1
+
+      assert {:noreply, [ack_message], _state} =
                TestReplicationConnection.handle_data(write_message, state)
+
+      # Validate acknowledgment structure
+      assert <<?r, ^expected_wal_end::64, ^expected_wal_end::64, ^expected_wal_end::64,
+               _timestamp::64, 1::8>> = ack_message
 
       # Should receive both threshold check messages
       assert_receive {:check_warning_threshold, warning_lag_ms}
@@ -539,8 +563,14 @@ defmodule Domain.Replication.ConnectionTest do
         <<?w, server_wal_start::64, server_wal_end::64, server_system_clock::64,
           begin_data::binary>>
 
-      assert {:noreply, [], _state} =
+      expected_wal_end = server_wal_end + 1
+
+      assert {:noreply, [ack_message], _state} =
                TestReplicationConnection.handle_data(write_message, state)
+
+      # Validate acknowledgment structure
+      assert <<?r, ^expected_wal_end::64, ^expected_wal_end::64, ^expected_wal_end::64,
+               _timestamp::64, 1::8>> = ack_message
 
       # Should receive both threshold check messages
       assert_receive {:check_warning_threshold, warning_lag_ms}


### PR DESCRIPTION
- log connection module for replication manager logs
- simplify bypass conditionals
- ACK write messages to avoid PG resending data