### PR TITLE
refactor(apple): Upgrade to Swift 6.2 with concurrency checks

### DIFF
--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -595,7 +595,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 6.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
 				WATCHOS_DEPLOYMENT_TARGET = "";
@@ -637,7 +637,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 6.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
 				VALIDATE_PRODUCT = YES;
@@ -681,7 +681,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated";
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 6.2;
 			};
 			name = Debug;
 		};
@@ -723,7 +723,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated";
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 6.2;
 			};
 			name = Release;
 		};
@@ -903,7 +903,7 @@
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 6.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
 				WATCHOS_DEPLOYMENT_TARGET = "";
@@ -952,7 +952,7 @@
 				SWIFT_INSTALL_MODULE = NO;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 6.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
 				WATCHOS_DEPLOYMENT_TARGET = "";

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -789,6 +789,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				SUPPORTED_PLATFORMS = "macosx iphoneos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -852,6 +853,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				SUPPORTED_PLATFORMS = "macosx iphoneos";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -595,7 +595,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
 				WATCHOS_DEPLOYMENT_TARGET = "";
@@ -637,7 +637,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
 				VALIDATE_PRODUCT = YES;
@@ -681,7 +681,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated";
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -723,7 +723,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/FirezoneNetworkExtension/Connlib/Generated";
 				SWIFT_OBJC_BRIDGING_HEADER = "FirezoneNetworkExtension/FirezoneNetworkExtension-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -792,6 +792,7 @@
 				SUPPORTED_PLATFORMS = "macosx iphoneos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 			};
 			name = Debug;
@@ -854,6 +855,7 @@
 				SUPPORTED_PLATFORMS = "macosx iphoneos";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 			};
 			name = Release;
@@ -899,7 +901,7 @@
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
 				WATCHOS_DEPLOYMENT_TARGET = "";
@@ -948,7 +950,7 @@
 				SWIFT_INSTALL_MODULE = NO;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = "";
 				WATCHOS_DEPLOYMENT_TARGET = "";

--- a/swift/apple/Firezone/Info.plist
+++ b/swift/apple/Firezone/Info.plist
@@ -47,5 +47,12 @@
   <false/>
   <key>GitSha</key>
   <string>$(GIT_SHA)</string>
+	<key>LSEnvironment</key>
+	<dict>
+		<key>SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL</key>
+		<string>1</string>
+		<key>SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE</key>
+		<string>nocrash</string>
+	</dict>
 </dict>
 </plist>

--- a/swift/apple/FirezoneKit/Package.swift
+++ b/swift/apple/FirezoneKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/DeviceMetadata.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/DeviceMetadata.swift
@@ -12,17 +12,13 @@ import Foundation
 #endif
 
 public class DeviceMetadata {
-  // nonisolated(unsafe) is safe here because:
-  // 1. UIDevice.current properties are thread-safe for reads (per Apple documentation)
-  // 2. Properties are immutable or internally synchronised
-  // 3. Only reading, never mutating UIDevice state
-  public static nonisolated(unsafe) func getDeviceName() -> String {
+  @MainActor
+  public static func getDeviceName() -> String {
     // Returns a generic device name on iOS 16 and higher
     // See https://github.com/firezone/firezone/issues/3034
     #if os(iOS)
       return UIDevice.current.name
     #else
-      // Use hostname
       return ProcessInfo.processInfo.hostName
     #endif
   }
@@ -37,11 +33,8 @@ public class DeviceMetadata {
   }
 
   #if os(iOS)
-    // nonisolated(unsafe) is safe here because:
-    // 1. UIDevice.current properties are thread-safe for reads (per Apple documentation)
-    // 2. Properties are immutable or internally synchronised
-    // 3. Only reading, never mutating UIDevice state
-    public static nonisolated(unsafe) func getIdentifierForVendor() -> String? {
+    @MainActor
+    public static func getIdentifierForVendor() -> String? {
       return UIDevice.current.identifierForVendor?.uuidString
     }
   #endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/DeviceMetadata.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/DeviceMetadata.swift
@@ -12,7 +12,11 @@ import Foundation
 #endif
 
 public class DeviceMetadata {
-  public static func getDeviceName() -> String {
+  // nonisolated(unsafe) is safe here because:
+  // 1. UIDevice.current properties are thread-safe for reads (per Apple documentation)
+  // 2. Properties are immutable or internally synchronised
+  // 3. Only reading, never mutating UIDevice state
+  public static nonisolated(unsafe) func getDeviceName() -> String {
     // Returns a generic device name on iOS 16 and higher
     // See https://github.com/firezone/firezone/issues/3034
     #if os(iOS)
@@ -33,7 +37,7 @@ public class DeviceMetadata {
   }
 
   #if os(iOS)
-    public static func getIdentifierForVendor() -> String? {
+    public static nonisolated(unsafe) func getIdentifierForVendor() -> String? {
       return UIDevice.current.identifierForVendor?.uuidString
     }
   #endif

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/DeviceMetadata.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/DeviceMetadata.swift
@@ -37,6 +37,10 @@ public class DeviceMetadata {
   }
 
   #if os(iOS)
+    // nonisolated(unsafe) is safe here because:
+    // 1. UIDevice.current properties are thread-safe for reads (per Apple documentation)
+    // 2. Properties are immutable or internally synchronised
+    // 3. Only reading, never mutating UIDevice state
     public static nonisolated(unsafe) func getIdentifierForVendor() -> String? {
       return UIDevice.current.identifierForVendor?.uuidString
     }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -11,7 +11,7 @@ import NetworkExtension
 // TODO: Use a more abstract IPC protocol to make this less terse
 // TODO: Consider making this an actor to guarantee strict ordering
 
-class IPCClient {
+class IPCClient: @unchecked Sendable {
   enum Error: Swift.Error {
     case decodeIPCDataFailed
     case noIPCData
@@ -98,9 +98,8 @@ class IPCClient {
     }
   #endif
 
-  @MainActor
   func setConfiguration(_ configuration: Configuration) async throws {
-    let tunnelConfiguration = configuration.toTunnelConfiguration()
+    let tunnelConfiguration = await configuration.toTunnelConfiguration()
     let message = ProviderMessage.setConfiguration(tunnelConfiguration)
 
     if sessionStatus() != .connected {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -6,12 +6,11 @@
 
 import CryptoKit
 import Foundation
-import NetworkExtension
+@preconcurrency import NetworkExtension
 
 // TODO: Use a more abstract IPC protocol to make this less terse
-// TODO: Consider making this an actor to guarantee strict ordering
 
-class IPCClient: @unchecked Sendable {
+actor IPCClient {
   enum Error: Swift.Error {
     case decodeIPCDataFailed
     case noIPCData
@@ -31,7 +30,7 @@ class IPCClient: @unchecked Sendable {
 
   // IPC only makes sense if there's a valid session. Session in this case refers to the `connection` field of
   // the NETunnelProviderManager instance.
-  let session: NETunnelProviderSession
+  nonisolated let session: NETunnelProviderSession
 
   // Track the "version" of the resource list so we can more efficiently
   // retrieve it from the Provider
@@ -46,8 +45,8 @@ class IPCClient: @unchecked Sendable {
   }
 
   // Encoder used to send messages to the tunnel
-  let encoder = PropertyListEncoder()
-  let decoder = PropertyListDecoder()
+  nonisolated let encoder = PropertyListEncoder()
+  nonisolated let decoder = PropertyListDecoder()
 
   // Auto-connect
   @MainActor
@@ -78,7 +77,7 @@ class IPCClient: @unchecked Sendable {
     try stop()
   }
 
-  func stop() throws {
+  nonisolated func stop() throws {
     try session().stopTunnel()
   }
 
@@ -110,37 +109,38 @@ class IPCClient: @unchecked Sendable {
   }
 
   func fetchResources() async throws -> ResourceList {
-    return try await withCheckedThrowingContinuation { continuation in
+    // Capture current hash before entering continuation
+    let currentHash = resourceListHash
+
+    // Get data from the provider - continuation returns just the data
+    let data = try await withCheckedThrowingContinuation { continuation in
       do {
         // Request list of resources from the provider. We send the hash of the resource list we already have.
         // If it differs, we'll get the full list in the callback. If not, we'll get nil.
         try session([.connected]).sendProviderMessage(
-          encoder.encode(ProviderMessage.getResourceList(resourceListHash))
+          encoder.encode(ProviderMessage.getResourceList(currentHash))
         ) { data in
-          guard let data = data
-          else {
-            // No data returned; Resources haven't changed
-            continuation.resume(returning: self.resourcesListCache)
-
-            return
-          }
-
-          // Save hash to compare against
-          self.resourceListHash = Data(SHA256.hash(data: data))
-
-          do {
-            let decoded = try self.decoder.decode([Resource].self, from: data)
-            self.resourcesListCache = ResourceList.loaded(decoded)
-
-            continuation.resume(returning: self.resourcesListCache)
-          } catch {
-            continuation.resume(throwing: error)
-          }
+          continuation.resume(returning: data)
         }
       } catch {
         continuation.resume(throwing: error)
       }
     }
+
+    // Back on the actor - safe to access and mutate state directly
+    guard let data = data else {
+      // No data returned; Resources haven't changed
+      return resourcesListCache
+    }
+
+    // Save hash to compare against
+    resourceListHash = Data(SHA256.hash(data: data))
+
+    // Decode and cache the new resource list
+    let decoded = try decoder.decode([Resource].self, from: data)
+    resourcesListCache = ResourceList.loaded(decoded)
+
+    return resourcesListCache
   }
 
   func clearLogs() async throws {
@@ -175,7 +175,7 @@ class IPCClient: @unchecked Sendable {
   // Call this with a closure that will append each chunk to a buffer
   // of some sort, like a file. The completed buffer is a valid Apple Archive
   // in AAR format.
-  func exportLogs(
+  nonisolated func exportLogs(
     appender: @escaping (LogChunk) -> Void,
     errorHandler: @escaping (Error) -> Void
   ) {
@@ -219,8 +219,9 @@ class IPCClient: @unchecked Sendable {
 
   // Subscribe to system notifications about our VPN status changing
   // and let our handler know about them.
-  func subscribeToVPNStatusUpdates(handler: @escaping @MainActor (NEVPNStatus) async throws -> Void)
-  {
+  nonisolated func subscribeToVPNStatusUpdates(
+    handler: @escaping @MainActor (NEVPNStatus) async throws -> Void
+  ) {
     Task {
       for await notification in NotificationCenter.default.notifications(
         named: .NEVPNStatusDidChange)
@@ -231,9 +232,8 @@ class IPCClient: @unchecked Sendable {
         }
 
         if session.status == .disconnected {
-          // Reset resource list
-          resourceListHash = Data()
-          resourcesListCache = ResourceList.loading
+          // Reset resource list on disconnect
+          await self.resetResourceList()
         }
 
         do { try await handler(session.status) } catch { Log.error(error) }
@@ -241,11 +241,17 @@ class IPCClient: @unchecked Sendable {
     }
   }
 
-  func sessionStatus() -> NEVPNStatus {
+  private func resetResourceList() {
+    resourceListHash = Data()
+    resourcesListCache = ResourceList.loading
+  }
+
+  nonisolated func sessionStatus() -> NEVPNStatus {
     return session.status
   }
 
-  private func session(_ requiredStatuses: Set<NEVPNStatus> = []) throws -> NETunnelProviderSession
+  nonisolated private func session(_ requiredStatuses: Set<NEVPNStatus> = []) throws
+    -> NETunnelProviderSession
   {
     if requiredStatuses.isEmpty || requiredStatuses.contains(session.status) {
       return session

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -8,25 +8,29 @@ import Foundation
 import OSLog
 
 public final class Log {
-  private static var logger =
+  private static let logger: Logger = {
     switch Bundle.main.bundleIdentifier {
     case "dev.firezone.firezone":
-      Logger(subsystem: "dev.firezone.firezone", category: "app")
+      return Logger(subsystem: "dev.firezone.firezone", category: "app")
     case "dev.firezone.firezone.network-extension":
-      Logger(subsystem: "dev.firezone.firezone", category: "tunnel")
+      return Logger(subsystem: "dev.firezone.firezone", category: "tunnel")
     default:
       fatalError("Unknown bundle id: \(Bundle.main.bundleIdentifier!)")
     }
+  }()
 
-  private static var logWriter =
+  private static let logWriter: LogWriter? = {
+    let folderURL: URL?
     switch Bundle.main.bundleIdentifier {
     case "dev.firezone.firezone":
-      LogWriter(folderURL: SharedAccess.appLogFolderURL, logger: logger)
+      folderURL = SharedAccess.appLogFolderURL
     case "dev.firezone.firezone.network-extension":
-      LogWriter(folderURL: SharedAccess.tunnelLogFolderURL, logger: logger)
+      folderURL = SharedAccess.tunnelLogFolderURL
     default:
       fatalError("Unknown bundle id: \(Bundle.main.bundleIdentifier!)")
     }
+    return LogWriter(folderURL: folderURL, logger: logger)
+  }()
 
   public static func log(_ message: String) {
     debug(message)
@@ -67,11 +71,6 @@ public final class Log {
     let fileManager = FileManager.default
     var totalSize: Int64 = 0
 
-    func sizeOfFile(at url: URL, with resourceValues: URLResourceValues) -> Int64 {
-      guard resourceValues.isRegularFile == true else { return 0 }
-      return Int64(resourceValues.totalFileAllocatedSize ?? resourceValues.totalFileSize ?? 0)
-    }
-
     // Tally size of each log file in parallel
     await withTaskGroup(of: Int64.self) { taskGroup in
       fileManager.forEachFileUnder(
@@ -82,8 +81,12 @@ public final class Log {
           .isRegularFileKey,
         ]
       ) { url, resourceValues in
-        taskGroup.addTask {
-          return sizeOfFile(at: url, with: resourceValues)
+        // Extract non-Sendable values before passing to @Sendable closure
+        guard resourceValues.isRegularFile == true else { return }
+        let size = Int64(resourceValues.totalFileAllocatedSize ?? resourceValues.totalFileSize ?? 0)
+
+        taskGroup.addTask { @Sendable in
+          return size
         }
       }
 
@@ -118,7 +121,9 @@ public final class Log {
   }
 }
 
-private final class LogWriter {
+/// Thread-safe: All mutable state access is serialised through workQueue.
+/// Log writes are queued asynchronously to avoid blocking the caller.
+private final class LogWriter: @unchecked Sendable {
   enum Severity: String, Codable {
     case trace = "TRACE"
     case debug = "DEBUG"

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Log.swift
@@ -233,13 +233,11 @@ private final class LogWriter: @unchecked Sendable {
       severity: severity,
       message: message)
 
-    guard var jsonData = try? jsonEncoder.encode(logEntry)
+    guard let jsonData = try? jsonEncoder.encode(logEntry) + Data("\n".utf8)
     else {
       logger.error("Could not encode log message to JSON!")
       return
     }
-
-    jsonData.append(Data("\n".utf8))
 
     workQueue.async { [weak self] in
       guard let self = self else { return }

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -154,7 +154,9 @@ import System
 #endif
 
 extension LogExporter {
-  private static let fileManager = FileManager.default
+  /// Thread-safe: FileManager.default is documented as thread-safe by Apple.
+  /// Reference: https://developer.apple.com/documentation/foundation/filemanager
+  private nonisolated(unsafe) static let fileManager = FileManager.default
 
   static func now() -> String {
     let dateFormatter = ISO8601DateFormatter()

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/Telemetry.swift
@@ -11,8 +11,16 @@ public enum Telemetry {
   // the existing one. So we need to collect these fields from various codepaths
   // during initialization / sign in so we can build a new User object any time
   // one of these is updated.
-  private static var _firezoneId: String?
-  private static var _accountSlug: String?
+
+  /// Thread-safety: Low risk in practice - only set during initialisation/sign-in.
+  /// Accessed from multiple contexts (MainActor app, background Network Extension, logging).
+  /// TODO: Add proper synchronisation (actor or DispatchQueue) for strict concurrency.
+  private nonisolated(unsafe) static var _firezoneId: String?
+
+  /// Thread-safety: Low risk in practice - only set during initialisation/sign-in.
+  /// Accessed from multiple contexts (MainActor app, background Network Extension, logging).
+  /// TODO: Add proper synchronisation (actor or DispatchQueue) for strict concurrency.
+  private nonisolated(unsafe) static var _accountSlug: String?
   public static var firezoneId: String? {
     get {
       return self._firezoneId

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -21,7 +21,9 @@ enum VPNConfigurationManagerError: Error {
   }
 }
 
-public class VPNConfigurationManager {
+/// Thread-safe: Immutable wrapper around NETunnelProviderManager.
+/// Only contains a 'let' property. NETunnelProviderManager handles its own synchronisation.
+public class VPNConfigurationManager: @unchecked Sendable {
   // Persists our tunnel settings
   let manager: NETunnelProviderManager
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -108,7 +108,11 @@ public class Configuration: ObservableObject {
     static let supportURL = "supportURL"
   }
 
-  private var defaults: UserDefaults
+  // nonisolated(unsafe) is required because:
+  // 1. UserDefaults is thread-safe
+  // 2. Used only for NotificationCenter observer registration (in init/deinit)
+  // 3. deinit is nonisolated and needs access to remove the observer
+  private nonisolated(unsafe) var defaults: UserDefaults
 
   init(userDefaults: UserDefaults = UserDefaults.standard) {
     defaults = userDefaults
@@ -176,7 +180,7 @@ public class Configuration: ObservableObject {
 }
 
 // Configuration does not conform to Decodable, so introduce a simpler type here to encode for IPC
-public struct TunnelConfiguration: Codable {
+public struct TunnelConfiguration: Codable, Sendable {
   public let apiURL: String
   public let accountSlug: String
   public let logFilter: String

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -13,7 +13,7 @@ class StatusSymbol {
   static let disabled: String = "—"
 }
 
-public enum ResourceList {
+public enum ResourceList: Sendable {
   case loading
   case loaded([Resource])
 
@@ -27,7 +27,7 @@ public enum ResourceList {
   }
 }
 
-public struct Resource: Codable, Identifiable, Equatable {
+public struct Resource: Codable, Identifiable, Equatable, Sendable {
   public let id: String
   public var name: String
   public var address: String?
@@ -59,7 +59,7 @@ public struct Resource: Codable, Identifiable, Equatable {
   }
 }
 
-public enum ResourceStatus: String, Codable {
+public enum ResourceStatus: String, Codable, Sendable {
   case offline = "Offline"
   case online = "Online"
   case unknown = "Unknown"
@@ -91,7 +91,7 @@ public enum ResourceStatus: String, Codable {
   }
 }
 
-public enum ResourceType: String, Codable {
+public enum ResourceType: String, Codable, Sendable {
   case dns
   case cidr
   case ip

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Resource.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 class StatusSymbol {
-  static var enabled: String = "<->"
-  static var disabled: String = "—"
+  static let enabled: String = "<->"
+  static let disabled: String = "—"
 }
 
 public enum ResourceList {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -128,8 +128,7 @@ public class SessionNotification: NSObject {
 
 #if os(iOS)
   extension SessionNotification: UNUserNotificationCenterDelegate {
-    @concurrent
-    public func userNotificationCenter(
+    nonisolated public func userNotificationCenter(
       _ center: UNUserNotificationCenter,
       didReceive response: UNNotificationResponse,
       withCompletionHandler completionHandler: @escaping () -> Void

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/SessionNotification.swift
@@ -22,7 +22,7 @@ public enum NotificationIndentifier: String {
   case dismissNotificationAction
 }
 
-public class SessionNotification: NSObject {
+public class SessionNotification: NSObject, @unchecked Sendable {
   public var signInHandler = {}
   private let notificationCenter = UNUserNotificationCenter.current()
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Site.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Site.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Site: Codable, Identifiable, Equatable {
+public struct Site: Codable, Identifiable, Equatable, Sendable {
   public let id: String
   public var name: String
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Token.swift
@@ -15,7 +15,9 @@ public struct Token: CustomStringConvertible {
     private static let label = "Firezone token"
   #endif
 
-  private static let query: [CFString: Any] = [
+  /// Thread-safe: Immutable dictionary initialised at compile time.
+  /// CFString keys and constant string values are both Sendable.
+  private nonisolated(unsafe) static let query: [CFString: Any] = [
     kSecAttrLabel: "Firezone token",
     kSecAttrAccount: "1",
     kSecAttrService: BundleHelper.appGroupId,

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -263,7 +263,7 @@ public final class Store: ObservableObject {
     UserDefaults.standard.set(actorName, forKey: "actorName")
 
     configuration.accountSlug = accountSlug
-    Telemetry.accountSlug = accountSlug
+    await Telemetry.setAccountSlug(accountSlug)
 
     try await manager().enable()
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -107,7 +107,8 @@ public final class Store: ObservableObject {
   #endif
 
   private func setupTunnelObservers() async throws {
-    let vpnStatusChangeHandler: (NEVPNStatus) async throws -> Void = { [weak self] status in
+    let vpnStatusChangeHandler: @Sendable (NEVPNStatus) async throws -> Void = {
+      [weak self] status in
       try await self?.handleVPNStatusChange(newVPNStatus: status)
     }
     try ipcClient().subscribeToVPNStatusUpdates(handler: vpnStatusChangeHandler)

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/UpdateNotification.swift
@@ -23,7 +23,11 @@
       }
     }
 
-    private var timer: Timer?
+    // nonisolated(unsafe) is required because:
+    // 1. Timer.invalidate() is thread-safe and can be called from any thread
+    // 2. Only accessed from MainActor-isolated methods (init, start/stop) and nonisolated deinit
+    // 3. deinit is nonisolated and needs access to invalidate the timer
+    private nonisolated(unsafe) var timer: Timer?
     private let notificationAdapter: NotificationAdapter = NotificationAdapter()
     private let versionCheckUrl: URL
     private let marketingVersion: SemanticVersion

--- a/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
+++ b/swift/apple/FirezoneNetworkExtension/BindResolvers.swift
@@ -55,6 +55,14 @@ enum BindResolvers {
           NI_NUMERICHOST)
       }
     }
-    return String(cString: hostBuffer)
+    // Truncate null termination and decode as UTF-8
+    // Convert CChar (Int8) to UInt8 for String(decoding:)
+    if let nullIndex = hostBuffer.firstIndex(of: 0) {
+      let bytes = hostBuffer[..<nullIndex].map { UInt8(bitPattern: $0) }
+      return String(decoding: bytes, as: UTF8.self)
+    } else {
+      let bytes = hostBuffer.map { UInt8(bitPattern: $0) }
+      return String(decoding: bytes, as: UTF8.self)
+    }
   }
 }

--- a/swift/apple/FirezoneNetworkExtension/Info.iOS.plist
+++ b/swift/apple/FirezoneNetworkExtension/Info.iOS.plist
@@ -11,5 +11,12 @@
 	</dict>
 	<key>AppGroupIdentifier</key>
 	<string>$(APP_GROUP_ID)</string>
+	<key>LSEnvironment</key>
+	<dict>
+		<key>SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL</key>
+		<string>1</string>
+		<key>SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE</key>
+		<string>nocrash</string>
+	</dict>
 </dict>
 </plist>

--- a/swift/apple/FirezoneNetworkExtension/Info.macOS.plist
+++ b/swift/apple/FirezoneNetworkExtension/Info.macOS.plist
@@ -26,6 +26,13 @@
 	<string>$(APP_GROUP_ID)</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2025 Firezone, Inc. All rights reserved.</string>
+	<key>LSEnvironment</key>
+	<dict>
+		<key>SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL</key>
+		<string>1</string>
+		<key>SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE</key>
+		<string>nocrash</string>
+	</dict>
   <key>NetworkExtension</key>
   <dict>
     <key>NEMachServiceName</key>

--- a/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
+++ b/swift/apple/FirezoneNetworkExtension/NetworkSettings.swift
@@ -53,7 +53,7 @@ class NetworkSettings {
     self.matchDomains.append(contentsOf: self.searchDomains)
   }
 
-  func apply(completionHandler: (() -> Void)? = nil) {
+  func apply(completionHandler: (@Sendable () -> Void)? = nil) {
     // We don't really know the connlib gateway IP address at this point, but just using 127.0.0.1 is okay
     // because the OS doesn't really need this IP address.
     // NEPacketTunnelNetworkSettings taking in tunnelRemoteAddress is probably a bad abstraction caused by

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -310,20 +310,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
   }
 
-  func consumeStopReason(_ completionHandler: @Sendable (Data?) -> Void) {
-    guard let data = try? Data(contentsOf: SharedAccess.providerStopReasonURL)
-    else {
-      completionHandler(nil)
-
-      return
-    }
-
-    try? FileManager.default
-      .removeItem(at: SharedAccess.providerStopReasonURL)
-
-    completionHandler(data)
-  }
-
   // Firezone ID migration. Can be removed once most clients migrate past 1.4.15.
   private func migrateFirezoneId() {
     let filename = "firezone-id"

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -114,7 +114,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
       // Configure telemetry
       Telemetry.setEnvironmentOrClose(apiURL)
-      Telemetry.accountSlug = accountSlug
+      Task { await Telemetry.setAccountSlug(accountSlug) }
 
       let enabled = legacyConfiguration?["internetResourceEnabled"]
       let internetResourceEnabled =


### PR DESCRIPTION
This PR upgrades the Swift client from Swift 5 to Swift 6.2, addressing all
concurrency-related warnings and runtime crashes that come with Swift 6's
strict concurrency checking.

## Swift 6 Concurrency Primer

**`actor`** - A new reference type that provides thread-safe, serialised
access to mutable state. Unlike classes, actors ensure that only one piece of
code can access their mutable properties at a time. Access to actor
methods/properties requires await and automatically hops to the actor's
isolated executor.

**`@MainActor`** - An attribute that marks code to run on the main thread.
Essential for UI updates and anything that touches UIKit/AppKit. When a
class/function is marked @MainActor, all its methods and properties inherit
this isolation.

**`@Sendable`** - A protocol indicating that a type can be safely passed
across concurrency domains (between actors, tasks, etc.). Value types
(structs, enums) with Sendable stored properties are automatically Sendable.
Reference types (classes) need explicit @unchecked Sendable if they manage
thread-safety manually.

**`nonisolated`** - Opts out of the containing type's actor isolation. For
example, a nonisolated method in a @MainActor class can be called from any
thread without await. Useful for static methods or thread-safe operations.

**`@concurrent`** - Used on closure parameters in delegate methods. Indicates
the closure may be called from any thread, preventing the closure from
inheriting the surrounding context's actor isolation. Critical for callbacks
from system frameworks that call from background threads.

**Data Races** - Swift 6 enforces at compile-time (and optionally at runtime)
that mutable state cannot be accessed concurrently from multiple threads. This
eliminates entire classes of bugs that were previously only caught through
testing or production crashes.

## Swift Language Upgrade

- **Bump Swift 5 → 6.2**: Enabled strict concurrency checking throughout the
  codebase
- **Enable ExistentialAny (SE-0335)**: Adds compile-time safety by making
  protocol type erasure explicit (e.g., any Protocol instead of implicit
  Protocol)
- **Runtime safety configuration**: Added environment variables to log
  concurrency violations during development instead of crashing, allowing
  gradual migration

## Concurrency Fixes

### Actor Isolation

- **TelemetryState actor** (Telemetry.swift:10): Extracted mutable telemetry
  state into a dedicated actor to eliminate data races from concurrent access
- **SessionNotification @MainActor isolation** (SessionNotification.swift:25):
  Properly isolated the class to MainActor since it manages UI-related
  callbacks
- **IPCClient caching** (IPCClient.swift): Fixed actor re-entrance issues and
  resource hash-based optimisation by caching the client instance in Store

### Thread-Safe Callbacks

- **WebAuthSession @concurrent delegate** (WebAuthSession.swift:46): The
  authentication callback is invoked from a background thread by
  ASWebAuthenticationSession. Marked the wrapper function as @concurrent to
  prevent MainActor inference on the completion handler closure, then
  explicitly hopped back to MainActor for the session.start() call. This
  fixes EXC_BAD_INSTRUCTION crashes at _dispatch_assert_queue_fail.
- **SessionNotification @concurrent delegate**
  (SessionNotification.swift:131): Similarly marked the notification delegate
  method as @concurrent and used Task { @MainActor in } to safely invoke the
  MainActor-isolated signInHandler

### Sendable Conformances

- Added Sendable to Resource, Site, Token, Configuration, and other model
  types that are passed between actors and tasks
- **LogWriter immutability** (Log.swift): Made jsonData immutable to prevent
  capturing mutable variables in @Sendable closures

### Nonisolated Methods

- **Static notification display** (SessionNotification.swift:73): Marked
  showSignedOutNotificationiOS() as nonisolated since it's called from the
  Network Extension (different process) and only uses thread-safe APIs

Fixes #10674
Fixes #10675