### PR TITLE
chore: enable lints in `dns-over-tcp`

### DIFF
--- a/rust/connlib/dns-over-tcp/Cargo.toml
+++ b/rust/connlib/dns-over-tcp/Cargo.toml
@@ -20,3 +20,6 @@ futures = { workspace = true }
 ip_network = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt", "macros"] }
 tun = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/connlib/dns-over-tcp/src/client.rs
+++ b/rust/connlib/dns-over-tcp/src/client.rs
@@ -135,7 +135,7 @@ impl<const MIN_PORT: u16, const MAX_PORT: u16> Client<MIN_PORT, MAX_PORT> {
         match packet.destination() {
             IpAddr::V4(v4) if v4 != ipv4_source => return false,
             IpAddr::V6(v6) if v6 != ipv6_source => return false,
-            _ => {}
+            IpAddr::V4(_) | IpAddr::V6(_) => {}
         }
 
         let remote = SocketAddr::new(packet.source(), tcp.source_port());

--- a/rust/connlib/dns-over-tcp/src/server.rs
+++ b/rust/connlib/dns-over-tcp/src/server.rs
@@ -182,7 +182,10 @@ impl Server {
         }
 
         for (handle, l3_tcp::AnySocket::Tcp(socket)) in self.sockets.iter_mut() {
-            let local = self.listen_endpoints.get(&handle).copied().unwrap();
+            let Some(local) = self.listen_endpoints.get(&handle).copied() else {
+                tracing::warn!(%handle, "No listen endpoint for socket");
+                continue;
+            };
 
             let _guard = tracing::trace_span!("socket", %handle).entered();
 

--- a/rust/connlib/dns-over-tcp/tests/client_and_server.rs
+++ b/rust/connlib/dns-over-tcp/tests/client_and_server.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::print_stdout)]
+
 use std::{
     collections::BTreeSet,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},

--- a/rust/connlib/dns-over-tcp/tests/smoke_server.rs
+++ b/rust/connlib/dns-over-tcp/tests/smoke_server.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::{
     collections::BTreeSet,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},


### PR DESCRIPTION
Appears to have been an oversight when we first introduced this crate.