### PR TITLE
ci: only use Microsoft key for Azure CLI repo

### DIFF
--- a/.github/actions/setup-azure-cli/action.yml
+++ b/.github/actions/setup-azure-cli/action.yml
@@ -5,9 +5,9 @@ runs:
   steps:
     - run: |
         sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
-        curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+        curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
         AZ_REPO=$(lsb_release -cs)
-        echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
         sudo apt-get update
         sudo apt-get install -y azure-cli
       shell: bash


### PR DESCRIPTION
Adding new keys to the `/etc/apt/trusted.gpg.d` keyring is not recommended because it will make `apt` accept packages from any repository signed by this key. This could lead to third-party repositories "overriding" packages from the official ones.

To prevent that, we create a dedicated keyring for the Microsoft key and specify that it is only to be used for packages from the `azure-cli` repository.