### PR TITLE
fix(phoenix-channel): flip boolean condition

### DIFF
--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -468,7 +468,7 @@ where
                     // Process join messages before other messages.
                     // Only process other messages if no room joins are pending.
                     let next_message = self.pending_joins.pop_front().or_else(|| {
-                        if self.pending_join_requests.is_empty() {
+                        if !self.pending_join_requests.is_empty() {
                             return None;
                         }
 


### PR DESCRIPTION
We don't want send any messages _while_ we are still joining the room. At present, this boolean condition is flipped which means we effectively only allow to send messages while we are joining a room.

It is odd that CI is actually so stable with this.