### PR TITLE
fix(portal): handle `jsonb` for embedded schemas

### DIFF
--- a/elixir/apps/domain/lib/domain.ex
+++ b/elixir/apps/domain/lib/domain.ex
@@ -35,28 +35,6 @@ defmodule Domain do
   end
 
   @doc """
-    Converts a map of string params to a schema struct with values casted.
-    This is useful for sending valid structs from the WAL consumers.
-  """
-  def struct_from_params(schema_module, params) do
-    schema_module.__schema__(:fields)
-    |> Enum.reduce(struct(schema_module), fn field, acc ->
-      case Map.get(params, to_string(field)) do
-        nil ->
-          acc
-
-        value ->
-          field_type = schema_module.__schema__(:type, field)
-
-          case Ecto.Type.cast(field_type, value) do
-            {:ok, casted_value} -> Map.put(acc, field, casted_value)
-            :error -> acc
-          end
-      end
-    end)
-  end
-
-  @doc """
   When used, dispatch to the appropriate schema/context/changeset/query/etc.
   """
   defmacro __using__(which) when is_atom(which) do

--- a/elixir/apps/domain/lib/domain/events/hooks/clients.ex
+++ b/elixir/apps/domain/lib/domain/events/hooks/clients.ex
@@ -1,7 +1,6 @@
 defmodule Domain.Events.Hooks.Clients do
   @behaviour Domain.Events.Hooks
-  alias Domain.PubSub
-  alias Domain.Clients
+  alias Domain.{Clients, PubSub, SchemaHelpers}
 
   @impl true
   def on_insert(_data), do: :ok
@@ -15,7 +14,7 @@ defmodule Domain.Events.Hooks.Clients do
 
   # Regular update
   def on_update(_old_data, data) do
-    client = Domain.struct_from_params(Clients.Client, data)
+    client = SchemaHelpers.struct_from_params(Clients.Client, data)
     PubSub.Client.broadcast(client.id, {:updated, client})
   end
 

--- a/elixir/apps/domain/lib/domain/replication/connection.ex
+++ b/elixir/apps/domain/lib/domain/replication/connection.ex
@@ -610,7 +610,6 @@ defmodule Domain.Replication.Connection do
         |> Tuple.to_list()
         |> Enum.zip(columns)
         |> Map.new(&decode_value/1)
-        |> Enum.into(%{})
       end
     end
   end

--- a/elixir/apps/domain/lib/domain/schema_helpers.ex
+++ b/elixir/apps/domain/lib/domain/schema_helpers.ex
@@ -1,0 +1,53 @@
+defmodule Domain.SchemaHelpers do
+  @doc """
+  Converts a map of string params to a schema struct with values casted.
+  Uses Ecto changesets for robust casting that handles all Ecto features.
+  """
+  def struct_from_params(schema_module, params) do
+    # Get schema metadata
+    fields = schema_module.__schema__(:fields)
+    embeds = schema_module.__schema__(:embeds)
+
+    # Build a minimal changeset module dynamically
+    changeset_fn = fn struct, attrs ->
+      struct
+      |> Ecto.Changeset.cast(attrs, fields -- embeds)
+      |> cast_all_embeds(schema_module, embeds)
+    end
+
+    # Apply the changeset
+    schema_module
+    |> struct()
+    |> changeset_fn.(params)
+    |> Ecto.Changeset.apply_changes()
+  end
+
+  # Cast all embedded fields
+  defp cast_all_embeds(changeset, schema_module, embeds) do
+    Enum.reduce(embeds, changeset, fn embed_field, acc ->
+      embed_type = schema_module.__schema__(:embed, embed_field)
+
+      case embed_type do
+        %Ecto.Embedded{cardinality: :one} ->
+          Ecto.Changeset.cast_embed(acc, embed_field, with: &embedded_changeset/2)
+
+        %Ecto.Embedded{cardinality: :many} ->
+          Ecto.Changeset.cast_embed(acc, embed_field, with: &embedded_changeset/2)
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  # Generic changeset function for embedded schemas
+  defp embedded_changeset(struct, params) do
+    schema_module = struct.__struct__
+    fields = schema_module.__schema__(:fields)
+    embeds = schema_module.__schema__(:embeds)
+
+    struct
+    |> Ecto.Changeset.cast(params, fields -- embeds)
+    |> cast_all_embeds(schema_module, embeds)
+  end
+end

--- a/elixir/apps/domain/test/domain/schema_helpers_test.exs
+++ b/elixir/apps/domain/test/domain/schema_helpers_test.exs
@@ -1,0 +1,185 @@
+defmodule Domain.SchemaHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias Domain.SchemaHelpers
+
+  defmodule NestedEmbedSchema do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    @primary_key false
+    embedded_schema do
+      field :nested_field, :string
+    end
+
+    def changeset(struct, params) do
+      cast(struct, params, [:nested_field])
+    end
+  end
+
+  defmodule EmbeddedSchema do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    @primary_key false
+    embedded_schema do
+      field :sub_field1, :string
+      field :sub_field2, :string
+      embeds_one :nested_item, NestedEmbedSchema
+    end
+
+    def changeset(struct, params) do
+      struct
+      |> cast(params, [:sub_field1, :sub_field2])
+      |> cast_embed(:nested_item)
+    end
+  end
+
+  defmodule ListItemSchema do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    @primary_key false
+    embedded_schema do
+      field :list_field1, :string
+      field :list_field2, :string, default: "default_value"
+    end
+
+    def changeset(struct, params) do
+      cast(struct, params, [:list_field1, :list_field2])
+    end
+  end
+
+  defmodule RootSchema do
+    use Ecto.Schema
+
+    @primary_key false
+    embedded_schema do
+      field :field1, :string
+      field :field2, :integer
+      field :field3, :boolean, default: false
+      embeds_one :embedded_item, EmbeddedSchema
+      embeds_many :list_items, ListItemSchema
+    end
+  end
+
+  # --- Test Cases ---
+
+  describe "struct_from_params/2" do
+    test "correctly casts basic types from string-keyed map" do
+      params = %{
+        "field1" => "Value 1",
+        "field2" => "100",
+        "field3" => "true"
+      }
+
+      result = SchemaHelpers.struct_from_params(RootSchema, params)
+
+      assert %RootSchema{
+               field1: "Value 1",
+               field2: 100,
+               field3: true,
+               embedded_item: nil,
+               list_items: []
+             } = result
+    end
+
+    test "correctly casts a single embedded schema (embeds_one)" do
+      params = %{
+        "field1" => "Root Value",
+        "embedded_item" => %{
+          "sub_field1" => "Sub Value 1",
+          "sub_field2" => "Sub Value 2"
+        }
+      }
+
+      result = SchemaHelpers.struct_from_params(RootSchema, params)
+
+      assert %RootSchema{field1: "Root Value", embedded_item: item} = result
+      assert %EmbeddedSchema{sub_field1: "Sub Value 1", sub_field2: "Sub Value 2"} = item
+    end
+
+    test "correctly casts a list of embedded schemas (embeds_many)" do
+      params = %{
+        "field1" => "Root With List",
+        "list_items" => [
+          %{"list_field1" => "Item A"},
+          %{"list_field1" => "Item B", "list_field2" => "custom_value"}
+        ]
+      }
+
+      result = SchemaHelpers.struct_from_params(RootSchema, params)
+
+      assert %RootSchema{field1: "Root With List", list_items: items} = result
+
+      assert [
+               %ListItemSchema{list_field1: "Item A", list_field2: "default_value"},
+               %ListItemSchema{list_field1: "Item B", list_field2: "custom_value"}
+             ] = items
+    end
+
+    test "handles deeply nested embedded schemas" do
+      params = %{
+        "field1" => "Deep Root",
+        "embedded_item" => %{
+          "sub_field1" => "Sub Level 1",
+          "nested_item" => %{
+            "nested_field" => "Deepest Value"
+          }
+        }
+      }
+
+      result = SchemaHelpers.struct_from_params(RootSchema, params)
+
+      assert %RootSchema{embedded_item: %EmbeddedSchema{nested_item: nested}} = result
+      assert %NestedEmbedSchema{nested_field: "Deepest Value"} = nested
+    end
+
+    test "ignores extra parameters not defined in the schema" do
+      params = %{
+        "field1" => "Extra Fields",
+        "field2" => "40",
+        "extra_field" => "should be ignored",
+        "embedded_item" => %{
+          "sub_field1" => "Sub with extra",
+          "extra_sub_field" => "also ignored"
+        }
+      }
+
+      result = SchemaHelpers.struct_from_params(RootSchema, params)
+
+      assert %RootSchema{field1: "Extra Fields", field2: 40, embedded_item: item} = result
+      assert %EmbeddedSchema{sub_field1: "Sub with extra", sub_field2: nil} = item
+      refute Map.has_key?(result, :extra_field)
+      refute Map.has_key?(item, :extra_sub_field)
+    end
+
+    test "handles empty params map" do
+      params = %{}
+      result = SchemaHelpers.struct_from_params(RootSchema, params)
+
+      assert %RootSchema{
+               field1: nil,
+               field2: nil,
+               field3: false,
+               embedded_item: nil,
+               list_items: []
+             } = result
+    end
+
+    test "handles empty list for embeds_many" do
+      params = %{"field1" => "No List Items", "list_items" => []}
+      result = SchemaHelpers.struct_from_params(RootSchema, params)
+
+      assert %RootSchema{field1: "No List Items", list_items: []} = result
+    end
+
+    test "handles empty map for embeds_one" do
+      params = %{"field1" => "Empty Embedded", "embedded_item" => %{}}
+      result = SchemaHelpers.struct_from_params(RootSchema, params)
+
+      assert %RootSchema{field1: "Empty Embedded", embedded_item: item} = result
+      assert %EmbeddedSchema{sub_field1: nil, sub_field2: nil} = item
+    end
+  end
+end

--- a/elixir/apps/domain/test/domain/schema_helpers_test.exs
+++ b/elixir/apps/domain/test/domain/schema_helpers_test.exs
@@ -3,6 +3,8 @@ defmodule Domain.SchemaHelpersTest do
 
   alias Domain.SchemaHelpers
 
+  # --- Test Schemas ---
+
   defmodule NestedEmbedSchema do
     use Ecto.Schema
     import Ecto.Changeset


### PR DESCRIPTION
In #9664, we introduced the `Domain.struct_from_params/2` function which converts a set of params containing string keys into a provided struct representing a schema module. This is used to broadcast actual structs pertaining to WAL data as opposed to simple string encodings of the data.

The problem is that function was a bit too naive and failed to properly cast embedded schemas, resulting in all embedded schema on the root struct being `nil` or `[]`.

To fix this, we need to do two things:

1. We now decode JSON/JSONB fields from binaries (strings) into actual lists and maps in the replication consumer module for downstream processors to use
2. We update our `struct_from_params/2` function to properly cast embedded schemas from these lists and maps using Ecto.Changeset's `apply_changes` function, which uses the same logic to instantiate the schemas as if we were saving a form or API request.

Lastly, tests are added to ensure this works under various scenarios, including nested embedded schemas which we use in some places.

Fixes #9835 

