### PR TITLE
chore(rust): bump boringtun

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.1"
-source = "git+https://github.com/firezone/boringtun?branch=master#5cb8ec28749fe6a81a33471cb77565376bcf1d67"
+source = "git+https://github.com/firezone/boringtun?branch=master#a99332c529ce7546e953de5b6618e4e8de7170f3"
 dependencies = [
  "aead",
  "base64 0.22.1",


### PR DESCRIPTION
Bumping the version to include https://github.com/firezone/boringtun/pull/105.