### PR TITLE
chore(snownet): improve logging of boringtun session index

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.1"
-source = "git+https://github.com/firezone/boringtun?branch=master#bda7276b68396a591b454605eff30717e692a194"
+source = "git+https://github.com/firezone/boringtun?branch=master#ed1de7c6ddf071d2895309f0fb153e9afb82fc99"
 dependencies = [
  "aead",
  "base64 0.22.1",

--- a/rust/connlib/snownet/src/index.rs
+++ b/rust/connlib/snownet/src/index.rs
@@ -1,3 +1,4 @@
+use boringtun::noise::Index;
 use rand::Rng;
 
 // A basic linear-feedback shift register implemented as xorshift, used to
@@ -36,7 +37,7 @@ impl IndexLfsr {
     }
 
     /// Generate the next value in the pseudorandom sequence
-    pub(crate) fn next(&mut self) -> u32 {
+    pub(crate) fn next(&mut self) -> Index {
         // 24-bit polynomial for randomness. This is arbitrarily chosen to
         // inject bitflips into the value.
         const LFSR_POLY: u32 = 0xd80000; // 24-bit polynomial
@@ -44,6 +45,7 @@ impl IndexLfsr {
         let value = self.lfsr - 1; // lfsr will never have value of 0
         self.lfsr = (self.lfsr >> 1) ^ ((0u32.wrapping_sub(self.lfsr & 1u32)) & LFSR_POLY);
         assert!(self.lfsr != self.initial, "Too many peers created");
-        value ^ self.mask
+
+        Index::new_local(value ^ self.mask)
     }
 }


### PR DESCRIPTION
Previously, boringtun's sender/receiver index of a session would just be rendered as a full u32. In reality, this u32 contains two pieces of information: The higher 24 bits identify the peer and the lower 8 bits identify the session with that peer. With the update to boringtun in https://github.com/firezone/boringtun/pull/112, we encode this logic in a dedicated type that has prints this information separately. Here is what the logs now look like:

```
2025-08-05T07:38:37.742Z DEBUG boringtun::noise: Received handshake_response local_idx=(3428714|1) remote_idx=(1937676|1)
2025-08-05T07:38:37.743Z DEBUG boringtun::noise: New session idx=(3428714|1)
2025-08-05T07:38:37.743Z DEBUG boringtun::noise: Sending keepalive local_idx=(3428714|1)
```