### PR TITLE
chore(portal): increase queue_target on bg nodes to 5000

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -18,6 +18,10 @@ if config_env() == :prod do
            {:ssl_opts, env_var_to_config!(:database_ssl_opts)},
            {:parameters, env_var_to_config!(:database_parameters)}
          ] ++
+           if(env_var_to_config(:background_jobs_enabled),
+             do: [{:queue_target, 5_000}],
+             else: []
+           ) ++
            if(env_var_to_config(:database_password),
              do: [{:password, env_var_to_config!(:database_password)}],
              else: []


### PR DESCRIPTION
The domain nodes that run background jobs aren't user-facing and as such, don't need short queue_interval times. They can afford to wait a few seconds for a connection from the pool to become available.

This should be a relatively low-risk change as it does not increase the resources used on the app server and database, it only relaxes the length of time we want for a connection to be available for us to use.