### PR TITLE
chore(dev): postgres max_connections=200

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
   postgres:
     # TODO: Enable pgaudit on dev instance. See https://github.com/pgaudit/pgaudit/issues/44#issuecomment-455090262
     image: postgres:17
-    command: ["postgres", "-c", "wal_level=logical"]
+    command:
+      ["postgres", "-c", "wal_level=logical", "-c", "max_connections=200"]
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
On machines with many cores, the elixir apps will crashloop because we exceed the number of allowed postgres connections. This raises the limit with virtually no downside except for a bit more memory usage.