### PR TITLE
ci: up the `veth-config` container last

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -158,7 +158,6 @@ jobs:
           docker compose up -d relay-2 --no-build
           docker compose up -d gateway --no-build
           docker compose up -d client --no-build
-          docker compose up veth-config
 
           if [[ -n "${{ matrix.test.stop_containers }}" ]]; then
             docker compose stop ${{ matrix.test.stop_containers }}
@@ -170,6 +169,7 @@ jobs:
           # Intended to mitigate <https://github.com/firezone/firezone/issues/5830>
           sleep 3
 
+          docker compose up veth-config
       - name: Add 50ms simulated API latency
         run: |
           docker compose exec -T -u root api sh -c 'apk add --update --no-cache iproute2-tc'


### PR DESCRIPTION
It appears that we still have a race condition where the `veth-config` container runs too early and ends up not applying the `XDP_PASS` program to all interfaces, causing the double symmetric NAT integration test to fail: https://github.com/firezone/firezone/actions/runs/17718375157/job/50346744176?pr=10347