### PR TITLE
fix: only disable offloading for relayed perf tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,10 +346,6 @@ services:
         ip route add 172.29.0.0/24 via 172.28.0.254
         ip -6 route add 172:29:0::/64 via 172:28:0::254
 
-        # Disable checksum offloading so that checksums are correct when they reach the relay
-        apk add --no-cache ethtool
-        ethtool -K eth0 tx off
-
         firezone-headless-client
     init: true
     build:
@@ -395,12 +391,6 @@ services:
         # Add static route to relay subnet via router
         ip route add 172.29.0.0/24 via 172.28.0.254
         ip -6 route add 172:29:0::/64 via 172:28:0::254
-
-        # Disable checksum offloading so that checksums are correct when they reach the relay
-        apk add --no-cache ethtool
-        ethtool -K eth0 tx off
-        ethtool -K eth1 tx off
-        ethtool -K eth2 tx off
 
         firezone-gateway
     init: true

--- a/scripts/tests/lib.sh
+++ b/scripts/tests/lib.sh
@@ -67,6 +67,29 @@ function force_relayed_connections() {
     fi
 }
 
+# Disables checksum offloading for Client and Gateway on all interfaces.
+# Without this, the eBPF kernel cannot update the checksums correctly.
+function disable_offloading() {
+    client_disable_offloading eth0
+    gateway_disable_offloading eth0
+    gateway_disable_offloading eth1
+    gateway_disable_offloading eth2
+}
+
+function client_disable_offloading() {
+    local interface="$1"
+
+    client apk add --no-cache ethtool
+    client ethtool -K "$interface" tx off
+}
+
+function gateway_disable_offloading() {
+    local interface="$1"
+
+    gateway apk add --no-cache ethtool
+    gateway ethtool -K "$interface" tx off
+}
+
 function client_curl_resource() {
     client curl --connect-timeout 30 --fail "$1" >/dev/null
 }

--- a/scripts/tests/perf/relayed-tcp-client2server.sh
+++ b/scripts/tests/perf/relayed-tcp-client2server.sh
@@ -4,6 +4,7 @@ set -euox pipefail
 
 source "./scripts/tests/lib.sh"
 force_relayed_connections ipv4 ipv4
+disable_offloading
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \

--- a/scripts/tests/perf/relayed-tcp-server2client.sh
+++ b/scripts/tests/perf/relayed-tcp-server2client.sh
@@ -4,6 +4,7 @@ set -euox pipefail
 
 source "./scripts/tests/lib.sh"
 force_relayed_connections ipv6 ipv4
+disable_offloading
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \

--- a/scripts/tests/perf/relayed-udp-client2server.sh
+++ b/scripts/tests/perf/relayed-udp-client2server.sh
@@ -4,6 +4,7 @@ set -euox pipefail
 
 source "./scripts/tests/lib.sh"
 force_relayed_connections ipv6 ipv6
+disable_offloading
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \

--- a/scripts/tests/perf/relayed-udp-server2client.sh
+++ b/scripts/tests/perf/relayed-udp-server2client.sh
@@ -4,6 +4,7 @@ set -euox pipefail
 
 source "./scripts/tests/lib.sh"
 force_relayed_connections ipv4 ipv6
+disable_offloading
 
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \

--- a/scripts/tests/relay-graceful-shutdown.sh
+++ b/scripts/tests/relay-graceful-shutdown.sh
@@ -4,6 +4,7 @@ source "./scripts/tests/lib.sh"
 
 # Arrange: Setup a relayed connection
 force_relayed_connections
+disable_offloading
 client_curl_resource "172.20.0.100/get"
 client_curl_resource "[172:20:0::100]/get"
 


### PR DESCRIPTION
Disabling GRO / GSO greatly hurts performance to the point where we see packet retransmissions of handshakes, causing `boringtun` to emit warnings.

GRO / GSO only need to be disabled for relayed tests so we move the respective functionality to those tests scripts.

Resolves: #10254