### PR TITLE
fix(connlib): always signal server-reflexive candidates

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -947,12 +947,11 @@ where
             tracing::trace!(%rid, ?event);
 
             match event {
-                allocation::Event::New(candidate)
-                    if candidate.kind() == CandidateKind::ServerReflexive =>
-                {
-                    self.shared_candidates.insert(candidate);
-                }
                 allocation::Event::New(candidate) => {
+                    if candidate.kind() == CandidateKind::ServerReflexive {
+                        self.shared_candidates.insert(candidate.clone());
+                    }
+
                     for (cid, agent, _span) in self.connections.connecting_agents_by_relay_mut(rid)
                     {
                         add_local_candidate(cid, agent, candidate.clone(), &mut self.pending_events)

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -948,8 +948,18 @@ where
 
             match event {
                 allocation::Event::New(candidate) => {
-                    if candidate.kind() == CandidateKind::ServerReflexive {
-                        self.shared_candidates.insert(candidate.clone());
+                    let should_add = if candidate.kind() == CandidateKind::ServerReflexive {
+                        // If it is a server-reflexive candidate, let the `shared_candidates` decide whether it should be used.
+
+                        self.shared_candidates.insert(candidate.clone())
+                    } else {
+                        // All other candidate types are always used.
+
+                        true
+                    };
+
+                    if !should_add {
+                        continue;
                     }
 
                     for (cid, agent, _span) in self.connections.connecting_agents_by_relay_mut(rid)


### PR DESCRIPTION
When we create a new connection, we seed the local ICE agent with all known local candidates, i.e. host addresses and allocations on relays. Server-reflexive candidates are never added to the local agent because you cannot send directly from a server-reflexive addresses. Instead, an agent sends from the _base_ of a server-reflexive candidate which in turn is known as a host candidate.

The server-reflexive candidate is however signaled to the remote so it can try and send packets to it. Those will then be mapped by the NAT to our host candidate.

In case we have just performed a network reset, our own server-reflexive candidate may not be known yet and therefore the seeding doesn't add an candidates. With no candidates being seeded, we also can't signal them to the remote.

For candidates discovered later in this process, the signalling happens as part of adding them to the local agent. Because server-reflexive candidates are not added to the local agent, we currently miss out on signaling those to the remote IF they weren't already present when the ICE agent got created.

This scenario can happen right after a network reset. In practice, it shouldn't be much of an issue though. As soon as we start sending from our host candidate, the remote will create a peer-reflexive candidate for it. It is however cleaner to directly send the server-reflexive candidate once we discover it.