### PR TITLE
feat: allow setting Internet Resource from headless client

### DIFF
--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -109,7 +109,7 @@ struct Cli {
         env = "FIREZONE_INTERNET_RESOURCE_ACTIVE",
         default_value_t = false
     )]
-    internet_resource_active: bool,
+    activate_internet_resource: bool,
 
     /// Disable sentry.io crash-reporting agent.
     #[arg(long, env = "FIREZONE_NO_TELEMETRY", default_value_t = false)]
@@ -351,7 +351,7 @@ fn try_main() -> Result<()> {
             Arc::new(tcp_socket_factory),
             Arc::new(UdpSocketFactory::default()),
             portal,
-            cli.internet_resource_active,
+            cli.activate_internet_resource,
             rt.handle().clone(),
         );
 

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -106,7 +106,7 @@ struct Cli {
     /// To actually use the Internet Resource, the user must also have a policy granting access to the Internet Resource.
     #[arg(
         long,
-        env = "FIREZONE_INTERNET_RESOURCE_ACTIVE",
+        env = "FIREZONE_ACTIVATE_INTERNET_RESOURCE",
         default_value_t = false
     )]
     activate_internet_resource: bool,

--- a/rust/headless-client/src/main.rs
+++ b/rust/headless-client/src/main.rs
@@ -101,6 +101,16 @@ struct Cli {
     #[arg(short = 'i', long, env = "FIREZONE_ID")]
     firezone_id: Option<String>,
 
+    /// Activate the Internet Resource.
+    ///
+    /// To actually use the Internet Resource, the user must also have a policy granting access to the Internet Resource.
+    #[arg(
+        long,
+        env = "FIREZONE_INTERNET_RESOURCE_ACTIVE",
+        default_value_t = false
+    )]
+    internet_resource_active: bool,
+
     /// Disable sentry.io crash-reporting agent.
     #[arg(long, env = "FIREZONE_NO_TELEMETRY", default_value_t = false)]
     no_telemetry: bool,
@@ -341,7 +351,7 @@ fn try_main() -> Result<()> {
             Arc::new(tcp_socket_factory),
             Arc::new(UdpSocketFactory::default()),
             portal,
-            false,
+            cli.internet_resource_active,
             rt.handle().clone(),
         );
 

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -13,6 +13,10 @@ export default function Headless({ os }: { os: OS }) {
         <ChangeItem pull="10533">
           Improves reliability by caching DNS responses as per their TTL.
         </ChangeItem>
+        <ChangeItem pull="10553">
+          Adds a CLI switch `--activate-internet-resource`. By default, the
+          Internet Resource is now off.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.3" date={new Date("2025-09-10")}>
         <ChangeItem pull="10126">


### PR DESCRIPTION
Currently, the Internet Resource cannot be toggled on/off in the headless client. With #10509, the default state of the Internet Resource is now disabled, meaning users of the headless client are no longer able to use the Internet Resource.

We fix this by introducing a new CLI argument `--activate-internet-resource` that can also be set via the env variable `FIREZONE_ACTIVATE_INTERNET_RESOURCE=true`.

Resolves: #8342