### PR TITLE
chore(rust): simplify stream logs feature

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2511,6 +2511,7 @@ name = "firezone-logging"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "firezone-telemetry",
  "nu-ansi-term 0.50.1",
  "output_vt100",
  "parking_lot",

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -184,8 +184,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
     }
 
     let eventloop = future::poll_fn({
-        let mut eventloop =
-            Eventloop::new(tunnel, portal, tun_device_manager, firezone_id, telemetry);
+        let mut eventloop = Eventloop::new(tunnel, portal, tun_device_manager, firezone_id);
 
         move |cx| eventloop.poll(cx)
     });

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -20,7 +20,6 @@ use secrecy::{Secret, SecretString};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
-    time::Duration,
 };
 use tokio::time::Instant;
 
@@ -283,8 +282,6 @@ fn main() -> Result<()> {
             new_network_notifier(tokio_handle.clone(), dns_control_method).await?;
         drop(tokio_handle);
 
-        let mut telemetry_refresh = tokio::time::interval(Duration::from_secs(60));
-
         let tun = tun_device.make_tun()?;
         session.set_tun(tun);
         session.set_dns(dns_controller.system_resolvers());
@@ -314,10 +311,6 @@ fn main() -> Result<()> {
                     session.reset();
                     continue;
                 },
-                _ = telemetry_refresh.tick() => {
-                    telemetry.refresh_config();
-                    continue;
-                }
                 event = event_stream.next() => event.context("event stream unexpectedly ran empty")?,
             };
 

--- a/rust/logging/Cargo.toml
+++ b/rust/logging/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+firezone-telemetry = { workspace = true }
 nu-ansi-term = { workspace = true }
 output_vt100 = { workspace = true }
 parking_lot = { workspace = true }


### PR DESCRIPTION
Instead of conditionally enabling the `logs` feature in the Sentry client, we always enable it and control via the `tracing` integration, which events should get forwarded to Sentry. The feature-flag check accesses only shared-memory and is therefore really fast.

We already re-evaluate feature flags on a timer which means this boolean will flip over automatically and logs will be streamed to Sentry.