### PR TITLE
fix(apple): sentry hang tracking for singleton

### DIFF
--- a/swift/apple/Firezone/Application/FirezoneApp.swift
+++ b/swift/apple/Firezone/Application/FirezoneApp.swift
@@ -115,6 +115,7 @@ struct FirezoneApp: App {
           alert.addButton(withTitle: "OK")
 
           // Show alert
+          SentrySDK.pauseAppHangTracking()
           alert.runModal()
 
           // Exit this instance since we can't terminate the other one


### PR DESCRIPTION
Trying to knock out some low-hanging Sentry alert fruit.

Fixes #10381 