### PR TITLE
fix(gateway): reset DNS resource NAT if proxy IPs change

### DIFF
--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -268,6 +268,10 @@ impl ClientOnGateway {
         self.recalculate_filters();
     }
 
+    /// Checks if the given proxy IPs assigned for a domain are consistent with what we have stored.
+    ///
+    /// When a Client signs out and back in again, it starts re-numbering DNS resources and thus may
+    /// reuse a proxy IP previously assigned to a different domain.
     fn have_proxy_ips_been_reassigned(
         &self,
         resource_id: ResourceId,

--- a/rust/connlib/tunnel/src/peer.rs
+++ b/rust/connlib/tunnel/src/peer.rs
@@ -121,8 +121,8 @@ impl ClientOnGateway {
         if self.have_proxy_ips_been_reassigned(resource_id, &name, &proxy_ips) {
             tracing::info!("Client has re-assigned proxy IPs, resetting DNS resource NAT");
 
-            self.nat_table.clear();
-            self.permanent_translations.clear();
+            self.nat_table = Default::default();
+            self.permanent_translations = Default::default();
         }
 
         let resource = self

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -50,6 +50,12 @@ impl NatTable {
         self.table.left_values().any(|(_, c)| c == &ip)
     }
 
+    pub(crate) fn clear(&mut self) {
+        self.table.clear();
+        self.last_seen.clear();
+        self.expired.clear();
+    }
+
     pub(crate) fn translate_outgoing(
         &mut self,
         packet: &IpPacket,

--- a/rust/connlib/tunnel/src/peer/nat_table.rs
+++ b/rust/connlib/tunnel/src/peer/nat_table.rs
@@ -50,12 +50,6 @@ impl NatTable {
         self.table.left_values().any(|(_, c)| c == &ip)
     }
 
-    pub(crate) fn clear(&mut self) {
-        self.table.clear();
-        self.last_seen.clear();
-        self.expired.clear();
-    }
-
     pub(crate) fn translate_outgoing(
         &mut self,
         packet: &IpPacket,

--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -32,6 +32,10 @@ export default function Gateway() {
           Introduces graceful shutdown, allowing Clients to immediately switch
           over a new Gateway instead of waiting for the ICE timeout (~15s).
         </ChangeItem>
+        <ChangeItem pull="10310">
+          Fixes an issue where packets for DNS resources could get routed to the
+          wrong address.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.4.15" date={new Date("2025-08-05")}>
         <ChangeItem pull="10109">


### PR DESCRIPTION
In #10040, we decided to persist a peer's routing state on the Gateway across ICE sessions. This routing state also includes the DNS resource NAT.

Prior to #10104 (which is not released yet), when a Client signs out and back in, it resets the proxy IP mapping for DNS resources and will start numbering them again from the front, i.e. starting from 100.96.0.1. With the state still being preserved on the Gateway, this represents a problem: We keep existing mappings around if there is still a NAT session for this proxy IP. However, if the proxy IP is actually for a different domain, this NAT session is meaningless. In fact, not replacing the IP is problematic as we will now route packets for the new proxy IP to the wrong destination.

The persistent DNS resource mapping from #10104 fixes this. In this PR, we add an additional check to the Gateway where we detect whether the Client has started to re-assign proxy IPs and if so, we completely reset the DNS resource NAT state including all existing NAT sessions.

Fixes #10268