### PR TITLE
refactor: prepare client `init` for upstream DoH servers

### DIFF
--- a/elixir/apps/api/lib/api/client/views/interface.ex
+++ b/elixir/apps/api/lib/api/client/views/interface.ex
@@ -2,6 +2,7 @@ defmodule API.Client.Views.Interface do
   alias Domain.{Accounts, Clients}
 
   def render(%Clients.Client{} = client) do
+    # Legacy field
     upstream_dns =
       client.account.config
       |> Map.get(:clients_upstream_dns, [])
@@ -10,11 +11,23 @@ defmodule API.Client.Views.Interface do
         Map.from_struct(%{dns_config | address: address})
       end)
 
+    upstream_do53 =
+      for %{protocol: :ip_port, address: address} <-
+            Map.get(client.account.config, :clients_upstream_dns, []),
+          {:ok, ip_port} <- [Domain.Types.IPPort.cast(address)] do
+        %{ip: Domain.Types.IPPort.to_string(%{ip_port | port: nil})}
+      end
+
     %{
       search_domain: client.account.config.search_domain,
-      upstream_dns: upstream_dns,
+      upstream_do53: upstream_do53,
+      # Populate from DB once present.
+      upstream_doh: [],
       ipv4: client.ipv4,
-      ipv6: client.ipv6
+      ipv6: client.ipv6,
+
+      # Legacy field
+      upstream_dns: upstream_dns
     }
   end
 end

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -351,6 +351,11 @@ defmodule API.Client.ChannelTest do
                  %{protocol: :ip_port, address: "1.1.1.1:53"},
                  %{protocol: :ip_port, address: "8.8.8.8:53"}
                ],
+               upstream_do53: [
+                 %{ip: "1.1.1.1"},
+                 %{ip: "8.8.8.8"}
+               ],
+               upstream_doh: [],
                search_domain: "example.com"
              }
     end
@@ -909,7 +914,12 @@ defmodule API.Client.ChannelTest do
                  upstream_dns: [
                    %{address: "1.1.1.1:53", protocol: :ip_port},
                    %{address: "8.8.8.8:53", protocol: :ip_port}
-                 ]
+                 ],
+                 upstream_do53: [
+                   %{ip: "1.1.1.1"},
+                   %{ip: "8.8.8.8"}
+                 ],
+                 upstream_doh: []
                }
              }
     end

--- a/elixir/apps/domain/lib/domain/accounts/config/changeset.ex
+++ b/elixir/apps/domain/lib/domain/accounts/config/changeset.ex
@@ -64,22 +64,6 @@ defmodule Domain.Accounts.Config.Changeset do
     end
   end
 
-  def normalize_dns_address(%Config.ClientsUpstreamDNS{protocol: :ip_port, address: address}) do
-    case IPPort.cast(address) do
-      {:ok, address} ->
-        address
-        |> IPPort.put_default_port(@default_dns_port)
-        |> to_string()
-
-      _ ->
-        address
-    end
-  end
-
-  def normalize_dns_address(%Config.ClientsUpstreamDNS{address: address}) do
-    address
-  end
-
   def client_upstream_dns_changeset(client_upstream_dns \\ %Config.ClientsUpstreamDNS{}, attrs) do
     client_upstream_dns
     |> cast(attrs, [:protocol, :address])
@@ -129,5 +113,21 @@ defmodule Domain.Accounts.Config.Changeset do
     |> cast(attrs, [])
     |> cast_embed(:outdated_gateway, with: &Config.Notifications.Email.Changeset.changeset/2)
     |> cast_embed(:idp_sync_error, with: &Config.Notifications.Email.Changeset.changeset/2)
+  end
+
+  defp normalize_dns_address(%Config.ClientsUpstreamDNS{protocol: :ip_port, address: address}) do
+    case IPPort.cast(address) do
+      {:ok, address} ->
+        address
+        |> IPPort.put_default_port(@default_dns_port)
+        |> to_string()
+
+      _ ->
+        address
+    end
+  end
+
+  defp normalize_dns_address(%Config.ClientsUpstreamDNS{address: address}) do
+    address
   end
 end

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -1026,11 +1026,11 @@ impl ClientState {
     }
 
     pub fn update_interface_config(&mut self, config: InterfaceConfig) {
-        tracing::trace!(upstream_dns = ?config.upstream_dns, search_domain = ?config.search_domain, ipv4 = %config.ipv4, ipv6 = %config.ipv6, "Received interface configuration from portal");
+        tracing::trace!(upstream_do53 = ?config.upstream_do53(), search_domain = ?config.search_domain, ipv4 = %config.ipv4, ipv6 = %config.ipv6, "Received interface configuration from portal");
 
         let changed = self
             .dns_config
-            .update_upstream_resolvers(config.upstream_dns);
+            .update_upstream_do53_resolvers(config.upstream_do53());
 
         if changed {
             self.dns_cache.flush("DNS servers changed");

--- a/rust/connlib/tunnel/src/tests/stub_portal.rs
+++ b/rust/connlib/tunnel/src/tests/stub_portal.rs
@@ -5,11 +5,8 @@ use super::{
     sim_net::Host,
     strategies::{resolved_ips, site_specific_dns_record, subdomain_records},
 };
-use crate::{client, proptest::*};
-use crate::{
-    client::DnsResource,
-    messages::{DnsServer, gateway},
-};
+use crate::{client, messages::UpstreamDo53, proptest::*};
+use crate::{client::DnsResource, messages::gateway};
 use connlib_model::{GatewayId, Site};
 use connlib_model::{ResourceId, SiteId};
 use dns_types::DomainName;
@@ -291,7 +288,7 @@ impl StubPortal {
     ) -> impl Strategy<Value = Host<RefClient>> + use<S1, S2>
     where
         S1: Strategy<Value = Vec<IpAddr>>,
-        S2: Strategy<Value = Vec<DnsServer>>,
+        S2: Strategy<Value = Vec<UpstreamDo53>>,
     {
         ref_client_host(
             Just(self.client_tunnel_ipv4),

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -269,12 +269,13 @@ impl TunnelTest {
                     .client
                     .exec_mut(|c| c.sut.update_system_resolvers(servers));
             }
-            Transition::UpdateUpstreamDnsServers(servers) => {
+            Transition::UpdateUpstreamDo53Servers(upstream_do53) => {
                 state.client.exec_mut(|c| {
                     c.sut.update_interface_config(Interface {
                         ipv4: c.sut.tunnel_ip_config().unwrap().v4,
                         ipv6: c.sut.tunnel_ip_config().unwrap().v6,
-                        upstream_dns: servers,
+                        upstream_dns: vec![],
+                        upstream_do53,
                         search_domain: ref_state.client.inner().search_domain.clone(),
                     })
                 });
@@ -284,7 +285,8 @@ impl TunnelTest {
                     c.sut.update_interface_config(Interface {
                         ipv4: c.sut.tunnel_ip_config().unwrap().v4,
                         ipv6: c.sut.tunnel_ip_config().unwrap().v6,
-                        upstream_dns: ref_state.client.inner().upstream_dns_resolvers(),
+                        upstream_dns: vec![],
+                        upstream_do53: ref_state.client.inner().upstream_dns_resolvers(),
                         search_domain,
                     })
                 });
@@ -310,7 +312,7 @@ impl TunnelTest {
             Transition::ReconnectPortal => {
                 let ipv4 = state.client.inner().sut.tunnel_ip_config().unwrap().v4;
                 let ipv6 = state.client.inner().sut.tunnel_ip_config().unwrap().v6;
-                let upstream_dns = ref_state.client.inner().upstream_dns_resolvers();
+                let upstream_do53 = ref_state.client.inner().upstream_dns_resolvers();
                 let all_resources = ref_state.client.inner().all_resources();
 
                 // Simulate receiving `init`.
@@ -318,7 +320,8 @@ impl TunnelTest {
                     c.sut.update_interface_config(Interface {
                         ipv4,
                         ipv6,
-                        upstream_dns,
+                        upstream_dns: Vec::new(),
+                        upstream_do53,
                         search_domain: ref_state.client.inner().search_domain.clone(),
                     });
                     c.update_relays(iter::empty(), state.relays.iter(), now);
@@ -402,7 +405,7 @@ impl TunnelTest {
                 let ipv4 = state.client.inner().sut.tunnel_ip_config().unwrap().v4;
                 let ipv6 = state.client.inner().sut.tunnel_ip_config().unwrap().v6;
                 let system_dns = ref_state.client.inner().system_dns_resolvers();
-                let upstream_dns = ref_state.client.inner().upstream_dns_resolvers();
+                let upstream_do53 = ref_state.client.inner().upstream_dns_resolvers();
                 let all_resources = ref_state.client.inner().all_resources();
                 let internet_resource_state = ref_state.client.inner().internet_resource_active;
 
@@ -413,7 +416,8 @@ impl TunnelTest {
                     c.sut.update_interface_config(Interface {
                         ipv4,
                         ipv6,
-                        upstream_dns,
+                        upstream_dns: Vec::new(),
+                        upstream_do53,
                         search_domain: ref_state.client.inner().search_domain.clone(),
                     });
                     c.sut.update_system_resolvers(system_dns);

--- a/rust/connlib/tunnel/src/tests/transition.rs
+++ b/rust/connlib/tunnel/src/tests/transition.rs
@@ -1,5 +1,6 @@
 use crate::{
     client::{CidrResource, IPV4_RESOURCES, IPV6_RESOURCES, Resource},
+    messages::UpstreamDo53,
     proptest::{host_v4, host_v6},
 };
 use connlib_model::{RelayId, ResourceId, Site};
@@ -10,7 +11,6 @@ use super::{
     reference::PrivateKey,
     sim_net::{Host, any_ip_stack},
 };
-use crate::messages::DnsServer;
 use prop::collection;
 use proptest::{prelude::*, sample};
 use std::{
@@ -66,8 +66,8 @@ pub(crate) enum Transition {
 
     /// The system's DNS servers changed.
     UpdateSystemDnsServers(Vec<IpAddr>),
-    /// The upstream DNS servers changed.
-    UpdateUpstreamDnsServers(Vec<DnsServer>),
+    /// The upstream Do53 servers changed.
+    UpdateUpstreamDo53Servers(Vec<UpstreamDo53>),
     /// The upstream search domain changed.
     UpdateUpstreamSearchDomain(Option<DomainName>),
 


### PR DESCRIPTION
In order to support multiple different protocols of upstream DNS resolvers, we deprecate the `upstream_dns` field in the client's `init` message and introduce two new fields:

- `upstream_do53`
- `upstream_doh`

For now, only `upstream_do53` is populated and `upstream_doh` is always empty.

On the client-side, we for now only introduce the `upstream_do53` field but fall-back to `upstream_dns` if that one is empty. This makes this PR backwards-compatible with the portal version that is currently deployed in production. Thus, this PR can be merged even prior to deploying the portal.

Internally, we prepare connlib's abstractions to deal with different kinds of upstreams by renaming all existing "upstream DNS" references to `upstream_do53`: DNS over port 53. That includes UDP as well as TCP DNS resolution.

Resolves: #10791