### PR TITLE
fix(portal): respect gateway_group_id filter in REST API

### DIFF
--- a/elixir/apps/api/lib/api/controllers/gateway_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/gateway_controller.ex
@@ -31,6 +31,13 @@ defmodule API.GatewayController do
       |> Pagination.params_to_list_opts()
       |> Keyword.put(:preload, :online?)
 
+    list_opts =
+      if group_id = params["gateway_group_id"] do
+        Keyword.put(list_opts, :filter, gateway_group_id: group_id)
+      else
+        list_opts
+      end
+
     with {:ok, gateways, metadata} <- Gateways.list_gateways(conn.assigns.subject, list_opts) do
       render(conn, :index, gateways: gateways, metadata: metadata)
     end

--- a/elixir/apps/api/test/api/controllers/gateway_controller_test.exs
+++ b/elixir/apps/api/test/api/controllers/gateway_controller_test.exs
@@ -30,6 +30,9 @@ defmodule API.GatewayControllerTest do
         for _ <- 1..3,
             do: Fixtures.Gateways.create_gateway(%{account: account, group: gateway_group})
 
+      other_group = Fixtures.Gateways.create_group(account: account)
+      Fixtures.Gateways.create_gateway(%{account: account, group: other_group})
+
       conn =
         conn
         |> authorize_conn(actor)


### PR DESCRIPTION
Fixes #9815