### PR TITLE
fix(connlib): sanitize resolvers before re-resolving portal URL

### DIFF
--- a/rust/client-shared/src/eventloop.rs
+++ b/rust/client-shared/src/eventloop.rs
@@ -200,12 +200,12 @@ impl Eventloop {
                     return Ok(ControlFlow::Continue(()));
                 };
 
+                let dns = tunnel.state_mut().update_system_resolvers(dns);
+
                 self.portal_cmd_tx
-                    .send(PortalCommand::UpdateDnsServers(dns.clone()))
+                    .send(PortalCommand::UpdateDnsServers(dns))
                     .await
                     .context("Failed to send message to portal")?;
-
-                tunnel.state_mut().update_system_resolvers(dns);
             }
             Command::SetInternetResourceState(active) => {
                 let Some(tunnel) = self.tunnel.as_mut() else {

--- a/rust/connlib/tunnel/src/client/dns_config.rs
+++ b/rust/connlib/tunnel/src/client/dns_config.rs
@@ -179,52 +179,80 @@ fn not_sentinel(srv: IpAddr) -> Option<IpAddr> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use super::*;
 
     #[test]
-    fn sentinel_dns_works() {
-        let servers = dns_list();
-        let sentinel_dns = sentinel_dns_mapping(&servers, vec![]);
+    fn maps_system_resolvers_to_sentinel_ips() {
+        let mut config = DnsConfig::default();
 
-        for server in servers {
-            assert!(
-                sentinel_dns
-                    .sentinel_by_upstream(server)
-                    .is_some_and(|ip| sentinel_ranges().iter().any(|e| e.contains(ip)))
-            )
-        }
+        let changed = config.update_system_resolvers(vec![
+            ip("1.1.1.1"),
+            ip("1.0.0.1"),
+            ip("2606:4700:4700::1111"),
+        ]);
+        assert!(changed);
+
+        assert_eq!(config.mapping().sentinel_ips().len(), 3);
+        assert_eq!(
+            config.mapping().upstream_sockets(),
+            vec![
+                socket("1.1.1.1:53"),
+                socket("1.0.0.1:53"),
+                socket("[2606:4700:4700::1111]:53"),
+            ]
+        );
     }
 
     #[test]
-    fn sentinel_dns_excludes_old_ones() {
-        let servers = dns_list();
-        let sentinel_dns_old = sentinel_dns_mapping(&servers, vec![]);
-        let sentinel_dns_new = sentinel_dns_mapping(&servers, sentinel_dns_old.sentinel_ips());
+    fn prefers_upstream_do53_over_system_resolvers() {
+        let mut config = DnsConfig::default();
 
-        assert!(
-            HashSet::<IpAddr>::from_iter(sentinel_dns_old.sentinel_ips())
-                .is_disjoint(&HashSet::from_iter(sentinel_dns_new.sentinel_ips()))
-        )
+        let changed = config.update_system_resolvers(vec![ip("1.1.1.1")]);
+        assert!(changed);
+        let changed = config.update_upstream_do53_resolvers(vec![ip("1.0.0.1")]);
+        assert!(changed);
+
+        assert_eq!(config.mapping().sentinel_ips().len(), 1);
+        assert_eq!(
+            config.mapping().upstream_sockets(),
+            vec![socket("1.0.0.1:53"),]
+        );
     }
 
-    fn sentinel_ranges() -> Vec<IpNetwork> {
-        vec![
-            IpNetwork::V4(DNS_SENTINELS_V4),
-            IpNetwork::V6(DNS_SENTINELS_V6),
-        ]
+    #[test]
+    fn filters_sentinel_ips_from_system() {
+        let mut config = DnsConfig::default();
+
+        let changed = config.update_system_resolvers(vec![ip("1.1.1.1"), ip("100.100.111.1")]);
+        assert!(changed);
+
+        assert_eq!(config.mapping().sentinel_ips().len(), 1);
+        assert_eq!(
+            config.mapping().upstream_sockets(),
+            vec![socket("1.1.1.1:53"),]
+        );
     }
 
-    fn dns_list() -> Vec<SocketAddr> {
-        vec![
-            dns("1.1.1.1:53"),
-            dns("1.0.0.1:53"),
-            dns("[2606:4700:4700::1111]:53"),
-        ]
+    #[test]
+    fn filters_sentinel_ips_from_upstream() {
+        let mut config = DnsConfig::default();
+
+        let changed =
+            config.update_upstream_do53_resolvers(vec![ip("1.1.1.1"), ip("100.100.111.1")]);
+        assert!(changed);
+
+        assert_eq!(config.mapping().sentinel_ips().len(), 1);
+        assert_eq!(
+            config.mapping().upstream_sockets(),
+            vec![socket("1.1.1.1:53"),]
+        );
     }
 
-    fn dns(address: &str) -> SocketAddr {
+    fn ip(address: &str) -> IpAddr {
         address.parse().unwrap()
+    }
+
+    fn socket(socket: &str) -> SocketAddr {
+        socket.parse().unwrap()
     }
 }

--- a/rust/connlib/tunnel/src/client/dns_config.rs
+++ b/rust/connlib/tunnel/src/client/dns_config.rs
@@ -7,7 +7,7 @@ use ip_network::IpNetwork;
 use url::Url;
 
 use crate::{
-    client::{IpProvider, DNS_SENTINELS_V4, DNS_SENTINELS_V6},
+    client::{DNS_SENTINELS_V4, DNS_SENTINELS_V6, IpProvider},
     dns::DNS_PORT,
 };
 

--- a/rust/connlib/tunnel/src/client/dns_config.rs
+++ b/rust/connlib/tunnel/src/client/dns_config.rs
@@ -111,6 +111,10 @@ impl DnsConfig {
         self.mapping.clone()
     }
 
+    pub(crate) fn system_dns_resolvers(&self) -> Vec<IpAddr> {
+        self.system_resolvers.clone()
+    }
+
     fn update_dns_mapping(&mut self) -> bool {
         let effective_dns_servers =
             effective_dns_servers(self.upstream_do53.clone(), self.system_resolvers.clone());


### PR DESCRIPTION
In #10817, connlib gained the ability to re-resolve the portal's hostname on WebSocket connection hiccups. The list of upstream servers used for that may contain sentinel DNS server IPs on certain systems if connlib's DNS control is currently active. Connlib filters these servers internally before computing the effective list of upstream servers.

The DNS client used by the event-loop contacts all servers in the list but waits for at most 2s before merging all received records together. If there are upstream DNS servers defined in the portal and those are also resources which we are currently not connected to, querying these servers would trigger a message to the portal, forming a circular dependency. This circular dependency is only broken by the 2s timeout. Whilst not fatal for connlib's functionality, it means that in such a situation, reconnecting to the portal always has to wait for this timeout.

To fix this, we first apply the system DNS resolvers to connlib and only pass the now returned sanitized list on to the DNS client.

Related: #10854