### PR TITLE
feat(linux): automatically add user to `firezone-client` group

### DIFF
--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -8,11 +8,9 @@ if [ -n "${PKEXEC_UID:-}" ]; then
     INVOKING_USER=$(id -un "$PKEXEC_UID" 2>/dev/null) # Detect user from PolicyKit.
 elif [ -n "${SUDO_USER:-}" ]; then
     INVOKING_USER="$SUDO_USER" # Detect user from `sudo apt/dnf install`.
-else
-    INVOKING_USER="root" # Fallback to root user so we always create a valid script.
 fi
 
-sudo sed -i "s/<<USER>>/${INVOKING_USER}/g" "/usr/lib/sysusers.d/firezone-client-tunnel.conf"
+sudo sed -i "s/<<USER>>/${INVOKING_USER:-root}/g" "/usr/lib/sysusers.d/firezone-client-tunnel.conf"
 
 # Creates the system group `firezone-client` and adds the group membership.
 sudo systemd-sysusers

--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -4,7 +4,17 @@ set -euo pipefail
 
 SERVICE_NAME="firezone-client-tunnel"
 
-# Creates the system group `firezone-client`
+if [ -n "$PKEXEC_UID" ]; then
+    INVOKING_USER=$(id -un "$PKEXEC_UID" 2>/dev/null) # Detect user from PolicyKit.
+elif [ -n "$SUDO_USER" ]; then
+    INVOKING_USER="$SUDO_USER" # Detect user from `sudo apt/dnf install`.
+else
+    INVOKING_USER="root" # Fallback to root user so we always create a valid script.
+fi
+
+sudo sed -i "s/<<USER>>/${INVOKING_USER}/g" "/usr/lib/sysusers.d/firezone-client-tunnel.conf"
+
+# Creates the system group `firezone-client` and adds the group membership.
 sudo systemd-sysusers
 
 echo "Starting and enabling Firezone Tunnel service..."

--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -4,10 +4,20 @@ set -euo pipefail
 
 SERVICE_NAME="firezone-client-tunnel"
 
+DISPLAY_USER=$(who | grep '(login screen)' | awk '{print $1}')
+
 if [ -n "${PKEXEC_UID:-}" ]; then
     INVOKING_USER=$(id -un "$PKEXEC_UID" 2>/dev/null) # Detect user from PolicyKit.
+
+    echo "Detected invoking user from PolicyKit: $INVOKING_USER"
 elif [ -n "${SUDO_USER:-}" ]; then
     INVOKING_USER="$SUDO_USER" # Detect user from `sudo apt/dnf install`.
+
+    echo "Detected invoking user from SUDO_USER: $INVOKING_USER"
+elif [ -n "${DISPLAY_USER:-}" ]; then
+    INVOKING_USER="$DISPLAY_USER" # Detect user from display session.
+
+    echo "Detected invoking user from display session: $INVOKING_USER"
 fi
 
 sudo sed -i "s/<<USER>>/${INVOKING_USER:-root}/g" "/usr/lib/sysusers.d/firezone-client-tunnel.conf"

--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -4,9 +4,9 @@ set -euo pipefail
 
 SERVICE_NAME="firezone-client-tunnel"
 
-if [ -n "$PKEXEC_UID" ]; then
+if [ -n "${PKEXEC_UID:-}" ]; then
     INVOKING_USER=$(id -un "$PKEXEC_UID" 2>/dev/null) # Detect user from PolicyKit.
-elif [ -n "$SUDO_USER" ]; then
+elif [ -n "${SUDO_USER:-}" ]; then
     INVOKING_USER="$SUDO_USER" # Detect user from `sudo apt/dnf install`.
 else
     INVOKING_USER="root" # Fallback to root user so we always create a valid script.

--- a/rust/gui-client/src-tauri/linux_package/sysusers.conf
+++ b/rust/gui-client/src-tauri/linux_package/sysusers.conf
@@ -2,3 +2,4 @@
 # This creates the `firezone-client` group automatically at startup
 
 g firezone-client -
+m <<USER>> firezone-client -


### PR DESCRIPTION
By checking various environment variables, we can automatically add the current user to the `firezone-client` group which allows them to connect to the IPC socket of the tunnel process. Unfortunately, they still have to create a new login session / reboot for that to be reflected.

The docs update for this will follow once we have cut a release with this code in it.