### PR TITLE
fix(apple): use all found system resolvers

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -463,12 +463,12 @@ extension Adapter: CallbackHandlerDelegate {
     for stringAddress in resolvers {
       if let ipv4Address = IPv4Address(stringAddress) {
         parsedResolvers.append("\(ipv4Address)")
-        break
+        continue
       }
 
       if let ipv6Address = IPv6Address(stringAddress) {
         parsedResolvers.append("\(ipv6Address)")
-        break
+        continue
       }
 
       Log.warning("IP address \(stringAddress) did not parse as either IPv4 or IPv6")

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="9991">
+          Fixes an issue where only the first system DNS resolver was used to
+          forward queries instead of all found ones.
+        </ChangeItem>
         <ChangeItem pull="9891">
           Fixes an issue where connections would sometimes take up to 90s to
           establish.


### PR DESCRIPTION
When validating the found system resolvers on macOS and iOS, we would stop after validating the first found resolver (usually IPv4) because `break` was used instead of `continue`.

Fixes #9914 