### PR TITLE
build(deps): bump Rust version to 1.90

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -62,7 +62,7 @@ COPY ${PACKAGE} .
 FROM runtime AS dev
 
 ARG PACKAGE
-ARG RUST_VERSION="1.89.0" # Keep in sync with `rust-toolchain.toml`
+ARG RUST_VERSION="1.90.0" # Keep in sync with `rust-toolchain.toml`
 
 WORKDIR /app
 

--- a/rust/connlib/phoenix-channel/tests/lib.rs
+++ b/rust/connlib/phoenix-channel/tests/lib.rs
@@ -1,6 +1,6 @@
+#![cfg(not(windows))] // For some reason, Windows doesn't like this test.
 #![allow(clippy::unwrap_used)]
 
-#[cfg(not(windows))] // For some reason, Windows doesn't like this test.
 #[tokio::test]
 async fn client_does_not_pipeline_messages() {
     use std::{str::FromStr, sync::Arc, time::Duration};

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0" # Keep in sync with `Dockerfile`
+channel = "1.90.0" # Keep in sync with `Dockerfile`
 components = ["rust-src", "rust-analyzer", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
One of the more quiet Rust releases with no new clippy lints that would require code updates.