### PR TITLE
feat(gateway,headless-client): set default log level to `INFO`

### DIFF
--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -46,7 +46,7 @@ where
         tracing::debug!("Failed to init terminal colors: {error}");
     }
 
-    let directives = std::env::var("RUST_LOG").unwrap_or_default();
+    let directives = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
 
     let (filter1, reload_handle1) =
         try_filter(&directives).context("Failed to parse directives")?;


### PR DESCRIPTION
Currently, the default log level for both the Gateway and the headless Client is actually `error` which basically means no logs at all. To avoid having to create additional configuration as part of the Debian packages, we set the default log level to `info`.