### PR TITLE
feat(connlib): make parallel requests with `HttpClient`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3552,6 +3552,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "futures",
  "http 1.3.1",
  "http-body-util",
  "hyper",
@@ -3559,6 +3560,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "socket-factory",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-rustls",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3563,6 +3563,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tracing",
  "webpki-roots 1.0.4",
 ]
@@ -8137,6 +8138,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/rust/connlib/http-client/Cargo.toml
+++ b/rust/connlib/http-client/Cargo.toml
@@ -21,9 +21,11 @@ tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 tracing = { workspace = true }
 webpki-roots = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+futures = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/connlib/http-client/Cargo.toml
+++ b/rust/connlib/http-client/Cargo.toml
@@ -17,15 +17,15 @@ hyper-util = { workspace = true, features = ["tokio"] }
 rustls = { workspace = true }
 rustls-pki-types = { workspace = true }
 socket-factory = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 tracing = { workspace = true }
 webpki-roots = { workspace = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
 futures = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/rust/connlib/http-client/Cargo.toml
+++ b/rust/connlib/http-client/Cargo.toml
@@ -20,6 +20,7 @@ socket-factory = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
+tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 webpki-roots = { workspace = true }
 

--- a/rust/connlib/http-client/lib.rs
+++ b/rust/connlib/http-client/lib.rs
@@ -21,6 +21,12 @@ type Connection = hyper::client::conn::http2::Connection<
     hyper_util::rt::TokioExecutor,
 >;
 
+/// A specialised HTTP2 client that plugs into our [`SocketFactory`] abstraction.
+///
+/// One instance of this client is tied to a given domain.
+/// It maintains a TCP connection and can send multiple requests across it in parallel.
+/// If the TCP connection fails, [`Closed`] is returned.
+/// In that case, the client becomes permanently unusable and should be discarded.
 #[derive(Clone)]
 pub struct HttpClient {
     host: String,


### PR DESCRIPTION
Our `socket-factory`-aware HttpClient is currently only able to handle a single request at a time. That is a result of the requirement that we wanted to support connections to different domains but also be able to "self-heal" those connections by establishing a new one if the current one failed.

As I am learning more about how connlib's DoH support is going to work, it became apparent that we will only ever need to connect to a single domain per instance of the `HttpClient`. In addition, it is quite important to allow for concurrent requests: We don't want to process DoH queries in sequence but instead make full use of the underlying HTTP2 protocol and send multiple requests in parallel.

This PR refactors the `HttpClient` (which isn't in use anywhere yet) to only support a single connection per instance. That connection is established when the instance is created. This is also conceptually easier to understand as we only manage a single connection without mutable state.

Related: #4668 