### PR TITLE
ci: silence 429s errors in link checker

### DIFF
--- a/.github/workflows/website-links.yml
+++ b/.github/workflows/website-links.yml
@@ -18,7 +18,7 @@ jobs:
         uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 # v2.6.1
         with:
           fail: false
-          args: --verbose --no-progress --exclude-all-private --max-concurrency 1 --retry-wait-time 60 --base https://firezone.dev .
+          args: --verbose --no-progress --exclude-all-private --max-concurrency 1 --retry-wait-time 60 --base https://firezone.dev --accept 100..=103,200..=299,429 .
           workingDirectory: website
 
       - name: Create Issue From File


### PR DESCRIPTION
Until https://github.com/lycheeverse/lychee/pull/1844 is shipped, we silence 429s as valid status codes whenever links are being checked by lychee.