### PR TITLE
fix(apple): use documents for tempfile

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -106,6 +106,7 @@ import System
     enum ExportError: Error {
       case invalidSourceDirectory
       case invalidFilePath
+      case documentDirectoryNotAvailable
     }
 
     static func export(to archiveURL: URL) async throws {
@@ -138,12 +139,16 @@ import System
       )
     }
 
-    // iOS doesn't let us save to any ol' place, we must write to our temporary
-    // directory and then the OS will move it into place when the ShareSheet
-    // is dismissed.
-    static func tempFile() -> URL {
+    static func tempFile() throws -> URL {
       let fileName = "firezone_logs_\(now()).zip"
-      return fileManager.temporaryDirectory.appendingPathComponent(fileName)
+
+      // The share sheet can read from the documents directory, but not the temp directory, so use the former.
+      guard let documentsPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+      else {
+        throw ExportError.documentDirectoryNotAvailable
+      }
+
+      return documentsPath.appendingPathComponent(fileName)
     }
   }
 #endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -515,7 +515,7 @@ public struct SettingsView: View {
                 action: {
                   self.isExportingLogs = true
                   Task.detached(priority: .background) {
-                    let archiveURL = LogExporter.tempFile()
+                    let archiveURL = try LogExporter.tempFile()
                     try await LogExporter.export(to: archiveURL)
                     await MainActor.run {
                       self.logTempZipFileURL = archiveURL

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="10019">
+          Fixes an issue on recent versions of iOS where the export logs sheet
+          would open and then immediately close.
+        </ChangeItem>
         <ChangeItem pull="9991">
           Fixes an issue where only the first system DNS resolver was used to
           forward queries instead of all found ones.


### PR DESCRIPTION
On iOS, we were using the tempfile directory to stage the log export, and then moving this into place from the share sheet presented to the user.

For some reason, this has stopped working in iOS 18.5.0, and we need to stage the file in the standard documents directory instead.


Fixes #10014 