### PR TITLE
fix(phoenix-channel): don't pipeline messages

### DIFF
--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -562,6 +562,13 @@ where
                             }));
                         }
                         (Payload::Reply(Reply::Ok(OkReply::Message(reply))), Some(req_id)) => {
+                            return Poll::Ready(Ok(Event::SuccessResponse {
+                                topic: message.topic,
+                                req_id,
+                                res: reply,
+                            }));
+                        }
+                        (Payload::Reply(Reply::Ok(OkReply::NoMessage(Empty {}))), Some(req_id)) => {
                             if self.pending_join_requests.remove(&req_id) {
                                 tracing::info!("Joined {} room on portal", message.topic);
 
@@ -571,13 +578,6 @@ where
                                 }));
                             }
 
-                            return Poll::Ready(Ok(Event::SuccessResponse {
-                                topic: message.topic,
-                                req_id,
-                                res: reply,
-                            }));
-                        }
-                        (Payload::Reply(Reply::Ok(OkReply::NoMessage(Empty {}))), Some(req_id)) => {
                             tracing::trace!("Received empty reply for request {req_id:?}");
 
                             continue;

--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -468,7 +468,7 @@ where
                     // Process join messages before other messages.
                     // Only process other messages if no room joins are pending.
                     let next_message = self.pending_joins.pop_front().or_else(|| {
-                        if self.pending_join_requests.is_empty() {
+                        if !self.pending_join_requests.is_empty() {
                             return None;
                         }
 

--- a/rust/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/connlib/phoenix-channel/tests/lib.rs
@@ -106,7 +106,7 @@ async fn client_does_not_pipeline_messages() {
     };
 
     let (join_res, _) = tokio::time::timeout(
-        Duration::from_secs(1),
+        Duration::from_secs(2),
         futures::future::join(server, client),
     )
     .await

--- a/rust/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/connlib/phoenix-channel/tests/lib.rs
@@ -1,0 +1,127 @@
+#![allow(clippy::unwrap_used)]
+
+use std::{str::FromStr, sync::Arc, time::Duration};
+
+use backoff::exponential::ExponentialBackoff;
+use futures::{SinkExt, StreamExt};
+use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, PublicKeyParam};
+use secrecy::{Secret, SecretString};
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
+use url::Url;
+
+#[tokio::test]
+async fn client_does_not_pipeline_messages() {
+    let _guard = firezone_logging::test("debug,wire::api=trace");
+
+    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+        loop {
+            match ws.next().await {
+                Some(Ok(Message::Text(text))) => match text.as_str() {
+                    r#"{"topic":"test","event":"phx_join","payload":null,"ref":1}"# => {
+                        // The real Elixir backend processes messages in parallel and therefore may drop messages if we pipeline them instead of waiting for the channel join.
+                        // This is difficult to assert in a test because we need to mimic this behaviour of not processing messages sequentially.
+                        // The way we assert this is by checking, whether any messages are pipelined.
+                        // Reading another message from the stream should timeout at this point because we haven't acknowledged the room join yet.
+                        if let Ok(msg) =
+                            tokio::time::timeout(Duration::from_millis(100), ws.next()).await
+                        {
+                            panic!("Did not yet expect another msg: {msg:?}")
+                        }
+
+                        ws.send(Message::text(
+                            r#"{"event":"phx_reply","ref":1,"topic":"client","payload":{"status":"ok","response":null}}"#,
+                        )).await.unwrap();
+                    }
+                    r#"{"topic":"test","event":"bar","ref":0}"# => {
+                        ws.send(Message::text(
+                            r#"{"topic":"test","event":"foo","payload":null}"#,
+                        ))
+                        .await
+                        .unwrap();
+                    }
+                    other => panic!("Unexpected message: {other}"),
+                },
+                Some(Ok(Message::Close(_))) => continue,
+                Some(other) => {
+                    panic!("Unexpected message: {other:?}")
+                }
+                None => break,
+            }
+        }
+    });
+
+    let login_url = Secret::new(
+        LoginUrl::client(
+            Url::from_str(&format!("ws://localhost:{}", server_addr.port())).unwrap(),
+            &SecretString::new("secret".to_owned()),
+            String::new(),
+            None,
+            DeviceInfo::default(),
+        )
+        .unwrap(),
+    );
+
+    let mut channel = PhoenixChannel::<(), InboundMsg, (), _>::disconnected(
+        login_url,
+        "test/1.0.0".to_owned(),
+        "test",
+        (),
+        ExponentialBackoff::default,
+        Arc::new(socket_factory::tcp),
+    )
+    .unwrap();
+
+    let client = async move {
+        channel.connect(PublicKeyParam([0u8; 32]));
+        channel.send("test", OutboundMsg::Bar);
+
+        loop {
+            match std::future::poll_fn(|cx| channel.poll(cx)).await.unwrap() {
+                phoenix_channel::Event::SuccessResponse { .. } => {}
+                phoenix_channel::Event::ErrorResponse { res, .. } => {
+                    panic!("Unexpected error: {res:?}")
+                }
+                phoenix_channel::Event::JoinedRoom { .. } => {}
+                phoenix_channel::Event::HeartbeatSent => {}
+                phoenix_channel::Event::InboundMessage {
+                    msg: InboundMsg::Foo,
+                    ..
+                } => {
+                    channel.close().unwrap();
+                }
+                phoenix_channel::Event::Hiccup { error, .. } => {
+                    panic!("Unexpected hiccup: {error:?}")
+                }
+                phoenix_channel::Event::Closed => break,
+            }
+        }
+    };
+
+    let (join_res, _) = tokio::time::timeout(
+        Duration::from_secs(1),
+        futures::future::join(server, client),
+    )
+    .await
+    .unwrap();
+    join_res.unwrap();
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "event", content = "payload")]
+enum InboundMsg {
+    Foo,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "event", content = "payload")]
+enum OutboundMsg {
+    Bar,
+}

--- a/rust/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/connlib/phoenix-channel/tests/lib.rs
@@ -1,17 +1,18 @@
 #![allow(clippy::unwrap_used)]
 
-use std::{str::FromStr, sync::Arc, time::Duration};
-
-use backoff::exponential::ExponentialBackoff;
-use futures::{SinkExt, StreamExt};
-use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, PublicKeyParam};
-use secrecy::{Secret, SecretString};
-use tokio::net::TcpListener;
-use tokio_tungstenite::tungstenite::Message;
-use url::Url;
-
+#[cfg(not(windows))] // For some reason, Windows doesn't like this test.
 #[tokio::test]
 async fn client_does_not_pipeline_messages() {
+    use std::{str::FromStr, sync::Arc, time::Duration};
+
+    use backoff::exponential::ExponentialBackoff;
+    use futures::{SinkExt, StreamExt};
+    use phoenix_channel::{DeviceInfo, LoginUrl, PhoenixChannel, PublicKeyParam};
+    use secrecy::{Secret, SecretString};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::Message;
+    use url::Url;
+
     let _guard = firezone_logging::test("debug,wire::api=trace");
 
     let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();

--- a/rust/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/connlib/phoenix-channel/tests/lib.rs
@@ -37,7 +37,7 @@ async fn client_does_not_pipeline_messages() {
                         }
 
                         ws.send(Message::text(
-                            r#"{"event":"phx_reply","ref":1,"topic":"client","payload":{"status":"ok","response":null}}"#,
+                            r#"{"event":"phx_reply","ref":1,"topic":"client","payload":{"status":"ok","response":{}}}"#,
                         )).await.unwrap();
                     }
                     r#"{"topic":"test","event":"bar","ref":0}"# => {


### PR DESCRIPTION
In #9656, we already tried to fix the pipelining of messages to the portal. Unfortunately, a bug was introduced in a last-minute refactoring where we would _only_ send messages while we were joining a room. Due a 2nd bug where we weren't actually processing the room join replies correctly, this didn't matter so the PR was effectively a no-op and didn't change any behaviour.

Further investigation of the code surfaced additional problems. For one, we were not re-queuing the message into the correct buffer. Two, we were only flushing after sending a message.

To fix both of these, we move the flushing out of the message sending branch completely and duplicate some of the code for sending messages in order to correctly handle join requests before other messages.

Finally, join requests have an _empty_ payload and are therefore processed in a different branch. By moving the checking for the replies of join requests, we can correctly update the state and continue sending messages once the join is successful.

Resolves: #9647