### PR TITLE
chore(telemetry): don't fmt fields from the `log` crate

### DIFF
--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -309,6 +309,7 @@ fn append_tracing_fields_to_message(mut log: Log) -> Option<Log> {
         "tracing.",
         "server.",
         "user.",
+        "log.",
         "parent_span_id",
     ];
 


### PR DESCRIPTION
Those are internal to `tracing` and don't need to be formatted into the message we send to Sentry.