### PR TITLE
fix(gateway): declare hard-dependency on systemd

### DIFF
--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -13,7 +13,6 @@ maintainer-scripts = "debian/"
 systemd-units = { enable = false }
 extended-description = "" # Empty string to avoid embedding the README
 revision = ""
-depends = ["systemd"]
 section = "Network"
 assets = [
     ["target/release/firezone-gateway", "usr/bin/", "755"],
@@ -22,7 +21,7 @@ assets = [
     ["debian/firezone-gateway.sysusers", "usr/lib/sysusers.d/firezone-gateway.conf", "644"],
     ["debian/firezone-gateway.tmpfiles", "usr/lib/tmpfiles.d/firezone-gateway.conf", "644"],
 ]
-depends = 'iptables'
+depends = 'iptables,systemd'
 
 [dependencies]
 anyhow = { workspace = true }

--- a/rust/gateway/Cargo.toml
+++ b/rust/gateway/Cargo.toml
@@ -13,6 +13,7 @@ maintainer-scripts = "debian/"
 systemd-units = { enable = false }
 extended-description = "" # Empty string to avoid embedding the README
 revision = ""
+depends = ["systemd"]
 section = "Network"
 assets = [
     ["target/release/firezone-gateway", "usr/bin/", "755"],

--- a/rust/gateway/debian/postinst
+++ b/rust/gateway/debian/postinst
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 
-# Script inspired by deb helper script from `cargo-deb`
-if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ]; then
-    # In case this system is running systemd, we need to ensure that all
-    # necessary users are created before starting.
-    if [ -d /run/systemd/system ]; then
-        systemd-sysusers firezone-gateway.conf >/dev/null || true
-    fi
-fi
+systemd-sysusers firezone-gateway.conf
 
 #DEBHELPER#
 

--- a/rust/gateway/debian/postinst
+++ b/rust/gateway/debian/postinst
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 systemd-sysusers firezone-gateway.conf
 
 #DEBHELPER#


### PR DESCRIPTION
Several aspects of the Gateway's Debian package depend on `systemd` being present. Without it, we don't have the necessary users and files in place for the Gateway to function. With that specified, we can fail the `postinst` script (and therefore the installation) if anything in there goes wrong.