### PR TITLE
feat(ffi): make all calls infallible

### DIFF
--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -289,7 +289,7 @@ impl Session {
     }
 
     pub fn set_dns(&self, dns_servers: Vec<String>) -> Result<(), ConnlibError> {
-        let dns_servers: Vec<std::net::IpAddr> = dns_servers
+        let dns_servers = dns_servers
             .into_iter()
             .map(|s| s.parse())
             .collect::<Result<_, _>>()

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -274,6 +274,8 @@ fn set_tun_from_search(session: &Session) -> Result<(), ConnlibError> {
 #[uniffi::export]
 impl Session {
     pub fn disconnect(&self) {
+        self.inner.stop();
+
         let Some(runtime) = self.runtime.as_ref() else {
             tracing::error!(
                 "No tokio runtime set! This should be impossible because we only clear it on `Drop`"
@@ -284,7 +286,6 @@ impl Session {
         runtime.block_on(async {
             self.telemetry.lock().await.stop().await;
         });
-        self.inner.stop();
     }
 
     pub fn set_internet_resource_state(&self, active: bool) {

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -288,16 +288,18 @@ impl Session {
         self.inner.set_internet_resource_state(active);
     }
 
-    pub fn set_dns(&self, dns_servers: Vec<String>) -> Result<(), ConnlibError> {
+    pub fn set_dns(&self, dns_servers: Vec<String>) {
         let dns_servers = dns_servers
             .into_iter()
-            .map(|s| s.parse())
-            .collect::<Result<_, _>>()
-            .context("Failed to parse DNS servers")?;
+            .filter_map(|server| {
+                server
+                    .parse()
+                    .inspect_err(|e| tracing::error!(%server, "Failed to parse DNS server as IP address: {e}"))
+                    .ok()
+            })
+            .collect();
 
         self.inner.set_dns(dns_servers);
-
-        Ok(())
     }
 
     pub fn reset(&self, reason: String) {

--- a/rust/client-ffi/src/lib.rs
+++ b/rust/client-ffi/src/lib.rs
@@ -273,15 +273,18 @@ fn set_tun_from_search(session: &Session) -> Result<(), ConnlibError> {
 
 #[uniffi::export]
 impl Session {
-    pub fn disconnect(&self) -> Result<(), ConnlibError> {
-        let runtime = self.runtime.as_ref().context("No runtime")?;
+    pub fn disconnect(&self) {
+        let Some(runtime) = self.runtime.as_ref() else {
+            tracing::error!(
+                "No tokio runtime set! This should be impossible because we only clear it on `Drop`"
+            );
+            return;
+        };
 
         runtime.block_on(async {
             self.telemetry.lock().await.stop().await;
         });
         self.inner.stop();
-
-        Ok(())
     }
 
     pub fn set_internet_resource_state(&self, active: bool) {

--- a/swift/apple/FirezoneNetworkExtension/Adapter.swift
+++ b/swift/apple/FirezoneNetworkExtension/Adapter.swift
@@ -19,8 +19,6 @@ enum AdapterError: Error {
   /// connlib failed to start
   case connlibConnectError(String)
 
-  case setDnsError(String)
-
   var localizedDescription: String {
     switch self {
     case .invalidSession(let session):
@@ -28,8 +26,6 @@ enum AdapterError: Error {
       return message
     case .connlibConnectError(let error):
       return "connlib failed to start: \(error)"
-    case .setDnsError(let error):
-      return "failed to set new DNS servers: \(error)"
     }
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -55,22 +55,18 @@ private func forwardCommands(from commandReceiver: Receiver<SessionCommand>, to 
       break
     }
 
-    do {
-      switch command {
-      case .disconnect:
-        session.disconnect()
+    switch command {
+    case .disconnect:
+      session.disconnect()
 
-      case .setInternetResourceState(let active):
-        session.setInternetResourceState(active: active)
+    case .setInternetResourceState(let active):
+      session.setInternetResourceState(active: active)
 
-      case .setDns(let servers):
-        session.setDns(dnsServers: servers)
+    case .setDns(let servers):
+      session.setDns(dnsServers: servers)
 
-      case .reset(let reason):
-        session.reset(reason: reason)
-      }
-    } catch {
-      Log.warning("Failed to forward command to session: \(error)")
+    case .reset(let reason):
+      session.reset(reason: reason)
     }
   }
 

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -58,7 +58,7 @@ private func forwardCommands(from commandReceiver: Receiver<SessionCommand>, to 
     do {
       switch command {
       case .disconnect:
-        try session.disconnect()
+        session.disconnect()
 
       case .setInternetResourceState(let active):
         session.setInternetResourceState(active: active)

--- a/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
+++ b/swift/apple/FirezoneNetworkExtension/SessionEventLoop.swift
@@ -64,7 +64,7 @@ private func forwardCommands(from commandReceiver: Receiver<SessionCommand>, to 
         session.setInternetResourceState(active: active)
 
       case .setDns(let servers):
-        try session.setDns(dnsServers: servers)
+        session.setDns(dnsServers: servers)
 
       case .reset(let reason):
         session.reset(reason: reason)


### PR DESCRIPTION
In the spirit of making Firezone as robust as possible, we make the FFI calls infallible and complete as much of the task as possible. For example, we don't fail `setDns` entirely just because we cannot parse a single DNS server's IP.

Resolves: #10611