### PR TITLE
fix(portal): send correct lsn when buffering

### DIFF
--- a/elixir/apps/domain/lib/domain/change_logs/replication_connection.ex
+++ b/elixir/apps/domain/lib/domain/change_logs/replication_connection.ex
@@ -62,10 +62,17 @@ defmodule Domain.ChangeLogs.ReplicationConnection do
       |> Map.keys()
       |> Enum.max()
 
-    %{state | flush_buffer: %{}, last_flushed_lsn: last_lsn}
+    %{state | flush_buffer: %{}, first_flush_buffer_lsn: nil, last_flushed_lsn: last_lsn}
   end
 
   defp buffer(state, lsn, op, table, account_id, old_data, data) do
+    first_flush_buffer_lsn =
+      if state.flush_buffer == %{} do
+        lsn
+      else
+        state.first_flush_buffer_lsn
+      end
+
     flush_buffer =
       state.flush_buffer
       |> Map.put_new(lsn, %{
@@ -78,6 +85,6 @@ defmodule Domain.ChangeLogs.ReplicationConnection do
         vsn: @vsn
       })
 
-    %{state | flush_buffer: flush_buffer}
+    %{state | flush_buffer: flush_buffer, first_flush_buffer_lsn: first_flush_buffer_lsn}
   end
 end

--- a/elixir/apps/domain/lib/domain/replication/connection.ex
+++ b/elixir/apps/domain/lib/domain/replication/connection.ex
@@ -395,9 +395,11 @@ defmodule Domain.Replication.Connection do
         %KeepAlive{reply: reply, wal_end: wal_end} = parse(data)
 
         wal_end =
-          if state.flush_interval > 0 do
-            # If we are flushing, we use the tracked last_flushed_lsn
-            state.last_flushed_lsn + 1
+          if state.flush_interval > 0 && map_size(state.flush_buffer) > 0 do
+            # If we are flushing and currently buffering data, we use the lowest lsn we have to flush
+            state.flush_buffer
+            |> Map.keys()
+            |> Enum.min()
           else
             # Otherwise, we assume to be current with the server
             wal_end + 1


### PR DESCRIPTION
This PR tries to solve 2 issues with the new buffering system:

If we have an amount of time without changes that needs to be buffered and written to the changelog: the postgres lag keeps increasing. This is annoying because we don't want the postgres to believe we have lag, some people have alerting based on pg lag :eyes:

On launch before the first flush, we send 1 as lsn to postgres as last_wal_received, etc.

I tried a basic solution but we could avoid doing the min every time by having another field in the `Domain.Replication.Connection` module

PS: Hard to add tests about that because we don't control pg keepalive in tests