### PR TITLE
fix(telemetry): don't append duplicate attributes in Sentry log

### DIFF
--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -388,6 +388,10 @@ fn append_tracing_fields_to_message(mut log: Log) -> Option<Log> {
             None => &key,
         };
 
+        if log.attributes.contains_key(key) {
+            continue;
+        }
+
         log.body.push_str(&format!(" {key}={attr_string}"));
         log.attributes.insert(key.to_owned(), attribute);
     }

--- a/rust/telemetry/src/lib.rs
+++ b/rust/telemetry/src/lib.rs
@@ -513,6 +513,15 @@ mod tests {
     }
 
     #[test]
+    fn does_not_append_same_attribute_twice() {
+        let log = log("Foobar", &[("handle_input:cid", "1234"), ("cid", "1234")]);
+
+        let log = append_tracing_fields_to_message(log).unwrap();
+
+        assert_eq!(log.body, "Foobar cid=1234")
+    }
+
+    #[test]
     fn trims_name_of_span_from_attribute() {
         let log = log(
             "Foobar",


### PR DESCRIPTION
When we are building the log message that is sent to Sentry, we append several attributes to mimic the formatting that we get from `tracing_subscriber::fmt`. To do that, we strip the span name from the attribute which can result in us processing the same attribute such as `cid` twice: Once from a span and once from the actual log message. In order to not append the same message twice, we check for its presence in the attributes map first.

This avoids having message in Sentry such as:

```
Sampled relay cid=c18e1da8-8ef8-4e11-a325-28d6b387d503 rid=3af15c76-9e84-46a6-90e1-63ecb2bc9f80 cid=c18e1da8-8ef8-4e11-a325-28d6b387d503
```