### PR TITLE
chore(ci): replace macos-13 runners with macos-26

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,8 +1,8 @@
 self-hosted-runner:
   labels:
-    - macos-13-xlarge
     - macos-14-xlarge
     - macos-15-xlarge
+    - macos-26-xlarge
     - ubuntu-22.04-arm-xlarge
     - ubuntu-22.04-xlarge
     - ubuntu-24.04-xlarge

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -65,9 +65,9 @@ jobs:
           [
             ubuntu-22.04,
             ubuntu-24.04,
-            macos-13,
             macos-14,
             macos-15,
+            macos-26,
             windows-2022,
             windows-2025,
           ]


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/13046