### PR TITLE
ci: remove jitter from docker-compose

### DIFF
--- a/scripts/router/router.sh
+++ b/scripts/router/router.sh
@@ -67,10 +67,9 @@ fi
 # Add configurable latency if specified
 if [ -n "${NETWORK_LATENCY_MS:-}" ]; then
     LATENCY=$((NETWORK_LATENCY_MS / 2)) # Latency is only applied to outbound packets. To achieve the actual configured latency, we apply half of it to each interface.
-    JITTER=$((LATENCY / 5))             # Vary latency by 20%
 
-    tc qdisc add dev internet root netem delay "${LATENCY}ms" "${JITTER}ms"
-    tc qdisc add dev internal root netem delay "${LATENCY}ms" "${JITTER}ms"
+    tc qdisc add dev internet root netem delay "${LATENCY}ms"
+    tc qdisc add dev internal root netem delay "${LATENCY}ms"
 fi
 
 echo "-----------------------------------------------------------------------------------------------"


### PR DESCRIPTION
Jitter causes packets to get re-ordered which makes it really hard to get predictable performance results. With jitter disabled, we get more consistent performance numbers.