### PR TITLE
ci: run all jobs in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,20 +47,17 @@ jobs:
             exit 0;
           fi
 
+          # For merge group, run all jobs
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "jobs_to_run=$jobs" >> "$GITHUB_OUTPUT"
+
+            exit 0;
+          fi
+
           # Fetch base ref for PRs
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch origin ${{ github.base_ref }} --depth=1
             git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }} > changed_files.txt
-
-            echo "Changed files:"
-            cat changed_files.txt
-          fi
-
-          # Fetch base ref for merge_group
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            # Base ref could be a few commits away, so fetch a few commits in case the queue is long
-            git fetch origin main --depth=20
-            git diff --name-only origin/main ${{ github.sha }} > changed_files.txt
 
             echo "Changed files:"
             cat changed_files.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
           # Fetch base ref for merge_group
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             # Base ref could be a few commits away, so fetch a few commits in case the queue is long
-            git fetch origin ${{ github.event.merge_group.base_ref }} --depth=20
-            git diff --name-only ${{ github.event.merge_group.base_ref }} ${{ github.sha }} > changed_files.txt
+            git fetch origin main --depth=20
+            git diff --name-only origin/main ${{ github.sha }} > changed_files.txt
 
             echo "Changed files:"
             cat changed_files.txt


### PR DESCRIPTION
Trying to be clever as to which jobs to run inside the merge queue doesn't seem to work. Therefore, we now revert to just running all jobs in there.