### PR TITLE
fix(elixir): handle nil external url config in dev mode

### DIFF
--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -294,7 +294,8 @@ if config_env() == :prod do
 
   # Sentry
 
-  with api_external_url <- env_var_to_config!(:api_external_url),
+  with api_external_url when not is_nil(api_external_url) <-
+         env_var_to_config!(:api_external_url),
        api_external_url_host <- URI.parse(api_external_url).host,
        environment_name when environment_name in [:staging, :production] <-
          (case api_external_url_host do


### PR DESCRIPTION
This is nil in local dev. Fixing this allows us to run the local dev in `:prod` mode to hit more codepaths.