### PR TITLE
chore(connlib): treat `Invalid Argument` as unreachable hosts

### DIFF
--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -147,7 +147,6 @@ impl Eventloop {
                         .downcast_ref::<io::Error>()
                         .is_some_and(is_unreachable)
                     {
-                        // `NetworkUnreachable`, `HostUnreachable`, `AddrNotAvailable` most likely means we don't have IPv4 or IPv6 connectivity.
                         tracing::debug!("{e:#}"); // Log these on DEBUG so they don't go completely unnoticed.
                         continue;
                     }
@@ -419,4 +418,7 @@ fn is_unreachable(e: &io::Error) -> bool {
     e.kind() == io::ErrorKind::NetworkUnreachable
         || e.kind() == io::ErrorKind::HostUnreachable
         || e.kind() == io::ErrorKind::AddrNotAvailable
+        // This is "Invalid argument" which can be a lot of things
+        // but pretty much all the ones we see in Sentry is from unreachable addresses.
+        || e.kind() == io::ErrorKind::InvalidInput
 }

--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -151,6 +151,15 @@ impl Eventloop {
                         continue;
                     }
 
+                    // Invalid Input can be all sorts of things but we mostly see it with unreachable addresses.
+                    if e.root_cause()
+                        .downcast_ref::<io::Error>()
+                        .is_some_and(|e| e.kind() == io::ErrorKind::InvalidInput)
+                    {
+                        tracing::debug!("{e:#}");
+                        continue;
+                    }
+
                     if e.root_cause()
                         .is::<firezone_tunnel::UdpSocketThreadStopped>()
                     {
@@ -418,7 +427,4 @@ fn is_unreachable(e: &io::Error) -> bool {
     e.kind() == io::ErrorKind::NetworkUnreachable
         || e.kind() == io::ErrorKind::HostUnreachable
         || e.kind() == io::ErrorKind::AddrNotAvailable
-        // This is "Invalid argument" which can be a lot of things
-        // but pretty much all the ones we see in Sentry is from unreachable addresses.
-        || e.kind() == io::ErrorKind::InvalidInput
 }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -106,6 +106,15 @@ impl Eventloop {
                         continue;
                     }
 
+                    // Invalid Input can be all sorts of things but we mostly see it with unreachable addresses.
+                    if e.root_cause()
+                        .downcast_ref::<io::Error>()
+                        .is_some_and(|e| e.kind() == io::ErrorKind::InvalidInput)
+                    {
+                        tracing::debug!("{e:#}");
+                        continue;
+                    }
+
                     if e.root_cause()
                         .downcast_ref::<io::Error>()
                         .is_some_and(|e| e.kind() == io::ErrorKind::PermissionDenied)
@@ -671,7 +680,4 @@ fn is_unreachable(e: &io::Error) -> bool {
     e.kind() == io::ErrorKind::NetworkUnreachable
         || e.kind() == io::ErrorKind::HostUnreachable
         || e.kind() == io::ErrorKind::AddrNotAvailable
-        // This is "Invalid argument" which can be a lot of things
-        // but pretty much all the ones we see in Sentry is from unreachable addresses.
-        || e.kind() == io::ErrorKind::InvalidInput
 }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -98,12 +98,10 @@ impl Eventloop {
                     continue;
                 }
                 Poll::Ready(Err(e)) => {
-                    if e.root_cause().downcast_ref::<io::Error>().is_some_and(|e| {
-                        e.kind() == io::ErrorKind::NetworkUnreachable
-                            || e.kind() == io::ErrorKind::HostUnreachable
-                            || e.kind() == io::ErrorKind::AddrNotAvailable
-                    }) {
-                        // `NetworkUnreachable`, `HostUnreachable`, `AddrNotAvailable` most likely means we don't have IPv4 or IPv6 connectivity.
+                    if e.root_cause()
+                        .downcast_ref::<io::Error>()
+                        .is_some_and(is_unreachable)
+                    {
                         tracing::debug!("{e:#}"); // Log these on DEBUG so they don't go completely unnoticed.
                         continue;
                     }
@@ -662,4 +660,18 @@ fn resolve_address_family(addr: &str, family: i32) -> Result<AddrInfoIter, Looku
             ..Default::default()
         }),
     )
+}
+
+fn is_unreachable(e: &io::Error) -> bool {
+    #[cfg(unix)]
+    if e.raw_os_error().is_some_and(|e| e == libc::EHOSTDOWN) {
+        return true;
+    }
+
+    e.kind() == io::ErrorKind::NetworkUnreachable
+        || e.kind() == io::ErrorKind::HostUnreachable
+        || e.kind() == io::ErrorKind::AddrNotAvailable
+        // This is "Invalid argument" which can be a lot of things
+        // but pretty much all the ones we see in Sentry is from unreachable addresses.
+        || e.kind() == io::ErrorKind::InvalidInput
 }


### PR DESCRIPTION
These appear to happen on systems that e.g. don't have IPv6 support or where the destination cannot be reached. It is a bit of a catch-all but all the ones I am seeing in Sentry are false-positives. To reduce the noise a bit, we log these on DEBUG now.