### PR TITLE
chore(snownet): fix buffering log message

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -459,7 +459,7 @@ where
                 ip_buffer.push(packet);
                 let num_buffered = ip_buffer.len();
 
-                tracing::debug!(%num_buffered, %cid, "ICE is still in progress, buffering WG handshake");
+                tracing::debug!(%num_buffered, %cid, "ICE is still in progress, buffering IP packet");
 
                 return Ok(None);
             }


### PR DESCRIPTION
What we are actually buffering here are unencrypted IP packets that are waiting for the tunnel to be established.