### PR TITLE
refactor(connlib): move log into state

### DIFF
--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -391,6 +391,10 @@ impl ClientState {
         packet: IpPacket,
         now: Instant,
     ) -> Option<snownet::Transmit> {
+        if packet.is_fz_p2p_control() {
+            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
+        }
+
         let non_dns_packet = match self.try_handle_dns(packet, now) {
             ControlFlow::Break(()) => return None,
             ControlFlow::Continue(non_dns_packet) => non_dns_packet,

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -92,6 +92,10 @@ impl GatewayState {
         packet: IpPacket,
         now: Instant,
     ) -> Result<Option<snownet::Transmit>> {
+        if packet.is_fz_p2p_control() {
+            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
+        }
+
         let dst = packet.destination();
 
         if !crate::is_peer(dst) {

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -222,10 +222,6 @@ impl ClientTunnel {
 
                 if let Some(packets) = device {
                     for packet in packets {
-                        if packet.is_fz_p2p_control() {
-                            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
-                        }
-
                         let ecn = packet.ecn();
 
                         match self.role_state.handle_tun_input(packet, now) {
@@ -404,10 +400,6 @@ impl GatewayTunnel {
 
                 if let Some(packets) = device {
                     for packet in packets {
-                        if packet.is_fz_p2p_control() {
-                            tracing::warn!("Packet matches heuristics of FZ p2p control protocol");
-                        }
-
                         let ecn = packet.ecn();
 
                         match self.role_state.handle_tun_input(packet, now) {


### PR DESCRIPTION
Instead of logging this inside the event-loop, it is better to move it into the corresponding handler function to free up the event-loop from as much "logic" as possible. It should ideally only be concerned with linking the state machine with the IO components that actually cause the side-effects.