### PR TITLE
chore(portal): add remaining simple indexes

### DIFF
--- a/elixir/apps/domain/priv/repo/migrations/20250920161120_recreate_flows_agm_index.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250920161120_recreate_flows_agm_index.exs
@@ -1,0 +1,14 @@
+defmodule Domain.Repo.Migrations.RecreateFlowsAgmIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def change do
+    create_if_not_exists(
+      index(:flows, [:actor_group_membership_id],
+        concurrently: true,
+        name: :flows_actor_group_membership_id_idx
+      )
+    )
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20250920161744_index_policies_on_resource_id.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250920161744_index_policies_on_resource_id.exs
@@ -1,0 +1,9 @@
+defmodule Domain.Repo.Migrations.IndexPoliciesOnResourceId do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def change do
+    create_if_not_exists(index(:policies, [:resource_id], concurrently: true))
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20250920161840_index_policies_on_actor_group_id.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250920161840_index_policies_on_actor_group_id.exs
@@ -1,0 +1,9 @@
+defmodule Domain.Repo.Migrations.IndexPoliciesOnActorGroupId do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def change do
+    create_if_not_exists(index(:policies, [:actor_group_id], concurrently: true))
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20250920164115_drop_resource_id_index_on_resource_connections.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20250920164115_drop_resource_id_index_on_resource_connections.exs
@@ -1,0 +1,10 @@
+defmodule Domain.Repo.Migrations.DropResourceIdIndexOnResourceConnections do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def change do
+    # redundant with the (resource_id, gateway_group_id) index
+    drop_if_exists(index(:resource_connections, [:resource_id], concurrently: true))
+  end
+end


### PR DESCRIPTION
- recreates the flows actor_group_membership index that didn't get created due to name collision with an existing index
- adds missing resource_id, actor_group_id indexes on policies
- removes redundant `resource_id` index on resource_connections since there's a composite index that matches already

Related: #10396 