### PR TITLE
fix(relay): swap MACs for relayed traffic

### DIFF
--- a/rust/relay/ebpf-turn-router/src/error.rs
+++ b/rust/relay/ebpf-turn-router/src/error.rs
@@ -6,7 +6,6 @@ pub enum Error {
     NotUdp,
     NotTurn,
     NotIp,
-    NoMacAddress,
     Ipv4PacketWithOptions,
     NotAChannelDataMessage,
     BadChannelDataLength,
@@ -41,7 +40,6 @@ impl aya_log_ebpf::WriteToBuf for Error {
             Error::NotUdp => "Not a UDP packet".write(buf),
             Error::NotTurn => "Not TURN traffic".write(buf),
             Error::NotIp => "Not an IP packet".write(buf),
-            Error::NoMacAddress => "No MAC address".write(buf),
             Error::Ipv4PacketWithOptions => "IPv4 packet has options".write(buf),
             Error::NotAChannelDataMessage => "Not a channel data message".write(buf),
             Error::BadChannelDataLength => {


### PR DESCRIPTION
In nearly all environments, we can safely assume that we will always use the same network gateway for forwarding relayed packets as the one we received them from.

By leveraging this assumption, we can simply swap the SRC and DST MAC addresses, removing the need to keep a HaspMap for these, which eliminates the need to worry about thread-safety for this particular functionality.

Related: #10138