### PR TITLE
fix(android): spawn shell to cargo

### DIFF
--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -284,7 +284,7 @@ val generateUniffiBindings =
                 commandLine(
                     "sh",
                     "-c",
-                    "cd ${rustDir.asFile} && cargo run --bin uniffi-bindgen generate --library --language kotlin ${input.asFile} --out-dir ${outDir.asFile} --no-format"
+                    "cd ${rustDir.asFile} && cargo run --bin uniffi-bindgen generate --library --language kotlin ${input.asFile} --out-dir ${outDir.asFile} --no-format",
                 )
             }
         }

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -279,23 +279,12 @@ val generateUniffiBindings =
         doLast {
             // Execute uniffi-bindgen command from the rust directory
             project.exec {
-                // Set working directory to the rust directory which is outside the gradle project
-                workingDir(rustDir)
-
-                // Build the command
+                // Spawn a shell to run the command; fixes PATH race conditions that can cause
+                // the cargo executable to not be found even though it is in the PATH.
                 commandLine(
-                    "cargo",
-                    "run",
-                    "--bin",
-                    "uniffi-bindgen",
-                    "generate",
-                    "--library",
-                    "--language",
-                    "kotlin",
-                    input.asFile,
-                    "--out-dir",
-                    outDir.asFile,
-                    "--no-format",
+                    "sh",
+                    "-c",
+                    "cd ${rustDir.asFile} && cargo run --bin uniffi-bindgen generate --library --language kotlin ${input.asFile} --out-dir ${outDir.asFile} --no-format"
                 )
             }
         }


### PR DESCRIPTION
Unfortunately this seems to be a race condition with read or setting the path properly for this exec block. I've verified `cargo` is in the PATH, and have tried this on a fresh Mac with Android Studio (latest release version).

Spawning cargo from `sh -c` fixes the issue.