### PR TITLE
refactor(connlib): avoid a copy of every packet

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -860,6 +860,10 @@ impl Allocation {
         );
     }
 
+    pub fn active_socket(&self) -> Option<SocketAddr> {
+        Some(self.active_socket?.addr)
+    }
+
     pub fn encode_channel_data_header(
         &mut self,
         peer: SocketAddr,

--- a/rust/connlib/snownet/src/lib.rs
+++ b/rust/connlib/snownet/src/lib.rs
@@ -15,8 +15,8 @@ pub use allocation::RelaySocket;
 #[allow(deprecated)] // Rust bug: `expect` doesn't seem to work on imports?
 pub use node::{Answer, Offer};
 pub use node::{
-    Client, ClientNode, Credentials, Event, HANDSHAKE_TIMEOUT, NoTurnServers, Node, Server,
-    ServerNode, Transmit, UnknownConnection,
+    BufferProvider, BufferRef, Client, ClientNode, Credentials, Event, HANDSHAKE_TIMEOUT,
+    NoTurnServers, Node, Server, ServerNode, Transmit, UnknownConnection,
 };
 pub use stats::{ConnectionStats, NodeStats};
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2333,6 +2333,7 @@ where
         };
     }
 
+    #[expect(clippy::too_many_arguments, reason = "Don't care.")]
     fn encapsulate<TId>(
         &mut self,
         cid: TId,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2611,9 +2611,12 @@ impl BufferProvider for BufferPool<Vec<u8>> {
         _: Option<SocketAddr>,
         _: SocketAddr,
         _: Ecn,
-        _: usize,
+        len: usize,
     ) -> Self::Buffer<'_> {
-        self.pull()
+        let mut buffer = self.pull();
+        buffer.resize(len, 0);
+
+        buffer
     }
 }
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1976,7 +1976,7 @@ impl PeerSocket {
         }
     }
 
-    fn buffer_size(&self, packet: &[u8]) -> usize {
+    fn required_buffer_size(&self, packet: &[u8]) -> usize {
         match self {
             PeerSocket::PeerToPeer { .. } | PeerSocket::PeerToRelay { .. } => packet.len() + 32,
             PeerSocket::RelayToPeer { .. } | PeerSocket::RelayToRelay { .. } => {
@@ -2354,10 +2354,10 @@ where
         let packet_src = socket.packet_src();
         let packet_dst = socket.packet_dst(self.relay.id, allocations)?;
         let packet_start = socket.packet_start();
-        let buffer_len = socket.buffer_size(packet_slice);
+        let buffer_len = std::cmp::max(socket.required_buffer_size(packet_slice), 148);
 
         let mut buffer =
-            buffer_provider.get_buffer(packet_src, packet_dst, packet.ecn(), buffer_len.max(148));
+            buffer_provider.get_buffer(packet_src, packet_dst, packet.ecn(), buffer_len);
 
         match self.tunnel.encapsulate_at(
             packet_slice,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2356,7 +2356,7 @@ where
         let buffer_len = socket.buffer_size(packet_slice);
 
         let mut buffer =
-            buffer_provider.get_buffer(packet_src, packet_dst, packet.ecn(), buffer_len);
+            buffer_provider.get_buffer(packet_src, packet_dst, packet.ecn(), buffer_len.max(148));
 
         match self.tunnel.encapsulate_at(
             packet_slice,

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -160,6 +160,10 @@ impl Io {
         self.nameservers.fastest()
     }
 
+    pub fn gso_queue_mut(&mut self) -> &mut GsoQueue {
+        &mut self.gso_queue
+    }
+
     pub fn poll<'b>(
         &mut self,
         cx: &mut Context<'_>,

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -373,7 +373,7 @@ impl Io {
         payload: &[u8],
         ecn: Ecn,
     ) {
-        self.gso_queue.enqueue(src, dst, payload, ecn);
+        self.gso_queue.enqueue_copy(src, dst, payload, ecn);
 
         self.packet_counter.add(
             1,

--- a/rust/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/connlib/tunnel/src/io/gso_queue.rs
@@ -110,7 +110,7 @@ pub struct BufferRef<'a> {
     chunk_size: usize,
 
     /// Phantom lifetime to ensure `BufferRef` doesn't outlive `GsoQueue`.
-    phantom_ref: PhantomData<&'a ()>,
+    phantom_ref: PhantomData<&'a mut ()>,
 }
 
 impl<'a> snownet::BufferRef<'a> for BufferRef<'a> {

--- a/rust/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/connlib/tunnel/src/io/gso_queue.rs
@@ -94,12 +94,12 @@ impl snownet::BufferProvider for GsoQueue {
 
         let (_, buffer) = batches.back_mut().expect("We just pushed an element");
 
-        return BufferRef {
+        BufferRef {
             inner: buffer,
             current_end: 0,
             chunk_size: payload_len,
             phantom_ref: PhantomData,
-        };
+        }
     }
 }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -178,16 +178,11 @@ impl ClientTunnel {
                             tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
                         }
 
-                        let ecn = packet.ecn();
-
-                        let Some(transmit) = self.role_state.handle_tun_input(packet, now) else {
-                            self.role_state.handle_timeout(now);
-                            continue;
-                        };
-
-                        self.io
-                            .send_network(transmit.src, transmit.dst, &transmit.payload, ecn);
+                        self.role_state
+                            .handle_tun_input(packet, now, self.io.gso_queue_mut());
                     }
+
+                    self.role_state.handle_timeout(now);
 
                     continue;
                 }
@@ -314,16 +309,11 @@ impl GatewayTunnel {
                             tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
                         }
 
-                        let ecn = packet.ecn();
-
-                        let Some(transmit) = self.role_state.handle_tun_input(packet, now)? else {
-                            self.role_state.handle_timeout(now, Utc::now());
-                            continue;
-                        };
-
-                        self.io
-                            .send_network(transmit.src, transmit.dst, &transmit.payload, ecn);
+                        self.role_state
+                            .handle_tun_input(packet, now, self.io.gso_queue_mut())?;
                     }
+
+                    self.role_state.handle_timeout(now, Utc::now());
 
                     continue;
                 }


### PR DESCRIPTION
One of the most CPU-intensive aspects of Firezone's data plane are the syscalls for reading from and writing to the UDP socket. To make this more efficient, most platforms offer ways of batch-sending messages in a single syscall, often referred to as GRO and GSO. The packets in a batch need to be of the same length and for the same destination. Effectively, we send one big packet in the syscall that looks like this:

```
| UDP header | payload | payload | payload | payload | payload 
```

The very last packet in such a batch is allowed to be shorter because it is still unambiguous how long it is assuming the payload size is known.

Such a GSO train / batch is constructed in Firezone in the `GsoQueue` component. This component maintains a map of buffers and appends a packet to the correct one given its destination, length etc.

Right now, this incurs a copy of each packet due to how `Node::encapsulate` works:

1. We pass an `IpPacket` that needs to be encrypted to `encapsulate`.
2. We figure out which Gateway it needs to go to.
3. We grab a buffer from the buffer-pool.
4. We encapsulate the packet and write the result to the buffer.
5. We return the buffer to the event-loop, i.e. `encapsulate` returns.
6. The event-loop appends the packet in the `GsoQueue` through a copy.

Whilst being easy to follow, this additional copy is unnecessary and can be avoided by passing a reference to the correct buffer from the `GsoQueue` directly to `Node::encapsulate`. This however is quite tricky. Internally, the `GsoQueue` maintains a map of buffers, indexed by source, destination, length, and ECN bits:

```
[10.0.0.1, 555] => | XX | XX | XX
[10.0.0.2, 444] => | YYY | YYY | YYY
```

Let's assume the above state and we are given a packet that needs to be sent to `10.0.0.2` of length `444`. This can be directly appended to an existing buffer inside the `GsoQueue`! To do that, we need to communicate "back" to the `GsoQueue` that we need a buffer of length `444` for the destination host `10.0.0.2`.

To achieve that, we introduce the `BufferProvider` abstraction. This trait is implemented by the `GsoQueue` component and allows us to request a buffer given a set of parameters such as source, destination, length etc. A unique set of these parameters indexes into the map of buffers and allows the `GsoQueue` to return a memory region that points directly to the end of an existing buffer.

As a result, instead of requesting a buffer from the pool as we do in step (3) above, `Node::encapsulate` now takes a `BufferProvider` argument. The destination buffer we write the packet to is now directly the one from the `GsoQueue`. Consequently, we also no longer need to return anything from `encapsulate`: The packet has already been written to a buffer provided by `BufferProvider`.

Benchmarking has shown that we spend about 20% of our CPU time on the main thread in `memcpy`'s. With this change, this number drops to XX%.

Resolves: #10110 