### PR TITLE
fix(connlib): patch `mio` to resolve panic bug on Windows

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4493,13 +4493,12 @@ dependencies = [
 [[package]]
 name = "mio"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+source = "git+https://github.com/firezone/mio?branch=fix%2Fpanic-invalid-state#64fc40ef248af392e1b01b0d4749506927cbc4cd"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -237,6 +237,7 @@ softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting 
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 moka = { git = "https://github.com/moka-rs/moka", branch = "main" } # Waiting for release.
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
+mio = { git = "https://github.com/firezone/mio", branch = "fix/panic-invalid-state" }
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']


### PR DESCRIPTION
The `mio` library which underpins `tokio` has a bug on Windows in regards to named pipes where under certain circumstances an "unreachable code" section is entered. See https://github.com/tokio-rs/mio/issues/1819 for the upstream bug report.

In this PR, we patch in a fork of `mio` that aims to fix these issues by handling the state transitions more gracefully. I am not a Windows expert by any means so this will need some rigorous testing to make sure the IPC channel between GUI and Tunnel service still works reliably.

Related: https://github.com/tokio-rs/mio/pull/1903