### PR TITLE
fix(rust): remove jemalloc

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2381,7 +2381,6 @@ dependencies = [
  "futures-bounded",
  "ip-packet",
  "ip_network",
- "jemallocator",
  "libc",
  "moka",
  "nix 0.30.1",
@@ -2550,7 +2549,6 @@ dependencies = [
  "futures",
  "hex",
  "hex-display",
- "jemallocator",
  "mio",
  "once_cell",
  "opentelemetry",
@@ -3906,26 +3904,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -93,7 +93,6 @@ ip-packet = { path = "connlib/ip-packet" }
 ip_network = { version = "0.4", default-features = false }
 ip_network_table = { version = "0.2", default-features = false }
 itertools = "0.14"
-jemallocator = "0.5.4"
 jni = "0.21.1"
 keyring = "3.6.2"
 known-folders = "1.2.0"

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -48,7 +48,6 @@ uuid = { workspace = true, features = ["v4"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = { workspace = true }
 dns-lookup = { workspace = true }
-jemallocator = { workspace = true }
 nix = { workspace = true, features = ["user"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -1,7 +1,3 @@
-#[cfg(all(target_os = "linux", not(target_arch = "arm")))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use crate::eventloop::{Eventloop, PHOENIX_TOPIC};
 use anyhow::{Context, Result};
 use backoff::ExponentialBackoffBuilder;

--- a/rust/relay/server/Cargo.toml
+++ b/rust/relay/server/Cargo.toml
@@ -53,7 +53,6 @@ uuid = { workspace = true, features = ["v4"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 aya = { workspace = true, features = ["tokio"] }
 aya-log = { workspace = true }
-jemallocator = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.build-dependencies]
 anyhow = "1"

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -1,9 +1,5 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
-#[cfg(all(target_os = "linux", not(target_arch = "arm")))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use anyhow::{Context, Result, bail};
 use backoff::ExponentialBackoffBuilder;
 use clap::Parser;


### PR DESCRIPTION
I am no longer able to compile `jemalloc` on my system in a debug build. It fails with the following error:

```
src/malloc_io.c: In function ‘buferror’:
src/malloc_io.c:107:16: error: returning ‘char *’ from a function with return type ‘int’ makes integer from pointer without a cast [-Wint-conversion]
  107 |         return strerror_r(err, buf, buflen);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This appears to be a problem with modern versions of clang/gcc. I believe this started happening when I recently upgraded my system. The upstream [`jemalloc`](https://github.com/jemalloc/jemalloc) repository is now archived and thus unmaintained. I am not sure if we ever measured a significant benefit in using `jemalloc`.

Related: https://github.com/servo/servo/issues/31059