### PR TITLE
refactor(windows): move `valueName` to `text` in `.admx`

### DIFF
--- a/rust/gui-client/src-admx-macro/lib.rs
+++ b/rust/gui-client/src-admx-macro/lib.rs
@@ -28,12 +28,17 @@ fn try_admx(attr: TokenStream, item: TokenStream) -> syn::Result<proc_macro2::To
         .descendants()
         .filter(|n| n.has_tag_name("policy"))
         .map(|policy| {
-            let value_name = policy.attribute("valueName").ok_or_else(|| {
-                syn::Error::new(
-                    admx_path.inner.span(),
-                    "Policy does not have a `valueName` attribute",
+            let value_name = policy
+                .attribute("valueName")
+                .or_else(|| policy
+                    .descendants()
+                    .find(|d| d.has_tag_name("text"))?
+                    .attribute("valueName")
                 )
-            })?;
+                .ok_or_else(|| syn::Error::new(
+                    admx_path.inner.span(),
+                    "Policy does not have a `valueName` attribute"
+                ))?;
             let key = policy.attribute("key").ok_or_else(|| {
                 syn::Error::new(
                     admx_path.inner.span(),

--- a/website/public/policy-templates/windows/firezone.admx
+++ b/website/public/policy-templates/windows/firezone.admx
@@ -23,12 +23,11 @@
       explainText="$(string.authURL_explain)"
       key="Software\Policies\Firezone"
       presentation="$(presentation.authURL)"
-      valueName="authURL"
     >
       <parentCategory ref="firezone" />
       <supportedOn ref="SUPPORTED_FZ_GUI_1_5_0" />
       <elements>
-        <text id="authURL" required="true" />
+        <text id="authURL" valueName="authURL" required="true" />
       </elements>
     </policy>
 
@@ -39,12 +38,11 @@
       explainText="$(string.apiURL_explain)"
       key="Software\Policies\Firezone"
       presentation="$(presentation.apiURL)"
-      valueName="apiURL"
     >
       <parentCategory ref="firezone" />
       <supportedOn ref="SUPPORTED_FZ_GUI_1_5_0" />
       <elements>
-        <text id="apiURL" required="true" />
+        <text id="apiURL" valueName="apiURL" required="true" />
       </elements>
     </policy>
 
@@ -55,12 +53,11 @@
       explainText="$(string.logFilter_explain)"
       key="Software\Policies\Firezone"
       presentation="$(presentation.logFilter)"
-      valueName="logFilter"
     >
       <parentCategory ref="firezone" />
       <supportedOn ref="SUPPORTED_FZ_GUI_1_5_0" />
       <elements>
-        <text id="logFilter" required="true" />
+        <text id="logFilter" valueName="logFilter" required="true" />
       </elements>
     </policy>
 
@@ -71,12 +68,11 @@
       explainText="$(string.accountSlug_explain)"
       key="Software\Policies\Firezone"
       presentation="$(presentation.accountSlug)"
-      valueName="accountSlug"
     >
       <parentCategory ref="firezone" />
       <supportedOn ref="SUPPORTED_FZ_GUI_1_5_0" />
       <elements>
-        <text id="accountSlug" required="true" />
+        <text id="accountSlug" valueName="accountSlug" required="true" />
       </elements>
     </policy>
 
@@ -141,12 +137,11 @@
       explainText="$(string.supportURL_explain)"
       key="Software\Policies\Firezone"
       presentation="$(presentation.supportURL)"
-      valueName="supportURL"
     >
       <parentCategory ref="firezone" />
       <supportedOn ref="SUPPORTED_FZ_GUI_1_5_0" />
       <elements>
-        <text id="supportURL" required="true" />
+        <text id="supportURL" valueName="supportURL" required="true" />
       </elements>
     </policy>
   </policies>


### PR DESCRIPTION
With a real AD (and not Intune), it seems the `valueName` attribute is required for text elements.

Supersedes: #9419
Co-authored-by: Antoine Labarussias <antoinelabarussias@gmail.com>