### PR TITLE
ci: only check for completed jobs every 60s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
             echo "Jobs not yet completed:"
             echo "$jobs_json" | jq -r '.[] | select(.status != "completed") | "- " + .name + " (Status: " + .status + ")" '
 
-            sleep 10
+            sleep 60
           done
 
   kotlin:


### PR DESCRIPTION
According to GitHub support, this API call is responsible for most of our API usage. Until we find a better way of organising this, checking every only minute should be fine too, even if it slows down the merge queue a bit.