### PR TITLE
fix(apply): only update `lastPath` on reset

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -136,9 +136,9 @@ class Adapter {
         // used anymore.
         session?.reset("primary network path changed")
         setSystemDefaultResolvers(path)
-      }
 
-      lastPath = path
+        lastPath = path
+      }
     }
   }
 


### PR DESCRIPTION
This is more of a guess but I think we should only store the `lastPath` if we reacted to it. If we skipped it because it wasn't relevant, then we should also not update it.