### PR TITLE
fix(apple): Ensure fetching resource state if already connected

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -107,7 +107,11 @@ public final class Store: ObservableObject {
       try await self?.handleVPNStatusChange(newVPNStatus: status)
     }
     try ipcClient().subscribeToVPNStatusUpdates(handler: vpnStatusChangeHandler)
-    self.vpnStatus = try ipcClient().sessionStatus()
+
+    let initialStatus = try ipcClient().sessionStatus()
+
+    // Handle initial status to ensure resources start loading if already connected
+    try await handleVPNStatusChange(newVPNStatus: initialStatus)
   }
 
   private func handleVPNStatusChange(newVPNStatus: NEVPNStatus) async throws {

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -32,6 +32,10 @@ export default function Apple() {
         <ChangeItem pull="10533">
           Improves reliability by caching DNS responses as per their TTL.
         </ChangeItem>
+        <ChangeItem pull="10567">
+          Fixes an issue where the Resources menu would not populate when
+          launching the app while already connected.
+        </ChangeItem>
       </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-09-10")}>
         <ChangeItem pull="10313">


### PR DESCRIPTION
Fixes an issue where the Resources menu would not populate when launching
the app while already connected by ensuring the initial VPN status
triggers the resource loading handler.


Fixes #9837