### PR TITLE
ci: add workflow inputs for `_build-data-plane.yml`

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -6,12 +6,8 @@ on:
       image_prefix:
         description: "The prefix to prepend to the image name to prevent SHA conflicts."
         required: false
-        type: choice
+        type: string
         default: ""
-        options:
-          - debug
-          - perf
-          - ""
       profile:
         description: "The Rust profile to build data plane components with."
         required: true

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       image_prefix:
-        description: "The prefix to prepend to the image name to prevent SHA conflicts."
+        description: "The prefix to prepend to the image name to prevent SHA conflicts ('', debug or perf)"
         required: false
         type: string
         default: ""

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -4,11 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       image_prefix:
-        description: |
-          The prefix to prepend to the image name to prevent SHA conflicts.
-          * Use "debug" to build debug binaries inside debug stage images + with debug tooling installed.
-          * Use "perf" to build release binaries inside debug stage images + with debug tooling installed.
-          * Leave blank to build release binaries inside release stage images.
+        description: "The prefix to prepend to the image name to prevent SHA conflicts."
         required: false
         type: choice
         default: ""
@@ -17,7 +13,7 @@ on:
           - perf
           - ""
       profile:
-        description: "The Rust profile to build data plane components with"
+        description: "The Rust profile to build data plane components with."
         required: true
         type: choice
         default: release
@@ -25,7 +21,7 @@ on:
           - release
           - debug
       stage:
-        description: "The stage of the data plane component images to build"
+        description: "The stage of the data plane component images to build."
         required: true
         type: choice
         default: release

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -2,6 +2,37 @@ name: Build data plane
 run-name: Triggered from ${{ github.event_name }} by ${{ github.actor }}
 on:
   workflow_dispatch:
+    inputs:
+      image_prefix:
+        description: |
+          The prefix to prepend to the image name to prevent SHA conflicts.
+          * Use "debug" to build debug binaries inside debug stage images + with debug tooling installed.
+          * Use "perf" to build release binaries inside debug stage images + with debug tooling installed.
+          * Leave blank to build release binaries inside release stage images.
+        required: false
+        type: choice
+        default: ""
+        options:
+          - debug
+          - perf
+          - ""
+      profile:
+        description: "The Rust profile to build data plane components with"
+        required: true
+        type: choice
+        default: release
+        options:
+          - release
+          - debug
+      stage:
+        description: "The stage of the data plane component images to build"
+        required: true
+        type: choice
+        default: release
+        options:
+          - release
+          - debug
+          - dev
   workflow_call:
     inputs:
       image_prefix:


### PR DESCRIPTION
In #10542, we split out a dedicated workflow for building the data plane artifacts. Unfortunately, we forgot to add an input section to the `workflow_dispatch` trigger. This is necessary to correctly build the artifacts for e.g. an upcoming release.

Here is a test-run: https://github.com/firezone/firezone/actions/runs/18485551622