### PR TITLE
refactor(connlib): set ECN bits directly on `Transmit`

### DIFF
--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -7,6 +7,7 @@ use bufferpool::BufferPool;
 use bytecodec::{DecodeExt as _, EncodeExt as _};
 use firezone_logging::err_with_src;
 use hex_display::HexDisplayExt as _;
+use ip_packet::Ecn;
 use rand::random;
 use ringbuffer::{AllocRingBuffer, RingBuffer as _};
 use std::{
@@ -1138,6 +1139,7 @@ impl Allocation {
             src: None,
             dst,
             payload: self.buffer_pool.pull_initialised(&encode(message)),
+            ecn: Ecn::NonEct,
         });
 
         true

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -148,7 +148,7 @@ impl ClientTunnel {
         // Drain all UDP packets that need to be sent.
         while let Some(trans) = self.role_state.poll_transmit() {
             self.io
-                .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
+                .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
         }
 
         // Return a future that "owns" our IO, polling it until all packets have been flushed.
@@ -185,7 +185,7 @@ impl ClientTunnel {
             // Drain all buffered transmits.
             while let Some(trans) = self.role_state.poll_transmit() {
                 self.io
-                    .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
+                    .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
                 ready = true;
             }
 
@@ -222,15 +222,13 @@ impl ClientTunnel {
 
                 if let Some(packets) = device {
                     for packet in packets {
-                        let ecn = packet.ecn();
-
                         match self.role_state.handle_tun_input(packet, now) {
                             Some(transmit) => {
                                 self.io.send_network(
                                     transmit.src,
                                     transmit.dst,
                                     &transmit.payload,
-                                    ecn,
+                                    transmit.ecn,
                                 );
                             }
                             None => {
@@ -321,7 +319,7 @@ impl GatewayTunnel {
         // Drain all UDP packets that need to be sent.
         while let Some(trans) = self.role_state.poll_transmit() {
             self.io
-                .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
+                .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
         }
 
         // Return a future that "owns" our IO, polling it until all packets have been flushed.
@@ -352,7 +350,7 @@ impl GatewayTunnel {
             // Drain all buffered transmits.
             while let Some(trans) = self.role_state.poll_transmit() {
                 self.io
-                    .send_network(trans.src, trans.dst, &trans.payload, Ecn::NonEct);
+                    .send_network(trans.src, trans.dst, &trans.payload, trans.ecn);
 
                 ready = true;
             }
@@ -400,15 +398,13 @@ impl GatewayTunnel {
 
                 if let Some(packets) = device {
                     for packet in packets {
-                        let ecn = packet.ecn();
-
                         match self.role_state.handle_tun_input(packet, now) {
                             Ok(Some(transmit)) => {
                                 self.io.send_network(
                                     transmit.src,
                                     transmit.dst,
                                     &transmit.payload,
-                                    ecn,
+                                    transmit.ecn,
                                 );
                             }
                             Ok(None) => {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -14,7 +14,6 @@ use futures::{FutureExt, future::BoxFuture};
 use gat_lending_iterator::LendingIterator;
 use io::{Buffers, Io};
 use ip_network::{Ipv4Network, Ipv6Network};
-use ip_packet::Ecn;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
 use std::{
     collections::BTreeSet,

--- a/rust/connlib/tunnel/src/tests/sim_relay.rs
+++ b/rust/connlib/tunnel/src/tests/sim_relay.rs
@@ -5,6 +5,7 @@ use super::{
 use bufferpool::Buffer;
 use connlib_model::RelayId;
 use firezone_relay::{AddressFamily, AllocationPort, ClientSocket, IpStack, PeerSocket};
+use ip_packet::Ecn;
 use proptest::prelude::*;
 use rand::{SeedableRng as _, rngs::StdRng};
 use secrecy::SecretString;
@@ -151,6 +152,7 @@ impl SimRelay {
             src: Some(src),
             dst,
             payload,
+            ecn: Ecn::NonEct,
         })
     }
 
@@ -176,6 +178,7 @@ impl SimRelay {
             src: Some(sending_socket),
             dst: receiving_socket,
             payload,
+            ecn: Ecn::NonEct,
         })
     }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -19,6 +19,7 @@ use bufferpool::BufferPool;
 use connlib_model::{ClientId, GatewayId, PublicKey, RelayId};
 use dns_types::ResponseCode;
 use dns_types::prelude::*;
+use ip_packet::Ecn;
 use rand::SeedableRng;
 use rand::distributions::DistString;
 use sha2::Digest;
@@ -529,6 +530,7 @@ impl TunnelTest {
                                 src: Some(src),
                                 dst,
                                 payload: self.buffer_pool.pull_initialised(&payload),
+                                ecn: Ecn::NonEct,
                             },
                             relay,
                             now,


### PR DESCRIPTION
Instead of mirroring the ECN bits of an IP packet on the resulting UDP packet in the event-loop, we can extend `Transmit` with an `ecn` field and directly set it every time we construct a `Transmit`, mirroring the ECN bits from the inner IP packet if the UDP packet contains an encapsulated IP packet.

Extracted from #10485