### PR TITLE
fix(ci): only tag latest on release

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -333,7 +333,6 @@ jobs:
           images: ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.name.image_name }}
           # We only version client and gateway
           tags: |
-            type=raw,value=latest
             type=raw,value={{branch}}
             type=raw,value=${{ inputs.sha }}
       - name: Sanitize github.ref_name
@@ -424,7 +423,6 @@ jobs:
         with:
           images: ${{ steps.login.outputs.registry }}/firezone/${{ matrix.image_prefix && format('{0}/', matrix.image_prefix) || '' }}${{ matrix.image.name }}
           tags: |
-            type=raw,value=latest
             type=raw,value={{branch}}
             type=raw,value=${{ inputs.sha }}
       - name: Create manifest list and push


### PR DESCRIPTION
This fixes an issue introduced when we moved to GHCR hosting where the `latest` tag was being applied to each `main` build of the `client` and `gateway` instead of publish builds only.