### PR TITLE
refactor(connlib): periodically record queue depths

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "dirs",
  "dns-types",
  "firezone-logging",
+ "firezone-telemetry",
  "futures",
  "gat-lending-iterator",
  "hex",
@@ -2606,6 +2607,7 @@ name = "firezone-telemetry"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "flume",
  "futures",
  "hex",
  "ip-packet",

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -13,6 +13,7 @@ axum = { workspace = true, features = ["http1", "tokio"] }
 clap = { workspace = true, features = ["derive", "env"] }
 dns-types = { workspace = true }
 firezone-logging = { workspace = true }
+firezone-telemetry = { workspace = true }
 futures = { workspace = true, features = ["std", "async-await"] }
 gat-lending-iterator = { workspace = true }
 hex = { workspace = true }

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -3,6 +3,7 @@ use crate::windows::TUNNEL_UUID;
 use crate::windows::error::{NOT_FOUND, NOT_SUPPORTED, OBJECT_EXISTS};
 use anyhow::{Context as _, Result};
 use firezone_logging::err_with_src;
+use firezone_telemetry::otel;
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use ip_packet::{IpPacket, IpPacketBuf};
 use ring::digest;

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -300,14 +300,14 @@ impl Tun {
         let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE); // We want to be able to batch-receive from this.
 
-        tokio::spawn(otel::metrics::system_queue_length(
+        tokio::spawn(otel::metrics::periodic_system_queue_length(
             outbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),
                 otel::attr::network_io_direction_transmit(),
             ],
         ));
-        tokio::spawn(otel::metrics::system_queue_length(
+        tokio::spawn(otel::metrics::periodic_system_queue_length(
             inbound_tx.downgrade(),
             [
                 otel::attr::queue_item_ip_packet(),

--- a/rust/bin-shared/src/tun_device_manager/windows.rs
+++ b/rust/bin-shared/src/tun_device_manager/windows.rs
@@ -298,6 +298,22 @@ impl Tun {
         );
         let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE); // We want to be able to batch-receive from this.
+
+        tokio::spawn(otel::metrics::system_queue_length(
+            outbound_tx.downgrade(),
+            [
+                otel::attr::queue_item_ip_packet(),
+                otel::attr::network_io_direction_transmit(),
+            ],
+        ));
+        tokio::spawn(otel::metrics::system_queue_length(
+            inbound_tx.downgrade(),
+            [
+                otel::attr::queue_item_ip_packet(),
+                otel::attr::network_io_direction_receive(),
+            ],
+        ));
+
         let send_thread = start_send_thread(outbound_rx, Arc::downgrade(&session))
             .context("Failed to start send thread")?;
         let recv_thread = start_recv_thread(inbound_tx, Arc::downgrade(&session))
@@ -364,21 +380,6 @@ impl tun::Tun for Tun {
             .map_err(io::Error::other)?;
 
         Ok(())
-    }
-
-    fn queue_lengths(&self) -> (usize, usize) {
-        self.state
-            .as_ref()
-            .map(|s| {
-                (
-                    s.inbound_rx.len(),
-                    s.outbound_tx
-                        .get_ref()
-                        .map(|s| QUEUE_SIZE - s.capacity())
-                        .unwrap_or_default(),
-                )
-            })
-            .unwrap_or_default()
     }
 }
 

--- a/rust/bin-shared/tests/dns_control_windows.rs
+++ b/rust/bin-shared/tests/dns_control_windows.rs
@@ -6,26 +6,20 @@ use std::{collections::BTreeSet, net::IpAddr};
 
 // Passes in CI but not locally. Maybe ReactorScram's dev system has IPv6 misconfigured. There it fails to pick up the IPv6 DNS servers.
 #[ignore = "Needs admin, changes system state"]
-#[test]
-fn dns_control() {
+#[tokio::test]
+async fn dns_control() {
     let _guard = firezone_logging::test("debug");
-
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .build()
-        .unwrap();
 
     let mut tun_dev_manager = firezone_bin_shared::TunDeviceManager::new(1280).unwrap();
     let _tun = tun_dev_manager.make_tun().unwrap();
 
-    rt.block_on(async {
-        tun_dev_manager
-            .set_ips(
-                [100, 92, 193, 137].into(),
-                [0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0xa, 0x9db5].into(),
-            )
-            .await
-    })
-    .unwrap();
+    tun_dev_manager
+        .set_ips(
+            [100, 92, 193, 137].into(),
+            [0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0xa, 0x9db5].into(),
+        )
+        .await
+        .unwrap();
 
     let mut dns_controller = DnsController {
         dns_control_method: DnsControlMethod::Nrpt,
@@ -41,12 +35,10 @@ fn dns_control() {
             0xfd00, 0x2021, 0x1111, 0x8000, 0x0100, 0x0100, 0x0111, 0x0004,
         ]),
     ];
-    rt.block_on(async {
-        dns_controller
-            .set_dns(fz_dns_servers.clone(), None)
-            .await
-            .unwrap();
-    });
+    dns_controller
+        .set_dns(fz_dns_servers.clone(), None)
+        .await
+        .unwrap();
 
     let adapter = ipconfig::get_adapters()
         .unwrap()

--- a/rust/client-ffi/src/platform/android/tun.rs
+++ b/rust/client-ffi/src/platform/android/tun.rs
@@ -1,3 +1,4 @@
+use firezone_telemetry::otel;
 use futures::SinkExt as _;
 use ip_packet::{IpPacket, IpPacketBuf};
 use std::os::fd::{FromRawFd, OwnedFd};
@@ -44,16 +45,6 @@ impl tun::Tun for Tun {
     ) -> Poll<usize> {
         self.inbound_rx.poll_recv_many(cx, buf, max)
     }
-
-    fn queue_lengths(&self) -> (usize, usize) {
-        (
-            self.inbound_rx.len(),
-            self.outbound_tx
-                .get_ref()
-                .map(|s| QUEUE_SIZE - s.capacity())
-                .unwrap_or_default(),
-        )
-    }
 }
 
 impl Tun {
@@ -68,6 +59,21 @@ impl Tun {
 
         let (inbound_tx, inbound_rx) = mpsc::channel(QUEUE_SIZE);
         let (outbound_tx, outbound_rx) = mpsc::channel(QUEUE_SIZE);
+
+        tokio::spawn(otel::metrics::periodic_system_queue_length(
+            outbound_tx.downgrade(),
+            [
+                otel::attr::queue_item_ip_packet(),
+                otel::attr::network_io_direction_transmit(),
+            ],
+        ));
+        tokio::spawn(otel::metrics::periodic_system_queue_length(
+            inbound_tx.downgrade(),
+            [
+                otel::attr::queue_item_ip_packet(),
+                otel::attr::network_io_direction_receive(),
+            ],
+        ));
 
         std::thread::Builder::new()
             .name("TUN send".to_owned())

--- a/rust/client-ffi/src/platform/fallback.rs
+++ b/rust/client-ffi/src/platform/fallback.rs
@@ -65,8 +65,4 @@ impl tun::Tun for Tun {
     fn name(&self) -> &str {
         todo!()
     }
-
-    fn queue_lengths(&self) -> (usize, usize) {
-        todo!()
-    }
 }

--- a/rust/connlib/tun/src/lib.rs
+++ b/rust/connlib/tun/src/lib.rs
@@ -26,7 +26,4 @@ pub trait Tun: Send + Sync + 'static {
 
     /// The name of the TUN device.
     fn name(&self) -> &str;
-
-    /// The number of inbounds and outbound packets sitting in queues.
-    fn queue_lengths(&self) -> (usize, usize);
 }

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -85,13 +85,6 @@ impl Device {
         Ok(())
     }
 
-    pub fn queue_lengths(&self) -> (usize, usize) {
-        self.tun
-            .as_ref()
-            .map(|t| t.queue_lengths())
-            .unwrap_or_default()
-    }
-
     fn tun(&mut self) -> io::Result<&mut dyn Tun> {
         Ok(self
             .tun

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -372,10 +372,6 @@ impl Tun for ValidateChecksumAdapter {
     fn name(&self) -> &str {
         self.inner.name()
     }
-
-    fn queue_lengths(&self) -> (usize, usize) {
-        self.inner.queue_lengths()
-    }
 }
 
 impl ValidateChecksumAdapter {

--- a/rust/telemetry/Cargo.toml
+++ b/rust/telemetry/Cargo.toml
@@ -6,6 +6,7 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+flume = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 ip-packet = { workspace = true }


### PR DESCRIPTION
Instead of recording the queue depths on every event-loop tick, we now record them once a second by setting a Gauge. Not only is that a simpler instrument to work with but it is significantly more performant. The current version - when metrics are enabled - takes on quite a bit of CPU time.

Resolves: #10237