### PR TITLE
fix(gateway): remove exclamation mark from sysusers.conf

### DIFF
--- a/rust/gateway/debian/firezone-gateway.sysusers
+++ b/rust/gateway/debian/firezone-gateway.sysusers
@@ -1,3 +1,3 @@
 # Declarative configuration for sysusers.d, creating a locked down system user named `firezone` and a corresponding group.
 
-u! firezone
+u firezone


### PR DESCRIPTION
This is only supported in very recent versions of systemd which is not yet present in the latest LTS.