### PR TITLE
fix(apple): Enforce single Firezone instance

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -117,7 +117,7 @@ struct FirezoneApp: App {
             alert.messageText = "Another Firezone Instance Detected"
             alert.informativeText = """
               Another instance of Firezone is already running. \
-              Please quit the other instance manually from the menu bar to continue.
+              Please quit the other instance from the menu bar to continue.
 
               Location: \(app.bundleURL?.path ?? "Unknown")
               """

--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -102,34 +102,23 @@ struct FirezoneApp: App {
       guard runningApps.count > 1 else { return }
 
       for app in runningApps where app != NSRunningApplication.current {
-        // Try to terminate the other instance
-        var terminated = app.terminate()
+        DispatchQueue.main.async {
+          let alert = NSAlert()
+          alert.messageText = "Another Firezone Instance Detected"
+          alert.informativeText = """
+            Another instance of Firezone is already running. \
+            Please quit the other instance from the menu bar to continue.
 
-        if !terminated {
-          // If graceful termination fails, force terminate
-          terminated = app.forceTerminate()
-        }
+            Location: \(app.bundleURL?.path ?? "Unknown")
+            """
+          alert.alertStyle = .warning
+          alert.addButton(withTitle: "OK")
 
-        if !terminated {
-          // If we still can't terminate, show an alert to the user
-          DispatchQueue.main.async {
-            let alert = NSAlert()
-            alert.messageText = "Another Firezone Instance Detected"
-            alert.informativeText = """
-              Another instance of Firezone is already running. \
-              Please quit the other instance from the menu bar to continue.
+          // Show alert
+          alert.runModal()
 
-              Location: \(app.bundleURL?.path ?? "Unknown")
-              """
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: "OK")
-
-            // Show the alert
-            alert.runModal()
-
-            // Exit this instance since we can't terminate the other one
-            NSApp.terminate(nil)
-          }
+          // Exit this instance since we can't terminate the other one
+          NSApp.terminate(nil)
         }
       }
     }

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="10313">
+          Fixes an issue where multiple concurrent Firezone macOS clients could
+          run simultaneously. We now enforce a single instance of the client.
+        </ChangeItem>
         <ChangeItem pull="10224">
           Fixes a minor DNS cache bug where newly-added DNS resources may not
           resolve for a few seconds after showing up in the Resource List.


### PR DESCRIPTION
 show an alert to the user and ask to quit previous Firezone instance manually before starting a new one.

Resolves: #10295 