### PR TITLE
feat(gateway): allow exporting metrics to an OTEL collector

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2586,6 +2586,7 @@ name = "firezone-telemetry"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures",
  "hex",
  "ip-packet",
  "moka",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "nix 0.29.0",
  "num_cpus",
  "opentelemetry",
+ "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "phoenix-channel",

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -27,6 +27,7 @@ libc = { workspace = true, features = ["std", "const-extern-fn", "extra_traits"]
 moka = { workspace = true, features = ["future"] }
 num_cpus = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
+opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }
 opentelemetry-stdout = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 phoenix-channel = { workspace = true }

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -14,7 +14,8 @@ use firezone_bin_shared::{
 use firezone_telemetry::{Telemetry, otel};
 use firezone_tunnel::GatewayTunnel;
 use ip_packet::IpPacket;
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use phoenix_channel::LoginUrl;
 use phoenix_channel::get_user_agent;
 
@@ -114,16 +115,36 @@ async fn try_main(cli: Cli) -> Result<ExitCode> {
     Telemetry::set_firezone_id(firezone_id.clone());
 
     if cli.metrics {
-        let exporter = opentelemetry_stdout::MetricExporter::default();
-        let reader = PeriodicReader::builder(exporter).build();
-        let provider = SdkMeterProvider::builder()
-            .with_reader(reader)
-            .with_resource(otel::default_resource_with([
-                otel::attr::service_name!(),
-                otel::attr::service_version!(),
-                otel::attr::service_instance_id(firezone_id.clone()),
-            ]))
-            .build();
+        let resource = otel::default_resource_with([
+            otel::attr::service_name!(),
+            otel::attr::service_version!(),
+            otel::attr::service_instance_id(firezone_id.clone()),
+        ]);
+
+        let provider = match cli.otlp_grpc_endpoint.clone() {
+            None => {
+                let exporter = opentelemetry_stdout::MetricExporter::default();
+
+                SdkMeterProvider::builder()
+                    .with_periodic_exporter(exporter)
+                    .with_resource(resource)
+                    .build()
+            }
+            Some(endpoint) => {
+                let grpc_endpoint = format!("http://{endpoint}");
+
+                let exporter = opentelemetry_otlp::MetricExporter::builder()
+                    .with_tonic()
+                    .with_endpoint(grpc_endpoint)
+                    .build()
+                    .context("Failed to build OTLP metric exporter")?;
+
+                SdkMeterProvider::builder()
+                    .with_periodic_exporter(exporter)
+                    .with_resource(resource)
+                    .build()
+            }
+        };
 
         opentelemetry::global::set_meter_provider(provider);
     }
@@ -260,9 +281,17 @@ struct Cli {
     #[arg(long, env = "FIREZONE_NUM_TUN_THREADS", default_value_t)]
     tun_threads: NumThreads,
 
-    /// Dump internal metrics to stdout every 60s.
+    /// Enable internal metrics.
+    ///
+    /// By default, they will be dumped to stdout every 60s.
     #[arg(long, hide = true, env = "FIREZONE_METRICS", default_value_t = false)]
     metrics: bool,
+
+    /// Which OTLP collector we should connect to.
+    ///
+    /// If set, we will report metrics to this collector via gRPC.
+    #[arg(long, env, hide = true)]
+    otlp_grpc_endpoint: Option<String>,
 
     /// Validates the checksums of all packets leaving the TUN device.
     #[arg(

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -6,11 +6,12 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+futures = { workspace = true }
 hex = { workspace = true }
 ip-packet = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
 opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
 reqwest = { workspace = true }
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing", "release-health", "logs"] }

--- a/rust/telemetry/src/feature_flags.rs
+++ b/rust/telemetry/src/feature_flags.rs
@@ -39,6 +39,10 @@ pub fn map_enobufs_to_would_block() -> bool {
     FEATURE_FLAGS.map_enobufs_to_wouldblock()
 }
 
+pub fn export_metrics() -> bool {
+    false // Placeholder until we actually deploy an OTEL collector.
+}
+
 pub(crate) async fn evaluate_now(user_id: String, env: Env) {
     if user_id.is_empty() {
         return;

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -15,7 +15,12 @@ pub mod feature_flags;
 pub mod otel;
 
 mod api_url;
+mod maybe_push_metrics_exporter;
+mod noop_push_metrics_exporter;
 mod posthog;
+
+pub use maybe_push_metrics_exporter::MaybePushMetricsExporter;
+pub use noop_push_metrics_exporter::NoopPushMetricsExporter;
 
 pub struct Dsn(&'static str);
 

--- a/rust/telemetry/src/maybe_push_metrics_exporter.rs
+++ b/rust/telemetry/src/maybe_push_metrics_exporter.rs
@@ -1,0 +1,38 @@
+use std::future::Future;
+
+use futures::future::Either;
+use opentelemetry_sdk::{
+    error::OTelSdkResult,
+    metrics::{Temporality, data::ResourceMetrics, exporter::PushMetricExporter},
+};
+
+pub struct MaybePushMetricsExporter<E, F> {
+    pub inner: E,
+    pub should_export: F,
+}
+
+impl<E, F> PushMetricExporter for MaybePushMetricsExporter<E, F>
+where
+    E: PushMetricExporter,
+    F: Fn() -> bool + Send + Sync + 'static,
+{
+    fn export(&self, metrics: &mut ResourceMetrics) -> impl Future<Output = OTelSdkResult> + Send {
+        if (self.should_export)() {
+            return Either::Left(self.inner.export(metrics));
+        }
+
+        Either::Right(std::future::ready(Ok(())))
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        self.inner.force_flush()
+    }
+
+    fn shutdown(&self) -> OTelSdkResult {
+        self.inner.shutdown()
+    }
+
+    fn temporality(&self) -> Temporality {
+        self.inner.temporality()
+    }
+}

--- a/rust/telemetry/src/noop_push_metrics_exporter.rs
+++ b/rust/telemetry/src/noop_push_metrics_exporter.rs
@@ -1,0 +1,26 @@
+use std::future::Future;
+
+use opentelemetry_sdk::{
+    error::OTelSdkResult,
+    metrics::{Temporality, data::ResourceMetrics, exporter::PushMetricExporter},
+};
+
+pub struct NoopPushMetricsExporter;
+
+impl PushMetricExporter for NoopPushMetricsExporter {
+    fn export(&self, _: &mut ResourceMetrics) -> impl Future<Output = OTelSdkResult> + Send {
+        std::future::ready(Ok(()))
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn temporality(&self) -> Temporality {
+        Temporality::default()
+    }
+}

--- a/rust/telemetry/src/otel.rs
+++ b/rust/telemetry/src/otel.rs
@@ -1,7 +1,7 @@
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::{
     Resource,
-    resource::{ResourceDetector, TelemetryResourceDetector},
+    resource::{EnvResourceDetector, ResourceDetector, TelemetryResourceDetector},
 };
 
 pub mod attr {
@@ -110,6 +110,7 @@ pub fn default_resource_with<const N: usize>(attributes: [KeyValue; N]) -> Resou
     Resource::builder_empty()
         .with_detector(Box::new(TelemetryResourceDetector))
         .with_detector(Box::new(OsResourceDetector))
+        .with_detector(Box::new(EnvResourceDetector::new()))
         .with_attributes(attributes)
         .build()
 }


### PR DESCRIPTION
As a first step in preparation for sending OTEL metrics from Clients and Gateways to a cloud-hosted OTEL collector, we extend the CLI of the Gateway with configuration options to provide a gRPC endpoint to an OTEL collector.

If `FIREZONE_METRICS` is set to `otel-collector` and an endpoint is configured via `OTLP_GRPC_ENDPOINT`, we will report our metrics to that collector.

The future plan for extending this is such that if `FIREZONE_METRICS` is set to `otel-collector` (which will likely be the default) and no `OTLP_GRPC_ENDPOINT` is set, then we will use our own, hosted OTEL collector and report metrics IF the `export-metrics` feature-flag is set to `true`.

This is a similar integration as we have done it with streaming logs to Sentry. We can therefore enable it on a similar granularity as we do with the logs and e.g. only enable it for the `firezone` account to start with.

In meantime, customers can already make use of those metrics if they'd like by using the current integration.

Resolves: #1550
Related: #7419 