### PR TITLE
refactor(connlib): remove concept of "ReplyMessages"

### DIFF
--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -96,7 +96,7 @@ impl Eventloop {
     pub(crate) fn new(
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
-        mut portal: PhoenixChannel<(), IngressMessages, (), PublicKeyParam>,
+        mut portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
         cmd_rx: mpsc::UnboundedReceiver<Command>,
         resource_list_sender: watch::Sender<Vec<ResourceView>>,
         tun_config_sender: watch::Sender<Option<TunConfig>>,
@@ -432,7 +432,7 @@ impl Eventloop {
 }
 
 async fn phoenix_channel_event_loop(
-    mut portal: PhoenixChannel<(), IngressMessages, (), PublicKeyParam>,
+    mut portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
     event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
 ) {
@@ -449,7 +449,7 @@ async fn phoenix_channel_event_loop(
                     break;
                 }
             }
-            Either::Left((Ok(phoenix_channel::Event::SuccessResponse { res: (), .. }), _)) => {}
+            Either::Left((Ok(phoenix_channel::Event::SuccessResponse { .. }), _)) => {}
             Either::Left((Ok(phoenix_channel::Event::ErrorResponse { res, req_id, topic }), _)) => {
                 match res {
                     ErrorReply::Disabled => {

--- a/rust/client-shared/src/lib.rs
+++ b/rust/client-shared/src/lib.rs
@@ -57,7 +57,7 @@ impl Session {
     pub fn connect(
         tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
         udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
-        portal: PhoenixChannel<(), IngressMessages, (), PublicKeyParam>,
+        portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
         handle: tokio::runtime::Handle,
     ) -> (Self, EventStream) {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();

--- a/rust/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/connlib/phoenix-channel/tests/lib.rs
@@ -70,7 +70,7 @@ async fn client_does_not_pipeline_messages() {
         .unwrap(),
     );
 
-    let mut channel = PhoenixChannel::<(), InboundMsg, (), _>::disconnected(
+    let mut channel = PhoenixChannel::<(), InboundMsg, _>::disconnected(
         login_url,
         "test/1.0.0".to_owned(),
         "test",

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -79,7 +79,7 @@ enum PortalCommand {
 impl Eventloop {
     pub(crate) fn new(
         tunnel: GatewayTunnel,
-        mut portal: PhoenixChannel<(), IngressMessages, (), PublicKeyParam>,
+        mut portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
         tun_device_manager: TunDeviceManager,
     ) -> Result<Self> {
         portal.connect(PublicKeyParam(tunnel.public_key().to_bytes()));
@@ -637,7 +637,7 @@ impl Eventloop {
 }
 
 async fn phoenix_channel_event_loop(
-    mut portal: PhoenixChannel<(), IngressMessages, (), PublicKeyParam>,
+    mut portal: PhoenixChannel<(), IngressMessages, PublicKeyParam>,
     event_tx: mpsc::Sender<Result<IngressMessages, phoenix_channel::Error>>,
     mut cmd_rx: mpsc::Receiver<PortalCommand>,
 ) {
@@ -661,7 +661,7 @@ async fn phoenix_channel_event_loop(
             }
             Either::Left((
                 Ok(
-                    phoenix_channel::Event::SuccessResponse { res: (), .. }
+                    phoenix_channel::Event::SuccessResponse { .. }
                     | phoenix_channel::Event::HeartbeatSent
                     | phoenix_channel::Event::JoinedRoom { .. },
                 ),

--- a/rust/relay/server/src/main.rs
+++ b/rust/relay/server/src/main.rs
@@ -416,7 +416,7 @@ struct Eventloop<R> {
     sockets: Sockets,
 
     server: Server<R>,
-    channel: Option<PhoenixChannel<JoinMessage, IngressMessage, (), NoParams>>,
+    channel: Option<PhoenixChannel<JoinMessage, IngressMessage, NoParams>>,
     sleep: Sleep,
 
     ebpf: Option<ebpf::Program>,
@@ -438,7 +438,7 @@ where
     fn new(
         server: Server<R>,
         ebpf: Option<ebpf::Program>,
-        channel: PhoenixChannel<JoinMessage, IngressMessage, (), NoParams>,
+        channel: PhoenixChannel<JoinMessage, IngressMessage, NoParams>,
         public_address: IpStack,
         last_heartbeat_sent: Arc<Mutex<Option<Instant>>>,
     ) -> Result<Self> {
@@ -719,9 +719,9 @@ where
         Ok(())
     }
 
-    fn handle_portal_event(&mut self, event: phoenix_channel::Event<IngressMessage, ()>) {
+    fn handle_portal_event(&mut self, event: phoenix_channel::Event<IngressMessage>) {
         match event {
-            Event::SuccessResponse { res: (), .. } => {}
+            Event::SuccessResponse { .. } => {}
             Event::JoinedRoom { topic } => {
                 tracing::info!(target: "relay", "Successfully joined room '{topic}'");
             }


### PR DESCRIPTION
In earlier versions of Firezone, the WebSocket protocol with the portal was using the request-response semantics built into Phoenix. This however is quite cumbersome to work with to due to the polymorphic nature of the protocol design.

We ended up moving away from it and instead only use one-way messages where each event directly corresponds to a message type. However, we have never removed the capability reply messages from the `phoenix-channel` module, instead all usages just set it to `()`.

We can simplify the code here by always setting this to `()`.

Resolves: #7091