### PR TITLE
feat(connlib): introduce 2s grace-period upon ICE disconnect

### DIFF
--- a/rust/connlib/snownet/src/utils.rs
+++ b/rust/connlib/snownet/src/utils.rs
@@ -1,14 +1,3 @@
-use std::time::Instant;
-
-pub fn earliest(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
-    match (left, right) {
-        (None, None) => None,
-        (Some(left), Some(right)) => Some(std::cmp::min(left, right)),
-        (Some(left), None) => Some(left),
-        (None, Some(right)) => Some(right),
-    }
-}
-
 pub fn channel_data_packet_buffer(payload: &[u8]) -> Vec<u8> {
     [&[0u8; 4] as &[u8], payload].concat()
 }


### PR DESCRIPTION
When Firezone detects that the user is switching networks, we perform an internal reset where we clear all connections and also all local candidates. As part of the reset, we then send STUN requests to our relays to re-discover our host and server-reflexive candidates. In this scenario, the Gateway is still connected to its network and is therefore able to send its candidates as soon as it receives the connection intent from the portal.

This opens us up to the following race condition which leads to a false-positive "ICE timeout":

1. Client roams network and clears all local state.
2. Client sends STUN binding requests to relays.
3. Client initiates a new connection.
4. Gateway acknowledges connection.
5. Client creates new ICE agent and attempts to seed it with local candidates. We don't have a response from the relays yet and therefore don't have any local candidates.
6. Client receives remote candidates and adds them to the agent.
7. ICE agent is unable to form pairs and therefore concludes that it is disconnected.
8. We treat the disconnected event as a connection failure and clear the connection.
9. Relays respond to STUN binding requests but we cannot add the new candidates to the connection because it is already cleared.

The ICE spec states that after an agent transitions into the "disconnected" state, it may transition back to "connected" if e.g. new candidates are added as those allow the forming of new pairs. In general, it is recommended to not treat "disconnected" as a permanent state. To honor this recommendation, we introduce a 2s grace-period in which we can recover from such a "disconnected" state.