### PR TITLE
feat(connlib): add `reason` argument to `reset` API

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -505,7 +505,7 @@ class TunnelService : VpnService() {
                             }
 
                             is TunnelCommand.Reset -> {
-                                session.reset()
+                                session.reset("roam")
                             }
                         }
                     }

--- a/rust/apple-client-ffi/src/lib.rs
+++ b/rust/apple-client-ffi/src/lib.rs
@@ -68,7 +68,7 @@ mod ffi {
             device_info: String,
         ) -> Result<WrappedSession, String>;
 
-        fn reset(self: &mut WrappedSession);
+        fn reset(self: &mut WrappedSession, reason: String);
 
         // Set system DNS resolvers
         //
@@ -346,8 +346,8 @@ impl WrappedSession {
         })
     }
 
-    fn reset(&mut self) {
-        self.inner.reset()
+    fn reset(&mut self, reason: String) {
+        self.inner.reset(reason)
     }
 
     fn set_dns(&mut self, dns_servers: String) -> Result<()> {

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -138,8 +138,8 @@ impl Session {
         Ok(())
     }
 
-    pub fn reset(&self) {
-        self.inner.reset()
+    pub fn reset(&self, reason: String) {
+        self.inner.reset(reason)
     }
 
     pub fn set_log_directives(&self, directives: String) -> Result<(), Error> {

--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -31,7 +31,7 @@ pub struct Eventloop {
 
 /// Commands that can be sent to the [`Eventloop`].
 pub enum Command {
-    Reset,
+    Reset(String),
     Stop,
     SetDns(Vec<IpAddr>),
     SetTun(Box<dyn Tun>),
@@ -108,8 +108,8 @@ impl Eventloop {
                     self.tunnel.set_tun(tun);
                     continue;
                 }
-                Poll::Ready(Some(Command::Reset)) => {
-                    self.tunnel.reset();
+                Poll::Ready(Some(Command::Reset(reason))) => {
+                    self.tunnel.reset(&reason);
                     self.portal
                         .connect(PublicKeyParam(self.tunnel.public_key().to_bytes()));
 

--- a/rust/client-shared/src/lib.rs
+++ b/rust/client-shared/src/lib.rs
@@ -82,8 +82,8 @@ impl Session {
     ///    However, if the user would now change _back_ to the previous network,
     ///    the TURN server would recognise the old allocation but the client already lost all its state associated with it.
     ///    To avoid race-conditions like this, we rebind the sockets to a new port.
-    pub fn reset(&self) {
-        let _ = self.channel.send(Command::Reset);
+    pub fn reset(&self, reason: String) {
+        let _ = self.channel.send(Command::Reset(reason));
     }
 
     /// Sets a new set of upstream DNS servers for this [`Session`].

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1476,8 +1476,8 @@ impl ClientState {
         self.buffered_events.pop_front()
     }
 
-    pub(crate) fn reset(&mut self, now: Instant) {
-        tracing::info!("Resetting network state");
+    pub(crate) fn reset(&mut self, now: Instant, reason: &str) {
+        tracing::info!("Resetting network state ({reason})");
 
         self.node.reset(now); // Clear all network connections.
         self.peers.clear(); // Clear all state associated with Gateways.

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -132,8 +132,8 @@ impl ClientTunnel {
         self.role_state.public_key()
     }
 
-    pub fn reset(&mut self) {
-        self.role_state.reset(Instant::now());
+    pub fn reset(&mut self, reason: &str) {
+        self.role_state.reset(Instant::now(), reason);
         self.io.reset();
     }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -259,7 +259,7 @@ impl TunnelTest {
                 );
 
                 state.client.exec_mut(|c| {
-                    c.sut.reset(now);
+                    c.sut.reset(now, "roam");
 
                     // In prod, we reconnect to the portal and receive a new `init` message.
                     c.update_relays(iter::empty(), state.relays.iter(), now);

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -369,7 +369,7 @@ impl<'a> Handler<'a> {
                         tracing::debug!("Ignoring network change since we're still signing in");
                     }
                     Session::Connected { connlib, .. } => {
-                        connlib.reset();
+                        connlib.reset("network changed".to_owned());
                     }
                     Session::WaitingForNetwork { api_url, token } => {
                         tracing::info!("Attempting to re-connect upon network change");

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -296,8 +296,7 @@ fn main() -> Result<()> {
                     break Ok(());
                 },
                 () = hangup.recv() => {
-                    tracing::info!("Caught SIGHUP");
-                    session.reset();
+                    session.reset("SIGHUP".to_owned());
                     continue;
                 },
                 result = dns_notifier.notified() => {
@@ -310,8 +309,7 @@ fn main() -> Result<()> {
                 },
                 result = network_notifier.notified() => {
                     result?;
-                    tracing::info!("Network change, resetting Session");
-                    session.reset();
+                    session.reset("network changed".to_owned());
                     continue;
                 },
                 event = event_stream.next() => event.context("event stream unexpectedly ran empty")?,

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -135,7 +135,7 @@ class Adapter {
       if lastRelevantPath?.connectivityDifferentFrom(path: path) != false {
         lastRelevantPath = path
 
-        session?.reset()
+        session?.reset("primary network path changed")
       }
 
       if shouldFetchSystemResolvers(path: path) {


### PR DESCRIPTION
In order to provide more detailed logs, why `connlib`'s network state is being reset, we add a `reason` parameter that is gets logged.

Resolves: #9867