### PR TITLE
chore: differentiate between `shutdown` and `shut down`

### DIFF
--- a/rust/apple-client-ffi/src/lib.rs
+++ b/rust/apple-client-ffi/src/lib.rs
@@ -387,7 +387,7 @@ impl Drop for WrappedSession {
             return;
         };
 
-        self.inner.stop(); // Instruct the event-loop to shutdown.
+        self.inner.stop(); // Instruct the event-loop to shut down.
         runtime.block_on(async {
             self.telemetry.stop().await;
 

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -208,7 +208,7 @@ impl Drop for Session {
             return;
         };
 
-        self.inner.stop(); // Instruct the event-loop to shutdown.
+        self.inner.stop(); // Instruct the event-loop to shut down.
 
         runtime.block_on(async {
             self.telemetry.lock().await.stop_on_crash().await;

--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -144,13 +144,13 @@ impl Eventloop {
             match self.tick().await {
                 Ok(ControlFlow::Continue(())) => continue,
                 Ok(ControlFlow::Break(())) => {
-                    self.shutdown_tunnel().await?;
+                    self.shut_down_tunnel().await?;
 
                     return Ok(());
                 }
                 Err(e) => {
                     // Ignore error from shutdown to not obscure the original error.
-                    let _ = self.shutdown_tunnel().await;
+                    let _ = self.shut_down_tunnel().await;
 
                     return Err(e);
                 }
@@ -469,16 +469,16 @@ impl Eventloop {
         Poll::Pending
     }
 
-    async fn shutdown_tunnel(&mut self) -> Result<()> {
+    async fn shut_down_tunnel(&mut self) -> Result<()> {
         let Some(tunnel) = self.tunnel.take() else {
             tracing::debug!("Tunnel has already been shut down");
             return Ok(());
         };
 
         tunnel
-            .shutdown()
+            .shut_down()
             .await
-            .context("Failed to shutdown tunnel")?;
+            .context("Failed to shut down tunnel")?;
 
         Ok(())
     }

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -282,7 +282,7 @@ impl ClientState {
         self.node.public_key()
     }
 
-    pub fn shutdown(&mut self, now: Instant) {
+    pub fn shut_down(&mut self, now: Instant) {
         tracing::info!("Initiating graceful shutdown");
 
         self.peers.clear();

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -79,7 +79,7 @@ impl GatewayState {
         self.node.public_key()
     }
 
-    pub fn shutdown(&mut self, now: Instant) {
+    pub fn shut_down(&mut self, now: Instant) {
         tracing::info!("Initiating graceful shutdown");
 
         self.peers.clear();

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -140,10 +140,10 @@ impl ClientTunnel {
         self.io.reset();
     }
 
-    /// Shutdown the Client tunnel.
-    pub fn shutdown(mut self) -> BoxFuture<'static, Result<()>> {
+    /// Shut down the Client tunnel.
+    pub fn shut_down(mut self) -> BoxFuture<'static, Result<()>> {
         // Initiate shutdown.
-        self.role_state.shutdown(Instant::now());
+        self.role_state.shut_down(Instant::now());
 
         // Drain all UDP packets that need to be sent.
         while let Some(trans) = self.role_state.poll_transmit() {
@@ -317,10 +317,10 @@ impl GatewayTunnel {
         self.role_state.public_key()
     }
 
-    /// Shutdown the Gateway tunnel.
-    pub fn shutdown(mut self) -> BoxFuture<'static, Result<()>> {
+    /// Shut down the Gateway tunnel.
+    pub fn shut_down(mut self) -> BoxFuture<'static, Result<()>> {
         // Initiate shutdown.
-        self.role_state.shutdown(Instant::now());
+        self.role_state.shut_down(Instant::now());
 
         // Drain all UDP packets that need to be sent.
         while let Some(trans) = self.role_state.poll_transmit() {

--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -128,13 +128,13 @@ impl Eventloop {
             match self.tick().await {
                 Ok(ControlFlow::Continue(())) => continue,
                 Ok(ControlFlow::Break(())) => {
-                    self.shutdown_tunnel().await?;
+                    self.shut_down_tunnel().await?;
 
                     return Ok(());
                 }
                 Err(e) => {
                     // Ignore shutdown error here to not obscure the original error.
-                    let _ = self.shutdown_tunnel().await;
+                    let _ = self.shut_down_tunnel().await;
 
                     return Err(e);
                 }
@@ -221,7 +221,7 @@ impl Eventloop {
         Poll::Pending
     }
 
-    async fn shutdown_tunnel(&mut self) -> Result<()> {
+    async fn shut_down_tunnel(&mut self) -> Result<()> {
         let Some(tunnel) = self.tunnel.take() else {
             tracing::debug!("Tunnel has already been shut down");
 
@@ -229,7 +229,7 @@ impl Eventloop {
         };
 
         tunnel
-            .shutdown()
+            .shut_down()
             .await
             .context("Failed to shutdown tunnel")?;
 

--- a/rust/gui-client/src-tauri/src/controller.rs
+++ b/rust/gui-client/src-tauri/src/controller.rs
@@ -660,7 +660,7 @@ impl<I: GuiIntegration> Controller<I> {
                     .set_tray_icon(system_tray::icon_terminating());
                 self.integration.show_notification(
                     "Firezone disconnected",
-                    "The Firezone Tunnel service was shutdown, quitting GUI process.",
+                    "The Firezone Tunnel service was shut down, quitting GUI process.",
                 )?;
 
                 return Ok(ControlFlow::Break(()));

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -287,7 +287,7 @@ export default function Android() {
           Advanced screen.
         </ChangeItem>
         <ChangeItem pull="6495">
-          Fixes a bug where the Firezone tunnel wasn't shutdown properly if you
+          Fixes a bug where the Firezone tunnel wasn't shut down properly if you
           disconnect the VPN in system settings.
         </ChangeItem>
         <ChangeItem pull="6434">Adds the Internet Resource feature.</ChangeItem>

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -288,7 +288,7 @@ export default function GUI({ os }: { os: OS }) {
       <Entry version="1.4.4" date={new Date("2025-02-11")}>
         <ChangeItem pull="8035">
           Shows a non-disruptive toast notification and quits the GUI client in
-          case the IPC service gets shutdown through the service manager.
+          case the IPC service gets shut down through the service manager.
         </ChangeItem>
         {os === OS.Windows && (
           <ChangeItem pull="8083">


### PR DESCRIPTION
In a prior code review, CoPilot flagged that we were using the noun "shutdown" as a verb in certain places.

Resolves: #10425