### PR TITLE
chore(connlib): print full error when failing to read IP packet

### DIFF
--- a/rust/connlib/tun/src/unix.rs
+++ b/rust/connlib/tun/src/unix.rs
@@ -80,7 +80,7 @@ where
                         };
                     }
                     Err(e) => {
-                        tracing::warn!("Failed to read from TUN FD: {e}");
+                        tracing::warn!("Failed to read from TUN FD: {:#}", anyhow::Error::new(e));
                         continue;
                     }
                 }


### PR DESCRIPTION
The error returned from `IpPacket::new` is an `anyhow::Error` but in order to return it from `async_io`, we need to wrap it in an `io::Error`. Printing an `io::Error` only prints the top-level error. To fix this, we re-wrap the `io::Error` in an `anyhow::Error` again and toggle "alternate" printing mode to see the full error chain.