### PR TITLE
refactor(portal): update okta directory schema

### DIFF
--- a/elixir/apps/domain/lib/domain/okta/auth_provider.ex
+++ b/elixir/apps/domain/lib/domain/okta/auth_provider.ex
@@ -23,7 +23,7 @@ defmodule Domain.Okta.AuthProvider do
     field :assigned_default_at, :utc_datetime_usec
 
     field :name, :string
-    field :org_domain, :string
+    field :okta_domain, :string
     field :client_id, :string
     field :client_secret, :string, redact: true
 

--- a/elixir/apps/domain/lib/domain/okta/auth_provider/changeset.ex
+++ b/elixir/apps/domain/lib/domain/okta/auth_provider/changeset.ex
@@ -7,7 +7,7 @@ defmodule Domain.Okta.AuthProvider.Changeset do
     Okta
   }
 
-  @required_fields ~w[name context org_domain client_id client_secret issuer]a
+  @required_fields ~w[name context okta_domain client_id client_secret issuer]a
   @fields @required_fields ++ ~w[disabled_at verified_at assigned_default_at]a
 
   def create(
@@ -39,7 +39,7 @@ defmodule Domain.Okta.AuthProvider.Changeset do
 
   defp changeset(changeset) do
     changeset
-    |> validate_length(:org_domain, min: 1, max: 255)
+    |> validate_length(:okta_domain, min: 1, max: 255)
     |> validate_length(:issuer, min: 1, max: 2_000)
     |> validate_length(:client_id, min: 1, max: 255)
     |> validate_length(:client_secret, min: 1, max: 255)

--- a/elixir/apps/domain/lib/domain/okta/auth_provider/query.ex
+++ b/elixir/apps/domain/lib/domain/okta/auth_provider/query.ex
@@ -17,7 +17,7 @@ defmodule Domain.Okta.AuthProvider.Query do
     where(querable, [providers: providers], providers.id == ^id)
   end
 
-  def by_org_domain(queryable, org_domain) do
-    where(queryable, [providers: providers], providers.org_domain == ^org_domain)
+  def by_okta_domain(queryable, okta_domain) do
+    where(queryable, [providers: providers], providers.okta_domain == ^okta_domain)
   end
 end

--- a/elixir/apps/domain/lib/domain/okta/directory.ex
+++ b/elixir/apps/domain/lib/domain/okta/directory.ex
@@ -3,7 +3,11 @@ defmodule Domain.Okta.Directory do
 
   schema "okta_directories" do
     belongs_to :account, Domain.Accounts.Account
-    field :org_domain, :string
+
+    field :client_id, :string
+    field :private_key_jwk, :map
+    field :kid, :string
+    field :okta_domain, :string
 
     field :issuer, :string
     field :name, :string

--- a/elixir/apps/domain/lib/domain/okta/directory/changeset.ex
+++ b/elixir/apps/domain/lib/domain/okta/directory/changeset.ex
@@ -6,8 +6,8 @@ defmodule Domain.Okta.Directory.Changeset do
     Okta.Directory
   }
 
-  @required_fields ~w[name org_domain issuer]a
-  @update_fields ~w[name error_count disabled_at disabled_reason synced_at error error_emailed_at]a
+  @required_fields ~w[name okta_domain issuer]a
+  @update_fields ~w[name private_key_jwk kid error_count disabled_at disabled_reason synced_at error error_emailed_at]a
 
   def create(attrs, %Auth.Subject{} = subject) do
     %Directory{}
@@ -26,7 +26,7 @@ defmodule Domain.Okta.Directory.Changeset do
   def changeset(changeset) do
     changeset
     |> validate_required(@required_fields)
-    |> validate_length(:org_domain, min: 1, max: 255)
+    |> validate_length(:okta_domain, min: 1, max: 255)
     |> validate_length(:issuer, min: 1, max: 2_000)
     |> validate_length(:name, min: 1, max: 255)
     |> validate_number(:error_count, greater_than_or_equal_to: 0)

--- a/elixir/apps/domain/lib/domain/okta/directory/query.ex
+++ b/elixir/apps/domain/lib/domain/okta/directory/query.ex
@@ -13,7 +13,7 @@ defmodule Domain.Okta.Directory.Query do
     where(queryable, [directories: directories], directories.account_id == ^account_id)
   end
 
-  def by_org_domain(queryable, org_domain) do
-    where(queryable, [directories: directories], directories.org_domain == ^org_domain)
+  def by_okta_domain(queryable, okta_domain) do
+    where(queryable, [directories: directories], directories.okta_domain == ^okta_domain)
   end
 end

--- a/elixir/apps/domain/priv/repo/migrations/20251020211234_create_okta_auth_providers.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251020211234_create_okta_auth_providers.exs
@@ -14,7 +14,7 @@ defmodule Domain.Repo.Migrations.CreateOktaAuthProviders do
 
       add(:issuer, :text, null: false)
       add(:name, :string, null: false)
-      add(:org_domain, :string, null: false)
+      add(:okta_domain, :string, null: false)
       add(:client_id, :string, null: false)
       add(:client_secret, :string, null: false)
 

--- a/elixir/apps/domain/priv/repo/migrations/20251020211242_create_okta_directories.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251020211242_create_okta_directories.exs
@@ -6,11 +6,12 @@ defmodule Domain.Repo.Migrations.CreateOktaDirectories do
       add(:id, :binary_id, null: false, primary_key: true)
 
       account()
-      add(:org_domain, :string, null: false)
 
-      add(:issuer, :text, null: false)
       add(:client_id, :string)
-      add(:client_secret, :string)
+      add(:private_key_jwk, :jsonb)
+      add(:kid, :string)
+      add(:okta_domain, :string, null: false)
+      add(:issuer, :text, null: false)
 
       add(:name, :string, null: false)
       add(:error_count, :integer, null: false, default: 0)
@@ -24,7 +25,7 @@ defmodule Domain.Repo.Migrations.CreateOktaDirectories do
       timestamps()
     end
 
-    create(index(:okta_directories, [:account_id, :org_domain], unique: true))
+    create(index(:okta_directories, [:account_id, :okta_domain], unique: true))
     create(index(:okta_directories, [:account_id, :issuer], unique: true))
     create(index(:okta_directories, [:account_id, :name], unique: true))
   end

--- a/elixir/apps/web/lib/web/oidc.ex
+++ b/elixir/apps/web/lib/web/oidc.ex
@@ -19,7 +19,7 @@ defmodule Web.OIDC do
 
   def config_for_provider(%Okta.AuthProvider{} = provider, redirect_uri) do
     with {:ok, config} <- Application.fetch_env(:domain, Domain.Okta.AuthProvider) do
-      discovery_document_uri = "https://#{provider.org_domain}/.well-known/openid-configuration"
+      discovery_document_uri = "https://#{provider.okta_domain}/.well-known/openid-configuration"
 
       config =
         Enum.into(config, %{


### PR DESCRIPTION
Why:

* The new Okta directory sync will use an "API service" integration in Okta.  This will require using a JWK to authenticate the client and hit the Okta APIs.