### PR TITLE
ci: install systemd-resolved in test-install script

### DIFF
--- a/scripts/tests/gui-client-install-linux-deb.sh
+++ b/scripts/tests/gui-client-install-linux-deb.sh
@@ -11,6 +11,7 @@ function debug_exit() {
     exit 1
 }
 
+sudo apt-get update
 sudo apt-get install --yes systemd-resolved
 
 # Test the deb package, since this script is the easiest place to get a release build

--- a/scripts/tests/gui-client-install-linux-deb.sh
+++ b/scripts/tests/gui-client-install-linux-deb.sh
@@ -11,6 +11,8 @@ function debug_exit() {
     exit 1
 }
 
+sudo apt-get install --yes systemd-resolved
+
 # Test the deb package, since this script is the easiest place to get a release build
 DEB_PATH=$(realpath "$BINARY_DEST_PATH.deb")
 sudo apt-get install "$DEB_PATH"


### PR DESCRIPTION
The additional dependency specified in #10783 breaks the CI smoke test because that package isn't installed.