### PR TITLE
feat(fz-cli): better secret handling

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2398,6 +2398,8 @@ dependencies = [
  "nix 0.30.1",
  "rpassword",
  "secrecy",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2397,6 +2397,7 @@ dependencies = [
  "clap",
  "nix 0.30.1",
  "rpassword",
+ "secrecy",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2396,6 +2396,7 @@ dependencies = [
  "anyhow",
  "clap",
  "nix 0.30.1",
+ "rpassword",
 ]
 
 [[package]]
@@ -6187,6 +6188,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6202,6 +6214,16 @@ dependencies = [
  "nix 0.29.0",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -139,6 +139,7 @@ reqwest = { version = "0.12.23", default-features = false }
 resolv-conf = "0.7.5"
 ringbuffer = "0.16.0"
 roxmltree = "0.20"
+rpassword = "7.4.0"
 rtnetlink = { version = "0.17.0", default-features = false, features = ["tokio_socket"] }
 rustls = { version = "0.23.31", default-features = false, features = ["ring"] }
 sadness-generator = "0.6.0"

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -10,6 +10,8 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 rpassword = { workspace = true }
 secrecy = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { workspace = true, features = ["user"] }

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -8,6 +8,7 @@ description = "CLI for managing Firezone installations"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+rpassword = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { workspace = true, features = ["user"] }

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -9,6 +9,7 @@ description = "CLI for managing Firezone installations"
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 rpassword = { workspace = true }
+secrecy = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { workspace = true, features = ["user"] }

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use secrecy::SecretString;
 
 const ETC_FIREZONE_GATEWAY_TOKEN: &str = "/etc/firezone/gateway-token";
 
@@ -35,7 +36,7 @@ fn main() -> Result<()> {
                     continue;
                 }
 
-                break token;
+                break SecretString::new(token);
             };
 
             install_firezone_gateway_token(token)?;
@@ -102,8 +103,10 @@ fn is_root() -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn install_firezone_gateway_token(token: String) -> Result<()> {
-    std::fs::write(ETC_FIREZONE_GATEWAY_TOKEN, token)
+fn install_firezone_gateway_token(token: SecretString) -> Result<()> {
+    use secrecy::ExposeSecret;
+
+    std::fs::write(ETC_FIREZONE_GATEWAY_TOKEN, token.expose_secret())
         .with_context(|| format!("Failed to write token to `{ETC_FIREZONE_GATEWAY_TOKEN}`"))?;
 
     Ok(())

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -25,21 +25,18 @@ fn main() -> Result<()> {
                 );
             }
 
-            let mut token = String::with_capacity(512); // Our tokens are ~270 characters, grab the next power of 2.
-
-            loop {
+            let token = loop {
                 println!("Paste the token from the portal's deploy page:");
 
-                let num_bytes = std::io::stdin()
-                    .read_line(&mut token)
-                    .context("Failed to read token from stdin")?;
+                let token =
+                    rpassword::read_password().context("Failed to read token from stdin")?;
 
-                if num_bytes == 0 || token.trim().is_empty() {
+                if token.trim().is_empty() {
                     continue;
                 }
 
-                break;
-            }
+                break token;
+            };
 
             install_firezone_gateway_token(token)?;
 

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -1,12 +1,29 @@
 #![expect(clippy::print_stdout, reason = "We are a CLI.")]
 
+use std::{process::Command, sync::LazyLock};
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use secrecy::SecretString;
+use secrecy::{ExposeSecret as _, SecretString};
+use tracing_subscriber::{EnvFilter, util::SubscriberInitExt};
 
 const ETC_FIREZONE_GATEWAY_TOKEN: &str = "/etc/firezone/gateway-token";
 
+static DRY_RUN: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("FZ_DRY_RUN")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_default()
+});
+
 fn main() -> Result<()> {
+    let _guard = tracing_subscriber::fmt()
+        .without_time()
+        .with_target(false)
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stdout)
+        .set_default();
+
     let cli = Cli::parse();
 
     use Component::*;
@@ -39,7 +56,7 @@ fn main() -> Result<()> {
                 break SecretString::new(token);
             };
 
-            install_firezone_gateway_token(token)?;
+            write_to_file(ETC_FIREZONE_GATEWAY_TOKEN, token)?;
 
             println!("Successfully installed token");
             println!("Tip: You can now start the Gateway with `firezone gateway enable`");
@@ -48,7 +65,8 @@ fn main() -> Result<()> {
             anyhow::ensure!(cfg!(target_os = "linux"), "Only supported Linux right now");
             anyhow::ensure!(is_root(), "Must be executed as root");
 
-            enable_gateway_service().context("Failed to enable `firezone-gateway.service`")?;
+            run("systemctl", "enable --now firezone-gateway.service")
+                .context("Failed to enable `firezone-gateway.service`")?;
 
             println!("Successfully enabled `firezone-gateway.service`");
         }
@@ -56,7 +74,8 @@ fn main() -> Result<()> {
             anyhow::ensure!(cfg!(target_os = "linux"), "Only supported Linux right now");
             anyhow::ensure!(is_root(), "Must be executed as root");
 
-            disable_gateway_service().context("Failed to disable `firezone-gateway.service`")?;
+            run("systemctl", "disable firezone-gateway.service")
+                .context("Failed to disable `firezone-gateway.service`")?;
 
             println!("Successfully disabled `firezone-gateway.service`");
         }
@@ -94,6 +113,10 @@ enum GatewayCommand {
 
 #[cfg(target_os = "linux")]
 fn is_root() -> bool {
+    if *DRY_RUN {
+        return true;
+    }
+
     nix::unistd::Uid::current().is_root()
 }
 
@@ -102,64 +125,37 @@ fn is_root() -> bool {
     true
 }
 
-#[cfg(target_os = "linux")]
-fn install_firezone_gateway_token(token: SecretString) -> Result<()> {
-    use secrecy::ExposeSecret;
+fn write_to_file(path: &str, content: SecretString) -> Result<()> {
+    tracing::debug!("Writing {} bytes to {path}", content.expose_secret().len());
 
-    std::fs::write(ETC_FIREZONE_GATEWAY_TOKEN, token.expose_secret())
-        .with_context(|| format!("Failed to write token to `{ETC_FIREZONE_GATEWAY_TOKEN}`"))?;
+    check_dry_run()?;
+
+    std::fs::write(path, content.expose_secret())
+        .with_context(|| format!("Failed to write to `{path}`"))?;
 
     Ok(())
 }
 
-#[cfg(not(target_os = "linux"))]
-fn install_firezone_gateway_token(token: String) -> Result<()> {
-    anyhow::bail!("Not implemented")
-}
+fn run(bin: &str, args: &str) -> Result<()> {
+    tracing::debug!("Running `{bin} {args}`");
 
-#[cfg(target_os = "linux")]
-fn enable_gateway_service() -> Result<()> {
-    use std::process::Command;
+    check_dry_run()?;
 
-    let output = Command::new("systemctl")
-        .arg("enable")
-        .arg("--now")
-        .arg("firezone-gateway.service")
+    let output = Command::new(bin)
+        .args(args.split_ascii_whitespace())
         .output()?;
 
     anyhow::ensure!(
         output.status.success(),
-        "`systemctl enable` exited with {}",
+        "`{bin} {args}` exited with {}",
         output.status
     );
 
     Ok(())
 }
 
-#[cfg(not(target_os = "linux"))]
-fn enable_gateway_service() -> Result<()> {
-    anyhow::bail!("Not implemented")
-}
-
-#[cfg(target_os = "linux")]
-fn disable_gateway_service() -> Result<()> {
-    use std::process::Command;
-
-    let output = Command::new("systemctl")
-        .arg("disable")
-        .arg("firezone-gateway.service")
-        .output()?;
-
-    anyhow::ensure!(
-        output.status.success(),
-        "`systemctl disable` exited with {}",
-        output.status
-    );
+fn check_dry_run() -> Result<()> {
+    anyhow::ensure!(!*DRY_RUN, "Aborting because `FZ_DRY_RUN=true`");
 
     Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn disable_gateway_service() -> Result<()> {
-    anyhow::bail!("Not implemented")
 }


### PR DESCRIPTION
This improves the secret handling inside `firezone-cli` by using the `rpassword` crate to hide the token from stdin and using `secrecy` to zeroize the memory afterwards. To make it easier to test locally, we add a dry run mode for local testing, hidden behind the `FZ_DRY_RUN` env variable.