### PR TITLE
refactor(ci): reuse `gcp-docker-login` action

### DIFF
--- a/.github/actions/gcp-docker-login/action.yml
+++ b/.github/actions/gcp-docker-login/action.yml
@@ -15,7 +15,9 @@ runs:
         service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
         export_environment_variables: true
         create_credentials_file: true
+
     - name: Login to Google Artifact Registry
+      if: ${{ runner.os == 'Linux' }}
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
         registry: "us-east1-docker.pkg.dev"
@@ -25,6 +27,7 @@ runs:
     # DockerHub has stupid rate limits (see https://www.docker.com/increase-rate-limits/)
     # Use Google's public mirror instead: https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images
     - name: Setup registry mirror
+      if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
         # Create daemon.json if it doesn't exist
@@ -38,5 +41,6 @@ runs:
         sudo service docker restart
 
     - name: Print docker system info
+      if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: docker system info

--- a/.github/actions/gcp-docker-login/action.yml
+++ b/.github/actions/gcp-docker-login/action.yml
@@ -3,7 +3,7 @@ description: "Login to the GCP docker registry"
 outputs:
   registry:
     description: "The full name of the registry we logged into"
-    value: ${{ format('us-east1-docker.pkg.dev/{0}', inputs.project) }}
+    value: ${{ format('us-east1-docker.pkg.dev/firezone-staging') }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/gcp-docker-login/action.yml
+++ b/.github/actions/gcp-docker-login/action.yml
@@ -1,9 +1,5 @@
 name: "GCP docker registry login"
 description: "Login to the GCP docker registry"
-inputs:
-  project:
-    description: "The GCP project name"
-    required: true
 outputs:
   registry:
     description: "The full name of the registry we logged into"
@@ -17,11 +13,8 @@ runs:
         token_format: access_token
         workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions"
         service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
-        export_environment_variables: false
+        export_environment_variables: true
         create_credentials_file: true
-    - name: Change current gcloud account
-      shell: bash
-      run: gcloud --quiet config set project ${{ inputs.project }}
     - name: Login to Google Artifact Registry
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -33,13 +33,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: auth
-      uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-      with:
-        workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions"
-        service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
-        export_environment_variables: true
-        create_credentials_file: true
+    - uses: ./.github/actions/gcp-docker-login
     - run: |
         echo "SCCACHE_GCS_BUCKET=firezone-staging-sccache" >> $GITHUB_ENV
         echo "SCCACHE_GCS_RW_MODE=READ_WRITE" >> $GITHUB_ENV

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -264,6 +264,7 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
       - uses: ./.github/actions/gcp-docker-login
+        id: login
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.arch.target }}
@@ -422,6 +423,7 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
       - uses: ./.github/actions/gcp-docker-login
+        id: login
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -78,8 +78,6 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - uses: ./.github/actions/gcp-docker-login
         id: login
-        with:
-          project: firezone-staging
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
@@ -266,9 +264,6 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
       - uses: ./.github/actions/gcp-docker-login
-        id: login
-        with:
-          project: firezone-staging
       - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.arch.target }}
@@ -427,9 +422,6 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
       - uses: ./.github/actions/gcp-docker-login
-        id: login
-        with:
-          project: firezone-staging
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -116,9 +116,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/gcp-docker-login
-        id: login
-        with:
-          project: firezone-staging
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.migrate --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations && mix ecto.seed'
       - name: Start docker compose in the background

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,9 +305,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/gcp-docker-login
-        id: login
-        with:
-          project: firezone-staging
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.seed --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations'
       - name: Start docker compose in the background

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/gcp-docker-login
+        id: login
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,14 +82,6 @@ jobs:
             -t ghcr.io/firezone/${{ steps.set-variables.outputs.artifact }}:${{ steps.set-variables.outputs.major_minor_version }} \
             -t ghcr.io/firezone/${{ steps.set-variables.outputs.artifact }}:latest \
             $SOURCE_TAG
-      - name: Authenticate to Google Cloud
-        id: auth
-        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-        with:
-          workload_identity_provider: "projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions"
-          service_account: "github-actions@github-iam-387915.iam.gserviceaccount.com"
-          export_environment_variables: true
-          create_credentials_file: true
       - name: Copy Google Cloud Storage binaries to "latest" version
         run: |
           set -xe

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/gcp-docker-login
-        id: login
-        with:
-          project: firezone-staging
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:


### PR DESCRIPTION
It appears the code for authenticating with GCP is duplicated in some of our workflows.