### PR TITLE
chore(linux): specify `systemd-resolved` dependency

### DIFF
--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",
           "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel"
         },
-        "desktopTemplate": "./linux_package/firezone-client-gui.desktop"
+        "desktopTemplate": "./linux_package/firezone-client-gui.desktop",
+        "depends": ["systemd-resolved"]
       },
       "rpm": {
         "postInstallScript": "./linux_package/postinst",


### PR DESCRIPTION
On Ubuntu, this should be the default anyway and already be installed but to be correct, we should list this dependency in the `depends` section of our `.deb`. That way, it will automatically get installed again if a user chooses to install the GUI client from our repository and doesn't have `systemd-resolved` installed.