### PR TITLE
ci: remove exception for OS error 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,9 +380,7 @@ jobs:
       - name: Ensure Client emitted no warnings
         if: "!cancelled()"
         run: |
-          # Disabling checksum offloading causes one or two "I/O error (os error 5)" warnings
-          docker compose logs client | \
-            grep --invert "I/O error (os error 5)" | \
+          docker compose logs client |
             grep "WARN" && exit 1 || exit 0
       - name: Ensure Relay-1 emitted no warnings
         if: "!cancelled()"
@@ -401,9 +399,7 @@ jobs:
       - name: Ensure Gateway emitted no warnings
         if: "!cancelled()"
         run: |
-          # Disabling checksum offloading causes one or two "I/O error (os error 5)" warnings
-          docker compose logs gateway | \
-            grep --invert "I/O error (os error 5)" | \
+          docker compose logs gateway |
             grep "WARN" && exit 1 || exit 0
 
   upload-bencher:


### PR DESCRIPTION
Now that we retry packets that encounter OS error 5, we no longer need to ignore those warnings in CI.

Related: #10279 