### PR TITLE
feat(gateway): don't apply traffic filters to ICMP errors

### DIFF
--- a/elixir/apps/web/lib/web/live/resources/components.ex
+++ b/elixir/apps/web/lib/web/live/resources/components.ex
@@ -206,14 +206,14 @@ defmodule Web.Resources.Components do
 
           <div class="mt-2.5 w-24">
             <.input
-              title="Allow ICMP traffic"
+              title="Allow ICMP echo requests/replies"
               type="checkbox"
               field={@forms_by_protocol[:icmp]}
               name={"#{@form.name}[icmp][enabled]"}
               checked={Map.has_key?(@forms_by_protocol, :icmp)}
               value="true"
               disabled={!@traffic_filters_enabled?}
-              label="ICMP"
+              label="ICMP echo"
             />
           </div>
         </div>

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -352,6 +352,14 @@ impl ClientOnGateway {
 
         self.ensure_client_ip(packet.destination())?;
 
+        // Always allow ICMP errors to pass through, even in the presence of filters that don't allow ICMP.
+        if packet
+            .icmp_unreachable_destination()
+            .is_ok_and(|e| e.is_some())
+        {
+            return Ok(Some(packet));
+        }
+
         if let Err(e) = self.ensure_allowed_resource(packet.source(), packet.source_protocol()) {
             tracing::debug!(
                 "Inbound packet is not allowed, perhaps from an old client session? error = {e:#}"

--- a/rust/connlib/tunnel/src/peer/filter_engine.rs
+++ b/rust/connlib/tunnel/src/peer/filter_engine.rs
@@ -138,4 +138,19 @@ mod tests {
 
         assert!(result.is_ok())
     }
+
+    #[test]
+    fn icmp_false_blocks_other_icmp_messages() {
+        let filter = FilterEngine::PermitSome(AllowRules {
+            udp: RangeInclusiveSet::default(),
+            tcp: RangeInclusiveSet::default(),
+            icmp: false,
+        });
+
+        let result = filter.apply(Err(UnsupportedProtocol::UnsupportedIcmpv4Type(
+            Icmpv4Type::TimestampRequest(icmpv4::TimestampMessage::from_bytes([0u8; 16])),
+        )));
+
+        assert!(result.is_err())
+    }
 }

--- a/rust/connlib/tunnel/src/peer/filter_engine.rs
+++ b/rust/connlib/tunnel/src/peer/filter_engine.rs
@@ -102,3 +102,40 @@ impl AllowRules {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ip_packet::{Icmpv4Type, Icmpv6Type, icmpv4, icmpv6};
+
+    use super::*;
+
+    #[test]
+    fn allows_icmpv4_destination_unreachable() {
+        let filter = FilterEngine::PermitSome(AllowRules {
+            udp: RangeInclusiveSet::default(),
+            tcp: RangeInclusiveSet::default(),
+            icmp: true,
+        });
+
+        let result = filter.apply(Err(UnsupportedProtocol::UnsupportedIcmpv4Type(
+            Icmpv4Type::DestinationUnreachable(icmpv4::DestUnreachableHeader::Host),
+        )));
+
+        assert!(result.is_ok())
+    }
+
+    #[test]
+    fn allows_icmpv6_destination_unreachable() {
+        let filter = FilterEngine::PermitSome(AllowRules {
+            udp: RangeInclusiveSet::default(),
+            tcp: RangeInclusiveSet::default(),
+            icmp: true,
+        });
+
+        let result = filter.apply(Err(UnsupportedProtocol::UnsupportedIcmpv6Type(
+            Icmpv6Type::DestinationUnreachable(icmpv6::DestUnreachableCode::Address),
+        )));
+
+        assert!(result.is_ok())
+    }
+}

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9834">
+          Excludes ICMP errors from the ICMP traffic filter. Those are now
+          always routed back to the client.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.12" date={new Date("2025-06-30")}>
         <ChangeItem pull="9657">
           Fixes an issue where connections would fail to establish if the


### PR DESCRIPTION
Firezone uses ICMP errors to signal to client applications that e.g. a certain IP is not reachable. This happens for example if a DNS resource only resolves to IPv4 addresses yet the client application attempted to use an IPv6 proxy address to connect to it.

In the presence of traffic filters for such a resource that does _not_ allow ICMP, we currently filter out these ICMP errors because - well - ICMP traffic is not allowed! However, even in the presence of ICMP traffic being allowed, we would fail to evaluate this filter because the ICMP error packet is not an ICMP echo reply and therefore doesn't have an ICMP identifier. We require this in the DNS resource NAT to identify "connections" and NAT them correctly. The same L4 component is used to evaluate the traffic filters.

ICMP errors are critical to many usage scenarios and algorithms like happy-eyeballs. Dropping them usually results in weird behaviour as client applications can then only react to timeouts.