### PR TITLE
fix(portal): don't prematurely reject access

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -258,10 +258,10 @@ defmodule API.Client.Channel do
       # if this was the last flow in its cache that was authorizing it.
       push(socket, "resource_deleted", flow.resource_id)
 
-      # If access was actually removed, we'll receive a different WAL message for the
-      # Resource/Policy/Membership, and access will be removed from the client there.
-      # Here, we just need to reset the flow.
-      if resource = Map.get(socket.assigns.resources, flow.resource_id) do
+      resource = Map.get(socket.assigns.resources, flow.resource_id)
+
+      # Access to resource is still allowed, allow creating a new flow
+      if resource and resource.id in Enum.map(authorized_resources(socket), & &1.id) do
         push(socket, "resource_created_or_updated", Views.Resource.render(resource))
       else
         Logger.warning("Active flow deleted for resource but resource not found in socket state",

--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -261,7 +261,7 @@ defmodule API.Client.Channel do
       resource = Map.get(socket.assigns.resources, flow.resource_id)
 
       # Access to resource is still allowed, allow creating a new flow
-      if resource and resource.id in Enum.map(authorized_resources(socket), & &1.id) do
+      if not is_nil(resource) and resource.id in Enum.map(authorized_resources(socket), & &1.id) do
         push(socket, "resource_created_or_updated", Views.Resource.render(resource))
       else
         Logger.warning("Active flow deleted for resource but resource not found in socket state",

--- a/elixir/apps/api/lib/api/gateway/views/flow.ex
+++ b/elixir/apps/api/lib/api/gateway/views/flow.ex
@@ -1,7 +1,7 @@
 defmodule API.Gateway.Views.Flow do
   def render_many(flows) do
     flows
-    |> Enum.map(fn {{client_id, resource_id}, _expires_at} ->
+    |> Enum.map(fn {{client_id, resource_id}, {_flow_id, _expires_at}} ->
       %{
         client_id: client_id,
         resource_id: resource_id

--- a/elixir/apps/api/lib/api/gateway/views/flow.ex
+++ b/elixir/apps/api/lib/api/gateway/views/flow.ex
@@ -1,7 +1,7 @@
 defmodule API.Gateway.Views.Flow do
   def render_many(flows) do
     flows
-    |> Enum.map(fn {{client_id, resource_id}, {_flow_id, _expires_at}} ->
+    |> Enum.map(fn {{client_id, resource_id}, _flow_map} ->
       %{
         client_id: client_id,
         resource_id: resource_id

--- a/elixir/apps/api/test/api/gateway/channel_test.exs
+++ b/elixir/apps/api/test/api/gateway/channel_test.exs
@@ -352,14 +352,16 @@ defmodule API.Gateway.ChannelTest do
           account: account,
           subject: subject,
           client: client,
-          resource: resource
+          resource: resource,
+          gateway: gateway
         )
 
       data = %{
         "id" => flow.id,
         "client_id" => client.id,
         "resource_id" => resource.id,
-        "account_id" => account.id
+        "account_id" => account.id,
+        "gateway_id" => gateway.id
       }
 
       send(
@@ -410,7 +412,8 @@ defmodule API.Gateway.ChannelTest do
           account: account,
           subject: subject,
           client: client,
-          resource: resource
+          resource: resource,
+          gateway: gateway
         )
 
       other_client = Fixtures.Clients.create_client(account: account, subject: subject)
@@ -426,7 +429,8 @@ defmodule API.Gateway.ChannelTest do
           account: account,
           subject: subject,
           client: other_client,
-          resource: resource
+          resource: resource,
+          gateway: gateway
         )
 
       other_flow2 =
@@ -434,7 +438,8 @@ defmodule API.Gateway.ChannelTest do
           account: account,
           subject: subject,
           client: client,
-          resource: other_resource
+          resource: other_resource,
+          gateway: gateway
         )
 
       # Build up flow cache
@@ -493,7 +498,8 @@ defmodule API.Gateway.ChannelTest do
         "id" => other_flow1.id,
         "client_id" => other_flow1.client_id,
         "resource_id" => other_flow1.resource_id,
-        "account_id" => other_flow1.account_id
+        "account_id" => other_flow1.account_id,
+        "gateway_id" => other_flow1.gateway_id
       }
 
       Events.Hooks.Flows.on_delete(data)
@@ -510,7 +516,8 @@ defmodule API.Gateway.ChannelTest do
         "id" => other_flow2.id,
         "client_id" => other_flow2.client_id,
         "resource_id" => other_flow2.resource_id,
-        "account_id" => other_flow2.account_id
+        "account_id" => other_flow2.account_id,
+        "gateway_id" => other_flow2.gateway_id
       }
 
       Events.Hooks.Flows.on_delete(data)
@@ -913,7 +920,8 @@ defmodule API.Gateway.ChannelTest do
           account: account,
           subject: subject,
           client: client,
-          resource: resource
+          resource: resource,
+          gateway: gateway
         )
 
       send(
@@ -935,7 +943,8 @@ defmodule API.Gateway.ChannelTest do
         "id" => flow.id,
         "client_id" => client.id,
         "resource_id" => resource.id,
-        "account_id" => account.id
+        "account_id" => account.id,
+        "gateway_id" => gateway.id
       }
 
       Events.Hooks.Flows.on_delete(data)
@@ -1080,7 +1089,8 @@ defmodule API.Gateway.ChannelTest do
           account: account,
           subject: subject,
           client: client,
-          resource: resource
+          resource: resource,
+          gateway: gateway
         )
 
       send(
@@ -1102,7 +1112,8 @@ defmodule API.Gateway.ChannelTest do
         "id" => flow.id,
         "client_id" => client.id,
         "resource_id" => resource.id,
-        "account_id" => account.id
+        "account_id" => account.id,
+        "gateway_id" => gateway.id
       }
 
       Events.Hooks.Flows.on_delete(data)

--- a/elixir/apps/domain/lib/domain/flows/flow/query.ex
+++ b/elixir/apps/domain/lib/domain/flows/flow/query.ex
@@ -26,10 +26,9 @@ defmodule Domain.Flows.Flow.Query do
     cutoff = DateTime.utc_now() |> DateTime.add(-14, :day)
 
     where(queryable, [flows: flows], flows.inserted_at > ^cutoff)
-    |> group_by([flows: flows], [flows.client_id, flows.resource_id])
     |> select(
       [flows: flows],
-      {{flows.client_id, flows.resource_id}, max(flows.inserted_at)}
+      {{flows.client_id, flows.resource_id}, {flows.id, flows.inserted_at}}
     )
   end
 

--- a/elixir/apps/domain/test/domain/flows_test.exs
+++ b/elixir/apps/domain/test/domain/flows_test.exs
@@ -420,7 +420,7 @@ defmodule Domain.FlowsTest do
   end
 
   describe "all_gateway_flows_for_cache!/1" do
-    test "returns the later of two client_id/resource_id pair", %{
+    test "returns all flows for client_id/resource_id pair", %{
       account: account,
       client: client,
       gateway: gateway,
@@ -456,32 +456,10 @@ defmodule Domain.FlowsTest do
 
       assert DateTime.compare(flow2.inserted_at, flow1.inserted_at) == :gt
 
-      assert [{{flow2.client_id, flow2.resource_id}, flow2.inserted_at}] ==
-               Flows.all_gateway_flows_for_cache!(gateway)
-    end
+      flows = all_gateway_flows_for_cache!(gateway)
 
-    test "returns flow when only one unique one exists", %{
-      account: account,
-      client: client,
-      gateway: gateway,
-      membership: membership,
-      resource: resource,
-      policy: policy,
-      subject: subject
-    } do
-      flow =
-        Fixtures.Flows.create_flow(
-          account: account,
-          subject: subject,
-          client: client,
-          actor_group_membership: membership,
-          policy: policy,
-          resource: resource,
-          gateway: gateway
-        )
-
-      assert [{{flow.client_id, flow.resource_id}, flow.inserted_at}] ==
-               Flows.all_gateway_flows_for_cache!(gateway)
+      assert {{flow1.client_id, flow1.resource_id}, {flow1.id, flow1.inserted_at}} in flows
+      assert {{flow2.client_id, flow2.resource_id}, {flow2.id, flow2.inserted_at}} in flows
     end
   end
 


### PR DESCRIPTION
Before:

- When a flow was deleted, we flapped the resource on the client, and sent `reject_access` naively for the flow's `{client_id, resource_id}` pair on the gateway. This resulted in lots of unneeded resource flappage on the client whenever bulk flow deletions happened.

After:

- When a flow is deleted, we check if this is an active flow for the client. If so, we flap the resource then in order to trigger generation of a new flow. If access was truly affected, that results in a loss of a resource, we will push `resource_deleted` for the update that triggered the flow deletion (for example the resource/policy removal). On the gateway, we only send `reject_access` if it was the last flow granting access for a particular `client/resource` tuple.


Why:

- While the access state is still correct in the previous implementation, we run the possibility of pushing way too many resource flaps to the client in an overly eager attempt to remove access the client may not have access to.

cc @thomaseizinger 

Related: https://firezonehq.slack.com/archives/C08FPHECLUF/p1753101115735179