### PR TITLE
ci: fail fast inside the merge queue

### DIFF
--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       security-events: write
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - language: "javascript-typescript"

--- a/.github/workflows/_control-plane.yml
+++ b/.github/workflows/_control-plane.yml
@@ -17,7 +17,7 @@ jobs:
     name: ${{ matrix.image_name }}
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - image_name: domain

--- a/.github/workflows/_data-plane.yml
+++ b/.github/workflows/_data-plane.yml
@@ -72,7 +72,7 @@ jobs:
     name: update-release-draft-${{ matrix.config_name }}
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           # mark:next-gateway-version
@@ -104,7 +104,7 @@ jobs:
       run:
         working-directory: rust
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # TODO: Add ARM64 support
         artifact: [firezone-client-headless-windows]
@@ -166,7 +166,7 @@ jobs:
       run:
         working-directory: rust
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # Copy input vars to matrix vars to conditionally exclude them
         image_prefix:
@@ -439,7 +439,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # Copy input vars to matrix vars to conditionally exclude them
         image_prefix:

--- a/.github/workflows/_elixir.yml
+++ b/.github/workflows/_elixir.yml
@@ -160,7 +160,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MIX_TEST_PARTITIONS: 1
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         MIX_TEST_PARTITION: [1]
     services:

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -98,7 +98,7 @@ jobs:
       HTTP_TEST_SERVER_TAG: ${{ inputs.http_test_server_tag }}
       FIREZONE_INC_BUF: true
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         test:
           - script: create-flow-from-icmp-error

--- a/.github/workflows/_kotlin.yml
+++ b/.github/workflows/_kotlin.yml
@@ -54,7 +54,7 @@ jobs:
     # Android SDK tools hardware accel is available only on Linux runners
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - package-type: aab

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -18,7 +18,7 @@ jobs:
   static-analysis:
     name: static-analysis-${{ matrix.runs-on }}
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         runs-on: [ubuntu-24.04, macos-14, windows-2022]
@@ -58,7 +58,7 @@ jobs:
   test:
     name: test-${{ matrix.runs-on }}
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # TODO: https://github.com/rust-lang/cargo/issues/5220
         runs-on:
@@ -133,7 +133,7 @@ jobs:
   fuzz:
     name: fuzz
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         fuzz-target: [ip_packet]
     runs-on: ubuntu-24.04
@@ -155,7 +155,7 @@ jobs:
   headless-client:
     name: headless-client-${{ matrix.test }}-${{ matrix.runs-on }}
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - { runs-on: windows-2022, test: token-path-windows.ps1 }

--- a/.github/workflows/_swift.yml
+++ b/.github/workflows/_swift.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write # for attaching the build artifacts to the release
       id-token: write
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - job_name: build-ios

--- a/.github/workflows/_tauri.yml
+++ b/.github/workflows/_tauri.yml
@@ -53,7 +53,7 @@ jobs:
   smoke-test:
     name: gui-smoke-test-${{ matrix.runs-on }}
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         runs-on: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
     runs-on: ${{ matrix.runs-on }}
@@ -97,7 +97,7 @@ jobs:
       contents: write # for attaching the build artifacts to the release
       id-token: write
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
 
   compatibility-tests:
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         client:
           - image: "ghcr.io/firezone/client"
@@ -271,7 +271,7 @@ jobs:
       RELAY_TAG: ${{ github.sha }}
       FIREZONE_INC_BUF: true
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         test:
           - tcp-client2server


### PR DESCRIPTION
Setting `fail-fast: false` unsurprisingly makes our CI fail pretty slowly. This is especially noticable in the merge queue where a long-running job could still hold up the entire queue even though a different job has failed already and the PR is never going to make it in anyway.

To avoid this scenario, we set `fail-fast: true` whenever we are in the merge queue.