### PR TITLE
refactor(connlib): extract `l4-udp-dns-client`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1338,6 +1338,7 @@ dependencies = [
  "firezone-tunnel",
  "futures",
  "ip_network",
+ "l4-udp-dns-client",
  "libc",
  "parking_lot",
  "phoenix-channel",
@@ -4176,6 +4177,18 @@ dependencies = [
  "anyhow",
  "dns-types",
  "futures",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "l4-udp-dns-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dns-types",
+ "futures",
+ "socket-factory",
  "tokio",
  "tracing",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "connlib/l3-tcp",
     "connlib/l3-udp-dns-client",
     "connlib/l4-tcp-dns-server",
+    "connlib/l4-udp-dns-client",
     "connlib/l4-udp-dns-server",
     "connlib/model",
     "connlib/phoenix-channel",
@@ -112,6 +113,7 @@ known-folders = "1.4.0"
 l3-tcp = { path = "connlib/l3-tcp" }
 l3-udp-dns-client = { path = "connlib/l3-udp-dns-client" }
 l4-tcp-dns-server = { path = "connlib/l4-tcp-dns-server" }
+l4-udp-dns-client = { path = "connlib/l4-udp-dns-client" }
 l4-udp-dns-server = { path = "connlib/l4-udp-dns-server" }
 libc = "0.2.176"
 libfuzzer-sys = "0.4"

--- a/rust/client-shared/Cargo.toml
+++ b/rust/client-shared/Cargo.toml
@@ -14,6 +14,7 @@ firezone-logging = { workspace = true }
 firezone-tunnel = { workspace = true }
 futures = { workspace = true }
 ip_network = { workspace = true }
+l4-udp-dns-client = { workspace = true }
 libc = { workspace = true }
 parking_lot = { workspace = true }
 phoenix-channel = { workspace = true }

--- a/rust/connlib/l4-udp-dns-client/Cargo.toml
+++ b/rust/connlib/l4-udp-dns-client/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "l4-udp-dns-client"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+dns-types = { workspace = true }
+futures = { workspace = true }
+socket-factory = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }
+
+[lints]
+workspace = true

--- a/rust/connlib/l4-udp-dns-client/lib.rs
+++ b/rust/connlib/l4-udp-dns-client/lib.rs
@@ -1,0 +1,158 @@
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use std::{
+    collections::BTreeSet,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::{Context as _, Result};
+use dns_types::DomainName;
+use futures::stream::FuturesUnordered;
+use futures::stream::StreamExt as _;
+use socket_factory::{SocketFactory, UdpSocket};
+
+/// A UDP DNS client, specialised for resolving host names to IP addresses.
+///
+/// The implementation uses a multi-shot approach where all configured upstream servers are contacted in parallel.
+/// All successful responses are merged together.
+pub struct UdpDnsClient {
+    socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
+    servers: Vec<IpAddr>,
+}
+
+impl UdpDnsClient {
+    const TIMEOUT: Duration = Duration::from_secs(2);
+
+    pub fn new(socket_factory: Arc<dyn SocketFactory<UdpSocket>>, servers: Vec<IpAddr>) -> Self {
+        Self {
+            socket_factory,
+            servers,
+        }
+    }
+
+    pub fn resolve(&self, host: String) -> impl Future<Output = Result<Vec<IpAddr>>> + use<> {
+        let servers = self.servers.clone();
+        let socket_factory = self.socket_factory.clone();
+
+        async move {
+            let host = DomainName::vec_from_str(&host).context("Failed to parse domain name")?;
+
+            let ips = servers
+                .iter()
+                .flat_map(|socket| {
+                    let socket = SocketAddr::new(*socket, 53);
+
+                    [
+                        send_query(
+                            socket_factory.clone(),
+                            socket,
+                            dns_types::Query::new(host.clone(), dns_types::RecordType::A),
+                        ),
+                        send_query(
+                            socket_factory.clone(),
+                            socket,
+                            dns_types::Query::new(host.clone(), dns_types::RecordType::AAAA),
+                        ),
+                    ]
+                })
+                .collect::<FuturesUnordered<_>>()
+                .collect::<Vec<_>>()
+                .await
+                .into_iter()
+                .flat_map(|result| result.inspect_err(|e| tracing::debug!("{e:#}")).ok())
+                .filter(|response| response.response_code() == dns_types::ResponseCode::NOERROR)
+                .flat_map(|response| {
+                    response
+                        .records()
+                        .filter_map(dns_types::records::extract_ip)
+                        .collect::<Vec<_>>()
+                })
+                .collect::<BTreeSet<_>>(); // Make them unique.
+
+            Ok(Vec::from_iter(ips))
+        }
+    }
+}
+
+async fn send_query(
+    socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
+    server: SocketAddr,
+    query: dns_types::Query,
+) -> Result<dns_types::Response> {
+    let bind_addr = match server {
+        SocketAddr::V4(_) => SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0),
+        SocketAddr::V6(_) => SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0),
+    };
+
+    // To avoid fragmentation, IP and thus also UDP packets can only reliably sent with an MTU of <= 1500 on the public Internet.
+    const BUF_SIZE: usize = 1500;
+
+    let udp_socket = socket_factory
+        .bind(bind_addr)
+        .context("Failed to bind UDP socket")?;
+
+    let response = tokio::time::timeout(
+        UdpDnsClient::TIMEOUT,
+        udp_socket.handshake::<BUF_SIZE>(server, &query.into_bytes()),
+    )
+    .await
+    .with_context(|| format!("DNS query to host {server} timed out"))??;
+
+    let response = dns_types::Response::parse(&response).context("Failed to parse DNS response")?;
+
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "Requires Internet"]
+    async fn can_resolve_host() {
+        let client = UdpDnsClient::new(
+            Arc::new(socket_factory::udp),
+            vec![IpAddr::from([1, 1, 1, 1])],
+        );
+
+        let ips = client.resolve("example.com".to_owned()).await.unwrap();
+
+        assert!(!ips.is_empty())
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires Internet"]
+    async fn times_out_unreachable_host() {
+        let client = UdpDnsClient::new(
+            Arc::new(socket_factory::udp),
+            vec![IpAddr::from([2, 2, 2, 2])],
+        );
+
+        let now = Instant::now();
+
+        let ips = client.resolve("example.com".to_owned()).await.unwrap();
+
+        assert!(ips.is_empty());
+        assert!(now.elapsed() >= UdpDnsClient::TIMEOUT)
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires Internet"]
+    async fn returns_all_valid_records() {
+        let client = UdpDnsClient::new(
+            Arc::new(socket_factory::udp),
+            vec![IpAddr::from([1, 1, 1, 1]), IpAddr::from([2, 2, 2, 2])],
+        );
+
+        let now = Instant::now();
+
+        let ips = client.resolve("example.com".to_owned()).await.unwrap();
+
+        assert!(!ips.is_empty());
+        assert!(now.elapsed() >= UdpDnsClient::TIMEOUT) // Still need to wait for the unreachable server.
+    }
+}


### PR DESCRIPTION
In order to bootstrap DoH servers, we need a way of reliably resolving the domain of the DoH server to an IP address. Initially, I thought that this would be tricky to do if we have to integrate this into the Client's state machine.

Whilst implementing DoH however, I realised that we can instead put this responsibility onto the IO layer of connlib. Similar to other cases, we can reuse external triggers as our retry mechanism in case of failure. In particular, we can simply issue UDP DNS queries for the DoH domain to all system-defined DNS resolvers every time we are told to send a DNS query over DoH but the corresponding client isn't initialized yet.

In other words, instead of building a retry mechanism ourselves, we attempt to repair any kind of broken state once per DNS query that we receive.

Performing this DNS resolution does require a bit of code. We already started to do something similar in #10817. In order to reuse that code, we extract it into a `l4-udp-dns-client` crate and slightly refactor its semantics. In particular, we now wait for the response of all upstream servers (but at most 2s) and combine the result.

The resulting `UdpDnsClient` can now be used inside the Client's event-loop to re-resolve the portal URL and will also be used as part of our DoH implementation to bootstrap the connection to the DoH server.

Related: #4668 