### PR TITLE
chore(ci): downgrade runners to free tier

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -26,17 +26,17 @@ runs:
         //registry.npmjs.org/:_authToken=${{ inputs.npmjs-token }}
         RC
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      if: "${{ inputs.lockfile-dir }}"
+      if: "${{ inputs.lockfile-dir != '' }}"
       with:
         version: latest
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      if: "${{ inputs.lockfile-dir }}"
+      if: "${{ inputs.lockfile-dir != '' }}"
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
         cache-dependency-path: ${{ inputs.pnpm-lockfile }}
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      if: "${{ ! inputs.lockfile-dir }}"
+      if: "${{ inputs.lockfile-dir == '' }}"
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -26,17 +26,17 @@ runs:
         //registry.npmjs.org/:_authToken=${{ inputs.npmjs-token }}
         RC
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      if: "${{ inputs.lockfile-dir != null }}"
+      if: "${{ inputs.lockfile-dir }}"
       with:
         version: latest
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      if: "${{ inputs.lockfile-dir != null }}"
+      if: "${{ inputs.lockfile-dir }}"
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
         cache-dependency-path: ${{ inputs.pnpm-lockfile }}
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      if: "${{ inputs.lockfile-dir == null }}"
+      if: "${{ ! inputs.lockfile-dir }}"
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -34,7 +34,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
-        cache-dependency-path: ${{ inputs.pnpm-lockfile }}
+        cache-dependency-path: ${{ inputs.lockfile-dir }}
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       if: "${{ inputs.lockfile-dir == '' }}"
       with:

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,6 +1,9 @@
 name: "Setup Node"
 description: "Sets up the correct Node version and installs pnpm"
 inputs:
+  lockfile-dir:
+    description: "Path to the pnpm-lock.yaml file"
+    required: false
   npmjs-token:
     description: "NPMJS token to use for authentication"
     required: true
@@ -23,9 +26,17 @@ runs:
         //registry.npmjs.org/:_authToken=${{ inputs.npmjs-token }}
         RC
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      if: "${{ inputs.lockfile-dir != '' }}"
       with:
         version: latest
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      if: "${{ inputs.lockfile-dir == '' }}"
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
+        cache-dependency-path: ${{ inputs.pnpm-lockfile }}
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      if: "${{ inputs.lockfile-dir == '' }}"
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -3,7 +3,7 @@ description: "Sets up the correct Node version and installs pnpm"
 inputs:
   lockfile-dir:
     description: "Path to the pnpm-lock.yaml file"
-    required: false
+    required: true
   npmjs-token:
     description: "NPMJS token to use for authentication"
     required: true
@@ -26,17 +26,10 @@ runs:
         //registry.npmjs.org/:_authToken=${{ inputs.npmjs-token }}
         RC
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      if: "${{ inputs.lockfile-dir != '' }}"
       with:
         version: latest
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      if: "${{ inputs.lockfile-dir != '' }}"
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
         cache-dependency-path: ${{ inputs.lockfile-dir }}
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      if: "${{ inputs.lockfile-dir == '' }}"
-      with:
-        node-version: ${{ inputs.node-version }}
-        cache: npm

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -22,10 +22,10 @@ runs:
         always-auth=true
         //registry.npmjs.org/:_authToken=${{ inputs.npmjs-token }}
         RC
+    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      with:
+        version: latest
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
-    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      with:
-        version: latest

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,6 +1,9 @@
 name: "Setup Node"
 description: "Sets up the correct Node version and installs pnpm"
 inputs:
+  npmjs-token:
+    description: "NPMJS token to use for authentication"
+    required: true
   node-version:
     description: "Version of nodejs to install"
     required: false
@@ -10,16 +13,14 @@ runs:
   steps:
     - name: Configure npm auth
       shell: bash
-      env:
-        NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
       run: |
-        if [[ -z "${NPMJS_TOKEN}" ]]; then
-          echo "NPMJS_TOKEN is not set. Add it as a repo/org secret." >&2
+        if [[ -z "${{ inputs.npmjs-token }}" ]]; then
+          echo "inputs.npmjs-token not provided" >&2
           exit 1
         fi
         cat > "$HOME/.npmrc" <<'RC'
         always-auth=true
-        //registry.npmjs.org/:_authToken=${NPMJS_TOKEN}
+        //registry.npmjs.org/:_authToken=${{ inputs.npmjs-token }}
         RC
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -8,9 +8,23 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      with:
-        version: 9.3
+    - name: Configure npm auth
+      shell: bash
+      env:
+        NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+      run: |
+        if [[ -z "${NPMJS_TOKEN}" ]]; then
+          echo "NPMJS_TOKEN is not set. Add it as a repo/org secret." >&2
+          exit 1
+        fi
+        cat > "$HOME/.npmrc" <<'RC'
+        always-auth=true
+        //registry.npmjs.org/:_authToken=${NPMJS_TOKEN}
+        RC
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
+        cache: pnpm
+    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      with:
+        version: latest

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -26,17 +26,17 @@ runs:
         //registry.npmjs.org/:_authToken=${{ inputs.npmjs-token }}
         RC
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      if: "${{ inputs.lockfile-dir != '' }}"
+      if: "${{ inputs.lockfile-dir != null }}"
       with:
         version: latest
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      if: "${{ inputs.lockfile-dir == '' }}"
+      if: "${{ inputs.lockfile-dir != null }}"
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
         cache-dependency-path: ${{ inputs.pnpm-lockfile }}
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      if: "${{ inputs.lockfile-dir == '' }}"
+      if: "${{ inputs.lockfile-dir == null }}"
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -42,41 +42,14 @@ runs:
       run: Set-MpPreference -DisableRealtimeMonitoring $true
       shell: powershell
 
-    - name: Extract Rust version
-      run: |
-        RUST_TOOLCHAIN=$(grep 'channel' rust-toolchain.toml | awk -F '"' '{print $2}')
-        echo "RUST_TOOLCHAIN=$RUST_TOOLCHAIN" >> $GITHUB_ENV
-      shell: bash
-      working-directory: ./rust
-
-    - name: Cache Rust toolchain
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.rustup/toolchains
-          ~/.rustup/update-hashes
-          ~/.rustup/settings.toml
-        key: rust-toolchain-${{ runner.os }}-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('rust/rust-toolchain.toml') }}
-        restore-keys: |
-          rust-toolchain-${{ runner.os }}-${{ env.RUST_TOOLCHAIN }}-
-          rust-toolchain-${{ runner.os }}-
-
-    - name: Cache cargo registry and git deps
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry/index
-          ~/.cargo/registry/cache
-          ~/.cargo/git/db
-        key: cargo-registry-${{ runner.os }}-${{ hashFiles('rust/**/Cargo.lock') }}
-        restore-keys: |
-          cargo-registry-${{ runner.os }}-
-
-    - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+    - uses: actions-rust-lang/setup-rust-toolchain@ab6845274e2ff01cd4462007e1a9d9df1ab49f42 # v1
       id: toolchain
       with:
-        toolchain: ${{ env.RUST_TOOLCHAIN }}
         components: rustfmt,clippy
+        target: ${{ inputs.targets }}
+        cache: true
+        cache-on-failure: true
+        rustflags: ""  # Don't set -D warnings by default
 
     # We use Azure Blob Storage for sccache because credits and GHA cache is too small (10 GB).
     # For this to work, you need an Azure Storage account and a blob container named `sccache`.
@@ -88,10 +61,6 @@ runs:
         echo "SCCACHE_AZURE_CONNECTION_STRING=${{ inputs.sccache_azure_connection_string }}" >> $GITHUB_ENV
         echo "SCCACHE_AZURE_BLOB_CONTAINER=sccache" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
-
-    - if: inputs.targets != ''
-      run: rustup target add ${{ inputs.targets }}
-      shell: bash
 
     - name: Install nightly Rust
       id: nightly

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -49,6 +49,29 @@ runs:
       shell: bash
       working-directory: ./rust
 
+    - name: Cache Rust toolchain
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.rustup/toolchains
+          ~/.rustup/update-hashes
+          ~/.rustup/settings.toml
+        key: rust-toolchain-${{ runner.os }}-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('rust/rust-toolchain.toml') }}
+        restore-keys: |
+          rust-toolchain-${{ runner.os }}-${{ env.RUST_TOOLCHAIN }}-
+          rust-toolchain-${{ runner.os }}-
+
+    - name: Cache cargo registry and git deps
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git/db
+        key: cargo-registry-${{ runner.os }}-${{ hashFiles('rust/**/Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-${{ runner.os }}-
+
     - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
       id: toolchain
       with:
@@ -74,8 +97,11 @@ runs:
       id: nightly
       run: |
         NIGHTLY="nightly-2025-05-30"
-        rustup toolchain install $NIGHTLY
-        rustup component add rust-src --toolchain $NIGHTLY
+        # Check if nightly toolchain is already installed
+        if ! rustup toolchain list | grep -q "$NIGHTLY"; then
+          rustup toolchain install $NIGHTLY
+          rustup component add rust-src --toolchain $NIGHTLY
+        fi
         echo "nightly=$NIGHTLY" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -42,14 +42,21 @@ runs:
       run: Set-MpPreference -DisableRealtimeMonitoring $true
       shell: powershell
 
+    - name: Extract Rust version
+      run: |
+        RUST_TOOLCHAIN=$(grep 'channel' rust/rust-toolchain.toml | awk -F '"' '{print $2}')
+        echo "RUST_TOOLCHAIN=$RUST_TOOLCHAIN" >> $GITHUB_ENV
+      shell: bash
+
     - uses: actions-rust-lang/setup-rust-toolchain@ab6845274e2ff01cd4462007e1a9d9df1ab49f42 # v1
       id: toolchain
       with:
+        toolchain: ${{ env.RUST_TOOLCHAIN }}
         components: rustfmt,clippy
         target: ${{ inputs.targets }}
         cache: true
         cache-on-failure: true
-        rustflags: ""  # Don't set -D warnings by default
+        rustflags: "" # Don't set -D warnings by default
 
     # We use Azure Blob Storage for sccache because credits and GHA cache is too small (10 GB).
     # For this to work, you need an Azure Storage account and a blob container named `sccache`.

--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -12,11 +12,18 @@ runs:
     - name: Cache apt packages
       if: ${{ runner.os == 'Linux' }}
       uses: actions/cache@v4
+      id: apt-cache
       with:
-        path: /var/cache/apt/archives
+        path: ~/apt-cache
         key: ${{ runner.os }}-apt-tauri-${{ hashFiles('.github/actions/setup-tauri-v2/action.yml') }}
         restore-keys: |
           ${{ runner.os }}-apt-tauri-
+
+    - name: Restore cached apt packages
+      if: ${{ runner.os == 'Linux' && steps.apt-cache.outputs.cache-hit == 'true' }}
+      run: |
+        sudo cp ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+      shell: bash
 
     - name: Apt-get update
       if: ${{ runner.os == 'Linux' }}
@@ -39,6 +46,13 @@ runs:
     - name: Install Tauri runtime deps
       if: ${{ runner.os == 'Linux' && inputs.runtime == 'true' }}
       run: sudo apt-get --yes install at-spi2-core xvfb
+      shell: bash
+
+    - name: Save apt packages to cache
+      if: ${{ runner.os == 'Linux' && steps.apt-cache.outputs.cache-hit != 'true' }}
+      run: |
+        mkdir -p ~/apt-cache
+        sudo cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
       shell: bash
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' }}

--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -5,7 +5,7 @@ inputs:
   runtime:
     description: "Whether to also set up runtime dependencies"
     required: false
-    default: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -17,17 +17,17 @@ runs:
         key: ${{ runner.os }}-apt-tauri-${{ hashFiles('.github/actions/setup-tauri-v2/action.yml') }}
         restore-keys: |
           ${{ runner.os }}-apt-tauri-
-    
+
     - name: Apt-get update
       if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get update
       shell: bash
-    
+
     - name: Install Tauri build deps
       if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get --yes install build-essential curl file libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev wget
       shell: bash
-    
+
     - name: Install gnome-keyring
       if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get --yes install gnome-keyring
@@ -35,7 +35,7 @@ runs:
       # This is only needed if we'll launch the Tauri GUI, so it's redundant for clippy / test
       # This is what the Tauri CI tests use
       # <https://github.com/tauri-apps/tauri/blob/3fb414b61ad7cfce67751230826fddfb39effec5/.github/workflows/bench.yml#L74>
-    
+
     - name: Install Tauri runtime deps
       if: ${{ runner.os == 'Linux' && inputs.runtime == 'true' }}
       run: sudo apt-get --yes install at-spi2-core xvfb

--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -9,14 +9,25 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Cache apt packages
+      if: ${{ runner.os == 'Linux' }}
+      uses: actions/cache@v4
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-apt-tauri-${{ hashFiles('.github/actions/setup-tauri-v2/action.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-tauri-
+    
     - name: Apt-get update
       if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get update
       shell: bash
+    
     - name: Install Tauri build deps
       if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get --yes install build-essential curl file libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev wget
       shell: bash
+    
     - name: Install gnome-keyring
       if: ${{ runner.os == 'Linux' }}
       run: sudo apt-get --yes install gnome-keyring
@@ -24,6 +35,7 @@ runs:
       # This is only needed if we'll launch the Tauri GUI, so it's redundant for clippy / test
       # This is what the Tauri CI tests use
       # <https://github.com/tauri-apps/tauri/blob/3fb414b61ad7cfce67751230826fddfb39effec5/.github/workflows/bench.yml#L74>
+    
     - name: Install Tauri runtime deps
       if: ${{ runner.os == 'Linux' && inputs.runtime == 'true' }}
       run: sudo apt-get --yes install at-spi2-core xvfb

--- a/.github/package.json
+++ b/.github/package.json
@@ -1,0 +1,15 @@
+{
+  "name": ".github",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "prettier": "^3.6.2"
+  }
+}

--- a/.github/pnpm-lock.yaml
+++ b/.github/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
+
+packages:
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+snapshots:
+
+  prettier@3.6.2: {}

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         pass_filenames: false
       - id: prettier
         name: Prettier
-        entry: pnpm run --dir .github/ prettier --check --ignore-unknown ../
+        entry: ./.github/node_modules/prettier/bin/prettier.cjs
         language: system
         pass_filenames: false
 

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -9,7 +9,8 @@ repos:
         pass_filenames: false
       - id: prettier
         name: Prettier
-        entry: ./.github/node_modules/prettier/bin/prettier.cjs
+        entry: pnpm
+        args: ["exec", "prettier", "--check", "--ignore-unknown", "."]
         language: system
         pass_filenames: false
 

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -10,7 +10,16 @@ repos:
       - id: prettier
         name: Prettier
         entry: pnpm
-        args: ["--dir", ".github", "exec", "prettier", "--check", "--ignore-unknown", "."]
+        args:
+          [
+            "--dir",
+            ".github",
+            "exec",
+            "prettier",
+            "--check",
+            "--ignore-unknown",
+            ".",
+          ]
         language: system
         pass_filenames: false
 

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: prettier
         name: Prettier
         entry: pnpm
-        args: ["exec", "prettier", "--check", "--ignore-unknown", "."]
+        args: ["--dir", ".github", "exec", "prettier", "--check", "--ignore-unknown", "."]
         language: system
         pass_filenames: false
 

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -16,9 +16,11 @@ repos:
             ".github",
             "exec",
             "prettier",
+            "--ignore-path",
+            "../.prettierignore",
             "--check",
             "--ignore-unknown",
-            ".",
+            "../",
           ]
         language: system
         pass_filenames: false

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         pass_filenames: false
       - id: prettier
         name: Prettier
-        entry: prettier --check --ignore-unknown .
+        entry: pnpm run --dir .github/ prettier --check --ignore-unknown ../
         language: system
         pass_filenames: false
 

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -292,11 +292,6 @@ jobs:
         with:
           targets: ${{ matrix.arch.target }}
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
-      - name: Cache toolchain
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
-        with:
-          path: /tmp/toolchain
-          key: ${{ runner.os }}-${{ matrix.arch.shortname }}-musl-cross
       - name: Install dependencies
         run: ${{ matrix.arch.install_dependencies }}
       - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   control-plane:
     name: ${{ matrix.image_name }}
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -132,7 +132,7 @@ jobs:
   data-plane-windows:
     name: client-windows-${{ matrix.target }}
     if: ${{ inputs.image_prefix != 'perf' }} # Perf testing happens only on Linux
-    runs-on: windows-2022-xlarge
+    runs-on: windows-2022
     defaults:
       run:
         working-directory: rust
@@ -193,7 +193,7 @@ jobs:
 
   data-plane-linux:
     name: ${{ matrix.name.image_name }}-${{ matrix.arch.shortname }}
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: rust
@@ -437,7 +437,7 @@ jobs:
     name: merge-${{ matrix.image.name }}
     needs: data-plane-linux
     if: ${{ always() }}
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   analyze:
     name: analyze-${{ matrix.working-directory }}
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-14-xlarge') || 'ubuntu-22.04-xlarge' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-14') || 'ubuntu-22.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir
@@ -44,7 +44,7 @@ jobs:
           reporter: java-junit
 
   type-check:
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir
@@ -82,7 +82,7 @@ jobs:
         run: mix dialyzer --format dialyxir
 
   static-analysis:
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir
@@ -111,7 +111,7 @@ jobs:
         run: mix deps.unlock --check-unused
 
   migrations-and-seed-test:
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir
@@ -150,7 +150,7 @@ jobs:
     name: acceptance-test-${{ matrix.MIX_TEST_PARTITION }}
     permissions:
       checks: write
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./elixir

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -186,6 +186,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
+          lockfile-dir: ./elixir/apps/web/assets
       - name: Compile Application
         run: mix compile --warnings-as-errors
       - name: Install Front-End Dependencies

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -184,6 +184,8 @@ jobs:
         with:
           mix_env: ${{ env.MIX_ENV }}
       - uses: ./.github/actions/setup-node
+        with:
+          npmjs-token: ${{ secrets.NPMJS_TOKEN }}
       - name: Compile Application
         run: mix compile --warnings-as-errors
       # Front-End deps cache

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -188,60 +188,14 @@ jobs:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
       - name: Compile Application
         run: mix compile --warnings-as-errors
-      # Front-End deps cache
-      - uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        name: pnpm Web Deps Cache
-        id: pnpm-web-deps-cache
-        env:
-          cache-name: pnpm-deps-web
-        with:
-          path: |
-            elixir/apps/web/assets/node_modules
-            elixir/esbuild-*
-            elixir/tailwind-*
-          key: ubuntu-22.04-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/pnpm-lock.yaml') }}
       - name: Install Front-End Dependencies
-        if: ${{ steps.pnpm-web-deps-cache.outputs.cache-hit != 'true' }}
         run: |
           cd apps/web
           mix assets.setup
-      - uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        name: Save pnpm Deps Cache
-        if: ${{ github.ref_name == 'main' }}
-        env:
-          cache-name: pnpm-deps-web
-        with:
-          path: |
-            elixir/apps/web/assets/node_modules
-            elixir/esbuild-*
-            elixir/tailwind-*
-          key: ubuntu-22.04-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/pnpm-lock.yaml') }}
-      # Front-End build cache, it rarely changes so we cache it aggressively too
-      - uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        name: Web Assets Cache
-        id: pnpm-web-build-cache
-        env:
-          cache-name: pnpm-build-web
-        with:
-          path: |
-            elixir/apps/web/assets/tmp
-            elixir/apps/web/priv/static
-          key: ubuntu-22.04-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/**') }}
       - name: Build Web Assets
-        if: ${{ steps.pnpm-web-build-cache.outputs.cache-hit != 'true' }}
         run: |
           cd apps/web
           mix assets.build
-      - uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        name: Save Web Assets Cache
-        if: ${{ github.ref_name == 'main' }}
-        env:
-          cache-name: pnpm-build-web
-        with:
-          path: |
-            elixir/apps/web/assets/tmp
-            elixir/apps/web/priv/static
-          key: ubuntu-22.04-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('elixir/apps/web/assets/**') }}
       # Run tests
       - name: Setup Database
         run: |

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -74,7 +74,7 @@ env:
 jobs:
   integration-tests:
     name: ${{ matrix.test.name }}
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   static-analysis:
     # Android SDK tools hardware accel is available only on Linux runners
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-android
@@ -25,7 +25,7 @@ jobs:
 
   update-release-draft:
     name: update-release-draft
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     permissions:
       contents: write # for updating the release draft
     env:
@@ -52,7 +52,7 @@ jobs:
     needs: update-release-draft
     if: "${{ github.event_name == 'workflow_dispatch' }}"
     # Android SDK tools hardware accel is available only on Linux runners
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -121,7 +121,7 @@ jobs:
 
   build_debug:
     # Android SDK tools hardware accel is available only on Linux runners
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     name: build-debug
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
-        runs-on: [ubuntu-22.04-xlarge, macos-14-xlarge, windows-2022-xlarge]
+        runs-on: [ubuntu-22.04, macos-14, windows-2022]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -65,13 +65,13 @@ jobs:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         runs-on:
           [
-            ubuntu-22.04-xlarge,
-            ubuntu-24.04-xlarge,
-            macos-13-xlarge,
-            macos-14-xlarge,
-            macos-15-xlarge,
-            windows-2022-xlarge,
-            windows-2025-xlarge,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            macos-13,
+            macos-14,
+            macos-15,
+            windows-2022,
+            windows-2025,
           ]
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         fuzz-target: [ip_packet]
-    runs-on: ubuntu-24.04-xlarge
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-rust
@@ -157,12 +157,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { runs-on: windows-2022-xlarge, test: token-path-windows.ps1 }
-          - { runs-on: windows-2025-xlarge, test: token-path-windows.ps1 }
-          - { runs-on: ubuntu-22.04-xlarge, test: linux-group.sh }
-          - { runs-on: ubuntu-24.04-xlarge, test: linux-group.sh }
-          - { runs-on: ubuntu-22.04-xlarge, test: token-path-linux.sh }
-          - { runs-on: ubuntu-24.04-xlarge, test: token-path-linux.sh }
+          - { runs-on: windows-2022, test: token-path-windows.ps1 }
+          - { runs-on: windows-2025, test: token-path-windows.ps1 }
+          - { runs-on: ubuntu-22.04, test: linux-group.sh }
+          - { runs-on: ubuntu-24.04, test: linux-group.sh }
+          - { runs-on: ubuntu-22.04, test: token-path-linux.sh }
+          - { runs-on: ubuntu-24.04, test: token-path-linux.sh }
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-lint:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
@@ -32,7 +32,7 @@ jobs:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 #v5.5.3
 
   version-check:
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check version is up to date
@@ -49,7 +49,7 @@ jobs:
           fi
 
   link-check:
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
@@ -64,7 +64,7 @@ jobs:
       - uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc # v2.0.1
 
   global-linter:
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -82,11 +82,12 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
+          lockfile-dir: ./.github
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y shfmt
-          npm install -g prettier
+          pnpm i
       - name: Run pre-commit
         run: |
           pre-commit install --config .github/pre-commit-config.yaml

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install -r .github/requirements.txt
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: ./.github/actions/setup-node
         with:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
       - name: Install dependencies

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -81,7 +81,7 @@ jobs:
           pip install -r .github/requirements.txt
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          npmjs-token: ${{ secrets.NPMJS_TOKEN }}
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y shfmt
-          pnpm i
+          pnpm i --frozen-lockfile --dir ./.github
       - name: Run pre-commit
         run: |
           pre-commit install --config .github/pre-commit-config.yaml

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   update-release-draft:
     name: update-release-draft
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     env:
       # mark:next-apple-version
       RELEASE_NAME: macos-client-1.5.8
@@ -26,7 +26,7 @@ jobs:
   build:
     name: ${{ matrix.job_name }}
     needs: update-release-draft
-    runs-on: macos-15-xlarge
+    runs-on: macos-15
     env:
       XCODE_MAJOR: 16
     permissions:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-node
+        with:
+          npmjs-token: ${{ secrets.NPMJS_TOKEN }}
       - run: pnpm install
       - run: pnpm eslint .
 
@@ -65,6 +67,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-node
+        with:
+          npmjs-token: ${{ secrets.NPMJS_TOKEN }}
       - uses: ./.github/actions/setup-rust
         with:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
@@ -133,6 +137,8 @@ jobs:
         with:
           fetch-tags: true # Otherwise we cannot embed the correct version into the build.
       - uses: ./.github/actions/setup-node
+        with:
+          npmjs-token: ${{ secrets.NPMJS_TOKEN }}
       - uses: ./.github/actions/setup-rust
         with:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           runtime: true
       - run: pnpm install

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -55,13 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          [
-            ubuntu-22.04,
-            ubuntu-24.04,
-            windows-2022,
-            windows-2025,
-          ]
+        runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
+          lockfile-dir: ./rust/gui-client
       - run: pnpm install
       - run: pnpm eslint .
 
@@ -69,6 +70,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
+          lockfile-dir: ./rust/gui-client
       - uses: ./.github/actions/setup-rust
         with:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
@@ -139,6 +141,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
+          lockfile-dir: ./rust/gui-client
       - uses: ./.github/actions/setup-rust
         with:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write # for updating the release draft
       id-token: write
     name: update-release-draft
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     env:
       # mark:next-gui-version
       RELEASE_NAME: gui-client-1.5.7
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   static-analysis:
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-node
@@ -57,10 +57,10 @@ jobs:
       matrix:
         runs-on:
           [
-            ubuntu-22.04-xlarge,
-            ubuntu-24.04-xlarge,
-            windows-2022-xlarge,
-            windows-2025-xlarge,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-2022,
+            windows-2025,
           ]
     runs-on: ${{ matrix.runs-on }}
     defaults:
@@ -103,15 +103,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-22.04-xlarge
+          - runs-on: ubuntu-22.04
             arch: x86_64
             os: linux
             pkg-extension: deb
-          - runs-on: ubuntu-22.04-arm-xlarge
+          - runs-on: ubuntu-22.04-arm
             arch: aarch64
             os: linux
             pkg-extension: deb
-          - runs-on: windows-2022-xlarge
+          - runs-on: windows-2022
             arch: x86_64
             os: windows
             pkg-extension: msi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
 
   notify:
     needs: ci
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     steps:
       - name: Send 'checks-passed' event
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
     needs: planner
     if: contains(needs.planner.outputs.jobs_to_run, 'static-analysis')
     uses: ./.github/workflows/_static-analysis.yml
+    secrets: inherit
   codeql:
     needs: planner
     if: contains(needs.planner.outputs.jobs_to_run, 'codeql')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   planner:
-    runs-on: ubuntu-latest-xlarge
+    runs-on: ubuntu-latest
     outputs:
       jobs_to_run: ${{ steps.plan.outputs.jobs_to_run }}
     steps:
@@ -116,7 +116,7 @@ jobs:
   required-check:
     name: required-check
     needs: planner
-    runs-on: ubuntu-latest-xlarge
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Wait for all jobs to complete
@@ -186,7 +186,7 @@ jobs:
 
   update-release-draft:
     name: update-release-draft-${{ matrix.config_name }}
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -275,7 +275,7 @@ jobs:
   perf-tests:
     name: perf-tests
     needs: build-perf-artifacts
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       id-token: write
@@ -386,7 +386,7 @@ jobs:
   upload-bencher:
     continue-on-error: true
     needs: perf-tests
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
     needs: planner
     if: contains(needs.planner.outputs.jobs_to_run, 'elixir')
     uses: ./.github/workflows/_elixir.yml
+    secrets: inherit
   rust:
     needs: planner
     if: contains(needs.planner.outputs.jobs_to_run, 'rust')

--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   publish_clients:
     name: Publish ${{ matrix.identifier }} to winget
-    runs-on: windows-latest-xlarge
+    runs-on: windows-latest
     strategy:
       matrix:
         include:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         startsWith(inputs.release_name || github.event.release.name, 'gateway') ||
         startsWith(inputs.release_name || github.event.release.name, 'headless-client')
       }}
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     permissions:
       # Needed to upload artifacts to a release
       packages: write
@@ -80,7 +80,7 @@ jobs:
             $SOURCE_TAG
 
   create-publish-pr:
-    runs-on: ubuntu-latest-xlarge
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   create_sentry_release:
     name: create_${{ matrix.component }}_sentry_release
-    runs-on: ubuntu-22.04-xlarge
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # TODO: This hack is needed because the macOS client isn't tagged as `apple-client`.

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linkChecker:
-    runs-on: ubuntu-latest-xlarge
+    runs-on: ubuntu-latest
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@ website/.next
 **/*.rs
 **/*.wxs
 **/pnpm-lock.yaml
+.github/pnpm-lock.yaml
 swift/apple/**/Contents.json
 rust/gui-client/src-frontend/generated
 rust/gui-client/dist

--- a/scripts/build/lib.sh
+++ b/scripts/build/lib.sh
@@ -12,9 +12,6 @@ function setup_runner() {
     # Use the latest version of Xcode - matches what we typically use for development
     sudo xcode-select --switch "$(ls -d /Applications/Xcode*${XCODE_MAJOR}*.app | sort -V | tail -n 1)"
 
-    # The GitHub runners stopped including the iOS SDK
-    xcodebuild -downloadPlatform iOS
-
     profiles_path="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
     keychain_pass=$(openssl rand -base64 32)
     keychain_path="$(mktemp -d)/app-signing.keychain-db"

--- a/scripts/tests/perf/relayed-udp-client2server.sh
+++ b/scripts/tests/perf/relayed-udp-client2server.sh
@@ -8,7 +8,7 @@ install_iptables_drop_rules
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \
   --udp \
-  --bandwidth 450M \
+  --bandwidth 300M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
 

--- a/scripts/tests/perf/relayed-udp-server2client.sh
+++ b/scripts/tests/perf/relayed-udp-server2client.sh
@@ -9,7 +9,7 @@ docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \
   --reverse \
   --udp \
-  --bandwidth 450M \
+  --bandwidth 300M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
 


### PR DESCRIPTION
To avoid burning Azure credits, we move the runners back down to the free tier. Now that caching is properly set up, this should incur only a minor increase in CI time.