### PR TITLE
chore(gateway): downgrade warning if peer not found

### DIFF
--- a/rust/gateway/src/eventloop.rs
+++ b/rust/gateway/src/eventloop.rs
@@ -523,7 +523,7 @@ impl Eventloop {
                     .state_mut()
                     .update_access_authorization_expiry(cid, rid, expires_at)
                 {
-                    tracing::warn!(%cid, %rid, "Failed to update expiry of access authorization: {e:#}")
+                    tracing::debug!(%cid, %rid, "Failed to update expiry of access authorization: {e:#}")
                 };
             }
         }


### PR DESCRIPTION
Logging this on WARN appears to be a bit excessive and there is not really anything we can do about it.

Resolves: #10813 