### PR TITLE
fix(portal): don't count internet site in limits

### DIFF
--- a/elixir/apps/domain/lib/domain/gateways.ex
+++ b/elixir/apps/domain/lib/domain/gateways.ex
@@ -23,6 +23,7 @@ defmodule Domain.Gateways do
   def count_groups_for_account(%Accounts.Account{} = account) do
     Group.Query.not_deleted()
     |> Group.Query.by_account_id(account.id)
+    |> Group.Query.by_managed_by(:account)
     |> Repo.aggregate(:count)
   end
 

--- a/elixir/apps/domain/test/domain/gateways_test.exs
+++ b/elixir/apps/domain/test/domain/gateways_test.exs
@@ -37,6 +37,11 @@ defmodule Domain.GatewaysTest do
 
       assert count_groups_for_account(account) == 0
     end
+
+    test "does not count internet site", %{account: account} do
+      Fixtures.Gateways.create_internet_group(account: account)
+      assert count_groups_for_account(account) == 0
+    end
   end
 
   describe "fetch_group_by_id/3" do


### PR DESCRIPTION
Starter plans don't have access to the internet site so it's not fair to count it against their limits.

Related: https://app.hubspot.com/contacts/23723443/record/0-5/29628021256