### PR TITLE
chore(snownet): print packets of unknown format

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -935,6 +935,8 @@ where
             return ControlFlow::Break(Ok(()));
         }
 
+        tracing::debug!(packet = %hex::encode(packet));
+
         ControlFlow::Break(Err(anyhow!("Packet has unknown format")))
     }
 


### PR DESCRIPTION
When receiving UDP packets that we cannot decode we log an error. In order to identify, whether we might have bugs in our decoding logic, we now also print the hex-encoding of the packet for further analysis on DEBUG.