### PR TITLE
chore(ci): set up sccache (again)

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -33,6 +33,9 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+    - run: echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
+      shell: bash
     - name: Disable Windows Defender
       if: ${{ runner.os == 'Windows' }}
       run: Set-MpPreference -DisableRealtimeMonitoring $true
@@ -62,3 +65,9 @@ runs:
 
         echo "nightly=$NIGHTLY" >> $GITHUB_OUTPUT
       shell: bash
+
+    - name: Start sccache
+      run: $SCCACHE_PATH --start-server
+      shell: bash
+      env:
+        SCCACHE_CONF: ".github/actions/setup-rust/sccache.toml"


### PR DESCRIPTION
This was removed in a8f93d24a31ef636db84a55dfd626a7c7a85a5ff but it turns out it's quite trivial just to use the GitHub actions cache (the default).

Fixes #10125 