### PR TITLE
chore(portal): remove Jason in favor of JSON

### DIFF
--- a/elixir/apps/api/lib/api/controllers/health_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/health_controller.ex
@@ -4,7 +4,7 @@ defmodule API.HealthController do
   def healthz(conn, _params) do
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(200, Jason.encode!(%{status: "ok"}))
+    |> send_resp(200, JSON.encode!(%{status: "ok"}))
     |> halt()
   end
 end

--- a/elixir/apps/api/lib/api/controllers/integrations/stripe/webhook_controller.ex
+++ b/elixir/apps/api/lib/api/controllers/integrations/stripe/webhook_controller.ex
@@ -13,7 +13,7 @@ defmodule API.Integrations.Stripe.WebhookController do
          :ok <- verify_timestamp(timestamp, @tolerance),
          secret = Billing.fetch_webhook_signing_secret!(),
          :ok <- verify_signatures(signatures, timestamp, body, secret),
-         {:ok, payload} <- Jason.decode(body),
+         {:ok, payload} <- JSON.decode(body),
          :ok <- Billing.handle_events([payload]) do
       send_resp(conn, 200, "")
     else

--- a/elixir/apps/api/mix.exs
+++ b/elixir/apps/api/mix.exs
@@ -58,7 +58,6 @@ defmodule API.MixProject do
       {:logger_json, "~> 7.0"},
 
       # Other deps
-      {:jason, "~> 1.2"},
       {:remote_ip, "~> 1.1"},
       {:open_api_spex, "~> 3.22.0"},
       {:ymlr, "~> 5.0"},

--- a/elixir/apps/api/test/api/controllers/integrations/stripe/webhook_controller_test.exs
+++ b/elixir/apps/api/test/api/controllers/integrations/stripe/webhook_controller_test.exs
@@ -39,7 +39,7 @@ defmodule API.Integrations.Stripe.WebhookControllerTest do
           "customer.subscription.updated",
           Mocks.Stripe.subscription_object(customer_id, %{}, %{}, 0)
         )
-        |> Jason.encode!()
+        |> JSON.encode!()
 
       signed_at = System.system_time(:second) - 15
       signature = generate_signature(signed_at, payload)
@@ -60,7 +60,7 @@ defmodule API.Integrations.Stripe.WebhookControllerTest do
           "customer.subscription.updated",
           Mocks.Stripe.subscription_object("cus_xxx", %{}, %{}, 0)
         )
-        |> Jason.encode!()
+        |> JSON.encode!()
 
       signed_at = System.system_time(:second) - 301
       signature = generate_signature(signed_at, payload)

--- a/elixir/apps/api/test/api/controllers/policy_controller_test.exs
+++ b/elixir/apps/api/test/api/controllers/policy_controller_test.exs
@@ -25,7 +25,7 @@ defmodule API.PolicyControllerTest do
         conn
         |> authorize_conn(actor)
         |> put_req_header("content-type", "application/json")
-        |> get("/policies", Jason.encode!(%{}))
+        |> get("/policies", JSON.encode!(%{}))
 
       assert %{
                "data" => data,

--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace.ex
@@ -128,7 +128,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace do
             "exp" => unix_timestamp + 3600,
             "iat" => unix_timestamp
           }
-          |> Jason.encode!()
+          |> JSON.encode!()
 
         jwt =
           JOSE.JWS.sign(jwk, claim_set, jws)

--- a/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/google_workspace/api_client.ex
@@ -58,14 +58,14 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClient do
 
     with {:ok, %Finch.Response{body: response, status: status}} when status in 200..299 <-
            Finch.request(request, @pool_name),
-         {:ok, %{"access_token" => access_token}} <- Jason.decode(response) do
+         {:ok, %{"access_token" => access_token}} <- JSON.decode(response) do
       {:ok, access_token}
     else
       {:ok, %Finch.Response{status: status}} when status in 500..599 ->
         {:error, :retry_later}
 
       {:ok, %Finch.Response{body: response, status: status}} ->
-        case Jason.decode(response) do
+        case JSON.decode(response) do
           {:ok, json_response} ->
             {:error, {status, json_response}}
 
@@ -202,7 +202,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClient do
     response = Finch.request(request, @pool_name)
 
     with {:ok, %Finch.Response{body: raw_body, status: 200}} <- response,
-         {:ok, json_response} <- Jason.decode(raw_body),
+         {:ok, json_response} <- JSON.decode(raw_body),
          {:ok, list} when is_list(list) <- Map.fetch(json_response, key) do
       {:ok, list, json_response["nextPageToken"]}
     else
@@ -225,7 +225,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClient do
           response: inspect(response)
         )
 
-        case Jason.decode(raw_body) do
+        case JSON.decode(raw_body) do
           {:ok, json_response} ->
             {:error, {status, json_response}}
 

--- a/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/microsoft_entra/api_client.ex
@@ -135,7 +135,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClient do
     response = Finch.request(request, @pool_name)
 
     with {:ok, %Finch.Response{body: raw_body, status: 200}} <- response,
-         {:ok, json_response} <- Jason.decode(raw_body),
+         {:ok, json_response} <- JSON.decode(raw_body),
          {:ok, list} when is_list(list) <- Map.fetch(json_response, "value") do
       {:ok, list, json_response["@odata.nextLink"]}
     else
@@ -158,7 +158,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClient do
           response: inspect(response)
         )
 
-        case Jason.decode(raw_body) do
+        case JSON.decode(raw_body) do
           {:ok, json_response} ->
             {:error, {status, json_response}}
 

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
@@ -126,7 +126,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     response = Finch.request(request, @pool_name)
 
     with {:ok, %Finch.Response{headers: headers, body: raw_body, status: 200}} <- response,
-         {:ok, list} when is_list(list) <- Jason.decode(raw_body) do
+         {:ok, list} when is_list(list) <- JSON.decode(raw_body) do
       {:ok, list, fetch_next_link(headers)}
     else
       {:ok, %Finch.Response{status: status}} when status in 201..299 ->
@@ -149,7 +149,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
           response: inspect(response)
         )
 
-        case Jason.decode(raw_body) do
+        case JSON.decode(raw_body) do
           {:ok, json_response} ->
             # Errors are in JSON body
             {:error, {status, json_response}}
@@ -277,7 +277,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     {:ok, JOSE.JWT.peek(token)}
   rescue
     ArgumentError -> {:error, "Could not parse token"}
-    Jason.DecodeError -> {:error, "Could not decode token json"}
+    JSON.DecodeError -> {:error, "Could not decode token json"}
     _ -> {:error, "Unknown error while parsing jwt"}
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/api_client.ex
@@ -277,7 +277,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClient do
     {:ok, JOSE.JWT.peek(token)}
   rescue
     ArgumentError -> {:error, "Could not parse token"}
-    JSON.DecodeError -> {:error, "Could not decode token json"}
+    Jason.DecodeError -> {:error, "Could not decode token json"}
     _ -> {:error, "Unknown error while parsing jwt"}
   end
 end

--- a/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
@@ -30,7 +30,7 @@ defmodule Domain.Auth.Adapters.OpenIDConnect.Settings.Changeset do
         {:error, %Mint.TransportError{reason: reason}} ->
           [{:discovery_document_uri, "is invalid, got #{inspect(reason)}"}]
 
-        {:error, %Jason.DecodeError{} = _error} ->
+        {:error, %JSON.DecodeError{} = _error} ->
           [{:discovery_document_uri, "is invalid, unable to parse response"}]
 
         {:error, {404, _body}} ->

--- a/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/openid_connect/settings/changeset.ex
@@ -30,7 +30,7 @@ defmodule Domain.Auth.Adapters.OpenIDConnect.Settings.Changeset do
         {:error, %Mint.TransportError{reason: reason}} ->
           [{:discovery_document_uri, "is invalid, got #{inspect(reason)}"}]
 
-        {:error, %JSON.DecodeError{} = _error} ->
+        {:error, %Jason.DecodeError{} = _error} ->
           [{:discovery_document_uri, "is invalid, unable to parse response"}]
 
         {:error, {404, _body}} ->

--- a/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
+++ b/elixir/apps/domain/lib/domain/billing/stripe/api_client.ex
@@ -177,13 +177,13 @@ defmodule Domain.Billing.Stripe.APIClient do
     |> Finch.request(@pool_name)
     |> case do
       {:ok, %Finch.Response{body: response, status: status}} when status in 200..299 ->
-        {:ok, Jason.decode!(response)}
+        {:ok, JSON.decode!(response)}
 
       {:ok, %Finch.Response{status: status}} when status in 500..599 ->
         {:error, :retry_later}
 
       {:ok, %Finch.Response{body: response, status: status}} ->
-        case Jason.decode(response) do
+        case JSON.decode(response) do
           {:ok, json_response} ->
             {:error, {status, json_response}}
 

--- a/elixir/apps/domain/lib/domain/component_versions.ex
+++ b/elixir/apps/domain/lib/domain/component_versions.ex
@@ -82,9 +82,9 @@ defmodule Domain.ComponentVersions do
   end
 
   defp decode_versions_response(response) do
-    case Jason.decode(response, keys: :atoms) do
-      {:ok, %{apple: _, android: _, gateway: _, gui: _, headless: _} = decoded_json} ->
-        decoded_json
+    case JSON.decode(response) do
+      {:ok, %{"apple" => apple, "android" => android, "gateway" => gateway, "gui" => gui, "headless" => headless}} ->
+        %{apple: apple, android: android, gateway: gateway, gui: gui, headless: headless}
 
       _ ->
         fetch_config!()

--- a/elixir/apps/domain/lib/domain/component_versions.ex
+++ b/elixir/apps/domain/lib/domain/component_versions.ex
@@ -83,7 +83,14 @@ defmodule Domain.ComponentVersions do
 
   defp decode_versions_response(response) do
     case JSON.decode(response) do
-      {:ok, %{"apple" => apple, "android" => android, "gateway" => gateway, "gui" => gui, "headless" => headless}} ->
+      {:ok,
+       %{
+         "apple" => apple,
+         "android" => android,
+         "gateway" => gateway,
+         "gui" => gui,
+         "headless" => headless
+       }} ->
         %{apple: apple, android: android, gateway: gateway, gui: gui, headless: headless}
 
       _ ->

--- a/elixir/apps/domain/lib/domain/config/caster.ex
+++ b/elixir/apps/domain/lib/domain/config/caster.ex
@@ -24,12 +24,12 @@ defmodule Domain.Config.Caster do
     end
   end
 
-  def cast(json, :embed) when is_binary(json), do: Jason.decode(json)
-  def cast(json, {:embed, _schema}) when is_binary(json), do: Jason.decode(json)
-  def cast(json, :map) when is_binary(json), do: Jason.decode(json)
-  def cast(json, {:map, _term}) when is_binary(json), do: Jason.decode(json)
-  def cast(json, :json_array) when is_binary(json), do: Jason.decode(json)
-  def cast(json, {:json_array, _term}) when is_binary(json), do: Jason.decode(json)
+  def cast(json, :embed) when is_binary(json), do: JSON.decode(json)
+  def cast(json, {:embed, _schema}) when is_binary(json), do: JSON.decode(json)
+  def cast(json, :map) when is_binary(json), do: JSON.decode(json)
+  def cast(json, {:map, _term}) when is_binary(json), do: JSON.decode(json)
+  def cast(json, :json_array) when is_binary(json), do: JSON.decode(json)
+  def cast(json, {:json_array, _term}) when is_binary(json), do: JSON.decode(json)
 
   def cast("true", :boolean), do: {:ok, true}
   def cast("false", :boolean), do: {:ok, false}

--- a/elixir/apps/domain/lib/domain/config/errors.ex
+++ b/elixir/apps/domain/lib/domain/config/errors.ex
@@ -57,9 +57,12 @@ defmodule Domain.Config.Errors do
     values_and_errors
     |> List.wrap()
     |> Enum.map_join("\n", fn {value, errors} ->
-      " - `#{format_value(sensitive?, value)}`: #{Enum.join(errors, ", ")}"
+      " - `#{format_value(sensitive?, value)}`: #{Enum.map_join(errors, ", ", &error_to_string/1)}"
     end)
   end
+
+  defp error_to_string(error) when is_binary(error), do: error
+  defp error_to_string(tuple) when is_tuple(tuple), do: inspect(tuple)
 
   defp format_value(true, _value), do: "**SENSITIVE-VALUE-REDACTED**"
   defp format_value(false, value), do: inspect(value)

--- a/elixir/apps/domain/lib/domain/config/fetcher.ex
+++ b/elixir/apps/domain/lib/domain/config/fetcher.ex
@@ -35,8 +35,8 @@ defmodule Domain.Config.Fetcher do
       {:ok, value} ->
         {:ok, value}
 
-      {:error, %Jason.DecodeError{} = decode_error} ->
-        reason = Jason.DecodeError.message(decode_error)
+      {:error, %JSON.DecodeError{} = decode_error} ->
+        reason = Exception.message(decode_error)
         {:error, {{value, [reason]}, module: module, key: key, source: source}}
 
       {:error, reason} ->

--- a/elixir/apps/domain/lib/domain/google_cloud_platform.ex
+++ b/elixir/apps/domain/lib/domain/google_cloud_platform.ex
@@ -45,7 +45,7 @@ defmodule Domain.GoogleCloudPlatform do
 
     case Finch.request(request, __MODULE__.Finch) do
       {:ok, %Finch.Response{status: 200, body: response}} ->
-        %{"access_token" => access_token, "expires_in" => expires_in} = Jason.decode!(response)
+        %{"access_token" => access_token, "expires_in" => expires_in} = JSON.decode!(response)
         access_token_expires_at = DateTime.utc_now() |> DateTime.add(expires_in - 1, :second)
         {:ok, access_token, access_token_expires_at}
 
@@ -123,7 +123,7 @@ defmodule Domain.GoogleCloudPlatform do
          request = Finch.build(:get, url, [{"Authorization", "Bearer #{access_token}"}]),
          {:ok, %Finch.Response{status: 200, body: response}} <-
            Finch.request(request, __MODULE__.Finch),
-         {:ok, %{"items" => items}} <- Jason.decode(response) do
+         {:ok, %{"items" => items}} <- JSON.decode(response) do
       instances =
         Enum.flat_map(items, fn
           {_zone, %{"instances" => instances}} ->
@@ -191,7 +191,7 @@ defmodule Domain.GoogleCloudPlatform do
       |> Keyword.fetch!(:cloud_metrics_endpoint_url)
       |> String.replace("${project_id}", project_id)
 
-    body = Jason.encode!(%{"timeSeries" => time_series})
+    body = JSON.encode!(%{"timeSeries" => time_series})
 
     with {:ok, access_token} <- fetch_and_cache_access_token(),
          request =

--- a/elixir/apps/domain/lib/domain/google_cloud_platform/url_signer.ex
+++ b/elixir/apps/domain/lib/domain/google_cloud_platform/url_signer.ex
@@ -60,12 +60,12 @@ defmodule Domain.GoogleCloudPlatform.URLSigner do
         :post,
         sign_endpoint_url,
         [{"Authorization", "Bearer #{oauth_access_token}"}],
-        Jason.encode!(%{"payload" => string_to_sign})
+        JSON.encode!(%{"payload" => string_to_sign})
       )
 
     with {:ok, %Finch.Response{status: 200, body: response}} <-
            Finch.request(request, Domain.GoogleCloudPlatform.Finch),
-         {:ok, %{"signedBlob" => signature}} <- Jason.decode(response) do
+         {:ok, %{"signedBlob" => signature}} <- JSON.decode(response) do
       signature =
         signature
         |> Base.decode64!()

--- a/elixir/apps/domain/lib/domain/replication/decoder.ex
+++ b/elixir/apps/domain/lib/domain/replication/decoder.ex
@@ -203,8 +203,8 @@ defmodule Domain.Replication.Decoder do
 
   # PostgreSQL double-encodes JSON in arrays, so we need to decode twice
   defp double_decode_json(json_str) do
-    with {:ok, first} <- Jason.decode(json_str),
-         {:ok, second} <- Jason.decode(first) do
+    with {:ok, first} <- JSON.decode(json_str),
+         {:ok, second} <- JSON.decode(first) do
       second
     else
       {:error, reason} ->

--- a/elixir/apps/domain/lib/domain/telemetry/healthz_plug.ex
+++ b/elixir/apps/domain/lib/domain/telemetry/healthz_plug.ex
@@ -13,7 +13,7 @@ defmodule Domain.Telemetry.HealthzPlug do
   def call(conn, _opts) do
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(200, Jason.encode!(%{status: :ok}))
+    |> send_resp(200, JSON.encode!(%{status: :ok}))
     |> halt()
   end
 end

--- a/elixir/apps/domain/lib/domain/types/protocols.ex
+++ b/elixir/apps/domain/lib/domain/types/protocols.ex
@@ -2,9 +2,9 @@ defimpl String.Chars, for: Postgrex.INET do
   def to_string(%Postgrex.INET{} = inet), do: Domain.Types.INET.to_string(inet)
 end
 
-defimpl Jason.Encoder, for: Postgrex.INET do
-  def encode(%Postgrex.INET{} = struct, opts) do
-    Jason.Encode.string("#{struct}", opts)
+defimpl JSON.Encoder, for: Postgrex.INET do
+  def encode(%Postgrex.INET{} = struct, _opts) do
+    "\"#{struct}\""
   end
 end
 

--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/api_client_test.exs
@@ -69,7 +69,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_users(api_token) ==
@@ -90,7 +90,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{})
+        JSON.encode!(%{})
       )
 
       assert list_users(api_token) == {:error, :invalid_response}
@@ -103,7 +103,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => "invalid data"})
+        JSON.encode!(%{"users" => "invalid data"})
       )
 
       assert list_users(api_token) == {:error, :invalid_response}
@@ -113,7 +113,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_users_list_endpoint(bypass, 200, "invalid json")
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} = list_users(api_token)
+      assert {:error, {:invalid_byte, _offset, _byte}} = list_users(api_token)
     end
   end
 
@@ -168,7 +168,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_organization_units(api_token) ==
@@ -189,7 +189,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{})
+        JSON.encode!(%{})
       )
 
       assert {:ok, organization_units} = list_organization_units(api_token)
@@ -203,7 +203,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"organizationUnits" => "invalid data"})
+        JSON.encode!(%{"organizationUnits" => "invalid data"})
       )
 
       assert list_organization_units(api_token) == {:error, :invalid_response}
@@ -214,7 +214,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(bypass, 200, "invalid json")
 
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} =
+      assert {:error, {:invalid_byte, _offset, _byte}} =
                list_organization_units(api_token)
     end
   end
@@ -272,7 +272,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_groups(api_token) ==
@@ -293,7 +293,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{})
+        JSON.encode!(%{})
       )
 
       assert list_groups(api_token) == {:error, :invalid_response}
@@ -306,7 +306,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => "invalid data"})
+        JSON.encode!(%{"groups" => "invalid data"})
       )
 
       assert list_groups(api_token) == {:error, :invalid_response}
@@ -316,7 +316,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(bypass, 200, "invalid json")
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} = list_groups(api_token)
+      assert {:error, {:invalid_byte, _offset, _byte}} = list_groups(api_token)
     end
   end
 
@@ -378,7 +378,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         bypass,
         group_id,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_group_members(api_token, group_id) ==
@@ -403,7 +403,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         bypass,
         group_id,
         200,
-        Jason.encode!(%{})
+        JSON.encode!(%{})
       )
 
       assert list_group_members(api_token, group_id) == {:ok, []}
@@ -418,7 +418,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         bypass,
         group_id,
         200,
-        Jason.encode!(%{"members" => "invalid data"})
+        JSON.encode!(%{"members" => "invalid data"})
       )
 
       assert list_group_members(api_token, group_id) == {:error, :invalid_response}
@@ -436,7 +436,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.APIClientTest do
         "invalid json"
       )
 
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} =
+      assert {:error, {:invalid_byte, _offset, _byte}} =
                list_group_members(api_token, group_id)
     end
   end

--- a/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/google_workspace/jobs/sync_directory_test.exs
@@ -40,19 +40,19 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => []})
+        JSON.encode!(%{"groups" => []})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"organizationUnits" => []})
+        JSON.encode!(%{"organizationUnits" => []})
       )
 
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => []})
+        JSON.encode!(%{"users" => []})
       )
 
       GoogleWorkspaceDirectory.mock_token_endpoint(bypass)
@@ -72,7 +72,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
         Plug.Conn.send_resp(
           conn,
           401,
-          Jason.encode!(%{
+          JSON.encode!(%{
             "error" => "unauthorized_client",
             "error_description" =>
               "Client is unauthorized to retrieve access tokens using this method, or client not authorized for any of the scopes requested."
@@ -100,19 +100,19 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => []})
+        JSON.encode!(%{"groups" => []})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"organizationUnits" => []})
+        JSON.encode!(%{"organizationUnits" => []})
       )
 
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => []})
+        JSON.encode!(%{"users" => []})
       )
 
       provider
@@ -281,19 +281,19 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => groups})
+        JSON.encode!(%{"groups" => groups})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"organizationUnits" => organization_units})
+        JSON.encode!(%{"organizationUnits" => organization_units})
       )
 
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => users})
+        JSON.encode!(%{"users" => users})
       )
 
       GoogleWorkspaceDirectory.mock_token_endpoint(bypass)
@@ -303,7 +303,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
           bypass,
           group["id"],
           200,
-          Jason.encode!(%{"members" => members})
+          JSON.encode!(%{"members" => members})
         )
       end)
 
@@ -398,19 +398,19 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => []})
+        JSON.encode!(%{"groups" => []})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"organizationUnits" => []})
+        JSON.encode!(%{"organizationUnits" => []})
       )
 
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => users})
+        JSON.encode!(%{"users" => users})
       )
 
       GoogleWorkspaceDirectory.mock_token_endpoint(bypass)
@@ -607,19 +607,19 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => groups})
+        JSON.encode!(%{"groups" => groups})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"organizationUnits" => organization_units})
+        JSON.encode!(%{"organizationUnits" => organization_units})
       )
 
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => users})
+        JSON.encode!(%{"users" => users})
       )
 
       GoogleWorkspaceDirectory.mock_token_endpoint(bypass)
@@ -628,14 +628,14 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
         bypass,
         "GROUP_ID1",
         200,
-        Jason.encode!(%{"members" => two_members})
+        JSON.encode!(%{"members" => two_members})
       )
 
       GoogleWorkspaceDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_ID2",
         200,
-        Jason.encode!(%{"members" => one_member})
+        JSON.encode!(%{"members" => one_member})
       )
 
       {:ok, pid} = Task.Supervisor.start_link()
@@ -731,19 +731,19 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => []})
+        JSON.encode!(%{"groups" => []})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"organizationUnits" => []})
+        JSON.encode!(%{"organizationUnits" => []})
       )
 
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => users})
+        JSON.encode!(%{"users" => users})
       )
 
       GoogleWorkspaceDirectory.mock_token_endpoint(bypass)
@@ -806,26 +806,26 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
       GoogleWorkspaceDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => groups})
+        JSON.encode!(%{"groups" => groups})
       )
 
       GoogleWorkspaceDirectory.mock_organization_units_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"organizationUnits" => []})
+        JSON.encode!(%{"organizationUnits" => []})
       )
 
       GoogleWorkspaceDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => []})
+        JSON.encode!(%{"users" => []})
       )
 
       GoogleWorkspaceDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_ID1",
         200,
-        Jason.encode!(%{"members" => []})
+        JSON.encode!(%{"members" => []})
       )
 
       GoogleWorkspaceDirectory.mock_token_endpoint(bypass)
@@ -894,7 +894,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
             "/admin/directory/v1/groups"
           ] do
         Bypass.stub(bypass, "GET", path, fn conn ->
-          Plug.Conn.send_resp(conn, 403, Jason.encode!(response))
+          Plug.Conn.send_resp(conn, 403, JSON.encode!(response))
         end)
       end
 
@@ -986,7 +986,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
             "/admin/directory/v1/groups"
           ] do
         Bypass.stub(bypass, "GET", path, fn conn ->
-          Plug.Conn.send_resp(conn, 401, Jason.encode!(response))
+          Plug.Conn.send_resp(conn, 401, JSON.encode!(response))
         end)
       end
 
@@ -1062,7 +1062,7 @@ defmodule Domain.Auth.Adapters.GoogleWorkspace.Jobs.SyncDirectoryTest do
             "/admin/directory/v1/groups"
           ] do
         Bypass.stub(bypass, "GET", path, fn conn ->
-          Plug.Conn.send_resp(conn, 403, Jason.encode!(response))
+          Plug.Conn.send_resp(conn, 403, JSON.encode!(response))
         end)
       end
 

--- a/elixir/apps/domain/test/domain/auth/adapters/jumpcloud/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/jumpcloud/jobs/sync_directory_test.exs
@@ -581,7 +581,7 @@ defmodule Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectoryTest do
         Bypass.stub(bypass, "GET", path, fn conn ->
           conn
           |> Plug.Conn.prepend_resp_headers([{"content-type", "application/json"}])
-          |> Plug.Conn.send_resp(401, Jason.encode!(response))
+          |> Plug.Conn.send_resp(401, JSON.encode!(response))
         end)
       end
 
@@ -607,7 +607,7 @@ defmodule Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectoryTest do
         Bypass.stub(bypass, "GET", path, fn conn ->
           conn
           |> Plug.Conn.prepend_resp_headers([{"content-type", "application/json"}])
-          |> Plug.Conn.send_resp(500, Jason.encode!(%{}))
+          |> Plug.Conn.send_resp(500, JSON.encode!(%{}))
         end)
       end
 
@@ -627,7 +627,7 @@ defmodule Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectoryTest do
         Bypass.stub(bypass, "GET", path, fn conn ->
           conn
           |> Plug.Conn.prepend_resp_headers([{"content-type", "application/json"}])
-          |> Plug.Conn.send_resp(500, Jason.encode!(%{}))
+          |> Plug.Conn.send_resp(500, JSON.encode!(%{}))
         end)
       end
 
@@ -658,7 +658,7 @@ defmodule Domain.Auth.Adapters.JumpCloud.Jobs.SyncDirectoryTest do
         Bypass.stub(bypass, "GET", path, fn conn ->
           conn
           |> Plug.Conn.prepend_resp_headers([{"content-type", "application/json"}])
-          |> Plug.Conn.send_resp(500, Jason.encode!(%{}))
+          |> Plug.Conn.send_resp(500, JSON.encode!(%{}))
         end)
       end
 

--- a/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/api_client_test.exs
@@ -76,7 +76,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       MicrosoftEntraDirectory.mock_users_list_endpoint(
         bypass,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_users(api_token) ==
@@ -97,7 +97,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       MicrosoftEntraDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{})
+        JSON.encode!(%{})
       )
 
       assert list_users(api_token) == {:error, :invalid_response}
@@ -110,7 +110,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       MicrosoftEntraDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"users" => "invalid data"})
+        JSON.encode!(%{"users" => "invalid data"})
       )
 
       assert list_users(api_token) == {:error, :invalid_response}
@@ -120,7 +120,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       api_token = Ecto.UUID.generate()
       bypass = Bypass.open()
       MicrosoftEntraDirectory.mock_users_list_endpoint(bypass, 200, "invalid json")
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} = list_users(api_token)
+      assert {:error, {:invalid_byte, _offset, _byte}} = list_users(api_token)
     end
   end
 
@@ -177,7 +177,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       MicrosoftEntraDirectory.mock_groups_list_endpoint(
         bypass,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_groups(api_token) ==
@@ -198,7 +198,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       MicrosoftEntraDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{})
+        JSON.encode!(%{})
       )
 
       assert list_groups(api_token) == {:error, :invalid_response}
@@ -211,7 +211,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       MicrosoftEntraDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"groups" => "invalid data"})
+        JSON.encode!(%{"groups" => "invalid data"})
       )
 
       assert list_groups(api_token) == {:error, :invalid_response}
@@ -222,7 +222,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
       bypass = Bypass.open()
       MicrosoftEntraDirectory.mock_groups_list_endpoint(bypass, 200, "invalid json")
 
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} =
+      assert {:error, {:invalid_byte, _offset, _byte}} =
                list_groups(api_token)
     end
   end
@@ -285,7 +285,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         bypass,
         group_id,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_group_members(api_token, group_id) ==
@@ -309,7 +309,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         bypass,
         group_id,
         200,
-        Jason.encode!(%{})
+        JSON.encode!(%{})
       )
 
       assert list_group_members(api_token, group_id) == {:error, :invalid_response}
@@ -324,7 +324,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         bypass,
         group_id,
         200,
-        Jason.encode!(%{"group_members" => "invalid data"})
+        JSON.encode!(%{"group_members" => "invalid data"})
       )
 
       assert list_group_members(api_token, group_id) == {:error, :invalid_response}
@@ -342,7 +342,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.APIClientTest do
         "invalid json"
       )
 
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} =
+      assert {:error, {:invalid_byte, _offset, _byte}} =
                list_group_members(api_token, group_id)
     end
   end

--- a/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/microsoft_entra/jobs/sync_directory_test.exs
@@ -81,13 +81,13 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
       MicrosoftEntraDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => groups})
+        JSON.encode!(%{"value" => groups})
       )
 
       MicrosoftEntraDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => users})
+        JSON.encode!(%{"value" => users})
       )
 
       Enum.each(groups, fn group ->
@@ -95,7 +95,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
           bypass,
           group["id"],
           200,
-          Jason.encode!(%{"value" => members})
+          JSON.encode!(%{"value" => members})
         )
       end)
 
@@ -184,13 +184,13 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
       MicrosoftEntraDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => []})
+        JSON.encode!(%{"value" => []})
       )
 
       MicrosoftEntraDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => users})
+        JSON.encode!(%{"value" => users})
       )
 
       {:ok, pid} = Task.Supervisor.start_link()
@@ -236,20 +236,20 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
       MicrosoftEntraDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => groups})
+        JSON.encode!(%{"value" => groups})
       )
 
       MicrosoftEntraDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_ALL_ID",
         200,
-        Jason.encode!(%{"value" => []})
+        JSON.encode!(%{"value" => []})
       )
 
       MicrosoftEntraDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => []})
+        JSON.encode!(%{"value" => []})
       )
 
       {:ok, pid} = Task.Supervisor.start_link()
@@ -304,13 +304,13 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
       MicrosoftEntraDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => []})
+        JSON.encode!(%{"value" => []})
       )
 
       MicrosoftEntraDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => users})
+        JSON.encode!(%{"value" => users})
       )
 
       {:ok, pid} = Task.Supervisor.start_link()
@@ -440,34 +440,34 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
       MicrosoftEntraDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => groups})
+        JSON.encode!(%{"value" => groups})
       )
 
       MicrosoftEntraDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"value" => users})
+        JSON.encode!(%{"value" => users})
       )
 
       MicrosoftEntraDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_ALL_ID",
         200,
-        Jason.encode!(%{"value" => two_members})
+        JSON.encode!(%{"value" => two_members})
       )
 
       MicrosoftEntraDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_ENGINEERING_ID",
         200,
-        Jason.encode!(%{"value" => one_member})
+        JSON.encode!(%{"value" => one_member})
       )
 
       MicrosoftEntraDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_FINANCE_ID",
         200,
-        Jason.encode!(%{"value" => []})
+        JSON.encode!(%{"value" => []})
       )
 
       {:ok, pid} = Task.Supervisor.start_link()
@@ -539,7 +539,7 @@ defmodule Domain.Auth.Adapters.MicrosoftEntra.Jobs.SyncDirectoryTest do
             "v1.0/groups"
           ] do
         Bypass.stub(bypass, "GET", path, fn conn ->
-          Plug.Conn.send_resp(conn, 401, Jason.encode!(response))
+          Plug.Conn.send_resp(conn, 401, JSON.encode!(response))
         end)
       end
 

--- a/elixir/apps/domain/test/domain/auth/adapters/okta/api_client_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/okta/api_client_test.exs
@@ -93,7 +93,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
       OktaDirectory.mock_users_list_endpoint(
         bypass,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_users(provider) ==
@@ -115,7 +115,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
       OktaDirectory.mock_users_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"invalid" => "format"})
+        JSON.encode!(%{"invalid" => "format"})
       )
 
       assert list_users(provider) == {:error, :invalid_response}
@@ -127,7 +127,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
     } do
       OktaDirectory.mock_users_list_endpoint(bypass, 200, "invalid json")
 
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} =
+      assert {:error, {:invalid_byte, _offset, _byte}} =
                list_users(provider)
     end
   end
@@ -185,7 +185,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
       OktaDirectory.mock_groups_list_endpoint(
         bypass,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_groups(provider) ==
@@ -207,7 +207,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
       OktaDirectory.mock_groups_list_endpoint(
         bypass,
         200,
-        Jason.encode!(%{"invalid" => "format"})
+        JSON.encode!(%{"invalid" => "format"})
       )
 
       assert list_groups(provider) == {:error, :invalid_response}
@@ -219,7 +219,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
     } do
       OktaDirectory.mock_groups_list_endpoint(bypass, 200, "invalid json")
 
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} =
+      assert {:error, {:invalid_byte, _offset, _byte}} =
                list_groups(provider)
     end
   end
@@ -281,7 +281,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
         bypass,
         group_id,
         400,
-        Jason.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
+        JSON.encode!(%{"error" => %{"code" => 400, "message" => "Bad Request"}})
       )
 
       assert list_group_members(provider, group_id) ==
@@ -307,7 +307,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
         bypass,
         group_id,
         200,
-        Jason.encode!(%{"invalid" => "data"})
+        JSON.encode!(%{"invalid" => "data"})
       )
 
       assert list_group_members(provider, group_id) == {:error, :invalid_response}
@@ -326,7 +326,7 @@ defmodule Domain.Auth.Adapters.Okta.APIClientTest do
         "invalid json"
       )
 
-      assert {:error, %Jason.DecodeError{data: "invalid json"}} =
+      assert {:error, {:invalid_byte, _offset, _byte}} =
                list_group_members(provider, group_id)
     end
   end

--- a/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/sync_directory_test.exs
+++ b/elixir/apps/domain/test/domain/auth/adapters/okta/jobs/sync_directory_test.exs
@@ -254,15 +254,15 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
         }
       ]
 
-      OktaDirectory.mock_groups_list_endpoint(bypass, 200, Jason.encode!(groups))
-      OktaDirectory.mock_users_list_endpoint(bypass, 200, Jason.encode!(users))
+      OktaDirectory.mock_groups_list_endpoint(bypass, 200, JSON.encode!(groups))
+      OktaDirectory.mock_users_list_endpoint(bypass, 200, JSON.encode!(users))
 
       Enum.each(groups, fn group ->
         OktaDirectory.mock_group_members_list_endpoint(
           bypass,
           group["id"],
           200,
-          Jason.encode!(members)
+          JSON.encode!(members)
         )
       end)
 
@@ -359,8 +359,8 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
           provider_identifier: "USER_JDOE_ID"
         )
 
-      OktaDirectory.mock_groups_list_endpoint(bypass, 200, Jason.encode!([]))
-      OktaDirectory.mock_users_list_endpoint(bypass, 200, Jason.encode!(users))
+      OktaDirectory.mock_groups_list_endpoint(bypass, 200, JSON.encode!([]))
+      OktaDirectory.mock_users_list_endpoint(bypass, 200, JSON.encode!(users))
 
       {:ok, pid} = Task.Supervisor.start_link()
       assert execute(%{task_supervisor: pid}) == :ok
@@ -681,28 +681,28 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
       deleted_membership = Fixtures.Actors.create_membership(account: account, group: group)
       Fixtures.Actors.create_membership(account: account, actor: actor, group: deleted_group)
 
-      OktaDirectory.mock_groups_list_endpoint(bypass, 200, Jason.encode!(groups))
-      OktaDirectory.mock_users_list_endpoint(bypass, 200, Jason.encode!(users))
+      OktaDirectory.mock_groups_list_endpoint(bypass, 200, JSON.encode!(groups))
+      OktaDirectory.mock_users_list_endpoint(bypass, 200, JSON.encode!(users))
 
       OktaDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_ENGINEERING_ID",
         200,
-        Jason.encode!(two_members)
+        JSON.encode!(two_members)
       )
 
       OktaDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_DEVOPS_ID",
         200,
-        Jason.encode!(one_member)
+        JSON.encode!(one_member)
       )
 
       OktaDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_FINANCE_ID",
         200,
-        Jason.encode!([])
+        JSON.encode!([])
       )
 
       {:ok, pid} = Task.Supervisor.start_link()
@@ -798,8 +798,8 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
         }
       ]
 
-      OktaDirectory.mock_groups_list_endpoint(bypass, 200, Jason.encode!([]))
-      OktaDirectory.mock_users_list_endpoint(bypass, 200, Jason.encode!(users))
+      OktaDirectory.mock_groups_list_endpoint(bypass, 200, JSON.encode!([]))
+      OktaDirectory.mock_users_list_endpoint(bypass, 200, JSON.encode!(users))
 
       {:ok, pid} = Task.Supervisor.start_link()
       assert execute(%{task_supervisor: pid}) == :ok
@@ -872,14 +872,14 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
         }
       ]
 
-      OktaDirectory.mock_users_list_endpoint(bypass, 200, Jason.encode!([]))
-      OktaDirectory.mock_groups_list_endpoint(bypass, 200, Jason.encode!(groups))
+      OktaDirectory.mock_users_list_endpoint(bypass, 200, JSON.encode!([]))
+      OktaDirectory.mock_groups_list_endpoint(bypass, 200, JSON.encode!(groups))
 
       OktaDirectory.mock_group_members_list_endpoint(
         bypass,
         "GROUP_DEVOPS_ID",
         200,
-        Jason.encode!([])
+        JSON.encode!([])
       )
 
       {:ok, pid} = Task.Supervisor.start_link()
@@ -909,7 +909,7 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
             "api/v1/groups"
           ] do
         Bypass.stub(bypass, "GET", path, fn conn ->
-          Plug.Conn.send_resp(conn, 401, Jason.encode!(response))
+          Plug.Conn.send_resp(conn, 401, JSON.encode!(response))
         end)
       end
 
@@ -962,7 +962,7 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectoryTest do
             "api/v1/groups"
           ] do
         Bypass.stub(bypass, "GET", path, fn conn ->
-          Plug.Conn.send_resp(conn, 401, Jason.encode!(response))
+          Plug.Conn.send_resp(conn, 401, JSON.encode!(response))
         end)
       end
 

--- a/elixir/apps/domain/test/domain/config/caster_test.exs
+++ b/elixir/apps/domain/test/domain/config/caster_test.exs
@@ -49,11 +49,8 @@ defmodule Domain.Config.CasterTest do
     end
 
     test "raises when JSON is not valid" do
-      assert cast("invalid json", :embed) ==
-               {:error, %Jason.DecodeError{position: 0, token: nil, data: "invalid json"}}
-
-      assert cast("invalid json", {:json_array, :embed}) ==
-               {:error, %Jason.DecodeError{position: 0, token: nil, data: "invalid json"}}
+      assert {:error, {:invalid_byte, _offset, _byte}} = cast("invalid json", :embed)
+      assert {:error, {:invalid_byte, _offset, _byte}} = cast("invalid json", {:json_array, :embed})
     end
   end
 end

--- a/elixir/apps/domain/test/domain/config/caster_test.exs
+++ b/elixir/apps/domain/test/domain/config/caster_test.exs
@@ -50,7 +50,9 @@ defmodule Domain.Config.CasterTest do
 
     test "raises when JSON is not valid" do
       assert {:error, {:invalid_byte, _offset, _byte}} = cast("invalid json", :embed)
-      assert {:error, {:invalid_byte, _offset, _byte}} = cast("invalid json", {:json_array, :embed})
+
+      assert {:error, {:invalid_byte, _offset, _byte}} =
+               cast("invalid json", {:json_array, :embed})
     end
   end
 end

--- a/elixir/apps/domain/test/domain/config/fetcher_test.exs
+++ b/elixir/apps/domain/test/domain/config/fetcher_test.exs
@@ -105,12 +105,12 @@ defmodule Domain.Config.FetcherTest do
       assert fetch_source_and_config(Test, :array, %{"ARRAY" => "0,1,2"}) ==
                {:ok, {:env, "ARRAY"}, [0, 1, 2]}
 
-      json = Jason.encode!(%{foo: :bar})
+      json = JSON.encode!(%{foo: :bar})
 
       assert fetch_source_and_config(Test, :json, %{"JSON" => json}) ==
                {:ok, {:env, "JSON"}, foo: "bar"}
 
-      json = Jason.encode!([%{foo: :bar}])
+      json = JSON.encode!([%{foo: :bar}])
 
       assert fetch_source_and_config(Test, :json_array, %{"JSON_ARRAY" => json}) ==
                {:ok, {:env, "JSON_ARRAY"}, [%{"foo" => "bar"}]}
@@ -123,17 +123,15 @@ defmodule Domain.Config.FetcherTest do
     end
 
     test "applies dump function" do
-      json = Jason.encode!(%{foo: :bar})
+      json = JSON.encode!(%{foo: :bar})
 
       assert fetch_source_and_config(Test, :json, %{"JSON" => json}) ==
                {:ok, {:env, "JSON"}, foo: "bar"}
     end
 
     test "does not apply dump function on invalid values" do
-      assert fetch_source_and_config(Test, :json, %{"JSON" => "foo"}) ==
-               {:error,
-                {{"foo", ["unexpected byte at position 0: 0x66 (\"f\")"]},
-                 [module: __MODULE__.Test, key: :json, source: {:env, "JSON"}]}}
+      assert {:error, {{"foo", [unexpected_end: 3]}, _meta}} =
+               fetch_source_and_config(Test, :json, %{"JSON" => "foo"})
     end
 
     test "returns error when type can't be casted" do
@@ -156,12 +154,12 @@ defmodule Domain.Config.FetcherTest do
                    source: {:env, "INTEGER"}
                  ]}}
 
-      json = Jason.encode!(%{foo: :bar})
+      json = JSON.encode!(%{foo: :bar})
 
       assert fetch_source_and_config(Test, :json, %{"JSON" => json}) ==
                {:ok, {:env, "JSON"}, foo: "bar"}
 
-      json = Jason.encode!([%{foo: :bar}])
+      json = JSON.encode!([%{foo: :bar}])
 
       assert fetch_source_and_config(Test, :json_array, %{"JSON_ARRAY" => json}) ==
                {:ok, {:env, "JSON_ARRAY"}, [%{"foo" => "bar"}]}

--- a/elixir/apps/domain/test/domain/config_test.exs
+++ b/elixir/apps/domain/test/domain/config_test.exs
@@ -283,7 +283,7 @@ defmodule Domain.ConfigTest do
 
       Errors:
 
-       - `**SENSITIVE-VALUE-REDACTED**`: unexpected byte at position 0: 0x66 ("f")\
+       - `**SENSITIVE-VALUE-REDACTED**`: {:unexpected_end, 3}\
       """
 
       assert_raise RuntimeError, message, fn ->

--- a/elixir/apps/domain/test/support/mocks/firezone_website.ex
+++ b/elixir/apps/domain/test/support/mocks/firezone_website.ex
@@ -6,7 +6,7 @@ defmodule Domain.Mocks.FirezoneWebsite do
     Bypass.stub(bypass, "GET", versions_path, fn conn ->
       conn = Plug.Conn.fetch_query_params(conn)
       send(test_pid, {:bypass_request, conn})
-      Plug.Conn.send_resp(conn, 200, Jason.encode!(versions))
+      Plug.Conn.send_resp(conn, 200, JSON.encode!(versions))
     end)
   end
 end

--- a/elixir/apps/domain/test/support/mocks/google_cloud_platform.ex
+++ b/elixir/apps/domain/test/support/mocks/google_cloud_platform.ex
@@ -53,7 +53,7 @@ defmodule Domain.Mocks.GoogleCloudPlatform do
     Bypass.stub(bypass, "GET", token_endpoint_path, fn conn ->
       conn = Plug.Conn.fetch_query_params(conn)
       send(test_pid, {:bypass_request, conn})
-      Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+      Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
     end)
 
     override_endpoint_url(:metadata_endpoint_url, "http://localhost:#{bypass.port}/")
@@ -70,7 +70,7 @@ defmodule Domain.Mocks.GoogleCloudPlatform do
       conn = Plug.Conn.fetch_query_params(conn)
       send(test_pid, {:bypass_request, conn})
       {:ok, binary, conn} = Plug.Conn.read_body(conn)
-      %{"payload" => payload} = Jason.decode!(binary)
+      %{"payload" => payload} = JSON.decode!(binary)
 
       resp =
         resp ||
@@ -79,7 +79,7 @@ defmodule Domain.Mocks.GoogleCloudPlatform do
             "signedBlob" => Domain.Crypto.hash(:md5, service_account_email <> payload)
           }
 
-      Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+      Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
     end)
 
     override_endpoint_url(
@@ -199,7 +199,7 @@ defmodule Domain.Mocks.GoogleCloudPlatform do
     Bypass.expect(bypass, "GET", aggregated_instances_endpoint_path, fn conn ->
       conn = Plug.Conn.fetch_query_params(conn)
       send(test_pid, {:bypass_request, conn})
-      Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+      Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
     end)
 
     override_endpoint_url(
@@ -218,9 +218,9 @@ defmodule Domain.Mocks.GoogleCloudPlatform do
     Bypass.expect(bypass, "POST", metrics_endpoint_path, fn conn ->
       conn = Plug.Conn.fetch_query_params(conn)
       {:ok, binary, conn} = Plug.Conn.read_body(conn)
-      body = Jason.decode!(binary)
+      body = JSON.decode!(binary)
       send(test_pid, {:bypass_request, conn, body})
-      Plug.Conn.send_resp(conn, 200, Jason.encode!(%{}))
+      Plug.Conn.send_resp(conn, 200, JSON.encode!(%{}))
     end)
 
     override_endpoint_url(

--- a/elixir/apps/domain/test/support/mocks/google_workspace_directory.ex
+++ b/elixir/apps/domain/test/support/mocks/google_workspace_directory.ex
@@ -27,7 +27,7 @@ defmodule Domain.Mocks.GoogleWorkspaceDirectory do
     Bypass.stub(bypass, "POST", token_endpoint_path, fn conn ->
       conn = Plug.Conn.fetch_query_params(conn)
       send(test_pid, {:bypass_request, conn})
-      Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+      Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
     end)
 
     override_token_endpoint("http://localhost:#{bypass.port}/")
@@ -40,7 +40,7 @@ defmodule Domain.Mocks.GoogleWorkspaceDirectory do
 
     resp =
       resp ||
-        Jason.encode!(%{
+        JSON.encode!(%{
           "kind" => "admin#directory#users",
           "users" => [
             %{
@@ -231,7 +231,7 @@ defmodule Domain.Mocks.GoogleWorkspaceDirectory do
 
     resp =
       resp ||
-        Jason.encode!(%{
+        JSON.encode!(%{
           "kind" => "admin#directory#org_units",
           "etag" => "\"FwDC5ZsOozt9qI9yuJfiMqwYO1K-EEG4flsXSov57CY/Y3F7O3B5N0h0C_3Pd3OMifRNUVc\"",
           "organizationUnits" => [
@@ -267,7 +267,7 @@ defmodule Domain.Mocks.GoogleWorkspaceDirectory do
 
     resp =
       resp ||
-        Jason.encode!(%{
+        JSON.encode!(%{
           "kind" => "admin#directory#groups",
           "etag" => "\"FwDC5ZsOozt9qI9yuJfiMqwYO1K-EEG4flsXSov57CY/Y3F7O3B5N0h0C_3Pd3OMifRNUVc\"",
           "groups" => [
@@ -334,7 +334,7 @@ defmodule Domain.Mocks.GoogleWorkspaceDirectory do
 
     resp =
       resp ||
-        Jason.encode!(%{
+        JSON.encode!(%{
           "kind" => "admin#directory#members",
           "etag" => "\"XXX\"",
           "members" => [

--- a/elixir/apps/domain/test/support/mocks/microsoft_entra_directory.ex
+++ b/elixir/apps/domain/test/support/mocks/microsoft_entra_directory.ex
@@ -12,7 +12,7 @@ defmodule Domain.Mocks.MicrosoftEntraDirectory do
 
     resp =
       resp ||
-        Jason.encode!(%{
+        JSON.encode!(%{
           "@odata.context" =>
             "https://graph.microsoft.com/v1.0/$metadata#users(id,displayName,userPrincipalName,mail,accountEnabled)",
           "value" => [
@@ -64,7 +64,7 @@ defmodule Domain.Mocks.MicrosoftEntraDirectory do
 
     resp =
       resp ||
-        Jason.encode!(%{
+        JSON.encode!(%{
           "@odata.context" => "https://graph.microsoft.com/v1.0/$metadata#groups(id,displayName)",
           "value" => [
             %{
@@ -123,7 +123,7 @@ defmodule Domain.Mocks.MicrosoftEntraDirectory do
 
     resp =
       resp ||
-        Jason.encode!(%{
+        JSON.encode!(%{
           "@odata.context" =>
             "https://graph.microsoft.com/v1.0/$metadata#users(id,displayName,userPrincipalName,accountEnabled)",
           "value" => memberships

--- a/elixir/apps/domain/test/support/mocks/okta_directory.ex
+++ b/elixir/apps/domain/test/support/mocks/okta_directory.ex
@@ -8,7 +8,7 @@ defmodule Domain.Mocks.OktaDirectory do
 
     resp =
       resp ||
-        Jason.encode!([
+        JSON.encode!([
           %{
             "id" => "OT6AZkcmzkDXwkXcjTHY",
             "status" => "ACTIVE",
@@ -76,7 +76,7 @@ defmodule Domain.Mocks.OktaDirectory do
 
     resp =
       resp ||
-        Jason.encode!([
+        JSON.encode!([
           %{
             "id" => "00gezqhvv4IFj2Avg5d7",
             "created" => "2024-02-07T04:32:03.000Z",
@@ -233,7 +233,7 @@ defmodule Domain.Mocks.OktaDirectory do
 
     resp =
       resp ||
-        Jason.encode!([
+        JSON.encode!([
           %{
             "id" => "00ue1rr3zgV1DjyfL5d7",
             "status" => "ACTIVE",

--- a/elixir/apps/domain/test/support/mocks/openid_connect.ex
+++ b/elixir/apps/domain/test/support/mocks/openid_connect.ex
@@ -6,7 +6,7 @@ defmodule Domain.Mocks.OpenIDConnect do
 
     Bypass.stub(bypass, "GET", "/.well-known/jwks.json", fn conn ->
       attrs = %{"keys" => [jwks()]}
-      Plug.Conn.resp(conn, 200, Jason.encode!(attrs))
+      Plug.Conn.resp(conn, 200, JSON.encode!(attrs))
     end)
 
     Bypass.stub(bypass, "GET", "/.well-known/openid-configuration", fn conn ->
@@ -91,7 +91,7 @@ defmodule Domain.Mocks.OpenIDConnect do
         "request_parameter_supported" => false
       }
 
-      Plug.Conn.resp(conn, 200, Jason.encode!(attrs))
+      Plug.Conn.resp(conn, 200, JSON.encode!(attrs))
     end)
 
     bypass
@@ -103,7 +103,7 @@ defmodule Domain.Mocks.OpenIDConnect do
     Bypass.expect(bypass, "POST", "/oauth/token", fn conn ->
       conn = fetch_conn_params(conn)
       send(test_pid, {:request, conn})
-      Plug.Conn.resp(conn, 200, Jason.encode!(attrs))
+      Plug.Conn.resp(conn, 200, JSON.encode!(attrs))
     end)
 
     bypass
@@ -115,7 +115,7 @@ defmodule Domain.Mocks.OpenIDConnect do
     Bypass.expect(bypass, "POST", "/oauth/token", fn conn ->
       conn = fetch_conn_params(conn)
       send(test_pid, {:request, conn})
-      Plug.Conn.resp(conn, 401, Jason.encode!(attrs))
+      Plug.Conn.resp(conn, 401, JSON.encode!(attrs))
     end)
 
     bypass
@@ -143,7 +143,7 @@ defmodule Domain.Mocks.OpenIDConnect do
 
       conn = fetch_conn_params(conn)
       send(test_pid, {:request, conn})
-      Plug.Conn.resp(conn, 200, Jason.encode!(attrs))
+      Plug.Conn.resp(conn, 200, JSON.encode!(attrs))
     end)
 
     bypass
@@ -171,7 +171,7 @@ defmodule Domain.Mocks.OpenIDConnect do
     {_alg, token} =
       jwk
       |> JOSE.JWK.from()
-      |> JOSE.JWS.sign(Jason.encode!(claims), %{"alg" => "RS256"})
+      |> JOSE.JWS.sign(JSON.encode!(claims), %{"alg" => "RS256"})
       |> JOSE.JWS.compact()
 
     token
@@ -200,7 +200,7 @@ defmodule Domain.Mocks.OpenIDConnect do
   end
 
   defp fetch_conn_params(conn) do
-    opts = Plug.Parsers.init(parsers: [:urlencoded, :json], pass: ["*/*"], json_decoder: Jason)
+    opts = Plug.Parsers.init(parsers: [:urlencoded, :json], pass: ["*/*"], json_decoder: JSON)
 
     conn
     |> Plug.Conn.fetch_query_params()

--- a/elixir/apps/domain/test/support/mocks/stripe.ex
+++ b/elixir/apps/domain/test/support/mocks/stripe.ex
@@ -37,7 +37,7 @@ defmodule Domain.Mocks.Stripe do
               resp
             )
 
-          Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+          Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
       end
     end)
 
@@ -70,7 +70,7 @@ defmodule Domain.Mocks.Stripe do
           conn = Plug.Conn.fetch_query_params(conn)
           conn = fetch_request_params(conn)
           send(test_pid, {:bypass_request, conn})
-          Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+          Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
       end
     end)
 
@@ -102,7 +102,7 @@ defmodule Domain.Mocks.Stripe do
         :ok ->
           conn = Plug.Conn.fetch_query_params(conn)
           send(test_pid, {:bypass_request, conn})
-          Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+          Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
       end
     end)
 
@@ -125,7 +125,7 @@ defmodule Domain.Mocks.Stripe do
         :ok ->
           conn = Plug.Conn.fetch_query_params(conn)
           send(test_pid, {:bypass_request, conn})
-          Plug.Conn.send_resp(conn, 200, Jason.encode!(customer))
+          Plug.Conn.send_resp(conn, 200, JSON.encode!(customer))
       end
     end)
 
@@ -148,7 +148,7 @@ defmodule Domain.Mocks.Stripe do
         :ok ->
           conn = Plug.Conn.fetch_query_params(conn)
           send(test_pid, {:bypass_request, conn})
-          Plug.Conn.send_resp(conn, 200, Jason.encode!(product))
+          Plug.Conn.send_resp(conn, 200, JSON.encode!(product))
       end
     end)
 
@@ -207,7 +207,7 @@ defmodule Domain.Mocks.Stripe do
         :ok ->
           conn = Plug.Conn.fetch_query_params(conn)
           send(test_pid, {:bypass_request, conn})
-          Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+          Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
       end
     end)
 
@@ -251,7 +251,7 @@ defmodule Domain.Mocks.Stripe do
           conn = Plug.Conn.fetch_query_params(conn)
           conn = fetch_request_params(conn)
           send(test_pid, {:bypass_request, conn})
-          Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+          Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
       end
     end)
 
@@ -282,7 +282,7 @@ defmodule Domain.Mocks.Stripe do
           conn = Plug.Conn.fetch_query_params(conn)
           conn = fetch_request_params(conn)
           send(test_pid, {:bypass_request, conn})
-          Plug.Conn.send_resp(conn, 200, Jason.encode!(resp))
+          Plug.Conn.send_resp(conn, 200, JSON.encode!(resp))
       end
     end)
 
@@ -442,7 +442,7 @@ defmodule Domain.Mocks.Stripe do
     }
 
     conn
-    |> Plug.Conn.send_resp(429, Jason.encode!(error_response))
+    |> Plug.Conn.send_resp(429, JSON.encode!(error_response))
   end
 
   def customer_object(id, name, email \\ nil, metadata \\ %{}) do

--- a/elixir/apps/domain/test/support/mocks/workos_directory.ex
+++ b/elixir/apps/domain/test/support/mocks/workos_directory.ex
@@ -79,7 +79,7 @@ defmodule Domain.Mocks.WorkOSDirectory do
 
       conn
       |> Plug.Conn.prepend_resp_headers([{"content-type", "application/json"}])
-      |> Plug.Conn.send_resp(200, Jason.encode!(resp))
+      |> Plug.Conn.send_resp(200, JSON.encode!(resp))
     end)
 
     bypass
@@ -105,7 +105,7 @@ defmodule Domain.Mocks.WorkOSDirectory do
 
       conn
       |> Plug.Conn.prepend_resp_headers([{"content-type", "application/json"}])
-      |> Plug.Conn.send_resp(200, Jason.encode!(resp))
+      |> Plug.Conn.send_resp(200, JSON.encode!(resp))
     end)
 
     bypass
@@ -131,7 +131,7 @@ defmodule Domain.Mocks.WorkOSDirectory do
 
       conn
       |> Plug.Conn.prepend_resp_headers([{"content-type", "application/json"}])
-      |> Plug.Conn.send_resp(200, Jason.encode!(resp))
+      |> Plug.Conn.send_resp(200, JSON.encode!(resp))
     end)
 
     bypass

--- a/elixir/apps/web/lib/web/controllers/health_controller.ex
+++ b/elixir/apps/web/lib/web/controllers/health_controller.ex
@@ -4,6 +4,6 @@ defmodule Web.HealthController do
   def healthz(conn, _params) do
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(200, Jason.encode!(%{status: "ok"}))
+    |> send_resp(200, JSON.encode!(%{status: "ok"}))
   end
 end

--- a/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/components.ex
+++ b/elixir/apps/web/lib/web/live/settings/identity_providers/google_workspace/components.ex
@@ -7,7 +7,7 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Components do
     |> Map.put("adapter", :google_workspace)
     |> Map.update("adapter_config", %{}, fn adapter_config ->
       Map.update(adapter_config, "service_account_json_key", nil, fn service_account_json_key ->
-        case Jason.decode(service_account_json_key) do
+        case JSON.decode(service_account_json_key) do
           {:ok, map} -> map
           {:error, _} -> service_account_json_key
         end
@@ -303,12 +303,12 @@ defmodule Web.Settings.IdentityProviders.GoogleWorkspace.Components do
                           changeset
                           |> Ecto.Changeset.apply_changes()
                           |> Map.from_struct()
-                          |> Jason.encode!()
+                          |> JSON.encode!()
 
                         %GoogleWorkspace.Settings.GoogleServiceAccountKey{} = struct ->
                           struct
                           |> Map.from_struct()
-                          |> Jason.encode!()
+                          |> JSON.encode!()
 
                         binary when is_binary(binary) ->
                           binary

--- a/elixir/apps/web/mix.exs
+++ b/elixir/apps/web/mix.exs
@@ -70,7 +70,6 @@ defmodule Web.MixProject do
       {:logger_json, "~> 7.0"},
 
       # Other deps
-      {:jason, "~> 1.2"},
       {:nimble_csv, "~> 1.2"},
 
       # Test deps

--- a/elixir/apps/web/test/support/acceptance_case/vault.ex
+++ b/elixir/apps/web/test/support/acceptance_case/vault.ex
@@ -119,7 +119,7 @@ defmodule Web.AcceptanceCase.Vault do
     body =
       cond do
         is_map(params_or_body) ->
-          Jason.encode!(params_or_body)
+          JSON.encode!(params_or_body)
 
         is_binary(params_or_body) ->
           params_or_body
@@ -134,7 +134,7 @@ defmodule Web.AcceptanceCase.Vault do
         :ok
 
       {:ok, status, _headers, body} ->
-        {:ok, {status, Jason.decode!(body)}}
+        {:ok, {status, JSON.decode!(body)}}
 
       {:error, reason} ->
         {:error, reason}

--- a/elixir/apps/web/test/web/acceptance/auth/email_test.exs
+++ b/elixir/apps/web/test/web/acceptance/auth/email_test.exs
@@ -144,7 +144,7 @@ defmodule Web.Acceptance.SignIn.EmailTest do
       |> Finch.request(TestPool)
 
     text_body =
-      Jason.decode!(body)
+      JSON.decode!(body)
       |> Map.fetch!("data")
       |> Enum.find(&(&1["subject"] == "Firezone sign in token" and email in &1["to"]))
       |> Map.fetch!("text_body")

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/edit_test.exs
@@ -72,7 +72,7 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.EditTest do
         discovery_document_uri:
           "http://localhost:#{bypass.port}/.well-known/openid-configuration",
         service_account_json_key:
-          Jason.encode!(%{
+          JSON.encode!(%{
             "type" => "service_account",
             "project_id" => "firezone-test",
             "private_key_id" => "e1fc5c12b490aaa1602f3de9133551952b749db3",

--- a/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
+++ b/elixir/apps/web/test/web/live/settings/identity_providers/google_workspace/new_test.exs
@@ -63,7 +63,7 @@ defmodule Web.Live.Settings.IdentityProviders.GoogleWorkspace.NewTest do
         discovery_document_uri:
           "http://localhost:#{bypass.port}/.well-known/openid-configuration",
         service_account_json_key:
-          Jason.encode!(%{
+          JSON.encode!(%{
             "type" => "service_account",
             "project_id" => "firezone-test",
             "private_key_id" => "e1fc5c12b490aaa1602f3de9133551952b749db3",

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -317,8 +317,7 @@ config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
   metadata: :all
 
-# Use Jason for JSON parsing in Phoenix
-config :phoenix, :json_library, Jason
+config :phoenix, :json_library, JSON
 
 config :swoosh, :api_client, Swoosh.ApiClient.Finch
 

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -36,7 +36,6 @@ defmodule Firezone.MixProject do
   defp deps do
     [
       # Shared deps
-      {:jason, "~> 1.2"},
       {:sentry, "~> 11.0"},
       {:hackney, "~> 1.19"},
       {:logger_json, "~> 7.0"},


### PR DESCRIPTION
Since Elixir 1.18, json encoding and decoding support is included in the standard library. This is built on OTP's native json support which is often faster than other implementations.

It mostly has the same API as the popular Jason library, differing mainly in the format of the error responses returned when decoding fails.

To minimize dependence on external libraries, we remove the Jason lib in favor of this external dependency.

Fixes #8011 