### PR TITLE
fix(gateway): re-join topic in phoenix-channel on error

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -652,6 +652,16 @@ async fn phoenix_channel_event_loop(
                     break;
                 }
             }
+            Either::Left((
+                Ok(phoenix_channel::Event::ErrorResponse {
+                    topic,
+                    res: phoenix_channel::ErrorReply::UnmatchedTopic,
+                    ..
+                }),
+                _,
+            )) => {
+                portal.join(topic, ());
+            }
             Either::Left((Ok(phoenix_channel::Event::ErrorResponse { topic, req_id, res }), _)) => {
                 tracing::warn!(%topic, %req_id, "Request failed: {res:?}");
             }


### PR DESCRIPTION
For whatever reason, we seem to sometimes lose the association with the "room" we are meant to be in in order to send messages to the portal. Without joining the right room, messages get dropped silently.

To fix this, we re-join the room on such errors. Long-term, this will be fixed by ditching phoenix-channel in favor of simple HTTP requests.

Related: #9649 