### PR TITLE
feat(clients): gracefully close connections on shutdown

### DIFF
--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -149,7 +149,8 @@ impl Eventloop {
                     return Ok(());
                 }
                 Err(e) => {
-                    self.shutdown_tunnel().await?;
+                    // Ignore error from shutdown to not obscure the original error.
+                    let _ = self.shutdown_tunnel().await;
 
                     return Err(e);
                 }

--- a/rust/client-shared/src/lib.rs
+++ b/rust/client-shared/src/lib.rs
@@ -166,6 +166,12 @@ impl EventStream {
     pub async fn next(&mut self) -> Option<Event> {
         future::poll_fn(|cx| self.poll_next(cx)).await
     }
+
+    pub async fn drain(&mut self) -> Vec<Event> {
+        futures::stream::poll_fn(|cx| self.poll_next(cx))
+            .collect()
+            .await
+    }
 }
 
 impl Drop for Session {

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -281,6 +281,8 @@ impl ClientState {
     }
 
     pub fn shutdown(&mut self, now: Instant) {
+        tracing::info!("Initiating graceful shutdown");
+
         self.peers.clear();
         self.node.close_all(p2p_control::goodbye(), now);
     }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -280,6 +280,11 @@ impl ClientState {
         self.node.public_key()
     }
 
+    pub fn shutdown(&mut self, now: Instant) {
+        self.peers.clear();
+        self.node.close_all(p2p_control::goodbye(), now);
+    }
+
     /// Updates the NAT for all domains resolved by the stub resolver on the corresponding gateway.
     ///
     /// In order to route traffic for DNS resources, the designated gateway needs to set up NAT from

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -420,6 +420,9 @@ fn try_main() -> Result<()> {
 
         drop(session);
 
+        // Drain the event-stream to allow the event-loop to gracefully shutdown.
+        let _ = tokio::time::timeout(Duration::from_secs(1), event_stream.drain()).await;
+
         result
     })?;
 


### PR DESCRIPTION
In #10076, connlib gained the ability to gracefully close connections between peers. The Gateway already uses this when it is being gracefully shutdown such as during an upgrade. This allows Clients to immediately fail-over to a different Gateway instead of waiting for an ICE timeout.

When a Client signs out, we currently just drop all the state, resulting in an ICE timeout on the Gateway ~15 seconds later. This makes it difficult for us to analyze, whether an ICE timeout in the logs presents an actual problem where a network connection got cut or whether the Client simply signed out.

Whilst not water-tight, attempting to gracefully close our connections when the Client signs out is better than nothing so we implement this here.

All Clients use the `Session` abstraction from `client-shared` which spawns the event-loop into a dedicated task.

- For the Linux and Windows GUI client, the already present tokio runtime instance of the tunnel service is used for this.
- For Android and Apple, we create a dedicated, single-threaded runtime instance for connlib.
- For the headless client, we also reuse the already existing tokio runtime instance of the binary.

In case of Android, Apple and the headless client, this means we need to ensure the tokio runtime instances stays alive long enough to actually complete the graceful shutdown task. We achieve this by draining the `EventStream` returned from `Session`. The `EventStream` is a wrapper around a channel connected to the event-loop. This stream only finishes once the event-loop is entirely dropped (and therefore completed the graceful shutdown) as it holds the sender-end of the channel.

In case of the Linux and Windows GUI client, the runtime outlives the `Session` because it is scoped to the entire tunnel process. Therefore, no additional measures are necessary there to ensure the graceful shutdown task completes.