### PR TITLE
chore(connlib): bump str0m

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7031,7 +7031,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "str0m"
 version = "0.9.0"
-source = "git+https://github.com/algesten/str0m?branch=main#3b3fe3181b3823f3b5a1d50f5ed9c49b043cf5be"
+source = "git+https://github.com/algesten/str0m?branch=main#44ab8e39ec6d4b4d8efd9f3c45994b55404f6b70"
 dependencies = [
  "combine",
  "crc",


### PR DESCRIPTION
This bumps our str0m dependency to include improvements that I've been making to the logs:

- https://github.com/algesten/str0m/pull/681
- https://github.com/algesten/str0m/pull/682

