### PR TITLE
refactor(connlib): use a lock-free queue for the buffer pool

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -998,7 +998,7 @@ name = "bufferpool"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "lockfree-object-pool",
+ "crossbeam-queue",
  "opentelemetry",
  "opentelemetry_sdk",
  "tokio",
@@ -1594,6 +1594,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4179,12 +4188,6 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
-
-[[package]]
-name = "lockfree-object-pool"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -63,6 +63,7 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 clap = "4.5.41"
 client-shared = { path = "client-shared" }
 connlib-model = { path = "connlib/model" }
+crossbeam-queue = "0.3.12"
 dashmap = "6.1.0"
 derive_more = "2.0.1"
 difference = "2.0.0"
@@ -101,7 +102,6 @@ l3-tcp = { path = "connlib/l3-tcp" }
 l4-tcp-dns-server = { path = "connlib/l4-tcp-dns-server" }
 l4-udp-dns-server = { path = "connlib/l4-udp-dns-server" }
 libc = "0.2.174"
-lockfree-object-pool = "0.1.6"
 log = "0.4"
 lru = "0.12.5"
 mio = "1.0.4"

--- a/rust/connlib/bufferpool/Cargo.toml
+++ b/rust/connlib/bufferpool/Cargo.toml
@@ -9,7 +9,7 @@ path = "lib.rs"
 
 [dependencies]
 bytes = { workspace = true }
-lockfree-object-pool = { workspace = true }
+crossbeam-queue = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 tracing = { workspace = true }
 


### PR DESCRIPTION
We use several buffer pools across `connlib` that are all backed by the same buffer-pool library. Within that library, we currently use another object-pool library to provide the actual pooling functionality.

Benchmarking has shown that spend quite a bit of time (a few % of total CPU time), fighting for the lock to either add or remote a buffer from the pool. This is unnecessary. By using a queue, we can remove buffers from the front and add buffers at the back, both of which can be implemented in a lock-free way such that they don't contend.

Using the well-known `crossbeam-queue` library, we have such a queue directly available.

I wasn't able to directly measure a performance gain in terms of throughput. What we can measure though, is how much time we spend dealing with our buffer pool vs everything else. If we compare the `perf` outputs that were recorded during an `iperf` run each, we can see that we spend about 60% less time dealing with the buffer pool than we did before.

|Before|After|
|---|---|
|<img width="1982" height="553" alt="Screenshot From 2025-07-24 20-27-50" src="https://github.com/user-attachments/assets/1698f28b-5821-456f-95fa-d6f85d901920" />|<img width="1982" height="553" alt="Screenshot From 2025-07-24 20-27-53" src="https://github.com/user-attachments/assets/4f26a2d1-03e3-4c0d-84da-82c53b9761dd" />|

The number in the thousands on the left is how often the respective function was the currently executing function during the profiling run.

Resolves: #9972