### PR TITLE
revert: "chore: bump Xcode version"

### DIFF
--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -28,7 +28,7 @@ jobs:
     needs: update-release-draft
     runs-on: macos-15
     env:
-      XCODE_MAJOR: 26
+      XCODE_MAJOR: 16
     permissions:
       contents: write # for attaching the build artifacts to the release
       id-token: write


### PR DESCRIPTION
Unfortunately whenever we pick an Xcode version that's not the installed default, Xcode complains it can't find the relevant iOS SDK. Rather than download them in our build script, we should just wait until the macOS-26 runners are out of beta and do our builds there with Xcode 26.

Reverts firezone/firezone#10499