### PR TITLE
fix(portal): inherit pid 1 in cmd

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -326,4 +326,4 @@ USER default
 # Tini would become an entrypoin script and would take care of zombie reaping no matter how you start the VM.
 ENTRYPOINT ["/sbin/tini", "--"]
 
-CMD bin/server
+CMD ["bin/server"]


### PR DESCRIPTION
Apparently using the shell form of this causes it not to inherit PID 1 from tini.