### PR TITLE
refactor(portal): add migrations needed for hard delete

### DIFF
--- a/elixir/apps/domain/priv/repo/manual_migrations/20250806045735_add_gateway_cascade_on_delete_constraint.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250806045735_add_gateway_cascade_on_delete_constraint.exs
@@ -1,0 +1,33 @@
+defmodule Domain.Repo.Migrations.AddGatewayCascadeOnDeleteConstraint do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TABLE gateways
+    DROP CONSTRAINT IF EXISTS gateways_group_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE gateways
+    ADD CONSTRAINT gateways_group_id_fkey
+    FOREIGN KEY (group_id)
+    REFERENCES gateway_groups(id)
+    ON DELETE CASCADE
+    """)
+  end
+
+  def down do
+    execute("""
+    ALTER TABLE gateways
+    DROP CONSTRAINT IF EXISTS gateways_group_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE gateways
+    ADD CONSTRAINT gateways_group_id_fkey
+    FOREIGN KEY (group_id)
+    REFERENCES gateway_groups(id)
+    ON DELETE NO ACTION
+    """)
+  end
+end

--- a/elixir/apps/domain/priv/repo/manual_migrations/20250806050048_add_auth_identity_cascade_on_delete_constraint.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250806050048_add_auth_identity_cascade_on_delete_constraint.exs
@@ -1,0 +1,59 @@
+defmodule Domain.Repo.Migrations.AddAuthIdentityCascadeOnDeleteConstraint do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TABLE auth_identities
+    DROP CONSTRAINT IF EXISTS auth_identities_provider_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE auth_identities
+    DROP CONSTRAINT IF EXISTS auth_identities_actor_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE auth_identities
+    ADD CONSTRAINT auth_identities_provider_id_fkey
+    FOREIGN KEY (provider_id)
+    REFERENCES auth_providers(id)
+    ON DELETE CASCADE
+    """)
+
+    execute("""
+    ALTER TABLE auth_identities
+    ADD CONSTRAINT auth_identities_actor_id_fkey
+    FOREIGN KEY (actor_id)
+    REFERENCES actors(id)
+    ON DELETE CASCADE
+    """)
+  end
+
+  def down do
+    execute("""
+    ALTER TABLE auth_identities
+    DROP CONSTRAINT IF EXISTS auth_identities_provider_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE auth_identities
+    DROP CONSTRAINT IF EXISTS auth_identities_actor_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE auth_identities
+    ADD CONSTRAINT auth_identities_provider_id_fkey
+    FOREIGN KEY (provider_id)
+    REFERENCES auth_providers(id)
+    ON DELETE NO ACTION
+    """)
+
+    execute("""
+    ALTER TABLE auth_identities
+    ADD CONSTRAINT auth_identities_actor_id_fkey
+    FOREIGN KEY (actor_id)
+    REFERENCES actors(id)
+    ON DELETE NO ACTION
+    """)
+  end
+end

--- a/elixir/apps/domain/priv/repo/manual_migrations/20250806050140_update_client_fk_constraints.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250806050140_update_client_fk_constraints.exs
@@ -1,0 +1,147 @@
+defmodule Domain.Repo.Migrations.UpdateClientFkConstraints do
+  use Ecto.Migration
+
+  def up do
+    # Rename Identity FK and add ON DELETE CASCADE
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS devices_identity_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT clients_identity_id_fkey
+    FOREIGN KEY (identity_id)
+    REFERENCES auth_identities(id)
+    ON DELETE CASCADE
+    """)
+
+    # Rename Actor FK and add ON DELETE CASCADE
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS devices_actor_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT clients_actor_id_fkey
+    FOREIGN KEY (actor_id)
+    REFERENCES actors(id)
+    ON DELETE CASCADE
+    """)
+
+    # Rename Account FK
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS devices_account_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT clients_account_id_fkey
+    FOREIGN KEY (account_id)
+    REFERENCES accounts(id)
+    ON DELETE CASCADE
+    """)
+
+    # Rename IPv4 FK
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS devices_ipv4_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT clients_ipv4_fkey
+    FOREIGN KEY (ipv4, account_id)
+    REFERENCES network_addresses(address, account_id)
+    ON DELETE NO ACTION
+    """)
+
+    # Rename IPv6 FK
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS devices_ipv6_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT clients_ipv6_fkey
+    FOREIGN KEY (ipv6, account_id)
+    REFERENCES network_addresses(address, account_id)
+    ON DELETE NO ACTION
+    """)
+  end
+
+  def down do
+    # Undo rename Identity FK and add ON DELETE CASCADE
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS devices_identity_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT devices_identity_id_fkey
+    FOREIGN KEY (identity_id)
+    REFERENCES auth_identities(id)
+    ON DELETE NO ACTION
+    """)
+
+    # Undo rename Actor FK and add ON DELETE CASCADE
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS devices_actor_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT devices_actor_id_fkey
+    FOREIGN KEY (actor_id)
+    REFERENCES actors(id)
+    ON DELETE NO ACTION
+    """)
+
+    # Undo rename Account FK
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS clients_account_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT devices_account_id_fkey
+    FOREIGN KEY (account_id)
+    REFERENCES accounts(id)
+    ON DELETE NO ACTION
+    """)
+
+    # Undo rename IPv4 FK
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS clients_ipv4_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT devices_ipv4_fkey
+    FOREIGN KEY (ipv4, account_id)
+    REFERENCES network_addresses(address, account_id)
+    ON DELETE NO ACTION
+    """)
+
+    # Undo rename IPv6 FK
+    execute("""
+    ALTER TABLE clients
+    DROP CONSTRAINT IF EXISTS clients_ipv6_fkey
+    """)
+
+    execute("""
+    ALTER TABLE clients
+    ADD CONSTRAINT devices_ipv6_fkey
+    FOREIGN KEY (ipv6, account_id)
+    REFERENCES network_addresses(address, account_id)
+    ON DELETE NO ACTION
+    """)
+  end
+end

--- a/elixir/apps/domain/priv/repo/manual_migrations/20250806050140_update_client_fk_constraints.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250806050140_update_client_fk_constraints.exs
@@ -82,7 +82,7 @@ defmodule Domain.Repo.Migrations.UpdateClientFkConstraints do
     # Undo rename Identity FK and add ON DELETE CASCADE
     execute("""
     ALTER TABLE clients
-    DROP CONSTRAINT IF EXISTS devices_identity_id_fkey
+    DROP CONSTRAINT IF EXISTS clients_identity_id_fkey
     """)
 
     execute("""
@@ -96,7 +96,7 @@ defmodule Domain.Repo.Migrations.UpdateClientFkConstraints do
     # Undo rename Actor FK and add ON DELETE CASCADE
     execute("""
     ALTER TABLE clients
-    DROP CONSTRAINT IF EXISTS devices_actor_id_fkey
+    DROP CONSTRAINT IF EXISTS clients_actor_id_fkey
     """)
 
     execute("""

--- a/elixir/apps/domain/priv/repo/manual_migrations/20250806050140_update_client_fk_constraints.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250806050140_update_client_fk_constraints.exs
@@ -71,6 +71,11 @@ defmodule Domain.Repo.Migrations.UpdateClientFkConstraints do
     REFERENCES network_addresses(address, account_id)
     ON DELETE NO ACTION
     """)
+
+    # Rename Primary Key Index
+    execute("""
+      ALTER INDEX devices_pkey RENAME TO clients_pkey;
+    """)
   end
 
   def down do
@@ -142,6 +147,11 @@ defmodule Domain.Repo.Migrations.UpdateClientFkConstraints do
     FOREIGN KEY (ipv6, account_id)
     REFERENCES network_addresses(address, account_id)
     ON DELETE NO ACTION
+    """)
+
+    # Undo rename Primary Key Index
+    execute("""
+      ALTER INDEX clients_pkey RENAME TO devices_pkey;
     """)
   end
 end

--- a/elixir/apps/domain/priv/repo/manual_migrations/20250806050230_update_relay_fk_constraint.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250806050230_update_relay_fk_constraint.exs
@@ -1,0 +1,33 @@
+defmodule Domain.Repo.Migrations.UpdateRelayFkConstraint do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TABLE relays
+    DROP CONSTRAINT IF EXISTS relays_group_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE relays
+    ADD CONSTRAINT relays_group_id_fkey
+    FOREIGN KEY (group_id)
+    REFERENCES relay_groups(id)
+    ON DELETE CASCADE
+    """)
+  end
+
+  def down do
+    execute("""
+    ALTER TABLE relays
+    DROP CONSTRAINT IF EXISTS relays_group_id_fkey
+    """)
+
+    execute("""
+    ALTER TABLE relays
+    ADD CONSTRAINT relays_group_id_fkey
+    FOREIGN KEY (group_id)
+    REFERENCES relay_groups(id)
+    ON DELETE NO ACTION
+    """)
+  end
+end

--- a/elixir/apps/domain/priv/repo/manual_migrations/20250806050303_allow_null_last_used_token_id_on_clients.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250806050303_allow_null_last_used_token_id_on_clients.exs
@@ -1,0 +1,15 @@
+defmodule Domain.Repo.Migrations.AllowNullLastUsedTokenIdOnClients do
+  use Ecto.Migration
+
+  def up do
+    alter table(:clients) do
+      modify(:last_used_token_id, :uuid, null: true)
+    end
+  end
+
+  def down do
+    alter table(:clients) do
+      modify(:last_used_token_id, :uuid, null: false)
+    end
+  end
+end


### PR DESCRIPTION
In preparation for transitioning from the portal from soft-delete to hard-delete some updates to the foreign key constraints were required.  Most of these updates are adding `ON DELETE CASCADE` constraints and relevant indexes.  These new constraints should have no effect on the current portal code as soft-deletes are still being used.

One other update in this PR is changing the FK constraint names on the clients table.  The names were `devices_*` due to the table originally being called `devices`.  This PR updates them to `clients_*`.

Related: #8187 