### PR TITLE
fix(apple): reset network on path status changes

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -123,6 +123,8 @@ class Adapter {
         // Tell the UI we're not connected
         self.packetTunnelProvider?.reasserting = true
       }
+
+      lastRelevantPath = nil
     } else {
       if self.packetTunnelProvider?.reasserting == true {
         self.packetTunnelProvider?.reasserting = false
@@ -521,6 +523,7 @@ extension Network.NWPath {
     // We define a path as different from another if the following properties change
     return path.supportsIPv4 != self.supportsIPv4 || path.supportsIPv6 != self.supportsIPv6
       || path.supportsDNS != self.supportsDNS
+      || path.status != self.status
       || path.availableInterfaces.first?.name != self.availableInterfaces.first?.name
       // Apple provides no documentation on whether order is meaningful, so assume it isn't.
       || Set(self.gateways) != Set(path.gateways)


### PR DESCRIPTION
Fixes an edge case where a WiFi interface could go offline, then come back online with the same connectivity, preventing the path update handler from reset connlib state.

This would cause an issue especially if the WiFi was disabled for more than 30 seconds / 2 minutes.