### PR TITLE
chore(snownet): allow filtering TURN traffic in logs

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -359,14 +359,14 @@ impl Allocation {
         let rtt = now.duration_since(backoff.start_time());
         Span::current().record("rtt", field::debug(rtt));
 
-        if tracing::enabled!(tracing::Level::DEBUG) {
+        if tracing::enabled!(target: "wire::turn", tracing::Level::DEBUG) {
             let request = original_request
                 .attributes()
                 .map(display_attr)
                 .collect::<Vec<_>>();
             let response = message.attributes().map(display_attr).collect::<Vec<_>>();
 
-            tracing::debug!(?request, ?response);
+            tracing::debug!(target: "wire::turn", ?request, ?response);
         }
 
         if let Some(error) = message.get_attribute::<ErrorCode>() {


### PR DESCRIPTION
Our TURN traffic is fairly minimal for this to be okay on DEBUG (instead of TRACE). However, it can be quite noisy when one is just scanning through the logs. Putting it on another target allows us to filter those out later.

Note that these only concern the TURN control protocol. Channel data messages are separate from this and **not** logged.