### PR TITLE
ci: don't restart portal at the beginning of the test

### DIFF
--- a/scripts/tests/direct-curl-api-restart.sh
+++ b/scripts/tests/direct-curl-api-restart.sh
@@ -2,12 +2,10 @@
 
 source "./scripts/tests/lib.sh"
 
-docker compose restart api # Restart portal
-
 client_curl_resource "172.20.0.100/get"
 client_curl_resource "[172:20:0::100]/get"
 
-docker compose restart api # Restart again
+docker compose restart api # Restart portal
 
 client_curl_resource "172.20.0.100/get"
 client_curl_resource "[172:20:0::100]/get"


### PR DESCRIPTION
Restarting the portal at the beginning of the test is useless. We haven't made any connections yet so restarting it will just get us back to the same state that we are already in.