### PR TITLE
ci: remove polling from `required-check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,40 +115,39 @@ jobs:
 
   required-check:
     name: required-check
-    needs: planner
+    needs:
+      [
+        kotlin,
+        swift,
+        elixir,
+        rust,
+        tauri,
+        static-analysis,
+        codeql,
+        control-plane,
+        data-plane,
+        data-plane-perf,
+        integration-tests,
+        compatibility-tests,
+        perf-tests,
+      ]
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Wait for all jobs to complete
-        timeout-minutes: 60
+      - name: Check if all jobs are successful
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -e
 
-          while true; do
-            jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select((.name | contains("required-check") | not) and (.name | contains("upload-bencher") | not)))')
+          jobs_json=$(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(select((.name | contains("required-check") | not) and (.name | contains("upload-bencher") | not)))')
+          failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')
 
-            total_jobs=$(echo "$jobs_json" | jq 'length')
-            failed_jobs=$(echo "$jobs_json" | jq -r '[.[] | select(.conclusion == "failure")] | length')
-            completed_jobs=$(echo "$jobs_json" | jq '[.[] | select(.status == "completed")] | length')
-
-            if [ "$failed_jobs" -gt 0 ]; then
-              echo "At least one job has failed."
-              exit 1
-            fi
-
-            echo "Completed: $completed_jobs/$total_jobs"
-
-            if [ "$completed_jobs" -eq "$total_jobs" ]; then
-              break
-            fi
-
-            echo "Jobs not yet completed:"
-            echo "$jobs_json" | jq -r '.[] | select(.status != "completed") | "- " + .name + " (Status: " + .status + ")" '
-
-            sleep 60
-          done
+          if [ "$failed_jobs" -gt 0 ]; then
+            echo "At least one job has failed."
+            exit 1
+          fi
 
   kotlin:
     needs: planner


### PR DESCRIPTION
Currently, we launch the `required_check` right away with all others and poll the GitHub API to see if all others have completed already. This eats into our API quota.

An easier way to do the same thing is to declare a dependency of the `required_check` onto all other jobs. Normally, this wouldn't work because we skip certain jobs if the related files haven't been modified. We can opt out of this default behaviour by telling GitHub to `always()` run our job. That way, it naturally gets scheduled after all others, even if some of the jobs have been skipped.