### PR TITLE
chore(connlib): silence hickory_resolver

### DIFF
--- a/rust/logging/src/lib.rs
+++ b/rust/logging/src/lib.rs
@@ -124,7 +124,7 @@ fn parse_filter(directives: &str) -> Result<EnvFilter, ParseError> {
     ///
     /// By prepending this directive to the active log filter, a simple directive like `debug` actually produces useful logs.
     /// If necessary, you can still activate logs from these crates by restating them in your directive with a lower filter, i.e. `netlink_proto=debug`.
-    const IRRELEVANT_CRATES: &str = "netlink_proto=warn,os_info=warn,rustls=warn,opentelemetry_sdk=info,opentelemetry=info,hyper_util=info,h2=info,hickory_proto=info";
+    const IRRELEVANT_CRATES: &str = "netlink_proto=warn,os_info=warn,rustls=warn,opentelemetry_sdk=info,opentelemetry=info,hyper_util=info,h2=info,hickory_proto=info,hickory_resolver=info";
 
     let env_filter = if directives.is_empty() {
         EnvFilter::try_new(IRRELEVANT_CRATES)?


### PR DESCRIPTION
Logs from the `hickory_resolver` module are a bit noisy, so filter those out from our logs.