### PR TITLE
fix(gui-client): ensure GUI client can access `firezone-id.json`

### DIFF
--- a/rust/bin-shared/src/device_id.rs
+++ b/rust/bin-shared/src/device_id.rs
@@ -18,7 +18,7 @@ pub struct DeviceId {
 ///
 /// e.g. `C:\ProgramData\dev.firezone.client/firezone-id.json` or
 /// `/var/lib/dev.firezone.client/config/firezone-id.json`.
-pub(crate) fn path() -> Result<PathBuf> {
+pub fn path() -> Result<PathBuf> {
     let path = crate::known_dirs::tunnel_service_config()
         .context("Failed to compute path for firezone-id file")?
         .join("firezone-id.json");

--- a/rust/gui-client/src-tauri/src/lib.rs
+++ b/rust/gui-client/src-tauri/src/lib.rs
@@ -20,3 +20,16 @@ pub mod settings;
 /// Tunnel service and GUI client are always bundled into a single release.
 /// Hence, we have a single constant for Tunnel service and GUI client.
 pub const RELEASE: &str = concat!("gui-client@", env!("CARGO_PKG_VERSION"));
+
+pub const FIREZONE_CLIENT_GROUP: &str = "firezone-client";
+
+#[cfg(target_os = "linux")]
+pub fn firezone_client_group() -> anyhow::Result<nix::unistd::Group> {
+    use anyhow::Context as _;
+
+    let group = nix::unistd::Group::from_name(FIREZONE_CLIENT_GROUP)
+        .context("can't get group by name")?
+        .with_context(|| format!("`{FIREZONE_CLIENT_GROUP}` group must exist on the system"))?;
+
+    Ok(group)
+}


### PR DESCRIPTION
I believe some of the recent changes around how we load the `firezone-id.json` from the GUI client surfaced that we in fact don't always have access to it. Previously, this was silenced because we would only optionally add it as context to the Sentry client.

Now, we need it to initialise telemetry so we know whether or not to send logs to Sentry.

In order to be able to access the file, we need to change the config's directory and the file to be owned by the `firezone-client` group.