### PR TITLE
feat(apt): sign contents of APT repository

### DIFF
--- a/.github/actions/setup-gpg/action.yml
+++ b/.github/actions/setup-gpg/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Set GnuPG options
       run: |
-        mkdir -p ~/.gnupg
+        mkdir --parents --mode 0700 ~/.gnupg
 
         echo "use-agent" >> ~/.gnupg/gpg.conf
         echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf

--- a/.github/actions/setup-gpg/action.yml
+++ b/.github/actions/setup-gpg/action.yml
@@ -16,6 +16,8 @@ runs:
   steps:
     - name: Set GnuPG options
       run: |
+        mkdir -p ~/.gnupg
+
         echo "use-agent" >> ~/.gnupg/gpg.conf
         echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
       shell: bash

--- a/.github/actions/setup-gpg/action.yml
+++ b/.github/actions/setup-gpg/action.yml
@@ -1,0 +1,29 @@
+name: "Setup GnuPG"
+description: "Sets up gpg for non-interactive signing"
+inputs:
+  key:
+    description: "The GPG key to import"
+    required: true
+  email:
+    description: "The email to associate with the key"
+    required: true
+outputs:
+  key_id:
+    description: The short-ID of the GPG key.
+    value: ${{ steps.import.outputs.key_id }}
+runs:
+  using: "composite"
+  steps:
+    - name: Set GnuPG options
+      run: |
+        echo "use-agent" >> ~/.gnupg/gpg.conf
+        echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+      shell: bash
+    - name: Import key
+      id: import
+      shell: bash
+      run: |
+        echo "${{ inputs.key }}" | gpg --import --batch
+        GPG_KEY_ID=$(gpg --list-secret-keys --with-colons ${{ inputs.email }} 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5)
+
+        echo "key_id=$GPG_KEY_ID" >> $GITHUB_OUTPUT

--- a/.github/workflows/_apt.yml
+++ b/.github/workflows/_apt.yml
@@ -18,6 +18,13 @@ jobs:
 
       - uses: ./.github/actions/setup-azure-cli
 
+      - uses: ./.github/actions/setup-gpg
+        id: setup-gpg
+        with:
+          key: ${{ secrets.APT_REPOSITORY_GPG_KEY }}
+          email: packages@firezone.dev
+
       - run: scripts/sync-apt.sh
         env:
           AZURERM_ARTIFACTS_CONNECTION_STRING: ${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}
+          GPG_KEY_ID: ${{ steps.setup-gpg.outputs.key_id }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -125,6 +125,12 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PR_BOT_GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-gpg
+        id: setup-gpg
+        if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
+        with:
+          key: ${{ secrets.RELEASE_PR_BOT_GPG_KEY }}
+          email: github-bot@firezone.dev
       - if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
         run: |
           set -x
@@ -133,18 +139,11 @@ jobs:
           version=${{ inputs.release_name || github.event.release.name }}
           version=${version#${{ matrix.tag_prefix }}-}
 
-          # Configure gpg
-          echo "$RELEASE_PR_BOT_GPG_KEY" | gpg --import --batch
-          GPG_KEY_ID=$(gpg --list-secret-keys --with-colons github-bot@firezone.dev 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5)
-
           # Configure git
           git config --local user.email "github-bot@firezone.dev"
           git config --local user.name "Firezone Bot"
-          git config --local user.signingkey "$GPG_KEY_ID"
+          git config --local user.signingkey "${{ steps.setup-gpg.outputs.key_id }}"
           git config --local commit.gpgsign true
-
-          echo "use-agent" >> ~/.gnupg/gpg.conf
-          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
 
           # Create the PR
           scripts/create-publish-pr.sh ${{ matrix.component }} "$version"

--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -11,6 +11,11 @@ if [ -z "${AZURERM_ARTIFACTS_CONNECTION_STRING:-}" ]; then
     exit 1
 fi
 
+if [ -z "${GPG_KEY_ID:-}" ]; then
+    echo "Error: GPG_KEY_ID not set"
+    exit 1
+fi
+
 cleanup() {
     rm -rf "${WORK_DIR}"
 }
@@ -64,6 +69,9 @@ Date: $(date -R -u)
 EOF
 
     apt-ftparchive release . >>Release
+
+    gpg --default-key "${GPG_KEY_ID}" -abs -o Release.gpg Release
+    gpg --default-key "${GPG_KEY_ID}" --clearsign -o InRelease Release
 done
 
 echo "Uploading metadata..."
@@ -74,5 +82,3 @@ az storage blob upload-batch \
     --connection-string "${AZURERM_ARTIFACTS_CONNECTION_STRING}" \
     --overwrite \
     --output table
-
-echo "Done"


### PR DESCRIPTION
In order to secure an APT repository, the `Release` file containing the hashes of all packages needs to be signed with a GPG key. These signatures simply need to be synced back up to the repository. The rest is handled by `apt` itself.

Resolves: #10599