### PR TITLE
fix(connlib): wait for sockets to be closed before rebinding

### DIFF
--- a/rust/connlib/tunnel/src/sockets.rs
+++ b/rust/connlib/tunnel/src/sockets.rs
@@ -318,7 +318,7 @@ impl ThreadedUdpSocket {
     }
 
     fn channels_mut(&mut self) -> Result<&mut Channels> {
-        Ok(self.channels.as_mut().context("Missing channels")?)
+        self.channels.as_mut().context("Missing channels")
     }
 }
 


### PR DESCRIPTION
Our `ThreadedUdpSocket` uses a background thread for the actual socket operation. It merely represents a handle to send and receive from these sockets but not the socket itself. Dropping the handle will shutdown the background thread but that is an asynchronous operation.

In order to be sure that we can rebind the same port, we need to wait for the background thread to stop.

We thus add a `Drop` implementation for the `ThreadedUdpSocket` that waits for its background thread to disappear before it continues.

Resolves: #9992