### PR TITLE
fix(connlib): retry packets on IO error 5

### DIFF
--- a/rust/bin-shared/tests/no_packet_loops_udp.rs
+++ b/rust/bin-shared/tests/no_packet_loops_udp.rs
@@ -45,14 +45,15 @@ async fn no_packet_loops_udp() {
         .unwrap();
 
     // Send a STUN request.
+    let packet = bufferpool
+        .pull_initialised(hex_literal::hex!("000100002112A4420123456789abcdef01234567").as_ref());
+
     socket
         .send(DatagramOut {
             src: None,
             dst: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(141, 101, 90, 0), 3478)), // stun.cloudflare.com,
-            packet: bufferpool.pull_initialised(
-                hex_literal::hex!("000100002112A4420123456789abcdef01234567").as_ref(),
-            ),
-            segment_size: None,
+            segment_size: packet.len(),
+            packet,
             ecn: Ecn::NonEct,
         })
         .await

--- a/rust/connlib/socket-factory/Cargo.toml
+++ b/rust/connlib/socket-factory/Cargo.toml
@@ -17,6 +17,12 @@ socket2 = { workspace = true }
 tokio = { workspace = true, features = ["net"] }
 tracing = { workspace = true }
 
+[target.'cfg(target_os = "android")'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 firezone-telemetry = { workspace = true }
 libc = { workspace = true }

--- a/rust/connlib/socket-factory/src/lib.rs
+++ b/rust/connlib/socket-factory/src/lib.rs
@@ -307,7 +307,7 @@ impl UdpSocket {
         )?;
 
         match self.send_transmit(&transmit).await {
-            Ok(()) => return Ok(()),
+            Ok(()) => Ok(()),
 
             // On Linux and Android, we retry sending once for os error 5.
             //
@@ -315,13 +315,13 @@ impl UdpSocket {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             Err(e) if is_os_error_5(&e) => {
                 self.send_transmit(&transmit).await?;
+
+                Ok(())
             }
 
             // Any other error or other OS returns the error directly.
-            Err(e) => return Err(e),
+            Err(e) => Err(e),
         }
-
-        Ok(())
     }
 
     async fn send_transmit(&self, transmit: &Transmit<'_>) -> Result<()> {

--- a/rust/connlib/tunnel/src/io/gso_queue.rs
+++ b/rust/connlib/tunnel/src/io/gso_queue.rs
@@ -97,7 +97,7 @@ impl Iterator for DrainDatagramsIter<'_> {
                 src: connection.src,
                 dst: connection.dst,
                 packet: buffer,
-                segment_size: Some(segment_size),
+                segment_size,
                 ecn: connection.ecn,
             });
         }
@@ -139,7 +139,7 @@ mod tests {
 
         assert_eq!(datagrams.len(), 1);
         assert_eq!(datagrams[0].packet.as_ref(), b"foobarbarbazfoobazfoo");
-        assert_eq!(datagrams[0].segment_size, Some(6));
+        assert_eq!(datagrams[0].segment_size, 6);
     }
 
     #[test]
@@ -156,10 +156,10 @@ mod tests {
 
         assert_eq!(datagrams.len(), 2);
         assert_eq!(datagrams[0].packet.as_ref(), b"foobarbarbaz");
-        assert_eq!(datagrams[0].segment_size, Some(6));
+        assert_eq!(datagrams[0].segment_size, 6);
         assert_eq!(datagrams[0].dst, DST_1);
         assert_eq!(datagrams[1].packet.as_ref(), b"barbarbafoofoo");
-        assert_eq!(datagrams[1].segment_size, Some(8));
+        assert_eq!(datagrams[1].segment_size, 8);
         assert_eq!(datagrams[1].dst, DST_2);
     }
 
@@ -180,10 +180,10 @@ mod tests {
 
         assert_eq!(datagrams.len(), 2);
         assert_eq!(datagrams[0].packet.as_ref(), b"foobarbarbazfoobazbazfoo");
-        assert_eq!(datagrams[0].segment_size, Some(6));
+        assert_eq!(datagrams[0].segment_size, 6);
         assert_eq!(datagrams[0].dst, DST_1);
         assert_eq!(datagrams[1].packet.as_ref(), b"barbarbafoofoo");
-        assert_eq!(datagrams[1].segment_size, Some(8));
+        assert_eq!(datagrams[1].segment_size, 8);
         assert_eq!(datagrams[1].dst, DST_2);
     }
 
@@ -201,10 +201,10 @@ mod tests {
 
         assert_eq!(datagrams.len(), 2);
         assert_eq!(datagrams[0].packet.as_ref(), b"foobarbarbazbar");
-        assert_eq!(datagrams[0].segment_size, Some(6));
+        assert_eq!(datagrams[0].segment_size, 6);
         assert_eq!(datagrams[0].dst, DST_1);
         assert_eq!(datagrams[1].packet.as_ref(), b"barbaz");
-        assert_eq!(datagrams[1].segment_size, Some(6));
+        assert_eq!(datagrams[1].segment_size, 6);
         assert_eq!(datagrams[1].dst, DST_1);
     }
 


### PR DESCRIPTION
Unfortunately, it isn't very easy to detect whether a socket supports GSO on Linux. Hence, `quinn-udp` simply probes for its support by trying to send GSO batches and effectively disables GSO by setting the `max-gso-segments` state variable to 1 if it encounters either EINVAL (-22) or EIO (-5).

For EINVAL, `quinn-udp` has an internal retry mechanism. For EIO, the `Transmit` which is passed to `quinn-udp` needs to be re-chunked and thus cannot be automatically retried.

In order to avoid dropping packets, we therefore add a once-off retry step to sending a datagram whenever we hit EIO on Linux or Android. If the error was due to GSO not being supported, the 2nd attempt should be successful and going forward, even the first one should be until we roam the socket (where this state variable gets reset).

These packet drops have been causing flakiness in CI ever since we merged the eBPF tests. Those disable checksum offloading which appears to trigger these errors.