### PR TITLE
fix(portal): use href for non-live routes

### DIFF
--- a/elixir/apps/web/lib/web/components/navigation_components.ex
+++ b/elixir/apps/web/lib/web/components/navigation_components.ex
@@ -342,7 +342,7 @@ defmodule Web.NavigationComponents do
   def website_link(assigns) do
     ~H"""
     <.link
-      navigate={"https://www.firezone.dev#{@path}?utm_source=product##{@fragment}"}
+      href={"https://www.firezone.dev#{@path}?utm_source=product##{@fragment}"}
       class={link_style()}
       target="_blank"
       {@rest}

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/components.ex
@@ -56,7 +56,7 @@ defmodule Web.Settings.IdentityProviders.Components do
         <span :if={@provider.adapter_state["status"]}>
           <.button
             size="xs"
-            navigate={
+            href={
               ~p"/#{@provider.account_id}/settings/identity_providers/google_workspace/#{@provider}/redirect"
             }
           >
@@ -112,7 +112,7 @@ defmodule Web.Settings.IdentityProviders.Components do
         <span :if={@provider.adapter_state["status"]}>
           <.button
             size="xs"
-            navigate={
+            href={
               ~p"/#{@provider.account_id}/settings/identity_providers/microsoft_entra/#{@provider}/redirect"
             }
           >
@@ -168,9 +168,7 @@ defmodule Web.Settings.IdentityProviders.Components do
         <span :if={@provider.adapter_state["status"]}>
           <.button
             size="xs"
-            navigate={
-              ~p"/#{@provider.account_id}/settings/identity_providers/okta/#{@provider}/redirect"
-            }
+            href={~p"/#{@provider.account_id}/settings/identity_providers/okta/#{@provider}/redirect"}
           >
             Connect IdP
           </.button>
@@ -198,7 +196,7 @@ defmodule Web.Settings.IdentityProviders.Components do
         <span :if={@provider.adapter_state["status"]}>
           <.button
             size="xs"
-            navigate={
+            href={
               ~p"/#{@provider.account_id}/settings/identity_providers/jumpcloud/#{@provider}/redirect"
             }
           >
@@ -228,7 +226,7 @@ defmodule Web.Settings.IdentityProviders.Components do
         <span :if={@provider.adapter_state["status"]}>
           <.button
             size="xs"
-            navigate={
+            href={
               ~p"/#{@provider.account_id}/settings/identity_providers/openid_connect/#{@provider}/redirect"
             }
           >

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/edit.ex
@@ -59,7 +59,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Edit do
     with {:ok, provider} <-
            Auth.update_provider(socket.assigns.provider, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/google_workspace/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/new.ex
@@ -73,7 +73,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.New do
     with {:ok, provider} <-
            Auth.create_provider(socket.assigns.account, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/google_workspace/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/edit.ex
@@ -56,7 +56,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.Edit do
     with {:ok, provider} <-
            Auth.update_provider(socket.assigns.provider, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/jumpcloud/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/jumpcloud/new.ex
@@ -74,7 +74,7 @@ defmodule Web.Settings.IdentityProviders.JumpCloud.New do
     with {:ok, provider} <-
            Auth.create_provider(socket.assigns.account, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/jumpcloud/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/edit.ex
@@ -55,7 +55,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.Edit do
     with {:ok, provider} <-
            Auth.update_provider(socket.assigns.provider, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/microsoft_entra/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/microsoft_entra/new.ex
@@ -73,7 +73,7 @@ defmodule Web.Settings.IdentityProviders.MicrosoftEntra.New do
     with {:ok, provider} <-
            Auth.create_provider(socket.assigns.account, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/microsoft_entra/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/edit.ex
@@ -62,7 +62,7 @@ defmodule Web.Settings.IdentityProviders.Okta.Edit do
     with {:ok, provider} <-
            Auth.update_provider(socket.assigns.provider, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/okta/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/okta/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/okta/new.ex
@@ -78,7 +78,7 @@ defmodule Web.Settings.IdentityProviders.Okta.New do
     with {:ok, provider} <-
            Auth.create_provider(socket.assigns.account, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/okta/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/edit.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/edit.ex
@@ -58,7 +58,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.Edit do
     with {:ok, provider} <-
            Auth.update_provider(socket.assigns.provider, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/openid_connect/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/new.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/openid_connect/new.ex
@@ -68,7 +68,7 @@ defmodule Web.Settings.IdentityProviders.OpenIDConnect.New do
     with {:ok, provider} <-
            Auth.create_provider(socket.assigns.account, attrs, socket.assigns.subject) do
       socket =
-        push_navigate(socket,
+        redirect(socket,
           to:
             ~p"/#{socket.assigns.account.id}/settings/identity_providers/openid_connect/#{provider}/redirect"
         )

--- a/elixir/apps/web/lib/web/live/sign_in.ex
+++ b/elixir/apps/web/lib/web/live/sign_in.ex
@@ -120,7 +120,7 @@ defmodule Web.SignIn do
           </p>
           <p class="py-2">
             Looking for a different account?
-            <.link navigate={~p"/"} class={[link_style()]}>
+            <.link href={~p"/"} class={[link_style()]}>
               See recently used accounts.
             </.link>
           </p>


### PR DESCRIPTION
When redirecting to paths that don't have LiveViews attached to them, LiveView complains and emits a warning. To reduce alarm noise this PR attempts to fix the issue.