### PR TITLE
ci: fix build context for relay container

### DIFF
--- a/scripts/compose/relay.yml
+++ b/scripts/compose/relay.yml
@@ -11,7 +11,7 @@ services:
     init: true
     build:
       target: ${DOCKER_BUILD_TARGET:-debug}
-      context: rust
+      context: ../../rust
       dockerfile: Dockerfile
       args:
         PACKAGE: firezone-relay


### PR DESCRIPTION
The build context is taken relative from where the file is defined, meaning we first need to navigate to directories up.