### PR TITLE
chore(apt): introduce `stable` and `preview` distributions

### DIFF
--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 #
-set -euo pipefail
+set -euox pipefail
 
-DISTRIBUTION="stable"
 COMPONENT="main"
 WORK_DIR="$(mktemp -d)"
-POOL_DIR="${WORK_DIR}/pool"
 DISTS_DIR="${WORK_DIR}/dists"
 
 if [ -z "${AZURERM_ARTIFACTS_CONNECTION_STRING:-}" ]; then
@@ -19,44 +17,42 @@ cleanup() {
 
 trap cleanup EXIT
 
-echo "Downloading packages..."
+for DISTRIBUTION in "stable" "preview"; do
+    POOL_DIR="${WORK_DIR}/pool-${DISTRIBUTION}"
 
-az storage blob download-batch \
-    --destination "${WORK_DIR}" \
-    --source apt \
-    --pattern "pool/*.deb" \
-    --connection-string "${AZURERM_ARTIFACTS_CONNECTION_STRING}" \
-    2>&1 | grep -v "WARNING" || true
+    echo "Downloading packages for distribution $DISTRIBUTION..."
 
-echo "Detecting architectures..."
-ARCHITECTURES=$(for deb in "${POOL_DIR}"/*.deb; do dpkg-deb -f "$deb" Architecture 2>/dev/null; done | sort -u | tr '\n' ' ')
+    az storage blob download-batch \
+        --destination "${WORK_DIR}" \
+        --source apt \
+        --pattern "pool-${DISTRIBUTION}/*.deb" \
+        --connection-string "${AZURERM_ARTIFACTS_CONNECTION_STRING}" \
+        2>&1 | grep -v "WARNING" || true
 
-if [ -z "$ARCHITECTURES" ]; then
-    echo "Error: Could not detect architectures"
-    exit 1
-fi
+    echo "Detecting architectures..."
+    ARCHITECTURES=$(for deb in "${POOL_DIR}"/*.deb; do dpkg-deb -f "$deb" Architecture 2>/dev/null; done | sort -u | tr '\n' ' ') || true
 
-echo "Found: ${ARCHITECTURES}"
+    echo "Found: ${ARCHITECTURES}"
 
-echo "Generating metadata..."
-mkdir -p "${DISTS_DIR}/${DISTRIBUTION}/${COMPONENT}"
+    echo "Generating metadata..."
+    mkdir -p "${DISTS_DIR}/${DISTRIBUTION}/${COMPONENT}"
 
-for ARCH in $ARCHITECTURES; do
-    BINARY_DIR="${DISTS_DIR}/${DISTRIBUTION}/${COMPONENT}/binary-${ARCH}"
-    mkdir -p "${BINARY_DIR}"
+    for ARCH in $ARCHITECTURES; do
+        BINARY_DIR="${DISTS_DIR}/${DISTRIBUTION}/${COMPONENT}/binary-${ARCH}"
+        mkdir -p "${BINARY_DIR}"
 
-    apt-ftparchive packages --arch "${ARCH}" "${POOL_DIR}/" >"${BINARY_DIR}/Packages"
-    gzip -k -f "${BINARY_DIR}/Packages"
+        apt-ftparchive packages --arch "${ARCH}" "${POOL_DIR}/" >"${BINARY_DIR}/Packages"
+        gzip -k -f "${BINARY_DIR}/Packages"
 
-    cat >"${BINARY_DIR}/Release" <<EOF
+        cat >"${BINARY_DIR}/Release" <<EOF
 Archive: ${DISTRIBUTION}
 Component: ${COMPONENT}
 Architecture: ${ARCH}
 EOF
-done
+    done
 
-cd "${DISTS_DIR}/${DISTRIBUTION}"
-cat >Release <<EOF
+    cd "${DISTS_DIR}/${DISTRIBUTION}"
+    cat >Release <<EOF
 Origin: Firezone
 Label: Firezone
 Suite: ${DISTRIBUTION}
@@ -67,7 +63,8 @@ Description: Firezone APT Repository
 Date: $(date -R -u)
 EOF
 
-apt-ftparchive release . >>Release
+    apt-ftparchive release . >>Release
+done
 
 echo "Uploading metadata..."
 az storage blob upload-batch \

--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-set -euox pipefail
+set -euo pipefail
 
 COMPONENT="main"
 WORK_DIR="$(mktemp -d)"


### PR DESCRIPTION
In order to distribute pre-releases, it is useful to have a `preview` distribution in addition to the `stable` one.