### PR TITLE
fix(portal): trigger email for Okta 4xx errors

### DIFF
--- a/elixir/apps/domain/lib/domain/auth/adapters/okta/jobs/sync_directory.ex
+++ b/elixir/apps/domain/lib/domain/auth/adapters/okta/jobs/sync_directory.ex
@@ -44,15 +44,15 @@ defmodule Domain.Auth.Adapters.Okta.Jobs.SyncDirectory do
         message = "#{error_code} => #{error_summary}"
         {:error, message, "Okta API returned #{status}: #{message}"}
 
-      # TODO: Okta API client needs to be updated to pull message from header
-      {:error, {401, ""}} ->
+      {:error, {401, error_map}} ->
+        user_message = inspect(error_map, pretty: true)
         message = "401 - Unauthorized"
-        {:error, message, message}
+        {:error, user_message, message}
 
-      # TODO: Okta API client needs to be updated to pull message from header
-      {:error, {403, ""}} ->
+      {:error, {403, error_map}} ->
+        user_message = inspect(error_map, pretty: true)
         message = "403 - Forbidden"
-        {:error, message, message}
+        {:error, user_message, message}
 
       {:error, :retry_later} ->
         message = "Okta API is temporarily unavailable"


### PR DESCRIPTION
When Okta returned a 4xx status code from the API, we had updated error handler to grab the errors from body or headers and return these.

However, the caller was expecting an explicit empty string for 401 and 403 errors in order to trigger the email send behavior.

Since that wasn't being matched, we were logging the error internally only, and continuing to retry the sync indefinitely without sending the user an email.


Fixes #8744 
Fixes #9825 