### PR TITLE
fix(relay): don't inline hotpath loop calls

### DIFF
--- a/rust/relay/ebpf-turn-router/src/checksum.rs
+++ b/rust/relay/ebpf-turn-router/src/checksum.rs
@@ -72,7 +72,7 @@ fn fold_u32_into_u16(mut csum: u32) -> u16 {
     csum as u16
 }
 
-#[inline(always)]
+#[inline(never)]
 fn fold_u128_into_u16(mut csum: u128) -> u16 {
     csum = (csum & 0xffff) + (csum >> 16);
     csum = (csum & 0xffff) + (csum >> 16);


### PR DESCRIPTION
When inlining large(ish) functions that are on the hot-path, it creates a much longer program for the eBPF verifier to validate since the verifier is working through all packet sizes and types. We're hitting an issue on GCP (in the 8-core dev VM, XDP-generic) where verification fails on `main` due to the inlining of some hot-path functions.

This PR is the smallest possible change that gets the program to load, highlighting the issue.

In practice, I'm not there is a detectable performance difference between having these inlined vs not (especially in DRV_MODE) so I'm not sure it's worth the potential debugging headaches later on.