### PR TITLE
fix(relay): XDP_PASS non-STUN UDP traffic

### DIFF
--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -586,11 +586,6 @@ where
                         ClientSocket::new(from),
                         Instant::now(),
                     ) {
-                        if self.ebpf.is_some() {
-                            tracing::debug!(target: "relay", %port, %peer, "Dropping client->peer ChannelData in userspace (handled by eBPF)");
-                            continue;
-                        }
-
                         // Re-parse as `ChannelData` if we should relay it.
                         let payload = ChannelData::parse(packet)
                             .expect("valid ChannelData if we should relay it")
@@ -617,11 +612,6 @@ where
                         PeerSocket::new(from),
                         AllocationPort::new(port),
                     ) {
-                        if self.ebpf.is_some() {
-                            tracing::debug!(target: "relay", %client, %channel, "Dropping peer->client traffic in userspace (handled by eBPF)");
-                            continue;
-                        }
-
                         let total_length = ChannelData::encode_header_to_slice(
                             channel,
                             packet.len() as u16,

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -586,6 +586,11 @@ where
                         ClientSocket::new(from),
                         Instant::now(),
                     ) {
+                        // If eBPF offloading is enabled, log a warning as this traffic should be handled by kernel
+                        if self.ebpf.is_some() {
+                            tracing::warn!(target: "relay", %port, %peer, "Relaying client->peer ChannelData in userspace! (should have been handled by eBPF)");
+                        }
+
                         // Re-parse as `ChannelData` if we should relay it.
                         let payload = ChannelData::parse(packet)
                             .expect("valid ChannelData if we should relay it")
@@ -612,6 +617,11 @@ where
                         PeerSocket::new(from),
                         AllocationPort::new(port),
                     ) {
+                        // If eBPF offloading is enabled, log a warning as this traffic should be handled by kernel
+                        if self.ebpf.is_some() {
+                            tracing::warn!(target: "relay", %client, %channel, "Relaying peer->client traffic in userspace! (should have been handled by eBPF)");
+                        }
+
                         let total_length = ChannelData::encode_header_to_slice(
                             channel,
                             packet.len() as u16,

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -586,9 +586,10 @@ where
                         ClientSocket::new(from),
                         Instant::now(),
                     ) {
-                        // If eBPF offloading is enabled, log a warning as this traffic should be handled by kernel
+                        // If eBPF offloading is enabled, drop ChannelData relay traffic (it's handled by kernel)
                         if self.ebpf.is_some() {
-                            tracing::warn!(target: "relay", %port, %peer, "Relaying client->peer ChannelData in userspace! (should have been handled by eBPF)");
+                            tracing::debug!(target: "relay", %port, %peer, "Dropping client->peer ChannelData in userspace (handled by eBPF)");
+                            continue;
                         }
 
                         // Re-parse as `ChannelData` if we should relay it.
@@ -617,9 +618,10 @@ where
                         PeerSocket::new(from),
                         AllocationPort::new(port),
                     ) {
-                        // If eBPF offloading is enabled, log a warning as this traffic should be handled by kernel
+                        // If eBPF offloading is enabled, drop peer->client relay traffic (it's handled by kernel)
                         if self.ebpf.is_some() {
-                            tracing::warn!(target: "relay", %client, %channel, "Relaying peer->client traffic in userspace! (should have been handled by eBPF)");
+                            tracing::debug!(target: "relay", %client, %channel, "Dropping peer->client traffic in userspace (handled by eBPF)");
+                            continue;
                         }
 
                         let total_length = ChannelData::encode_header_to_slice(

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -586,7 +586,6 @@ where
                         ClientSocket::new(from),
                         Instant::now(),
                     ) {
-                        // If eBPF offloading is enabled, drop ChannelData relay traffic (it's handled by kernel)
                         if self.ebpf.is_some() {
                             tracing::debug!(target: "relay", %port, %peer, "Dropping client->peer ChannelData in userspace (handled by eBPF)");
                             continue;
@@ -618,7 +617,6 @@ where
                         PeerSocket::new(from),
                         AllocationPort::new(port),
                     ) {
-                        // If eBPF offloading is enabled, drop peer->client relay traffic (it's handled by kernel)
                         if self.ebpf.is_some() {
                             tracing::debug!(target: "relay", %client, %channel, "Dropping peer->client traffic in userspace (handled by eBPF)");
                             continue;


### PR DESCRIPTION
To prevent userspace relaying, all traffic that seemingly looked like STUN/TURN but we couldn't handle via the eBPF codepath we would `XDP_DROP`.

This turned out to be too heavy-handed of an approach since it end up matching DNS query responses as well due to them arriving within the TURN ephemeral port range.

To fix this, we `XDP_PASS` the traffic up the stack so that the kernel is able to match it to existing conntrack entries.

We've identified a minor race condition where the first few channel data packets might be dropped when a channel is first being bound, but fixing this will be saved for a later PR.

Related: https://github.com/firezone/infra/pull/132