### PR TITLE
feat(connlib): introduce `DoHUrl` abstraction

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2067,6 +2067,7 @@ dependencies = [
  "domain",
  "hex-literal",
  "http 1.3.1",
+ "serde",
  "thiserror 2.0.17",
  "tracing",
  "url",

--- a/rust/connlib/dns-types/Cargo.toml
+++ b/rust/connlib/dns-types/Cargo.toml
@@ -12,6 +12,7 @@ base64 = { workspace = true, features = ["alloc"] }
 bytes = { workspace = true }
 domain = { version = "0.11", features = ["serde"] } # Not a workspace dependency because we don't want any other crates to depend on it.
 http = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/rust/connlib/dns-types/lib.rs
+++ b/rust/connlib/dns-types/lib.rs
@@ -417,7 +417,7 @@ impl fmt::Display for DoHUrl {
 
 impl fmt::Debug for DoHUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("DoHUrl").field(&self.to_str()).finish()
+        write!(f, "{}", self.to_str())
     }
 }
 

--- a/rust/connlib/tunnel/src/client/dns_config.rs
+++ b/rust/connlib/tunnel/src/client/dns_config.rs
@@ -3,8 +3,8 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
+use dns_types::DoHUrl;
 use ip_network::IpNetwork;
-use url::Url;
 
 use crate::{
     client::{DNS_SENTINELS_V4, DNS_SENTINELS_V6, IpProvider},
@@ -22,7 +22,7 @@ pub(crate) struct DnsConfig {
     /// The DoH resolvers configured in the portal.
     ///
     /// Has priority over system-configured DNS servers.
-    upstream_doh: Vec<Url>,
+    upstream_doh: Vec<DoHUrl>,
 
     /// Maps from connlib-assigned IP of a DNS server back to the originally configured system DNS resolver.
     mapping: DnsMapping,
@@ -87,7 +87,7 @@ impl DnsConfig {
     }
 
     #[must_use = "Check if the DNS mapping has changed"]
-    pub(crate) fn update_upstream_doh_resolvers(&mut self, servers: Vec<Url>) -> bool {
+    pub(crate) fn update_upstream_doh_resolvers(&mut self, servers: Vec<DoHUrl>) -> bool {
         tracing::debug!(?servers, "Received upstream-defined DoH servers");
 
         self.upstream_doh = servers;

--- a/rust/connlib/tunnel/src/messages.rs
+++ b/rust/connlib/tunnel/src/messages.rs
@@ -4,12 +4,11 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use boringtun::x25519;
 use chrono::{DateTime, Utc, serde::ts_seconds};
 use connlib_model::RelayId;
-use dns_types::DomainName;
+use dns_types::{DoHUrl, DomainName};
 use ip_network::IpNetwork;
 use secrecy::ExposeSecret as _;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use url::Url;
 
 pub mod client;
 pub mod gateway;
@@ -196,7 +195,7 @@ impl Interface {
             .collect()
     }
 
-    pub fn upstream_doh(&self) -> Vec<Url> {
+    pub fn upstream_doh(&self) -> Vec<DoHUrl> {
         self.upstream_doh.iter().map(|u| u.url.clone()).collect()
     }
 }
@@ -208,7 +207,7 @@ pub struct UpstreamDo53 {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct UpstreamDoH {
-    pub url: Url,
+    pub url: DoHUrl,
 }
 
 /// A single relay

--- a/rust/connlib/tunnel/src/tests/strategies.rs
+++ b/rust/connlib/tunnel/src/tests/strategies.rs
@@ -8,7 +8,7 @@ use crate::client::{
 use crate::messages::{UpstreamDo53, UpstreamDoH};
 use crate::{IPV4_TUNNEL, IPV6_TUNNEL, proptest::*};
 use connlib_model::{RelayId, Site};
-use dns_types::{DomainName, OwnedRecordData};
+use dns_types::{DoHUrl, DomainName, OwnedRecordData};
 use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools;
 use prop::sample;
@@ -22,7 +22,6 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Duration,
 };
-use url::Url;
 
 pub(crate) fn global_dns_records(at: Instant) -> impl Strategy<Value = DnsRecords> {
     collection::btree_map(
@@ -206,12 +205,12 @@ pub(crate) fn do53_servers() -> impl Strategy<Value = BTreeSet<IpAddr>> {
     })
 }
 
-pub(crate) fn doh_server() -> impl Strategy<Value = Url> {
+pub(crate) fn doh_server() -> impl Strategy<Value = DoHUrl> {
     prop_oneof![
-        Just(Url::parse("https://dns.quad9.net/dns-query").unwrap()),
-        Just(Url::parse("https://cloudflare-dns.com/dns-query").unwrap()),
-        Just(Url::parse("https://dns.google/dns-query").unwrap()),
-        Just(Url::parse("https://dns.opendoh.com/dns-query").unwrap()),
+        Just(DoHUrl::quad9()),
+        Just(DoHUrl::cloudflare()),
+        Just(DoHUrl::google()),
+        Just(DoHUrl::opendns()),
     ]
 }
 


### PR DESCRIPTION
When connlib processes DoH queries, we need to pass the server's URL around a lot. In order to bootstrap the HTTP client, we need to extract the host part of this URL and resolve it for IP addresses using the system resolver. A regular URL doesn't necessarily have a host: It could be relative. This creates an error path within our code that _should_ never get hit for DoH URLs as those are always absolute.

To avoid this error path, we follow the "parse, don't validate" approach typical among strongly typed languages. We create our own type that can only be constructed from absolute URLs. If we receive a URL from the portal that is not absolute, we already fail at the deserialization step. Using data privacy of the encapsulated url, we can then guarantee that the host-part of the URL is always there and can access it in an infallible way.

Given that we are now already parsing the URL to begin with, I've also opted to directly implement an optimisation where we create a fast-path for the 4 known DoH providers that we have which allows us to pass them around and copy them without incurring extra allocations.

Finally, this custom type also comes with its own Display/Debug implementation, making the log output a bit easier to read.