### PR TITLE
ci: install latest Azure CLI for APT sync

### DIFF
--- a/.github/actions/setup-azure-cli/action.yml
+++ b/.github/actions/setup-azure-cli/action.yml
@@ -1,0 +1,13 @@
+name: "Setup Azure CLI"
+description: "Installs the latest Azure CLI version"
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
+        curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+        AZ_REPO=$(lsb_release -cs)
+        echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+        sudo apt-get update
+        sudo apt-get install -y azure-cli
+      shell: bash

--- a/.github/workflows/_apt.yml
+++ b/.github/workflows/_apt.yml
@@ -15,10 +15,16 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - name: Sync APT metadata
-        uses: azure/cli@v2
-        with:
-          azcliversion: 2.68.0
-          inlineScript: $GITHUB_WORKSPACE/scripts/sync-apt.sh
+
+      - name: Install Azure CLI
+        run: |
+          sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
+          curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+          AZ_REPO=$(lsb_release -cs)
+          echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+          sudo apt-get update
+          sudo apt-get install -y azure-cli
+
+      - run: scripts/sync-apt.sh
         env:
           AZURERM_ARTIFACTS_CONNECTION_STRING: ${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}

--- a/.github/workflows/_apt.yml
+++ b/.github/workflows/_apt.yml
@@ -20,4 +20,5 @@ jobs:
         with:
           azcliversion: 2.68.0
           inlineScript: $GITHUB_WORKSPACE/scripts/sync-apt.sh
+        env:
           AZURERM_ARTIFACTS_CONNECTION_STRING: ${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}

--- a/.github/workflows/_apt.yml
+++ b/.github/workflows/_apt.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - run: scripts/sync-apt.sh
-        env:
+      - name: Sync APT metadata
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.68.0
+          inlineScript: $GITHUB_WORKSPACE/scripts/sync-apt.sh
           AZURERM_ARTIFACTS_CONNECTION_STRING: ${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}

--- a/.github/workflows/_apt.yml
+++ b/.github/workflows/_apt.yml
@@ -16,14 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Azure CLI
-        run: |
-          sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
-          curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
-          AZ_REPO=$(lsb_release -cs)
-          echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-          sudo apt-get update
-          sudo apt-get install -y azure-cli
+      - uses: ./.github/actions/setup-azure-cli
 
       - run: scripts/sync-apt.sh
         env:


### PR DESCRIPTION
Whichever version of the CLI is installed on the GitHub runners doesn't appear to be able to run our script (which works just fine locally).