### PR TITLE
fix(ci): remove extraneous caching

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -54,7 +54,7 @@ runs:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
         components: rustfmt,clippy
         target: ${{ inputs.targets }}
-        cache: true
+        cache: ${{ github.ref_name == 'main' }}
         cache-on-failure: true
         rustflags: "" # Don't set -D warnings by default
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -54,7 +54,7 @@ runs:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
         components: rustfmt,clippy
         target: ${{ inputs.targets }}
-        cache: ${{ github.ref_name == 'main' }}
+        cache: true
         cache-on-failure: true
         rustflags: "" # Don't set -D warnings by default
 

--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -55,7 +55,7 @@ runs:
         sudo cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
       shell: bash
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-      if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' }}
+      if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' && github.ref_name == 'main' }}
       id: cache-webview2-installer
       with:
         path: WebView2Installer.exe

--- a/.github/actions/setup-tauri-v2/action.yml
+++ b/.github/actions/setup-tauri-v2/action.yml
@@ -55,11 +55,11 @@ runs:
         sudo cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
       shell: bash
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-      if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' && github.ref_name == 'main' }}
+      if: ${{ runner.os == 'Windows' && inputs.runtime == 'true' }}
       id: cache-webview2-installer
       with:
         path: WebView2Installer.exe
-        key: ${{ runner.os }}-${{ runner.arch }}-webview2-offline-installer
+        key: webview2-offline-installer
     - name: Download WebView2 bootstrapper
       if: ${{ runner.os == 'Windows' && steps.cache-webview2-installer.outputs.cache-hit != 'true' && inputs.runtime == 'true' }}
       # This is the "Evergreen" bootstrapper from Microsoft

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -148,13 +148,13 @@ jobs:
 
       - name: Add 50ms simulated API latency
         run: |
-          docker compose exec -T -u root api sh -c 'apk add --no-cache iproute2-tc'
+          docker compose exec -T -u root api sh -c 'apk add --update --no-cache iproute2-tc'
           docker compose exec -T -u root api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
 
       - name: Add 10ms simulated gateway latency
         run: |
           # compatibility test images won't have the `tc` command
-          docker compose exec -T gateway sh -c 'apk add --no-cache iproute2-tc'
+          docker compose exec -T gateway sh -c 'apk add --update --no-cache iproute2-tc'
           docker compose exec -T gateway sh -c 'tc qdisc add dev eth0 root netem delay 10ms'
 
       - run: ./scripts/tests/${{ matrix.test.name }}.sh

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -68,12 +68,6 @@ jobs:
         with:
           targets: ${{ matrix.rust-targets }}
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
-      - uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        name: Restore Swift DerivedData Cache
-        id: cache
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-${{ hashFiles('swift/*', 'rust/**/*.rs', 'rust/**/*.toml', 'rust/**/*.lock}') }}
       - run: ${{ matrix.build-script }}
         env:
           IOS_APP_PROVISIONING_PROFILE: "${{ secrets.APPLE_IOS_APP_PROVISIONING_PROFILE }}"
@@ -145,11 +139,3 @@ jobs:
 
           sentry-cli debug-files upload --log-level info --project apple-client --include-sources ${{ runner.temp }}
           sentry-cli debug-files upload --log-level info --project apple-client --include-sources ./rust/target
-      - uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        if: ${{ steps.cache.outputs.cache-hit != 'true'}}
-        name: Save Swift DerivedData Cache
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData
-          # Swift benefits heavily from build cache, so aggressively write a new one
-          # on each build on `main` and attempt to restore it in PR builds with broader restore-key.
-          key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -13,12 +13,12 @@ ENV LANG=C.UTF-8 \
 WORKDIR /bin
 
 ## curl is needed to run tests (`main` runs CI against `release` images) and `firezone-relay` needs `curl` in its entry script.
-RUN apk add --no-cache curl
+RUN apk add --no-cache --update curl
 
 # Gateway specific runtime base image
 FROM runtime_base AS runtime_firezone-gateway
 ## iptables are needed only by gateway for masquerading
-RUN apk add --no-cache iptables ip6tables
+RUN apk add --no-cache --update iptables ip6tables
 COPY ./docker-init-gateway.sh ./docker-init.sh
 
 # Relay specific runtime base image
@@ -46,7 +46,7 @@ CMD ${PACKAGE}
 # Build an image for GitHub Actions which includes debug asserts and more test utilities
 FROM runtime AS debug
 
-RUN apk add --no-cache iperf3 bind-tools iproute2 jq procps iptables
+RUN apk add --no-cache --update iperf3 bind-tools iproute2 jq procps iptables
 
 ## Build first with `cargo build --target ${TARGET} -p ${PACKAGE} && mv /target/${TARGET}/debug/${PACKAGE} .`
 ARG PACKAGE

--- a/rust/Dockerfile.xdp-tools
+++ b/rust/Dockerfile.xdp-tools
@@ -10,7 +10,7 @@
 
 FROM alpine:latest
 
-RUN apk add --no-cache \
+RUN apk add --no-cache --update \
 	git \
 	clang \
 	pkgconfig \

--- a/scripts/tests/direct-download-packet-loss.sh
+++ b/scripts/tests/direct-download-packet-loss.sh
@@ -2,7 +2,7 @@
 
 source "./scripts/tests/lib.sh"
 
-client apk add --no-cache iproute2
+client apk add --no-cache --update iproute2
 client tc qdisc add dev eth0 root netem loss 20%
 
 client sh -c "curl --fail --output download.file http://download.httpbin/bytes?num=10000000" &

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -20,7 +20,7 @@ function relay2() {
 
 function install_iptables_drop_rules() {
     # Install `iptables` to have it available in the compatibility tests
-    client apk add iptables
+    client apk add --update --no-cache iptables
 
     # Execute within the client container because doing so from the host is not reliable in CI.
     client iptables -A OUTPUT -d 172.28.0.105 -j DROP

--- a/scripts/tests/tcp-dns.sh
+++ b/scripts/tests/tcp-dns.sh
@@ -2,7 +2,7 @@
 
 source "./scripts/tests/lib.sh"
 
-client sh -c "apk add bind-tools" # The compat tests run using the production image which doesn't have `dig`.
+client sh -c "apk add --update --no-cache bind-tools" # The compat tests run using the production image which doesn't have `dig`.
 
 echo "Resolving DNS resource over TCP with search domain"
 client sh -c "dig +search +tcp dns"


### PR DESCRIPTION
- Removes the swift DerivedData cache. This was added to attempt to speed up the Swift builds in CI but in reality, those are already fast and the cache did not speed them up.
- Removes the runner.os/arch specifier from the Webview installer cache key. The binary download is hardcoded for a specific windows version / arch already so the cache key just adds unneeded complexity.

These caches are getting saved on PR runs which consumes excess GHA cache storage.