### PR TITLE
chore(snownet): fix `handle_timeout` span

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1911,7 +1911,7 @@ where
         TId: Copy + Ord + fmt::Display,
         RId: Copy + Ord + fmt::Display,
     {
-        let _guard = tracing::debug_span!("handle_timeout", %cid);
+        let _guard = tracing::info_span!("handle_timeout", %cid);
 
         self.agent.handle_timeout(now);
         self.state.handle_timeout(&mut self.agent, now);

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1911,7 +1911,7 @@ where
         TId: Copy + Ord + fmt::Display,
         RId: Copy + Ord + fmt::Display,
     {
-        let _guard = tracing::info_span!("handle_timeout", %cid);
+        let _guard = tracing::info_span!("handle_timeout", %cid).entered();
 
         self.agent.handle_timeout(now);
         self.state.handle_timeout(&mut self.agent, now);


### PR DESCRIPTION
Spans only attach to logs of lower severity, i.e. a DEBUG span is only visible for DEBUG and TRACE statements. In order to see the connection ID here with our INFO statements, we need to make it an INFO span.

Also, a span does nothing unless it is entered :man_facepalming: 