### PR TITLE
fix(ci): fix update-release-draft for gui-client

### DIFF
--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -19,6 +19,9 @@ permissions:
 
 jobs:
   update-release-draft:
+    permissions:
+      contents: write # for updating the release draft
+      id-token: write
     name: update-release-draft
     runs-on: ubuntu-22.04-xlarge
     env:


### PR DESCRIPTION
Needs contents-write perms to create draft releases.

Related: https://github.com/firezone/firezone/actions/runs/15990137167