### PR TITLE
test: remove curl retry in favor of keep-alive

### DIFF
--- a/scripts/tests/direct-download-roaming-network.sh
+++ b/scripts/tests/direct-download-roaming-network.sh
@@ -7,9 +7,8 @@ client sh -c \
     "curl \
         --fail \
         --max-time 12 \
-        --retry 1 \
-        --continue-at - \
-        --limit-rate 1M \
+        --keepalive-time 1 \
+        --limit-rate 1000000 \
         --output download.file \
         http://download.httpbin/bytes?num=10000000" &
 

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -3,19 +3,19 @@
 set -euox pipefail
 
 function client() {
-    docker compose exec -it client "$@"
+    docker compose exec -T client "$@"
 }
 
 function gateway() {
-    docker compose exec -it gateway "$@"
+    docker compose exec -T gateway "$@"
 }
 
 function relay1() {
-    docker compose exec -it relay-1 "$@"
+    docker compose exec -T relay-1 "$@"
 }
 
 function relay2() {
-    docker compose exec -it relay-2 "$@"
+    docker compose exec -T relay-2 "$@"
 }
 
 function install_iptables_drop_rules() {


### PR DESCRIPTION
At present, the `direct-download-roaming-network` integration test is a bit odd. It uses the `--retry` switch from `curl` to retry the download once it failed. However, what we want to show with this integration test is that a TCP connection can survive network roaming. We can show that successfully but only if we specify the `--keepalive-time` option, otherwise the download stalls.

From inspecting the network logs, this is because `curl` simply waits for more data to be downloaded. After a network reset, the connection however is gone and the _client_ (in this case `curl`) needs to send at least 1 packet to re-establish the connection. By using the keep-alive option, we can send such a packet and the download completes successfully.