### PR TITLE
build(deps): Bump nodejs to 22

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -10,7 +10,7 @@ inputs:
   node-version:
     description: "Version of nodejs to install"
     required: false
-    default: "20"
+    default: "22"
 runs:
   using: "composite"
   steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 # These are used for the dev environment.
 # This should match the versions used in the built product.
-nodejs 20.14.0
+nodejs 22.20.0
 elixir 1.18.4-otp-27
 erlang 27.3.4.1
 
@@ -12,4 +12,4 @@ shfmt 3.9.0
 shellcheck 0.9.0
 
 # GUI client
-pnpm 10.13.1
+pnpm 10.18.3


### PR DESCRIPTION
Bumps node from the now-unsupported 20 LTS to the currently active 22 LTS which fixes a few compile warnings for the website.