### PR TITLE
ci: bump Ubuntu runners to 24.04

### DIFF
--- a/.github/workflows/_build_artifacts.yml
+++ b/.github/workflows/_build_artifacts.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   control-plane:
     name: ${{ matrix.image_name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -193,7 +193,7 @@ jobs:
 
   data-plane-linux:
     name: ${{ matrix.name.image_name }}-${{ matrix.arch.shortname }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: rust
@@ -448,7 +448,7 @@ jobs:
     name: merge-${{ matrix.image.name }}
     needs: data-plane-linux
     if: ${{ always() }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   analyze:
     name: analyze-${{ matrix.working-directory }}
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-14') || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-14') || 'ubuntu-24.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./elixir
@@ -44,7 +44,7 @@ jobs:
           reporter: java-junit
 
   type-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./elixir
@@ -65,10 +65,10 @@ jobs:
         id: plt_cache
         with:
           path: elixir/priv/plts
-          key: dialyzer-ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-${{ hashFiles('elixir/mix.lock') }}
+          key: dialyzer-ubuntu-24.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-${{ hashFiles('elixir/mix.lock') }}
           # This will make sure that we can incrementally build the PLT from older cache and save it under a new key
           restore-keys: |
-            dialyzer-ubuntu-22.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-
+            dialyzer-ubuntu-24.04-${{ runner.arch }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-
       - name: Create PLTs
         if: ${{ steps.plt_cache.outputs.cache-hit != 'true' }}
         run: mix dialyzer --plt
@@ -82,7 +82,7 @@ jobs:
         run: mix dialyzer --format dialyxir
 
   static-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./elixir
@@ -111,7 +111,7 @@ jobs:
         run: mix deps.unlock --check-unused
 
   migrations-and-seed-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./elixir
@@ -150,7 +150,7 @@ jobs:
     name: acceptance-test-${{ matrix.MIX_TEST_PARTITION }}
     permissions:
       checks: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./elixir

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -74,7 +74,7 @@ env:
 jobs:
   integration-tests:
     name: ${{ matrix.test.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   static-analysis:
     # Android SDK tools hardware accel is available only on Linux runners
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-android
@@ -25,7 +25,7 @@ jobs:
 
   update-release-draft:
     name: update-release-draft
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # for updating the release draft
     env:
@@ -52,7 +52,7 @@ jobs:
     needs: update-release-draft
     if: "${{ github.event_name == 'workflow_dispatch' }}"
     # Android SDK tools hardware accel is available only on Linux runners
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -121,7 +121,7 @@ jobs:
 
   build_debug:
     # Android SDK tools hardware accel is available only on Linux runners
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: build-debug
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
-        runs-on: [ubuntu-22.04, macos-14, windows-2022]
+        runs-on: [ubuntu-24.04, macos-14, windows-2022]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -65,7 +65,7 @@ jobs:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         runs-on:
           [
-            ubuntu-22.04,
+            ubuntu-24.04,
             ubuntu-24.04,
             macos-13,
             macos-14,

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -65,7 +65,7 @@ jobs:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         runs-on:
           [
-            ubuntu-24.04,
+            ubuntu-22.04,
             ubuntu-24.04,
             macos-13,
             macos-14,

--- a/.github/workflows/_static-analysis.yml
+++ b/.github/workflows/_static-analysis.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-lint:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
@@ -32,7 +32,7 @@ jobs:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 #v5.5.3
 
   version-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check version is up to date
@@ -49,7 +49,7 @@ jobs:
           fi
 
   link-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
@@ -64,7 +64,7 @@ jobs:
       - uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc # v2.0.1
 
   global-linter:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -75,7 +75,7 @@ jobs:
         id: cache
         with:
           path: ~/.cache/pip
-          key: ubuntu-22.04-${{ runner.arch }}-pip-${{ hashFiles('.github/requirements.txt') }}
+          key: ubuntu-24.04-${{ runner.arch }}-pip-${{ hashFiles('.github/requirements.txt') }}
       - name: Install Python Dependencies
         run: |
           pip install -r .github/requirements.txt

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   update-release-draft:
     name: update-release-draft
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       # mark:next-apple-version
       RELEASE_NAME: macos-client-1.5.8

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04, windows-2022, windows-2025]
+        runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write # for updating the release draft
       id-token: write
     name: update-release-draft
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       # mark:next-gui-version
       RELEASE_NAME: gui-client-1.5.7
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   static-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-node
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
+        runs-on: [ubuntu-24.04, ubuntu-24.04, windows-2022, windows-2025]
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
 
   notify:
     needs: ci
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Send 'checks-passed' event
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
 
   update-release-draft:
     name: update-release-draft-${{ matrix.config_name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -277,7 +277,7 @@ jobs:
   perf-tests:
     name: perf-tests
     needs: build-perf-artifacts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
@@ -405,7 +405,7 @@ jobs:
   upload-bencher:
     continue-on-error: true
     needs: perf-tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         startsWith(inputs.release_name || github.event.release.name, 'gateway') ||
         startsWith(inputs.release_name || github.event.release.name, 'headless-client')
       }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload artifacts to a release
       packages: write

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   create_sentry_release:
     name: create_${{ matrix.component }}_sentry_release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         # TODO: This hack is needed because the macOS client isn't tagged as `apple-client`.

--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linkChecker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:


### PR DESCRIPTION
Ubuntu 22.04 is over 3 years old and therefore ships with quite an old kernel. Our production VMs (for relays) all run Ubuntu 24.04 so it makes sense to build and test them on the same kernel / OS release. For consistency reasons, we therefore bump all runners to 24.04.