### PR TITLE
fix(gui-client): set IO error type for missing non-tunnel routes

### DIFF
--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -251,7 +251,10 @@ fn get_best_non_tunnel_route(dst: IpAddr) -> io::Result<Route> {
         .filter(|adapter| is_up(adapter))
         .filter_map(|adapter| find_best_route_for_luid(&adapter.Luid, dst).ok())
         .min()
-        .ok_or(io::Error::other("No route to host"))?;
+        .ok_or(io::Error::new(
+            io::ErrorKind::HostUnreachable,
+            "No route to host",
+        ))?;
 
     tracing::debug!(src = %route.addr, %dst, "Resolved best route outside of tunnel interface");
 


### PR DESCRIPTION
On Windows - in order to prevent routing loops - we resolve the best "non-tunnel" route to a particular host for each IP address. The resulting source IP is then used as source for packets leaving our interface. In case the system doesn't have IPv6 connectivity or are simply no routes available, we fail this "source IP resolver" with an IO error.

Presently, this uses the "other" IO error type which causes this to be logged on a WARN level in the event-loop. The IO error types `HostUnreachable` and `NetworkUnreachable` are expected during normal operation of Firezone and are therefore only logged on DEBUG.

By changing this IO error type, we fix the WARN log spam on Windows for machines without IPv6 connectivity.