### PR TITLE
feat(relay): learn interface addresses

### DIFF
--- a/rust/relay/ebpf-shared/src/lib.rs
+++ b/rust/relay/ebpf-shared/src/lib.rs
@@ -204,6 +204,60 @@ impl Default for Config {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct InterfaceAddressV4 {
+    address: [u8; 4],
+    learned: bool,
+}
+
+impl InterfaceAddressV4 {
+    pub fn set(&mut self, addr: Ipv4Addr) {
+        self.address = addr.octets();
+        self.learned = true;
+    }
+
+    pub fn get(&self) -> Option<Ipv4Addr> {
+        if self.learned {
+            Some(self.address.into())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_learned(&self) -> bool {
+        self.learned
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct InterfaceAddressV6 {
+    address: [u8; 16],
+    learned: bool,
+}
+
+impl InterfaceAddressV6 {
+    pub fn set(&mut self, addr: Ipv6Addr) {
+        self.address = addr.octets();
+        self.learned = true;
+    }
+
+    pub fn get(&self) -> Option<Ipv6Addr> {
+        if self.learned {
+            Some(self.address.into())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_learned(&self) -> bool {
+        self.learned
+    }
+}
+
+#[repr(C)]
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct StatsEvent {
@@ -233,4 +287,8 @@ mod userspace {
     unsafe impl aya::Pod for PortAndPeerV6 {}
 
     unsafe impl aya::Pod for Config {}
+
+    unsafe impl aya::Pod for InterfaceAddressV4 {}
+
+    unsafe impl aya::Pod for InterfaceAddressV6 {}
 }

--- a/rust/relay/ebpf-turn-router/src/error.rs
+++ b/rust/relay/ebpf-turn-router/src/error.rs
@@ -2,6 +2,8 @@ use core::num::NonZeroUsize;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Error {
+    InterfaceIpv4AddressAccessFailed,
+    InterfaceIpv6AddressAccessFailed,
     PacketTooShort,
     NotUdp,
     NotTurn,
@@ -35,6 +37,8 @@ impl aya_log_ebpf::WriteToBuf for Error {
     fn write(self, buf: &mut [u8]) -> Option<NonZeroUsize> {
         // Use a simpler match structure to help the verifier
         let msg = match self {
+            Error::InterfaceIpv4AddressAccessFailed => "Failed to access interface IPv4 address",
+            Error::InterfaceIpv6AddressAccessFailed => "Failed to access interface IPv6 address",
             Error::PacketTooShort => "Packet is too short",
             Error::NotUdp => "Not a UDP packet",
             Error::NotTurn => "Not TURN traffic",

--- a/rust/relay/ebpf-turn-router/src/error.rs
+++ b/rust/relay/ebpf-turn-router/src/error.rs
@@ -37,8 +37,12 @@ impl aya_log_ebpf::WriteToBuf for Error {
     fn write(self, buf: &mut [u8]) -> Option<NonZeroUsize> {
         // Use a simpler match structure to help the verifier
         let msg = match self {
-            Error::InterfaceIpv4AddressAccessFailed => "Failed to access interface IPv4 address",
-            Error::InterfaceIpv6AddressAccessFailed => "Failed to access interface IPv6 address",
+            Error::InterfaceIpv4AddressAccessFailed => {
+                "Failed to get pointer to interface IPv4 address map"
+            }
+            Error::InterfaceIpv6AddressAccessFailed => {
+                "Failed to get pointer to interface IPv6 address map"
+            }
             Error::PacketTooShort => "Packet is too short",
             Error::NotUdp => "Not a UDP packet",
             Error::NotTurn => "Not TURN traffic",

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -397,12 +397,13 @@ fn try_handle_ipv6_channel_data_to_udp(
 
 #[inline(always)]
 fn learn_interface_ipv4_address(ipv4: &Ip4) -> Result<(), Error> {
-    let interface_addr = match INT_ADDR_V4.get_ptr_mut(0) {
-        Some(addr) => addr,
-        None => return Err(Error::InterfaceIpv4AddressAccessFailed),
-    };
+    let interface_addr = INT_ADDR_V4
+        .get_ptr_mut(0)
+        .ok_or(Error::InterfaceIpv4AddressAccessFailed)?;
 
     let dst_ip = ipv4.dst();
+
+    // SAFETY: These are per-cpu maps so we don't need to worry about thread safety.
     unsafe {
         if !(*interface_addr).is_learned() {
             (*interface_addr).set(dst_ip);
@@ -414,12 +415,13 @@ fn learn_interface_ipv4_address(ipv4: &Ip4) -> Result<(), Error> {
 
 #[inline(always)]
 fn learn_interface_ipv6_address(ipv6: &Ip6) -> Result<(), Error> {
-    let interface_addr = match INT_ADDR_V6.get_ptr_mut(0) {
-        Some(addr) => addr,
-        None => return Err(Error::InterfaceIpv6AddressAccessFailed),
-    };
+    let interface_addr = INT_ADDR_V6
+        .get_ptr_mut(0)
+        .ok_or(Error::InterfaceIpv6AddressAccessFailed)?;
 
     let dst_ip = ipv6.dst();
+
+    // SAFETY: These are per-cpu maps so we don't need to worry about thread safety.
     unsafe {
         if !(*interface_addr).is_learned() {
             (*interface_addr).set(dst_ip);


### PR DESCRIPTION
In order to support cross-stack relaying, we need to know what the source IP is going to be to write the packets from. To know this, we can simply learn the destination IP address for incoming packets to our XDP program.

A separate cache is used per IP stack in order be a bit more cache line friendly and prevent contention when only IP stack lookup is needed.

Related: #10192 