### PR TITLE
fix(apple): reset network on wake from sleep

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -135,8 +135,11 @@ class Adapter {
         // If our primary interface changes, we can be certain the old socket shouldn't be
         // used anymore.
         session?.reset("primary network path changed")
-        setSystemDefaultResolvers(path)
       }
+
+      // connectivityDifferentFrom does not report DNS server changes, so always set those here because connlib
+      // will no-op duplicate calls.
+      setSystemDefaultResolvers(path)
 
       lastPath = path
     }
@@ -510,9 +513,8 @@ extension Network.NWPath {
     return path.supportsIPv4 != self.supportsIPv4 || path.supportsIPv6 != self.supportsIPv6
       || path.supportsDNS != self.supportsDNS
       || path.status != self.status
-      || path.availableInterfaces.first?.name != self.availableInterfaces.first?.name
-      // Apple provides no documentation on whether order is meaningful, so assume it isn't.
-      || Set(self.gateways) != Set(path.gateways)
+      || path.availableInterfaces.first != self.availableInterfaces.first
+      || path.gateways != self.gateways
   }
 }
 

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -129,17 +129,16 @@ class Adapter {
       }
 
       if lastPath?.connectivityDifferentFrom(path: path) != false {
-        // Tell connlib to reset network state, but only do so if our connectivity has
+        // Tell connlib to reset network state and DNS resolvers, but only do so if our connectivity has
         // meaningfully changed. On darwin, this is needed to send packets
         // out of a different interface even when 0.0.0.0 is used as the source.
         // If our primary interface changes, we can be certain the old socket shouldn't be
         // used anymore.
-        session?.reset("primary network path changed")
+        reset(reason: "primary network path changed", path: path)
+      } else {
+        // Reset only resolvers
+        setSystemDefaultResolvers(path)
       }
-
-      // connectivityDifferentFrom does not report DNS server changes, so always set those here because connlib
-      // will no-op duplicate calls.
-      setSystemDefaultResolvers(path)
 
       lastPath = path
     }
@@ -259,6 +258,14 @@ class Adapter {
       } else {
         completionHandler(resourceListJSON)
       }
+    }
+  }
+
+  func reset(reason: String, path: Network.NWPath? = nil) {
+    session?.reset(reason)
+
+    if let path = (path ?? lastPath) {
+      setSystemDefaultResolvers(path)
     }
   }
 

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -118,6 +118,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
   }
 
+  override func wake() {
+    adapter?.reset(reason: "awoke from sleep")
+  }
+
   // This can be called by the system, or initiated by connlib.
   // When called by the system, we call Adapter.stop() from here.
   // When initiated by connlib, we've already called stop() there.

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -26,9 +26,8 @@ export default function Apple() {
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
         <ChangeItem pull="10056">
-          Fixes an issue where Firezone's system resolvers may not be when the
-          system's DNS resolvers change unless there was also a network
-          connectivity change.
+          Fixes an issue where connectivity could be lost for up to 20 seconds
+          after waking from sleep.
         </ChangeItem>
       </Unreleased>
       <Entry version="1.5.5" date={new Date("2025-07-28")}>

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,13 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="10056">
+          Fixes an issue where Firezone's system resolvers may not be when the
+          system's DNS resolvers change unless there was also a network
+          connectivity change.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.5" date={new Date("2025-07-28")}>
         <ChangeItem pull="10022">
           Fixes a bug on iOS where network connectivity changes (such as from


### PR DESCRIPTION
When a mac device goes to sleep, it typically does not turn off the WiFi radio. If the mac never leaves the network it was on upon sleep, then upon wake it will never receive a path update, and we would not have performed a connlib network reset.

To fix this, we now properly detect a wake from sleep event and issue a network reset.

Fixes #10056 