### PR TITLE
ci: add latency to routers

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -169,6 +169,8 @@ jobs:
           # Intended to mitigate <https://github.com/firezone/firezone/issues/5830>
           sleep 3
 
+          docker compose up veth-config
+
       - run: ./scripts/tests/${{ matrix.test.script }}.sh
 
       - name: Ensure Client emitted no warnings

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -169,18 +169,6 @@ jobs:
           # Intended to mitigate <https://github.com/firezone/firezone/issues/5830>
           sleep 3
 
-          docker compose up veth-config
-      - name: Add 50ms simulated API latency
-        run: |
-          docker compose exec -T -u root api sh -c 'apk add --update --no-cache iproute2-tc'
-          docker compose exec -T -u root api sh -c 'tc qdisc add dev eth0 root netem delay 50ms'
-
-      - name: Add 10ms simulated gateway latency
-        run: |
-          # compatibility test images won't have the `tc` command
-          docker compose exec -T gateway sh -c 'apk add --update --no-cache iproute2-tc'
-          docker compose exec -T gateway sh -c 'tc qdisc add dev eth0 root netem delay 10ms'
-
       - run: ./scripts/tests/${{ matrix.test.script }}.sh
 
       - name: Ensure Client emitted no warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,11 +336,6 @@ jobs:
           docker compose up -d gateway --no-build
           docker compose up -d client --no-build
           docker compose up veth-config
-      - name: Add 10ms simulated latency
-        run: |
-          docker compose exec -T client tc qdisc add dev eth0 root netem delay 10ms
-          docker compose exec -T gateway tc qdisc add dev eth0 root netem delay 10ms
-          docker compose exec -T relay-1 tc qdisc add dev eth0 root netem delay 10ms
       - name: "Performance test: ${{ matrix.flavour }}-${{ matrix.test }}"
         timeout-minutes: 5
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
         8081 172.28.0.100 tcp
         8081 172:28:0::100 tcp
       MASQUERADE_TYPE: ""
+      NETWORK_LATENCY_MS: 50
     networks:
       app-internal:
         ipv4_address: 172.28.0.254
@@ -225,6 +226,7 @@ services:
       service: router
     environment:
       MASQUERADE_TYPE: ${CLIENT_MASQUERADE:-}
+      NETWORK_LATENCY_MS: 10
     networks:
       client-internal:
         ipv4_address: 172.30.0.254
@@ -298,6 +300,7 @@ services:
       service: router
     environment:
       MASQUERADE_TYPE: ${GATEWAY_MASQUERADE:-}
+      NETWORK_LATENCY_MS: 10
     networks:
       gateway-internal:
         ipv4_address: 172.31.0.254
@@ -342,6 +345,7 @@ services:
         49152-65535 172.29.1.100 udp
         3478 172:29:1::100 udp
         49152-65535 172:29:1::100 udp
+      NETWORK_LATENCY_MS: 30
     networks:
       relay-1-internal:
         ipv4_address: 172.29.1.254
@@ -388,6 +392,7 @@ services:
         49152-65535 172.29.2.100 udp
         3478 172:29:2::100 udp
         49152-65535 172:29:2::100 udp
+      NETWORK_LATENCY_MS: 30
     networks:
       relay-2-internal:
         ipv4_address: 172.29.2.254

--- a/scripts/router/router.sh
+++ b/scripts/router/router.sh
@@ -64,6 +64,14 @@ if [ -n "${PORT_FORWARDS:-}" ]; then
     done
 fi
 
+# Add configurable latency if specified
+if [ -n "${NETWORK_LATENCY_MS:-}" ]; then
+    LATENCY=$((NETWORK_LATENCY_MS / 2)) # Latency is only applied to outbound packets. To achieve the actual configured latency, we apply half of it to each interface.
+
+    tc qdisc add dev internet root netem delay "${LATENCY}ms"
+    tc qdisc add dev internal root netem delay "${LATENCY}ms"
+fi
+
 echo "-----------------------------------------------------------------------------------------------"
 cat "$CONFIG_FILE"
 echo "-----------------------------------------------------------------------------------------------"


### PR DESCRIPTION
Now that we have a more realistic network setup in our compose file, we can extend our router containers to apply the latency on the network path. This means any use of the compose file has a latency by default, simplifying our CI setup. It also allows us to restart containers without having to re-apply the latency which is useful during performance testing.