### PR TITLE
ci: use `base_ref` instead of `base_sha`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             # Base ref could be a few commits away, so fetch a few commits in case the queue is long
             git fetch origin ${{ github.event.merge_group.base_ref }} --depth=20
-            git diff --name-only ${{ github.event.merge_group.base_sha }} ${{ github.sha }} > changed_files.txt
+            git diff --name-only ${{ github.event.merge_group.base_ref }} ${{ github.sha }} > changed_files.txt
 
             echo "Changed files:"
             cat changed_files.txt


### PR DESCRIPTION
CI sometimes appears to have issues where it cannot find a certain commit. Referencing the `ref` directly should fix this.