### PR TITLE
ci: reduce UDP perf test bitrate

### DIFF
--- a/scripts/tests/perf/relayed-udp-client2server.sh
+++ b/scripts/tests/perf/relayed-udp-client2server.sh
@@ -8,7 +8,7 @@ install_iptables_drop_rules
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \
   --udp \
-  --bandwidth 500M \
+  --bandwidth 450M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
 

--- a/scripts/tests/perf/relayed-udp-server2client.sh
+++ b/scripts/tests/perf/relayed-udp-server2client.sh
@@ -9,7 +9,7 @@ docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \
   --reverse \
   --udp \
-  --bandwidth 500M \
+  --bandwidth 450M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
 


### PR DESCRIPTION
Forcing 500MBit/s through a relayed connection in CI makes the user-space relay fall-over and drop control messages, leading to ICE timeouts of the connection.