### PR TITLE
chore(rust): always build tests with opt-level 2

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -279,3 +279,6 @@ debug = 2
 [profile.dev.package.firezone-gui-client]
 debug = "full"
 split-debuginfo = "packed"
+
+[profile.test]
+opt-level = 2 # Otherwise `tunnel_test` is very slow.


### PR DESCRIPTION
I used to set this only locally to speed up working on `tunnel_test`. Most likely, this is something that all Rust devs would benefit from when working on `connlib` so it is better to set this in our repo-specific cargo config. It does make compilation of tests a bit slower. Unfortunately, there isn't a good way of splitting this though. If the opt-level is applied more selectively, `cargo` cannot reuse the compilation artifacts between different compile runs and needs to recompile all dependencies.