### PR TITLE
chore(dependabot): Add 28-day cooldown for supply-chain security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,23 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+
+# Define reusable security configuration using YAML anchors
+x-security-config: &default-security-config
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7
+    semver-major-days: 7
+    semver-minor-days: 7
+    semver-patch-days: 7
 updates:
   - package-ecosystem: mix
     directory: elixir/
-    schedule:
-      interval: monthly
+    <<: *default-security-config
   - package-ecosystem: pip
     directory: /.github
-    schedule:
-      interval: monthly
+    <<: *default-security-config
   - package-ecosystem: github-actions
     directories:
       - "/"
@@ -25,13 +33,11 @@ updates:
       - "/.github/actions/setup-postgres"
       - "/.github/actions/setup-rust"
       - "/.github/actions/setup-tauri-v2"
-    schedule:
-      interval: monthly
+    <<: *default-security-config
   - package-ecosystem: cargo
     directory: rust/
     open-pull-requests-limit: 20
-    schedule:
-      interval: weekly
+    <<: *default-security-config
     groups:
       tauri:
         patterns:
@@ -67,8 +73,7 @@ updates:
           - rand_*
   - package-ecosystem: gradle
     directory: kotlin/android/
-    schedule:
-      interval: monthly
+    <<: *default-security-config
     ignore:
       # Depends on JDK version which is bundled with Android Studio (JDK 17)
       - dependency-name: org.jetbrains.kotlin:kotlin-gradle-plugin
@@ -127,16 +132,13 @@ updates:
 
   - package-ecosystem: swift
     directory: swift/apple/FirezoneKit
-    schedule:
-      interval: monthly
+    <<: *default-security-config
   - package-ecosystem: npm
     directory: website/
-    schedule:
-      interval: monthly
+    <<: *default-security-config
   - package-ecosystem: npm
     directory: rust/gui-client/
-    schedule:
-      interval: monthly
+    <<: *default-security-config
     groups:
       tauri:
         patterns:
@@ -161,5 +163,4 @@ updates:
           - "@types/react-dom"
   - package-ecosystem: npm
     directory: elixir/apps/web/assets/
-    schedule:
-      interval: monthly
+    <<: *default-security-config


### PR DESCRIPTION
Configure Dependabot with a 28-day cooldown period across all package ecosystems to protect against supply-chain attacks. This ensures newly released packages undergo community vetting before adoption.

Key changes:
- Add 7-day cooldown for all dependency types (major, minor, patch)
- Switch from monthly to weekly checks to ensure timely updates after cooldown expires
- Use YAML anchors to maintain DRY configuration (we can unfold them if we need custom config)

Security rationale:
- Most supply-chain attacks are discovered within a few days of release
- Patch versions are particularly vulnerable as they're often auto-merged with less scrutiny
- Weekly checks + 28-day cooldown = roughly matching previous elixir dependency update cadence

Note: Security updates bypass the cooldown and are applied immediately, ensuring critical CVEs are patched without delay