### PR TITLE
chore(headless-client): don't make failures look like crashes

### DIFF
--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -151,7 +151,23 @@ enum Cmd {
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const RELEASE: &str = concat!("headless-client@", env!("CARGO_PKG_VERSION"));
 
-fn main() -> Result<()> {
+#[expect(
+    clippy::print_stderr,
+    reason = "No logger is active when we are printing this error."
+)]
+fn main() {
+    match try_main() {
+        Ok(()) => {}
+        Err(e) => {
+            // Print chain of errors manually to avoid it looking like a crash with stacktrace.
+            eprintln!("{e:#}");
+
+            std::process::exit(1);
+        }
+    }
+}
+
+fn try_main() -> Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Calling `install_default` only once per process should always succeed");


### PR DESCRIPTION
Returning an error from `main` by default prints a backtrace. This may lead users to believe that the program is crashing when in fact it is exiting in a controlled way but with an error (such as when we don't have Internet during startup).

Printing the chain of errors ourselves resolves this.
