### PR TITLE
test(portal): fix flaky acceptance auth test

### DIFF
--- a/elixir/apps/web/test/web/acceptance/auth_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth_test.exs
@@ -38,7 +38,7 @@ defmodule Web.Acceptance.AuthTest do
       |> visit(~p"/#{account}")
       |> Auth.authenticate(identity)
       |> visit(~p"/#{account}/actors")
-      |> assert_el(Query.css("#user-menu-button"))
+      |> assert_el(Query.css("#user-menu-button", visible: true))
       |> click(Query.css("#user-menu-button"))
       |> assert_el(Query.link("Sign out", visible: true))
       |> click(Query.link("Sign out"))


### PR DESCRIPTION
Occasionally, this fails because the element is found, but not visible due to a race condition. To fix this, we assert that the element should be visible before clicking on it.

Fixes https://github.com/firezone/firezone/actions/runs/16751908154/job/47424125321