### PR TITLE
ci: add work-around for apple-client tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,23 +117,29 @@ jobs:
     runs-on: ubuntu-latest-xlarge
     strategy:
       matrix:
-        component:
-          - android-client
-          - apple-client
-          - gateway
-          - gui-client
-          - headless-client
+        include:
+          # TODO: This hack is needed because the macOS client isn't tagged as `apple-client`.
+          - tag_prefix: gateway
+            component: gateway
+          - tag_prefix: gui-client
+            component: gui-client
+          - tag_prefix: headless-client
+            component: headless-client
+          - tag_prefix: macos-client
+            component: apple-client
+          - tag_prefix: android-client
+            component: android-client
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
-      - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.component) }}
+      - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
         run: |
           set -x
 
           # Extract version from release name
           version=${{ inputs.release_name || github.event.release.name }}
-          version=${version#${{ matrix.component }}-}
+          version=${version#${{ matrix.tag_prefix }}-}
 
           # Configure gpg
           echo "$RELEASE_PR_BOT_GPG_KEY" | gpg --import --batch

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-22.04-xlarge
     strategy:
       matrix:
+        # TODO: This hack is needed because the macOS client isn't tagged as `apple-client`.
         include:
           - component: gateway
             projects: gateway


### PR DESCRIPTION
The current Git tag for releases of the Apple client is out-of-line with the naming of rest of the repository. Ideally, the tag would be renamed to `apple-client-X.Y.Z` as it represents the version for both the macOS and iOS client.

I am not familiar with the redirect system on our website to confidentially do this without breaking anything, so the easiest fix here is to employ the same hack we already do for Sentry where we special-case the `macos-client` tag.

Resolves: #9871 