### PR TITLE
docs(website): add changelog entries

### DIFF
--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -20,7 +20,12 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9725">
+          Fixes an issue where Firezone failed to sign-in on systems with
+          non-ASCII characters in their kernel build name.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.2" date={new Date("2025-06-30")}>
         <ChangeItem pull="9621">
           Fixes an issue where the VPN permission screen wouldn't dismiss after

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -32,6 +32,10 @@ export default function Apple() {
         <ChangeItem pull="9536">
           Uses `.zip` to compress logs instead of Apple Archive.
         </ChangeItem>
+        <ChangeItem pull="9725">
+          Fixes an issue where Firezone failed to sign-in on systems with
+          non-ASCII characters in their kernel build name.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.3" date={new Date("2025-06-19")}>
         <ChangeItem pull="9564">

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,19 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9779">Fixes a rare crash during sign-in.</ChangeItem>
+        <ChangeItem pull="9725">
+          Fixes an issue where Firezone failed to sign-in on systems with
+          non-ASCII characters in their kernel build name.
+        </ChangeItem>
+        {os === OS.Windows && (
+          <ChangeItem pull="9696">
+            Establishes connections quicker by narrowing the set of network
+            changes we react to.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.5.4" date={new Date("2025-06-19")}>
         <ChangeItem pull="9564">
           Fixes an issue where connections would fail to establish if both

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -28,6 +28,14 @@ export default function Gateway() {
           Fixes an issue where connections would fail to establish if the
           Gateway was under high load.
         </ChangeItem>
+        <ChangeItem pull="9725">
+          Fixes an issue where Firezone failed to sign-in on systems with
+          non-ASCII characters in their kernel build name.
+        </ChangeItem>
+        <ChangeItem pull="9655">
+          Allows long-lived TCP connections to remain open by increasing the NAT
+          TTL to 2h.
+        </ChangeItem>
       </Entry>
       <Entry version="1.4.11" date={new Date("2025-06-19")}>
         <ChangeItem pull="9564">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -15,6 +15,16 @@ export default function Headless({ os }: { os: OS }) {
           Fixes an issue where connections would fail to establish if both
           Client and Gateway were behind symmetric NAT.
         </ChangeItem>
+        <ChangeItem pull="9725">
+          Fixes an issue where Firezone failed to sign-in on systems with
+          non-ASCII characters in their kernel build name.
+        </ChangeItem>
+        {os === OS.Windows && (
+          <ChangeItem pull="9696">
+            Establishes connections quicker by narrowing the set of network
+            changes we react to.
+          </ChangeItem>
+        )}
       </Entry>
       <Entry version="1.5.0" date={new Date("2025-06-05")}>
         <ChangeItem pull="9300">


### PR DESCRIPTION
We've not added changelog entries for several of the PRs that went in recently. This adds some for the more user-facing changes and fixes that we are shipping.