### PR TITLE
chore(ci): Use GitHub Actions Cache for CI layer cache

### DIFF
--- a/.github/README_CI.md
+++ b/.github/README_CI.md
@@ -31,28 +31,4 @@ done
 
 ## Adding a new repository to Google Cloud workload identity
 
-We are using a separate Google Cloud project for GitHub Actions workload
-federation, if you need `auth` action to work from a new repo - it needs to be
-added to the principal set of a GitHub Actions service account:
-
-```
-export REPO="firezone/firezone"
-gcloud iam service-accounts add-iam-policy-binding "github-actions@github-iam-387915.iam.gserviceaccount.com" \
-  --project="github-iam-387915" \
-  --role="roles/iam.workloadIdentityUser" \
-  --member="principalSet://iam.googleapis.com/projects/397012414171/locations/global/workloadIdentityPools/github-actions-pool/attribute.repository/${REPO}"
-```
-
-for more details see https://github.com/google-github-actions/auth.
-
-## Busting the GCP Docker layer cache
-
-If you find yourself hitting strange Docker image issues like Rust binaries
-failing to start inside Docker images, you may need to bust the GCP layer cache.
-
-To do so:
-
-- Login to [GCP](console.cloud.google.com)
-- Ensure `firezone-staging` project is selected
-- Navigate to the artifact registry service
-- Delete all image versions for the appropriate `cache/` image repository
+Use Terraform configuration for this. See the `iam.tf` configuration in the https://github.com/firezone/infra repo for an example.

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -105,7 +105,7 @@ jobs:
             type=gha,scope=${{ matrix.image_name }}:${{ env.CACHE_TAG }}
             type=gha,scope=${{ matrix.image_name }}:main
           cache-to: |
-            type=gha,scope=${{ matrix.image_name}}:${{ env.CACHE_TAG }},mode=max,ignore-error=true
+            type=gha,scope=${{ matrix.image_name }}:${{ env.CACHE_TAG }},mode=max,ignore-error=true
           push: true
           tags: |
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ inputs.sha }}

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -102,10 +102,10 @@ jobs:
           target: ${{ matrix.target }}
           context: elixir
           cache-from: |
-            type=registry,ref=${{ steps.login.outputs.registry }}/firezone/cache/${{ matrix.image_name }}:${{ env.CACHE_TAG }}
-            type=registry,ref=${{ steps.login.outputs.registry }}/firezone/cache/${{ matrix.image_name }}:main
+            type=gha,scope=${{ matrix.image_name }}:${{ env.CACHE_TAG }}
+            type=gha,scope=${{ matrix.image_name }}:main
           cache-to: |
-            type=registry,ref=${{steps.login.outputs.registry}}/firezone/cache/${{ matrix.image_name}}:${{ env.CACHE_TAG }},mode=max
+            type=gha,scope=${{ matrix.image_name}}:${{ env.CACHE_TAG }},mode=max,ignore-error=true
           push: true
           tags: |
             ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_name }}:${{ inputs.sha }}
@@ -365,10 +365,10 @@ jobs:
             TARGET=${{ matrix.arch.target }}
           context: rust
           cache-from: |
-            type=registry,ref=${{ steps.login.outputs.registry }}/firezone/cache/${{ matrix.name.image_name }}:${{ env.CACHE_TAG }}
-            type=registry,ref=${{ steps.login.outputs.registry }}/firezone/cache/${{ matrix.name.image_name }}:main
+            type=gha,scope=${{ matrix.name.image_name }}:${{ env.CACHE_TAG }}
+            type=gha,scope=${{ matrix.name.image_name }}:main
           cache-to: |
-            type=registry,ref=${{ steps.login.outputs.registry }}/firezone/cache/${{ matrix.name.image_name }}:${{ env.CACHE_TAG }},mode=max
+            type=gha,scope=${{ matrix.name.image_name }}:${{ env.CACHE_TAG }},mode=max,ignore-error=true
           target: ${{ matrix.stage }}
           outputs: type=image,name=${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest


### PR DESCRIPTION
Since GCP artifact registry is cost-prohibitive, we can use the GitHub Actions Cache for docker layer caching for CI builds.

See https://docs.docker.com/build/cache/backends/gha/