### PR TITLE
fix(gateway): trim whitespace from systemd credential

### DIFF
--- a/rust/gateway/src/main.rs
+++ b/rust/gateway/src/main.rs
@@ -276,7 +276,7 @@ async fn read_systemd_credential(name: &str) -> Result<SecretString> {
     let path = PathBuf::from(creds_dir).join(name);
     let content = tokio::fs::read_to_string(&path).await?;
 
-    Ok(SecretString::new(content))
+    Ok(SecretString::new(content.trim().to_owned()))
 }
 
 #[derive(Parser, Debug)]
@@ -457,7 +457,7 @@ mod tests {
         let cred_path = temp_dir.path().join("FIREZONE_TOKEN");
 
         // Write token to credential file
-        std::fs::write(cred_path, "systemd-token").unwrap();
+        std::fs::write(cred_path, "systemd-token\n").unwrap();
 
         // Set CREDENTIALS_DIRECTORY environment variable
         unsafe {


### PR DESCRIPTION
Unix tools often write a newline at the end of a file. When using the file's contents as a token, they need to match byte-for-byte otherwise we cannot authenticate to the portal. To ensure that, we trim the content from the file before creating the `SecretString`.