### PR TITLE
fix(connlib): log fragmented IP packets on debug

### DIFF
--- a/rust/connlib/ip-packet/src/lib.rs
+++ b/rust/connlib/ip-packet/src/lib.rs
@@ -205,6 +205,8 @@ impl IpPacket {
 
         let ip = IpSlice::from_slice(&buf.inner[..len]).context("Failed to parse IP packet")?;
 
+        anyhow::ensure!(!ip.is_fragmenting_payload(), Fragmented);
+
         let src_ip = ip.source_addr();
         let dst_ip = ip.destination_addr();
 
@@ -901,6 +903,10 @@ impl IpPacket {
         &mut self.buf[self.ip_header_length..self.len]
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("Fragmented IP packets are unsupported")]
+pub struct Fragmented;
 
 fn extract_l4_proto(payload: &[u8], protocol: IpNumber) -> Result<Layer4Protocol> {
     // ICMP messages SHOULD always contain at least 8 bytes of the original L4 payload.

--- a/rust/connlib/tun/Cargo.toml
+++ b/rust/connlib/tun/Cargo.toml
@@ -11,7 +11,7 @@ ip-packet = { workspace = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 libc = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["net", "rt", "sync"] }
 tracing = { workspace = true }
 
 [lints]


### PR DESCRIPTION
When an application sends UDP packets that are larger than the MTU of the underlying interface, the kernel fragments the packet at the IP level. Firezone does not support fragmented IP packets because we need to pack each IP packet into a UDP packet.

Right now, we don't check for fragmented IP packets which results in packet parsing errors because the slice we are trying to parse the packet from is not long enough.

To avoid spamming Sentry in these cases, we explicitly check for fragmented IP packets and only log those on DEBUG.

Resolves: #10335