### PR TITLE
chore(portal): use local website url for versions in dev

### DIFF
--- a/elixir/config/dev.exs
+++ b/elixir/config/dev.exs
@@ -15,6 +15,9 @@ config :domain, outbound_email_adapter_configured?: true
 
 config :domain, run_manual_migrations: true
 
+config :domain, Domain.ComponentVersions,
+  firezone_releases_url: "http://localhost:3000/api/releases"
+
 config :domain, Domain.Billing,
   enabled: System.get_env("BILLING_ENABLED", "false") == "true",
   secret_key: System.get_env("STRIPE_SECRET_KEY", "sk_dev_1111"),


### PR DESCRIPTION
When starting a local client with a local portal, this URL is hit and times out, causing noise in the local gateway log.

In order to develop against this API in local dev, it might be better to use the local website URL as well.