### PR TITLE
fix(ci): use correct index module name

### DIFF
--- a/elixir/apps/domain/priv/repo/manual_migrations/20250725031509_reindex_flows_on_expires_at.exs
+++ b/elixir/apps/domain/priv/repo/manual_migrations/20250725031509_reindex_flows_on_expires_at.exs
@@ -1,4 +1,4 @@
-defmodule Domain.Repo.Migrations.IndexFlowsOnExpiresAt do
+defmodule Domain.Repo.Migrations.ReindexFlowsOnExpiresAt do
   use Ecto.Migration
 
   @disable_ddl_transaction true


### PR DESCRIPTION
This gets redefined twice which could lead to indexes failing to run properly.