### PR TITLE
feat(portal): add RSA and JWK helper modules

### DIFF
--- a/elixir/apps/domain/lib/domain/crypto/jwk.ex
+++ b/elixir/apps/domain/lib/domain/crypto/jwk.ex
@@ -1,0 +1,108 @@
+defmodule Domain.Crypto.JWK do
+  alias Domain.Crypto.RSA
+
+  @moduledoc """
+  Generate a JOSE JWK (private) and a JWKS (public-only) from an RSA keypair.
+  """
+
+  @default_bits 2048
+
+  @type jwk :: %{String.t() => String.t()}
+  @type public_jwk :: %{String.t() => String.t()}
+  @type jwks :: %{String.t() => [public_jwk()]}
+  @type t :: %{jwk: jwk(), jwks: jwks(), kid: String.t()}
+
+  @doc """
+  Returns:
+    * `:jwk` — private JWK (keep secret; use to sign)
+    * `:jwks` — public JWKS map (share; use to publish)
+    * `:kid` — key ID consistent with RFC 7638 thumbprint
+  """
+  @spec generate_jwk_and_jwks(pos_integer()) :: t()
+  def generate_jwk_and_jwks(bits \\ @default_bits) do
+    # Generate RSA keypair
+    keypair = RSA.generate(bits)
+
+    # Extract RSA components from the private key tuple
+    {:RSAPrivateKey, _v, n, e, d, p, q, e1, e2, coeff, _other} = keypair.private
+
+    # Create JWK (private key for signing)
+    jwk = %{
+      "kty" => "RSA",
+      "alg" => "RS256",
+      "use" => "sig",
+      "n" => url_encode_int(n),
+      "e" => url_encode_int(e),
+      "d" => url_encode_int(d),
+      "p" => url_encode_int(p),
+      "q" => url_encode_int(q),
+      "dp" => url_encode_int(e1),
+      "dq" => url_encode_int(e2),
+      "qi" => url_encode_int(coeff)
+    }
+
+    # Generate key ID using RFC 7638 thumbprint
+    thumbprint_json =
+      Jason.encode!(%{
+        "e" => jwk["e"],
+        "kty" => jwk["kty"],
+        "n" => jwk["n"]
+      })
+
+    kid = :crypto.hash(:sha256, thumbprint_json) |> Base.url_encode64(padding: false)
+
+    # Add kid to JWK
+    jwk = Map.put(jwk, "kid", kid)
+
+    # Create JWKS (public key set for verification)
+    public_jwk = %{
+      "kty" => "RSA",
+      "alg" => "RS256",
+      "use" => "sig",
+      "kid" => kid,
+      "n" => jwk["n"],
+      "e" => jwk["e"]
+    }
+
+    jwks = %{
+      "keys" => [public_jwk]
+    }
+
+    %{
+      jwk: jwk,
+      jwks: jwks,
+      kid: kid
+    }
+  end
+
+  @spec extract_public_key_components(jwk()) :: public_jwk()
+  def extract_public_key_components(private_jwk) do
+    %{
+      "kty" => private_jwk["kty"],
+      "alg" => private_jwk["alg"],
+      "use" => private_jwk["use"],
+      "kid" => private_jwk["kid"],
+      "n" => private_jwk["n"],
+      "e" => private_jwk["e"]
+    }
+  end
+
+  @spec url_encode_int(non_neg_integer()) :: String.t()
+  defp url_encode_int(int) when is_integer(int) do
+    int
+    |> int_to_bin()
+    |> Base.url_encode64(padding: false)
+  end
+
+  # Helper function to convert integer to binary
+  @spec int_to_bin(non_neg_integer()) :: binary()
+  defp int_to_bin(int) when is_integer(int) do
+    # Convert integer to minimal binary representation
+    hex_string = Integer.to_string(int, 16)
+    # Ensure even number of hex digits
+    hex_string =
+      if rem(String.length(hex_string), 2) == 1, do: "0" <> hex_string, else: hex_string
+
+    Base.decode16!(hex_string, case: :mixed)
+  end
+end

--- a/elixir/apps/domain/lib/domain/crypto/rsa.ex
+++ b/elixir/apps/domain/lib/domain/crypto/rsa.ex
@@ -1,0 +1,62 @@
+defmodule Domain.Crypto.RSA do
+  @moduledoc """
+  Generate RSA keypairs using Erlang/OTP's :public_key.
+
+  - `generate/1` returns PEM and DER for both private and public keys.
+  """
+
+  @default_bits 2048
+  @public_exponent 65_537
+
+  @type t :: %{
+          private: :public_key.rsa_private_key(),
+          public: :public_key.rsa_public_key(),
+          private_pem: binary(),
+          public_pem: binary(),
+          private_der: binary(),
+          public_der: binary()
+        }
+
+  @doc """
+  Generate an RSA keypair.
+
+  ## Options
+    * `bits` — modulus size (default: 2048)
+
+  ## Returns
+    `%{private_pem, public_pem, private_der, public_der}`
+  """
+  @spec generate(pos_integer()) :: t()
+  def generate(bits \\ @default_bits) do
+    # Private key as an Erlang record tuple:
+    # {:RSAPrivateKey, v, n, e, d, p, q, e1, e2, coeff, other}
+    priv = :public_key.generate_key({:rsa, bits, @public_exponent})
+
+    {:RSAPrivateKey, _v, n, e, _d, _p, _q, _e1, _e2, _coeff, _other} = priv
+    pub = {:RSAPublicKey, n, e}
+
+    # DER encodings (raw ASN.1 DER)
+    priv_der = :public_key.der_encode(:RSAPrivateKey, priv)
+    pub_der = :public_key.der_encode(:RSAPublicKey, pub)
+
+    # PEM entries (PKCS#1 for private; SPKI for public)
+    priv_pem =
+      :public_key.pem_encode([
+        :public_key.pem_entry_encode(:RSAPrivateKey, priv)
+      ])
+
+    pub_pem =
+      :public_key.pem_encode([
+        :public_key.pem_entry_encode(:SubjectPublicKeyInfo, pub)
+      ])
+
+    %{
+      private: priv,
+      public: pub,
+      private_pem: priv_pem,
+      public_pem: pub_pem,
+      private_der: priv_der,
+      public_der: pub_der
+    }
+  end
+end


### PR DESCRIPTION
Why:

* Adding RSA and JWK helper crypto modules to centralize functionality for any RSA or JWK needs.