### PR TITLE
fix(portal): gracefully account deletions in changelog

### DIFF
--- a/elixir/apps/domain/lib/domain/change_logs/replication_connection.ex
+++ b/elixir/apps/domain/lib/domain/change_logs/replication_connection.ex
@@ -17,6 +17,10 @@ defmodule Domain.ChangeLogs.ReplicationConnection do
   def on_write(state, _lsn, _op, "tokens", _old_data, %{"type" => "relay_group"}), do: state
 
   # Handle accounts specially
+  def on_write(state, lsn, op, "accounts", %{"id" => account_id} = old_data, data) do
+    buffer(state, lsn, op, "accounts", account_id, old_data, data)
+  end
+
   def on_write(state, lsn, op, "accounts", old_data, %{"id" => account_id} = data) do
     buffer(state, lsn, op, "accounts", account_id, old_data, data)
   end

--- a/elixir/apps/domain/test/domain/change_logs/replication_connection_test.exs
+++ b/elixir/apps/domain/test/domain/change_logs/replication_connection_test.exs
@@ -12,7 +12,7 @@ defmodule Domain.ChangeLogs.ReplicationConnectionTest do
   end
 
   describe "on_write/6 for inserts" do
-    test "ignores account inserts", %{account: account} do
+    test "handles account inserts", %{account: account} do
       initial_state = %{flush_buffer: %{}}
 
       result_state =
@@ -245,7 +245,7 @@ defmodule Domain.ChangeLogs.ReplicationConnectionTest do
   end
 
   describe "on_write/6 for deletes" do
-    test "ignores account deletes", %{account: account} do
+    test "handles account deletes", %{account: account} do
       initial_state = %{flush_buffer: %{}}
 
       result_state =
@@ -258,7 +258,19 @@ defmodule Domain.ChangeLogs.ReplicationConnectionTest do
           nil
         )
 
-      assert result_state == initial_state
+      assert result_state == %{
+               flush_buffer: %{
+                 12345 => %{
+                   data: nil,
+                   table: "accounts",
+                   vsn: 0,
+                   op: :delete,
+                   account_id: account.id,
+                   lsn: 12345,
+                   old_data: %{"id" => account.id, "name" => "deleted account"}
+                 }
+               }
+             }
     end
 
     test "adds delete operation to flush buffer for non-soft-deleted records", %{account: account} do


### PR DESCRIPTION
When an account is perma-deleted, we need to handle that with another function clause matching the WAL message coming into the change logs replication connection module.