### PR TITLE
fix(gateway): temporarily make `expires_at` optional

### DIFF
--- a/rust/connlib/tunnel/src/messages/gateway.rs
+++ b/rust/connlib/tunnel/src/messages/gateway.rs
@@ -176,8 +176,9 @@ pub struct AllowAccess {
 pub struct Authorization {
     pub client_id: ClientId,
     pub resource_id: ResourceId,
-    #[serde(with = "ts_seconds")]
-    pub expires_at: DateTime<Utc>,
+    #[serde(with = "ts_seconds_option")]
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>, // TODO: Remove `Option` once API implements this field
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -421,6 +421,10 @@ impl Eventloop {
                     expires_at,
                 } in authorizations
                 {
+                    let Some(expires_at) = expires_at else {
+                        continue;
+                    };
+
                     if let Err(e) = self.tunnel.state_mut().update_access_authorization_expiry(
                         client_id,
                         resource_id,


### PR DESCRIPTION
In order to unblock the release of the Gateway, we make this field optional. We need something like #9974 to properly fix this but it is unclear when that will be merged and deployed. It is not pressing to handle the updated expiry right now so we can just make it optional.