### PR TITLE
chore(infra): push relay binary to gcp

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -320,7 +320,6 @@ jobs:
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}
       # For pushing built images to Google Cloud Storage
       - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-        continue-on-error: true
         with:
           token_format: access_token
           workload_identity_provider: "projects/85623168602/locations/global/workloadIdentityPools/github-pool/providers/github-provider"

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -318,6 +318,25 @@ jobs:
 
           # Used for Docker images
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}
+      # For pushing built images to Google Cloud Storage
+      - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+        continue-on-error: true
+        with:
+          token_format: access_token
+          workload_identity_provider: "projects/85623168602/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "github-account@firezone-staging.iam.gserviceaccount.com"
+          export_environment_variables: true
+          create_credentials_file: true
+      - name: Copy relay to Google Cloud Storage
+        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
+        run: |
+          gcloud storage cp \
+            "$BINARY_DEST_PATH" \
+            gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}
+
+          gcloud storage cp \
+            "$BINARY_DEST_PATH".sha256sum.txt \
+            gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt
       - name: Upload Release Assets
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.release_name }}
         env:

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -320,6 +320,7 @@ jobs:
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}
       # For pushing built images to Google Cloud Storage
       - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+        # if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
         with:
           token_format: access_token
           workload_identity_provider: "projects/85623168602/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
@@ -327,7 +328,7 @@ jobs:
           export_environment_variables: true
           create_credentials_file: true
       - name: Copy relay to Google Cloud Storage
-        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
+        # if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
         run: |
           set -e
           gcloud storage cp \

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -330,6 +330,7 @@ jobs:
       - name: Copy relay to Google Cloud Storage
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
         run: |
+          set -e
           gcloud storage cp \
             "$BINARY_DEST_PATH" \
             gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -320,7 +320,7 @@ jobs:
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}
       # For pushing built images to Google Cloud Storage
       - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-        # if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
+        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
         with:
           token_format: access_token
           workload_identity_provider: "projects/85623168602/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
@@ -328,7 +328,7 @@ jobs:
           export_environment_variables: true
           create_credentials_file: true
       - name: Copy relay to Google Cloud Storage
-        # if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
+        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
         run: |
           set -e
           gcloud storage cp \


### PR DESCRIPTION
The COS images we currently use to run our Relays ship with an older Linux kernel that doesn't have some of the nice verifier improvements for our eBPF relay.

To fix this, we need to use Ubuntu 24.04. To keep things simple there, we would like to avoid installing Docker on that image and instead run the Relay raw. To support that, we first need to push the built relay binary to our staging cloud storage bucket.

Related: #10177
Related: https://github.com/firezone/infra/pull/116