### PR TITLE
fix(relay): re-add eBPF channel map entry on refresh

### DIFF
--- a/rust/relay/server/src/server.rs
+++ b/rust/relay/server/src/server.rs
@@ -708,6 +708,14 @@ where
                 (sender, requested_channel),
             );
 
+            self.pending_commands
+                .push_back(Command::CreateChannelBinding {
+                    client: sender,
+                    channel_number: requested_channel,
+                    peer: channel.peer_address,
+                    allocation_port: channel.allocation,
+                });
+
             tracing::info!(target: "relay", allocation = %allocation.port, peer = %peer_address, channel = %requested_channel.value(), "Refreshed channel binding");
 
             self.authenticate_and_send(


### PR DESCRIPTION
TURN channels have a 5 minute cooldown period after they expire where they cannot be rebound to another peer but can be refreshed and thus "reactivated".

To stop routing packets when the channel expires, we remove it from the channel map of the eBPF code. The client however knows that it still has a channel that it can reactivate for another 5min. In case it chooses to do so, we refresh the channel in userspace but until now, forget to re-populate the eBPF map. This effectively blocks this communication path from working because the relay reports the channel from being refreshed successfully, yet the new eBPF kernel drops all packets without a map entry.