### PR TITLE
feat(gateway): extend ICE timeout

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -915,7 +915,7 @@ checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
 [[package]]
 name = "boringtun"
 version = "0.6.1"
-source = "git+https://github.com/firezone/boringtun?branch=master#069a483bb185422feaeddf37d3af62beb650803c"
+source = "git+https://github.com/firezone/boringtun?branch=master#8300b7fe57e66c051d5632a5434c30010b523ea9"
 dependencies = [
  "aead",
  "base64 0.22.1",

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2430,7 +2430,7 @@ mod tests {
 
     #[test]
     fn default_ice_timeout() {
-        let mut agent = IceAgent::new();
+        let mut agent = new_agent();
 
         apply_default_stun_timings(&mut agent);
 
@@ -2439,7 +2439,7 @@ mod tests {
 
     #[test]
     fn idle_ice_timeout() {
-        let mut agent = IceAgent::new();
+        let mut agent = new_agent();
 
         apply_idle_stun_timings(&mut agent);
 

--- a/rust/connlib/snownet/src/node.rs
+++ b/rust/connlib/snownet/src/node.rs
@@ -2422,13 +2422,18 @@ fn new_server_agent() -> IceAgent {
 }
 
 fn apply_default_stun_timings(agent: &mut IceAgent) {
-    agent.set_max_stun_retransmits(12);
-    agent.set_max_stun_rto(Duration::from_millis(1500));
+    let retrans = if agent.controlling() { 12 } else { 45 };
+    let max_stun_rto = if agent.controlling() { 1500 } else { 15_000 };
+
+    agent.set_max_stun_retransmits(retrans);
+    agent.set_max_stun_rto(Duration::from_millis(max_stun_rto));
     agent.set_initial_stun_rto(Duration::from_millis(250))
 }
 
 fn apply_idle_stun_timings(agent: &mut IceAgent) {
-    agent.set_max_stun_retransmits(4);
+    let retrans = if agent.controlling() { 4 } else { 40 };
+
+    agent.set_max_stun_retransmits(retrans);
     agent.set_max_stun_rto(Duration::from_secs(25));
     agent.set_initial_stun_rto(Duration::from_secs(25));
 }
@@ -2485,7 +2490,7 @@ mod tests {
 
         apply_default_stun_timings(&mut agent);
 
-        assert_eq!(agent.ice_timeout(), Duration::from_millis(15250))
+        assert_eq!(agent.ice_timeout(), Duration::from_millis(600_750))
     }
 
     #[test]
@@ -2494,7 +2499,7 @@ mod tests {
 
         apply_idle_stun_timings(&mut agent);
 
-        assert_eq!(agent.ice_timeout(), Duration::from_secs(100))
+        assert_eq!(agent.ice_timeout(), Duration::from_secs(1000))
     }
 
     #[test]

--- a/rust/connlib/snownet/src/node/connections.rs
+++ b/rust/connlib/snownet/src/node/connections.rs
@@ -522,6 +522,8 @@ mod tests {
                 None,
                 0,
                 Instant::now(),
+                Instant::now(),
+                Duration::ZERO,
             ),
             remote_pub_key: PublicKey::from(rand::random::<[u8; 32]>()),
             next_wg_timer_update: Instant::now(),

--- a/rust/connlib/tunnel/src/client.rs
+++ b/rust/connlib/tunnel/src/client.rs
@@ -188,6 +188,7 @@ impl ClientState {
         records: BTreeSet<DnsResourceRecord>,
         is_internet_resource_active: bool,
         now: Instant,
+        unix_ts: Duration,
     ) -> Self {
         Self {
             resources_gateways: Default::default(),
@@ -198,7 +199,7 @@ impl ClientState {
             buffered_events: Default::default(),
             tun_config: Default::default(),
             buffered_packets: Default::default(),
-            node: ClientNode::new(seed, now),
+            node: ClientNode::new(seed, now, unix_ts),
             sites_status: Default::default(),
             gateways_site: Default::default(),
             stub_resolver: StubResolver::new(records),
@@ -2033,7 +2034,13 @@ mod tests {
 
     impl ClientState {
         pub fn for_test() -> ClientState {
-            ClientState::new(rand::random(), Default::default(), false, Instant::now())
+            ClientState::new(
+                rand::random(),
+                Default::default(),
+                false,
+                Instant::now(),
+                Duration::ZERO,
+            )
         }
     }
 

--- a/rust/connlib/tunnel/src/gateway.rs
+++ b/rust/connlib/tunnel/src/gateway.rs
@@ -73,10 +73,10 @@ impl DnsResourceNatEntry {
 }
 
 impl GatewayState {
-    pub(crate) fn new(seed: [u8; 32], now: Instant) -> Self {
+    pub(crate) fn new(seed: [u8; 32], now: Instant, unix_ts: Duration) -> Self {
         Self {
             peers: Default::default(),
-            node: ServerNode::new(seed, now),
+            node: ServerNode::new(seed, now, unix_ts),
             next_expiry_resources_check: Default::default(),
             buffered_events: VecDeque::default(),
             buffered_transmits: VecDeque::default(),

--- a/rust/connlib/tunnel/src/lib.rs
+++ b/rust/connlib/tunnel/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
     task::{Context, Poll, ready},
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 use tun::Tun;
 
@@ -124,6 +124,9 @@ impl ClientTunnel {
                 records,
                 is_internet_resource_active,
                 Instant::now(),
+                SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .expect("Should be able to compute UNIX timestamp"),
             ),
             buffers: Buffers::default(),
             packet_counter: opentelemetry::global::meter("connlib")
@@ -300,7 +303,13 @@ impl GatewayTunnel {
     ) -> Self {
         Self {
             io: Io::new(tcp_socket_factory, udp_socket_factory.clone(), nameservers),
-            role_state: GatewayState::new(rand::random(), Instant::now()),
+            role_state: GatewayState::new(
+                rand::random(),
+                Instant::now(),
+                SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .expect("Should be able to compute UNIX timestamp"),
+            ),
             buffers: Buffers::default(),
             packet_counter: opentelemetry::global::meter("connlib")
                 .u64_counter("system.network.packets")

--- a/rust/connlib/tunnel/src/tests/sim_gateway.rs
+++ b/rust/connlib/tunnel/src/tests/sim_gateway.rs
@@ -315,8 +315,16 @@ impl RefGateway {
         id: GatewayId,
         tcp_resources: BTreeSet<SocketAddr>,
         now: Instant,
+        utc_now: DateTime<Utc>,
     ) -> SimGateway {
-        let mut sut = GatewayState::new(self.key.0, now); // Cheating a bit here by reusing the key as seed.
+        let mut sut = GatewayState::new(
+            self.key.0,
+            now,
+            utc_now
+                .signed_duration_since(DateTime::UNIX_EPOCH)
+                .to_std()
+                .unwrap(),
+        ); // Cheating a bit here by reusing the key as seed.
         sut.update_tun_device(IpConfig {
             v4: self.tunnel_ip4,
             v6: self.tunnel_ip6,

--- a/rust/connlib/tunnel/src/tests/sut.rs
+++ b/rust/connlib/tunnel/src/tests/sut.rs
@@ -55,7 +55,7 @@ impl TunnelTest {
     pub(crate) fn init_test(ref_state: &ReferenceState, flux_capacitor: FluxCapacitor) -> Self {
         // Construct client, gateway and relay from the initial state.
         let mut client = ref_state.client.map(
-            |ref_client, _, _| ref_client.init(flux_capacitor.now()),
+            |ref_client, _, _| ref_client.init(flux_capacitor.now(), flux_capacitor.now()),
             debug_span!("client"),
         );
 
@@ -73,6 +73,7 @@ impl TunnelTest {
                                 .flatten()
                                 .copied()
                                 .collect(),
+                            flux_capacitor.now(),
                             flux_capacitor.now(),
                         )
                     },
@@ -124,6 +125,7 @@ impl TunnelTest {
     ) -> Self {
         let mut buffered_transmits = BufferedTransmits::default();
         let now = state.flux_capacitor.now();
+        let utc_now = state.flux_capacitor.now();
 
         // Act: Apply the transition
         match transition {
@@ -426,7 +428,7 @@ impl TunnelTest {
                 let internet_resource_state = ref_state.client.inner().internet_resource_active;
 
                 state.client.exec_mut(|c| {
-                    c.restart(key, internet_resource_state, now);
+                    c.restart(key, internet_resource_state, now, utc_now);
 
                     // Apply to new instance.
                     c.sut.update_interface_config(Interface {


### PR DESCRIPTION
Currently, a `snownet` Client and Server always have the same ICE timeout configuration. This doesn't necessarily have to be the case. A Gateway cannot establish connections to a Client anyway and thus, we can have much laxer requirements on when we detect that a Client has disappeared (without saying "goodbye").

Extending the idle and default ICE timeout values should hopefully reduce the number of false-positive disconnects that users may experience where a Gateway cuts a connection because it believes the Client is gone when in reality, perhaps a few STUN packets just got lost or backed up.

Changing the ICE timeout exposes a few corner-cases in how we track and use time within `snownet`. In particular, it is now obviously possible for a Gateway to still retain the connection state of a Client whilst the Client has long disconnected but now reconnects using the same ICE credentials and private key.

Our proptests uncovered some state misalignment in that scenario due to some remaining time impurity within `boringtun` (see https://github.com/firezone/boringtun/pull/126 for details). In addition, our idle state transitions needed to be updated to also take into account candidate changes on both sides in order to achieve a deterministic outcome.