### PR TITLE
fix(linux): introduce tiered routing tables

### DIFF
--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -477,6 +477,8 @@ fn route_from_message(message: &RouteMessage) -> Option<IpNetwork> {
 }
 
 async fn flush_routing_tables(handle: Handle) -> Result<()> {
+    tracing::debug!("Flushing routing table");
+
     let routes = list_routes(&handle)
         .await?
         .into_iter()

--- a/rust/bin-shared/src/tun_device_manager/linux.rs
+++ b/rust/bin-shared/src/tun_device_manager/linux.rs
@@ -167,14 +167,26 @@ impl TunDeviceManager {
             .context("Failed to bring up interface")?;
 
         if res_v4.is_ok() {
-            match install_rules([make_rule(handle, FIREZONE_TABLE_USER, 100).v4()]).await {
+            match install_rules([
+                make_rule(handle, FIREZONE_TABLE_USER, 100).v4(),
+                make_rule(handle, FIREZONE_TABLE_LINK_SCOPE, 200).v4(),
+                make_rule(handle, FIREZONE_TABLE_INTERNET, 300).v4(),
+            ])
+            .await
+            {
                 Ok(()) => tracing::debug!("Successfully created routing rules for IPv4"),
                 Err(e) => tracing::warn!("Failed to add IPv4 routing rules: {e}"),
             }
         }
 
         if res_v6.is_ok() {
-            match install_rules([make_rule(handle, FIREZONE_TABLE_USER, 100).v6()]).await {
+            match install_rules([
+                make_rule(handle, FIREZONE_TABLE_USER, 100).v6(),
+                make_rule(handle, FIREZONE_TABLE_LINK_SCOPE, 200).v6(),
+                make_rule(handle, FIREZONE_TABLE_INTERNET, 300).v6(),
+            ])
+            .await
+            {
                 Ok(()) => tracing::debug!("Successfully created routing rule for IPv6"),
                 Err(e) => tracing::warn!("Failed to add IPv6 routing rules: {e}"),
             }

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -10,7 +10,14 @@ export default function GUI({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os == OS.Linux && (
+          <ChangeItem pull="10742">
+            Fixes an issue where CIDR/IP resources whose routes conflict with
+            the local network where not routable.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.5.8" date={new Date("2025-10-16")}>
         <ChangeItem pull="10509">
           Fixes an issue where the Internet Resource could be briefly active on

--- a/website/src/components/Changelog/GUI.tsx
+++ b/website/src/components/Changelog/GUI.tsx
@@ -14,7 +14,7 @@ export default function GUI({ os }: { os: OS }) {
         {os == OS.Linux && (
           <ChangeItem pull="10742">
             Fixes an issue where CIDR/IP resources whose routes conflict with
-            the local network where not routable.
+            the local network were not routable.
           </ChangeItem>
         )}
       </Unreleased>

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -9,7 +9,14 @@ export default function Headless({ os }: { os: OS }) {
   return (
     <Entries downloadLinks={downloadLinks(os)} title={title(os)}>
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        {os == OS.Linux && (
+          <ChangeItem pull="10742">
+            Fixes an issue where CIDR/IP resources whose routes conflict with
+            the local network where not routable.
+          </ChangeItem>
+        )}
+      </Unreleased>
       <Entry version="1.5.4" date={new Date("2025-10-16")}>
         <ChangeItem pull="10533">
           Improves reliability by caching DNS responses as per their TTL.

--- a/website/src/components/Changelog/Headless.tsx
+++ b/website/src/components/Changelog/Headless.tsx
@@ -13,7 +13,7 @@ export default function Headless({ os }: { os: OS }) {
         {os == OS.Linux && (
           <ChangeItem pull="10742">
             Fixes an issue where CIDR/IP resources whose routes conflict with
-            the local network where not routable.
+            the local network were not routable.
           </ChangeItem>
         )}
       </Unreleased>


### PR DESCRIPTION
With the fix of taking into account link-scoped routes in #10554 we introduced a bug: If a customer defines routes in Firezone that conflict with the link-scope ones, those currently take priority as they are usually more specific.

To fix this, we introduce tiered routing tables controlled by a set of rules with different priority.

1. In the first "Firezone" routing table, we add all CIDR/IP routes that users define in Firezone.
2. In the second "Firezone" routing table, we sync in all link-scope routes from the system.
3. In the third "Firezone" routing table, we only add the Internet Resource if it is active.

By evaluating the routing tables in this order, we effectively always prioritize Firezone-controlled routes over local ones but still allow access to LAN resources when the Internet Resource is active.