### PR TITLE
fix(connlib): classify WireGuard first

### DIFF
--- a/rust/connlib/tunnel/src/packet_kind.rs
+++ b/rust/connlib/tunnel/src/packet_kind.rs
@@ -37,14 +37,14 @@ impl From<Kind> for opentelemetry::Value {
 
 pub fn classify(packet: &[u8]) -> Kind {
     match packet {
-        [0..=3, ..] => Kind::Stun,
-        // Channel-data is a 4-byte header so the actual payload starts on the 5th byte
-        [64..=79, _, _, _, 0..=3, ..] => Kind::StunOverTurn,
+        payload if snownet::is_wireguard(payload) => Kind::Wireguard,
         [64..=79, _, _, _, payload @ ..] if snownet::is_wireguard(payload) => {
             Kind::WireguardOverTurn
         }
+        [0..=3, ..] => Kind::Stun,
+        // Channel-data is a 4-byte header so the actual payload starts on the 5th byte
+        [64..=79, _, _, _, 0..=3, ..] => Kind::StunOverTurn,
         [64..=79, _, _, _, ..] => Kind::UnknownOverTurn,
-        payload if snownet::is_wireguard(payload) => Kind::Wireguard,
         _ => Kind::Unknown,
     }
 }


### PR DESCRIPTION
WireGuard packets can have all kinds of byte-patterns at the very front of the packet. Thus, we need to first check if a payload is a WireGuard packet before attempting to classify it as anything else.

This function is currently only used for logging purposes. `snownet` has its own logic for de-multiplexing and classifying packets.