### PR TITLE
chore(portal): URI-decode user agent

### DIFF
--- a/elixir/apps/domain/lib/domain/version.ex
+++ b/elixir/apps/domain/lib/domain/version.ex
@@ -1,6 +1,7 @@
 defmodule Domain.Version do
   def fetch_version(user_agent) when is_binary(user_agent) do
     user_agent
+    |> URI.decode()
     |> String.split(" ")
     |> Enum.find_value(fn
       "relay/" <> version -> version

--- a/elixir/apps/domain/test/domain/version_test.exs
+++ b/elixir/apps/domain/test/domain/version_test.exs
@@ -1,0 +1,21 @@
+defmodule Domain.VersionTest do
+  use Domain.DataCase, async: true
+  import Domain.Version
+
+  describe "fetch_version/1" do
+    test "returns connlib version when user agent contains URI-encoded chars" do
+      user_agent = "connlib%2F1.2.3%20with%20spaces"
+      assert fetch_version(user_agent) == {:ok, "1.2.3"}
+    end
+
+    test "returns connlib version when user agent contains UTF-8 characters" do
+      user_agent = "connlib%2F1.2.3%205.4.292-Paimon-君の名は。/18a0a2d5"
+      assert fetch_version(user_agent) == {:ok, "1.2.3"}
+    end
+
+    test "returns connlib version when user agent contains no percent-encoding" do
+      user_agent = "connlib/1.2.3 with spaces"
+      assert fetch_version(user_agent) == {:ok, "1.2.3"}
+    end
+  end
+end

--- a/elixir/apps/web/lib/web/live/clients/show.ex
+++ b/elixir/apps/web/lib/web/live/clients/show.ex
@@ -148,7 +148,7 @@ defmodule Web.Clients.Show do
           <.vertical_table_row>
             <:label>User agent</:label>
             <:value>
-              {@client.last_seen_user_agent}
+              {URI.decode(@client.last_seen_user_agent)}
             </:value>
           </.vertical_table_row>
           <.vertical_table_row>


### PR DESCRIPTION
Some user agents are URI-encoded since they contain non-ASCII characters. To display these properly, we URI-decode the client's user agent, which is a no-op if there are no encoded characters.

Related: https://github.com/firezone/firezone/pull/9725
Related: https://github.com/firezone/firezone/issues/9706