### PR TITLE
feat(telemetry): grab env and `distinct_id` from Sentry session

### DIFF
--- a/rust/apple-client-ffi/src/lib.rs
+++ b/rust/apple-client-ffi/src/lib.rs
@@ -264,12 +264,7 @@ impl WrappedSession {
         runtime.block_on(telemetry.start(&api_url, RELEASE, APPLE_DSN, device_id.clone()));
         Telemetry::set_account_slug(account_slug.clone());
 
-        analytics::identify(
-            device_id.clone(),
-            api_url.to_string(),
-            RELEASE.to_owned(),
-            Some(account_slug),
-        );
+        analytics::identify(RELEASE.to_owned(), Some(account_slug));
 
         init_logging(log_dir.into(), log_filter)?;
         install_rustls_crypto_provider();

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -237,12 +237,7 @@ fn connect(
     runtime.block_on(telemetry.start(&api_url, RELEASE, platform::DSN, device_id.clone()));
     Telemetry::set_account_slug(account_slug.clone());
 
-    analytics::identify(
-        device_id.clone(),
-        api_url.to_string(),
-        RELEASE.to_owned(),
-        Some(account_slug),
-    );
+    analytics::identify(RELEASE.to_owned(), Some(account_slug));
 
     init_logging(&PathBuf::from(log_dir), log_filter)?;
     install_rustls_crypto_provider();

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -52,7 +52,6 @@ pub struct Eventloop {
     tunnel: GatewayTunnel,
     portal: PhoenixChannel<(), IngressMessages, (), PublicKeyParam>,
     tun_device_manager: Arc<Mutex<TunDeviceManager>>,
-    firezone_id: String,
 
     resolve_tasks:
         futures_bounded::FuturesTupleSet<Result<Vec<IpAddr>, Arc<anyhow::Error>>, ResolveTrigger>,
@@ -68,14 +67,12 @@ impl Eventloop {
         tunnel: GatewayTunnel,
         mut portal: PhoenixChannel<(), IngressMessages, (), PublicKeyParam>,
         tun_device_manager: TunDeviceManager,
-        firezone_id: String,
     ) -> Self {
         portal.connect(PublicKeyParam(tunnel.public_key().to_bytes()));
 
         Self {
             tunnel,
             portal,
-            firezone_id,
             tun_device_manager: Arc::new(Mutex::new(tun_device_manager)),
             resolve_tasks: futures_bounded::FuturesTupleSet::new(DNS_RESOLUTION_TIMEOUT, 1000),
             set_interface_tasks: futures_bounded::FuturesSet::new(Duration::from_secs(5), 10),

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -385,12 +385,7 @@ impl Eventloop {
                 if let Some(account_slug) = init.account_slug {
                     Telemetry::set_account_slug(account_slug.clone());
 
-                    analytics::identify(
-                        self.firezone_id.clone(),
-                        self.portal.url(),
-                        RELEASE.to_owned(),
-                        Some(account_slug),
-                    )
+                    analytics::identify(RELEASE.to_owned(), Some(account_slug))
                 }
 
                 self.tunnel.state_mut().update_relays(

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -134,13 +134,8 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
         opentelemetry::global::set_meter_provider(provider);
     }
 
-    let login = LoginUrl::gateway(
-        cli.api_url,
-        &cli.token,
-        firezone_id.clone(),
-        cli.firezone_name,
-    )
-    .context("Failed to construct URL for logging into portal")?;
+    let login = LoginUrl::gateway(cli.api_url, &cli.token, firezone_id, cli.firezone_name)
+        .context("Failed to construct URL for logging into portal")?;
 
     let resolv_conf = resolv_conf::Config::parse(
         std::fs::read_to_string("/etc/resolv.conf").context("Failed to read /etc/resolv.conf")?,
@@ -184,7 +179,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
     }
 
     let eventloop = future::poll_fn({
-        let mut eventloop = Eventloop::new(tunnel, portal, tun_device_manager, firezone_id);
+        let mut eventloop = Eventloop::new(tunnel, portal, tun_device_manager);
 
         move |cx| eventloop.poll(cx)
     });

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -583,18 +583,13 @@ impl<'a> Handler<'a> {
                             firezone_telemetry::GUI_DSN,
                             self.device_id.id.clone(),
                         )
-                        .await
-                }
+                        .await;
 
-                if let Some(account_slug) = account_slug {
-                    Telemetry::set_account_slug(account_slug.clone());
+                    if let Some(account_slug) = account_slug {
+                        Telemetry::set_account_slug(account_slug.clone());
 
-                    analytics::identify(
-                        self.device_id.id.clone(),
-                        environment,
-                        release,
-                        Some(account_slug),
-                    );
+                        analytics::identify(release, Some(account_slug));
+                    }
                 }
             }
         }

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -179,13 +179,6 @@ fn main() -> Result<()> {
         None => device_id::get_or_create().context("Could not get `firezone_id` from CLI, could not read it from disk, could not generate it and save it to disk")?.id,
     };
 
-    analytics::identify(
-        firezone_id.clone(),
-        cli.api_url.to_string(),
-        RELEASE.to_owned(),
-        None,
-    );
-
     let mut telemetry = Telemetry::default();
     if cli.is_telemetry_allowed() {
         rt.block_on(telemetry.start(
@@ -194,6 +187,8 @@ fn main() -> Result<()> {
             firezone_telemetry::HEADLESS_DSN,
             firezone_id.clone(),
         ));
+
+        analytics::identify(RELEASE.to_owned(), None);
     }
 
     tracing::info!(arch = std::env::consts::ARCH, version = VERSION);

--- a/rust/telemetry/src/analytics.rs
+++ b/rust/telemetry/src/analytics.rs
@@ -20,7 +20,7 @@ pub fn new_session(maybe_legacy_id: String, api_url: String) {
         if let Err(e) = capture(
             "new_session",
             distinct_id,
-            ApiUrl(&api_url),
+            ApiUrl::new(&api_url),
             NewSessionProperties {
                 api_url: api_url.clone(),
             },

--- a/rust/telemetry/src/analytics.rs
+++ b/rust/telemetry/src/analytics.rs
@@ -35,9 +35,11 @@ pub fn new_session(maybe_legacy_id: String, api_url: String) {
 /// Associate several properties with the current telemetry user.
 pub fn identify(release: String, account_slug: Option<String>) {
     let Some(env) = Telemetry::current_env() else {
+        tracing::debug!("Cannot send $identify: Unknown env");
         return;
     };
     let Some(distinct_id) = Telemetry::current_user() else {
+        tracing::debug!("Cannot send $identify: Unknown user");
         return;
     };
 
@@ -88,7 +90,7 @@ where
         .json(&CaptureRequest {
             api_key: api_key.to_string(),
             distinct_id,
-            event,
+            event: event.clone(),
             properties,
         })
         .send()
@@ -102,6 +104,8 @@ where
 
         bail!("Failed to capture event; status={status}, body={body}")
     }
+
+    tracing::debug!(%event);
 
     Ok(())
 }

--- a/rust/telemetry/src/api_url.rs
+++ b/rust/telemetry/src/api_url.rs
@@ -1,0 +1,25 @@
+#[derive(Debug, PartialEq)]
+pub(crate) struct ApiUrl<'a>(&'a str);
+
+impl ApiUrl<'static> {
+    pub(crate) const PROD: Self = ApiUrl("wss://api.firezone.dev");
+    pub(crate) const STAGING: Self = ApiUrl("wss://api.firez.one");
+    pub(crate) const DOCKER_COMPOSE: Self = ApiUrl("ws://api:8081");
+    pub(crate) const LOCALHOST: Self = ApiUrl("ws://localhost:8081");
+}
+
+impl<'a> ApiUrl<'a> {
+    pub(crate) fn new(url: &'a str) -> Self {
+        Self(url.trim_end_matches("/"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trailing_slash_is_trimmed() {
+        assert_eq!(ApiUrl::new("wss://api.firezone.dev/"), ApiUrl::PROD)
+    }
+}


### PR DESCRIPTION
At present, our primary indicator as to whether telemetry is active is whether we have a Sentry session. For our analytics events however, we currently require passing in the Firezone ID and API url again. This makes it difficult to send analytics events from areas of the code that don't have this information available.

To still allow for that, we integrate the `analytics` module more tightly with the Sentry session. This allows us to drop two parameters from the `$identify` event and also means we now respect the `NO_TELEMETRY` setting for these events except for `new_session`. This event is sent regardless because it allows us to track, how many on-prem installations of Firezone are out there.