### PR TITLE
chore(rust): ban `keys` and `values` from `HashMap`

### DIFF
--- a/rust/clippy.toml
+++ b/rust/clippy.toml
@@ -1,6 +1,8 @@
 avoid-breaking-exported-api = false # We don't publish anything to crates.io, hence we don't need to worry about breaking Rust API changes.
 disallowed-methods = [
   { path = "std::collections::HashMap::iter", reason = "HashMap has non-deterministic iteration order, use BTreeMap instead" },
+  { path = "std::collections::HashMap::keys", reason = "HashMap has non-deterministic iteration order, use BTreeMap instead" },
+  { path = "std::collections::HashMap::values", reason = "HashMap has non-deterministic iteration order, use BTreeMap instead" },
   { path = "std::collections::HashSet::iter", reason = "HashSet has non-deterministic iteration order, use BTreeSet instead" },
   { path = "std::collections::HashMap::iter_mut", reason = "HashMap has non-deterministic iteration order, use BTreeMap instead" },
   { path = "tracing::subscriber::set_global_default", reason = "Does not init `LogTracer`, use `firezone_logging::init` instead." },

--- a/rust/connlib/dns-over-tcp/src/client.rs
+++ b/rust/connlib/dns-over-tcp/src/client.rs
@@ -29,7 +29,7 @@ pub struct Client<const MIN_PORT: u16 = 49152, const MAX_PORT: u16 = 65535> {
 
     sockets: SocketSet<'static>,
     sockets_by_remote: BTreeMap<SocketAddr, l3_tcp::SocketHandle>,
-    local_ports_by_socket: HashMap<l3_tcp::SocketHandle, u16>,
+    local_ports_by_socket: BTreeMap<l3_tcp::SocketHandle, u16>,
     /// Queries we should send to a DNS resolver.
     pending_queries_by_remote: HashMap<SocketAddr, VecDeque<dns_types::Query>>,
     /// Queries we have sent to a DNS resolver and are waiting for a reply.

--- a/rust/connlib/dns-over-tcp/src/server.rs
+++ b/rust/connlib/dns-over-tcp/src/server.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     net::SocketAddr,
     time::{Duration, Instant},
 };
@@ -20,7 +20,7 @@ pub struct Server {
     interface: Interface,
 
     sockets: SocketSet<'static>,
-    listen_endpoints: HashMap<SocketHandle, SocketAddr>,
+    listen_endpoints: BTreeMap<SocketHandle, SocketAddr>,
 
     /// Tracks the [`SocketHandle`] on which we need to send a reply for a given query by the local socket address, remote socket address and query ID.
     pending_sockets_by_local_remote_and_query_id:
@@ -85,7 +85,7 @@ impl Server {
 
         let mut sockets =
             SocketSet::new(Vec::with_capacity(addresses.len() * NUM_CONCURRENT_CLIENTS));
-        let mut listen_endpoints = HashMap::with_capacity(addresses.len());
+        let mut listen_endpoints = BTreeMap::new();
 
         for listen_endpoint in addresses {
             for _ in 0..NUM_CONCURRENT_CLIENTS {


### PR DESCRIPTION
In addition to the `iter` functions, `keys` and `values` also iterate over the contents of a `HashMap` and are thus non-deterministic. This can create problems where our test-suite is non-deterministic.