### PR TITLE
fix(portal): separate dev and runtime Oban configs

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -202,28 +202,6 @@ config :domain, outbound_email_adapter_configured?: false
 
 config :domain, web_external_url: "http://localhost:13000"
 
-config :domain, Oban,
-  plugins: [
-    # Keep the last 90 days of completed, cancelled, and discarded jobs
-    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 90},
-
-    # Rescue jobs that may have failed due to transient errors like deploys
-    # or network issues. It's not guaranteed that the job won't be executed
-    # twice, so for now we disable it since all of our Oban jobs can be retried
-    # without loss.
-    # {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}
-
-    # Periodic jobs
-    {Oban.Plugins.Cron,
-     crontab: [
-       # Delete expired flows every minute
-       {"* * * * *", Domain.Flows.Jobs.DeleteExpiredFlows}
-     ]}
-  ],
-  queues: [default: 10],
-  engine: Oban.Engines.Basic,
-  repo: Domain.Repo
-
 ###############################
 ##### Web #####################
 ###############################

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -20,6 +20,28 @@ config :domain, Domain.Billing,
   secret_key: System.get_env("STRIPE_SECRET_KEY", "sk_dev_1111"),
   webhook_signing_secret: System.get_env("STRIPE_WEBHOOK_SIGNING_SECRET", "whsec_dev_1111")
 
+config :domain, Oban,
+  plugins: [
+    # Keep the last 90 days of completed, cancelled, and discarded jobs
+    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 90},
+
+    # Rescue jobs that may have failed due to transient errors like deploys
+    # or network issues. It's not guaranteed that the job won't be executed
+    # twice, so for now we disable it since all of our Oban jobs can be retried
+    # without loss.
+    # {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}
+
+    # Periodic jobs
+    {Oban.Plugins.Cron,
+     crontab: [
+       # Delete expired flows every minute
+       {"* * * * *", Domain.Flows.Jobs.DeleteExpiredFlows}
+     ]}
+  ],
+  queues: [default: 10],
+  engine: Oban.Engines.Basic,
+  repo: Domain.Repo
+
 ###############################
 ##### Web #####################
 ###############################

--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -20,6 +20,8 @@ config :domain, Domain.Billing,
   secret_key: System.get_env("STRIPE_SECRET_KEY", "sk_dev_1111"),
   webhook_signing_secret: System.get_env("STRIPE_WEBHOOK_SIGNING_SECRET", "whsec_dev_1111")
 
+# Oban has its own config validation that prevents overriding config in runtime.exs,
+# so we explicitly set the config in dev.exs, test.exs, and runtime.exs (for prod) only.
 config :domain, Oban,
   plugins: [
     # Keep the last 90 days of completed, cancelled, and discarded jobs

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -148,7 +148,10 @@ if config_env() == :prod do
       env_var_to_config!(:background_jobs_enabled) and
         Enum.member?(env_var_to_config!(:auth_provider_adapters), :mock)
 
+  # Oban has its own config validation that prevents overriding config in runtime.exs,
+  # so we explicitly set the config in dev.exs, test.exs, and runtime.exs (for prod) only.
   config :domain, Oban,
+    # Periodic jobs don't make sense in tests
     plugins: [
       # Keep the last 90 days of completed, cancelled, and discarded jobs
       {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 90},

--- a/elixir/config/runtime.exs
+++ b/elixir/config/runtime.exs
@@ -149,12 +149,26 @@ if config_env() == :prod do
         Enum.member?(env_var_to_config!(:auth_provider_adapters), :mock)
 
   config :domain, Oban,
-    queues:
-      if(env_var_to_config!(:background_jobs_enabled),
-        do: [default: 10],
-        # Using an empty queue prevents jobs from running on other nodes
-        else: []
-      )
+    plugins: [
+      # Keep the last 90 days of completed, cancelled, and discarded jobs
+      {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 90},
+
+      # Rescue jobs that may have failed due to transient errors like deploys
+      # or network issues. It's not guaranteed that the job won't be executed
+      # twice, so for now we disable it since all of our Oban jobs can be retried
+      # without loss.
+      # {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}
+
+      # Periodic jobs
+      {Oban.Plugins.Cron,
+       crontab: [
+         # Delete expired flows every minute
+         {"* * * * *", Domain.Flows.Jobs.DeleteExpiredFlows}
+       ]}
+    ],
+    queues: if(env_var_to_config!(:background_jobs_enabled), do: [default: 10], else: []),
+    engine: Oban.Engines.Basic,
+    repo: Domain.Repo
 
   if web_external_url = env_var_to_config!(:web_external_url) do
     %{

--- a/elixir/config/test.exs
+++ b/elixir/config/test.exs
@@ -20,6 +20,31 @@ config :domain, Domain.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   queue_target: 1000
 
+# Oban has its own config validation that prevents overriding config in runtime.exs,
+# so we explicitly set the config in dev.exs, test.exs, and runtime.exs (for prod) only.
+config :domain, Oban,
+  # Periodic jobs don't make sense in tests
+  plugins: [
+    # Keep the last 90 days of completed, cancelled, and discarded jobs
+    # {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 90},
+
+    # Rescue jobs that may have failed due to transient errors like deploys
+    # or network issues. It's not guaranteed that the job won't be executed
+    # twice, so for now we disable it since all of our Oban jobs can be retried
+    # without loss.
+    # {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}
+
+    # Periodic jobs
+    # {Oban.Plugins.Cron,
+    #  crontab: [
+    #    # Delete expired flows every minute
+    #    {"* * * * *", Domain.Flows.Jobs.DeleteExpiredFlows}
+    #  ]}
+  ],
+  queues: [default: 10],
+  engine: Oban.Engines.Basic,
+  repo: Domain.Repo
+
 config :domain, Domain.ChangeLogs.ReplicationConnection,
   replication_slot_name: "test_change_logs_slot",
   publication_name: "test_change_logs_publication",


### PR DESCRIPTION
Oban includes its own configuration validation, which seems to prevent `runtime.exs` from overriding any compile-time options. This prevents us from using ENV vars to configure it, such as restricting job execution to `domain` nodes by setting `queues: []`. To fix that, we make sure to set Oban configuration in env-specific files `config/dev.exs` and `config/test.exs`, and at runtime for prod with `config/runtime.exs`.

Fixes #10016