### PR TITLE
fix(connlib): exit phoenix-channel event-loop on error

### DIFF
--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -479,10 +479,9 @@ async fn phoenix_channel_event_loop(
                 "Hiccup in portal connection: {error:#}"
             ),
             Either::Left((Err(e), _)) => {
-                if event_tx.send(PortalEvent::Error(e)).await.is_err() {
-                    tracing::debug!("Event channel closed: exiting phoenix-channel event-loop");
-                    break;
-                }
+                let _ = event_tx.send(PortalEvent::Error(e)).await; // We don't care about the result because we ar exiting anyway.
+
+                break;
             }
             Either::Right((Some(PortalCommand::Send(msg)), _)) => {
                 portal.send(PHOENIX_TOPIC, msg);

--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -479,7 +479,7 @@ async fn phoenix_channel_event_loop(
                 "Hiccup in portal connection: {error:#}"
             ),
             Either::Left((Err(e), _)) => {
-                let _ = event_tx.send(PortalEvent::Error(e)).await; // We don't care about the result because we ar exiting anyway.
+                let _ = event_tx.send(PortalEvent::Error(e)).await; // We don't care about the result because we are exiting anyway.
 
                 break;
             }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -632,10 +632,9 @@ async fn phoenix_channel_event_loop(
                 "Hiccup in portal connection: {error:#}"
             ),
             Either::Left((Err(e), _)) => {
-                if event_tx.send(Err(e)).await.is_err() {
-                    tracing::debug!("Event channel closed: exiting phoenix-channel event-loop");
-                    break;
-                }
+                let _ = event_tx.send(Err(e)).await; // We don't care about the result because we ar exiting anyway.
+
+                break;
             }
             Either::Right((Some(PortalCommand::Send(msg)), _)) => {
                 portal.send(PHOENIX_TOPIC, msg);

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -632,7 +632,7 @@ async fn phoenix_channel_event_loop(
                 "Hiccup in portal connection: {error:#}"
             ),
             Either::Left((Err(e), _)) => {
-                let _ = event_tx.send(Err(e)).await; // We don't care about the result because we ar exiting anyway.
+                let _ = event_tx.send(Err(e)).await; // We don't care about the result because we are exiting anyway.
 
                 break;
             }


### PR DESCRIPTION
We cannot poll the `PhoenixChannel` after it has returned an error, otherwise it will panic. Therefore, we exit the event-loop then. The outer event-loop also exits as soon as it receives an error from this channel so this is fine.

`PhoenixChannel` only returns an error when it has irrecoverably disconnected, e.g. after the retries have been exhausted or we hit a 4xx error on the WebSocket connection.