### PR TITLE
chore(ci): Add 50ms simulated API latency

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Add 50ms simulated API latency
         run: |
-          docker compose exec -d apk add iproute2-tc
+          docker compose exec -d api apk add --no-cache iproute2-tc
           docker compose exec -d api tc qdisc add dev eth0 root netem delay 50ms
 
       - run: ./scripts/tests/${{ matrix.test.name }}.sh

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -148,20 +148,20 @@ jobs:
 
       - name: Add 50ms simulated API latency
         run: |
-          docker compose exec -d api apk add --no-cache iproute2-tc
-          docker compose exec -d api tc qdisc add dev eth0 root netem delay 50ms
+          docker compose exec -T api apk add --no-cache iproute2
+          docker compose exec -T api tc qdisc add dev eth0 root netem delay 50ms
 
       - name: Add 5ms simulated client latency
         run: |
           # compatibility test images won't have the `tc` command
-          docker compose exec -d client apk add --no-cache iproute2-tc
-          docker compose exec -d client tc qdisc add dev eth0 root netem delay 50ms
+          docker compose exec -T client apk add --no-cache iproute2
+          docker compose exec -T client tc qdisc add dev eth0 root netem delay 50ms
 
       - name: Add 5ms simulated gateway latency
         run: |
           # compatibility test images won't have the `tc` command
-          docker compose exec -d gateway apk add --no-cache iproute2-tc
-          docker compose exec -d gateway tc qdisc add dev eth0 root netem delay 50ms
+          docker compose exec -T gateway apk add --no-cache iproute2
+          docker compose exec -T gateway tc qdisc add dev eth0 root netem delay 50ms
 
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -148,20 +148,20 @@ jobs:
 
       - name: Add 50ms simulated API latency
         run: |
-          docker compose exec -T api apk add --no-cache iproute2
-          docker compose exec -T api tc qdisc add dev eth0 root netem delay 50ms
+          docker compose exec -T api sh -c 'apk add --no-cache iproute2'
+          docker compose exec -T api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
       - name: Add 5ms simulated client latency
         run: |
           # compatibility test images won't have the `tc` command
-          docker compose exec -T client apk add --no-cache iproute2
-          docker compose exec -T client tc qdisc add dev eth0 root netem delay 50ms
+          docker compose exec -T client sh -c 'apk add --no-cache iproute2'
+          docker compose exec -T client sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
       - name: Add 5ms simulated gateway latency
         run: |
           # compatibility test images won't have the `tc` command
-          docker compose exec -T gateway apk add --no-cache iproute2
-          docker compose exec -T gateway tc qdisc add dev eth0 root netem delay 50ms
+          docker compose exec -T gateway sh -c 'apk add --no-cache iproute2'
+          docker compose exec -T gateway sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -148,19 +148,19 @@ jobs:
 
       - name: Add 50ms simulated API latency
         run: |
-          docker compose exec -T api sh -c 'apk add --no-cache iproute2'
-          docker compose exec -T api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
+          docker compose exec -T -u root api sh -c 'apk add --no-cache iproute2-tc'
+          docker compose exec -T -u root api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
       - name: Add 5ms simulated client latency
         run: |
           # compatibility test images won't have the `tc` command
-          docker compose exec -T client sh -c 'apk add --no-cache iproute2'
+          docker compose exec -T client sh -c 'apk add --no-cache iproute2-tc'
           docker compose exec -T client sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
       - name: Add 5ms simulated gateway latency
         run: |
           # compatibility test images won't have the `tc` command
-          docker compose exec -T gateway sh -c 'apk add --no-cache iproute2'
+          docker compose exec -T gateway sh -c 'apk add --no-cache iproute2-tc'
           docker compose exec -T gateway sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
       - run: ./scripts/tests/${{ matrix.test.name }}.sh

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -151,6 +151,18 @@ jobs:
           docker compose exec -d api apk add --no-cache iproute2-tc
           docker compose exec -d api tc qdisc add dev eth0 root netem delay 50ms
 
+      - name: Add 5ms simulated client latency
+        run: |
+          # compatibility test images won't have the `tc` command
+          docker compose exec -d client apk add --no-cache iproute2-tc
+          docker compose exec -d client tc qdisc add dev eth0 root netem delay 50ms
+
+      - name: Add 5ms simulated gateway latency
+        run: |
+          # compatibility test images won't have the `tc` command
+          docker compose exec -d gateway apk add --no-cache iproute2-tc
+          docker compose exec -d gateway tc qdisc add dev eth0 root netem delay 50ms
+
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 
       - name: Ensure Client emitted no warnings

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -151,17 +151,11 @@ jobs:
           docker compose exec -T -u root api sh -c 'apk add --no-cache iproute2-tc'
           docker compose exec -T -u root api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
-      - name: Add 5ms simulated client latency
-        run: |
-          # compatibility test images won't have the `tc` command
-          docker compose exec -T client sh -c 'apk add --no-cache iproute2-tc'
-          docker compose exec -T client sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
-
-      - name: Add 5ms simulated gateway latency
+      - name: Add 10ms simulated gateway latency
         run: |
           # compatibility test images won't have the `tc` command
           docker compose exec -T gateway sh -c 'apk add --no-cache iproute2-tc'
-          docker compose exec -T gateway sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
+          docker compose exec -T gateway sh -c 'tc qdisc add dev eth0 root netem delay 10ms'
 
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -146,6 +146,10 @@ jobs:
           # Intended to mitigate <https://github.com/firezone/firezone/issues/5830>
           sleep 3
 
+      - name: Add 50ms simulated API latency
+        run: |
+          docker compose exec -d api tc qdisc add dev eth0 root netem delay 50ms
+
       - run: ./scripts/tests/${{ matrix.test.name }}.sh
 
       - name: Ensure Client emitted no warnings

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Add 50ms simulated API latency
         run: |
           docker compose exec -T -u root api sh -c 'apk add --no-cache iproute2-tc'
-          docker compose exec --privileged -T -u root api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
+          docker compose exec -T -u root api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
       - name: Add 5ms simulated client latency
         run: |

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -148,6 +148,7 @@ jobs:
 
       - name: Add 50ms simulated API latency
         run: |
+          docker compose exec -d apk add iproute2-tc
           docker compose exec -d api tc qdisc add dev eth0 root netem delay 50ms
 
       - run: ./scripts/tests/${{ matrix.test.name }}.sh

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Add 50ms simulated API latency
         run: |
           docker compose exec -T -u root api sh -c 'apk add --no-cache iproute2-tc'
-          docker compose exec -T -u root api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
+          docker compose exec --privileged -T -u root api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
       - name: Add 5ms simulated client latency
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,6 +175,8 @@ services:
       FEATURE_IDP_SYNC_ENABLED: "true"
       FEATURE_REST_API_ENABLED: "true"
       FEATURE_INTERNET_RESOURCE_ENABLED: "true"
+    cap_add:
+      - NET_ADMIN # Needed to run `tc` commands to add simulated delay
     depends_on:
       vault:
         condition: "service_healthy"


### PR DESCRIPTION
In the real world, it's entirely possible that the latency between clients, gateways, and relays is much lower than the latency to the API nodes. This added latency will test that we can handle such cases reliably.