### PR TITLE
ci: restart `veth-config` on failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -416,6 +416,7 @@ services:
     pid: host
     network_mode: host
     privileged: true
+    restart: on-failure
     command:
       - sh
       - -c
@@ -427,7 +428,8 @@ services:
         # Safe to attach to all veth interfaces on the host
         for dev in $$VETHS; do
           echo "Attaching XDP to: $$dev"
-          ip link set dev $$dev xdpdrv obj /xdp/xdp_pass.o sec xdp 2>/dev/null
+          ip link set dev $$dev xdpdrv off # Clear any existing XDP program.
+          ip link set dev $$dev xdpdrv obj /xdp/xdp_pass.o sec xdp
         done
 
         echo "Done configuring $$(echo "$$VETHS" | wc -w) veth interfaces"


### PR DESCRIPTION
For improved resilience, any failure during the startup of `veth-config` should restart the container and try again to attach it.