### PR TITLE
chore(rust): bump str0m

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6963,7 +6963,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.9.0"
-source = "git+https://github.com/algesten/str0m?branch=main#2153bf0385c12d09907b872158e15012755fe5f2"
+source = "git+https://github.com/algesten/str0m?branch=main#3d6e3d2f2745c9e8c561603b99c034c9bab7670f"
 dependencies = [
  "combine",
  "crc",

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2397,7 +2397,7 @@ impl fmt::Display for SessionId {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 
     use super::*;
 


### PR DESCRIPTION
The latest version of str0m includes a fix that would result in an immediate ICE timeout if a remote candidate was added prior to a local candidate. We mitigated this in #9793 to make Firezone overall more resilient towards sudden changes in the ICE connection state.

As a defense-in-depth measure, we also fixed this issue in str0m by not transitioning to `Disconnected` if haven't even formed an candidate pairs yet.

Diff: https://github.com/algesten/str0m/compare/2153bf0385c12d09907b872158e15012755fe5f2...3d6e3d2f2745c9e8c561603b99c034c9bab7670f