### PR TITLE
feat(snownet): reduce rekey-attempt-time to 15s

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.1"
-source = "git+https://github.com/firezone/boringtun?branch=master#5b1892f0616f97d82599b6e324356aa9ea629c33"
+source = "git+https://github.com/firezone/boringtun?branch=master#3d5df9c2a6f55424e02671374f835cc7db1d7a44"
 dependencies = [
  "aead",
  "base64 0.22.1",

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2214,12 +2214,7 @@ where
             .decapsulate_at(Some(src), packet, ip_packet.buf(), now)
         {
             TunnResult::Done => ControlFlow::Break(Ok(())),
-            TunnResult::Err(e @ WireGuardError::InvalidAeadTag)
-                if crate::is_handshake(packet)
-                    && feature_flags::fail_handshake_on_decryption_errors() =>
-            {
-                analytics::feature_flag_called("fail-handshake-on-decryption-errors");
-
+            TunnResult::Err(e @ WireGuardError::InvalidAeadTag) if crate::is_handshake(packet) => {
                 tracing::info!("Connection handshake failed ({e})");
                 self.state = ConnectionState::Failed;
 

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -25,6 +25,10 @@ export default function Android() {
           Fixes an issue where Firezone failed to sign-in on systems with
           non-ASCII characters in their kernel build name.
         </ChangeItem>
+        <ChangeItem pull="9891">
+          Fixes an issue where connections would sometimes take up to 90s to
+          establish.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.2" date={new Date("2025-06-30")}>
         <ChangeItem pull="9621">

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9891">
+          Fixes an issue where connections would sometimes take up to 90s to
+          establish.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.4" date={new Date("2025-07-11")}>
         <ChangeItem pull="9597">
           Fixes an issue where certain log files would not be recreated after

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,12 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9891">
+          Fixes an issue where connections would sometimes take up to 90s to
+          establish.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.5" date={new Date("2025-07-09")}>
         <ChangeItem pull="9779">Fixes a rare crash during sign-in.</ChangeItem>
         <ChangeItem pull="9725">

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -34,6 +34,10 @@ export default function Gateway() {
           Adds support for translating Time-Exceeded ICMP errors in the DNS
           resource NAT, allowing `tracepath` to work through a Firezone tunnel.
         </ChangeItem>
+        <ChangeItem pull="9891">
+          Fixes an issue where connections would sometimes take up to 90s to
+          establish.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.12" date={new Date("2025-06-30")}>
         <ChangeItem pull="9657">

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -9,7 +9,12 @@ export default function Headless({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="9891">
+          Fixes an issue where connections would sometimes take up to 90s to
+          establish.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.1" date={new Date("2025-07-04")}>
         <ChangeItem pull="9564">
           Fixes an issue where connections would fail to establish if both


### PR DESCRIPTION
From Sentry reports and user-submitted logs, we know that it is possible for Client and Gateway to de-sync in regards to what each other's public key is. In such a scenario, ICE will succeed to make a connection but `boringtun` will fail to handshake a tunnel. By default, `boringtun` tries for 90s to handshake a session before it gives up and expires it.

In Firezone, the ICE agent takes care of establishing connectivity whereas `boringtun` itself just encrypts and decrypts packets. As such, if ICE is working, we know that packets aren't getting lost but instead, there must be some other issue as to why we cannot establish a session.

To improve the UX in these error cases, we reduce the rekey-attempt-time to 15s. This roughly matches our ICE timeout. Those 15s count from the moment we send the first handshake which is just after ICE completes. Thus we can be sure that after at most 15s, we either have a working WireGuard session or the connection gets cleaned up.

Related: #9890
Related: #9850