### PR TITLE
chore: render contextual information more Sentry-friendly

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -944,6 +944,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
+
+[[package]]
 name = "boringtun"
 version = "0.6.1"
 source = "git+https://github.com/firezone/boringtun?branch=master#ed1de7c6ddf071d2895309f0fb153e9afb82fc99"
@@ -6907,6 +6913,7 @@ name = "snownet"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bnum",
  "boringtun",
  "bufferpool",
  "bytecodec",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -56,6 +56,7 @@ aya-log-ebpf = { git = "https://github.com/aya-rs/aya" }
 backoff = { version = "0.4", features = ["tokio"] }
 base64 = { version = "0.22.1", default-features = false }
 bimap = "0.6"
+bnum = "0.13.0"
 boringtun = { version = "0.6", default-features = false }
 bufferpool = { path = "connlib/bufferpool" }
 bytecodec = "0.5.0"

--- a/rust/connlib/snownet/Cargo.toml
+++ b/rust/connlib/snownet/Cargo.toml
@@ -6,6 +6,7 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bnum = { workspace = true }
 boringtun = { workspace = true }
 bufferpool = { workspace = true }
 bytecodec = { workspace = true }

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -1530,10 +1530,9 @@ where
 }
 
 fn into_u256(key: [u8; 32]) -> bnum::BUint<4> {
-    // SAFETY: Byte arrays are always valid types and don't have padding.
-    let digits = unsafe { mem::transmute::<[u8; 32], [u64; 4]>(key) };
-
-    bnum::types::U256::from_digits(digits)
+    // Note: `parse_str_radix` panics when the number is too big.
+    // We are passing 32 u8's though which fits exactly into a u256.
+    bnum::types::U256::parse_str_radix(&hex::encode(key), 16)
 }
 
 fn add_local_candidate<TId>(


### PR DESCRIPTION
Sentry can group issues together that have unique identifiers in their message. Unfortunately, it does that only well for integers and UUIDs and not so much for hex-values. To avoid alert fatigue, we render the public key as a u256 which hopefully allows Sentry to group these together.