### PR TITLE
chore(connlib): add "wake reason" to `poll_timeout`

### DIFF
--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -161,8 +161,8 @@ impl ClientTunnel {
                 continue;
             }
 
-            if let Some(timeout) = self.role_state.poll_timeout() {
-                self.io.reset_timeout(timeout);
+            if let Some((timeout, reason)) = self.role_state.poll_timeout() {
+                self.io.reset_timeout(timeout, reason);
             }
 
             match self.io.poll(cx, &mut self.buffers)? {
@@ -275,8 +275,8 @@ impl GatewayTunnel {
                 continue;
             }
 
-            if let Some(timeout) = self.role_state.poll_timeout() {
-                self.io.reset_timeout(timeout);
+            if let Some((timeout, reason)) = self.role_state.poll_timeout() {
+                self.io.reset_timeout(timeout, reason);
             }
 
             match self.io.poll(cx, &mut self.buffers)? {

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -198,7 +198,7 @@ impl SimClient {
         self.tcp_dns_client.handle_timeout(now);
         self.tcp_client.handle_timeout(now);
 
-        if self.sut.poll_timeout().is_some_and(|t| t <= now) {
+        if self.sut.poll_timeout().is_some_and(|(t, _)| t <= now) {
             self.sut.handle_timeout(now)
         }
     }

--- a/rust/connlib/tunnel/src/utils.rs
+++ b/rust/connlib/tunnel/src/utils.rs
@@ -3,7 +3,7 @@ use connlib_model::RelayId;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools as _;
 use snownet::RelaySocket;
-use std::{collections::BTreeSet, net::SocketAddr, time::Instant};
+use std::{collections::BTreeSet, net::SocketAddr};
 
 pub fn turn(relays: &[Relay]) -> BTreeSet<(RelayId, RelaySocket, String, String, String)> {
     relays
@@ -55,15 +55,6 @@ pub fn turn(relays: &[Relay]) -> BTreeSet<(RelayId, RelaySocket, String, String,
             )
         })
         .collect()
-}
-
-pub fn earliest(left: Option<Instant>, right: Option<Instant>) -> Option<Instant> {
-    match (left, right) {
-        (None, None) => None,
-        (Some(left), Some(right)) => Some(std::cmp::min(left, right)),
-        (Some(left), None) => Some(left),
-        (None, Some(right)) => Some(right),
-    }
 }
 
 pub(crate) fn network_contains_network(ip_a: IpNetwork, ip_b: IpNetwork) -> bool {


### PR DESCRIPTION
In order to debug timer interactions, it is useful to know when and why connlib wants to be woken to perform tasks.