### PR TITLE
chore(kotlin): format generated sources

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -16,3 +16,4 @@ pnpm 10.18.3
 
 # Android app
 java openjdk-17
+ktlint 1.7.1

--- a/kotlin/android/app/build.gradle.kts
+++ b/kotlin/android/app/build.gradle.kts
@@ -284,7 +284,7 @@ val generateUniffiBindings =
                 commandLine(
                     "sh",
                     "-c",
-                    "cd ${rustDir.asFile} && cargo run --bin uniffi-bindgen generate --library --language kotlin ${input.asFile} --out-dir ${outDir.asFile} --no-format",
+                    "cd ${rustDir.asFile} && cargo run --bin uniffi-bindgen generate --library --language kotlin ${input.asFile} --out-dir ${outDir.asFile}",
                 )
             }
         }


### PR DESCRIPTION
When viewing the generated sources, code is a lot easier to follow if it is properly formatted. For this, we need to install the `ktlint` tool.