### PR TITLE
fix(ci): RUN_MANUAL_MIGRATIONS=true

### DIFF
--- a/scripts/compose/portal.yml
+++ b/scripts/compose/portal.yml
@@ -53,7 +53,7 @@ services:
     image: alpine:latest # Dummy, will always be overridden.
     environment:
       # Database
-      RUN_CONDITIONAL_MIGRATIONS: "true"
+      RUN_MANUAL_MIGRATIONS: "true"
       DATABASE_HOST: postgres
       DATABASE_PORT: 5432
       DATABASE_NAME: firezone_dev


### PR DESCRIPTION
This variable was renamed and not updated in our docker-compose.yml, causing intermittent errors like this one:

https://github.com/firezone/firezone/actions/runs/17835644646/job/50712540454