### PR TITLE
fix: specify linux/amd64 platform for dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -329,6 +329,7 @@ services:
       args:
         PACKAGE: firezone-headless-client
     image: ${CLIENT_IMAGE:-ghcr.io/firezone/debug/client}:${CLIENT_TAG:-main}
+    platform: linux/amd64
     privileged: true # Needed to tune `sysctl` inside container.
     cap_add:
       - NET_ADMIN
@@ -360,6 +361,7 @@ services:
       args:
         PACKAGE: firezone-gateway
     image: ${GATEWAY_IMAGE:-ghcr.io/firezone/debug/gateway}:${GATEWAY_TAG:-main}
+    platform: linux/amd64
     cap_add:
       - NET_ADMIN
     sysctls:
@@ -443,6 +445,7 @@ services:
       args:
         PACKAGE: firezone-relay
     image: ${RELAY_IMAGE:-ghcr.io/firezone/debug/relay}:${RELAY_TAG:-main}
+    platform: linux/amd64
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 10s
@@ -482,6 +485,7 @@ services:
       args:
         PACKAGE: firezone-relay
     image: ${RELAY_IMAGE:-ghcr.io/firezone/debug/relay}:${RELAY_TAG:-main}
+    platform: linux/amd64
     healthcheck:
       test: ["CMD-SHELL", "lsof -i UDP | grep firezone-relay"]
       start_period: 10s


### PR DESCRIPTION
These are needed on arm64 platforms since we only build `debug` images for amd64.