### PR TITLE
feat(telemetry): log use of `map-enobufs-to-wouldblock`

### DIFF
--- a/rust/connlib/socket-factory/src/lib.rs
+++ b/rust/connlib/socket-factory/src/lib.rs
@@ -356,6 +356,9 @@ impl UdpSocket {
                         if e.raw_os_error().is_some_and(|e| e == libc::ENOBUFS)
                             && firezone_telemetry::feature_flags::map_enobufs_to_would_block() =>
                     {
+                        firezone_telemetry::analytics::feature_flag_called(
+                            "map-enobufs-to-wouldblock",
+                        );
                         tracing::debug!("Encountered ENOBUFS, treating as WouldBlock");
 
                         Err(io::Error::from(io::ErrorKind::WouldBlock))


### PR DESCRIPTION
In order to better track, how well our `ENOBUFS` mitigation is working, we should log the use of our feature flag to PostHog. This will give us some stats how often this is happening. That combined with the lack of error reports should give us good confidence in permanently enabling this behaviour.