### PR TITLE
fix(apple): prevent utun increments from IPC calls

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/LogExporter.swift
@@ -29,7 +29,6 @@ import System
 
     static func export(
       to archiveURL: URL,
-      store: Store,
       session: NETunnelProviderSession
     ) async throws {
       guard let logFolderURL = SharedAccess.logFolderURL
@@ -53,13 +52,10 @@ import System
         .appendingPathComponent("tunnel.zip")
       fileManager.createFile(atPath: tunnelLogURL.path, contents: nil)
       let fileHandle = try FileHandle(forWritingTo: tunnelLogURL)
+      defer { try? fileHandle.close() }
 
       // 3. Await tunnel log export from tunnel process
-      try await IPCClient.exportLogs(
-        session: session,
-        configuration: store.configuration,
-        fileHandle: fileHandle
-      )
+      try await IPCClient.exportLogs(session: session, fileHandle: fileHandle)
 
       // 4. Create app log archive
       let appLogURL = sharedLogFolderURL.appendingPathComponent("app.zip")

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Managers/VPNConfigurationManager.swift
@@ -130,7 +130,7 @@ public class VPNConfigurationManager: @unchecked Sendable {
       configuration.internetResourceEnabled = internetResourceEnabled == "true"
     }
 
-    try await IPCClient.setConfiguration(session: session, configuration)
+    try await IPCClient.setConfiguration(session: session, configuration.toTunnelConfiguration())
 
     // Remove fields to prevent confusion if the user sees these in System Settings and wonders why they're stale.
     if let protocolConfiguration = manager.protocolConfiguration as? NETunnelProviderProtocol {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Models/Configuration.swift
@@ -203,3 +203,11 @@ public struct TunnelConfiguration: Codable, Sendable {
     self.internetResourceEnabled = internetResourceEnabled
   }
 }
+
+extension TunnelConfiguration: Equatable {
+  public static func == (lhs: TunnelConfiguration, rhs: TunnelConfiguration) -> Bool {
+    return lhs.apiURL == rhs.apiURL && lhs.accountSlug == rhs.accountSlug
+      && lhs.logFilter == rhs.logFilter
+      && lhs.internetResourceEnabled == rhs.internetResourceEnabled
+  }
+}

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -44,6 +44,7 @@ public final class Store: ObservableObject {
   private var resourcesTimer: Timer?
   private var resourceUpdateTask: Task<Void, Never>?
   public let configuration: Configuration
+  private var lastSavedConfiguration: TunnelConfiguration?
   private var vpnConfigurationManager: VPNConfigurationManager?
   private var cancellables: Set<AnyCancellable> = []
 
@@ -69,15 +70,26 @@ public final class Store: ObservableObject {
       .debounce(for: .seconds(0.3), scheduler: DispatchQueue.main)  // These happen quite frequently
       .sink(receiveValue: { [weak self] _ in
         guard let self = self else { return }
+        let current = self.configuration.toTunnelConfiguration()
 
-        if self.vpnConfigurationManager != nil {
-          Task {
-            do {
-              guard let session = try self.manager().session() else { return }
-              try await IPCClient.setConfiguration(session: session, self.configuration)
-            } catch {
-              Log.error(error)
-            }
+        if self.vpnConfigurationManager == nil {
+          // No manager yet, nothing to update
+          return
+        }
+
+        if self.lastSavedConfiguration == current {
+          // No changes
+          return
+        }
+
+        self.lastSavedConfiguration = current
+
+        Task {
+          do {
+            guard let session = try self.manager().session() else { return }
+            try await IPCClient.setConfiguration(session: session, current)
+          } catch {
+            Log.error(error)
           }
         }
       })
@@ -126,7 +138,7 @@ public final class Store: ObservableObject {
 
     IPCClient.subscribeToVPNStatusUpdates(session: session, handler: vpnStatusChangeHandler)
 
-    let initialStatus = IPCClient.sessionStatus(session: session)
+    let initialStatus = session.status
 
     // Handle initial status to ensure resources start loading if already connected
     try await handleVPNStatusChange(newVPNStatus: initialStatus)
@@ -210,7 +222,7 @@ public final class Store: ObservableObject {
       guard let session = try manager().session() else {
         throw VPNConfigurationManagerError.managerNotInitialized
       }
-      try IPCClient.start(session: session, configuration: configuration)
+      try IPCClient.start(session: session)
     }
   }
   func installVPNConfiguration() async throws {
@@ -238,17 +250,7 @@ public final class Store: ObservableObject {
       throw VPNConfigurationManagerError.managerNotInitialized
     }
 
-    #if os(macOS)
-      // On macOS, the system removes the utun interface on stop ONLY if the VPN is in a connected state.
-      // So we need to do a dry run start-then-stop if we're not connected, to ensure the interface is removed.
-      if vpnStatus == .connected || vpnStatus == .connecting || vpnStatus == .reasserting {
-        try IPCClient.stop(session: session)
-      } else {
-        try IPCClient.dryStartStopCycle(session: session, configuration: configuration)
-      }
-    #else
-      try IPCClient.stop(session: session)
-    #endif
+    session.stopTunnel()
   }
 
   func signIn(authResponse: AuthResponse) async throws {
@@ -272,7 +274,7 @@ public final class Store: ObservableObject {
     guard let session = try manager().session() else {
       throw VPNConfigurationManagerError.managerNotInitialized
     }
-    try IPCClient.start(session: session, token: authResponse.token, configuration: configuration)
+    try IPCClient.start(session: session, token: authResponse.token)
   }
 
   func signOut() async throws {
@@ -280,6 +282,13 @@ public final class Store: ObservableObject {
       throw VPNConfigurationManagerError.managerNotInitialized
     }
     try await IPCClient.signOut(session: session)
+  }
+
+  func clearLogs() async throws {
+    guard let session = try manager().session() else {
+      throw VPNConfigurationManagerError.managerNotInitialized
+    }
+    try await IPCClient.clearLogs(session: session)
   }
 
   // MARK: Private functions
@@ -356,7 +365,8 @@ public final class Store: ObservableObject {
     let currentHash = resourceListHash
 
     // If no data returned, resources haven't changed - no update needed
-    guard let data = try await IPCClient.fetchResources(session: session, currentHash: currentHash) else {
+    guard let data = try await IPCClient.fetchResources(session: session, currentHash: currentHash)
+    else {
       return
     }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Stores/Store.swift
@@ -282,13 +282,6 @@ public final class Store: ObservableObject {
     try await IPCClient.signOut(session: session)
   }
 
-  func clearLogs() async throws {
-    guard let session = try manager().session() else {
-      throw VPNConfigurationManagerError.managerNotInitialized
-    }
-    try await IPCClient.clearLogs(session: session)
-  }
-
   // MARK: Private functions
 
   private func markAlertAsShown(_ id: String) {

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -627,6 +627,7 @@ public struct SettingsView: View {
             }
             try await LogExporter.export(
               to: destinationURL,
+              store: store,
               session: session
             )
 
@@ -713,7 +714,8 @@ public struct SettingsView: View {
         guard let session = try store.manager().session() else {
           throw VPNConfigurationManagerError.managerNotInitialized
         }
-        let providerLogFolderSize = try await IPCClient.getLogFolderSize(session: session)
+        let providerLogFolderSize = try await IPCClient.getLogFolderSize(
+          session: session, configuration: store.configuration)
         let totalSize = logFolderSize + providerLogFolderSize
       #else
         let totalSize = logFolderSize
@@ -749,7 +751,10 @@ public struct SettingsView: View {
     try Log.clear(in: SharedAccess.logFolderURL)
 
     #if os(macOS)
-      try await store.clearLogs()
+      guard let session = try store.manager().session() else {
+        throw VPNConfigurationManagerError.managerNotInitialized
+      }
+      try await IPCClient.clearLogs(session: session, configuration: store.configuration)
     #endif
   }
 

--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Views/SettingsView.swift
@@ -627,7 +627,6 @@ public struct SettingsView: View {
             }
             try await LogExporter.export(
               to: destinationURL,
-              store: store,
               session: session
             )
 
@@ -714,8 +713,7 @@ public struct SettingsView: View {
         guard let session = try store.manager().session() else {
           throw VPNConfigurationManagerError.managerNotInitialized
         }
-        let providerLogFolderSize = try await IPCClient.getLogFolderSize(
-          session: session, configuration: store.configuration)
+        let providerLogFolderSize = try await IPCClient.getLogFolderSize(session: session)
         let totalSize = logFolderSize + providerLogFolderSize
       #else
         let totalSize = logFolderSize
@@ -751,10 +749,7 @@ public struct SettingsView: View {
     try Log.clear(in: SharedAccess.logFolderURL)
 
     #if os(macOS)
-      guard let session = try store.manager().session() else {
-        throw VPNConfigurationManagerError.managerNotInitialized
-      }
-      try await IPCClient.clearLogs(session: session, configuration: store.configuration)
+      try await store.clearLogs()
     #endif
   }
 

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -13,7 +13,6 @@ enum PacketTunnelProviderError: Error {
   case tunnelConfigurationIsInvalid
   case firezoneIdIsInvalid
   case tokenNotFoundInKeychain
-  case dryStartStopCycle
 }
 
 class PacketTunnelProvider: NEPacketTunnelProvider {
@@ -56,10 +55,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     options: [String: NSObject]?,
     completionHandler: @escaping @Sendable (Error?) -> Void
   ) {
-    // Dummy start to get the extension running on macOS after upgrade
-    if options?["dryRun"] as? Bool == true {
-      Log.info("Dry run startup requested - extension awakened but not starting tunnel")
-      return completionHandler(PacketTunnelProviderError.dryStartStopCycle)
+    // Dummy start to attach a utun for cleanup later
+    if options?["dryStart"] as? Bool == true {
+      Log.info("Dry start requested - extension awakened and temporarily starting tunnel")
+      return completionHandler(nil)
     }
 
     // Log version on actual tunnel start
@@ -67,20 +66,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
     let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
     Log.info("Starting tunnel - Version: \(version), Build: \(build)")
-
-    // Try to load configuration from options first (passed from client at startup)
-    if let configData = options?["configuration"] as? Data {
-      do {
-        let decoder = PropertyListDecoder()
-        let configFromOptions = try decoder.decode(TunnelConfiguration.self, from: configData)
-        Log.info("Loaded configuration from startTunnel options")
-        // Save it for future fallback (e.g., system-initiated restarts)
-        configFromOptions.save()
-        self.tunnelConfiguration = configFromOptions
-      } catch {
-        Log.error(error)
-      }
-    }
 
     // If the tunnel starts up before the GUI after an upgrade crossing the 1.4.15 version boundary,
     // the old system settings-based config will still be present and the new configuration will be empty.

--- a/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
+++ b/swift/apple/FirezoneNetworkExtension/PacketTunnelProvider.swift
@@ -56,8 +56,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     completionHandler: @escaping @Sendable (Error?) -> Void
   ) {
     // Dummy start to attach a utun for cleanup later
-    if options?["dryStart"] as? Bool == true {
-      Log.info("Dry start requested - extension awakened and temporarily starting tunnel")
+    if options?["cycleStart"] as? Bool == true {
+      Log.info("Cycle start requested - extension awakened and temporarily starting tunnel")
       return completionHandler(nil)
     }
 

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,10 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="10855">
+          Fixes an issue on macOS where the <code>utun</code> index would
+          auto-increment by itself on configuration updates.
+        </ChangeItem>
         <ChangeItem pull="10752">
           Fixes an issue where the reported client version was out of date.
         </ChangeItem>


### PR DESCRIPTION
On macOS, IPC calls to the network extension can wake it whilst not
connected, causing the system to create a utun device.
If startTunnel() is not subsequently called, these devices
persist and accumulate over time.

The existing dryStartStopCycle() mechanism was introduced to wake the
extension after upgrades, but other IPC operations (log management
functions) could also wake the extension without proper cleanup.

Solution
--------

Add wrapper functions in IPCClient that automatically handle wake-up
and cleanup lifecycle for IPC calls made whilst disconnected:

- Check VPN connection status
- If connected: execute IPC operation directly (utun already exists)
- If disconnected: wake extension → wait 500ms → execute IPC → cleanup

Implementation
--------------

For async IPC operations (clearLogs, getLogFolderSize):
  Created free functions in IPCClient that wrap low-level IPC calls
  with wrapIPCCallIfNeeded():
  - clearLogsWithCleanup(store:session:)
  - getLogFolderSizeWithCleanup(store:session:)

For callback-based exportLogs:
  We cannot use wrapper because exportLogs returns immediately and uses
  callbacks for streaming chunks. Wrapper would call stop() before
  export finishes, killing the extension mid-stream.

  Solution: Manual wake-up/cleanup in LogExporter where we already have
  continuation that waits for chunk.done signal:
  1. Check if extension needs waking (vpnStatus != .connected)
  2. If yes: wake extension, wait 500ms
  3. Start export with callbacks
  4. When chunk.done=true: cleanup utun device, then resume continuation
  5. On error: cleanup utun device, then resume with error
  
  
  Fixes #10580 