### PR TITLE
feat(gateway): respond with ICMP error for filtered packets

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -163,7 +163,8 @@ impl GatewayState {
             .context("Failed to translate outbound packet")?
         {
             TranslateOutboundResult::Send(ip_packet) => Ok(Some(ip_packet)),
-            TranslateOutboundResult::DestinationUnreachable(reply) => {
+            TranslateOutboundResult::DestinationUnreachable(reply)
+            | TranslateOutboundResult::Filtered(reply) => {
                 let Some(transmit) = encrypt_packet(reply, cid, &mut self.node, now)? else {
                     return Ok(None);
                 };
@@ -172,7 +173,6 @@ impl GatewayState {
 
                 Ok(None)
             }
-            TranslateOutboundResult::Filtered => Ok(None),
         }
     }
 

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -358,13 +358,21 @@ impl ClientOnGateway {
 
         let Some(state) = self.permanent_translations.get_mut(&packet.destination()) else {
             return Ok(TranslateOutboundResult::DestinationUnreachable(
-                ip_packet::make::icmp_dst_unreachable(&packet)?,
+                ip_packet::make::icmp_dest_unreachable(
+                    &packet,
+                    ip_packet::icmpv4::DestUnreachableHeader::Network,
+                    ip_packet::icmpv6::DestUnreachableCode::Address,
+                )?,
             ));
         };
 
         if state.resolved_ip.is_ipv4() != dst.is_ipv4() {
             return Ok(TranslateOutboundResult::DestinationUnreachable(
-                ip_packet::make::icmp_dst_unreachable(&packet)?,
+                ip_packet::make::icmp_dest_unreachable(
+                    &packet,
+                    ip_packet::icmpv4::DestUnreachableHeader::Network,
+                    ip_packet::icmpv6::DestUnreachableCode::Address,
+                )?,
             ));
         }
 

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -401,7 +401,6 @@ impl ReferenceState {
                 payload,
             } => state.client.exec_mut(|client| {
                 client.on_icmp_packet(
-                    *src,
                     dst.clone(),
                     *seq,
                     *identifier,
@@ -419,7 +418,6 @@ impl ReferenceState {
             } => {
                 state.client.exec_mut(|client| {
                     client.on_udp_packet(
-                        *src,
                         dst.clone(),
                         *sport,
                         *dport,
@@ -438,7 +436,6 @@ impl ReferenceState {
             } => {
                 state.client.exec_mut(|client| {
                     client.on_tcp_packet(
-                        *src,
                         dst.clone(),
                         *sport,
                         *dport,

--- a/rust/connlib/tunnel/src/tests/reference.rs
+++ b/rust/connlib/tunnel/src/tests/reference.rs
@@ -394,11 +394,11 @@ impl ReferenceState {
                 }
             }
             Transition::SendIcmpPacket {
-                src,
                 dst,
                 seq,
                 identifier,
                 payload,
+                ..
             } => state.client.exec_mut(|client| {
                 client.on_icmp_packet(
                     dst.clone(),
@@ -410,11 +410,11 @@ impl ReferenceState {
                 )
             }),
             Transition::SendUdpPacket {
-                src,
                 dst,
                 sport,
                 dport,
                 payload,
+                ..
             } => {
                 state.client.exec_mut(|client| {
                     client.on_udp_packet(
@@ -428,11 +428,11 @@ impl ReferenceState {
                 });
             }
             Transition::SendTcpPayload {
-                src,
                 dst,
                 sport,
                 dport,
                 payload,
+                ..
             } => {
                 state.client.exec_mut(|client| {
                     client.on_tcp_packet(

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -718,10 +718,6 @@ impl RefClient {
             gateway
         };
 
-        if !self.is_tunnel_ip(src) {
-            return;
-        }
-
         tracing::debug!(%payload, "Sending packet");
 
         map(self)

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -661,7 +661,6 @@ impl RefClient {
         );
     }
 
-    #[expect(clippy::too_many_arguments, reason = "We don't care.")]
     #[tracing::instrument(level = "debug", skip_all, fields(dst, resource, gateway))]
     fn on_packet<E>(
         &mut self,

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -597,13 +597,6 @@ impl RefClient {
             .collect()
     }
 
-    pub(crate) fn is_tunnel_ip(&self, ip: IpAddr) -> bool {
-        match ip {
-            IpAddr::V4(ip4) => self.tunnel_ip4 == ip4,
-            IpAddr::V6(ip6) => self.tunnel_ip6 == ip6,
-        }
-    }
-
     pub(crate) fn tunnel_ip_for(&self, dst: IpAddr) -> IpAddr {
         match dst {
             IpAddr::V4(_) => self.tunnel_ip4.into(),
@@ -611,10 +604,8 @@ impl RefClient {
         }
     }
 
-    #[expect(clippy::too_many_arguments, reason = "We don't care.")]
     pub(crate) fn on_icmp_packet(
         &mut self,
-        src: IpAddr,
         dst: Destination,
         seq: Seq,
         identifier: Identifier,
@@ -623,7 +614,6 @@ impl RefClient {
         gateway_by_ip: impl Fn(IpAddr) -> Option<GatewayId>,
     ) {
         self.on_packet(
-            src,
             dst.clone(),
             (dst, seq, identifier),
             |ref_client| &mut ref_client.expected_icmp_handshakes,
@@ -633,10 +623,8 @@ impl RefClient {
         );
     }
 
-    #[expect(clippy::too_many_arguments, reason = "We don't care.")]
     pub(crate) fn on_udp_packet(
         &mut self,
-        src: IpAddr,
         dst: Destination,
         sport: SPort,
         dport: DPort,
@@ -645,7 +633,6 @@ impl RefClient {
         gateway_by_ip: impl Fn(IpAddr) -> Option<GatewayId>,
     ) {
         self.on_packet(
-            src,
             dst.clone(),
             (dst, sport, dport),
             |ref_client| &mut ref_client.expected_udp_handshakes,
@@ -655,10 +642,8 @@ impl RefClient {
         );
     }
 
-    #[expect(clippy::too_many_arguments, reason = "We don't care.")]
     pub(crate) fn on_tcp_packet(
         &mut self,
-        src: IpAddr,
         dst: Destination,
         sport: SPort,
         dport: DPort,
@@ -667,7 +652,6 @@ impl RefClient {
         gateway_by_ip: impl Fn(IpAddr) -> Option<GatewayId>,
     ) {
         self.on_packet(
-            src,
             dst.clone(),
             (dst, sport, dport),
             |ref_client| &mut ref_client.expected_tcp_exchanges,
@@ -681,7 +665,6 @@ impl RefClient {
     #[tracing::instrument(level = "debug", skip_all, fields(dst, resource, gateway))]
     fn on_packet<E>(
         &mut self,
-        src: IpAddr,
         dst: Destination,
         packet_id: E,
         map: impl FnOnce(&mut Self) -> &mut BTreeMap<GatewayId, BTreeMap<u64, E>>,

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -27,6 +27,9 @@ export default function Gateway() {
           Excludes ICMP errors from the ICMP traffic filter. Those are now
           always routed back to the client.
         </ChangeItem>
+        <ChangeItem pull="9816">
+          Responds with ICMP errors for filtered packets.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.12" date={new Date("2025-06-30")}>
         <ChangeItem pull="9657">


### PR DESCRIPTION
When defining a resource, a Firezone admin can define traffic filters to only allow traffic on certain TCP and/or UDP ports and/or restrict traffic on the ICMP protocol.

Presently, when a packet is filtered out on the Gateway, we simply drop it. Dropping packets means the sending application can only react to timeouts and has no other means on error handling. ICMP was conceived to deal with these kind of situations. In particular, the "destination unreachable" type has a dedicated code for filtered packets: "Communication administratively prohibited".

Instead of just dropping the not-allowed packet, we now send back an ICMP error with this particular code set, thus informing the sending application that the packet did not get lost but was in fact not routed for policy reasons.

When setting a traffic filter that does not allow TCP traffic, attempting to `curl` such a resource now results in the following:

```
❯ sudo docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'curl -v example.com'
* Host example.com:80 was resolved.
* IPv6: fd00:2021:1111:8000::, fd00:2021:1111:8000::1, fd00:2021:1111:8000::2, fd00:2021:1111:8000::3
* IPv4: 100.96.0.1, 100.96.0.2, 100.96.0.3, 100.96.0.4
*   Trying [fd00:2021:1111:8000::]:80...
* connect to fd00:2021:1111:8000:: port 80 from fd00:2021:1111::1e:7658 port 34560 failed: Permission denied
*   Trying [fd00:2021:1111:8000::1]:80...
* connect to fd00:2021:1111:8000::1 port 80 from fd00:2021:1111::1e:7658 port 34828 failed: Permission denied
*   Trying [fd00:2021:1111:8000::2]:80...
* connect to fd00:2021:1111:8000::2 port 80 from fd00:2021:1111::1e:7658 port 44314 failed: Permission denied
*   Trying [fd00:2021:1111:8000::3]:80...
* connect to fd00:2021:1111:8000::3 port 80 from fd00:2021:1111::1e:7658 port 37628 failed: Permission denied
*   Trying 100.96.0.1:80...
* connect to 100.96.0.1 port 80 from 100.66.110.26 port 53780 failed: Host is unreachable
*   Trying 100.96.0.2:80...
* connect to 100.96.0.2 port 80 from 100.66.110.26 port 60748 failed: Host is unreachable
*   Trying 100.96.0.3:80...
* connect to 100.96.0.3 port 80 from 100.66.110.26 port 38378 failed: Host is unreachable
*   Trying 100.96.0.4:80...
* connect to 100.96.0.4 port 80 from 100.66.110.26 port 49866 failed: Host is unreachable
* Failed to connect to example.com port 80 after 9 ms: Could not connect to server
* closing connection #0
curl: (7) Failed to connect to example.com port 80 after 9 ms: Could not connect to server
```