### PR TITLE
fix(ci): temporarily suppress fxhash unmaintained

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -91,6 +91,8 @@ ignore = [
 
     "RUSTSEC-2024-0429", # `glib`, need to wait for tauri to upgrade
 
+    "RUSTSEC-2025-0057", # `fxhash` is unmaintained, used by transitive dependencies. See #10297.
+
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
Ignoring for now to get CI to pass, since this isn't an urgent problem.

Related: #10297 