### PR TITLE
fix(portal): use correct password generation algorithm

### DIFF
--- a/elixir/apps/domain/lib/domain/relays.ex
+++ b/elixir/apps/domain/lib/domain/relays.ex
@@ -276,7 +276,7 @@ defmodule Domain.Relays do
       when is_binary(stamp_secret) do
     salt = generate_hash(public_key)
     expires_at = DateTime.to_unix(expires_at, :second)
-    password = generate_hash("#{expires_at}:#{salt}:#{stamp_secret}")
+    password = generate_hash("#{expires_at}:#{stamp_secret}:#{salt}")
 
     %{username: "#{expires_at}:#{salt}", password: password, expires_at: expires_at}
   end

--- a/elixir/apps/domain/test/domain/relays_test.exs
+++ b/elixir/apps/domain/test/domain/relays_test.exs
@@ -804,7 +804,7 @@ defmodule Domain.RelaysTest do
       assert username_salt == "5d9CsB7vot2KRIXMGXivBcgmjnW0ClvN5q/DxOeFotA"
       assert DateTime.from_unix!(expires_at_unix) == DateTime.truncate(expires_at, :second)
       assert username == "1696118400:5d9CsB7vot2KRIXMGXivBcgmjnW0ClvN5q/DxOeFotA"
-      assert password == "GmFbvRR/LGes0VUmNhzwxG2K2Ww6Y0GTaLVS4S5QJOs"
+      assert password == "+dkKyS/Rl06h5jatgTWfKcZoeDxEmT+TfsrH4x4cddA"
     end
   end
 


### PR DESCRIPTION
In #9870, the password generation algorithm was broken. The correct order of the elements in the hash is: expiry, stamp_secret, salt. The relay expects this order when it re-generates the password to validate the message.

Due to a different bug in our CI system, we weren't actually checking for warnings / errors in our perf-test suite: https://github.com/firezone/firezone/actions/runs/16285038111/job/45982241021#step:9:66