### PR TITLE
ci: extend `sccache` startup timeout

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -45,8 +45,6 @@ runs:
         echo "SCCACHE_GCS_RW_MODE=READ_WRITE" >> $GITHUB_ENV
       shell: bash
     - uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
-      env:
-        SCCACHE_CONF: ".github/actions/setup-rust/sccache.toml"
     - run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
       shell: bash
 
@@ -83,3 +81,5 @@ runs:
     - name: Start sccache
       run: $SCCACHE_PATH --start-server
       shell: bash
+      env:
+        SCCACHE_CONF: ".github/actions/setup-rust/sccache.toml"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -45,6 +45,8 @@ runs:
         echo "SCCACHE_GCS_RW_MODE=READ_WRITE" >> $GITHUB_ENV
       shell: bash
     - uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
+      env:
+        SCCACHE_CONF: ".github/actions/setup-rust/sccache.toml"
     - run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
       shell: bash
 

--- a/.github/actions/setup-rust/sccache.toml
+++ b/.github/actions/setup-rust/sccache.toml
@@ -1,0 +1,1 @@
+server_startup_timeout_ms = 20000 # Default is 10_000


### PR DESCRIPTION
It appears that recently, our CI jobs are often timing out on attempting to startup up the sccache server for Rust caching. We attempt to fix this by increasing the timeout to 20s.