### PR TITLE
revert(ci): re-add relayed integration tests

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -112,6 +112,10 @@ jobs:
           - name: dns-nm
           - name: tcp-dns
           - name: relay-graceful-shutdown
+          - name: relayed-curl-api-down
+          - name: relayed-curl-api-restart
+          - name: relayed-dns-api-down
+          - name: relayed-dns-api-restart
           - name: systemd/dns-systemd-resolved
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/scripts/tests/relayed-curl-api-down.sh
+++ b/scripts/tests/relayed-curl-api-down.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+source "./scripts/tests/lib.sh"
+
+install_iptables_drop_rules
+
+client_curl_resource "172.20.0.100/get"
+
+docker compose stop api # Stop portal
+
+client_curl_resource "172.20.0.100/get"

--- a/scripts/tests/relayed-curl-api-restart.sh
+++ b/scripts/tests/relayed-curl-api-restart.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+source "./scripts/tests/lib.sh"
+
+install_iptables_drop_rules
+
+docker compose restart api # Restart portal
+
+client_curl_resource "172.20.0.100/get"
+
+docker compose restart api # Restart again
+
+client_curl_resource "172.20.0.100/get"

--- a/scripts/tests/relayed-dns-api-down.sh
+++ b/scripts/tests/relayed-dns-api-down.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+source "./scripts/tests/lib.sh"
+
+HTTPBIN=dns.httpbin.search.test
+
+function run_test() {
+    echo "# Access httpbin by DNS"
+    client_curl_resource "$HTTPBIN/get"
+
+    echo "# Make sure it's going through the tunnel"
+    client_nslookup "$HTTPBIN" | grep "100\\.96\\.0\\."
+}
+
+install_iptables_drop_rules
+
+run_test
+
+docker compose stop api
+
+run_test

--- a/scripts/tests/relayed-dns-api-restart.sh
+++ b/scripts/tests/relayed-dns-api-restart.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source "./scripts/tests/lib.sh"
+
+HTTPBIN=dns.httpbin.search.test
+
+function run_test() {
+    echo "# Access httpbin by DNS"
+    client_curl_resource "$HTTPBIN/get"
+
+    echo "# Make sure it's going through the tunnel"
+    client_nslookup "$HTTPBIN" | grep "100\\.96\\.0\\."
+}
+
+install_iptables_drop_rules
+
+run_test
+
+# Restart relays with new IP
+RELAY_1_PUBLIC_IP4_ADDR="172.28.0.102" docker compose up -d relay-1
+RELAY_2_PUBLIC_IP4_ADDR="172.28.0.202" docker compose up -d relay-2
+
+run_test


### PR DESCRIPTION
These were removed in #6922 which lost us the ability to ensure that portal changes don't introduce any connectivity bugs when a user is on a relayed connection and his/her portal connection lapses.

The suspected connectivity bug may have been introduced in #6761 