### PR TITLE
fix(connlib): update the current socket when in idle mode

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2086,7 +2086,9 @@ where
                             Some(peer_socket)
                         }
                         ConnectionState::Idle { peer_socket } => {
-                            self.state = ConnectionState::Idle { peer_socket };
+                            self.state = ConnectionState::Idle {
+                                peer_socket: remote_socket,
+                            };
 
                             Some(peer_socket)
                         }


### PR DESCRIPTION
In case we received a newly nominated socket from `str0m` whilst our connection was in idle mode, we mistakenly did not apply that and kept using the old one. ICE would still be functioning in this case because `str0m` would have updated its internal state but we would be sending packets into Nirvana.

I don't think that this is likely to be hit in production though as it would be quite unusual to receive a new nomination whilst the connection was completely idle.