### PR TITLE
feat(gateway): improve state tracking of DNS resource NAT

### DIFF
--- a/rust/connlib/tunnel/src/gateway/nat_table.rs
+++ b/rust/connlib/tunnel/src/gateway/nat_table.rs
@@ -139,7 +139,7 @@ impl NatTable {
         let inside = (src, dst);
 
         self.table.insert(inside, outside);
-        self.state_by_inside.insert(outside, EntryState::new(now));
+        self.state_by_inside.insert(inside, EntryState::new(now));
         self.expired.remove(&outside);
 
         tracing::debug!(?inside, ?outside, "New NAT session");

--- a/rust/connlib/tunnel/src/gateway/nat_table.rs
+++ b/rust/connlib/tunnel/src/gateway/nat_table.rs
@@ -16,8 +16,8 @@ use std::time::{Duration, Instant};
 /// Thus, purely an L3 NAT would not be sufficient as it would be impossible to map back to the proxy IP.
 #[derive(Default, Debug)]
 pub(crate) struct NatTable {
-    pub(crate) table: BiMap<(Protocol, IpAddr), (Protocol, IpAddr)>,
-    pub(crate) last_seen: BTreeMap<(Protocol, IpAddr), Instant>,
+    table: BiMap<(Protocol, IpAddr), (Protocol, IpAddr)>,
+    last_seen: BTreeMap<(Protocol, IpAddr), Instant>,
 
     // We don't bother with proactively freeing this because a single entry is only ~20 bytes and it gets cleanup once the connection to the client goes away.
     expired: HashSet<(Protocol, IpAddr)>,

--- a/rust/connlib/tunnel/src/gateway/nat_table.rs
+++ b/rust/connlib/tunnel/src/gateway/nat_table.rs
@@ -113,7 +113,7 @@ impl NatTable {
                 }));
             }
 
-            if self.expired.contains(&outside) {
+            if self.expired.contains(&inside) {
                 return Ok(TranslateIncomingResult::ExpiredNatSession);
             }
 
@@ -138,7 +138,7 @@ impl NatTable {
             return Ok(TranslateIncomingResult::Ok { proto, src });
         }
 
-        if self.expired.contains(&outside) {
+        if self.expired.contains(&inside) {
             return Ok(TranslateIncomingResult::ExpiredNatSession);
         }
 

--- a/rust/connlib/tunnel/src/gateway/nat_table.rs
+++ b/rust/connlib/tunnel/src/gateway/nat_table.rs
@@ -118,7 +118,7 @@ impl NatTable {
 
         self.table.insert(inside, outside);
         self.state_by_inside.insert(inside, EntryState::new(now));
-        self.expired.insert(outside);
+        self.expired.remove(&outside);
 
         tracing::debug!(?inside, ?outside, "New NAT session");
 

--- a/rust/connlib/tunnel/src/gateway/nat_table.rs
+++ b/rust/connlib/tunnel/src/gateway/nat_table.rs
@@ -94,11 +94,11 @@ impl NatTable {
                 self.expired.insert(outside);
             }
 
-            // TODO: We should always have an entry here.
-            self.state_by_inside
-                .entry(inside)
-                .or_insert(EntryState::new(now))
-                .last_outgoing = now;
+            match self.state_by_inside.get_mut(&inside) {
+                Some(entry) => entry.last_outgoing = now,
+                None => tracing::warn!(?inside, "Missing NAT state entry"),
+            }
+
             return Ok(outside);
         }
 


### PR DESCRIPTION
Right now, the state tracking within the DNS resource NAT table is pretty simple:

- We map from inside to outside and back
- When we see a TCP RST, we remove it immediately

To improve our logs a bit and make the NAT table more robust, we extend it by:

- Tracking last inbound and outbound packet
- Tracking FIN and RST flags

This allows us to fully observe e.g. a TCP shutdown where both parties send TCP FIN. It also allows us to remove entries that have never been confirmed after a shorter amount of time.

Resolves: #10795 