### PR TITLE
ci: faster client healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,7 @@ services:
   client:
     healthcheck:
       test: ["CMD-SHELL", "ip link | grep tun-firezone"]
+      <<: *health-check
     environment:
       FIREZONE_DNS_CONTROL: "${FIREZONE_DNS_CONTROL:-etc-resolv-conf}"
       FIREZONE_TOKEN: "n.SFMyNTY.g2gDaANtAAAAJGM4OWJjYzhjLTkzOTItNGRhZS1hNDBkLTg4OGFlZjZkMjhlMG0AAAAkN2RhN2QxY2QtMTExYy00NGE3LWI1YWMtNDAyN2I5ZDIzMGU1bQAAACtBaUl5XzZwQmstV0xlUkFQenprQ0ZYTnFJWktXQnMyRGR3XzJ2Z0lRdkZnbgYAR_ywiZQBYgABUYA.PLNlzyqMSgZlbQb1QX5EzZgYNuY9oeOddP0qDkTwtGg"


### PR DESCRIPTION
The default healthcheck only checks every 30s which unnecessarily delays the docker-compose setup. By adding our common healthcheck params to the client, we can increase the startup speed.