### PR TITLE
chore(portal): drop id in favor of lsn pkey

### DIFF
--- a/elixir/apps/domain/lib/domain/change_logs/change_log.ex
+++ b/elixir/apps/domain/lib/domain/change_logs/change_log.ex
@@ -1,10 +1,11 @@
 defmodule Domain.ChangeLogs.ChangeLog do
   use Domain, :schema
 
+  @primary_key false
   schema "change_logs" do
     belongs_to :account, Domain.Accounts.Account
 
-    field :lsn, :integer
+    field :lsn, :integer, primary_key: true
     field :table, :string
     field :op, Ecto.Enum, values: [:insert, :update, :delete]
     field :old_data, :map

--- a/elixir/apps/domain/priv/repo/manual_migrations/20250806081944_move_pkey_to_lsn_on_change_logs.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250806081944_move_pkey_to_lsn_on_change_logs.exs
@@ -1,0 +1,23 @@
+defmodule Domain.Repo.Migrations.MovePkeyToLsnOnChangeLogs do
+  use Ecto.Migration
+
+  def up do
+    alter table(:change_logs) do
+      remove(:id)
+    end
+
+    drop(index(:change_logs, [:lsn]))
+
+    execute("ALTER TABLE change_logs ADD PRIMARY KEY (lsn)")
+  end
+
+  def down do
+    execute("ALTER TABLE change_logs DROP CONSTRAINT change_logs_pkey")
+
+    alter table(:change_logs) do
+      add(:id, :uuid, default: fragment("gen_random_uuid()"), primary_key: true)
+    end
+
+    create(index(:change_logs, [:lsn]))
+  end
+end


### PR DESCRIPTION
On the `change_logs` table, we want to minimize write overhead as much as possible. One major way to do this is the minimize the number of indexes maintained.

Because `lsn` is guaranteed to be unique, we can use it as the primary, saving us an index (and column).

**NOTE**: This migration will need to acquire a lock on the table, so it's added as a manual migration to execute out of band. Since we don't read ChangeLogs anywhere, it should be fine for the app servers to come up without this migration applied.