### PR TITLE
refactor(connlib): move client phoenix-channel to separate task

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1347,6 +1347,7 @@ dependencies = [
  "dns-types",
  "firezone-logging",
  "firezone-tunnel",
+ "futures",
  "ip_network",
  "libc",
  "phoenix-channel",

--- a/rust/client-shared/Cargo.toml
+++ b/rust/client-shared/Cargo.toml
@@ -12,6 +12,7 @@ connlib-model = { workspace = true }
 dns-types = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-tunnel = { workspace = true }
+futures = { workspace = true }
 ip_network = { workspace = true }
 libc = { workspace = true }
 phoenix-channel = { workspace = true }

--- a/rust/client-shared/src/lib.rs
+++ b/rust/client-shared/src/lib.rs
@@ -138,10 +138,14 @@ async fn connect(
     cmd_rx: UnboundedReceiver<Command>,
     event_tx: Sender<Event>,
 ) -> Result<()> {
-    let tunnel = ClientTunnel::new(tcp_socket_factory, udp_socket_factory);
-    let mut eventloop = Eventloop::new(tunnel, portal, cmd_rx, event_tx);
-
-    std::future::poll_fn(|cx| eventloop.poll(cx)).await?;
+    Eventloop::new(
+        ClientTunnel::new(tcp_socket_factory, udp_socket_factory),
+        portal,
+        cmd_rx,
+        event_tx,
+    )
+    .run()
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
Currently, `connlib`'s event-loop for clients uses manual polling to advance the state of the tunnel and the phoenix-channel. Manual polling is powerful but also easy to get wrong, resulting in task-wakeup bugs.

Additionally, if the tunnel is very busy with processing packets, the phoenix-channel may not get enough CPU time, resulting in a loss of the WebSocket connection.

To fix this, we move the phoenix-channel to a separate task and use channels to connect it with `connlib`'s main event-loop. This one is now primarily focused on advancing the tunnel state, effectively offloading the problem of fair scheduling to the tokio runtime.

Related: #10003