### PR TITLE
fix(ci): fix missing daemon.json to use GCR

### DIFF
--- a/.github/actions/gcp-docker-login/action.yml
+++ b/.github/actions/gcp-docker-login/action.yml
@@ -34,8 +34,14 @@ runs:
     - name: Setup registry mirror
       shell: bash
       run: |
+        # Create daemon.json if it doesn't exist
+        if [ ! -f /etc/docker/daemon.json ]; then
+          echo '{}' | sudo tee /etc/docker/daemon.json > /dev/null
+        fi
+
+        # Add or update registry-mirrors configuration
         echo "$(jq '. += { "registry-mirrors": ["https://mirror.gcr.io"] }' /etc/docker/daemon.json)" > new_daemon.json
-        sudo mv -f new_daemon.json /etc/docker/daemon.json
+        sudo mv new_daemon.json /etc/docker/daemon.json
         sudo service docker restart
 
     - name: Print docker system info


### PR DESCRIPTION
The docker registry is woefully unreliable due to rate limits and such. We have an action to use the GCP mirror, but it never took effect because of a minor bug - daemon.json is not present.

Related: https://github.com/firezone/firezone/actions/runs/15945772933/job/44979632073?pr=9703