### PR TITLE
refactor(connlib): use dedicated UDP DNS client

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2688,6 +2688,7 @@ dependencies = [
  "ip_network_table",
  "itertools 0.14.0",
  "l3-tcp",
+ "l3-udp-dns-client",
  "l4-tcp-dns-server",
  "l4-udp-dns-server",
  "lru",

--- a/rust/connlib/l3-udp-dns-client/lib.rs
+++ b/rust/connlib/l3-udp-dns-client/lib.rs
@@ -8,7 +8,7 @@ use anyhow::{Context as _, Result, anyhow, bail};
 use ip_packet::IpPacket;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
-const TIMEOUT: Duration = Duration::from_secs(5);
+const TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A sans-io DNS-over-UDP client.
 pub struct Client<const MIN_PORT: u16 = 49152, const MAX_PORT: u16 = 65535> {

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -33,6 +33,7 @@ ip-packet = { workspace = true }
 ip_network = { workspace = true }
 ip_network_table = { workspace = true }
 itertools = { workspace = true, features = ["use_std"] }
+l3-udp-dns-client = { workspace = true }
 l4-tcp-dns-server = { workspace = true }
 l4-udp-dns-server = { workspace = true }
 lru = { workspace = true }

--- a/rust/connlib/tunnel/Cargo.toml
+++ b/rust/connlib/tunnel/Cargo.toml
@@ -17,7 +17,7 @@ bufferpool = { workspace = true }
 bytes = { workspace = true, features = ["std"] }
 chrono = { workspace = true }
 connlib-model = { workspace = true }
-derive_more = { workspace = true, features = ["debug", "from"] }
+derive_more = { workspace = true, features = ["debug", "from", "display"] }
 divan = { workspace = true, optional = true }
 dns-over-tcp = { workspace = true }
 dns-types = { workspace = true }

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -124,7 +124,7 @@ impl RecursiveQuery {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum Transport {
     Udp,
     Tcp,

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -92,38 +92,6 @@ pub(crate) struct RecursiveResponse {
     pub transport: Transport,
 }
 
-impl RecursiveQuery {
-    pub(crate) fn via_udp(
-        local: SocketAddr,
-        remote: SocketAddr,
-        server: SocketAddr,
-        message: dns_types::Query,
-    ) -> Self {
-        Self {
-            server,
-            local,
-            remote,
-            message,
-            transport: Transport::Udp,
-        }
-    }
-
-    pub(crate) fn via_tcp(
-        local: SocketAddr,
-        remote: SocketAddr,
-        server: SocketAddr,
-        message: dns_types::Query,
-    ) -> Self {
-        Self {
-            server,
-            local,
-            remote,
-            message,
-            transport: Transport::Tcp,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display)]
 pub(crate) enum Transport {
     #[display("UDP")]

--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -124,9 +124,11 @@ impl RecursiveQuery {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::Display)]
 pub(crate) enum Transport {
+    #[display("UDP")]
     Udp,
+    #[display("TCP")]
     Tcp,
 }
 

--- a/rust/connlib/tunnel/src/expiring_map.rs
+++ b/rust/connlib/tunnel/src/expiring_map.rs
@@ -53,6 +53,7 @@ where
         self.inner.get(key)
     }
 
+    #[cfg(test)]
     pub fn remove(&mut self, key: &K) -> Option<Entry<V>> {
         self.expiration.retain(|_, keys| {
             keys.retain(|k| k != key);

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -456,12 +456,13 @@ impl GatewayTunnel {
 
                 for query in udp_dns_queries {
                     if let Some(nameserver) = self.io.fastest_nameserver() {
-                        self.io.send_dns_query(dns::RecursiveQuery::via_udp(
-                            query.local,
-                            query.remote,
-                            SocketAddr::new(nameserver, dns::DNS_PORT),
-                            query.message,
-                        ));
+                        self.io.send_dns_query(dns::RecursiveQuery {
+                            server: SocketAddr::new(nameserver, dns::DNS_PORT),
+                            local: query.local,
+                            remote: query.remote,
+                            message: query.message,
+                            transport: dns::Transport::Udp,
+                        });
                     } else {
                         tracing::warn!(query = ?query.message, "No nameserver available to handle UDP DNS query");
 
@@ -479,12 +480,13 @@ impl GatewayTunnel {
 
                 for query in tcp_dns_queries {
                     if let Some(nameserver) = self.io.fastest_nameserver() {
-                        self.io.send_dns_query(dns::RecursiveQuery::via_tcp(
-                            query.local,
-                            query.remote,
-                            SocketAddr::new(nameserver, dns::DNS_PORT),
-                            query.message,
-                        ));
+                        self.io.send_dns_query(dns::RecursiveQuery {
+                            server: SocketAddr::new(nameserver, dns::DNS_PORT),
+                            local: query.local,
+                            remote: query.remote,
+                            message: query.message,
+                            transport: dns::Transport::Tcp,
+                        });
                     } else {
                         tracing::warn!(query = ?query.message, "No nameserver available to handle TCP DNS query");
 

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -458,7 +458,7 @@ impl GatewayTunnel {
                     if let Some(nameserver) = self.io.fastest_nameserver() {
                         self.io.send_dns_query(dns::RecursiveQuery::via_udp(
                             query.local,
-                            query.from,
+                            query.remote,
                             SocketAddr::new(nameserver, dns::DNS_PORT),
                             query.message,
                         ));
@@ -466,7 +466,7 @@ impl GatewayTunnel {
                         tracing::warn!(query = ?query.message, "No nameserver available to handle UDP DNS query");
 
                         if let Err(e) = self.io.send_udp_dns_response(
-                            query.from,
+                            query.remote,
                             query.local,
                             dns_types::Response::servfail(&query.message),
                         ) {


### PR DESCRIPTION
By default, DNS queries are sent over UDP by most systems. UDP is an easy to understand protocol because each packet stands by itself and at least as far as UDP is concerned, the payload is contained within a single packet.

In Firezone, we receive all DNS traffic on the TUN device as IP packets. Processing the UDP packets is trivial as each query is contained within a single IP packet. For TCP, we first need to assemble the TCP stream before we can read the entire query.

In case a DNS query is not for a Firezone DNS resource, we want to forward it to the specified upstream resolver, either directly from the system or - in case the specified upstream resolver is an IP resource - through the tunnel as an IP packet. Specifically, the forwarding of UDP DNS packets through the tunnel currently happens like this:

IP packet -> read UDP payload -> parse DNS query -> mangle original destination IP to new upstream -> send through tunnel

For TCP DNS queries, it is not quite as easy as we have to decode the incoming TCP stream first before we can parse the DNS query. Thus, when we want to then forward the query, we need to open our own TCP stream to the upstream resolver and encode the DNS query onto that stream, sending each IP packet from the TCP client through the tunnel.

The difference in these designs makes several code paths in connlib hard to follow.

Therefore - and despite the simplicity of DNS over UDP - we already created our own "Layer 3 UDP DNS"-client. This PR now integrates this client into the tunnel. Using this new client, we can simplify the processing of UDP DNS queries because we never have to "go back" to the original IP packet. Instead, when a DNS query needs to be forwarded to an usptream resolver through the tunnel, we simply tell the Layer 3 UDP DNS client to make a new DNS query. The processing of the resulting IP packet then happens in a different place, right next to where we also process the IP packets of the TCP DNS client.

That simplifications unlocks further refactorings where we now only process DNS queries in a single place and the transport we received it over is a simple function parameter with the control flow for both of them being identical.

Related: #4668