### PR TITLE
ci: increase txqueuelen in containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
         ip -6 route add 203:0:113::/64 via 172:30:0::254
 
         # Disable checksum offloading so that checksums are correct when they reach the relay
-        apk add --no-cache ethtool
+        apk add --no-cache ethtool iproute2
         ethtool -K eth0 tx off
 
         ip link set dev eth0 txqueuelen 100000
@@ -259,7 +259,7 @@ services:
         ip -6 route add 203:0:113::/64 via 172:31:0::254
 
         # Disable checksum offloading so that checksums are correct when they reach the relay
-        apk add --no-cache ethtool
+        apk add --no-cache ethtool iproute2
         ethtool -K eth0 tx off
         ethtool -K eth1 tx off
         ethtool -K eth2 tx off

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,8 @@ services:
         apk add --no-cache ethtool
         ethtool -K eth0 tx off
 
+        ip link set dev eth0 txqueuelen 100000
+
         exec firezone-headless-client
     init: true
     build:
@@ -261,6 +263,10 @@ services:
         ethtool -K eth0 tx off
         ethtool -K eth1 tx off
         ethtool -K eth2 tx off
+
+        ip link set dev eth0 txqueuelen 100000
+        ip link set dev eth1 txqueuelen 100000
+        ip link set dev eth2 txqueuelen 100000
 
         exec firezone-gateway
     init: true

--- a/scripts/router/router.sh
+++ b/scripts/router/router.sh
@@ -72,6 +72,9 @@ if [ -n "${NETWORK_LATENCY_MS:-}" ]; then
     tc qdisc add dev internal root netem delay "${LATENCY}ms"
 fi
 
+ip link set dev internal txqueuelen 100000
+ip link set dev internet txqueuelen 100000
+
 echo "-----------------------------------------------------------------------------------------------"
 cat "$CONFIG_FILE"
 echo "-----------------------------------------------------------------------------------------------"


### PR DESCRIPTION
By default, Docker creates network interfaces with a txqueuelen of 1000. This is pretty small and causes unnecessary packet drops when running perf tests in that setup.