### PR TITLE
test(portal): Flows.delete_expired_flows/0

### DIFF
--- a/elixir/apps/domain/test/domain/flows_test.exs
+++ b/elixir/apps/domain/test/domain/flows_test.exs
@@ -758,6 +758,21 @@ defmodule Domain.FlowsTest do
     end
   end
 
+  describe "delete_expired_flows/0" do
+    test "deletes only expired flows", %{account: account} do
+      expired_at = DateTime.utc_now() |> DateTime.add(-1, :day)
+      flow1 = Fixtures.Flows.create_flow(account: account, expires_at: expired_at)
+
+      not_expired_at = DateTime.utc_now() |> DateTime.add(1, :day)
+      flow2 = Fixtures.Flows.create_flow(account: account, expires_at: not_expired_at)
+
+      delete_expired_flows()
+
+      assert Repo.get(Flows.Flow, flow1.id) == nil
+      assert [^flow2] = Repo.all(Flows.Flow)
+    end
+  end
+
   describe "delete_stale_flows_on_connect/2" do
     setup %{
       account: account

--- a/elixir/apps/domain/test/support/fixtures/flows.ex
+++ b/elixir/apps/domain/test/support/fixtures/flows.ex
@@ -80,6 +80,8 @@ defmodule Domain.Fixtures.Flows do
         %{id: subject.token_id}
       end)
 
+    expires_at = Map.get(attrs, :expires_at, subject.expires_at)
+
     Flows.Flow.Changeset.create(%{
       token_id: token_id,
       policy_id: policy_id,
@@ -91,7 +93,7 @@ defmodule Domain.Fixtures.Flows do
       client_remote_ip: client.last_seen_remote_ip,
       client_user_agent: client.last_seen_user_agent,
       gateway_remote_ip: gateway.last_seen_remote_ip,
-      expires_at: subject.expires_at || DateTime.utc_now() |> DateTime.add(14, :day)
+      expires_at: expires_at
     })
     |> Repo.insert!()
   end


### PR DESCRIPTION
Adds a missing test for the `Flows.delete_expired_flows/0` function.