### PR TITLE
fix(apple): don't return Data() to fetchResources

### DIFF
--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -303,7 +303,10 @@ class Adapter: @unchecked Sendable {
       let firezoneResources = uniffiResources.map { self.convertResource($0) }
 
       guard let encoded = try? PropertyListEncoder().encode(firezoneResources)
-      else { return completionHandler(nil) }
+      else {
+        Log.log("Failed to encode resources as PropertyList")
+        return completionHandler(nil)
+      }
 
       if hash == Data(SHA256.hash(data: encoded)) {
         // nothing changed

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -297,24 +297,19 @@ class Adapter: @unchecked Sendable {
       guard let self = self else { return }
 
       // Convert uniffi resources to FirezoneKit resources and encode with PropertyList
-      let propertyListData: Data
-      if let uniffiResources = self.resources {
-        let firezoneResources = uniffiResources.map { self.convertResource($0) }
-        guard let encoded = try? PropertyListEncoder().encode(firezoneResources) else {
-          Log.log("Failed to encode resources as PropertyList")
-          completionHandler(nil)
-          return
-        }
-        propertyListData = encoded
-      } else {
-        propertyListData = Data()
-      }
+      guard let uniffiResources = self.resources
+      else { return completionHandler(nil) }
 
-      if hash == Data(SHA256.hash(data: propertyListData)) {
+      let firezoneResources = uniffiResources.map { self.convertResource($0) }
+
+      guard let encoded = try? PropertyListEncoder().encode(firezoneResources)
+      else { return completionHandler(nil) }
+
+      if hash == Data(SHA256.hash(data: encoded)) {
         // nothing changed
         completionHandler(nil)
       } else {
-        completionHandler(propertyListData)
+        completionHandler(encoded)
       }
     }
   }


### PR DESCRIPTION
When the tunnel first comes up, the first call to `fetchResources` was returning an empty `Data()` instance that the receiver would fail to decode properly because it assumes if a `Data` is non-nil, it is a list of Resources.

This resulted in a decode error each time the tunnel was started.

Related: https://github.com/firezone/firezone/pull/10603#discussion_r2438472011