### PR TITLE
build(deps): update to `mio` v1.1.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1235,7 +1235,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4462,13 +4462,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
-source = "git+https://github.com/firezone/mio?branch=fix%2Fpanic-invalid-state#64fc40ef248af392e1b01b0d4749506927cbc4cd"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9312,9 +9313,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
@@ -9398,6 +9399,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -108,7 +108,7 @@ libc = "0.2.175"
 libfuzzer-sys = "0.4"
 log = "0.4"
 lru = "0.12.5"
-mio = "1.0.4"
+mio = "1.1.0"
 moka = "0.12.11"
 native-dialog = "0.7.0"
 netlink-packet-core = "0.7"
@@ -237,7 +237,6 @@ softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting 
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 moka = { git = "https://github.com/moka-rs/moka", branch = "main" } # Waiting for release.
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
-mio = { git = "https://github.com/firezone/mio", branch = "fix/panic-invalid-state" }
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']


### PR DESCRIPTION
The patch we have contributed to `mio` has been merged and released. We remove the dependency on our fork again.