### PR TITLE
refactor(connlib): only enable `wire` logs in debug builds

### DIFF
--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -45,10 +45,6 @@ impl Device {
             if let Some(query) = parse_dns_query(packet) {
                 tracing::trace!(target: "wire::dns::qry", ?query);
             }
-
-            if packet.is_fz_p2p_control() {
-                tracing::warn!("Packet matches heuristics of FZ-internal p2p control protocol");
-            }
         }
 
         Poll::Ready(n)

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -39,11 +39,17 @@ impl Device {
 
         let n = std::task::ready!(tun.poll_recv_many(cx, buf, max));
 
-        for packet in &buf[..n] {
-            tracing::trace!(target: "wire::dev::recv", ?packet);
+        #[cfg(debug_assertions)]
+        {
+            // Having these trace statements is quite expensive, even if they are not turned on.
+            // We are talking 5+ % of CPU time here just for checking whether or not this should get logged.
 
-            if let Some(query) = parse_dns_query(packet) {
-                tracing::trace!(target: "wire::dns::qry", ?query);
+            for packet in &buf[..n] {
+                tracing::trace!(target: "wire::dev::recv", ?packet);
+
+                if let Some(query) = parse_dns_query(packet) {
+                    tracing::trace!(target: "wire::dns::qry", ?query);
+                }
             }
         }
 
@@ -60,11 +66,14 @@ impl Device {
     }
 
     pub fn send(&mut self, packet: IpPacket) -> io::Result<()> {
-        if let Some(response) = parse_dns_response(&packet) {
-            tracing::trace!(target: "wire::dns::res", ?response);
-        }
+        #[cfg(debug_assertions)]
+        {
+            if let Some(response) = parse_dns_response(&packet) {
+                tracing::trace!(target: "wire::dns::res", ?response);
+            }
 
-        tracing::trace!(target: "wire::dev::send", ?packet);
+            tracing::trace!(target: "wire::dev::send", ?packet);
+        }
 
         debug_assert!(
             !packet.is_fz_p2p_control(),
@@ -89,6 +98,7 @@ fn io_error_not_initialized() -> io::Error {
     io::Error::new(io::ErrorKind::NotConnected, "device is not initialized yet")
 }
 
+#[cfg(debug_assertions)]
 fn parse_dns_query(packet: &IpPacket) -> Option<dns_types::Query> {
     let udp = packet.as_udp()?;
     if udp.destination_port() != crate::dns::DNS_PORT {
@@ -98,6 +108,7 @@ fn parse_dns_query(packet: &IpPacket) -> Option<dns_types::Query> {
     dns_types::Query::parse(udp.payload()).ok()
 }
 
+#[cfg(debug_assertions)]
 fn parse_dns_response(packet: &IpPacket) -> Option<dns_types::Response> {
     let udp = packet.as_udp()?;
     if udp.source_port() != crate::dns::DNS_PORT {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -174,6 +174,10 @@ impl ClientTunnel {
                     let now = Instant::now();
 
                     for packet in packets {
+                        if packet.is_fz_p2p_control() {
+                            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
+                        }
+
                         let ecn = packet.ecn();
 
                         let Some(transmit) = self.role_state.handle_tun_input(packet, now) else {
@@ -306,6 +310,10 @@ impl GatewayTunnel {
                     let now = Instant::now();
 
                     for packet in packets {
+                        if packet.is_fz_p2p_control() {
+                            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
+                        }
+
                         let ecn = packet.ecn();
 
                         let Some(transmit) = self.role_state.handle_tun_input(packet, now)? else {


### PR DESCRIPTION
As profiling shows, even if the log target isn't enabled, simply checking whether or not it is enabled is a significant performance hit. By guarding these behind `debug_assertions`, I was able to almost achieve 3.75 Gbits/s locally (when rebased onto #9998). Obviously, this doesn't quite translate into real-world improvements but it is nonetheless a welcome improvement.

```
Connecting to host 172.20.0.110, port 5201
[  5] local 100.93.174.92 port 34678 connected to 172.20.0.110 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec   401 MBytes  3.37 Gbits/sec   14    644 KBytes       
[  5]   1.00-2.00   sec   448 MBytes  3.76 Gbits/sec    3    976 KBytes       
[  5]   2.00-3.00   sec   453 MBytes  3.80 Gbits/sec   43    979 KBytes       
[  5]   3.00-4.00   sec   449 MBytes  3.77 Gbits/sec   21    911 KBytes       
[  5]   4.00-5.00   sec   452 MBytes  3.79 Gbits/sec    4   1.15 MBytes       
[  5]   5.00-6.00   sec   451 MBytes  3.78 Gbits/sec   81   1.01 MBytes       
[  5]   6.00-7.00   sec   445 MBytes  3.73 Gbits/sec   39    705 KBytes       
[  5]   7.00-8.00   sec   436 MBytes  3.66 Gbits/sec    3   1016 KBytes       
[  5]   8.00-9.00   sec   460 MBytes  3.85 Gbits/sec    1    956 KBytes       
[  5]   9.00-10.00  sec   453 MBytes  3.80 Gbits/sec    0   1.19 MBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  4.34 GBytes  3.73 Gbits/sec  209             sender
[  5]   0.00-10.00  sec  4.34 GBytes  3.73 Gbits/sec                  receiver
```

I didn't want to remove the `wire` logs entirely because they are quite useful for debugging. However, they are also exactly this: A debugging tool. In a production build, we are very unlikely to turn these on which makes `debug_assertions` a good tool for keeping these around without interfering with performance.