### PR TITLE
chore(ci): copy staging artifacts to azure

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -316,14 +316,15 @@ jobs:
           sha256sum ${{ matrix.name.package }} > ${{ matrix.name.package }}.sha256sum.txt
       # For pushing built images to Google Cloud Storage
       - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
+        # if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
+        if: ${{ matrix.name.artifact == 'firezone-relay' }}
         with:
           token_format: access_token
           workload_identity_provider: "projects/85623168602/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "github-account@firezone-staging.iam.gserviceaccount.com"
           export_environment_variables: true
           create_credentials_file: true
-      - name: Copy relay to Google Cloud Storage
+      - name: Copy relay to Cloud Storage
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
         run: |
           set -e
@@ -334,6 +335,22 @@ jobs:
           gcloud storage cp \
             "${{ matrix.name.package }}".sha256sum.txt \
             gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt
+
+          az storage blob upload \
+            --container-name artifacts \
+            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}" \
+            --file "${{ matrix.name.package }}" \
+            --overwrite true \
+            --no-progress \
+            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+
+          az storage blob upload \
+            --container-name artifacts \
+            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt" \
+            --file "${{ matrix.name.package }}.sha256sum.txt" \
+            --overwrite true \
+            --no-progress \
+            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
       - name: Upload Release Assets
         if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.release_name }}
         env:

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -324,17 +324,16 @@ jobs:
           export_environment_variables: true
           create_credentials_file: true
       - name: Copy relay to Cloud Storage
-        # if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
-        if: ${{ matrix.name.artifact == 'firezone-relay' }}
+        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
         run: |
           set -e
-          # gcloud storage cp \
-          #   "${{ matrix.name.package }}" \
-          #   gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}
-          #
-          # gcloud storage cp \
-          #   "${{ matrix.name.package }}".sha256sum.txt \
-          #   gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt
+          gcloud storage cp \
+            "${{ matrix.name.package }}" \
+            gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}
+
+          gcloud storage cp \
+            "${{ matrix.name.package }}".sha256sum.txt \
+            gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt
 
           az storage blob upload \
             --container-name artifacts \

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -316,8 +316,7 @@ jobs:
           sha256sum ${{ matrix.name.package }} > ${{ matrix.name.package }}.sha256sum.txt
       # For pushing built images to Google Cloud Storage
       - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-        # if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
-        if: ${{ matrix.name.artifact == 'firezone-relay' }}
+        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
         with:
           token_format: access_token
           workload_identity_provider: "projects/85623168602/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
@@ -325,7 +324,8 @@ jobs:
           export_environment_variables: true
           create_credentials_file: true
       - name: Copy relay to Cloud Storage
-        if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
+        # if: ${{ inputs.profile == 'release' && matrix.stage == 'release' && matrix.name.artifact == 'firezone-relay' }}
+        if: ${{ matrix.name.artifact == 'firezone-relay' }}
         run: |
           set -e
           gcloud storage cp \

--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -328,13 +328,13 @@ jobs:
         if: ${{ matrix.name.artifact == 'firezone-relay' }}
         run: |
           set -e
-          gcloud storage cp \
-            "${{ matrix.name.package }}" \
-            gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}
-
-          gcloud storage cp \
-            "${{ matrix.name.package }}".sha256sum.txt \
-            gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt
+          # gcloud storage cp \
+          #   "${{ matrix.name.package }}" \
+          #   gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}
+          #
+          # gcloud storage cp \
+          #   "${{ matrix.name.package }}".sha256sum.txt \
+          #   gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt
 
           az storage blob upload \
             --container-name artifacts \


### PR DESCRIPTION
To deploy the relays on Azure, we need to make sure the binaries are copied there, similar to GCP. This adds a job step to do just that, placing them into a storage account + container using new infra provisioned in Azure.