### PR TITLE
fix(ci): increase service healthcheck timeout by 5s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ x-phoenix-config: &phoenix-config
 
 x-health-check: &health-check
   interval: 1s
-  retries: 10
+  retries: 15
   timeout: 1s
 
 services:
@@ -89,7 +89,6 @@ services:
         condition: "service_healthy"
     healthcheck:
       test: ["CMD-SHELL", "curl -f localhost:8081/healthz"]
-      start_period: 5s # API could take a second or two to boot on slow GH runners
       <<: *health-check
     networks:
       app-internal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
         condition: "service_healthy"
     healthcheck:
       test: ["CMD-SHELL", "curl -f localhost:8081/healthz"]
+      start_period: 5s # API could take a second or two to boot on slow GH runners
       <<: *health-check
     networks:
       app-internal:


### PR DESCRIPTION
The API service sometimes fails to get its `/healthz` endpoint up within 10s on slow GitHub runners. To fix we increase the health check timeout by 5s.

Related: https://github.com/firezone/firezone/actions/runs/17873470250/job/50831320777?pr=10396