### PR TITLE
fix(snownet): wake idle connection on upsert

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1761,7 +1761,7 @@ where
             Self::Failed | Self::Connecting { .. } => return,
         };
 
-        self.transition_to_connected(peer_socket, agent, packet, now);
+        self.transition_to_connected(peer_socket, agent, tracing::field::debug(packet), now);
     }
 
     fn on_incoming(&mut self, agent: &mut IceAgent, packet: &IpPacket, now: Instant) {
@@ -1774,7 +1774,7 @@ where
             Self::Failed | Self::Connecting { .. } => return,
         };
 
-        self.transition_to_connected(peer_socket, agent, packet, now);
+        self.transition_to_connected(peer_socket, agent, tracing::field::debug(packet), now);
     }
 
     fn transition_to_idle(&mut self, peer_socket: PeerSocket<RId>, agent: &mut IceAgent) {
@@ -1787,10 +1787,10 @@ where
         &mut self,
         peer_socket: PeerSocket<RId>,
         agent: &mut IceAgent,
-        packet: &IpPacket,
+        trigger: impl tracing::Value,
         now: Instant,
     ) {
-        tracing::debug!(?packet, "Connection resumed");
+        tracing::debug!(trigger, "Connection resumed");
         *self = Self::Connected {
             peer_socket,
             last_outgoing: now,


### PR DESCRIPTION
When a connection is in idle-mode, it only sends a STUN request every 25 seconds. If the Client disconnects e.g. due to a network partition, it may send a new connection intent later. If the Gateway's connection is still around then because it was in idle mode, it won't send any candidates to the remote, making the Client's connection fail with "no candidates received".

To alleviate this, we wake a connection out of idle mode every time it is being upserted. This ensures that the connection will fail within 15s IF the above scenario happens, allowing the Client to reconnect within a much shorter time-frame.

Note that attempting to repair such a connection is likely pointless. It is much safer to discard it and let them both establish a new connection.

Related: #9862