### PR TITLE
fix(gui-client): don't stop service after upgrade on Fedora

### DIFF
--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Usage: dpkg will call this after installing our files
-# This must be idempotent
 
 set -euo pipefail
 

--- a/rust/gui-client/src-tauri/linux_package/preinst
+++ b/rust/gui-client/src-tauri/linux_package/preinst
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Usage: dpkg will call this after installing our files
-# This must be idempotent
 
 set -euo pipefail
 

--- a/rust/gui-client/src-tauri/linux_package/prerm_deb
+++ b/rust/gui-client/src-tauri/linux_package/prerm_deb
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Usage: dpkg will call this after installing our files
 
 set -euo pipefail
 

--- a/rust/gui-client/src-tauri/linux_package/prerm_rpm
+++ b/rust/gui-client/src-tauri/linux_package/prerm_rpm
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SERVICE_NAME="firezone-client-tunnel"
+
+# `rpm` calls `prerm` of the old package _after_ it has installed the new package.
+# The first parameter indicates, how many other instances of the package are still installed.
+# If we are being upgraded, this will be 1.
+# In that case, we do _not_ want to stop the systemd service, otherwise the user will be greeted with "Firezone Tunnel service is not running".
+if [ "$1" == 1 ]; then
+    return
+fi
+
+sudo systemctl disable "$SERVICE_NAME"
+sudo systemctl stop "$SERVICE_NAME"

--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -11,7 +11,7 @@
       "deb": {
         "preInstallScript": "./linux_package/preinst",
         "postInstallScript": "./linux_package/postinst",
-        "preRemoveScript": "./linux_package/prerm",
+        "preRemoveScript": "./linux_package/prerm_deb",
         "files": {
           "/usr/lib/systemd/system/firezone-client-tunnel.service": "./linux_package/firezone-client-tunnel.service",
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",
@@ -21,7 +21,7 @@
       },
       "rpm": {
         "postInstallScript": "./linux_package/postinst",
-        "preRemoveScript": "./linux_package/prerm",
+        "preRemoveScript": "./linux_package/prerm_rpm",
         "files": {
           "/usr/lib/systemd/system/firezone-client-tunnel.service": "./linux_package/firezone-client-tunnel.service",
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -18,6 +18,12 @@ export default function GUI({ os }: { os: OS }) {
         <ChangeItem pull="10533">
           Improves reliability by caching DNS responses as per their TTL.
         </ChangeItem>
+        {os == OS.Linux && (
+          <ChangeItem pull="10539">
+            Fixes an issue where the Tunnel Service was not running after a
+            version upgrade.
+          </ChangeItem>
+        )}
       </Unreleased>
       <Entry version="1.5.7" date={new Date("2025-09-10")}>
         <ChangeItem pull="10104">


### PR DESCRIPTION
On Fedora, when a package gets upgraded, the new package is installed first, followed by the uninstall of the old package. As a result, the `prerm` script is called after the `postinst` script of the new package.

In our `prerm` script, we stop the tunnel service. On package upgrades, this results in us stopping the tunnel service after installing the new package, confronting the user with an error that the tunnel service is not running.

`rpm` passes arguments to these maintenance scripts. In the case of `prerm`, we receive the count of how many other instances of this packages are installed. To fix this bug, we check whether the first argument to the script is "1", meaning that we are being upgraded and should not stop the tunnel service.