### PR TITLE
ci: promote preview `.deb` to stable on release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -180,41 +180,38 @@ jobs:
           projects: ${{ matrix.projects }}
           sentry_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-  upload-deb-packages:
+  promote-deb-packages:
     runs-on: ubuntu-24.04
-    if: >-
-      ${{
-        startsWith(inputs.release_name || github.event.release.name, 'gateway') ||
-        startsWith(inputs.release_name || github.event.release.name, 'gui-client')
-      }}
+    strategy:
+      matrix:
+        include:
+          - tag_prefix: gateway
+            deb_name: firezone-gateway
+          - tag_prefix: gui-client
+            deb_name: firezone-client-gui
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
-      - name: Download .deb packages from release
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Copy preview archive to import-stable
+        if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
         run: |
-          set -xe
+          set -e
 
-          # Download all .deb assets
-          gh release download "${{ inputs.release_name || github.event.release.name }}" --pattern "*.deb"
+          # Extract version from release name
+          version=${{ inputs.release_name || github.event.release.name }}
+          version=${version#${{ matrix.tag_prefix }}-}
 
-          # List downloaded files for verification
-          ls -lh ./*.deb
-
-      - name: Upload to Azure Blob Storage
-        run: az storage blob upload-batch \
-          --destination apt \
-          --source . \
-          --pattern "*.deb" \
-          --destination-path import-stable \
-          --overwrite \
-          --no-progress \
-          --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
+          # Copy `.deb`s to `import-stable`
+          az storage blob copy start-batch \
+            --destination-container apt \
+            --source-container apt \
+            --pattern "pool-preview/${{ matrix.deb_name }}_$version*" \
+            --destination-path import-stable \
+            --connection-string "${{ secrets.AZURERM_ARTIFACTS_CONNECTION_STRING }}"
 
   regenerate-apt-index:
-    needs: upload-deb-packages
+    needs: promote-deb-packages
     uses: ./.github/workflows/_apt.yml
     secrets: inherit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -194,6 +194,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/setup-azure-cli
+
       - name: Copy preview archive to import-stable
         if: ${{ startsWith(inputs.release_name || github.event.release.name, matrix.tag_prefix) }}
         run: |

--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -57,7 +57,7 @@ for DISTRIBUTION in "stable" "preview"; do
     if [ "$(ls -A "${IMPORT_DIR}")" ]; then
         echo "Normalizing package names..."
 
-        for deb in "${IMPORT_DIR}"/*.deb; do
+        for deb in "${IMPORT_DIR}"/**.deb; do
             if [ -f "$deb" ]; then
                 # Extract metadata from the .deb file
                 PACKAGE=$(dpkg-deb -f "$deb" Package 2>/dev/null)

--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -8,6 +8,7 @@
 # The `pool-` directories are referenced by the live repository metadata and the files in there need to atomically change with the metadata.
 
 set -euo pipefail
+shopt -s globstar
 
 COMPONENT="main"
 WORK_DIR="$(mktemp -d)"
@@ -57,7 +58,11 @@ for DISTRIBUTION in "stable" "preview"; do
     if [ "$(ls -A "${IMPORT_DIR}")" ]; then
         echo "Normalizing package names..."
 
-        for deb in "${IMPORT_DIR}"/**.deb; do
+        for deb in "${IMPORT_DIR}"/**; do
+            if [[ ! "$deb" == *.deb ]]; then
+                continue
+            fi
+
             if [ -f "$deb" ]; then
                 # Extract metadata from the .deb file
                 PACKAGE=$(dpkg-deb -f "$deb" Package 2>/dev/null)

--- a/scripts/sync-apt.sh
+++ b/scripts/sync-apt.sh
@@ -90,7 +90,7 @@ for DISTRIBUTION in "stable" "preview"; do
         done
 
         echo "Importing new packages..."
-        mv --force --target-directory="${POOL_DIR}/" "${IMPORT_DIR}"/*.deb
+        mv --force --target-directory="${POOL_DIR}/" "${IMPORT_DIR}"/**/*.deb
     fi
 
     if [ -z "$(ls -A "${POOL_DIR}")" ]; then


### PR DESCRIPTION
The current CI job expects the release to have the `.deb` files attached. Since writing that workflow, I've changed my mind on attaching the `.deb` files there. Instead, they are only uploaded to the repository. Without documentation on how to use them, these `.deb` files are unlikely to provide a good user experience.

We change the job to instead promote the latest "preview` archives to the stable repo.