### PR TITLE
ci(gui-client): fix `.deb` test installation 

### DIFF
--- a/rust/gui-client/src-tauri/linux_package/postinst
+++ b/rust/gui-client/src-tauri/linux_package/postinst
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SERVICE_NAME="firezone-client-tunnel"
 
-DISPLAY_USER=$(who | grep '(login screen)' | awk '{print $1}')
+DISPLAY_USER=$(who | awk '{print $1}' | head -n 1)
 
 if [ -n "${PKEXEC_UID:-}" ]; then
     INVOKING_USER=$(id -un "$PKEXEC_UID" 2>/dev/null) # Detect user from PolicyKit.


### PR DESCRIPTION
The current test installation fails because it is operating in a headless environment without a display user. Some more testing of the `who` command showed that we can simply take the first user. That avoids `grep` which was previously failing with an exit code of 1, aborting the installation because our `postinst` script has `pipefail` set.