### PR TITLE
chore(portal): downgrade expected wal log to info

### DIFF
--- a/elixir/apps/domain/lib/domain/replication/manager.ex
+++ b/elixir/apps/domain/lib/domain/replication/manager.ex
@@ -60,7 +60,7 @@ defmodule Domain.Replication.Manager do
         {:EXIT, pid, _reason},
         %{connection_module: connection_module, connection_pid: pid} = state
       ) do
-    Logger.warning("#{connection_module}: Replication connection died, restarting immediately",
+    Logger.info("#{connection_module}: Replication connection died, restarting immediately",
       died_pid: inspect(pid),
       died_node: node(pid)
     )


### PR DESCRIPTION
This is expected during deploys so we downgrade it to info to avoid sending to Sentry.