### PR TITLE
fix(phoenix-channel): replace all non-ASCII chars in user agent

### DIFF
--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -824,6 +824,8 @@ fn make_request(url: Url, host: String, user_agent: String) -> Request {
     OsRng.fill_bytes(&mut r);
     let key = base64::engine::general_purpose::STANDARD.encode(r);
 
+    let user_agent = user_agent.replace(|c| !c.is_ascii(), "");
+
     Request::builder()
         .method("GET")
         .header("Host", host)

--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -824,7 +824,7 @@ fn make_request(url: Url, host: String, user_agent: String) -> Request {
     OsRng.fill_bytes(&mut r);
     let key = base64::engine::general_purpose::STANDARD.encode(r);
 
-    let user_agent = user_agent.replace(|c| !c.is_ascii(), "");
+    let user_agent = user_agent.replace(|c: char| !c.is_ascii(), "");
 
     Request::builder()
         .method("GET")


### PR DESCRIPTION
HTTP headers only reliably support ASCII characters. We include information like the user's kernel build name in there and therefore need to strip non-ASCII characters from that to avoid encoding errors.

Fixes: #9706