### PR TITLE
feat(gateway): capture domain name of flow

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -475,6 +475,7 @@ impl GatewayState {
                         inner_dst_ip = %flow.inner_dst_ip,
                         inner_src_port = %flow.inner_src_port,
                         inner_dst_port = %flow.inner_dst_port,
+                        inner_domain = flow.inner_domain.map(tracing::field::display),
 
                         outer_src_ip = %flow.outer_src_ip,
                         outer_dst_ip = %flow.outer_dst_ip,
@@ -502,6 +503,7 @@ impl GatewayState {
                         inner_dst_ip = %flow.inner_dst_ip,
                         inner_src_port = %flow.inner_src_port,
                         inner_dst_port = %flow.inner_dst_port,
+                        inner_domain = flow.inner_domain.map(tracing::field::display),
 
                         outer_src_ip = %flow.outer_src_ip,
                         outer_dst_ip = %flow.outer_dst_ip,

--- a/rust/connlib/tunnel/src/gateway/client_on_gateway.rs
+++ b/rust/connlib/tunnel/src/gateway/client_on_gateway.rs
@@ -439,6 +439,8 @@ impl ClientOnGateway {
             ));
         }
 
+        flow_tracker::inbound_wg::record_domain(state.domain.clone());
+
         let (source_protocol, real_ip) =
             self.nat_table
                 .translate_outgoing(&packet, resolved_ip, now)?;

--- a/scripts/tests/download-concurrent.sh
+++ b/scripts/tests/download-concurrent.sh
@@ -35,6 +35,7 @@ rx_bytes=0
 
 for flow in "${flows[@]}"; do
     assert_eq "$(get_flow_field "$flow" "inner_dst_ip")" "172.21.0.101"
+    assert_eq "$(get_flow_field "$flow" "inner_domain")" "download.httpbin"
     rx_bytes+="$(get_flow_field "$flow" "rx_bytes")"
 done
 

--- a/scripts/tests/download.sh
+++ b/scripts/tests/download.sh
@@ -26,4 +26,5 @@ assert_eq "${#flows[@]}" 1
 
 flow="${flows[0]}"
 assert_eq "$(get_flow_field "$flow" "inner_dst_ip")" "172.21.0.101"
+assert_eq "$(get_flow_field "$flow" "inner_domain")" "download.httpbin"
 assert_gteq "$(get_flow_field "$flow" "rx_bytes")" 10000000


### PR DESCRIPTION
Whenever we route a packet from the Client to a DNS resource, we now also capture the domain name. If this is the first packet and we are thus creating a new flow, we'll save that domain in it. Later packets for the same IP are rolled up under the same flow and thus don't need to re-set the domain.

Resolves: #10691 