### PR TITLE
fix(android): handle exceptions when creating a new session

### DIFF
--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -311,7 +311,7 @@ class TunnelService : VpnService() {
                             }
                         }
                 } catch (e: ConnlibException) {
-                    Log.e(TAG, "Failed to start session", e);
+                    Log.e(TAG, "Failed to start session", e)
 
                     e.close()
                 } finally {

--- a/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
+++ b/kotlin/android/app/src/main/java/dev/firezone/android/tunnel/TunnelService.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
+import uniffi.connlib.ConnlibException
 import uniffi.connlib.DeviceInfo
 import uniffi.connlib.Event
 import uniffi.connlib.ProtectSocket
@@ -283,38 +284,44 @@ class TunnelService : VpnService() {
             commandChannel = Channel<TunnelCommand>(Channel.UNLIMITED)
 
             serviceScope.launch {
-                Session
-                    .newAndroid(
-                        apiUrl = config.apiUrl,
-                        token = token,
-                        accountSlug = config.accountSlug,
-                        deviceId = deviceId(),
-                        deviceName = getDeviceName(),
-                        osVersion = Build.VERSION.RELEASE,
-                        logDir = getLogDir(),
-                        logFilter = config.logFilter,
-                        isInternetResourceActive = resourceState.isEnabled(),
-                        protectSocket = protectSocket,
-                        deviceInfo = deviceInfo,
-                    ).use { session ->
-                        startNetworkMonitoring()
-                        startDisconnectMonitoring()
+                try {
+                    Session
+                        .newAndroid(
+                            apiUrl = config.apiUrl,
+                            token = token,
+                            accountSlug = config.accountSlug,
+                            deviceId = deviceId(),
+                            deviceName = getDeviceName(),
+                            osVersion = Build.VERSION.RELEASE,
+                            logDir = getLogDir(),
+                            logFilter = config.logFilter,
+                            isInternetResourceActive = resourceState.isEnabled(),
+                            protectSocket = protectSocket,
+                            deviceInfo = deviceInfo,
+                        ).use { session ->
+                            startNetworkMonitoring()
+                            startDisconnectMonitoring()
 
-                        eventLoop(session, commandChannel!!)
+                            eventLoop(session, commandChannel!!)
 
-                        Log.i(TAG, "Event-loop finished")
+                            Log.i(TAG, "Event-loop finished")
 
-                        commandChannel = null
-                        tunnelState = State.DOWN
-
-                        if (startedByUser) {
-                            updateStatusNotification(TunnelStatusNotification.SignedOut)
+                            if (startedByUser) {
+                                updateStatusNotification(TunnelStatusNotification.SignedOut)
+                            }
                         }
+                } catch (e: ConnlibException) {
+                    Log.e(TAG, "Failed to start session", e);
 
-                        stopNetworkMonitoring()
-                        stopDisconnectMonitoring()
-                        stopSelf()
-                    }
+                    e.close()
+                } finally {
+                    commandChannel = null
+                    tunnelState = State.DOWN
+
+                    stopNetworkMonitoring()
+                    stopDisconnectMonitoring()
+                    stopSelf()
+                }
             }
         }
     }

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -20,7 +20,12 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="10667">
+          Fixes an issue where the Tunnel service would crash when trying to
+          connect Firezone without an Internet connection.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.5" date={new Date("2025-10-18")}>
         <ChangeItem pull="10509">
           Fixes an issue where the Internet Resource could be briefly active on


### PR DESCRIPTION
The `Session.newAndroid` constructor can throw an exception. Unfortunately, the Kotlin compiler didn't warn us about that and thus, any errors when creating a new session caused the service process to crash.

We fix this by wrapping the entire thing in a `try-catch-finally` block.

Resolves: #10289 