### PR TITLE
refactor(connlib): use `anyhow::Error` for recursive DNS

### DIFF
--- a/rust/connlib/tunnel/src/dns.rs
+++ b/rust/connlib/tunnel/src/dns.rs
@@ -9,7 +9,6 @@ use firezone_logging::err_with_src;
 use itertools::Itertools;
 use pattern::{Candidate, Pattern};
 use std::collections::{BTreeSet, VecDeque};
-use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -86,7 +85,7 @@ pub(crate) struct RecursiveResponse {
     pub query: dns_types::Query,
 
     /// The result of forwarding the DNS query.
-    pub message: io::Result<dns_types::Response>,
+    pub message: Result<dns_types::Response>,
 
     /// The transport we used.
     pub transport: Transport,

--- a/rust/connlib/tunnel/src/io.rs
+++ b/rust/connlib/tunnel/src/io.rs
@@ -55,7 +55,7 @@ pub struct Io {
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
 
-    dns_queries: FuturesTupleSet<io::Result<dns_types::Response>, DnsQueryMetaData>,
+    dns_queries: FuturesTupleSet<Result<dns_types::Response>, DnsQueryMetaData>,
 
     timeout: Option<Pin<Box<tokio::time::Sleep>>>,
 
@@ -311,7 +311,10 @@ impl Io {
                 Err(e @ futures_bounded::Timeout { .. }) => dns::RecursiveResponse {
                     server: meta.server,
                     query: meta.query,
-                    message: Err(io::Error::new(io::ErrorKind::TimedOut, e)),
+                    message: Err(anyhow::Error::new(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        e,
+                    ))),
                     transport: meta.transport,
                     local: meta.local,
                     remote: meta.remote,

--- a/rust/connlib/tunnel/src/io/nameserver_set.rs
+++ b/rust/connlib/tunnel/src/io/nameserver_set.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
     task::{Context, Poll, ready},
     time::{Duration, Instant},
 };
 
+use anyhow::Result;
 use dns_types::{DomainNameRef, Query, RecordType, ResponseCode, prelude::*};
 use futures_bounded::FuturesTupleSet;
 use socket_factory::{SocketFactory, TcpSocket, UdpSocket};
@@ -27,7 +27,7 @@ pub struct NameserverSet {
 
     tcp_socket_factory: Arc<dyn SocketFactory<TcpSocket>>,
     udp_socket_factory: Arc<dyn SocketFactory<UdpSocket>>,
-    queries: FuturesTupleSet<io::Result<dns_types::Response>, QueryMetaData>,
+    queries: FuturesTupleSet<Result<dns_types::Response>, QueryMetaData>,
 }
 
 struct QueryMetaData {

--- a/rust/connlib/tunnel/src/io/tcp_dns.rs
+++ b/rust/connlib/tunnel/src/io/tcp_dns.rs
@@ -1,5 +1,6 @@
-use std::{io, net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
+use anyhow::Result;
 use socket_factory::{SocketFactory, TcpSocket};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
@@ -7,7 +8,7 @@ pub async fn send(
     factory: Arc<dyn SocketFactory<TcpSocket>>,
     server: SocketAddr,
     query: dns_types::Query,
-) -> io::Result<dns_types::Response> {
+) -> Result<dns_types::Response> {
     tracing::trace!(target: "wire::dns::recursive::tcp", %server, domain = %query.domain());
 
     let tcp_socket = factory.bind(server)?; // TODO: Optimise this to reuse a TCP socket to the same resolver.
@@ -27,7 +28,7 @@ pub async fn send(
     let mut response = vec![0u8; response_length];
     tcp_stream.read_exact(&mut response).await?;
 
-    let message = dns_types::Response::parse(&response).map_err(io::Error::other)?;
+    let message = dns_types::Response::parse(&response)?;
 
     Ok(message)
 }

--- a/rust/connlib/tunnel/src/io/udp_dns.rs
+++ b/rust/connlib/tunnel/src/io/udp_dns.rs
@@ -1,16 +1,16 @@
 use std::{
-    io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
 };
 
+use anyhow::Result;
 use socket_factory::{SocketFactory, UdpSocket};
 
 pub async fn send(
     factory: Arc<dyn SocketFactory<UdpSocket>>,
     server: SocketAddr,
     query: dns_types::Query,
-) -> io::Result<dns_types::Response> {
+) -> Result<dns_types::Response> {
     tracing::trace!(target: "wire::dns::recursive::udp", %server, domain = %query.domain());
 
     let bind_addr = match server {
@@ -27,7 +27,7 @@ pub async fn send(
         .handshake::<BUF_SIZE>(server, &query.into_bytes())
         .await?;
 
-    let response = dns_types::Response::parse(&response).map_err(io::Error::other)?;
+    let response = dns_types::Response::parse(&response)?;
 
     Ok(response)
 }


### PR DESCRIPTION
With the introduction of DoH, we will need a more advanced error type for recursive DNS responses. In particular, a DoH query might fail because the underlying TCP connection got closed. With #10856, the HTTP client no longer supports retries but instead needs to be recreated.

In order to accurately detect this failure case, we need `anyhow`'s downcasting abilities.

This PR prepares the already existing code for that by switching from `io::Error` to `anyhow::Error`.