### PR TITLE
fix(snownet): discard channel-data messages from old allocations

### DIFF
--- a/rust/connlib/snownet/src/channel_data.rs
+++ b/rust/connlib/snownet/src/channel_data.rs
@@ -3,7 +3,22 @@ use std::io;
 
 const HEADER_LEN: usize = 4;
 
-pub fn decode(data: &[u8]) -> Result<(u16, &[u8]), io::Error> {
+pub struct Packet<'a> {
+    channel: u16,
+    payload: &'a [u8],
+}
+
+impl<'a> Packet<'a> {
+    pub(crate) fn channel(&self) -> u16 {
+        self.channel
+    }
+
+    pub(crate) fn payload(&self) -> &'a [u8] {
+        self.payload
+    }
+}
+
+pub fn decode(data: &[u8]) -> Result<Packet, io::Error> {
     if data.len() < HEADER_LEN {
         return Err(io::Error::new(
             io::ErrorKind::UnexpectedEof,
@@ -33,7 +48,10 @@ pub fn decode(data: &[u8]) -> Result<(u16, &[u8]), io::Error> {
         ));
     }
 
-    Ok((channel_number, &payload[..length]))
+    Ok(Packet {
+        channel: channel_number,
+        payload,
+    })
 }
 
 /// Encode the channel data header (number + length) to the given slice.

--- a/rust/connlib/snownet/src/channel_data.rs
+++ b/rust/connlib/snownet/src/channel_data.rs
@@ -23,11 +23,11 @@ pub fn decode(data: &[u8]) -> Result<(u16, &[u8]), io::Error> {
 
     let length = u16::from_be_bytes([header[2], header[3]]) as usize;
 
-    if payload.len() < length {
+    if payload.len() != length {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
-                "channel data message specified {length} bytes but the payload is only {} bytes",
+                "channel data message specified {length} bytes but the payload is {} bytes",
                 payload.len()
             ),
         ));

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -841,6 +841,12 @@ where
                     .values_mut()
                     .find(|a| a.server().matches(from))
                 else {
+                    if crate::channel_data::decode(packet).is_ok() {
+                        tracing::debug!("Packet was a channel data message for unknown allocation");
+
+                        return ControlFlow::Break(()); // Stop processing the packet.
+                    }
+
                     // False-positive, continue processing packet elsewhere
                     return ControlFlow::Continue((from, packet, None));
                 };


### PR DESCRIPTION
When we invalidate or discard an allocation, it may happen that a relay still sends channel-data messages to us. We don't recognize those and will therefore attempt to parse them as WireGuard packets, ultimately ending in an "Packet has unknown format" error.

To avoid this, we check if the packet is a valid channel-data message even if we presently don't have an allocation on the relay that is sending us the packet. In those cases, we can stop processing the packet, thus avoiding these errors from being logged.