### PR TITLE
refactor(connlib): improve fairness of event-loop

### DIFF
--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -254,8 +254,8 @@ impl Eventloop {
         Ok(())
     }
 
-    fn handle_tunnel_error(&mut self, e: TunnelError) -> Result<()> {
-        for e in e {
+    fn handle_tunnel_error(&mut self, mut e: TunnelError) -> Result<()> {
+        for e in e.iter() {
             if e.root_cause()
                 .downcast_ref::<io::Error>()
                 .is_some_and(is_unreachable)

--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -255,7 +255,7 @@ impl Eventloop {
     }
 
     fn handle_tunnel_error(&mut self, mut e: TunnelError) -> Result<()> {
-        for e in e.iter() {
+        for e in e.drain() {
             if e.root_cause()
                 .downcast_ref::<io::Error>()
                 .is_some_and(is_unreachable)

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -3,8 +3,9 @@ mod nameserver_set;
 mod tcp_dns;
 mod udp_dns;
 
-use crate::{device_channel::Device, dns, otel, sockets::Sockets};
+use crate::{TunnelError, device_channel::Device, dns, otel, sockets::Sockets};
 use anyhow::{Context as _, Result};
+use chrono::{DateTime, Utc};
 use futures::FutureExt as _;
 use futures_bounded::FuturesTupleSet;
 use gat_lending_iterator::LendingIterator;
@@ -82,13 +83,91 @@ impl Default for Buffers {
     }
 }
 
-pub enum Input<D, I> {
-    Timeout(Instant),
-    Device(D),
-    Network(I),
-    TcpDnsQuery(l4_tcp_dns_server::Query),
-    UdpDnsQuery(l4_udp_dns_server::Query),
-    DnsResponse(dns::RecursiveResponse),
+pub struct Input<D, I> {
+    pub now: Instant,
+    pub now_utc: DateTime<Utc>,
+    pub timeout: bool,
+    pub device: Option<D>,
+    pub network: Option<I>,
+    pub tcp_dns_query: Option<l4_tcp_dns_server::Query>,
+    pub udp_dns_query: Option<l4_udp_dns_server::Query>,
+    pub dns_response: Option<dns::RecursiveResponse>,
+    pub error: TunnelError,
+}
+
+impl<D, I> Input<D, I> {
+    fn error(e: impl Into<anyhow::Error>) -> Self {
+        Self {
+            now: Instant::now(),
+            now_utc: Utc::now(),
+            timeout: false,
+            device: None,
+            network: None,
+            tcp_dns_query: None,
+            udp_dns_query: None,
+            dns_response: None,
+            error: TunnelError::single(e),
+        }
+    }
+
+    fn from_polls(
+        timeout: bool,
+        device: Poll<D>,
+        network: Poll<Result<I>>,
+        tcp_dns_query: Poll<Result<l4_tcp_dns_server::Query>>,
+        udp_dns_query: Poll<Result<l4_udp_dns_server::Query>>,
+        dns_response: Poll<dns::RecursiveResponse>,
+    ) -> Self {
+        let mut error = TunnelError::default();
+
+        Self {
+            now: Instant::now(),
+            now_utc: Utc::now(),
+            timeout,
+            device: poll_to_option(device),
+            network: poll_result_to_option(network, &mut error),
+            tcp_dns_query: poll_result_to_option(tcp_dns_query, &mut error),
+            udp_dns_query: poll_result_to_option(udp_dns_query, &mut error),
+            dns_response: poll_to_option(dns_response),
+            error,
+        }
+    }
+
+    fn into_poll(self) -> Poll<Self> {
+        if !self.timeout
+            && self.device.is_none()
+            && self.network.is_none()
+            && self.tcp_dns_query.is_none()
+            && self.udp_dns_query.is_none()
+            && self.dns_response.is_none()
+        {
+            return Poll::Pending;
+        }
+
+        Poll::Ready(self)
+    }
+}
+
+fn poll_to_option<T>(poll: Poll<T>) -> Option<T> {
+    match poll {
+        Poll::Ready(r) => Some(r),
+        Poll::Pending => None,
+    }
+}
+
+fn poll_result_to_option<T, E>(poll: Poll<Result<T, E>>, error: &mut TunnelError) -> Option<T>
+where
+    anyhow::Error: From<E>,
+{
+    match poll {
+        Poll::Ready(Ok(r)) => Some(r),
+        Poll::Ready(Err(e)) => {
+            error.push(e);
+
+            None
+        }
+        Poll::Pending => None,
+    }
 }
 
 const DNS_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
@@ -157,14 +236,14 @@ impl Io {
         cx: &mut Context<'_>,
         buffers: &'b mut Buffers,
     ) -> Poll<
-        Result<
-            Input<
-                impl Iterator<Item = IpPacket> + use<'b>,
-                impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>,
-            >,
+        Input<
+            impl Iterator<Item = IpPacket> + use<'b>,
+            impl for<'a> LendingIterator<Item<'a> = DatagramIn<'a>> + use<>,
         >,
     > {
-        ready!(self.flush(cx)?);
+        if let Err(e) = ready!(self.flush(cx)) {
+            return Poll::Ready(Input::error(e));
+        }
 
         if self.reval_nameserver_interval.poll_tick(cx).is_ready() {
             self.nameservers.evaluate();
@@ -173,93 +252,83 @@ impl Io {
         // We purposely don't want to block the event loop here because we can do plenty of other work while this is running.
         let _ = self.nameservers.poll(cx);
 
-        if let Poll::Ready(network) = self.sockets.poll_recv_from(cx) {
-            return Poll::Ready(Ok(Input::Network(
-                network
-                    .context("UDP socket failed")?
-                    .filter(is_max_wg_packet_size),
-            )));
-        }
+        let network = self.sockets.poll_recv_from(cx).map(|network| {
+            Ok(network
+                .context("UDP socket failed")?
+                .filter(is_max_wg_packet_size))
+        });
 
-        if let Poll::Ready(num_packets) =
-            self.tun
-                .poll_read_many(cx, &mut buffers.ip, MAX_INBOUND_PACKET_BATCH)
-        {
-            let num_ipv4 = buffers.ip[..num_packets]
-                .iter()
-                .filter(|p| p.ipv4_header().is_some())
-                .count();
-            let num_ipv6 = num_packets - num_ipv4;
+        let device = self
+            .tun
+            .poll_read_many(cx, &mut buffers.ip, MAX_INBOUND_PACKET_BATCH)
+            .map(|num_packets| {
+                let num_ipv4 = buffers.ip[..num_packets]
+                    .iter()
+                    .filter(|p| p.ipv4_header().is_some())
+                    .count();
+                let num_ipv6 = num_packets - num_ipv4;
 
-            self.packet_counter.add(
-                num_ipv4 as u64,
-                &[
-                    otel::attr::network_type_ipv4(),
-                    otel::attr::network_io_direction_receive(),
-                ],
-            );
-            self.packet_counter.add(
-                num_ipv6 as u64,
-                &[
-                    otel::attr::network_type_ipv6(),
-                    otel::attr::network_io_direction_receive(),
-                ],
-            );
+                self.packet_counter.add(
+                    num_ipv4 as u64,
+                    &[
+                        otel::attr::network_type_ipv4(),
+                        otel::attr::network_io_direction_receive(),
+                    ],
+                );
+                self.packet_counter.add(
+                    num_ipv6 as u64,
+                    &[
+                        otel::attr::network_type_ipv6(),
+                        otel::attr::network_io_direction_receive(),
+                    ],
+                );
 
-            return Poll::Ready(Ok(Input::Device(buffers.ip.drain(..num_packets))));
-        }
+                buffers.ip.drain(..num_packets)
+            });
 
-        if let Poll::Ready(query) = self.udp_dns_server.poll(cx) {
-            return Poll::Ready(Ok(Input::UdpDnsQuery(
-                query.context("Failed to poll UDP DNS server")?,
-            )));
-        }
+        let udp_dns_query = self
+            .udp_dns_server
+            .poll(cx)
+            .map(|query| query.context("Failed to poll UDP DNS server"));
 
-        if let Poll::Ready(query) = self.tcp_dns_server.poll(cx) {
-            return Poll::Ready(Ok(Input::TcpDnsQuery(
-                query.context("Failed to poll TCP DNS server")?,
-            )));
-        }
+        let tcp_dns_query = self
+            .tcp_dns_server
+            .poll(cx)
+            .map(|query| query.context("Failed to poll TCP DNS server"));
 
-        match self.dns_queries.poll_unpin(cx) {
-            Poll::Ready((result, meta)) => {
-                let response = match result {
-                    Ok(result) => dns::RecursiveResponse {
-                        server: meta.server,
-                        query: meta.query,
-                        message: result,
-                        transport: meta.transport,
-                    },
-                    Err(e @ futures_bounded::Timeout { .. }) => dns::RecursiveResponse {
-                        server: meta.server,
-                        query: meta.query,
-                        message: Err(io::Error::new(io::ErrorKind::TimedOut, e)),
-                        transport: meta.transport,
-                    },
-                };
+        let dns_response = self
+            .dns_queries
+            .poll_unpin(cx)
+            .map(|(result, meta)| match result {
+                Ok(result) => dns::RecursiveResponse {
+                    server: meta.server,
+                    query: meta.query,
+                    message: result,
+                    transport: meta.transport,
+                },
+                Err(e @ futures_bounded::Timeout { .. }) => dns::RecursiveResponse {
+                    server: meta.server,
+                    query: meta.query,
+                    message: Err(io::Error::new(io::ErrorKind::TimedOut, e)),
+                    transport: meta.transport,
+                },
+            });
 
-                return Poll::Ready(Ok(Input::DnsResponse(response)));
-            }
-            Poll::Pending => {}
-        }
+        let timeout = self
+            .timeout
+            .as_mut()
+            .map(|timeout| timeout.poll_unpin(cx).is_ready())
+            .unwrap_or(false);
 
-        if let Some(timeout) = self.timeout.as_mut()
-            && timeout.poll_unpin(cx).is_ready()
-        {
-            // Always emit `now` as the timeout value.
-            // This ensures that time within our state machine is always monotonic.
-            // If we were to use the `deadline` of the timer instead, time may go backwards.
-            // That is because it is valid to set a `Sleep` to a timestamp in the past.
-            // It will resolve immediately but it will still report the old timestamp as its deadline.
-            // To guard against this case, specifically call `Instant::now` here.
-            let now = Instant::now();
-
-            self.timeout = None; // Clear the timeout.
-
-            return Poll::Ready(Ok(Input::Timeout(now)));
-        }
-
-        Poll::Pending
+        Input::from_polls(
+            timeout,
+            device,
+            network,
+            tcp_dns_query,
+            udp_dns_query,
+            dns_response,
+        )
+        .into_poll()
     }
 
     pub fn flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -83,6 +83,10 @@ impl Default for Buffers {
     }
 }
 
+/// Represents all IO sources that may be ready during a single event-loop tick.
+///
+/// This structure allows us to batch-process multiple ready sources rather than
+/// handling them one at a time, improving fairness and preventing starvation.
 pub struct Input<D, I> {
     pub now: Instant,
     pub now_utc: DateTime<Utc>,

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -140,6 +140,7 @@ impl<D, I> Input<D, I> {
             && self.tcp_dns_query.is_none()
             && self.udp_dns_query.is_none()
             && self.dns_response.is_none()
+            && self.error.is_empty()
         {
             return Poll::Pending;
         }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -602,7 +602,7 @@ impl TunnelError {
         self.errors.is_empty()
     }
 
-    pub fn iter(&mut self) -> impl Iterator<Item = anyhow::Error> {
+    pub fn drain(&mut self) -> impl Iterator<Item = anyhow::Error> {
         mem::take(&mut self.errors).into_iter()
     }
 }

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -611,6 +611,10 @@ impl Drop for TunnelError {
             self.errors.is_empty(),
             "should never drop `TunnelError` without consuming errors"
         );
+
+        if !self.errors.is_empty() {
+            tracing::error!("should never drop `TunnelError` without consuming errors")
+        }
     }
 }
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -171,19 +171,18 @@ impl ClientTunnel {
             }
 
             // Process all IO sources that are ready.
-            if let Poll::Ready(input) = self.io.poll(cx, &mut self.buffers) {
-                let io::Input {
-                    now,
-                    now_utc: _,
-                    timeout,
-                    dns_response,
-                    tcp_dns_query: _,
-                    udp_dns_query: _,
-                    device,
-                    network,
-                    error,
-                } = input;
-
+            if let Poll::Ready(io::Input {
+                now,
+                now_utc: _,
+                timeout,
+                dns_response,
+                tcp_dns_query: _,
+                udp_dns_query: _,
+                device,
+                network,
+                error,
+            }) = self.io.poll(cx, &mut self.buffers)
+            {
                 if let Some(response) = dns_response {
                     self.role_state.handle_dns_response(response);
                     self.role_state.handle_timeout(now);
@@ -338,19 +337,18 @@ impl GatewayTunnel {
             }
 
             // Process all IO sources that are ready.
-            if let Poll::Ready(input) = self.io.poll(cx, &mut self.buffers) {
-                let io::Input {
-                    now,
-                    now_utc,
-                    timeout,
-                    dns_response,
-                    tcp_dns_query,
-                    udp_dns_query,
-                    device,
-                    network,
-                    mut error,
-                } = input;
-
+            if let Poll::Ready(io::Input {
+                now,
+                now_utc,
+                timeout,
+                dns_response,
+                tcp_dns_query,
+                udp_dns_query,
+                device,
+                network,
+                mut error,
+            }) = self.io.poll(cx, &mut self.buffers)
+            {
                 if let Some(response) = dns_response {
                     let message = response.message.unwrap_or_else(|e| {
                         tracing::debug!("DNS query failed: {e}");

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -869,6 +869,7 @@ impl TunnelTest {
 
                 Ok(())
             }
+            ClientEvent::Error(_) => unreachable!("ClientState never emits `TunnelError`"),
         }
     }
 
@@ -1006,5 +1007,6 @@ fn on_gateway_event(
                     .unwrap()
             })
         }
+        GatewayEvent::Error(_) => unreachable!("GatewayState never emits `TunnelError`"),
     }
 }

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -256,7 +256,7 @@ impl Eventloop {
     }
 
     fn handle_tunnel_error(&mut self, mut e: TunnelError) -> Result<()> {
-        for e in e.iter() {
+        for e in e.drain() {
             if e.root_cause()
                 .downcast_ref::<io::Error>()
                 .is_some_and(is_unreachable)

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -257,8 +257,8 @@ impl Eventloop {
         Ok(())
     }
 
-    fn handle_tunnel_error(&mut self, e: TunnelError) -> Result<()> {
-        for e in e {
+    fn handle_tunnel_error(&mut self, mut e: TunnelError) -> Result<()> {
+        for e in e.iter() {
             if e.root_cause()
                 .downcast_ref::<io::Error>()
                 .is_some_and(is_unreachable)


### PR DESCRIPTION
The event-loop inside `Tunnel` processes input according to a certain priority. We only take input from lower priority sources when the higher priority sources are not ready. The current priorities are:

- Flush all buffers
- Read from UDP sockets
- Read from TUN device
- Read from DNS servers
- Process recursive DNS queries
- Check timeout

The idea of this priority ordering is to keep all kinds of processing bounded and "finish" any kind of work that is on-going before taking on new work. Anything that sits in a buffer is basically done with processing and just needs to be written out to the network / device. Arriving UDP packets have already traversed the network and been encrypted on the other end, meaning they are higher priority than reading from the TUN device. Packets from the TUN device still need to be encrypted and sent to the remote.

Whilst there is merit in this design, it also bears the potential of starving input sources further down if the top ones are extremely busy. To prevent this, we refactor `Io` to read from all input sources and present it to the event-loop as a batch, allowing all sources to make progress before looping around. Since this event-loop has first been conceived, we have refactored `Io` to use background threads for the UDP sockets and TUN device, meaning they will make progress by themselves anyway until the channels to the main-thread fill up. As such, there shouldn't be any latency increase in processing packets even though we are performing slightly more work per event-loop tick.

This kind of batch-processing highlights a problem: Bailing out with an error midway through processing a batch leaves the remainder of the batch unprocessed, essentially dropping packets. To fix this, we introduce a new `TunnelError` type that presents a collection of errors that we encountered while processing the batch. This might actually also be a problem with what is currently in `main` because we are already batch-processing packets there but possibly are bailing out midway through the batch.