### PR TITLE
chore(client-ffi): tweak uniffi settings

### DIFF
--- a/rust/client-ffi/uniffi.toml
+++ b/rust/client-ffi/uniffi.toml
@@ -8,3 +8,5 @@ experimental_sendable_value_types = true
 generate_immutable_records = true
 
 [bindings.kotlin]
+android = true
+generate_immutable_records = true

--- a/rust/client-ffi/uniffi.toml
+++ b/rust/client-ffi/uniffi.toml
@@ -4,13 +4,7 @@
 # Enable experimental features for better async support
 experimental_sendable_value_types = true
 
-# Configure async runtime for Swift
-# This enables proper async/await bridging from Rust to Swift
-async_runtime = "tokio"
-
 # Generate proper Swift concurrency annotations
 generate_immutable_records = true
 
 [bindings.kotlin]
-# Kotlin configuration (already working)
-async_runtime = "tokio"


### PR DESCRIPTION
As far as I can tell, the `async_runtime` config option doesn't exist in UniFFI, hence we remove that.

Whilst going through the UniFFI docs, I also noticed that there is a specific flag about Android that we can toggle on. Effectively, this uses the shared [`SystemCleaner`](https://developer.android.com/reference/android/system/SystemCleaner) instead of a per-thread one which is supposed to be more performant.

Finally, using immutable records seems like a good idea as mutating any FFI-originated field is not going to be reflected in connlib's state. Preventing that at compile-time has a good chance of reducing bugs.