### PR TITLE
chore: remove `pull_policy` from containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -520,7 +520,6 @@ services:
   # You'll also need the extcap plugin: https://github.com/siemens/cshargextcap
   gostwire:
     image: "ghcr.io/siemens/ghostwire"
-    pull_policy: always
     restart: "unless-stopped"
     read_only: true
     entrypoint:
@@ -559,7 +558,6 @@ services:
 
   edgeshark:
     image: "ghcr.io/siemens/packetflix"
-    pull_policy: "always"
     read_only: true
     restart: "unless-stopped"
     entrypoint:


### PR DESCRIPTION
Having to pull these every time one does `docker compose up` is annoying and unnecessary.