### PR TITLE
refactor(connlib): directly implement `async fn`

### DIFF
--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -40,10 +40,6 @@ async fn no_packet_loops_udp() {
     let socket =
         udp_socket_factory(&SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))).unwrap();
 
-    std::future::poll_fn(|cx| socket.poll_send_ready(cx))
-        .await
-        .unwrap();
-
     // Send a STUN request.
     socket
         .send(DatagramOut {

--- a/rust/connlib/socket-factory/src/lib.rs
+++ b/rust/connlib/socket-factory/src/lib.rs
@@ -5,14 +5,14 @@ use gat_lending_iterator::LendingIterator;
 use ip_packet::{Ecn, Ipv4Header, Ipv6Header, UdpHeader};
 use opentelemetry::KeyValue;
 use parking_lot::Mutex;
-use quinn_udp::{EcnCodepoint, Transmit};
+use quinn_udp::{EcnCodepoint, Transmit, UdpSockRef};
 use std::collections::HashMap;
 use std::io;
 use std::io::IoSliceMut;
 use std::ops::Deref;
 use std::{
     net::{IpAddr, SocketAddr},
-    task::{Context, Poll, ready},
+    task::{Context, Poll},
 };
 
 use std::any::Any;
@@ -262,43 +262,35 @@ pub struct DatagramOut {
 
 impl UdpSocket {
     pub async fn recv_from(&self) -> Result<DatagramSegmentIter> {
-        std::future::poll_fn(|cx| self.poll_recv_from(cx)).await
-    }
-
-    fn poll_recv_from(&self, cx: &mut Context<'_>) -> Poll<Result<DatagramSegmentIter>> {
-        let Self {
-            port, inner, state, ..
-        } = self;
-
         // Stack-allocate arrays for buffers and meta. The size is implied from the const-generic default on `DatagramSegmentIter`.
         let mut bufs = std::array::from_fn(|_| self.buffer_pool.pull());
         let mut meta = std::array::from_fn(|_| quinn_udp::RecvMeta::default());
 
-        loop {
-            ready!(inner.poll_recv_ready(cx)).context("Failed to poll UDP socket for readiness")?;
+        let recv = || {
+            // Fancy std-functions ahead: `each_mut` transforms our array into an array of references to our items and `map` allows us to create an `IoSliceMut` out of each element.
+            // `state.recv` requires us to pass `IoSliceMut` but later on, we need the original buffer again because `DatagramSegmentIter` needs to own them.
+            // That is why we cannot just create an `IoSliceMut` to begin with.
+            let mut bufs = bufs.each_mut().map(|b| IoSliceMut::new(b));
 
-            let recv = || {
-                // Fancy std-functions ahead: `each_mut` transforms our array into an array of references to our items and `map` allows us to create an `IoSliceMut` out of each element.
-                // `state.recv` requires us to pass `IoSliceMut` but later on, we need the original buffer again because `DatagramSegmentIter` needs to own them.
-                // That is why we cannot just create an `IoSliceMut` to begin with.
-                let mut bufs = bufs.each_mut().map(|b| IoSliceMut::new(b));
-                let socket = (&inner).into();
+            self.state
+                .recv(UdpSockRef::from(&self.inner), &mut bufs, &mut meta)
+        };
 
-                state.recv(socket, &mut bufs, &mut meta)
-            };
+        let len = self
+            .inner
+            .async_io(Interest::READABLE, recv)
+            .await
+            .context("Failed to read from socket")?;
 
-            if let Ok(len) = inner.try_io(Interest::READABLE, recv) {
-                self.gro_batch_histogram.record(
-                    len as u64,
-                    &[
-                        KeyValue::new("network.transport", "udp"),
-                        KeyValue::new("network.io.direction", "receive"),
-                    ],
-                );
+        self.gro_batch_histogram.record(
+            len as u64,
+            &[
+                KeyValue::new("network.transport", "udp"),
+                KeyValue::new("network.io.direction", "receive"),
+            ],
+        );
 
-                return Poll::Ready(Ok(DatagramSegmentIter::new(bufs, meta, *port, len)));
-            }
-        }
+        Ok(DatagramSegmentIter::new(bufs, meta, self.port, len))
     }
 
     pub fn poll_send_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/rust/connlib/socket-factory/src/lib.rs
+++ b/rust/connlib/socket-factory/src/lib.rs
@@ -293,10 +293,6 @@ impl UdpSocket {
         Ok(DatagramSegmentIter::new(bufs, meta, self.port, len))
     }
 
-    pub fn poll_send_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.inner.poll_send_ready(cx)
-    }
-
     pub async fn send(&self, datagram: DatagramOut) -> Result<()> {
         let transmit = self.prepare_transmit(
             datagram.dst,


### PR DESCRIPTION
At present, and as a result of how `connlib` evolved, we still implement a `Poll`-based function for receiving data on our UDP socket. Ever since we moved to dedicated threads for the UDP socket, we can directly block on "block" on receiving datagrams and don't have to poll the socket.

This simplifies the implementation a fair bit. Additionally, it made me reailise that we currently don't expose any errors on the UDP socket. Likely, those will be ephemeral but it is still better than completely silencing them.