### PR TITLE
chore(ci): use bin/ prefix for binary artifacts

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -304,16 +304,16 @@ jobs:
             gs://firezone-staging-artifacts/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt
 
           az storage blob upload \
-            --container-name artifacts \
-            --name "bin/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}" \
+            --container-name binaries \
+            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}" \
             --file "${{ matrix.name.package }}" \
             --overwrite true \
             --no-progress \
             --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
 
           az storage blob upload \
-            --container-name artifacts \
-            --name "bin/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt" \
+            --container-name binaries \
+            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt" \
             --file "${{ matrix.name.package }}.sha256sum.txt" \
             --overwrite true \
             --no-progress \

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -305,7 +305,7 @@ jobs:
 
           az storage blob upload \
             --container-name artifacts \
-            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}" \
+            --name "bin/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}" \
             --file "${{ matrix.name.package }}" \
             --overwrite true \
             --no-progress \
@@ -313,7 +313,7 @@ jobs:
 
           az storage blob upload \
             --container-name artifacts \
-            --name "${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt" \
+            --name "bin/${{ matrix.name.image_name }}/${{ inputs.sha }}/${{ matrix.arch.shortname }}.sha256sum.txt" \
             --file "${{ matrix.name.package }}.sha256sum.txt" \
             --overwrite true \
             --no-progress \


### PR DESCRIPTION
We'll be using a consistent `artifacts` storage account for these built binaries, so we've renamed the container to `binaries`.

The apt packages would be under the `apt` container at `artifacts.firezone.dev/apt/` accordingly.

Related: firezone/infra#182
