### PR TITLE
feat(connlib): set core affinity for connlib's threads

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "client-shared",
+ "connlib-core-affinity",
  "connlib-model",
  "dns-types",
  "firezone-logging",
@@ -365,7 +366,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1347,6 +1348,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "client-shared",
+ "connlib-core-affinity",
  "connlib-model",
  "dns-types",
  "firezone-logging",
@@ -1475,6 +1477,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
+name = "connlib-core-affinity"
+version = "0.1.0"
+dependencies = [
+ "core_affinity",
+ "tracing",
+]
+
+[[package]]
 name = "connlib-model"
 version = "0.1.0"
 dependencies = [
@@ -1580,6 +1590,17 @@ dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.10.0",
  "libc",
+]
+
+[[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
 ]
 
 [[package]]
@@ -1975,7 +1996,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2296,7 +2317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2395,6 +2416,7 @@ dependencies = [
  "bufferpool",
  "bytes",
  "clap",
+ "connlib-core-affinity",
  "dashmap",
  "dirs",
  "dns-types",
@@ -2697,6 +2719,7 @@ dependencies = [
  "bufferpool",
  "bytes",
  "chrono",
+ "connlib-core-affinity",
  "connlib-model",
  "derive_more 2.0.1",
  "divan",
@@ -3414,6 +3437,12 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -4279,7 +4308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4832,6 +4861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4846,7 +4885,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -5606,7 +5645,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix 0.38.44",
  "tracing",
@@ -5888,7 +5927,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6278,7 +6317,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6291,7 +6330,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7933,7 +7972,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9285,7 +9324,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "client-ffi",
     "client-shared",
     "connlib/bufferpool",
+    "connlib/core-affinity",
     "connlib/dns-over-tcp",
     "connlib/dns-types",
     "connlib/etherparse-ext",
@@ -65,7 +66,9 @@ caps = "0.5.5"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "oldtime", "serde"] }
 clap = "4.5.47"
 client-shared = { path = "client-shared" }
+connlib-core-affinity = { path = "connlib/core-affinity" }
 connlib-model = { path = "connlib/model" }
+core_affinity = "0.8.3"
 crossbeam-queue = "0.3.12"
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", default-features = false }

--- a/rust/apple-client-ffi/Cargo.toml
+++ b/rust/apple-client-ffi/Cargo.toml
@@ -14,6 +14,7 @@ doc = false
 anyhow = { workspace = true }
 backoff = { workspace = true }
 client-shared = { workspace = true }
+connlib-core-affinity = { workspace = true }
 connlib-model = { workspace = true }
 dns-types = { workspace = true }
 firezone-logging = { workspace = true }

--- a/rust/apple-client-ffi/src/tun.rs
+++ b/rust/apple-client-ffi/src/tun.rs
@@ -1,3 +1,4 @@
+use connlib_core_affinity::{ThreadId, set_core_affinity};
 use firezone_telemetry::otel;
 use futures::SinkExt as _;
 use ip_packet::{IpPacket, IpPacketBuf, IpVersion};
@@ -46,6 +47,8 @@ impl Tun {
         std::thread::Builder::new()
             .name("TUN send".to_owned())
             .spawn(move || {
+                set_core_affinity(ThreadId::TunSend);
+
                 firezone_logging::unwrap_or_warn!(
                     tun::unix::tun_send(fd, outbound_rx, write),
                     "Failed to send to TUN device: {}"
@@ -55,6 +58,8 @@ impl Tun {
         std::thread::Builder::new()
             .name("TUN recv".to_owned())
             .spawn(move || {
+                set_core_affinity(ThreadId::TunRecv);
+
                 firezone_logging::unwrap_or_warn!(
                     tun::unix::tun_recv(fd, inbound_tx, read),
                     "Failed to recv from TUN device: {}"

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 atomicwrites = { workspace = true }
 axum = { workspace = true, features = ["http1", "tokio"] }
 clap = { workspace = true, features = ["derive", "env"] }
+connlib-core-affinity = { workspace = true }
 dns-types = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }

--- a/rust/bin-shared/Cargo.toml
+++ b/rust/bin-shared/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = { workspace = true }
 atomicwrites = { workspace = true }
 axum = { workspace = true, features = ["http1", "tokio"] }
 clap = { workspace = true, features = ["derive", "env"] }
-connlib-core-affinity = { workspace = true }
 dns-types = { workspace = true }
 firezone-logging = { workspace = true }
 firezone-telemetry = { workspace = true }
@@ -34,6 +33,7 @@ uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 atomicwrites = { workspace = true }
+connlib-core-affinity = { workspace = true }
 dirs = { workspace = true }
 libc = { workspace = true }
 netlink-packet-core = { workspace = true }
@@ -45,6 +45,7 @@ tokio-util = { workspace = true }
 zbus = { workspace = true } # Can't use `zbus`'s `tokio` feature here, or it will break toast popups all the way over in `gui-client`.
 
 [target.'cfg(windows)'.dependencies]
+connlib-core-affinity = { workspace = true }
 dashmap = { workspace = true }
 ipconfig = "0.3.2"
 itertools = { workspace = true }

--- a/rust/client-ffi/Cargo.toml
+++ b/rust/client-ffi/Cargo.toml
@@ -13,6 +13,7 @@ doc = false
 anyhow = { workspace = true }
 backoff = { workspace = true }
 client-shared = { workspace = true }
+connlib-core-affinity = { workspace = true }
 connlib-model = { workspace = true }
 dns-types = { workspace = true }
 firezone-logging = { workspace = true }

--- a/rust/client-ffi/src/platform/android/tun.rs
+++ b/rust/client-ffi/src/platform/android/tun.rs
@@ -1,3 +1,4 @@
+use connlib_core_affinity::{ThreadId, set_core_affinity};
 use firezone_telemetry::otel;
 use futures::SinkExt as _;
 use ip_packet::{IpPacket, IpPacketBuf};
@@ -78,6 +79,8 @@ impl Tun {
         std::thread::Builder::new()
             .name("TUN send".to_owned())
             .spawn(move || {
+                set_core_affinity(ThreadId::TunSend);
+
                 firezone_logging::unwrap_or_warn!(
                     tun::unix::tun_send(fd, outbound_rx, write),
                     "Failed to send to TUN device: {}"
@@ -87,6 +90,8 @@ impl Tun {
         std::thread::Builder::new()
             .name("TUN recv".to_owned())
             .spawn(move || {
+                set_core_affinity(ThreadId::TunRecv);
+
                 firezone_logging::unwrap_or_warn!(
                     tun::unix::tun_recv(fd, inbound_tx, read),
                     "Failed to recv from TUN device: {}"

--- a/rust/connlib/core-affinity/Cargo.toml
+++ b/rust/connlib/core-affinity/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "connlib-core-affinity"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+core_affinity = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/connlib/core-affinity/Cargo.toml
+++ b/rust/connlib/core-affinity/Cargo.toml
@@ -7,8 +7,10 @@ license = { workspace = true }
 [lib]
 path = "lib.rs"
 
-[dependencies]
+[target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies]
 core_affinity = { workspace = true }
+
+[dependencies]
 tracing = { workspace = true }
 
 [lints]

--- a/rust/connlib/core-affinity/lib.rs
+++ b/rust/connlib/core-affinity/lib.rs
@@ -1,0 +1,38 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+#[derive(Debug, Clone, Copy)]
+pub enum ThreadId {
+    TunSend = 0,
+    TunRecv = 1,
+    UdpV4 = 2,
+    UdpV6 = 3,
+    Main = 4,
+}
+
+const NUM_THREADS: usize = 5; // Should be equal to number of variants in `ThreadId`.
+
+pub fn set_core_affinity(thread: ThreadId) {
+    let Some(core_ids) = core_affinity::get_core_ids() else {
+        tracing::debug!("Unable to retrieve core IDs");
+        return;
+    };
+
+    if core_ids.len() < NUM_THREADS {
+        tracing::debug!(num_cores = %core_ids.len(), num_threads = %NUM_THREADS, "Not enough cores to uniquely assign threads");
+        return;
+    }
+
+    let Some(core) = core_ids.get(thread as usize) else {
+        tracing::debug!(?thread, "Failed to get core by index");
+        return;
+    };
+
+    let result = core_affinity::set_for_current(*core);
+
+    if !result {
+        tracing::info!(?thread, ?core, "Failed to set core affinity");
+        return;
+    }
+
+    tracing::debug!(?thread, ?core, "Set core affinity");
+}

--- a/rust/connlib/core-affinity/lib.rs
+++ b/rust/connlib/core-affinity/lib.rs
@@ -11,6 +11,7 @@ pub enum ThreadId {
 
 const NUM_THREADS: usize = 5; // Should be equal to number of variants in `ThreadId`.
 
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 pub fn set_core_affinity(thread: ThreadId) {
     let Some(core_ids) = core_affinity::get_core_ids() else {
         tracing::debug!("Unable to retrieve core IDs");
@@ -35,4 +36,10 @@ pub fn set_core_affinity(thread: ThreadId) {
     }
 
     tracing::debug!(?thread, ?core, "Set core affinity");
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub fn set_core_affinity(_: ThreadId) {
+    tracing::debug!("MacOS / iOS do not support setting core affinity");
+    return;
 }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -16,6 +16,7 @@ boringtun = { workspace = true }
 bufferpool = { workspace = true }
 bytes = { workspace = true, features = ["std"] }
 chrono = { workspace = true }
+connlib-core-affinity = { workspace = true }
 connlib-model = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 divan = { workspace = true, optional = true }

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -6,6 +6,7 @@ mod udp_dns;
 use crate::{TunnelError, device_channel::Device, dns, otel, sockets::Sockets};
 use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
+use connlib_core_affinity::{ThreadId, set_core_affinity};
 use futures::FutureExt as _;
 use futures_bounded::FuturesTupleSet;
 use gat_lending_iterator::LendingIterator;
@@ -151,6 +152,8 @@ impl Io {
     ) -> Self {
         let mut sockets = Sockets::default();
         sockets.rebind(udp_socket_factory.clone()); // Bind sockets on startup.
+
+        set_core_affinity(ThreadId::Main);
 
         Self {
             outbound_packet_buffer: VecDeque::default(),

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -242,6 +242,7 @@ skip = [
     "getrandom",
     "hashbrown",
     "heck",
+    "hermit-abi",
     "indexmap",
     "itertools",
     "libloading",


### PR DESCRIPTION
Currently, `connlib` has 5 worker threads for packet handling: TUN send, TUN recv, UDPv4, UDPv6 and the "main" processing thread where everything comes together, i.e. packet encryption / decryption and routing.

If we have more than 5 cores, it makes sense to pin these threads to specific cores to be more friendly to CPU caches.