### PR TITLE
feat(portal): allow queue_target and queue_interval via ENV

### DIFF
--- a/elixir/apps/domain/lib/domain/config/definitions.ex
+++ b/elixir/apps/domain/lib/domain/config/definitions.ex
@@ -67,6 +67,8 @@ defmodule Domain.Config.Definitions do
          :database_user,
          :database_password,
          :database_pool_size,
+         :database_queue_target,
+         :database_queue_interval,
          :database_ssl_enabled,
          :database_ssl_opts,
          :database_parameters,
@@ -299,6 +301,16 @@ defmodule Domain.Config.Definitions do
   defconfig(:database_pool_size, :integer,
     default: fn -> :erlang.system_info(:logical_processors_available) * 2 end
   )
+
+  @doc """
+  The target threshold for the length of time in milliseconds that a query should wait in the queue
+  """
+  defconfig(:database_queue_target, :integer, default: 500)
+
+  @doc """
+  How often to check for queries that exceeded 2 * `database_queue_target` milliseconds
+  """
+  defconfig(:database_queue_interval, :integer, default: 1000)
 
   @doc """
   Whether to connect to the database over SSL.

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -14,14 +14,12 @@ if config_env() == :prod do
            {:username, env_var_to_config!(:database_user)},
            {:port, env_var_to_config!(:database_port)},
            {:pool_size, env_var_to_config!(:database_pool_size)},
+           {:queue_target, env_var_to_config!(:database_queue_target)},
+           {:queue_interval, env_var_to_config!(:database_queue_interval)},
            {:ssl, env_var_to_config!(:database_ssl_enabled)},
            {:ssl_opts, env_var_to_config!(:database_ssl_opts)},
            {:parameters, env_var_to_config!(:database_parameters)}
          ] ++
-           if(env_var_to_config(:background_jobs_enabled),
-             do: [{:queue_target, 5_000}],
-             else: []
-           ) ++
            if(env_var_to_config(:database_password),
              do: [{:password, env_var_to_config!(:database_password)}],
              else: []


### PR DESCRIPTION
These parameters should be tuned to how long we expect "normal" queries to take against the SQL instance. For smaller instances, "normal" queries may take longer than 500ms, so we need to be able to configure these via our Terraform configuration.

If not specified, the same defaults are used as before.

Related: https://github.com/firezone/infra/pull/82