### PR TITLE
fix(relay): increase nonce usage to 10000

### DIFF
--- a/rust/relay/server/src/auth.rs
+++ b/rust/relay/server/src/auth.rs
@@ -347,7 +347,7 @@ mod tests {
 
         nonces.add_new(nonce);
 
-        for _ in 0..100 {
+        for _ in 0..10_000 {
             nonces.handle_nonce_used(nonce).unwrap();
         }
 

--- a/rust/relay/server/src/auth.rs
+++ b/rust/relay/server/src/auth.rs
@@ -166,7 +166,7 @@ pub(crate) struct Nonces {
 
 impl Nonces {
     /// How many requests a client can perform with the same nonce.
-    const NUM_REQUESTS: u64 = 100;
+    const NUM_REQUESTS: u64 = 10_000;
 
     pub(crate) fn add_new(&mut self, nonce: Uuid) {
         self.inner.insert(nonce, Self::NUM_REQUESTS);


### PR DESCRIPTION
On a Gateway with a busy connections, only being able to use a nonce 100 times causes unnecessary churn. We increase this to 10000 to be able to handle bursts of messages such as channel bindings better.