### PR TITLE
feat(portal): add Debian/Ubuntu deployment tab

### DIFF
--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -31,7 +31,7 @@ defmodule Web.Sites.NewToken do
     {:noreply,
      assign(socket,
        uri: uri,
-       selected_tab: Map.get(params, "method", "systemd-instructions")
+       selected_tab: Map.get(params, "method", "debian-instructions")
      )}
   end
 
@@ -68,6 +68,61 @@ defmodule Web.Sites.NewToken do
           </div>
 
           <.tabs :if={@env} id="deployment-instructions">
+            <:tab
+              id="debian-instructions"
+              icon="hero-command-line"
+              label="Debian / Ubuntu"
+              phx_click="tab_selected"
+              selected={@selected_tab == "debian-instructions"}
+            >
+              <p class="p-6">
+                Step 1: Add the Firezone package repository.
+              </p>
+
+              <.code_block
+                id="code-sample-debian1"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+                phx-update="ignore"
+              ><%= debian_command_apt_repository() %></.code_block>
+
+              <p class="p-6">
+                Step 2: Install the Gateway:
+              </p>
+
+              <.code_block
+                id="code-sample-debian2"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+                phx-update="ignore"
+              ><%= debian_command_install() %></.code_block>
+
+              <p class="p-6">
+                Step 3: Copy the token:
+              </p>
+
+              <.code_block
+                id="code-sample-debian3"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+                phx-update="ignore"
+              ><%= token(@env) %></.code_block>
+
+              <p class="p-6">
+                Step 4: Configure the token:
+              </p>
+
+              <.code_block
+                id="code-sample-debian4"
+                class="w-full text-xs whitespace-pre-line"
+                phx-no-format
+                phx-update="ignore"
+              ><%= debian_command_authenticate() %></.code_block>
+
+              <p class="p-6">
+                Step 5: You are now ready to manage the Gateway using the <code>firezone</code> CLI.
+              </p>
+            </:tab>
             <:tab
               id="systemd-instructions"
               icon="hero-command-line"
@@ -253,6 +308,27 @@ defmodule Web.Sites.NewToken do
     {"FIREZONE_TOKEN", value} = List.keyfind(env, "FIREZONE_TOKEN", 0)
 
     value
+  end
+
+  defp debian_command_apt_repository do
+    """
+    mkdir --parents /etc/apt/keyrings
+    wget https://artifacts.firezone.dev/apt/key.gpg -O /etc/apt/keyrings/firezone.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/firezone.gpg] https://artifacts.firezone.dev/apt/ stable main" > /etc/apt/sources.list.d/firezone.list
+    """
+  end
+
+  defp debian_command_install do
+    """
+    sudo apt update
+    sudo apt install firezone-gateway
+    """
+  end
+
+  defp debian_command_authenticate do
+    """
+    sudo firezone gateway authenticate
+    """
   end
 
   defp docker_command(env) do

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -70,7 +70,7 @@ defmodule Web.Sites.NewToken do
           <.tabs :if={@env} id="deployment-instructions">
             <:tab
               id="debian-instructions"
-              icon="hero-command-line"
+              icon="os-debian"
               label="Debian / Ubuntu"
               phx_click="tab_selected"
               selected={@selected_tab == "debian-instructions"}

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -313,7 +313,7 @@ defmodule Web.Sites.NewToken do
   defp debian_command_apt_repository do
     """
     mkdir --parents /etc/apt/keyrings
-    wget https://artifacts.firezone.dev/apt/key.gpg -O /etc/apt/keyrings/firezone.gpg
+    wget -qO- https://artifacts.firezone.dev/apt/key.gpg | gpg --dearmor -o /etc/apt/keyrings/firezone.gpg
     echo "deb [signed-by=/etc/apt/keyrings/firezone.gpg] https://artifacts.firezone.dev/apt/ stable main" > /etc/apt/sources.list.d/firezone.list
     """
   end

--- a/elixir/apps/web/lib/web/live/sites/new_token.ex
+++ b/elixir/apps/web/lib/web/live/sites/new_token.ex
@@ -320,14 +320,14 @@ defmodule Web.Sites.NewToken do
 
   defp debian_command_install do
     """
-    sudo apt update
-    sudo apt install firezone-gateway
+    apt update
+    apt install firezone-gateway
     """
   end
 
   defp debian_command_authenticate do
     """
-    sudo firezone gateway authenticate
+    firezone gateway authenticate
     """
   end
 

--- a/website/src/app/kb/administer/upgrading/readme.mdx
+++ b/website/src/app/kb/administer/upgrading/readme.mdx
@@ -47,7 +47,18 @@ image with the newer version and then restarting. See below for specific steps
 depending on how you've deployed your Gateway:
 
 <TabsGroup>
-<TabsItem title="Docker" active>
+<TabsItem title="APT repository" active>
+
+If you installed the Gateway from the `artifacts.firezone.dev` APT repository,
+you can upgrade the Gateway via `apt`:
+
+```bash
+sudo apt update
+sudo apt upgrade firezone-gateway
+```
+
+</TabsItem>
+<TabsItem title="Docker">
 
 Copy-paste the following command to upgrade your Docker-based Gateway:
 


### PR DESCRIPTION
Now that we have an APT repository for Debian / Ubuntu packages, we should also tell our users about it. We introduce a new "Debian / Ubuntu" tab on the deployments screen in the portal. The tab is selected by default as it should provide the best user experience for manually deployed Gateways:

- Updates are as easy as `sudo apt upgrade`
- The systemd file and token are fully managed in the background

Here is what the new tab looks like:

<img width="679" height="786" alt="image" src="https://github.com/user-attachments/assets/da69fc55-6a6a-476d-bed4-634dd05df8bc" />


Resolves: #10701 