### PR TITLE
fix(gui-client): move `tslink` metadata

### DIFF
--- a/rust/gui-client/src-tauri/Cargo.toml
+++ b/rust/gui-client/src-tauri/Cargo.toml
@@ -8,6 +8,9 @@ default-run = "firezone-gui-client"
 authors = ["Firezone, Inc."]
 license = { workspace = true }
 
+[package.metadata.tslink]
+enum_representation = "discriminated"
+
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem
 # DO NOT REMOVE!!
@@ -98,6 +101,3 @@ tempfile = { workspace = true }
 
 [lints]
 workspace = true
-
-[tslink]
-enum_representation = "discriminated"


### PR DESCRIPTION
A recent release of `tslink` now supports configuration via the `package.metadata` table which resolved a warning about "unknown key" that we have seeing for a while.