### PR TITLE
fix(ci): compute sha256sum of binaries earlier

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -318,6 +318,7 @@ jobs:
 
           # Used for Docker images
           cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} ${{ matrix.name.package }}
+          sha256sum ${{ matrix.name.package }} > ${{ matrix.name.package }}.sha256sum.txt
       # For pushing built images to Google Cloud Storage
       - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
@@ -354,11 +355,11 @@ jobs:
           fi
 
           # Used for release artifact
-          cp target/${{ matrix.arch.target }}/${{ inputs.profile }}/${{ matrix.name.package }} "$BINARY_DEST_PATH"
-          sha256sum "$BINARY_DEST_PATH" > "$BINARY_DEST_PATH".sha256sum.txt
+          cp ${{ matrix.name.package }} "$BINARY_DEST_PATH"
+          cp ${{ matrix.name.package }}.sha256sum.txt "$BINARY_DEST_PATH".sha256sum.txt
           gh release upload ${{ matrix.name.release_name }} \
-            ${{ env.BINARY_DEST_PATH }} \
-            ${{ env.BINARY_DEST_PATH }}.sha256sum.txt \
+            "$BINARY_DEST_PATH" \
+            "$BINARY_DEST_PATH".sha256sum.txt \
             "$clobber" \
             --repo ${{ github.repository }}
       - name: Set up QEMU


### PR DESCRIPTION
Fixes an issue where the sha256sum.txt of the relay was not available.

Related: #10198 