### PR TITLE
fix(apple/ios): less aggressive setDns to avoid update loops

### DIFF
--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="10075">
+          Fixes an issue on iOS where the tunnel may never fully come up after
+          signing in due to a network connectivity reset loop.
+        </ChangeItem>
         <ChangeItem pull="10056">
           Fixes an issue where connectivity could be lost for up to 20 seconds
           after waking from sleep.


### PR DESCRIPTION
In https://github.com/firezone/firezone/pull/10022/files#diff-a84e8f62a17ac67f781019e6ac0456567fd18ffa7c13b3248609d78debb6480eL342 we removed the path connectivity filter that prevented path update loops on iOS. This was done to try and respond more aggressively to path updates in order to set system DNS resolvers, because we can't glean from the path's instance properties that any DNS configuration has changed - we simply have to assume so.

Unfortunately, that caused an issue where we now enter a path update loop and effectively never fully bring the tunnel up.

I've spent lots of time looking for a reliable work around that would allow us to both, (1) respond to path updates for DNS configuration changes on the system (we have to blindly react to these), and (2) avoid path update loops, but alas, without a significant time investment, there doesn't seem to be a way.

So, we only set system resolvers on iOS in the path update handler if there was _also_ a detectable connectivity change, and settle on the assumption that **most** DNS configuration changes will be accompanied by a network connectivity change as well.