### PR TITLE
feat(connlib): roll-over WireGuard session on connection upsert

### DIFF
--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -276,6 +276,15 @@ where
                 &mut self.pending_events,
             );
 
+            // Initiate a new WG session.
+            //
+            // We can have up to 8 concurrent WireGuard sessions in boringtun before the oldest one get overwritten.
+            // Also, whilst we are are handshaking a new session, we won't send another handshake.
+            // Thus, even rapidely successive connection upserts should be handled just fine.
+            if c.agent.controlling() {
+                c.initiate_wg_session(&mut self.allocations, &mut self.buffered_transmits, now);
+            }
+
             return Ok(());
         }
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -279,7 +279,7 @@ where
             // Initiate a new WG session.
             //
             // We can have up to 8 concurrent WireGuard sessions in boringtun before the oldest one get overwritten.
-            // Also, whilst we are are handshaking a new session, we won't send another handshake.
+            // Also, whilst we are handshaking a new session, we won't send another handshake.
             // Thus, even rapidely successive connection upserts should be handled just fine.
             if c.agent.controlling() {
                 c.initiate_wg_session(&mut self.allocations, &mut self.buffered_transmits, now);

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -278,7 +278,7 @@ where
 
             // Initiate a new WG session.
             //
-            // We can have up to 8 concurrent WireGuard sessions in boringtun before the oldest one get overwritten.
+            // We can have up to 8 concurrent WireGuard sessions in boringtun before the oldest one gets overwritten.
             // Also, whilst we are handshaking a new session, we won't send another handshake.
             // Thus, even rapid successive connection upserts should be handled just fine.
             if c.agent.controlling() {

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2368,9 +2368,10 @@ where
             return;
         };
 
-        let socket = self
-            .socket()
-            .expect("cannot force handshake while not connected");
+        let Some(socket) = self.socket() else {
+            tracing::error!("Cannot initiate WG session without a socket");
+            return;
+        };
 
         transmits.extend(make_owned_transmit(
             self.relay,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2074,7 +2074,7 @@ where
                     );
 
                     if self.agent.controlling() {
-                        self.force_handshake(allocations, transmits, now);
+                        self.initiate_wg_session(allocations, transmits, now);
                     }
                 }
                 IceAgentEvent::IceRestart(_) | IceAgentEvent::IceConnectionStateChange(_) => {}
@@ -2346,7 +2346,7 @@ where
         control_flow
     }
 
-    fn force_handshake(
+    fn initiate_wg_session(
         &mut self,
         allocations: &mut BTreeMap<RId, Allocation>,
         transmits: &mut VecDeque<Transmit>,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -280,7 +280,7 @@ where
             //
             // We can have up to 8 concurrent WireGuard sessions in boringtun before the oldest one get overwritten.
             // Also, whilst we are handshaking a new session, we won't send another handshake.
-            // Thus, even rapidely successive connection upserts should be handled just fine.
+            // Thus, even rapidly successive connection upserts should be handled just fine.
             if c.agent.controlling() {
                 c.initiate_wg_session(&mut self.allocations, &mut self.buffered_transmits, now);
             }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -280,7 +280,7 @@ where
             //
             // We can have up to 8 concurrent WireGuard sessions in boringtun before the oldest one get overwritten.
             // Also, whilst we are handshaking a new session, we won't send another handshake.
-            // Thus, even rapidly successive connection upserts should be handled just fine.
+            // Thus, even rapid successive connection upserts should be handled just fine.
             if c.agent.controlling() {
                 c.initiate_wg_session(&mut self.allocations, &mut self.buffered_transmits, now);
             }


### PR DESCRIPTION
When a Client upserts a connection to a Gateway, we currently assume that the connection is still intact. After all, it hasn't hit an ICE timeout, otherwise the connection would not be present in memory. If however the Gateway restarted or somehow lost its connection state and the Client hasn't noticed yet, then the upsert will be an _insert_ for the Gateway and ICE will create a new connection for us.

In order to ensure that the WireGuard tunnel state and ICE are synchronized at all times, we also need to handshake a new session.

`boringtun` maintains up to 8 concurrent sessions for us. This allows for a smooth roll-over where packets encrypted with the keys from previous sessions can still be decrypted. Thus, we can easily roll-over the session on every connection upsert without any trouble.

To ensure that this doesn't happen _very_ rapidly, we debounce these proactive session roll-overs to happen at most every 20s.

This follows the idea of MADR-0017.