### PR TITLE
refactor(connlib): increase UDP queues on desktop platforms

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2674,6 +2674,7 @@ dependencies = [
  "test-strategy",
  "thiserror 2.0.15",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tun",

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -50,6 +50,7 @@ socket-factory = { workspace = true }
 socket2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 tun = { workspace = true }
 uuid = { workspace = true, features = ["std", "v4"] }


### PR DESCRIPTION
On desktop platforms, we can easily afford to have larger queues here despite each item in there being 65k. Benchmarking showed that we do sometimes fill these up.

Related: #7452 