### PR TITLE
chore(connlib): tune down INFO logs

### DIFF
--- a/rust/connlib/dns-over-tcp/src/server.rs
+++ b/rust/connlib/dns-over-tcp/src/server.rs
@@ -98,7 +98,7 @@ impl Server {
                 listen_endpoints.insert(handle, listen_endpoint);
             }
 
-            tracing::info!(%listen_endpoint, concurrency = %NUM_CONCURRENT_CLIENTS, "Created listening TCP socket");
+            tracing::debug!(%listen_endpoint, concurrency = %NUM_CONCURRENT_CLIENTS, "Created listening TCP socket");
         }
 
         self.sockets = sockets;

--- a/rust/connlib/phoenix-channel/src/lib.rs
+++ b/rust/connlib/phoenix-channel/src/lib.rs
@@ -590,7 +590,7 @@ where
                         }
                         (Payload::Reply(Reply::Ok(OkReply::NoMessage(Empty {}))), Some(req_id)) => {
                             if self.pending_join_requests.remove(&req_id).is_some() {
-                                tracing::info!("Joined {} room on portal", message.topic);
+                                tracing::debug!("Joined {} room on portal", message.topic);
 
                                 // For `phx_join` requests, `reply` is empty so we can safely ignore it.
                                 return Poll::Ready(Ok(Event::JoinedRoom {

--- a/rust/connlib/snownet/src/allocation.rs
+++ b/rust/connlib/snownet/src/allocation.rs
@@ -940,7 +940,7 @@ impl Allocation {
     }
 
     fn log_update(&self, now: Instant) {
-        tracing::info!(
+        tracing::debug!(
             host_ip4 = ?self.ip4_host_candidate.as_ref().map(|c| c.addr()),
             host_ip6 = ?self.ip6_host_candidate.as_ref().map(|c| c.addr()),
             srflx_ip4 = ?self.ip4_srflx_candidate.as_ref().map(|c| c.addr()),

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -414,7 +414,7 @@ where
             return;
         };
 
-        tracing::info!(?candidate, "Received candidate from remote");
+        tracing::debug!(?candidate, "Received candidate from remote");
 
         agent.add_remote_candidate(candidate.clone());
 
@@ -998,7 +998,7 @@ where
         {
             conn.first_handshake_completed_at = Some(now);
 
-            tracing::info!(%cid, duration_since_intent = ?conn.duration_since_intent(now), "Completed wireguard handshake");
+            tracing::debug!(%cid, duration_since_intent = ?conn.duration_since_intent(now), "Completed wireguard handshake");
 
             self.pending_events
                 .push_back(Event::ConnectionEstablished(cid))
@@ -1311,7 +1311,7 @@ fn generate_optimistic_candidates(agent: &mut IceAgent) {
         .collect::<Vec<_>>();
 
     for c in optimistic_candidates {
-        tracing::info!(candidate = ?c, "Adding optimistic candidate for remote");
+        tracing::debug!(candidate = ?c, "Adding optimistic candidate for remote");
 
         agent.add_remote_candidate(c);
     }
@@ -1343,7 +1343,7 @@ fn signal_candidate_to_remote<TId>(
     candidate: &Candidate,
     pending_events: &mut VecDeque<Event<TId>>,
 ) {
-    tracing::info!(?candidate, "Signalling candidate to remote");
+    tracing::debug!(?candidate, "Signalling candidate to remote");
 
     pending_events.push_back(Event::NewIceCandidate {
         connection: id,


### PR DESCRIPTION
Several of these INFO logs are actually quite noisy, like exchanging candidates with Gateways or updating the allocation. We barely look at the INFO logs from customers and primarily investigate issues with DEBUG logs streamed to Sentry.