### PR TITLE
fix(apple): queue path updates onto workQueue

### DIFF
--- a/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
+++ b/swift/apple/FirezoneKit/Sources/FirezoneKit/Helpers/IPCClient.swift
@@ -73,7 +73,6 @@ enum IPCClient {
     let _ = try await sendProviderMessage(session: session, message: message)
   }
 
-
   // MARK: - Low-level IPC operations
 
   @MainActor

--- a/website/src/components/Changelog/Apple.tsx
+++ b/website/src/components/Changelog/Apple.tsx
@@ -25,6 +25,9 @@ export default function Apple() {
     <Entries downloadLinks={downloadLinks} title="macOS / iOS">
       {/* When you cut a release, remove any solved issues from the "known issues" lists over in `client-apps`. This must not be done when the issue's PR merges. */}
       <Unreleased>
+        <ChangeItem pull="10986">
+          Fixes a minor race condition that could arise on sign out.
+        </ChangeItem>
         <ChangeItem pull="10855">
           Fixes an issue on macOS where the <code>utun</code> index would
           auto-increment by itself on configuration updates.


### PR DESCRIPTION
Path updates are received on a queue which can be (and is typically) on a different thread from the one the workQueue runs on. Since we are sharing instance properties across these two threads, we need to make sure reads and writes to all properties ideally happen on the same queue.

Moving `Adapter` to an actor class could solve these issues, but that is a much larger refactor to be done in #10895 and we'd like to ship this fix in the next release to verify it fixes our issue.