### PR TITLE
ci: fail perf & integration tests on warnings

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -152,16 +152,10 @@ jobs:
         if: "!cancelled()"
         run: docker compose logs client
 
-      - name: Ensure Relay-1 emitted no warnings
-        if: "!cancelled()"
-        run: docker compose logs relay-1 | grep "WARN" && exit 1 || exit 0
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
 
-      - name: Ensure Relay-2 emitted no warnings
-        if: "!cancelled()"
-        run: docker compose logs relay-2 | grep "WARN" && exit 1 || exit 0
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -146,24 +146,28 @@ jobs:
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 
       - name: Ensure Client emitted no warnings
+        if: "!cancelled()"
         run: ! docker compose logs client | grep "WARN"
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client
 
       - name: Ensure Relay-1 emitted no warnings
+        if: "!cancelled()"
         run: ! docker compose logs relay-1 | grep "WARN"
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
 
       - name: Ensure Relay-2 emitted no warnings
+        if: "!cancelled()"
         run: ! docker compose logs relay-2 | grep "WARN"
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2
 
       - name: Ensure Gateway emitted no warnings
+        if: "!cancelled()"
         run: ! docker compose logs gateway | grep "WARN"
       - name: Show Gateway logs
         if: "!cancelled()"

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -147,28 +147,28 @@ jobs:
 
       - name: Ensure Client emitted no warnings
         if: "!cancelled()"
-        run: ! docker compose logs client | grep "WARN"
+        run: docker compose logs client | grep "WARN" && exit 1 || exit 0
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client
 
       - name: Ensure Relay-1 emitted no warnings
         if: "!cancelled()"
-        run: ! docker compose logs relay-1 | grep "WARN"
+        run: docker compose logs relay-1 | grep "WARN" && exit 1 || exit 0
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
 
       - name: Ensure Relay-2 emitted no warnings
         if: "!cancelled()"
-        run: ! docker compose logs relay-2 | grep "WARN"
+        run: docker compose logs relay-2 | grep "WARN" && exit 1 || exit 0
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2
 
       - name: Ensure Gateway emitted no warnings
         if: "!cancelled()"
-        run: ! docker compose logs gateway | grep "WARN"
+        run: docker compose logs gateway | grep "WARN" && exit 1 || exit 0
       - name: Show Gateway logs
         if: "!cancelled()"
         run: docker compose logs gateway

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -146,25 +146,25 @@ jobs:
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 
       - name: Ensure Client emitted no warnings
-        run: docker compose logs client | grep --quiet --invert "WARN"
+        run: ! docker compose logs client | grep "WARN"
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client
 
       - name: Ensure Relay-1 emitted no warnings
-        run: docker compose logs relay-1 | grep --quiet --invert "WARN"
+        run: ! docker compose logs relay-1 | grep "WARN"
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
 
       - name: Ensure Relay-2 emitted no warnings
-        run: docker compose logs relay-2 | grep --quiet --invert "WARN"
+        run: ! docker compose logs relay-2 | grep "WARN"
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2
 
       - name: Ensure Gateway emitted no warnings
-        run: docker compose logs gateway | grep --quiet --invert "WARN"
+        run: ! docker compose logs gateway | grep "WARN"
       - name: Show Gateway logs
         if: "!cancelled()"
         run: docker compose logs gateway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,28 +367,28 @@ jobs:
 
       - name: Ensure Client emitted no warnings
         if: "!cancelled()"
-        run: ! docker compose logs client | grep "WARN"
+        run: docker compose logs client | grep "WARN" && exit 1 || exit 0
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client
 
       - name: Ensure Relay-1 emitted no warnings
         if: "!cancelled()"
-        run: ! docker compose logs relay-1 | grep "WARN"
+        run: docker compose logs relay-1 | grep "WARN" && exit 1 || exit 0
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
 
       - name: Ensure Relay-2 emitted no warnings
         if: "!cancelled()"
-        run: ! docker compose logs relay-2 | grep "WARN"
+        run: docker compose logs relay-2 | grep "WARN" && exit 1 || exit 0
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2
 
       - name: Ensure Gateway emitted no warnings
         if: "!cancelled()"
-        run: ! docker compose logs gateway | grep "WARN"
+        run: docker compose logs gateway | grep "WARN" && exit 1 || exit 0
       - name: Show Gateway logs
         if: "!cancelled()"
         run: docker compose logs gateway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,25 +366,25 @@ jobs:
         run: docker compose logs iperf3
 
       - name: Ensure Client emitted no warnings
-        run: docker compose logs client | grep --quiet --invert "WARN"
+        run: ! docker compose logs client | grep "WARN"
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client
 
       - name: Ensure Relay-1 emitted no warnings
-        run: docker compose logs relay-1 | grep --quiet --invert "WARN"
+        run: ! docker compose logs relay-1 | grep "WARN"
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
 
       - name: Ensure Relay-2 emitted no warnings
-        run: docker compose logs relay-2 | grep --quiet --invert "WARN"
+        run: ! docker compose logs relay-2 | grep "WARN"
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2
 
       - name: Ensure Gateway emitted no warnings
-        run: docker compose logs gateway | grep --quiet --invert "WARN"
+        run: ! docker compose logs gateway | grep "WARN"
       - name: Show Gateway logs
         if: "!cancelled()"
         run: docker compose logs gateway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,30 @@ jobs:
         if: "!cancelled()"
         run: docker compose logs iperf3
 
+      - name: Ensure Client emitted no warnings
+        run: docker compose logs client | grep --quiet --invert "WARN"
+      - name: Show Client logs
+        if: "!cancelled()"
+        run: docker compose logs client
+
+      - name: Ensure Relay-1 emitted no warnings
+        run: docker compose logs relay-1 | grep --quiet --invert "WARN"
+      - name: Show Relay-1 logs
+        if: "!cancelled()"
+        run: docker compose logs relay-1
+
+      - name: Ensure Relay-2 emitted no warnings
+        run: docker compose logs relay-2 | grep --quiet --invert "WARN"
+      - name: Show Relay-2 logs
+        if: "!cancelled()"
+        run: docker compose logs relay-2
+
+      - name: Ensure Gateway emitted no warnings
+        run: docker compose logs gateway | grep --quiet --invert "WARN"
+      - name: Show Gateway logs
+        if: "!cancelled()"
+        run: docker compose logs gateway
+
   upload-bencher:
     continue-on-error: true
     needs: perf-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,24 +366,28 @@ jobs:
         run: docker compose logs iperf3
 
       - name: Ensure Client emitted no warnings
+        if: "!cancelled()"
         run: ! docker compose logs client | grep "WARN"
       - name: Show Client logs
         if: "!cancelled()"
         run: docker compose logs client
 
       - name: Ensure Relay-1 emitted no warnings
+        if: "!cancelled()"
         run: ! docker compose logs relay-1 | grep "WARN"
       - name: Show Relay-1 logs
         if: "!cancelled()"
         run: docker compose logs relay-1
 
       - name: Ensure Relay-2 emitted no warnings
+        if: "!cancelled()"
         run: ! docker compose logs relay-2 | grep "WARN"
       - name: Show Relay-2 logs
         if: "!cancelled()"
         run: docker compose logs relay-2
 
       - name: Ensure Gateway emitted no warnings
+        if: "!cancelled()"
         run: ! docker compose logs gateway | grep "WARN"
       - name: Show Gateway logs
         if: "!cancelled()"


### PR DESCRIPTION
We already do the same thing for our integration tests. It turns out that it wasn't working there either though.

Related: #9874 