### PR TITLE
fix(ci): remove comment in multi-line command

### DIFF
--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -345,7 +345,6 @@ jobs:
           gh release upload ${{ matrix.name.release_name }} \
             "$BINARY_DEST_PATH" \
             "$BINARY_DEST_PATH".sha256sum.txt \
-            # "$BINARY_DEST_PATH".deb \ # Enable this once we have all the necessary documentation in place.
             "$clobber" \
             --repo ${{ github.repository }}
 


### PR DESCRIPTION
This comment breaks the multi-line command. The debian archive will be available from the APT repository so uploading that to the releases page is not actually necessary. We can still do it later if we want to though. For now, remove the comment to make the workflow work again.