### PR TITLE
fix(staging): Update Docker registry

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -196,7 +196,7 @@ config :domain, :enabled_features,
 
 config :domain, sign_up_whitelisted_domains: []
 
-config :domain, docker_registry: "us-east1-docker.pkg.dev/firezone-staging/firezone"
+config :domain, docker_registry: "ghcr.io/firezone"
 
 config :domain, outbound_email_adapter_configured?: false
 


### PR DESCRIPTION
Sets the current Docker registry, with `/dev` suffix to prefer latest
dev gateway release