### PR TITLE
chore(connlib): silence EHOSTDOWN errors

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1346,6 +1346,7 @@ dependencies = [
  "firezone-logging",
  "firezone-tunnel",
  "ip_network",
+ "libc",
  "phoenix-channel",
  "secrecy",
  "serde",

--- a/rust/client-shared/Cargo.toml
+++ b/rust/client-shared/Cargo.toml
@@ -13,6 +13,7 @@ dns-types = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-tunnel = { workspace = true }
 ip_network = { workspace = true }
+libc = { workspace = true }
 phoenix-channel = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }


### PR DESCRIPTION
Certain UNIX systems such as macOS also use the EHOSTDOWN error to signal that a packet cannot be sent to a certain IP. There is nothing we can do about this error so we downgrade it from a WARN to a DEBUG like we do for other kinds of "unreachable" errors.