### PR TITLE
chore(connlib): improve error message for filtered packets

### DIFF
--- a/rust/connlib/tunnel/src/peer/filter_engine.rs
+++ b/rust/connlib/tunnel/src/peer/filter_engine.rs
@@ -24,7 +24,7 @@ pub(crate) enum Filtered {
     Udp,
     #[error("ICMP not allowed")]
     Icmp,
-    #[error(transparent)]
+    #[error("Failed to evaluate filter")]
     UnsupportedProtocol(#[from] UnsupportedProtocol),
 }
 


### PR DESCRIPTION
When a packet gets filtered because we are unable to evaluate the source protocol (i.e. TCP/UDP/ICMP), then the current error message currently misleadingly says that the packet got filtered because the protocol is not supported.

The truth however is that we were never able to apply the filter in the first place. This is a subtle difference that is quite important when debugging filtered packets. To improve this, we add an error message to the stack here.