### PR TITLE
ci: run `veth-config` after containers have started up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -757,6 +757,8 @@ services:
         condition: "service_healthy"
       client-router:
         condition: "service_healthy"
+      gateway:
+        condition: "service_healthy"
 
   otel:
     image: otel/opentelemetry-collector:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -753,6 +753,10 @@ services:
         condition: "service_healthy"
       relay-2-router:
         condition: "service_healthy"
+      gateway-router:
+        condition: "service_healthy"
+      client-router:
+        condition: "service_healthy"
 
   otel:
     image: otel/opentelemetry-collector:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -365,6 +365,8 @@ services:
 
   # Run with DOCKER_BUILD_TARGET=dev to build Rust inside Docker
   client:
+    healthcheck:
+      test: ["CMD-SHELL", "ip link | grep tun-firezone"]
     environment:
       FIREZONE_DNS_CONTROL: "${FIREZONE_DNS_CONTROL:-etc-resolv-conf}"
       FIREZONE_TOKEN: "n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAR_ywiZQBYgABUYA.PLNlzyqMSgZlbQb1QX5EzZgYNuY9oeOddP0qDkTwtGg"
@@ -758,6 +760,8 @@ services:
       client-router:
         condition: "service_healthy"
       gateway:
+        condition: "service_healthy"
+      client:
         condition: "service_healthy"
 
   otel:


### PR DESCRIPTION
In order to make relaying reliable, we need to delay the startup of `veth-config` until all containers have booted successfully, otherwise the XDP_PASS program is not attached and relayed traffic is being dropped.