### PR TITLE
fix(gui-client): stop telemetry in tunnel service on disconnect

### DIFF
--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -456,6 +456,7 @@ impl<'a> Handler<'a> {
         match msg {
             client_shared::Event::Disconnected(error) => {
                 self.session = Session::None;
+                self.telemetry.stop_on_crash().await;
                 self.dns_controller.deactivate()?;
                 self.send_ipc(ServerMsg::OnDisconnect {
                     error_msg: error.to_string(),
@@ -526,6 +527,7 @@ impl<'a> Handler<'a> {
             }
             ClientMsg::Disconnect => {
                 self.session = Session::None;
+                self.telemetry.stop().await;
                 self.dns_controller.deactivate()?;
 
                 // Always send `DisconnectedGracefully` even if we weren't connected,


### PR DESCRIPTION
In order to re-initialise telemetry on a new session, we need to make sure it is de-initialised on every session disconnect.