### PR TITLE
chore(rust): fix lockfile

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]


### PR DESCRIPTION
It appears that the recent dependabot PRs didn't update the lockfile correctly.