### PR TITLE
fix(apple): flush dns cache on resource updates

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -372,8 +372,15 @@ extension Adapter: CallbackHandlerDelegate {
     workQueue.async { [weak self] in
       guard let self = self else { return }
 
-      // Update resource List. We don't care what's inside.
-      resourceListJSON = resourceList
+      if resourceListJSON != resourceList, let networkSettings = self.networkSettings {
+        // Update resource List. We don't care what's inside.
+        resourceListJSON = resourceList
+
+        // Apply network settings to flush DNS cache when resources change
+        // This ensures new DNS resources are immediately resolvable
+        Log.log("Reapplying network settings to flush DNS cache after resource update")
+        networkSettings.apply()
+      }
 
       self.resourcesUpdated()
     }

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,12 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="10224">
+          Fixes a minor DNS cache bug where newly-added DNS resources may not
+          resolve for a few seconds after showing up in the Resource List.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.7" date={new Date("2025-08-07")}>
         <ChangeItem pull="10143">
           Fixes an issue on iOS 17 and below that caused the tunnel to crash


### PR DESCRIPTION
In the following sequence of events, a user will be unable to connect to the DNS resource for a few seconds because macOS is caching the queries, preventing connlib from seeing them.

1. User signs in
2. User has _no_ access to DNS Resource A
3. User queries for DNS Resource A - NXDOMAIN -> macOS caches this
4. Admin grants access to DNS Resource A
5. User tries query again -> connlib never sees the query -> cache hit -> NXDOMAIN

To fix this, we call `networkSettings.apply()` whenever the resource list has changed. This has been tested to trigger a DNS cache flush on macOS.