### PR TITLE
feat(snownet): use in-flight channels to relay data

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -1955,11 +1955,24 @@ mod tests {
     }
 
     #[test]
-    fn does_not_relay_to_with_unbound_channel() {
+    fn relays_to_inflight_channel() {
         let mut allocation = Allocation::for_test_ip4(Instant::now())
             .with_binding_response(PEER1, Instant::now())
             .with_allocate_response(&[RELAY_ADDR_IP4], Instant::now());
         allocation.bind_channel(PEER2_IP4, Instant::now());
+
+        let mut buffer = channel_data_packet_buffer(b"foobar");
+        let encode_ok =
+            allocation.encode_channel_data_header(PEER2_IP4, &mut buffer, Instant::now());
+
+        assert!(encode_ok.is_some())
+    }
+
+    #[test]
+    fn does_not_relay_to_with_unbound_channel() {
+        let mut allocation = Allocation::for_test_ip4(Instant::now())
+            .with_binding_response(PEER1, Instant::now())
+            .with_allocate_response(&[RELAY_ADDR_IP4], Instant::now());
 
         let mut buffer = channel_data_packet_buffer(b"foobar");
         let encode_ok =


### PR DESCRIPTION
In #7548, we added a feature to Firezone where TURN channels get bound on-demand as they are needed. To ensure many communication paths work, we also proactively bind them as soon as we receive a candidate from a remote.

When a new remote candidate gets added, str0m forms pairs with all the existing local candidates and starts testing these candidate pairs. For local relay candidates, this means sending a channel data message from the allocation.

At the moment, this results in the following pattern in the logs:

```
Received candidate from remote cid=20af9d29-c973-4d77-909a-abed5d7a0234 candidate=Candidate(relay=[3231E680683CFC98E69A12A60F426AA5E5F110CB]:62759/udp raddr=[59A533B0D4D3CB3717FD3D655E1D419E1C9C0772]:0 prio=37492735)
No channel to peer, binding new one active_socket=462A7A508E3C99875E69C2519CA020330A6004EC:3478 peer=[3231E680683CFC98E69A12A60F426AA5E5F110CB]:62759
Already binding a channel to peer active_socket=Some(462A7A508E3C99875E69C2519CA020330A6004EC:3478) peer=[3231E680683CFC98E69A12A60F426AA5E5F110CB]:62759
class=success response from=462A7A508E3C99875E69C2519CA020330A6004EC:3478 method=channel bind rtt=9.928424ms tid=042F52145848D6C1574BB997 
```

What happens here is:

1. We receive a new candidate and proactively bind a channel (this is a silent operation and therefore not visible in the logs).
2. str0m formed new pairs for these candidates and starts testing them, triggering a new channel binding because the previous one isn't completed yet.
3. We refuse to make another channel binding because we see that we already have one in-flight.
4. The channel binding succeeds.

What we do now is:

If we want to send data to a peer through a channel, we check whether we have a connected OR an in-flight channel and send it in both cases. If the channel binding is still in-flight, we therefore just pipeline the channel data message just after it. Chances are that - assuming no packet re-orderings on the network - by the time our channel data message arrives at the relay that binding is active and can be relayed.

This allows the very first binding attempt from str0m to already succeed instead of waiting for the timeout and sending another binding request. In addition, it makes these logs less confusing.