### PR TITLE
chore(connlib): harmonise naming of IDs

### DIFF
--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -193,15 +193,15 @@ impl Eventloop {
     fn handle_tunnel_event(&mut self, event: firezone_tunnel::ClientEvent) -> Option<Event> {
         match event {
             firezone_tunnel::ClientEvent::AddedIceCandidates {
-                conn_id: gateway,
+                conn_id: gid,
                 candidates,
             } => {
-                tracing::debug!(%gateway, ?candidates, "Sending new ICE candidates to gateway");
+                tracing::debug!(%gid, ?candidates, "Sending new ICE candidates to gateway");
 
                 self.portal.send(
                     PHOENIX_TOPIC,
                     EgressMessages::BroadcastIceCandidates(GatewaysIceCandidates {
-                        gateway_ids: vec![gateway],
+                        gateway_ids: vec![gid],
                         candidates,
                     }),
                 );
@@ -209,15 +209,15 @@ impl Eventloop {
                 None
             }
             firezone_tunnel::ClientEvent::RemovedIceCandidates {
-                conn_id: gateway,
+                conn_id: gid,
                 candidates,
             } => {
-                tracing::debug!(%gateway, ?candidates, "Sending invalidated ICE candidates to gateway");
+                tracing::debug!(%gid, ?candidates, "Sending invalidated ICE candidates to gateway");
 
                 self.portal.send(
                     PHOENIX_TOPIC,
                     EgressMessages::BroadcastInvalidatedIceCandidates(GatewaysIceCandidates {
-                        gateway_ids: vec![gateway],
+                        gateway_ids: vec![gid],
                         candidates,
                     }),
                 );

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -283,7 +283,7 @@ impl StubResolver {
                 self.get_or_assign_aaaa_records(domain.clone(), resource)
             }
             (RecordType::SRV | RecordType::TXT, Some(resource)) => {
-                tracing::debug!(%qtype, resource = %resource.id, "Forwarding query for DNS resource to corresponding site");
+                tracing::debug!(%qtype, rid = %resource.id, "Forwarding query for DNS resource to corresponding site");
 
                 return ResolveStrategy::RecurseSite(resource.id);
             }
@@ -323,11 +323,11 @@ impl StubResolver {
     }
 }
 
-pub fn is_subdomain(name: &dns_types::DomainName, resource: &str) -> bool {
-    let pattern = match Pattern::new(resource) {
+pub fn is_subdomain(name: &dns_types::DomainName, pattern: &str) -> bool {
+    let pattern = match Pattern::new(pattern) {
         Ok(p) => p,
         Err(e) => {
-            tracing::warn!(%resource, "Unable to parse pattern: {}", err_with_src(&e));
+            tracing::warn!(%pattern, "Unable to parse pattern: {}", err_with_src(&e));
             return false;
         }
     };

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -209,7 +209,7 @@ impl ClientOnGateway {
         resource: crate::messages::gateway::ResourceDescription,
         expires_at: Option<DateTime<Utc>>,
     ) {
-        tracing::info!(client = %self.id, resource = %resource.id(), expires = ?expires_at.map(|e| e.to_rfc3339()), "Allowing access to resource");
+        tracing::info!(cid = %self.id, rid = %resource.id(), expires = ?expires_at.map(|e| e.to_rfc3339()), "Allowing access to resource");
 
         match self.resources.entry(resource.id()) {
             hash_map::Entry::Vacant(v) => {
@@ -233,13 +233,9 @@ impl ClientOnGateway {
         self.recalculate_filters();
     }
 
-    pub(crate) fn update_resource_expiry(
-        &mut self,
-        resource: ResourceId,
-        new_expiry: DateTime<Utc>,
-    ) {
-        let Some(resource) = self.resources.get_mut(&resource) else {
-            tracing::debug!(%resource, "Unknown resource");
+    pub(crate) fn update_resource_expiry(&mut self, rid: ResourceId, new_expiry: DateTime<Utc>) {
+        let Some(resource) = self.resources.get_mut(&rid) else {
+            tracing::debug!(%rid, "Unknown resource");
 
             return;
         };
@@ -256,11 +252,11 @@ impl ClientOnGateway {
     }
 
     pub(crate) fn retain_authorizations(&mut self, authorization: BTreeSet<ResourceId>) {
-        for (resource, _) in self
+        for (rid, _) in self
             .resources
             .extract_if(|resource, _| !authorization.contains(resource))
         {
-            tracing::info!(%resource, "Revoking resource authorization");
+            tracing::info!(%rid, "Revoking resource authorization");
         }
 
         self.recalculate_filters();

--- a/rust/connlib/tunnel/src/tests/sim_client.rs
+++ b/rust/connlib/tunnel/src/tests/sim_client.rs
@@ -525,12 +525,12 @@ impl RefClient {
             if let Some(overlapping_resource) = table.exact_match(resource.address)
                 && self.is_connected_to_internet_or_cidr(*overlapping_resource)
             {
-                tracing::debug!(%overlapping_resource, resource = %resource.id, address = %resource.address, "Already connected to resource with this exact address, retaining existing route");
+                tracing::debug!(%overlapping_resource, rid = %resource.id, address = %resource.address, "Already connected to resource with this exact address, retaining existing route");
 
                 continue;
             }
 
-            tracing::debug!(resource = %resource.id, address = %resource.address, "Adding CIDR route");
+            tracing::debug!(rid = %resource.id, address = %resource.address, "Adding CIDR route");
 
             table.insert(resource.address, resource.id);
         }
@@ -750,16 +750,16 @@ impl RefClient {
         }
     }
 
-    fn set_resource_online(&mut self, resource: ResourceId) {
-        let Some(site) = self.site_for_resource(resource) else {
-            tracing::error!(%resource, "Unknown resource or multi-site resource");
+    fn set_resource_online(&mut self, rid: ResourceId) {
+        let Some(site) = self.site_for_resource(rid) else {
+            tracing::error!(%rid, "Unknown resource or multi-site resource");
             return;
         };
 
         let previous = self.site_status.insert(site.id, ResourceStatus::Online);
 
         if previous.is_none_or(|s| s != ResourceStatus::Online) {
-            tracing::debug!(%resource, "Resource is now online");
+            tracing::debug!(%rid, "Resource is now online");
         }
     }
 
@@ -767,17 +767,17 @@ impl RefClient {
         self.is_connected_to_cidr(resource) || self.is_connected_to_internet(resource)
     }
 
-    fn connect_to_internet_or_cidr_resource(&mut self, resource: ResourceId) {
-        if self.internet_resource.is_some_and(|r| r == resource) {
+    fn connect_to_internet_or_cidr_resource(&mut self, rid: ResourceId) {
+        if self.internet_resource.is_some_and(|r| r == rid) {
             self.connected_internet_resource = true;
             return;
         }
 
-        if self.cidr_resources.iter().any(|(_, r)| *r == resource) {
-            let is_new = self.connected_cidr_resources.insert(resource);
+        if self.cidr_resources.iter().any(|(_, r)| *r == rid) {
+            let is_new = self.connected_cidr_resources.insert(rid);
 
             if is_new {
-                tracing::debug!(%resource, "Now connected to CIDR resource");
+                tracing::debug!(%rid, "Now connected to CIDR resource");
             }
         }
     }


### PR DESCRIPTION
When filtering through logs in Sentry, it is useful to narrow them down by context of a client, gateway or resource. Currently, these fields are sometimes called `client`, `cid`, `client_id` etc and the same for the Gateway and Resources.

To make this filtering easier, name all of them `cid` for Client IDs, `gid` for Gateway IDs and `rid` for Resource IDs.