### PR TITLE
test(ci): test 20% packet loss

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -103,6 +103,7 @@ jobs:
           - name: direct-curl-api-down
           - name: direct-curl-api-restart
           - name: direct-curl-ecn
+          - name: direct-curl-packet-loss
           - name: direct-dns-api-down
           - name: direct-dns-two-resources
           - name: direct-dns

--- a/scripts/tests/direct-curl-packet-loss.sh
+++ b/scripts/tests/direct-curl-packet-loss.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+source "./scripts/tests/lib.sh"
+
+client apk add --no-cache iproute2
+client tc qdisc add dev eth0 root netem loss 20%
+
+client_curl_resource "172.20.0.100/get"


### PR DESCRIPTION
Packet loss is a reality on the modern internet. Ideally, Firezone should be able to handle some level of packet loss and still function reliably, especially considering all of the UDP-based protocols we rely on.

To test this, we set an extreme packet loss of 20% and perform a 10 MB download through Firezone. Doing so actually exposed a bug:

For DNS resources, we need to set up the DNS resource NAT on the Gateway which happens through the p2p control protocol. This packet is resent at most every 2s but only if there are any other DNS queries. If we don't receive another DNS query but get traffic for the resource, we keep buffering those packets without trying to re-send the `AssignedIp`s packet.