### PR TITLE
fix(portal): use `[]:53` for ipv6 addresses

### DIFF
--- a/elixir/apps/api/lib/api/client/views/interface.ex
+++ b/elixir/apps/api/lib/api/client/views/interface.ex
@@ -10,16 +10,14 @@ defmodule API.Client.Views.Interface do
     upstream_dns =
       clients_upstream_dns
       |> Enum.map(fn %{address: address} = dns_config ->
-        ip = URI.parse("//" <> address).host
+        ip = if String.contains?(address, ":"), do: "[#{address}]", else: address
         Map.from_struct(%{dns_config | address: "#{ip}:53"})
       end)
 
     # new field - no port
     upstream_do53 =
       clients_upstream_dns
-      |> Enum.map(fn %{address: address} ->
-        %{ip: URI.parse("//" <> address).host}
-      end)
+      |> Enum.map(fn %{address: address} -> %{ip: address} end)
 
     %{
       search_domain: client.account.config.search_domain,

--- a/elixir/apps/api/test/api/client/channel_test.exs
+++ b/elixir/apps/api/test/api/client/channel_test.exs
@@ -8,6 +8,7 @@ defmodule API.Client.ChannelTest do
       Fixtures.Accounts.create_account(
         config: %{
           clients_upstream_dns: [
+            %{protocol: "ip_port", address: "1:2:3:4:5:6:7:8"},
             %{protocol: "ip_port", address: "1.1.1.1"},
             %{protocol: "ip_port", address: "8.8.8.8"}
           ],
@@ -348,10 +349,12 @@ defmodule API.Client.ChannelTest do
                ipv4: client.ipv4,
                ipv6: client.ipv6,
                upstream_dns: [
+                 %{address: "[1:2:3:4:5:6:7:8]:53", protocol: :ip_port},
                  %{protocol: :ip_port, address: "1.1.1.1:53"},
                  %{protocol: :ip_port, address: "8.8.8.8:53"}
                ],
                upstream_do53: [
+                 %{ip: "1:2:3:4:5:6:7:8"},
                  %{ip: "1.1.1.1"},
                  %{ip: "8.8.8.8"}
                ],
@@ -912,10 +915,12 @@ defmodule API.Client.ChannelTest do
                  ipv6: client.ipv6,
                  search_domain: "new.example.com",
                  upstream_dns: [
+                   %{address: "[1:2:3:4:5:6:7:8]:53", protocol: :ip_port},
                    %{address: "1.1.1.1:53", protocol: :ip_port},
                    %{address: "8.8.8.8:53", protocol: :ip_port}
                  ],
                  upstream_do53: [
+                   %{ip: "1:2:3:4:5:6:7:8"},
                    %{ip: "1.1.1.1"},
                    %{ip: "8.8.8.8"}
                  ],


### PR DESCRIPTION
connlib expects the following format for IP addresses:

- ipv4:port
- ipv6
- \[ipv6]:port

When storing the clients_upstream_dns values from the form in the admin portal, we do not add brackets to IPv6 addresses, so URI.parse thinks the address contains a port and strips the trailing `:` off.

We then sent these invalid IPs down to connlib which causes a deserialization error.

To fix, we simply ensure IPs sent to connlib adhere to one of the formats above.

Related: #10851