### PR TITLE
feat(apt): import `.deb` files from `import-` directory

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -198,7 +198,7 @@ jobs:
         run: |
           set -xe
 
-          # Download all .deb assets directly to pool
+          # Download all .deb assets
           gh release download "${{ inputs.release_name || github.event.release.name }}" --pattern "*.deb"
 
           # List downloaded files for verification
@@ -209,7 +209,7 @@ jobs:
           --destination apt \
           --source . \
           --pattern "*.deb" \
-          --destination-path pool \
+          --destination-path import-stable \
           --overwrite \
           --no-progress \
           --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"

--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -73,11 +73,13 @@ for DISTRIBUTION in "stable" "preview"; do
     echo "Generating metadata..."
     mkdir -p "${DISTS_DIR}/${DISTRIBUTION}/${COMPONENT}"
 
+    cd "$WORK_DIR"
+
     for ARCH in $ARCHITECTURES; do
         BINARY_DIR="${DISTS_DIR}/${DISTRIBUTION}/${COMPONENT}/binary-${ARCH}"
         mkdir -p "${BINARY_DIR}"
 
-        apt-ftparchive packages --arch "${ARCH}" "${POOL_DIR}/" >"${BINARY_DIR}/Packages"
+        apt-ftparchive packages --arch "${ARCH}" "pool-${DISTRIBUTION}" >"${BINARY_DIR}/Packages"
         gzip -k -f "${BINARY_DIR}/Packages"
 
         cat >"${BINARY_DIR}/Release" <<EOF

--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -89,7 +89,7 @@ for DISTRIBUTION in "stable" "preview"; do
     fi
 
     if [ -z "$(ls -A "${POOL_DIR}")" ]; then
-        echo "No packages for distribtion ${DISTRIBUTION}"
+        echo "No packages for distribution ${DISTRIBUTION}"
 
         continue
     fi


### PR DESCRIPTION
Currently, the `sync-apt.sh` script just generates metadata for all packages found in the `.deb` directory. Unfortunately, this requires the packages to already be uploaded with a certain naming convention, otherwise `apt-ftparchive packages` doesn't actually detect them and creates an empty `Packages` file.

The solution here is to extend the `sync-apt.sh` script to normalize the filename to what we need it to be. This requires us to upload the new `.deb` files to the `pool` directory. Instead of messing around with the existing files in there, we slightly change how the `sync-apt.sh` script works.

In its new version, it expects packages to be in the `import-stable` and `import-preview` directories. It will then download these, normalize their names and move them to a local `pool-stable` and `pool-preview` directory respectively (potentially overwriting and existing one that is already there, this allows for updating packages).

As a final step, it will generate the metadata for all packages in `pool-stable` and `pool-preview`, upload both directories, upload the metadata and then delete the imported `.deb` files.