### PR TITLE
chore: move "duplicate counter" WireGuard errors to DEBUG

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1340,6 +1340,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "bimap",
+ "boringtun",
  "chrono",
  "connlib-model",
  "dns-types",

--- a/rust/client-shared/Cargo.toml
+++ b/rust/client-shared/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 anyhow = { workspace = true }
 backoff = { workspace = true }
 bimap = { workspace = true }
+boringtun = { workspace = true }
 connlib-model = { workspace = true }
 dns-types = { workspace = true }
 firezone-logging = { workspace = true }


### PR DESCRIPTION
I _think_ these aren't of an immediate concern and appear to happen during regular operation of WireGuard tunnels.