### PR TITLE
chore(ci): enable data plane arm64 debug images

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -189,9 +189,8 @@ jobs:
 
         # Syntax is weird because https://github.com/actions/runner/issues/1512
         exclude:
-          # Exclude debug builds for non-amd64 targets since they won't be used.
+          # Devs are either on amd64 or arm64
           - { stage: debug, arch: { platform: linux/arm/v7 } }
-          - { stage: debug, arch: { platform: linux/arm64 } }
           # Exclude http-test-server from perf image builds
           - { image_prefix: perf, name: { package: http-test-server } }
 


### PR DESCRIPTION
On developers with Apple Silicon machines, this allows for testing native binaries without having to build data plane images.