### PR TITLE
chore(portal): remove gateway masquerade option

### DIFF
--- a/elixir/apps/api/lib/api/gateway/channel.ex
+++ b/elixir/apps/api/lib/api/gateway/channel.ex
@@ -38,10 +38,6 @@ defmodule API.Gateway.Channel do
     OpenTelemetry.Tracer.with_span "gateway.after_join" do
       :ok = Gateways.Presence.connect(socket.assigns.gateway)
 
-      config = Domain.Config.fetch_env!(:domain, Domain.Gateways)
-      ipv4_masquerade_enabled? = Keyword.fetch!(config, :gateway_ipv4_masquerade)
-      ipv6_masquerade_enabled? = Keyword.fetch!(config, :gateway_ipv6_masquerade)
-
       # Return all connected relays for the account
       relay_credentials_expire_at = DateTime.utc_now() |> DateTime.add(14, :day)
       {:ok, relays} = select_relays(socket)
@@ -54,9 +50,10 @@ defmodule API.Gateway.Channel do
         account_slug: account.slug,
         interface: Views.Interface.render(socket.assigns.gateway),
         relays: Views.Relay.render_many(relays, relay_credentials_expire_at),
+        # These aren't used but needed for API compatibility
         config: %{
-          ipv4_masquerade_enabled: ipv4_masquerade_enabled?,
-          ipv6_masquerade_enabled: ipv6_masquerade_enabled?
+          ipv4_masquerade_enabled: true,
+          ipv6_masquerade_enabled: true
         }
       })
 

--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -110,11 +110,6 @@ defmodule Domain.Config.Definitions do
        [
          :auth_provider_adapters
        ]},
-      {"Gateways",
-       [
-         :gateway_ipv4_masquerade,
-         :gateway_ipv6_masquerade
-       ]},
       {"Outbound Emails",
        [
          :outbound_email_from,
@@ -565,13 +560,6 @@ defmodule Domain.Config.Definitions do
     default: %{},
     dump: &Dumper.keyword/1
   )
-
-  ##############################################
-  ## Gateways
-  ##############################################
-
-  defconfig(:gateway_ipv4_masquerade, :boolean, default: true)
-  defconfig(:gateway_ipv6_masquerade, :boolean, default: true)
 
   ##############################################
   ## HTTP Client Settings

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -104,10 +104,6 @@ config :domain, Domain.Tokens,
   key_base: "5OVYJ83AcoQcPmdKNksuBhJFBhjHD1uUa9mDOHV/6EIdBQ6pXksIhkVeWIzFk5S2",
   salt: "t01wa0K4lUd7mKa0HAtZdE+jFOPDDej2"
 
-config :domain, Domain.Gateways,
-  gateway_ipv4_masquerade: true,
-  gateway_ipv6_masquerade: true
-
 config :domain, Domain.Telemetry, metrics_reporter: nil, healthz_port: 4000
 
 config :domain, Domain.Analytics,

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -67,10 +67,6 @@ if config_env() == :prod do
     key_base: env_var_to_config!(:tokens_key_base),
     salt: env_var_to_config!(:tokens_salt)
 
-  config :domain, Domain.Gateways,
-    gateway_ipv4_masquerade: env_var_to_config!(:gateway_ipv4_masquerade),
-    gateway_ipv6_masquerade: env_var_to_config!(:gateway_ipv6_masquerade)
-
   config :domain, Domain.Auth.Adapters.GoogleWorkspace.APIClient,
     finch_transport_opts: env_var_to_config!(:http_client_ssl_opts)
 


### PR DESCRIPTION
AFAIK these are ignored by connlib. Instead, we configure masquerading on the host.