### PR TITLE
fix(apple): increase sensitivity of network reset

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -68,9 +68,6 @@ class Adapter {
     private let systemConfigurationResolvers = SystemConfigurationResolvers()
   #endif
 
-  /// Track our last fetched DNS resolvers to know whether to tell connlib they've updated
-  private var lastFetchedResolvers: [String] = []
-
   /// Remembers the last _relevant_ path update.
   /// A path update is considered relevant if certain properties change that require us to reset connlib's
   /// network state.
@@ -142,8 +139,7 @@ class Adapter {
         let resolvers = getSystemDefaultResolvers(
           interfaceName: path.availableInterfaces.first?.name)
 
-        if self.lastFetchedResolvers != resolvers,
-          let encoded = try? JSONEncoder().encode(resolvers),
+        if let encoded = try? JSONEncoder().encode(resolvers),
           let jsonResolvers = String(data: encoded, encoding: .utf8)?.intoRustString()
         {
 
@@ -154,9 +150,6 @@ class Adapter {
             let msg = (error as? RustString)?.toString() ?? "Unknown error"
             Log.error(AdapterError.setDnsError(msg))
           }
-
-          // Update our state tracker
-          self.lastFetchedResolvers = resolvers
         }
       }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -71,10 +71,8 @@ class Adapter {
   /// Track our last fetched DNS resolvers to know whether to tell connlib they've updated
   private var lastFetchedResolvers: [String] = []
 
-  /// Remembers the last _relevant_ path update.
-  /// A path update is considered relevant if certain properties change that require us to reset connlib's
-  /// network state.
-  private var lastRelevantPath: Network.NWPath?
+  /// Remembers the last path update to determine when connectivity changes
+  private var lastPath: Network.NWPath?
 
   /// Private queue used to ensure consistent ordering among path update and connlib callbacks
   /// This is the primary async primitive used in this class.
@@ -132,38 +130,34 @@ class Adapter {
       // out of a different interface even when 0.0.0.0 is used as the source.
       // If our primary interface changes, we can be certain the old socket shouldn't be
       // used anymore.
-      if lastRelevantPath?.connectivityDifferentFrom(path: path) != false {
-        lastRelevantPath = path
 
-        session?.reset("primary network path changed")
-      }
+      session?.reset("network path changed")
 
-      if shouldFetchSystemResolvers(path: path) {
-        let resolvers = getSystemDefaultResolvers(
-          interfaceName: path.availableInterfaces.first?.name)
+      let resolvers = getSystemDefaultResolvers(interfaceName: path.availableInterfaces.first?.name)
 
-        if self.lastFetchedResolvers != resolvers,
-          let encoded = try? JSONEncoder().encode(resolvers),
-          let jsonResolvers = String(data: encoded, encoding: .utf8)?.intoRustString()
-        {
-
-          do {
-            try session?.setDns(jsonResolvers)
-          } catch let error {
-            // `toString` needed to deep copy the string and avoid a possible dangling pointer
-            let msg = (error as? RustString)?.toString() ?? "Unknown error"
-            Log.error(AdapterError.setDnsError(msg))
-          }
-
-          // Update our state tracker
-          self.lastFetchedResolvers = resolvers
+      if self.lastFetchedResolvers != resolvers,
+        let encoded = try? JSONEncoder().encode(resolvers),
+        let jsonResolvers = String(data: encoded, encoding: .utf8)?.intoRustString()
+      {
+        do {
+          try session?.setDns(jsonResolvers)
+        } catch let error {
+          // `toString` needed to deep copy the string and avoid a possible dangling pointer
+          let msg = (error as? RustString)?.toString() ?? "Unknown error"
+          Log.error(AdapterError.setDnsError(msg))
         }
+
+        // Update our state tracker
+        self.lastFetchedResolvers = resolvers
       }
 
       if self.packetTunnelProvider?.reasserting == true {
         self.packetTunnelProvider?.reasserting = false
       }
     }
+
+    // Update our path tracker
+    self.lastPath = path
   }
 
   /// Currently disabled resources
@@ -520,13 +514,3 @@ extension Adapter: CallbackHandlerDelegate {
     }
   }
 #endif
-
-extension Network.NWPath {
-  func connectivityDifferentFrom(path: Network.NWPath) -> Bool {
-    // We define a path as different from another if the following properties change
-    return path.supportsIPv4 != self.supportsIPv4 || path.supportsIPv6 != self.supportsIPv6
-      || path.availableInterfaces.first?.name != self.availableInterfaces.first?.name
-      // Apple provides no documentation on whether order is meaningful, so assume it isn't.
-      || Set(self.gateways) != Set(path.gateways)
-  }
-}

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -30,6 +30,10 @@ export default function Apple() {
           flaky connections, requiring signing out and signin back in to
           recover.
         </ChangeItem>
+        <ChangeItem pull="9993">
+          Fixes an issue where DNS resolvers could be lost upon waking from
+          sleep, leading to broken Internet connectivity.
+        </ChangeItem>
         <ChangeItem pull="9891">
           Fixes an issue where connections would sometimes take up to 90s to
           establish.


### PR DESCRIPTION
On Apple platforms, we tried to be clever about filtering path updates from the network connectivity change monitor, because there can be a flurry of them upon waking from sleep or network roaming.

However, because of this, we had a bug that could occur in certain situations (such as waking from sleep) where we could effectively "land" on an empty DNS resolver list. This could happen if:


1. We receive a path update handler that meaningfully changes connectivity, but its `supportsDNS` property is `false`. This means it hasn't received any resolvers from DHCP yet. We would then setDns with an empty resolver list.
2. We then receive a path update handler with the _only_ change being `supportDNS=true`. Since we didn't count this change as a meaningful path change, we skipped the `setDns` call, and connlib would be stuck without DNS resolution.

To fix the above, we stop trying to be clever about connectivity changes, and just use `oldPath != path`. That will increase reset a bit, but it will now handle other edge cases such as an IP address changing on the primary interface, any other interfaces change, and the like.

Fixes #9866 