### PR TITLE
chore: install JDK via `.tool-versions`

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -12,11 +12,6 @@ runs:
         targets: armv7-linux-androideabi aarch64-linux-android x86_64-linux-android i686-linux-android
         sccache_azure_connection_string: ${{ inputs.sccache_azure_connection_string }}
 
-    - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-      with:
-        distribution: temurin
-        java-version: 17
-
     - uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
 
     - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-tags: true # Otherwise we cannot embed the correct version into the build.
+      - uses: marocchino/tool-versions-action@18a164fa2b0db1cc1edf7305fcb17ace36d1c306 # v1.2.0
       - uses: ./.github/actions/setup-android
         with:
           sccache_azure_connection_string: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -13,3 +13,6 @@ shellcheck 0.9.0
 
 # GUI client
 pnpm 10.18.3
+
+# Android app
+java openjdk-17


### PR DESCRIPTION
For working on the Android app, we need an installation of the JDK. Currently, that is being installed separately in CI. We already have `.tool-versions` which is designed to take care of this so we add OpenJDK 17 to the list of required tools and remove the dedicated CI step.