### PR TITLE
feat(telemetry): pre-resolve Sentry ingest host

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6021,6 +6021,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http 1.3.1",
  "http-body",
  "http-body-util",

--- a/rust/apple-client-ffi/src/lib.rs
+++ b/rust/apple-client-ffi/src/lib.rs
@@ -263,7 +263,7 @@ impl WrappedSession {
             .enable_all()
             .build()?;
 
-        let mut telemetry = Telemetry::default();
+        let mut telemetry = Telemetry::new().context("Failed to create telemetry client")?;
         runtime.block_on(telemetry.start(&api_url, RELEASE, APPLE_DSN, device_id.clone()));
         Telemetry::set_account_slug(account_slug.clone());
 

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -233,7 +233,7 @@ fn connect(
         .build()
         .context("Failed to create tokio runtime")?;
 
-    let mut telemetry = Telemetry::default();
+    let mut telemetry = Telemetry::new().context("Failed to create telemetry client")?;
     runtime.block_on(telemetry.start(&api_url, RELEASE, platform::DSN, device_id.clone()));
     Telemetry::set_account_slug(account_slug.clone());
 

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> ExitCode {
         .install_default()
         .expect("Calling `install_default` only once per process should always succeed");
 
-    let mut telemetry = Telemetry::default();
+    let mut telemetry = Telemetry::new().expect("Failed to create telemetry client");
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -281,6 +281,8 @@ impl<'a> Handler<'a> {
     ) -> Result<Self> {
         dns_controller.deactivate()?;
 
+        let telemetry = Telemetry::new().context("Failed to create telemetry client")?;
+
         tracing::info!(
             server_pid = std::process::id(),
             "Listening for GUI to connect over IPC..."
@@ -306,7 +308,7 @@ impl<'a> Handler<'a> {
             ipc_tx,
             log_filter_reloader,
             session: Session::None,
-            telemetry: Telemetry::default(),
+            telemetry,
             tun_device,
             dns_notifier,
             network_notifier,

--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -112,7 +112,7 @@ fn parse_filter(directives: &str) -> Result<EnvFilter, ParseError> {
     ///
     /// By prepending this directive to the active log filter, a simple directive like `debug` actually produces useful logs.
     /// If necessary, you can still activate logs from these crates by restating them in your directive with a lower filter, i.e. `netlink_proto=debug`.
-    const IRRELEVANT_CRATES: &str = "netlink_proto=warn,os_info=warn,rustls=warn,opentelemetry_sdk=info,opentelemetry=info,hyper_util=info";
+    const IRRELEVANT_CRATES: &str = "netlink_proto=warn,os_info=warn,rustls=warn,opentelemetry_sdk=info,opentelemetry=info,hyper_util=info,h2=info";
 
     let env_filter = if directives.is_empty() {
         EnvFilter::try_new(IRRELEVANT_CRATES)?

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -125,15 +125,20 @@ fn main() {
         .build()
         .expect("Failed to build tokio runtime");
 
-    let mut telemetry = Telemetry::default();
-    if args.telemetry {
+    let mut telemetry = if args.telemetry {
+        let mut telemetry = Telemetry::new().expect("Failed to create telemetry client");
+
         runtime.block_on(telemetry.start(
             args.api_url.as_str(),
             VERSION.unwrap_or("unknown"),
             RELAY_DSN,
             String::new(), // Relays don't have a Firezone ID.
         ));
-    }
+
+        telemetry
+    } else {
+        Telemetry::disabled()
+    };
 
     match runtime.block_on(try_main(args)) {
         Ok(()) => runtime.block_on(telemetry.stop()),

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -13,7 +13,7 @@ moka = { workspace = true, features = ["sync"] }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["http2"] }
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing", "release-health", "logs"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -428,10 +428,7 @@ impl sentry::TransportFactory for TransportFactory {
             .http2_keep_alive_while_idle(true)
             .http2_keep_alive_timeout(Duration::from_secs(1))
             .http2_keep_alive_interval(Duration::from_secs(5)) // Ensure we detect broken connections, i.e. when enabling / disabling the Internet Resource.
-            .resolve_to_addrs(
-                "o4507971108339712.ingest.us.sentry.io",
-                &self.ingest_domain_addresses,
-            )
+            .resolve_to_addrs(INGEST_HOST, &self.ingest_domain_addresses)
             .build()
             .expect("Failed to build HTTP client");
 


### PR DESCRIPTION
Our Sentry client needs to resolve DNS before being able to send logs or errors to the backend. Currently, this DNS resolution happens on-demand as we don't take any control of the underlying HTTP client.

In addition, this will use HTTP/1.1 by default which isn't as efficient as it could be, especially with concurrent requests.

Finally, if we decide to ever proxy all Sentry for traffic through our own domain, we have to take control of the underlying client anyway.

To resolve all of the above, we create a custom `TransportFactory` where we reuse the existing `ReqwestHttpTransport` but provide an already configured `reqwest::Client` that always uses HTTP/2 with a pre-configured set of DNS records for the given ingest host.