### PR TITLE
fix(connlib): clear join requests on reconnect

### DIFF
--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -517,6 +517,11 @@ where
 
                             continue;
                         }
+                    } else if !self.pending_messages.is_empty() {
+                        tracing::trace!(
+                            requests = ?self.pending_join_requests,
+                            "Unable to send message because we are waiting for JOIN requests to complete"
+                        );
                     }
                 }
                 Poll::Ready(Err(e)) => {

--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -398,6 +398,11 @@ where
                         self.heartbeat.reset();
                         self.state = State::Connected(stream);
 
+                        // Clear local state.
+                        // Joins are only valid whilst we are connected, so we need to discard any previous ones on reconnect.
+                        self.pending_joins.clear();
+                        self.pending_join_requests.clear();
+
                         let (host, _) = self.url_prototype.expose_secret().host_and_port();
 
                         tracing::info!(%host, "Connected to portal");

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -21,6 +21,11 @@ export default function Android() {
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9985">
+          Fixes an issue where control plane messages could be stuck forever on
+          flaky connections, requiring signing out and signin back in to
+          recover.
+        </ChangeItem>
         <ChangeItem pull="9725">
           Fixes an issue where Firezone failed to sign-in on systems with
           non-ASCII characters in their kernel build name.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,11 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9985">
+          Fixes an issue where control plane messages could be stuck forever on
+          flaky connections, requiring signing out and signin back in to
+          recover.
+        </ChangeItem>
         <ChangeItem pull="9891">
           Fixes an issue where connections would sometimes take up to 90s to
           establish.

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -11,6 +11,11 @@ export default function GUI({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9985">
+          Fixes an issue where control plane messages could be stuck forever on
+          flaky connections, requiring signing out and signin back in to
+          recover.
+        </ChangeItem>
         <ChangeItem pull="9891">
           Fixes an issue where connections would sometimes take up to 90s to
           establish.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -10,6 +10,11 @@ export default function Headless({ os }: { os: OS }) {
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9985">
+          Fixes an issue where control plane messages could be stuck forever on
+          flaky connections, requiring signing out and signin back in to
+          recover.
+        </ChangeItem>
         <ChangeItem pull="9891">
           Fixes an issue where connections would sometimes take up to 90s to
           establish.


### PR DESCRIPTION
Room join requests on the portal are only valid whilst we have a WebSocket connection. To make sure the portal processes all our requests correctly, we need to hold all other messages back while we are waiting to join the room.

If the connection flaps while we are waiting to join a room, we may have a lingering join request that never gets fulfilled and thus blocks the sending of messages forever.