### PR TITLE
chore(rust): allow `too_many_arguments` repo-wide

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -221,6 +221,7 @@ redundant_else = "warn"
 redundant_clone = "warn"
 unwrap_in_result = "warn"
 unwrap_used = "warn"
+too_many_arguments = "allow" # Don't care.
 
 [workspace.lints.rustdoc]
 private-intra-doc-links = "allow" # We don't publish any of our docs but want to catch dead links.

--- a/rust/apple-client-ffi/src/lib.rs
+++ b/rust/apple-client-ffi/src/lib.rs
@@ -242,9 +242,6 @@ fn init_logging(log_dir: PathBuf, log_filter: String) -> Result<()> {
 }
 
 impl WrappedSession {
-    // TODO: Refactor this when we refactor PhoenixChannel.
-    // See https://github.com/firezone/firezone/issues/2158
-    #[expect(clippy::too_many_arguments)]
     fn connect(
         api_url: String,
         token: String,

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -217,7 +217,6 @@ impl Drop for Session {
     }
 }
 
-#[expect(clippy::too_many_arguments, reason = "We don't care.")]
 fn connect(
     api_url: String,
     token: String,

--- a/rust/connlib/phoenix-channel/src/login_url.rs
+++ b/rust/connlib/phoenix-channel/src/login_url.rs
@@ -251,7 +251,6 @@ fn get_host_name() -> Option<String> {
     hostname::get().ok().and_then(|x| x.into_string().ok())
 }
 
-#[expect(clippy::too_many_arguments)]
 fn get_websocket_path<E>(
     mut api_url: Url,
     token: &SecretString,

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -683,7 +683,6 @@ where
     }
 
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
     fn init_connection(
         &mut self,
         cid: TId,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -598,7 +598,6 @@ impl ClientState {
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(%rid))]
-    #[expect(clippy::too_many_arguments)]
     pub fn handle_flow_created(
         &mut self,
         rid: ResourceId,

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -242,7 +242,6 @@ impl GatewayState {
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(%cid))]
-    #[expect(clippy::too_many_arguments)]
     pub fn authorize_flow(
         &mut self,
         cid: ClientId,

--- a/rust/connlib/tunnel/src/tests/assertions.rs
+++ b/rust/connlib/tunnel/src/tests/assertions.rs
@@ -158,7 +158,6 @@ pub(crate) fn assert_resource_status(ref_client: &RefClient, sim_client: &SimCli
     }
 }
 
-#[expect(clippy::too_many_arguments)]
 fn assert_packets_properties<T, U>(
     ref_client: &RefClient,
     sent_requests: &HashMap<(T, U), IpPacket>,

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -176,7 +176,6 @@ enum EventloopTick {
 pub struct FailedToReceiveHello(anyhow::Error);
 
 impl<I: GuiIntegration> Controller<I> {
-    #[expect(clippy::too_many_arguments, reason = "We don't care.")]
     pub(crate) async fn start(
         ctlr_tx: CtlrTx,
         integration: I,


### PR DESCRIPTION
We always end up allow this lint when it pops up so we can also just allow it for the whole repo in general. Most of the time, the reason for too many arguments are borrow-checker limitations of Rust where mutable references need to be tracked explicitly.