### PR TITLE
ci: reduce target bitrate for UDP perf tests to 600Mbit/s

### DIFF
--- a/scripts/tests/perf/direct-udp-client2server.sh
+++ b/scripts/tests/perf/direct-udp-client2server.sh
@@ -7,7 +7,7 @@ source "./scripts/tests/lib.sh"
 docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \
   --udp \
-  --bandwidth 1G \
+  --bandwidth 600M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
 

--- a/scripts/tests/perf/direct-udp-server2client.sh
+++ b/scripts/tests/perf/direct-udp-server2client.sh
@@ -8,7 +8,7 @@ docker compose exec --env RUST_LOG=info -it client /bin/sh -c 'iperf3 \
   --time 30 \
   --reverse \
   --udp \
-  --bandwidth 1G \
+  --bandwidth 600M \
   --client 172.20.0.110 \
   --json' >>"${TEST_NAME}.json"
 


### PR DESCRIPTION
To achieve a more stable CI, we need to reduce the target bitrate of the UDP perf tests. Now that we no longer have GSO enabled in the tests, the most we can achieve in CI is 600Mbit/s. Forcing more packets through the tunnel results in all sorts of warnings which end up failing CI.