### PR TITLE
feat(headless-client): allow exporting metrics via OTLP

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2515,6 +2515,7 @@ dependencies = [
  "libc",
  "nix 0.30.1",
  "opentelemetry",
+ "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "phoenix-channel",

--- a/rust/headless-client/Cargo.toml
+++ b/rust/headless-client/Cargo.toml
@@ -21,6 +21,7 @@ futures = { workspace = true }
 humantime = { workspace = true }
 ip-packet = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
+opentelemetry-otlp = { workspace = true, features = ["metrics", "grpc-tonic"] }
 opentelemetry-stdout = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 phoenix-channel = { workspace = true }


### PR DESCRIPTION
In order to explore our metrics more easily, we add an exporter via OTLP to the headless-client. The Gateway already supports this.