### PR TITLE
feat(portal): extend DNS settings to allow for DoH providers

### DIFF
--- a/elixir/apps/api/lib/api/client/views/interface.ex
+++ b/elixir/apps/api/lib/api/client/views/interface.ex
@@ -2,21 +2,21 @@ defmodule API.Client.Views.Interface do
   alias Domain.Clients
 
   def render(%Clients.Client{} = client) do
-    clients_upstream_dns = Map.get(client.account.config, :clients_upstream_dns, [])
+    clients_upstream_dns_entries = Map.get(client.account.config, :clients_upstream_dns, [])
 
     # TODO: DOH RESOLVERS
     # Remove this old field once clients are upgraded.
-    # old field - append normalized port
+    # Legacy field - append normalized port for backwards compatibility
     upstream_dns =
-      clients_upstream_dns
+      clients_upstream_dns_entries
       |> Enum.map(fn %{address: address} = dns_config ->
         ip = if String.contains?(address, ":"), do: "[#{address}]", else: address
         Map.from_struct(%{dns_config | address: "#{ip}:53"})
       end)
 
-    # new field - no port
+    # New field - just IPs
     upstream_do53 =
-      clients_upstream_dns
+      clients_upstream_dns_entries
       |> Enum.map(fn %{address: address} -> %{ip: address} end)
 
     %{

--- a/elixir/apps/api/lib/api/client/views/interface.ex
+++ b/elixir/apps/api/lib/api/client/views/interface.ex
@@ -19,7 +19,7 @@ defmodule API.Client.Views.Interface do
           legacy_dns =
             Enum.map(addresses, fn %{address: address} ->
               ip = if String.contains?(address, ":"), do: "[#{address}]", else: address
-              %{protocol: "ip_port", address: "#{ip}:53"}
+              %{protocol: :ip_port, address: "#{ip}:53"}
             end)
 
           {do53, [], legacy_dns}

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -7,11 +7,14 @@ defmodule API.Client.ChannelTest do
     account =
       Fixtures.Accounts.create_account(
         config: %{
-          upstream_do53: [
-            %{address: "1:2:3:4:5:6:7:8"},
-            %{address: "1.1.1.1"},
-            %{address: "8.8.8.8"}
-          ],
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "1:2:3:4:5:6:7:8"},
+              %{address: "1.1.1.1"},
+              %{address: "8.8.8.8"}
+            ]
+          },
           search_domain: "example.com"
         },
         features: %{

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -7,10 +7,10 @@ defmodule API.Client.ChannelTest do
     account =
       Fixtures.Accounts.create_account(
         config: %{
-          clients_upstream_dns: [
-            %{protocol: "ip_port", address: "1:2:3:4:5:6:7:8"},
-            %{protocol: "ip_port", address: "1.1.1.1"},
-            %{protocol: "ip_port", address: "8.8.8.8"}
+          upstream_do53: [
+            %{address: "1:2:3:4:5:6:7:8"},
+            %{address: "1.1.1.1"},
+            %{address: "8.8.8.8"}
           ],
           search_domain: "example.com"
         },

--- a/elixir/apps/api/test/api/client/views/interface_test.exs
+++ b/elixir/apps/api/test/api/client/views/interface_test.exs
@@ -1,0 +1,159 @@
+defmodule API.Client.Views.InterfaceTest do
+  use API.ChannelCase, async: true
+  alias API.Client.Views.Interface
+
+  describe "render/1" do
+    test "renders interface config with Do53 resolvers" do
+      account =
+        Fixtures.Accounts.create_account(
+          config: %{
+            clients_upstream_dns: %{
+              type: :custom,
+              addresses: [
+                %{address: "1.1.1.1"},
+                %{address: "8.8.8.8"}
+              ]
+            },
+            search_domain: "example.com"
+          }
+        )
+
+      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
+
+      result = Interface.render(client)
+
+      assert result.search_domain == "example.com"
+      assert result.ipv4 == client.ipv4
+      assert result.ipv6 == client.ipv6
+
+      # New Do53 format
+      assert result.upstream_do53 == [
+               %{ip: "1.1.1.1"},
+               %{ip: "8.8.8.8"}
+             ]
+
+      # Legacy format
+      assert result.upstream_dns == [
+               %{protocol: "ip_port", address: "1.1.1.1:53"},
+               %{protocol: "ip_port", address: "8.8.8.8:53"}
+             ]
+
+      # No DoH provider set
+      assert result.upstream_doh == []
+    end
+
+    test "renders interface config with Google DoH provider" do
+      account =
+        Fixtures.Accounts.create_account(
+          config: %{
+            clients_upstream_dns: %{
+              type: :google,
+              addresses: []
+            },
+            search_domain: "example.com"
+          }
+        )
+
+      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
+
+      result = Interface.render(client)
+
+      assert result.search_domain == "example.com"
+      assert result.upstream_do53 == []
+      assert result.upstream_dns == []
+
+      assert result.upstream_doh == [
+               %{url: "https://dns.google/dns-query"}
+             ]
+    end
+
+    test "renders interface config with Cloudflare DoH provider" do
+      account =
+        Fixtures.Accounts.create_account(
+          config: %{
+            clients_upstream_dns: %{
+              type: :cloudflare,
+              addresses: []
+            }
+          }
+        )
+
+      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
+
+      result = Interface.render(client)
+
+      assert result.upstream_doh == [
+               %{url: "https://cloudflare-dns.com/dns-query"}
+             ]
+    end
+
+    test "renders interface config with Quad9 DoH provider" do
+      account =
+        Fixtures.Accounts.create_account(
+          config: %{
+            clients_upstream_dns: %{
+              type: :quad9,
+              addresses: []
+            }
+          }
+        )
+
+      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
+
+      result = Interface.render(client)
+
+      assert result.upstream_doh == [
+               %{url: "https://dns.quad9.net/dns-query"}
+             ]
+    end
+
+    test "renders interface config with OpenDNS DoH provider" do
+      account =
+        Fixtures.Accounts.create_account(
+          config: %{
+            clients_upstream_dns: %{
+              type: :opendns,
+              addresses: []
+            }
+          }
+        )
+
+      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
+
+      result = Interface.render(client)
+
+      assert result.upstream_doh == [
+               %{url: "https://doh.opendns.com/dns-query"}
+             ]
+    end
+
+    test "renders empty upstream_doh when no provider is set" do
+      account = Fixtures.Accounts.create_account()
+      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
+
+      result = Interface.render(client)
+
+      assert result.upstream_doh == []
+    end
+
+    test "renders empty upstream_do53 and upstream_dns when only DoH provider is set" do
+      account =
+        Fixtures.Accounts.create_account(
+          config: %{
+            clients_upstream_dns: %{
+              type: :google,
+              addresses: []
+            }
+          }
+        )
+
+      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
+
+      result = Interface.render(client)
+
+      assert result.upstream_do53 == []
+      assert result.upstream_dns == []
+      assert result.upstream_doh == [%{url: "https://dns.google/dns-query"}]
+    end
+  end
+end

--- a/elixir/apps/api/test/api/client/views/interface_test.exs
+++ b/elixir/apps/api/test/api/client/views/interface_test.exs
@@ -34,86 +34,24 @@ defmodule API.Client.Views.InterfaceTest do
 
       # Legacy format
       assert result.upstream_dns == [
-               %{protocol: "ip_port", address: "1.1.1.1:53"},
-               %{protocol: "ip_port", address: "8.8.8.8:53"}
+               %{protocol: :ip_port, address: "1.1.1.1:53"},
+               %{protocol: :ip_port, address: "8.8.8.8:53"}
              ]
 
       # No DoH provider set
       assert result.upstream_doh == []
     end
 
-    test "renders interface config with Google DoH provider" do
+    test "renders interface config with DoH provider despite addresses if type is :secure" do
       account =
         Fixtures.Accounts.create_account(
           config: %{
             clients_upstream_dns: %{
-              type: :google,
-              addresses: []
-            },
-            search_domain: "example.com"
-          }
-        )
-
-      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
-
-      result = Interface.render(client)
-
-      assert result.search_domain == "example.com"
-      assert result.upstream_do53 == []
-      assert result.upstream_dns == []
-
-      assert result.upstream_doh == [
-               %{url: "https://dns.google/dns-query"}
-             ]
-    end
-
-    test "renders interface config with Cloudflare DoH provider" do
-      account =
-        Fixtures.Accounts.create_account(
-          config: %{
-            clients_upstream_dns: %{
-              type: :cloudflare,
-              addresses: []
-            }
-          }
-        )
-
-      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
-
-      result = Interface.render(client)
-
-      assert result.upstream_doh == [
-               %{url: "https://cloudflare-dns.com/dns-query"}
-             ]
-    end
-
-    test "renders interface config with Quad9 DoH provider" do
-      account =
-        Fixtures.Accounts.create_account(
-          config: %{
-            clients_upstream_dns: %{
-              type: :quad9,
-              addresses: []
-            }
-          }
-        )
-
-      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
-
-      result = Interface.render(client)
-
-      assert result.upstream_doh == [
-               %{url: "https://dns.quad9.net/dns-query"}
-             ]
-    end
-
-    test "renders interface config with OpenDNS DoH provider" do
-      account =
-        Fixtures.Accounts.create_account(
-          config: %{
-            clients_upstream_dns: %{
-              type: :opendns,
-              addresses: []
+              type: :secure,
+              doh_provider: :opendns,
+              addresses: [
+                %{address: "1.1.1.1"}
+              ]
             }
           }
         )
@@ -125,35 +63,9 @@ defmodule API.Client.Views.InterfaceTest do
       assert result.upstream_doh == [
                %{url: "https://doh.opendns.com/dns-query"}
              ]
-    end
-
-    test "renders empty upstream_doh when no provider is set" do
-      account = Fixtures.Accounts.create_account()
-      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
-
-      result = Interface.render(client)
-
-      assert result.upstream_doh == []
-    end
-
-    test "renders empty upstream_do53 and upstream_dns when only DoH provider is set" do
-      account =
-        Fixtures.Accounts.create_account(
-          config: %{
-            clients_upstream_dns: %{
-              type: :google,
-              addresses: []
-            }
-          }
-        )
-
-      client = Fixtures.Clients.create_client(account: account) |> Domain.Repo.preload(:account)
-
-      result = Interface.render(client)
 
       assert result.upstream_do53 == []
       assert result.upstream_dns == []
-      assert result.upstream_doh == [%{url: "https://dns.google/dns-query"}]
     end
   end
 end

--- a/elixir/apps/domain/lib/domain/accounts/config.ex
+++ b/elixir/apps/domain/lib/domain/accounts/config.ex
@@ -8,7 +8,6 @@ defmodule Domain.Accounts.Config do
     embeds_many :clients_upstream_dns, ClientsUpstreamDNS,
       primary_key: false,
       on_replace: :delete do
-      field :protocol, Ecto.Enum, values: [:ip_port, :dns_over_tls, :dns_over_http]
       field :address, :string
     end
 
@@ -21,8 +20,6 @@ defmodule Domain.Accounts.Config do
       embeds_one :idp_sync_error, Domain.Accounts.Config.Notifications.Email, on_replace: :update
     end
   end
-
-  def supported_dns_protocols, do: ~w[ip_port]a
 
   @doc """
   Returns a default config with defaults set

--- a/elixir/apps/domain/lib/domain/accounts/config/changeset.ex
+++ b/elixir/apps/domain/lib/domain/accounts/config/changeset.ex
@@ -6,18 +6,27 @@ defmodule Domain.Accounts.Config.Changeset do
   def changeset(config \\ %Config{}, attrs) do
     config
     |> cast(attrs, [:search_domain])
-    |> cast_embed(:clients_upstream_dns,
-      with: &clients_upstream_dns_changeset/2,
-      sort_param: :clients_upstream_dns_sort,
-      drop_param: :clients_upstream_dns_drop
-    )
+    |> cast_embed(:clients_upstream_dns, with: &clients_upstream_dns_changeset/2)
     |> cast_embed(:notifications, with: &notifications_changeset/2)
     |> validate_search_domain()
-    |> validate_unique_clients_upstream_dns()
   end
 
-  def clients_upstream_dns_changeset(clients_upstream_dns \\ %Config.ClientsUpstreamDNS{}, attrs) do
+  def clients_upstream_dns_changeset(clients_upstream_dns \\ %Config.ClientsUpstreamDns{}, attrs) do
     clients_upstream_dns
+    |> cast(attrs, [:type, :doh_provider])
+    |> validate_required([:type])
+    |> cast_embed(:addresses,
+      with: &address_changeset/2,
+      sort_param: :addresses_sort,
+      drop_param: :addresses_drop
+    )
+    |> validate_doh_provider_for_secure()
+    |> validate_addresses_for_type()
+    |> validate_custom_has_addresses()
+  end
+
+  def address_changeset(address \\ %Config.ClientsUpstreamDns.Address{}, attrs) do
+    address
     |> cast(attrs, [:address])
     |> validate_required([:address])
     |> trim_change(:address)
@@ -53,18 +62,60 @@ defmodule Domain.Accounts.Config.Changeset do
     end)
   end
 
-  defp validate_unique_clients_upstream_dns(changeset) do
-    with false <- has_errors?(changeset, :clients_upstream_dns),
-         {_data_or_changes, clients_upstream_dns} <- fetch_field(changeset, :clients_upstream_dns) do
-      addresses =
-        clients_upstream_dns
-        |> Enum.map(&normalize_dns_address/1)
-        |> Enum.reject(&is_nil/1)
-
-      if addresses -- Enum.uniq(addresses) == [] do
-        changeset
+  defp validate_doh_provider_for_secure(changeset) do
+    with true <- changeset.valid?,
+         {_data_or_changes, type} <- fetch_field(changeset, :type),
+         {_data_or_changes, doh_provider} <- fetch_field(changeset, :doh_provider) do
+      if type == :secure and is_nil(doh_provider) do
+        add_error(changeset, :doh_provider, "must be selected when using secure DNS")
       else
-        add_error(changeset, :clients_upstream_dns, "all addresses must be unique")
+        changeset
+      end
+    else
+      _ -> changeset
+    end
+  end
+
+  defp validate_addresses_for_type(changeset) do
+    with true <- changeset.valid?,
+         {_data_or_changes, type} <- fetch_field(changeset, :type),
+         {_data_or_changes, addresses} <- fetch_field(changeset, :addresses) do
+      case type do
+        :custom ->
+          validate_custom_addresses(changeset, addresses)
+
+        _ ->
+          # For system and secure DNS, addresses are ignored but not cleared
+          # This allows users to switch between types without losing their custom addresses
+          changeset
+      end
+    else
+      _ -> changeset
+    end
+  end
+
+  defp validate_custom_addresses(changeset, addresses) do
+    # Check for unique addresses
+    normalized_addresses =
+      addresses
+      |> Enum.map(&normalize_dns_address/1)
+      |> Enum.reject(&is_nil/1)
+
+    if normalized_addresses -- Enum.uniq(normalized_addresses) == [] do
+      changeset
+    else
+      add_error(changeset, :addresses, "all addresses must be unique")
+    end
+  end
+
+  defp validate_custom_has_addresses(changeset) do
+    with true <- changeset.valid?,
+         {_data_or_changes, type} <- fetch_field(changeset, :type),
+         {_data_or_changes, addresses} <- fetch_field(changeset, :addresses) do
+      if type == :custom and Enum.empty?(addresses) do
+        add_error(changeset, :addresses, "must have at least one custom resolver")
+      else
+        changeset
       end
     else
       _ -> changeset
@@ -99,7 +150,7 @@ defmodule Domain.Accounts.Config.Changeset do
     |> cast_embed(:idp_sync_error, with: &Config.Notifications.Email.Changeset.changeset/2)
   end
 
-  defp normalize_dns_address(%Config.ClientsUpstreamDNS{address: address}) do
+  defp normalize_dns_address(%Config.ClientsUpstreamDns.Address{address: address}) do
     address
   end
 

--- a/elixir/apps/domain/priv/repo/migrations/20251114111414_simplify_account_client_dns.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251114111414_simplify_account_client_dns.exs
@@ -1,0 +1,58 @@
+defmodule Domain.Repo.Migrations.SimplifyAccountClientDNS do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE accounts
+    SET config = config - 'clients_upstream_dns' || jsonb_build_object(
+      'clients_upstream_dns',
+      COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'address',
+              CASE
+                WHEN dns->>'address' ~ '^[0-9.]+:[0-9]+$' THEN
+                  -- IPv4 with port: strip the port
+                  substring(dns->>'address' from '^([0-9.]+):[0-9]+$')
+                WHEN dns->>'address' ~ '^\\\[.*\\\]:[0-9]+$' THEN
+                  -- IPv6 with port in brackets: strip brackets and port
+                  substring(dns->>'address' from '^\\\[(.+)\\\]:[0-9]+$')
+                ELSE
+                  -- No port or already just IP: use as-is
+                  dns->>'address'
+              END
+            )
+          )
+          FROM jsonb_array_elements(config->'clients_upstream_dns') AS dns
+          WHERE dns->>'address' IS NOT NULL AND dns->>'address' != ''
+        ),
+        '[]'::jsonb
+      )
+    )
+    WHERE config->'clients_upstream_dns' IS NOT NULL
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE accounts
+    SET config = config - 'clients_upstream_dns' || jsonb_build_object(
+      'clients_upstream_dns',
+      COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'protocol', 'ip_port',
+              'address', dns->>'address'
+            )
+          )
+          FROM jsonb_array_elements(config->'clients_upstream_dns') AS dns
+        ),
+        '[]'::jsonb
+      )
+    )
+    WHERE config->'clients_upstream_dns' IS NOT NULL
+    """)
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20251118053209_refactor_clients_upstream_dns.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251118053209_refactor_clients_upstream_dns.exs
@@ -1,0 +1,96 @@
+defmodule Domain.Repo.Migrations.RefactorClientsUpstreamDns do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE accounts
+    SET config = jsonb_set(
+      config,
+      '{clients_upstream_dns}',
+      CASE
+        -- If clients_upstream_dns is an array (old structure)
+        WHEN jsonb_typeof(config->'clients_upstream_dns') = 'array' THEN
+          CASE
+            -- If array is empty or null, default to system
+            WHEN jsonb_array_length(COALESCE(config->'clients_upstream_dns', '[]'::jsonb)) = 0 THEN
+              '{"type": "system", "addresses": []}'::jsonb
+            -- If array has entries, convert to custom type with addresses
+            ELSE
+              jsonb_build_object(
+                'type', 'custom',
+                'addresses', (
+                  SELECT jsonb_agg(
+                    jsonb_build_object(
+                      'address',
+                      CASE
+                        -- Strip port from ip_port protocol entries
+                        WHEN dns->>'protocol' = 'ip_port' AND dns->>'address' ~ '^[0-9.]+:[0-9]+$' THEN
+                          substring(dns->>'address' from '^([0-9.]+):[0-9]+$')
+                        WHEN dns->>'protocol' = 'ip_port' AND dns->>'address' ~ '^\\\[.*\\\]:[0-9]+$' THEN
+                          substring(dns->>'address' from '^\\\[(.+)\\\]:[0-9]+$')
+                        ELSE
+                          dns->>'address'
+                      END
+                    )
+                  )
+                  FROM jsonb_array_elements(config->'clients_upstream_dns') AS dns
+                  WHERE dns->>'address' IS NOT NULL AND dns->>'address' != ''
+                )
+              )
+          END
+        -- If already an object or null, keep as-is (already migrated or default)
+        WHEN jsonb_typeof(config->'clients_upstream_dns') = 'object' THEN
+          config->'clients_upstream_dns'
+        ELSE
+          '{"type": "system", "addresses": []}'::jsonb
+      END
+    )
+    WHERE config IS NOT NULL
+    AND (
+      config->'clients_upstream_dns' IS NULL
+      OR jsonb_typeof(config->'clients_upstream_dns') = 'array'
+    )
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE accounts
+    SET config = jsonb_set(
+      config,
+      '{clients_upstream_dns}',
+      CASE
+        -- If clients_upstream_dns is an object (new structure)
+        WHEN jsonb_typeof(config->'clients_upstream_dns') = 'object' THEN
+          CASE
+            -- If type is custom, convert addresses back to array format
+            WHEN config->'clients_upstream_dns'->>'type' = 'custom' THEN
+              COALESCE(
+                (
+                  SELECT jsonb_agg(
+                    jsonb_build_object(
+                      'protocol', 'ip_port',
+                      'address', addr->>'address' || ':53'
+                    )
+                  )
+                  FROM jsonb_array_elements(config->'clients_upstream_dns'->'addresses') AS addr
+                ),
+                '[]'::jsonb
+              )
+            -- For system or DoH providers, return empty array
+            ELSE
+              '[]'::jsonb
+          END
+        -- If already an array, keep as-is
+        WHEN jsonb_typeof(config->'clients_upstream_dns') = 'array' THEN
+          config->'clients_upstream_dns'
+        ELSE
+          '[]'::jsonb
+      END
+    )
+    WHERE config IS NOT NULL
+    AND config->'clients_upstream_dns' IS NOT NULL
+    AND jsonb_typeof(config->'clients_upstream_dns') = 'object'
+    """)
+  end
+end

--- a/elixir/apps/domain/priv/repo/migrations/20251118053209_refactor_clients_upstream_dns.exs
+++ b/elixir/apps/domain/priv/repo/migrations/20251118053209_refactor_clients_upstream_dns.exs
@@ -8,48 +8,17 @@ defmodule Domain.Repo.Migrations.RefactorClientsUpstreamDns do
       config,
       '{clients_upstream_dns}',
       CASE
-        -- If clients_upstream_dns is an array (old structure)
-        WHEN jsonb_typeof(config->'clients_upstream_dns') = 'array' THEN
-          CASE
-            -- If array is empty or null, default to system
-            WHEN jsonb_array_length(COALESCE(config->'clients_upstream_dns', '[]'::jsonb)) = 0 THEN
-              '{"type": "system", "addresses": []}'::jsonb
-            -- If array has entries, convert to custom type with addresses
-            ELSE
-              jsonb_build_object(
-                'type', 'custom',
-                'addresses', (
-                  SELECT jsonb_agg(
-                    jsonb_build_object(
-                      'address',
-                      CASE
-                        -- Strip port from ip_port protocol entries
-                        WHEN dns->>'protocol' = 'ip_port' AND dns->>'address' ~ '^[0-9.]+:[0-9]+$' THEN
-                          substring(dns->>'address' from '^([0-9.]+):[0-9]+$')
-                        WHEN dns->>'protocol' = 'ip_port' AND dns->>'address' ~ '^\\\[.*\\\]:[0-9]+$' THEN
-                          substring(dns->>'address' from '^\\\[(.+)\\\]:[0-9]+$')
-                        ELSE
-                          dns->>'address'
-                      END
-                    )
-                  )
-                  FROM jsonb_array_elements(config->'clients_upstream_dns') AS dns
-                  WHERE dns->>'address' IS NOT NULL AND dns->>'address' != ''
-                )
-              )
-          END
-        -- If already an object or null, keep as-is (already migrated or default)
-        WHEN jsonb_typeof(config->'clients_upstream_dns') = 'object' THEN
-          config->'clients_upstream_dns'
-        ELSE
+        WHEN jsonb_array_length(config->'clients_upstream_dns') = 0 THEN
           '{"type": "system", "addresses": []}'::jsonb
+        ELSE
+          jsonb_build_object(
+            'type', 'custom',
+            'addresses', config->'clients_upstream_dns'
+          )
       END
     )
-    WHERE config IS NOT NULL
-    AND (
-      config->'clients_upstream_dns' IS NULL
-      OR jsonb_typeof(config->'clients_upstream_dns') = 'array'
-    )
+    WHERE config->'clients_upstream_dns' IS NOT NULL
+    AND jsonb_typeof(config->'clients_upstream_dns') = 'array'
     """)
   end
 
@@ -60,36 +29,13 @@ defmodule Domain.Repo.Migrations.RefactorClientsUpstreamDns do
       config,
       '{clients_upstream_dns}',
       CASE
-        -- If clients_upstream_dns is an object (new structure)
-        WHEN jsonb_typeof(config->'clients_upstream_dns') = 'object' THEN
-          CASE
-            -- If type is custom, convert addresses back to array format
-            WHEN config->'clients_upstream_dns'->>'type' = 'custom' THEN
-              COALESCE(
-                (
-                  SELECT jsonb_agg(
-                    jsonb_build_object(
-                      'protocol', 'ip_port',
-                      'address', addr->>'address' || ':53'
-                    )
-                  )
-                  FROM jsonb_array_elements(config->'clients_upstream_dns'->'addresses') AS addr
-                ),
-                '[]'::jsonb
-              )
-            -- For system or DoH providers, return empty array
-            ELSE
-              '[]'::jsonb
-          END
-        -- If already an array, keep as-is
-        WHEN jsonb_typeof(config->'clients_upstream_dns') = 'array' THEN
-          config->'clients_upstream_dns'
+        WHEN config->'clients_upstream_dns'->>'type' = 'custom' THEN
+          COALESCE(config->'clients_upstream_dns'->'addresses', '[]'::jsonb)
         ELSE
           '[]'::jsonb
       END
     )
-    WHERE config IS NOT NULL
-    AND config->'clients_upstream_dns' IS NOT NULL
+    WHERE config->'clients_upstream_dns' IS NOT NULL
     AND jsonb_typeof(config->'clients_upstream_dns') = 'object'
     """)
   end

--- a/elixir/apps/domain/test/domain/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/accounts_test.exs
@@ -360,7 +360,10 @@ defmodule Domain.AccountsTest do
           monthly_active_users_count: -1
         },
         config: %{
-          clients_upstream_dns: [%{address: "!!!"}]
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [%{address: "!!!"}]
+          }
         }
       }
 
@@ -369,9 +372,11 @@ defmodule Domain.AccountsTest do
       assert errors_on(changeset) == %{
                name: ["should be at most 64 character(s)"],
                config: %{
-                 clients_upstream_dns: [
-                   %{address: ["must be a valid IP address"]}
-                 ]
+                 clients_upstream_dns: %{
+                   addresses: [
+                     %{address: ["must be a valid IP address"]}
+                   ]
+                 }
                }
              }
     end
@@ -393,10 +398,13 @@ defmodule Domain.AccountsTest do
           }
         },
         config: %{
-          clients_upstream_dns: [
-            %{address: "1.1.1.1"},
-            %{address: "8.8.8.8"}
-          ]
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "1.1.1.1"},
+              %{address: "8.8.8.8"}
+            ]
+          }
         }
       }
 
@@ -412,9 +420,11 @@ defmodule Domain.AccountsTest do
 
       assert is_nil(account.metadata.stripe.customer_id)
 
-      assert account.config.clients_upstream_dns == [
-               %Domain.Accounts.Config.UpstreamDo53{address: "1.1.1.1"},
-               %Domain.Accounts.Config.UpstreamDo53{address: "8.8.8.8"}
+      assert account.config.clients_upstream_dns.type == :custom
+
+      assert account.config.clients_upstream_dns.addresses == [
+               %Domain.Accounts.Config.ClientsUpstreamDns.Address{address: "1.1.1.1"},
+               %Domain.Accounts.Config.ClientsUpstreamDns.Address{address: "8.8.8.8"}
              ]
     end
 
@@ -468,7 +478,10 @@ defmodule Domain.AccountsTest do
           monthly_active_users_count: -1
         },
         config: %{
-          clients_upstream_dns: [%{address: "!!!"}]
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [%{address: "!!!"}]
+          }
         }
       }
 
@@ -483,9 +496,11 @@ defmodule Domain.AccountsTest do
                  monthly_active_users_count: ["must be greater than or equal to 0"]
                },
                config: %{
-                 clients_upstream_dns: [
-                   %{address: ["must be a valid IP address"]}
-                 ]
+                 clients_upstream_dns: %{
+                   addresses: [
+                     %{address: ["must be a valid IP address"]}
+                   ]
+                 }
                }
              }
     end
@@ -493,28 +508,36 @@ defmodule Domain.AccountsTest do
     test "trims client upstream dns config address fields", %{account: account} do
       attrs = %{
         config: %{
-          clients_upstream_dns: [
-            %{address: "   1.1.1.1"},
-            %{address: "8.8.8.8   "}
-          ]
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "   1.1.1.1"},
+              %{address: "8.8.8.8   "}
+            ]
+          }
         }
       }
 
       assert {:ok, account} = update_account_by_id(account.id, attrs)
 
-      assert account.config.clients_upstream_dns == [
-               %Domain.Accounts.Config.UpstreamDo53{address: "1.1.1.1"},
-               %Domain.Accounts.Config.UpstreamDo53{address: "8.8.8.8"}
+      assert account.config.clients_upstream_dns.type == :custom
+
+      assert account.config.clients_upstream_dns.addresses == [
+               %Domain.Accounts.Config.ClientsUpstreamDns.Address{address: "1.1.1.1"},
+               %Domain.Accounts.Config.ClientsUpstreamDns.Address{address: "8.8.8.8"}
              ]
     end
 
     test "returns error on duplicate upstream dns config addresses", %{account: account} do
       attrs = %{
         config: %{
-          clients_upstream_dns: [
-            %{address: "1.1.1.1"},
-            %{address: "1.1.1.1   "}
-          ]
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "1.1.1.1"},
+              %{address: "1.1.1.1   "}
+            ]
+          }
         }
       }
 
@@ -522,7 +545,30 @@ defmodule Domain.AccountsTest do
 
       assert errors_on(changeset) == %{
                config: %{
-                 clients_upstream_dns: ["all addresses must be unique"]
+                 clients_upstream_dns: %{
+                   addresses: ["all addresses must be unique"]
+                 }
+               }
+             }
+    end
+
+    test "returns error when custom type has no addresses", %{account: account} do
+      attrs = %{
+        config: %{
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: []
+          }
+        }
+      }
+
+      assert {:error, changeset} = update_account_by_id(account.id, attrs)
+
+      assert errors_on(changeset) == %{
+               config: %{
+                 clients_upstream_dns: %{
+                   addresses: ["must have at least one custom resolver"]
+                 }
                }
              }
     end
@@ -530,9 +576,12 @@ defmodule Domain.AccountsTest do
     test "does not allow ports", %{account: account} do
       attrs = %{
         config: %{
-          clients_upstream_dns: [
-            %{address: "1.1.1.1:53"}
-          ]
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "1.1.1.1:53"}
+            ]
+          }
         }
       }
 
@@ -540,9 +589,11 @@ defmodule Domain.AccountsTest do
 
       assert errors_on(changeset) == %{
                config: %{
-                 clients_upstream_dns: [
-                   %{address: ["must not include a port"]}
-                 ]
+                 clients_upstream_dns: %{
+                   addresses: [
+                     %{address: ["must not include a port"]}
+                   ]
+                 }
                }
              }
     end
@@ -550,9 +601,12 @@ defmodule Domain.AccountsTest do
     test "returns error on dns config address in IPv4 sentinel range", %{account: account} do
       attrs = %{
         config: %{
-          clients_upstream_dns: [
-            %{address: "100.64.10.1"}
-          ]
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "100.64.10.1"}
+            ]
+          }
         }
       }
 
@@ -560,9 +614,11 @@ defmodule Domain.AccountsTest do
 
       assert errors_on(changeset) == %{
                config: %{
-                 clients_upstream_dns: [
-                   %{address: ["cannot be in the CIDR 100.64.0.0/10"]}
-                 ]
+                 clients_upstream_dns: %{
+                   addresses: [
+                     %{address: ["cannot be in the CIDR 100.64.0.0/10"]}
+                   ]
+                 }
                }
              }
     end
@@ -570,9 +626,12 @@ defmodule Domain.AccountsTest do
     test "returns error on dns config address in IPv6 sentinel range", %{account: account} do
       attrs = %{
         config: %{
-          clients_upstream_dns: [
-            %{address: "fd00:2021:1111:10::"}
-          ]
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "fd00:2021:1111:10::"}
+            ]
+          }
         }
       }
 
@@ -580,9 +639,11 @@ defmodule Domain.AccountsTest do
 
       assert errors_on(changeset) == %{
                config: %{
-                 clients_upstream_dns: [
-                   %{address: ["cannot be in the CIDR fd00:2021:1111::/48"]}
-                 ]
+                 clients_upstream_dns: %{
+                   addresses: [
+                     %{address: ["cannot be in the CIDR fd00:2021:1111::/48"]}
+                   ]
+                 }
                }
              }
     end
@@ -695,6 +756,133 @@ defmodule Domain.AccountsTest do
              }
     end
 
+    test "accepts DoH provider", %{account: account} do
+      attrs = %{
+        config: %{
+          clients_upstream_dns: %{
+            type: :cloudflare,
+            addresses: []
+          }
+        }
+      }
+
+      assert {:ok, account} = update_account_by_id(account.id, attrs)
+      assert account.config.clients_upstream_dns.type == :cloudflare
+    end
+
+    test "accepts all valid DoH providers", %{account: account} do
+      for provider <- [:google, :quad9, :cloudflare, :opendns] do
+        attrs = %{
+          config: %{
+            clients_upstream_dns: %{
+              type: provider,
+              addresses: []
+            }
+          }
+        }
+
+        assert {:ok, account} = update_account_by_id(account.id, attrs)
+        assert account.config.clients_upstream_dns.type == provider
+      end
+    end
+
+    test "returns error when both Do53 and DoH provider are set", %{account: account} do
+      attrs = %{
+        config: %{
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "1.1.1.1"}
+            ]
+          }
+        }
+      }
+
+      # Try to update with a different type without clearing addresses
+      # This should fail validation
+      attrs2 = %{
+        config: %{
+          clients_upstream_dns: %{
+            type: :cloudflare,
+            addresses: [%{address: "1.1.1.1"}]
+          }
+        }
+      }
+
+      assert {:error, changeset} = update_account_by_id(account.id, attrs)
+
+      assert errors_on(changeset) == %{
+               config: %{
+                 clients_upstream_dns: %{
+                   addresses: ["should be empty for this resolver type"]
+                 }
+               }
+             }
+    end
+
+    test "allows switching from Do53 to DoH provider", %{account: account} do
+      # First set custom DNS
+      attrs = %{
+        config: %{
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "1.1.1.1"}
+            ]
+          }
+        }
+      }
+
+      assert {:ok, account} = update_account_by_id(account.id, attrs)
+      assert account.config.clients_upstream_dns.type == :custom
+      assert length(account.config.clients_upstream_dns.addresses) == 1
+
+      # Now switch to DoH provider
+      attrs = %{
+        config: %{
+          clients_upstream_dns: %{
+            type: :cloudflare,
+            addresses: []
+          }
+        }
+      }
+
+      assert {:ok, account} = update_account_by_id(account.id, attrs)
+      assert account.config.clients_upstream_dns.type == :cloudflare
+      assert account.config.clients_upstream_dns.addresses == []
+    end
+
+    test "allows switching from DoH provider to Do53", %{account: account} do
+      # First set DoH provider
+      attrs = %{
+        config: %{
+          clients_upstream_dns: %{
+            type: :cloudflare,
+            addresses: []
+          }
+        }
+      }
+
+      assert {:ok, account} = update_account_by_id(account.id, attrs)
+      assert account.config.clients_upstream_dns.type == :cloudflare
+
+      # Now switch to custom DNS
+      attrs = %{
+        config: %{
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "1.1.1.1"}
+            ]
+          }
+        }
+      }
+
+      assert {:ok, account} = update_account_by_id(account.id, attrs)
+      assert account.config.clients_upstream_dns.type == :custom
+      assert length(account.config.clients_upstream_dns.addresses) == 1
+    end
+
     test "updates account and broadcasts a message", %{account: account} do
       Bypass.open()
       |> Domain.Mocks.Stripe.mock_update_customer_endpoint(account)
@@ -716,10 +904,13 @@ defmodule Domain.AccountsTest do
           }
         },
         config: %{
-          clients_upstream_dns: [
-            %{address: "1.1.1.1"},
-            %{address: "8.8.8.8"}
-          ]
+          clients_upstream_dns: %{
+            type: :custom,
+            addresses: [
+              %{address: "1.1.1.1"},
+              %{address: "8.8.8.8"}
+            ]
+          }
         }
       }
 
@@ -742,9 +933,11 @@ defmodule Domain.AccountsTest do
       assert account.metadata.stripe.billing_email ==
                attrs.metadata.stripe.billing_email
 
-      assert account.config.clients_upstream_dns == [
-               %Domain.Accounts.Config.UpstreamDo53{address: "1.1.1.1"},
-               %Domain.Accounts.Config.UpstreamDo53{address: "8.8.8.8"}
+      assert account.config.clients_upstream_dns.type == :custom
+
+      assert account.config.clients_upstream_dns.addresses == [
+               %Domain.Accounts.Config.ClientsUpstreamDns.Address{address: "1.1.1.1"},
+               %Domain.Accounts.Config.ClientsUpstreamDns.Address{address: "8.8.8.8"}
              ]
     end
 

--- a/elixir/apps/domain/test/domain/accounts_test.exs
+++ b/elixir/apps/domain/test/domain/accounts_test.exs
@@ -360,7 +360,7 @@ defmodule Domain.AccountsTest do
           monthly_active_users_count: -1
         },
         config: %{
-          clients_upstream_dns: [%{protocol: "ip_port", address: "!!!"}]
+          clients_upstream_dns: [%{address: "!!!"}]
         }
       }
 
@@ -394,8 +394,8 @@ defmodule Domain.AccountsTest do
         },
         config: %{
           clients_upstream_dns: [
-            %{protocol: "ip_port", address: "1.1.1.1"},
-            %{protocol: "ip_port", address: "8.8.8.8"}
+            %{address: "1.1.1.1"},
+            %{address: "8.8.8.8"}
           ]
         }
       }
@@ -413,14 +413,8 @@ defmodule Domain.AccountsTest do
       assert is_nil(account.metadata.stripe.customer_id)
 
       assert account.config.clients_upstream_dns == [
-               %Domain.Accounts.Config.ClientsUpstreamDNS{
-                 protocol: :ip_port,
-                 address: "1.1.1.1"
-               },
-               %Domain.Accounts.Config.ClientsUpstreamDNS{
-                 protocol: :ip_port,
-                 address: "8.8.8.8"
-               }
+               %Domain.Accounts.Config.UpstreamDo53{address: "1.1.1.1"},
+               %Domain.Accounts.Config.UpstreamDo53{address: "8.8.8.8"}
              ]
     end
 
@@ -474,7 +468,7 @@ defmodule Domain.AccountsTest do
           monthly_active_users_count: -1
         },
         config: %{
-          clients_upstream_dns: [%{protocol: "ip_port", address: "!!!"}]
+          clients_upstream_dns: [%{address: "!!!"}]
         }
       }
 
@@ -500,8 +494,8 @@ defmodule Domain.AccountsTest do
       attrs = %{
         config: %{
           clients_upstream_dns: [
-            %{protocol: "ip_port", address: "   1.1.1.1"},
-            %{protocol: "ip_port", address: "8.8.8.8   "}
+            %{address: "   1.1.1.1"},
+            %{address: "8.8.8.8   "}
           ]
         }
       }
@@ -509,14 +503,8 @@ defmodule Domain.AccountsTest do
       assert {:ok, account} = update_account_by_id(account.id, attrs)
 
       assert account.config.clients_upstream_dns == [
-               %Domain.Accounts.Config.ClientsUpstreamDNS{
-                 protocol: :ip_port,
-                 address: "1.1.1.1"
-               },
-               %Domain.Accounts.Config.ClientsUpstreamDNS{
-                 protocol: :ip_port,
-                 address: "8.8.8.8"
-               }
+               %Domain.Accounts.Config.UpstreamDo53{address: "1.1.1.1"},
+               %Domain.Accounts.Config.UpstreamDo53{address: "8.8.8.8"}
              ]
     end
 
@@ -524,8 +512,8 @@ defmodule Domain.AccountsTest do
       attrs = %{
         config: %{
           clients_upstream_dns: [
-            %{protocol: "ip_port", address: "1.1.1.1"},
-            %{protocol: "ip_port", address: "1.1.1.1   "}
+            %{address: "1.1.1.1"},
+            %{address: "1.1.1.1   "}
           ]
         }
       }
@@ -543,7 +531,7 @@ defmodule Domain.AccountsTest do
       attrs = %{
         config: %{
           clients_upstream_dns: [
-            %{protocol: "ip_port", address: "1.1.1.1:53"}
+            %{address: "1.1.1.1:53"}
           ]
         }
       }
@@ -563,7 +551,7 @@ defmodule Domain.AccountsTest do
       attrs = %{
         config: %{
           clients_upstream_dns: [
-            %{protocol: "ip_port", address: "100.64.10.1"}
+            %{address: "100.64.10.1"}
           ]
         }
       }
@@ -583,7 +571,7 @@ defmodule Domain.AccountsTest do
       attrs = %{
         config: %{
           clients_upstream_dns: [
-            %{protocol: "ip_port", address: "fd00:2021:1111:10::"}
+            %{address: "fd00:2021:1111:10::"}
           ]
         }
       }
@@ -729,8 +717,8 @@ defmodule Domain.AccountsTest do
         },
         config: %{
           clients_upstream_dns: [
-            %{protocol: "ip_port", address: "1.1.1.1"},
-            %{protocol: "ip_port", address: "8.8.8.8"}
+            %{address: "1.1.1.1"},
+            %{address: "8.8.8.8"}
           ]
         }
       }
@@ -755,14 +743,8 @@ defmodule Domain.AccountsTest do
                attrs.metadata.stripe.billing_email
 
       assert account.config.clients_upstream_dns == [
-               %Domain.Accounts.Config.ClientsUpstreamDNS{
-                 protocol: :ip_port,
-                 address: "1.1.1.1"
-               },
-               %Domain.Accounts.Config.ClientsUpstreamDNS{
-                 protocol: :ip_port,
-                 address: "8.8.8.8"
-               }
+               %Domain.Accounts.Config.UpstreamDo53{address: "1.1.1.1"},
+               %Domain.Accounts.Config.UpstreamDo53{address: "8.8.8.8"}
              ]
     end
 

--- a/elixir/apps/domain/test/support/fixtures/accounts.ex
+++ b/elixir/apps/domain/test/support/fixtures/accounts.ex
@@ -11,11 +11,14 @@ defmodule Domain.Fixtures.Accounts do
       legal_name: "l-acc-#{unique_num}",
       slug: "acc_#{unique_num}",
       config: %{
-        clients_upstream_dns: [
-          %{address: "1.1.1.1"},
-          %{address: "2606:4700:4700::1111"},
-          %{address: "9.9.9.9"}
-        ]
+        clients_upstream_dns: %{
+          type: :custom,
+          addresses: [
+            %{address: "1.1.1.1"},
+            %{address: "2606:4700:4700::1111"},
+            %{address: "9.9.9.9"}
+          ]
+        }
       },
       features: %{
         policy_conditions: true,

--- a/elixir/apps/domain/test/support/fixtures/accounts.ex
+++ b/elixir/apps/domain/test/support/fixtures/accounts.ex
@@ -12,9 +12,9 @@ defmodule Domain.Fixtures.Accounts do
       slug: "acc_#{unique_num}",
       config: %{
         clients_upstream_dns: [
-          %{protocol: "ip_port", address: "1.1.1.1"},
-          %{protocol: "ip_port", address: "2606:4700:4700::1111"},
-          %{protocol: "ip_port", address: "9.9.9.9"}
+          %{address: "1.1.1.1"},
+          %{address: "2606:4700:4700::1111"},
+          %{address: "9.9.9.9"}
         ]
       },
       features: %{

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -183,6 +183,10 @@ defmodule Web.Settings.DNS do
                       {"OpenDNS", :opendns}
                     ]}
                   />
+                  <p class="mt-4 text-sm text-neutral-500">
+                    <strong>Note:</strong>
+                    Secure DNS is only supported on very recent Clients. Ensure your users are using the latest version to benefit from Secure DNS.
+                  </p>
                 </div>
 
                 <div

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -203,19 +203,11 @@ defmodule Web.Settings.DNS do
   end
 
   defp dns_options do
-    supported_dns_protocols = Enum.map(Accounts.Config.supported_dns_protocols(), &to_string/1)
-
     [
       [key: "IP", value: "ip_port"],
-      [key: "DNS over TLS", value: "dns_over_tls"],
-      [key: "DNS over HTTPS", value: "dns_over_https"]
+      [key: "DNS over TLS", value: "dns_over_tls", disabled: true],
+      [key: "DNS over HTTPS", value: "dns_over_https", disabled: true]
     ]
-    |> Enum.map(fn option ->
-      case option[:value] in supported_dns_protocols do
-        true -> option
-        false -> option ++ [disabled: true]
-      end
-    end)
   end
 
   defp dns_config_errors(changes) when changes == %{} do

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -126,8 +126,10 @@ defmodule Web.Settings.DNS do
                           "p-5 text-gray-500 bg-white border border-gray-200",
                           "rounded cursor-pointer peer-checked:border-accent-500",
                           "peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100",
-                          @doh_disabled && "opacity-50 cursor-not-allowed"
+                          @doh_disabled && "opacity-50 cursor-not-allowed",
+                          "relative group"
                         ]}
+                        title={@doh_disabled && "Coming soon"}
                       >
                         <div class="block">
                           <div class="w-full font-semibold mb-3">
@@ -135,9 +137,6 @@ defmodule Web.Settings.DNS do
                           </div>
                           <div class="w-full text-sm">
                             Use DNS-over-HTTPS from trusted providers.
-                          </div>
-                          <div :if={@doh_disabled} class="w-full text-xs text-gray-400 mt-2">
-                            Coming soon
                           </div>
                         </div>
                       </label>

--- a/elixir/apps/web/lib/web/live/settings/dns.ex
+++ b/elixir/apps/web/lib/web/live/settings/dns.ex
@@ -8,9 +8,12 @@ defmodule Web.Settings.DNS do
       # Ensure config has proper defaults
       account = %{account | config: Domain.Accounts.Config.ensure_defaults(account.config)}
 
+      doh_disabled = System.get_env("DISABLE_DOH_RESOLVERS") == "true"
+
       socket =
         socket
         |> assign(page_title: "DNS")
+        |> assign(doh_disabled: doh_disabled)
         |> init(account)
 
       {:ok, socket}
@@ -113,20 +116,28 @@ defmodule Web.Settings.DNS do
                         field={dns_form[:type]}
                         value="secure"
                         checked={"#{dns_form[:type].value}" == "secure"}
+                        disabled={@doh_disabled}
                         required
                       />
-                      <label for="dns-type--secure" class={~w[
-                        inline-flex items-center justify-between w-full
-                        p-5 text-gray-500 bg-white border border-gray-200
-                        rounded cursor-pointer peer-checked:border-accent-500
-                        peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100
-                      ]}>
+                      <label
+                        for="dns-type--secure"
+                        class={[
+                          "inline-flex items-center justify-between w-full",
+                          "p-5 text-gray-500 bg-white border border-gray-200",
+                          "rounded cursor-pointer peer-checked:border-accent-500",
+                          "peer-checked:text-accent-500 hover:text-gray-600 hover:bg-gray-100",
+                          @doh_disabled && "opacity-50 cursor-not-allowed"
+                        ]}
+                      >
                         <div class="block">
                           <div class="w-full font-semibold mb-3">
                             <.icon name="hero-lock-closed" class="w-5 h-5 mr-1" /> Secure DNS
                           </div>
                           <div class="w-full text-sm">
                             Use DNS-over-HTTPS from trusted providers.
+                          </div>
+                          <div :if={@doh_disabled} class="w-full text-xs text-gray-400 mt-2">
+                            Coming soon
                           </div>
                         </div>
                       </label>

--- a/elixir/apps/web/test/web/live/settings/dns_test.exs
+++ b/elixir/apps/web/test/web/live/settings/dns_test.exs
@@ -189,7 +189,7 @@ defmodule Web.Live.Settings.DNSTest do
     }
 
     lv
-    |> render_change(:change, attrs)
+    |> form("form", attrs)
     |> render_submit()
 
     account = Domain.Accounts.fetch_account_by_id!(account.id)
@@ -221,7 +221,7 @@ defmodule Web.Live.Settings.DNSTest do
 
     html =
       lv
-      |> render_change(:change, attrs)
+      |> form("form", attrs)
       |> render_submit()
 
     assert html =~ "must have at least one custom resolver"
@@ -313,10 +313,10 @@ defmodule Web.Live.Settings.DNSTest do
     }
 
     lv
-    |> render_change(:change, attrs)
+    |> form("form", attrs)
     |> render_submit()
 
-    account = Domain.Accounts.fetch_account_by_id!(account.id)
+    account = Repo.reload!(account)
     assert account.config.clients_upstream_dns.type == :secure
     assert account.config.clients_upstream_dns.doh_provider == :google
     assert Enum.empty?(account.config.clients_upstream_dns.addresses)

--- a/elixir/apps/web/test/web/live/settings/dns_test.exs
+++ b/elixir/apps/web/test/web/live/settings/dns_test.exs
@@ -189,7 +189,7 @@ defmodule Web.Live.Settings.DNSTest do
     }
 
     lv
-    |> form("form", attrs)
+    |> render_change(:change, attrs)
     |> render_submit()
 
     account = Domain.Accounts.fetch_account_by_id!(account.id)
@@ -221,7 +221,7 @@ defmodule Web.Live.Settings.DNSTest do
 
     html =
       lv
-      |> form("form", attrs)
+      |> render_change(:change, attrs)
       |> render_submit()
 
     assert html =~ "must have at least one custom resolver"
@@ -313,41 +313,13 @@ defmodule Web.Live.Settings.DNSTest do
     }
 
     lv
-    |> form("form", attrs)
+    |> render_change(:change, attrs)
     |> render_submit()
 
     account = Domain.Accounts.fetch_account_by_id!(account.id)
     assert account.config.clients_upstream_dns.type == :secure
     assert account.config.clients_upstream_dns.doh_provider == :google
     assert Enum.empty?(account.config.clients_upstream_dns.addresses)
-  end
-
-  test "requires doh_provider when type is secure", %{
-    account: account,
-    identity: identity,
-    conn: conn
-  } do
-    {:ok, lv, _html} =
-      conn
-      |> authorize_conn(identity)
-      |> live(~p"/#{account}/settings/dns")
-
-    attrs = %{
-      account: %{
-        config: %{
-          clients_upstream_dns: %{
-            type: "secure"
-          }
-        }
-      }
-    }
-
-    html =
-      lv
-      |> form("form", attrs)
-      |> render_submit()
-
-    assert html =~ "must be selected when using secure DNS"
   end
 
   test "saves system resolver selection", %{
@@ -400,32 +372,28 @@ defmodule Web.Live.Settings.DNSTest do
       |> live(~p"/#{account}/settings/dns")
 
     # Switch to system
-    lv
-    |> form("form", %{
-      account: %{
-        config: %{
-          clients_upstream_dns: %{
-            type: "system"
+    render_change(lv, :change, %{
+      "account" => %{
+        "config" => %{
+          "clients_upstream_dns" => %{
+            "type" => "system"
           }
         }
       }
     })
-    |> render_change()
 
     # Switch back to secure - DoH provider should still be there
     html =
-      lv
-      |> form("form", %{
-        account: %{
-          config: %{
-            clients_upstream_dns: %{
-              type: "secure",
-              doh_provider: "quad9"
+      render_change(lv, :change, %{
+        "account" => %{
+          "config" => %{
+            "clients_upstream_dns" => %{
+              "type" => "secure",
+              "doh_provider" => "quad9"
             }
           }
         }
       })
-      |> render_change()
 
     assert html =~ "Quad9 DNS"
   end
@@ -451,33 +419,28 @@ defmodule Web.Live.Settings.DNSTest do
       |> live(~p"/#{account}/settings/dns")
 
     # Switch to system
-    lv
-    |> form("form", %{
-      account: %{
-        config: %{
-          clients_upstream_dns: %{
-            type: "system"
+    render_change(lv, :change, %{
+      "account" => %{
+        "config" => %{
+          "clients_upstream_dns" => %{
+            "type" => "system"
           }
         }
       }
     })
-    |> render_change()
 
     # Switch back to custom - addresses should still be there
     html =
-      lv
-      |> form("form", %{
-        account: %{
-          config: %{
-            clients_upstream_dns: %{
-              type: "custom",
-              addresses: %{"0" => %{"address" => "8.8.8.8"}}
+      render_change(lv, :change, %{
+        "account" => %{
+          "config" => %{
+            "clients_upstream_dns" => %{
+              "type" => "custom",
+              "addresses" => %{"0" => %{"address" => "8.8.8.8"}}
             }
           }
         }
-      }
       })
-      |> render_change()
 
     assert html =~ "8.8.8.8"
   end

--- a/website/src/app/kb/deploy/dns/readme.mdx
+++ b/website/src/app/kb/deploy/dns/readme.mdx
@@ -102,36 +102,37 @@ feedback on
 
 </Alert>
 
-## Configuring Client DNS upstream resolvers
+## Configuring Client DNS
+
+Go to `Settings -> DNS` to configure how Firezone Clients should resolve DNS.
+
+### Default system resolvers
+
+By default, Firezone Clients will use the system resolvers, typically set by the
+DHCP server of their local network.
+
+### Secure DNS
+
+<Alert color="info">
+  Secure DNS was added in macOS 1.5.10, iOS 1.5.10, Android 1.5.7, Windows
+  1.5.9, and Linux 1.5.9.
+</Alert>
+
+Firezone Clients can use the DNS-over-HTTPS protocol for all non-Firezone
+resources. Secure DNS encrypts all DNS traffic, preventing middleboxes
+(including ISPs) from seeing or manipulating DNS traffic. This is especially
+useful on insecure or untrusted networks.
+
+### Custom resolvers
 
 Upstream DNS in all Clients can be configured with the servers of your choosing
 so that all queries on Client devices will be forwarded to the servers you
 specify for all non-Firezone resources.
 
-Go to `Settings -> DNS` and enter IPv4 and/or IPv6 servers to use as fallback
-resolvers. Firezone Clients will use these servers in the order they are defined
-for any query that doesn't match a Resource the user has access to.
-
 <Alert color="warning">
   When setting custom upstream resolvers, it is **highly** recommended to
   configure **both** an IPv4 and IPv6 option. Otherwise, a Client that has only
   IPv4 or IPv6 connectivity may not be able to resolve DNS queries.
-</Alert>
-
-<Alert color="warning">
-  Firezone Clients support only DNS over UDP/53 at this time. DNS-over-TLS and
-  DNS-over-HTTPS upstream servers are not yet supported.
-</Alert>
-
-If no custom resolvers are configured, Firezone Clients will fall back to the
-default system resolvers, typically set by the DHCP server of their local
-network.
-
-<Alert color="info">
-  Custom resolvers such as
-  [Cloudflare](https://developers.cloudflare.com/1.1.1.1/setup/#1111-for-families)
-  or [NextDNS](https://nextdns.io) can be used to block malware, ads, adult
-  material and other content for all users in your Firezone account.
 </Alert>
 
 ## Configuring Gateway resolvers


### PR DESCRIPTION
In order to allow customers to make use of connlib's DoH functionality, we need a configuration UI for it. We take inspiration from the "New Resource" page and implement a 3-choice UI component for configuring how Clients should resolve DNS queries:

- System
- Secure DNS
- Custom

The secure and custom DNS options show an additional form when selected for either picking a DoH provider or the addresses of the custom DNS servers.

Right now, the "Secure DNS" part is disabled if the `DISABLE_DOH_PROVIDER` env variable is set. We render a "Coming soon" tooltip on hover:

<img width="1534" height="1100" alt="image" src="https://github.com/user-attachments/assets/a12a6ba4-806f-4d19-8aea-5c1cd981d609" />

This allows us to test this in staging and still ship to production if needed prior to enabling it.

Resolves: #4668
Resolves: #10792
Resolves: #10786