### PR TITLE
feat(connlib): discard intermediate resource and TUN updates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1360,6 +1360,7 @@ dependencies = [
  "thiserror 2.0.15",
  "time",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tun",
  "url",
@@ -7996,6 +7997,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/rust/apple-client-ffi/src/lib.rs
+++ b/rust/apple-client-ffi/src/lib.rs
@@ -142,8 +142,8 @@ impl CallbackHandler {
         tunnel_address_v6: Ipv6Addr,
         dns_addresses: Vec<IpAddr>,
         search_domain: Option<DomainName>,
-        route_list_v4: Vec<Ipv4Network>,
-        route_list_v6: Vec<Ipv6Network>,
+        route_list_v4: impl IntoIterator<Item = Ipv4Network>,
+        route_list_v6: impl IntoIterator<Item = Ipv6Network>,
     ) {
         match (
             serde_json::to_string(&dns_addresses),
@@ -315,21 +315,14 @@ impl WrappedSession {
 
             while let Some(event) = event_stream.next().await {
                 match event {
-                    Event::TunInterfaceUpdated {
-                        ipv4,
-                        ipv6,
-                        dns,
-                        search_domain,
-                        ipv4_routes,
-                        ipv6_routes,
-                    } => {
+                    Event::TunInterfaceUpdated(config) => {
                         callback_handler.on_set_interface_config(
-                            ipv4,
-                            ipv6,
-                            dns,
-                            search_domain,
-                            ipv4_routes,
-                            ipv6_routes,
+                            config.ip.v4,
+                            config.ip.v6,
+                            config.dns_sentinel_ips(),
+                            config.search_domain,
+                            config.ipv4_routes,
+                            config.ipv6_routes,
                         );
                     }
                     Event::ResourcesUpdated(resource_views) => {

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -175,8 +175,8 @@ impl TunDeviceManager {
 
     pub async fn set_routes(
         &mut self,
-        ipv4: Vec<Ipv4Network>,
-        ipv6: Vec<Ipv6Network>,
+        ipv4: impl IntoIterator<Item = Ipv4Network>,
+        ipv6: impl IntoIterator<Item = Ipv6Network>,
     ) -> Result<()> {
         let new_routes: HashSet<IpNetwork> = ipv4
             .into_iter()

--- a/rust/bin-shared/src/tun_device_manager/macos.rs
+++ b/rust/bin-shared/src/tun_device_manager/macos.rs
@@ -29,8 +29,8 @@ impl TunDeviceManager {
     )]
     pub async fn set_routes(
         &mut self,
-        _ipv4: Vec<Ipv4Network>,
-        _ipv6: Vec<Ipv6Network>,
+        _ipv4: impl IntoIterator<Item = Ipv4Network>,
+        _ipv6: impl IntoIterator<Item = Ipv6Network>,
     ) -> Result<()> {
         bail!("Not implemented")
     }

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -99,8 +99,11 @@ impl TunDeviceManager {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub async fn set_routes(&mut self, v4: Vec<Ipv4Network>, v6: Vec<Ipv6Network>) -> Result<()> {
+    pub async fn set_routes(
+        &mut self,
+        v4: impl IntoIterator<Item = Ipv4Network>,
+        v6: impl IntoIterator<Item = Ipv6Network>,
+    ) -> Result<()> {
         let iface_idx = self
             .iface_idx
             .context("Cannot set routes without having created TUN device")?;

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -99,6 +99,7 @@ impl TunDeviceManager {
         Ok(())
     }
 
+    #[expect(clippy::unused_async, reason = "Must match Linux API")]
     pub async fn set_routes(
         &mut self,
         v4: impl IntoIterator<Item = Ipv4Network>,

--- a/rust/client-shared/Cargo.toml
+++ b/rust/client-shared/Cargo.toml
@@ -23,6 +23,7 @@ socket-factory = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true, features = ["rt", "sync"] }
+tokio-stream = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, features = ["std", "attributes"] }
 tun = { workspace = true }
 url = { workspace = true, features = ["serde"] }

--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -110,7 +110,7 @@ enum CombinedEvent {
 }
 
 impl Eventloop {
-    pub async fn run(mut self) -> Result<()> {
+    pub async fn run(mut self) -> Result<(), DisconnectError> {
         loop {
             match future::poll_fn(|cx| self.next_event(cx)).await {
                 CombinedEvent::Command(None) => return Ok(()),
@@ -128,7 +128,9 @@ impl Eventloop {
                     self.handle_portal_message(msg).await?;
                 }
                 CombinedEvent::Portal(None) => {
-                    return Err(anyhow::Error::msg("portal task exited unexpectedly"));
+                    return Err(DisconnectError(anyhow::Error::msg(
+                        "portal task exited unexpectedly",
+                    )));
                 }
             }
         }

--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -443,7 +443,7 @@ async fn phoenix_channel_event_loop(
                 "Hiccup in portal connection: {error:#}"
             ),
             Either::Left((Err(e), _)) => {
-                let _ = event_tx.send(PortalEvent::Error(e)).await; // We don't care about the result because we are exiting anyway.
+                let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.
 
                 break;
             }

--- a/rust/client-shared/src/lib.rs
+++ b/rust/client-shared/src/lib.rs
@@ -133,7 +133,7 @@ impl Drop for Session {
 
 /// A supervisor task that handles, when [`connect`] exits.
 async fn connect_supervisor(
-    connect_handle: JoinHandle<Result<()>>,
+    connect_handle: JoinHandle<Result<(), DisconnectError>>,
     event_tx: tokio::sync::mpsc::Sender<Event>,
 ) {
     let task = async {

--- a/rust/client-shared/src/lib.rs
+++ b/rust/client-shared/src/lib.rs
@@ -2,6 +2,7 @@
 pub use crate::serde_routelist::{V4RouteList, V6RouteList};
 pub use connlib_model::StaticSecret;
 pub use eventloop::{DisconnectError, Event};
+pub use firezone_tunnel::TunConfig;
 pub use firezone_tunnel::messages::client::{IngressMessages, ResourceDescription};
 
 use anyhow::{Context as _, Result};

--- a/rust/client-shared/src/serde_routelist.rs
+++ b/rust/client-shared/src/serde_routelist.rs
@@ -13,7 +13,7 @@ struct Cidr<T> {
 pub struct V4RouteList(Vec<Cidr<Ipv4Addr>>);
 
 impl V4RouteList {
-    pub fn new(route: Vec<Ipv4Network>) -> Self {
+    pub fn new(route: impl IntoIterator<Item = Ipv4Network>) -> Self {
         Self(
             route
                 .into_iter()
@@ -32,7 +32,7 @@ impl V4RouteList {
 pub struct V6RouteList(Vec<Cidr<Ipv6Addr>>);
 
 impl V6RouteList {
-    pub fn new(route: Vec<Ipv6Network>) -> Self {
+    pub fn new(route: impl IntoIterator<Item = Ipv6Network>) -> Self {
         Self(
             route
                 .into_iter()

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -446,6 +446,12 @@ pub struct TunConfig {
     pub ipv6_routes: BTreeSet<Ipv6Network>,
 }
 
+impl TunConfig {
+    pub fn dns_sentinel_ips(&self) -> Vec<IpAddr> {
+        self.dns_by_sentinel.left_values().copied().collect()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IpConfig {
     pub v4: Ipv4Addr,

--- a/rust/gui-client/src-tauri/src/service.rs
+++ b/rust/gui-client/src-tauri/src/service.rs
@@ -473,19 +473,16 @@ impl<'a> Handler<'a> {
                 })
                 .await?
             }
-            client_shared::Event::TunInterfaceUpdated {
-                ipv4,
-                ipv6,
-                dns,
-                search_domain,
-                ipv4_routes,
-                ipv6_routes,
-            } => {
+            client_shared::Event::TunInterfaceUpdated(config) => {
                 self.session.transition_to_connected()?;
 
-                self.tun_device.set_ips(ipv4, ipv6).await?;
-                self.dns_controller.set_dns(dns, search_domain).await?;
-                self.tun_device.set_routes(ipv4_routes, ipv6_routes).await?;
+                self.tun_device.set_ips(config.ip.v4, config.ip.v6).await?;
+                self.dns_controller
+                    .set_dns(config.dns_sentinel_ips(), config.search_domain)
+                    .await?;
+                self.tun_device
+                    .set_routes(config.ipv4_routes, config.ipv6_routes)
+                    .await?;
                 self.dns_controller.flush()?;
             }
             client_shared::Event::ResourcesUpdated(resources) => {

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -328,18 +328,10 @@ fn main() -> Result<()> {
                     // On every Resources update, flush DNS to mitigate <https://github.com/firezone/firezone/issues/5052>
                     dns_controller.flush()?;
                 }
-                client_shared::Event::TunInterfaceUpdated {
-                    ipv4,
-                    ipv6,
-                    dns,
-                    search_domain,
-                    ipv4_routes,
-                    ipv6_routes,
-                } => {
-                    tun_device.set_ips(ipv4, ipv6).await?;
-                    tun_device.set_routes(ipv4_routes, ipv6_routes).await?;
-
-                    dns_controller.set_dns(dns, search_domain).await?;
+                client_shared::Event::TunInterfaceUpdated(config) => {
+                    tun_device.set_ips(config.ip.v4, config.ip.v6).await?;
+                    dns_controller.set_dns(config.dns_sentinel_ips(), config.search_domain).await?;
+                    tun_device.set_routes(config.ipv4_routes, config.ipv6_routes).await?;
 
                     // `on_set_interface_config` is guaranteed to be called when the tunnel is completely ready
                     // <https://github.com/firezone/firezone/pull/6026#discussion_r1692297438>


### PR DESCRIPTION
Right now, the Client event-loops have a channel with 1000 items for sending new resource lists and updates to the TUN device to the host app. This is kind of unnecessary as we always only care about the last version of these. Intermediate updates that the host app doesn't process are effectively irrelevant.

We've had an issue before where a bug in the portal caused us to receive many updates to resources which ended up crashing Client apps because this channel filled up.

To be more resilient on this front, we refactor the Client event loop to use a `watch` channel for this. Watch channels only retain the last value that got sent into them.