### PR TITLE
fix(gui-client): don't panic on existing session

### DIFF
--- a/rust/client-shared/src/lib.rs
+++ b/rust/client-shared/src/lib.rs
@@ -27,11 +27,12 @@ const PHOENIX_TOPIC: &str = "client";
 ///
 /// A session is created using [`Session::connect`].
 /// To stop the session, simply drop this struct.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Session {
     channel: UnboundedSender<Command>,
 }
 
+#[derive(Debug)]
 pub struct EventStream {
     channel: Receiver<Event>,
 }

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -178,7 +178,7 @@ struct Handler<'a> {
     telemetry_refresh: tokio::time::Interval,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 enum Session {
     /// We've launched `connlib` but haven't heard back from it yet.
     Creating {
@@ -600,13 +600,13 @@ impl<'a> Handler<'a> {
         Ok(())
     }
 
-    /// Connects connlib
-    ///
-    /// Panics if there's no Tokio runtime or if connlib is already connected.
     fn try_connect(&mut self, api_url: &str, token: SecretString) -> Result<Session> {
         let started_at = Instant::now();
 
-        assert!(self.session.is_none());
+        if !self.session.is_none() {
+            tracing::warn!(session = ?self.session, "Connecting despite existing session");
+        }
+
         let device_id = device_id::get_or_create().context("Failed to get-or-create device ID")?;
 
         let url = LoginUrl::client(


### PR DESCRIPTION
Customer hit what seems to be a rare race condition where we try to connect whilst we already have a session. I don't know which state it is in so I am replacing it with a WARN log to learn more about this in Sentry in case it gets hit again.