### PR TITLE
ci: revise Rust caching configuration

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -61,6 +61,7 @@ runs:
       with:
         workspaces: rust
         cache-targets: false # Don't cache `target` directory, we use sccache for that.
+        save-if: ${{ github.ref == 'refs/heads/main' }} # Only save on main
 
     # We use Azure Blob Storage for sccache because credits and GHA cache is too small (10 GB).
     # For this to work, you need an Azure Storage account and a blob container named `sccache`.

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -54,9 +54,7 @@ runs:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
         components: rustfmt,clippy
         target: ${{ inputs.targets }}
-        cache: true
-        cache-on-failure: true
-        rustflags: "" # Don't set -D warnings by default
+        cache: false
         rust-src-dir: "rust"
 
     # We use Azure Blob Storage for sccache because credits and GHA cache is too small (10 GB).

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -55,7 +55,7 @@ runs:
         components: rustfmt,clippy
         target: ${{ inputs.targets }}
         cache: true
-        cache-targets: false
+        cache-targets: false # Disable caching of `target` directory, we use sccache for that.
         rust-src-dir: "rust"
 
     # We use Azure Blob Storage for sccache because credits and GHA cache is too small (10 GB).

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -54,7 +54,8 @@ runs:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
         components: rustfmt,clippy
         target: ${{ inputs.targets }}
-        cache: false
+        cache: true
+        cache-targets: false
         rust-src-dir: "rust"
 
     # We use Azure Blob Storage for sccache because credits and GHA cache is too small (10 GB).

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -48,7 +48,7 @@ runs:
         echo "RUST_TOOLCHAIN=$RUST_TOOLCHAIN" >> $GITHUB_ENV
       shell: bash
 
-    - uses: actions-rust-lang/setup-rust-toolchain@ab6845274e2ff01cd4462007e1a9d9df1ab49f42 # v1
+    - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
       id: toolchain
       with:
         toolchain: ${{ env.RUST_TOOLCHAIN }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -54,9 +54,13 @@ runs:
         toolchain: ${{ env.RUST_TOOLCHAIN }}
         components: rustfmt,clippy
         target: ${{ inputs.targets }}
-        cache: true
-        cache-targets: false # Disable caching of `target` directory, we use sccache for that.
-        rust-src-dir: "rust"
+        cache: false # We explicitly configure the cache below because it doesn't forward `cache-targets`.
+
+    - name: Cache registry
+      uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+      with:
+        workspaces: rust
+        cache-targets: false # Don't cache `target` directory, we use sccache for that.
 
     # We use Azure Blob Storage for sccache because credits and GHA cache is too small (10 GB).
     # For this to work, you need an Azure Storage account and a blob container named `sccache`.

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -57,6 +57,7 @@ runs:
         cache: true
         cache-on-failure: true
         rustflags: "" # Don't set -D warnings by default
+        rust-src-dir: "rust"
 
     # We use Azure Blob Storage for sccache because credits and GHA cache is too small (10 GB).
     # For this to work, you need an Azure Storage account and a blob container named `sccache`.

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -11,10 +11,8 @@ permissions:
   contents: "read"
   id-token: "write"
 
-# Never tolerate warnings. Duplicated in `_tauri.yml`
 env:
-  RUSTFLAGS: "-Dwarnings --cfg tokio_unstable"
-  RUSTDOCFLAGS: "-D warnings"
+  RUSTFLAGS: "--cfg tokio_unstable"
 
 jobs:
   static-analysis:

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -7,10 +7,7 @@ defaults:
   run:
     working-directory: ./rust/gui-client
 
-# Never tolerate warnings. Source of truth is `_rust.yml`
 env:
-  RUSTFLAGS: "-Dwarnings"
-  RUSTDOCFLAGS: "-D warnings"
   TSLINK_BUILD: true
 
 permissions:


### PR DESCRIPTION
We primarily rely on sccache for speeding up our Rust builds. The `setup-rust-toolchain` action configures `rust-cache` in addition but tries to set it up for the root of the repository which doesn't work in our scenario. It is also unnecessary to set up additional caching for the `target` directory because we use `sccache` anyway.

sccache only caches compile artifacts but it can also be beneficial to cache the downloaded Rust sources. Those aren't very big so we use the `rust-cache` action for that but disable the `target` cache. This config option isn't forwarded by `setup-rust-toolchain` so we disable its cache integration and use `rust-cache` directly.