### PR TITLE
fix(ci): bump tauri setup timeout to 15m

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
-        timeout-minutes: 10
+        timeout-minutes: 15
       - uses: taiki-e/install-action@d31232495ad76f47aad66e3501e47780b49f0f3e # v2.57.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -171,7 +171,7 @@ jobs:
         with:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
-        timeout-minutes: 10
+        timeout-minutes: 15
       - run: scripts/tests/${{ matrix.test }}
         name: "test script"
         working-directory: ./

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -147,7 +147,7 @@ jobs:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
       - uses: ./.github/actions/setup-tauri-v2
         # Installing new packages can take time
-        timeout-minutes: 10
+        timeout-minutes: 15
       - uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2.0.0
         with:
           token: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
These occasionally take just a bit more time to complete.

Related: https://github.com/firezone/firezone/actions/runs/17403822300/job/49402974171