### PR TITLE
refactor(windows): share src IP cache across UDP sockets

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1714,6 +1714,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2332,7 @@ dependencies = [
  "bufferpool",
  "bytes",
  "clap",
+ "dashmap",
  "dirs",
  "dns-types",
  "firezone-logging",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6870,7 +6870,6 @@ dependencies = [
  "ip-packet",
  "libc",
  "opentelemetry",
- "parking_lot",
  "quinn-udp",
  "socket2",
  "tokio",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -65,6 +65,7 @@ client-shared = { path = "client-shared" }
 connlib-model = { path = "connlib/model" }
 derive_more = "2.0.1"
 difference = "2.0.0"
+dashmap = "6.1.0"
 dirs = "6.0.0"
 divan = "0.1.21"
 dns-lookup = "2.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -63,9 +63,9 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 clap = "4.5.41"
 client-shared = { path = "client-shared" }
 connlib-model = { path = "connlib/model" }
+dashmap = "6.1.0"
 derive_more = "2.0.1"
 difference = "2.0.0"
-dashmap = "6.1.0"
 dirs = "6.0.0"
 divan = "0.1.21"
 dns-lookup = "2.0"

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -43,6 +43,7 @@ rtnetlink = { workspace = true }
 zbus = { workspace = true } # Can't use `zbus`'s `tokio` feature here, or it will break toast popups all the way over in `gui-client`.
 
 [target.'cfg(windows)'.dependencies]
+dashmap = { workspace = true }
 ipconfig = "0.3.2"
 itertools = { workspace = true }
 known-folders = { workspace = true }
@@ -53,7 +54,6 @@ windows-core = { workspace = true }
 windows-implement = { workspace = true }
 winreg = { workspace = true }
 wintun = "0.5.1"
-dashmap = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -53,6 +53,7 @@ windows-core = { workspace = true }
 windows-implement = { workspace = true }
 winreg = { workspace = true }
 wintun = "0.5.1"
+dashmap = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true

--- a/rust/bin-shared/src/linux.rs
+++ b/rust/bin-shared/src/linux.rs
@@ -2,7 +2,7 @@ use std::{io, net::SocketAddr};
 
 use crate::FIREZONE_MARK;
 use nix::sys::socket::{setsockopt, sockopt};
-use socket_factory::{TcpSocket, UdpSocket};
+use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 
 pub fn tcp_socket_factory(socket_addr: SocketAddr) -> io::Result<TcpSocket> {
     let socket = socket_factory::tcp(socket_addr)?;
@@ -10,8 +10,20 @@ pub fn tcp_socket_factory(socket_addr: SocketAddr) -> io::Result<TcpSocket> {
     Ok(socket)
 }
 
-pub fn udp_socket_factory(socket_addr: SocketAddr) -> io::Result<UdpSocket> {
-    let socket = socket_factory::udp(socket_addr)?;
-    setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK)?;
-    Ok(socket)
+pub struct UdpSocketFactory;
+
+impl SocketFactory<UdpSocket> for UdpSocketFactory {
+    fn bind(&self, local: SocketAddr) -> io::Result<UdpSocket> {
+        let socket = socket_factory::udp(local)?;
+        setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK)?;
+        Ok(socket)
+    }
+
+    fn reset(&self) {}
+}
+
+impl Default for UdpSocketFactory {
+    fn default() -> Self {
+        Self
+    }
 }

--- a/rust/bin-shared/src/linux.rs
+++ b/rust/bin-shared/src/linux.rs
@@ -10,7 +10,7 @@ pub fn tcp_socket_factory(socket_addr: SocketAddr) -> io::Result<TcpSocket> {
     Ok(socket)
 }
 
-pub struct UdpSocketFactory;
+pub struct UdpSocketFactory {}
 
 impl SocketFactory<UdpSocket> for UdpSocketFactory {
     fn bind(&self, local: SocketAddr) -> io::Result<UdpSocket> {
@@ -24,6 +24,6 @@ impl SocketFactory<UdpSocket> for UdpSocketFactory {
 
 impl Default for UdpSocketFactory {
     fn default() -> Self {
-        Self
+        Self {}
     }
 }

--- a/rust/bin-shared/src/linux.rs
+++ b/rust/bin-shared/src/linux.rs
@@ -10,6 +10,7 @@ pub fn tcp_socket_factory(socket_addr: SocketAddr) -> io::Result<TcpSocket> {
     Ok(socket)
 }
 
+#[derive(Default)]
 pub struct UdpSocketFactory {}
 
 impl SocketFactory<UdpSocket> for UdpSocketFactory {
@@ -20,10 +21,4 @@ impl SocketFactory<UdpSocket> for UdpSocketFactory {
     }
 
     fn reset(&self) {}
-}
-
-impl Default for UdpSocketFactory {
-    fn default() -> Self {
-        Self {}
-    }
 }

--- a/rust/bin-shared/src/linux.rs
+++ b/rust/bin-shared/src/linux.rs
@@ -4,13 +4,13 @@ use crate::FIREZONE_MARK;
 use nix::sys::socket::{setsockopt, sockopt};
 use socket_factory::{TcpSocket, UdpSocket};
 
-pub fn tcp_socket_factory(socket_addr: &SocketAddr) -> io::Result<TcpSocket> {
+pub fn tcp_socket_factory(socket_addr: SocketAddr) -> io::Result<TcpSocket> {
     let socket = socket_factory::tcp(socket_addr)?;
     setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK)?;
     Ok(socket)
 }
 
-pub fn udp_socket_factory(socket_addr: &SocketAddr) -> io::Result<UdpSocket> {
+pub fn udp_socket_factory(socket_addr: SocketAddr) -> io::Result<UdpSocket> {
     let socket = socket_factory::udp(socket_addr)?;
     setsockopt(&socket, sockopt::Mark, &FIREZONE_MARK)?;
     Ok(socket)

--- a/rust/bin-shared/src/macos.rs
+++ b/rust/bin-shared/src/macos.rs
@@ -3,7 +3,7 @@ use std::io;
 
 pub use socket_factory::tcp as tcp_socket_factory;
 
-pub struct UdpSocketFactory;
+pub struct UdpSocketFactory {}
 
 impl SocketFactory<UdpSocket> for UdpSocketFactory {
     fn bind(&self, local: SocketAddr) -> io::Result<UdpSocket> {
@@ -15,6 +15,6 @@ impl SocketFactory<UdpSocket> for UdpSocketFactory {
 
 impl Default for UdpSocketFactory {
     fn default() -> Self {
-        Self
+        Self {}
     }
 }

--- a/rust/bin-shared/src/macos.rs
+++ b/rust/bin-shared/src/macos.rs
@@ -1,20 +1,16 @@
 use socket_factory::{SocketFactory, UdpSocket};
 use std::io;
+use std::net::SocketAddr;
 
 pub use socket_factory::tcp as tcp_socket_factory;
 
+#[derive(Default)]
 pub struct UdpSocketFactory {}
 
 impl SocketFactory<UdpSocket> for UdpSocketFactory {
     fn bind(&self, local: SocketAddr) -> io::Result<UdpSocket> {
-        socket_factory::udp(socket_addr)
+        socket_factory::udp(local)
     }
 
     fn reset(&self) {}
-}
-
-impl Default for UdpSocketFactory {
-    fn default() -> Self {
-        Self {}
-    }
 }

--- a/rust/bin-shared/src/macos.rs
+++ b/rust/bin-shared/src/macos.rs
@@ -1,3 +1,6 @@
+use socket_factory::{SocketFactory, UdpSocket};
+use std::io;
+
 pub use socket_factory::tcp as tcp_socket_factory;
 
 pub struct UdpSocketFactory;

--- a/rust/bin-shared/src/macos.rs
+++ b/rust/bin-shared/src/macos.rs
@@ -1,2 +1,17 @@
 pub use socket_factory::tcp as tcp_socket_factory;
-pub use socket_factory::udp as udp_socket_factory;
+
+pub struct UdpSocketFactory;
+
+impl SocketFactory<UdpSocket> for UdpSocketFactory {
+    fn bind(&self, local: SocketAddr) -> io::Result<UdpSocket> {
+        socket_factory::udp(socket_addr)
+    }
+
+    fn reset(&self) {}
+}
+
+impl Default for UdpSocketFactory {
+    fn default() -> Self {
+        Self
+    }
+}

--- a/rust/bin-shared/src/windows.rs
+++ b/rust/bin-shared/src/windows.rs
@@ -113,7 +113,7 @@ pub fn tcp_socket_factory(addr: SocketAddr) -> io::Result<TcpSocket> {
 /// Determining this mapping requires several syscalls and therefore is too expensive to perform on every packet.
 /// To speed things up, we therefore implement a cache across all UDP sockets created by a given [`UdpSocketFactory`].
 ///
-/// This cache needs to be reset whenever we are roaming networks which happens in the [`reset`] function.
+/// This cache needs to be reset whenever we are roaming networks which happens in the [`SocketFactory::reset`] function.
 ///
 /// As most of the time we will only read from the cache, we use a [`DashMap`] (a concurrent hash-map).
 pub struct UdpSocketFactory {

--- a/rust/bin-shared/tests/no_packet_loops_tcp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_tcp.rs
@@ -29,7 +29,7 @@ async fn no_packet_loops_tcp() {
         .unwrap();
 
     let remote = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::from([1, 1, 1, 1]), 80));
-    let socket = tcp_socket_factory(&remote).unwrap();
+    let socket = tcp_socket_factory(remote).unwrap();
     let mut stream = socket.connect(remote).await.unwrap();
 
     // Send an HTTP request

--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -38,7 +38,7 @@ async fn no_packet_loops_udp() {
 
     // Make a socket.
     let socket =
-        udp_socket_factory(&SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))).unwrap();
+        udp_socket_factory(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))).unwrap();
 
     // Send a STUN request.
     socket

--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -2,9 +2,10 @@
 
 use bufferpool::BufferPool;
 use bytes::BytesMut;
-use firezone_bin_shared::{TunDeviceManager, platform::udp_socket_factory};
+use firezone_bin_shared::{TunDeviceManager, platform::UdpSocketFactory};
 use gat_lending_iterator::LendingIterator as _;
 use ip_network::Ipv4Network;
+use socket_factory::SocketFactory as _;
 use ip_packet::Ecn;
 use socket_factory::DatagramOut;
 use std::{
@@ -36,9 +37,12 @@ async fn no_packet_loops_udp() {
         .await
         .unwrap();
 
+    let factory = UdpSocketFactory::default();
+
     // Make a socket.
-    let socket =
-        udp_socket_factory(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))).unwrap();
+    let socket = factory
+        .bind(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)))
+        .unwrap();
 
     // Send a STUN request.
     socket

--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -5,9 +5,9 @@ use bytes::BytesMut;
 use firezone_bin_shared::{TunDeviceManager, platform::UdpSocketFactory};
 use gat_lending_iterator::LendingIterator as _;
 use ip_network::Ipv4Network;
-use socket_factory::SocketFactory as _;
 use ip_packet::Ecn;
 use socket_factory::DatagramOut;
+use socket_factory::SocketFactory as _;
 use std::{
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},
     time::Duration,

--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -113,7 +113,7 @@ async fn connect(
     let mut errors = Vec::with_capacity(addresses.len());
 
     for addr in addresses {
-        let Ok(socket) = socket_factory(&addr) else {
+        let Ok(socket) = socket_factory.bind(addr) else {
             continue;
         };
 

--- a/rust/connlib/socket-factory/Cargo.toml
+++ b/rust/connlib/socket-factory/Cargo.toml
@@ -12,7 +12,6 @@ derive_more = { workspace = true, features = ["debug"] }
 gat-lending-iterator = { workspace = true }
 ip-packet = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
-parking_lot = { workspace = true }
 quinn-udp = { workspace = true }
 socket2 = { workspace = true }
 tokio = { workspace = true, features = ["net"] }

--- a/rust/connlib/socket-factory/src/lib.rs
+++ b/rust/connlib/socket-factory/src/lib.rs
@@ -22,6 +22,7 @@ use tokio::io::Interest;
 
 pub trait SocketFactory<S>: Send + Sync + 'static {
     fn bind(&self, local: SocketAddr) -> io::Result<S>;
+    fn reset(&self);
 }
 
 pub const SEND_BUFFER_SIZE: usize = ONE_MB;
@@ -35,6 +36,8 @@ where
     fn bind(&self, local: SocketAddr) -> io::Result<S> {
         (self)(local)
     }
+
+    fn reset(&self) {}
 }
 
 pub fn tcp(addr: SocketAddr) -> io::Result<TcpSocket> {

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -321,6 +321,8 @@ impl Io {
     }
 
     pub fn reset(&mut self) {
+        self.tcp_socket_factory.reset();
+        self.udp_socket_factory.reset();
         self.sockets.rebind(self.udp_socket_factory.clone());
         self.gso_queue.clear();
         self.dns_queries = FuturesTupleSet::new(DNS_QUERY_TIMEOUT, 1000);

--- a/rust/connlib/tunnel/src/io/tcp_dns.rs
+++ b/rust/connlib/tunnel/src/io/tcp_dns.rs
@@ -10,7 +10,7 @@ pub async fn send(
 ) -> io::Result<dns_types::Response> {
     tracing::trace!(target: "wire::dns::recursive::tcp", %server, domain = %query.domain());
 
-    let tcp_socket = factory(&server)?; // TODO: Optimise this to reuse a TCP socket to the same resolver.
+    let tcp_socket = factory.bind(server)?; // TODO: Optimise this to reuse a TCP socket to the same resolver.
     let mut tcp_stream = tcp_socket.connect(server).await?;
 
     let query = query.into_bytes();

--- a/rust/connlib/tunnel/src/io/udp_dns.rs
+++ b/rust/connlib/tunnel/src/io/udp_dns.rs
@@ -21,7 +21,7 @@ pub async fn send(
     // To avoid fragmentation, IP and thus also UDP packets can only reliably sent with an MTU of <= 1500 on the public Internet.
     const BUF_SIZE: usize = 1500;
 
-    let udp_socket = factory(&bind_addr)?;
+    let udp_socket = factory.bind(bind_addr)?;
 
     let response = udp_socket
         .handshake::<BUF_SIZE>(server, &query.into_bytes())

--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -311,7 +311,7 @@ fn listen(
     let mut last_err = None;
 
     for addr in addresses {
-        match sf(addr) {
+        match sf.bind(*addr) {
             Ok(s) => return Ok(s),
             Err(e) => {
                 tracing::debug!(%addr, "Failed to listen on UDP socket: {e}");

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -4,7 +4,7 @@ use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use firezone_bin_shared::{
     TunDeviceManager, device_id, http_health_check,
-    platform::{tcp_socket_factory, udp_socket_factory},
+    platform::{tcp_socket_factory, UdpSocketFactory},
 };
 
 use firezone_telemetry::{
@@ -165,7 +165,7 @@ async fn try_main(cli: Cli, telemetry: &mut Telemetry) -> Result<()> {
 
     let mut tunnel = GatewayTunnel::new(
         Arc::new(tcp_socket_factory),
-        Arc::new(udp_socket_factory),
+        Arc::new(UdpSocketFactory::default()),
         nameservers,
     );
     let portal = PhoenixChannel::disconnected(

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -4,7 +4,7 @@ use backoff::ExponentialBackoffBuilder;
 use clap::Parser;
 use firezone_bin_shared::{
     TunDeviceManager, device_id, http_health_check,
-    platform::{tcp_socket_factory, UdpSocketFactory},
+    platform::{UdpSocketFactory, tcp_socket_factory},
 };
 
 use firezone_telemetry::{

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -10,7 +10,7 @@ use firezone_bin_shared::{
     DnsControlMethod, DnsController, TunDeviceManager,
     device_id::{self, DeviceId},
     device_info, known_dirs,
-    platform::{tcp_socket_factory, UdpSocketFactory},
+    platform::{UdpSocketFactory, tcp_socket_factory},
     signals,
 };
 use firezone_logging::{FilterReloadHandle, err_with_src};

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -10,7 +10,7 @@ use firezone_bin_shared::{
     DnsControlMethod, DnsController, TunDeviceManager,
     device_id::{self, DeviceId},
     device_info, known_dirs,
-    platform::{tcp_socket_factory, udp_socket_factory},
+    platform::{tcp_socket_factory, UdpSocketFactory},
     signals,
 };
 use firezone_logging::{FilterReloadHandle, err_with_src};
@@ -636,7 +636,7 @@ impl<'a> Handler<'a> {
         let dns = self.dns_controller.system_resolvers();
         let (connlib, event_stream) = client_shared::Session::connect(
             Arc::new(tcp_socket_factory),
-            Arc::new(udp_socket_factory),
+            Arc::new(UdpSocketFactory::default()),
             portal,
             tokio::runtime::Handle::current(),
         );

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use firezone_bin_shared::{
     DnsControlMethod, DnsController, TOKEN_ENV_KEY, TunDeviceManager, device_id, device_info,
     new_dns_notifier, new_network_notifier,
-    platform::{tcp_socket_factory, UdpSocketFactory},
+    platform::{UdpSocketFactory, tcp_socket_factory},
     signals,
 };
 use firezone_telemetry::{Telemetry, analytics, otel};

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use firezone_bin_shared::{
     DnsControlMethod, DnsController, TOKEN_ENV_KEY, TunDeviceManager, device_id, device_info,
     new_dns_notifier, new_network_notifier,
-    platform::{tcp_socket_factory, udp_socket_factory},
+    platform::{tcp_socket_factory, UdpSocketFactory},
     signals,
 };
 use firezone_telemetry::{Telemetry, analytics, otel};
@@ -265,7 +265,7 @@ fn main() -> Result<()> {
         )?;
         let (session, mut event_stream) = client_shared::Session::connect(
             Arc::new(tcp_socket_factory),
-            Arc::new(udp_socket_factory),
+            Arc::new(UdpSocketFactory::default()),
             portal,
             rt.handle().clone(),
         );


### PR DESCRIPTION
When looking through customer logs, we see a lot of "Resolved best route outside of tunnel" messages. Those get logged every time we need to rerun our re-implementation of Windows' weighting algorithm as to which source interface / IP a packet should be sent from.

Currently, this gets cached in every socket instance so for the peer-to-peer socket, this is only computed once per destination IP. However, for DNS queries, we make a new socket for every query. Using a new source port DNS queries is recommended to avoid fingerprinting of DNS queries. Using a new socket also means that we need to re-run this algorithm every time we make a DNS query which is why we see this log so often.

To fix this, we need to share this cache across all UDP sockets. Cache invalidation is one of the hardest problems in computer science and this instance is no different. This cache needs to be reset every time we roam as that changes the weighting of which source interface to use.

To achieve this, we extend the `SocketFactory` trait with a `reset` method. This method is called whenever we roam and can then reset a shared cache inside the `UdpSocketFactory`. The "source IP resolver" function that is passed to the UDP socket now simply accesses this shared cache and inserts a new entry when it needs to resolve the IP.

As an added benefit, this may speed up DNS queries on Windows a bit (although I haven't benchmarked it). It should certainly drastically reduce the amount of syscalls we make on Windows.