### PR TITLE
ci: fix double symmetric NAT test failure

### DIFF
--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -108,7 +108,8 @@ jobs:
           - script: dns-api-down
           - script: dns-nm
           - script: dns-two-resources
-          - script: systemd/dns-systemd-resolved
+          - name: dns-systemd-resolved
+            script: systemd/dns-systemd-resolved
           - script: tcp-dns
             # Setting both client and gateway to random masquerade will force relay-relay candidate pair
           - name: download-double-symmetric-nat

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -132,6 +132,10 @@ jobs:
       - uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.migrate --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations && mix ecto.seed'
+      - name: Disable checksum offloading
+        run: |
+          # Force checksum calculation on the host since some tests run on the host
+          sudo ethtool -K eth0 tx off
       - name: Start docker compose in the background
         run: |
           set -xe

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -177,12 +177,6 @@ jobs:
           sudo ethtool -K eth0 tx off
           sudo ethtool -K docker0 tx off
 
-          VETHS=$(ip -json link show type veth | jq -r '.[].ifname')
-
-          for dev in $VETHS; do
-            ethtool -K $dev tx off
-          done
-
       - run: ./scripts/tests/${{ matrix.test.script }}.sh
       - name: Ensure Client emitted no warnings
         if: "!cancelled()"

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -160,7 +160,7 @@ jobs:
           docker compose up -d relay-2 --no-build
           docker compose up -d gateway --no-build
           docker compose up -d client --no-build
-          docker compose up -d veth-config
+          docker compose up -d network-config
 
           docker compose exec -d relay-1 /bin/sh -c 'xdpdump -i eth0 -w /tmp/packets.pcap --rx-capture entry,exit'
           docker compose exec -d relay-2 /bin/sh -c 'xdpdump -i eth0 -w /tmp/packets.pcap --rx-capture entry,exit'

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -116,7 +116,7 @@ jobs:
             client_masquerade: random
             gateway_masquerade: random
             rust_log: debug
-            stop_containers: relay-2 # Force single relay
+            single_relay: true # Force single relay
           - script: download-packet-loss
             rust_log: debug
           - script: download-roaming-network
@@ -161,9 +161,14 @@ jobs:
           docker compose up -d client --no-build
           docker compose up -d veth-config
 
-          if [[ -n "${{ matrix.test.stop_containers }}" ]]; then
-            docker compose stop ${{ matrix.test.stop_containers }}
+          docker compose exec -d relay-1 /bin/sh -c 'xdpdump -i eth0 -w /tmp/packets.pcap --rx-capture entry,exit'
+          docker compose exec -d relay-2 /bin/sh -c 'xdpdump -i eth0 -w /tmp/packets.pcap --rx-capture entry,exit'
+
+          if [[ -n "${{ matrix.test.single_relay }}" ]]; then
+            docker compose stop relay-2
           fi
+
+          sleep 3 # Let everything settle for a bit
       - run: ./scripts/tests/${{ matrix.test.script }}.sh
       - name: Ensure Client emitted no warnings
         if: "!cancelled()"
@@ -198,3 +203,37 @@ jobs:
       - name: Show API logs
         if: "!cancelled()"
         run: docker compose logs api
+
+      - name: Ensure no eBPF checksum errors on relay-1
+        if: "!cancelled()"
+        run: |
+          set -xe
+
+          docker compose exec relay-1 pkill xdpdump
+          docker compose cp relay-1:/tmp/packets.pcap ./relay-1-packets.pcap
+
+          ! tcpdump -r ./relay-1-packets.pcap -v | grep "bad"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: "!success()"
+        with:
+          overwrite: true
+          name: ${{ matrix.test.name || matrix.test.script }}-relay-1-xdpdump
+          path: ./relay-1-packets.pcap
+
+      - name: Ensure no eBPF checksum errors on relay-2
+        if: "!cancelled() && !matrix.test.single_relay"
+        run: |
+          set -xe
+
+          docker compose exec relay-2 pkill xdpdump
+          docker compose cp relay-2:/tmp/packets.pcap ./relay-2-packets.pcap
+
+          ! tcpdump -r ./relay-2-packets.pcap -v | grep "bad"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: "!success() && !matrix.test.single_relay"
+        with:
+          overwrite: true
+          name: ${{ matrix.test.name || matrix.test.script }}-relay-2-xdpdump
+          path: ./relay-2-packets.pcap

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -165,13 +165,6 @@ jobs:
           if [[ -n "${{ matrix.test.stop_containers }}" ]]; then
             docker compose stop ${{ matrix.test.stop_containers }}
           fi
-
-          # Wait a few seconds for the services to fully start. GH runners are
-          # slow, so this gives the Client enough time to initialize its tun interface,
-          # for example.
-          # Intended to mitigate <https://github.com/firezone/firezone/issues/5830>
-          sleep 3
-
       - run: ./scripts/tests/${{ matrix.test.script }}.sh
         if: ${{ matrix.test.skip != 'true' }}
 

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -217,7 +217,7 @@ jobs:
           docker compose exec relay-1 pkill xdpdump
           docker compose cp relay-1:/tmp/packets.pcap ./relay-1-packets.pcap
 
-          ! tcpdump -nr ./relay-1-packets.pcap -v | grep "bad"
+          ! tcpdump -nnnr ./relay-1-packets.pcap -v | grep "bad"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: "!success()"
@@ -234,7 +234,7 @@ jobs:
           docker compose exec relay-2 pkill xdpdump
           docker compose cp relay-2:/tmp/packets.pcap ./relay-2-packets.pcap
 
-          ! tcpdump -nr ./relay-2-packets.pcap -v | grep "bad"
+          ! tcpdump -nnnr ./relay-2-packets.pcap -v | grep "bad"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: "!success() && !matrix.test.single_relay"

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -117,7 +117,6 @@ jobs:
             gateway_masquerade: random
             rust_log: debug
             stop_containers: relay-2 # Force single relay
-            skip: true
           - script: download-packet-loss
             rust_log: debug
           - script: download-roaming-network
@@ -166,8 +165,6 @@ jobs:
             docker compose stop ${{ matrix.test.stop_containers }}
           fi
       - run: ./scripts/tests/${{ matrix.test.script }}.sh
-        if: ${{ matrix.test.skip != 'true' }}
-
       - name: Ensure Client emitted no warnings
         if: "!cancelled()"
         run: |

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -220,7 +220,7 @@ jobs:
           docker compose exec relay-1 pkill xdpdump
           docker compose cp relay-1:/tmp/packets.pcap ./relay-1-packets.pcap
 
-          ! tcpdump -nnnr ./relay-1-packets.pcap -v | grep "bad"
+          ! tcpdump -nnnr ./relay-1-packets.pcap -v | grep "bad \w* cksum"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: "!success()"
@@ -237,7 +237,7 @@ jobs:
           docker compose exec relay-2 pkill xdpdump
           docker compose cp relay-2:/tmp/packets.pcap ./relay-2-packets.pcap
 
-          ! tcpdump -nnnr ./relay-2-packets.pcap -v | grep "bad"
+          ! tcpdump -nnnr ./relay-2-packets.pcap -v | grep "bad \w* cksum"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: "!success() && !matrix.test.single_relay"

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -217,7 +217,7 @@ jobs:
           docker compose exec relay-1 pkill xdpdump
           docker compose cp relay-1:/tmp/packets.pcap ./relay-1-packets.pcap
 
-          ! tcpdump -r ./relay-1-packets.pcap -v | grep "bad"
+          ! tcpdump -nr ./relay-1-packets.pcap -v | grep "bad"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: "!success()"
@@ -234,7 +234,7 @@ jobs:
           docker compose exec relay-2 pkill xdpdump
           docker compose cp relay-2:/tmp/packets.pcap ./relay-2-packets.pcap
 
-          ! tcpdump -r ./relay-2-packets.pcap -v | grep "bad"
+          ! tcpdump -nr ./relay-2-packets.pcap -v | grep "bad"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: "!success() && !matrix.test.single_relay"

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -136,6 +136,7 @@ jobs:
         run: |
           # Force checksum calculation on the host since some tests run on the host
           sudo ethtool -K eth0 tx off
+          sudo ethtool -K docker0 tx off
       - name: Start docker compose in the background
         run: |
           set -xe

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -160,6 +160,7 @@ jobs:
           docker compose up -d relay-2 --no-build
           docker compose up -d gateway --no-build
           docker compose up -d client --no-build
+          docker compose up -d veth-config
 
           if [[ -n "${{ matrix.test.stop_containers }}" ]]; then
             docker compose stop ${{ matrix.test.stop_containers }}
@@ -170,8 +171,6 @@ jobs:
           # for example.
           # Intended to mitigate <https://github.com/firezone/firezone/issues/5830>
           sleep 3
-
-          docker compose up veth-config
 
       - run: ./scripts/tests/${{ matrix.test.script }}.sh
         if: ${{ matrix.test.skip != 'true' }}

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -132,11 +132,6 @@ jobs:
       - uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.migrate --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations && mix ecto.seed'
-      - name: Disable checksum offloading
-        run: |
-          # Force checksum calculation on the host since some tests run on the host
-          sudo ethtool -K eth0 tx off
-          sudo ethtool -K docker0 tx off
       - name: Start docker compose in the background
         run: |
           set -xe
@@ -175,6 +170,19 @@ jobs:
           fi
 
           sleep 3 # Let everything settle for a bit
+
+      - name: Disable checksum offloading
+        run: |
+          # Force checksum calculation on the host since some tests run on the host
+          sudo ethtool -K eth0 tx off
+          sudo ethtool -K docker0 tx off
+
+          VETHS=$(ip -json link show type veth | jq -r '.[].ifname')
+
+          for dev in $VETHS; do
+            ethtool -K $dev tx off
+          done
+
       - run: ./scripts/tests/${{ matrix.test.script }}.sh
       - name: Ensure Client emitted no warnings
         if: "!cancelled()"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
           docker compose up -d relay-1 relay-2 --no-build
           docker compose up -d gateway --no-build
           docker compose up -d client --no-build
-          docker compose up veth-config
+          docker compose up -d network-config
       - name: "Performance test: ${{ matrix.flavour }}-${{ matrix.test }}"
         timeout-minutes: 5
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -417,7 +417,10 @@ services:
   # The "recommended" way to do this is to set both veth interfaces' GRO to on, or attach an XDP program
   # that does XDP_PASS to the host side veth interface. The GRO method is not reliable and was shown to
   # only pass packets in large bursts every 15-20 seconds which breaks ICE setup, so we use the XDP method.
-  veth-config:
+  #
+  # For correct behaviour, we also disable any kind of offloading for all veth and bridge devices.
+  # This forces the kernel to calculate all checksums in software.
+  network-config:
     image: ghcr.io/firezone/xdp-pass
     pid: host
     network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,8 +429,6 @@ services:
       - |
         set -e
 
-        apk add jq ethtool
-
         VETHS=$$(ip -json link show type veth | jq -r '.[].ifname')
 
         for dev in $$VETHS; do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,9 +429,10 @@ services:
       - |
         set -e
 
-        VETHS=$$(ip link show type veth | grep '^[0-9]' | awk '{print $$2}' | cut -d: -f1 | cut -d@ -f1)
+        apk add jq
 
-        # Safe to attach to all veth interfaces on the host
+        VETHS=$$(ip -json link show type veth | jq -r '.[].ifname')
+
         for dev in $$VETHS; do
           echo "Attaching XDP to: $$dev"
           ip link set dev $$dev xdpdrv off # Clear any existing XDP program.
@@ -441,6 +442,14 @@ services:
         done
 
         echo "Done configuring $$(echo "$$VETHS" | wc -w) veth interfaces"
+
+        BRIDGES=$$(ip -json link show type bridge | jq -r '.[].ifname')
+
+        for dev in $$BRIDGES; do
+          ethtool -K $$dev tx off # Disable offloading.
+        done
+
+        echo "Done configuring $$(echo "$$BRIDGES" | wc -w) bridge interfaces"
     depends_on:
       relay-1:
         condition: "service_healthy"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -436,6 +436,8 @@ services:
           echo "Attaching XDP to: $$dev"
           ip link set dev $$dev xdpdrv off # Clear any existing XDP program.
           ip link set dev $$dev xdpdrv obj /xdp/xdp_pass.o sec xdp
+
+          ethtool -K $$dev tx off # Disable offloading.
         done
 
         echo "Done configuring $$(echo "$$VETHS" | wc -w) veth interfaces"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -326,6 +326,8 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.29.1.254
         ip -6 route add 203:0:113::/64 via 172:29:1::254
 
+        ethtool -K eth0 tx off
+
         firezone-relay
     depends_on:
       relay-1-router:
@@ -372,6 +374,8 @@ services:
         # Add static route to internet subnet via router
         ip -4 route add 203.0.113.0/24 via 172.29.2.254
         ip -6 route add 203:0:113::/64 via 172:29:2::254
+
+        ethtool -K eth0 tx off
 
         firezone-relay
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -326,6 +326,7 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.29.1.254
         ip -6 route add 203:0:113::/64 via 172:29:1::254
 
+        apk add --no-cache ethtool
         ethtool -K eth0 tx off
 
         firezone-relay
@@ -375,6 +376,7 @@ services:
         ip -4 route add 203.0.113.0/24 via 172.29.2.254
         ip -6 route add 203:0:113::/64 via 172:29:2::254
 
+        apk add --no-cache ethtool
         ethtool -K eth0 tx off
 
         firezone-relay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,7 +429,7 @@ services:
       - |
         set -e
 
-        apk add jq
+        apk add jq ethtool
 
         VETHS=$$(ip -json link show type veth | jq -r '.[].ifname')
 

--- a/rust/relay/ebpf-turn-router/src/try_handle_turn/from_ipv4_channel/to_ipv6_channel.rs
+++ b/rust/relay/ebpf-turn-router/src/try_handle_turn/from_ipv4_channel/to_ipv6_channel.rs
@@ -55,7 +55,12 @@ pub fn to_ipv6_channel(
     };
 
     let (old_channel_number, old_channel_data_length) = {
-        let old_cd = unsafe { ref_mut_at::<CdHdr>(ctx, EthHdr::LEN + Ipv4Hdr::LEN + UdpHdr::LEN)? };
+        let old_cd = unsafe {
+            ref_mut_at::<CdHdr>(
+                ctx,
+                old_data_offset + EthHdr::LEN + Ipv4Hdr::LEN + UdpHdr::LEN,
+            )?
+        };
 
         (old_cd.number(), old_cd.length())
     };

--- a/scripts/tests/download-roaming-network.sh
+++ b/scripts/tests/download-roaming-network.sh
@@ -25,6 +25,9 @@ docker network connect firezone_client-internal firezone-client-1 --ip 172.30.0.
 client ip -4 route add 203.0.113.0/24 via 172.30.0.254
 client ip -6 route add 203:0:113::/64 via 172:30:0::254
 
+# Disable checksum offload again to calculate checksums in software so that checksum verification passes
+client ethtool -K eth0 tx off
+
 # Send SIGHUP, triggering `reconnect` internally
 sudo kill -s HUP "$(ps -C firezone-headless-client -o pid=)"
 

--- a/scripts/tests/systemd/dns-systemd-resolved.sh
+++ b/scripts/tests/systemd/dns-systemd-resolved.sh
@@ -30,9 +30,6 @@ sudo cp "scripts/tests/systemd/$SERVICE_NAME.service" /usr/lib/systemd/system/
 HTTPBIN=dns
 HTTPBIN_FQDN="$HTTPBIN.httpbin.search.test"
 
-# Force checksum calculation on the host so that checksum verification passes
-sudo ethtool -K eth0 tx off
-
 # I'm assuming the docker iface name is relatively constant
 DOCKER_IFACE="docker0"
 FZ_IFACE="tun-firezone"

--- a/scripts/tests/systemd/dns-systemd-resolved.sh
+++ b/scripts/tests/systemd/dns-systemd-resolved.sh
@@ -30,6 +30,9 @@ sudo cp "scripts/tests/systemd/$SERVICE_NAME.service" /usr/lib/systemd/system/
 HTTPBIN=dns
 HTTPBIN_FQDN="$HTTPBIN.httpbin.search.test"
 
+# Force checksum calculation on the host so that checksum verification passes
+sudo ethtool -K eth0 tx off
+
 # I'm assuming the docker iface name is relatively constant
 DOCKER_IFACE="docker0"
 FZ_IFACE="tun-firezone"


### PR DESCRIPTION
As it turns out, the flaky test was caused by a bug in the eBPF kernel where we read the old channel data header from the wrong offset. This made us essentially read garbage data for the channel number, causing us to:

a. Compute a bad checksum
b. Send the packet on a completely wrong channel

The reason this caused a flaky test is that it requires on side to pick IPv4 to talk to the relay and the other side IPv6. The happy-eyeballs approach of the `allocation` module made that non-deterministic, only exposing this bug occasionally.

To ensure these kind of things are detected earlier in the future, I am adding an additional CI step that checks all packets emitted by the eBPF kernel for checksum errors.

Fixes: #10404 