### PR TITLE
feat(connlib): send ICMP errors for fragmented IP packets

### DIFF
--- a/rust/apple-client-ffi/src/tun.rs
+++ b/rust/apple-client-ffi/src/tun.rs
@@ -16,7 +16,7 @@ const QUEUE_SIZE: usize = 10_000;
 pub struct Tun {
     name: String,
     outbound_tx: PollSender<IpPacket>,
-    inbound_rx: mpsc::Receiver<IpPacket>,
+    inbound_rx: mpsc::Receiver<IpPacketBuf>,
 }
 
 impl Tun {
@@ -92,7 +92,7 @@ impl tun::Tun for Tun {
     fn poll_recv_many(
         &mut self,
         cx: &mut Context,
-        buf: &mut Vec<IpPacket>,
+        buf: &mut Vec<IpPacketBuf>,
         max: usize,
     ) -> Poll<usize> {
         self.inbound_rx.poll_recv_many(cx, buf, max)

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -338,7 +338,7 @@ const QUEUE_SIZE: usize = 10_000;
 #[derive(Debug)]
 pub struct Tun {
     outbound_tx: PollSender<IpPacket>,
-    inbound_rx: mpsc::Receiver<IpPacket>,
+    inbound_rx: mpsc::Receiver<IpPacketBuf>,
 }
 
 impl Tun {
@@ -441,7 +441,7 @@ impl tun::Tun for Tun {
     fn poll_recv_many(
         &mut self,
         cx: &mut Context,
-        buf: &mut Vec<IpPacket>,
+        buf: &mut Vec<IpPacketBuf>,
         max: usize,
     ) -> Poll<usize> {
         self.inbound_rx.poll_recv_many(cx, buf, max)

--- a/rust/client-ffi/src/platform/fallback.rs
+++ b/rust/client-ffi/src/platform/fallback.rs
@@ -57,7 +57,7 @@ impl tun::Tun for Tun {
     fn poll_recv_many(
         &mut self,
         _: &mut std::task::Context,
-        _: &mut Vec<ip_packet::IpPacket>,
+        _: &mut Vec<ip_packet::IpPacketBuf>,
         _: usize,
     ) -> std::task::Poll<usize> {
         todo!()

--- a/rust/connlib/dns-over-tcp/src/codec.rs
+++ b/rust/connlib/dns-over-tcp/src/codec.rs
@@ -28,25 +28,6 @@ pub fn try_send(socket: &mut l3_tcp::Socket, message: &[u8]) -> Result<()> {
         "Not enough space in write buffer for DNS message"
     );
 
-    // if tracing::event_enabled!(target: "wire::dns::tcp::send", tracing::Level::TRACE) {
-    //     if let Some(ParsedMessage {
-    //         qid,
-    //         qname,
-    //         qtype,
-    //         response,
-    //         rcode,
-    //         records,
-    //     }) = parse(message)
-    //     {
-    //         if response {
-    //             let records = records.into_iter().join(" | ");
-    //             tracing::trace!(target: "wire::dns::tcp::send", %qid, %rcode, "{:5} {qname} => [{records}]", qtype.to_string());
-    //         } else {
-    //             tracing::trace!(target: "wire::dns::tcp::send", %qid, "{:5} {qname}", qtype.to_string());
-    //         }
-    //     }
-    // }
-
     Ok(())
 }
 
@@ -70,25 +51,6 @@ where
         .context("Failed to recv TCP data")?
         .transpose()
         .context("Failed to parse DNS message")?;
-
-    // if tracing::event_enabled!(target: "wire::dns::tcp::recv", tracing::Level::TRACE) {
-    //     if let Some(ParsedMessage {
-    //         qid,
-    //         qname,
-    //         qtype,
-    //         rcode,
-    //         response,
-    //         records,
-    //     }) = maybe_message.and_then(parse)
-    //     {
-    //         if response {
-    //             let records = records.into_iter().join(" | ");
-    //             tracing::trace!(target: "wire::dns::tcp::recv", %qid, %rcode, "{:5} {qname} => [{records}]", qtype.to_string());
-    //         } else {
-    //             tracing::trace!(target: "wire::dns::tcp::recv", %qid, "{:5} {qname}", qtype.to_string());
-    //         }
-    //     }
-    // }
 
     Ok(maybe_message)
 }

--- a/rust/connlib/dns-over-tcp/tests/client_and_server.rs
+++ b/rust/connlib/dns-over-tcp/tests/client_and_server.rs
@@ -9,9 +9,7 @@ use dns_types::{Query, RecordType, ResponseBuilder, ResponseCode};
 
 #[test]
 fn smoke() {
-    let _guard = firezone_logging::test(
-        "netlink_proto=off,wire::dns::res=trace,dns_over_tcp=trace,smoltcp=trace,debug",
-    );
+    let _guard = firezone_logging::test("netlink_proto=off,dns_over_tcp=trace,smoltcp=trace,debug");
 
     let ipv4 = Ipv4Addr::from([100, 90, 215, 97]);
     let ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0x0016, 0x588f]);
@@ -46,9 +44,7 @@ fn smoke() {
 
 #[test]
 fn no_panic_after_set_listen_address() {
-    let _guard = firezone_logging::test(
-        "netlink_proto=off,wire::dns::res=trace,dns_over_tcp=trace,smoltcp=trace,debug",
-    );
+    let _guard = firezone_logging::test("netlink_proto=off,dns_over_tcp=trace,smoltcp=trace,debug");
 
     let ipv4 = Ipv4Addr::from([100, 90, 215, 97]);
     let ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0x0016, 0x588f]);

--- a/rust/connlib/dns-over-tcp/tests/smoke_server.rs
+++ b/rust/connlib/dns-over-tcp/tests/smoke_server.rs
@@ -18,7 +18,7 @@ const CLIENT_CONCURRENCY: usize = 3;
 #[tokio::test]
 #[ignore = "Requires root & IP forwarding"]
 async fn smoke() {
-    let _guard = firezone_logging::test("netlink_proto=off,wire::dns=trace,debug");
+    let _guard = firezone_logging::test("netlink_proto=off,debug");
 
     let ipv4 = Ipv4Addr::from([100, 90, 215, 97]);
     let ipv6 = Ipv6Addr::from([0xfd00, 0x2021, 0x1111, 0x0, 0x0, 0x0, 0x0016, 0x588f]);

--- a/rust/connlib/l3-tcp/src/stub_device.rs
+++ b/rust/connlib/l3-tcp/src/stub_device.rs
@@ -72,8 +72,9 @@ impl smoltcp::phy::TxToken for SmolTxToken<'_> {
 
         let mut ip_packet_buf = IpPacketBuf::new();
         let result = f(ip_packet_buf.buf());
+        ip_packet_buf.set_len(len);
 
-        let mut ip_packet = match IpPacket::new(ip_packet_buf, len) {
+        let mut ip_packet = match IpPacket::new(ip_packet_buf) {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!("Received invalid IP packet: {e:#}");

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -7,6 +7,7 @@ use bufferpool::BufferPool;
 use bytecodec::{DecodeExt as _, EncodeExt as _};
 use firezone_logging::err_with_src;
 use hex_display::HexDisplayExt as _;
+use ip_packet::Ecn;
 use rand::random;
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 use std::{
@@ -1138,6 +1139,7 @@ impl Allocation {
             src: None,
             dst,
             payload: self.buffer_pool.pull_initialised(&encode(message)),
+            ecn: Ecn::NonEct,
         });
 
         true

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2424,9 +2424,10 @@ where
             // In our API, we parse the packets directly as an IpPacket.
             // Thus, the caller can query whatever data they'd like, not just the source IP so we don't return it in addition.
             TunnResult::WriteToTunnelV4(packet, ip) => {
-                let packet_len = packet.len();
+                let len = packet.len();
+                ip_packet.set_len(len);
 
-                match IpPacket::new(ip_packet, packet_len).context("Failed to parse IP packet") {
+                match IpPacket::new(ip_packet).context("Failed to parse IP packet") {
                     Ok(p) => {
                         debug_assert_eq!(p.source(), IpAddr::V4(ip));
 
@@ -2436,9 +2437,10 @@ where
                 }
             }
             TunnResult::WriteToTunnelV6(packet, ip) => {
-                let packet_len = packet.len();
+                let len = packet.len();
+                ip_packet.set_len(len);
 
-                match IpPacket::new(ip_packet, packet_len).context("Failed to parse IP packet") {
+                match IpPacket::new(ip_packet).context("Failed to parse IP packet") {
                     Ok(p) => {
                         debug_assert_eq!(p.source(), IpAddr::V6(ip));
 

--- a/rust/connlib/tun/src/lib.rs
+++ b/rust/connlib/tun/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use ip_packet::IpPacket;
+use ip_packet::{IpPacket, IpPacketBuf};
 
 #[cfg(target_family = "unix")]
 pub mod ioctl;
@@ -20,7 +20,7 @@ pub trait Tun: Send + Sync + 'static {
     fn poll_recv_many(
         &mut self,
         cx: &mut Context,
-        buf: &mut Vec<IpPacket>,
+        buf: &mut Vec<IpPacketBuf>,
         max: usize,
     ) -> Poll<usize>;
 

--- a/rust/connlib/tun/src/unix.rs
+++ b/rust/connlib/tun/src/unix.rs
@@ -39,7 +39,7 @@ where
 
 pub fn tun_recv<T>(
     fd: T,
-    inbound_tx: mpsc::Sender<IpPacket>,
+    inbound_tx: mpsc::Sender<IpPacketBuf>,
     read: impl Fn(i32, &mut IpPacketBuf) -> std::result::Result<usize, io::Error>,
 ) -> Result<()>
 where
@@ -63,10 +63,9 @@ where
                             return Ok(None);
                         }
 
-                        let packet = IpPacket::new(ip_packet_buf, len)
-                            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+                        ip_packet_buf.set_len(len);
 
-                        Ok(Some(packet))
+                        Ok(Some(ip_packet_buf))
                     })
                     .await;
 

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -391,6 +391,10 @@ impl ClientState {
         packet: IpPacket,
         now: Instant,
     ) -> Option<snownet::Transmit> {
+        if packet.is_fz_p2p_control() {
+            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
+        }
+
         let non_dns_packet = match self.try_handle_dns(packet, now) {
             ControlFlow::Break(()) => return None,
             ControlFlow::Continue(non_dns_packet) => non_dns_packet,

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -395,6 +395,9 @@ impl ClientState {
             tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
         }
 
+        #[cfg(debug_assertions)]
+        tracing::trace!(target: "wire::dev::recv", ?packet);
+
         let non_dns_packet = match self.try_handle_dns(packet, now) {
             ControlFlow::Break(()) => return None,
             ControlFlow::Continue(non_dns_packet) => non_dns_packet,

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -39,16 +39,6 @@ impl Device {
 
         let n = std::task::ready!(tun.poll_recv_many(cx, buf, max));
 
-        #[cfg(debug_assertions)]
-        {
-            // Having these trace statements is quite expensive, even if they are not turned on.
-            // We are talking 5+ % of CPU time here just for checking whether or not this should get logged.
-
-            for packet in &buf[..n] {
-                tracing::trace!(target: "wire::dev::recv", ?packet);
-            }
-        }
-
         Poll::Ready(n)
     }
 

--- a/rust/connlib/tunnel/src/device_channel.rs
+++ b/rust/connlib/tunnel/src/device_channel.rs
@@ -1,4 +1,4 @@
-use ip_packet::IpPacket;
+use ip_packet::{IpPacket, IpPacketBuf};
 use std::io;
 use std::task::{Context, Poll, Waker};
 use tun::Tun;
@@ -29,7 +29,7 @@ impl Device {
     pub(crate) fn poll_read_many(
         &mut self,
         cx: &mut Context<'_>,
-        buf: &mut Vec<IpPacket>,
+        buf: &mut Vec<IpPacketBuf>,
         max: usize,
     ) -> Poll<usize> {
         let Some(tun) = self.tun.as_mut() else {

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -96,6 +96,9 @@ impl GatewayState {
             tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
         }
 
+        #[cfg(debug_assertions)]
+        tracing::trace!(target: "wire::dev::recv", ?packet);
+
         let dst = packet.destination();
 
         if !crate::is_peer(dst) {

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -92,6 +92,10 @@ impl GatewayState {
         packet: IpPacket,
         now: Instant,
     ) -> Result<Option<snownet::Transmit>> {
+        if packet.is_fz_p2p_control() {
+            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
+        }
+
         let dst = packet.destination();
 
         if !crate::is_peer(dst) {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -148,7 +148,7 @@ impl ClientTunnel {
         // Drain all UDP packets that need to be sent.
         while let Some(trans) = self.role_state.poll_transmit() {
             self.io
-                .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
+                .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
         }
 
         // Return a future that "owns" our IO, polling it until all packets have been flushed.
@@ -185,7 +185,7 @@ impl ClientTunnel {
             // Drain all buffered transmits.
             while let Some(trans) = self.role_state.poll_transmit() {
                 self.io
-                    .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
+                    .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
                 ready = true;
             }
 
@@ -226,15 +226,13 @@ impl ClientTunnel {
                             tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
                         }
 
-                        let ecn = packet.ecn();
-
                         match self.role_state.handle_tun_input(packet, now) {
                             Some(transmit) => {
                                 self.io.send_network(
                                     transmit.src,
                                     transmit.dst,
                                     &transmit.payload,
-                                    ecn,
+                                    transmit.ecn,
                                 );
                             }
                             None => {
@@ -325,7 +323,7 @@ impl GatewayTunnel {
         // Drain all UDP packets that need to be sent.
         while let Some(trans) = self.role_state.poll_transmit() {
             self.io
-                .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
+                .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
         }
 
         // Return a future that "owns" our IO, polling it until all packets have been flushed.
@@ -356,7 +354,7 @@ impl GatewayTunnel {
             // Drain all buffered transmits.
             while let Some(trans) = self.role_state.poll_transmit() {
                 self.io
-                    .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
+                    .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
 
                 ready = true;
             }
@@ -408,15 +406,13 @@ impl GatewayTunnel {
                             tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
                         }
 
-                        let ecn = packet.ecn();
-
                         match self.role_state.handle_tun_input(packet, now) {
                             Ok(Some(transmit)) => {
                                 self.io.send_network(
                                     transmit.src,
                                     transmit.dst,
                                     &transmit.payload,
-                                    ecn,
+                                    transmit.ecn,
                                 );
                             }
                             Ok(None) => {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -222,10 +222,6 @@ impl ClientTunnel {
 
                 if let Some(packets) = device {
                     for packet in packets {
-                        if packet.is_fz_p2p_control() {
-                            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
-                        }
-
                         match self.role_state.handle_tun_input(packet, now) {
                             Some(transmit) => {
                                 self.io.send_network(
@@ -402,10 +398,6 @@ impl GatewayTunnel {
 
                 if let Some(packets) = device {
                     for packet in packets {
-                        if packet.is_fz_p2p_control() {
-                            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
-                        }
-
                         match self.role_state.handle_tun_input(packet, now) {
                             Ok(Some(transmit)) => {
                                 self.io.send_network(

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -355,6 +355,12 @@ impl GatewayTunnel {
                 ready = true;
             }
 
+            // Drain all buffered IP packets.
+            while let Some(packet) = self.role_state.poll_packets() {
+                self.io.send_tun(packet);
+                ready = true;
+            }
+
             // Process all IO sources that are ready.
             if let Poll::Ready(io::Input {
                 now,

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -14,7 +14,6 @@ use futures::{FutureExt, future::BoxFuture};
 use gat_lending_iterator::LendingIterator;
 use io::{Buffers, Io};
 use ip_network::{Ipv4Network, Ipv6Network};
-use ip_packet::Ecn;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::BTreeSet,

--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -12,7 +12,7 @@ use firezone_telemetry::{
 };
 use firezone_tunnel::GatewayTunnel;
 use hickory_resolver::config::ResolveHosts;
-use ip_packet::IpPacket;
+use ip_packet::{IpPacket, IpPacketBuf};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use phoenix_channel::LoginUrl;
@@ -384,7 +384,7 @@ impl Tun for ValidateChecksumAdapter {
     fn poll_recv_many(
         &mut self,
         cx: &mut std::task::Context,
-        buf: &mut Vec<IpPacket>,
+        buf: &mut Vec<IpPacketBuf>,
         max: usize,
     ) -> std::task::Poll<usize> {
         self.inner.poll_recv_many(cx, buf, max)

--- a/rust/tests/fuzz/fuzz_targets/ip_packet.rs
+++ b/rust/tests/fuzz/fuzz_targets/ip_packet.rs
@@ -14,8 +14,9 @@ fuzz_target!(|input: Input| {
     let mut buf = IpPacketBuf::new();
     let len = input.data.len();
     buf.buf()[..len].copy_from_slice(&input.data[..len]);
+    buf.set_len(len);
 
-    if let Ok(mut packet) = IpPacket::new(buf, len) {
+    if let Ok(mut packet) = IpPacket::new(buf) {
         test_all_getters(&packet);
 
         for action in input.setters {


### PR DESCRIPTION
When an application sends UDP packets that are larger than the MTU of the underlying interface, the kernel fragments the packet at the IP level. Firezone does not support fragmented IP packets because we need to pack each IP packet into a UDP packet.

Right now, we don't check for fragmented IP packets which results in packet parsing errors because the slice we are trying to parse the packet from is not long enough.

Our only option is to drop all fragmented IP packets because we cannot process them. When an application doesn't want its packets to be fragmented, it can set specific socket options that translate to the "DONTFRAGMENT" bit in the IP header. this tells routers along the way that the packet should never get fragmented. In case it would have to but the bit is set, these routers then send back an ICMP error.

Even though this bit may not be set, Firezone will send these ICMP errors going forward as a best-effort attempt to tell the kernel / application that its packets are being dropped.