### PR TITLE
chore: fix invalid build stage in `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,7 +399,7 @@ services:
 
   download.httpbin: # Named after `httpbin` because that is how DNS resources are configured for the test setup.
     build:
-      target: dev
+      target: debug
       context: rust
       dockerfile: Dockerfile
       cache_from:


### PR DESCRIPTION
We have since removed the `dev` stage from the Rust Dockerfile.

Resolves: #9768