### PR TITLE
revert: specify `systemd-resolved` dependency

### DIFF
--- a/rust/gui-client/src-tauri/tauri.conf.json
+++ b/rust/gui-client/src-tauri/tauri.conf.json
@@ -17,8 +17,7 @@
           "/usr/lib/sysusers.d/firezone-client-tunnel.conf": "./linux_package/sysusers.conf",
           "/usr/bin/firezone-client-tunnel": "../../target/release/firezone-client-tunnel"
         },
-        "desktopTemplate": "./linux_package/firezone-client-gui.desktop",
-        "depends": ["systemd-resolved"]
+        "desktopTemplate": "./linux_package/firezone-client-gui.desktop"
       },
       "rpm": {
         "postInstallScript": "./linux_package/postinst",


### PR DESCRIPTION
I can't make the CI smoke install work with this change.

Reverts firezone/firezone#10783