### PR TITLE
chore: bump to upstream `proptest`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5761,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "proptest"
 version = "1.9.0"
-source = "git+https://github.com/firezone/proptest?branch=feat%2Fstate-machine-closure#ea2146e4c6116c855571e5a0f717eaaab8821ff0"
+source = "git+https://github.com/proptest-rs/proptest?branch=main#9b103797a9787378c55b1c2a79c9ffed13d26891"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "proptest-state-machine"
 version = "0.6.0"
-source = "git+https://github.com/firezone/proptest?branch=feat%2Fstate-machine-closure#ea2146e4c6116c855571e5a0f717eaaab8821ff0"
+source = "git+https://github.com/proptest-rs/proptest?branch=main#9b103797a9787378c55b1c2a79c9ffed13d26891"
 dependencies = [
  "proptest",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -252,8 +252,8 @@ softbuffer = { git = "https://github.com/rust-windowing/softbuffer" } # Waiting 
 str0m = { git = "https://github.com/algesten/str0m", branch = "main" }
 moka = { git = "https://github.com/moka-rs/moka", branch = "main" } # Waiting for release.
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch = "main" } # Waiting for release.
-proptest = { git = "https://github.com/firezone/proptest", branch = "feat/state-machine-closure" }
-proptest-state-machine = { git = "https://github.com/firezone/proptest", branch = "feat/state-machine-closure" }
+proptest = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
+proptest-state-machine = { git = "https://github.com/proptest-rs/proptest", branch = "main" } # Waiting for release.
 
 # Enforce `tracing-macros` to have released `tracing` version.
 [patch.'https://github.com/tokio-rs/tracing']


### PR DESCRIPTION
The changes from our fork have been upstreamed successfully. We can therefore switch our dependency back to that.