### PR TITLE
chore(gateway): include ID of unknown peer in error message

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -139,7 +139,7 @@ impl GatewayState {
         let peer = self
             .peers
             .get_mut(&cid)
-            .context("Failed to find connection by ID")?;
+            .with_context(|| format!("No peer for connection {cid}"))?;
 
         if let Some(fz_p2p_control) = packet.as_fz_p2p_control() {
             let Some(immediate_response) =


### PR DESCRIPTION
This will help with diagnosing issues in Sentry.