### PR TITLE
refactor(swift): revise event-loop

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -21,12 +21,9 @@ func runSessionEventLoop(
 
   // Multiplex between commands and events
   await withTaskGroup(of: Void.self) { group in
-    // Event polling task - polls Rust for events and sends to eventSender
     group.addTask {
       while !Task.isCancelled {
-        // Poll for next event from Rust
         guard let event = await session.nextEvent() else {
-          // No event returned - session has ended
           Log.log("Event stream ended")
           break
         }
@@ -35,7 +32,6 @@ func runSessionEventLoop(
       }
     }
 
-    // Command handling task - receives commands from commandReceiver
     group.addTask {
       for await command in commandReceiver.stream {
         handleCommand(command, session: session)

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -34,7 +34,11 @@ func runSessionEventLoop(
 
     group.addTask {
       for await command in commandReceiver.stream {
-        handleCommand(command, session: session)
+        do {
+          try handleCommand(command, session: session)
+        } catch {
+            Log.error("Failed to forward command to session: \(error)")
+        }
       }
 
       Log.log("Command stream ended")
@@ -47,24 +51,16 @@ func runSessionEventLoop(
 }
 
 /// Handles a command by calling the appropriate session method.
-private func handleCommand(_ command: SessionCommand, session: Session) {
+private func handleCommand(_ command: SessionCommand, session: Session) throws {
   switch command {
   case .disconnect:
-    do {
-      try session.disconnect()
-    } catch {
-      Log.error(error)
-    }
+    try session.disconnect()
 
   case .setInternetResourceState(let active):
     session.setInternetResourceState(active: active)
 
   case .setDns(let servers):
-    do {
-      try session.setDns(dnsServers: servers)
-    } catch {
-      Log.error(error)
-    }
+    try session.setDns(dnsServers: servers)
 
   case .reset(let reason):
     session.reset(reason: reason)

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -39,12 +39,6 @@ func runSessionEventLoop(
     group.addTask {
       for await command in commandReceiver.stream {
         handleCommand(command, session: session)
-
-        // Exit loop if disconnect command
-        if case .disconnect = command {
-          Log.log("Disconnect command received, exiting command loop")
-          break
-        }
       }
 
       Log.log("Command handling finished")

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -46,7 +46,6 @@ func runSessionEventLoop(
 
     // Wait for first task to complete, then cancel all
     _ = await group.next()
-    Log.log("One task completed, cancelling event loop")
     group.cancelAll()
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -51,28 +51,23 @@ private func forwardEvents(from session: Session, to eventSender: Sender<Event>)
 private func forwardCommands(from commandReceiver: Receiver<SessionCommand>, to session: Session) async {
   for await command in commandReceiver.stream {
     do {
-      try handleCommand(command, session: session)
+      switch command {
+      case .disconnect:
+        try session.disconnect()
+
+      case .setInternetResourceState(let active):
+        session.setInternetResourceState(active: active)
+
+      case .setDns(let servers):
+        try session.setDns(dnsServers: servers)
+
+      case .reset(let reason):
+        session.reset(reason: reason)
+      }
     } catch {
       Log.error("Failed to forward command to session: \(error)")
     }
   }
 
   Log.log("Command stream ended")
-}
-
-/// Handles a command by calling the appropriate session method.
-private func handleCommand(_ command: SessionCommand, session: Session) throws {
-  switch command {
-  case .disconnect:
-    try session.disconnect()
-
-  case .setInternetResourceState(let active):
-    session.setInternetResourceState(active: active)
-
-  case .setDns(let servers):
-    try session.setDns(dnsServers: servers)
-
-  case .reset(let reason):
-    session.reset(reason: reason)
-  }
 }

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -27,14 +27,14 @@ func runSessionEventLoop(
         // Poll for next event from Rust
         guard let event = await session.nextEvent() else {
           // No event returned - session has ended
-          Log.log("SessionEventLoop: Event stream ended, exiting event loop")
+          Log.log("Event stream ended, exiting event loop")
           break
         }
 
         eventSender.send(event)
       }
 
-      Log.log("SessionEventLoop: Event polling finished")
+      Log.log("Event polling finished")
     }
 
     // Command handling task - receives commands from commandReceiver
@@ -44,17 +44,17 @@ func runSessionEventLoop(
 
         // Exit loop if disconnect command
         if case .disconnect = command {
-          Log.log("SessionEventLoop: Disconnect command received, exiting command loop")
+          Log.log("Disconnect command received, exiting command loop")
           break
         }
       }
 
-      Log.log("SessionEventLoop: Command handling finished")
+      Log.log("Command handling finished")
     }
 
     // Wait for first task to complete, then cancel all
     _ = await group.next()
-    Log.log("SessionEventLoop: One task completed, cancelling event loop")
+    Log.log("One task completed, cancelling event loop")
     group.cancelAll()
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -70,7 +70,7 @@ private func forwardCommands(from commandReceiver: Receiver<SessionCommand>, to 
         session.reset(reason: reason)
       }
     } catch {
-      Log.error("Failed to forward command to session: \(error)")
+      Log.warning("Failed to forward command to session: \(error)")
     }
   }
 

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -50,6 +50,11 @@ private func forwardEvents(from session: Session, to eventSender: Sender<Event>)
 /// Forwards commands from the command receiver to the session.
 private func forwardCommands(from commandReceiver: Receiver<SessionCommand>, to session: Session) async {
   for await command in commandReceiver.stream {
+    if Task.isCancelled {
+      Log.log("Command forwarding cancelled")
+      break
+    }
+
     do {
       switch command {
       case .disconnect:

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -40,7 +40,7 @@ func runSessionEventLoop(
     // Command handling task - receives commands from commandReceiver
     group.addTask {
       for await command in commandReceiver.stream {
-        await handleCommand(command, session: session)
+        handleCommand(command, session: session)
 
         // Exit loop if disconnect command
         if case .disconnect = command {
@@ -60,7 +60,7 @@ func runSessionEventLoop(
 }
 
 /// Handles a command by calling the appropriate session method.
-private func handleCommand(_ command: SessionCommand, session: Session) async {
+private func handleCommand(_ command: SessionCommand, session: Session) {
   switch command {
   case .disconnect:
     do {

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -27,7 +27,7 @@ func runSessionEventLoop(
         // Poll for next event from Rust
         guard let event = await session.nextEvent() else {
           // No event returned - session has ended
-          Log.log("Event stream ended, exiting event loop")
+          Log.log("Event stream ended")
           break
         }
 
@@ -41,7 +41,7 @@ func runSessionEventLoop(
         handleCommand(command, session: session)
       }
 
-      Log.log("Command handling finished")
+      Log.log("Command stream ended")
     }
 
     // Wait for first task to complete, then cancel all

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -33,8 +33,6 @@ func runSessionEventLoop(
 
         eventSender.send(event)
       }
-
-      Log.log("Event polling finished")
     }
 
     // Command handling task - receives commands from commandReceiver


### PR DESCRIPTION
This is a follow-up from #10368 where we revise the forwarding logic in `runSessionEventLoop`. Redundant logs are removed and the only exit conditions from the event-loop are now the closing of either the event or the command stream. The event-stream will only close once `connlib` has successfully shut down and the command stream will only close of the adapter shuts down (and thus drops the sender-side of the channel).