### PR TITLE
fix(portal): groom resource list and flows periodically

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -20,6 +20,11 @@ defmodule API.Client.Channel do
   require Logger
   require OpenTelemetry.Tracer
 
+  # For time-based policy conditions, we need to determine whether we still have access
+  # If not, we need to send resource_deleted so that if it's added back later, the client's
+  # connlib state will be cleaned up so it can request a new connection.
+  @reassess_allowed_resources_every :timer.minutes(1)
+
   @gateway_compatibility [
     # We introduced new websocket protocol and the clients of version 1.4+
     # are only compatible with gateways of version 1.4+

--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -1265,7 +1265,7 @@ defmodule API.Client.Channel do
   end
 
   defp authorized_resources(socket) do
-    OpenTelemetry.Tracer.with_span "client.compute_authorized_resource_ids",
+    OpenTelemetry.Tracer.with_span "client.authorized_resources",
       attributes: %{
         account_id: socket.assigns.client.account_id
       } do

--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -75,7 +75,6 @@ defmodule API.Client.Channel do
       @recompute_authorized_resources_every
     )
 
-    Process
     # Initialize the cache.
     socket =
       socket

--- a/elixir/apps/domain/lib/domain/application.ex
+++ b/elixir/apps/domain/lib/domain/application.ex
@@ -75,7 +75,6 @@ defmodule Domain.Application do
     end
   end
 
-  # TODO: Configure Oban workers to only run on domain nodes
   defp oban do
     [{Oban, Application.fetch_env!(:domain, Oban)}]
   end

--- a/elixir/apps/domain/lib/domain/flows.ex
+++ b/elixir/apps/domain/lib/domain/flows.ex
@@ -162,6 +162,12 @@ defmodule Domain.Flows do
     end
   end
 
+  def delete_expired_flows do
+    Flow.Query.all()
+    |> Flow.Query.expired()
+    |> Repo.delete_all()
+  end
+
   def delete_flows_for(%Domain.Accounts.Account{} = account) do
     Flow.Query.all()
     |> Flow.Query.by_account_id(account.id)

--- a/elixir/apps/domain/lib/domain/flows/flow/query.ex
+++ b/elixir/apps/domain/lib/domain/flows/flow/query.ex
@@ -5,6 +5,11 @@ defmodule Domain.Flows.Flow.Query do
     from(flows in Domain.Flows.Flow, as: :flows)
   end
 
+  def expired(queryable) do
+    now = DateTime.utc_now()
+    where(queryable, [flows: flows], flows.expires_at <= ^now)
+  end
+
   def not_expired(queryable) do
     now = DateTime.utc_now()
     where(queryable, [flows: flows], flows.expires_at > ^now)

--- a/elixir/apps/domain/lib/domain/flows/jobs/delete_expired_flows.ex
+++ b/elixir/apps/domain/lib/domain/flows/jobs/delete_expired_flows.ex
@@ -4,11 +4,16 @@ defmodule Domain.Flows.Jobs.DeleteExpiredFlows do
   """
   use Oban.Worker, queue: :default
 
+  require Logger
+
   alias Domain.Flows
 
   @impl Oban.Worker
   def perform(_args) do
-    dbg(Flows.delete_expired_flows())
+    {count, nil} = Flows.delete_expired_flows()
+
+    Logger.info("Deleted #{count} expired flows")
+
     :ok
   end
 end

--- a/elixir/apps/domain/lib/domain/flows/jobs/delete_expired_flows.ex
+++ b/elixir/apps/domain/lib/domain/flows/jobs/delete_expired_flows.ex
@@ -1,0 +1,14 @@
+defmodule Domain.Flows.Jobs.DeleteExpiredFlows do
+  @moduledoc """
+  Job to delete expired flows.
+  """
+  use Oban.Worker, queue: :default
+
+  alias Domain.Flows
+
+  @impl Oban.Worker
+  def perform(_args) do
+    dbg(Flows.delete_expired_flows())
+    :ok
+  end
+end

--- a/elixir/apps/domain/priv/repo/manual_migrations/20250725031509_reindex_flows_on_expires_at.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250725031509_reindex_flows_on_expires_at.exs
@@ -1,0 +1,13 @@
+defmodule Domain.Repo.Migrations.IndexFlowsOnExpiresAt do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def change do
+    drop_if_exists(index(:flows, [:account_id, :expires_at, :gateway_id], concurrently: true))
+
+    create_if_not_exists(
+      index(:flows, [:expires_at, :account_id, :gateway_id], concurrently: true)
+    )
+  end
+end

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -203,8 +203,25 @@ config :domain, outbound_email_adapter_configured?: false
 config :domain, web_external_url: "http://localhost:13000"
 
 config :domain, Oban,
-  engine: Oban.Engines.Basic,
+  plugins: [
+    # Keep the last 90 days of completed, cancelled, and discarded jobs
+    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 90},
+
+    # Rescue jobs that may have failed due to transient errors like deploys
+    # or network issues. It's not guaranteed that the job won't be executed
+    # twice, so for now we disable it since all of our Oban jobs can be retried
+    # without loss.
+    # {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}
+
+    # Periodic jobs
+    {Oban.Plugins.Cron,
+     crontab: [
+       # Delete expired flows every minute
+       {"* * * * *", Domain.Flows.Jobs.DeleteExpiredFlows}
+     ]}
+  ],
   queues: [default: 10],
+  engine: Oban.Engines.Basic,
   repo: Domain.Repo
 
 ###############################

--- a/elixir/config/prod.exs
+++ b/elixir/config/prod.exs
@@ -8,18 +8,6 @@ config :domain, Domain.Repo,
   pool_size: 10,
   show_sensitive_data_on_connection_error: false
 
-config :domain, Oban,
-  plugins: [
-    # Keep the last 90 days of completed, cancelled, and discarded jobs
-    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 90}
-
-    # Rescue jobs that may have failed due to transient errors like deploys
-    # or network issues. It's not guaranteed that the job won't be executed
-    # twice, so for now we disable it since all of our Oban jobs can be retried
-    # without loss.
-    # {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}
-  ]
-
 ###############################
 ##### Web #####################
 ###############################

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -148,6 +148,14 @@ if config_env() == :prod do
       env_var_to_config!(:background_jobs_enabled) and
         Enum.member?(env_var_to_config!(:auth_provider_adapters), :mock)
 
+  config :domain, Oban,
+    queues:
+      if(env_var_to_config!(:background_jobs_enabled),
+        do: [default: 10],
+        # Using an empty queue prevents jobs from running on other nodes
+        else: []
+      )
+
   if web_external_url = env_var_to_config!(:web_external_url) do
     %{
       scheme: web_external_url_scheme,


### PR DESCRIPTION
Time-based policy conditions are tricky. When they authorize a flow, we correctly tell the Gateway to remove access when the time window expires.

However, we do nothing on the client to reset the connectivity state. This means that whenever the window of time of access was re-entered, the client would essentially never be able to connect to it again until the resource was toggled.

To fix this, we add a 1-minute check in the client channel that re-checks allowed resources, and updates the client state with the difference. This means that policies that have time-based conditions are only accurate to the minute, but this is how they're presented anyhow.


For good measure, we also add a periodic job that runs every minute to delete expired Flows. This will propagate to the Gateway where, if the access for a particular client-resource is determined to be actually gone, will receive `reject_access`.

Zooming out a bit, this PR furthers the theme that:

- Client channels react to underlying resource / policy / membership changes directly, while
- Gateway channels react primarily to flows being deleted, or the downstream effects of a prior client authorization