### PR TITLE
refactor(portal): use list comprehensions in cache

### DIFF
--- a/elixir/apps/domain/lib/domain/cache/client.ex
+++ b/elixir/apps/domain/lib/domain/cache/client.ex
@@ -96,9 +96,9 @@ defmodule Domain.Cache.Client do
     resource = Enum.find(cache.connectable_resources, :not_found, fn r -> r.id == rid_bytes end)
 
     policy =
-      cache.policies
-      |> Enum.filter(fn {_id, policy} -> policy.resource_id == rid_bytes end)
-      |> Enum.map(fn {_id, policy} -> policy end)
+      for {_id, %{resource_id: ^rid_bytes} = p} <- cache.policies do
+        p
+      end
       |> Policies.longest_conforming_policy_for_client(client, subject.expires_at)
 
     with %Cache.Cacheable.Resource{} <- resource,
@@ -163,19 +163,13 @@ defmodule Domain.Cache.Client do
 
     # connlib can handle all resource attribute changes except for changing sites, so we can omit the deleted IDs
     # of added resources since they'll be updated gracefully.
-    removed =
-      (cache.connectable_resources -- connectable_resources)
-      |> Enum.filter(fn r ->
-        if toggle do
-          r
-        else
-          r.id not in added_ids
-        end
-      end)
+    removed_ids =
+      for r <- cache.connectable_resources -- connectable_resources,
+          toggle or r.id not in added_ids do
+        load!(r.id)
+      end
 
     cache = %{cache | connectable_resources: connectable_resources}
-
-    removed_ids = Enum.map(removed, fn r -> load!(r.id) end)
 
     {:ok, added, removed_ids, cache}
   end
@@ -240,7 +234,6 @@ defmodule Domain.Cache.Client do
     remaining_resource_ids =
       updated_policies
       |> Enum.map(fn {_id, p} -> p.resource_id end)
-      |> Enum.uniq()
       |> MapSet.new()
 
     updated_resources =
@@ -524,11 +517,9 @@ defmodule Domain.Cache.Client do
         end)
 
       memberships =
-        Actors.all_memberships_for_actor_id!(client.actor_id)
-        |> Enum.map(fn membership ->
-          {dump!(membership.group_id), dump!(membership.id)}
-        end)
-        |> Enum.into(%{})
+        for memberships <- Actors.all_memberships_for_actor_id!(client.actor_id),
+            do: {dump!(memberships.group_id), dump!(memberships.id)},
+            into: %{}
 
       cache
       |> Map.put(:memberships, memberships)
@@ -537,11 +528,12 @@ defmodule Domain.Cache.Client do
   end
 
   defp adapted_resources(conforming_resource_ids, resources, client) do
-    conforming_resource_ids
-    |> Enum.map(fn id -> Map.get(resources, id) end)
-    |> Enum.map(fn r -> adapt(r, client) end)
-    |> Enum.reject(fn r -> is_nil(r) end)
-    |> Enum.filter(fn r -> r.gateway_groups != [] end)
+    for id <- conforming_resource_ids,
+        adapted_resource = Map.get(resources, id) |> adapt(client),
+        not is_nil(adapted_resource),
+        adapted_resource.gateway_groups != [] do
+      id
+    end
   end
 
   defp conforming_resource_ids(policies, client) when is_map(policies) do

--- a/elixir/apps/domain/lib/domain/cache/client.ex
+++ b/elixir/apps/domain/lib/domain/cache/client.ex
@@ -150,7 +150,7 @@ defmodule Domain.Cache.Client do
   end
 
   def recompute_connectable_resources(cache, client, opts \\ []) do
-    {toggle, _opts} = Keyword.pop(opts, :toggle)
+    {toggle, _opts} = Keyword.pop(opts, :toggle, false)
 
     connectable_resources =
       cache.policies

--- a/elixir/apps/domain/lib/domain/cache/client.ex
+++ b/elixir/apps/domain/lib/domain/cache/client.ex
@@ -96,9 +96,7 @@ defmodule Domain.Cache.Client do
     resource = Enum.find(cache.connectable_resources, :not_found, fn r -> r.id == rid_bytes end)
 
     policy =
-      for {_id, %{resource_id: ^rid_bytes} = p} <- cache.policies do
-        p
-      end
+      for({_id, %{resource_id: ^rid_bytes} = p} <- cache.policies, do: p)
       |> Policies.longest_conforming_policy_for_client(client, subject.expires_at)
 
     with %Cache.Cacheable.Resource{} <- resource,

--- a/elixir/apps/domain/lib/domain/cache/client.ex
+++ b/elixir/apps/domain/lib/domain/cache/client.ex
@@ -532,7 +532,7 @@ defmodule Domain.Cache.Client do
         adapted_resource = Map.get(resources, id) |> adapt(client),
         not is_nil(adapted_resource),
         adapted_resource.gateway_groups != [] do
-      id
+      adapted_resource
     end
   end
 

--- a/elixir/apps/domain/lib/domain/cache/client.ex
+++ b/elixir/apps/domain/lib/domain/cache/client.ex
@@ -175,7 +175,9 @@ defmodule Domain.Cache.Client do
 
     cache = %{cache | connectable_resources: connectable_resources}
 
-    {:ok, added, Enum.map(removed, & &1.id) |> Enum.map(&load!/1), cache}
+    removed_ids = Enum.map(removed, fn r -> load!(r.id) end)
+
+    {:ok, added, removed_ids, cache}
   end
 
   @doc """


### PR DESCRIPTION
Elixir's [list comprehensions](https://hexdocs.pm/elixir/comprehensions.html) are more concise and [often faster](https://stackoverflow.com/questions/55038704/elixir-enum-map-vs-for-comprehension) (~2x) than using multiple Enum.filter and Enum.map calls.

Since I was in these modules debugging possible a race condition for #10375, I decided to go ahead and update some of these hot functions to use the more modern approach.