### PR TITLE
fix(portal): only process jsonb strings

### DIFF
--- a/elixir/apps/domain/lib/domain/replication/connection.ex
+++ b/elixir/apps/domain/lib/domain/replication/connection.ex
@@ -579,10 +579,6 @@ defmodule Domain.Replication.Connection do
         {:delete, old, nil}
       end
 
-      defp decode_value({nil, column}) do
-        {column.name, nil}
-      end
-
       defp decode_value({value, %{type: type} = column})
            when type in ["json", "jsonb"] and is_binary(value) do
         case JSON.decode(value) do

--- a/elixir/apps/domain/lib/domain/replication/connection.ex
+++ b/elixir/apps/domain/lib/domain/replication/connection.ex
@@ -583,7 +583,8 @@ defmodule Domain.Replication.Connection do
         {column.name, nil}
       end
 
-      defp decode_value({value, %{type: type} = column}) when type in ["json", "jsonb"] do
+      defp decode_value({value, %{type: type} = column})
+           when type in ["json", "jsonb"] and is_binary(value) do
         case JSON.decode(value) do
           {:ok, decoded} ->
             {column.name, decoded}

--- a/elixir/apps/domain/test/domain/replication/connection_test.exs
+++ b/elixir/apps/domain/test/domain/replication/connection_test.exs
@@ -620,6 +620,7 @@ defmodule Domain.Replication.ConnectionTest do
           %{name: "id", type: "integer"},
           %{name: "data_map", type: "jsonb"},
           %{name: "data_list", type: "jsonb"},
+          %{name: "data_toast", type: "jsonb"},
           %{name: "data_null", type: "jsonb"}
         ]
       }
@@ -632,10 +633,11 @@ defmodule Domain.Replication.ConnectionTest do
 
       json_map_string = ~s({"a": 1, "b": {"c": true}})
       json_list_string = ~s([1, "two", false, null])
+      json_unchanged_toast = :unchanged_toast
 
       insert_msg = %Domain.Replication.Decoder.Messages.Insert{
         relation_id: 123,
-        tuple_data: {101, json_map_string, json_list_string, nil}
+        tuple_data: {101, json_map_string, json_list_string, json_unchanged_toast, nil}
       }
 
       {:noreply, [], new_state} =
@@ -651,7 +653,8 @@ defmodule Domain.Replication.ConnectionTest do
                "id" => 101,
                "data_map" => %{"a" => 1, "b" => %{"c" => true}},
                "data_list" => [1, "two", false, nil],
-               "data_null" => nil
+               "data_null" => nil,
+               "data_toast" => :unchanged_toast
              }
     end
 


### PR DESCRIPTION
As a followup to #9882, we need to ensure that `jsonb` columns that have value data other than strings are not decoded as jsonb. An example of when this happens is when Postgres sends an `:unchanged_toast` to indicate the data hasn't changed.