### PR TITLE
ci(apple): explicitly select Xcode 26.0

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -28,7 +28,7 @@ jobs:
     needs: update-release-draft
     runs-on: macos-15
     env:
-      XCODE_MAJOR: 26
+      XCODE_VERSION: 26.0
     permissions:
       contents: write # for attaching the build artifacts to the release
       id-token: write

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -28,7 +28,7 @@ jobs:
     needs: update-release-draft
     runs-on: macos-15
     env:
-      XCODE_VERSION: 26.0
+      XCODE_VERSION: "26.0"
     permissions:
       contents: write # for attaching the build artifacts to the release
       id-token: write

--- a/scripts/build/lib.sh
+++ b/scripts/build/lib.sh
@@ -10,7 +10,7 @@ function setup_runner() {
     local ne_profile_file="$4"
 
     # Use the latest version of Xcode - matches what we typically use for development
-    sudo xcode-select --switch "$(ls -d /Applications/Xcode*${XCODE_MAJOR}*.app | sort -V | tail -n 1)"
+    sudo xcode-select --switch "$(ls -d /Applications/Xcode*${XCODE_VERSION}*.app | sort -V | tail -n 1)"
 
     profiles_path="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
     keychain_pass=$(openssl rand -base64 32)


### PR DESCRIPTION
In order to build the iOS app with the Xcode version that is installed on the GitHub runners, we need to select the Xcode version by major and minor version. Currently, the iOS builds are failing because Xcode 26.1 also exists but iOS 26.1 isn't supported (or released?).

See https://github.com/firezone/firezone/actions/runs/18239282351/job/51938727311.