### PR TITLE
fix(connlib): don't panic in fallible function

### DIFF
--- a/rust/connlib/dns-over-tcp/src/server.rs
+++ b/rust/connlib/dns-over-tcp/src/server.rs
@@ -249,7 +249,7 @@ fn try_recv_query(
             socket.abort();
             socket
                 .listen(listen)
-                .expect("Can always listen after `abort()`");
+                .context("Failed to move socket to LISTEN state")?;
         }
     }
 


### PR DESCRIPTION
Panicking - even though it is unlikely to happen here - is unnecessary because we can simply return an error instead.