### PR TITLE
fix(portal): update deletion circuit breaker

### DIFF
--- a/elixir/apps/domain/lib/domain/actors/group/sync.ex
+++ b/elixir/apps/domain/lib/domain/actors/group/sync.ex
@@ -77,27 +77,16 @@ defmodule Domain.Actors.Group.Sync do
 
     delete_percentage = (deletion_length / groups_length * 100) |> round()
 
-    cond do
-      groups_length > 40 and delete_percentage >= 25 ->
-        Logger.error("Refusing to mass delete groups",
-          groups_length: groups_length,
-          deletion_length: deletion_length,
-          provider_id: provider.id
-        )
+    if delete_percentage >= 75 do
+      Logger.error("Refusing to mass delete groups",
+        groups_length: groups_length,
+        deletion_length: deletion_length,
+        provider_id: provider.id
+      )
 
-        {:error, "Sync deletion of groups too large"}
-
-      groups_length <= 40 and delete_percentage >= 50 ->
-        Logger.error("Refusing to mass delete groups",
-          groups_length: groups_length,
-          deletion_length: deletion_length,
-          provider_id: provider.id
-        )
-
-        {:error, "Sync deletion of groups too large"}
-
-      true ->
-        :ok
+      {:error, "Sync deletion of groups too large"}
+    else
+      :ok
     end
   end
 

--- a/elixir/apps/domain/lib/domain/auth/identity/sync.ex
+++ b/elixir/apps/domain/lib/domain/auth/identity/sync.ex
@@ -86,27 +86,16 @@ defmodule Domain.Auth.Identity.Sync do
 
     delete_percentage = (deletion_length / identities_length * 100) |> round()
 
-    cond do
-      identities_length > 40 and delete_percentage >= 25 ->
-        Logger.error("Refusing to mass delete identities",
-          identities_length: identities_length,
-          deletion_length: deletion_length,
-          provider_id: provider.id
-        )
+    if delete_percentage >= 75 do
+      Logger.error("Refusing to mass delete identities",
+        identities_length: identities_length,
+        deletion_length: deletion_length,
+        provider_id: provider.id
+      )
 
-        {:error, "Sync deletion of identities too large"}
-
-      identities_length <= 40 and delete_percentage >= 50 ->
-        Logger.error("Refusing to mass delete identities",
-          identities_length: identities_length,
-          deletion_length: deletion_length,
-          provider_id: provider.id
-        )
-
-        {:error, "Sync deletion of identities too large"}
-
-      true ->
-        :ok
+      {:error, "Sync deletion of identities too large"}
+    else
+      :ok
     end
   end
 


### PR DESCRIPTION
Why:

* The directory sync circuit breaker was put in place to prevent errors in IdP API responses from deleting identities and groups incorrectly and thus also deleting policies. This was especially an issue with Google Workspace sync.  The circuit breaker has done a good job of catching some erroneous API responses, however, it is now preventing legitimate syncs where large numbers of groups are needing to be deleted.  While a few options have been quickly talked about, no final solution has been decided on. In the mean time, this commit will update the threshold of what is considered a "mass deletion" to 75% from 25%.  This should give some time to figure out what a more permanent solution will look like.

Fixes #10892 
