### PR TITLE
fix(portal): `phx-ignore` checkbox changes

### DIFF
--- a/elixir/apps/web/lib/web/live/policies/components.ex
+++ b/elixir/apps/web/lib/web/live/policies/components.ex
@@ -650,11 +650,10 @@ defmodule Web.Policies.Components do
         <p class="text-sm text-neutral-500 mb-4">
           Allow access when the Client is manually verified by the administrator.
         </p>
-        <div class="space-y-2">
+        <div class="space-y-2" phx-update="ignore" id="conditions-client-verified-values">
           <.input
             type="checkbox"
             label="Require client verification"
-            field={condition_form[:values]}
             name="policy[conditions][client_verified][values][]"
             id="policy_conditions_client_verified_value"
             disabled={@disabled}

--- a/elixir/apps/web/lib/web/live/resources/components.ex
+++ b/elixir/apps/web/lib/web/live/resources/components.ex
@@ -138,11 +138,10 @@ defmodule Web.Resources.Components do
       ]}>
         <div class="flex items-top mb-4">
           <.input type="hidden" name={"#{@form.name}[tcp][protocol]"} value="tcp" />
-          <div class="mt-2.5 w-24">
+          <div class="mt-2.5 w-24" phx-update="ignore" id="tcp-filter-checkbox">
             <.input
               title="Restrict traffic to TCP traffic"
               type="checkbox"
-              field={@forms_by_protocol[:tcp]}
               name={"#{@form.name}[tcp][enabled]"}
               checked={Map.has_key?(@forms_by_protocol, :tcp)}
               value="true"
@@ -171,10 +170,9 @@ defmodule Web.Resources.Components do
 
         <div class="flex items-top mb-4">
           <.input type="hidden" name={"#{@form.name}[udp][protocol]"} value="udp" />
-          <div class="mt-2.5 w-24">
+          <div class="mt-2.5 w-24" phx-update="ignore" id="udp-filter-checkbox">
             <.input
               type="checkbox"
-              field={@forms_by_protocol[:udp]}
               name={"#{@form.name}[udp][enabled]"}
               checked={Map.has_key?(@forms_by_protocol, :udp)}
               value="true"
@@ -204,11 +202,10 @@ defmodule Web.Resources.Components do
         <div class="flex items-top mb-4">
           <.input type="hidden" name={"#{@form.name}[icmp][protocol]"} value="icmp" />
 
-          <div class="mt-2.5 w-24">
+          <div class="mt-2.5 w-24" phx-update="ignore" id="icmp-filter-checkbox">
             <.input
               title="Allow ICMP echo requests/replies"
               type="checkbox"
-              field={@forms_by_protocol[:icmp]}
               name={"#{@form.name}[icmp][enabled]"}
               checked={Map.has_key?(@forms_by_protocol, :icmp)}
               value="true"


### PR DESCRIPTION
On Resources and Policies forms, we were triggering the form's validation helpers when checking and unchecking a checkbox. Unfortunately this causes the checkbox to be reset since it was not saved across the to_form(changeset) rebuilding.

To prevent this, we simply ignore checkbox changes from triggering form validations. We can also remove the `field=` property on these because we are setting the `checked` property ourselves.

This will be refactored to be made simpler with the new modals approach, so a minimal fix is implemented for now.

Related: https://firezonehq.slack.com/archives/C098RV5BL1K/p1763024374383399
Fixes: #9143