### PR TITLE
fix(ci): ensure version markers are replaced across all files

### DIFF
--- a/rust/client-ffi/src/platform/android.rs
+++ b/rust/client-ffi/src/platform/android.rs
@@ -5,9 +5,9 @@ mod make_writer;
 mod tun;
 
 // mark:next-android-version
-pub const RELEASE: &str = "connlib-android@1.5.2";
+pub const RELEASE: &str = "connlib-android@1.5.6";
 // mark:next-android-version
-pub const VERSION: &str = "1.5.2";
+pub const VERSION: &str = "1.5.6";
 pub const COMPONENT: &str = "android-client";
 
 /// We have valid use cases for headless Android clients

--- a/rust/client-ffi/src/platform/android.rs
+++ b/rust/client-ffi/src/platform/android.rs
@@ -5,9 +5,9 @@ mod make_writer;
 mod tun;
 
 // mark:next-android-version
-pub const RELEASE: &str = "connlib-android@1.5.6";
+pub const RELEASE: &str = "connlib-android@1.5.7";
 // mark:next-android-version
-pub const VERSION: &str = "1.5.6";
+pub const VERSION: &str = "1.5.7";
 pub const COMPONENT: &str = "android-client";
 
 /// We have valid use cases for headless Android clients

--- a/rust/client-ffi/src/platform/apple.rs
+++ b/rust/client-ffi/src/platform/apple.rs
@@ -5,10 +5,10 @@ mod make_writer;
 mod tun;
 
 // mark:next-apple-version
-pub const RELEASE: &str = "connlib-apple@1.5.8";
+pub const RELEASE: &str = "connlib-apple@1.5.10";
 
 // mark:next-apple-version
-pub const VERSION: &str = "1.5.8";
+pub const VERSION: &str = "1.5.10";
 
 pub const COMPONENT: &str = "apple-client";
 

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -98,7 +98,7 @@ function apple() {
     find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_apple_client_version}"'/g;}' {} \;
     find .github -type f -exec sed "${SEDARG[@]}" -e '/mark:next-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_apple_client_version}"'/g;}' {} \;
     find swift -type f -name "project.pbxproj" -exec sed "${SEDARG[@]}" -e "s/MARKETING_VERSION = .*;/MARKETING_VERSION = ${next_apple_client_version};/" {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -exec sed "${SEDARG[@]}" -e '/mark:next-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_apple_client_version}"'/;}' {} \;
+    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_apple_client_version}"'/;}' {} \;
     cargo_update_workspace
 }
 
@@ -134,7 +134,7 @@ function android() {
     find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_android_client_version}"'/g;}' {} \;
     find .github -type f -exec sed "${SEDARG[@]}" -e '/mark:next-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_android_client_version}"'/g;}' {} \;
     find kotlin -type f -name "*.gradle.kts" -exec sed "${SEDARG[@]}" -e '/mark:next-android-version/{n;s/versionName =.*/versionName = "'"${next_android_client_version}"'"/;}' {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -exec sed "${SEDARG[@]}" -e '/mark:next-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_android_client_version}"'/;}' {} \;
+    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_android_client_version}"'/;}' {} \;
     cargo_update_workspace
 }
 
@@ -158,7 +158,7 @@ function gui() {
     find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_gui_client_version}"'/g;}' {} \;
     find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_gui_client_version}"'/g;}' {} \;
     find .github -type f -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_client_version}"'/g;}' {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_client_version}"'/;}' {} \;
+    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_client_version}"'/;}' {} \;
     find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "vite.config.ts" -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_client_version}"'/;}' {} \;
     cargo_update_workspace
 }
@@ -182,7 +182,7 @@ function headless() {
     find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_headless_client_version}"'/g;}' {} \;
     find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_headless_client_version}"'/g;}' {} \;
     find .github -name "*.yml" -exec sed "${SEDARG[@]}" -e '/mark:next-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_headless_client_version}"'/g;}' {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -exec sed "${SEDARG[@]}" -e '/mark:next-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_headless_client_version}"'/;}' {} \;
+    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_headless_client_version}"'/;}' {} \;
     cargo_update_workspace
 }
 
@@ -205,7 +205,7 @@ function gateway() {
     find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_gateway_version}"'/g;}' {} \;
     find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_gateway_version}"'/g;}' {} \;
     find .github -type f -exec sed "${SEDARG[@]}" -e '/mark:next-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gateway_version}"'/g;}' {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -exec sed "${SEDARG[@]}" -e '/mark:next-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gateway_version}"'/;}' {} \;
+    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gateway_version}"'/;}' {} \;
     cargo_update_workspace
 }
 

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-# This is script is used to bump the versions in support of our release process.
+# This script is used to bump the versions in support of our release process.
 
 # See discussion here: https://github.com/firezone/firezone/issues/2041
 # and PR changing it here: https://github.com/firezone/firezone/pull/2949
@@ -41,6 +41,16 @@ function update_changelog() {
       /<Entry version=\"${current_version}\"/i\\
       <Unreleased></Unreleased>
     " "$changelog_file"
+}
+
+function update_version_marker() {
+    local marker="$1"
+    local new_version="$2"
+
+    # Use git grep to find files containing the marker (much faster and git-aware)
+    git grep -l "$marker" 2>/dev/null | while IFS= read -r file; do
+        sed "${SEDARG[@]}" -e "/${marker}/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/${new_version}/;}" "$file"
+    done
 }
 
 function update_version_variables() {
@@ -94,11 +104,9 @@ function apple() {
     next_apple_client_version="1.5.10"
 
     update_changelog "website/src/components/Changelog/Apple.tsx" "$current_apple_client_version"
-    find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_apple_client_version}"'/g;}' {} \;
-    find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_apple_client_version}"'/g;}' {} \;
-    find .github -type f -exec sed "${SEDARG[@]}" -e '/mark:next-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_apple_client_version}"'/g;}' {} \;
-    find swift -type f -name "project.pbxproj" -exec sed "${SEDARG[@]}" -e "s/MARKETING_VERSION = .*;/MARKETING_VERSION = ${next_apple_client_version};/" {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-apple-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_apple_client_version}"'/;}' {} \;
+    update_version_marker "mark:current-apple-version" "$current_apple_client_version"
+    update_version_marker "mark:next-apple-version" "$next_apple_client_version"
+
     cargo_update_workspace
 }
 
@@ -113,7 +121,7 @@ function apple() {
 # As such, the process for releasing Android is similar to Apple.
 #
 # Instructions:
-# 1. Run the `Kotlin` workflow from `main`. This will push an AAB to Firebase.
+# 1. Run the `Kotlin` workflow from `main`. This will push an AAB to Firebase
 #    and upload a new APK to the drafted release.
 # 2. Sign in to Firebase and download the build AAB, optionally distributing it
 #    for release testing to perform any final QA tests.
@@ -130,11 +138,9 @@ function android() {
     next_android_client_version="1.5.7"
 
     update_changelog "website/src/components/Changelog/Android.tsx" "$current_android_client_version"
-    find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_android_client_version}"'/g;}' {} \;
-    find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_android_client_version}"'/g;}' {} \;
-    find .github -type f -exec sed "${SEDARG[@]}" -e '/mark:next-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_android_client_version}"'/g;}' {} \;
-    find kotlin -type f -name "*.gradle.kts" -exec sed "${SEDARG[@]}" -e '/mark:next-android-version/{n;s/versionName =.*/versionName = "'"${next_android_client_version}"'"/;}' {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-android-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_android_client_version}"'/;}' {} \;
+    update_version_marker "mark:current-android-version" "$current_android_client_version"
+    update_version_marker "mark:next-android-version" "$next_android_client_version"
+
     cargo_update_workspace
 }
 
@@ -155,11 +161,9 @@ function gui() {
     next_gui_client_version="1.5.9"
 
     update_changelog "website/src/components/Changelog/GUI.tsx" "$current_gui_client_version"
-    find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_gui_client_version}"'/g;}' {} \;
-    find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_gui_client_version}"'/g;}' {} \;
-    find .github -type f -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_client_version}"'/g;}' {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_client_version}"'/;}' {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "vite.config.ts" -exec sed "${SEDARG[@]}" -e '/mark:next-gui-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gui_client_version}"'/;}' {} \;
+    update_version_marker "mark:current-gui-version" "$current_gui_client_version"
+    update_version_marker "mark:next-gui-version" "$next_gui_client_version"
+
     cargo_update_workspace
 }
 
@@ -179,10 +183,9 @@ function headless() {
     next_headless_client_version="1.5.5"
 
     update_changelog "website/src/components/Changelog/Headless.tsx" "$current_headless_client_version"
-    find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_headless_client_version}"'/g;}' {} \;
-    find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_headless_client_version}"'/g;}' {} \;
-    find .github -name "*.yml" -exec sed "${SEDARG[@]}" -e '/mark:next-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_headless_client_version}"'/g;}' {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-headless-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_headless_client_version}"'/;}' {} \;
+    update_version_marker "mark:current-headless-version" "$current_headless_client_version"
+    update_version_marker "mark:next-headless-version" "$next_headless_client_version"
+
     cargo_update_workspace
 }
 
@@ -202,10 +205,9 @@ function gateway() {
     next_gateway_version="1.4.18"
 
     update_changelog "website/src/components/Changelog/Gateway.tsx" "$current_gateway_version"
-    find website -type f -name "redirects.js" -exec sed "${SEDARG[@]}" -e '/mark:current-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_gateway_version}"'/g;}' {} \;
-    find website -type f -name "route.ts" -exec sed "${SEDARG[@]}" -e '/mark:current-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${current_gateway_version}"'/g;}' {} \;
-    find .github -type f -exec sed "${SEDARG[@]}" -e '/mark:next-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gateway_version}"'/g;}' {} \;
-    find rust -path rust/gui-client/node_modules -prune -o -path rust/target -prune -o -name "Cargo.toml" -o -name "*.rs" -exec sed "${SEDARG[@]}" -e '/mark:next-gateway-version/{n;s/[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/'"${next_gateway_version}"'/;}' {} \;
+    update_version_marker "mark:current-gateway-version" "$current_gateway_version"
+    update_version_marker "mark:next-gateway-version" "$next_gateway_version"
+
     cargo_update_workspace
 }
 

--- a/swift/apple/Firezone.xcodeproj/project.pbxproj
+++ b/swift/apple/Firezone.xcodeproj/project.pbxproj
@@ -581,7 +581,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/debug";
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.5.10;
+				MARKETING_VERSION = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
@@ -625,7 +625,7 @@
 				);
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-ios/release";
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.5.10;
+				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
@@ -668,7 +668,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/debug";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/debug";
-				MARKETING_VERSION = 1.5.10;
+				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
@@ -710,7 +710,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=arm64e]" = "$(CONNLIB_TARGET_DIR)/aarch64-apple-darwin/release";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(CONNLIB_TARGET_DIR)/x86_64-apple-darwin/release";
-				MARKETING_VERSION = 1.5.10;
+				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "-lconnlib";
 				OTHER_SWIFT_FLAGS = "-D UNIFFI";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited).network-extension";
@@ -887,7 +887,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.5.10;
+				MARKETING_VERSION = "$(inherited)";
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -937,7 +937,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.4;
-				MARKETING_VERSION = 1.5.10;
+				MARKETING_VERSION = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/swift/apple/Firezone/xcconfig/config.xcconfig
+++ b/swift/apple/Firezone/xcconfig/config.xcconfig
@@ -9,3 +9,6 @@ CODE_SIGN_STYLE = Automatic
 
 // Include the dynamic build number created during the build phase
 #include? "dynamic_build_number.xcconfig"
+
+// mark:next-apple-version
+MARKETING_VERSION=1.5.10

--- a/website/src/components/Changelog/Android.tsx
+++ b/website/src/components/Changelog/Android.tsx
@@ -20,7 +20,11 @@ export default function Android() {
   return (
     <Entries downloadLinks={downloadLinks} title="Android">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="10752">
+          Fixes an issue where the reported client version was out of date.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.6" date={new Date("2025-10-28")}>
         <ChangeItem pull="10667">
           Fixes an issue where the Tunnel service would crash when trying to

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -24,7 +24,11 @@ export default function Apple() {
   return (
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
-      <Unreleased></Unreleased>
+      <Unreleased>
+        <ChangeItem pull="10752">
+          Fixes an issue where the reported client version was out of date.
+        </ChangeItem>
+      </Unreleased>
       <Entry version="1.5.9" date={new Date("2025-10-20")}>
         <ChangeItem pull="10603">
           Fixes an issue on macOS where DNS resources might fail to be routed


### PR DESCRIPTION
Upon moving the version string from PKG_VERSION and Cargo.toml, we lost the bump version automation. To avoid more bugs here in the future, we now check for the version marker across all Git-tracked files, regardless of their extension.

Fixes #10748 