### PR TITLE
fix(portal): relax gateway group perms

### DIFF
--- a/elixir/apps/domain/lib/domain/gateways.ex
+++ b/elixir/apps/domain/lib/domain/gateways.ex
@@ -24,7 +24,14 @@ defmodule Domain.Gateways do
   end
 
   def fetch_group_by_id(id, %Auth.Subject{} = subject, opts \\ []) do
-    with :ok <- Auth.ensure_has_permissions(subject, Authorizer.manage_gateways_permission()),
+    required_permissions =
+      {:one_of,
+       [
+         Authorizer.manage_gateways_permission(),
+         Authorizer.connect_gateways_permission()
+       ]}
+
+    with :ok <- Auth.ensure_has_permissions(subject, required_permissions),
          true <- Repo.valid_uuid?(id) do
       Group.Query.all()
       |> Group.Query.by_id(id)

--- a/elixir/apps/domain/test/domain/gateways_test.exs
+++ b/elixir/apps/domain/test/domain/gateways_test.exs
@@ -87,11 +87,15 @@ defmodule Domain.GatewaysTest do
     } do
       subject = Fixtures.Auth.remove_permissions(subject)
 
-      assert fetch_group_by_id(Ecto.UUID.generate(), subject) ==
-               {:error,
-                {:unauthorized,
-                 reason: :missing_permissions,
-                 missing_permissions: [Gateways.Authorizer.manage_gateways_permission()]}}
+      assert {:error,
+              {:unauthorized,
+               reason: :missing_permissions, missing_permissions: [{:one_of, missing_permissions}]}} =
+               fetch_group_by_id(Ecto.UUID.generate(), subject)
+
+      assert Enum.sort(missing_permissions) == [
+               Gateways.Authorizer.connect_gateways_permission(),
+               Gateways.Authorizer.manage_gateways_permission()
+             ]
     end
   end
 


### PR DESCRIPTION
This is hit by the client channel when a gateway group needs to be hydrated, which should only require "connect gateways" permissions.