### PR TITLE
fix(snownet): don't generate candidates of mixed IP version

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1213,6 +1213,7 @@ fn generate_optimistic_candidates(agent: &mut IceAgent) {
 
     let optimistic_candidates = public_ips
         .cartesian_product(host_candidates)
+        .filter(|(ip, base)| ip.is_ipv4() == base.is_ipv4())
         .filter_map(|(ip, base)| {
             let addr = SocketAddr::new(ip, base.port());
 


### PR DESCRIPTION
When we shipped the feature of optimistc server-reflexive candidates, we failed to add a check to only combine address and base such that they are the same IP version. This is not harmful but unnecessary noise.