### PR TITLE
refactor(apple): Convert IPCClient from actor to stateless enum

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -6,6 +6,7 @@
 
 import AppleArchive
 import Foundation
+@preconcurrency import NetworkExtension
 import System
 
 /// Convenience module for smoothing over the differences between exporting logs on macOS and iOS.
@@ -28,7 +29,7 @@ import System
 
     static func export(
       to archiveURL: URL,
-      with ipcClient: IPCClient
+      session: NETunnelProviderSession
     ) async throws {
       guard let logFolderURL = SharedAccess.logFolderURL
       else {
@@ -54,7 +55,8 @@ import System
 
       // 3. Await tunnel log export from tunnel process
       try await withCheckedThrowingContinuation { continuation in
-        ipcClient.exportLogs(
+        IPCClient.exportLogs(
+          session: session,
           appender: { chunk in
             do {
               // Append each chunk to the archive

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -101,7 +101,6 @@ public class VPNConfigurationManager: @unchecked Sendable {
     }
 
     let configuration = Configuration.shared
-    let ipcClient = IPCClient(session: session)
 
     if let actorName = legacyConfiguration["actorName"] {
       UserDefaults.standard.set(actorName, forKey: "actorName")
@@ -131,7 +130,7 @@ public class VPNConfigurationManager: @unchecked Sendable {
       configuration.internetResourceEnabled = internetResourceEnabled == "true"
     }
 
-    try await ipcClient.setConfiguration(configuration)
+    try await IPCClient.setConfiguration(session: session, configuration)
 
     // Remove fields to prevent confusion if the user sees these in System Settings and wonders why they're stale.
     if let protocolConfiguration = manager.protocolConfiguration as? NETunnelProviderProtocol {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -622,9 +622,12 @@ public struct SettingsView: View {
 
         Task {
           do {
+            guard let session = try store.manager().session() else {
+              throw VPNConfigurationManagerError.managerNotInitialized
+            }
             try await LogExporter.export(
               to: destinationURL,
-              with: store.ipcClient()
+              session: session
             )
 
             window.contentViewController?.presentingViewController?.dismiss(self)
@@ -707,7 +710,10 @@ public struct SettingsView: View {
 
     do {
       #if os(macOS)
-        let providerLogFolderSize = try await store.ipcClient().getLogFolderSize()
+        guard let session = try store.manager().session() else {
+          throw VPNConfigurationManagerError.managerNotInitialized
+        }
+        let providerLogFolderSize = try await IPCClient.getLogFolderSize(session: session)
         let totalSize = logFolderSize + providerLogFolderSize
       #else
         let totalSize = logFolderSize


### PR DESCRIPTION
Refactors IPCClient from an actor to a stateless enum with static
methods, removing unnecessary actor isolation and instance management.

- IPCClient: Actor → enum with static methods taking session parameter
- Store: Removed IPCClient instance caching, added resource list caching
- Store: Moved resource fetching logic from IPCClient into Store
- All call sites: Updated to pass session directly to static methods

Store now directly manages resource list hashing and caching via
fetchResources() method, using SHA256 hash optimisation to avoid
redundant updates when resource lists haven't changed.