### PR TITLE
chore(rust): log environment when updating feature flags

### DIFF
--- a/rust/telemetry/src/feature_flags.rs
+++ b/rust/telemetry/src/feature_flags.rs
@@ -61,7 +61,7 @@ pub(crate) async fn evaluate_now(user_id: String, env: Env) {
         scope.set_context("flags", sentry_flag_context(flags));
     });
 
-    tracing::debug!(flags = ?FEATURE_FLAGS, "Evaluated feature-flags");
+    tracing::debug!(%env, flags = ?FEATURE_FLAGS, "Evaluated feature-flags");
 }
 
 pub(crate) fn reevaluate(user_id: String, env: &str) {


### PR DESCRIPTION
It is useful to know, which environment we've updated the feature-flags for.