### PR TITLE
fix(rust): only apply filter to select tracing layers

### DIFF
--- a/rust/apple-client-ffi/src/lib.rs
+++ b/rust/apple-client-ffi/src/lib.rs
@@ -207,12 +207,13 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<()> {
         return Ok(());
     }
 
-    let (env_filter, reload_handle) = firezone_logging::try_filter(&log_filter)?;
+    let (file_log_filter, file_reload_handle) = firezone_logging::try_filter(&log_filter)?;
+    let (oslog_log_filter, oslog_reload_handle) = firezone_logging::try_filter(&log_filter)?;
 
     let (file_layer, handle) = firezone_logging::file::layer(&log_dir, "connlib");
 
     let subscriber = tracing_subscriber::registry()
-        .with(env_filter)
+        .with(file_layer.with_filter(file_log_filter))
         .with(
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
@@ -224,10 +225,12 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<()> {
                 .with_writer(make_writer::MakeWriter::new(
                     "dev.firezone.firezone",
                     "connlib",
-                )),
+                ))
+                .with_filter(oslog_log_filter),
         )
-        .with(file_layer)
         .with(sentry_layer());
+
+    let reload_handle = file_reload_handle.merge(oslog_reload_handle);
 
     firezone_logging::init(subscriber)?;
 

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -250,8 +250,7 @@ fn setup_tracing(args: &Args) -> Result<FilterReloadHandle> {
             let (filter, reload_handle) = firezone_logging::try_filter(&directives)?;
 
             let dispatch: Dispatch = tracing_subscriber::registry()
-                .with(log_layer(args))
-                .with(filter)
+                .with(log_layer(args).with_filter(filter))
                 .with(sentry_layer())
                 .into();
 
@@ -296,9 +295,8 @@ fn setup_tracing(args: &Args) -> Result<FilterReloadHandle> {
             let (filter, reload_handle) = firezone_logging::try_filter(&directives)?;
 
             let dispatch: Dispatch = tracing_subscriber::registry()
-                .with(log_layer(args))
+                .with(log_layer(args).with_filter(filter))
                 .with(tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("relay")))
-                .with(filter)
                 .with(sentry_layer())
                 .into();
 


### PR DESCRIPTION
Applying a filter globally to the entire subscriber means it filters events for all layers. This prevents the Sentry layer from uploading DEBUG logs if configured.