### PR TITLE
chore(telemetry): use Firezone-specific ingest hosts

### DIFF
--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -41,7 +41,7 @@ pub struct Dsn {
 // > DSNs are safe to keep public because they only allow submission of new events and related event data; they do not allow read access to any information.
 // <https://docs.sentry.io/concepts/key-terms/dsn-explainer/#dsn-utilization>
 
-const INGEST_HOST: &str = "o4507971108339712.ingest.us.sentry.io";
+const INGEST_HOST: &str = "sentry.firezone.dev";
 
 pub const ANDROID_DSN: Dsn = Dsn {
     public_key: "928a6ee1f6af9734100b8bc89b2dc87d",

--- a/rust/telemetry/src/posthog.rs
+++ b/rust/telemetry/src/posthog.rs
@@ -10,7 +10,7 @@ pub(crate) const API_KEY_ON_PREM: &str = "phc_4R9Ii6q4SEofVkH7LvajwuJ3nsGFhCj0Zl
 pub(crate) static RUNTIME: LazyLock<Runtime> = LazyLock::new(init_runtime);
 pub(crate) static CLIENT: LazyLock<reqwest::Result<reqwest::Client>> = LazyLock::new(init_client);
 
-pub(crate) const INGEST_HOST: &str = "us.i.posthog.com";
+pub(crate) const INGEST_HOST: &str = "posthog.firezone.dev";
 
 pub(crate) fn api_key_for_env(env: Env) -> Option<&'static str> {
     match env {


### PR DESCRIPTION
These give us more control over where this traffic goes. For example, based on this, we will be able to exclude this traffic from the Internet Resource.