### PR TITLE
refactor(connlib): allow creating multiple layer 4 DNS servers

### DIFF
--- a/rust/connlib/l4-udp-dns-server/lib.rs
+++ b/rust/connlib/l4-udp-dns-server/lib.rs
@@ -11,55 +11,35 @@ use futures::{
 };
 use std::{
     io,
-    net::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs},
+    net::{SocketAddr, ToSocketAddrs},
     sync::{Arc, Weak},
     task::{Context, Poll},
 };
 use tokio::net::UdpSocket;
 
 pub struct Server {
-    // Strong references to the UDP sockets.
-    udp_v4: Option<Arc<UdpSocket>>,
-    udp_v6: Option<Arc<UdpSocket>>,
+    // Strong references to the UDP socket.
+    socket: Option<Arc<UdpSocket>>,
 
-    // Streams that read incoming queries from the UDP sockets.
-    reading_udp_v4_queries: BoxStream<'static, Result<(SocketAddr, dns_types::Query)>>,
-    reading_udp_v6_queries: BoxStream<'static, Result<(SocketAddr, dns_types::Query)>>,
+    // Stream that read incoming queries from the UDP sockets.
+    reading_udp_queries: BoxStream<'static, Result<(SocketAddr, dns_types::Query)>>,
 
-    // Futures that send responses on the UDP sockets.
-    sending_udp_v4_responses: FuturesUnordered<BoxFuture<'static, Result<()>>>,
-    sending_udp_v6_responses: FuturesUnordered<BoxFuture<'static, Result<()>>>,
+    // Futures that send responses on the UDP socket.
+    sending_udp_responses: FuturesUnordered<BoxFuture<'static, Result<()>>>,
 
     waker: AtomicWaker,
 }
 
 impl Server {
-    pub fn rebind_ipv4(&mut self, socket: SocketAddrV4) -> Result<()> {
-        self.udp_v4 = None;
-        self.reading_udp_v4_queries = stream::empty().boxed();
-        self.sending_udp_v4_responses.clear();
+    pub fn rebind(&mut self, socket: SocketAddr) -> Result<()> {
+        self.socket = None;
+        self.reading_udp_queries = stream::empty().boxed();
+        self.sending_udp_responses.clear();
 
         let udp_socket = Arc::new(make_udp_socket(socket)?);
 
-        self.reading_udp_v4_queries = udp_dns_query_stream(Arc::downgrade(&udp_socket));
-        self.udp_v4 = Some(udp_socket);
-
-        self.waker.wake();
-
-        tracing::debug!(%socket, "Listening for UDP DNS queries");
-
-        Ok(())
-    }
-
-    pub fn rebind_ipv6(&mut self, socket: SocketAddrV6) -> Result<()> {
-        self.udp_v6 = None;
-        self.reading_udp_v6_queries = stream::empty().boxed();
-        self.sending_udp_v6_responses.clear();
-
-        let udp_socket = Arc::new(make_udp_socket(socket)?);
-
-        self.reading_udp_v6_queries = udp_dns_query_stream(Arc::downgrade(&udp_socket));
-        self.udp_v6 = Some(udp_socket);
+        self.reading_udp_queries = udp_dns_query_stream(Arc::downgrade(&udp_socket));
+        self.socket = Some(udp_socket);
 
         self.waker.wake();
 
@@ -73,14 +53,12 @@ impl Server {
         to: SocketAddr,
         response: dns_types::Response,
     ) -> io::Result<()> {
-        let (udp_socket, workers) = match (to, self.udp_v4.clone(), self.udp_v6.clone()) {
-            (SocketAddr::V4(_), Some(socket), _) => (socket, &mut self.sending_udp_v4_responses),
-            (SocketAddr::V6(_), _, Some(socket)) => (socket, &mut self.sending_udp_v6_responses),
-            (SocketAddr::V4(_), None, _) => return Err(io::Error::other("No UDPv4 socket")),
-            (SocketAddr::V6(_), _, None) => return Err(io::Error::other("No UDPv6 socket")),
-        };
+        let udp_socket = self
+            .socket
+            .clone()
+            .ok_or(io::Error::other("No UDP socket"))?;
 
-        workers.push(
+        self.sending_udp_responses.push(
             async move {
                 // TODO: Make this limit configurable.
                 // The current 1200 are conservative and should be safe for the public Internet and our WireGuard tunnel.
@@ -102,40 +80,29 @@ impl Server {
 
     pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<Query>> {
         loop {
-            if let Poll::Ready(Some(result)) = self.sending_udp_v4_responses.poll_next_unpin(cx) {
+            if let Poll::Ready(Some(result)) = self.sending_udp_responses.poll_next_unpin(cx) {
                 result
-                    .context("Failed to send UDPv4 DNS response")
+                    .context("Failed to send UDP DNS response")
                     .map_err(anyhow_to_io)?;
 
                 continue;
             }
 
-            if let Poll::Ready(Some(result)) = self.sending_udp_v6_responses.poll_next_unpin(cx) {
-                result
-                    .context("Failed to send UDPv6 DNS response")
-                    .map_err(anyhow_to_io)?;
-
-                continue;
-            }
-
-            if let Poll::Ready(Some(result)) = self.reading_udp_v4_queries.poll_next_unpin(cx) {
+            if let Poll::Ready(Some(result)) = self.reading_udp_queries.poll_next_unpin(cx) {
                 let (from, message) = result
-                    .context("Failed to read UDPv4 DNS query")
+                    .context("Failed to read UDP DNS query")
                     .map_err(anyhow_to_io)?;
+
+                let local = self
+                    .socket
+                    .as_ref()
+                    .context("No UDP socket")
+                    .map_err(anyhow_to_io)?
+                    .local_addr()?;
 
                 return Poll::Ready(Ok(Query {
-                    source: from,
-                    message,
-                }));
-            }
-
-            if let Poll::Ready(Some(result)) = self.reading_udp_v6_queries.poll_next_unpin(cx) {
-                let (from, message) = result
-                    .context("Failed to read UDPv6 DNS query")
-                    .map_err(anyhow_to_io)?;
-
-                return Poll::Ready(Ok(Query {
-                    source: from,
+                    local,
+                    from,
                     message,
                 }));
             }
@@ -176,7 +143,8 @@ async fn read_udp_query(socket: Arc<UdpSocket>) -> Result<(SocketAddr, dns_types
 }
 
 pub struct Query {
-    pub source: SocketAddr,
+    pub local: SocketAddr,
+    pub from: SocketAddr,
     pub message: dns_types::Query,
 }
 
@@ -195,12 +163,9 @@ fn make_udp_socket(socket: impl ToSocketAddrs) -> Result<UdpSocket> {
 impl Default for Server {
     fn default() -> Self {
         Self {
-            udp_v4: None,
-            udp_v6: None,
-            reading_udp_v4_queries: stream::empty().boxed(),
-            reading_udp_v6_queries: stream::empty().boxed(),
-            sending_udp_v4_responses: FuturesUnordered::new(),
-            sending_udp_v6_responses: FuturesUnordered::new(),
+            socket: None,
+            reading_udp_queries: stream::empty().boxed(),
+            sending_udp_responses: FuturesUnordered::new(),
             waker: AtomicWaker::new(),
         }
     }
@@ -209,38 +174,64 @@ impl Default for Server {
 #[cfg(all(test, unix))]
 mod tests {
     use std::future::poll_fn;
-    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
     use std::process::ExitStatus;
 
     use super::*;
 
     #[tokio::test]
-    async fn smoke() {
+    async fn smoke_ipv4() {
         let mut server = Server::default();
 
-        let v4_socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 127), 8080);
-        let v6_socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
+        let socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 127), 8080));
 
         let server_task = tokio::spawn(async move {
-            server.rebind_ipv4(v4_socket).unwrap();
-            server.rebind_ipv6(v6_socket).unwrap();
+            server.rebind(socket).unwrap();
 
             loop {
                 let query = poll_fn(|cx| server.poll(cx)).await.unwrap();
 
                 server
-                    .send_response(query.source, dns_types::Response::no_error(&query.message))
+                    .send_response(query.from, dns_types::Response::no_error(&query.message))
                     .unwrap();
             }
         });
 
-        assert!(dig(v4_socket.into()).await.success());
-        assert!(dig(v4_socket.into()).await.success());
-        assert!(dig(v4_socket.into()).await.success());
+        assert!(dig(socket).await.success());
+        assert!(dig(socket).await.success());
+        assert!(dig(socket).await.success());
 
-        assert!(dig(v6_socket.into()).await.success());
-        assert!(dig(v6_socket.into()).await.success());
-        assert!(dig(v6_socket.into()).await.success());
+        assert!(!server_task.is_finished());
+
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn smoke_ipv6() {
+        let mut server = Server::default();
+
+        let socket = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+            8080,
+            0,
+            0,
+        ));
+
+        let server_task = tokio::spawn(async move {
+            server.rebind(socket).unwrap();
+
+            loop {
+                let query = poll_fn(|cx| server.poll(cx)).await.unwrap();
+
+                server
+                    .send_response(query.from, dns_types::Response::no_error(&query.message))
+                    .unwrap();
+            }
+        });
+
+        assert!(dig(socket).await.success());
+        assert!(dig(socket).await.success());
+        assert!(dig(socket).await.success());
 
         assert!(!server_task.is_finished());
 

--- a/rust/connlib/tunnel/src/client/dns_config.rs
+++ b/rust/connlib/tunnel/src/client/dns_config.rs
@@ -49,6 +49,7 @@ impl DnsMapping {
     // For such small numbers, linear search is usually more efficient.
     // Most importantly, it is much easier for us to retain the ordering of the DNS servers if we don't use a map.
 
+    #[cfg(test)]
     pub(crate) fn sentinel_by_upstream(&self, upstream: SocketAddr) -> Option<IpAddr> {
         self.inner
             .iter()

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -14,9 +14,9 @@ use ip_packet::{Ecn, IpPacket, MAX_FZ_PAYLOAD};
 use nameserver_set::NameserverSet;
 use socket_factory::{DatagramIn, SocketFactory, TcpSocket, UdpSocket};
 use std::{
-    collections::{BTreeSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     io,
-    net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll, ready},
@@ -49,8 +49,8 @@ pub struct Io {
     nameservers: NameserverSet,
     reval_nameserver_interval: tokio::time::Interval,
 
-    udp_dns_server: l4_udp_dns_server::Server,
-    tcp_dns_server: l4_tcp_dns_server::Server,
+    udp_dns_server: BTreeMap<SocketAddr, l4_udp_dns_server::Server>,
+    tcp_dns_server: BTreeMap<SocketAddr, l4_tcp_dns_server::Server>,
 
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
@@ -68,6 +68,8 @@ pub struct Io {
 struct DnsQueryMetaData {
     query: dns_types::Query,
     server: SocketAddr,
+    local: SocketAddr,
+    remote: SocketAddr,
     transport: dns::Transport,
 }
 
@@ -93,8 +95,8 @@ pub struct Input<D, I> {
     pub timeout: bool,
     pub device: Option<D>,
     pub network: Option<I>,
-    pub tcp_dns_query: Option<l4_tcp_dns_server::Query>,
-    pub udp_dns_query: Option<l4_udp_dns_server::Query>,
+    pub tcp_dns_queries: Vec<l4_tcp_dns_server::Query>,
+    pub udp_dns_queries: Vec<l4_udp_dns_server::Query>,
     pub dns_response: Option<dns::RecursiveResponse>,
     pub error: TunnelError,
 }
@@ -107,8 +109,8 @@ impl<D, I> Input<D, I> {
             timeout: false,
             device: None,
             network: None,
-            tcp_dns_query: None,
-            udp_dns_query: None,
+            tcp_dns_queries: Vec::new(),
+            udp_dns_queries: Vec::new(),
             dns_response: None,
             error: TunnelError::single(e),
         }
@@ -179,16 +181,22 @@ impl Io {
         }
     }
 
-    pub fn rebind_dns_ipv4(&mut self, socket: SocketAddrV4) -> Result<()> {
-        self.udp_dns_server.rebind_ipv4(socket)?;
-        self.tcp_dns_server.rebind_ipv4(socket)?;
+    pub fn rebind_dns(&mut self, sockets: Vec<SocketAddr>) -> Result<()> {
+        tracing::debug!(?sockets, "Rebinding DNS servers");
 
-        Ok(())
-    }
+        self.udp_dns_server.clear();
+        self.tcp_dns_server.clear();
 
-    pub fn rebind_dns_ipv6(&mut self, socket: SocketAddrV6) -> Result<()> {
-        self.udp_dns_server.rebind_ipv6(socket)?;
-        self.tcp_dns_server.rebind_ipv6(socket)?;
+        for socket in sockets {
+            let mut udp = l4_udp_dns_server::Server::default();
+            let mut tcp = l4_tcp_dns_server::Server::default();
+
+            udp.rebind(socket)?;
+            tcp.rebind(socket)?;
+
+            self.udp_dns_server.insert(socket, udp);
+            self.tcp_dns_server.insert(socket, tcp);
+        }
 
         Ok(())
     }
@@ -214,6 +222,8 @@ impl Io {
         if let Err(e) = ready!(self.flush(cx)) {
             return Poll::Ready(Input::error(e));
         }
+
+        let mut error = TunnelError::default();
 
         if self.reval_nameserver_interval.poll_tick(cx).is_ready() {
             self.nameservers.evaluate();
@@ -258,15 +268,33 @@ impl Io {
                 buffers.ip.drain(..num_packets)
             });
 
-        let udp_dns_query = self
+        let udp_dns_queries = self
             .udp_dns_server
-            .poll(cx)
-            .map(|query| query.context("Failed to poll UDP DNS server"));
+            .values_mut()
+            .flat_map(|s| match s.poll(cx) {
+                Poll::Ready(Ok(q)) => Some(q),
+                Poll::Ready(Err(e)) => {
+                    error.push(e);
 
-        let tcp_dns_query = self
+                    None
+                }
+                Poll::Pending => None,
+            })
+            .collect::<Vec<_>>();
+
+        let tcp_dns_queries = self
             .tcp_dns_server
-            .poll(cx)
-            .map(|query| query.context("Failed to poll TCP DNS server"));
+            .values_mut()
+            .flat_map(|s| match s.poll(cx) {
+                Poll::Ready(Ok(q)) => Some(q),
+                Poll::Ready(Err(e)) => {
+                    error.push(e);
+
+                    None
+                }
+                Poll::Pending => None,
+            })
+            .collect::<Vec<_>>();
 
         let dns_response = self
             .dns_queries
@@ -277,12 +305,16 @@ impl Io {
                     query: meta.query,
                     message: result,
                     transport: meta.transport,
+                    local: meta.local,
+                    remote: meta.remote,
                 },
                 Err(e @ futures_bounded::Timeout { .. }) => dns::RecursiveResponse {
                     server: meta.server,
                     query: meta.query,
                     message: Err(io::Error::new(io::ErrorKind::TimedOut, e)),
                     transport: meta.transport,
+                    local: meta.local,
+                    remote: meta.remote,
                 },
             });
 
@@ -299,14 +331,13 @@ impl Io {
         if !timeout
             && device.is_pending()
             && network.is_pending()
-            && tcp_dns_query.is_pending()
-            && udp_dns_query.is_pending()
+            && tcp_dns_queries.is_empty()
+            && udp_dns_queries.is_empty()
             && dns_response.is_pending()
+            && error.is_empty()
         {
             return Poll::Pending;
         }
-
-        let mut error = TunnelError::default();
 
         Poll::Ready(Input {
             now: Instant::now(),
@@ -314,8 +345,8 @@ impl Io {
             timeout,
             device: poll_to_option(device),
             network: poll_result_to_option(network, &mut error),
-            tcp_dns_query: poll_result_to_option(tcp_dns_query, &mut error),
-            udp_dns_query: poll_result_to_option(udp_dns_query, &mut error),
+            tcp_dns_queries,
+            udp_dns_queries,
             dns_response: poll_to_option(dns_response),
             error,
         })
@@ -436,10 +467,12 @@ impl Io {
             query: query.message.clone(),
             server: query.server,
             transport: query.transport,
+            local: query.local,
+            remote: query.remote,
         };
 
         match query.transport {
-            dns::Transport::Udp { .. } => {
+            dns::Transport::Udp => {
                 if self
                     .dns_queries
                     .try_push(
@@ -451,7 +484,7 @@ impl Io {
                     tracing::debug!("Failed to queue UDP DNS query")
                 }
             }
-            dns::Transport::Tcp { .. } => {
+            dns::Transport::Tcp => {
                 if self
                     .dns_queries
                     .try_push(
@@ -469,17 +502,25 @@ impl Io {
     pub(crate) fn send_udp_dns_response(
         &mut self,
         to: SocketAddr,
+        from: SocketAddr,
         message: dns_types::Response,
     ) -> io::Result<()> {
-        self.udp_dns_server.send_response(to, message)
+        self.udp_dns_server
+            .get_mut(&from)
+            .ok_or(io::Error::other("No DNS server"))?
+            .send_response(to, message)
     }
 
     pub(crate) fn send_tcp_dns_response(
         &mut self,
         to: SocketAddr,
+        from: SocketAddr,
         message: dns_types::Response,
     ) -> io::Result<()> {
-        self.tcp_dns_server.send_response(to, message)
+        self.tcp_dns_server
+            .get_mut(&from)
+            .ok_or(io::Error::other("No DNS server"))?
+            .send_response(to, message)
     }
 }
 

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -538,6 +538,8 @@ impl TunnelTest {
                             query: query.message,
                             message: Ok(response), // TODO: Vary this?
                             transport,
+                            local: query.local,
+                            remote: query.remote,
                         },
                         now,
                     )


### PR DESCRIPTION
Within Firezone, there are multiple components that deal with DNS queries. Two of those components are the `l4-udp-dns-server` and `l4-tcp-dns-server`. Both of them are responsible for receiving DNS queries on layer 4, i.e. UDP or TCP. In other words, they do _not_ operate on an IP level (which would be layer 3) but instead use `UdpSocket` and `TcpListener` to receive queries and sent back responses.

Right now, the interfaces of these crates are designed for the usecase of receiving forwarded DNS queries from the CLient on the Gateway's TUN device. This is a special-case of DNS resolution. When receiving a TXT or SRV query for a domain that is covered by a DNS resources, Firezone Client's will forward that query to the corresponding Gateway and resolve it in its network context. SRV and TXT records are commonly used for service discovery and as such, should be resolved in the network context of the service, i.e. the site that assigned to the resource.

For that usecase, it made sense to allow each DNS server to listen on 1 IPv4 and 1 IPv6 address. Since then, our event-loop has evolved a bit, being able to handle multiple inputs at once. As such, we can simplify the API of these crates to only listen on a single address and instead create multiple instances of them inside `Io`. Depending on how the design of our DNS implementation for the Clients evolves, this may be used to listen on multiple IPs later (e.g. from the `127.0.0.0/8` subnet).

Related: #8263