### PR TITLE
ci: bump `sccache` action

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -44,7 +44,7 @@ runs:
         echo "SCCACHE_GCS_BUCKET=firezone-staging-sccache" >> $GITHUB_ENV
         echo "SCCACHE_GCS_RW_MODE=READ_WRITE" >> $GITHUB_ENV
       shell: bash
-    - uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
+    - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
     - run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
Whilst investigating some ephemeral CI errors, I noticed that `sccache-action` is quite outdated.