### PR TITLE
chore(gui-client): tidy up `postinst` script

### DIFF
--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -25,7 +25,6 @@ sed -i "s/<<USER>>/${INVOKING_USER:-root}/g" "/usr/lib/sysusers.d/firezone-clien
 # Creates the system group `firezone-client` and adds the group membership.
 systemd-sysusers firezone-client-tunnel.conf
 
-echo "Starting and enabling Firezone Tunnel service..."
 systemctl daemon-reload
 systemctl enable "$SERVICE_NAME"
 systemctl restart "$SERVICE_NAME"

--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -23,7 +23,7 @@ fi
 sed -i "s/<<USER>>/${INVOKING_USER:-root}/g" "/usr/lib/sysusers.d/firezone-client-tunnel.conf"
 
 # Creates the system group `firezone-client` and adds the group membership.
-systemd-sysusers
+systemd-sysusers firezone-client-tunnel.conf
 
 echo "Starting and enabling Firezone Tunnel service..."
 systemctl daemon-reload

--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -20,12 +20,12 @@ elif [ -n "${DISPLAY_USER:-}" ]; then
     echo "Detected invoking user from display session: $INVOKING_USER"
 fi
 
-sudo sed -i "s/<<USER>>/${INVOKING_USER:-root}/g" "/usr/lib/sysusers.d/firezone-client-tunnel.conf"
+sed -i "s/<<USER>>/${INVOKING_USER:-root}/g" "/usr/lib/sysusers.d/firezone-client-tunnel.conf"
 
 # Creates the system group `firezone-client` and adds the group membership.
-sudo systemd-sysusers
+systemd-sysusers
 
 echo "Starting and enabling Firezone Tunnel service..."
-sudo systemctl daemon-reload
-sudo systemctl enable "$SERVICE_NAME"
-sudo systemctl restart "$SERVICE_NAME"
+systemctl daemon-reload
+systemctl enable "$SERVICE_NAME"
+systemctl restart "$SERVICE_NAME"


### PR DESCRIPTION
Specifying `sudo` in the script is unnecessary as it already runs as root. Additionally, only executing `systemd-sysusers` for our config file is better because it narrows the scope of what should be done.