### PR TITLE
feat(telemetry): pre-resolve PostHog ingest host

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6021,6 +6021,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http 1.3.1",
  "http-body",
  "http-body-util",

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -13,7 +13,7 @@ moka = { workspace = true, features = ["sync"] }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 parking_lot = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["http2"] }
 sentry = { workspace = true, features = ["contexts", "backtrace", "debug-images", "panic", "reqwest", "rustls", "tracing", "release-health", "logs"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/telemetry/src/posthog.rs
+++ b/rust/telemetry/src/posthog.rs
@@ -54,7 +54,7 @@ fn init_client() -> reqwest::Result<reqwest::Client> {
         .pool_max_idle_per_host(1)
         .http2_prior_knowledge() // We know PostHog supports HTTP/2.
         .http2_keep_alive_timeout(Duration::from_secs(1))
-        .http2_keep_alive_interval(Duration::from_secs(5)) // Use keep-alives to detect broken connections.
+        .http2_keep_alive_interval(Duration::from_secs(5)) // Use keep-alive to detect broken connections.
         .resolve_to_addrs(INGEST_HOST, &ingest_host_addresses)
         .build()
 }


### PR DESCRIPTION
In order to effectively share the HTTP client for requests to PostHog, we pre-resolve the IPs of the host and create a lazily initialised `reqwest::Client` that gets shared between all analytics calls.