### PR TITLE
fix(connlib): limit the number of optimistic candidates

### DIFF
--- a/website/src/components/Changelog/Gateway.tsx
+++ b/website/src/components/Changelog/Gateway.tsx
@@ -22,7 +22,12 @@ export default function Gateway() {
 
   return (
     <Entries downloadLinks={downloadLinks} title="Gateway">
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="10367">
+          Fixes a rare CPU-spike issue in case a Client connected with many
+          possible IPv6 addresses.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.4.16" date={new Date("2025-09-10")}>
         <ChangeItem pull="10231">
           Remove the FIREZONE_NUM_TUN_THREADS env variable. The Gateway will now


### PR DESCRIPTION
To facilitate direct connections, `connlib` generates "optimistic" candidates that combine the port of the host candidate with the IP of the server-reflexive candidate. This allows sysadmins to port-forward the Firezone port 52625 on the Gateway, allowing for direct connections to happen behind symmetric NAT.

This feature is only really useful for IPv4 as IPv6 doesn't need symmetric NAT due to the larger address space. It is also quite common that users have multiple IPv6 addresses on a single interface. The combination of the two can result in CPU spikes on the Gateway if a client connects and sends over e.g. 10 IPv6 host candidates and various IPv6 server-reflexive candidates. The Gateway then ends up in a loop where it creates an NxM matrix of all these candidates.

To mitigate this, we disable optimistic candidates for IPv6 altogether and limit the number of IPv4 optimistic candidates to 2.