### PR TITLE
refactor(relay): use zero check for is_learned

### DIFF
--- a/rust/relay/ebpf-shared/src/lib.rs
+++ b/rust/relay/ebpf-shared/src/lib.rs
@@ -208,25 +208,21 @@ impl Default for Config {
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct InterfaceAddressV4 {
     address: [u8; 4],
-    learned: bool,
 }
 
 impl InterfaceAddressV4 {
+    const ZERO: [u8; 4] = [0; 4];
+
     pub fn set(&mut self, addr: Ipv4Addr) {
         self.address = addr.octets();
-        self.learned = true;
     }
 
-    pub fn get(&self) -> Option<Ipv4Addr> {
-        if self.learned {
-            Some(self.address.into())
-        } else {
-            None
-        }
+    pub fn get(&self) -> Ipv4Addr {
+        self.address.into()
     }
 
     pub fn is_learned(&self) -> bool {
-        self.learned
+        self.address != Self::ZERO
     }
 }
 
@@ -235,25 +231,21 @@ impl InterfaceAddressV4 {
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct InterfaceAddressV6 {
     address: [u8; 16],
-    learned: bool,
 }
 
 impl InterfaceAddressV6 {
+    const ZERO: [u8; 16] = [0; 16];
+
     pub fn set(&mut self, addr: Ipv6Addr) {
         self.address = addr.octets();
-        self.learned = true;
     }
 
-    pub fn get(&self) -> Option<Ipv6Addr> {
-        if self.learned {
-            Some(self.address.into())
-        } else {
-            None
-        }
+    pub fn get(&self) -> Ipv6Addr {
+        self.address.into()
     }
 
     pub fn is_learned(&self) -> bool {
-        self.learned
+        self.address != Self::ZERO
     }
 }
 

--- a/rust/relay/ebpf-shared/src/lib.rs
+++ b/rust/relay/ebpf-shared/src/lib.rs
@@ -217,12 +217,12 @@ impl InterfaceAddressV4 {
         self.address = addr.octets();
     }
 
-    pub fn get(&self) -> Ipv4Addr {
-        self.address.into()
-    }
-
-    pub fn is_learned(&self) -> bool {
-        self.address != Self::ZERO
+    pub fn get(&self) -> Option<Ipv4Addr> {
+        if self.address != Self::ZERO {
+            Some(self.address.into())
+        } else {
+            None
+        }
     }
 }
 
@@ -240,12 +240,12 @@ impl InterfaceAddressV6 {
         self.address = addr.octets();
     }
 
-    pub fn get(&self) -> Ipv6Addr {
-        self.address.into()
-    }
-
-    pub fn is_learned(&self) -> bool {
-        self.address != Self::ZERO
+    pub fn get(&self) -> Option<Ipv6Addr> {
+        if self.address != Self::ZERO {
+            Some(self.address.into())
+        } else {
+            None
+        }
     }
 }
 

--- a/rust/relay/ebpf-turn-router/src/main.rs
+++ b/rust/relay/ebpf-turn-router/src/main.rs
@@ -405,7 +405,7 @@ fn learn_interface_ipv4_address(ipv4: &Ip4) -> Result<(), Error> {
 
     // SAFETY: These are per-cpu maps so we don't need to worry about thread safety.
     unsafe {
-        if !(*interface_addr).is_learned() {
+        if (*interface_addr).get().is_none() {
             (*interface_addr).set(dst_ip);
         }
     }
@@ -423,7 +423,7 @@ fn learn_interface_ipv6_address(ipv6: &Ip6) -> Result<(), Error> {
 
     // SAFETY: These are per-cpu maps so we don't need to worry about thread safety.
     unsafe {
-        if !(*interface_addr).is_learned() {
+        if (*interface_addr).get().is_none() {
             (*interface_addr).set(dst_ip);
         }
     }


### PR DESCRIPTION
Simplifies the interface map we store to use a zero-check instead of explicit bool.

Related: https://github.com/firezone/firezone/pull/10200#discussion_r2281117072