### PR TITLE
feat(snownet): re-send local candidates on connection upsert

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1459,12 +1459,7 @@ fn add_local_candidate<TId>(
 {
     // srflx candidates don't need to be added to the local agent because we always send from the `base` anyway.
     if candidate.kind() == CandidateKind::ServerReflexive {
-        tracing::info!(?candidate, "Signalling candidate to remote");
-
-        pending_events.push_back(Event::NewIceCandidate {
-            connection: id,
-            candidate: candidate.to_sdp_string(),
-        });
+        signal_candidate_to_remote(id, &candidate, pending_events);
         return;
     }
 
@@ -1472,12 +1467,20 @@ fn add_local_candidate<TId>(
         return;
     };
 
+    signal_candidate_to_remote(id, candidate, pending_events);
+}
+
+fn signal_candidate_to_remote<TId>(
+    id: TId,
+    candidate: &Candidate,
+    events: &mut VecDeque<Event<TId>>,
+) {
     tracing::info!(?candidate, "Signalling candidate to remote");
 
-    pending_events.push_back(Event::NewIceCandidate {
+    events.push_back(Event::NewIceCandidate {
         connection: id,
         candidate: candidate.to_sdp_string(),
-    })
+    });
 }
 
 fn invalidate_allocation_candidates<TId, RId>(


### PR DESCRIPTION
The ICE connections in `snownet` are designed to be idempotent. In particular, we generate the ICE credentials for both Client and Gateway in the portal based on the Client and Gateway ID as well as their public keys. This allows us to bundle together a "connection intent" with a resource authorization. In particular, it means we can send repeated connection intents to the portal and process them as a no-op if the ICE credentials haven't changed.

From inspecting logs of customers, we learn that sometimes connections fail with "no candidates received". I think this is a result of making a new connection on the client whilst the Gateway still has a local connection state. If that happens, the Gateway needs to resend its local candidates to the Client for the Client to re-connect.

Typically, there should be no way for the Client to lose its connection state whilst the Gateway retains it. The only case where this happens is when we roam, but we also rotate the key then which changes our ICE credentials and therefore creates a new connection state on both ends.

I think what may happen here is that the Gateway's connection state went idle and therefore, the ICE timeout is much longer than on the Client.

Adding an existing candidate again on the remote is a no-op because they are being checked for duplicates.