### PR TITLE
chore: bump Xcode version

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -28,7 +28,7 @@ jobs:
     needs: update-release-draft
     runs-on: macos-15
     env:
-      XCODE_MAJOR: 16
+      XCODE_MAJOR: 26
     permissions:
       contents: write # for attaching the build artifacts to the release
       id-token: write


### PR DESCRIPTION
Use latest Xcode 26.0, which is now officially available on the same
macos-15 runner.