### PR TITLE
fix(snownet): fail connection on `WrongKey` during handshake

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2214,7 +2214,7 @@ where
             .decapsulate_at(Some(src), packet, ip_packet.buf(), now)
         {
             TunnResult::Done => ControlFlow::Break(Ok(())),
-            TunnResult::Err(e @ WireGuardError::InvalidAeadTag)
+            TunnResult::Err(e @ (WireGuardError::InvalidAeadTag | WireGuardError::WrongKey))
                 if crate::is_handshake(packet)
                     && feature_flags::fail_handshake_on_decryption_errors() =>
             {


### PR DESCRIPTION
In addition to decryption errors when parsing a handshake response, there are several failure cases when parsing handshake _initiations_. One of them is `WrongKey`, which essentially means that the remote peer is a different public key as to what we expect them to be. `boringtun` drops these packets, triggering the 5s retry on the remote peer, only to result in the same behaviour. This repeats for 90s until the remote gives up.

These handshake initiations can only happens whilst we have a working ICE connection to transport the packets. By immediately failing the connection, we will trigger an ICE timeout and require the Client to start-over with making a connection.

Related: #9850