### PR TITLE
chore(ci): increase perf test time to 30s

### DIFF
--- a/scripts/tests/perf/direct-tcp-client2server.sh
+++ b/scripts/tests/perf/direct-tcp-client2server.sh
@@ -5,6 +5,7 @@ set -euox pipefail
 source "./scripts/tests/lib.sh"
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
+  --time 30 \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
 

--- a/scripts/tests/perf/direct-tcp-server2client.sh
+++ b/scripts/tests/perf/direct-tcp-server2client.sh
@@ -5,6 +5,7 @@ set -euox pipefail
 source "./scripts/tests/lib.sh"
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
+  --time 30 \
   --reverse \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"

--- a/scripts/tests/perf/direct-udp-client2server.sh
+++ b/scripts/tests/perf/direct-udp-client2server.sh
@@ -5,6 +5,7 @@ set -euox pipefail
 source "./scripts/tests/lib.sh"
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
+  --time 30 \
   --udp \
   --bandwidth 500M \
   --client 172.20.0.110 \

--- a/scripts/tests/perf/direct-udp-server2client.sh
+++ b/scripts/tests/perf/direct-udp-server2client.sh
@@ -5,6 +5,7 @@ set -euox pipefail
 source "./scripts/tests/lib.sh"
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
+  --time 30 \
   --reverse \
   --udp \
   --bandwidth 500M \

--- a/scripts/tests/perf/relayed-tcp-client2server.sh
+++ b/scripts/tests/perf/relayed-tcp-client2server.sh
@@ -6,6 +6,7 @@ source "./scripts/tests/lib.sh"
 install_iptables_drop_rules
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
+  --time 30 \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
 

--- a/scripts/tests/perf/relayed-tcp-server2client.sh
+++ b/scripts/tests/perf/relayed-tcp-server2client.sh
@@ -6,6 +6,7 @@ source "./scripts/tests/lib.sh"
 install_iptables_drop_rules
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
+  --time 30 \
   --reverse \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"

--- a/scripts/tests/perf/relayed-udp-client2server.sh
+++ b/scripts/tests/perf/relayed-udp-client2server.sh
@@ -6,6 +6,7 @@ source "./scripts/tests/lib.sh"
 install_iptables_drop_rules
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
+  --time 30 \
   --udp \
   --bandwidth 500M \
   --client 172.20.0.110 \

--- a/scripts/tests/perf/relayed-udp-server2client.sh
+++ b/scripts/tests/perf/relayed-udp-server2client.sh
@@ -6,6 +6,7 @@ source "./scripts/tests/lib.sh"
 install_iptables_drop_rules
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
+  --time 30 \
   --reverse \
   --udp \
   --bandwidth 500M \


### PR DESCRIPTION
Our ICE timeout is ~15s, so it would be a good idea to ensure the perf tests span a possible ICE timeout if it occurs in the test, so that we may detect cases where high throughput may cause an ICE timeout.