### PR TITLE
fix(portal): maintain identity preload on client

### DIFF
--- a/elixir/apps/api/lib/api/client/channel.ex
+++ b/elixir/apps/api/lib/api/client/channel.ex
@@ -267,7 +267,8 @@ defmodule API.Client.Channel do
       Map.take(socket.assigns.resources, MapSet.to_list(socket.assigns.authorized_resource_ids))
       |> Map.values()
 
-    # 2. Update our state
+    # 2. Update our state - maintain preloaded identity
+    client = %{client | identity: socket.assigns.client.identity}
     socket = assign(socket, client: client)
 
     # 3. If client's verification status changed, send diff of resources


### PR DESCRIPTION
When updating a client, we need to maintain the preloaded `identity` association to use for the IdP policy condition.