### PR TITLE
feat(gateway): emit resource name and address in flow logs

### DIFF
--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -465,8 +465,10 @@ impl GatewayState {
                     tracing::trace!(
                         target: "flow_logs::tcp",
 
-                        client = %flow.client,
-                        resource = %flow.resource,
+                        client_id = %flow.client,
+                        resource_id = %flow.resource_id,
+                        resource_name = %flow.resource_name,
+                        resource_address = %flow.resource_address,
                         start = ?flow.start,
                         end = ?flow.end,
                         last_packet = ?flow.last_packet,
@@ -493,8 +495,10 @@ impl GatewayState {
                     tracing::trace!(
                         target: "flow_logs::udp",
 
-                        client = %flow.client,
-                        resource = %flow.resource,
+                        client_id = %flow.client,
+                        resource_id = %flow.resource_id,
+                        resource_name = %flow.resource_name,
+                        resource_address = %flow.resource_address,
                         start = ?flow.start,
                         end = ?flow.end,
                         last_packet = ?flow.last_packet,


### PR DESCRIPTION
To allow for better analysis of flow logs, we embed the resource name and its address into the flow flogs. For the Internet Resource, the name will be displayed as "Internet` and the address is either `0.0.0.0/0` or `::/0` depending on the IP version of the packet. For CIDR resources, the address is the subnet and for DNS resources, it is the domain pattern.

Resolves: #10693