### PR TITLE
chore: fix `cargo deny` errors

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8248,9 +8248,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -93,6 +93,13 @@ ignore = [
 
     "RUSTSEC-2025-0057", # `fxhash` is unmaintained, used by transitive dependencies. See #10297.
 
+    # `rust-unic` crates are unmaintained but still pulled in via tauri.
+    "RUSTSEC-2025-0075",
+    "RUSTSEC-2025-0080",
+    "RUSTSEC-2025-0081",
+    "RUSTSEC-2025-0098",
+    "RUSTSEC-2025-0100",
+
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
The crates from https://github.com/open-i18n/rust-unic are unmaintained but they are still being pulled in via `tauri`. Unfortunately, we have to wait for an MSRV bump from `tauri` before the update of `urlpattern` can be completed. Until then, we need to ignore these advisories to keep our CI passing.

Related: https://github.com/tauri-apps/tauri/pull/14195