### PR TITLE
fix: use our own docker install action

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -1,0 +1,73 @@
+name: "Setup Docker"
+description: "Install Docker from static binaries"
+
+inputs:
+  version:
+    description: "Docker version to install"
+    required: false
+    default: "29.0.0"
+  architecture:
+    description: "Architecture to install (x86_64 or aarch64)"
+    required: false
+    default: "x86_64"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download and install Docker
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        DOCKER_VERSION="${{ inputs.version }}"
+        DOCKER_ARCH="${{ inputs.architecture }}"
+        DOCKER_URL="https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz"
+
+        echo "Downloading Docker ${DOCKER_VERSION} for ${DOCKER_ARCH}..."
+        curl -fsSL "${DOCKER_URL}" -o /tmp/docker.tgz
+
+        echo "Extracting Docker binaries..."
+        tar -xzf /tmp/docker.tgz -C /tmp
+
+        echo "Installing Docker binaries to /usr/local/bin..."
+        sudo cp /tmp/docker/* /usr/local/bin/
+        sudo chmod +x /usr/local/bin/docker*
+        sudo chmod +x /usr/local/bin/containerd*
+        sudo chmod +x /usr/local/bin/ctr
+        sudo chmod +x /usr/local/bin/runc
+
+        echo "Cleaning up..."
+        rm -rf /tmp/docker /tmp/docker.tgz
+
+        echo "Docker binaries installed successfully"
+        docker --version
+
+    - name: Start Docker daemon
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        echo "Starting containerd..."
+        sudo containerd &
+
+        # Wait a moment for containerd to start
+        sleep 2
+
+        echo "Starting dockerd..."
+        sudo dockerd --host=unix:///var/run/docker.sock &
+
+        # Wait for Docker daemon to be ready
+        echo "Waiting for Docker daemon to be ready..."
+        timeout=30
+        elapsed=0
+        while ! docker info >/dev/null 2>&1; do
+          if [ $elapsed -ge $timeout ]; then
+            echo "ERROR: Docker daemon failed to start within ${timeout} seconds"
+            exit 1
+          fi
+          sleep 1
+          elapsed=$((elapsed + 1))
+        done
+
+        echo "Docker daemon is ready"
+        docker info

--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -14,6 +14,30 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Stop existing Docker daemon
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        echo "Stopping existing Docker daemon..."
+        sudo systemctl stop docker.socket || true
+        sudo systemctl stop docker.service || true
+        sudo systemctl stop containerd.service || true
+
+        # Kill any remaining processes
+        sudo pkill -9 dockerd || true
+        sudo pkill -9 containerd || true
+
+        # Clean up pid files
+        sudo rm -f /var/run/docker.pid || true
+        sudo rm -f /run/docker.pid || true
+        sudo rm -f /var/run/containerd/containerd.pid || true
+
+        # Wait a moment for cleanup
+        sleep 2
+
+        echo "Existing Docker daemon stopped"
+
     - name: Download and install Docker
       shell: bash
       run: |
@@ -42,27 +66,58 @@ runs:
         echo "Docker binaries installed successfully"
         docker --version
 
-    - name: Start Docker daemon
+    - name: Configure and start Docker daemon
       shell: bash
       run: |
         set -euo pipefail
 
+        # Create containerd config directory
+        sudo mkdir -p /etc/containerd
+
+        # Generate default containerd config
+        sudo containerd config default | sudo tee /etc/containerd/config.toml
+
+        # Create Docker daemon config
+        sudo mkdir -p /etc/docker
+        cat <<EOF | sudo tee /etc/docker/daemon.json
+        {
+          "features": {
+            "containerd-snapshotter": true
+          }
+        }
+        EOF
+
         echo "Starting containerd..."
         sudo containerd &
 
-        # Wait a moment for containerd to start
-        sleep 2
+        # Wait for containerd to start
+        echo "Waiting for containerd to be ready..."
+        sleep 3
+
+        # Verify containerd is running
+        if ! sudo ctr version >/dev/null 2>&1; then
+          echo "ERROR: containerd failed to start"
+          ps aux | grep containerd || true
+          exit 1
+        fi
+        echo "containerd is ready"
 
         echo "Starting dockerd..."
         sudo dockerd --host=unix:///var/run/docker.sock &
 
         # Wait for Docker daemon to be ready
         echo "Waiting for Docker daemon to be ready..."
-        timeout=30
+        timeout=60
         elapsed=0
         while ! docker info >/dev/null 2>&1; do
           if [ $elapsed -ge $timeout ]; then
             echo "ERROR: Docker daemon failed to start within ${timeout} seconds"
+            echo "--- dockerd logs ---"
+            sudo journalctl -u docker --no-pager -n 50 || true
+            echo "--- containerd logs ---"
+            sudo journalctl -u containerd --no-pager -n 50 || true
+            echo "--- processes ---"
+            ps aux | grep -E 'docker|containerd' || true
             exit 1
           fi
           sleep 1

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -153,8 +153,7 @@ jobs:
           MIN_VERSION="${{ matrix.test.min_gateway_version }}"
 
           [ "$(printf '%s\n' "$MIN_VERSION" "$ACTUAL_VERSION" | sort --version-sort | head -n1)" == "$MIN_VERSION" ]
-      # We need at least Docker v28.1 which is not yet available on GitHub actions runners
-      - uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
+      - uses: ./.github/actions/setup-docker
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.migrate --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations && mix ecto.seed'
       - name: Start docker compose in the background

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,8 +286,7 @@ jobs:
       - uses: ./.github/actions/ghcr-docker-login
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      # We need at least Docker v28.1 which is not yet available on GitHub actions runners
-      - uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
+      - uses: ./.github/actions/setup-docker
       - name: Seed database
         run: docker compose run elixir /bin/sh -c 'cd apps/domain && mix ecto.migrate --migrations-path priv/repo/migrations --migrations-path priv/repo/manual_migrations && mix ecto.seed'
       - name: Increase max UDP buffer sizes


### PR DESCRIPTION
The docker install action is currently broken, causing all our integration test workflows to fail with a 404. The install action itself doesn't do much and the archive is available under a different name. To unblock CI, replace the current action with a custom one.

Related: https://github.com/docker/setup-docker-action/issues/186