### PR TITLE
fix(ci): migrate with manual migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
       # We need at least Docker v28.1 which is not yet available on GitHub actions runners
       - uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
       - name: Seed database
-        run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.seed --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations'
+        run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.migrate --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations && mix ecto.seed'
       - name: Increase max UDP buffer sizes
         run: |
           sudo sysctl -w net.core.wmem_max=16777216 # 16 MB


### PR DESCRIPTION
In 0b09d9f2f5, the `--migrations-path` arguments were added to the `Seed database` step. These only work for the `ecto.migrate` and family of commands, and not with `ecto.seed`. This meant all of our CI has essentially not been running the manual migrations.

Then, #10377 we fixed the env var when starting the services so that manual migrations are run. That env var, however, only applies to "releases", which the `elixir` service is not.

This caused the API service to try and run the missing manual migrations upon startup, which failed because they would then be run out-of-order.

To fix all of the above, we fix the `Seed database` step of the perf-tests job to ensure it runs all migrations. The other places where we seed the database already handled this properly.